### PR TITLE
feat(dev): CTL-1789 — emit phase.advance.applied and attribute who asserted each terminal

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -535,6 +535,16 @@ jobs:
         run: bash __tests__/phase-artifact-gate.test.sh
 
       - name: Run stable unit tests
+        # CTL-1789 round-1 P2 (Codex): assertion-evidence.test.mjs and
+        # assertion-evidence-parity.test.mjs are added below. The parity
+        # suite is the ONLY mechanism keeping the two hand-written bash
+        # mirrors of ASSERTED_BY (phase-agent-emit-complete's --asserted-by
+        # default, orchestrate-revive's flag) byte-identical to the JS
+        # registry — and a parity check that never runs enforces nothing, so
+        # omitting it here would reproduce the exact gap it was written to
+        # close. Both are pure, hermetic, sub-millisecond file reads: no
+        # timers, no fs.watch, no sandbox dependency, so neither can flake.
+        #
         # CTL-1678 round-7 (Codex): the four drain suites added below
         # (__tests__/config-drain-disabled, __tests__/doctor-drain-disabled,
         # cli/drain, drain-event) had NO required-CI coverage, so every regression
@@ -596,6 +606,8 @@ jobs:
             beliefs/shadow-store.test.mjs \
             beliefs/why.test.mjs \
             abort-worker.test.mjs \
+            assertion-evidence.test.mjs \
+            assertion-evidence-parity.test.mjs \
             autotune-decision.test.mjs \
             autotune-lifecycle.test.mjs \
             autotune-writeback.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -850,6 +850,14 @@ a revive, a resume, and a new-work pull).
   callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the
   fail direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` /
   `no-marker` / `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued.
+  **One registry, two unavoidable bash mirrors**: the JS writers (`recovery.mjs`,
+  `sdk-run-phase-agent.mjs`) import `ASSERTED_BY`, but `phase-agent-emit-complete` (its
+  `--asserted-by` default) and `orchestrate-revive` (its flag value) are bash and cannot. Those two
+  literals are held byte-identical to the registry MECHANICALLY by
+  `execution-core/assertion-evidence-parity.test.mjs` — the same one-registry/hand-written-mirror/
+  cross-stack-parity-suite discipline as `lib/secret-contract.mjs`. Each anchor matches on the
+  variable/flag, never the value, and fails CLOSED when an anchor disappears, so a rename on either
+  side alone fails rather than silently reclassifying valid terminals as `unknown-writer`.
 - **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline pass
   after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has cycled.
 - **Scope**: only the terminal-**success** writers are stamped (plus the SDK backstop). The ~20
@@ -867,6 +875,9 @@ a revive, a resume, and a new-work pull).
   `recovery.mjs` source-scan).
 - `plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts` — orch-monitor producer
   parity (GitHub/Linear/service-health names + prefix-family invariant).
+- `plugins/dev/scripts/execution-core/assertion-evidence-parity.test.mjs` — CTL-1789 writer-id
+  parity: the `ASSERTED_BY` registry vs its two bash mirrors, plus a no-re-typed-literal check on
+  the JS writers. Wired into the required `execution-core-tests` stable list.
 
 See `thoughts/shared/plans/2026-06-16-ctl-1142.md` §3.8.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -832,7 +832,14 @@ a revive, a resume, and a new-work pull).
   `from`/`to` are also promoted to attributes (`catalyst.advance.*`) because otel-forward strips
   `body.payload` off-machine. `from` is re-derived with the extracted pure `latestLivePhase(signals)`
   — the SAME function `deriveAdvancement` keys off, so the audit can never name a different
-  predecessor than the FSM used.
+  predecessor than the FSM used. **One exception — the remediate detour**: `remediate` is
+  ANCILLARY (∉ `PHASES`), so `latestLivePhase` can never return it, and
+  `maybeResetForRemediateCycle` has already deleted `phase-remediate.json` before the sweep reads
+  its map. Left on `latestLivePhase` alone, every remediation re-entry named `from=implement` and
+  classified its evidence off the stale implement terminal — laundering a FABRICATED remediation
+  into a DECLARED advance. That one edge is resolved through `resolveReapPredecessor` over the
+  PRE-reset snapshot (with `remediateRaw` for the deleted file), the same snapshot + resolver the
+  predecessor reap uses, so the audit's `from` and the reaped worker are always the same phase.
 - **`assertedBy` on the phase signal** (`execution-core/assertion-evidence.mjs`, a zero-import leaf
   owning `ASSERTED_BY` + `classifyAdvanceEvidence`/`explainAdvanceEvidence`). Three producers can
   write a terminal `done` and were previously byte-indistinguishable: the agent's own

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -814,8 +814,41 @@ a fully-dead daemon is a _missing series_, which `count_over_time == 0` cannot a
 **`<name>` slot exceptions** (in `recovery.mjs`, NOT pipeline phases): `dispatch`
 (`phase.dispatch.failed.<ticket>` — the only exception with a terminal-status suffix that matches
 the pattern; real phase rides `payload.target_phase`); `scheduler` (internal observability:
-`yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate `held`). The latter two never
-match the terminal-status set.
+`yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate — `held` on a refusal,
+`applied` on a performed advance, CTL-1789). The latter two never match the terminal-status set, so
+`tryPhaseLifecycleRoute` returns `[]` for every event in them — pure audit, zero wake side effect.
+
+### Advancement-gate observability + terminal attribution (CTL-1789)
+
+The advancement gate used to emit **only on refusal**: 2026-08 held 307 `phase.advance.held` events
+and zero `phase.advance.*` of any other name, so the FSM's actual advances were invisible and every
+consumer had to infer them from the successor phase's dispatch (which conflates a fresh advance with
+a revive, a resume, and a new-work pull).
+
+- **`phase.advance.applied.<TICKET>`** (`recovery.mjs` `defaultAppendPhaseAdvanceAppliedEvent`,
+  emitted from the scheduler's advancement sweep inside the `dv.ok` branch, i.e. only after
+  `dispatchAndVerify` confirmed a live successor worker). Severity **INFO** (`held` stays WARN).
+  Payload: `{from, to, evidence, evidence_reason, asserted_by, assertion_ref}`; `evidence` plus
+  `from`/`to` are also promoted to attributes (`catalyst.advance.*`) because otel-forward strips
+  `body.payload` off-machine. `from` is re-derived with the extracted pure `latestLivePhase(signals)`
+  — the SAME function `deriveAdvancement` keys off, so the audit can never name a different
+  predecessor than the FSM used.
+- **`assertedBy` on the phase signal** (`execution-core/assertion-evidence.mjs`, a zero-import leaf
+  owning `ASSERTED_BY` + `classifyAdvanceEvidence`/`explainAdvanceEvidence`). Three producers can
+  write a terminal `done` and were previously byte-indistinguishable: the agent's own
+  `phase-agent-emit-complete` (**declared**), `flipSignalDoneOnSuccess`'s clean-SDK-exit flip
+  (**fabricated** — the agent never declared anything), and the recovery-reclaim / legacy-revive
+  synthetic completes (**fabricated** — inferred from a work-done probe). Writers stamp their id:
+  the wrapper defaults to `phase-agent-emit-complete` and accepts `--asserted-by` so infrastructure
+  callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the
+  fail direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` /
+  `no-marker` / `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued.
+- **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline pass
+  after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has cycled.
+- **Scope**: only the terminal-**success** writers are stamped (plus the SDK backstop). The ~20
+  `stalled`/`failed`/`aborted`/`needs-human` writers are deliberately unstamped — those statuses are
+  never advance-eligible (`deriveAdvancement` gates on `done`, or `skipped` for `monitor-deploy`
+  only), so they can never be the `from` signal of an applied advance.
 
 **Enforcement surfaces:**
 

--- a/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-emit-complete.test.sh
@@ -791,6 +791,59 @@ else
 	assert_eq "boom" "$P_REASON" "malformed payload: base failure_reason preserved"
 fi
 
+# CTL-1789: `assertedBy` records WHO asserted the phase finished. The wrapper's
+# DEFAULT is "the agent ran me itself" (declared); infrastructure invoking the
+# wrapper on a dead worker's behalf passes --asserted-by so the advancement audit
+# classifies the terminal as fabricated instead.
+echo ""
+echo "Test 49 (CTL-1789): signal gains assertedBy=phase-agent-emit-complete by default"
+fresh_env t49
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete >/dev/null 2>&1)
+ASSERTED=$(jq -r '.assertedBy' "$SIGNAL")
+assert_eq "phase-agent-emit-complete" "$ASSERTED" "default assertedBy = the wrapper (declared)"
+# The default event payload must NOT gain the field — test 47 snapshots its keys.
+LINE=$(read_event_line)
+PAYLOAD_KEYS=$(echo "$LINE" | jq -cS '.body.payload | keys')
+assert_eq '["phase","status","ticket"]' "$PAYLOAD_KEYS" "assertedBy stays out of the event payload"
+
+echo ""
+echo "Test 50 (CTL-1789): --asserted-by overrides the marker (fabricated terminals)"
+fresh_env t50
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-research.json"
+echo '{"status":"in-progress","ticket":"CTL-100","phase":"research"}' >"$SIGNAL"
+PROJ_DIR="$(seed_thoughts_project "${TEST_DIR}/proj" research CTL-100)"
+(cd "$PROJ_DIR" && "$EMIT_SCRIPT" --phase research --ticket CTL-100 --status complete \
+	--asserted-by recovery-reclaim >/dev/null 2>&1)
+ASSERTED=$(jq -r '.assertedBy' "$SIGNAL")
+NEW_STATUS=$(jq -r '.status' "$SIGNAL")
+assert_eq "recovery-reclaim" "$ASSERTED" "--asserted-by is written verbatim"
+assert_eq "done" "$NEW_STATUS" "--asserted-by does not disturb the status flip"
+
+echo ""
+echo "Test 51 (CTL-1789): a non-success terminal is stamped too"
+fresh_env t51
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"running","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status failed --reason "tests red" \
+	>/dev/null 2>&1
+ASSERTED=$(jq -r '.assertedBy' "$SIGNAL")
+FAILREASON=$(jq -r '.failureReason' "$SIGNAL")
+assert_eq "phase-agent-emit-complete" "$ASSERTED" "failed terminal also carries assertedBy"
+assert_eq "tests red" "$FAILREASON" "failureReason still written alongside assertedBy"
+
+echo ""
+echo "Test 52 (CTL-1789): --no-signal-update callers write NO marker"
+fresh_env t52
+SIGNAL="${CATALYST_ORCHESTRATOR_DIR}/workers/CTL-100/phase-implement.json"
+echo '{"status":"stalled","ticket":"CTL-100","phase":"implement"}' >"$SIGNAL"
+"$EMIT_SCRIPT" --phase implement --ticket CTL-100 --status failed --no-signal-update \
+	>/dev/null 2>&1
+HAS_ASSERTED=$(jq -r 'has("assertedBy")' "$SIGNAL")
+assert_eq "false" "$HAS_ASSERTED" "--no-signal-update leaves the signal untouched"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-emit-complete: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/broker/namespace-contract.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.mjs
@@ -61,8 +61,11 @@ export const KNOWN_PHASES = Object.freeze([
 //     do NOT match PHASE_EVENT_PATTERN's (complete|failed|…) set, so they create
 //     no routing collisions. Listed here for completeness.
 //   "advance" — recovery.mjs emits `phase.advance.held.<ticket>` when the
-//     phase-advance step is blocked by a safety gate. Same as "scheduler": the
-//     action "held" does not match PHASE_EVENT_PATTERN's routing suffixes.
+//     phase-advance step is blocked by a safety gate, and (CTL-1789)
+//     `phase.advance.applied.<ticket>` when it performs one. Same as
+//     "scheduler": neither action ("held", "applied") matches
+//     PHASE_EVENT_PATTERN's routing suffixes, so tryPhaseLifecycleRoute returns
+//     [] for both — zero routing/wake side effect.
 export const INTENTIONAL_PHASE_SLOT_EXCEPTIONS = Object.freeze([
   "dispatch",
   "scheduler",

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -57,6 +57,8 @@ const INLINE_EVENT_NAMES = [
   "monitor.replica.degraded.team", // replica-health-event.mjs (CAT-35)
   "monitor.replica.recovered.team", // replica-health-event.mjs (CAT-35)
   "phase.triage.linear-transition.CTL-1", // triage-transition-event.mjs:53
+  "phase.advance.held.CTL-1",         // CTL-755 recovery.mjs defaultAppendPhaseAdvanceHeldEvent
+  "phase.advance.applied.CTL-1",      // CTL-1789 recovery.mjs defaultAppendPhaseAdvanceAppliedEvent
   "linear.state.write.CTL-1",         // linear-state-write-event.mjs:77
   "agent.waiting_on_user",            // wait-event.mjs:buildWaitEnvelope
   "agent.resumed",                    // wait-event.mjs:buildWaitEnvelope
@@ -159,6 +161,29 @@ describe("recovery.mjs dynamic phase-slot producers", () => {
     expect(isAllowedPhaseSlot("dispatch")).toBe(true);
     // "dispatch" is NOT a canonical pipeline phase
     expect(KNOWN_PHASES.includes("dispatch")).toBe(false);
+  });
+
+  // CTL-1789: the new applied-advance event joins phase.advance.held in the
+  // "advance" exception slot. The load-bearing property is that its ACTION
+  // ("applied") stays OUT of PHASE_EVENT_PATTERN's routing suffix set — if a
+  // future edit added it there, router.mjs's tryPhaseLifecycleRoute would start
+  // waking orchestrator sessions on every phase advance (a wake storm at ~9
+  // events/ticket) and the event would stop being pure audit.
+  test("CTL-1789: phase.advance.applied is allowed but creates NO routing match", () => {
+    const appliedName = "phase.advance.applied.CTL-1";
+    const heldName = "phase.advance.held.CTL-1";
+    for (const name of [appliedName, heldName]) {
+      // Not broker-protected → shouldSkipEvent ingests it normally.
+      expect(isBrokerProtectedName(name), `${name} must not be broker-protected`).toBe(false);
+      // Not in the routing namespace → tryPhaseLifecycleRoute returns [].
+      expect(PHASE_EVENT_PATTERN.test(name), `${name} must not match the routing pattern`).toBe(
+        false
+      );
+      expect(phaseSlotOf(name), `${name} must not resolve to a routable phase slot`).toBeNull();
+    }
+    // The slot itself is a documented exception (used by both actions).
+    expect(isAllowedPhaseSlot("advance")).toBe(true);
+    expect(KNOWN_PHASES.includes("advance")).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/assertion-evidence-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/assertion-evidence-parity.test.mjs
@@ -1,0 +1,116 @@
+// assertion-evidence-parity.test.mjs — CTL-1789 round-1 P2 (Codex).
+//
+// The writer vocabulary in assertion-evidence.mjs (ASSERTED_BY) has two BASH
+// consumers that cannot import it: `phase-agent-emit-complete` hard-codes the
+// default `phase-agent-emit-complete`, and `orchestrate-revive` hard-codes
+// `revive-synthesized` in its `--asserted-by` flag. Before this file, each side
+// was asserted independently — the JS tests pinned the constants, the bash test
+// pinned the literal — so a rename on ONE side passed every test while silently
+// reclassifying valid DECLARED/FABRICATED terminals as `absent`/`unknown-writer`
+// and corrupting the advancement audit this ticket exists to produce.
+//
+// This is the same shape as lib/secret-contract.mjs and its independently
+// maintained bash mirror: one registry, an unavoidable hand-written mirror, and
+// a cross-stack parity suite that fails if either half moves alone. A bash
+// script cannot import an .mjs constant, so parity is verified mechanically here
+// rather than shared by construction.
+//
+// TWO RULES this file exists to enforce:
+//   1. bash literal  == the registered constant   (the cross-language mirror)
+//   2. JS writers    use ASSERTED_BY.X, never a re-typed literal (one JS source)
+//
+// FAIL CLOSED: extraction that finds no anchor — or more than one — is a
+// FAILURE, not a skip. A refactor that renames the variable or restructures the
+// flag must break this test loudly rather than quietly stop checking anything.
+// Every anchor below matches on the VARIABLE / FLAG / ASSIGNMENT TARGET, never
+// on the expected value: an anchor containing the value would keep matching
+// after a one-sided rename and would therefore prove nothing.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ASSERTED_BY } from "./assertion-evidence.mjs";
+
+const SCRIPTS_DIR = join(import.meta.dir, "..");
+const EMIT_COMPLETE = join(SCRIPTS_DIR, "phase-agent-emit-complete");
+const ORCHESTRATE_REVIVE = join(SCRIPTS_DIR, "orchestrate-revive");
+const JS_WRITERS = ["recovery.mjs", "sdk-run-phase-agent.mjs"];
+
+// readBash — file contents with whole-line `#` comments removed, so prose that
+// merely MENTIONS `--asserted-by` is not mistaken for a call site.
+function readBash(path) {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((l) => !/^\s*#/.test(l))
+    .join("\n");
+}
+
+function extractAll(src, re) {
+  return [...src.matchAll(re)].map((m) => m[1]);
+}
+
+// The wrapper's top-level default assignment. The `--asserted-by` case arm
+// (`\t\tASSERTED_BY="$2"`) is indented, so `^` excludes it; the `$`-guard is
+// belt-and-braces if that indentation ever changes.
+const emitCompleteDefaults = () =>
+  extractAll(readBash(EMIT_COMPLETE), /^ASSERTED_BY="([^"\n]*)"$/gm).filter(
+    (v) => !v.startsWith("$")
+  );
+
+// orchestrate-revive's flag usage, anchored on the flag.
+const reviveFlagValues = () =>
+  extractAll(readBash(ORCHESTRATE_REVIVE), /--asserted-by[ \t]+([A-Za-z0-9._-]+)/g);
+
+describe("CTL-1789 P2: ASSERTED_BY vocabulary parity — JS registry vs its bash consumers", () => {
+  test("phase-agent-emit-complete's default == ASSERTED_BY.PHASE_AGENT", () => {
+    const found = emitCompleteDefaults();
+    expect(found).toHaveLength(1); // fail closed: exactly one literal to compare
+    expect(found[0]).toBe(ASSERTED_BY.PHASE_AGENT);
+  });
+
+  test("orchestrate-revive's --asserted-by == ASSERTED_BY.REVIVE_SYNTHESIZED", () => {
+    const found = reviveFlagValues();
+    expect(found).toHaveLength(1); // fail closed
+    expect(found[0]).toBe(ASSERTED_BY.REVIVE_SYNTHESIZED);
+  });
+
+  test("every writer id embedded in bash is a REGISTERED id (no unknown-writer drift)", () => {
+    // Catches what the per-site expectations above could miss: a bash literal
+    // renamed to something the registry does not contain AT ALL. Such an id
+    // classifies `absent` / `unknown-writer` in classifySignal — precisely the
+    // silent corruption this suite exists to prevent.
+    const registered = Object.values(ASSERTED_BY);
+    const embedded = [...emitCompleteDefaults(), ...reviveFlagValues()];
+    expect(embedded.length).toBeGreaterThan(0); // fail closed on a vanished anchor
+    for (const id of embedded) expect(registered).toContain(id);
+  });
+
+  test("the JS writers consume the registry symbolically, never a re-typed literal", () => {
+    // recovery.mjs and sdk-run-phase-agent.mjs CAN import the constant, so they
+    // must — a bare literal there would be a third place to rename. Anchored on
+    // the ASSIGNMENT TARGET (`assertedBy =`/`asserted_by:` / the `--asserted-by`
+    // argv element), so an unrelated string that merely happens to equal a
+    // writer id (sdk-run-phase-agent's `attentionReason = "sdk-backstop"`) is
+    // not a match. The rule is "no re-typed STRING LITERAL" — a pass-through
+    // variable or a `null` default is fine; `"phase-agent-emit-complete"` is not.
+    for (const f of JS_WRITERS) {
+      const src = readFileSync(join(import.meta.dir, f), "utf8");
+      expect(src).toContain('from "./assertion-evidence.mjs"');
+      const assigned = [
+        ...extractAll(src, /\bassertedBy\s*[:=]\s*([^,;\n]+)/g),
+        ...extractAll(src, /\basserted_by\s*:\s*([^,;\n]+)/g),
+        ...extractAll(src, /"--asserted-by",\s*([^,\n]+)/g),
+      ].map((s) => s.trim());
+      expect(assigned.length).toBeGreaterThan(0); // fail closed
+      // No RHS may be a re-typed string literal.
+      for (const rhs of assigned) expect(/^["'`]/.test(rhs)).toBe(false);
+      // …and the import must actually be load-bearing in this file.
+      expect(assigned.some((rhs) => rhs.startsWith("ASSERTED_BY."))).toBe(true);
+    }
+  });
+
+  test("the registry's ids are unique (a collision would merge two writers' verdicts)", () => {
+    const values = Object.values(ASSERTED_BY);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/plugins/dev/scripts/execution-core/assertion-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/assertion-evidence.mjs
@@ -1,0 +1,127 @@
+// assertion-evidence.mjs — CTL-1789. Who asserted that a phase finished?
+//
+// A phase signal reaching a terminal SUCCESS status (`done`, or `skipped` on
+// monitor-deploy) is the ONLY input the scheduler's advancement FSM keys off.
+// Three structurally different producers can write that terminal, and until this
+// module existed they were byte-indistinguishable on disk:
+//
+//   A. the phase agent ran its own `phase-agent-emit-complete` wrapper
+//      → the agent DECLARED it finished.
+//   B. `flipSignalDoneOnSuccess` flipped an in-flight signal to `done` because
+//      the SDK/codex query exited cleanly — WITHOUT the agent ever declaring
+//      anything (sdk-run-phase-agent.mjs).
+//   C. a recovery/revive path inferred completion from a work-done probe and
+//      invoked the same wrapper on the dead worker's behalf.
+//
+// B and C are FABRICATED terminals: infrastructure asserting on the agent's
+// behalf. They are legitimate (they are what keeps a pipeline moving past a
+// crashed worker) but they are NOT the agent's own claim, and an audit that
+// cannot tell them apart cannot answer "how much of this pipeline actually ran".
+//
+// `assertedBy` is the one-string marker every terminal-success writer now stamps
+// onto the signal file. This module owns the vocabulary and the classifier.
+//
+// ZERO-IMPORT LEAF, deliberately (same discipline as lib/secret-contract.mjs):
+// no node builtins, no sibling modules. `catalyst doctor`'s bare-node runtime,
+// the bash-adjacent test harness, and the scheduler all consume it without
+// dragging in config.mjs's bun:sqlite graph.
+//
+// SEMANTIC WARNING for downstream consumers: `assertedBy` records WHO WROTE THE
+// TERMINAL, not whether the work was really done. A phase agent that runs its
+// wrapper without doing anything useful still classifies as `declared`. The axis
+// is declared-by-agent vs fabricated-by-infrastructure — nothing more.
+
+// ASSERTED_BY — the registered writer ids. One per terminal-success writer.
+export const ASSERTED_BY = Object.freeze({
+  // A — the phase skill invoked the wrapper itself. The wrapper's DEFAULT, so a
+  // caller that passes no --asserted-by is recorded as the agent's own claim.
+  PHASE_AGENT: "phase-agent-emit-complete",
+  // C — execution-core recovery reclaim (recovery.mjs defaultEmitComplete):
+  // the worker died, a work-done probe said the artifact landed, so the reclaim
+  // ran the wrapper on its behalf.
+  RECOVERY_RECLAIM: "recovery-reclaim",
+  // C (legacy wave orchestration) — orchestrate-revive's synthetic complete.
+  REVIVE_SYNTHESIZED: "revive-synthesized",
+  // B — sdk-run-phase-agent.mjs flipSignalDoneOnSuccess. Shared by the SDK and
+  // codex-exec launch verbs (codex imports the same function).
+  SDK_SUCCESS_FLIP: "sdk-success-flip",
+  // B (non-success) — sdk-run-phase-agent.mjs defaultWriteSignalTerminal, the
+  // stalled/failed/turn-cap-exhausted backstop. Never advance-eligible, stamped
+  // so the marker's coverage of the SDK writer pair is not half-missing.
+  SDK_BACKSTOP: "sdk-backstop",
+});
+
+// EVIDENCE — the three-valued advance-evidence contract. Exactly three values,
+// forever; diagnosability rides `evidenceReason`, never a fourth value.
+export const EVIDENCE = Object.freeze({
+  DECLARED: "declared",
+  FABRICATED: "fabricated",
+  ABSENT: "absent",
+});
+
+export const EVIDENCE_VALUES = Object.freeze([
+  EVIDENCE.DECLARED,
+  EVIDENCE.FABRICATED,
+  EVIDENCE.ABSENT,
+]);
+
+// EVIDENCE_REASONS — why an `absent` is absent. Null for declared/fabricated.
+export const EVIDENCE_REASONS = Object.freeze([
+  "no-predecessor", // the FSM advanced off nothing readable (new-work entry, reset cycle)
+  "unreadable-signal", // the predecessor signal file was missing or unparseable
+  "no-marker", // signal present, but written before this marker shipped (or by an unstamped writer)
+  "unknown-writer", // signal carries an assertedBy this contract does not recognize
+]);
+
+const DECLARED_WRITERS = new Set([ASSERTED_BY.PHASE_AGENT]);
+
+const FABRICATED_WRITERS = new Set([
+  ASSERTED_BY.RECOVERY_RECLAIM,
+  ASSERTED_BY.REVIVE_SYNTHESIZED,
+  ASSERTED_BY.SDK_SUCCESS_FLIP,
+  ASSERTED_BY.SDK_BACKSTOP,
+]);
+
+// classifySignal — the single implementation. Returns the full triple so the
+// two exported entry points never duplicate the branching.
+//
+// FAIL DIRECTION: every unrecognized shape resolves to `absent`, never to
+// `declared`. An audit that over-reports agent assertions is worse than one that
+// under-reports them — `absent` says "I cannot prove who asserted this", which
+// is exactly true for a legacy signal, an unreadable file, or a writer that has
+// not been folded onto the contract yet.
+function classifySignal(sig) {
+  if (sig === null || sig === undefined || typeof sig !== "object" || Array.isArray(sig)) {
+    return { evidence: EVIDENCE.ABSENT, evidenceReason: "unreadable-signal", assertedBy: null };
+  }
+  const a = sig.assertedBy;
+  if (typeof a !== "string" || a === "") {
+    return { evidence: EVIDENCE.ABSENT, evidenceReason: "no-marker", assertedBy: null };
+  }
+  if (DECLARED_WRITERS.has(a)) {
+    return { evidence: EVIDENCE.DECLARED, evidenceReason: null, assertedBy: a };
+  }
+  if (FABRICATED_WRITERS.has(a)) {
+    return { evidence: EVIDENCE.FABRICATED, evidenceReason: null, assertedBy: a };
+  }
+  return { evidence: EVIDENCE.ABSENT, evidenceReason: "unknown-writer", assertedBy: a };
+}
+
+// classifyAdvanceEvidence — pure. Given the PARSED predecessor phase signal (or
+// null/undefined when there is none), return one of EVIDENCE_VALUES.
+export function classifyAdvanceEvidence(sig) {
+  return classifySignal(sig).evidence;
+}
+
+// explainAdvanceEvidence — pure. Same classification plus the diagnostic
+// `evidenceReason` and the raw `assertedBy` string.
+//
+// `predecessorPhase` is the phase whose signal `sig` is. Passing null/undefined
+// (there was no predecessor to read) short-circuits to the `no-predecessor`
+// reason, which is NOT derivable from a signal — it is a caller-side fact.
+export function explainAdvanceEvidence(sig, { predecessorPhase = null } = {}) {
+  if (typeof predecessorPhase !== "string" || predecessorPhase === "") {
+    return { evidence: EVIDENCE.ABSENT, evidenceReason: "no-predecessor", assertedBy: null };
+  }
+  return classifySignal(sig);
+}

--- a/plugins/dev/scripts/execution-core/assertion-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/assertion-evidence.mjs
@@ -32,6 +32,16 @@
 // is declared-by-agent vs fabricated-by-infrastructure — nothing more.
 
 // ASSERTED_BY — the registered writer ids. One per terminal-success writer.
+//
+// THIS IS THE ONLY SOURCE. JS writers (recovery.mjs, sdk-run-phase-agent.mjs)
+// import these symbols. The two BASH writers cannot — `phase-agent-emit-complete`
+// hard-codes PHASE_AGENT as its --asserted-by default and `orchestrate-revive`
+// hard-codes REVIVE_SYNTHESIZED — so those mirrors are held honest MECHANICALLY
+// by assertion-evidence-parity.test.mjs, which extracts each bash literal and
+// compares it to the row here. Renaming EITHER side alone fails that suite; an
+// undetected drift would silently reclassify a valid declared/fabricated
+// terminal as absent/unknown-writer and corrupt the advancement audit. Same
+// discipline as lib/secret-contract.mjs and its bash mirror. CTL-1789 P2.
 export const ASSERTED_BY = Object.freeze({
   // A — the phase skill invoked the wrapper itself. The wrapper's DEFAULT, so a
   // caller that passes no --asserted-by is recorded as the agent's own claim.

--- a/plugins/dev/scripts/execution-core/assertion-evidence.test.mjs
+++ b/plugins/dev/scripts/execution-core/assertion-evidence.test.mjs
@@ -1,0 +1,172 @@
+// assertion-evidence.test.mjs — CTL-1789 classifier truth table.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test assertion-evidence.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  ASSERTED_BY,
+  EVIDENCE,
+  EVIDENCE_VALUES,
+  EVIDENCE_REASONS,
+  classifyAdvanceEvidence,
+  explainAdvanceEvidence,
+} from "./assertion-evidence.mjs";
+
+describe("CTL-1789 assertion-evidence contract", () => {
+  test("EVIDENCE_VALUES is exactly the three-valued contract", () => {
+    expect(EVIDENCE_VALUES).toEqual(["declared", "fabricated", "absent"]);
+  });
+
+  test("every ASSERTED_BY id is classified (no id falls through to unknown-writer)", () => {
+    for (const id of Object.values(ASSERTED_BY)) {
+      const r = explainAdvanceEvidence({ assertedBy: id }, { predecessorPhase: "implement" });
+      expect(r.evidenceReason, `${id} is registered but not classified`).toBeNull();
+      expect([EVIDENCE.DECLARED, EVIDENCE.FABRICATED]).toContain(r.evidence);
+    }
+  });
+
+  test("the wrapper's own id is the ONLY declared writer", () => {
+    const declared = Object.values(ASSERTED_BY).filter(
+      (id) => classifyAdvanceEvidence({ assertedBy: id }) === EVIDENCE.DECLARED
+    );
+    expect(declared).toEqual([ASSERTED_BY.PHASE_AGENT]);
+    expect(ASSERTED_BY.PHASE_AGENT).toBe("phase-agent-emit-complete");
+  });
+});
+
+describe("classifyAdvanceEvidence", () => {
+  test("phase-agent-emit-complete → declared", () => {
+    expect(classifyAdvanceEvidence({ assertedBy: ASSERTED_BY.PHASE_AGENT })).toBe("declared");
+  });
+
+  test.each([
+    ASSERTED_BY.SDK_SUCCESS_FLIP,
+    ASSERTED_BY.SDK_BACKSTOP,
+    ASSERTED_BY.RECOVERY_RECLAIM,
+    ASSERTED_BY.REVIVE_SYNTHESIZED,
+  ])("%s → fabricated", (id) => {
+    expect(classifyAdvanceEvidence({ assertedBy: id })).toBe("fabricated");
+  });
+
+  test("a signal with no assertedBy (legacy, pre-CTL-1789) → absent", () => {
+    expect(classifyAdvanceEvidence({ status: "done", ticket: "CTL-1" })).toBe("absent");
+  });
+
+  // The fail direction is the whole point: an unrecognized writer must NOT be
+  // read as the agent's own claim.
+  test("an UNKNOWN writer id fails to absent, never to declared", () => {
+    expect(classifyAdvanceEvidence({ assertedBy: "some-future-writer" })).toBe("absent");
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "done"],
+    ["an array", []],
+    ["a number", 7],
+  ])("a non-object signal (%s) → absent", (_label, sig) => {
+    expect(classifyAdvanceEvidence(sig)).toBe("absent");
+  });
+
+  test.each([
+    ["empty string", ""],
+    ["a number", 3],
+    ["null", null],
+    ["an object", {}],
+  ])("a non-string assertedBy (%s) → absent", (_label, a) => {
+    expect(classifyAdvanceEvidence({ assertedBy: a })).toBe("absent");
+  });
+});
+
+describe("explainAdvanceEvidence — diagnosable absent", () => {
+  test("no predecessor phase → no-predecessor", () => {
+    expect(explainAdvanceEvidence({ assertedBy: ASSERTED_BY.PHASE_AGENT })).toEqual({
+      evidence: "absent",
+      evidenceReason: "no-predecessor",
+      assertedBy: null,
+    });
+  });
+
+  test("unreadable/absent signal for a real predecessor → unreadable-signal", () => {
+    expect(explainAdvanceEvidence(null, { predecessorPhase: "implement" })).toEqual({
+      evidence: "absent",
+      evidenceReason: "unreadable-signal",
+      assertedBy: null,
+    });
+  });
+
+  test("legacy signal with no marker → no-marker", () => {
+    expect(explainAdvanceEvidence({ status: "done" }, { predecessorPhase: "plan" })).toEqual({
+      evidence: "absent",
+      evidenceReason: "no-marker",
+      assertedBy: null,
+    });
+  });
+
+  test("unregistered writer → unknown-writer, and the raw id is preserved", () => {
+    expect(
+      explainAdvanceEvidence({ assertedBy: "mystery-flip" }, { predecessorPhase: "verify" })
+    ).toEqual({
+      evidence: "absent",
+      evidenceReason: "unknown-writer",
+      assertedBy: "mystery-flip",
+    });
+  });
+
+  test("declared/fabricated carry a null reason and the raw id", () => {
+    expect(
+      explainAdvanceEvidence(
+        { assertedBy: ASSERTED_BY.PHASE_AGENT },
+        { predecessorPhase: "research" }
+      )
+    ).toEqual({
+      evidence: "declared",
+      evidenceReason: null,
+      assertedBy: "phase-agent-emit-complete",
+    });
+    expect(
+      explainAdvanceEvidence(
+        { assertedBy: ASSERTED_BY.SDK_SUCCESS_FLIP },
+        { predecessorPhase: "research" }
+      )
+    ).toEqual({
+      evidence: "fabricated",
+      evidenceReason: null,
+      assertedBy: "sdk-success-flip",
+    });
+  });
+
+  test("every emitted evidenceReason is in the documented EVIDENCE_REASONS set", () => {
+    const seen = [
+      explainAdvanceEvidence({}, {}),
+      explainAdvanceEvidence(null, { predecessorPhase: "implement" }),
+      explainAdvanceEvidence({ status: "done" }, { predecessorPhase: "implement" }),
+      explainAdvanceEvidence({ assertedBy: "x" }, { predecessorPhase: "implement" }),
+    ].map((r) => r.evidenceReason);
+    expect(seen).toEqual(EVIDENCE_REASONS.slice());
+    for (const r of seen) expect(EVIDENCE_REASONS).toContain(r);
+  });
+
+  test("explain and classify never disagree on the evidence value", () => {
+    const fixtures = [
+      { assertedBy: ASSERTED_BY.PHASE_AGENT },
+      { assertedBy: ASSERTED_BY.SDK_SUCCESS_FLIP },
+      { assertedBy: "unknown" },
+      { status: "done" },
+      null,
+    ];
+    for (const f of fixtures) {
+      expect(explainAdvanceEvidence(f, { predecessorPhase: "implement" }).evidence).toBe(
+        classifyAdvanceEvidence(f)
+      );
+    }
+  });
+
+  test("the module is a zero-import leaf (no imports at all)", () => {
+    // The contract that lets catalyst doctor's bare-node runtime consume it.
+    const src = readFileSync(new URL("./assertion-evidence.mjs", import.meta.url), "utf8");
+    expect(/^\s*import\s/m.test(src)).toBe(false);
+    expect(/\brequire\s*\(/.test(src)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -96,6 +96,7 @@ import { phaseIndex, isKnownPhase } from "../lib/phase-fsm.mjs";
 // supersede-guard below.
 import { RECOVERY_PASS_PHASE } from "./recovery-reasoning.mjs";
 import { classifyEventStream } from "../lib/event-stream-class.mjs"; // CTL-1488: coordination/telemetry split
+import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789: terminal-writer attribution
 import { readWorkerSignals, TERMINAL, listDispatchedPhases } from "./signal-reader.mjs";
 import { reconcileAll } from "./monitor.mjs";
 import { listProjects } from "./registry.mjs";
@@ -408,7 +409,9 @@ export function reconstructWorkerState(orchDir, { statJob = defaultStatJob } = {
 // PURE given the injected statJob / probes / emitComplete / appendEvent — no
 // fs / spawn of its own.
 
-function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
+// CTL-1789: exported so the argv contract (notably --asserted-by) is pinnable
+// without shelling out to the real wrapper. The `{ spawn }` seam already existed.
+export function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
   const args = [
     "--phase",
     signal.phase,
@@ -420,6 +423,11 @@ function defaultEmitComplete({ orchDir, signal }, { spawn = spawnSync } = {}) {
     orchDir,
     "--orch-id",
     signal.raw?.orchestrator ?? signal.ticket,
+    // CTL-1789: this complete is INFERRED from a work-done probe — the worker
+    // died without declaring anything. Mark the terminal fabricated so the
+    // advancement audit does not read it as the agent's own claim.
+    "--asserted-by",
+    ASSERTED_BY.RECOVERY_RECLAIM,
   ];
   const sessionId = signal.raw?.catalystSessionId;
   if (sessionId) {
@@ -1248,6 +1256,69 @@ export function defaultAppendPhaseAdvanceHeldEvent({ orchId, ticket, reason, blo
       payloadExtras: { blockers: blockers ?? [] },
     }),
     "advance-held"
+  );
+}
+
+// CTL-1789: the POSITIVE half of the advancement gate —
+// phase.advance.applied.<ticket>.
+//
+// Until this event existed the gate emitted ONLY on refusal (phase.advance.held),
+// so a month of logs could say why the FSM declined 307 times and nothing at all
+// about the advances it actually performed. "The pipeline advanced" was
+// unobservable; every consumer had to infer it from the SUCCESSOR phase's
+// dispatch, which conflates a fresh advance with a revive, a resume, and a
+// new-work pull.
+//
+// Emitted from exactly one place — the scheduler's advancement sweep, inside the
+// `dv.ok` branch, i.e. AFTER dispatchAndVerify has confirmed a live successor
+// worker. One event per successful advance (~9 per ticket), never per tick.
+//
+// `evidence` is the CTL-1789 second half: three-valued
+// (declared|fabricated|absent) attribution of the `from` phase's terminal — see
+// assertion-evidence.mjs. Promoted to an ATTRIBUTE (not just body.payload)
+// because otel-forward strips body.payload off-machine; `from`/`to` ride along
+// as attributes for the same reason (both bounded ≤10-value enums, so no Loki
+// cardinality risk). `evidence_reason` and `asserted_by` stay in the payload —
+// diagnostics, not dashboard dimensions.
+//
+// INFO severity, deliberately: `held` is a WARN because a refusal may need an
+// operator; a performed advance is the system working.
+//
+// Best-effort, never throws (appendEnvelopeBestEffort). The scheduler additionally
+// wraps the call in safeEmit — an audit emit must never abort a tick.
+export function defaultAppendPhaseAdvanceAppliedEvent({
+  orchId,
+  ticket,
+  from,
+  to,
+  evidence,
+  evidenceReason = null,
+  assertedBy = null,
+  assertionRef = null,
+}) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "advance",
+      ticket,
+      orchId,
+      action: "applied",
+      severityText: "INFO",
+      severityNumber: 9,
+      payloadExtras: {
+        from: from ?? null,
+        to: to ?? null,
+        evidence,
+        evidence_reason: evidenceReason,
+        asserted_by: assertedBy,
+        assertion_ref: assertionRef,
+      },
+      attrExtras: {
+        "catalyst.advance.evidence": evidence,
+        "catalyst.advance.from": from ?? undefined,
+        "catalyst.advance.to": to ?? undefined,
+      },
+    }),
+    "advance-applied"
   );
 }
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -8,8 +8,11 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789
 import {
   buildEventEnvelope,
+  defaultEmitComplete, // CTL-1789: argv contract (--asserted-by)
+  defaultAppendPhaseAdvanceAppliedEvent, // CTL-1789
   classifyWorker,
   jobLifecycle,
   reconstructWorkerState,
@@ -6655,5 +6658,127 @@ describe("CTL-1643: escalateOnce verified-or-loud label application", () => {
     }));
     expect(appendEscalated.calls.length).toBe(1);
     expect(recordEscalation.calls.length).toBe(1);
+  });
+});
+
+// ─── CTL-1789: reclaim marks its synthetic complete as FABRICATED ────────────
+//
+// The reclaim path invokes the SAME wrapper a healthy agent would, so before this
+// its terminal was byte-indistinguishable from a real agent declaration. The
+// --asserted-by flag is the whole discriminator.
+describe("defaultEmitComplete — CTL-1789 --asserted-by argv contract", () => {
+  test("passes --asserted-by recovery-reclaim", () => {
+    let seen = null;
+    defaultEmitComplete(
+      { orchDir: "/orch", signal: { ticket: "CTL-1", phase: "implement", raw: {} } },
+      {
+        spawn: (bin, args) => {
+          seen = { bin, args };
+          return { status: 0, stdout: "", stderr: "" };
+        },
+      }
+    );
+    expect(seen.bin).toMatch(/phase-agent-emit-complete$/);
+    const i = seen.args.indexOf("--asserted-by");
+    expect(i).toBeGreaterThan(-1);
+    expect(seen.args[i + 1]).toBe(ASSERTED_BY.RECOVERY_RECLAIM);
+    expect(seen.args[i + 1]).toBe("recovery-reclaim");
+    // …and it does NOT pass --no-signal-update: the reclaim OWNS the signal flip,
+    // which is exactly why the marker has to be right.
+    expect(seen.args).not.toContain("--no-signal-update");
+  });
+
+  test("the session-id branch keeps the flag (order-independent lookup)", () => {
+    let seen = null;
+    defaultEmitComplete(
+      {
+        orchDir: "/orch",
+        signal: { ticket: "CTL-1", phase: "pr", raw: { catalystSessionId: "sess-9" } },
+      },
+      {
+        spawn: (_bin, args) => {
+          seen = args;
+          return { status: 0 };
+        },
+      }
+    );
+    expect(seen[seen.indexOf("--asserted-by") + 1]).toBe("recovery-reclaim");
+    expect(seen[seen.indexOf("--session-id") + 1]).toBe("sess-9");
+  });
+});
+
+describe("defaultAppendPhaseAdvanceAppliedEvent — CTL-1789 envelope shape", () => {
+  let prevDir;
+  let dir;
+  beforeEach(() => {
+    prevDir = process.env.CATALYST_DIR;
+    dir = mkdtempSync(join(tmpdir(), "advapplied-"));
+    process.env.CATALYST_DIR = dir;
+  });
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function readOnly() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(dir, "events", `${ym}.jsonl`), "utf8")
+      .trim()
+      .split("\n");
+    expect(lines).toHaveLength(1);
+    return JSON.parse(lines[0]);
+  }
+
+  test("name / severity / payload / promoted attributes", () => {
+    expect(
+      defaultAppendPhaseAdvanceAppliedEvent({
+        orchId: "CTL-1",
+        ticket: "CTL-1",
+        from: "plan",
+        to: "implement",
+        evidence: "declared",
+        evidenceReason: null,
+        assertedBy: ASSERTED_BY.PHASE_AGENT,
+        assertionRef: "workers/CTL-1/phase-plan.json",
+      })
+    ).toBe(true);
+    const e = readOnly();
+    expect(e.attributes["event.name"]).toBe("phase.advance.applied.CTL-1");
+    expect(e.attributes["event.action"]).toBe("applied");
+    expect(e.attributes["catalyst.advance.evidence"]).toBe("declared");
+    expect(e.attributes["catalyst.advance.from"]).toBe("plan");
+    expect(e.attributes["catalyst.advance.to"]).toBe("implement");
+    expect(e.severityText).toBe("INFO");
+    expect(e.severityNumber).toBe(9);
+    expect(e.body.payload).toMatchObject({
+      phase: "advance",
+      ticket: "CTL-1",
+      status: "applied",
+      from: "plan",
+      to: "implement",
+      evidence: "declared",
+      asserted_by: "phase-agent-emit-complete",
+      assertion_ref: "workers/CTL-1/phase-plan.json",
+    });
+  });
+
+  test("a null `from` drops the attribute but keeps the payload field", () => {
+    defaultAppendPhaseAdvanceAppliedEvent({
+      orchId: "CTL-2",
+      ticket: "CTL-2",
+      from: null,
+      to: "research",
+      evidence: "absent",
+      evidenceReason: "no-predecessor",
+    });
+    const e = readOnly();
+    // vetAttrs drops non-strings → absence, not a literal "null" dimension.
+    expect("catalyst.advance.from" in e.attributes).toBe(false);
+    expect(e.body.payload.from).toBeNull();
+    expect(e.body.payload.evidence_reason).toBe("no-predecessor");
+    expect(e.body.payload.asserted_by).toBeNull();
+    expect(e.body.payload.assertion_ref).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2019,10 +2019,16 @@ export function readAllEligibleTickets() {
 // consume this same function: a second, independently-derived `from` would drift
 // from the FSM's actual input the moment either supersession rule changes.
 //
-// NOTE on the remediate detour: `remediate` ∉ PHASES, so it is invisible here. On
-// the remediate→verify re-entry the cycle signals have already been deleted, so
-// this returns `implement` — which is genuinely the signal the FSM keyed off. It
-// is NOT the worker to reap; that is resolveReapPredecessor's separate job.
+// NOTE on the remediate detour: `remediate` ∉ PHASES (it is ANCILLARY), so it is
+// structurally invisible here — this function can never return it, for any input.
+// On the remediate→verify re-entry it returns `implement`, which is the signal
+// the FSM mechanically keyed off after maybeResetForRemediateCycle deleted the
+// cycle signals — but `implement` is NOT the phase whose terminal caused that
+// advance, and its (stale) terminal must NOT be the one the audit classifies.
+// CTL-1789 round-1 P1: both the predecessor reap AND the phase.advance.applied
+// audit resolve that one edge through resolveReapPredecessor over the PRE-reset
+// snapshot instead. Callers wanting the FSM's raw input still use this function;
+// callers naming the phase that just finished must layer the detour on top.
 export function latestLivePhase(signals) {
   const sig = signals ?? {};
   const liveSet = new Set(livePhaseEntries(sig).map(([p]) => p));
@@ -7239,10 +7245,27 @@ export function schedulerTick(
       // so the first pipeline pass after deploy reads `absent` /
       // evidence_reason="no-marker". Do not alarm on `absent` until a full ticket
       // has cycled through.
-      const fromPhase = latestLivePhase(signals);
+      //
+      // REMEDIATE DETOUR (CTL-1789 round-1 P1, Codex): latestLivePhase scans
+      // PHASES, and `remediate` is an ANCILLARY phase (∉ PHASES) — so it can
+      // NEVER return `remediate`, whether or not the signal still exists. On
+      // top of that, maybeResetForRemediateCycle deleted phase-remediate.json
+      // above, before `signals` was even read. Left alone, every remediation
+      // re-entry therefore reported `from=implement` and classified its
+      // evidence off the long-finished implement signal — laundering a
+      // FABRICATED remediation terminal into a DECLARED one, corrupting the
+      // exact metric this event exists to produce. Resolve that one edge from
+      // the SAME pre-reset snapshot and the SAME resolver the predecessor-reap
+      // path uses (resolveReapPredecessor), so the audit's `from` and the
+      // reaped worker can never be two different phases for one advance. Every
+      // other edge stays on latestLivePhase — the FSM's own input.
+      const detour = resolveReapPredecessor(preResetSignals, next);
+      const fromPhase =
+        detour?.phase === REMEDIATE_PHASE ? REMEDIATE_PHASE : latestLivePhase(signals);
       const fromRaw = fromPhase
         ? fromPhase === REMEDIATE_PHASE
-          ? (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, fromPhase))
+          ? // the reset already deleted the file — remediateRaw is the pre-reset capture
+            (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, fromPhase))
           : readPhaseSignalRaw(orchDir, ticket, fromPhase)
         : null;
       const ev = explainAdvanceEvidence(fromRaw, { predecessorPhase: fromPhase });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -71,6 +71,7 @@ export { EMPTY_WORKER_DIR_GRACE_DEFAULT_MS };
 // budget) live here. deriveAdvancement stays pure — the impure reads happen in
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
+import { explainAdvanceEvidence } from "./assertion-evidence.mjs"; // CTL-1789: from-phase terminal attribution
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
@@ -212,6 +213,7 @@ import {
   defaultAppendCooldownGcEvent,
   defaultAppendCooldownEscalatedEvent,
   defaultAppendPhaseAdvanceHeldEvent,
+  defaultAppendPhaseAdvanceAppliedEvent, // CTL-1789: the positive half of the advancement gate
   defaultAppendRunawayEvent,
   defaultAppendOrphanDetectedEvent,
 } from "./recovery.mjs";
@@ -1997,6 +1999,39 @@ export function readAllEligibleTickets() {
   return all;
 }
 
+// latestLivePhase — the pipeline phase whose status deriveAdvancement keys off:
+// the highest-ordinal PHASES entry that is BOTH present in the signal map and
+// still live (not superseded by a later dispatch). Returns null when the map
+// holds no live known phase.
+//
+// CTL-1660 P1 round 3 (Codex #3081): pick the latest phase from the LIVE set, not a
+// raw ordinal scan. With an older `review: done` behind a newly redispatched
+// `implement: running`, the ordinal scan selected the stale `review`, saw `done`,
+// and returned `pr` — dispatching the PR phase while the replacement implementation
+// was still running, skipping its verify and review entirely. (This became
+// reachable once livePhaseEntries admitted such tickets to the advancement sweep,
+// so the two must consume the same supersession decision.)
+//
+// CTL-1789 extracted this out of deriveAdvancement — with ZERO behaviour change —
+// so the advancement sweep can name the `from` side of the edge it just applied.
+// deriveAdvancement returns only `next`; the phase it advanced FROM was discarded,
+// which made a from→to audit event impossible to emit honestly. Both callers MUST
+// consume this same function: a second, independently-derived `from` would drift
+// from the FSM's actual input the moment either supersession rule changes.
+//
+// NOTE on the remediate detour: `remediate` ∉ PHASES, so it is invisible here. On
+// the remediate→verify re-entry the cycle signals have already been deleted, so
+// this returns `implement` — which is genuinely the signal the FSM keyed off. It
+// is NOT the worker to reap; that is resolveReapPredecessor's separate job.
+export function latestLivePhase(signals) {
+  const sig = signals ?? {};
+  const liveSet = new Set(livePhaseEntries(sig).map(([p]) => p));
+  let latest = null;
+  // remediate ∉ PHASES → invisible here
+  for (const p of PHASES) if (p in sig && liveSet.has(p)) latest = p;
+  return latest;
+}
+
 // deriveAdvancement — pure. Given a ticket's phase→status signals, return the
 // phase the FSM owes next, or null. The next phase is owed when the latest
 // known phase is `done` and its transition() successor is a non-terminal phase
@@ -2009,22 +2044,12 @@ export function readAllEligibleTickets() {
 // remediateCycleCount: 0 }, which preserves the legacy verify → review edge.
 export function deriveAdvancement(signals, { verifyVerdict, remediateCycleCount = 0 } = {}) {
   const sig = signals ?? {};
-  // CTL-1660 P1 round 3 (Codex #3081): pick the latest phase from the LIVE set, not a
-  // raw ordinal scan. With an older `review: done` behind a newly redispatched
-  // `implement: running`, the ordinal scan selected the stale `review`, saw `done`,
-  // and returned `pr` — dispatching the PR phase while the replacement implementation
-  // was still running, skipping its verify and review entirely. (This became
-  // reachable once livePhaseEntries admitted such tickets to the advancement sweep,
-  // so the two must consume the same supersession decision.)
-  //
   // The `in sig` guards below still consult the FULL signal map on purpose: refusing
   // to advance into a successor that has any signal at all — even a stale one — is
   // the conservative direction. It can only withhold an advancement, never invent a
   // wrong one.
   const liveSet = new Set(livePhaseEntries(sig).map(([p]) => p));
-  let latest = null;
-  // remediate ∉ PHASES → invisible here
-  for (const p of PHASES) if (p in sig && liveSet.has(p)) latest = p;
+  const latest = latestLivePhase(sig);
   // CTL-703: `skipped` is advancement-eligible for monitor-deploy ONLY.
   // monitor-deploy `skipped` must advance to teardown (just as `done` does),
   // so the pipeline can reach the dedicated teardown phase even when no deploy
@@ -4364,6 +4389,11 @@ export function schedulerTick(
     // CTL-755: held-indicator audit emitter — phase.advance.held.<ticket>.
     // Best-effort, only-on-state-change. Mirrors appendDispatchRequestedEvent.
     appendPhaseAdvanceHeldEvent = defaultAppendPhaseAdvanceHeldEvent,
+    // CTL-1789: applied-advance audit emitter — phase.advance.applied.<ticket>.
+    // Best-effort, one per VERIFIED advance. Default-on (mirrors the held seam):
+    // the advancement gate must not stay refusal-only on any host that forgets to
+    // wire it. Tests inject a spy.
+    appendPhaseAdvanceAppliedEvent = defaultAppendPhaseAdvanceAppliedEvent,
     // CTL-757: canonical linear.state.write audit emitter, injectable for tests.
     // Caller-emitted at the 4 scheduler write sites (scheduler-advance,
     // preemption-resume, terminal-sweep, reconcile-backstop) via the emitStateWrite
@@ -7191,6 +7221,45 @@ export function schedulerTick(
     });
     if (dv.ok) {
       advanced.push({ ticket, phase: next });
+      // CTL-1789: the ONLY point at which "the FSM advanced this ticket" is both
+      // true and verified — dispatchAndVerify has already confirmed a live
+      // successor worker. Emit the positive half of the advancement gate.
+      //
+      // `from` is re-derived with latestLivePhase from the SAME post-sanitize map
+      // deriveAdvancement consumed above, so the audit names the FSM's actual
+      // input rather than a second, independently-guessed predecessor.
+      //
+      // `evidence` classifies WHO wrote that from-phase's terminal: the agent's
+      // own wrapper (declared) vs an infrastructure flip/reclaim (fabricated) vs
+      // unprovable (absent). Costs one readFileSync per SUCCESSFUL advance — the
+      // same read emitPredecessorReap performs a few lines below, not a per-tick
+      // per-ticket cost.
+      //
+      // ROLLOUT: every signal written before this shipped carries no assertedBy,
+      // so the first pipeline pass after deploy reads `absent` /
+      // evidence_reason="no-marker". Do not alarm on `absent` until a full ticket
+      // has cycled through.
+      const fromPhase = latestLivePhase(signals);
+      const fromRaw = fromPhase
+        ? fromPhase === REMEDIATE_PHASE
+          ? (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, fromPhase))
+          : readPhaseSignalRaw(orchDir, ticket, fromPhase)
+        : null;
+      const ev = explainAdvanceEvidence(fromRaw, { predecessorPhase: fromPhase });
+      safeEmit(
+        appendPhaseAdvanceAppliedEvent,
+        {
+          orchId: ticket,
+          ticket,
+          from: fromPhase,
+          to: next,
+          evidence: ev.evidence,
+          evidenceReason: ev.evidenceReason,
+          assertedBy: ev.assertedBy,
+          assertionRef: fromPhase ? `workers/${ticket}/phase-${fromPhase}.json` : null,
+        },
+        { ticket, phase: "advance" }
+      );
       // CTL-755: a verified triage→research promotion consumed a slot this tick.
       // liveCount was read at the top of the tick (before this dispatch), so the
       // promotion has not yet incremented it — STEP C subtracts promotedCount
@@ -8884,6 +8953,9 @@ function runTick() {
       // tests inject a stub through startScheduler so a daemon tick never shells out.
       fetchBatch: runningOpts.fetchBatch,
       appendPhaseAdvanceHeldEvent: runningOpts.appendPhaseAdvanceHeldEvent,
+      // CTL-1789: same shape — undefined keeps schedulerTick's default-on
+      // defaultAppendPhaseAdvanceAppliedEvent; a test injects a spy.
+      appendPhaseAdvanceAppliedEvent: runningOpts.appendPhaseAdvanceAppliedEvent,
       // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
       // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
       // resolver the J4 census uses (never removes a dir whose worktree hosts a live
@@ -9647,6 +9719,7 @@ export function startScheduler({
   checkSequencing, // CTL-537: optional override; runTick defaults to defaultCheckSequencing.
   fetchBatch, // CTL-755/784: optional override; schedulerTick defaults to fetchTicketsBatch.
   appendPhaseAdvanceHeldEvent, // CTL-755: optional override; defaults to defaultAppendPhaseAdvanceHeldEvent.
+  appendPhaseAdvanceAppliedEvent, // CTL-1789: optional override; defaults to defaultAppendPhaseAdvanceAppliedEvent.
   // CTL-764 Phase 5: optional worker.transition emitter override (test seam).
   // Undefined → runTick threads the real defaultAppendWorkerTransitionEvent into
   // the per-tick schedulerTick opts (production). A test injects a spy here to
@@ -9714,6 +9787,7 @@ export function startScheduler({
     checkSequencing, // CTL-537: optional override (default defaultCheckSequencing)
     fetchBatch, // CTL-755/784: optional admission-gate batch hydration seam
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
+    appendPhaseAdvanceAppliedEvent, // CTL-1789: optional applied-advance emit seam
     appendWorkerTransitionEvent, // CTL-764: optional worker.transition emitter override (test seam; runTick defaults to defaultAppendWorkerTransitionEvent)
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
     checkOpenPrs, // CTL-1157: optional terminal-sweep open-PR gate override (runTick arms the real one)

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -94,7 +94,10 @@ import {
   computeDeadHosts,
   // CTL-1667: current-run PR reader (for terminalDoneOnce gate tests)
   readCurrentRunPrNumber,
+  // CTL-1789: the extracted from-phase resolver the advancement audit names
+  latestLivePhase,
 } from "./scheduler.mjs";
+import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789
 import { createTicketStateCache } from "./linear-cache.mjs";
 import { fetchTicketsBatch } from "./linear-query.mjs"; // CTL-784: cache-reuse tests drive the real batch
 import { reclaimDeadWorkIfPossible } from "./recovery.mjs";
@@ -13985,5 +13988,178 @@ describe("CTL-1667 (review fix, round 3): sanitize stale post-PR signals before 
     // is monitor-merge — proof the ticket was reachable, not excluded.
     expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-84", phase: "monitor-merge" }]);
     expect(r.advanced).toEqual([{ ticket: "CTL-84", phase: "monitor-merge" }]);
+  });
+});
+
+// ─── CTL-1789: phase.advance.applied — the positive half of the gate ─────────
+//
+// Before this, the advancement gate emitted ONLY on refusal (phase.advance.held):
+// a month of production logs held 307 `held` events and zero `phase.advance.*` of
+// any other name, so the FSM's actual advances were unobservable. Every consumer
+// had to infer "the pipeline advanced" from the SUCCESSOR phase's dispatch, which
+// conflates a fresh advance with a revive, a resume, and a new-work pull.
+//
+// These tests pin (a) exactly one applied event per VERIFIED advance, (b) the
+// from→to edge it names, and (c) the three-valued `evidence` attribution of the
+// from-phase's terminal writer.
+describe("CTL-1789 phase.advance.applied", () => {
+  // appliedEvents — narrow the fixture event log to this ticket's applied events.
+  function appliedEvents(ticket) {
+    return readEventLog().filter(
+      (e) => e?.attributes?.["event.name"] === `phase.advance.applied.${ticket}`
+    );
+  }
+
+  // advanceTick — the standard admission-gated advancement tick used below.
+  function advanceTick(extra = {}) {
+    return schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      verifyDispatched: verifyOk,
+      fetchBatch: mkBatch(() => relUnblocked()),
+      liveBackgroundCount: () => 0,
+      ...extra,
+    });
+  }
+
+  test("latestLivePhase names exactly the phase deriveAdvancement keys off", () => {
+    // Pure-function parity: the extracted resolver must not drift from the FSM's
+    // own input. triage:done → the FSM owes research, keyed off `triage`.
+    expect(latestLivePhase({ triage: "done" })).toBe("triage");
+    expect(deriveAdvancement({ triage: "done" })).toBe("research");
+    // Backward re-dispatch (CTL-1660): a stale higher-ordinal `review` is
+    // superseded by the fresher `implement`, so BOTH agree on `implement`.
+    const backward = { review: "done", implement: "done" };
+    expect(latestLivePhase(backward)).toBe("implement");
+    expect(deriveAdvancement(backward)).toBe("verify");
+    // Nothing live → null, and no advancement.
+    expect(latestLivePhase({})).toBeNull();
+    expect(deriveAdvancement({})).toBeNull();
+    expect(latestLivePhase(null)).toBeNull();
+  });
+
+  test("a verified advance emits exactly ONE applied event naming from→to", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-7", "triage", {
+      ticket: "CTL-7",
+      phase: "triage",
+      status: "done",
+      assertedBy: ASSERTED_BY.PHASE_AGENT,
+    });
+    const r = advanceTick();
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+
+    const evs = appliedEvents("CTL-7");
+    expect(evs).toHaveLength(1);
+    expect(evs[0].body.payload).toMatchObject({
+      phase: "advance",
+      ticket: "CTL-7",
+      status: "applied",
+      from: "triage",
+      to: "research",
+      evidence: "declared",
+      evidence_reason: null,
+      asserted_by: "phase-agent-emit-complete",
+      assertion_ref: "workers/CTL-7/phase-triage.json",
+    });
+    // INFO, not WARN — a performed advance is the system working (held is WARN).
+    expect(evs[0].severityText).toBe("INFO");
+    expect(evs[0].severityNumber).toBe(9);
+    // Promoted to ATTRIBUTES so the dimension survives otel-forward stripping
+    // body.payload off-machine.
+    expect(evs[0].attributes["catalyst.advance.evidence"]).toBe("declared");
+    expect(evs[0].attributes["catalyst.advance.from"]).toBe("triage");
+    expect(evs[0].attributes["catalyst.advance.to"]).toBe("research");
+    // Coordination stream class (phase.advance.* — same as held).
+    expect(evs[0].attributes["event.stream_class"]).toBe("coordination");
+  });
+
+  test("an SDK-flipped terminal is classified FABRICATED, not declared", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-7", "triage", {
+      ticket: "CTL-7",
+      phase: "triage",
+      status: "done",
+      assertedBy: ASSERTED_BY.SDK_SUCCESS_FLIP,
+    });
+    const r = advanceTick();
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+
+    const evs = appliedEvents("CTL-7");
+    expect(evs).toHaveLength(1);
+    expect(evs[0].body.payload.evidence).toBe("fabricated");
+    expect(evs[0].body.payload.asserted_by).toBe("sdk-success-flip");
+    expect(evs[0].attributes["catalyst.advance.evidence"]).toBe("fabricated");
+  });
+
+  test("a legacy signal (written before the marker shipped) → absent/no-marker", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done"); // no assertedBy — the pre-CTL-1789 shape
+    const r = advanceTick();
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+
+    const evs = appliedEvents("CTL-7");
+    expect(evs).toHaveLength(1);
+    expect(evs[0].body.payload.evidence).toBe("absent");
+    expect(evs[0].body.payload.evidence_reason).toBe("no-marker");
+    expect(evs[0].body.payload.asserted_by).toBeNull();
+  });
+
+  test("a HELD advance emits no applied event (the two are mutually exclusive)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    // No free slot → the admission gate refuses the triage→research promotion.
+    const r = advanceTick({ liveBackgroundCount: () => 5 });
+    expect(r.advanced).toEqual([]);
+    expect(appliedEvents("CTL-7")).toHaveLength(0);
+  });
+
+  test("a FAILED dispatch emits no applied event", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    const r = advanceTick({ dispatch: fakeDispatch({ code: 1, stderr: "boom" }) });
+    expect(r.advanced).toEqual([]);
+    expect(appliedEvents("CTL-7")).toHaveLength(0);
+  });
+
+  test("a THROWING emitter is swallowed — the advance still lands (safeEmit)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    let called = 0;
+    const r = advanceTick({
+      dispatch,
+      appendPhaseAdvanceAppliedEvent: () => {
+        called++;
+        throw new Error("audit emitter exploded");
+      },
+    });
+    expect(called).toBe(1); // the emitter really ran (and really threw)
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "research" }]);
+  });
+
+  test("the emitter receives the resolved from/to/evidence triple (injection seam)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-7", "implement", {
+      ticket: "CTL-7",
+      phase: "implement",
+      status: "done",
+      assertedBy: ASSERTED_BY.RECOVERY_RECLAIM,
+    });
+    const seen = [];
+    advanceTick({ appendPhaseAdvanceAppliedEvent: (a) => seen.push(a) });
+    expect(seen).toEqual([
+      {
+        orchId: "CTL-7",
+        ticket: "CTL-7",
+        from: "implement",
+        to: "verify",
+        evidence: "fabricated",
+        evidenceReason: null,
+        assertedBy: "recovery-reclaim",
+        assertionRef: "workers/CTL-7/phase-implement.json",
+      },
+    ]);
   });
 });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -320,9 +320,9 @@ describe("isTicketInFlight", () => {
       expect(isTicketInFlight({ triage: "done", implement: "failed" })).toBe(false);
     });
     test("two stale predecessors (research aborted, plan stalled), implement (latest) done → in-flight", () => {
-      expect(
-        isTicketInFlight({ research: "aborted", plan: "stalled", implement: "done" })
-      ).toBe(true);
+      expect(isTicketInFlight({ research: "aborted", plan: "stalled", implement: "done" })).toBe(
+        true
+      );
     });
     test("the LATEST phase failing still vetoes even with earlier successes", () => {
       expect(isTicketInFlight({ research: "done", implement: "done", verify: "failed" })).toBe(
@@ -338,9 +338,7 @@ describe("isTicketInFlight", () => {
     test("an unknown/non-pipeline phase name never supersedes or is superseded", () => {
       // e.g. a recovery-pass inspection signal — isPhantomWorkerDir handles
       // that separately; isTicketInFlight's ordering logic must ignore it.
-      expect(
-        isTicketInFlight({ implement: "failed", "recovery-pass": "done" })
-      ).toBe(false);
+      expect(isTicketInFlight({ implement: "failed", "recovery-pass": "done" })).toBe(false);
     });
     test("teardown (terminal, outside phaseIndex) alongside a stale earlier failure is still terminal", () => {
       expect(isTicketInFlight({ implement: "failed", teardown: "done" })).toBe(false);
@@ -363,9 +361,7 @@ describe("isTicketInFlight", () => {
       expect(isTicketInFlight({ review: "done", implement: "running" })).toBe(true);
     });
     test("plan re-dispatched (failing) after implement+verify already completed → NOT in-flight", () => {
-      expect(
-        isTicketInFlight({ implement: "done", verify: "done", plan: "failed" })
-      ).toBe(false);
+      expect(isTicketInFlight({ implement: "done", verify: "done", plan: "failed" })).toBe(false);
     });
   });
 });
@@ -10304,7 +10300,9 @@ describe("schedulerTick — new-work dispatch fails over an offline HRW owner (C
       hasTriageArtifact: () => true,
     });
     expect(existsSync(join(orchDir, ".liveness-deflap.json"))).toBe(true);
-    const leftoverTmp = readdirSync(orchDir).filter((f) => f.startsWith(".liveness-deflap.json.tmp"));
+    const leftoverTmp = readdirSync(orchDir).filter((f) =>
+      f.startsWith(".liveness-deflap.json.tmp")
+    );
     expect(leftoverTmp).toEqual([]);
   });
 
@@ -10875,12 +10873,16 @@ describe("CTL-1191 — recovery passes HRW-gated over the surviving roster (Pass
       unstuckSweep: {
         ...unstuckOpts(escalateWithError),
         collectCandidates: () => [
-          { ticket: T_MINI, phase: "pr", evidence: { reason: "unknown", ticket: T_MINI, phase: "pr" } },
+          {
+            ticket: T_MINI,
+            phase: "pr",
+            evidence: { reason: "unknown", ticket: T_MINI, phase: "pr" },
+          },
         ],
       },
     });
     // Tick must not throw; the ticket is still recorded as escalated (label landed)
-    expect(res.unstuckEscalated?.some(e => e.ticket === T_MINI)).toBe(true);
+    expect(res.unstuckEscalated?.some((e) => e.ticket === T_MINI)).toBe(true);
   });
 });
 
@@ -11975,7 +11977,10 @@ describe("CTL-1068: convergeStartedHeldLabels (unit)", () => {
     // Step 1 — admission tick applies "queued" (convergeHeldLabel, as the A.7
     // admission loop does for a triaged-but-not-yet-admitted ticket). Before this
     // fix, this call left the label in Linear but NO local trace of it.
-    const applyWs = { applyLabel: () => ({ applied: true, reason: null }), removeLabel: () => ({ removed: true }) };
+    const applyWs = {
+      applyLabel: () => ({ applied: true, reason: null }),
+      removeLabel: () => ({ removed: true }),
+    };
     const writes = convergeHeldLabel("CTL-1571", [], "queued", applyWs, { orchDir });
     expect(writes).toBe(1);
     expect(existsSync(markerPath("CTL-1571", "queued", "applied"))).toBe(true);
@@ -12871,7 +12876,8 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
       appendWorkerTransitionEvent: (ev) => transitions.push(ev),
     });
     const cleared = transitions.find(
-      (e) => e.ticket === "CTL-R41" && e.toDisposition === null && e.source === "scheduler-admission"
+      (e) =>
+        e.ticket === "CTL-R41" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeUndefined();
   });
@@ -12894,7 +12900,8 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
       appendWorkerTransitionEvent: (ev) => transitions.push(ev),
     });
     const cleared = transitions.find(
-      (e) => e.ticket === "CTL-R42" && e.toDisposition === null && e.source === "scheduler-admission"
+      (e) =>
+        e.ticket === "CTL-R42" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeDefined();
     expect(cleared.fromDisposition).toBe("queued");
@@ -12920,7 +12927,8 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
     });
     await new Promise((r) => setTimeout(r, 0)); // let the write settle
     const cleared = transitions.find(
-      (e) => e.ticket === "CTL-R51" && e.toDisposition === null && e.source === "scheduler-admission"
+      (e) =>
+        e.ticket === "CTL-R51" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeUndefined();
   });
@@ -12941,7 +12949,8 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
     });
     await new Promise((r) => setTimeout(r, 0)); // let the write settle
     const cleared = transitions.find(
-      (e) => e.ticket === "CTL-R52" && e.toDisposition === null && e.source === "scheduler-admission"
+      (e) =>
+        e.ticket === "CTL-R52" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeDefined();
     expect(cleared.fromDisposition).toBe("blocked");
@@ -12963,7 +12972,8 @@ describe("CTL-764 Phase 5 — schedulerTick emits worker.transition events", () 
     });
     await new Promise((r) => setTimeout(r, 0));
     const cleared = transitions.find(
-      (e) => e.ticket === "CTL-R53" && e.toDisposition === null && e.source === "scheduler-admission"
+      (e) =>
+        e.ticket === "CTL-R53" && e.toDisposition === null && e.source === "scheduler-admission"
     );
     expect(cleared).toBeUndefined();
   });
@@ -13130,9 +13140,13 @@ describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
         latchHasNoClock: (t) => t === "A",
         invokeRecoveryPass: () => ({ dispatched: false }),
         recordIntent: () => {},
-      },
+      }
     );
-    expect(r).toMatchObject({ dispatched: false, reason: "all-candidates-exhausted", latchedNoClock: true });
+    expect(r).toMatchObject({
+      dispatched: false,
+      reason: "all-candidates-exhausted",
+      latchedNoClock: true,
+    });
   });
 
   test("(CTL-1610) well-formed exhausted cohort (all clocked) → latchedNoClock:false", () => {
@@ -13144,7 +13158,7 @@ describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
         latchHasNoClock: () => false,
         invokeRecoveryPass: () => ({ dispatched: false }),
         recordIntent: () => {},
-      },
+      }
     );
     expect(r).toMatchObject({ reason: "all-candidates-exhausted", latchedNoClock: false });
   });
@@ -13152,7 +13166,12 @@ describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
   test("(CTL-1610) latchHasNoClock defaults to a safe no-op (bare tick → latchedNoClock:false)", () => {
     const r = holisticBoardHealthAct(
       { candidates: ["A"], decision: {} },
-      { shouldSkipItem: () => true, skipReason: () => "escalated", invokeRecoveryPass: () => ({}), recordIntent: () => {} },
+      {
+        shouldSkipItem: () => true,
+        skipReason: () => "escalated",
+        invokeRecoveryPass: () => ({}),
+        recordIntent: () => {},
+      }
     );
     expect(r.latchedNoClock).toBe(false);
   });
@@ -13172,7 +13191,7 @@ describe("holisticBoardHealthAct — Phase 3 repair signal (CTL-1610)", () => {
         latchHasNoClock: () => true,
         invokeRecoveryPass: () => ({}),
         recordIntent: () => {},
-      },
+      }
     );
     expect(r.latchedNoClock).toBe(true); // caller checks this and calls restampNoClockEscalations
   });
@@ -13334,7 +13353,10 @@ describe("CTL-1605: STEP A terminal-stale short-circuit", () => {
     );
     // Exactly ONE aggregate transition, not one per cleared label.
     expect(evictTransitions).toHaveLength(1);
-    expect(evictTransitions[0]).toMatchObject({ toDisposition: null, fromDisposition: "needs-human" });
+    expect(evictTransitions[0]).toMatchObject({
+      toDisposition: null,
+      fromDisposition: "needs-human",
+    });
   });
 
   test("multi-label terminal ticket, needs-human in CTL-1078 backoff (unconfirmed) + blocked confirmed → NO to:null worker.transition (false disposition-clear guarded)", () => {
@@ -13375,7 +13397,8 @@ describe("CTL-1605: STEP A terminal-stale short-circuit", () => {
     expect(evicted).toEqual([]);
     // The false "disposition-clear" event this fix exists to stop must NEVER appear.
     const falseClears = transitions.filter(
-      (e) => e.ticket === "CTL-34" && e.source === "terminal-stale-evict" && e.toDisposition === null
+      (e) =>
+        e.ticket === "CTL-34" && e.source === "terminal-stale-evict" && e.toDisposition === null
     );
     expect(falseClears).toEqual([]);
   });
@@ -13453,9 +13476,12 @@ describe("CTL-1605 review: STEP A terminal-stale live label refresh", () => {
       writeStatus: ws,
       verifyDispatched: verifyOk,
       liveBackgroundCount: () => 0,
-      fetchBatch: batchWith(() => relBlockedBy("CTL-DEP5", { state: "Done", labels: ["blocked"] }), {
-        "CTL-DEP5": "In Progress",
-      }),
+      fetchBatch: batchWith(
+        () => relBlockedBy("CTL-DEP5", { state: "Done", labels: ["blocked"] }),
+        {
+          "CTL-DEP5": "In Progress",
+        }
+      ),
       readTicketLabels: () => ({ ok: false, labels: null, code: 1, stderr: "boom" }),
       evictWorkerDir: (t) => {
         evicted.push(t);
@@ -13576,13 +13602,22 @@ describe("CTL-1667: terminalDoneOnce current-PR-merged gate", () => {
       readEligible: () => [],
       dispatch: ctl1667Dispatch,
       writeStatus: makeWriteStatus(dones),
-      prAdapter: { prView: () => { throw new Error("gh down"); } },
+      prAdapter: {
+        prView: () => {
+          throw new Error("gh down");
+        },
+      },
     });
     expect(dones).toEqual([]); // conservative: no Done on unverifiable merge
   });
 
   test("CTL-1667: readCurrentRunPrNumber returns the PR number from phase-pr.json", () => {
-    writeSignalRaw("CTL-74", "pr", { ticket: "CTL-74", phase: "pr", status: "done", pr: { number: 999 } });
+    writeSignalRaw("CTL-74", "pr", {
+      ticket: "CTL-74",
+      phase: "pr",
+      status: "done",
+      pr: { number: 999 },
+    });
     expect(readCurrentRunPrNumber(orchDir, "CTL-74")).toBe(999);
   });
 
@@ -14161,5 +14196,147 @@ describe("CTL-1789 phase.advance.applied", () => {
         assertionRef: "workers/CTL-7/phase-implement.json",
       },
     ]);
+  });
+
+  // ── CTL-1789 round-1 P1 (Codex): the remediate→verify re-entry ─────────────
+  //
+  // The FSM's remediate detour is the ONE edge `latestLivePhase` structurally
+  // cannot name: `remediate` is an ANCILLARY phase (∉ PHASES), and by the time
+  // the advancement sweep reaches the audit emit, maybeResetForRemediateCycle
+  // has already DELETED phase-remediate.json anyway. So a from-phase derived
+  // from latestLivePhase alone reports EVERY remediation re-entry as
+  // `from=implement`, and classifies its evidence off the long-finished
+  // implement signal — which laundered a FABRICATED remediation terminal into
+  // a DECLARED one and corrupted the very metric this ticket exists to produce.
+  //
+  // The fixture makes the two answers maximally distinguishable: implement is
+  // DECLARED (agent's own wrapper) while remediate is FABRICATED (an SDK
+  // success-flip). Reading the wrong signal is therefore not a cosmetic
+  // mislabel — it inverts the evidence verdict.
+  test("a remediate→verify re-entry names from=remediate, classified from the REMEDIATE signal", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-7", "implement", {
+      ticket: "CTL-7",
+      phase: "implement",
+      status: "done",
+      assertedBy: ASSERTED_BY.PHASE_AGENT, // declared — the decoy
+    });
+    writeSignalRaw("CTL-7", "verify", {
+      ticket: "CTL-7",
+      phase: "verify",
+      status: "done",
+      assertedBy: ASSERTED_BY.PHASE_AGENT,
+    });
+    writeSignalRaw("CTL-7", "remediate", {
+      ticket: "CTL-7",
+      phase: "remediate",
+      status: "done",
+      assertedBy: ASSERTED_BY.SDK_SUCCESS_FLIP, // fabricated — the truth
+    });
+
+    const r = advanceTick();
+    // remediate done → the cycle reset wipes verify+remediate and re-dispatches
+    // a fresh verify. This is the re-entry edge.
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "verify" }]);
+
+    const evs = appliedEvents("CTL-7");
+    expect(evs).toHaveLength(1);
+    expect(evs[0].body.payload).toMatchObject({
+      from: "remediate",
+      to: "verify",
+      evidence: "fabricated",
+      evidence_reason: null,
+      asserted_by: "sdk-success-flip",
+      assertion_ref: "workers/CTL-7/phase-remediate.json",
+    });
+    // The from-phase attribute is what off-machine consumers see (otel-forward
+    // strips body.payload), so it must carry the detour too.
+    expect(evs[0].attributes["catalyst.advance.from"]).toBe("remediate");
+    expect(evs[0].attributes["catalyst.advance.evidence"]).toBe("fabricated");
+    // Explicitly NOT the long-finished implement worker's declared terminal.
+    expect(evs[0].body.payload.from).not.toBe("implement");
+    expect(evs[0].body.payload.evidence).not.toBe("declared");
+  });
+
+  // The detour must be resolved from the SAME snapshot + resolver the
+  // predecessor-reap path uses, so the audit and the reap can never name two
+  // different predecessors for one advance.
+  test("the applied event and the predecessor reap agree on the remediate predecessor", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    const mkSig = (phase, bg, assertedBy) => ({
+      ticket: "CTL-7",
+      phase,
+      status: "done",
+      bg_job_id: bg,
+      assertedBy,
+    });
+    writeSignalRaw(
+      "CTL-7",
+      "implement",
+      mkSig("implement", "impl1111-0000-0000-0000-000000000000", ASSERTED_BY.PHASE_AGENT)
+    );
+    writeSignalRaw(
+      "CTL-7",
+      "verify",
+      mkSig("verify", "veri2222-0000-0000-0000-000000000000", ASSERTED_BY.PHASE_AGENT)
+    );
+    writeSignalRaw(
+      "CTL-7",
+      "remediate",
+      mkSig("remediate", "reme3333-0000-0000-0000-000000000000", ASSERTED_BY.RECOVERY_RECLAIM)
+    );
+
+    const r = advanceTick();
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "verify" }]);
+
+    const applied = appliedEvents("CTL-7");
+    expect(applied).toHaveLength(1);
+    const reaps = readEventLog().filter(
+      (e) => e.event === "phase.predecessor.reap-requested" && e.ticket === "CTL-7"
+    );
+    expect(reaps).toHaveLength(1);
+    expect(reaps[0].phase).toBe("remediate");
+    // ONE advance, ONE predecessor — the audit's `from` is the reaped worker.
+    expect(applied[0].body.payload.from).toBe(reaps[0].phase);
+    expect(applied[0].body.payload.evidence).toBe("fabricated");
+    expect(applied[0].body.payload.asserted_by).toBe("recovery-reclaim");
+  });
+
+  // The OTHER detour edge (verify → remediate) has no reset in front of it, so
+  // latestLivePhase already names it correctly. Pinned so the P1 fix cannot
+  // over-reach and rewrite the direction that was never broken.
+  test("the verify→remediate edge still names from=verify", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-7", "implement", {
+      ticket: "CTL-7",
+      phase: "implement",
+      status: "done",
+      assertedBy: ASSERTED_BY.PHASE_AGENT,
+    });
+    writeSignalRaw("CTL-7", "verify", {
+      ticket: "CTL-7",
+      phase: "verify",
+      status: "done",
+      assertedBy: ASSERTED_BY.PHASE_AGENT,
+    });
+    // verify.json with regression_risk ≥ 5 → verdict fail → route to remediate.
+    const wdir = join(orchDir, "workers", "CTL-7");
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      join(wdir, "verify.json"),
+      JSON.stringify({ regression_risk: 8, findings: [], gates: {} })
+    );
+
+    const r = advanceTick();
+    expect(r.advanced).toEqual([{ ticket: "CTL-7", phase: "remediate" }]);
+
+    const evs = appliedEvents("CTL-7");
+    expect(evs).toHaveLength(1);
+    expect(evs[0].body.payload).toMatchObject({
+      from: "verify",
+      to: "remediate",
+      evidence: "declared",
+      assertion_ref: "workers/CTL-7/phase-verify.json",
+    });
   });
 });

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -69,6 +69,7 @@ import { classifyEventStream } from "../lib/event-stream-class.mjs"; // CTL-1488
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { nodeClass } from "./lib/node-class.mjs";
 import { registerSdkWorker as defaultRegisterSdkWorker } from "./sdk-worker-registry.mjs";
+import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789: terminal-writer attribution
 
 // phase-agent-dispatch + phase-agent-emit-complete sit one directory up.
 const PHASE_AGENT_DISPATCH_BIN = fileURLToPath(
@@ -451,6 +452,8 @@ function defaultWriteSignalTerminal(signalFile, status, reason) {
     const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
     sig.status = status;
     sig.attentionReason = reason || "sdk-backstop";
+    // CTL-1789: record WHO asserted this terminal. Infrastructure, not the agent.
+    sig.assertedBy = ASSERTED_BY.SDK_BACKSTOP;
     sig.updatedAt = ts;
     sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), [status]: ts };
     const tmp = `${signalFile}.tmp.${process.pid}`;
@@ -531,6 +534,11 @@ export function flipSignalDoneOnSuccess(signalFile, generation) {
     }
     const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
     sig.status = "done";
+    // CTL-1789: this flip fires on a CLEAN SDK EXIT, not on an agent declaring
+    // completion — the agent never ran its wrapper (if it had, `status` would
+    // already be terminal and the in-flight precondition above would have
+    // returned). Stamp it FABRICATED so the advancement audit can subtract it.
+    sig.assertedBy = ASSERTED_BY.SDK_SUCCESS_FLIP;
     sig.completedAt = ts;
     sig.updatedAt = ts;
     sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), done: ts };

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -22,6 +22,7 @@ import {
   flipSignalDoneOnSuccess,
   runPrelaunch,
 } from "./sdk-run-phase-agent.mjs";
+import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789: terminal-writer attribution
 
 // ── Fakes ───────────────────────────────────────────────────────────────────
 
@@ -1157,6 +1158,34 @@ describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
     expect("failureReason" in after).toBe(false);
   });
 
+  // CTL-1789: this flip is the canonical FABRICATED terminal — a clean SDK exit,
+  // NOT the agent declaring completion. It must stamp its own writer id so the
+  // advancement audit can subtract it from the declared advances. Without the
+  // marker the signal is byte-indistinguishable from a wrapper-written one.
+  test("CTL-1789: a flipped terminal is stamped assertedBy=sdk-success-flip", () => {
+    const after = flipCase("dispatched");
+    expect(after.assertedBy).toBe("sdk-success-flip");
+    expect(after.assertedBy).toBe(ASSERTED_BY.SDK_SUCCESS_FLIP);
+    // …and it is NOT the wrapper's declared id.
+    expect(after.assertedBy).not.toBe(ASSERTED_BY.PHASE_AGENT);
+  });
+
+  test("CTL-1789: a bowed-out stale-generation flip stamps NOTHING", () => {
+    // The fence returns before any mutation — the newer dispatch's in-flight
+    // signal must not gain a terminal-writer marker it never earned.
+    const dir = mkdtempSync(join(tmpdir(), "sdk-fence-mark-"));
+    const signalFile = join(dir, "phase-implement.json");
+    writeFileSync(
+      signalFile,
+      JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement", generation: 6 })
+    );
+    flipSignalDoneOnSuccess(signalFile, 5);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    rmSync(dir, { recursive: true, force: true });
+    expect(after.status).toBe("dispatched");
+    expect("assertedBy" in after).toBe(false);
+  });
+
   test("running (in-flight) → done", () => {
     expect(flipCase("running").status).toBe("done");
   });
@@ -1434,6 +1463,26 @@ describe("defaultEmitBackstop → defaultWriteSignalStalled terminal-status guar
     const { dir, signalFile } = seedSignal("dispatched");
     emit(signalFile);
     expect(JSON.parse(readFileSync(signalFile, "utf8")).status).toBe("stalled");
+    rmSync(dir, { recursive: true, force: true });
+  });
+  // CTL-1789: the backstop is infrastructure asserting a terminal, so it stamps
+  // its own writer id too. `stalled` is never advance-eligible, so this never
+  // changes an advance's evidence — it keeps the SDK writer PAIR fully covered
+  // rather than half-marked.
+  test("CTL-1789: the backstop stamps assertedBy=sdk-backstop", () => {
+    const { dir, signalFile } = seedSignal("dispatched");
+    emit(signalFile);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.assertedBy).toBe(ASSERTED_BY.SDK_BACKSTOP);
+    expect(after.assertedBy).toBe("sdk-backstop");
+    rmSync(dir, { recursive: true, force: true });
+  });
+  test("CTL-1789: a preserved terminal 'done' gains NO backstop marker", () => {
+    const { dir, signalFile } = seedSignal("done");
+    emit(signalFile);
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(after.status).toBe("done");
+    expect("assertedBy" in after).toBe(false); // the guard returned before any write
     rmSync(dir, { recursive: true, force: true });
   });
   test("a terminal 'done' success is NOT clobbered to stalled", () => {

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -675,6 +675,12 @@ phase_revive_emit_complete() {
     # CTL-1789: --asserted-by marks this terminal FABRICATED — revive synthesized
     # the completion from a progress probe; the agent never declared anything.
     # Vocabulary: execution-core/assertion-evidence.mjs (REVIVE_SYNTHESIZED).
+    # bash cannot import that constant, so the literal below is held honest
+    # MECHANICALLY by execution-core/assertion-evidence-parity.test.mjs — it
+    # extracts this flag's value and compares it to the registry, so renaming
+    # one side alone FAILS rather than silently classifying the terminal as
+    # absent/unknown-writer. Keep it a bare literal after the flag; the parity
+    # extractor is anchored on that shape and fails closed if it changes.
     if ! "$bin" --phase "$phase" --ticket "$ticket" --status complete \
          --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
          --asserted-by revive-synthesized \

--- a/plugins/dev/scripts/orchestrate-revive
+++ b/plugins/dev/scripts/orchestrate-revive
@@ -672,8 +672,12 @@ phase_revive_emit_complete() {
   local bin
   bin="${CATALYST_PHASE_EMIT_COMPLETE_BIN:-${SCRIPT_DIR}/phase-agent-emit-complete}"
   if [ -x "$bin" ]; then
+    # CTL-1789: --asserted-by marks this terminal FABRICATED — revive synthesized
+    # the completion from a progress probe; the agent never declared anything.
+    # Vocabulary: execution-core/assertion-evidence.mjs (REVIVE_SYNTHESIZED).
     if ! "$bin" --phase "$phase" --ticket "$ticket" --status complete \
          --orch-dir "$ORCH_DIR" --orch-id "$ORCH_ID" \
+         --asserted-by revive-synthesized \
          --reason "synthesized-by-revive: ${progress_reason}" \
          >/dev/null 2>&1; then
       echo "phase-revive: ${ticket}/${phase} helper=phase-agent-emit-complete exit=$?" >&2

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -106,7 +106,13 @@ SESSION_ID="${CATALYST_SESSION_ID-}"
 NO_SIGNAL_UPDATE=0
 # CTL-1789: default = the phase agent ran this wrapper itself (a DECLARED
 # terminal). Must stay byte-identical to ASSERTED_BY.PHASE_AGENT in
-# execution-core/assertion-evidence.mjs.
+# execution-core/assertion-evidence.mjs — bash cannot import that constant, so
+# the mirror is held honest MECHANICALLY by
+# execution-core/assertion-evidence-parity.test.mjs, which extracts this literal
+# and compares it to the registry. Renaming one side alone FAILS that test; an
+# unnoticed drift would reclassify every declared terminal as
+# absent/unknown-writer. Keep the assignment a plain literal on its own line —
+# the parity extractor is anchored on that shape and fails closed if it changes.
 ASSERTED_BY="phase-agent-emit-complete"
 
 while [[ $# -gt 0 ]]; do

--- a/plugins/dev/scripts/phase-agent-emit-complete
+++ b/plugins/dev/scripts/phase-agent-emit-complete
@@ -32,7 +32,18 @@
 #     [--orch-dir <path>] \
 #     [--orch-id <id>] \
 #     [--session-id <id>] \
+#     [--asserted-by <writer-id>] \
 #     [--no-signal-update]
+#
+# --asserted-by (CTL-1789): the writer id stamped onto the signal file's
+#   `assertedBy` field, recording WHO asserted this phase finished. Defaults to
+#   "phase-agent-emit-complete" — i.e. the phase agent ran this wrapper itself
+#   and DECLARED completion. Infrastructure that invokes this wrapper on a dead
+#   worker's behalf (execution-core recovery reclaim, orchestrate-revive's
+#   synthetic complete) passes its own id so the terminal is classified as
+#   FABRICATED, not declared. Vocabulary + classifier:
+#   execution-core/assertion-evidence.mjs. Signal-file only — deliberately NOT
+#   added to the event payload (test 47 snapshots the default payload keys).
 #
 # --payload-json (CTL-1410): merge a caller-supplied JSON object into the event's
 #   body.payload (caller fields as base; the canonical phase/ticket/status fields
@@ -93,6 +104,10 @@ ORCH_DIR="${CATALYST_ORCHESTRATOR_DIR-}"
 ORCH_ID="${CATALYST_ORCHESTRATOR_ID-}"
 SESSION_ID="${CATALYST_SESSION_ID-}"
 NO_SIGNAL_UPDATE=0
+# CTL-1789: default = the phase agent ran this wrapper itself (a DECLARED
+# terminal). Must stay byte-identical to ASSERTED_BY.PHASE_AGENT in
+# execution-core/assertion-evidence.mjs.
+ASSERTED_BY="phase-agent-emit-complete"
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
@@ -130,6 +145,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--session-id)
 		SESSION_ID="$2"
+		shift 2
+		;;
+	--asserted-by)
+		ASSERTED_BY="$2"
 		shift 2
 		;;
 	--no-signal-update)
@@ -443,9 +462,11 @@ if [[ -n $ORCH_DIR && $NO_SIGNAL_UPDATE -eq 0 ]]; then
 			--arg phase "$PHASE" \
 			--arg host_name "$_EMIT_HOST_NAME" \
 			--arg host_id "$_EMIT_HOST_ID" \
+			--arg asserted_by "$ASSERTED_BY" \
 			".status = \$status
            | ${SET_COMPLETED}
            | .updatedAt = \$ts
+           | (if \$asserted_by == \"\" then . else .assertedBy = \$asserted_by end)
            | (if \$rawstatus == \"complete\" then .failureReason = null
               elif \$reason == \"\" then .
               else .failureReason = \$reason end)


### PR DESCRIPTION
Closes CTL-1789.

## Why

We cannot currently count our own advancements. **MEASURED on mini:** `2026-08.jsonl` contains **307 `phase.advance.held.<T>`** events and **zero** of any other `phase.advance.*` name — the advancement gate emits only when it **refuses** to advance. So the central question of the reliability initiative — *how often does the pipeline advance on a fabricated terminal rather than a declared one?* — has no data behind it.

This is the measurement instrument for invariant I11. It ships first, before the behaviour change it justifies (CTL-1790).

## What

- New zero-import leaf `execution-core/assertion-evidence.mjs` classifying a terminal as `declared` | `fabricated` | `absent`.
- `phase.advance.applied.<TICKET>` emitted at the advancement site with `{from, to, evidence, assertion_ref, asserted_by}`, registered in the namespace contract + parity test.
- `assertedBy` stamped by every terminal-signal writer — including `orchestrate-revive`'s synthesized completion, which the design pass had missed.

## Behaviour change

**None.** Additive emission plus a new signal field. Bare-node doctor parity is byte-identical.

## Verification

Every new test was run as a negative control — the production change was disabled, the specific new tests were observed to FAIL, then restored and observed to pass. One test ("throwing emitter is swallowed") passed under its own negative control, proving nothing; it was strengthened with a call counter until it failed correctly.

Adversarially reviewed against the diff by a second agent: **VERDICT: SAFE-TO-MERGE**.

Pre-existing test failures on `main` were baselined in a pristine worktree and match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144RKpHEbUrj5UHTF5JeAjk