### PR TITLE
fix(dev): CTL-1791 — delete claim.mjs dispatch-claim, the high-water+1 generation the CTL-736 fence forbids

### DIFF
--- a/plugins/dev/scripts/execution-core/claim.mjs
+++ b/plugins/dev/scripts/execution-core/claim.mjs
@@ -10,18 +10,24 @@
 //   • claimPhase(orchDir, ticket, phase, generation) — open(O_CREAT|O_EXCL) of
 //     ${orchDir}/workers/<ticket>/<phase>.claim.<generation>. Exactly one
 //     caller wins per generation; concurrent same-generation callers collide.
-//   • The generation is a monotonic FENCING TOKEN. A fresh dispatch claims
-//     gen=currentGeneration+1 (1 when nothing is held); a revive (sequential,
-//     post-death) claims the next generation — a NEW filename, so O_EXCL
-//     succeeds for it regardless of whether the dead generation's claim file is
-//     still on disk.
+//   • The generation is a monotonic FENCING TOKEN, derived from the SIGNAL, not
+//     from the live claim set: a fresh dispatch (no signal) claims 1; a revive
+//     claims signal.generation + 1 — a NEW filename, so O_EXCL succeeds for it
+//     regardless of whether the dead generation's claim file is still on disk.
+//     Deriving it from the on-disk high-water mark instead re-opens the very
+//     double-spawn this file closes; see the CLI note below (CTL-1791).
 //   • The signal carries `generation`; the worker receives CATALYST_GENERATION
 //     in its env and asserts isCurrentGeneration(signal, mine) before emitting
 //     any outcome (the structural replacement for the bg_job_id orphan-bow-out).
 //
-// PURE filesystem primitives — no event log, no spawn. Both a library (imported
-// by recovery.mjs / tests) and a CLI (shelled into by phase-agent-dispatch and
-// phase-agent-emit-complete, which are bash).
+// PURE filesystem primitives — no event log, no spawn.
+//
+// CONSUMER STATUS (verified CTL-1791): nothing in the production tree imports
+// this module or shells into its CLI. `phase-agent-dispatch` reimplements the
+// claim in pure bash (`set -o noclobber`) and only keeps the claim-file FORMAT
+// in sync; `phase-agent-emit-complete` reimplements isCurrentGeneration's
+// semantics in bash. This file is the reference implementation those two are
+// held against, plus its own test — not a live dependency of either.
 
 import { openSync, writeSync, closeSync, unlinkSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -69,11 +75,14 @@ export function releaseClaim(orchDir, ticket, phase, generation) {
 }
 
 // currentGeneration — the high-water generation held for (ticket, phase): the
-// max `.claim.<n>` suffix in the worker dir, or 0 if none. A spawn-path
-// dispatcher claims this + 1, which unifies fresh (0→1) and revive (N→N+1) and
-// survives a deleted-signal worktree recreate (a stale claim tombstone still
-// advances the high-water mark, so the recreate's re-dispatch claims a fresh
-// generation instead of colliding on gen 1).
+// max `.claim.<n>` suffix in the worker dir, or 0 if none.
+//
+// READ-ONLY OBSERVABILITY ONLY. A spawn path must NEVER claim this + 1: the
+// claim set is mutated by the very computation that reads it, so two staggered
+// dispatchers observe different high-water marks, compute different targets, and
+// each wins its own O_EXCL file — the double-spawn the fence exists to close
+// (CTL-1667, CTL-1791). The spawn target comes from the SIGNAL. This function
+// backs the `current-generation` subcommand (inspection) and nothing else.
 export function currentGeneration(orchDir, ticket, phase) {
   let names;
   try {
@@ -108,9 +117,19 @@ export function isCurrentGeneration(signal, myGeneration) {
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 //
+// NOTE (CTL-1791): there is deliberately NO `dispatch-claim` subcommand. It used
+// to exist and computed `currentGeneration + 1` — a target derived from the LIVE
+// claim-file high-water mark, which is precisely what the CTL-736 fence forbids:
+// two staggered dispatchers each see the OTHER's claim, compute DIFFERENT
+// targets (A: max 2 → 3, then B: max 3 → 4), each win their own O_EXCL file, and
+// both spawn a worker — the double-spawn this file exists to make impossible.
+// The claim set is mutated by that very computation, so it can never be a stable
+// input to it. The live dispatcher (`phase-agent-dispatch`, pure bash, `set -o
+// noclobber`) derives the target from the SIGNAL instead (fresh → 1, revive →
+// signal.generation + 1) and never shelled into this CLI. The subcommand had
+// zero production callers and existed only to be tested. Do not reintroduce it.
+//
 // Subcommands (all stdout is one JSON line unless noted):
-//   dispatch-claim <orchDir> <ticket> <phase>
-//       compute gen = currentGeneration+1, claim it → {won, generation}. exit 0.
 //   claim <orchDir> <ticket> <phase> <generation>
 //       claim an explicit generation → {won, generation}. exit 0 even on loss
 //       (a lost race is a normal outcome the caller reads from .won).
@@ -145,12 +164,6 @@ function readSignal(orchDir, ticket, phase) {
 function cli(argv) {
   const [cmd, orchDir, ticket, phase, gen] = argv;
   switch (cmd) {
-    case "dispatch-claim": {
-      const generation = currentGeneration(orchDir, ticket, phase) + 1;
-      const res = claimPhase(orchDir, ticket, phase, generation);
-      process.stdout.write(JSON.stringify(res) + "\n");
-      return 0;
-    }
     case "claim": {
       const res = claimPhase(orchDir, ticket, phase, Number(gen));
       process.stdout.write(JSON.stringify(res) + "\n");
@@ -181,7 +194,7 @@ function cli(argv) {
     default:
       process.stderr.write(
         `claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: claim.mjs <dispatch-claim|claim|current-generation|release|fence-check> …\n",
+          "usage: claim.mjs <claim|current-generation|release|fence-check> …\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/claim.test.mjs
@@ -146,16 +146,29 @@ function runCli(args, env = {}) {
   });
 }
 
-describe("CLI: dispatch-claim", () => {
-  it("computes gen = currentGeneration + 1, claims it, prints {won, generation}", () => {
+// CTL-1791 guard. `dispatch-claim` used to derive its target generation from the
+// LIVE claim-file high-water mark (currentGeneration + 1) — the exact derivation
+// the CTL-736 fence forbids, because the claim set is mutated by the computation
+// that reads it, so two staggered dispatchers compute DIFFERENT targets and each
+// wins its own O_EXCL file. It had zero production callers (the live dispatcher
+// is pure bash and derives the target from the SIGNAL). It is deleted; this test
+// keeps it deleted.
+describe("CLI: dispatch-claim is REMOVED (CTL-736 invariant guard)", () => {
+  it("rejects dispatch-claim as an unknown subcommand and creates no claim file", () => {
     const r = runCli(["dispatch-claim", ORCH_DIR, "CTL-1", "implement"]);
-    expect(r.status).toBe(0);
-    const out = JSON.parse(r.stdout);
-    expect(out.won).toBe(true);
-    expect(out.generation).toBe(1); // fresh ⇒ gen 1
-    // A second dispatch-claim (e.g. revive) bumps to gen 2.
-    const r2 = runCli(["dispatch-claim", ORCH_DIR, "CTL-1", "implement"]);
-    expect(JSON.parse(r2.stdout).generation).toBe(2);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("unknown subcommand: dispatch-claim");
+    // No high-water-derived claim may be created as a side effect.
+    expect(existsSync(claimPath(ORCH_DIR, "CTL-1", "implement", 1))).toBe(false);
+    expect(currentGeneration(ORCH_DIR, "CTL-1", "implement")).toBe(0);
+  });
+
+  it("does not advertise dispatch-claim in the usage string", () => {
+    const r = runCli(["bogus-subcommand"]);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("usage: claim.mjs <claim|current-generation|release|fence-check>");
+    expect(r.stderr).not.toContain("dispatch-claim");
   });
 });
 


### PR DESCRIPTION
Part of CTL-1791.

## Why

`claim.mjs`'s `dispatch-claim` subcommand has **no production caller** — but it is **armed, not inert**. It implements the high-water+1 generation algorithm that `phase-agent-dispatch:678-704` names in its own comments as the live CTL-736 double-spawn bug, **and the test asserted that behaviour as correct**. Deleting the subcommand without the test would leave a test certifying the bug; deleting neither leaves a loaded gun with a friendly usage string.

## What

- Removes the `dispatch-claim` case arm and its usage token.
- Replaces the test that codified the forbidden behaviour with a guard test asserting the subcommand is **rejected** (exit 1), creates no claim file, and is absent from usage.
- Corrects two **factually false** doc comments found in the process: `claim.mjs`'s header claimed it is imported by `recovery.mjs` and shelled into by two bash scripts (none of which is true — `recovery.mjs` imports `cluster-claim-sync.mjs`/`fence-event.mjs`, and both bash scripts reimplement the semantics), and `currentGeneration`'s doc actively recommended *"A spawn-path dispatcher claims this + 1"* — the exact derivation this deletion exists to forbid. Deleting the subcommand while leaving comments recommending it is how it gets reintroduced.

## Scope correction — the rest of CTL-1791 is NOT in this PR

The ticket also proposed deleting the ADR-011 SQLite archive index. **That premise was proven false during implementation and the item is blocked**, not skipped:

- `~/catalyst/archives/<TICKET>/` (written by `phase-teardown`) and `~/catalyst/archives/<orchId>/` (written by `catalyst-archive.ts sweep`) are **different namespaces sharing a parent directory**. mini's 91 populated dirs are ticket-keyed. Deleting `catalyst-archive.ts` would remove the entire orchId-keyed artifact-persistence system for the `catalyst-legacy` path, which is installed and documented as the runtime fallback — not an unused index.
- The proposed replacement teardown gate (`.teardown-complete`) is present on only **2 of 91** dirs, and those dirs are ticket-keyed while `/catalyst-dev:teardown` takes an orchId. It would swap an always-failing gate for a differently-always-failing one that *looks* correct, on a skill guarding destructive worktree removal.

The ticket has been updated with this correction.

## Verification

`claim.test.mjs` 20→21 pass. `grep -rn dispatch-claim` over the tree returns only the two edited files. Adversarially reviewed against the diff: **VERDICT: SAFE-TO-MERGE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144RKpHEbUrj5UHTF5JeAjk