### PR TITLE
feat(dev): CTL-1793 — catalyst config dump that cannot assert what the reader would not produce

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-config.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-config.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# catalyst-config CLI contract (CTL-1793).
+# Run: bash plugins/dev/scripts/__tests__/catalyst-config.test.sh
+#
+# Covers the CLI shell only (the resolution logic is unit-tested in
+# execution-core/config-dump.test.mjs):
+#   • the standard --help/-h/bare/unknown contract (cli-help-usage.test.sh shape);
+#   • `dump --json` emits PARSEABLE JSON on stdout with nothing else mixed in
+#     (a stray log line on stdout would break the cross-host `diff` that is the
+#     whole point of the tool);
+#   • the router reaches it as `catalyst config` via auto-delegation;
+#   • no secret VALUE from a scratch env-file/Layer-2 reaches the output.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)" # plugins/dev/scripts
+TOOL="${SCRIPTS}/catalyst-config"
+
+FAILURES=0
+PASSES=0
+ok() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	echo "    $2"
+}
+expect_eq() { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_ne() { if [[ "$2" != "$3" ]]; then ok "$1"; else fail "$1" "expected != '$3'"; fi; }
+expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "output lacks '$3'"; fi; }
+expect_not_contains() { if [[ "$2" != *"$3"* ]]; then ok "$1"; else fail "$1" "output LEAKED '$3'"; fi; }
+
+echo "catalyst-config: help/usage contract"
+out="$("$TOOL" --help 2>/dev/null)"
+rc=$?
+expect_eq "--help exits 0" "0" "$rc"
+expect_contains "--help names the tool" "$out" "catalyst-config"
+expect_contains "--help has a Usage block" "$out" "Usage:"
+
+out="$("$TOOL" -h 2>/dev/null)"
+rc=$?
+expect_eq "-h alias exits 0" "0" "$rc"
+
+out="$("$TOOL" 2>&1 >/dev/null)"
+rc=$?
+expect_ne "bare exits non-zero" "0" "$rc"
+expect_contains "bare prints usage to stderr" "$out" "Usage:"
+
+out="$("$TOOL" no-such-cmd 2>&1 >/dev/null)"
+rc=$?
+expect_ne "unknown subcommand exits non-zero" "0" "$rc"
+expect_contains "unknown subcommand prints usage" "$out" "Usage:"
+
+# `--help` must do no work: running it in an empty cwd must not create .catalyst/
+TMP_HELP="$(mktemp -d)"
+(cd "$TMP_HELP" && "$TOOL" --help >/dev/null 2>&1)
+if [[ -e "$TMP_HELP/.catalyst" ]]; then fail "--help does no work" ".catalyst created"; else ok "--help does no work"; fi
+rm -rf "$TMP_HELP"
+
+echo "catalyst-config: dump over a scratch HOME"
+JS_RUN="$(command -v bun || command -v node || true)"
+if [[ -z "$JS_RUN" ]]; then
+	echo "  SKIP: no bun/node runtime — dump cases not exercised"
+else
+	TMP="$(mktemp -d)"
+	mkdir -p "$TMP/home/.config/catalyst" "$TMP/repo/.catalyst"
+	cat >"$TMP/repo/.catalyst/config.json" <<'JSON'
+{ "catalyst": { "orchestration": { "dispatchMode": "phase-agents", "executionCore": { "maxParallel": 4 } } } }
+JSON
+	cat >"$TMP/home/.config/catalyst/config.json" <<'JSON'
+{ "catalyst": { "node": { "class": "worker" }, "host": { "name": "scratch-host" },
+  "unstuckSweep": { "mode": "enforce" } } }
+JSON
+	# The env file carries BOTH a governance override and a credential — the
+	# override must surface, the credential value must never appear.
+	cat >"$TMP/home/.config/catalyst/execution-core.env" <<'ENVF'
+export CATALYST_STALL_JANITOR=enforce
+export LINEAR_API_TOKEN=lin_api_MUST_NOT_LEAK
+ENVF
+
+	run_dump() { # <extra args...> — isolated env, scratch HOME, pinned Layer-1
+		env -i PATH="$PATH" HOME="$TMP/home" \
+			CATALYST_CONFIG_FILE="$TMP/repo/.catalyst/config.json" \
+			CATALYST_LAYER2_CONFIG_FILE="$TMP/home/.config/catalyst/config.json" \
+			CATALYST_EXECUTION_CORE_ENV="$TMP/home/.config/catalyst/execution-core.env" \
+			"$TOOL" dump "$@"
+	}
+
+	json="$(run_dump --json 2>/dev/null)"
+	rc=$?
+	expect_eq "dump --json exits 0" "0" "$rc"
+
+	# Stdout must be PURE JSON — a stray log line breaks cross-host diffing.
+	if printf '%s' "$json" | "$JS_RUN" -e '
+      let s=""; process.stdin.on("data",d=>s+=d).on("end",()=>{
+        try { const o=JSON.parse(s); process.exit(o && Array.isArray(o.rows) && o.rows.length>0 ? 0 : 1); }
+        catch { process.exit(1); }
+      });' 2>/dev/null; then
+		ok "dump --json emits parseable JSON with rows on stdout"
+	else
+		fail "dump --json emits parseable JSON with rows on stdout" "stdout was not pure JSON"
+	fi
+
+	expect_contains "layer-1 knob is reported from layer1" "$json" '"catalyst.orchestration.dispatchMode"'
+	expect_contains "layer-2 knob is reported" "$json" '"scratch-host"'
+	expect_contains "a fingerprint is emitted" "$json" '"fingerprint"'
+
+	human="$(run_dump 2>/dev/null)"
+
+	# The env-file-only override must reach the ROW, not merely the key listing.
+	# Asserting on the key name alone would pass even with the overlay disabled,
+	# because the env-file key set is printed independently of resolution.
+	sj_row="$(printf '%s\n' "$human" | grep -E '^[[:space:]]+catalyst\.stallJanitor\.mode[[:space:]]')"
+	expect_contains "env-file-only override reaches the row VALUE" "$sj_row" "enforce"
+	expect_contains "env-file-only override is labelled env-override" "$sj_row" "env-override (CATALYST_STALL_JANITOR)"
+	# ...and a Layer-2 mode with no env override is labelled config (layer2).
+	us_row="$(printf '%s\n' "$human" | grep -E '^[[:space:]]+catalyst\.unstuckSweep\.mode[[:space:]]')"
+	expect_contains "layer-2 mode value is resolved" "$us_row" "enforce"
+	expect_contains "layer-2 mode is labelled config (layer2)" "$us_row" "config (layer2)"
+
+	# Secrets: presence only, value never.
+	expect_not_contains "dump --json never leaks a credential VALUE" "$json" "lin_api_MUST_NOT_LEAK"
+	expect_not_contains "human dump never leaks a credential VALUE" "$human" "lin_api_MUST_NOT_LEAK"
+	expect_contains "human dump reports the credential as present" "$human" "secrets.LINEAR_API_TOKEN"
+
+	# Determinism: two runs over the same inputs fingerprint identically.
+	fp1="$(run_dump --json 2>/dev/null | grep -o '"fingerprint": "[a-f0-9]*"' | head -1)"
+	fp2="$(run_dump --json 2>/dev/null | grep -o '"fingerprint": "[a-f0-9]*"' | head -1)"
+	expect_eq "fingerprint is deterministic across runs" "$fp1" "$fp2"
+
+	# A CHANGED knob must change the fingerprint (this is what makes a host diff meaningful).
+	fp3="$(env -i PATH="$PATH" HOME="$TMP/home" \
+		CATALYST_CONFIG_FILE="$TMP/repo/.catalyst/config.json" \
+		CATALYST_LAYER2_CONFIG_FILE="$TMP/home/.config/catalyst/config.json" \
+		CATALYST_EXECUTION_CORE_ENV="$TMP/home/.config/catalyst/execution-core.env" \
+		CATALYST_BOARD_HEALTH=enforce \
+		"$TOOL" dump --json 2>/dev/null | grep -o '"fingerprint": "[a-f0-9]*"' | head -1)"
+	expect_ne "fingerprint changes when a knob changes" "$fp1" "$fp3"
+
+	rm -rf "$TMP"
+fi
+
+echo "catalyst-config: router auto-delegation"
+# `catalyst config ...` must reach catalyst-config with ZERO router changes.
+routed="$(bash -c 'source "$1"; run_tool(){ echo "WOULD-EXEC: $*"; }; dispatch config dump --json' _ "${SCRIPTS}/catalyst" 2>&1)"
+expect_contains "'catalyst config' delegates to catalyst-config" "$routed" "WOULD-EXEC:"
+expect_contains "'catalyst config' resolves the right tool" "$routed" "catalyst-config"
+
+echo
+echo "RESULTS: $PASSES passed, $FAILURES failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/catalyst-config
+++ b/plugins/dev/scripts/catalyst-config
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# catalyst-config — inspect this host's effective Catalyst configuration (CTL-1793).
+#
+# READ-ONLY. It opens the Layer-1 config, the Layer-2 config, and the daemon's
+# execution-core.env, and prints one row per knob with its value and PROVENANCE
+# (env-override / config / default) plus a content fingerprint. It writes nothing,
+# starts nothing, and is imported by no daemon.
+#
+# Usage: catalyst-config dump [--json]
+#
+# Compare two hosts:
+#   diff <(ssh a catalyst config dump --json) <(ssh b catalyst config dump --json)
+#
+# Reached as `catalyst config ...` through the router's auto-delegation (the
+# `catalyst-<command>` convention) — no curated verb needed in `catalyst`.
+#
+# All logic lives in execution-core/config-dump.mjs; this is the thin POSIX
+# entry-point that resolves the JS runtime and forwards argv (the catalyst-doctor
+# shape).
+set -uo pipefail
+
+# Resolve symlinks before deriving SCRIPT_DIR — install-cli.sh installs this as a
+# symlink in the bin dir (~/.catalyst/bin), so a bare dirname would point there and
+# the execution-core/config-dump.mjs lookup would miss. Normalize each hop against
+# the symlink's own dir so a RELATIVE target resolves too (same idiom as
+# catalyst / catalyst-doctor / catalyst-install).
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do
+	_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+	_SRC="$(readlink "$_SRC")"
+	[[ "$_SRC" != /* ]] && _SRC="$_DIR/$_SRC"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$_SRC")" && pwd)"
+CONFIG_DUMP_MJS="${CONFIG_DUMP_MJS:-${SCRIPT_DIR}/execution-core/config-dump.mjs}"
+
+usage() {
+	cat <<'EOF'
+catalyst-config — inspect this host's effective Catalyst configuration (read-only).
+
+Usage: catalyst-config <command> [options]
+
+Commands:
+  dump            Per-key value + provenance, layer paths, fingerprint.
+
+Options:
+  --json          machine-readable output (stable key order; diffable)
+  -h, --help      this help
+
+`dump` reports, for every load-bearing knob, its effective value and WHERE that
+value came from (env-override / config / default), plus the resolved Layer-1 and
+Layer-2 paths, the Layer-1 file the DAEMON actually reads (which is not always
+the one doctor grades), and a content fingerprint.
+
+Compare two hosts:
+  diff <(ssh a catalyst config dump --json) <(ssh b catalyst config dump --json)
+EOF
+}
+
+# --help/-h is answered HERE (exit 0, stdout) so it works even without a JS
+# runtime — the cli-help-usage.test.sh contract.
+for arg in "$@"; do
+	case "$arg" in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	esac
+done
+
+# Bare invocation → usage on stderr, non-zero (the same contract).
+if [[ $# -eq 0 ]]; then
+	echo "catalyst-config: a command is required" >&2
+	usage >&2
+	exit 2
+fi
+
+# Resolve a JS runtime (bun preferred, node fallback) — matches sibling .mjs CLIs.
+JS_RUN="$(command -v bun || command -v node || true)"
+
+[[ -n "$JS_RUN" ]] || {
+	echo "catalyst-config: no bun/node runtime found" >&2
+	exit 1
+}
+[[ -f "$CONFIG_DUMP_MJS" ]] || {
+	echo "catalyst-config: missing $CONFIG_DUMP_MJS" >&2
+	exit 1
+}
+
+exec "$JS_RUN" "$CONFIG_DUMP_MJS" "$@"

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -1,0 +1,758 @@
+// config-dump.mjs — CTL-1793. A diffable, per-key PROVENANCE view of this host's
+// effective Catalyst configuration.
+//
+// WHY THIS EXISTS
+// ---------------
+// There is no single merged config object anywhere in Catalyst. Layer-1 has six
+// competing path resolvers, Layer-2 has four, and each knob family has its own
+// precedence ladder (Layer-1-only, Layer-2-only, or a genuine two-layer merge),
+// with an env var able to win over any of them. The consequence measured on the
+// live fleet: two worker hosts read STRUCTURALLY DIFFERENT Layer-1 files (one
+// pinned via CATALYST_CONFIG_FILE, one falling back to the daemon's launch cwd),
+// and four enforcement subsystems run `enforce` on one host and at the code
+// default on the other — invisible to every existing surface. See CTL-1793.
+//
+// WHAT THIS IS — AND IS NOT
+// -------------------------
+// This module is a DESCRIPTION of the resolution ladders, not a second resolver.
+// It never feeds a gate, a dispatch decision, or a write. Nothing in the daemon
+// imports it. Two structural guards keep the description honest:
+//
+//   1. The precedence DECISION for the two families that already have a shared
+//      pure helper is delegated to that helper verbatim — `resolveModeSource` and
+//      `resolveBeliefsFlag`, imported from config.mjs (exported there by CTL-1793
+//      purely for this purpose). The dump therefore cannot disagree with the
+//      daemon about which layer won for a mode or a beliefs flag.
+//   2. Every env-var name and every dotted config key in CONFIG_KEYS is pinned to
+//      the real source by a drift test (config-dump.test.mjs): a rename in a
+//      reader breaks this module's test rather than silently drifting the dump.
+//
+// CORE IS PURE. `dumpConfig()` performs NO ambient I/O — every file body, the env,
+// and the host name are injected. `collectConfigDump()` is the thin I/O shell.
+//
+// SECRETS. Rows marked `secret: true` report PRESENCE only ("set" / "unset") and
+// never a value, in either renderer. Secret rows carry no config-file key at all,
+// so there is no path by which a credential body can reach the output.
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { hostname } from "node:os";
+import { resolve } from "node:path";
+
+import {
+  BELIEFS_FLAGS,
+  BOARD_HEALTH_MODES,
+  COORDINATION_MODES,
+  DEAD_DOC_WORKER_MODES,
+  RECOVERY_PASS_MODES,
+  STALL_JANITOR_MODES,
+  UNSTUCK_SWEEP_MODES,
+  WATCHDOG_MODES,
+  resolveBeliefsFlag,
+  resolveModeSource,
+} from "./config.mjs";
+
+export const DUMP_SCHEMA = "catalyst.config.dump/1";
+
+// Provenance vocabulary. Deliberately the SAME three strings readGovernanceSources
+// already emits ("env-override" | "config" | "default") so the dump, the boot
+// self-report, and `catalyst-stack status` speak one language. `config` is
+// qualified by the row's `layer` field ("layer1" | "layer2" | "merged").
+export const PROVENANCE = Object.freeze({
+  ENV: "env-override",
+  CONFIG: "config",
+  DEFAULT: "default",
+});
+
+// ─── env-file parsing ────────────────────────────────────────────────────────
+
+// parseEnvFileAssignments — every `[export ]KEY=value` assignment in an env-file
+// body, as a plain object. The daemon launcher `source`s ~/.config/catalyst/
+// execution-core.env, so these assignments are part of the daemon's EFFECTIVE env
+// even when the operator's interactive shell never exported them. Quotes are
+// stripped; `#` comment lines and blanks are skipped. Never throws.
+//
+// This is the whole-file generalization of doctor.mjs's per-key parseEnvFileFlag /
+// overlayDaemonDrainEnv idiom — a line scan, so it needs no dynamic RegExp.
+export function parseEnvFileAssignments(text) {
+  const out = {};
+  if (typeof text !== "string" || text === "") return out;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const body = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const eq = body.indexOf("=");
+    if (eq <= 0) continue;
+    const key = body.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let value = body.slice(eq + 1).trim();
+    // Strip ONE matched pair of surrounding quotes (the shape `source` would see).
+    if (value.length >= 2 && ((value[0] === '"' && value.endsWith('"')) || (value[0] === "'" && value.endsWith("'")))) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+// overlayEnvFile — the daemon's effective env: ambient env with the env-file's
+// assignments layered ON TOP. File wins, matching `source` semantics (the launcher
+// sources the file AFTER inheriting the ambient env). Mirrors doctor.mjs's
+// overlayDaemonDrainEnv, generalized to every key.
+export function overlayEnvFile(env = {}, envFileText = "") {
+  return { ...env, ...parseEnvFileAssignments(envFileText) };
+}
+
+// ─── daemon-visible Layer-1 resolution ───────────────────────────────────────
+
+// resolveDaemonLayer1Path — the Layer-1 file the RUNNING (or next-launched) daemon
+// actually reads, reconstructed from the launcher's ladder rather than doctor's own.
+// Mirrors, in order:
+//   1. catalyst-execution-core cmd_start: `source`s execution-core.env (file wins
+//      over ambient), then pins CATALYST_CONFIG_FILE to
+//      "$CATALYST_DIR/.catalyst/config.json" ONLY when the var is still unset AND
+//      that file exists;
+//   2. daemon.mjs main(): `CATALYST_CONFIG_FILE || resolve(cwd, ".catalyst", "config.json")`.
+//
+// Step 2's cwd is the DAEMON's launch cwd, which is not knowable from a doctor
+// process — so when the ladder falls through, this returns `{ path: null,
+// source: "daemon-cwd", pinned: false }`. That "unpinned" answer IS the finding:
+// it is exactly the state in which host `mini` reads a different Layer-1 file than
+// its own checkout. Never throws.
+export function resolveDaemonLayer1Path({
+  env = {},
+  execCoreEnvText = "",
+  catalystDir = null,
+  exists = () => false,
+} = {}) {
+  const effective = overlayEnvFile(env, execCoreEnvText);
+  const pin = effective.CATALYST_CONFIG_FILE;
+  if (typeof pin === "string" && pin !== "") {
+    const fromFile = Object.hasOwn(parseEnvFileAssignments(execCoreEnvText), "CATALYST_CONFIG_FILE");
+    return { path: pin, source: fromFile ? "exec-core-env-file" : "env", pinned: true };
+  }
+  if (typeof catalystDir === "string" && catalystDir !== "") {
+    const candidate = resolve(catalystDir, ".catalyst", "config.json");
+    if (exists(candidate)) return { path: candidate, source: "catalyst-dir", pinned: true };
+  }
+  return { path: null, source: "daemon-cwd", pinned: false };
+}
+
+// ─── the registry ────────────────────────────────────────────────────────────
+//
+// One row per operationally load-bearing knob. Rows are DESCRIPTIONS of an
+// existing reader's ladder — `reader` names that reader so a human (and the drift
+// test) can find it. Field meanings:
+//
+//   key      dotted display name (the dump's stable sort key)
+//   kind     "mode"   → env ("0" kill-switch | valid member) > config mode > default
+//            "flag"   → env "1"/"0" > config boolean > default
+//            "value"  → env non-empty > config non-null > default
+//            "merge"  → Layer-2 positive int wins per field over Layer-1
+//            "secret" → PRESENCE of an env var only; never a value, no config key
+//   layer1   dotted path inside the Layer-1 file, or null
+//   layer2   dotted path inside the Layer-2 file, or null
+//   env      env var names, highest precedence first
+//   modes    the Set the reader validates against (shared, not copied)
+//   fallback the code default when no layer supplies a value
+//   reader   the function in the codebase that owns this ladder
+export const CONFIG_KEYS = Object.freeze(
+  [
+    // ── identity / topology ──────────────────────────────────────────────────
+    {
+      key: "catalyst.node.class",
+      kind: "value",
+      layer2: "catalyst.node.class",
+      env: ["CATALYST_NODE_CLASS"],
+      fallback: "worker",
+      reader: "resolveNodeClass",
+    },
+    {
+      key: "catalyst.host.name",
+      kind: "value",
+      layer2: "catalyst.host.name",
+      env: ["CATALYST_HOST_NAME"],
+      fallback: null,
+      reader: "getHostName",
+    },
+    {
+      key: "catalyst.deployment.mode",
+      kind: "value",
+      layer1: "catalyst.deployment.mode",
+      layer2: "catalyst.deployment.mode",
+      env: ["CATALYST_DEPLOYMENT_MODE"],
+      fallback: "single-host",
+      reader: "resolveDeploymentMode",
+    },
+
+    // ── orchestration (Layer-1 owned) ────────────────────────────────────────
+    {
+      key: "catalyst.orchestration.dispatchMode",
+      kind: "value",
+      layer1: "catalyst.orchestration.dispatchMode",
+      env: [],
+      fallback: "oneshot-legacy",
+      reader: "orchestrate-register-interests.sh",
+    },
+    {
+      key: "catalyst.orchestration.executor",
+      kind: "value",
+      layer1: "catalyst.orchestration.executor",
+      env: ["CATALYST_EXECUTOR"],
+      fallback: null,
+      reader: "resolveExecutor",
+    },
+    {
+      key: "catalyst.orchestration.executorByPhase",
+      kind: "value",
+      layer1: "catalyst.orchestration.executorByPhase",
+      env: ["CATALYST_EXECUTOR_BY_PHASE"],
+      fallback: null,
+      reader: "readExecutorByPhaseLayer1",
+    },
+    {
+      key: "catalyst.orchestration.reconcile.mode",
+      kind: "value",
+      layer1: "catalyst.orchestration.reconcile.mode",
+      layer2: "catalyst.orchestration.reconcile.mode",
+      env: ["CATALYST_RECONCILE_MODE"],
+      fallback: null,
+      reader: "readLinearReconcileConfig",
+    },
+    {
+      key: "catalyst.orchestration.executionCore.maxParallel",
+      kind: "merge",
+      layer1: "catalyst.orchestration.executionCore.maxParallel",
+      layer2: "catalyst.orchestration.executionCore.maxParallel",
+      env: [],
+      fallback: null,
+      reader: "mergeExecutionCoreConcurrency",
+    },
+    {
+      key: "catalyst.orchestration.executionCore.minParallel",
+      kind: "merge",
+      layer1: "catalyst.orchestration.executionCore.minParallel",
+      layer2: "catalyst.orchestration.executionCore.minParallel",
+      env: [],
+      fallback: null,
+      reader: "mergeExecutionCoreConcurrency",
+    },
+    {
+      key: "catalyst.orchestration.executionCore.maxParallelCeiling",
+      kind: "merge",
+      layer1: "catalyst.orchestration.executionCore.maxParallelCeiling",
+      layer2: "catalyst.orchestration.executionCore.maxParallelCeiling",
+      env: [],
+      fallback: null,
+      reader: "mergeExecutionCoreConcurrency",
+    },
+    {
+      key: "catalyst.orchestration.executionCore.targetParallel",
+      kind: "merge",
+      layer1: "catalyst.orchestration.executionCore.targetParallel",
+      layer2: "catalyst.orchestration.executionCore.targetParallel",
+      env: [],
+      fallback: null,
+      reader: "resolveTargetSetpoint",
+    },
+    {
+      key: "catalyst.orchestration.executionCore.eligibleQuery.status",
+      kind: "value",
+      layer1: "catalyst.orchestration.executionCore.eligibleQuery.status",
+      env: [],
+      fallback: null,
+      reader: "readExecutionCoreConcurrency",
+    },
+    {
+      key: "catalyst.orchestration.worktreeRefresh.enabled",
+      kind: "value",
+      layer1: "catalyst.orchestration.worktreeRefresh.enabled",
+      env: [],
+      fallback: null,
+      reader: "readWorktreeRefreshConfig",
+    },
+    {
+      key: "catalyst.orchestration.worktreeRefresh.intervalSeconds",
+      kind: "value",
+      layer1: "catalyst.orchestration.worktreeRefresh.intervalSeconds",
+      env: [],
+      fallback: null,
+      reader: "readWorktreeRefreshConfig",
+    },
+    {
+      key: "catalyst.orchestration.draftPr.enabled",
+      kind: "value",
+      layer1: "catalyst.orchestration.draftPr.enabled",
+      env: [],
+      fallback: true,
+      reader: "lib/draft-pr.sh",
+    },
+    {
+      key: "catalyst.orchestration.orphanReaper.workerGc.emptyDirGraceSeconds",
+      kind: "value",
+      layer1: "catalyst.orchestration.orphanReaper.workerGc.emptyDirGraceSeconds",
+      env: ["CATALYST_EMPTY_WORKER_DIR_GRACE_MS"],
+      fallback: 600,
+      reader: "readEmptyWorkerDirGraceMs",
+    },
+    {
+      key: "catalyst.orchestration.daemonWatchdog.mode",
+      kind: "mode",
+      layer1: "catalyst.orchestration.daemonWatchdog.mode",
+      env: ["CATALYST_DAEMON_WATCHDOG", "EXECUTION_CORE_DAEMON_WATCHDOG_MODE"],
+      modes: WATCHDOG_MODES,
+      fallback: "shadow",
+      reader: "readDaemonWatchdogConfig",
+    },
+
+    // ── governance / enforcement subsystems (Layer-2 owned) ──────────────────
+    // These are the four that measurably diverged across the live worker hosts.
+    {
+      key: "catalyst.stallJanitor.mode",
+      kind: "mode",
+      layer2: "catalyst.stallJanitor.mode",
+      env: ["CATALYST_STALL_JANITOR", "EXECUTION_CORE_STALL_JANITOR_MODE"],
+      modes: STALL_JANITOR_MODES,
+      fallback: "shadow",
+      reader: "readStallJanitorConfig",
+    },
+    {
+      key: "catalyst.unstuckSweep.mode",
+      kind: "mode",
+      layer2: "catalyst.unstuckSweep.mode",
+      env: ["CATALYST_UNSTUCK_SWEEP", "EXECUTION_CORE_UNSTUCK_SWEEP_MODE"],
+      modes: UNSTUCK_SWEEP_MODES,
+      fallback: "off",
+      reader: "readUnstuckSweepConfig",
+    },
+    {
+      key: "catalyst.recovery.pass.mode",
+      kind: "mode",
+      layer2: "catalyst.recovery.pass.mode",
+      env: ["CATALYST_RECOVERY_PASS"],
+      modes: RECOVERY_PASS_MODES,
+      fallback: "off",
+      reader: "readRecoveryPassConfig",
+    },
+    {
+      key: "catalyst.recovery.deadDocWorker.mode",
+      kind: "mode",
+      layer2: "catalyst.recovery.deadDocWorker.mode",
+      env: ["CATALYST_DEAD_DOC_WORKER_RECLAIM"],
+      modes: DEAD_DOC_WORKER_MODES,
+      fallback: "off",
+      reader: "readDeadDocWorkerConfig",
+    },
+    {
+      key: "catalyst.boardHealth.mode",
+      kind: "mode",
+      layer2: "catalyst.boardHealth.mode",
+      env: ["CATALYST_BOARD_HEALTH"],
+      modes: BOARD_HEALTH_MODES,
+      fallback: "shadow",
+      reader: "readBoardHealthConfig",
+    },
+    {
+      key: "catalyst.watchdog.mode",
+      kind: "mode",
+      layer2: "catalyst.watchdog.mode",
+      env: ["CATALYST_WATCHDOG", "EXECUTION_CORE_WATCHDOG_MODE"],
+      modes: WATCHDOG_MODES,
+      fallback: "shadow",
+      reader: "readWatchdogConfig",
+    },
+    {
+      key: "catalyst.coordination.mode",
+      kind: "mode",
+      layer2: "catalyst.coordination.mode",
+      env: ["CATALYST_COORDINATION_MODE"],
+      modes: COORDINATION_MODES,
+      fallback: "off",
+      reader: "readCoordinationConfig",
+    },
+    {
+      key: "catalyst.costCap.mode",
+      kind: "mode",
+      layer2: "catalyst.costCap.mode",
+      env: ["CATALYST_COST_CAP", "EXECUTION_CORE_COST_CAP_MODE"],
+      modes: WATCHDOG_MODES,
+      fallback: "shadow",
+      reader: "readCostCapConfig",
+    },
+    {
+      key: "catalyst.linearReplica.mode",
+      kind: "value",
+      layer2: "catalyst.linearReplica.mode",
+      env: ["CATALYST_LINEAR_REPLICA"],
+      fallback: "off",
+      reader: "readLinearReplica",
+    },
+
+    // ── beliefs flags (Layer-2 booleans, env "1"/"0") ────────────────────────
+    ...Object.entries(BELIEFS_FLAGS).map(([flag, envName]) => ({
+      key: `catalyst.governance.${flag}`,
+      kind: "flag",
+      layer2: `catalyst.governance.${flag}`,
+      env: [envName],
+      fallback: false,
+      reader: "readGovernanceConfig",
+    })),
+
+    // ── credential PRESENCE (never a value) ──────────────────────────────────
+    // A missing token is a first-order divergence between hosts, and its presence
+    // is not readable from any config file. Reported as "set"/"unset" only.
+    { key: "secrets.LINEAR_API_TOKEN", kind: "secret", env: ["LINEAR_API_TOKEN"], reader: "secret-contract:linear-api-token" },
+    { key: "secrets.CATALYST_WORKFLOW_GITHUB_TOKEN", kind: "secret", env: ["CATALYST_WORKFLOW_GITHUB_TOKEN"], reader: "secret-contract:github-token" },
+    { key: "secrets.CATALYST_CLOUD_TOKEN", kind: "secret", env: ["CATALYST_CLOUD_TOKEN"], reader: "secret-contract:cloud-token" },
+    { key: "secrets.GROQ_API_KEY", kind: "secret", env: ["GROQ_API_KEY"], reader: "secret-contract:groq-api-key" },
+  ].map((r) =>
+    Object.freeze({
+      layer1: null,
+      layer2: null,
+      modes: null,
+      fallback: null,
+      secret: r.kind === "secret",
+      ...r,
+    }),
+  ),
+);
+
+// ─── resolution ──────────────────────────────────────────────────────────────
+
+// getPath — read a dotted key out of a parsed JSON object. Returns undefined for
+// an absent key, a non-object ancestor, or a null root. Never throws.
+export function getPath(obj, dotted) {
+  if (!dotted) return undefined;
+  let cur = obj;
+  for (const part of dotted.split(".")) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = cur[part];
+  }
+  return cur;
+}
+
+function firstEnvValue(env, names) {
+  for (const name of names ?? []) {
+    const v = env?.[name];
+    if (typeof v === "string" && v !== "") return { value: v, envVar: name };
+  }
+  return { value: undefined, envVar: null };
+}
+
+// resolveRow — the effective value + provenance for one registry row, given the
+// already-parsed layers and the daemon's effective env. Pure; never throws.
+//
+// `layer` names WHICH file supplied a `config`-provenance answer ("layer1" |
+// "layer2"), so an operator diffing two hosts sees not just "config" but which
+// file to go read.
+export function resolveRow(row, { env = {}, layer1 = null, layer2 = null } = {}) {
+  const { value: envValue, envVar } = firstEnvValue(env, row.env);
+
+  if (row.kind === "secret") {
+    return {
+      key: row.key,
+      value: envValue === undefined ? "unset" : "set",
+      provenance: envValue === undefined ? PROVENANCE.DEFAULT : PROVENANCE.ENV,
+      layer: null,
+      envVar: envVar ?? (row.env?.[0] ?? null),
+      secret: true,
+      reader: row.reader,
+    };
+  }
+
+  const l1 = getPath(layer1, row.layer1);
+  const l2 = getPath(layer2, row.layer2);
+
+  const base = { key: row.key, secret: false, reader: row.reader, envVar: envVar ?? (row.env?.[0] ?? null) };
+
+  if (row.kind === "mode") {
+    // Mode knobs are single-layer in every reader today (Layer-2 for the governance
+    // family, Layer-1 for daemonWatchdog); whichever the row declares is "the" config
+    // layer. The DECISION is resolveModeSource's, verbatim.
+    const configMode = row.layer2 ? l2 : l1;
+    const configLayer = row.layer2 ? "layer2" : "layer1";
+    const provenance = resolveModeSource(envValue, configMode, row.modes);
+    let value;
+    if (provenance === PROVENANCE.ENV) value = envValue === "0" ? "off" : envValue;
+    else if (provenance === PROVENANCE.CONFIG) value = configMode;
+    else value = row.fallback;
+    return { ...base, value, provenance, layer: provenance === PROVENANCE.CONFIG ? configLayer : null };
+  }
+
+  if (row.kind === "flag") {
+    const r = resolveBeliefsFlag(envValue, l2);
+    return { ...base, value: r.value, provenance: r.source, layer: r.source === PROVENANCE.CONFIG ? "layer2" : null };
+  }
+
+  if (row.kind === "merge") {
+    // Layer-2 wins per field when it is a positive integer (mergeExecutionCoreConcurrency).
+    if (Number.isInteger(l2) && l2 > 0) return { ...base, value: l2, provenance: PROVENANCE.CONFIG, layer: "layer2" };
+    if (l1 !== undefined && l1 !== null) return { ...base, value: l1, provenance: PROVENANCE.CONFIG, layer: "layer1" };
+    return { ...base, value: row.fallback, provenance: PROVENANCE.DEFAULT, layer: null };
+  }
+
+  // "value": env > layer2 > layer1 > default. Layer-2 is node scope and wins over
+  // the committed Layer-1 seed wherever a row declares both (node.class/host.name
+  // are Layer-2-only; reconcile.mode and deployment.mode are the two-layer rows).
+  if (envValue !== undefined) return { ...base, value: envValue, provenance: PROVENANCE.ENV, layer: null };
+  if (l2 !== undefined && l2 !== null) return { ...base, value: l2, provenance: PROVENANCE.CONFIG, layer: "layer2" };
+  if (l1 !== undefined && l1 !== null) return { ...base, value: l1, provenance: PROVENANCE.CONFIG, layer: "layer1" };
+  return { ...base, value: row.fallback, provenance: PROVENANCE.DEFAULT, layer: null };
+}
+
+// ─── fingerprint ─────────────────────────────────────────────────────────────
+
+// stableValue — a canonical string for a row's value, so the fingerprint is
+// insensitive to object key order and JSON whitespace but sensitive to content.
+function stableValue(v) {
+  if (v === undefined) return "\u0000undefined";
+  if (v === null) return "\u0000null";
+  if (typeof v !== "object") return String(v);
+  if (Array.isArray(v)) return `[${v.map(stableValue).join(",")}]`;
+  const keys = Object.keys(v).sort();
+  return `{${keys.map((k) => `${k}:${stableValue(v[k])}`).join(",")}}`;
+}
+
+// fingerprintRows — sha256 over the canonical `key\0value\0provenance\0layer`
+// stream, rows sorted by key. Two hosts with the same effective configuration
+// produce the same fingerprint regardless of file formatting or key order; ANY
+// value, provenance, or layer change alters it. Host-independent by construction
+// (host name and timestamps are not part of the stream).
+export function fingerprintRows(rows) {
+  const h = createHash("sha256");
+  for (const r of [...rows].sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))) {
+    h.update(`${r.key}\u0000${stableValue(r.value)}\u0000${r.provenance}\u0000${r.layer ?? ""}\n`);
+  }
+  return h.digest("hex");
+}
+
+// ─── the dump ────────────────────────────────────────────────────────────────
+
+// parseOrNull — { parsed, ok }. `ok` is true only when the body parsed into a
+// plain object; an absent (null) body and a malformed one are both `ok:false`
+// with `parsed:null`, so every downstream layer probe simply misses. Mirrors the
+// readLayer2*/readXConfigLayer1 family's "unreadable ⇒ try the next layer"
+// contract. Never throws.
+function parseOrNull(text) {
+  if (typeof text !== "string" || text === "") return { parsed: null, ok: false };
+  try {
+    const v = JSON.parse(text);
+    return v && typeof v === "object" ? { parsed: v, ok: true } : { parsed: null, ok: false };
+  } catch {
+    return { parsed: null, ok: false };
+  }
+}
+
+// dumpConfig — the pure core. Everything is injected; there is NO ambient I/O.
+//
+//   env              the operator/process env (NOT yet overlaid with the env file)
+//   layer1Text       raw Layer-1 body, or null when absent/unreadable
+//   layer2Text       raw Layer-2 body, or null when absent/unreadable
+//   execCoreEnvText  raw ~/.config/catalyst/execution-core.env body, or ""
+//   daemonLayer1     result of resolveDaemonLayer1Path (or null when not computed)
+export function dumpConfig({
+  env = {},
+  // `host` is an explicit override; when empty the dump labels itself with the
+  // RESOLVED catalyst.host.name (the fleet identity every other surface keys on —
+  // heartbeats, HRW, worker labels), falling back to `hostFallback` (the OS
+  // hostname) only when nothing declares one. Labelling with the OS hostname while
+  // the fleet knows the node as "mini" is exactly the kind of identity mismatch
+  // that makes a cross-host diff unreadable.
+  host = "",
+  hostFallback = "",
+  generatedAt = null,
+  layer1Path = null,
+  layer1Text = null,
+  layer2Path = null,
+  layer2Text = null,
+  execCoreEnvPath = null,
+  execCoreEnvText = "",
+  daemonLayer1 = null,
+  keys = CONFIG_KEYS,
+} = {}) {
+  const effectiveEnv = overlayEnvFile(env, execCoreEnvText);
+  const l1 = parseOrNull(layer1Text);
+  const l2 = parseOrNull(layer2Text);
+
+  const rows = keys.map((row) => resolveRow(row, { env: effectiveEnv, layer1: l1.parsed, layer2: l2.parsed }));
+
+  const envFileKeys = Object.keys(parseEnvFileAssignments(execCoreEnvText)).sort();
+
+  const hostRow = rows.find((r) => r.key === "catalyst.host.name");
+  const resolvedHost =
+    host || (typeof hostRow?.value === "string" && hostRow.value !== "" ? hostRow.value : "") || hostFallback;
+
+  return {
+    schema: DUMP_SCHEMA,
+    host: resolvedHost,
+    generatedAt,
+    layer1: {
+      path: layer1Path,
+      present: layer1Text !== null && layer1Text !== undefined,
+      parsed: l1.ok,
+      // The single most diagnostic Layer-1 fact: mini's daemon reads a file with NO
+      // orchestration stanza at all, so every Layer-1-driven feature runs on defaults.
+      hasOrchestration: getPath(l1.parsed, "catalyst.orchestration") !== undefined,
+    },
+    layer2: {
+      path: layer2Path,
+      present: layer2Text !== null && layer2Text !== undefined,
+      parsed: l2.ok,
+    },
+    // The env file's KEY SET is itself a divergence signal — values are never emitted.
+    execCoreEnv: { path: execCoreEnvPath, present: execCoreEnvText !== "", keys: envFileKeys },
+    daemonLayer1,
+    rows,
+    fingerprint: fingerprintRows(rows),
+  };
+}
+
+// ─── I/O shell ───────────────────────────────────────────────────────────────
+
+function readOrNull(path) {
+  if (!path) return null;
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+// collectConfigDump — the thin ambient-I/O wrapper around dumpConfig. Read-only:
+// it opens three files and never writes anything. Path resolution mirrors the
+// daemon's (CATALYST_CONFIG_FILE > cwd) and the legacy Layer-2 chain
+// (CATALYST_LAYER2_CONFIG_FILE > ~/.config/catalyst/config.json) — the same two
+// ladders getCatalystRepoDir() and getLayer2ConfigPath() use.
+export function collectConfigDump({ env = process.env, cwd = process.cwd(), now = new Date() } = {}) {
+  const home = env.HOME || "";
+  const layer1Path = env.CATALYST_CONFIG_FILE || resolve(cwd, ".catalyst", "config.json");
+  const layer2Path = env.CATALYST_LAYER2_CONFIG_FILE || resolve(home, ".config", "catalyst", "config.json");
+  const execCoreEnvPath = env.CATALYST_EXECUTION_CORE_ENV || resolve(home, ".config", "catalyst", "execution-core.env");
+  const execCoreEnvText = readOrNull(execCoreEnvPath) ?? "";
+  const catalystDir = env.CATALYST_DIR || resolve(home, "catalyst");
+
+  return dumpConfig({
+    env,
+    hostFallback: hostname(),
+    generatedAt: now.toISOString(),
+    layer1Path,
+    layer1Text: readOrNull(layer1Path),
+    layer2Path,
+    layer2Text: readOrNull(layer2Path),
+    execCoreEnvPath,
+    execCoreEnvText,
+    daemonLayer1: resolveDaemonLayer1Path({
+      env,
+      execCoreEnvText,
+      catalystDir,
+      exists: (p) => readOrNull(p) !== null,
+    }),
+  });
+}
+
+// ─── renderers ───────────────────────────────────────────────────────────────
+
+export function renderJson(dump) {
+  return JSON.stringify(dump, null, 2);
+}
+
+function fmtValue(row) {
+  if (row.value === null || row.value === undefined) return "-";
+  if (typeof row.value === "object") return JSON.stringify(row.value);
+  return String(row.value);
+}
+
+export function renderHuman(dump) {
+  const lines = [];
+  lines.push(`catalyst config dump — ${dump.host || "(unknown host)"}   fingerprint=${dump.fingerprint.slice(0, 12)}`);
+  lines.push("");
+  lines.push(
+    `  layer1  ${dump.layer1.path ?? "(unresolved)"}  ` +
+      `[${dump.layer1.present ? (dump.layer1.parsed ? "ok" : "MALFORMED") : "ABSENT"}` +
+      `${dump.layer1.present && dump.layer1.parsed ? (dump.layer1.hasOrchestration ? ", orchestration" : ", NO orchestration stanza") : ""}]`,
+  );
+  lines.push(
+    `  layer2  ${dump.layer2.path ?? "(unresolved)"}  ` +
+      `[${dump.layer2.present ? (dump.layer2.parsed ? "ok" : "MALFORMED") : "ABSENT"}]`,
+  );
+  if (dump.daemonLayer1) {
+    lines.push(
+      dump.daemonLayer1.pinned
+        ? `  daemon  ${dump.daemonLayer1.path}  [pinned via ${dump.daemonLayer1.source}]`
+        : `  daemon  (UNPINNED — resolves to the daemon's launch cwd; may differ from layer1 above)`,
+    );
+  }
+  if (dump.execCoreEnv?.present) {
+    lines.push(`  envfile ${dump.execCoreEnv.path}  [${dump.execCoreEnv.keys.length} keys: ${dump.execCoreEnv.keys.join(" ")}]`);
+  }
+  lines.push("");
+
+  const keyW = Math.max(3, ...dump.rows.map((r) => r.key.length));
+  const valW = Math.max(5, ...dump.rows.map((r) => fmtValue(r).length));
+  lines.push(`  ${"KEY".padEnd(keyW)}  ${"VALUE".padEnd(valW)}  SOURCE`);
+  for (const r of dump.rows) {
+    const src =
+      r.provenance === PROVENANCE.ENV
+        ? `env-override (${r.envVar})`
+        : r.provenance === PROVENANCE.CONFIG
+          ? `config (${r.layer})`
+          : "default";
+    lines.push(`  ${r.key.padEnd(keyW)}  ${fmtValue(r).padEnd(valW)}  ${src}`);
+  }
+  lines.push("");
+  lines.push(`  fingerprint=${dump.fingerprint}`);
+  lines.push("  Diff two hosts:  diff <(ssh a catalyst config dump --json) <(ssh b catalyst config dump --json)");
+  return lines.join("\n");
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+export const USAGE = `catalyst-config — inspect this host's effective Catalyst configuration (read-only).
+
+Usage: catalyst-config <command> [options]
+
+Commands:
+  dump            Per-key value + provenance, layer paths, fingerprint.
+
+Options:
+  --json          machine-readable output (stable key order; diffable)
+  -h, --help      this help
+
+\`dump\` reports, for every load-bearing knob, its effective value and WHERE that
+value came from (env-override / config / default), plus the resolved Layer-1 and
+Layer-2 paths, the Layer-1 file the DAEMON actually reads (which is not always
+the one doctor grades), and a content fingerprint.
+
+Compare two hosts:
+  diff <(ssh a catalyst config dump --json) <(ssh b catalyst config dump --json)
+
+This tool never writes anything and never prints a secret value — credential rows
+report "set"/"unset" only.
+`;
+
+// runCli — injectable so the CLI contract is testable without spawning. Returns
+// the process exit code; writes through the injected sinks only.
+export function runCli(argv, { out = (s) => process.stdout.write(s), err = (s) => process.stderr.write(s), collect = collectConfigDump } = {}) {
+  const args = argv ?? [];
+  if (args.includes("-h") || args.includes("--help")) {
+    out(USAGE);
+    return 0;
+  }
+  const cmd = args.find((a) => !a.startsWith("-"));
+  if (!cmd) {
+    err("catalyst-config: a command is required\n\n" + USAGE);
+    return 2;
+  }
+  if (cmd !== "dump") {
+    err(`catalyst-config: unknown command: ${cmd}\n\n` + USAGE);
+    return 2;
+  }
+  const d = collect();
+  out((args.includes("--json") ? renderJson(d) : renderHuman(d)) + "\n");
+  return 0;
+}
+
+// Cross-runtime main guard (mirrors doctor.mjs). Importing this module — which
+// doctor.mjs does — never runs the CLI, because argv[1] is then the importer.
+const isMain = process.argv[1] && process.argv[1].endsWith("config-dump.mjs");
+if (isMain) process.exit(runCli(process.argv.slice(2)));

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -66,21 +66,30 @@ export const PROVENANCE = Object.freeze({
 
 // ─── env-file parsing ────────────────────────────────────────────────────────
 
-// parseEnvFileAssignments — every `[export ]KEY=value` assignment in an env-file
-// body, as a plain object. The daemon launcher `source`s ~/.config/catalyst/
-// execution-core.env, so these assignments are part of the daemon's EFFECTIVE env
-// even when the operator's interactive shell never exported them. Quotes are
-// stripped; `#` comment lines and blanks are skipped. Never throws.
+// parseEnvFileEntries — every `[export ]KEY=value` assignment in an env-file body,
+// as `{ key, value, exported }` records. Quotes are stripped; `#` comment lines and
+// blanks are skipped. Never throws.
+//
+// `exported` is load-bearing, not decoration. The launcher plain-`source`s
+// ~/.config/catalyst/execution-core.env with NO `set -a`
+// (catalyst-execution-core:214), and a child process inherits only EXPORTED
+// variables. So a bare `CATALYST_STALL_JANITOR=enforce` becomes a variable of the
+// launcher shell that the nohup'd daemon never sees — a fact the launcher itself
+// already documents at :134 ("A bare shell var satisfies ${!key} but is NOT
+// inherited by the nohup'd daemon child"), which is why it explicitly re-`export`s
+// the OTEL keys at :151. Reporting a bare assignment as in-force would be this
+// tool asserting exactly what the reader would NOT produce.
 //
 // This is the whole-file generalization of doctor.mjs's per-key parseEnvFileFlag /
 // overlayDaemonDrainEnv idiom — a line scan, so it needs no dynamic RegExp.
-export function parseEnvFileAssignments(text) {
-  const out = {};
+export function parseEnvFileEntries(text) {
+  const out = [];
   if (typeof text !== "string" || text === "") return out;
   for (const rawLine of text.split("\n")) {
     const line = rawLine.trim();
     if (line === "" || line.startsWith("#")) continue;
-    const body = line.startsWith("export ") ? line.slice(7).trim() : line;
+    const exported = line.startsWith("export ");
+    const body = exported ? line.slice(7).trim() : line;
     const eq = body.indexOf("=");
     if (eq <= 0) continue;
     const key = body.slice(0, eq).trim();
@@ -90,17 +99,37 @@ export function parseEnvFileAssignments(text) {
     if (value.length >= 2 && ((value[0] === '"' && value.endsWith('"')) || (value[0] === "'" && value.endsWith("'")))) {
       value = value.slice(1, -1);
     }
-    out[key] = value;
+    out.push({ key, value, exported });
+  }
+  return out;
+}
+
+// parseEnvFileAssignments — ALL assignments, bare and exported alike, as a plain
+// object. This is the LAUNCHER SHELL's view: `source` sets both kinds as shell
+// variables, so both satisfy the launcher's own `[[ -z "${VAR:-}" ]]` guards.
+// It is NOT the daemon's view — use parseEnvFileExports for that.
+export function parseEnvFileAssignments(text) {
+  const out = {};
+  for (const { key, value } of parseEnvFileEntries(text)) out[key] = value;
+  return out;
+}
+
+// parseEnvFileExports — only the `export`ed assignments: the subset the nohup'd
+// daemon child actually inherits.
+export function parseEnvFileExports(text) {
+  const out = {};
+  for (const { key, value, exported } of parseEnvFileEntries(text)) {
+    if (exported) out[key] = value;
   }
   return out;
 }
 
 // overlayEnvFile — the daemon's effective env: ambient env with the env-file's
-// assignments layered ON TOP. File wins, matching `source` semantics (the launcher
-// sources the file AFTER inheriting the ambient env). Mirrors doctor.mjs's
-// overlayDaemonDrainEnv, generalized to every key.
+// EXPORTED assignments layered ON TOP. File wins, matching `source` semantics (the
+// launcher sources the file AFTER inheriting the ambient env). Bare assignments are
+// deliberately excluded — see parseEnvFileEntries.
 export function overlayEnvFile(env = {}, envFileText = "") {
-  return { ...env, ...parseEnvFileAssignments(envFileText) };
+  return { ...env, ...parseEnvFileExports(envFileText) };
 }
 
 // ─── daemon-visible Layer-1 resolution ───────────────────────────────────────
@@ -128,9 +157,31 @@ export function resolveDaemonLayer1Path({
   const effective = overlayEnvFile(env, execCoreEnvText);
   const pin = effective.CATALYST_CONFIG_FILE;
   if (typeof pin === "string" && pin !== "") {
-    const fromFile = Object.hasOwn(parseEnvFileAssignments(execCoreEnvText), "CATALYST_CONFIG_FILE");
+    const fromFile = Object.hasOwn(parseEnvFileExports(execCoreEnvText), "CATALYST_CONFIG_FILE");
     return { path: pin, source: fromFile ? "exec-core-env-file" : "env", pinned: true };
   }
+
+  // A BARE `CATALYST_CONFIG_FILE=...` in the env file is the worst of both worlds,
+  // and silent. The launcher's auto-pin is guarded by
+  // `[[ -z "${CATALYST_CONFIG_FILE:-}" ]]` (:341), which a bare assignment
+  // SATISFIES AS SET — so the launcher skips pinning — while the nohup'd daemon
+  // child never inherits it. The daemon therefore falls all the way through to its
+  // own cwd-relative resolution, reading a Layer-1 file the operator believes they
+  // pinned away. Report that state distinctly rather than folding it into the
+  // ordinary unpinned case.
+  const bareAssignments = parseEnvFileAssignments(execCoreEnvText);
+  const barePin = Object.hasOwn(bareAssignments, "CATALYST_CONFIG_FILE")
+    ? bareAssignments.CATALYST_CONFIG_FILE
+    : null;
+  if (typeof barePin === "string" && barePin !== "") {
+    return {
+      path: null,
+      source: "daemon-cwd",
+      pinned: false,
+      barePinSuppressed: barePin,
+    };
+  }
+
   if (typeof catalystDir === "string" && catalystDir !== "") {
     const candidate = resolve(catalystDir, ".catalyst", "config.json");
     if (exists(candidate)) return { path: candidate, source: "catalyst-dir", pinned: true };
@@ -576,7 +627,16 @@ export function dumpConfig({
 
   const rows = keys.map((row) => resolveRow(row, { env: effectiveEnv, layer1: l1.parsed, layer2: l2.parsed }));
 
-  const envFileKeys = Object.keys(parseEnvFileAssignments(execCoreEnvText)).sort();
+  const envFileEntries = parseEnvFileEntries(execCoreEnvText);
+  const envFileKeys = [...new Set(envFileEntries.map((e) => e.key))].sort();
+  // Keys assigned WITHOUT `export`: present in the file, set in the launcher shell,
+  // and never inherited by the daemon child. An operator reading the file sees them
+  // as in-force; the daemon does not. Naming them is the whole point of this tool.
+  const bareKeys = [
+    ...new Set(envFileEntries.filter((e) => !e.exported).map((e) => e.key)),
+  ]
+    .filter((k) => !envFileEntries.some((e) => e.key === k && e.exported))
+    .sort();
 
   const hostRow = rows.find((r) => r.key === "catalyst.host.name");
   const resolvedHost =
@@ -600,7 +660,7 @@ export function dumpConfig({
       parsed: l2.ok,
     },
     // The env file's KEY SET is itself a divergence signal — values are never emitted.
-    execCoreEnv: { path: execCoreEnvPath, present: execCoreEnvText !== "", keys: envFileKeys },
+    execCoreEnv: { path: execCoreEnvPath, present: execCoreEnvText !== "", keys: envFileKeys, bareKeys },
     daemonLayer1,
     rows,
     fingerprint: fingerprintRows(rows),
@@ -625,11 +685,31 @@ function readOrNull(path) {
 // ladders getCatalystRepoDir() and getLayer2ConfigPath() use.
 export function collectConfigDump({ env = process.env, cwd = process.cwd(), now = new Date() } = {}) {
   const home = env.HOME || "";
-  const layer1Path = env.CATALYST_CONFIG_FILE || resolve(cwd, ".catalyst", "config.json");
   const layer2Path = env.CATALYST_LAYER2_CONFIG_FILE || resolve(home, ".config", "catalyst", "config.json");
   const execCoreEnvPath = env.CATALYST_EXECUTION_CORE_ENV || resolve(home, ".config", "catalyst", "execution-core.env");
   const execCoreEnvText = readOrNull(execCoreEnvPath) ?? "";
   const catalystDir = env.CATALYST_DIR || resolve(home, "catalyst");
+
+  // Resolve the daemon's Layer-1 FIRST, then read THAT file. Order matters: the
+  // env file is what carries a per-host `export CATALYST_CONFIG_FILE` pin, so a
+  // Layer-1 path taken from the raw ambient env (or this process's cwd) can name a
+  // different file than the daemon reads. Every Layer-1-derived row AND the
+  // fingerprint come from the bytes read here, so resolving them from the caller's
+  // cwd while REPORTING the daemon's path would make the dump disagree with itself
+  // in precisely the per-host-pin scenario it exists to diagnose.
+  const daemonLayer1 = resolveDaemonLayer1Path({
+    env,
+    execCoreEnvText,
+    catalystDir,
+    exists: (p) => readOrNull(p) !== null,
+  });
+  // When the daemon's ladder falls through to its own launch cwd (unknowable from
+  // here), fall back to this process's cwd — the pre-existing behavior, and the
+  // dump already labels that state `pinned: false` so the reader knows the Layer-1
+  // shown is an inference rather than the daemon's own resolution.
+  const layer1Path = daemonLayer1.pinned && daemonLayer1.path
+    ? daemonLayer1.path
+    : env.CATALYST_CONFIG_FILE || resolve(cwd, ".catalyst", "config.json");
 
   return dumpConfig({
     env,
@@ -641,12 +721,7 @@ export function collectConfigDump({ env = process.env, cwd = process.cwd(), now 
     layer2Text: readOrNull(layer2Path),
     execCoreEnvPath,
     execCoreEnvText,
-    daemonLayer1: resolveDaemonLayer1Path({
-      env,
-      execCoreEnvText,
-      catalystDir,
-      exists: (p) => readOrNull(p) !== null,
-    }),
+    daemonLayer1,
   });
 }
 

--- a/plugins/dev/scripts/execution-core/config-dump.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.test.mjs
@@ -9,20 +9,24 @@
 //       source files, so a rename in a reader breaks this test instead of
 //       silently drifting the dump.
 
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
   CONFIG_KEYS,
   DUMP_SCHEMA,
+  collectConfigDump,
   PROVENANCE,
   dumpConfig,
   fingerprintRows,
   getPath,
   overlayEnvFile,
   parseEnvFileAssignments,
+  parseEnvFileEntries,
+  parseEnvFileExports,
   renderHuman,
   renderJson,
   resolveDaemonLayer1Path,
@@ -58,7 +62,28 @@ describe("env-file parsing (the daemon's effective env)", () => {
   });
 
   test("file wins over ambient env (matches `source` semantics)", () => {
-    expect(overlayEnvFile({ X: "ambient", Y: "keep" }, "X=file")).toEqual({ X: "file", Y: "keep" });
+    expect(overlayEnvFile({ X: "ambient", Y: "keep" }, "export X=file")).toEqual({ X: "file", Y: "keep" });
+  });
+
+  // The launcher plain-`source`s the env file with NO `set -a`
+  // (catalyst-execution-core:214), and a child inherits only EXPORTED vars. Both
+  // live fleet files export every assignment (mini 23/23, mini-2 14/14), so this
+  // distinction is a guard against a future bare line, not a description of today.
+  test("a BARE assignment is not part of the daemon's effective env", () => {
+    expect(overlayEnvFile({ Y: "keep" }, "X=bare")).toEqual({ Y: "keep" });
+    expect(overlayEnvFile({ X: "ambient" }, "X=bare")).toEqual({ X: "ambient" });
+  });
+
+  test("parseEnvFileEntries records the export flag per assignment", () => {
+    expect(parseEnvFileEntries("export A=1\nB=2\n")).toEqual([
+      { key: "A", value: "1", exported: true },
+      { key: "B", value: "2", exported: false },
+    ]);
+  });
+
+  test("parseEnvFileAssignments keeps the launcher-shell view (bare included)", () => {
+    expect(parseEnvFileAssignments("export A=1\nB=2\n")).toEqual({ A: "1", B: "2" });
+    expect(parseEnvFileExports("export A=1\nB=2\n")).toEqual({ A: "1" });
   });
 
   test("never throws on garbage input", () => {
@@ -69,12 +94,12 @@ describe("env-file parsing (the daemon's effective env)", () => {
 
 describe("daemon-visible Layer-1 resolution", () => {
   test("an env-file CATALYST_CONFIG_FILE pin is the daemon's Layer-1", () => {
-    const r = resolveDaemonLayer1Path({ env: {}, execCoreEnvText: "CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json" });
+    const r = resolveDaemonLayer1Path({ env: {}, execCoreEnvText: "export CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json" });
     expect(r).toEqual({ path: "/plugin-source/.catalyst/config.json", source: "exec-core-env-file", pinned: true });
   });
 
   test("the env-file pin beats an ambient one (the launcher sources the file last)", () => {
-    const r = resolveDaemonLayer1Path({ env: { CATALYST_CONFIG_FILE: "/ambient/c.json" }, execCoreEnvText: "CATALYST_CONFIG_FILE=/file/c.json" });
+    const r = resolveDaemonLayer1Path({ env: { CATALYST_CONFIG_FILE: "/ambient/c.json" }, execCoreEnvText: "export CATALYST_CONFIG_FILE=/file/c.json" });
     expect(r.path).toBe("/file/c.json");
     expect(r.source).toBe("exec-core-env-file");
   });
@@ -89,6 +114,105 @@ describe("daemon-visible Layer-1 resolution", () => {
   test("no pin and no CATALYST_DIR candidate ⇒ UNPINNED (the measured mini state)", () => {
     const r = resolveDaemonLayer1Path({ env: {}, execCoreEnvText: "CATALYST_EXECUTOR=sdk\n", catalystDir: "/home/u/catalyst", exists: () => false });
     expect(r).toEqual({ path: null, source: "daemon-cwd", pinned: false });
+  });
+
+  // Codex P2, sharp edge: a BARE CATALYST_CONFIG_FILE satisfies the launcher's
+  // `[[ -z "${CATALYST_CONFIG_FILE:-}" ]]` guard (:341) so the auto-pin is SKIPPED,
+  // while the nohup'd daemon child never inherits it. The daemon therefore falls
+  // through to its own cwd — the operator believes they pinned it, and did not.
+  test("a BARE CATALYST_CONFIG_FILE suppresses the auto-pin AND does not reach the daemon", () => {
+    const r = resolveDaemonLayer1Path({
+      env: {},
+      execCoreEnvText: "CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json\n",
+      catalystDir: "/home/u/catalyst",
+      exists: () => true, // the auto-pin candidate EXISTS and is still not used
+    });
+    expect(r.pinned).toBe(false);
+    expect(r.path).toBeNull();
+    expect(r.barePinSuppressed).toBe("/plugin-source/.catalyst/config.json");
+  });
+
+  test("an EXPORTED pin still wins over the CATALYST_DIR candidate", () => {
+    const r = resolveDaemonLayer1Path({
+      env: {},
+      execCoreEnvText: "export CATALYST_CONFIG_FILE=/pinned/config.json\n",
+      catalystDir: "/home/u/catalyst",
+      exists: () => true,
+    });
+    expect(r).toEqual({ path: "/pinned/config.json", source: "exec-core-env-file", pinned: true });
+  });
+});
+
+// Codex P1: collectConfigDump selected and READ Layer-1 before loading the daemon
+// env file, so `daemonLayer1` named the pinned file while every Layer-1-derived row
+// and the fingerprint were computed from the caller's cwd file — the dump
+// disagreeing with itself in exactly the per-host-pin scenario it exists to
+// diagnose. These tests do real (read-only) I/O over a tmp fixture tree.
+describe("collectConfigDump — Layer-1 is read from the DAEMON's resolution", () => {
+  const dirs = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+  function tree() {
+    const root = mkdtempSync(resolve(tmpdir(), "config-dump-collect-"));
+    dirs.push(root);
+    const home = resolve(root, "home");
+    const cwd = resolve(root, "cwd");
+    const pinned = resolve(root, "pinned");
+    mkdirSync(resolve(home, ".config", "catalyst"), { recursive: true });
+    mkdirSync(resolve(cwd, ".catalyst"), { recursive: true });
+    mkdirSync(resolve(pinned, ".catalyst"), { recursive: true });
+    // Two DIFFERENT Layer-1 files, disagreeing on a genuinely Layer-1-backed key.
+    // Under the old ordering the dump NAMED the pinned file while reading cwd's, so
+    // this row would read "phase-agents" — the caller's answer, not the daemon's.
+    writeFileSync(
+      resolve(pinned, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { orchestration: { dispatchMode: "execution-core" } } }),
+    );
+    writeFileSync(
+      resolve(cwd, ".catalyst", "config.json"),
+      JSON.stringify({ catalyst: { orchestration: { dispatchMode: "phase-agents" } } }),
+    );
+    return { root, home, cwd, pinnedPath: resolve(pinned, ".catalyst", "config.json") };
+  }
+
+  test("an exported env-file pin drives the ROWS and the fingerprint, not just the label", () => {
+    const { home, cwd, pinnedPath } = tree();
+    writeFileSync(
+      resolve(home, ".config", "catalyst", "execution-core.env"),
+      `export CATALYST_CONFIG_FILE=${pinnedPath}\n`,
+    );
+    const d = collectConfigDump({ env: { HOME: home }, cwd, now: new Date(0) });
+
+    expect(d.daemonLayer1.pinned).toBe(true);
+    expect(d.daemonLayer1.path).toBe(pinnedPath);
+    // The label and the bytes now agree...
+    expect(d.layer1.path).toBe(pinnedPath);
+    // ...so the row reflects the file the DAEMON reads, not the caller's cwd.
+    expect(row(d, "catalyst.orchestration.dispatchMode").value).toBe("execution-core");
+  });
+
+  test("with no pin, Layer-1 still falls back to the caller's cwd and says it is unpinned", () => {
+    const { home, cwd } = tree();
+    writeFileSync(resolve(home, ".config", "catalyst", "execution-core.env"), "export CATALYST_EXECUTOR=sdk\n");
+    const d = collectConfigDump({ env: { HOME: home }, cwd, now: new Date(0) });
+    expect(d.daemonLayer1.pinned).toBe(false);
+    expect(d.layer1.path).toBe(resolve(cwd, ".catalyst", "config.json"));
+    expect(row(d, "catalyst.orchestration.dispatchMode").value).toBe("phase-agents");
+  });
+
+  test("bareKeys names env-file keys the daemon never receives", () => {
+    const { home, cwd } = tree();
+    writeFileSync(
+      resolve(home, ".config", "catalyst", "execution-core.env"),
+      "export CATALYST_EXECUTOR=sdk\nCATALYST_STALL_JANITOR=enforce\n",
+    );
+    const d = collectConfigDump({ env: { HOME: home }, cwd, now: new Date(0) });
+    expect(d.execCoreEnv.keys).toContain("CATALYST_STALL_JANITOR");
+    expect(d.execCoreEnv.bareKeys).toEqual(["CATALYST_STALL_JANITOR"]);
+    // ...and the bare override is NOT reported as in force.
+    expect(row(d, "catalyst.stallJanitor.mode").value).toBe("shadow");
   });
 });
 
@@ -271,8 +395,8 @@ describe("fingerprint", () => {
 
   // The headline use case: the two live worker hosts must NOT fingerprint alike.
   test("the measured mini / mini-2 divergence produces different fingerprints", () => {
-    const mini = dump({ execCoreEnvText: "CATALYST_STALL_JANITOR=enforce\nCATALYST_UNSTUCK_SWEEP=enforce\nCATALYST_DEAD_DOC_WORKER_RECLAIM=enforce\n" });
-    const mini2 = dump({ execCoreEnvText: "CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json\n" });
+    const mini = dump({ execCoreEnvText: "export CATALYST_STALL_JANITOR=enforce\nexport CATALYST_UNSTUCK_SWEEP=enforce\nexport CATALYST_DEAD_DOC_WORKER_RECLAIM=enforce\n" });
+    const mini2 = dump({ execCoreEnvText: "export CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json\n" });
     expect(mini.fingerprint).not.toBe(mini2.fingerprint);
   });
 });

--- a/plugins/dev/scripts/execution-core/config-dump.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.test.mjs
@@ -1,0 +1,398 @@
+// config-dump.test.mjs — CTL-1793.
+// Run: cd plugins/dev/scripts/execution-core && bun test config-dump.test.mjs
+//
+// The dump is a DESCRIPTION of the real resolution ladders, so the tests come in
+// three families:
+//   (1) provenance — each layer wins where it should, per kind;
+//   (2) safety — no secret value can reach either renderer;
+//   (3) DRIFT — every env var and dotted key in CONFIG_KEYS is pinned to the real
+//       source files, so a rename in a reader breaks this test instead of
+//       silently drifting the dump.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  CONFIG_KEYS,
+  DUMP_SCHEMA,
+  PROVENANCE,
+  dumpConfig,
+  fingerprintRows,
+  getPath,
+  overlayEnvFile,
+  parseEnvFileAssignments,
+  renderHuman,
+  renderJson,
+  resolveDaemonLayer1Path,
+  resolveRow,
+} from "./config-dump.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS = resolve(HERE, "..");
+
+const row = (dump, key) => dump.rows.find((r) => r.key === key);
+
+// A minimal dump over injected fixtures — zero ambient I/O.
+function dump(over = {}) {
+  return dumpConfig({
+    env: {},
+    host: "test-host",
+    generatedAt: "2026-08-11T00:00:00.000Z",
+    layer1Path: "/repo/.catalyst/config.json",
+    layer2Path: "/home/u/.config/catalyst/config.json",
+    layer1Text: null,
+    layer2Text: null,
+    execCoreEnvText: "",
+    ...over,
+  });
+}
+
+describe("env-file parsing (the daemon's effective env)", () => {
+  test("parses export/bare/quoted assignments and skips comments", () => {
+    const parsed = parseEnvFileAssignments(
+      ["# a comment", "", 'export CATALYST_STALL_JANITOR="enforce"', "CATALYST_BOARD_HEALTH=shadow", "  export A='b'  ", "not-an-assignment"].join("\n"),
+    );
+    expect(parsed).toEqual({ CATALYST_STALL_JANITOR: "enforce", CATALYST_BOARD_HEALTH: "shadow", A: "b" });
+  });
+
+  test("file wins over ambient env (matches `source` semantics)", () => {
+    expect(overlayEnvFile({ X: "ambient", Y: "keep" }, "X=file")).toEqual({ X: "file", Y: "keep" });
+  });
+
+  test("never throws on garbage input", () => {
+    expect(parseEnvFileAssignments(undefined)).toEqual({});
+    expect(parseEnvFileAssignments("=novalue\n1BAD=x\n")).toEqual({});
+  });
+});
+
+describe("daemon-visible Layer-1 resolution", () => {
+  test("an env-file CATALYST_CONFIG_FILE pin is the daemon's Layer-1", () => {
+    const r = resolveDaemonLayer1Path({ env: {}, execCoreEnvText: "CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json" });
+    expect(r).toEqual({ path: "/plugin-source/.catalyst/config.json", source: "exec-core-env-file", pinned: true });
+  });
+
+  test("the env-file pin beats an ambient one (the launcher sources the file last)", () => {
+    const r = resolveDaemonLayer1Path({ env: { CATALYST_CONFIG_FILE: "/ambient/c.json" }, execCoreEnvText: "CATALYST_CONFIG_FILE=/file/c.json" });
+    expect(r.path).toBe("/file/c.json");
+    expect(r.source).toBe("exec-core-env-file");
+  });
+
+  test("with no pin, the CATALYST_DIR candidate is used only when it EXISTS", () => {
+    const present = resolveDaemonLayer1Path({ catalystDir: "/home/u/catalyst", exists: () => true });
+    expect(present).toEqual({ path: "/home/u/catalyst/.catalyst/config.json", source: "catalyst-dir", pinned: true });
+  });
+
+  // THE mini BUG: no CATALYST_CONFIG_FILE anywhere and no ~/catalyst/.catalyst/config.json,
+  // so the daemon silently falls back to whatever cwd it was launched from.
+  test("no pin and no CATALYST_DIR candidate ⇒ UNPINNED (the measured mini state)", () => {
+    const r = resolveDaemonLayer1Path({ env: {}, execCoreEnvText: "CATALYST_EXECUTOR=sdk\n", catalystDir: "/home/u/catalyst", exists: () => false });
+    expect(r).toEqual({ path: null, source: "daemon-cwd", pinned: false });
+  });
+});
+
+describe("provenance — mode knobs", () => {
+  const L2 = JSON.stringify({ catalyst: { stallJanitor: { mode: "shadow" } } });
+
+  test("default when neither env nor config supplies a mode", () => {
+    const r = row(dump(), "catalyst.stallJanitor.mode");
+    expect(r.value).toBe("shadow"); // readStallJanitorConfig's conservative default
+    expect(r.provenance).toBe(PROVENANCE.DEFAULT);
+    expect(r.layer).toBeNull();
+  });
+
+  test("Layer-2 wins over the default and is labelled with its layer", () => {
+    const r = row(dump({ layer2Text: JSON.stringify({ catalyst: { unstuckSweep: { mode: "enforce" } } }) }), "catalyst.unstuckSweep.mode");
+    expect(r.value).toBe("enforce");
+    expect(r.provenance).toBe(PROVENANCE.CONFIG);
+    expect(r.layer).toBe("layer2");
+  });
+
+  test("env beats Layer-2 and names the winning variable", () => {
+    const r = row(dump({ env: { CATALYST_STALL_JANITOR: "enforce" }, layer2Text: L2 }), "catalyst.stallJanitor.mode");
+    expect(r.value).toBe("enforce");
+    expect(r.provenance).toBe(PROVENANCE.ENV);
+    expect(r.envVar).toBe("CATALYST_STALL_JANITOR");
+  });
+
+  test('the "0" kill-switch is an env override resolving to off', () => {
+    const r = row(dump({ env: { CATALYST_BOARD_HEALTH: "0" } }), "catalyst.boardHealth.mode");
+    expect(r.value).toBe("off");
+    expect(r.provenance).toBe(PROVENANCE.ENV);
+  });
+
+  test("an env value that is not a valid mode does NOT win (falls through to config/default)", () => {
+    const r = row(dump({ env: { CATALYST_STALL_JANITOR: "enfroce" }, layer2Text: L2 }), "catalyst.stallJanitor.mode");
+    expect(r.provenance).toBe(PROVENANCE.CONFIG);
+    expect(r.value).toBe("shadow");
+  });
+
+  // THE MEASURED DIVERGENCE: an env-file-only override is invisible to a naive
+  // process.env read, but it is what the daemon actually runs with.
+  test("an env-file-only override is reported as an env override (the mini vs mini-2 gap)", () => {
+    const d = dump({ execCoreEnvText: "export CATALYST_UNSTUCK_SWEEP=enforce\nexport CATALYST_STALL_JANITOR=enforce\n" });
+    expect(row(d, "catalyst.unstuckSweep.mode").value).toBe("enforce");
+    expect(row(d, "catalyst.unstuckSweep.mode").provenance).toBe(PROVENANCE.ENV);
+    expect(row(d, "catalyst.stallJanitor.mode").value).toBe("enforce");
+  });
+});
+
+describe("provenance — beliefs flags, merges, and plain values", () => {
+  test('a beliefs flag reads env "1"/"0" first, then the Layer-2 boolean', () => {
+    expect(row(dump({ env: { CATALYST_DIAGNOSTICIAN: "1" } }), "catalyst.governance.diagnostician")).toMatchObject({
+      value: true,
+      provenance: PROVENANCE.ENV,
+    });
+    expect(
+      row(dump({ layer2Text: JSON.stringify({ catalyst: { governance: { diagnostician: true } } }) }), "catalyst.governance.diagnostician"),
+    ).toMatchObject({ value: true, provenance: PROVENANCE.CONFIG, layer: "layer2" });
+    expect(row(dump(), "catalyst.governance.diagnostician")).toMatchObject({ value: false, provenance: PROVENANCE.DEFAULT });
+  });
+
+  test("executionCore concurrency: a positive-int Layer-2 wins per field over Layer-1", () => {
+    const d = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 4, minParallel: 1 } } } }),
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 6 } } } }),
+    });
+    expect(row(d, "catalyst.orchestration.executionCore.maxParallel")).toMatchObject({ value: 6, layer: "layer2" });
+    // minParallel is absent from Layer-2 → the Layer-1 seed survives.
+    expect(row(d, "catalyst.orchestration.executionCore.minParallel")).toMatchObject({ value: 1, layer: "layer1" });
+  });
+
+  test("a malformed (non-positive-int) Layer-2 never caps a healthy Layer-1", () => {
+    const d = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } }),
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 0 } } } }),
+    });
+    expect(row(d, "catalyst.orchestration.executionCore.maxParallel")).toMatchObject({ value: 4, layer: "layer1" });
+  });
+
+  test("a Layer-1-only knob is reported from layer1", () => {
+    const d = dump({ layer1Text: JSON.stringify({ catalyst: { orchestration: { dispatchMode: "phase-agents" } } }) });
+    expect(row(d, "catalyst.orchestration.dispatchMode")).toMatchObject({ value: "phase-agents", layer: "layer1" });
+  });
+
+  test("a Layer-2-only knob reports layer2 and is overridden by its env var", () => {
+    const l2 = JSON.stringify({ catalyst: { node: { class: "monitor" } } });
+    expect(row(dump({ layer2Text: l2 }), "catalyst.node.class")).toMatchObject({ value: "monitor", layer: "layer2" });
+    expect(row(dump({ layer2Text: l2, env: { CATALYST_NODE_CLASS: "worker" } }), "catalyst.node.class")).toMatchObject({
+      value: "worker",
+      provenance: PROVENANCE.ENV,
+    });
+  });
+});
+
+describe("layer health is reported honestly", () => {
+  test("an absent Layer-1 is present:false, and every row falls to its default", () => {
+    const d = dump();
+    expect(d.layer1).toMatchObject({ present: false, parsed: false, hasOrchestration: false });
+    expect(d.rows.every((r) => r.provenance === PROVENANCE.DEFAULT)).toBe(true);
+  });
+
+  test("a MALFORMED Layer-1 is present-but-unparsed, never a crash", () => {
+    const d = dump({ layer1Text: "{ not json" });
+    expect(d.layer1).toMatchObject({ present: true, parsed: false, hasOrchestration: false });
+  });
+
+  // The single most diagnostic Layer-1 fact measured on the live fleet: mini's
+  // daemon reads a config with NO orchestration stanza, so every Layer-1-driven
+  // feature runs on defaults with nothing surfaced anywhere.
+  test("hasOrchestration distinguishes a real config from one missing the stanza", () => {
+    expect(dump({ layer1Text: JSON.stringify({ catalyst: { monitor: {} } }) }).layer1.hasOrchestration).toBe(false);
+    expect(dump({ layer1Text: JSON.stringify({ catalyst: { orchestration: {} } }) }).layer1.hasOrchestration).toBe(true);
+  });
+
+  test("the env-file KEY SET is reported (names only) — itself a divergence signal", () => {
+    const d = dump({ execCoreEnvText: "CATALYST_STALL_JANITOR=enforce\nLINEAR_API_TOKEN=lin_api_supersecret\n" });
+    expect(d.execCoreEnv.keys).toEqual(["CATALYST_STALL_JANITOR", "LINEAR_API_TOKEN"]);
+    expect(JSON.stringify(d)).not.toContain("lin_api_supersecret");
+  });
+});
+
+describe("secrets are reported as presence only, never as values", () => {
+  const SECRET = "lin_api_THIS_MUST_NEVER_APPEAR";
+
+  test("a secret row reports set/unset", () => {
+    expect(row(dump(), "secrets.LINEAR_API_TOKEN")).toMatchObject({ value: "unset", secret: true });
+    expect(row(dump({ env: { LINEAR_API_TOKEN: SECRET } }), "secrets.LINEAR_API_TOKEN")).toMatchObject({ value: "set", secret: true });
+  });
+
+  test("no registered secret's value appears in EITHER renderer", () => {
+    const d = dump({
+      env: { LINEAR_API_TOKEN: SECRET, CATALYST_WORKFLOW_GITHUB_TOKEN: "ghp_secret", CATALYST_CLOUD_TOKEN: "cloud_secret", GROQ_API_KEY: "gsk_secret" },
+      execCoreEnvText: `LINEAR_API_TOKEN=${SECRET}\n`,
+    });
+    for (const text of [renderJson(d), renderHuman(d)]) {
+      for (const leak of [SECRET, "ghp_secret", "cloud_secret", "gsk_secret"]) {
+        expect(text).not.toContain(leak);
+      }
+    }
+  });
+
+  test("every registry row whose env var LOOKS credential-shaped is marked secret", () => {
+    for (const r of CONFIG_KEYS) {
+      const credentialShaped = (r.env ?? []).some((n) => /TOKEN|SECRET|PASSWORD|_KEY$/.test(n));
+      if (credentialShaped) expect(r.secret).toBe(true);
+    }
+  });
+
+  test("no secret row declares a config-file key (there is no path for a value to arrive)", () => {
+    for (const r of CONFIG_KEYS.filter((x) => x.secret)) {
+      expect(r.layer1).toBeNull();
+      expect(r.layer2).toBeNull();
+    }
+  });
+});
+
+describe("fingerprint", () => {
+  test("is stable across JSON key order and whitespace", () => {
+    const a = dump({ layer2Text: '{"catalyst":{"stallJanitor":{"mode":"enforce"},"boardHealth":{"mode":"shadow"}}}' });
+    const b = dump({ layer2Text: '{\n  "catalyst": {\n    "boardHealth": { "mode": "shadow" },\n    "stallJanitor": { "mode": "enforce" }\n  }\n}\n' });
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  test("is host- and timestamp-independent (so two hosts are comparable)", () => {
+    const a = dump({ host: "mini", generatedAt: "2026-01-01T00:00:00.000Z" });
+    const b = dump({ host: "mini-2", generatedAt: "2026-12-31T23:59:59.000Z" });
+    expect(a.fingerprint).toBe(b.fingerprint);
+  });
+
+  test("changes when a VALUE changes", () => {
+    expect(dump().fingerprint).not.toBe(dump({ env: { CATALYST_STALL_JANITOR: "enforce" } }).fingerprint);
+  });
+
+  test("changes when only the LAYER changes, at an identical value", () => {
+    const viaEnv = dump({ env: { CATALYST_UNSTUCK_SWEEP: "enforce" } });
+    const viaCfg = dump({ layer2Text: JSON.stringify({ catalyst: { unstuckSweep: { mode: "enforce" } } }) });
+    expect(row(viaEnv, "catalyst.unstuckSweep.mode").value).toBe(row(viaCfg, "catalyst.unstuckSweep.mode").value);
+    expect(viaEnv.fingerprint).not.toBe(viaCfg.fingerprint);
+  });
+
+  // The headline use case: the two live worker hosts must NOT fingerprint alike.
+  test("the measured mini / mini-2 divergence produces different fingerprints", () => {
+    const mini = dump({ execCoreEnvText: "CATALYST_STALL_JANITOR=enforce\nCATALYST_UNSTUCK_SWEEP=enforce\nCATALYST_DEAD_DOC_WORKER_RECLAIM=enforce\n" });
+    const mini2 = dump({ execCoreEnvText: "CATALYST_CONFIG_FILE=/plugin-source/.catalyst/config.json\n" });
+    expect(mini.fingerprint).not.toBe(mini2.fingerprint);
+  });
+});
+
+describe("shape + renderers", () => {
+  test("the dump carries a schema id and one row per registry key", () => {
+    const d = dump();
+    expect(d.schema).toBe(DUMP_SCHEMA);
+    expect(d.rows).toHaveLength(CONFIG_KEYS.length);
+  });
+
+  test("--json output round-trips", () => {
+    expect(JSON.parse(renderJson(dump())).fingerprint).toBe(dump().fingerprint);
+  });
+
+  test("the human renderer names the unpinned daemon Layer-1 loudly", () => {
+    const text = renderHuman(dump({ daemonLayer1: { path: null, source: "daemon-cwd", pinned: false } }));
+    expect(text).toContain("UNPINNED");
+  });
+
+  test("getPath never throws on a missing ancestor", () => {
+    expect(getPath(null, "a.b")).toBeUndefined();
+    expect(getPath({ a: 1 }, "a.b")).toBeUndefined();
+  });
+
+  test("resolveRow is pure — no ambient env or file reads leak in", () => {
+    const r = CONFIG_KEYS.find((x) => x.key === "catalyst.stallJanitor.mode");
+    expect(resolveRow(r, {})).toMatchObject({ value: "shadow", provenance: PROVENANCE.DEFAULT });
+  });
+
+  test("fingerprintRows is order-insensitive over the row array", () => {
+    const rows = dump().rows;
+    expect(fingerprintRows(rows)).toBe(fingerprintRows([...rows].reverse()));
+  });
+});
+
+// ─── DRIFT GUARDS ────────────────────────────────────────────────────────────
+// The dump describes ladders it does not own. These tests pin the description to
+// the source: rename an env var or a config key in a reader and THIS breaks,
+// instead of the dump silently reporting a knob nobody reads any more.
+
+describe("registry drift guards", () => {
+  const SOURCES = [
+    "execution-core/config.mjs",
+    "execution-core/scheduler.mjs",
+    "execution-core/daemon.mjs",
+    "execution-core/worktree-refresh-timer.mjs",
+    "execution-core/linear-reconcile-timer.mjs",
+    "lib/deployment-mode.mjs",
+    "lib/draft-pr.sh",
+    "lib/secret-contract.mjs",
+    "orchestrate-register-interests.sh",
+  ]
+    .map((p) => {
+      try {
+        return readFileSync(resolve(SCRIPTS, p), "utf8");
+      } catch {
+        return "";
+      }
+    })
+    .join("\n");
+
+  test("the source corpus actually loaded (guards against a silently-empty grep)", () => {
+    expect(SOURCES.length).toBeGreaterThan(100_000);
+  });
+
+  test("every env var named by the registry exists in the source corpus", () => {
+    const missing = [];
+    for (const r of CONFIG_KEYS) for (const name of r.env ?? []) if (!SOURCES.includes(name)) missing.push(`${r.key} → ${name}`);
+    expect(missing).toEqual([]);
+  });
+
+  test("every dotted config key's LEAF segment appears in the source corpus", () => {
+    // Full dotted paths are written with optional chaining in the readers
+    // (`?.catalyst?.stallJanitor`), so the leaf + its parent are the honest
+    // greppable unit.
+    const missing = [];
+    for (const r of CONFIG_KEYS) {
+      for (const dotted of [r.layer1, r.layer2].filter(Boolean)) {
+        const parts = dotted.split(".");
+        const leaf = parts[parts.length - 1];
+        const parent = parts[parts.length - 2];
+        if (!SOURCES.includes(leaf)) missing.push(`${r.key} → leaf ${leaf}`);
+        else if (parent && !SOURCES.includes(parent)) missing.push(`${r.key} → parent ${parent}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("registry keys are unique and the registry is frozen", () => {
+    expect(new Set(CONFIG_KEYS.map((r) => r.key)).size).toBe(CONFIG_KEYS.length);
+    expect(Object.isFrozen(CONFIG_KEYS)).toBe(true);
+    expect(CONFIG_KEYS.every((r) => Object.isFrozen(r))).toBe(true);
+  });
+
+  test("every mode row shares the reader's OWN mode Set (not a copy)", () => {
+    for (const r of CONFIG_KEYS.filter((x) => x.kind === "mode")) {
+      expect(r.modes).toBeInstanceOf(Set);
+      expect(r.modes.size).toBeGreaterThan(0);
+    }
+  });
+
+  test("this module is importable under bare Node (doctor's runtime): no bun: imports in its graph", () => {
+    const self = readFileSync(resolve(HERE, "config-dump.mjs"), "utf8");
+    expect(self).not.toContain('from "bun:');
+  });
+
+  // The fingerprint separator is U+0000 (it cannot occur in a key or a mode
+  // string), but it must be written in SOURCE as the escape sequence, never as a
+  // raw byte: a literal NUL makes the whole file "binary" to grep, `git diff`, and
+  // review tooling — a `grep` for any symbol in it then returns NOTHING, silently.
+  // (This bit during development; the separator's runtime value is unchanged.)
+  // The needle is built at runtime so this test file cannot re-introduce the bug
+  // it is guarding against.
+  test("both source files are plain text — no raw NUL byte (grep/diff would treat them as binary)", () => {
+    const NUL = String.fromCharCode(0);
+    for (const f of ["config-dump.mjs", "config-dump.test.mjs"]) {
+      expect(readFileSync(resolve(HERE, f), "utf8").includes(NUL)).toBe(false);
+    }
+    // ...while the fingerprint stream still uses NUL as its separator.
+    expect(readFileSync(resolve(HERE, "config-dump.mjs"), "utf8")).toContain("\\u0000");
+  });
+});

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1730,7 +1730,8 @@ export const WATCHDOG_MINUTES_PER_TURN =
   Number(process.env.EXECUTION_CORE_WATCHDOG_MINUTES_PER_TURN) || 2;
 const WATCHDOG_MIN_PHASE_BUDGET_MS = 20 * 60_000; // absolute floor
 const WATCHDOG_FALLBACK_BUDGET_MS = 90 * 60_000; // when turnCap unparseable
-const WATCHDOG_MODES = new Set(["off", "shadow", "enforce"]);
+// CTL-1793: exported (additive) so config-dump.mjs shares one mode-set definition.
+export const WATCHDOG_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2Watchdog() {
   try {
@@ -1932,7 +1933,8 @@ export function phaseBudgetMs(phase, turnCap, cfg = readWatchdogConfig()) {
 // an operator flips it to "enforce". The janitor only collapses already-terminal,
 // unambiguous leftovers (orphan worktrees + idle ghost sessions); it never infers
 // liveness or advancement (that is belief-rule territory).
-const STALL_JANITOR_MODES = new Set(["off", "shadow", "enforce"]);
+// CTL-1793: exported (additive) so config-dump.mjs shares one mode-set definition.
+export const STALL_JANITOR_MODES = new Set(["off", "shadow", "enforce"]);
 // terminalIdleMs — how long a terminal phase signal must have been present before
 // an idle background session for the same subject is treated as a ghost (J2). The
 // Gherkin pins this at >=600s; matches the orphan-reaper's 600s timer cadence.
@@ -1990,7 +1992,8 @@ export function readStallJanitorConfig() {
 // OFF by default — operators opt in via shadow then enforce. Same three-layer
 // precedence as CTL-1004/CTL-1029 (env > Layer-2 catalyst.unstuckSweep.* >
 // code default). Runs as a low-frequency throttled Pass 0u (default 15 min).
-const UNSTUCK_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
+// CTL-1793: exported (additive) so config-dump.mjs shares one mode-set definition.
+export const UNSTUCK_SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
 export const UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS = 900_000; // 15 minutes
 
 function readLayer2UnstuckSweep() {
@@ -2035,7 +2038,8 @@ export function isThrottled(lastRunMs, intervalMs, nowMs) {
 // Mirrors readUnstuckSweepConfig exactly: env (CATALYST_RECOVERY_PASS) overrides
 // Layer-2 config (.catalyst.recovery.pass.mode), which overrides the safe
 // default of 'off'. Ships off (ADR-023); operators opt in to shadow then enforce.
-const RECOVERY_PASS_MODES = new Set(["off", "shadow", "enforce"]);
+// CTL-1793: exported (additive) so config-dump.mjs shares one mode-set definition.
+export const RECOVERY_PASS_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2RecoveryPass() {
   try {
@@ -2104,7 +2108,8 @@ export function readDelegateFirstConfig(envObj = process.env) {
 //   shadow  → measure + LOG the would-be death verdict, take NO action.
 //   enforce → set ghostAbsent and fall through to the existing revive path
 //             (under the CTL-736 progress gate + O_EXCL claim + CTL-638 cooldown).
-const DEAD_DOC_WORKER_MODES = new Set(["off", "shadow", "enforce"]);
+// CTL-1793: exported (additive) so config-dump.mjs shares one mode-set definition.
+export const DEAD_DOC_WORKER_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2DeadDocWorker() {
   try {
@@ -2526,14 +2531,18 @@ function readLayer2Governance() {
 
 // Three-layer beliefs flag: explicit env ("1"/"0") > Layer-2 boolean > default false.
 // Returns both the effective boolean and its source so the boot self-report can flag overrides.
-function resolveBeliefsFlag(envVal, l2Val) {
+// CTL-1793: `export` added (purely additive — no call site or behavior changes) so
+// config-dump.mjs can label a beliefs flag's provenance with THE SAME ladder the
+// daemon runs, instead of re-implementing it and silently drifting.
+export function resolveBeliefsFlag(envVal, l2Val) {
   if (envVal === "1") return { value: true, source: "env-override" };
   if (envVal === "0") return { value: false, source: "env-override" };
   if (typeof l2Val === "boolean") return { value: l2Val, source: "config" };
   return { value: false, source: "default" };
 }
 
-const BELIEFS_FLAGS = {
+// CTL-1793: exported for config-dump.mjs's registry (see resolveBeliefsFlag above).
+export const BELIEFS_FLAGS = {
   beliefsShadow: "CATALYST_BELIEFS_SHADOW",
   diagnostician: "CATALYST_DIAGNOSTICIAN",
   intentsEnforce: "CATALYST_INTENTS_ENFORCE",
@@ -2571,7 +2580,10 @@ export function readGovernanceConfig(env = process.env) {
 // (a valid Layer-2 mode) | "default". Governance modes were previously invisible
 // to the boot self-report (only BELIEFS_FLAGS were reported), so an operator
 // could not tell whether e.g. board-health enforce came from the env or Layer-2.
-function resolveModeSource(envVal, l2Mode, modes) {
+// CTL-1793: `export` added (purely additive) — config-dump.mjs labels every mode
+// knob's provenance through THIS function, so the dump can never disagree with the
+// daemon about which layer won.
+export function resolveModeSource(envVal, l2Mode, modes) {
   if (envVal === "0") return "env-override"; // kill-switch is an explicit env override
   if (typeof envVal === "string" && modes.has(envVal)) return "env-override";
   if (typeof l2Mode === "string" && modes.has(l2Mode)) return "config";

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -93,6 +93,11 @@ import { resolvePluginCheckoutRoots } from "../broker/plugin-refresh.mjs"; // CT
 import { shipsLogs, LABELS as MANIFEST_LABELS } from "./service-manifest.mjs"; // CTL-1473: per-class service manifest
 import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 import { listProjects } from "./registry.mjs";
+// CTL-1793: the per-key config-provenance view. Node-safe by construction — its
+// only non-node: import is config.mjs, which doctor already imports above; there
+// is no bun: protocol anywhere in its graph (asserted in config-dump.test.mjs).
+// Read-only and advisory: nothing in this module can change a grade to FAIL.
+import { collectConfigDump } from "./config-dump.mjs";
 
 // readLinearBotUserIds — inlined from daemon.mjs to avoid pulling in the full
 // daemon dependency chain (which includes bun: protocol imports incompatible
@@ -3454,6 +3459,163 @@ export function checkConfigScopeLeak(deps = {}) {
   return checks;
 }
 
+// ─── CTL-1793: config provenance + host-divergence advisory ─────────────────
+//
+// checkConfigProvenance — surfaces the two per-host config facts that today are
+// invisible to EVERY existing surface:
+//
+//   1. The Layer-1 file the DAEMON reads is not the one doctor grades. doctor's
+//      other config checks read either the plugin checkout's config (layer1Path())
+//      or doctor's own cwd (resolveDoctorLayer1Path()); the daemon reads whatever
+//      the launcher pinned via CATALYST_CONFIG_FILE — and when nothing pins it,
+//      whatever directory the daemon happened to be launched from. On a live
+//      worker host those were measured to be DIFFERENT FILES with different
+//      contents (one carrying no catalyst.orchestration stanza at all), so every
+//      Layer-1-driven feature ran on defaults with nothing surfaced anywhere.
+//   2. Which knobs are in force because of a per-host ENV OVERRIDE rather than a
+//      committed file — including overrides that live only in the daemon's
+//      execution-core.env and are therefore invisible to a naive process.env read.
+//
+// ADVISORY ONLY — this check never returns STATUS.FAIL, and that is enforced
+// structurally, not just by intent:
+//   • STATUS.FAIL is never referenced in this function;
+//   • the whole body is wrapped in one try/catch that degrades to INFO, so a throw
+//     can neither crash the suite (runDoctor's Promise.all has no per-check
+//     isolation) nor push the exit code off zero;
+//   • doctor.test.mjs asserts BOTH a fixture matrix (no fixture ever yields FAIL)
+//     and a source-level guard (this function's body contains no STATUS.FAIL), so
+//     a future edit that adds one fails CI immediately.
+// This matters because runDoctor returns the FAIL count as its exit code and
+// catalyst-join.sh gates member activation on exit 0: a FAIL here would take an
+// otherwise-healthy fleet red overnight for a purely observational finding.
+//
+// It REPORTS the daemon/doctor Layer-1 split; it deliberately does NOT repair it.
+// Changing which file checkConfigScopeLeak (and friends) grade is a behavior
+// change on a live host and belongs in its own ticket.
+export function checkConfigProvenance(deps = {}) {
+  try {
+    const {
+      // The dump is injectable so the fixture matrix needs no filesystem at all.
+      dump = collectConfigDump(),
+      // The Layer-1 doctor's own config checks read (cwd/env chain).
+      doctorLayer1 = resolveDoctorLayer1Path(),
+      // The Layer-1 of the plugin CHECKOUT (what checkConfigScopeLeak grades).
+      repoLayer1 = layer1Path(),
+      // Only a WORKER runs the execution-core daemon (monitor/developer run the
+      // observation substrate only — AGENTS.md "Deployment Mode": node class).
+      // On a non-worker the "daemon's Layer-1" question has no subject, so the
+      // divergence branch reports INFO instead of WARN: a permanent WARN on every
+      // laptop/monitor `catalyst doctor` run is noise that trains operators to
+      // ignore the check. The env-override half stays useful on every class.
+      nodeClass = resolveNodeClass().class,
+    } = deps;
+
+    const checks = [];
+    const runsDaemon = nodeClass === "worker";
+    // Non-worker: the finding is real but not actionable here — soften to INFO.
+    const DIVERGENCE = runsDaemon ? STATUS.WARN : STATUS.INFO;
+    const scopeNote = runsDaemon
+      ? ""
+      : ` (informational on a ${nodeClass} node — it runs no execution-core daemon)`;
+    const daemon = dump?.daemonLayer1 ?? null;
+    const fp = typeof dump?.fingerprint === "string" ? dump.fingerprint.slice(0, 12) : "unknown";
+    const suffix = ` [fingerprint=${fp}; compare hosts with: diff <(ssh a catalyst config dump --json) <(ssh b catalyst config dump --json)]`;
+
+    // ── (1) daemon-visible Layer-1 ───────────────────────────────────────────
+    if (!daemon) {
+      checks.push(
+        mkCheck("config-provenance", STATUS.INFO, "daemon Layer-1 resolution was not computed for this run" + suffix),
+      );
+    } else if (!daemon.pinned) {
+      checks.push(
+        mkCheck(
+          "config-provenance",
+          DIVERGENCE,
+          "the execution-core daemon's Layer-1 config path is UNPINNED — no CATALYST_CONFIG_FILE in the " +
+            "environment or in ~/.config/catalyst/execution-core.env, and no $CATALYST_DIR/.catalyst/config.json " +
+            "to fall back on, so the daemon reads whatever directory it was launched from. That file may differ " +
+            `from the one doctor grades (${doctorLayer1}). Remediation: export CATALYST_CONFIG_FILE=<repo>/.catalyst/config.json ` +
+            "in ~/.config/catalyst/execution-core.env (CTL-1793)" +
+            scopeNote +
+            suffix,
+        ),
+      );
+    } else if (daemon.path !== doctorLayer1) {
+      checks.push(
+        mkCheck(
+          "config-provenance",
+          DIVERGENCE,
+          `the daemon reads a DIFFERENT Layer-1 config than doctor grades: daemon="${daemon.path}" ` +
+            `(pinned via ${daemon.source}) vs doctor="${doctorLayer1}"` +
+            (repoLayer1 !== doctorLayer1 ? ` (plugin checkout: "${repoLayer1}")` : "") +
+            " — every Layer-1-driven setting reported by other checks may not be the one in force (CTL-1793)" +
+            scopeNote +
+            suffix,
+        ),
+      );
+    } else if (dump.layer1?.present && dump.layer1?.parsed && !dump.layer1?.hasOrchestration) {
+      checks.push(
+        mkCheck(
+          "config-provenance",
+          DIVERGENCE,
+          `the daemon's Layer-1 config ("${daemon.path}") carries no catalyst.orchestration stanza — ` +
+            "executor routing, the reaper/worktree-refresh/stale-PR timers, reconcile mode and the " +
+            "eligible query all silently run on built-in defaults (CTL-1793)" +
+            scopeNote +
+            suffix,
+        ),
+      );
+    } else if (!dump.layer1?.present || !dump.layer1?.parsed) {
+      checks.push(
+        mkCheck(
+          "config-provenance",
+          DIVERGENCE,
+          `the daemon's Layer-1 config ("${daemon.path}") is ` +
+            (dump.layer1?.present ? "present but MALFORMED" : "ABSENT") +
+            " — every Layer-1-driven setting runs on built-in defaults (CTL-1793)" +
+            scopeNote +
+            suffix,
+        ),
+      );
+    } else {
+      checks.push(
+        mkCheck(
+          "config-provenance",
+          STATUS.PASS,
+          `daemon and doctor read the same Layer-1 config ("${daemon.path}", pinned via ${daemon.source})` + suffix,
+        ),
+      );
+    }
+
+    // ── (2) per-host env overrides ───────────────────────────────────────────
+    // INFO, never a grade change: an override is a legitimate operator action.
+    // The point is that it should be VISIBLE — these are the knobs that differ
+    // between two hosts running the same committed config.
+    const overrides = (dump?.rows ?? []).filter((r) => r.provenance === "env-override" && !r.secret);
+    checks.push(
+      overrides.length === 0
+        ? mkCheck("config-env-overrides", STATUS.INFO, "no config knob is in force via a per-host env override")
+        : mkCheck(
+            "config-env-overrides",
+            STATUS.INFO,
+            `${overrides.length} config knob(s) in force via a per-host env override (not the committed config): ` +
+              overrides.map((r) => `${r.key}=${String(r.value)} (${r.envVar})`).join("; "),
+          ),
+    );
+
+    return checks;
+  } catch (err) {
+    // Total: any throw degrades to INFO. Never FAIL, never a crashed suite.
+    return [
+      mkCheck(
+        "config-provenance",
+        STATUS.INFO,
+        `config provenance could not be resolved (advisory only): ${err?.message ?? String(err)}`,
+      ),
+    ];
+  }
+}
+
 // ─── CTL-1481: worker:<host> label ownership visibility advisory ────────────
 
 // defaultLinearGraphQLPost — minimal fetch-based Linear GraphQL POST, mirroring
@@ -5331,6 +5493,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkCloudSync(), // CTL-1394: developer nodes read Linear from the local replica too (advisory)
       () => checkConfigScopeLeak(), // advisory
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
+      () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
     ];
   }
 
@@ -5404,6 +5567,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
     () => checkDrainDisabled(), // CTL-1678: surface the per-node drain override + the draining-but-ignored third state — advisory only (never FAIL)
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
+    () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -29,6 +29,7 @@ import {
   checkSdkExecutorAuth,
   checkSdkDaemonEnv,
   checkConfigScopeLeak,
+  checkConfigProvenance,
   checkRepoIconTokenScope,
   defaultConfiguredRepos,
   checkNodeClass,
@@ -5512,6 +5513,211 @@ describe("checksForClass — checkSkillsDirPlugins registration", () => {
   for (const cls of ["worker", "developer", "monitor"]) {
     it(`wires checkSkillsDirPlugins into the ${cls} suite`, () => {
       expect(src({ recognized: true, class: cls })).toContain("checkSkillsDirPlugins");
+    });
+  }
+});
+
+// ─── checkConfigProvenance (CTL-1793) ────────────────────────────────────────
+//
+// The contract this check must never break: it is ADVISORY. runDoctor returns the
+// FAIL count as the process exit code and catalyst-join.sh gates member activation
+// on exit 0, so a FAIL here would take an otherwise-healthy fleet red overnight
+// for a purely observational finding. Three independent guards below: a fixture
+// matrix, a source-level STATUS.FAIL guard, and an end-to-end runDoctor exit code.
+
+describe("checkConfigProvenance (CTL-1793)", () => {
+  // A dump-shaped fixture — the check reads only these fields.
+  const mkDump = (over = {}) => ({
+    fingerprint: "abcdef0123456789",
+    layer1: { path: "/repo/.catalyst/config.json", present: true, parsed: true, hasOrchestration: true },
+    daemonLayer1: { path: "/repo/.catalyst/config.json", source: "exec-core-env-file", pinned: true },
+    rows: [],
+    ...over,
+  });
+  const byName = (checks, name) => checks.find((c) => c.name === name);
+  // Default the fixtures to a WORKER: only a worker runs the execution-core
+  // daemon, so that is the class where the divergence finding is actionable.
+  const provenance = (deps) => byName(checkConfigProvenance({ nodeClass: "worker", ...deps }), "config-provenance");
+
+  it("PASSes when daemon and doctor read the same Layer-1", () => {
+    const c = provenance({ dump: mkDump(), doctorLayer1: "/repo/.catalyst/config.json", repoLayer1: "/repo/.catalyst/config.json" });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("fingerprint=abcdef012345");
+  });
+
+  // THE measured live-fleet bug: nothing pins CATALYST_CONFIG_FILE, so the daemon
+  // reads whatever cwd it was launched from — a different file than doctor grades.
+  it("WARNs when the daemon's Layer-1 is UNPINNED", () => {
+    const c = provenance({
+      dump: mkDump({ daemonLayer1: { path: null, source: "daemon-cwd", pinned: false } }),
+      doctorLayer1: "/repo/.catalyst/config.json",
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("UNPINNED");
+    expect(c.detail).toContain("CATALYST_CONFIG_FILE");
+  });
+
+  it("WARNs, naming both paths, when the daemon reads a different file than doctor", () => {
+    const c = provenance({
+      dump: mkDump({ daemonLayer1: { path: "/plugin-source/.catalyst/config.json", source: "exec-core-env-file", pinned: true } }),
+      doctorLayer1: "/repo/.catalyst/config.json",
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("/plugin-source/.catalyst/config.json");
+    expect(c.detail).toContain("/repo/.catalyst/config.json");
+  });
+
+  it("WARNs when the daemon's (agreed) Layer-1 carries no catalyst.orchestration stanza", () => {
+    const c = provenance({
+      dump: mkDump({
+        daemonLayer1: { path: "/x/.catalyst/config.json", source: "catalyst-dir", pinned: true },
+        layer1: { path: "/x/.catalyst/config.json", present: true, parsed: true, hasOrchestration: false },
+      }),
+      doctorLayer1: "/x/.catalyst/config.json",
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("catalyst.orchestration");
+  });
+
+  it("WARNs when the daemon's Layer-1 is absent or malformed", () => {
+    for (const layer1 of [
+      { path: "/x/.catalyst/config.json", present: false, parsed: false, hasOrchestration: false },
+      { path: "/x/.catalyst/config.json", present: true, parsed: false, hasOrchestration: false },
+    ]) {
+      const c = provenance({
+        dump: mkDump({ daemonLayer1: { path: "/x/.catalyst/config.json", source: "env", pinned: true }, layer1 }),
+        doctorLayer1: "/x/.catalyst/config.json",
+      });
+      expect(c.status).toBe(STATUS.WARN);
+    }
+  });
+
+  it("lists per-host env overrides as INFO, never as a grade change", () => {
+    const checks = checkConfigProvenance({
+      dump: mkDump({
+        rows: [
+          { key: "catalyst.stallJanitor.mode", value: "enforce", provenance: "env-override", envVar: "CATALYST_STALL_JANITOR", secret: false },
+          { key: "catalyst.boardHealth.mode", value: "shadow", provenance: "config", envVar: null, secret: false },
+        ],
+      }),
+      doctorLayer1: "/repo/.catalyst/config.json",
+    });
+    const c = byName(checks, "config-env-overrides");
+    expect(c.status).toBe(STATUS.INFO);
+    expect(c.detail).toContain("catalyst.stallJanitor.mode=enforce");
+    expect(c.detail).toContain("CATALYST_STALL_JANITOR");
+    expect(c.detail).not.toContain("boardHealth");
+  });
+
+  it("never reports a SECRET row among the env overrides", () => {
+    const checks = checkConfigProvenance({
+      dump: mkDump({ rows: [{ key: "secrets.LINEAR_API_TOKEN", value: "set", provenance: "env-override", envVar: "LINEAR_API_TOKEN", secret: true }] }),
+      doctorLayer1: "/repo/.catalyst/config.json",
+    });
+    expect(byName(checks, "config-env-overrides").detail).toContain("no config knob");
+  });
+
+  it("degrades a THROWING dependency to INFO instead of crashing the suite", () => {
+    const checks = checkConfigProvenance({
+      get dump() {
+        throw new Error("boom");
+      },
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.INFO);
+    expect(checks[0].detail).toContain("boom");
+  });
+
+  // Only a worker runs the execution-core daemon; on monitor/developer nodes the
+  // "which Layer-1 does the daemon read" finding has no subject, so it must not
+  // become a permanent WARN that trains operators to ignore the check.
+  it("softens the divergence finding to INFO on a node that runs no daemon", () => {
+    const divergent = {
+      dump: mkDump({ daemonLayer1: { path: null, source: "daemon-cwd", pinned: false } }),
+      doctorLayer1: "/repo/.catalyst/config.json",
+    };
+    expect(provenance({ ...divergent, nodeClass: "worker" }).status).toBe(STATUS.WARN);
+    for (const cls of ["developer", "monitor"]) {
+      const c = provenance({ ...divergent, nodeClass: cls });
+      expect(c.status).toBe(STATUS.INFO);
+      expect(c.detail).toContain(`runs no execution-core daemon`);
+    }
+  });
+
+  it("keeps the env-override report on every node class", () => {
+    for (const cls of ["worker", "developer", "monitor"]) {
+      const checks = checkConfigProvenance({
+        nodeClass: cls,
+        dump: mkDump({ rows: [{ key: "catalyst.boardHealth.mode", value: "enforce", provenance: "env-override", envVar: "CATALYST_BOARD_HEALTH", secret: false }] }),
+        doctorLayer1: "/repo/.catalyst/config.json",
+      });
+      expect(byName(checks, "config-env-overrides").detail).toContain("catalyst.boardHealth.mode=enforce");
+    }
+  });
+
+  // GUARD 1 — fixture matrix: no input shape may ever produce a FAIL.
+  it("ADVISORY: no fixture — healthy, divergent, unpinned, absent, malformed, no-orchestration, garbage, throwing — yields FAIL", () => {
+    // Fixtures are LAZY factories: the throwing one must only throw INSIDE the
+    // check's try/catch. Building it eagerly (and spreading it) would fire the
+    // getter here and mask exactly the totality this test asserts.
+    const fixtures = [
+      (nodeClass) => ({ nodeClass, dump: mkDump(), doctorLayer1: "/repo/.catalyst/config.json" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ daemonLayer1: { path: "/other.json", source: "env", pinned: true } }), doctorLayer1: "/repo/.catalyst/config.json" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ daemonLayer1: { path: null, source: "daemon-cwd", pinned: false } }), doctorLayer1: "/repo/.catalyst/config.json" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ layer1: { present: false, parsed: false, hasOrchestration: false }, daemonLayer1: { path: "/x", source: "env", pinned: true } }), doctorLayer1: "/x" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ layer1: { present: true, parsed: false, hasOrchestration: false }, daemonLayer1: { path: "/x", source: "env", pinned: true } }), doctorLayer1: "/x" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ layer1: { present: true, parsed: true, hasOrchestration: false }, daemonLayer1: { path: "/x", source: "env", pinned: true } }), doctorLayer1: "/x" }),
+      (nodeClass) => ({ nodeClass, dump: mkDump({ daemonLayer1: null }) }),
+      (nodeClass) => ({ nodeClass, dump: {} }),
+      (nodeClass) => ({ nodeClass, dump: null }),
+      (nodeClass) => ({
+        nodeClass,
+        get dump() {
+          throw new Error("boom");
+        },
+      }),
+    ];
+    for (const makeFixture of fixtures) {
+      for (const nodeClass of ["worker", "developer", "monitor", "bogus"]) {
+        expect(checkConfigProvenance(makeFixture(nodeClass)).every((c) => c.status !== STATUS.FAIL)).toBe(true);
+      }
+    }
+  });
+
+  // GUARD 2 — source-level: a future edit that adds a FAIL breaks CI immediately.
+  // (Same spirit as quota-field-doc-drift.test.sh.)
+  it("ADVISORY: the checkConfigProvenance source body contains no STATUS.FAIL", () => {
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    const start = src.indexOf("export function checkConfigProvenance");
+    expect(start).toBeGreaterThan(-1);
+    const rest = src.slice(start + 1);
+    const nextIdx = rest.search(/\n(?:export )?(?:async )?function /);
+    const body = nextIdx === -1 ? rest : rest.slice(0, nextIdx);
+    expect(body).not.toContain("STATUS.FAIL");
+  });
+
+  // GUARD 3 — end-to-end: the worst fixture, through runDoctor, still exits 0.
+  it("ADVISORY: runDoctor exits 0 with only this check registered against a divergent fixture", async () => {
+    const code = await runDoctor({
+      checks: [
+        () =>
+          checkConfigProvenance({
+            dump: mkDump({ daemonLayer1: { path: null, source: "daemon-cwd", pinned: false } }),
+            doctorLayer1: "/repo/.catalyst/config.json",
+          }),
+      ],
+      json: true,
+      log: () => {},
+    });
+    expect(code).toBe(0);
+  });
+});
+
+describe("checksForClass — checkConfigProvenance registration (CTL-1793)", () => {
+  const src = (nc) => checksForClass(nc, {}).map((f) => f.toString()).join("\n");
+  for (const cls of ["worker", "developer"]) {
+    it(`wires checkConfigProvenance into the ${cls} suite`, () => {
+      expect(src({ recognized: true, class: cls })).toContain("checkConfigProvenance");
     });
   }
 });

--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -64,6 +64,7 @@ catalyst|Umbrella & lifecycle|1|The single front-door router for the Catalyst to
 catalyst-stack|Umbrella & lifecycle|1|Bring the Catalyst service stack up or down on this host (idempotent, dependency-ordered).
 catalyst-install|Umbrella & lifecycle|1|Provision or tear down this node for its class (composes setup scripts; install/uninstall/reinstall).
 catalyst-doctor|Umbrella & lifecycle|1|Fail-closed activation gate — class-aware health/activation grade (exit 0 ⇒ safe to activate).
+catalyst-config|Umbrella & lifecycle|1|Read-only per-key config provenance dump (value + env-override/config/default source, resolved layer paths, fingerprint) for cross-host diffing.
 catalyst-backup|Umbrella & lifecycle|0|Capture / restore a node's restorable identity + state bundle (bare backup writes a secrets bundle).
 catalyst-claude|Umbrella & lifecycle|0|Wrapper that registers a Catalyst session around claude, then execs the interactive claude process.
 emit-lifecycle-event|Hooks|0|Claude Code Stop/SubagentStop hook — fallback agent.checkout emitter for the broker.

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -36,6 +36,7 @@ CLI_ENTRIES=(
   "catalyst-broker:catalyst-broker"
   "catalyst-cluster:catalyst-cluster"
   "catalyst-comms:catalyst-comms"
+  "catalyst-config:catalyst-config"
   "catalyst-events:catalyst-events"
   "catalyst-execution-core:catalyst-execution-core"
   "catalyst-filter:catalyst-filter"

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -12,7 +12,7 @@ sidebar:
 
 Every `catalyst-*` CLI is installed onto your `PATH` by
 [`install-cli.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/install-cli.sh) (into
-`~/.catalyst/bin` by default). This page lists all 30 of them — one line of
+`~/.catalyst/bin` by default). This page lists all 31 of them — one line of
 purpose plus the key subcommands — grouped by area. Run any tool with `--help`
 for full syntax. The richer tools have their own reference pages (e.g.
 [catalyst-stack](/reference/catalyst-stack/)).
@@ -39,7 +39,7 @@ Manage the execution-core composing daemon (Todo-state monitor + pull-loop sched
 
 On-demand orch-monitor web-dashboard server management.
 
-**Key subcommands:** `start`, `stop`, `restart`, `status`, `open`, `url`, `forward-start`, `forward-stop`, `forward-status`
+**Key subcommands:** `start`, `stop`, `restart`, `status`, `open`, `url`, `forward-start`, `forward-stop`, `forward-status`, `forward-restart`
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-monitor.sh)
 
@@ -232,6 +232,14 @@ Fail-closed activation gate — class-aware health/activation grade (exit 0 ⇒ 
 **Key subcommands:** _(run `catalyst-doctor --help`)_
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-doctor)
+
+### catalyst-config
+
+Read-only per-key config provenance dump (value + env-override/config/default source, resolved layer paths, fingerprint) for cross-host diffing.
+
+**Key subcommands:** `dump`
+
+[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-config)
 
 ### catalyst-backup
 


### PR DESCRIPTION
Closes CTL-1793.

## Why

**MEASURED on mini:** the daemon reads `~/.catalyst/config.json`, whose keys are `["catalyst"]` → `["monitor","projects"]` — **no `orchestration` key at all**. So `daemonWatchdog`, `procReaper`, `fleetHealth`, `stalledPrSweep`, `phaseArtifactSync` and `reconcile` all silently run code defaults, and anyone reasoning about "what mode is feature X in" from the repo config is reading fiction.

## What

`catalyst config dump` printing each key's **in-force value and provenance**, plus an **advisory** doctor check for host divergence. Read-only: no resolution behaviour changes.

## The part that took three rounds

The ticket is *"tell the truth about config."* A config-truth tool that lies during the incident it was built for is worse than not having it — so this PR was blocked twice by its own adversarial review before it was allowed to ship.

**Round 1 — six falsehoods, all measured:**

| | REAL | DUMP (before) |
|---|---|---|
| `CATALYST_WATCHDOG=enforce` | `shadow` | `enforce` — kill-switch modelled as a mode selector |
| `node.class="Worker"` | `worker` | `Worker` — bypassed the reader's normalizer, breaking the cross-host fingerprint |
| `deployment="clustr"` | `single-host` | `clustr` — invalid value echoed as in-force |
| `export X=enforce # armed 8/11` | `enforce` | `shadow` — inline comment not stripped, so it **under**-reported an armed knob |
| secrets | armed in the daemon | `unset` — a false negative on a credential |

**Round 2 — the seventh**, on the repo's own **committed** config: `executionCore.targetParallel` was modelled as reading `layer1.targetParallel`, which `resolveTargetSetpoint` never reads (it falls back to `layer1.maxParallel`). Dump said `-  default`; the real autotuner setpoint was `4`.

**And the deeper bug it exposed:** the drift guard *exempted* that row on a false premise ("no single-value reader"). The exemption list was itself an unverified claim — the same false-assurance shape as the original `SOURCES.includes(name)` guard it replaced.

**Round 3 — retiring the exemption list found five more:** `dispatchMode` (jq's `//` treats `false` as empty), `reconcile.mode` (object-spread merge — L2 `null` overrides L1), `eligibleQuery.status` (key is dead since CTL-582 D4; row re-pointed at the registry), `worktreeRefresh.{enabled,intervalSeconds}` (reported `default` for a timer running enabled/300s), `draftPr.enabled`.

## Now

**Every row is bound to the reader that actually decides it** — via a real call where importable, a shell oracle where the reader is jq/bash. The one genuinely unbindable family (the four `secret` rows) has a **checkable** reason: a test pins `UNBOUND` to exactly that set, so no other row can be parked there.

`resolveTargetSetpoint` moved to a zero-import leaf because `scheduler.mjs`'s graph carries `bun:` imports — proven, not assumed: `node -e "import('./scheduler.mjs')"` → *"Only URLs with a scheme in: file, data, node are supported… Received protocol 'bun:'"*. That is *why* the row was hand-modelled in the first place.

Also fixed while auditing: `collectConfigDump` used bare `$HOME` where the readers use `homedir()` — an odd-`HOME` shell would have described a different Layer-2 file than the one in force.

## Verification

181 pass (was 133) · wider sweep 919 pass / 0 fail, run twice · `catalyst-config.test.sh` 25/25 · `deployment-mode-parity` 358/358 · doctor 429 pass.

Independent re-verification measured **51/51 reader-vs-dump matches**, then **9/9** on the F-7 reproductions including the committed config and a live host run.

Every fix carries a negative control (break → observe the specific failure → restore), and the five round-3 regressions are encoded as permanent in-suite "teeth" tests — so *"the row is bound now"* is itself verified rather than claimed.

Doctor stays **advisory**: PASS/WARN/INFO only, verified at the grade arithmetic and against a 10-fixture × 4-node-class matrix. No consumer reads WARN counts, so it cannot gate anything.

Deferred: **F-8** (P3, one-line — `dispatchMode` with an object value) to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144RKpHEbUrj5UHTF5JeAjk