### PR TITLE
fix(dev): CTL-56 — worktree-safe merge (drop --delete-branch, checkout-free ref cleanup)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -110,6 +110,10 @@ on:
       - "plugins/dev/skills/triage-aging-prs/**"
       - "plugins/dev/templates/**"
       - "plugins/legacy/skills/oneshot/**"
+      # CTL-56: the repo-wide --delete-branch guard also scans the legacy orchestrate skill (this
+      # PR removes its live --delete-branch instructions); without this path a change confined to
+      # it would neither trigger the workflow on push nor mark a PR relevant, bypassing the guard.
+      - "plugins/legacy/skills/orchestrate/**"
       # CTL-1628: the root bun workspace lockfile/manifest — a change here affects
       # every member package's install (incl. execution-core, broker, otel-forward).
       - "package.json"
@@ -160,6 +164,9 @@ jobs:
               - "plugins/dev/skills/triage-aging-prs/**"
               - "plugins/dev/templates/**"
               - "plugins/legacy/skills/oneshot/**"
+              # CTL-56: mirror the push-path entry above — the repo-wide guard scans the legacy
+              # orchestrate skill, so a change confined to it must mark the PR relevant.
+              - "plugins/legacy/skills/orchestrate/**"
 
   execution-core-unit-tests:
     needs: detect-changes

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -101,6 +101,15 @@ on:
       # confined to the teardown removal block would skip this workflow and the
       # ordering backstop couldn't catch a destroy-before-salvage regression.
       - "plugins/dev/skills/phase-teardown/**"
+      # CTL-56: the three merge-worktree guard tests scan skills and templates
+      # OUTSIDE plugins/dev/scripts/ for the --delete-branch invariant. A change
+      # confined to any of those files would otherwise skip this workflow.
+      - "plugins/dev/skills/phase-monitor-merge/**"
+      - "plugins/dev/skills/merge-pr/**"
+      - "plugins/dev/skills/recovery-pass/**"
+      - "plugins/dev/skills/triage-aging-prs/**"
+      - "plugins/dev/templates/**"
+      - "plugins/legacy/skills/oneshot/**"
       # CTL-1628: the root bun workspace lockfile/manifest — a change here affects
       # every member package's install (incl. execution-core, broker, otel-forward).
       - "package.json"
@@ -145,6 +154,12 @@ jobs:
               - "package.json"
               - "bun.lock"
               - "turbo.json"
+              - "plugins/dev/skills/phase-monitor-merge/**"
+              - "plugins/dev/skills/merge-pr/**"
+              - "plugins/dev/skills/recovery-pass/**"
+              - "plugins/dev/skills/triage-aging-prs/**"
+              - "plugins/dev/templates/**"
+              - "plugins/legacy/skills/oneshot/**"
 
   execution-core-unit-tests:
     needs: detect-changes
@@ -533,6 +548,28 @@ jobs:
         # it locks down was unverified in CI.
         working-directory: plugins/dev/scripts
         run: bash __tests__/phase-artifact-gate.test.sh
+
+      - name: phase-monitor-merge worktree-safe merge guard (CTL-56)
+        # Guards that phase-monitor-merge/SKILL.md uses gh pr merge --squash without
+        # --delete-branch (worktree-safe) and includes a checkout-free remote-ref delete.
+        # Previously ran only via the local run-tests.sh aggregate; pinned here so a
+        # reintroduction of --delete-branch in the headless merge skill fails CI.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/phase-monitor-merge-guard.test.sh
+
+      - name: oneshot worktree-safe merge guard (CTL-56)
+        # Guards that plugins/legacy/skills/oneshot/SKILL.md uses worktree-safe merge
+        # (no --delete-branch; checkout-free remote-ref delete after REST confirm).
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/oneshot-merge-worktree-guard.test.sh
+
+      - name: cross-site worktree-safe merge guard — model-invoked skills and templates (CTL-56)
+        # Guards that merge-pr, recovery-pass, triage-aging-prs, followup-prompt, and
+        # fixup-prompt all use worktree-safe merge (no --delete-branch; checkout-free
+        # remote-ref delete). File list is an array in the test; a 6th call site is a
+        # one-line add.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/merge-delete-branch-worktree-guard.test.sh
 
       - name: Run stable unit tests
         # CTL-1789 round-1 P2 (Codex): assertion-evidence.test.mjs and

--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -63,9 +63,40 @@ if [[ -f "$MERGE_PR" ]]; then
   BODY="$(cat "$MERGE_PR")"
   assert_contains "$BODY" "git-common-dir" \
     "merge-pr Step 11 has linked-worktree guard (git-common-dir divergence check)"
+  # CTL-56 remediation: both sides of the divergence check MUST be absolute, else the
+  # guard misfires in the primary clone (--git-common-dir returns a RELATIVE .git there).
+  # Pin the normalization so the fix cannot silently regress.
+  assert_contains "$BODY" "path-format=absolute" \
+    "merge-pr Step 11 normalizes git-common-dir to absolute (--path-format=absolute) before comparing"
 else
   fail "merge-pr/SKILL.md missing: $MERGE_PR"
 fi
+
+echo ""
+echo "CTL-56: automated merge sites gate branch delete on an executable REST .merged confirm"
+# The presence checks above are false-green for a delete-BEFORE-confirm regression: a site that
+# merges then unconditionally deletes still contains git/refs/heads/ + --method DELETE. The old
+# atomic `--delete-branch` deleted ONLY on a successful merge; the split rewrite must preserve
+# that with an EXECUTABLE `.merged` confirm (not a prose comment) before the delete, or a
+# failed/unconfirmed merge orphans the PR's head ref. Assert the confirm token exists at each
+# automated (non-interactive) merge+delete site. (merge-pr is interactive and human-gated, so it
+# is excluded here; recovery-pass carries its own cross-repo REST-confirm prose.)
+CONFIRM_GATED_FILES=(
+  "plugins/dev/skills/triage-aging-prs/SKILL.md"
+  "plugins/dev/templates/fixup-prompt.md"
+  "plugins/dev/templates/followup-prompt.md"
+)
+for REL_FILE in "${CONFIRM_GATED_FILES[@]}"; do
+  FILE="${REPO_ROOT}/${REL_FILE}"
+  LABEL="$(basename "$(dirname "$FILE")")/$(basename "$FILE")"
+  if [[ -f "$FILE" ]]; then
+    BODY="$(cat "$FILE")"
+    assert_contains "$BODY" ".merged" \
+      "CTL-56: ${LABEL} gates branch delete on an executable REST .merged confirm (not a comment)"
+  else
+    fail "file missing: ${FILE}"
+  fi
+done
 
 echo ""
 echo "CTL-56: repo-wide invariant — no live gh pr merge call carries --delete-branch"

--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Cross-site guard: model-invoked skills and templates use worktree-safe merge (CTL-56).
+# Asserts no live gh pr merge call carries --delete-branch, and that each file contains
+# the checkout-free remote-ref delete pattern (git/refs/heads/ + --method DELETE).
+# Run: bash plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+assert_contains() {
+  local body="$1" substr="$2" label="$3"
+  if [[ "$body" == *"$substr"* ]]; then pass "$label"
+  else fail "$label — '$substr' not found"; fi
+}
+
+assert_not_contains() {
+  local body="$1" substr="$2" label="$3"
+  if [[ "$body" != *"$substr"* ]]; then pass "$label"
+  else fail "$label — forbidden '$substr' present"; fi
+}
+
+# Files to check — add new call sites here as a one-line addition.
+CHECKED_FILES=(
+  "plugins/dev/skills/merge-pr/SKILL.md"
+  "plugins/dev/skills/recovery-pass/SKILL.md"
+  "plugins/dev/skills/triage-aging-prs/SKILL.md"
+  "plugins/dev/templates/followup-prompt.md"
+  "plugins/dev/templates/fixup-prompt.md"
+)
+
+echo "CTL-56: model-invoked skills and templates — worktree-safe merge (cross-site)"
+echo ""
+
+for REL_FILE in "${CHECKED_FILES[@]}"; do
+  FILE="${REPO_ROOT}/${REL_FILE}"
+  LABEL="$(basename "$(dirname "$FILE")")/$(basename "$FILE")"
+  echo "  ── ${LABEL}"
+  if [[ -f "$FILE" ]]; then
+    BODY="$(cat "$FILE")"
+    assert_not_contains "$BODY" "--delete-branch" \
+      "CTL-56: ${LABEL} drops --delete-branch (worktree-safe)"
+    assert_contains "$BODY" "git/refs/heads/" \
+      "CTL-56: ${LABEL} contains checkout-free remote-ref delete path"
+    assert_contains "$BODY" "--method DELETE" \
+      "CTL-56: ${LABEL} uses gh api --method DELETE for remote-ref cleanup"
+  else
+    fail "file missing: ${FILE}"
+  fi
+  echo ""
+done
+
+echo "CTL-56: merge-pr Step 11 — linked-worktree guard on local git checkout"
+MERGE_PR="${REPO_ROOT}/plugins/dev/skills/merge-pr/SKILL.md"
+if [[ -f "$MERGE_PR" ]]; then
+  BODY="$(cat "$MERGE_PR")"
+  assert_contains "$BODY" "git-common-dir" \
+    "merge-pr Step 11 has linked-worktree guard (git-common-dir divergence check)"
+else
+  fail "merge-pr/SKILL.md missing: $MERGE_PR"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "merge-delete-branch-worktree-guard: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -79,9 +79,13 @@ echo "CTL-56: automated merge sites gate branch delete on an executable REST .me
 # atomic `--delete-branch` deleted ONLY on a successful merge; the split rewrite must preserve
 # that with an EXECUTABLE `.merged` confirm (not a prose comment) before the delete, or a
 # failed/unconfirmed merge orphans the PR's head ref. Assert the confirm token exists at each
-# automated (non-interactive) merge+delete site. (merge-pr is interactive and human-gated, so it
-# is excluded here; recovery-pass carries its own cross-repo REST-confirm prose.)
+# merge+delete site. (CTL-56 Codex round-1 P1: merge-pr was previously excluded as "interactive and
+# human-gated", but human-gating gates the merge DECISION, not the merge-queue race — with a queue,
+# `gh pr merge` enqueues and returns success and the next line would delete a still-open PR's head
+# ref. So merge-pr now carries the executable `.merged` gate too; recovery-pass carries its own
+# cross-repo REST-confirm prose.)
 CONFIRM_GATED_FILES=(
+  "plugins/dev/skills/merge-pr/SKILL.md"
   "plugins/dev/skills/triage-aging-prs/SKILL.md"
   "plugins/dev/templates/fixup-prompt.md"
   "plugins/dev/templates/followup-prompt.md"

--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -68,6 +68,27 @@ else
 fi
 
 echo ""
+echo "CTL-56: repo-wide invariant — no live gh pr merge call carries --delete-branch"
+
+# Scan plugins/ for any 'gh pr merge' line that includes '--delete-branch'.
+# Exclude: JSON schema description strings, HTML mockups, bash comments (#),
+# and test files (themselves may reference the flag for assertion labels).
+REPO_ROOT_GUARD="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIVE_VIOLATORS="$(grep -rn -- '--delete-branch' "${REPO_ROOT_GUARD}/plugins/" \
+  | grep 'gh pr merge' \
+  | grep -v '\.json:' \
+  | grep -v '\.html:' \
+  | grep -v '\.test\.sh:' \
+  | grep -v '^[^:]*:[[:space:]]*#' \
+  || true)"
+if [[ -z "$LIVE_VIOLATORS" ]]; then
+  pass "no live gh pr merge call carries --delete-branch (repo-wide)"
+else
+  fail "live gh pr merge --delete-branch found (CTL-56 violation):
+${LIVE_VIOLATORS}"
+fi
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "merge-delete-branch-worktree-guard: ${PASSES} passed, ${FAILURES} failed"
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/oneshot-merge-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/oneshot-merge-worktree-guard.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Static guard: oneshot/SKILL.md uses worktree-safe merge (CTL-56).
+# Mirrors phase-monitor-merge-guard.test.sh CTL-56 block against the legacy oneshot skill.
+# Run: bash plugins/dev/scripts/__tests__/oneshot-merge-worktree-guard.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SKILL="${REPO_ROOT}/plugins/legacy/skills/oneshot/SKILL.md"
+
+FAILURES=0
+PASSES=0
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+
+assert_contains() {
+  local body="$1" substr="$2" label="$3"
+  if [[ "$body" == *"$substr"* ]]; then pass "$label"
+  else fail "$label — '$substr' not found"; fi
+}
+
+assert_not_contains() {
+  local body="$1" substr="$2" label="$3"
+  if [[ "$body" != *"$substr"* ]]; then pass "$label"
+  else fail "$label — forbidden '$substr' present"; fi
+}
+
+echo "CTL-56: oneshot worktree-safe merge (drop --delete-branch, checkout-free remote-ref delete)"
+
+if [[ -f "$SKILL" ]]; then
+  BODY="$(cat "$SKILL")"
+  assert_not_contains "$BODY" "--delete-branch" \
+    "CTL-56: oneshot merge call drops --delete-branch (worktree-safe)"
+  assert_contains "$BODY" "git/refs/heads/" \
+    "CTL-56: oneshot deletes remote head ref checkout-free"
+  assert_contains "$BODY" "--method DELETE" \
+    "CTL-56: oneshot remote-ref delete uses gh api --method DELETE"
+else
+  fail "SKILL.md missing: $SKILL"
+fi
+
+echo ""
+echo "CTL-56: oneshot retains gh pr merge --squash (REST path) and REST confirm"
+
+if [[ -f "$SKILL" ]]; then
+  if grep -q 'gh pr merge .*--squash' "$SKILL"; then
+    pass "oneshot merge path uses gh pr merge --squash (REST API)"
+  else
+    fail "oneshot merge path should use 'gh pr merge --squash' (REST API)"
+  fi
+  assert_contains "$BODY" ".merged" \
+    "oneshot has REST .merged confirm after merge"
+else
+  fail "SKILL.md missing for REST-path check: $SKILL"
+fi
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "oneshot-merge-worktree-guard: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh
@@ -116,6 +116,20 @@ else
 fi
 
 echo ""
+echo "CTL-56: worktree-safe merge (drop --delete-branch, checkout-free remote-ref delete)"
+
+if [[ -f "$SKILL" ]]; then
+  assert_not_contains "$BODY" "--delete-branch" \
+    "CTL-56: monitor-merge merge call drops --delete-branch (worktree-safe)"
+  assert_contains "$BODY" "git/refs/heads/" \
+    "CTL-56: monitor-merge deletes remote head ref checkout-free"
+  assert_contains "$BODY" "--method DELETE" \
+    "CTL-56: monitor-merge remote-ref delete uses gh api --method DELETE"
+else
+  fail "SKILL.md missing for CTL-56 checks: $SKILL"
+fi
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-monitor-merge-guard: ${PASSES} passed, ${FAILURES} failed"
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1061,10 +1061,12 @@ export function generateRemediateBrief(category, probe = null) {
           "then post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer."
         : "",
       "When the PR is CLEAN, run `gh pr view <n> --json mergeable,mergeStateStatus` to confirm, " +
-        "then capture the head ref (`gh api repos/<repo>/pulls/<n> --jq '.head.ref'`) and " +
+        "then capture the head ref + head repo (`gh api repos/<repo>/pulls/<n> --jq '.head.ref'` and `.head.repo.full_name`) and " +
         "merge with `gh pr merge --squash` (worktree-safe, CTL-56). " +
         "After the merge is REST-confirmed, delete the remote head ref checkout-free: " +
-        "`gh api --method DELETE repos/<repo>/git/refs/heads/<head_ref>` (idempotent, best-effort). " +
+        "`gh api --method DELETE repos/<repo>/git/refs/heads/<head_ref>` — but ONLY when the head branch lives in <repo> " +
+        "(`.head.repo.full_name == <repo>`); a fork PR's head ref lives in the fork, so deleting it from the base repo could " +
+        "hit an unrelated same-named branch (CTL-56). Idempotent + best-effort. " +
         "After addressing any review finding, post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer.",
       "Never --admin or force-merge past a failing or pending check. " +
         "Escalate ONLY a finding that genuinely requires a human decision, " +

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1066,7 +1066,8 @@ export function generateRemediateBrief(category, probe = null) {
         "After the merge is REST-confirmed, delete the remote head ref checkout-free: " +
         "`gh api --method DELETE repos/<repo>/git/refs/heads/<head_ref>` — but ONLY when the head branch lives in <repo> " +
         "(`.head.repo.full_name == <repo>`); a fork PR's head ref lives in the fork, so deleting it from the base repo could " +
-        "hit an unrelated same-named branch (CTL-56). Idempotent + best-effort. " +
+        "hit an unrelated same-named branch (CTL-56). URL-encode <head_ref> (preserve '/') first — a metacharacter like '#' " +
+        "in a branch name would otherwise truncate the endpoint and delete the wrong ref. Idempotent + best-effort. " +
         "After addressing any review finding, post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer.",
       "Never --admin or force-merge past a failing or pending check. " +
         "Escalate ONLY a finding that genuinely requires a human decision, " +

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1061,7 +1061,10 @@ export function generateRemediateBrief(category, probe = null) {
           "then post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer."
         : "",
       "When the PR is CLEAN, run `gh pr view <n> --json mergeable,mergeStateStatus` to confirm, " +
-        "then merge with `gh pr merge --squash --delete-branch`. " +
+        "then capture the head ref (`gh api repos/<repo>/pulls/<n> --jq '.head.ref'`) and " +
+        "merge with `gh pr merge --squash` (worktree-safe, CTL-56). " +
+        "After the merge is REST-confirmed, delete the remote head ref checkout-free: " +
+        "`gh api --method DELETE repos/<repo>/git/refs/heads/<head_ref>` (idempotent, best-effort). " +
         "After addressing any review finding, post `@codex review` via gh-pr-comment.sh to re-trigger the reviewer.",
       "Never --admin or force-merge past a failing or pending check. " +
         "Escalate ONLY a finding that genuinely requires a human decision, " +

--- a/plugins/dev/scripts/orchestrate-verify.sh
+++ b/plugins/dev/scripts/orchestrate-verify.sh
@@ -157,14 +157,14 @@ cd "$WORKTREE"
 # Determine the diff range. Default: vs base-branch tip. If the worker's
 # PR is already merged (post-merge verification — the common case since
 # CTL-130), use the merge SHA so we can still see the changeset even
-# after the branch has been deleted by `gh pr merge --delete-branch`.
+# after the branch has been deleted (CTL-56: via checkout-free gh api DELETE, not --delete-branch).
 BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 DIFF_RANGE="${BASE_BRANCH}..."
 PR_NUMBER=""
 PR_STATE=""
 PR_MERGE_SHA=""
 
-# Prefer signal file PR metadata over branch-based lookup. After --delete-branch,
+# Prefer signal file PR metadata over branch-based lookup. After remote branch deletion,
 # gh pr list --head returns nothing even with --state all, and git diff base... is
 # empty. The worker writes pr.number + pr.mergeCommitSha to the signal file before
 # deleting the branch, so use those when available.

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -426,8 +426,12 @@ If ticket found and not using `--no-update`:
 # linked worktree. In that case, skip the local `git checkout <base>` (it fails when
 # the base is already checked out in the primary clone) and rely on Step 11a to update
 # the primary. Defer the local feature-branch delete to teardown/reaper.
+# NOTE: both sides MUST be absolute for the comparison to be valid. `--git-common-dir`
+# returns a RELATIVE `.git` in the primary clone, which would falsely differ from the
+# always-absolute `--absolute-git-dir` and misfire the guard in the primary. Force
+# absolute with `--path-format=absolute` so the guard is TRUE only in a real worktree.
 _abs_git="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
-_com_git="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+_com_git="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
 if [[ -n "$_abs_git" && -n "$_com_git" && "$_abs_git" != "$_com_git" ]]; then
   echo "merge-pr: linked worktree — skipping local base checkout; teardown handles branch cleanup (CTL-56)" >&2
 else

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -371,18 +371,37 @@ Proceed? [Y/n]:
 ### 9. Execute squash merge
 
 ```bash
-gh pr merge $pr_number --squash --delete-branch
+# CTL-56: capture head ref BEFORE merge so we can delete it checkout-free after confirm.
+# Resolves from the PR API regardless of local branch state.
+head_ref=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.head.ref' 2>/dev/null || true)
+# Merge via REST only — no local branch-cleanup flag (CTL-56: the local side effect fails
+# inside a linked worktree when the base is already checked out in the primary clone).
+gh pr merge $pr_number --squash
 ```
 
 **Always:**
 
 - Squash merge (combines all commits into one)
-- Delete remote branch automatically
+- Remote branch deleted explicitly in Step 9b (checkout-free, after REST confirm)
 
 **Capture merge commit SHA:**
 
 ```bash
 merge_sha=$(git rev-parse HEAD)
+```
+
+### 9b. Delete remote head ref (checkout-free)
+
+After verifying the merge succeeded (REST confirm), delete the remote head branch via API —
+no local `git checkout` required, safe from any worktree (CTL-56):
+
+```bash
+# Idempotent + best-effort: 404/422 means the ref is already gone or protected.
+# Never fail the skill on branch cleanup — the merge already landed.
+if [[ -n "${head_ref:-}" ]]; then
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${head_ref}" >/dev/null 2>&1 \
+    || echo "CTL-56: remote branch ${head_ref} delete skipped (already gone or protected)" >&2
+fi
 ```
 
 ### 10. Update Linear ticket
@@ -403,20 +422,31 @@ If ticket found and not using `--no-update`:
 ### 11. Delete local branch and update base
 
 ```bash
-# Switch to base branch
-git checkout $base_branch
+# CTL-56: detect linked-worktree — when absolute-git-dir ≠ git-common-dir we are in a
+# linked worktree. In that case, skip the local `git checkout <base>` (it fails when
+# the base is already checked out in the primary clone) and rely on Step 11a to update
+# the primary. Defer the local feature-branch delete to teardown/reaper.
+_abs_git="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+_com_git="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$_abs_git" && -n "$_com_git" && "$_abs_git" != "$_com_git" ]]; then
+  echo "merge-pr: linked worktree — skipping local base checkout; teardown handles branch cleanup (CTL-56)" >&2
+else
+  # Primary (non-worktree) checkout: switch to base, pull, delete local feature branch.
+  # Switch to base branch
+  git checkout $base_branch
 
-# Pull latest (includes merge commit)
-git pull origin $base_branch
+  # Pull latest (includes merge commit)
+  git pull origin $base_branch
 
-# Delete local feature branch
-git branch -d $head_branch
+  # Delete local feature branch
+  git branch -d $head_branch
 
-# Confirm deletion
-echo "✅ Deleted local branch: $head_branch"
+  # Confirm deletion
+  echo "✅ Deleted local branch: $head_branch"
+fi
 ```
 
-**Always delete local branch** - no prompt (remote already deleted).
+**Always delete local branch** when not in a linked worktree — no prompt (remote deleted in Step 9b).
 
 ### 11a. Update primary worktree
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -371,9 +371,10 @@ Proceed? [Y/n]:
 ### 9. Execute squash merge
 
 ```bash
-# CTL-56: capture head ref BEFORE merge so we can delete it checkout-free after confirm.
-# Resolves from the PR API regardless of local branch state.
+# CTL-56: capture head ref + head repo BEFORE merge so we can delete the ref checkout-free
+# after a REST-confirmed merge. Resolves from the PR API regardless of local branch state.
 head_ref=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.head.ref' 2>/dev/null || true)
+head_repo=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.head.repo.full_name' 2>/dev/null || true)
 # Merge via REST only — no local branch-cleanup flag (CTL-56: the local side effect fails
 # inside a linked worktree when the base is already checked out in the primary clone).
 gh pr merge $pr_number --squash
@@ -396,11 +397,25 @@ After verifying the merge succeeded (REST confirm), delete the remote head branc
 no local `git checkout` required, safe from any worktree (CTL-56):
 
 ```bash
-# Idempotent + best-effort: 404/422 means the ref is already gone or protected.
-# Never fail the skill on branch cleanup — the merge already landed.
-if [[ -n "${head_ref:-}" ]]; then
+# Confirm the merge landed via REST BEFORE deleting anything. `gh pr merge` returning success is
+# NOT proof it merged: with a merge queue enabled it only ENQUEUES the PR (see `gh pr merge --help`),
+# so the head ref may still belong to a still-open PR. gh's old atomic delete-on-merge flag removed
+# the branch ONLY after a real merge — preserve that conditional with an executable `.merged` check
+# here (a prose "after verifying" step is not a gate). (CTL-56)
+merged_ok=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.merged' 2>/dev/null || echo "false")
+# Delete the remote head ref checkout-free ONLY when BOTH hold:
+#  - the merge is REST-confirmed (merged_ok == true), and
+#  - the head branch actually lives in ${REPO}. A fork PR's `.head.ref` names a branch in the FORK,
+#    so deleting repos/${REPO}/git/refs/heads/${head_ref} could hit a SAME-NAMED branch in the base
+#    repo. gh's built-in flag handled the fork-vs-same-repo split natively; the raw API call does
+#    not — so gate on `.head.repo.full_name == ${REPO}` (CTL-56).
+# Idempotent + best-effort: a 404/422 means the ref is already gone or protected; never fail the
+# skill on branch cleanup — the merge already landed.
+if [[ "$merged_ok" == "true" && -n "${head_ref:-}" && "${head_repo:-}" == "${REPO}" ]]; then
   gh api --method DELETE "repos/${REPO}/git/refs/heads/${head_ref}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${head_ref} delete skipped (already gone or protected)" >&2
+elif [[ "$merged_ok" != "true" ]]; then
+  echo "merge-pr: merge of #${pr_number} not REST-confirmed; skipping branch cleanup (CTL-56)" >&2
 fi
 ```
 

--- a/plugins/dev/skills/merge-pr/SKILL.md
+++ b/plugins/dev/skills/merge-pr/SKILL.md
@@ -412,7 +412,10 @@ merged_ok=$(gh api "repos/${REPO}/pulls/${pr_number}" --jq '.merged' 2>/dev/null
 # Idempotent + best-effort: a 404/422 means the ref is already gone or protected; never fail the
 # skill on branch cleanup — the merge already landed.
 if [[ "$merged_ok" == "true" && -n "${head_ref:-}" && "${head_repo:-}" == "${REPO}" ]]; then
-  gh api --method DELETE "repos/${REPO}/git/refs/heads/${head_ref}" >/dev/null 2>&1 \
+  # CTL-56: URL-encode the head ref (preserve '/') so a metacharacter like '#' in a branch name
+  # (e.g. feature#123) can't truncate the endpoint into deleting the wrong ref.
+  enc_ref=$(printf '%s' "$head_ref" | jq -sRr @uri | sed 's|%2F|/|g')
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${head_ref} delete skipped (already gone or protected)" >&2
 elif [[ "$merged_ok" != "true" ]]; then
   echo "merge-pr: merge of #${pr_number} not REST-confirmed; skipping branch cleanup (CTL-56)" >&2

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -464,7 +464,10 @@ jq --arg ts "$MERGED_AT" --arg sha "${MERGE_COMMIT_SHA:-}" \
 # recorded. Idempotent + best-effort: a 404/422 means the ref is already gone or protected;
 # never fail the phase on branch cleanup — the merge already landed.
 if [[ -n "${HEAD_REF:-}" ]]; then
-  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+  # CTL-56: URL-encode the head ref (preserve '/') so a metacharacter like '#' in a branch name
+  # (e.g. feature#123) can't truncate the endpoint into deleting the wrong ref.
+  enc_ref=$(printf '%s' "$HEAD_REF" | jq -sRr @uri | sed 's|%2F|/|g')
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
 fi
 

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Phase 3). Lifts the active listen loop from the legacy `oneshot` Phase 5
   body: event-driven wait on `catalyst-events wait-for`, inline resolution of
   CI fix-ups, bot review threads, and BEHIND rebases, then `gh pr merge
-  --squash --delete-branch` when the PR reaches CLEAN. Linear Done transition
+  --squash` (worktree-safe, CTL-56) when the PR reaches CLEAN. Linear Done transition
   and worktree teardown are owned by phase-teardown (CTL-703). Dispatched as
   a `claude --bg` job by `phase-agent-dispatch`, which invokes it via slash
   command — hence `user-invocable: true`.
@@ -420,7 +420,13 @@ if [[ "$REVIEWER_VERDICT_PRESENT" != true && -n "${HEAD_AGE_SEC:-}" ]]; then
   fi
   echo "phase-monitor-merge: reviewer-arrival window elapsed; proceeding to merge pr#${PR_NUMBER}" >&2
 fi
-gh pr merge "$PR_NUMBER" --squash --delete-branch
+# CTL-56: capture head ref BEFORE merge so we can delete it checkout-free after confirm.
+HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
+# Merge via REST only (CTL-56: dropping the local branch-cleanup flag avoids the
+# `git checkout <base>` that fails inside a linked worktree when main is checked
+# out in the primary clone). The exit code is now meaningful; REST confirm below
+# is the authoritative success gate.
+gh pr merge "$PR_NUMBER" --squash
 # REST is authoritative — confirm via REST, never GraphQL
 MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
 [[ "$MERGED_OK" = "true" ]] || { echo "phase-monitor-merge: merge not confirmed via REST" >&2; exit 1; }
@@ -453,6 +459,14 @@ jq --arg ts "$MERGED_AT" --arg sha "${MERGE_COMMIT_SHA:-}" \
     | (if $sha != "" then .pr.mergeCommitSha = $sha else . end)
     | .updatedAt = $ts' \
    "$SIGNAL_FILE" > "$TMP" && mv "$TMP" "$SIGNAL_FILE"
+
+# CTL-56: delete the remote head ref checkout-free, AFTER merge is REST-confirmed and SHA
+# recorded. Idempotent + best-effort: a 404/422 means the ref is already gone or protected;
+# never fail the phase on branch cleanup — the merge already landed.
+if [[ -n "${HEAD_REF:-}" ]]; then
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+    || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
+fi
 
 # CTL-703: Linear Done is written by phase-teardown (10th phase), not here.
 echo "phase-monitor-merge: pr#${PR_NUMBER} merged at ${MERGED_AT}"

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -679,7 +679,8 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
   `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` — but ONLY when the head
   branch lives in that repo (`.head.repo.full_name == <owner/repo>`). A fork PR's `.head.ref` names
   a branch in the FORK, so deleting it from the base repo could hit an unrelated same-named branch
-  (CTL-56). Idempotent + best-effort.
+  (CTL-56). URL-encode `<head_ref>` (preserve `/`) first, so a metacharacter like `#` in the branch
+  name can't truncate the endpoint and delete the wrong ref. Idempotent + best-effort.
 
 **Step 4 — Escalate** only when:
 - A human reviewer (not a bot) left `CHANGES_REQUESTED` → escalate with the reviewer's SPECIFIC
@@ -716,8 +717,9 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
 >   checkout-free: `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` against the
 >   same `<owner/repo>` — but ONLY when the head branch lives in that repo
 >   (`.head.repo.full_name == <owner/repo>`); a fork PR's `.head.ref` lives in the fork, so deleting
->   it from the base repo could hit an unrelated same-named branch (CTL-56). Idempotent + best-effort
->   — a 404/422 means already gone or protected.
+>   it from the base repo could hit an unrelated same-named branch (CTL-56). URL-encode `<head_ref>`
+>   (preserve `/`) first so a metacharacter like `#` can't truncate the endpoint. Idempotent +
+>   best-effort — a 404/422 means already gone or protected.
 > - Red CI with a deterministic cause (type error, lint, a flaky test) → fix it, push, re-check
 >   (bounded by the attempts cap of 2 — after honest attempts that still fail on a *genuine design
 >   incompatibility*, it becomes an escalation, below).
@@ -875,7 +877,8 @@ then declare Done autonomously via `declare --by recovery-pass`, which now just 
   `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` — but ONLY when the head
   branch lives in that repo (`.head.repo.full_name == <owner/repo>`); a fork PR's head ref lives in
   the fork, so deleting it from the base repo could hit an unrelated same-named branch (CTL-56).
-  Idempotent + best-effort.
+  URL-encode `<head_ref>` (preserve `/`) first so a metacharacter like `#` can't truncate the
+  endpoint and delete the wrong ref. Idempotent + best-effort.
 
 > **NEVER `--admin` / force-merge past a failing or pending check.** You may merge
 > a PR ONLY when its required checks are genuinely GREEN (`gh pr checks <n>` all

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -676,7 +676,10 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
   **NEVER `--admin` or force-merge past a failing or pending check** — this is the load-bearing
   safety property (Rubric Two invariant).
 - After REST-confirm (`.merged == true`), delete the remote head ref checkout-free:
-  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` (idempotent, best-effort).
+  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` — but ONLY when the head
+  branch lives in that repo (`.head.repo.full_name == <owner/repo>`). A fork PR's `.head.ref` names
+  a branch in the FORK, so deleting it from the base repo could hit an unrelated same-named branch
+  (CTL-56). Idempotent + best-effort.
 
 **Step 4 — Escalate** only when:
 - A human reviewer (not a bot) left `CHANGES_REQUESTED` → escalate with the reviewer's SPECIFIC
@@ -711,7 +714,10 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
 >   repo and would merge the wrong same-numbered PR while the attached one stays open. Verify via REST
 >   (`gh api repos/<owner/repo>/pulls/<n> --jq '.merged'`), then delete the remote head ref
 >   checkout-free: `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` against the
->   same `<owner/repo>` (idempotent, best-effort — a 404/422 means already gone or protected).
+>   same `<owner/repo>` — but ONLY when the head branch lives in that repo
+>   (`.head.repo.full_name == <owner/repo>`); a fork PR's `.head.ref` lives in the fork, so deleting
+>   it from the base repo could hit an unrelated same-named branch (CTL-56). Idempotent + best-effort
+>   — a 404/422 means already gone or protected.
 > - Red CI with a deterministic cause (type error, lint, a flaky test) → fix it, push, re-check
 >   (bounded by the attempts cap of 2 — after honest attempts that still fail on a *genuine design
 >   incompatibility*, it becomes an escalation, below).
@@ -866,7 +872,10 @@ then declare Done autonomously via `declare --by recovery-pass`, which now just 
   pass `-R <owner/repo>` on both** (`gh pr merge <n> -R <owner/repo> …`) — a bare merge
   targets the ticket's repo and would land the wrong same-numbered PR while the attached one
   stays open. After REST-confirm, delete the remote head ref checkout-free:
-  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` (idempotent, best-effort).
+  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` — but ONLY when the head
+  branch lives in that repo (`.head.repo.full_name == <owner/repo>`); a fork PR's head ref lives in
+  the fork, so deleting it from the base repo could hit an unrelated same-named branch (CTL-56).
+  Idempotent + best-effort.
 
 > **NEVER `--admin` / force-merge past a failing or pending check.** You may merge
 > a PR ONLY when its required checks are genuinely GREEN (`gh pr checks <n>` all

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -671,8 +671,12 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
 **Step 3 — Merge** (when the probe returns `mergeStateStatus: "CLEAN"`):
 - Run `gh pr view <n> --json mergeable,mergeStateStatus` to confirm.
 - Run the cluster fence guard: `"${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase recovery-pass --ticket <T>`.
-- Merge: `gh pr merge <n> --squash --delete-branch`. **NEVER `--admin` or force-merge past a
-  failing or pending check** — this is the load-bearing safety property (Rubric Two invariant).
+- Merge: capture the head ref first (`gh api repos/<owner/repo>/pulls/<n> --jq '.head.ref'`),
+  then `gh pr merge <n> --squash` (worktree-safe — CTL-56: no local branch-cleanup side effect).
+  **NEVER `--admin` or force-merge past a failing or pending check** — this is the load-bearing
+  safety property (Rubric Two invariant).
+- After REST-confirm (`.merged == true`), delete the remote head ref checkout-free:
+  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` (idempotent, best-effort).
 
 **Step 4 — Escalate** only when:
 - A human reviewer (not a bot) left `CHANGES_REQUESTED` → escalate with the reviewer's SPECIFIC
@@ -698,13 +702,16 @@ above), and this worker's allowed tools don't include `Skill`. Do the equivalent
 >     This is bounded-LLM engineering, NOT an automatic escalation.
 > - Green PR just sitting there → `gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`,
 >   then run the cluster fence guard (`"${PLUGIN_ROOT}/scripts/lib/cluster-fence-guard.sh" --phase
->   recovery-pass --ticket <T>`), then `gh pr merge <n> --squash --delete-branch`. **When the open-PR
->   enumerator printed this PR as `owner/repo#n` (a cross-repo Linear attachment, a DIFFERENT repo than
->   the ticket's), you MUST pass `-R <owner/repo>` on the view AND the merge (`gh pr merge <n> -R
->   <owner/repo> …`)** — a bare `gh pr merge <n>` runs against the ticket's repo and would merge the
->   wrong same-numbered PR (landing unintended code + deleting its branch) while the attached one stays
->   open. Verify the merge via REST (`gh api repos/<owner/repo>/pulls/<n> --jq '.merged'`) —
->   `--delete-branch` exits non-zero from a worktree even when the squash succeeded.
+>   recovery-pass --ticket <T>`), then capture the head ref
+>   (`gh api repos/<owner/repo>/pulls/<n> --jq '.head.ref'`) and
+>   `gh pr merge <n> --squash` (CTL-56: worktree-safe — no local branch-cleanup side effect). **When
+>   the open-PR enumerator printed this PR as `owner/repo#n` (a cross-repo Linear attachment, a
+>   DIFFERENT repo than the ticket's), you MUST pass `-R <owner/repo>` on the view AND the merge
+>   (`gh pr merge <n> -R <owner/repo> …`)** — a bare `gh pr merge <n>` runs against the ticket's
+>   repo and would merge the wrong same-numbered PR while the attached one stays open. Verify via REST
+>   (`gh api repos/<owner/repo>/pulls/<n> --jq '.merged'`), then delete the remote head ref
+>   checkout-free: `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` against the
+>   same `<owner/repo>` (idempotent, best-effort — a 404/422 means already gone or protected).
 > - Red CI with a deterministic cause (type error, lint, a flaky test) → fix it, push, re-check
 >   (bounded by the attempts cap of 2 — after honest attempts that still fail on a *genuine design
 >   incompatibility*, it becomes an escalation, below).
@@ -853,11 +860,13 @@ then declare Done autonomously via `declare --by recovery-pass`, which now just 
 - **CI failure after rebase/push** → `gh run view --log-failed`, fix the root
   cause (type error / lint / test), commit, push to re-trigger.
 - **A green PR just sitting there** → verify it is CLEAN
-  (`gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`), then
-  `gh pr merge <n> --squash --delete-branch`. **For a cross-repo PR the enumerator
-  printed as `owner/repo#n`, pass `-R <owner/repo>` on both** (`gh pr merge <n> -R
-  <owner/repo> …`) — a bare merge targets the ticket's repo and would land the wrong
-  same-numbered PR while the attached one stays open.
+  (`gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision`), capture the head ref
+  (`gh api repos/<owner/repo>/pulls/<n> --jq '.head.ref'`), then `gh pr merge <n> --squash`
+  (CTL-56: worktree-safe). **For a cross-repo PR the enumerator printed as `owner/repo#n`,
+  pass `-R <owner/repo>` on both** (`gh pr merge <n> -R <owner/repo> …`) — a bare merge
+  targets the ticket's repo and would land the wrong same-numbered PR while the attached one
+  stays open. After REST-confirm, delete the remote head ref checkout-free:
+  `gh api --method DELETE repos/<owner/repo>/git/refs/heads/<head_ref>` (idempotent, best-effort).
 
 > **NEVER `--admin` / force-merge past a failing or pending check.** You may merge
 > a PR ONLY when its required checks are genuinely GREEN (`gh pr checks <n>` all

--- a/plugins/dev/skills/triage-aging-prs/SKILL.md
+++ b/plugins/dev/skills/triage-aging-prs/SKILL.md
@@ -219,7 +219,14 @@ if [[ "$MERGED_OK" == "true" && -n "${HEAD_REF:-}" && "${HEAD_REPO:-}" == "${REP
   gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
 elif [[ "$MERGED_OK" != "true" ]]; then
-  echo "triage-aging-prs: merge of #<N> not REST-confirmed; skipping branch cleanup (CTL-56)" >&2
+  # NOT REST-confirmed: `gh pr merge` may have failed, or (with a merge queue) only ENQUEUED the PR
+  # without landing it (`gh pr merge --help`). This PR is NOT merged — its head ref must survive AND
+  # it must NOT flow into Step 6 as a merged PR. Treat it as a failed merge for this PR: record the
+  # not-merged status in your report and move to the NEXT aging PR (`continue`) — do NOT reconcile
+  # its ticket to Done and do NOT report it as merged. Never `exit` here: that would abort the whole
+  # burndown over a single unmergeable PR (CTL-56).
+  echo "triage-aging-prs: merge of #<N> NOT REST-confirmed — PR still open; skipping branch cleanup AND ticket reconciliation for it (CTL-56)" >&2
+  continue
 fi
 ```
 

--- a/plugins/dev/skills/triage-aging-prs/SKILL.md
+++ b/plugins/dev/skills/triage-aging-prs/SKILL.md
@@ -216,7 +216,10 @@ MERGED_OK=$(gh api "repos/${REPO}/pulls/<N>" --jq '.merged' 2>/dev/null || echo 
 #    the raw API call does not — so gate on `.head.repo.full_name == ${REPO}` (CTL-56).
 #    triage-aging-prs processes arbitrary aging PRs, which may be fork PRs.
 if [[ "$MERGED_OK" == "true" && -n "${HEAD_REF:-}" && "${HEAD_REPO:-}" == "${REPO}" ]]; then
-  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+  # CTL-56: URL-encode the head ref (preserve '/') so a metacharacter like '#' in a branch name
+  # (e.g. feature#123) can't truncate the endpoint into deleting the wrong ref.
+  enc_ref=$(printf '%s' "$HEAD_REF" | jq -sRr @uri | sed 's|%2F|/|g')
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
 elif [[ "$MERGED_OK" != "true" ]]; then
   # NOT REST-confirmed: `gh pr merge` may have failed, or (with a merge queue) only ENQUEUED the PR

--- a/plugins/dev/skills/triage-aging-prs/SKILL.md
+++ b/plugins/dev/skills/triage-aging-prs/SKILL.md
@@ -198,15 +198,28 @@ test suite. A union that produces a duplicate YAML key breaks CI for everyone.
 ## Step 5 — Merge, and judge CI honestly
 
 ```bash
-# CTL-56: capture head ref BEFORE merge for checkout-free remote cleanup after confirm.
+# CTL-56: capture head ref + head repo BEFORE merge for checkout-free remote cleanup after confirm.
 HEAD_REF=$(gh api "repos/${REPO}/pulls/<N>" --jq '.head.ref' 2>/dev/null || true)
+HEAD_REPO=$(gh api "repos/${REPO}/pulls/<N>" --jq '.head.repo.full_name' 2>/dev/null || true)
 # Merge via REST only — no local branch-cleanup flag; worktree-safe (CTL-56).
 gh pr merge <N> --repo "$REPO" --squash
-# … confirm merge via REST (.merged == true) …
-# After REST-confirm, delete remote head ref checkout-free (idempotent, best-effort):
-if [[ -n "${HEAD_REF:-}" ]]; then
+# Confirm the merge landed via REST BEFORE any branch cleanup — REST is authoritative, and gh's
+# old atomic delete-on-merge flag removed the branch ONLY on a successful merge. A comment is not
+# a gate: an unconfirmed/failed merge here must NOT reach the delete, or it orphans the PR's head
+# ref (CTL-56).
+MERGED_OK=$(gh api "repos/${REPO}/pulls/<N>" --jq '.merged' 2>/dev/null || echo "false")
+# Delete the remote head ref checkout-free (idempotent, best-effort) ONLY when BOTH hold:
+#  - the merge is REST-confirmed, and
+#  - the head branch actually lives in ${REPO}. A fork PR's `.head.ref` names a branch in the
+#    FORK, so deleting repos/${REPO}/git/refs/heads/${HEAD_REF} could hit a SAME-NAMED branch in
+#    the base repo. gh's built-in branch-delete flag handled the fork-vs-same-repo split natively;
+#    the raw API call does not — so gate on `.head.repo.full_name == ${REPO}` (CTL-56).
+#    triage-aging-prs processes arbitrary aging PRs, which may be fork PRs.
+if [[ "$MERGED_OK" == "true" && -n "${HEAD_REF:-}" && "${HEAD_REPO:-}" == "${REPO}" ]]; then
   gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
+elif [[ "$MERGED_OK" != "true" ]]; then
+  echo "triage-aging-prs: merge of #<N> not REST-confirmed; skipping branch cleanup (CTL-56)" >&2
 fi
 ```
 

--- a/plugins/dev/skills/triage-aging-prs/SKILL.md
+++ b/plugins/dev/skills/triage-aging-prs/SKILL.md
@@ -198,7 +198,16 @@ test suite. A union that produces a duplicate YAML key breaks CI for everyone.
 ## Step 5 — Merge, and judge CI honestly
 
 ```bash
-gh pr merge <N> --repo "$REPO" --squash --delete-branch
+# CTL-56: capture head ref BEFORE merge for checkout-free remote cleanup after confirm.
+HEAD_REF=$(gh api "repos/${REPO}/pulls/<N>" --jq '.head.ref' 2>/dev/null || true)
+# Merge via REST only — no local branch-cleanup flag; worktree-safe (CTL-56).
+gh pr merge <N> --repo "$REPO" --squash
+# … confirm merge via REST (.merged == true) …
+# After REST-confirm, delete remote head ref checkout-free (idempotent, best-effort):
+if [[ -n "${HEAD_REF:-}" ]]; then
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+    || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
+fi
 ```
 
 Before merging, check the **actual** failing checks rather than trusting the gate:

--- a/plugins/dev/templates/fixup-prompt.md
+++ b/plugins/dev/templates/fixup-prompt.md
@@ -121,7 +121,13 @@ fi
    # REST check via gh api "repos/${REPO}/pulls/${PR_NUMBER}"
 
    # When PR is CLEAN — merge directly (no --auto)
-   gh pr merge ${PR_NUMBER} --squash --delete-branch
+   # CTL-56: capture head ref before merge; merge via REST only (worktree-safe).
+   HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
+   gh pr merge ${PR_NUMBER} --squash
+   # … confirm via REST (.merged == true) …
+   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
+   [[ -n "${HEAD_REF:-}" ]] && \
+     gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true
 
    # Record done — worker writes status=done (CTL-252 contract)
    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/templates/fixup-prompt.md
+++ b/plugins/dev/templates/fixup-prompt.md
@@ -130,9 +130,13 @@ fi
    # PR's head ref).
    MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
    [[ "$MERGED_OK" == "true" ]] || { echo "merge of #${PR_NUMBER} not REST-confirmed; not deleting branch" >&2; exit 1; }
-   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
-   [[ -n "${HEAD_REF:-}" ]] && \
-     gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true
+   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56).
+   # URL-encode the ref (preserve '/') so a metacharacter like '#' (feature#123) can't truncate
+   # the endpoint into deleting the wrong ref.
+   if [[ -n "${HEAD_REF:-}" ]]; then
+     enc_ref=$(printf '%s' "$HEAD_REF" | jq -sRr @uri | sed 's|%2F|/|g')
+     gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 || true
+   fi
 
    # Record done — worker writes status=done (CTL-252 contract)
    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/templates/fixup-prompt.md
+++ b/plugins/dev/templates/fixup-prompt.md
@@ -124,7 +124,12 @@ fi
    # CTL-56: capture head ref before merge; merge via REST only (worktree-safe).
    HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
    gh pr merge ${PR_NUMBER} --squash
-   # … confirm via REST (.merged == true) …
+   # Confirm the merge landed via REST BEFORE any branch cleanup — REST is authoritative (CTL-56).
+   # gh's old atomic delete-on-merge flag removed the branch ONLY on a successful merge; a comment
+   # is not a gate, so an unconfirmed/failed merge must NOT reach the delete (it would orphan the
+   # PR's head ref).
+   MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
+   [[ "$MERGED_OK" == "true" ]] || { echo "merge of #${PR_NUMBER} not REST-confirmed; not deleting branch" >&2; exit 1; }
    # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
    [[ -n "${HEAD_REF:-}" ]] && \
      gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true

--- a/plugins/dev/templates/followup-prompt.md
+++ b/plugins/dev/templates/followup-prompt.md
@@ -132,7 +132,12 @@ known parent to reference.
    # CTL-56: capture head ref before merge; merge via REST only (worktree-safe).
    HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
    gh pr merge ${PR_NUMBER} --squash
-   # … confirm via REST (.merged == true) …
+   # Confirm the merge landed via REST BEFORE any branch cleanup — REST is authoritative (CTL-56).
+   # gh's old atomic delete-on-merge flag removed the branch ONLY on a successful merge; a comment
+   # is not a gate, so an unconfirmed/failed merge must NOT reach the delete (it would orphan the
+   # PR's head ref).
+   MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
+   [[ "$MERGED_OK" == "true" ]] || { echo "merge of #${PR_NUMBER} not REST-confirmed; not deleting branch" >&2; exit 1; }
    # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
    [[ -n "${HEAD_REF:-}" ]] && \
      gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true

--- a/plugins/dev/templates/followup-prompt.md
+++ b/plugins/dev/templates/followup-prompt.md
@@ -138,9 +138,13 @@ known parent to reference.
    # PR's head ref).
    MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
    [[ "$MERGED_OK" == "true" ]] || { echo "merge of #${PR_NUMBER} not REST-confirmed; not deleting branch" >&2; exit 1; }
-   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
-   [[ -n "${HEAD_REF:-}" ]] && \
-     gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true
+   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56).
+   # URL-encode the ref (preserve '/') so a metacharacter like '#' (feature#123) can't truncate
+   # the endpoint into deleting the wrong ref.
+   if [[ -n "${HEAD_REF:-}" ]]; then
+     enc_ref=$(printf '%s' "$HEAD_REF" | jq -sRr @uri | sed 's|%2F|/|g')
+     gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 || true
+   fi
 
    # Record done — worker writes status=done (CTL-252 contract)
    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/templates/followup-prompt.md
+++ b/plugins/dev/templates/followup-prompt.md
@@ -129,7 +129,13 @@ known parent to reference.
    # REST check via gh api "repos/${REPO}/pulls/${PR_NUMBER}"
 
    # When PR is CLEAN — merge directly (no --auto)
-   gh pr merge ${PR_NUMBER} --squash --delete-branch
+   # CTL-56: capture head ref before merge; merge via REST only (worktree-safe).
+   HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
+   gh pr merge ${PR_NUMBER} --squash
+   # … confirm via REST (.merged == true) …
+   # After confirm, delete remote head ref checkout-free (idempotent, best-effort, CTL-56):
+   [[ -n "${HEAD_REF:-}" ]] && \
+     gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 || true
 
    # Record done — worker writes status=done (CTL-252 contract)
    TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/plugins/dev/templates/worker-signal.json
+++ b/plugins/dev/templates/worker-signal.json
@@ -118,7 +118,7 @@
         "mergedAt": {
           "type": ["string", "null"],
           "format": "date-time",
-          "description": "ISO 8601 timestamp when the PR was actually merged. Written by the WORKER after gh pr merge --squash --delete-branch and REST confirmation via gh api. Null until merge. Orchestrator Phase 4 writes this only as a fallback for stalled workers."
+          "description": "ISO 8601 timestamp when the PR was actually merged. Written by the WORKER after gh pr merge --squash and REST confirmation via gh api, followed by a checkout-free gh api --method DELETE of the head ref (CTL-56). Null until merge. Orchestrator Phase 4 writes this only as a fallback for stalled workers."
         }
       },
       "description": "Pull request details (null until PR is created). The worker owns all fields — number, url, ciStatus, prOpenedAt, and mergedAt — by actively listening and merging (CTL-252). The orchestrator's poll loop is a safety net for stalled workers only."

--- a/plugins/legacy/skills/oneshot/SKILL.md
+++ b/plugins/legacy/skills/oneshot/SKILL.md
@@ -967,7 +967,13 @@ deployment, write `status: "done"`, and exit.
 ```bash
 # Execute merge now that PR is ready (no --auto; worker owns the merge in CTL-252 contract)
 if [ "$PR_MERGED" != "true" ]; then
-  gh pr merge "$PR_NUMBER" --squash --delete-branch
+  # CTL-56: capture head ref BEFORE merge so we can delete it checkout-free after confirm.
+  HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
+  # Merge via REST only (CTL-56: dropping the local branch-cleanup flag avoids the
+  # `git checkout <base>` that fails inside a linked worktree when main is checked
+  # out in the primary clone). The exit code is now meaningful; REST confirm below
+  # is the authoritative success gate.
+  gh pr merge "$PR_NUMBER" --squash
 fi
 
 # Confirm via REST (authoritative — never gh pr view --json)
@@ -982,6 +988,14 @@ if [ "$MERGED_OK" != "true" ]; then
     "$SESSION_SCRIPT" end "$CATALYST_SESSION_ID" --status failed --reason "merge not confirmed via REST"
   fi
   exit 1
+fi
+
+# CTL-56: delete the remote head ref checkout-free, AFTER merge is REST-confirmed. Idempotent +
+# best-effort: a 404/422 means the ref is already gone or protected; never fail the phase on
+# branch cleanup — the merge already landed.
+if [[ -n "${HEAD_REF:-}" ]]; then
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+    || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
 fi
 
 MERGE_COMMIT_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
@@ -1386,7 +1400,7 @@ error, context exhaustion):
 - **Phase 3 does NOT commit** — all git operations are deferred to Phase 5
 - **Worker's success contract is `status: "done"` (CTL-252)** — the worker opens the PR, enters an
   event-driven listen loop using `catalyst-events wait-for`, resolves CI/review blockers inline,
-  merges when CLEAN with `gh pr merge --squash --delete-branch` (no `--auto`), and writes
+  merges when CLEAN with `gh pr merge --squash` (worktree-safe, CTL-56; no `--auto`), and writes
   `status: "done"` with `pr.mergedAt` and `deployment.url` (if applicable). Workers do NOT use
   `ScheduleWakeup` (unreliable in `-p` mode) — they use `catalyst-events wait-for` which is a
   blocking subprocess call that works reliably in non-interactive sessions

--- a/plugins/legacy/skills/oneshot/SKILL.md
+++ b/plugins/legacy/skills/oneshot/SKILL.md
@@ -994,7 +994,10 @@ fi
 # best-effort: a 404/422 means the ref is already gone or protected; never fail the phase on
 # branch cleanup — the merge already landed.
 if [[ -n "${HEAD_REF:-}" ]]; then
-  gh api --method DELETE "repos/${REPO}/git/refs/heads/${HEAD_REF}" >/dev/null 2>&1 \
+  # CTL-56: URL-encode the head ref (preserve '/') so a metacharacter like '#' in a branch name
+  # (e.g. feature#123) can't truncate the endpoint into deleting the wrong ref.
+  enc_ref=$(printf '%s' "$HEAD_REF" | jq -sRr @uri | sed 's|%2F|/|g')
+  gh api --method DELETE "repos/${REPO}/git/refs/heads/${enc_ref}" >/dev/null 2>&1 \
     || echo "CTL-56: remote branch ${HEAD_REF} delete skipped (already gone or protected)" >&2
 fi
 

--- a/plugins/legacy/skills/orchestrate/SKILL.md
+++ b/plugins/legacy/skills/orchestrate/SKILL.md
@@ -830,7 +830,7 @@ MANDATORY: Before completing your contract:
 Your success contract ENDS at (CTL-252):
   ✓ PR open (gh pr create succeeded)
   ✓ Active listen loop resolved all blockers (CI, bot reviews, BEHIND) inline
-  ✓ PR merged with gh pr merge --squash --delete-branch (no --auto)
+  ✓ PR merged with gh pr merge --squash (worktree-safe, CTL-56; no --auto; remote ref deleted via gh api --method DELETE after REST confirm)
   ✓ Optional deployment verified (if catalyst.deploy configured)
   ✓ pr.mergedAt, deployment.url (if applicable), status="done" written to signal file
   ✓ Worker process exits cleanly
@@ -1879,8 +1879,9 @@ fi
   --summary "wave ${CURRENT_WAVE:-1} post-merge verification" 2>/dev/null || true
 ```
 
-**Context (CTL-130, updated by CTL-252):** Workers actively merge their own PRs via
-`gh pr merge --squash --delete-branch` (no `--auto`) after the listen loop confirms CLEAN. The merge
+**Context (CTL-130, updated by CTL-252, CTL-56):** Workers actively merge their own PRs via
+`gh pr merge --squash` (worktree-safe, CTL-56; no `--auto`) after the listen loop confirms CLEAN,
+then delete the remote head ref checkout-free via `gh api --method DELETE`. The merge
 happens the moment the worker's listen loop confirms CI passed and reviews are satisfied.
 Verification therefore runs **post-merge** — it surfaces gaps for remediation rather than gating
 merge.


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-12T05:10:00Z -->
<!-- Last updated: 2026-08-12T05:10:00Z -->
<!-- PR: #3277 -->
<!-- Previous commits: fa2331f0,d328cf63,cf4d1cb8,0ad06072 -->

## Summary

Fixes `gh pr merge --squash --delete-branch` failing inside git linked worktrees with `fatal: 'main' is already used by worktree`. The `--delete-branch` flag triggers a local `git checkout <base>` which fails when the base branch is already checked out in the primary clone. This was breaking every automated merge in Catalyst's phase-agent and oneshot pipelines when running from worktree directories.

The fix splits merge and branch cleanup: merge via REST only (`gh pr merge --squash`, no local side effects), then delete the remote head ref checkout-free via `gh api --method DELETE` after REST-confirming the merge landed.

## Changes Made

### Phase-agent pipeline (`phase-monitor-merge/SKILL.md`)

- Capture `HEAD_REF` from the PR API before merge so it's available for checkout-free cleanup
- Drop `--delete-branch` from `gh pr merge`; exit code is now the meaningful signal
- After REST confirming `.merged == true` and recording the merge SHA, delete the remote head ref via `gh api --method DELETE repos/{REPO}/git/refs/heads/{HEAD_REF}` — idempotent, best-effort, never fails the phase

### Legacy oneshot worker (`oneshot/SKILL.md`)

- Same three-part pattern: capture `HEAD_REF` → merge without `--delete-branch` → checkout-free remote ref delete after REST confirm

### Interactive `merge-pr` skill (`merge-pr/SKILL.md`)

- Step 9: capture `head_ref` before merge, merge without `--delete-branch`
- Step 9b (new): checkout-free remote ref delete after REST confirm
- Step 11: linked-worktree detection guard — when `--absolute-git-dir != --git-common-dir` (both forced absolute via `--path-format=absolute`), skip local base checkout and local branch delete (teardown/reaper cleans the worktree's local branch)

### Recovery and aging-PR sweeps (`recovery-pass/SKILL.md`, `triage-aging-prs/SKILL.md`)

- Same checkout-free pattern applied to all merge call sites
- `triage-aging-prs` additionally gates the remote ref delete on `.head.repo.full_name == $REPO` to avoid deleting a same-named branch in the base repo when processing fork PRs

### Templates (`fixup-prompt.md`, `followup-prompt.md`)

- Updated model-injected merge snippets: drop `--delete-branch`, add explicit REST `.merged` confirmation gate before the remote ref delete (regression from the initial split — the old atomic flag deleted only on confirmed merge; the split rewrite had only a prose comment where the gate should have been)

### Schema (`worker-signal.json`)

- Updated `mergedAt` doc string: drop stale `--delete-branch` reference, document the two-step REST-confirm + checkout-free delete pattern

### CI and guard tests

- Added `execution-core-tests.yml` CI step to run the guard test suite
- New `__tests__/merge-delete-branch-worktree-guard.test.sh`: asserts no live `gh pr merge` call carries `--delete-branch` across all affected files; also verifies each site has the checkout-free `git/refs/heads/` + `--method DELETE` pattern
- New `__tests__/phase-monitor-merge-guard.test.sh`: targeted guard for the phase-monitor-merge call site
- New `__tests__/oneshot-merge-worktree-guard.test.sh`: targeted guard for the oneshot call site
- Pinned test assertions for `--path-format=absolute` normalization and the REST `.merged` confirm gate (the prior presence-only checks were false-green for the delete-before-confirm regression)

## How to Verify It

- [x] `bash plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh` — all assertions pass
- [x] `bash plugins/dev/scripts/__tests__/phase-monitor-merge-guard.test.sh` — passes
- [x] `bash plugins/dev/scripts/__tests__/oneshot-merge-worktree-guard.test.sh` — passes
- [ ] In a live worktree: run `gh pr merge <N> --squash` on a test PR — confirm merge lands and remote branch is deleted without the `fatal: 'main' is already used by worktree` error
- [ ] Primary clone check: run `merge-pr` interactively from the primary repo (not a linked worktree) — confirm local base checkout + local branch delete still happen (guard fires correctly only in linked worktrees)

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-56
