### PR TITLE
feat(dev): CTL-1774 — thread appendDelegateEvent through delegate-first routing seam

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -353,9 +353,9 @@ CTL-707 replaced the binary CTL-667 rebase with a 4-layer strategy:
 
 Before config resolution, signal creation, rebase, and worker launch, the dispatcher resolves the
 ticket worktree through an explicit flag, the project registry, the current repository, then a
-backwards-compatible cwd fallback. It changes into that resolved tree, making dispatch safe from
-any caller cwd; the JS caller's `cwd` remains a belt-and-braces reinforcement. This also prevents
-L3 destroy-and-recreate from selecting a bystander worktree.
+backwards-compatible cwd fallback. It changes into that resolved tree, making dispatch safe from any
+caller cwd; the JS caller's `cwd` remains a belt-and-braces reinforcement. This also prevents L3
+destroy-and-recreate from selecting a bystander worktree.
 
 - **L1 — Periodic background refresh** (`execution-core/worktree-refresh-timer.mjs`): keeps idle
   running worktrees current. Config
@@ -374,18 +374,17 @@ L3 destroy-and-recreate from selecting a bystander worktree.
 | `phase.<phase>.auto-rebased.<ticket>`                | INFO     | L1 + L2 (clean/additive) |
 | `phase.<phase>.rebase-conflict-categorized.<ticket>` | WARN     | L2 (pre-stall)           |
 | `phase.<phase>.rebase-conflict-stalled.<ticket>`     | ERROR    | L2 (terminal)            |
-| `phase.<phase>.dispatch-cwd-corrected.<ticket>`      | WARN     | CAT-31 resolver           |
+| `phase.<phase>.dispatch-cwd-corrected.<ticket>`      | WARN     | CAT-31 resolver          |
 
 Loki:
 `{job="catalyst-events"} | json | attributes["event.name"] =~ "phase\\..*\\.auto-rebased\\..*"`
 (swap suffix per event).
 
 Invariants (unchanged from CTL-667): **cwd-independent** (the target is resolved, not inherited);
-**fresh-only** (resume `--resume-session` skips, CTL-658);
-**build-phase-only** (`is_rebase_phase` in `lib/phase-sequence.sh`;
-`triage`/`pr`/`remediate`/`monitor-*`/`teardown` exempt); **local-only** (never pushes/touches the
-PR; `.catalyst/config.json`,`.trunk/*` stashed across rebase); transient `git fetch` failure (rc=1)
-→ proceed un-rebased.
+**fresh-only** (resume `--resume-session` skips, CTL-658); **build-phase-only** (`is_rebase_phase`
+in `lib/phase-sequence.sh`; `triage`/`pr`/`remediate`/`monitor-*`/`teardown` exempt); **local-only**
+(never pushes/touches the PR; `.catalyst/config.json`,`.trunk/*` stashed across rebase); transient
+`git fetch` failure (rc=1) → proceed un-rebased.
 
 ### PR as the durable work record (CTL-783)
 
@@ -447,8 +446,8 @@ The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode 
 Pass 0r and Pass 0u share the same production act-seam dependencies. `runTick` constructs the
 PR-state resolver, background-job liveness probe, stall clearer, and status writer once; Pass 0u
 uses them to build its act registry, while Pass 0r receives both that registry and the raw bundle
-for capability-checked fallback construction. An injected partial registry therefore falls back
-to real dependencies instead of either using inert defaults or failing as unavailable.
+for capability-checked fallback construction. An injected partial registry therefore falls back to
+real dependencies instead of either using inert defaults or failing as unavailable.
 
 The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact
 `.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the
@@ -761,21 +760,22 @@ file's edit isn't invisible to the salvage the same way it's invisible to plain 
 dirty/uninitialized submodule (any depth, via `git submodule status --recursive`) is salvaged
 recursively — its own uncommitted diff + untracked files, not just the superproject's opaque
 `Subproject commit <sha>-dirty` marker. The orphan-sweep's `ORPHAN_GITFILE` case (a stale/missing
-`.git` file pointer — not a usable git worktree, so the git-based primitive above can't inspect it at
-all) instead calls the primitive's sibling `salvage_raw_directory` (plain `tar`, no git involved)
+`.git` file pointer — not a usable git worktree, so the git-based primitive above can't inspect it
+at all) instead calls the primitive's sibling `salvage_raw_directory` (plain `tar`, no git involved)
 before its `rm -rf`. Because the sweep runs every 1–3h and revisits a retained
 `SALVAGE_UNPUSHED`/`SALVAGE_DIRTY` worktree every pass, orphan-sweep wraps its own calls in a
 `salvage_worktree_dedup` fingerprint check (HEAD sha + a git-blob-hash of the working diff/staged
-diff/untracked-file set, stored per-worktree under `~/catalyst/salvage/.state/`) so an unchanged tree
-is NOT re-archived under a new unique name every single sweep — this dedup lives in orphan-sweep.sh
-itself, not inside `salvage_worktree`, so the primitive's other callers (each acting on a worktree
-exactly once) and its own multi-call test contract are unaffected. The `worktree.salvage.*` prefix is
-**unprotected** under the CTL-1142 namespace contract (no `isBrokerProtectedName` collision — it
-routes through `shouldSkipEvent` normally). Salvage is best-effort/fail-open — it never blocks a
-removal — layered on top of the existing fail-closed `_removal_guard_ok` live-handle gate, which is
-re-asserted immediately after salvage completes (not just before it starts) at every synchronous call
-site, since salvage's own duration widens the window a live handle could appear in. (Retention/GC of
-`~/catalyst/salvage/` beyond the dedup above is deferred follow-up.)
+diff/untracked-file set, stored per-worktree under `~/catalyst/salvage/.state/`) so an unchanged
+tree is NOT re-archived under a new unique name every single sweep — this dedup lives in
+orphan-sweep.sh itself, not inside `salvage_worktree`, so the primitive's other callers (each acting
+on a worktree exactly once) and its own multi-call test contract are unaffected. The
+`worktree.salvage.*` prefix is **unprotected** under the CTL-1142 namespace contract (no
+`isBrokerProtectedName` collision — it routes through `shouldSkipEvent` normally). Salvage is
+best-effort/fail-open — it never blocks a removal — layered on top of the existing fail-closed
+`_removal_guard_ok` live-handle gate, which is re-asserted immediately after salvage completes (not
+just before it starts) at every synchronous call site, since salvage's own duration widens the
+window a live handle could appear in. (Retention/GC of `~/catalyst/salvage/` beyond the dedup above
+is deferred follow-up.)
 
 ### Linear app-actor self-echo guard (`botUserId`)
 
@@ -845,8 +845,8 @@ a fully-dead daemon is a _missing series_, which `count_over_time == 0` cannot a
 **`<name>` slot exceptions** (in `recovery.mjs`, NOT pipeline phases): `dispatch`
 (`phase.dispatch.failed.<ticket>` — the only exception with a terminal-status suffix that matches
 the pattern; real phase rides `payload.target_phase`); `scheduler` (internal observability:
-`yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate — `held` on a refusal,
-`applied` on a performed advance, CTL-1789). The latter two never match the terminal-status set, so
+`yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate — `held` on a refusal, `applied`
+on a performed advance, CTL-1789). The latter two never match the terminal-status set, so
 `tryPhaseLifecycleRoute` returns `[]` for every event in them — pure audit, zero wake side effect.
 
 ### Advancement-gate observability + terminal attribution (CTL-1789)
@@ -861,10 +861,10 @@ a revive, a resume, and a new-work pull).
   `dispatchAndVerify` confirmed a live successor worker). Severity **INFO** (`held` stays WARN).
   Payload: `{from, to, evidence, evidence_reason, asserted_by, assertion_ref}`; `evidence` plus
   `from`/`to` are also promoted to attributes (`catalyst.advance.*`) because otel-forward strips
-  `body.payload` off-machine. `from` is re-derived with the extracted pure `latestLivePhase(signals)`
-  — the SAME function `deriveAdvancement` keys off, so the audit can never name a different
-  predecessor than the FSM used. **One exception — the remediate detour**: `remediate` is
-  ANCILLARY (∉ `PHASES`), so `latestLivePhase` can never return it, and
+  `body.payload` off-machine. `from` is re-derived with the extracted pure
+  `latestLivePhase(signals)` — the SAME function `deriveAdvancement` keys off, so the audit can
+  never name a different predecessor than the FSM used. **One exception — the remediate detour**:
+  `remediate` is ANCILLARY (∉ `PHASES`), so `latestLivePhase` can never return it, and
   `maybeResetForRemediateCycle` has already deleted `phase-remediate.json` before the sweep reads
   its map. Left on `latestLivePhase` alone, every remediation re-entry named `from=implement` and
   classified its evidence off the stale implement terminal — laundering a FABRICATED remediation
@@ -878,10 +878,10 @@ a revive, a resume, and a new-work pull).
   (**fabricated** — the agent never declared anything), and the recovery-reclaim / legacy-revive
   synthetic completes (**fabricated** — inferred from a work-done probe). Writers stamp their id:
   the wrapper defaults to `phase-agent-emit-complete` and accepts `--asserted-by` so infrastructure
-  callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the
-  fail direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` /
-  `no-marker` / `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued.
-  **One registry, two unavoidable bash mirrors**: the JS writers (`recovery.mjs`,
+  callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the fail
+  direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` / `no-marker` /
+  `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued. **One
+  registry, two unavoidable bash mirrors**: the JS writers (`recovery.mjs`,
   `sdk-run-phase-agent.mjs`) import `ASSERTED_BY`, but `phase-agent-emit-complete` (its
   `--asserted-by` default) and `orchestrate-revive` (its flag value) are bash and cannot. Those two
   literals are held byte-identical to the registry MECHANICALLY by
@@ -889,8 +889,9 @@ a revive, a resume, and a new-work pull).
   cross-stack-parity-suite discipline as `lib/secret-contract.mjs`. Each anchor matches on the
   variable/flag, never the value, and fails CLOSED when an anchor disappears, so a rename on either
   side alone fails rather than silently reclassifying valid terminals as `unknown-writer`.
-- **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline pass
-  after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has cycled.
+- **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline
+  pass after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has
+  cycled.
 - **Scope**: only the terminal-**success** writers are stamped (plus the SDK backstop). The ~20
   `stalled`/`failed`/`aborted`/`needs-human` writers are deliberately unstamped — those statuses are
   never advance-eligible (`deriveAdvancement` gates on `done`, or `skipped` for `monitor-deploy`

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -41,22 +41,24 @@ try {
   // sees stdout, which stays pure JSON.
   log = pino({ name: "execution-core", level: process.env.LOG_LEVEL ?? "info" }, process.stderr);
 } catch (err) {
-  const emit = (level) => (...args) => {
-    // pino-style: log.info(obj, msg) OR log.info(msg). Console-shim flattens.
-    // warn/error/fatal → stderr so CLI commands that write JSON to stdout are
-    // not polluted by log messages (CTL-854). info/debug/trace → stdout to
-    // preserve the existing observable behavior for test suites that capture
-    // stdout for informational output.
-    const stream =
-      level === "warn" || level === "error" || level === "fatal"
-        ? process.stderr
-        : process.stdout;
-    stream.write(
-      `[execution-core:${level}] ${args
-        .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
-        .join(" ")}\n`,
-    );
-  };
+  const emit =
+    (level) =>
+    (...args) => {
+      // pino-style: log.info(obj, msg) OR log.info(msg). Console-shim flattens.
+      // warn/error/fatal → stderr so CLI commands that write JSON to stdout are
+      // not polluted by log messages (CTL-854). info/debug/trace → stdout to
+      // preserve the existing observable behavior for test suites that capture
+      // stdout for informational output.
+      const stream =
+        level === "warn" || level === "error" || level === "fatal"
+          ? process.stderr
+          : process.stdout;
+      stream.write(
+        `[execution-core:${level}] ${args
+          .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+          .join(" ")}\n`
+      );
+    };
   log = {
     info: emit("info"),
     warn: emit("warn"),
@@ -67,7 +69,7 @@ try {
     child: () => log,
   };
   process.stderr.write(
-    `[execution-core] WARN: pino unavailable (${err?.message ?? err}); using console shim\n`,
+    `[execution-core] WARN: pino unavailable (${err?.message ?? err}); using console shim\n`
   );
 }
 export { log };
@@ -78,7 +80,11 @@ export { log };
 // reimplemented here. See lib/deployment-mode.mjs's file header for the
 // naming rule ("deployment mode", never bare "mode") and the env-vs-file
 // asymmetry caveat.
-export { DEPLOYMENT_MODES, resolveDeploymentMode, getDeploymentMode } from "../lib/deployment-mode.mjs";
+export {
+  DEPLOYMENT_MODES,
+  resolveDeploymentMode,
+  getDeploymentMode,
+} from "../lib/deployment-mode.mjs";
 
 // --- Paths ---
 // Re-resolved per call so tests can redirect by setting CATALYST_DIR;
@@ -156,7 +162,12 @@ export function getDaemonRuntimeEnvPath(orchDir) {
 // the boot-drain-is-authoritative rule), so readers consume it without re-deriving.
 export function writeDaemonRuntimeEnv(
   orchDir,
-  { env = process.env, pid = process.pid, pidFile = null, now = () => new Date().toISOString() } = {}
+  {
+    env = process.env,
+    pid = process.pid,
+    pidFile = null,
+    now = () => new Date().toISOString(),
+  } = {}
 ) {
   const payload = {
     pid,
@@ -177,7 +188,9 @@ export function writeDaemonRuntimeEnv(
     const tmp = `${p}.tmp`;
     writeFileSync(tmp, JSON.stringify(payload));
     renameSync(tmp, p);
-  } catch { /* best-effort */ }
+  } catch {
+    /* best-effort */
+  }
   return payload;
 }
 
@@ -241,12 +254,21 @@ export function readDaemonRuntimeEnv(
 // (which read surfaces pre-source from execution-core.env — correct for a stopped
 // daemon, where next-start config is the running truth-to-be). `source` names which
 // tier answered so operator surfaces can say so.
-export function resolveDrainStateForRead(orchDir, { env = process.env, readRuntime = readDaemonRuntimeEnv } = {}) {
+export function resolveDrainStateForRead(
+  orchDir,
+  { env = process.env, readRuntime = readDaemonRuntimeEnv } = {}
+) {
   const runtime = readRuntime(orchDir);
   if (runtime) {
     const flagPresent = existsSync(getDrainFlagPath(orchDir));
     const disabled = !!runtime.drainDisabled;
-    return { flagPresent, disabled, draining: flagPresent && !disabled, source: "daemon-runtime", daemonPid: runtime.pid };
+    return {
+      flagPresent,
+      disabled,
+      draining: flagPresent && !disabled,
+      source: "daemon-runtime",
+      daemonPid: runtime.pid,
+    };
   }
   return { ...resolveDrainState(orchDir, { env }), source: "env" };
 }
@@ -279,11 +301,23 @@ export function getDrainedMarkerPath(orchDir) {
 export function applyBootDrainPolicy(orchDir, { env = process.env } = {}) {
   const flag = getDrainFlagPath(orchDir);
   const drainedMarker = getDrainedMarkerPath(orchDir);
-  try { rmSync(flag, { force: true }); } catch { /* best-effort */ }
-  try { rmSync(drainedMarker, { force: true }); } catch { /* best-effort */ }
+  try {
+    rmSync(flag, { force: true });
+  } catch {
+    /* best-effort */
+  }
+  try {
+    rmSync(drainedMarker, { force: true });
+  } catch {
+    /* best-effort */
+  }
   const drained = env.CATALYST_BOOT_DRAINED === "1";
   if (drained) {
-    try { writeFileSync(flag, ""); } catch { /* best-effort */ }
+    try {
+      writeFileSync(flag, "");
+    } catch {
+      /* best-effort */
+    }
   }
   return { drained };
 }
@@ -346,10 +380,7 @@ export function getRunsRoot() {
 // Env name matches orchestrate-healthcheck's CATALYST_HEALTHCHECK_JOBS_ROOT so
 // tests override one variable for both.
 export function getJobsRoot() {
-  return (
-    process.env.CATALYST_HEALTHCHECK_JOBS_ROOT ??
-    resolve(homedir(), ".claude", "jobs")
-  );
+  return process.env.CATALYST_HEALTHCHECK_JOBS_ROOT ?? resolve(homedir(), ".claude", "jobs");
 }
 
 // The unified monthly event log. UTC month to match the writer —
@@ -490,9 +521,10 @@ export function isHostNamePinnedFromConfig() {
   if (typeof env === "string" && env.length > 0) return true;
   try {
     const parsed = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"));
-    return typeof parsed?.catalyst?.host?.name === "string" &&
-           parsed.catalyst.host.name.length > 0;
-  } catch { return false; }
+    return typeof parsed?.catalyst?.host?.name === "string" && parsed.catalyst.host.name.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 // --- Node class (CTL-1344) ---
@@ -562,7 +594,13 @@ export function resolveNodeClass() {
 
   // Absent / explicit "unset" sentinel (undefined key or JSON null) ⇒ worker.
   if (raw === undefined || raw === null) {
-    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+    return {
+      class: NODE_CLASS_DEFAULT,
+      source: "default",
+      inferred: true,
+      recognized: true,
+      raw: null,
+    };
   }
   // Present but not a string ⇒ explicit misconfiguration, never a silent worker.
   if (typeof raw !== "string") {
@@ -571,7 +609,13 @@ export function resolveNodeClass() {
   const normalized = raw.trim().toLowerCase();
   // Empty/whitespace string ⇒ "cleared" (mirrors an empty env var) ⇒ worker.
   if (normalized.length === 0) {
-    return { class: NODE_CLASS_DEFAULT, source: "default", inferred: true, recognized: true, raw: null };
+    return {
+      class: NODE_CLASS_DEFAULT,
+      source: "default",
+      inferred: true,
+      recognized: true,
+      raw: null,
+    };
   }
   if (NODE_CLASSES.includes(normalized)) {
     return { class: normalized, source, inferred: false, recognized: true, raw };
@@ -653,7 +697,12 @@ const EXECUTOR_ALIASES = Object.freeze({
 // executor → catalyst.dispatch.mode value. Closed enum {phase-agents |
 // oneshot-legacy | sdk | codex-exec}: "bg" maps to the existing "phase-agents"
 // label so the telemetry name is stable across the rename.
-export const DISPATCH_MODES = Object.freeze(["phase-agents", "oneshot-legacy", "sdk", "codex-exec"]);
+export const DISPATCH_MODES = Object.freeze([
+  "phase-agents",
+  "oneshot-legacy",
+  "sdk",
+  "codex-exec",
+]);
 const DISPATCH_MODE_BY_EXECUTOR = Object.freeze({
   bg: "phase-agents",
   sdk: "sdk",
@@ -732,7 +781,13 @@ export function resolveExecutor(configPath) {
 
   // Absent / explicit "unset" sentinel (undefined key or JSON null) ⇒ node-class default.
   if (raw === undefined || raw === null) {
-    return { executor: nodeClassDefault, source: "default", inferred: true, recognized: true, raw: null };
+    return {
+      executor: nodeClassDefault,
+      source: "default",
+      inferred: true,
+      recognized: true,
+      raw: null,
+    };
   }
   // Present but not a string ⇒ explicit misconfiguration, never a silent sdk.
   if (typeof raw !== "string") {
@@ -741,7 +796,13 @@ export function resolveExecutor(configPath) {
   const normalized = raw.trim().toLowerCase();
   // Empty/whitespace string ⇒ "cleared" (mirrors an empty env var) ⇒ node-class default.
   if (normalized.length === 0) {
-    return { executor: nodeClassDefault, source: "default", inferred: true, recognized: true, raw: null };
+    return {
+      executor: nodeClassDefault,
+      source: "default",
+      inferred: true,
+      recognized: true,
+      raw: null,
+    };
   }
   // CTL-1457: canonicalize a compound alias (claude-bg→bg …) before the membership
   // check. An alias is never "" so this stays after the cleared-string short-circuit.
@@ -937,7 +998,11 @@ export function codexConfig({ configPath, env = process.env } = {}) {
     ? l1.writableRoots.filter((v) => typeof v === "string" && v.trim() !== "")
     : [];
   return {
-    codexHome: resolveNonEmptyString(env.CATALYST_CODEX_HOME, l1.codexHome, `${catalystDir()}/codex-home`),
+    codexHome: resolveNonEmptyString(
+      env.CATALYST_CODEX_HOME,
+      l1.codexHome,
+      `${catalystDir()}/codex-home`
+    ),
     bin: resolveNonEmptyString(env.CATALYST_CODEX_BIN, l1.bin, "codex"),
     model: resolveNonEmptyString(env.CATALYST_CODEX_MODEL, l1.model, null),
     writableRoots: writableRoots.length > 0 ? writableRoots : [catalystDir()],
@@ -961,8 +1026,8 @@ export function getStaticRoster() {
     if (hosts.length > 0) return hosts;
   }
   try {
-    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))
-      ?.catalyst?.cluster?.staticRoster;
+    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cluster
+      ?.staticRoster;
     if (Array.isArray(raw)) {
       const hosts = raw.filter((h) => typeof h === "string" && h.length > 0);
       if (hosts.length > 0) return hosts;
@@ -984,7 +1049,11 @@ export function getStaticRoster() {
 // (it never empties the roster, which would mass-evict the fleet under HRW).
 function readClusterRepoRoster() {
   const cluster = readClusterConfig();
-  if (cluster && schemaCompat(cluster.schemaVersion) !== "too-new" && Array.isArray(cluster.roster)) {
+  if (
+    cluster &&
+    schemaCompat(cluster.schemaVersion) !== "too-new" &&
+    Array.isArray(cluster.roster)
+  ) {
     const hosts = cluster.roster.filter((h) => typeof h === "string" && h.length > 0);
     if (hosts.length > 0) return hosts;
   }
@@ -1070,10 +1139,12 @@ export function getLivenessAnchorIssue() {
   const env = process.env.CATALYST_LIVENESS_ANCHOR_ISSUE;
   if (typeof env === "string" && env.length > 0) return env;
   try {
-    const a = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))
-      ?.catalyst?.cluster?.livenessAnchorIssue;
+    const a = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cluster
+      ?.livenessAnchorIssue;
     if (typeof a === "string" && a.length > 0) return a;
-  } catch { /* missing/malformed → null */ }
+  } catch {
+    /* missing/malformed → null */
+  }
   return null;
 }
 
@@ -1129,8 +1200,7 @@ export const HEARTBEAT_INTERVAL_MS =
 // HEARTBEAT_GRACE_MS — how long after the last heartbeat a host is considered
 // dead (CTL-863). 10 minutes is deliberately generous: a false eviction on a
 // live-but-slow host is worse than a slow takeover. Env-overridable for tests.
-export const HEARTBEAT_GRACE_MS =
-  Number(process.env.EXECUTION_CORE_HEARTBEAT_GRACE_MS) || 600_000;
+export const HEARTBEAT_GRACE_MS = Number(process.env.EXECUTION_CORE_HEARTBEAT_GRACE_MS) || 600_000;
 
 // CTL-1529 — how far back the BOUNDED heartbeat tail read tries to reach.
 //
@@ -1205,7 +1275,7 @@ export function resolveHeartbeatTailWindowMs(
     min = HEARTBEAT_TAIL_WINDOW_MIN_MS,
     max = HEARTBEAT_TAIL_WINDOW_MAX_MS,
     onInvalid = null,
-  } = {},
+  } = {}
 ) {
   // Unset / empty is the documented way to take the default — stay silent.
   if (raw === undefined || raw === null) return defaultMs;
@@ -1218,7 +1288,8 @@ export function resolveHeartbeatTailWindowMs(
     reason = "not a finite number"; // NaN ("abc"), Infinity, -Infinity, 1e400
   } else {
     const v = Math.floor(n);
-    if (v < min) reason = `below the ${min}ms minimum (must exceed HEARTBEAT_GRACE_MS to make stale-vs-absent decidable)`;
+    if (v < min)
+      reason = `below the ${min}ms minimum (must exceed HEARTBEAT_GRACE_MS to make stale-vs-absent decidable)`;
     else if (v > max) reason = `above the ${max}ms maximum (the monthly log's own horizon)`;
     else return v;
   }
@@ -1233,13 +1304,13 @@ export const HEARTBEAT_TAIL_WINDOW_MS = resolveHeartbeatTailWindowMs(
       try {
         log.warn(
           { raw, reason, min, max, usingMs: defaultMs },
-          "ctl-1529: EXECUTION_CORE_HEARTBEAT_TAIL_WINDOW_MS is invalid — ignoring it and using the default window",
+          "ctl-1529: EXECUTION_CORE_HEARTBEAT_TAIL_WINDOW_MS is invalid — ignoring it and using the default window"
         );
       } catch {
         /* logger unavailable (bare import in a test) — the fallback still applies */
       }
     },
-  },
+  }
 );
 
 // resolveRestoreHoldMs — parse the CTL-1091 restore-hold override with the
@@ -1266,7 +1337,7 @@ export function resolveRestoreHoldMs(rawStr, defaultMs) {
 // for the validation contract — explicit 0 opt-out honored; empty/negative → default).
 export const HEARTBEAT_RESTORE_HOLD_MS = resolveRestoreHoldMs(
   process.env.EXECUTION_CORE_HEARTBEAT_RESTORE_HOLD_MS,
-  HEARTBEAT_GRACE_MS,
+  HEARTBEAT_GRACE_MS
 );
 
 // CLUSTER_SYNC_INTERVAL_MS — how often the daemon git-pulls the catalyst-cluster
@@ -1309,8 +1380,7 @@ export const RECONCILE_BLIND_ALERT_MS =
 
 // Debounce window: state_changed events that enter the eligible state coalesce
 // into one reconcile poll per affected project per burst.
-export const EVENT_DEBOUNCE_MS =
-  Number(process.env.EXECUTION_CORE_DEBOUNCE_MS) || 5_000;
+export const EVENT_DEBOUNCE_MS = Number(process.env.EXECUTION_CORE_DEBOUNCE_MS) || 5_000;
 
 // CTL triage-entry fix (Phase 0): poll interval for draining the unified event
 // log. The fs.watch tailer (startTailing) is unreliable for cross-process
@@ -1319,8 +1389,7 @@ export const EVENT_DEBOUNCE_MS =
 // readNewEvents() deterministically so new-work discovery is near-instant.
 // readNewEvents is cheap (fstat + read of only the bytes appended since the
 // durable cursor) and idempotent, so a tight interval is safe.
-export const TAILER_POLL_INTERVAL_MS =
-  Number(process.env.EXECUTION_CORE_TAILER_POLL_MS) || 2_000;
+export const TAILER_POLL_INTERVAL_MS = Number(process.env.EXECUTION_CORE_TAILER_POLL_MS) || 2_000;
 
 // CTL-533: a worker whose signal has not been updated within this window is
 // "stale" — a precondition for the Step G stalled scan to consult git/PR
@@ -1347,8 +1416,7 @@ export const BUSY_CEILING_MS =
 // wedged-never-started (stop + replace via the normal revive path; escalate
 // needs-human after repeated ineffective replacements). 120s comfortably
 // exceeds registration + first-turn latency. Env-overridable.
-export const NEVER_STARTED_MS =
-  Number(process.env.CATALYST_NEVER_STARTED_MS) || 120_000;
+export const NEVER_STARTED_MS = Number(process.env.CATALYST_NEVER_STARTED_MS) || 120_000;
 
 // CTL-809 — ghost-breaker just-dispatched grace. The reclaim alive-branch
 // cross-checks the FRESH `claude agents` snapshot to catch a jobLifecycle-alive
@@ -1358,8 +1426,7 @@ export const NEVER_STARTED_MS =
 // `claude agents` yet, so its absence is NOT proof of death — only reclaim on
 // absence once past this window. Comfortably exceeds observed `claude --bg`
 // registration latency + one warmer interval. Env-overridable.
-export const GHOST_GRACE_MS =
-  Number(process.env.EXECUTION_CORE_GHOST_GRACE_MS) || 90_000;
+export const GHOST_GRACE_MS = Number(process.env.EXECUTION_CORE_GHOST_GRACE_MS) || 90_000;
 
 // CTL-868 — zombie state.json staleness floor. The CTL-809 ghost-breaker only
 // fires when the `claude agents` snapshot is FRESH (absent-from-fresh = ghost).
@@ -1437,14 +1504,11 @@ export function readWaitWatcherConfig() {
 export const MEMORY_SAMPLE_INTERVAL_MS =
   Number(process.env.EXECUTION_CORE_MEMORY_SAMPLE_INTERVAL_MS) || 30_000;
 
-export const WORKER_RSS_WARN_MB =
-  Number(process.env.EXECUTION_CORE_WORKER_RSS_WARN_MB) || 1500;
+export const WORKER_RSS_WARN_MB = Number(process.env.EXECUTION_CORE_WORKER_RSS_WARN_MB) || 1500;
 
-export const WORKER_RSS_KILL_MB =
-  Number(process.env.EXECUTION_CORE_WORKER_RSS_KILL_MB) || 4000;
+export const WORKER_RSS_KILL_MB = Number(process.env.EXECUTION_CORE_WORKER_RSS_KILL_MB) || 4000;
 
-export const WORKER_OOM_KILLER =
-  process.env.EXECUTION_CORE_WORKER_OOM_KILLER !== "0";
+export const WORKER_OOM_KILLER = process.env.EXECUTION_CORE_WORKER_OOM_KILLER !== "0";
 
 export const KILL_SUSTAINED_SAMPLES =
   Number(process.env.EXECUTION_CORE_KILL_SUSTAINED_SAMPLES) || 3;
@@ -1498,7 +1562,10 @@ export function readFleetHealthConfigLayer1(configPath) {
     return fh && typeof fh === "object" ? fh : {};
   } catch (err) {
     if (err?.code !== "ENOENT") {
-      log.warn({ configPath, err: err.message }, "fleet-health: Layer-1 config unreadable; using defaults");
+      log.warn(
+        { configPath, err: err.message },
+        "fleet-health: Layer-1 config unreadable; using defaults"
+      );
     }
     return {};
   }
@@ -1523,18 +1590,18 @@ export function readFleetHealthConfig(configPath) {
   const swapTrip = fleetHealthNumber(
     process.env.EXECUTION_CORE_FLEET_SWAP_MB_THRESHOLD,
     l1.swapUsedMbThreshold,
-    FLEET_HEALTH_DEFAULTS.swapUsedMbThreshold,
+    FLEET_HEALTH_DEFAULTS.swapUsedMbThreshold
   );
   let swapClear = fleetHealthNumber(
     process.env.EXECUTION_CORE_FLEET_SWAP_MB_CLEAR_THRESHOLD,
     l1.swapUsedMbClearThreshold,
-    FLEET_HEALTH_DEFAULTS.swapUsedMbClearThreshold,
+    FLEET_HEALTH_DEFAULTS.swapUsedMbClearThreshold
   );
   if (swapClear >= swapTrip) {
     const clamped = Math.max(0, swapTrip - 1);
     log.warn(
       { swapClear, swapTrip, clamped },
-      "fleet-health: swapUsedMbClearThreshold >= swapUsedMbThreshold — clamping clear below trip to keep a real hysteresis band",
+      "fleet-health: swapUsedMbClearThreshold >= swapUsedMbThreshold — clamping clear below trip to keep a real hysteresis band"
     );
     swapClear = clamped;
   }
@@ -1549,12 +1616,12 @@ export function readFleetHealthConfig(configPath) {
     intervalMs: fleetHealthNumber(
       process.env.EXECUTION_CORE_FLEET_HEALTH_INTERVAL_MS,
       l1.intervalMs,
-      FLEET_HEALTH_DEFAULTS.intervalMs,
+      FLEET_HEALTH_DEFAULTS.intervalMs
     ),
     jobsThreshold: fleetHealthNumber(
       process.env.EXECUTION_CORE_FLEET_JOBS_THRESHOLD,
       l1.jobsThreshold,
-      FLEET_HEALTH_DEFAULTS.jobsThreshold,
+      FLEET_HEALTH_DEFAULTS.jobsThreshold
     ),
     swapUsedMbThreshold: swapTrip,
     // CTL-1503 — lower clear threshold for the swap hysteresis band; the latch
@@ -1563,12 +1630,12 @@ export function readFleetHealthConfig(configPath) {
     agentsThreshold: fleetHealthNumber(
       process.env.EXECUTION_CORE_FLEET_AGENTS_THRESHOLD,
       l1.agentsThreshold,
-      FLEET_HEALTH_DEFAULTS.agentsThreshold,
+      FLEET_HEALTH_DEFAULTS.agentsThreshold
     ),
     procsThreshold: fleetHealthNumber(
       process.env.EXECUTION_CORE_FLEET_PROCS_THRESHOLD,
       l1.procsThreshold,
-      FLEET_HEALTH_DEFAULTS.procsThreshold,
+      FLEET_HEALTH_DEFAULTS.procsThreshold
     ),
     // Self-heal: env=1 enables; otherwise Layer-1 selfHealEnabled===true enables;
     // else DEFAULT OFF (emit-only).
@@ -1583,7 +1650,7 @@ export function readFleetHealthConfig(configPath) {
     sustainedTicks: fleetHealthNumber(
       process.env.EXECUTION_CORE_FLEET_SUSTAINED_TICKS,
       l1.sustainedTicks,
-      FLEET_HEALTH_DEFAULTS.sustainedTicks,
+      FLEET_HEALTH_DEFAULTS.sustainedTicks
     ),
   };
 }
@@ -1625,8 +1692,7 @@ export const AUTOTUNE_MEM_CRITICAL_PCT =
   Number(process.env.EXECUTION_CORE_AUTOTUNE_MEM_CRITICAL_PCT) || 5;
 
 // Memory-free threshold for warn guard (below this → suppress growth).
-export const AUTOTUNE_MEM_WARN_PCT =
-  Number(process.env.EXECUTION_CORE_AUTOTUNE_MEM_WARN_PCT) || 20;
+export const AUTOTUNE_MEM_WARN_PCT = Number(process.env.EXECUTION_CORE_AUTOTUNE_MEM_WARN_PCT) || 20;
 
 // Kill-switch: EXECUTION_CORE_AUTOTUNE=0 disables all sampling and Layer-2 writes.
 export const AUTOTUNE_ENABLED = process.env.EXECUTION_CORE_AUTOTUNE !== "0";
@@ -1662,15 +1728,17 @@ export const AUTOTUNE_CLAUDE_SHED_FACTOR =
 
 export const WATCHDOG_MINUTES_PER_TURN =
   Number(process.env.EXECUTION_CORE_WATCHDOG_MINUTES_PER_TURN) || 2;
-const WATCHDOG_MIN_PHASE_BUDGET_MS = 20 * 60_000;   // absolute floor
-const WATCHDOG_FALLBACK_BUDGET_MS = 90 * 60_000;    // when turnCap unparseable
+const WATCHDOG_MIN_PHASE_BUDGET_MS = 20 * 60_000; // absolute floor
+const WATCHDOG_FALLBACK_BUDGET_MS = 90 * 60_000; // when turnCap unparseable
 const WATCHDOG_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2Watchdog() {
   try {
     const w = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.watchdog;
     return w && typeof w === "object" ? w : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 function resolveMode(envVal, l2Val) {
   for (const v of [envVal, l2Val]) {
@@ -1690,18 +1758,23 @@ function resolveCount(envVal, l2Val, def) {
 export function readWatchdogConfig() {
   const l2 = readLayer2Watchdog();
   // CATALYST_WATCHDOG=0 is the kill-switch → mode:off (back-compat).
-  const mode = process.env.CATALYST_WATCHDOG === "0"
-    ? "off"
-    : resolveMode(process.env.EXECUTION_CORE_WATCHDOG_MODE, l2.mode);
+  const mode =
+    process.env.CATALYST_WATCHDOG === "0"
+      ? "off"
+      : resolveMode(process.env.EXECUTION_CORE_WATCHDOG_MODE, l2.mode);
   const silenceThresholdMs =
     Number(process.env.EXECUTION_CORE_WATCHDOG_SILENCE_MS) ||
     (Number(l2.silenceThresholdMinutes) || 0) * 60_000 ||
     30 * 60_000;
   const phaseBudgetMultiplier =
     Number(process.env.EXECUTION_CORE_WATCHDOG_BUDGET_MULTIPLIER) ||
-    Number(l2.phaseBudgetMultiplier) || 1.5;
+    Number(l2.phaseBudgetMultiplier) ||
+    1.5;
   const reviveBudget = resolveCount(
-    process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET, l2.reviveBudget, 0);
+    process.env.EXECUTION_CORE_WATCHDOG_REVIVE_BUDGET,
+    l2.reviveBudget,
+    0
+  );
   return { mode, silenceThresholdMs, phaseBudgetMultiplier, reviveBudget };
 }
 
@@ -1734,7 +1807,7 @@ export function readDaemonWatchdogConfigLayer1(configPath) {
     if (err?.code !== "ENOENT") {
       log.warn(
         { configPath, err: err.message },
-        "daemon-watchdog: Layer-1 config unreadable; using defaults",
+        "daemon-watchdog: Layer-1 config unreadable; using defaults"
       );
     }
     return {};
@@ -1755,32 +1828,32 @@ export function readDaemonWatchdogConfig(configPath) {
     intervalMs: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_INTERVAL_MS,
       l1.intervalMs,
-      DAEMON_WATCHDOG_DEFAULTS.intervalMs,
+      DAEMON_WATCHDOG_DEFAULTS.intervalMs
     ),
     dlqMaxBytes: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_DLQ_MAX_BYTES,
       l1.dlqMaxBytes,
-      DAEMON_WATCHDOG_DEFAULTS.dlqMaxBytes,
+      DAEMON_WATCHDOG_DEFAULTS.dlqMaxBytes
     ),
     stalenessMs: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_STALENESS_MS,
       l1.stalenessMs,
-      DAEMON_WATCHDOG_DEFAULTS.stalenessMs,
+      DAEMON_WATCHDOG_DEFAULTS.stalenessMs
     ),
     cooldownMs: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_COOLDOWN_MS,
       l1.cooldownMs,
-      DAEMON_WATCHDOG_DEFAULTS.cooldownMs,
+      DAEMON_WATCHDOG_DEFAULTS.cooldownMs
     ),
     sustainedTicks: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_SUSTAINED_TICKS,
       l1.sustainedTicks,
-      DAEMON_WATCHDOG_DEFAULTS.sustainedTicks,
+      DAEMON_WATCHDOG_DEFAULTS.sustainedTicks
     ),
     verifyTicks: fleetHealthNumber(
       process.env.EXECUTION_CORE_DAEMON_WATCHDOG_VERIFY_TICKS,
       l1.verifyTicks,
-      DAEMON_WATCHDOG_DEFAULTS.verifyTicks,
+      DAEMON_WATCHDOG_DEFAULTS.verifyTicks
     ),
   };
 }
@@ -1791,15 +1864,17 @@ export function readDaemonWatchdogConfig(configPath) {
 // "enforce"). CATALYST_COST_CAP=0 is the kill-switch → "off". The cost SIGNAL is
 // Prometheus (the single source of truth — claude_code_cost_usage_USD_total by
 // session_id); enforcement FAILS OPEN when Prom is unreachable.
-const COST_CAP_DEFAULT_USD = 40;          // $40/phase-session ≈ 1.6× the most expensive legit autonomous run ever (28d, n=1548; max $24.97)
-const COST_CAP_DEFAULT_POLL_SEC = 30;     // per-session Prom cadence — NOT every tick
+const COST_CAP_DEFAULT_USD = 40; // $40/phase-session ≈ 1.6× the most expensive legit autonomous run ever (28d, n=1548; max $24.97)
+const COST_CAP_DEFAULT_POLL_SEC = 30; // per-session Prom cadence — NOT every tick
 const COST_CAP_DEFAULT_PROM_URL = "http://100.65.193.30:9098"; // OTel/Prom stack on Tailscale
 
 function readLayer2CostCap() {
   try {
     const c = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.costCap;
     return c && typeof c === "object" ? c : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 function resolvePositiveNumber(envVal, l2Val, def) {
   for (const v of [envVal, l2Val]) {
@@ -1818,15 +1893,26 @@ function resolveNonEmptyString(envVal, l2Val, def) {
 
 export function readCostCapConfig() {
   const l2 = readLayer2CostCap();
-  const mode = process.env.CATALYST_COST_CAP === "0"
-    ? "off"
-    : resolveMode(process.env.EXECUTION_CORE_COST_CAP_MODE, l2.mode); // shares {off,shadow,enforce}
+  const mode =
+    process.env.CATALYST_COST_CAP === "0"
+      ? "off"
+      : resolveMode(process.env.EXECUTION_CORE_COST_CAP_MODE, l2.mode); // shares {off,shadow,enforce}
   const capUsd = resolvePositiveNumber(
-    process.env.EXECUTION_CORE_COST_CAP_USD, l2.perSessionUsd, COST_CAP_DEFAULT_USD);
-  const pollMs = resolvePositiveNumber(
-    process.env.EXECUTION_CORE_COST_CAP_POLL_SEC, l2.pollEverySec, COST_CAP_DEFAULT_POLL_SEC) * 1000;
+    process.env.EXECUTION_CORE_COST_CAP_USD,
+    l2.perSessionUsd,
+    COST_CAP_DEFAULT_USD
+  );
+  const pollMs =
+    resolvePositiveNumber(
+      process.env.EXECUTION_CORE_COST_CAP_POLL_SEC,
+      l2.pollEverySec,
+      COST_CAP_DEFAULT_POLL_SEC
+    ) * 1000;
   const promBaseUrl = resolveNonEmptyString(
-    process.env.EXECUTION_CORE_COST_CAP_PROM_URL, l2.promBaseUrl, COST_CAP_DEFAULT_PROM_URL);
+    process.env.EXECUTION_CORE_COST_CAP_PROM_URL,
+    l2.promBaseUrl,
+    COST_CAP_DEFAULT_PROM_URL
+  );
   return { mode, capUsd, pollMs, promBaseUrl };
 }
 
@@ -1866,7 +1952,9 @@ function readLayer2StallJanitor() {
   try {
     const sj = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.stallJanitor;
     return sj && typeof sj === "object" ? sj : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readStallJanitorConfig() {
@@ -1909,7 +1997,9 @@ function readLayer2UnstuckSweep() {
   try {
     const us = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.unstuckSweep;
     return us && typeof us === "object" ? us : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readUnstuckSweepConfig() {
@@ -1938,7 +2028,7 @@ export function readUnstuckSweepConfig() {
 // Extracted as a standalone export so tests can assert the throttle guard
 // and future low-frequency passes can reuse the same helper.
 export function isThrottled(lastRunMs, intervalMs, nowMs) {
-  return (nowMs - lastRunMs) < intervalMs;
+  return nowMs - lastRunMs < intervalMs;
 }
 
 // CTL-1176: Pass 0r — LLM reasoning recovery pass config reader.
@@ -1951,7 +2041,9 @@ function readLayer2RecoveryPass() {
   try {
     const rp = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery?.pass;
     return rp && typeof rp === "object" ? rp : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readRecoveryPassConfig(envObj = process.env) {
@@ -1985,7 +2077,9 @@ function readLayer2DelegateFirst() {
   try {
     const df = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.delegateFirst;
     return df && typeof df === "object" ? df : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 // env (CATALYST_DELEGATE_FIRST) overrides Layer-2 (.catalyst.delegateFirst.mode),
@@ -2017,9 +2111,12 @@ const DEAD_DOC_WORKER_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2DeadDocWorker() {
   try {
-    const d = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery?.deadDocWorker;
+    const d = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery
+      ?.deadDocWorker;
     return d && typeof d === "object" ? d : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readDeadDocWorkerConfig() {
@@ -2067,7 +2164,9 @@ function readLayer2BoardHealth() {
   try {
     const b = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.boardHealth;
     return b && typeof b === "object" ? b : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readBoardHealthConfig(env = process.env) {
@@ -2129,7 +2228,9 @@ function readLayer2Coordination() {
   try {
     const c = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.coordination;
     return c && typeof c === "object" ? c : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 export function readCoordinationConfig(env = process.env) {
@@ -2184,9 +2285,7 @@ export const DELEGATE_RUNNER_MODES = new Set(["on", "off"]);
 
 function readPositiveIntEnv(raw, fallback) {
   const n = Number(raw);
-  return typeof raw === "string" && raw !== "" && Number.isFinite(n) && n > 0
-    ? n
-    : fallback;
+  return typeof raw === "string" && raw !== "" && Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
 // CTL-1331 follow-up: the gateway freshness window for the RECLAIM sweep's per-signal
@@ -2423,22 +2522,24 @@ function readLayer2Governance() {
   try {
     const g = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.governance;
     return g && typeof g === "object" ? g : {};
-  } catch { return {}; }
+  } catch {
+    return {};
+  }
 }
 
 // Three-layer beliefs flag: explicit env ("1"/"0") > Layer-2 boolean > default false.
 // Returns both the effective boolean and its source so the boot self-report can flag overrides.
 function resolveBeliefsFlag(envVal, l2Val) {
-  if (envVal === "1") return { value: true,  source: "env-override" };
+  if (envVal === "1") return { value: true, source: "env-override" };
   if (envVal === "0") return { value: false, source: "env-override" };
   if (typeof l2Val === "boolean") return { value: l2Val, source: "config" };
   return { value: false, source: "default" };
 }
 
 const BELIEFS_FLAGS = {
-  beliefsShadow:        "CATALYST_BELIEFS_SHADOW",
-  diagnostician:        "CATALYST_DIAGNOSTICIAN",
-  intentsEnforce:       "CATALYST_INTENTS_ENFORCE",
+  beliefsShadow: "CATALYST_BELIEFS_SHADOW",
+  diagnostician: "CATALYST_DIAGNOSTICIAN",
+  intentsEnforce: "CATALYST_INTENTS_ENFORCE",
   advanceShadowSummary: "CATALYST_ADVANCE_SHADOW_SUMMARY",
 };
 
@@ -2494,22 +2595,22 @@ export function readGovernanceSources(env = process.env) {
   out.boardHealth = resolveModeSource(
     env.CATALYST_BOARD_HEALTH,
     readLayer2BoardHealth().mode,
-    BOARD_HEALTH_MODES,
+    BOARD_HEALTH_MODES
   );
   out.recoveryPass = resolveModeSource(
     env.CATALYST_RECOVERY_PASS,
     readLayer2RecoveryPass().mode,
-    RECOVERY_PASS_MODES,
+    RECOVERY_PASS_MODES
   );
   out.unstuckSweep = resolveModeSource(
     env.CATALYST_UNSTUCK_SWEEP ?? env.EXECUTION_CORE_UNSTUCK_SWEEP_MODE,
     readLayer2UnstuckSweep().mode,
-    UNSTUCK_SWEEP_MODES,
+    UNSTUCK_SWEEP_MODES
   );
   out.deadDocWorker = resolveModeSource(
     env.CATALYST_DEAD_DOC_WORKER_RECLAIM,
     readLayer2DeadDocWorker().mode,
-    DEAD_DOC_WORKER_MODES,
+    DEAD_DOC_WORKER_MODES
   );
   return out;
 }

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1975,6 +1975,33 @@ export function readRecoveryPassConfig(envObj = process.env) {
   return { mode };
 }
 
+// CTL-1774: delegate-first mode reader. Mirrors readRecoveryPassConfig exactly:
+// env (CATALYST_DELEGATE_FIRST) overrides Layer-2 config
+// (.catalyst.delegateFirst.mode), which overrides the safe default of 'off'.
+// Ships off; operators opt in to shadow (dry-run evidence) then enforce.
+const DELEGATE_FIRST_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2DelegateFirst() {
+  try {
+    const df = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.delegateFirst;
+    return df && typeof df === "object" ? df : {};
+  } catch { return {}; }
+}
+
+// env (CATALYST_DELEGATE_FIRST) overrides Layer-2 (.catalyst.delegateFirst.mode),
+// which overrides the safe default "off". "0" is the kill-switch. Mirrors
+// readRecoveryPassConfig exactly.
+export function readDelegateFirstConfig(envObj = process.env) {
+  const l2 = readLayer2DelegateFirst();
+  const env = envObj.CATALYST_DELEGATE_FIRST;
+  let mode;
+  if (env === "0") mode = "off";
+  else if (typeof env === "string" && DELEGATE_FIRST_MODES.has(env)) mode = env;
+  else if (typeof l2.mode === "string" && DELEGATE_FIRST_MODES.has(l2.mode)) mode = l2.mode;
+  else mode = "off";
+  return { mode };
+}
+
 // CTL-1245: dead-but-running doc-worker reclaim mode reader. Mirrors
 // readRecoveryPassConfig / readUnstuckSweepConfig exactly: env
 // (CATALYST_DEAD_DOC_WORKER_RECLAIM) overrides Layer-2 config

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2082,9 +2082,6 @@ function readLayer2DelegateFirst() {
   }
 }
 
-// env (CATALYST_DELEGATE_FIRST) overrides Layer-2 (.catalyst.delegateFirst.mode),
-// which overrides the safe default "off". "0" is the kill-switch. Mirrors
-// readRecoveryPassConfig exactly.
 export function readDelegateFirstConfig(envObj = process.env) {
   const l2 = readLayer2DelegateFirst();
   const env = envObj.CATALYST_DELEGATE_FIRST;

--- a/plugins/dev/scripts/execution-core/delegate-emit-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-emit-wiring.test.mjs
@@ -1,0 +1,261 @@
+// delegate-emit-wiring.test.mjs — CTL-1774 Phase 3: spy-based emit tests for all 6
+// routeStuckTicketToDelegate call sites. Each test injects appendDelegateEvent as a spy
+// via the new param (which doesn't exist yet → Red) and asserts it is called in shadow mode.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-emit-wiring.test.mjs
+//
+// Scrub CATALYST_* env before attributing failures to this change — see the
+// scheduler-test-flaky-order-env memory for the known flaky-baseline family.
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { maybeEscalateDispatchFailures } from "./scheduler.mjs";
+import { defaultEscalate } from "./stale-pr-rescue-timer.mjs";
+import { sweepMissingTriage, reconcileAll, __resetForTests } from "./monitor.mjs";
+import { dropProject } from "./eligible-set.mjs";
+
+// ── common fixtures ───────────────────────────────────────────────────────────
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+let prevDelegateFirst;
+
+const enrolledTeams = new Set();
+const registryEntries = [];
+
+function writeRegistry() {
+  writeFileSync(
+    join(catalystDir, "execution-core", "registry.json"),
+    JSON.stringify({ projects: registryEntries }, null, 2),
+  );
+}
+
+function enroll(team, eligibleQuery) {
+  const repoRoot = mkdtempSync(join(catalystDir, `repo-${team}-`));
+  registryEntries.push({ team, repoRoot, eligibleQuery: eligibleQuery ?? null });
+  writeRegistry();
+  enrolledTeams.add(team);
+  return repoRoot;
+}
+
+function execReturning(nodesByTeam) {
+  const fn = (_cmd, args) => {
+    fn.calls += 1;
+    const team = args[args.indexOf("--team") + 1];
+    return { code: 0, stdout: JSON.stringify({ nodes: nodesByTeam[team] ?? [] }), stderr: "" };
+  };
+  fn.calls = 0;
+  return fn;
+}
+
+const node = (identifier, priority = 2) => ({ identifier, state: { name: "Todo" }, priority });
+
+// fakeWriteStatus — mirrors the scheduler.test.mjs helper so maybeEscalateDispatchFailures
+// has a working applyLabel without shelling out to linearis.
+const fakeWriteStatus = (applied = []) => ({
+  applyLabel: ({ ticket, label }) => { applied.push({ ticket, label }); return { applied: true }; },
+  transition: () => {},
+  applyPhaseStatus: () => {},
+});
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  prevDelegateFirst = process.env.CATALYST_DELEGATE_FIRST;
+  orchDir = mkdtempSync(join(tmpdir(), "del-emit-orch-"));
+  catalystDir = mkdtempSync(join(tmpdir(), "del-emit-cat-"));
+  process.env.CATALYST_DIR = catalystDir;
+  mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+  __resetForTests();
+  enrolledTeams.clear();
+  registryEntries.length = 0;
+});
+
+afterEach(() => {
+  for (const t of enrolledTeams) dropProject(t);
+  __resetForTests();
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  if (prevDelegateFirst === undefined) delete process.env.CATALYST_DELEGATE_FIRST;
+  else process.env.CATALYST_DELEGATE_FIRST = prevDelegateFirst;
+  rmSync(orchDir, { recursive: true, force: true });
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+// ── Site 1: maybeEscalateDispatchFailures (scheduler.mjs) ────────────────────
+
+describe("CTL-1774 Phase 3 — Site 1: maybeEscalateDispatchFailures", () => {
+  // DISPATCH_FAILURE_ESCALATION_THRESHOLD = 3 (not exported); 10 is safely above it
+  const overThreshold = 10;
+
+  test("shadow mode: appendDelegateEvent called with delegate.would-route (site: dispatch-failures)", () => {
+    const delegateSpy = mock(() => {});
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+
+    maybeEscalateDispatchFailures(orchDir, marker, {
+      writeStatus: ws,
+      appendEvent: () => {},
+      env: { CATALYST_DELEGATE_FIRST: "shadow" },
+      // ↓ CTL-1774 Phase 3: new param — does not exist yet → spy never called → Red
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).toHaveBeenCalledTimes(1);
+    const evt = delegateSpy.mock.calls[0][0];
+    expect(evt.name).toBe("delegate.would-route");
+    expect(evt.ticket).toBe("CTL-5");
+    expect(evt.site).toBe("dispatch-failures");
+    // Shadow: label is still applied (no enqueue), spy was just an observer
+    expect(applied).toEqual([expect.objectContaining({ ticket: "CTL-5", label: "needs-human" })]);
+  });
+
+  test("off mode: appendDelegateEvent NOT called (byte-identical to today)", () => {
+    const delegateSpy = mock(() => {});
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+
+    maybeEscalateDispatchFailures(orchDir, marker, {
+      writeStatus: ws,
+      appendEvent: () => {},
+      env: { CATALYST_DELEGATE_FIRST: "off" },
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).not.toHaveBeenCalled();
+  });
+
+  test("enforce + runner disabled: appendDelegateEvent called with delegate.route-fallback", () => {
+    const delegateSpy = mock(() => {});
+    const applied = [];
+    const ws = fakeWriteStatus(applied);
+    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+
+    // enforce mode with no runner → fail-safe gate fires → route-fallback
+    maybeEscalateDispatchFailures(orchDir, marker, {
+      writeStatus: ws,
+      appendEvent: () => {},
+      env: { CATALYST_DELEGATE_FIRST: "enforce" },
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).toHaveBeenCalledTimes(1);
+    const evt = delegateSpy.mock.calls[0][0];
+    expect(evt.name).toBe("delegate.route-fallback");
+    expect(evt.ticket).toBe("CTL-5");
+    expect(evt.reason).toBe("runner-disabled");
+  });
+});
+
+// ── Site 6: defaultEscalate (stale-pr-rescue-timer.mjs) ──────────────────────
+
+describe("CTL-1774 Phase 3 — Site 6: defaultEscalate", () => {
+  test("shadow mode: appendDelegateEvent called with delegate.would-route (site: stale-pr-rescue)", () => {
+    const delegateSpy = mock(() => {});
+    const applyLabelMock = mock(() => ({ applied: true }));
+    const linearWrite = { applyLabel: applyLabelMock, transition: () => {}, applyPhaseStatus: () => {} };
+
+    defaultEscalate("CTL-6", { reason: "unresolvable-conflict" }, {
+      orchDir,
+      linearWrite,
+      env: { CATALYST_DELEGATE_FIRST: "shadow" },
+      // ↓ CTL-1774 Phase 3: new param — does not exist yet → spy never called → Red
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).toHaveBeenCalledTimes(1);
+    const evt = delegateSpy.mock.calls[0][0];
+    expect(evt.name).toBe("delegate.would-route");
+    expect(evt.ticket).toBe("CTL-6");
+    expect(evt.site).toBe("stale-pr-rescue");
+  });
+
+  test("off mode: appendDelegateEvent NOT called", () => {
+    const delegateSpy = mock(() => {});
+    const linearWrite = fakeWriteStatus();
+
+    defaultEscalate("CTL-6", { reason: "unresolvable-conflict" }, {
+      orchDir,
+      linearWrite,
+      env: { CATALYST_DELEGATE_FIRST: "off" },
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── Site 5: dispatchTriage → labelNeedsHuman (monitor.mjs) ───────────────────
+
+describe("CTL-1774 Phase 3 — Site 5: sweepMissingTriage / dispatchTriage default labelNeedsHuman", () => {
+  test("shadow mode: appendDelegateEvent called with delegate.would-route (site: triage-redispatch-cap)", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+
+    // Seed the triage dispatch count at the cap limit (count: 3 = TRIAGE_DISPATCH_CAP default)
+    const countsDir = join(realOrchDir, ".triage-dispatch-counts");
+    mkdirSync(countsDir, { recursive: true });
+    writeFileSync(join(countsDir, "ENG-9.json"), JSON.stringify({ count: 3 }));
+
+    // Populate the eligible set for the ENG team
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileAll({ exec });
+
+    const delegateSpy = mock(() => {});
+
+    // Set CATALYST_DELEGATE_FIRST=shadow so the routeStuckTicketToDelegate inside
+    // the default labelNeedsHuman closure activates shadow mode. The closure uses
+    // process.env (the routeStuckTicketToDelegate default env).
+    process.env.CATALYST_DELEGATE_FIRST = "shadow";
+
+    sweepMissingTriage({
+      orchDir: realOrchDir,
+      dispatch: mock(() => ({ code: 0 })),
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+      readMaxParallelFn: () => 6,
+      liveBackgroundCount: () => 0,
+      // ↓ CTL-1774 Phase 3: new param — does not exist yet → spy never called → Red
+      // After Green: sweepMissingTriage threads this to dispatchTriage, which passes
+      // it to the default labelNeedsHuman closure via routeStuckTicketToDelegate.
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).toHaveBeenCalledTimes(1);
+    const evt = delegateSpy.mock.calls[0][0];
+    expect(evt.name).toBe("delegate.would-route");
+    expect(evt.site).toBe("triage-redispatch-cap");
+  });
+
+  test("off mode (CATALYST_DELEGATE_FIRST unset): appendDelegateEvent NOT called at triage cap", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+
+    const countsDir = join(realOrchDir, ".triage-dispatch-counts");
+    mkdirSync(countsDir, { recursive: true });
+    writeFileSync(join(countsDir, "ENG-9.json"), JSON.stringify({ count: 3 }));
+
+    const exec = execReturning({ ENG: [node("ENG-9")] });
+    reconcileAll({ exec });
+
+    delete process.env.CATALYST_DELEGATE_FIRST; // off (default)
+
+    const delegateSpy = mock(() => {});
+    sweepMissingTriage({
+      orchDir: realOrchDir,
+      dispatch: mock(() => ({ code: 0 })),
+      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      appendEvent: () => {},
+      readMaxParallelFn: () => 6,
+      liveBackgroundCount: () => 0,
+      appendDelegateEvent: delegateSpy,
+    });
+
+    expect(delegateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-emit-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-emit-wiring.test.mjs
@@ -30,7 +30,7 @@ const registryEntries = [];
 function writeRegistry() {
   writeFileSync(
     join(catalystDir, "execution-core", "registry.json"),
-    JSON.stringify({ projects: registryEntries }, null, 2),
+    JSON.stringify({ projects: registryEntries }, null, 2)
   );
 }
 
@@ -57,7 +57,10 @@ const node = (identifier, priority = 2) => ({ identifier, state: { name: "Todo" 
 // fakeWriteStatus — mirrors the scheduler.test.mjs helper so maybeEscalateDispatchFailures
 // has a working applyLabel without shelling out to linearis.
 const fakeWriteStatus = (applied = []) => ({
-  applyLabel: ({ ticket, label }) => { applied.push({ ticket, label }); return { applied: true }; },
+  applyLabel: ({ ticket, label }) => {
+    applied.push({ ticket, label });
+    return { applied: true };
+  },
   transition: () => {},
   applyPhaseStatus: () => {},
 });
@@ -95,7 +98,12 @@ describe("CTL-1774 Phase 3 — Site 1: maybeEscalateDispatchFailures", () => {
     const delegateSpy = mock(() => {});
     const applied = [];
     const ws = fakeWriteStatus(applied);
-    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+    const marker = {
+      ticket: "CTL-5",
+      phase: "research",
+      code: 2,
+      consecutiveFailures: overThreshold,
+    };
 
     maybeEscalateDispatchFailures(orchDir, marker, {
       writeStatus: ws,
@@ -118,7 +126,12 @@ describe("CTL-1774 Phase 3 — Site 1: maybeEscalateDispatchFailures", () => {
     const delegateSpy = mock(() => {});
     const applied = [];
     const ws = fakeWriteStatus(applied);
-    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+    const marker = {
+      ticket: "CTL-5",
+      phase: "research",
+      code: 2,
+      consecutiveFailures: overThreshold,
+    };
 
     maybeEscalateDispatchFailures(orchDir, marker, {
       writeStatus: ws,
@@ -134,7 +147,12 @@ describe("CTL-1774 Phase 3 — Site 1: maybeEscalateDispatchFailures", () => {
     const delegateSpy = mock(() => {});
     const applied = [];
     const ws = fakeWriteStatus(applied);
-    const marker = { ticket: "CTL-5", phase: "research", code: 2, consecutiveFailures: overThreshold };
+    const marker = {
+      ticket: "CTL-5",
+      phase: "research",
+      code: 2,
+      consecutiveFailures: overThreshold,
+    };
 
     // enforce mode with no runner → fail-safe gate fires → route-fallback
     maybeEscalateDispatchFailures(orchDir, marker, {
@@ -158,15 +176,23 @@ describe("CTL-1774 Phase 3 — Site 6: defaultEscalate", () => {
   test("shadow mode: appendDelegateEvent called with delegate.would-route (site: stale-pr-rescue)", () => {
     const delegateSpy = mock(() => {});
     const applyLabelMock = mock(() => ({ applied: true }));
-    const linearWrite = { applyLabel: applyLabelMock, transition: () => {}, applyPhaseStatus: () => {} };
+    const linearWrite = {
+      applyLabel: applyLabelMock,
+      transition: () => {},
+      applyPhaseStatus: () => {},
+    };
 
-    defaultEscalate("CTL-6", { reason: "unresolvable-conflict" }, {
-      orchDir,
-      linearWrite,
-      env: { CATALYST_DELEGATE_FIRST: "shadow" },
-      // ↓ CTL-1774 Phase 3: new param — does not exist yet → spy never called → Red
-      appendDelegateEvent: delegateSpy,
-    });
+    defaultEscalate(
+      "CTL-6",
+      { reason: "unresolvable-conflict" },
+      {
+        orchDir,
+        linearWrite,
+        env: { CATALYST_DELEGATE_FIRST: "shadow" },
+        // ↓ CTL-1774 Phase 3: new param — does not exist yet → spy never called → Red
+        appendDelegateEvent: delegateSpy,
+      }
+    );
 
     expect(delegateSpy).toHaveBeenCalledTimes(1);
     const evt = delegateSpy.mock.calls[0][0];
@@ -179,12 +205,16 @@ describe("CTL-1774 Phase 3 — Site 6: defaultEscalate", () => {
     const delegateSpy = mock(() => {});
     const linearWrite = fakeWriteStatus();
 
-    defaultEscalate("CTL-6", { reason: "unresolvable-conflict" }, {
-      orchDir,
-      linearWrite,
-      env: { CATALYST_DELEGATE_FIRST: "off" },
-      appendDelegateEvent: delegateSpy,
-    });
+    defaultEscalate(
+      "CTL-6",
+      { reason: "unresolvable-conflict" },
+      {
+        orchDir,
+        linearWrite,
+        env: { CATALYST_DELEGATE_FIRST: "off" },
+        appendDelegateEvent: delegateSpy,
+      }
+    );
 
     expect(delegateSpy).not.toHaveBeenCalled();
   });
@@ -216,7 +246,13 @@ describe("CTL-1774 Phase 3 — Site 5: sweepMissingTriage / dispatchTriage defau
     sweepMissingTriage({
       orchDir: realOrchDir,
       dispatch: mock(() => ({ code: 0 })),
-      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      applyTriageStatus: () => ({
+        applied: false,
+        verified: false,
+        from_state: null,
+        to_state: null,
+        reason: null,
+      }),
       appendEvent: () => {},
       readMaxParallelFn: () => 6,
       liveBackgroundCount: () => 0,
@@ -249,7 +285,13 @@ describe("CTL-1774 Phase 3 — Site 5: sweepMissingTriage / dispatchTriage defau
     sweepMissingTriage({
       orchDir: realOrchDir,
       dispatch: mock(() => ({ code: 0 })),
-      applyTriageStatus: () => ({ applied: false, verified: false, from_state: null, to_state: null, reason: null }),
+      applyTriageStatus: () => ({
+        applied: false,
+        verified: false,
+        from_state: null,
+        to_state: null,
+        reason: null,
+      }),
       appendEvent: () => {},
       readMaxParallelFn: () => 6,
       liveBackgroundCount: () => 0,

--- a/plugins/dev/scripts/execution-core/delegate-event.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-event.mjs
@@ -1,0 +1,101 @@
+// delegate-event.mjs — CTL-1774 Phase 2: delegate.* event emitter leaf module.
+//
+// Builds and appends one delegate.* event to the unified event log.
+// Modelled on worker-transition-event.mjs (leaf emitter): imports only
+// getEventLogPath + log from config.mjs and buildCatalystResource from
+// lib/catalyst-resource.mjs — no heavy execution-core graph.
+//
+// Dims land in BOTH attributes (otel-forward strips body.payload off-machine)
+// and body.payload (broker reads raw JSONL).
+//
+// The three names — delegate.would-route, delegate.routed, delegate.route-fallback —
+// are already registered in broker/namespace-parity.test.mjs:67-70 and are not
+// broker-protected (they route through shouldSkipEvent normally).
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+/**
+ * buildDelegateEvent — returns a canonical JSONL line (string + "\n") for a
+ * delegate.* INFO event.
+ *
+ * @param {object} opts
+ * @param {string} opts.name     "delegate.would-route" | "delegate.routed" | "delegate.route-fallback"
+ * @param {string} opts.ticket   Linear ticket identifier
+ * @param {string|null} [opts.site]     caller site identifier (e.g. "terminal-sweep")
+ * @param {string|null} [opts.reason]   short reason string
+ * @param {string|null} [opts.orchId]   orchestrator id (falls back to ticket)
+ * @param {string|null} [opts.causedBy] triggering event id (ADR-022 absence-detection)
+ */
+export function buildDelegateEvent({
+  name,
+  ticket,
+  site = null,
+  reason = null,
+  orchId = null,
+  causedBy = null,
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const orchVal = orchId ?? ticket;
+  // event.action is the second dot-segment: "would-route", "routed", "route-fallback"
+  const action = name.split(".").slice(1).join(".");
+
+  const attributes = {
+    "event.name": name,
+    "event.entity": "delegate",
+    "event.action": action,
+    "event.label": ticket,
+    "catalyst.orchestration": orchVal,
+    "linear.issue.identifier": ticket,
+  };
+  // omit null dims from attributes (don't send null strings over OTLP)
+  if (site != null) attributes["catalyst.delegate.site"] = site;
+  if (reason != null) attributes["catalyst.delegate.reason"] = reason;
+
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "INFO",
+      severityNumber: 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      caused_by: causedBy,
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes,
+      body: {
+        payload: { ticket, name, site, reason },
+      },
+    }) + "\n"
+  );
+}
+
+/**
+ * appendDelegateEvent — appends the event to the unified event log.
+ *
+ * Accepts an optional second argument `append` for test injection (same pattern
+ * as appendWorkerTransitionEvent). Returns true on success, false on any error
+ * (never throws).
+ *
+ * @param {object} evt   see buildDelegateEvent params
+ * @param {function} [append]  injectable append function (default: real fs append)
+ */
+export function appendDelegateEvent(evt, append = defaultAppend) {
+  try {
+    const line = buildDelegateEvent(evt);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error({ err: err.message, kind: "delegate-event" }, "delegate: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/delegate-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-event.test.mjs
@@ -1,0 +1,125 @@
+// delegate-event.test.mjs — CTL-1774 Phase 2: delegate-event.mjs leaf emitter
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-event.test.mjs
+import { describe, test, expect } from "bun:test";
+import {
+  buildDelegateEvent,
+  appendDelegateEvent,
+} from "./delegate-event.mjs";
+
+// ─── broker namespace-contract import ────────────────────────────────────────
+// Import isBrokerProtectedName from the broker package directly.
+// The broker package needs its own pino install; if that's absent in this env
+// the namespace-safety test falls back to a local mirror of the predicate.
+let isBrokerProtectedName;
+try {
+  const m = await import("../broker/namespace-contract.mjs");
+  isBrokerProtectedName = m.isBrokerProtectedName;
+} catch {
+  // Minimal mirror: delegate.* is not in FORBIDDEN_PREFIXES ("filter." / "broker.daemon")
+  // and not in PROTECTED_EXACT_NAMES ("session.heartbeat").
+  isBrokerProtectedName = (name) =>
+    name.startsWith("filter.") ||
+    name.startsWith("broker.daemon") ||
+    name === "session.heartbeat";
+}
+
+// ─── buildDelegateEvent ───────────────────────────────────────────────────────
+
+describe("buildDelegateEvent", () => {
+  test("envelope shape — parseable JSON line ending with \\n", () => {
+    const line = buildDelegateEvent({
+      name: "delegate.would-route",
+      ticket: "CTL-9",
+      site: "terminal-sweep",
+      reason: "stalled",
+      orchId: "CTL-9",
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+  });
+
+  test("attributes['event.name'] and body.payload.site present", () => {
+    const line = buildDelegateEvent({
+      name: "delegate.would-route",
+      ticket: "CTL-9",
+      site: "terminal-sweep",
+      reason: "stalled",
+      orchId: "CTL-9",
+    });
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("delegate.would-route");
+    expect(ev.attributes["event.action"]).toBe("would-route");
+    expect(ev.body.payload.site).toBe("terminal-sweep");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("all three names produce the correct event.action split", () => {
+    for (const [name, action] of [
+      ["delegate.would-route", "would-route"],
+      ["delegate.routed", "routed"],
+      ["delegate.route-fallback", "route-fallback"],
+    ]) {
+      const ev = JSON.parse(buildDelegateEvent({ name, ticket: "CTL-1" }));
+      expect(ev.attributes["event.name"]).toBe(name);
+      expect(ev.attributes["event.action"]).toBe(action);
+    }
+  });
+
+  test("orchId falls back to ticket when not provided", () => {
+    const ev = JSON.parse(buildDelegateEvent({ name: "delegate.would-route", ticket: "CTL-42" }));
+    expect(ev.attributes["catalyst.orchestration"]).toBe("CTL-42");
+  });
+
+  test("orchId is used when provided", () => {
+    const ev = JSON.parse(buildDelegateEvent({
+      name: "delegate.would-route",
+      ticket: "CTL-42",
+      orchId: "CTL-99",
+    }));
+    expect(ev.attributes["catalyst.orchestration"]).toBe("CTL-99");
+  });
+
+  test("resource contains service.name === 'catalyst.execution-core'", () => {
+    const ev = JSON.parse(buildDelegateEvent({ name: "delegate.would-route", ticket: "CTL-1" }));
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.resource["service.namespace"]).toBe("catalyst");
+  });
+});
+
+// ─── appendDelegateEvent ─────────────────────────────────────────────────────
+
+describe("appendDelegateEvent", () => {
+  test("happy path — appends exactly one line and returns true", () => {
+    const lines = [];
+    const result = appendDelegateEvent(
+      { name: "delegate.would-route", ticket: "CTL-9", site: "manual", reason: "smoke" },
+      (line) => lines.push(line),
+    );
+    expect(result).toBe(true);
+    expect(lines).toHaveLength(1);
+    const ev = JSON.parse(lines[0]);
+    expect(ev.attributes["event.name"]).toBe("delegate.would-route");
+  });
+
+  test("returns false (never throws) when append throws", () => {
+    const result = appendDelegateEvent(
+      { name: "delegate.would-route", ticket: "CTL-9" },
+      () => { throw new Error("no write"); },
+    );
+    expect(result).toBe(false);
+  });
+});
+
+// ─── namespace safety ────────────────────────────────────────────────────────
+
+describe("delegate.* namespace safety", () => {
+  test("none of the three delegate names are broker-protected", () => {
+    for (const name of ["delegate.would-route", "delegate.routed", "delegate.route-fallback"]) {
+      expect(isBrokerProtectedName(name)).toBe(false);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/delegate-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-event.test.mjs
@@ -1,10 +1,7 @@
 // delegate-event.test.mjs — CTL-1774 Phase 2: delegate-event.mjs leaf emitter
 // Run: cd plugins/dev/scripts/execution-core && bun test delegate-event.test.mjs
 import { describe, test, expect } from "bun:test";
-import {
-  buildDelegateEvent,
-  appendDelegateEvent,
-} from "./delegate-event.mjs";
+import { buildDelegateEvent, appendDelegateEvent } from "./delegate-event.mjs";
 
 // ─── broker namespace-contract import ────────────────────────────────────────
 // Import isBrokerProtectedName from the broker package directly.
@@ -18,9 +15,7 @@ try {
   // Minimal mirror: delegate.* is not in FORBIDDEN_PREFIXES ("filter." / "broker.daemon")
   // and not in PROTECTED_EXACT_NAMES ("session.heartbeat").
   isBrokerProtectedName = (name) =>
-    name.startsWith("filter.") ||
-    name.startsWith("broker.daemon") ||
-    name === "session.heartbeat";
+    name.startsWith("filter.") || name.startsWith("broker.daemon") || name === "session.heartbeat";
 }
 
 // ─── buildDelegateEvent ───────────────────────────────────────────────────────
@@ -75,11 +70,13 @@ describe("buildDelegateEvent", () => {
   });
 
   test("orchId is used when provided", () => {
-    const ev = JSON.parse(buildDelegateEvent({
-      name: "delegate.would-route",
-      ticket: "CTL-42",
-      orchId: "CTL-99",
-    }));
+    const ev = JSON.parse(
+      buildDelegateEvent({
+        name: "delegate.would-route",
+        ticket: "CTL-42",
+        orchId: "CTL-99",
+      })
+    );
     expect(ev.attributes["catalyst.orchestration"]).toBe("CTL-99");
   });
 
@@ -97,7 +94,7 @@ describe("appendDelegateEvent", () => {
     const lines = [];
     const result = appendDelegateEvent(
       { name: "delegate.would-route", ticket: "CTL-9", site: "manual", reason: "smoke" },
-      (line) => lines.push(line),
+      (line) => lines.push(line)
     );
     expect(result).toBe(true);
     expect(lines).toHaveLength(1);
@@ -106,10 +103,9 @@ describe("appendDelegateEvent", () => {
   });
 
   test("returns false (never throws) when append throws", () => {
-    const result = appendDelegateEvent(
-      { name: "delegate.would-route", ticket: "CTL-9" },
-      () => { throw new Error("no write"); },
-    );
+    const result = appendDelegateEvent({ name: "delegate.would-route", ticket: "CTL-9" }, () => {
+      throw new Error("no write");
+    });
     expect(result).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/delegate-first.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.mjs
@@ -67,12 +67,12 @@ export function routeStuckTicketToDelegate(
 
   // helper: call the Phase-1 label chokepoint and return { labelled: bool }
   const labelDirect = () => {
-    const labelled = labelNeedsHumanUnlessBeliefOwner(
-      orchDir,
-      ticket,
-      applyLabel,
-      { env, site, log: logArg, explanation }
-    );
+    const labelled = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, applyLabel, {
+      env,
+      site,
+      log: logArg,
+      explanation,
+    });
     return labelled;
   };
 
@@ -110,16 +110,11 @@ export function routeStuckTicketToDelegate(
   }
 
   const enqueue = deps.enqueue ?? enqueueDelegateIntent;
-  const q = enqueue(
-    ticket,
-    { kind, phase: "recovery-pass", reason, boardContext, briefObj },
-    deps
-  );
+  const q = enqueue(ticket, { kind, phase: "recovery-pass", reason, boardContext, briefObj }, deps);
 
   // Mirror enqueueRecoveryItemDelegate's `initiated` predicate: a fresh enqueue
   // OR an idempotent no-op both mean the delegate already owns the ticket.
-  const initiated =
-    q.enqueued || q.reason === "already-pending" || q.reason === "worker-live";
+  const initiated = q.enqueued || q.reason === "already-pending" || q.reason === "worker-live";
 
   if (initiated) {
     appendEvent({ name: "delegate.routed", ticket, site, reason: q.reason });

--- a/plugins/dev/scripts/execution-core/delegate-first.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.mjs
@@ -9,15 +9,13 @@
 // Ordered fallback: (auto-fix [deferred]) → delegate → human.
 import { enqueueDelegateIntent } from "./delegate-queue.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
-import { readDelegateRunnerConfig } from "./config.mjs";
+import { readDelegateRunnerConfig, readDelegateFirstConfig } from "./config.mjs";
 
-const VALID_MODES = new Set(["off", "shadow", "enforce"]);
-
-// readDelegateFirstMode — read CATALYST_DELEGATE_FIRST; default "off".
-// Mirrors readBoardHealthConfig/CATALYST_RECOVERY_PASS parsing style.
+// readDelegateFirstMode — env → Layer-2 → "off". Delegates to the config-ladder
+// reader in config.mjs (CTL-1774 Gap B fix). The (env = process.env) injection
+// contract is preserved: all existing callers that pass an explicit env bag still work.
 export function readDelegateFirstMode(env = process.env) {
-  const raw = env.CATALYST_DELEGATE_FIRST ?? "off";
-  return VALID_MODES.has(raw) ? raw : "off";
+  return readDelegateFirstConfig(env).mode;
 }
 
 // ── routeStuckTicketToDelegate ────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/delegate-first.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.test.mjs
@@ -1,5 +1,6 @@
 // delegate-first.test.mjs — CTL-1609 Phase 2: routeStuckTicketToDelegate seam
-import { mkdtempSync, rmSync } from "node:fs";
+//                            CTL-1774 Phase 1: Layer-2 config ladder for readDelegateFirstMode
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -61,6 +62,70 @@ describe("readDelegateFirstMode", () => {
 
   test("returns off for unrecognised values (fail-safe)", () => {
     expect(readDelegateFirstMode({ CATALYST_DELEGATE_FIRST: "bogus" })).toBe("off");
+  });
+});
+
+// ─── CTL-1774 Phase 1: Layer-2 config ladder for readDelegateFirstMode ───────
+//
+// These tests verify the env → Layer-2 → safe-default ladder, mirroring the
+// readRecoveryPassConfig / readDeadDocWorkerConfig pattern.  Uses
+// CATALYST_LAYER2_CONFIG_FILE to override the Layer-2 path in tests.
+
+describe("readDelegateFirstMode — Layer-2 config ladder (CTL-1774)", () => {
+  const DF_ENVS = ["CATALYST_DELEGATE_FIRST", "CATALYST_LAYER2_CONFIG_FILE"];
+  let saved = {}, tmp;
+  beforeEach(() => {
+    for (const k of DF_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    tmp = mkdtempSync(join(tmpdir(), "ctl1774-df-"));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+  });
+  afterEach(() => {
+    for (const k of DF_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
+    saved = {}; rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test("safe default: mode=off when env unset and no Layer-2 key", () => {
+    expect(readDelegateFirstMode(process.env)).toBe("off");
+  });
+
+  test("Layer-2 used when env unset — THIS IS THE TEST THAT FAILS RED TODAY", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { delegateFirst: { mode: "shadow" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    expect(readDelegateFirstMode(process.env)).toBe("shadow");
+  });
+
+  test("env wins over Layer-2", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { delegateFirst: { mode: "shadow" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_DELEGATE_FIRST = "enforce";
+    expect(readDelegateFirstMode(process.env)).toBe("enforce");
+  });
+
+  test("kill-switch: CATALYST_DELEGATE_FIRST=0 maps to off even if Layer-2 says enforce", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { delegateFirst: { mode: "enforce" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_DELEGATE_FIRST = "0";
+    expect(readDelegateFirstMode(process.env)).toBe("off");
+  });
+
+  test("invalid env falls through to Layer-2 (env not a hard override when unrecognised)", () => {
+    const cfg = join(tmp, "config.json");
+    writeFileSync(cfg, JSON.stringify({ catalyst: { delegateFirst: { mode: "shadow" } } }));
+    process.env.CATALYST_LAYER2_CONFIG_FILE = cfg;
+    process.env.CATALYST_DELEGATE_FIRST = "garbage";
+    expect(readDelegateFirstMode(process.env)).toBe("shadow");
+  });
+
+  test("safe default when env unset and Layer-2 file absent", () => {
+    // CATALYST_LAYER2_CONFIG_FILE points at absent.json (set in beforeEach)
+    expect(readDelegateFirstMode(process.env)).toBe("off");
+  });
+
+  test("injection contract preserved: explicit env bag still works", () => {
+    expect(readDelegateFirstMode({ CATALYST_DELEGATE_FIRST: "shadow" })).toBe("shadow");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/delegate-first.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-first.test.mjs
@@ -4,10 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  readDelegateFirstMode,
-  routeStuckTicketToDelegate,
-} from "./delegate-first.mjs";
+import { readDelegateFirstMode, routeStuckTicketToDelegate } from "./delegate-first.mjs";
 
 // ─── test helpers ────────────────────────────────────────────────────────────
 
@@ -73,15 +70,22 @@ describe("readDelegateFirstMode", () => {
 
 describe("readDelegateFirstMode — Layer-2 config ladder (CTL-1774)", () => {
   const DF_ENVS = ["CATALYST_DELEGATE_FIRST", "CATALYST_LAYER2_CONFIG_FILE"];
-  let saved = {}, tmp;
+  let saved = {},
+    tmp;
   beforeEach(() => {
-    for (const k of DF_ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
+    for (const k of DF_ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
     tmp = mkdtempSync(join(tmpdir(), "ctl1774-df-"));
     process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
   });
   afterEach(() => {
-    for (const k of DF_ENVS) { saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]); }
-    saved = {}; rmSync(tmp, { recursive: true, force: true });
+    for (const k of DF_ENVS) {
+      saved[k] === undefined ? delete process.env[k] : (process.env[k] = saved[k]);
+    }
+    saved = {};
+    rmSync(tmp, { recursive: true, force: true });
   });
 
   test("safe default: mode=off when env unset and no Layer-2 key", () => {
@@ -221,7 +225,10 @@ describe("routeStuckTicketToDelegate (CTL-1609)", () => {
     const opts = makeOpts({
       labelCalls,
       events,
-      enqueueFn: () => { enqueueCalled = true; return { enqueued: true, reason: "enqueued" }; },
+      enqueueFn: () => {
+        enqueueCalled = true;
+        return { enqueued: true, reason: "enqueued" };
+      },
       env: { CATALYST_DELEGATE_FIRST: "shadow" },
     });
 
@@ -242,7 +249,10 @@ describe("routeStuckTicketToDelegate (CTL-1609)", () => {
     let enqueueCalled = false;
     const opts = makeOpts({
       labelCalls,
-      enqueueFn: () => { enqueueCalled = true; return { enqueued: true }; },
+      enqueueFn: () => {
+        enqueueCalled = true;
+        return { enqueued: true };
+      },
       env: { CATALYST_DELEGATE_FIRST: "off" },
     });
 
@@ -258,7 +268,10 @@ describe("routeStuckTicketToDelegate (CTL-1609)", () => {
     let enqueueCalled = false;
     const opts = makeOpts({
       labelCalls,
-      enqueueFn: () => { enqueueCalled = true; return { enqueued: true }; },
+      enqueueFn: () => {
+        enqueueCalled = true;
+        return { enqueued: true };
+      },
       env: {},
     });
 

--- a/plugins/dev/scripts/execution-core/delegate-shadow-e2e.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-shadow-e2e.test.mjs
@@ -54,7 +54,11 @@ describe("CTL-1774 Phase 4 — end-to-end integration", () => {
 
     // Real emitter wrote to the event log
     const now = new Date();
-    const logPath = join(catalystDir, "events", `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`);
+    const logPath = join(
+      catalystDir,
+      "events",
+      `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`
+    );
     const raw = readFileSync(logPath, "utf8").trim().split("\n");
     expect(raw).toHaveLength(1);
     const ev = JSON.parse(raw[0]);
@@ -69,7 +73,9 @@ describe("CTL-1774 Phase 4 — end-to-end integration", () => {
     try {
       readFileSync(join(orchDir, ".delegate-queue"), "utf8");
       queueExists = true;
-    } catch { /* expected */ }
+    } catch {
+      /* expected */
+    }
     expect(queueExists).toBe(false);
   });
 
@@ -89,9 +95,18 @@ describe("CTL-1774 Phase 4 — end-to-end integration", () => {
 
     // No file written
     const now = new Date();
-    const logPath = join(catalystDir, "events", `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`);
+    const logPath = join(
+      catalystDir,
+      "events",
+      `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`
+    );
     let fileExists = false;
-    try { readFileSync(logPath, "utf8"); fileExists = true; } catch { /* expected */ }
+    try {
+      readFileSync(logPath, "utf8");
+      fileExists = true;
+    } catch {
+      /* expected */
+    }
     expect(fileExists).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/delegate-shadow-e2e.test.mjs
+++ b/plugins/dev/scripts/execution-core/delegate-shadow-e2e.test.mjs
@@ -1,0 +1,97 @@
+// delegate-shadow-e2e.test.mjs — CTL-1774 Phase 4: integration test
+// Proves the operator-facing contract through the REAL (un-spied) emitter path:
+// shadow mode writes one `delegate.would-route` JSONL line to a temp event log;
+// off mode writes nothing.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test delegate-shadow-e2e.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { routeStuckTicketToDelegate } from "./delegate-first.mjs";
+import { appendDelegateEvent } from "./delegate-event.mjs";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+let prevDelegateFirst;
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  prevDelegateFirst = process.env.CATALYST_DELEGATE_FIRST;
+  orchDir = mkdtempSync(join(tmpdir(), "del-e2e-orch-"));
+  catalystDir = mkdtempSync(join(tmpdir(), "del-e2e-cat-"));
+  process.env.CATALYST_DIR = catalystDir;
+  // Create the events dir so the real emitter can write to it.
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+});
+
+afterEach(() => {
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  if (prevDelegateFirst === undefined) delete process.env.CATALYST_DELEGATE_FIRST;
+  else process.env.CATALYST_DELEGATE_FIRST = prevDelegateFirst;
+  rmSync(orchDir, { recursive: true, force: true });
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+describe("CTL-1774 Phase 4 — end-to-end integration", () => {
+  test("shadow mode: real appendDelegateEvent writes one delegate.would-route line to the event log", () => {
+    const labelSpy = mock(() => ({ applied: true }));
+
+    routeStuckTicketToDelegate(orchDir, "CTL-TEST", {
+      site: "terminal-sweep",
+      reason: "stalled",
+      applyLabel: { applyLabel: labelSpy, transition: () => {}, applyPhaseStatus: () => {} },
+      env: { CATALYST_DELEGATE_FIRST: "shadow" },
+      appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: "CTL-TEST" }),
+    });
+
+    // Label spy called — shadow mutates nothing but still labels
+    expect(labelSpy).toHaveBeenCalledTimes(1);
+
+    // Real emitter wrote to the event log
+    const now = new Date();
+    const logPath = join(catalystDir, "events", `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`);
+    const raw = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(raw).toHaveLength(1);
+    const ev = JSON.parse(raw[0]);
+    expect(ev.attributes["event.name"]).toBe("delegate.would-route");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-TEST");
+    expect(ev.attributes["catalyst.delegate.site"]).toBe("terminal-sweep");
+    expect(ev.attributes["catalyst.delegate.reason"]).toBe("stalled");
+    expect(ev.severityText).toBe("INFO");
+
+    // Verify .delegate-queue/ was NOT created — shadow never enqueues
+    let queueExists = false;
+    try {
+      readFileSync(join(orchDir, ".delegate-queue"), "utf8");
+      queueExists = true;
+    } catch { /* expected */ }
+    expect(queueExists).toBe(false);
+  });
+
+  test("off mode: no event written to the event log (byte-identical to pre-CTL-1774 behavior)", () => {
+    const labelSpy = mock(() => ({ applied: true }));
+
+    routeStuckTicketToDelegate(orchDir, "CTL-TEST", {
+      site: "terminal-sweep",
+      reason: "stalled",
+      applyLabel: { applyLabel: labelSpy, transition: () => {}, applyPhaseStatus: () => {} },
+      env: { CATALYST_DELEGATE_FIRST: "off" },
+      appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: "CTL-TEST" }),
+    });
+
+    // Label still applied in off mode
+    expect(labelSpy).toHaveBeenCalledTimes(1);
+
+    // No file written
+    const now = new Date();
+    const logPath = join(catalystDir, "events", `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}.jsonl`);
+    let fileExists = false;
+    try { readFileSync(logPath, "utf8"); fileExists = true; } catch { /* expected */ }
+    expect(fileExists).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -25,7 +25,18 @@
 // The 10-min periodic reconcile (RECONCILE_INTERVAL_MS) remains the
 // missed-webhook backstop for all three handlers.
 
-import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync, existsSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import {
+  watch,
+  openSync,
+  fstatSync,
+  readSync,
+  closeSync,
+  mkdirSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+} from "node:fs";
 // CTL-1744: delegate-lands claim markers. A zero-import leaf so scheduler.mjs can
 // read them too without creating a scheduler↔monitor cycle (monitor already
 // imports scheduler). See delegate-claims.mjs for the full rationale.
@@ -53,7 +64,11 @@ import {
 // (linear-query.mjs never imports replica-read.mjs either; daemon.mjs:681 builds
 // the reader and passes it in). monitor.mjs stays Node-loadable.
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
-import { claimDispatchSync, readTriageAttemptCountSync, bumpTriageAttemptCountSync } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count
+import {
+  claimDispatchSync,
+  readTriageAttemptCountSync,
+  bumpTriageAttemptCountSync,
+} from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
   runEligibleQuery,
@@ -72,7 +87,12 @@ import {
   upsertTicket,
 } from "./eligible-set.mjs";
 import { loadCursor, saveCursor, resolveStartOffset } from "./event-cursor.mjs";
-import { dispatchTicket, settleDispatchSync, sdkSignalRunnable, backstopOnRejection } from "./dispatch.mjs"; // CTL-1367 P1: settle async (sdk) triage dispatch synchronously + backstop a rejected async dispatch
+import {
+  dispatchTicket,
+  settleDispatchSync,
+  sdkSignalRunnable,
+  backstopOnRejection,
+} from "./dispatch.mjs"; // CTL-1367 P1: settle async (sdk) triage dispatch synchronously + backstop a rejected async dispatch
 import { abortWorker as defaultAbortWorker } from "./abort-worker.mjs";
 import {
   applyTriageStatus as defaultApplyTriageStatus,
@@ -340,7 +360,10 @@ const knownProjects = new Set();
 // poll clears the alert. `appendHealthEvent` is an injectable test seam — it
 // also gates the CTL-1628 `monitor.reconcile.eligible_persist_failure.<TEAM>`
 // event fired below when the eligible-set disk projection write fails.
-export function reconcileProject(team, { exec, delegateExec, appendHealthEvent, replica, onSource } = {}) {
+export function reconcileProject(
+  team,
+  { exec, delegateExec, appendHealthEvent, replica, onSource } = {}
+) {
   const entry = getProjectConfig(team);
   if (!entry) {
     log.warn({ team }, "reconcile: no registry entry for team — skipping");
@@ -421,11 +444,10 @@ export function reconcileProject(team, { exec, delegateExec, appendHealthEvent, 
     // (CTL-1628 r2) additionally lets recordReconcileSuccess's eventual
     // recovery event name the stage that actually recovered, rather than
     // hard-coding "reconcile-poll-succeeded" for a streak the poll never failed.
-    recordReconcileFailure(
-      team,
-      `eligible-persist-failed: ${err.message}`,
-      { origin: "persist", ...(appendHealthEvent ? { appendEvent: appendHealthEvent } : {}) }
-    );
+    recordReconcileFailure(team, `eligible-persist-failed: ${err.message}`, {
+      origin: "persist",
+      ...(appendHealthEvent ? { appendEvent: appendHealthEvent } : {}),
+    });
   }
 }
 
@@ -567,7 +589,15 @@ export function handleStateChangedEvent(
   // single call. Either way, the budget gates all dispatchTriage calls below.
   const budget =
     triageBudget ??
-    computeTriageBudget({ orchDir, concurrency, readMaxParallelFn, liveBackgroundCount, dispatchMode, countSdkInflight, hasInProcessRoute });
+    computeTriageBudget({
+      orchDir,
+      concurrency,
+      readMaxParallelFn,
+      liveBackgroundCount,
+      dispatchMode,
+      countSdkInflight,
+      hasInProcessRoute,
+    });
   for (const p of listProjects()) {
     const query = resolveEligibleQuery(p);
     if (query.team !== parsed.teamKey) continue;
@@ -894,19 +924,27 @@ function dispatchTriage(
   // deleting orchDir/.triage-dispatch-counts/<ticket>.json.
   // CTL-1649: use fleet-wide count (max of host-local and fence) so an ownership
   // churn cannot restart the counter at 0 on the new owner.
-  if (fleetTriageDispatchCount(orchDir, identifier, { multiHost, readFenceCount: readFenceTriageAttempt }) >= TRIAGE_DISPATCH_CAP) {
+  if (
+    fleetTriageDispatchCount(orchDir, identifier, {
+      multiHost,
+      readFenceCount: readFenceTriageAttempt,
+    }) >= TRIAGE_DISPATCH_CAP
+  ) {
     // Codex R2: the final allowed attempt may still be RUNNING — triage.json is
     // naturally absent until it finishes. Defer the park while in flight.
     if (isTriageInFlight(readTriageSignalStatus(orchDir, identifier))) return false;
     try {
       labelNeedsHuman(orchDir, identifier);
     } catch (err) {
-      log.warn({ identifier, err: err.message }, "ctl-1441: needs-human label at triage cap threw — continuing");
+      log.warn(
+        { identifier, err: err.message },
+        "ctl-1441: needs-human label at triage cap threw — continuing"
+      );
     }
     if (markTriageCapped(orchDir, identifier)) {
       log.warn(
         { identifier, cap: TRIAGE_DISPATCH_CAP },
-        "ctl-1441: triage re-dispatch cap reached — parked needs-human; delete .triage-dispatch-counts/<ticket>.json to re-arm",
+        "ctl-1441: triage re-dispatch cap reached — parked needs-human; delete .triage-dispatch-counts/<ticket>.json to re-arm"
       );
     }
     return false;
@@ -927,7 +965,10 @@ function dispatchTriage(
     const a = fetchAssignee(identifier, { gateway, replica });
     if (!a.known) {
       // Unreadable delegate → HOLD (sweepMissingTriage retries next reconcile).
-      log.info({ identifier, known: false }, "monitor: triage dispatch held — delegate unreadable (CTL-1174)");
+      log.info(
+        { identifier, known: false },
+        "monitor: triage dispatch held — delegate unreadable (CTL-1174)"
+      );
       return false;
     }
     if (a.delegate == null) {
@@ -991,7 +1032,11 @@ function dispatchTriage(
       // A replica row updated AFTER the verdict invalidates it (Codex R7): the
       // ticket may have legitimately re-entered Triage since the negative.
       const invalidated = Number.isFinite(rowMs) && typeof m?.ts === "number" && rowMs > m.ts;
-      if (!invalidated && typeof m?.ts === "number" && Date.now() - m.ts < TRIAGE_REVALIDATE_NEGATIVE_MS) {
+      if (
+        !invalidated &&
+        typeof m?.ts === "number" &&
+        Date.now() - m.ts < TRIAGE_REVALIDATE_NEGATIVE_MS
+      ) {
         log.debug(
           { identifier, cachedLive: m.live ?? null },
           "dispatchTriage: Triage-board revalidation negative still cached — skipping without a read (CTL-1589)"
@@ -1063,16 +1108,18 @@ function dispatchTriage(
       if (!existsSync(warned)) {
         try {
           writeFileSync(warned, new Date().toISOString());
-        } catch { /* best-effort */ }
+        } catch {
+          /* best-effort */
+        }
         log.warn(
           { identifier },
-          "ctl-1441: phase-triage.json was done but triage.json is missing — retired the stale signal for a real re-triage (bounded by the dispatch cap)",
+          "ctl-1441: phase-triage.json was done but triage.json is missing — retired the stale signal for a real re-triage (bounded by the dispatch cap)"
         );
       }
     } catch (err) {
       log.warn(
         { identifier, err: err.message },
-        "ctl-1441: could not retire the stale done triage signal — skipping this dispatch (a counted no-op would burn the cap)",
+        "ctl-1441: could not retire the stale done triage signal — skipping this dispatch (a counted no-op would burn the cap)"
       );
       return false;
     }
@@ -1120,9 +1167,9 @@ function dispatchTriage(
       // strand at "dispatched"; sweepMissingTriage re-attempts on the next reconcile.
       onSettled: backstopOnRejection(
         { orchDir, ticket: identifier, phase: "triage", log },
-        { emitBackstop },
+        { emitBackstop }
       ),
-    },
+    }
   );
   if (r.code !== 0) {
     log.warn({ identifier, code: r.code }, "monitor: triage dispatch failed");
@@ -1175,7 +1222,15 @@ function dispatchTriage(
   // and never blocks the triage dispatch.
   if (clusterGeneration != null) {
     try {
-      stampWorkerLabel({ ticket: identifier, hostName: self, knownHosts: roster, replica, applyLabel, removeLabel, log });
+      stampWorkerLabel({
+        ticket: identifier,
+        hostName: self,
+        knownHosts: roster,
+        replica,
+        applyLabel,
+        removeLabel,
+        log,
+      });
     } catch (err) {
       log.warn({ identifier, err: err.message }, "monitor: stampWorkerLabel threw — continuing");
     }
@@ -1211,7 +1266,7 @@ export const TRIAGE_DISPATCH_CAP = Number(process.env.CATALYST_TRIAGE_DISPATCH_C
 export function readTriageSignalStatus(orchDir, ticket) {
   try {
     const sig = JSON.parse(
-      readFileSync(join(orchDir, "workers", ticket, "phase-triage.json"), "utf8"),
+      readFileSync(join(orchDir, "workers", ticket, "phase-triage.json"), "utf8")
     );
     return typeof sig?.status === "string" ? sig.status : null;
   } catch {
@@ -1270,7 +1325,11 @@ function writeTriageDispatchRecord(orchDir, ticket, rec) {
   }
 }
 
-export function bumpTriageDispatchCount(orchDir, ticket, { now = () => new Date().toISOString() } = {}) {
+export function bumpTriageDispatchCount(
+  orchDir,
+  ticket,
+  { now = () => new Date().toISOString() } = {}
+) {
   const prior = readTriageDispatchRecord(orchDir, ticket) ?? {};
   const count = (typeof prior.count === "number" ? prior.count : 0) + 1;
   writeTriageDispatchRecord(orchDir, ticket, { ...prior, count, lastDispatchAt: now() });
@@ -1280,7 +1339,11 @@ export function bumpTriageDispatchCount(orchDir, ticket, { now = () => new Date(
 export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISOString() } = {}) {
   const prior = readTriageDispatchRecord(orchDir, ticket) ?? {};
   if (prior.cappedAt) return false; // already parked once
-  writeTriageDispatchRecord(orchDir, ticket, { ...prior, cappedAt: now(), cap: TRIAGE_DISPATCH_CAP });
+  writeTriageDispatchRecord(orchDir, ticket, {
+    ...prior,
+    cappedAt: now(),
+    cap: TRIAGE_DISPATCH_CAP,
+  });
   return true;
 }
 
@@ -1302,7 +1365,7 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
 export function fleetTriageDispatchCount(
   orchDir,
   identifier,
-  { multiHost = false, readFenceCount = readTriageAttemptCountSync } = {},
+  { multiHost = false, readFenceCount = readTriageAttemptCountSync } = {}
 ) {
   const hostLocal = readTriageDispatchCount(orchDir, identifier);
   if (!multiHost) return hostLocal;
@@ -1332,7 +1395,8 @@ function triageStateTickets(entry, { replica, runTriageState }) {
   const onSource = (source, count) => {
     const line = { team: query.team, triage_source: source, triage_count: count };
     if (source === "replica") log.info(line, "triage sweep: Triage-state source");
-    else if (source === "no-triage-status") log.debug(line, "triage sweep: team configures no Triage state");
+    else if (source === "no-triage-status")
+      log.debug(line, "triage sweep: team configures no Triage state");
     else
       log.warn(
         line,
@@ -1480,14 +1544,19 @@ export function sweepMissingTriage({
       // Codex R4: at a saturated fleet, still ROUTE capped tickets (their park is
       // capacity-independent and dispatchTriage's cap gate runs before its
       // budget gate); everything else waits for the next sweep.
-      if (budget.remaining <= 0 && readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP) continue;
+      if (
+        budget.remaining <= 0 &&
+        readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP
+      )
+        continue;
       if (hasTriageArtifact(orchDir, t.identifier)) continue;
       // CTL-1589 (Codex R4): a Triage-STATE ticket whose triage worker is
       // in-flight right now has no artifact yet and would route to an
       // idempotent no-op launch — which still decrements the sweep budget
       // (code 0) and would pay a pointless live revalidation read. Skip it
       // here; the eligible half keeps its pre-existing behavior.
-      if (t.fromTriageBoard && isTriageInFlight(readTriageSignalStatus(orchDir, t.identifier))) continue;
+      if (t.fromTriageBoard && isTriageInFlight(readTriageSignalStatus(orchDir, t.identifier)))
+        continue;
       // CTL-1441 guard (a) note: the done-signal/missing-triage.json mismatch is
       // handled INSIDE dispatchTriage (post-gates, launch-imminent — Codex R3),
       // where the stale completion signal is retired immediately before a real
@@ -1792,8 +1861,10 @@ export function readNewCoordinationComments({ foldOnly = false } = {}) {
       // Emit observability breadcrumb so operators can confirm the mirror tail fired.
       // Name satisfies CTL-1142 namespace contract (not filter.* / broker.daemon.* /
       // phase.<KNOWN_PHASE>.*). The dedup above ensures at-most-once per comment.
-      const ticket = event?.attributes?.["linear.issue.identifier"] ??
-        event?.body?.payload?.ticket ?? event?.detail?.ticket;
+      const ticket =
+        event?.attributes?.["linear.issue.identifier"] ??
+        event?.body?.payload?.ticket ??
+        event?.detail?.ticket;
       if (ticket) {
         log.info({ ticket }, `comment.wake.cross-host.${ticket}`);
       }
@@ -1957,10 +2028,7 @@ export function startMonitor({
     // boots single-host and later has a peer added must still start draining the
     // mirror without a restart — the startTailing watcher gate is startup-only,
     // so this poll is the sole path that re-arms on a live roster expansion.
-    coordinationPollTimer = setInterval(
-      () => readNewCoordinationComments(),
-      tailerPollMs
-    );
+    coordinationPollTimer = setInterval(() => readNewCoordinationComments(), tailerPollMs);
   }
   reconcileTimer = setInterval(() => {
     reconcileAll({ exec });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -81,6 +81,7 @@ import {
   removeLabel, // CTL-1481: worker:<host> swap (remove-before-add)
 } from "./linear-write.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
+import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import {
@@ -546,6 +547,10 @@ export function handleStateChangedEvent(
     // CTL-1481: worker:<host> label-stamp seam — threaded through to
     // dispatchTriage (undefined → real default; tests inject a fake).
     stampWorkerLabel,
+    // CTL-1774: injectable delegate-event emitter — threaded through to
+    // dispatchTriage so its default labelNeedsHuman closure emits delegate.*
+    // events in shadow/enforce mode. Default = real event-log append.
+    appendDelegateEvent = defaultAppendDelegateEvent,
   } = {}
 ) {
   const parsed = parseStateChangedEvent(event);
@@ -593,6 +598,7 @@ export function handleStateChangedEvent(
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
           stampWorkerLabel, // CTL-1481
+          appendDelegateEvent, // CTL-1774
         });
       }
     } else if (!parsed.toState || parsed.toState === query.status) {
@@ -651,6 +657,7 @@ export function handleStateChangedEvent(
           isDraining, // CTL-1095
           emitBackstop, // CTL-1367 P1
           stampWorkerLabel, // CTL-1481
+          appendDelegateEvent, // CTL-1774
         });
       } else {
         log.debug(
@@ -787,6 +794,10 @@ function dispatchTriage(
     // tests inject a spy. The bg path is synchronous → the detached handler never
     // fires, so this is a no-op on bg.
     emitBackstop,
+    // CTL-1774: injectable emitter for delegate.* events (shadow/enforce observability).
+    // Default = real event-log append; tests inject a spy. Must appear before
+    // labelNeedsHuman so the default closure can close over it.
+    appendDelegateEvent = defaultAppendDelegateEvent,
     // CTL-1441: needs-human application at the re-dispatch cap. Injectable so
     // tests never spawn a real linearis write; default = the label-guard path.
     labelNeedsHuman = (dir, t) =>
@@ -804,6 +815,7 @@ function dispatchTriage(
         // defaulting to Infinity. Lazy: the state.json read is paid only on the
         // enforce path that actually enqueues.
         deps: { orchDir: dir, maxParallel: () => readMaxParallel(dir) },
+        appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId }), // CTL-1774
       }),
     // CTL-1589 (Codex R3): when set (the sweep's Triage-BOARD candidates), the
     // ticket's LIVE state must still equal this workflow-state name at launch.
@@ -1408,6 +1420,10 @@ export function sweepMissingTriage({
   // CTL-1441: needs-human at the re-dispatch cap — threaded through to
   // dispatchTriage (undefined → real label-guard default; tests inject a spy).
   labelNeedsHuman,
+  // CTL-1774: injectable delegate-event emitter — threaded through to
+  // dispatchTriage so its default labelNeedsHuman closure can emit delegate.*
+  // events in shadow/enforce mode. Default = real event-log append.
+  appendDelegateEvent = defaultAppendDelegateEvent,
   // CTL-1481: worker:<host> label-stamp seam — threaded through to
   // dispatchTriage (undefined → real default; tests inject a fake).
   stampWorkerLabel,
@@ -1499,6 +1515,7 @@ export function sweepMissingTriage({
         claimDispatch, // CTL-862
         emitBackstop, // CTL-1367 P1
         ...(labelNeedsHuman ? { labelNeedsHuman } : {}), // CTL-1441
+        appendDelegateEvent, // CTL-1774
         stampWorkerLabel, // CTL-1481
       });
     }

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -352,6 +352,7 @@ import { stampWorkerLabel as defaultStampWorkerLabel } from "./worker-label.mjs"
 // phase.triage.linear-transition event). Best-effort: swallow-on-error.
 import { appendLinearStateWriteEvent } from "./linear-state-write-event.mjs";
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 Phase 5
+import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { resolveTicketType } from "./ticket-type.mjs"; // CTL-1023: work-type dimension
 // CTL-642 + CTL-758: the SHARED Linear terminal-state predicate. isLinearTerminal
 // ({Done,Canceled} — its OWN set) backs both the reconcile-backstop's
@@ -2807,7 +2808,7 @@ export function gcDispatchCooldowns(orchDir, eligibleIdentifiers, now) {
 export function maybeEscalateDispatchFailures(
   orchDir,
   marker,
-  { writeStatus, appendEvent, env = process.env } = {}
+  { writeStatus, appendEvent, env = process.env, appendDelegateEvent = defaultAppendDelegateEvent } = {}
 ) {
   if (!marker || marker.consecutiveFailures < DISPATCH_FAILURE_ESCALATION_THRESHOLD) return false;
   const result = routeStuckTicketToDelegate(orchDir, marker.ticket, {
@@ -2817,6 +2818,7 @@ export function maybeEscalateDispatchFailures(
     applyLabel: writeStatus,
     env,
     log,
+    appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: marker.ticket }), // CTL-1774
     explanation: {
       escalation_type: "authorization",
       problem: `dispatch failed ${marker.consecutiveFailures}× on ${marker.phase} (${marker.code})`,
@@ -4647,6 +4649,10 @@ export function schedulerTick(
     // false → the bg node with no in-process route is byte-identical (countSdkInflight
     // is never called; and even when armed it is 0 on a node nothing routes in-process).
     hasInProcessRoute = false,
+    // CTL-1774: delegate.* event emitter for shadow/enforce mode observability.
+    // Default-on (real event-log append) so production never loses a signal;
+    // unit tests inject a spy to assert calls without writing to disk.
+    appendDelegateEvent = defaultAppendDelegateEvent,
   } = {}
 ) {
   const _hasTriageArtifact = hasTriageArtifact ?? defaultHasTriageArtifact;
@@ -6574,6 +6580,7 @@ export function schedulerTick(
                 applyLabel: writeStatus,
                 env,
                 log,
+                appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: member }), // CTL-1774
                 explanation: {
                   escalation_type: "decision",
                   problem: `${member} is in a dependency cycle: ${anomaly.members.join(" → ")}`,
@@ -7541,6 +7548,7 @@ export function schedulerTick(
               applyLabel: writeStatus,
               env,
               log,
+              appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: member }), // CTL-1774
               explanation: {
                 escalation_type: "decision",
                 problem: `${member} is in a dependency cycle among eligible tickets: ${anomaly.members.join(" → ")}`,
@@ -8241,6 +8249,7 @@ export function schedulerTick(
               applyLabel: writeStatus,
               env,
               log,
+              appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
               explanation: {
                 problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
                 call_to_action: `decide whether to retry ${ticket} or close it`,
@@ -9023,6 +9032,12 @@ function runTick() {
       // startScheduler({ appendWorkerTransitionEvent }).
       appendWorkerTransitionEvent:
         runningOpts.appendWorkerTransitionEvent ?? defaultAppendWorkerTransitionEvent,
+      // CTL-1774: the LIVE delegate-event emitter. schedulerTick defaults to
+      // defaultAppendDelegateEvent, so bare unit ticks that don't inject it are
+      // already wired to the real log. runTick threads it explicitly so tests
+      // injected via startScheduler({ appendDelegateEvent }) reach all tick sites.
+      appendDelegateEvent:
+        runningOpts.appendDelegateEvent ?? defaultAppendDelegateEvent,
       // CTL-642/758: the LIVE PR-merged adapter. Without this the recovery
       // short-circuit's pr-merged branch (terminal-state.mjs) AND the reconcile
       // backstop (reconcileTerminalBackstop gate 2) are BOTH inert in production —
@@ -9748,6 +9763,10 @@ export function startScheduler({
   // the per-tick schedulerTick opts (production). A test injects a spy here to
   // capture transitions through the production runTick path.
   appendWorkerTransitionEvent,
+  // CTL-1774: optional delegate-event emitter override (test seam). Undefined →
+  // runTick threads defaultAppendDelegateEvent (the real log append). A test
+  // injects a spy here to capture delegate events through the production runTick path.
+  appendDelegateEvent,
   // CTL-642/758: the LIVE PR-merged adapter, wired into the production daemon
   // path so the recovery short-circuit's pr-merged branch + the reconcile
   // backstop actually fire (both inert while prAdapter === undefined). Built
@@ -9812,6 +9831,7 @@ export function startScheduler({
     appendPhaseAdvanceHeldEvent, // CTL-755: optional held-indicator emit seam
     appendPhaseAdvanceAppliedEvent, // CTL-1789: optional applied-advance emit seam
     appendWorkerTransitionEvent, // CTL-764: optional worker.transition emitter override (test seam; runTick defaults to defaultAppendWorkerTransitionEvent)
+    appendDelegateEvent, // CTL-1774: optional delegate-event emitter override (test seam; runTick defaults to defaultAppendDelegateEvent)
     prAdapter, // CTL-642/758: live PR-merged adapter (built once above), threaded per-tick
     checkOpenPrs, // CTL-1157: optional terminal-sweep open-PR gate override (runTick arms the real one)
     classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -2808,7 +2808,12 @@ export function gcDispatchCooldowns(orchDir, eligibleIdentifiers, now) {
 export function maybeEscalateDispatchFailures(
   orchDir,
   marker,
-  { writeStatus, appendEvent, env = process.env, appendDelegateEvent = defaultAppendDelegateEvent } = {}
+  {
+    writeStatus,
+    appendEvent,
+    env = process.env,
+    appendDelegateEvent = defaultAppendDelegateEvent,
+  } = {}
 ) {
   if (!marker || marker.consecutiveFailures < DISPATCH_FAILURE_ESCALATION_THRESHOLD) return false;
   const result = routeStuckTicketToDelegate(orchDir, marker.ticket, {
@@ -8909,10 +8914,7 @@ function runTick() {
     // and Pass 0r's fallback registry construction.
     const unstuckSeamDeps = {
       orchDir: runningOpts.orchDir,
-      clearStall: defaultClearStall(
-        runningOpts.orchDir,
-        runningOpts.writeStatus ?? linearWrite
-      ),
+      clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
       writeStatus: runningOpts.writeStatus ?? linearWrite,
       resolvePrState: (ticket) => {
         const adapter = runningOpts.prAdapter;
@@ -9036,8 +9038,7 @@ function runTick() {
       // defaultAppendDelegateEvent, so bare unit ticks that don't inject it are
       // already wired to the real log. runTick threads it explicitly so tests
       // injected via startScheduler({ appendDelegateEvent }) reach all tick sites.
-      appendDelegateEvent:
-        runningOpts.appendDelegateEvent ?? defaultAppendDelegateEvent,
+      appendDelegateEvent: runningOpts.appendDelegateEvent ?? defaultAppendDelegateEvent,
       // CTL-642/758: the LIVE PR-merged adapter. Without this the recovery
       // short-circuit's pr-merged branch (terminal-state.mjs) AND the reconcile
       // backstop (reconcileTerminalBackstop gate 2) are BOTH inert in production —

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -21,6 +21,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { jobLifecycle } from "./recovery.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
+import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { fenceGuard } from "./fence-guard.mjs";
 import { appendFileSync } from "node:fs";
 import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
@@ -323,7 +324,7 @@ function defaultDispatchRescue(ticket, opts) {
 export function defaultEscalate(
   ticket,
   detail,
-  { orchDir, linearWrite, multiHost = false, gateway = undefined, self = undefined, env = process.env, maxParallel = undefined } = {}
+  { orchDir, linearWrite, multiHost = false, gateway = undefined, self = undefined, env = process.env, maxParallel = undefined, appendDelegateEvent = defaultAppendDelegateEvent } = {}
 ) {
   let routed = false;
   let labelled = false;
@@ -342,6 +343,7 @@ export function defaultEscalate(
         applyLabel: linearWrite,
         env,
         log,
+        appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
         explanation: {
           problem: `stale PR for ${ticket} could not be rescued: ${detail?.reason ?? "unresolvable conflict"}`,
           call_to_action: `resolve the PR conflict for ${ticket} or close the PR`,

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -324,7 +324,16 @@ function defaultDispatchRescue(ticket, opts) {
 export function defaultEscalate(
   ticket,
   detail,
-  { orchDir, linearWrite, multiHost = false, gateway = undefined, self = undefined, env = process.env, maxParallel = undefined, appendDelegateEvent = defaultAppendDelegateEvent } = {}
+  {
+    orchDir,
+    linearWrite,
+    multiHost = false,
+    gateway = undefined,
+    self = undefined,
+    env = process.env,
+    maxParallel = undefined,
+    appendDelegateEvent = defaultAppendDelegateEvent,
+  } = {}
 ) {
   let routed = false;
   let labelled = false;
@@ -335,7 +344,12 @@ export function defaultEscalate(
     // generation must LOUDLY proceed with the label rather than silently drop a
     // human escalation. A genuine supersession (readable generation, fresh
     // foreign owner / authoritative read says not-current) still suppresses.
-    if (fenceGuard({ ticket, orchDir, multiHost, gateway, self }, { proceedOnMissingGeneration: true })) {
+    if (
+      fenceGuard(
+        { ticket, orchDir, multiHost, gateway, self },
+        { proceedOnMissingGeneration: true }
+      )
+    ) {
       const r = routeStuckTicketToDelegate(orchDir, ticket, {
         site: "stale-pr-rescue",
         reason: detail?.reason ?? "unresolvable-conflict",
@@ -397,8 +411,7 @@ function recordEscalationOutcome(orchDir, ticket, rescueState, outcome, nowMs, e
   // latch-always behavior rather than silently retrying forever. In production
   // `escalate` defaults to defaultEscalate, which always returns the contract, so
   // the strict path is the one that actually runs.
-  const hasContract =
-    outcome != null && typeof outcome === "object" && "confirmed" in outcome;
+  const hasContract = outcome != null && typeof outcome === "object" && "confirmed" in outcome;
   const confirmed = !hasContract || outcome.confirmed === true;
   if (confirmed) {
     writeRescueState(orchDir, ticket, {
@@ -490,8 +503,7 @@ export function startStalePrRescueTimer({
       // CTL-863: live per-tick cluster-size gate. Re-read the roster each tick so
       // a 1→2 roster growth arms the fence zombie-guard on the very next tick with
       // no daemon restart. An explicitly-injected `multiHost` (tests) is honored.
-      const tickMultiHost =
-        multiHost === undefined ? getClusterHosts().length > 1 : multiHost;
+      const tickMultiHost = multiHost === undefined ? getClusterHosts().length > 1 : multiHost;
       await runTick({
         orchDir,
         orchId,
@@ -644,7 +656,17 @@ async function processTicket({
     // unconfirmed escalation (delegate route that may still fail, fence
     // suppression, missing transport) would leave the PR neither retried nor
     // surfaced. Unconfirmed → stay retryable AND say so loudly.
-    if (recordEscalationOutcome(orchDir, ticket, rescueState, stalledOutcome, nowMs, emit, "rescue_worker_stalled")) {
+    if (
+      recordEscalationOutcome(
+        orchDir,
+        ticket,
+        rescueState,
+        stalledOutcome,
+        nowMs,
+        emit,
+        "rescue_worker_stalled"
+      )
+    ) {
       emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: "rescue_worker_stalled" });
     }
     return;
@@ -773,7 +795,9 @@ async function processTicket({
       // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
       // permanent skip in decideRescue, so it is written only when the needs-human
       // label is confirmed applied.
-      if (recordEscalationOutcome(orchDir, ticket, rescueState, outcome, nowMs, emit, decision.reason)) {
+      if (
+        recordEscalationOutcome(orchDir, ticket, rescueState, outcome, nowMs, emit, decision.reason)
+      ) {
         emit(`phase.rescue.escalated.${ticket}`, { ticket, reason: decision.reason });
       }
       return;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1176,6 +1176,39 @@ The productivity signal requires peers to publish `last_advance_at` in their hea
 During a mixed-version fleet rollout, a peer without that field is treated as unknown and is not
 flagged; the invariant begins observing that peer only after the upgraded publisher supplies it.
 
+### Delegate-first escalation routing (CTL-1609 / CTL-1774)
+
+When a ticket is about to be labelled `needs-human`, the delegate-first seam can route it to the
+delegate runner instead. `CATALYST_DELEGATE_FIRST=shadow` is the safe dry-run: it emits a
+`delegate.would-route` event on the unified event log (with the ticket, site, and reason) and still
+labels `needs-human` — so an operator can prove the seam works before committing to `enforce`. In
+`enforce`, the label is suppressed and the ticket is enqueued to the delegate runner (with a
+fail-safe fallback to labelling if the runner is not enabled).
+
+Mode resolves from the env var over Layer-2 over the safe default of `off`. The `0` kill-switch and
+any unset/garbage value resolve to `off`.
+
+| Key | Default | Notes |
+| --- | ------- | ----- |
+| `CATALYST_DELEGATE_FIRST` _(env var)_ | `off` | `off` / `0` (kill-switch — strict no-op, byte-identical to not setting the flag), `shadow` (emit `delegate.would-route` on the event log; still labels `needs-human`), `enforce` (enqueue to the delegate runner instead of labelling; fail-safe: falls back to labelling if the runner is not enabled). Garbage values fall back to `off`. Overrides Layer-2. |
+| `catalyst.delegateFirst.mode` _(Layer-2)_ | `off` | Same three values; honored when the env var is absent or unrecognised. |
+
+**Fail-safe gate.** `enforce` silences `needs-human` only when the delegate runner is confirmed
+enabled (via `CATALYST_BOARD_HEALTH`/`CATALYST_RECOVERY_PASS`). Lighting only `CATALYST_DELEGATE_FIRST=enforce`
+without a live runner would enqueue intents that drain never, with the label suppressed — a silent
+black hole. The gate catches this: if no runner is on, it emits `delegate.route-fallback` with
+`reason:"runner-disabled"` and falls back to labelling immediately.
+
+**Observable shadow events.** With shadow mode active, every `routeStuckTicketToDelegate` call
+emits one of three `delegate.*` events:
+
+- `delegate.would-route` — shadow hit (ticket + site + reason)
+- `delegate.routed` — enforce hit, successfully enqueued
+- `delegate.route-fallback` — enforce hit, fell back to label (reason attached)
+
+All three are safe for LogQL/Loki filters:
+`{job="catalyst-events"} | json | attributes["event.name"] =~ "delegate\\..*"`
+
 ### Monitor reply-route trusted origins (CTL-1573)
 
 `POST /api/ticket/<ticket>/reply` posts operator-authored text to Linear, and the monitor binds

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -76,10 +76,10 @@ GitHub organization. Three keys, and the first two are easy to confuse:
 }
 ```
 
-| Key         | What it does                                                                                                 |
-| ----------- | ------------------------------------------------------------------------------------------------------------ |
+| Key         | What it does                                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------- |
 | `org`       | **GitHub owner** hosting this project's `thoughts` repo — provisioning clones `github.com/<org>/thoughts.git` |
-| `profile`   | **HumanLayer profile name** — the key under `.thoughts.profiles` in `humanlayer.json`                        |
+| `profile`   | **HumanLayer profile name** — the key under `.thoughts.profiles` in `humanlayer.json`                         |
 | `directory` | Subdirectory inside the thoughts repo for this project's notes (defaults to the repo's own basename)          |
 | `user`      | Username passed to the thoughts CLI; `null` uses the CLI default                                              |
 
@@ -91,8 +91,8 @@ above is the real shape: code under `github.com/groundworkapp/Adva`, thoughts un
 `provision-thoughts.sh` reads `org` from each registered project's own `.catalyst/config.json`. If
 `org` is absent it falls back to `profile`, then to the org segment of the project's checkout path —
 each fallback prints a `WARN` naming the project, because both are guesses that are only right when
-the names happen to coincide. Set `org` explicitly on every project; a missing `org` degrades
-loudly but never aborts a node join.
+the names happen to coincide. Set `org` explicitly on every project; a missing `org` degrades loudly
+but never aborts a node join.
 
 ## How work runs: `dispatchMode`
 
@@ -143,12 +143,12 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.orphanPrSweep.repo`                            | _(auto-detected)_            | The `org/repo` slug to pass to `gh pr list`. Falls back to top-level `.catalyst/config.json` repo fields, then `gh repo view`. Set this explicitly when auto-detection is unreliable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `orchestration.stalledPrSweep.enabled`                        | `false`                      | Periodically sweep all in-flight worker PRs for review-latency, CI-health, and no-push signals independent of worker liveness (CTL-1608). **Default-off** — enable only after validating thresholds on the live board. When enabled the timer writes `workers/<TICKET>/stalled-pr.json`; board-health reads those stamps via `getStalledPrState` and emits `nudge-stalled-pr` moves.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 | `orchestration.stalledPrSweep.intervalSeconds`                | `900`                        | How often the stalled-PR sweep ticks (seconds). Configurable per the `CATALYST_BH_STALLED_PR_*` env thresholds below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `orchestration.githubQuotaSweep.enabled`                      | `true`                       | Sample the host's GitHub core REST quota and atomically publish it to `<orchDir>/github-quota.json`. Set `false` to disable the timer; a previous snapshot may remain on disk but becomes stale and cannot arm board-health.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `orchestration.githubQuotaSweep.intervalSeconds`              | `300`                        | How often the daemon runs the quota sampler (seconds). The sampler calls the quota-reporting endpoint, which does not consume the core quota it reports.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `responder.intervalSeconds`                                   | `180`                        | How often the daemon-health responder launchd sweep runs (seconds, clamped 60–900). The responder (`health-responder.sh`, CTL-1509) detects a dead/stale cloud-sync replica writer and issues bounded `launchctl kickstart`s, escalating after the attempt cap. Baked into the launchd plist at install time (`install-health-responder.sh`); re-run `catalyst-stack install-services` after changing it.                                                                                                                                                                                                                                                                                                          |
+| `orchestration.githubQuotaSweep.enabled`                      | `true`                       | Sample the host's GitHub core REST quota and atomically publish it to `<orchDir>/github-quota.json`. Set `false` to disable the timer; a previous snapshot may remain on disk but becomes stale and cannot arm board-health.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `orchestration.githubQuotaSweep.intervalSeconds`              | `300`                        | How often the daemon runs the quota sampler (seconds). The sampler calls the quota-reporting endpoint, which does not consume the core quota it reports.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `responder.intervalSeconds`                                   | `180`                        | How often the daemon-health responder launchd sweep runs (seconds, clamped 60–900). The responder (`health-responder.sh`, CTL-1509) detects a dead/stale cloud-sync replica writer and issues bounded `launchctl kickstart`s, escalating after the attempt cap. Baked into the launchd plist at install time (`install-health-responder.sh`); re-run `catalyst-stack install-services` after changing it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `orchestration.reconcile.mode`                                | `off`                        | Completion-declaration reconcile timer (CTL-1371). Linear state is driven by **explicit completion declarations** — the model/pipeline/human says "this is done" via `catalyst-linear-reconcile declare <TICKET>` — **never** inferred from PR/merge state (a draft PR opens while work is in progress; a merged PR is not yet Done — the pipeline puts deploy-verification + teardown between merge and Done). The timer drains _pending_ declarations and makes Linear reflect them, retrying any write that didn't land. `off` = inert (also the default); `notify` = compute drift + emit `ticket.completion.drift.<ticket>` events but **never write** (safe first-ship); `write` = write the declared state via the canonical primitive. Runs on the daemon event loop, separate from the dispatch scheduler. Idempotent + CTL-758 backward-write guard (never resurrects a Canceled ticket, never regresses a Done one). |
 | `orchestration.reconcile.intervalSeconds`                     | `600`                        | How often the drain timer ticks (seconds).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `EXECUTION_CORE_RECONCILE_BLIND_ALERT_MS`                     | `300000`                     | Time-based total-board-blindness alarm. When every registered team's reconcile is failing and no team has succeeded inside this window, execution-core raises the fleet admission alert and emits `fleet.health.degraded`. This complements `EXECUTION_CORE_RECONCILE_FAILURE_ALERT_THRESHOLD`; it does not replace the count-based per-team latch. |
+| `EXECUTION_CORE_RECONCILE_BLIND_ALERT_MS`                     | `300000`                     | Time-based total-board-blindness alarm. When every registered team's reconcile is failing and no team has succeeded inside this window, execution-core raises the fleet admission alert and emits `fleet.health.degraded`. This complements `EXECUTION_CORE_RECONCILE_FAILURE_ALERT_THRESHOLD`; it does not replace the count-based per-team latch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `orchestration.reconcile.declarationsDir`                     | `~/catalyst/completions`     | Directory holding the durable per-ticket completion markers (`<TICKET>.json`). Overridable via `CATALYST_COMPLETIONS_DIR`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `orchestration.orphanReaper.jobGc.enabled`                    | `true`                       | Enable periodic GC of stale `~/.claude/jobs/<id>` dirs (CTL-1165 D3). Set `false` to disable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `orchestration.orphanReaper.jobGc.retentionSeconds`           | `86400`                      | Delete a job dir only if its mtime is older than this many seconds (default 24 h). Env `CATALYST_JOB_GC_RETENTION_SECONDS` overrides.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
@@ -156,10 +156,10 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.orphanReaper.workerGc.enabled`                 | `true`                       | Enable periodic GC of stale `execution-core/workers/<TICKET>/` dirs (CTL-1205). Set `false` to disable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `orchestration.orphanReaper.workerGc.retentionSeconds`        | `86400`                      | Delete a worker dir only if its mtime is older than this many seconds (default 24 h). Env `CATALYST_WORKER_GC_RETENTION_SECONDS` overrides.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `orchestration.orphanReaper.workerGc.batchCap`                | `100`                        | Max worker dirs deleted per sweep tick. Env `CATALYST_WORKER_GC_BATCH_CAP` overrides.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `orchestration.orphanReaper.workerGc.emptyDirGraceSeconds`    | `600`                        | Grace window before a worker dir carrying ZERO phase signals is treated as reclaimable residue rather than `phase-agent-dispatch`'s mkdir→first-signal window (CAT-24). Below it the scheduler still counts the ticket as started; above it the ticket is re-pulled as new work. A zero-signal dir preserving a non-empty `inbox.jsonl` is re-pullable immediately regardless. Env `CATALYST_EMPTY_WORKER_DIR_GRACE_MS` (milliseconds) overrides. |
-| `orchestration.orphanReaper.procReaper.mode`                  | `shadow`                     | Orphan child-process reaper mode. `off` disables it; `shadow` (the default) logs `procOrphans.would-reap` for each candidate but **kills nothing**; `enforce` actually `SIGTERM`→grace→`SIGKILL`s them. Candidates are (a) orphaned reparented `node`/`bun` grandchildren a dead worker left behind, and (b) since CTL-1531, an orphan of **any** command that satisfies the ownership conjunction `ppid == 1` **and** cwd under `worktreeRoot` **and** that cwd definitely no longer exists (the `sh -c` runaway class) — that widened class is gated by its own `widenMode` knob and is **not** armed by setting this one to `enforce`. Ships in `shadow` so the never-kill allowlist + live-agent process-tree correlation — and the widened class in particular — can be audited on real hosts before any `enforce` flip.                                                                                                                                                                                                                                 |
-| `orchestration.orphanReaper.procReaper.widenMode`             | `shadow`                     | **Independent** rollout mode for the CTL-1531 *widened* (any-command) orphan class, deliberately NOT derived from `mode`. `off` removes the widened admission entirely (a byte-identical revert of the feature); `shadow` (the default) classifies and reports widened candidates via `procOrphans.would-reap` but **never signals them, even when `mode` is already `enforce`**; `enforce` lets a widened candidate follow `mode`, so BOTH knobs must be open before an arbitrary PPID-1 command is signalled. An unrecognized value degrades to `shadow`, never to `enforce`. This exists because a host that already carries `mode: "enforce"` — granted for the narrow `node`/`bun` class after *its* shadow bake — must not inherit authority over the widened class on deploy; ADR-023 requires a per-actuator shadow window and an operator-owned flip. Mirrors `orphan-sweep.sh`'s `SWEEP_PROC_WIDEN`. |
-| `orchestration.orphanReaper.procReaper.widenMaxKills`         | `5`                          | Per-run cap on **confirmed** terminations from the widened class (`0` = uncapped), mirroring `orphan-sweep.sh`'s `SWEEP_PROC_WIDEN_MAX_KILLS` and vector 2's `SWEEP_MAX_REMOVALS`. Delivered signals carry a second ceiling of `widenMaxKills × 2`, since a candidate is worth at most SIGTERM + SIGKILL; counting confirmed exits (not attempts) against the first ceiling is what stops a process that ignores SIGTERM from consuming a slot forever. The widened class's authorizing evidence — "this cwd no longer exists" — is **correlated** across a host, so a run that wants to kill more than a handful is a root-level event that wants a human. A non-numeric **or non-integer** value degrades to `5`, never to uncapped — a fractional cap such as `0.5` used to floor to `0`, which is the documented *uncapped* value, so a config typo silently removed the ceiling. |
+| `orchestration.orphanReaper.workerGc.emptyDirGraceSeconds`    | `600`                        | Grace window before a worker dir carrying ZERO phase signals is treated as reclaimable residue rather than `phase-agent-dispatch`'s mkdir→first-signal window (CAT-24). Below it the scheduler still counts the ticket as started; above it the ticket is re-pulled as new work. A zero-signal dir preserving a non-empty `inbox.jsonl` is re-pullable immediately regardless. Env `CATALYST_EMPTY_WORKER_DIR_GRACE_MS` (milliseconds) overrides.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `orchestration.orphanReaper.procReaper.mode`                  | `shadow`                     | Orphan child-process reaper mode. `off` disables it; `shadow` (the default) logs `procOrphans.would-reap` for each candidate but **kills nothing**; `enforce` actually `SIGTERM`→grace→`SIGKILL`s them. Candidates are (a) orphaned reparented `node`/`bun` grandchildren a dead worker left behind, and (b) since CTL-1531, an orphan of **any** command that satisfies the ownership conjunction `ppid == 1` **and** cwd under `worktreeRoot` **and** that cwd definitely no longer exists (the `sh -c` runaway class) — that widened class is gated by its own `widenMode` knob and is **not** armed by setting this one to `enforce`. Ships in `shadow` so the never-kill allowlist + live-agent process-tree correlation — and the widened class in particular — can be audited on real hosts before any `enforce` flip.                                                                                                   |
+| `orchestration.orphanReaper.procReaper.widenMode`             | `shadow`                     | **Independent** rollout mode for the CTL-1531 _widened_ (any-command) orphan class, deliberately NOT derived from `mode`. `off` removes the widened admission entirely (a byte-identical revert of the feature); `shadow` (the default) classifies and reports widened candidates via `procOrphans.would-reap` but **never signals them, even when `mode` is already `enforce`**; `enforce` lets a widened candidate follow `mode`, so BOTH knobs must be open before an arbitrary PPID-1 command is signalled. An unrecognized value degrades to `shadow`, never to `enforce`. This exists because a host that already carries `mode: "enforce"` — granted for the narrow `node`/`bun` class after _its_ shadow bake — must not inherit authority over the widened class on deploy; ADR-023 requires a per-actuator shadow window and an operator-owned flip. Mirrors `orphan-sweep.sh`'s `SWEEP_PROC_WIDEN`.                  |
+| `orchestration.orphanReaper.procReaper.widenMaxKills`         | `5`                          | Per-run cap on **confirmed** terminations from the widened class (`0` = uncapped), mirroring `orphan-sweep.sh`'s `SWEEP_PROC_WIDEN_MAX_KILLS` and vector 2's `SWEEP_MAX_REMOVALS`. Delivered signals carry a second ceiling of `widenMaxKills × 2`, since a candidate is worth at most SIGTERM + SIGKILL; counting confirmed exits (not attempts) against the first ceiling is what stops a process that ignores SIGTERM from consuming a slot forever. The widened class's authorizing evidence — "this cwd no longer exists" — is **correlated** across a host, so a run that wants to kill more than a handful is a root-level event that wants a human. A non-numeric **or non-integer** value degrades to `5`, never to uncapped — a fractional cap such as `0.5` used to floor to `0`, which is the documented _uncapped_ value, so a config typo silently removed the ceiling.                                           |
 | `orchestration.orphanReaper.procReaper.graceMs`               | `5000`                       | Milliseconds to wait after `SIGTERM` before re-probing and (only if still alive) `SIGKILL`ing, so `node`/`bun` can flush.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `orchestration.orphanReaper.procReaper.minEtimeSec`           | `900`                        | A process must have run at least this long (elapsed time) before it is eligible — corroboration only, never the sole gate.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `orchestration.orphanReaper.procReaper.worktreeRoot`          | `~/catalyst/wt`              | Only orphans whose working directory is under this root are reapable; an interactive `claude` or dev shell outside it is never touched.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
@@ -169,17 +169,17 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 | `orchestration.fleetHealth.jobsThreshold`                     | `500`                        | `~/.claude/jobs` dir count at or above which the `jobs` signal trips.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `orchestration.fleetHealth.agentsThreshold`                   | `12`                         | Live background-agent count at or above which the `agents` signal trips.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | `orchestration.fleetHealth.procsThreshold`                    | `40`                         | Resident `node`/`bun` worker-process count at or above which the `procs` signal trips.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `orchestration.fleetHealth.swapUsedMbThreshold`               | `24576`                      | macOS swap-used MB at or above which the `swap` signal TRIPS (edge-triggered since CTL-1503). Raised above a 16 GB Mac's normal-swap ceiling so it stops firing every tick. Env `EXECUTION_CORE_FLEET_SWAP_MB_THRESHOLD`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `orchestration.fleetHealth.swapUsedMbClearThreshold`          | `16384`                      | CTL-1503 hysteresis band — the latched swap degradation CLEARS (fires `fleet.health.recovered` once) only when swap drops strictly below this LOWER threshold, so a value hovering in `[clear, trip)` can't re-flap. Clamped below `swapUsedMbThreshold` if misconfigured. Env `EXECUTION_CORE_FLEET_SWAP_MB_CLEAR_THRESHOLD`. |
+| `orchestration.fleetHealth.swapUsedMbThreshold`               | `24576`                      | macOS swap-used MB at or above which the `swap` signal TRIPS (edge-triggered since CTL-1503). Raised above a 16 GB Mac's normal-swap ceiling so it stops firing every tick. Env `EXECUTION_CORE_FLEET_SWAP_MB_THRESHOLD`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `orchestration.fleetHealth.swapUsedMbClearThreshold`          | `16384`                      | CTL-1503 hysteresis band — the latched swap degradation CLEARS (fires `fleet.health.recovered` once) only when swap drops strictly below this LOWER threshold, so a value hovering in `[clear, trip)` can't re-flap. Clamped below `swapUsedMbThreshold` if misconfigured. Env `EXECUTION_CORE_FLEET_SWAP_MB_CLEAR_THRESHOLD`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `orchestration.fleetHealth.selfHealEnabled`                   | `false`                      | Whether a sustained breach triggers self-heal (the two orphan-reaper intents plus a bounded `ppid==1` `node`/`bun` child sweep). **Default OFF** — the first ship is a pure alert. Enable with `EXECUTION_CORE_FLEET_SELF_HEAL=1`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `orchestration.fleetHealth.sustainedTicks`                    | `2`                          | Consecutive degraded ticks required before self-heal fires (once per breach episode; re-armed only after a healthy tick).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `orchestration.daemonWatchdog.mode`                           | `shadow`                     | Stuck-but-alive daemon watchdog (CTL-1502). `off` disables; `shadow` detects + logs `would-restart` but never restarts; `enforce` restarts a stuck daemon (otel-forward) once per breach episode. Precedence: `CATALYST_DAEMON_WATCHDOG=0` (kill-switch → `off`) → `EXECUTION_CORE_DAEMON_WATCHDOG_MODE` → this key → `shadow`. |
-| `orchestration.daemonWatchdog.intervalMs`                     | `120000`                     | How often the probe checks the stuck predicates (ms). Env `EXECUTION_CORE_DAEMON_WATCHDOG_INTERVAL_MS`. |
-| `orchestration.daemonWatchdog.dlqMaxBytes`                    | `1073741824`                 | DLQ-file size (bytes, via `statSync` — O(1), robust past 2 GB) at or above which the `dlq` predicate trips. Default 1 GiB. Env `EXECUTION_CORE_DAEMON_WATCHDOG_DLQ_MAX_BYTES`. |
-| `orchestration.daemonWatchdog.stalenessMs`                    | `900000`                     | How long the checkpoint's `lastForwardedTs` may stay frozen — while the event log has fresher writes (real backlog) — before the `lag` predicate trips. Default 15 min. Env `EXECUTION_CORE_DAEMON_WATCHDOG_STALENESS_MS`. |
-| `orchestration.daemonWatchdog.cooldownMs`                     | `900000`                     | Minimum time between restarts (ms). Default 15 min — deliberately > the 600s launchd `StartInterval` so the two supervision layers never race. Env `EXECUTION_CORE_DAEMON_WATCHDOG_COOLDOWN_MS`. |
-| `orchestration.daemonWatchdog.sustainedTicks`                 | `2`                          | Consecutive breach ticks required before the watchdog acts (hysteresis). Env `EXECUTION_CORE_DAEMON_WATCHDOG_SUSTAINED_TICKS`. |
-| `orchestration.daemonWatchdog.verifyTicks`                    | `2`                          | Post-restart re-check window: if the predicate is still tripped after this many ticks, the watchdog escalates (latched alert + `severity:high` finding) instead of restarting again. Env `EXECUTION_CORE_DAEMON_WATCHDOG_VERIFY_TICKS`. |
+| `orchestration.daemonWatchdog.mode`                           | `shadow`                     | Stuck-but-alive daemon watchdog (CTL-1502). `off` disables; `shadow` detects + logs `would-restart` but never restarts; `enforce` restarts a stuck daemon (otel-forward) once per breach episode. Precedence: `CATALYST_DAEMON_WATCHDOG=0` (kill-switch → `off`) → `EXECUTION_CORE_DAEMON_WATCHDOG_MODE` → this key → `shadow`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `orchestration.daemonWatchdog.intervalMs`                     | `120000`                     | How often the probe checks the stuck predicates (ms). Env `EXECUTION_CORE_DAEMON_WATCHDOG_INTERVAL_MS`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `orchestration.daemonWatchdog.dlqMaxBytes`                    | `1073741824`                 | DLQ-file size (bytes, via `statSync` — O(1), robust past 2 GB) at or above which the `dlq` predicate trips. Default 1 GiB. Env `EXECUTION_CORE_DAEMON_WATCHDOG_DLQ_MAX_BYTES`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `orchestration.daemonWatchdog.stalenessMs`                    | `900000`                     | How long the checkpoint's `lastForwardedTs` may stay frozen — while the event log has fresher writes (real backlog) — before the `lag` predicate trips. Default 15 min. Env `EXECUTION_CORE_DAEMON_WATCHDOG_STALENESS_MS`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `orchestration.daemonWatchdog.cooldownMs`                     | `900000`                     | Minimum time between restarts (ms). Default 15 min — deliberately > the 600s launchd `StartInterval` so the two supervision layers never race. Env `EXECUTION_CORE_DAEMON_WATCHDOG_COOLDOWN_MS`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `orchestration.daemonWatchdog.sustainedTicks`                 | `2`                          | Consecutive breach ticks required before the watchdog acts (hysteresis). Env `EXECUTION_CORE_DAEMON_WATCHDOG_SUSTAINED_TICKS`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `orchestration.daemonWatchdog.verifyTicks`                    | `2`                          | Post-restart re-check window: if the predicate is still tripped after this many ticks, the watchdog escalates (latched alert + `severity:high` finding) instead of restarting again. Env `EXECUTION_CORE_DAEMON_WATCHDOG_VERIFY_TICKS`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `catalyst.stallJanitor.censusIntervalSeconds` _(Layer 2)_     | `900` (15 min)               | How often the stall-janitor's git-heavy worktree/stall censuses (J1 orphan-worktree, J3 stall-clear, J4 terminal-signal GC) may run, off the per-tick scheduler hot path. Each fires a `git worktree list` per repo plus a `git status` per terminal worktree, so running them every tick on a many-worktree host ages the daemon heartbeat and holds new-work dispatch; this cadence keeps them off the hot path while the cheap J2 ghost-session kill still runs every tick (CTL-1324). Env `CATALYST_STALL_JANITOR_INTERVAL_MS` (milliseconds) overrides.                                                                                                                                                                                                                                                                                                                                                                    |
 
 The orphan child-process reaper is the corroboration-heavy companion to the session-level reaper:
@@ -190,7 +190,7 @@ to act unless every signal corroborates: a successful `claude agents` read this 
 aborts the whole sweep), the process is reparented and outside the live-agent process tree, its
 command and working directory match, and it has persisted across two consecutive sweeps.
 
-CTL-1531 widened *which commands* can be a candidate without relaxing any of that corroboration. A
+CTL-1531 widened _which commands_ can be a candidate without relaxing any of that corroboration. A
 non-`node`/`bun` orphan — the motivating case was four `sh -c "while :; do :; done"` loops that
 pegged ~4 cores for 16.5 h from a worktree that had been deleted — is admitted **only** on positive
 ownership evidence: strictly `ppid == 1`, cwd under `worktreeRoot`, and that cwd path no longer
@@ -198,14 +198,14 @@ existing. Both new probes fail closed (an unresolvable cwd, or a cwd-existence c
 answer, spares the process), nothing outside `worktreeRoot` is ever a candidate regardless of ppid
 or command, and the widened row still passes through every pre-existing gate.
 
-That "cwd no longer exists" probe is **tri-state**, not a boolean: it distinguishes *definitely gone*
-(a `stat` errno of `ENOENT`) from *cannot tell* (`EACCES` on an unreadable parent, `EIO` on a failing
-disk, `ESTALE`/`ENOTCONN` on a dropped network mount), and spares on the latter. A plain
+That "cwd no longer exists" probe is **tri-state**, not a boolean: it distinguishes _definitely
+gone_ (a `stat` errno of `ENOENT`) from _cannot tell_ (`EACCES` on an unreadable parent, `EIO` on a
+failing disk, `ESTALE`/`ENOTCONN` on a dropped network mount), and spares on the latter. A plain
 `existsSync`/`[[ -d ]]` collapses both into `false`, which would read an unanswerable probe as
 positive evidence the worktree was deleted — the inversion of the fail-closed rule, on the one
 conjunct that authorizes killing an arbitrary command.
 
-Because the widened class can signal *any* command, it is staged behind its **own** rollout mode —
+Because the widened class can signal _any_ command, it is staged behind its **own** rollout mode —
 `procReaper.widenMode` in the daemon, `SWEEP_PROC_WIDEN` in the shell sweep — which defaults to
 `shadow` **independently of `procReaper.mode`**. A host already running `mode: "enforce"` therefore
 merely observes the new class until an operator flips the second knob (ADR-023: dark by default, one
@@ -218,33 +218,35 @@ line or event payload: an arbitrary command's argv routinely carries tokens, pas
 URLs, and both logs are persisted (the daemon's is shipped to Loki), so only pid, command basename
 and reason are recorded.
 
-The same widening lands in the hourly `orphan-sweep.sh` vector 1 as an **additional** branch alongside the legacy
-`bun run|turbo|node` branch (which stays path-unrestricted). Both implementations also carry a
-widened-class-only **command denylist** (`tmux`, `screen`, `sshd`, `ssh`, `mosh-server`, `login`,
-`launchd`, `init`, `systemd`, `nohup` — anchored so the `progname: ` setproctitle form such as
-`tmux: server …` and `sshd: ryan [priv]` is matched): a session multiplexer is `ppid == 1` by
-construction and inherits its cwd from whatever shell started it, so one kill would close every pane
-the operator has open.
+The same widening lands in the hourly `orphan-sweep.sh` vector 1 as an **additional** branch
+alongside the legacy `bun run|turbo|node` branch (which stays path-unrestricted). Both
+implementations also carry a widened-class-only **command denylist** (`tmux`, `screen`, `sshd`,
+`ssh`, `mosh-server`, `login`, `launchd`, `init`, `systemd`, `nohup` — anchored so the `progname: `
+setproctitle form such as `tmux: server …` and `sshd: ryan [priv]` is matched): a session
+multiplexer is `ppid == 1` by construction and inherits its cwd from whatever shell started it, so
+one kill would close every pane the operator has open.
 
 The shell branch is staged by these env vars (set them in the LaunchAgent's `EnvironmentVariables`;
-`SWEEP_PROC_WIDEN` is baked into the shipped plist template by `install-orphan-sweep.sh`, which preserves an existing flip across the plist regeneration that every routine `install-services` performs — see `docs/orphan-sweep.md` → "Flipping the widened branch to enforce"):
+`SWEEP_PROC_WIDEN` is baked into the shipped plist template by `install-orphan-sweep.sh`, which
+preserves an existing flip across the plist regeneration that every routine `install-services`
+performs — see `docs/orphan-sweep.md` → "Flipping the widened branch to enforce"):
 
-| Env                             | Default  | Meaning                                                                                                                                                                                                                     |
-| ------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SWEEP_PROC_WIDEN`              | `shadow` | `off` \| `shadow` \| `enforce` for the widened branch. **Dark by default** per ADR-023 — the flip to `enforce` is operator-owned, never enable-on-merge. Any other value logs a warning and falls back to `shadow`.            |
+| Env                             | Default  | Meaning                                                                                                                                                                                                                                                                                                      |
+| ------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SWEEP_PROC_WIDEN`              | `shadow` | `off` \| `shadow` \| `enforce` for the widened branch. **Dark by default** per ADR-023 — the flip to `enforce` is operator-owned, never enable-on-merge. Any other value logs a warning and falls back to `shadow`.                                                                                          |
 | `SWEEP_PROC_WIDEN_MAX_KILLS`    | `5`      | Per-run cap on **confirmed** widened terminations (`0` = uncapped), mirroring vector 2's `SWEEP_MAX_REMOVALS`. Counted on the enforcing path only, so `shadow` still reports the full candidate set. Overflow is logged and deferred to the next run. Delivered signals carry a second ceiling of `cap × 2`. |
-| `SWEEP_PROC_WIDEN_MIN_AGE_SECS` | `900`    | Minimum process age (elapsed seconds) for a widened kill, matching `procReaper.minEtimeSec`. An unreadable age fails closed.                                                                                                  |
-| `SWEEP_PROC_WIDEN_GRACE_SECS`   | `5`      | Seconds to wait for a **confirmed exit** after each of SIGTERM and SIGKILL. `kill` reports delivery, not exit — only a process observed to have actually gone is logged and emitted as reclaimed.                              |
-| `SWEEP_PROC_CWD_TIMEOUT_SECS`   | `5`      | Deadline for the per-pid `lsof` cwd probe, so one hung/stale mount cannot wedge the LaunchAgent run. A timed-out probe yields an unknown cwd (spare), never a truncated path.                                                    |
-| `CATALYST_LSOF_TIMEOUT_MS`      | `5000`   | The daemon-side sibling: the deadline `proc-reaper.mjs` puts on its own `lsof` cwd probe (single-pid and batched). A value outside `(0, 600000]` degrades to `5000`, never to unbounded. Scope is `lsof` only — the cwd **existence** probe is unbounded on both sides (declared, not implied). |
+| `SWEEP_PROC_WIDEN_MIN_AGE_SECS` | `900`    | Minimum process age (elapsed seconds) for a widened kill, matching `procReaper.minEtimeSec`. An unreadable age fails closed.                                                                                                                                                                                 |
+| `SWEEP_PROC_WIDEN_GRACE_SECS`   | `5`      | Seconds to wait for a **confirmed exit** after each of SIGTERM and SIGKILL. `kill` reports delivery, not exit — only a process observed to have actually gone is logged and emitted as reclaimed.                                                                                                            |
+| `SWEEP_PROC_CWD_TIMEOUT_SECS`   | `5`      | Deadline for the per-pid `lsof` cwd probe, so one hung/stale mount cannot wedge the LaunchAgent run. A timed-out probe yields an unknown cwd (spare), never a truncated path.                                                                                                                                |
+| `CATALYST_LSOF_TIMEOUT_MS`      | `5000`   | The daemon-side sibling: the deadline `proc-reaper.mjs` puts on its own `lsof` cwd probe (single-pid and batched). A value outside `(0, 600000]` degrades to `5000`, never to unbounded. Scope is `lsof` only — the cwd **existence** probe is unbounded on both sides (declared, not implied).              |
 
 Both implementations refuse to run the widened branch at all when the worktree root itself is
 missing or unreadable (`SWEEP_WT_ROOT` in the shell, `procReaper.worktreeRoot` in the daemon): a
-renamed or unmounted root makes *every* cwd beneath it look deleted in the same pass, which is a
+renamed or unmounted root makes _every_ cwd beneath it look deleted in the same pass, which is a
 root-level fault rather than N independent orphans — and two-sweep persistence is no defense there,
 because the same correlated fault answers both sweeps. Both also bound the widened class per run
 (`widenMaxKills` / `SWEEP_PROC_WIDEN_MAX_KILLS`), bound the `lsof` cwd probe with a deadline so one
-hung mount cannot wedge the sweep, and treat a liveness probe that *could not answer* as unknown
+hung mount cannot wedge the sweep, and treat a liveness probe that _could not answer_ as unknown
 rather than as a confirmed exit — so a reclamation is only ever recorded for a process observed to
 have actually gone.
 
@@ -444,11 +446,11 @@ Never commit this. One file per project, linked by `projectKey`. It holds API ke
 }
 ```
 
-| Integration | Required fields               | Used by                   |
-| ----------- | ----------------------------- | ------------------------- |
+| Integration | Required fields               | Used by                                             |
+| ----------- | ----------------------------- | --------------------------------------------------- |
 | Linear      | `apiToken`, `teamKey`         | catalyst-dev, catalyst-pm, orch-monitor inbox reply |
-| Sentry      | `org`, `project`, `authToken` | catalyst-debugging        |
-| PostHog     | `apiKey`, `projectId`         | catalyst-analytics        |
+| Sentry      | `org`, `project`, `authToken` | catalyst-debugging                                  |
+| PostHog     | `apiKey`, `projectId`         | catalyst-analytics                                  |
 
 Only set up the integrations you use — the setup script asks about each one.
 
@@ -456,29 +458,28 @@ Only set up the integrations you use — the setup script asks about each one.
 
 The orch-monitor Inbox's reply/unblock feature
 ([`lib/linear-comment.mjs`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/orch-monitor/lib/linear-comment.mjs))
-posts comments as **you**, not as the Catalyst app — a Linear provenance gate (CTL-1567) deliberately
-ignores app-authored comments, so a reply posted as the bot would silently do nothing. It resolves a
-candidate token from, in priority order: env `LINEAR_API_TOKEN` → env `LINEAR_API_KEY` → this file's
-`linear.apiToken` → the nested `catalyst.linear.apiToken` — and identity-checks EACH candidate, using
-the first one that resolves to a real human (skipping, not failing on, any that resolve to an app
-actor).
+posts comments as **you**, not as the Catalyst app — a Linear provenance gate (CTL-1567)
+deliberately ignores app-authored comments, so a reply posted as the bot would silently do nothing.
+It resolves a candidate token from, in priority order: env `LINEAR_API_TOKEN` → env `LINEAR_API_KEY`
+→ this file's `linear.apiToken` → the nested `catalyst.linear.apiToken` — and identity-checks EACH
+candidate, using the first one that resolves to a real human (skipping, not failing on, any that
+resolve to an app actor).
 
 This matters because `LINEAR_API_TOKEN`/`LINEAR_API_KEY` are not exclusively a personal-token slot:
-`lib/linear-app-actor.sh` exports the app-actor's own OAuth token into those same two env vars for any
-daemon that needs bot credentials (broker/execution-core/monitor heartbeats). If your monitor process
-sources that script, its env will always carry a non-empty (but bot) token — the identity walk exists
-precisely so your real `linear.apiToken` here still gets tried and used instead of being permanently
-shadowed. Generate a personal key at Linear → Settings → API → Personal API keys (`lin_api_...`, not
-an OAuth `lin_oauth_...` value) and put it here.
+`lib/linear-app-actor.sh` exports the app-actor's own OAuth token into those same two env vars for
+any daemon that needs bot credentials (broker/execution-core/monitor heartbeats). If your monitor
+process sources that script, its env will always carry a non-empty (but bot) token — the identity
+walk exists precisely so your real `linear.apiToken` here still gets tried and used instead of being
+permanently shadowed. Generate a personal key at Linear → Settings → API → Personal API keys
+(`lin_api_...`, not an OAuth `lin_oauth_...` value) and put it here.
 
 ## Event forwarders (`catalyst.observability.forwarders`)
 
-The `catalyst-otel-forward` daemon tails the canonical event log
-(`~/catalyst/events/YYYY-MM.jsonl`) and fans events out to OTLP/HTTP, PostHog, and Cloudflare
-Analytics Engine. Config lives in the Layer-2 file above under
-`catalyst.observability.forwarders`. **All forwarders are disabled by default.** This section is
-the authoritative schema; the developer reference `plugins/dev/references/event-forwarding.md`
-covers architecture, lifecycle, and DLQ operations.
+The `catalyst-otel-forward` daemon tails the canonical event log (`~/catalyst/events/YYYY-MM.jsonl`)
+and fans events out to OTLP/HTTP, PostHog, and Cloudflare Analytics Engine. Config lives in the
+Layer-2 file above under `catalyst.observability.forwarders`. **All forwarders are disabled by
+default.** This section is the authoritative schema; the developer reference
+`plugins/dev/references/event-forwarding.md` covers architecture, lifecycle, and DLQ operations.
 
 ```json
 {
@@ -516,17 +517,17 @@ covers architecture, lifecycle, and DLQ operations.
 
 ### OTLP forwarder keys
 
-| Key                  | Default                | Description                                                                                                                                             |
-| -------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enabled`            | `false`                | Enable the OTLP/HTTP forwarder.                                                                                                                        |
-| `endpoint`           | `http://localhost:4318`| Collector ingest. `OTEL_EXPORTER_OTLP_ENDPOINT` overrides it; a `:4317` port is auto-rewritten to `:4318` for HTTP.                                     |
-| `batchSize`          | `100`                  | Advisory target only — **not currently enforced**. Each flush sends the whole accumulated buffer for that destination in one request; a hard per-request cap is a follow-up (CTL-1506). |
-| `flushIntervalMs`    | `5000`                 | Per-forwarder flush cadence — each enabled destination runs its own timer at its own interval (CTL-1506). A destination's flushes are serialized independently: a tick arriving while its previous flush is still in flight is a no-op, so this is a floor. |
-| `lokiAcceptWindowMs` | `3600000` (1 h)        | Age cutoff for Loki records (CTL-1506). Records older than this are dropped with a `forward_dropped` (`drop_reason: "aged"`) event before any send. Note the *effective* send cutoff is slightly stricter — `lokiAcceptWindowMs − min(timeoutMs, lokiAcceptWindowMs/4)` — a delivery margin so a near-cutoff record can't age past the window mid-request. Tune to your Loki `reject_old_samples_max_age`. |
-| `maxRetryElapsedMs`  | `60000` (60 s)         | Max elapsed time for HTTP retry backoff on a retryable failure (`429`/`5xx`/network) before the batch is dead-lettered (CTL-1506). Terminal `4xx` (not `429`) is dropped immediately, never retried or DLQ'd. |
+| Key                  | Default                 | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+| -------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`            | `false`                 | Enable the OTLP/HTTP forwarder.                                                                                                                                                                                                                                                                                                                                                                            |
+| `endpoint`           | `http://localhost:4318` | Collector ingest. `OTEL_EXPORTER_OTLP_ENDPOINT` overrides it; a `:4317` port is auto-rewritten to `:4318` for HTTP.                                                                                                                                                                                                                                                                                        |
+| `batchSize`          | `100`                   | Advisory target only — **not currently enforced**. Each flush sends the whole accumulated buffer for that destination in one request; a hard per-request cap is a follow-up (CTL-1506).                                                                                                                                                                                                                    |
+| `flushIntervalMs`    | `5000`                  | Per-forwarder flush cadence — each enabled destination runs its own timer at its own interval (CTL-1506). A destination's flushes are serialized independently: a tick arriving while its previous flush is still in flight is a no-op, so this is a floor.                                                                                                                                                |
+| `lokiAcceptWindowMs` | `3600000` (1 h)         | Age cutoff for Loki records (CTL-1506). Records older than this are dropped with a `forward_dropped` (`drop_reason: "aged"`) event before any send. Note the _effective_ send cutoff is slightly stricter — `lokiAcceptWindowMs − min(timeoutMs, lokiAcceptWindowMs/4)` — a delivery margin so a near-cutoff record can't age past the window mid-request. Tune to your Loki `reject_old_samples_max_age`. |
+| `maxRetryElapsedMs`  | `60000` (60 s)          | Max elapsed time for HTTP retry backoff on a retryable failure (`429`/`5xx`/network) before the batch is dead-lettered (CTL-1506). Terminal `4xx` (not `429`) is dropped immediately, never retried or DLQ'd.                                                                                                                                                                                              |
 
-PostHog and Cloudflare AE keys mirror the JSON above; see the developer reference for their
-delivery semantics.
+PostHog and Cloudflare AE keys mirror the JSON above; see the developer reference for their delivery
+semantics.
 
 ## Cluster machine-level cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
 
@@ -573,10 +574,10 @@ packaging — one declarative field that sets sensible **defaults for levers tha
 (cluster-roster membership, boot-drain, which daemons start, where board reads come from). It adds
 **no** new dispatch gate; the scheduler is unchanged.
 
-| Class       | What it is                                                                                                                                                                                                                                                                            |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `developer` | A daemonless client you chat on. Not in the cluster roster, boots drained, runs no execution-core daemon or broker — it reads board UI data from a worker's monitor (agent Linear reads follow the two-mode rule — see the `catalyst-dev:linearis` skill's "Reading Linear" section). On `catalyst-stack start`, the event-mirror daemon fans worker host event logs into the local copy so `catalyst-events tail`/`wait-for` see fleet events. |
-| `worker`    | Runs the full stack and picks up work (the default; a laptop that both runs the daemon and is chatted on is a "head-full worker").                                                                                                                                                    |
+| Class       | What it is                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `developer` | A daemonless client you chat on. Not in the cluster roster, boots drained, runs no execution-core daemon or broker — it reads board UI data from a worker's monitor (agent Linear reads follow the two-mode rule — see the `catalyst-dev:linearis` skill's "Reading Linear" section). On `catalyst-stack start`, the event-mirror daemon fans worker host event logs into the local copy so `catalyst-events tail`/`wait-for` see fleet events.                                                                     |
+| `worker`    | Runs the full stack and picks up work (the default; a laptop that both runs the daemon and is chatted on is a "head-full worker").                                                                                                                                                                                                                                                                                                                                                                                  |
 | `monitor`   | A dedicated reporting host (CTL-1654). Like `developer` it carries the observation substrate (broker + monitor + event-mirror) without the execution layer (no heartbeat, no dispatch, no recovery). The event-mirror daemon (`event-mirror/index.ts`, launchd-supervised) fans each worker host's event log into the local `~/catalyst/events/YYYY-MM.jsonl` via ssh-tail with per-host byte cursors, so `catalyst-events tail`/`wait-for` resolve fleet events locally. Verify with `catalyst-stack verify-node`. |
 
 The class is **machine-local**, so it lives in **Layer-2** (`~/.config/catalyst/config.json`) beside
@@ -606,8 +607,8 @@ not per-repo:
 
 `CATALYST_DRAIN_DISABLED=1` is a **worker-only, per-node** override that makes the node
 **permanently ignore the drain flag**. It exists because an unattributed recurring writer (CTL-1675)
-keeps silently setting the drain sentinel fleet-wide, halting all new-work admission; this env lets a
-worker neutralize that flag durably without a code change.
+keeps silently setting the drain sentinel fleet-wide, halting all new-work admission; this env lets
+a worker neutralize that flag durably without a code change.
 
 - **Where to set it:** in the durable **Layer-2** `~/.config/catalyst/execution-core.env` (it is
   `source`d into the daemon's environment at launch), then `catalyst-stack restart`.
@@ -615,9 +616,9 @@ worker neutralize that flag durably without a code change.
   unset, `0`, `true`, empty — leaves the node honoring the flag. **Unset (the fleet default) is a
   byte-for-byte no-op**; nothing changes until it is set.
 - **What it does:** it makes `isDraining()` return `false` at the single admission chokepoint, so
-  **every** new-work consumer (the scheduler dispatch gate, the monitor triage-dispatch gate, and the
-  admission-state reporter) admits work again through one seam. The physical `drain` file is left in
-  place — the override neutralizes it, it does not delete it.
+  **every** new-work consumer (the scheduler dispatch gate, the monitor triage-dispatch gate, and
+  the admission-state reporter) admits work again through one seam. The physical `drain` file is
+  left in place — the override neutralizes it, it does not delete it.
 - **Tripwire (attribution):** whenever the flag is present but ignored, the daemon emits a
   once-per-episode **`node.drain.ignored`** event carrying the flag's mtime and a truncated `ps`
   snapshot, to keep gathering evidence for CTL-1675. It re-arms once the flag is removed and
@@ -741,7 +742,8 @@ plist; the launcher sources it from a `0600` file at run time.
    ```
 
    The command refuses to change the Layer-2 read flag until the seed checks in step 3 are genuinely
-   green. Use `catalyst-stack activate-replica --dry-run` to preview the config merge without writing.
+   green. Use `catalyst-stack activate-replica --dry-run` to preview the config merge without
+   writing.
 
 5. On a worker node, restart execution-core so the scheduler constructs its replica reader:
 
@@ -763,24 +765,25 @@ authoritative acceptance check—an installed service alone is not proof of a us
 ## Deployment mode (`catalyst.deployment.mode`, CTL-1617)
 
 `catalyst.deployment.mode` is the ONE declared answer to a question the system otherwise infers from
-side effects — whether a webhook tunnel happens to be configured, whether a cluster roster happens to
-resolve to more than one host. It is resolved **identically** by two independently maintained
+side effects — whether a webhook tunnel happens to be configured, whether a cluster roster happens
+to resolve to more than one host. It is resolved **identically** by two independently maintained
 implementations — `lib/deployment-mode.mjs` (Node/ESM) and `lib/catalyst-deployment-mode.sh` (the
-Bash mirror, since Bash cannot import a JS leaf) — kept honest by a fixture-matrix cross-stack parity
-test (`__tests__/deployment-mode-parity.test.sh`).
+Bash mirror, since Bash cannot import a JS leaf) — kept honest by a fixture-matrix cross-stack
+parity test (`__tests__/deployment-mode-parity.test.sh`).
 
-| Value                  | Meaning                                                                                                                       |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `single-host` (default) | A lone node — no cluster substrate expected.                                                                                  |
-| `cluster`               | A coordinated multi-host fleet; roster/HRW/liveness are graded by `catalyst doctor`.                                          |
-| `cloud`                 | A managed-container node; the smee webhook tunnel must NOT be live and secrets are platform-delivered.                       |
+| Value                   | Meaning                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------ |
+| `single-host` (default) | A lone node — no cluster substrate expected.                                                           |
+| `cluster`               | A coordinated multi-host fleet; roster/HRW/liveness are graded by `catalyst doctor`.                   |
+| `cloud`                 | A managed-container node; the smee webhook tunnel must NOT be live and secrets are platform-delivered. |
 
 A 4th `both` value was deliberately rejected (CTL-1617 design §2) — the provider's own
 `webhook.delivery.id` already makes concurrent smee+cloud ingestion dedup-safe without one.
 
-Deployment mode is genuinely **fleet-scoped**, so — unlike `catalyst.node.class` — it lives primarily
-in **Layer-1** (committed, shared by the whole repo checkout), with a **Layer-2 override** as the
-exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding to `single-host`):
+Deployment mode is genuinely **fleet-scoped**, so — unlike `catalyst.node.class` — it lives
+primarily in **Layer-1** (committed, shared by the whole repo checkout), with a **Layer-2 override**
+as the exception hatch (e.g. a laptop dev-clone of a cluster-declared repo overriding to
+`single-host`):
 
 In `.catalyst/config.json` (Layer-1, fleet-wide default):
 
@@ -801,12 +804,12 @@ deployment-mode WARN (advisory only — nothing else changes).
 
 **Resolution** (`resolveDeploymentMode()` / `catalyst_resolve_deployment_mode`):
 
-| Precedence | Source                                                |
-| ---------- | ------------------------------------------------------ |
-| 1          | `CATALYST_DEPLOYMENT_MODE` env var                     |
-| 2          | `catalyst.deployment.mode` in the Layer-2 config       |
-| 3          | `catalyst.deployment.mode` in the Layer-1 config       |
-| 4          | constant default `single-host`                         |
+| Precedence | Source                                           |
+| ---------- | ------------------------------------------------ |
+| 1          | `CATALYST_DEPLOYMENT_MODE` env var               |
+| 2          | `catalyst.deployment.mode` in the Layer-2 config |
+| 3          | `catalyst.deployment.mode` in the Layer-1 config |
+| 4          | constant default `single-host`                   |
 
 - **Absent everywhere ⇒ `single-host`** — zero-config, zero-behavior-change. (Once wired: a WARN
   will note the value was inferred — the resolver itself is deliberately log-free; the WARN lives in
@@ -816,8 +819,8 @@ deployment-mode WARN (advisory only — nothing else changes).
   it degrades to `single-host` (the safest direction) at the layer it was found. (Future behavior,
   PR2: `catalyst doctor` will FAIL until the value is corrected.)
 - A missing/malformed config file, or a present-but-non-string value (`true`, `123`, `[]`), both
-  settle rather than throw — see `lib/deployment-mode.mjs`'s `classifyCandidate` for the full validity
-  ladder.
+  settle rather than throw — see `lib/deployment-mode.mjs`'s `classifyCandidate` for the full
+  validity ladder.
 - **ENV-vs-FILE asymmetry**: `CATALYST_DEPLOYMENT_MODE` is captured into a long-lived daemon's
   environment once, at launch. Layer-1/Layer-2 file edits are picked up **live**, on every call. A
   daemon needs restarting for an env change to take effect.
@@ -827,68 +830,68 @@ deployment-mode WARN (advisory only — nothing else changes).
   start of every resolution, so it always reflects the latest call). Grading that breadcrumb is
   future doctor work (PR2) — nothing consumes it yet.
 
-PR1 (this file) ships the resolver in isolation — nothing outside its own tests imports it yet; wiring
-into webhook ingestion gating, secret-provider selection, and `catalyst doctor`'s roster-consistency
-checks lands in later PRs of the CTL-1617 migration plan.
+PR1 (this file) ships the resolver in isolation — nothing outside its own tests imports it yet;
+wiring into webhook ingestion gating, secret-provider selection, and `catalyst doctor`'s
+roster-consistency checks lands in later PRs of the CTL-1617 migration plan.
 
 ## Secret contract registry (CTL-1616)
 
-Every secret Catalyst resolves — the GitHub token, the Linear API token, the OAuth-mint
-credentials, the cloud token, the Groq key, the cluster age-key — is a row in **one frozen
-registry**, `SECRET_REGISTRY` in `plugins/dev/scripts/lib/secret-contract.mjs`. It **models** what
-used to be independently hand-rolled resolution ladders per secret (the 2026-08-02 fleet 401
-outage was four divergent copies of one chain) — the Linear-token read and the Linear OAuth-mint
-trio are live consumers of it, but the `github-token`/`webhook-secret` rows and the `groq-api-key`
-row are not yet RESOLVED through the registry: the live GitHub-token/webhook-secret value paths
-(CTL-1612's `catalyst-secret-env.sh` / `github-auth-preflight.mjs`) and Groq's pre-existing
+Every secret Catalyst resolves — the GitHub token, the Linear API token, the OAuth-mint credentials,
+the cloud token, the Groq key, the cluster age-key — is a row in **one frozen registry**,
+`SECRET_REGISTRY` in `plugins/dev/scripts/lib/secret-contract.mjs`. It **models** what used to be
+independently hand-rolled resolution ladders per secret (the 2026-08-02 fleet 401 outage was four
+divergent copies of one chain) — the Linear-token read and the Linear OAuth-mint trio are live
+consumers of it, but the `github-token`/`webhook-secret` rows and the `groq-api-key` row are not yet
+RESOLVED through the registry: the live GitHub-token/webhook-secret value paths (CTL-1612's
+`catalyst-secret-env.sh` / `github-auth-preflight.mjs`) and Groq's pre-existing
 `lib/api-key-health.mjs` ladder remain their own, unrepointed implementations — but the
 `github-token`/`webhook-secret` ROWS do have one live production consumer already:
 `execution-core/cluster-sync.mjs` imports `SECRET_REGISTRY` and derives its boot-captured secret
 membership (which changed credentials require daemon-restart signaling) from these rows' delivery
 types, so their fields are load-bearing even before the resolution cutover (`docs/architecture.md`'s
-Secret Contract section has the full per-row cutover status). Bash cannot import a JS leaf, so the registry has a
-second, independently-maintained encoding — `plugins/dev/scripts/lib/catalyst-secret-contract.sh` —
-kept honest by a cross-stack **three-way parity test**
-(`__tests__/secret-contract-parity.test.sh`): bash and JS must each match a computed-expected
-value, never merely match each other, and the two registries must enumerate identical row-id sets.
-Both files are zero-import leaves (`node:fs`/`node:os`/`node:path` only on the JS side) so
-`catalyst doctor`, which runs under bare Node, can import the engine without pulling in
-`execution-core/config.mjs`'s `bun:sqlite`-reaching module graph.
+Secret Contract section has the full per-row cutover status). Bash cannot import a JS leaf, so the
+registry has a second, independently-maintained encoding —
+`plugins/dev/scripts/lib/catalyst-secret-contract.sh` — kept honest by a cross-stack **three-way
+parity test** (`__tests__/secret-contract-parity.test.sh`): bash and JS must each match a
+computed-expected value, never merely match each other, and the two registries must enumerate
+identical row-id sets. Both files are zero-import leaves (`node:fs`/`node:os`/`node:path` only on
+the JS side) so `catalyst doctor`, which runs under bare Node, can import the engine without pulling
+in `execution-core/config.mjs`'s `bun:sqlite`-reaching module graph.
 
 ### Registry rows
 
 A row is a data fact, not code — the ~7-case engine below is what walks it. Every row declares:
 
-| Field           | Meaning                                                                                                     |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| `id`            | Canonical identity; doubles as the SOPS bare-file basename for file-backed rows.                             |
-| `envNames`      | Env-var aliases, precedence order (empty for rows with no direct env alias).                                |
-| `delivery`      | One of the 7 delivery types below.                                                                           |
-| `configJsonPath`| Dotted path inside the resolved Layer-2 JSON, for `config-json`/`platform-env` rows; `null` otherwise.       |
-| `rotation`      | `{ class, trigger? }` — see Rotation below.                                                                  |
-| `bootstrapFor`  | `"cluster"` \| `"cloud"` \| `null` — the deployment mode this row bootstraps.                                |
+| Field            | Meaning                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `id`             | Canonical identity; doubles as the SOPS bare-file basename for file-backed rows.                       |
+| `envNames`       | Env-var aliases, precedence order (empty for rows with no direct env alias).                           |
+| `delivery`       | One of the 7 delivery types below.                                                                     |
+| `configJsonPath` | Dotted path inside the resolved Layer-2 JSON, for `config-json`/`platform-env` rows; `null` otherwise. |
+| `rotation`       | `{ class, trigger? }` — see Rotation below.                                                            |
+| `bootstrapFor`   | `"cluster"` \| `"cloud"` \| `null` — the deployment mode this row bootstraps.                          |
 
 Rows with a more specific shape declare additional fields: `familyPrefix` (the one
-`bare-file-family` row), `defaultLocalPath` (the one `local-only` row, resolved relative to
-`HOME`), and — `linear-worker-actor` only — `credentialEnvPair` (an env-var pair checked ahead of
-every config-file tier) and `legacyConfigTiers` + `requiredObjectFields` (§ Linear worker-actor
-tiers below).
+`bare-file-family` row), `defaultLocalPath` (the one `local-only` row, resolved relative to `HOME`),
+and — `linear-worker-actor` only — `credentialEnvPair` (an env-var pair checked ahead of every
+config-file tier) and `legacyConfigTiers` + `requiredObjectFields` (§ Linear worker-actor tiers
+below).
 
 The 11 seed rows:
 
-| id                          | delivery          | rotation                | bootstrapFor | notes                                                                 |
-| ---------------------------- | ----------------- | ------------------------ | ------------ | ---------------------------------------------------------------------- |
-| `github-token`                | `bare-file`        | `re-armable` / `timer`   | —            | aliases `GH_TOKEN`, `GITHUB_TOKEN`                                    |
-| `webhook-secret`               | `bare-file`        | `boot-only`              | —            | env alias `CATALYST_WEBHOOK_SECRET`                                   |
-| `linear-webhook-secret`        | `bare-file-family` | `boot-only`              | —            | `familyPrefix: "linear-webhook-secret-"`; a predicate, not a scalar   |
-| `claude-accounts.env`          | `env-file`         | `boot-only`              | —            | presence-only (a whole sourced env file, not one value)               |
-| `execution-core.env`           | `env-file`         | `boot-only`              | —            | same shape as `claude-accounts.env`                                   |
-| `linear-api-token`             | `env-alias`        | `re-armable` / `on-401`  | —            | aliases `LINEAR_API_TOKEN`, `LINEAR_API_KEY`                          |
-| `linear-orchestrator-actor`    | `config-json`      | `re-armable` / `on-401`  | —            | `catalyst.linear.bot.orchestrator` — kept separate from worker-actor  |
-| `linear-worker-actor`          | `config-json`      | `boot-only`              | —            | `catalyst.linear.bot.worker` + a legacy fallback chain (below)        |
-| `groq-api-key`                 | `config-json`      | `boot-only`              | —            | env alias `GROQ_API_KEY`, config path `groq.apiKey`                   |
-| `cloud-token`                  | `platform-env`     | `boot-only`              | `cloud`      | default env-var `CATALYST_CLOUD_TOKEN`; the NAME is itself resolvable |
-| `age-key`                      | `local-only`       | `n/a`                    | `cluster`    | presence-checked only, never value-read; default `~/.config/catalyst/age.key` |
+| id                          | delivery           | rotation                | bootstrapFor | notes                                                                         |
+| --------------------------- | ------------------ | ----------------------- | ------------ | ----------------------------------------------------------------------------- |
+| `github-token`              | `bare-file`        | `re-armable` / `timer`  | —            | aliases `GH_TOKEN`, `GITHUB_TOKEN`                                            |
+| `webhook-secret`            | `bare-file`        | `boot-only`             | —            | env alias `CATALYST_WEBHOOK_SECRET`                                           |
+| `linear-webhook-secret`     | `bare-file-family` | `boot-only`             | —            | `familyPrefix: "linear-webhook-secret-"`; a predicate, not a scalar           |
+| `claude-accounts.env`       | `env-file`         | `boot-only`             | —            | presence-only (a whole sourced env file, not one value)                       |
+| `execution-core.env`        | `env-file`         | `boot-only`             | —            | same shape as `claude-accounts.env`                                           |
+| `linear-api-token`          | `env-alias`        | `re-armable` / `on-401` | —            | aliases `LINEAR_API_TOKEN`, `LINEAR_API_KEY`                                  |
+| `linear-orchestrator-actor` | `config-json`      | `re-armable` / `on-401` | —            | `catalyst.linear.bot.orchestrator` — kept separate from worker-actor          |
+| `linear-worker-actor`       | `config-json`      | `boot-only`             | —            | `catalyst.linear.bot.worker` + a legacy fallback chain (below)                |
+| `groq-api-key`              | `config-json`      | `boot-only`             | —            | env alias `GROQ_API_KEY`, config path `groq.apiKey`                           |
+| `cloud-token`               | `platform-env`     | `boot-only`             | `cloud`      | default env-var `CATALYST_CLOUD_TOKEN`; the NAME is itself resolvable         |
+| `age-key`                   | `local-only`       | `n/a`                   | `cluster`    | presence-checked only, never value-read; default `~/.config/catalyst/age.key` |
 
 `linear-orchestrator-actor` and `linear-worker-actor` are deliberately separate rows — they mint
 identically and differ only in their config path, an easy-to-collapse-wrongly refactor the registry
@@ -899,15 +902,15 @@ exists to prevent.
 The engine dispatches on exactly one of 7 delivery types — parity cost between the bash and JS
 implementations scales per type, not per row:
 
-| Delivery           | Resolution chain                                                                                                     |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `bare-file`          | explicit `CATALYST_<ID>_FILE` override → `CATALYST_CONFIG_DIR` → the directory holding `CATALYST_LAYER2_CONFIG_FILE` (or its `~/.config/catalyst/config.json` default) → XDG dir → falls back to an inherited env alias if no file is found |
-| `bare-file-family`   | not a resolvable scalar — a membership predicate (`isSecretFamilyMember`) over an open-ended prefix family          |
-| `env-file`           | presence/non-empty check of a whole file at the same bare-file candidate paths (the file is *sourced*, not read for one value) |
-| `env-alias`          | first non-empty `envNames` entry, in order — no file search at all                                                  |
-| `config-json`        | env alias (if any) → the resolved Layer-2 JSON's `configJsonPath`                                                   |
-| `platform-env`       | the row's env-var **name** is itself resolved (env override → Layer-2 name override → default), then that variable's value is read |
-| `local-only`         | `statSync` presence check of a single path only — the value is never read                                           |
+| Delivery           | Resolution chain                                                                                                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bare-file`        | explicit `CATALYST_<ID>_FILE` override → `CATALYST_CONFIG_DIR` → the directory holding `CATALYST_LAYER2_CONFIG_FILE` (or its `~/.config/catalyst/config.json` default) → XDG dir → falls back to an inherited env alias if no file is found |
+| `bare-file-family` | not a resolvable scalar — a membership predicate (`isSecretFamilyMember`) over an open-ended prefix family                                                                                                                                  |
+| `env-file`         | presence/non-empty check of a whole file at the same bare-file candidate paths (the file is _sourced_, not read for one value)                                                                                                              |
+| `env-alias`        | first non-empty `envNames` entry, in order — no file search at all                                                                                                                                                                          |
+| `config-json`      | env alias (if any) → the resolved Layer-2 JSON's `configJsonPath`                                                                                                                                                                           |
+| `platform-env`     | the row's env-var **name** is itself resolved (env override → Layer-2 name override → default), then that variable's value is read                                                                                                          |
+| `local-only`       | `statSync` presence check of a single path only — the value is never read                                                                                                                                                                   |
 
 **Bare-file candidate directory ≠ `resolveLayer2Path()`.** `secretFileCandidates()`
 (`secret-contract.mjs:607-620`, mirrored in `catalyst-secret-contract.sh:355-380`) builds its
@@ -916,27 +919,27 @@ Layer-2-directory candidate straight from `CATALYST_LAYER2_CONFIG_FILE` (or the 
 `CATALYST_MACHINE_CONFIG`-only override is never consulted here, unlike every `config-json`/
 `platform-env` row (below). An operator who sets only `CATALYST_MACHINE_CONFIG=/custom/config.json`
 and drops a sibling `/custom/github-token` next to it will find that file skipped: both engines
-still search the home/XDG locations. Provision bare-file secrets via `CATALYST_CONFIG_DIR`, the
-XDG directory, or `CATALYST_LAYER2_CONFIG_FILE` itself so both engines look in the same place.
+still search the home/XDG locations. Provision bare-file secrets via `CATALYST_CONFIG_DIR`, the XDG
+directory, or `CATALYST_LAYER2_CONFIG_FILE` itself so both engines look in the same place.
 
 ### Resolution result
 
-`resolveSecret(id, { env, deploymentMode, cwd })` (JS) / `catalyst_resolve_secret <id>` (bash)
-never throws. It returns `{ value, source, provider, rotation, ...extras }` for a known id, or
+`resolveSecret(id, { env, deploymentMode, cwd })` (JS) / `catalyst_resolve_secret <id>` (bash) never
+throws. It returns `{ value, source, provider, rotation, ...extras }` for a known id, or
 `{ value: null, source: null, provider: null, rotation: null }` for an unknown one. `provider` is
 the row's `delivery` — a logging breadcrumb only; callers never branch on it. `source` is one of
 `shared-file` | `operator-override` | `inherited` | `config-json` | `legacy-config-json` |
-`platform-env` | `present` | `absent` | `none` — with two exceptions, both of them a *known* id
-whose `source` collapses to `null` while `provider`/`rotation` stay populated (unlike the
-unknown-id shape, where every field is `null`): the one `bare-file-family` row
-(`linear-webhook-secret`) has no scalar value, so it resolves to
+`platform-env` | `present` | `absent` | `none` — with two exceptions, both of them a _known_ id
+whose `source` collapses to `null` while `provider`/`rotation` stay populated (unlike the unknown-id
+shape, where every field is `null`): the one `bare-file-family` row (`linear-webhook-secret`) has no
+scalar value, so it resolves to
 `{ value: null, source: null, provider: "bare-file-family", rotation: {...} }`; and, in genuine
 cloud mode, any row other than the `cloud-token` bootstrap row itself resolves the identical
 `{ value: null, source: null, provider, rotation }` shape (that row's own `provider`/`rotation`)
 when `cloud-token` fails to resolve — the bootstrap short-circuit, § Cloud guard below. Both are
 normal, expected states — not evidence of an unknown id — so callers must not treat a `null`
-`source` as impossible or unknown-id-only. The bash mirror echoes the same three fields
-pipe-joined (`value|source|provider`) and additionally exports non-secret
+`source` as impossible or unknown-id-only. The bash mirror echoes the same three fields pipe-joined
+(`value|source|provider`) and additionally exports non-secret
 `CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell — but deliberately
 **never exports the resolved value** (`export -n` is reasserted on every call, since bash's export
 attribute is sticky across reassignment), so a long-lived daemon shell can't leak a credential into
@@ -944,23 +947,23 @@ every child process it launches.
 
 ### Cloud guard
 
-The cloud provider only ever activates when the full CTL-1617 deployment-mode object satisfies
-**all three**: `mode === "cloud"`, `inferred === false`, and `recognized !== false`. Because the
-guard lives once in the shared engine, every row gets it for free. When genuinely cloud, resolution
+The cloud provider only ever activates when the full CTL-1617 deployment-mode object satisfies **all
+three**: `mode === "cloud"`, `inferred === false`, and `recognized !== false`. Because the guard
+lives once in the shared engine, every row gets it for free. When genuinely cloud, resolution
 short-circuits to a pure env-alias read of `envNames` for the secret **value** — no file search for
 the value, ever — with one carve-out: `cloud-token` itself is `platform-env` delivery, and even in
 genuine cloud mode it first resolves its env-var **name** via `resolveCloudTokenName()` (env
-override → the Layer-2 file's `catalyst.cloud.tokenEnv` → default), so a managed container can
-still consult a config file to learn *which* variable to read before reading that variable's
-value. Anything else (single-host, cluster, or an inferred/unrecognized cloud guess) runs the row's
-normal delivery-type chain unchanged.
+override → the Layer-2 file's `catalyst.cloud.tokenEnv` → default), so a managed container can still
+consult a config file to learn _which_ variable to read before reading that variable's value.
+Anything else (single-host, cluster, or an inferred/unrecognized cloud guess) runs the row's normal
+delivery-type chain unchanged.
 
 A second gate — the **bootstrap short-circuit** — applies only in genuine cloud mode: if the active
-mode's `bootstrapFor` row (`cloud-token`) fails to resolve, every *other* cloud-mode secret
+mode's `bootstrapFor` row (`cloud-token`) fails to resolve, every _other_ cloud-mode secret
 resolution returns `{ value: null, source: null, provider, rotation }` (that row's own `provider`
 and `rotation`, populated) without probing further, so a half-provisioned managed container fails
-loudly and coherently instead of limping through partial resolution. The
-bootstrap row itself is exempt from this check (it must resolve on its own terms).
+loudly and coherently instead of limping through partial resolution. The bootstrap row itself is
+exempt from this check (it must resolve on its own terms).
 
 ### Layer-2 path resolution
 
@@ -983,24 +986,25 @@ in which case the canonical (new) path wins and a one-time-per-message `WARN` is
 
 Every row declares a rotation class:
 
-| Class                   | Meaning                                                                                          |
-| ------------------------ | ------------------------------------------------------------------------------------------------- |
-| `boot-only`              | Captured once (at daemon boot, or per-call for a config-json mint) — a value change requires a restart to take effect. |
-| `re-armable` / `timer`   | Proactively re-checked on a recurring tick — the row's declared shape (`github-token`). Its actual re-arm today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile` (called every daemon cluster-sync tick in `execution-core/daemon.mjs`), not through this contract's own `registerRearmHook`/`armSecret` seam — see below, `github-token` remains hookless. |
-| `re-armable` / `on-401`  | Reactively re-minted on an observed auth failure, not a timer (the Linear OAuth-mint shape).      |
-| `n/a`                    | The row's value is never fetched at all (only `age-key` — rotation isn't a question the contract can answer for a presence-only row). |
+| Class                   | Meaning                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `boot-only`             | Captured once (at daemon boot, or per-call for a config-json mint) — a value change requires a restart to take effect.                                                                                                                                                                                                                                                             |
+| `re-armable` / `timer`  | Proactively re-checked on a recurring tick — the row's declared shape (`github-token`). Its actual re-arm today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile` (called every daemon cluster-sync tick in `execution-core/daemon.mjs`), not through this contract's own `registerRearmHook`/`armSecret` seam — see below, `github-token` remains hookless. |
+| `re-armable` / `on-401` | Reactively re-minted on an observed auth failure, not a timer (the Linear OAuth-mint shape).                                                                                                                                                                                                                                                                                       |
+| `n/a`                   | The row's value is never fetched at all (only `age-key` — rotation isn't a question the contract can answer for a presence-only row).                                                                                                                                                                                                                                              |
 
-`armSecret(id, { env, deploymentMode })` never throws and returns `{ armed, rotated,
-restartRequired }`. `restartRequired` is the literal signal the 2026-08-02 outage lacked: it is
-`true` exactly when a `boot-only` row's resolved value has changed since the last observation.
-`registerRearmHook(id, fn)` attaches an in-process rearm implementation to a `re-armable` row — it
-refuses (returns `false`, never throws) against a `boot-only`/`n/a` row, an unknown id, or a
-non-function, so a hookless row can never silently claim "no restart needed". A `re-armable` row
-with **no** hook registered degrades to exactly the same `boot-only`-shaped behavior (resolve
-fresh, diff against the last-observed value, report `restartRequired` on change) — the capability
-ceiling is honest either way. As shipped, `linear-orchestrator-actor` has a real hook (registered
-by `execution-core/linear-remint.mjs` against its cooldown-guarded reminter); `github-token` and
-`linear-api-token` remain hookless, so both currently take the degrade path in practice.
+`armSecret(id, { env, deploymentMode })` never throws and returns
+`{ armed, rotated, restartRequired }`. `restartRequired` is the literal signal the 2026-08-02 outage
+lacked: it is `true` exactly when a `boot-only` row's resolved value has changed since the last
+observation. `registerRearmHook(id, fn)` attaches an in-process rearm implementation to a
+`re-armable` row — it refuses (returns `false`, never throws) against a `boot-only`/`n/a` row, an
+unknown id, or a non-function, so a hookless row can never silently claim "no restart needed". A
+`re-armable` row with **no** hook registered degrades to exactly the same `boot-only`-shaped
+behavior (resolve fresh, diff against the last-observed value, report `restartRequired` on change) —
+the capability ceiling is honest either way. As shipped, `linear-orchestrator-actor` has a real hook
+(registered by `execution-core/linear-remint.mjs` against its cooldown-guarded reminter);
+`github-token` and `linear-api-token` remain hookless, so both currently take the degrade path in
+practice.
 
 ### Linear worker-actor's legacy fallback tiers
 
@@ -1020,18 +1024,18 @@ part of this fold.)
    legacy file (walking up from `cwd` for a `.catalyst/config.json` `projectKey`, reading a sibling
    `config-<key>.json`) — **the generalization**: that sibling now resolves relative to the
    canonical `resolveLayer2Path()` directory, not the old script's hardcoded
-   `$HOME/.config/catalyst`, so it moves with `CATALYST_LAYER2_CONFIG_FILE`/`CATALYST_MACHINE_CONFIG`
-   overrides exactly like every other row's Layer-2-relative path. An operator relying on the old
-   hardcoded location under a custom Layer-2 path gets a different (but now-correct-for-the-chain)
-   file here than the pre-fold script read.
+   `$HOME/.config/catalyst`, so it moves with
+   `CATALYST_LAYER2_CONFIG_FILE`/`CATALYST_MACHINE_CONFIG` overrides exactly like every other row's
+   Layer-2-relative path. An operator relying on the old hardcoded location under a custom Layer-2
+   path gets a different (but now-correct-for-the-chain) file here than the pre-fold script read.
 4. `legacyConfigTiers`' `global-legacy` tier, tried only once tier 3 also misses: the global
    `catalyst.linear.agent` path in the canonical Layer-2 file.
 
 A row that declares `requiredObjectFields` (only `linear-worker-actor`, requiring `clientId` and
-`clientSecret`) must find every named field present and non-blank in a candidate tier's raw
-object value before that tier is allowed to win — a partially-populated tier (e.g. a
-credential-free `{webhookSecret, botUserId}` object) falls through to the next tier instead of
-capturing resolution and failing downstream.
+`clientSecret`) must find every named field present and non-blank in a candidate tier's raw object
+value before that tier is allowed to win — a partially-populated tier (e.g. a credential-free
+`{webhookSecret, botUserId}` object) falls through to the next tier instead of capturing resolution
+and failing downstream.
 
 ### Doctor integration
 
@@ -1091,16 +1095,17 @@ observability only.
 ### Broker watchdog session eviction (CTL-1516)
 
 The broker's watchdog tick keeps per-session bookkeeping (`lastHeartbeat`, `workerToOrchestrator`)
-and a wake-dedup cache (`_emittedWakeCache`). So these stay bounded over a long-lived broker process,
-the tick sweeps expired wake-cache entries every pass and evicts a session's heartbeat/orchestrator
-rows once it is definitively finished. This knob is an env var on the `catalyst-broker` process:
+and a wake-dedup cache (`_emittedWakeCache`). So these stay bounded over a long-lived broker
+process, the tick sweeps expired wake-cache entries every pass and evicts a session's
+heartbeat/orchestrator rows once it is definitively finished. This knob is an env var on the
+`catalyst-broker` process:
 
 - `FILTER_HEARTBEAT_EVICT_MS` (default `1800000`, 30 min) — horizon past which a **stale** session's
   `lastHeartbeat` + `workerToOrchestrator` rows are evicted even if it never matched an interest. A
   session reported `dead` by `claude agents` is evicted immediately; an unknown-liveness session is
   evicted only once it is both stale (past `FILTER_HEARTBEAT_STALE_MS`) **and** older than this
-  horizon, so eviction can never precede the stale threshold. Generous by default
-  (≈10× `FILTER_HEARTBEAT_STALE_MS`) so only unambiguously-finished sessions are dropped — a genuine
+  horizon, so eviction can never precede the stale threshold. Generous by default (≈10×
+  `FILTER_HEARTBEAT_STALE_MS`) so only unambiguously-finished sessions are dropped — a genuine
   revival simply re-checks-in and recreates the rows.
 
 ### Phase-artifact thoughts sync (`catalyst.phaseArtifactSync.mode`, CTL-1490)
@@ -1108,23 +1113,23 @@ rows once it is definitively finished. This knob is an env var on the `catalyst-
 Phase skills write a durable local thoughts doc after each phase (the record
 `reconstruct-ticket-state.mjs`'s thoughts-artifact walk reads to figure out where a ticket left off
 after a crash or cross-host takeover — see `docs/orchestrator-overview.md`). Pushing that doc
-off-machine (`humanlayer thoughts sync`) is what makes it survive the *local* disk being lost too,
+off-machine (`humanlayer thoughts sync`) is what makes it survive the _local_ disk being lost too,
 not just the process. `catalyst.phaseArtifactSync.mode` controls when that push happens:
 
-| Mode (`resolve_phase_artifact_sync_mode` in `plugins/dev/scripts/lib/phase-artifact-sync-mode.sh`) | Behavior |
-| --- | --- |
-| `off` (default) | Roster-gated, byte-identical to pre-CTL-1490 behavior: a single-host roster (`.catalyst/hosts.json` absent or ≤1 entry) skips the sync entirely (exit 0, no push); a multi-host roster syncs, and a sync failure blocks the phase (`exit 11`, terminal event `failed`, reason `thoughts_sync_failed`). |
-| `shadow` | Always syncs regardless of roster size, but a failure never blocks the phase — it appends a `thoughts.sync.failed.<phase>.<ticket>` WARN event to the unified event log and continues (`exit 0`). Use this to observe sync reliability on a single-host node before turning `enforce` on. |
-| `enforce` | Always syncs regardless of roster size, and a failure blocks the phase exactly like `off`'s multi-host path (`exit 11`, terminal event `failed`, reason `thoughts_sync_failed`). |
+| Mode (`resolve_phase_artifact_sync_mode` in `plugins/dev/scripts/lib/phase-artifact-sync-mode.sh`) | Behavior                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `off` (default)                                                                                    | Roster-gated, byte-identical to pre-CTL-1490 behavior: a single-host roster (`.catalyst/hosts.json` absent or ≤1 entry) skips the sync entirely (exit 0, no push); a multi-host roster syncs, and a sync failure blocks the phase (`exit 11`, terminal event `failed`, reason `thoughts_sync_failed`). |
+| `shadow`                                                                                           | Always syncs regardless of roster size, but a failure never blocks the phase — it appends a `thoughts.sync.failed.<phase>.<ticket>` WARN event to the unified event log and continues (`exit 0`). Use this to observe sync reliability on a single-host node before turning `enforce` on.              |
+| `enforce`                                                                                          | Always syncs regardless of roster size, and a failure blocks the phase exactly like `off`'s multi-host path (`exit 11`, terminal event `failed`, reason `thoughts_sync_failed`).                                                                                                                       |
 
 Any unrecognized value fails safe to `off` — a typo can never silently start (or silently stop)
 pushing thoughts docs off-machine.
 
-**Precedence** (`plugins/dev/scripts/lib/phase-artifact-sync-mode.sh`): the `CATALYST_PHASE_ARTIFACT_SYNC_MODE`
-env var (case-insensitive, whitespace-stripped) wins over `.catalyst/config.json`'s
-`catalyst.phaseArtifactSync.mode`, which wins over the `off` default. Consumed by
-`plugins/dev/scripts/lib/thoughts-sync-gate.sh`, called from every phase skill immediately before its
-terminal `phase-agent-emit-complete` call.
+**Precedence** (`plugins/dev/scripts/lib/phase-artifact-sync-mode.sh`): the
+`CATALYST_PHASE_ARTIFACT_SYNC_MODE` env var (case-insensitive, whitespace-stripped) wins over
+`.catalyst/config.json`'s `catalyst.phaseArtifactSync.mode`, which wins over the `off` default.
+Consumed by `plugins/dev/scripts/lib/thoughts-sync-gate.sh`, called from every phase skill
+immediately before its terminal `phase-agent-emit-complete` call.
 
 ```json
 {
@@ -1152,25 +1157,25 @@ rest of the recovery family (which ships `off`), the board-health delegate **def
 shadow is itself a dark state — it emits the scan and mutates nothing (the no-mutation guarantee is
 structural, not configured), so the telemetry that is the feature's whole point ships on.
 
-| Key                                                     | Default           | Notes                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CATALYST_BOARD_HEALTH` _(env var)_                     | `shadow`          | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (CTL-1300 — on a proceeding scan, dispatch **one holistic recovery-pass delegate** anchored to a flagged ticket and carrying the whole-board context; reuses the capped + cooldown'd recovery-pass actuator. **Operator-gated — never auto-enabled**). Garbage values fall back to `shadow`. Overrides Layer-2. |
-| `catalyst.boardHealth.mode` _(Layer-2)_                 | `shadow`          | Same three values; honored when the env var is unset.                                                                                                                                                                                                                                                                                                                                                                             |
-| `CATALYST_BH_GH_QUOTA` _(env var)_                      | `shadow`          | GitHub core REST quota invariant mode: `off` skips the snapshot read, `shadow` publishes quota state but keeps the invariant unobservable, and `enforce` lets a fresh low/exhausted snapshot trip Gate 3 with `rate-limit-cliff`. Garbage values fall back to `shadow`. Overrides Layer-2.                                                                                                                        |
-| `catalyst.boardHealth.githubQuota` _(Layer-2)_           | `shadow`          | Same three values; honored when `CATALYST_BH_GH_QUOTA` is unset.                                                                                                                                                                                                                                                                                                                                                                  |
-| `CATALYST_BH_GH_CORE_PCT`                                | `10`              | Remaining core REST percentage at or below which the quota state is `low`.                                                                                                                                                                                                                                                                                                                                                        |
-| `CATALYST_BH_GH_QUOTA_STALE_MS`                          | `900000` (15 min) | Maximum snapshot age. A missing or older snapshot is unknown and unobservable, even in `enforce`.                                                                                                                                                                                                                                                                                                                                  |
-| `CATALYST_BH_PRODUCTIVITY` _(env var)_                   | `shadow`          | Per-host productivity invariant mode: `off` skips the peer-heartbeat read, `shadow` publishes productivity status but keeps the invariant unobservable, and `enforce` reports a live peer that owns work but has not advanced past a phase boundary within the configured window. The resulting move is escalate-only and cannot dispatch a recovery delegate. Garbage values fall back to `shadow`. Overrides Layer-2. |
-| `catalyst.boardHealth.productivity` _(Layer-2)_          | `shadow`          | Same three values; honored when `CATALYST_BH_PRODUCTIVITY` is unset. |
-| `CATALYST_BH_UNPRODUCTIVE_MS`                            | `86400000` (24 h) | Maximum age of a live owning peer's last phase-boundary advance before the productivity invariant reports it as unproductive. |
-| `CATALYST_BH_INTERVAL_MS`                               | `300000` (5 min)  | Cadence floor — the scan runs at most once per interval per host.                                                                                                                                                                                                                                                                                                                                                                 |
-| `CATALYST_BH_DISPATCH_STALL_MS`                         | `600000` (10 min) | Dispatch-liveness threshold: free slots + a queue + no dispatch within this window flags a wedge.                                                                                                                                                                                                                                                                                                                                 |
-| `CATALYST_BH_WORKER_AGE_MS`                             | `14400000` (4 h)  | Fallback worker-age threshold (per-phase normals override it).                                                                                                                                                                                                                                                                                                                                                                    |
-| `CATALYST_BH_PROJECT_SILENCE_MS`                        | `86400000` (24 h) | Project-silence threshold (no ticket movement in the project past this window).                                                                                                                                                                                                                                                                                                                                                   |
-| `CATALYST_BH_UNOWNED_INFLIGHT_MS`                       | `86400000` (24 h)   | Stale-unowned threshold (CTL-1475). A Linear state like `Implement` is a **claim** that a worker is on the ticket, not a label — and nothing takes the claim back when the worker dies. Past this age with **no live worker signal and no confirmed-open PR**, the ticket is flagged `unownedInFlight` and proposed as a **tier2 (anchorable)** `recover-unowned-in-flight` move, so the delegate dispatches a recovery pass rather than merely reporting it. Such tickets are invisible to every other path: admission only pulls `Todo`, and the recovery census scans worker dirs they have no entry in. Deliberately conservative — any evidence of ownership spares the ticket, since a false negative costs one more scan while a false positive re-dispatches work a human is holding. |
-| `CATALYST_BH_STALLED_PR_REVIEW_MS`                     | `259200000` (72 h / 3 d)  | CTL-1608. How long a PR may sit without a review-request being responded to before board-health emits a `nudge-stalled-pr` move. Requires `orchestration.stalledPrSweep.enabled: true`. The stalled-PR timer stamps `reviewRequestedAt` in `workers/<TICKET>/stalled-pr.json`; board-health compares `now - reviewRequestedAt` against this threshold. |
-| `CATALYST_BH_STALLED_PR_CI_MS`                         | `172800000` (48 h / 2 d)     | CTL-1608. How long a PR may have a continuously-failing CI check before it is flagged stalled. The timer stamps `ciFirstFailedAt` on first CI failure detection. |
-| `CATALYST_BH_STALLED_PR_NOPUSH_MS`                     | `432000000` (120 h / 5 d)   | CTL-1608. How long a PR may go without a push (no new commits) while still open before it is flagged stalled. The timer stamps `lastPushAt` on each push detected. |
+| Key                                             | Default                   | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_BOARD_HEALTH` _(env var)_             | `shadow`                  | `off` / `0` (kill-switch — strict no-op), `shadow` (scan + emit `recovery.board-scan`, take no action), `enforce` (CTL-1300 — on a proceeding scan, dispatch **one holistic recovery-pass delegate** anchored to a flagged ticket and carrying the whole-board context; reuses the capped + cooldown'd recovery-pass actuator. **Operator-gated — never auto-enabled**). Garbage values fall back to `shadow`. Overrides Layer-2.                                                                                                                                                                                                                                                                                                                                                             |
+| `catalyst.boardHealth.mode` _(Layer-2)_         | `shadow`                  | Same three values; honored when the env var is unset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `CATALYST_BH_GH_QUOTA` _(env var)_              | `shadow`                  | GitHub core REST quota invariant mode: `off` skips the snapshot read, `shadow` publishes quota state but keeps the invariant unobservable, and `enforce` lets a fresh low/exhausted snapshot trip Gate 3 with `rate-limit-cliff`. Garbage values fall back to `shadow`. Overrides Layer-2.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `catalyst.boardHealth.githubQuota` _(Layer-2)_  | `shadow`                  | Same three values; honored when `CATALYST_BH_GH_QUOTA` is unset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `CATALYST_BH_GH_CORE_PCT`                       | `10`                      | Remaining core REST percentage at or below which the quota state is `low`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `CATALYST_BH_GH_QUOTA_STALE_MS`                 | `900000` (15 min)         | Maximum snapshot age. A missing or older snapshot is unknown and unobservable, even in `enforce`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `CATALYST_BH_PRODUCTIVITY` _(env var)_          | `shadow`                  | Per-host productivity invariant mode: `off` skips the peer-heartbeat read, `shadow` publishes productivity status but keeps the invariant unobservable, and `enforce` reports a live peer that owns work but has not advanced past a phase boundary within the configured window. The resulting move is escalate-only and cannot dispatch a recovery delegate. Garbage values fall back to `shadow`. Overrides Layer-2.                                                                                                                                                                                                                                                                                                                                                                       |
+| `catalyst.boardHealth.productivity` _(Layer-2)_ | `shadow`                  | Same three values; honored when `CATALYST_BH_PRODUCTIVITY` is unset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `CATALYST_BH_UNPRODUCTIVE_MS`                   | `86400000` (24 h)         | Maximum age of a live owning peer's last phase-boundary advance before the productivity invariant reports it as unproductive.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `CATALYST_BH_INTERVAL_MS`                       | `300000` (5 min)          | Cadence floor — the scan runs at most once per interval per host.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `CATALYST_BH_DISPATCH_STALL_MS`                 | `600000` (10 min)         | Dispatch-liveness threshold: free slots + a queue + no dispatch within this window flags a wedge.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `CATALYST_BH_WORKER_AGE_MS`                     | `14400000` (4 h)          | Fallback worker-age threshold (per-phase normals override it).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `CATALYST_BH_PROJECT_SILENCE_MS`                | `86400000` (24 h)         | Project-silence threshold (no ticket movement in the project past this window).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `CATALYST_BH_UNOWNED_INFLIGHT_MS`               | `86400000` (24 h)         | Stale-unowned threshold (CTL-1475). A Linear state like `Implement` is a **claim** that a worker is on the ticket, not a label — and nothing takes the claim back when the worker dies. Past this age with **no live worker signal and no confirmed-open PR**, the ticket is flagged `unownedInFlight` and proposed as a **tier2 (anchorable)** `recover-unowned-in-flight` move, so the delegate dispatches a recovery pass rather than merely reporting it. Such tickets are invisible to every other path: admission only pulls `Todo`, and the recovery census scans worker dirs they have no entry in. Deliberately conservative — any evidence of ownership spares the ticket, since a false negative costs one more scan while a false positive re-dispatches work a human is holding. |
+| `CATALYST_BH_STALLED_PR_REVIEW_MS`              | `259200000` (72 h / 3 d)  | CTL-1608. How long a PR may sit without a review-request being responded to before board-health emits a `nudge-stalled-pr` move. Requires `orchestration.stalledPrSweep.enabled: true`. The stalled-PR timer stamps `reviewRequestedAt` in `workers/<TICKET>/stalled-pr.json`; board-health compares `now - reviewRequestedAt` against this threshold.                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `CATALYST_BH_STALLED_PR_CI_MS`                  | `172800000` (48 h / 2 d)  | CTL-1608. How long a PR may have a continuously-failing CI check before it is flagged stalled. The timer stamps `ciFirstFailedAt` on first CI failure detection.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `CATALYST_BH_STALLED_PR_NOPUSH_MS`              | `432000000` (120 h / 5 d) | CTL-1608. How long a PR may go without a push (no new commits) while still open before it is flagged stalled. The timer stamps `lastPushAt` on each push detected.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 The productivity signal requires peers to publish `last_advance_at` in their heartbeat records.
 During a mixed-version fleet rollout, a peer without that field is treated as unknown and is not
@@ -1188,19 +1193,19 @@ fail-safe fallback to labelling if the runner is not enabled).
 Mode resolves from the env var over Layer-2 over the safe default of `off`. The `0` kill-switch and
 any unset/garbage value resolve to `off`.
 
-| Key | Default | Notes |
-| --- | ------- | ----- |
-| `CATALYST_DELEGATE_FIRST` _(env var)_ | `off` | `off` / `0` (kill-switch — strict no-op, byte-identical to not setting the flag), `shadow` (emit `delegate.would-route` on the event log; still labels `needs-human`), `enforce` (enqueue to the delegate runner instead of labelling; fail-safe: falls back to labelling if the runner is not enabled). Garbage values fall back to `off`. Overrides Layer-2. |
-| `catalyst.delegateFirst.mode` _(Layer-2)_ | `off` | Same three values; honored when the env var is absent or unrecognised. |
+| Key                                       | Default | Notes                                                                                                                                                                                                                                                                                                                                                          |
+| ----------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_DELEGATE_FIRST` _(env var)_     | `off`   | `off` / `0` (kill-switch — strict no-op, byte-identical to not setting the flag), `shadow` (emit `delegate.would-route` on the event log; still labels `needs-human`), `enforce` (enqueue to the delegate runner instead of labelling; fail-safe: falls back to labelling if the runner is not enabled). Garbage values fall back to `off`. Overrides Layer-2. |
+| `catalyst.delegateFirst.mode` _(Layer-2)_ | `off`   | Same three values; honored when the env var is absent or unrecognised.                                                                                                                                                                                                                                                                                         |
 
 **Fail-safe gate.** `enforce` silences `needs-human` only when the delegate runner is confirmed
-enabled (via `CATALYST_BOARD_HEALTH`/`CATALYST_RECOVERY_PASS`). Lighting only `CATALYST_DELEGATE_FIRST=enforce`
-without a live runner would enqueue intents that drain never, with the label suppressed — a silent
-black hole. The gate catches this: if no runner is on, it emits `delegate.route-fallback` with
-`reason:"runner-disabled"` and falls back to labelling immediately.
+enabled (via `CATALYST_BOARD_HEALTH`/`CATALYST_RECOVERY_PASS`). Lighting only
+`CATALYST_DELEGATE_FIRST=enforce` without a live runner would enqueue intents that drain never, with
+the label suppressed — a silent black hole. The gate catches this: if no runner is on, it emits
+`delegate.route-fallback` with `reason:"runner-disabled"` and falls back to labelling immediately.
 
-**Observable shadow events.** With shadow mode active, every `routeStuckTicketToDelegate` call
-emits one of three `delegate.*` events:
+**Observable shadow events.** With shadow mode active, every `routeStuckTicketToDelegate` call emits
+one of three `delegate.*` events:
 
 - `delegate.would-route` — shadow hit (ticket + site + reason)
 - `delegate.routed` — enforce hit, successfully enqueued
@@ -1219,9 +1224,15 @@ it existed for.)
 
 Trusted **by default**, all qualified with the port the server actually bound:
 
-- loopback — on a wildcard bind the **whole `127.0.0.0/8` range** (so `127.0.0.2` and the Debian-conventional `127.0.1.1` work), otherwise only when the bind is itself the loopback address — a LAN-bound monitor does not own `<loopback>:<port>`) — `localhost`, plus the literal(s) matching the **bound address family**
+- loopback — on a wildcard bind the **whole `127.0.0.0/8` range** (so `127.0.0.2` and the
+  Debian-conventional `127.0.1.1` work), otherwise only when the bind is itself the loopback address
+  — a LAN-bound monitor does not own `<loopback>:<port>`) — `localhost`, plus the literal(s)
+  matching the **bound address family**
 
-**Residual, and the real fix.** Host *names* (`localhost`, `os.hostname()`) are family-ambiguous — the browser picks. Under a single-family bind, a process squatting the other family's port can serve a page whose `Origin` is one of those names. No allowlist setting closes this; **bind dual-stack** and the squat becomes impossible rather than merely untrusted:
+**Residual, and the real fix.** Host _names_ (`localhost`, `os.hostname()`) are family-ambiguous —
+the browser picks. Under a single-family bind, a process squatting the other family's port can serve
+a page whose `Origin` is one of those names. No allowlist setting closes this; **bind dual-stack**
+and the squat becomes impossible rather than merely untrusted:
 
 ```bash
 MONITOR_HOST=:: catalyst-monitor restart   # `start` no-ops when a monitor is already running
@@ -1229,49 +1240,59 @@ MONITOR_HOST=:: catalyst-monitor restart   # `start` no-ops when a monitor is al
 
 > **Dev-server note.** A prefix assignment (`MONITOR_HOST=:: catalyst-monitor restart`) exists only
 > for that command. `bun run dev:ui` is a separate process, so **export** `MONITOR_HOST` (and
-> `MONITOR_PORT`) in the shell that runs it, or the Vite proxy will target the default `127.0.0.1:7400`
-> instead of the monitor's actual bind.
+> `MONITOR_PORT`) in the shell that runs it, or the Vite proxy will target the default
+> `127.0.0.1:7400` instead of the monitor's actual bind.
 
 > **Management-CLI gap (CTL-1599).** `catalyst-monitor.sh` still prints, opens, and health-probes
 > `http://localhost:$PORT` regardless of `MONITOR_HOST`, so a specific non-loopback bind will show a
 > wrong URL and a failing probe even when the monitor is healthy. Wiring the CLI through is tracked
 > separately; the allowlist itself honors the bind correctly.
 
-| Env var | Default | Notes |
-| ------- | ------- | ----- |
-| `MONITOR_HOST` | `0.0.0.0` | Bind address. `::` binds dual-stack (accepts IPv4-mapped too) and is the remedy above. A **specific** address or hostname narrows the allowlist to that socket only — the monitor stops trusting other local interfaces and this host's own names, since it no longer owns those sockets. (binding `0.0.0.0` is IPv4-only, so `[::1]` is not trusted: another service can bind `[::1]` on the same port and its origin would otherwise pass)
-- this machine's own names, **wildcard binds only** (the bare label of an FQDN is included so `http://mini:7400` works when `os.hostname()` is `mini.corp.example`; this trusts whatever that label resolves to, so on a network where a search domain or stale record maps it elsewhere, prefer a specific bind or an explicit `MONITOR_TRUSTED_ORIGINS`) (a name resolves to whichever interface DNS/mDNS picks, which need not be the one a specific bind listens on) — `os.hostname()` and its short label, plus the **actual** mDNS name on macOS (`scutil --get LocalHostName`). A `<short>.local` alias is **not** synthesized: when it is not the name the system really advertises, nothing owns it, so any LAN host could claim it over mDNS and pass the guard.
-- this machine's own non-loopback addresses (LAN, Tailscale `100.x`) — but **only for a wildcard bind** (`0.0.0.0`/`::`). A server bound to one specific address trusts only that address, since another service can hold the same port on a different interface
+| Env var        | Default   | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| -------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MONITOR_HOST` | `0.0.0.0` | Bind address. `::` binds dual-stack (accepts IPv4-mapped too) and is the remedy above. A **specific** address or hostname narrows the allowlist to that socket only — the monitor stops trusting other local interfaces and this host's own names, since it no longer owns those sockets. (binding `0.0.0.0` is IPv4-only, so `[::1]` is not trusted: another service can bind `[::1]` on the same port and its origin would otherwise pass) |
+
+- this machine's own names, **wildcard binds only** (the bare label of an FQDN is included so
+  `http://mini:7400` works when `os.hostname()` is `mini.corp.example`; this trusts whatever that
+  label resolves to, so on a network where a search domain or stale record maps it elsewhere, prefer
+  a specific bind or an explicit `MONITOR_TRUSTED_ORIGINS`) (a name resolves to whichever interface
+  DNS/mDNS picks, which need not be the one a specific bind listens on) — `os.hostname()` and its
+  short label, plus the **actual** mDNS name on macOS (`scutil --get LocalHostName`). A
+  `<short>.local` alias is **not** synthesized: when it is not the name the system really
+  advertises, nothing owns it, so any LAN host could claim it over mDNS and pass the guard.
+- this machine's own non-loopback addresses (LAN, Tailscale `100.x`) — but **only for a wildcard
+  bind** (`0.0.0.0`/`::`). A server bound to one specific address trusts only that address, since
+  another service can hold the same port on a different interface
 
 Own names are trusted **only on the bound port, and only under the scheme the monitor serves
-(`http`)**: a bare `http://mini` would let any *other* service on the same machine (e.g. something on
-`:80`) drive the reply route. Comparison keys are full origins (`scheme://host[:port]`), so `http`
-and `https` on the same host are distinct — a compromised plaintext endpoint cannot drive an HTTPS
-route. On macOS the machine's real Bonjour name (`scutil --get LocalHostName`) is included, since it need
-not share the first label of `os.hostname()`; it is cached for **5 minutes** (the lookup spawns a
-subprocess and the allowlist rebuilds on rejected requests, so it must not run per-request — but a
-renamed `LocalHostName` then takes effect without a daemon restart). Only `http`/`https` origins are
-accepted — a non-special scheme such as `chrome-extension://` serializes to the opaque `"null"`,
-which would otherwise match every opaque origin.
+(`http`)**: a bare `http://mini` would let any _other_ service on the same machine (e.g. something
+on `:80`) drive the reply route. Comparison keys are full origins (`scheme://host[:port]`), so
+`http` and `https` on the same host are distinct — a compromised plaintext endpoint cannot drive an
+HTTPS route. On macOS the machine's real Bonjour name (`scutil --get LocalHostName`) is included,
+since it need not share the first label of `os.hostname()`; it is cached for **5 minutes** (the
+lookup spawns a subprocess and the allowlist rebuilds on rejected requests, so it must not run
+per-request — but a renamed `LocalHostName` then takes effect without a daemon restart). Only
+`http`/`https` origins are accepted — a non-special scheme such as `chrome-extension://` serializes
+to the opaque `"null"`, which would otherwise match every opaque origin.
 
 The allowlist is rebuilt on a **60s TTL** and again on any rejection, so an address that appears
-later (Tailscale connecting, a DHCP change) is trusted without a restart, and one that is *removed*
+later (Tailscale connecting, a DHCP change) is trusted without a restart, and one that is _removed_
 stops being trusted within the TTL rather than lingering until the daemon restarts.
 
-| Env var                    | Default | Notes                                                                                                                                                                                                                                                                                                                       |
-| -------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MONITOR_TRUSTED_ORIGINS`  | unset   | Comma- or whitespace-separated extra origins for deployments reached by a name that cannot be derived from `os.hostname()` — a **reverse proxy** or a full **Tailscale MagicDNS** alias. Accepts full origins (`https://catalyst.example`) or bare `host:port` (`mini-2.tail1234.ts.net:7400`). Entries are taken **exactly as given** (not widened to the bound port) and canonicalized the way a browser serializes `Origin`, so an IDN name may be written in either Unicode or punycode. |
-| `MONITOR_TLS_PROXY_PEERS` | unset | Peer addresses of the **TLS-terminating reverse proxy** (comma-separated, e.g. `127.0.0.1,::1`). Requests arriving *from these peers* are classified `https` when the accounts `?refresh=true` guard probes the trusted-origin set — **required** when `MONITOR_TRUSTED_ORIGINS` lists an `https://` origin served through a local proxy, or every proxied refresh 403s (with it unset, all requests are plaintext). This is a deliberate operator declaration: `X-Forwarded-Proto` is never trusted (client-spoofable, and appending proxies put the client's value first). IPv4-mapped spellings are normalized, so `127.0.0.1` also matches a dual-stack bind's `::ffff:127.0.0.1`. |
-| `MONITOR_DEV_UI=1` / `NODE_ENV=development` | unset | Trusts the Vite dev origin (`http://localhost:5173` — one spelling, since Vite binds a single address family and the other would be available to any local process). **Not needed for the standard `bun run dev:ui` flow** — the Vite proxy sends the monitor's own origin (`ui/vite.config.ts`), so proxied replies are already trusted. Accepts `1`/`true`/`yes`/`on`. Use only for a dev setup that bypasses that proxy, and note it must be set on the **monitor** process (`dev:ui` starts Vite only; the monitor runs out-of-band). |
-| `MONITOR_DEV_UI_ORIGINS` | unset | Overrides the dev origins above (same format), for a non-default Vite port. Same caveat: set it on the monitor process. |
+| Env var                                     | Default | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MONITOR_TRUSTED_ORIGINS`                   | unset   | Comma- or whitespace-separated extra origins for deployments reached by a name that cannot be derived from `os.hostname()` — a **reverse proxy** or a full **Tailscale MagicDNS** alias. Accepts full origins (`https://catalyst.example`) or bare `host:port` (`mini-2.tail1234.ts.net:7400`). Entries are taken **exactly as given** (not widened to the bound port) and canonicalized the way a browser serializes `Origin`, so an IDN name may be written in either Unicode or punycode.                                                                                                                                                                                           |
+| `MONITOR_TLS_PROXY_PEERS`                   | unset   | Peer addresses of the **TLS-terminating reverse proxy** (comma-separated, e.g. `127.0.0.1,::1`). Requests arriving _from these peers_ are classified `https` when the accounts `?refresh=true` guard probes the trusted-origin set — **required** when `MONITOR_TRUSTED_ORIGINS` lists an `https://` origin served through a local proxy, or every proxied refresh 403s (with it unset, all requests are plaintext). This is a deliberate operator declaration: `X-Forwarded-Proto` is never trusted (client-spoofable, and appending proxies put the client's value first). IPv4-mapped spellings are normalized, so `127.0.0.1` also matches a dual-stack bind's `::ffff:127.0.0.1`. |
+| `MONITOR_DEV_UI=1` / `NODE_ENV=development` | unset   | Trusts the Vite dev origin (`http://localhost:5173` — one spelling, since Vite binds a single address family and the other would be available to any local process). **Not needed for the standard `bun run dev:ui` flow** — the Vite proxy sends the monitor's own origin (`ui/vite.config.ts`), so proxied replies are already trusted. Accepts `1`/`true`/`yes`/`on`. Use only for a dev setup that bypasses that proxy, and note it must be set on the **monitor** process (`dev:ui` starts Vite only; the monitor runs out-of-band).                                                                                                                                              |
+| `MONITOR_DEV_UI_ORIGINS`                    | unset   | Overrides the dev origins above (same format), for a non-default Vite port. Same caveat: set it on the monitor process.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 **Set this if replies 403.** A monitor opened through a proxy/alias not in the default set will
 reject every reply until the name is listed here. Addresses are re-derived automatically (see the
-TTL above); a *name* the daemon cannot derive still needs this variable.
+TTL above); a _name_ the daemon cannot derive still needs this variable.
 
 Prefer writing a **full origin** (`https://catalyst.example`) over a bare host: a full origin pins
-the scheme, whereas a bare `host[:port]` cannot state one and is therefore trusted under both
-`http` and `https`.
+the scheme, whereas a bare `host[:port]` cannot state one and is therefore trusted under both `http`
+and `https`.
 
 Requests with **no** `Origin` are allowed — browsers always send it on a POST, so only non-browser
 clients (`curl`, tests) omit it, and those are not CSRF vectors. This guard stops a browser being
@@ -1343,19 +1364,20 @@ daemon. These knobs are env vars on the `catalyst-broker` process:
 
 The broker's watchdog can edge-trigger a `broker.daemon.degraded` / `broker.daemon.recovered` pair
 when its **interest table is empty while the fleet is actively working** — an empty table on an idle
-fleet is the healthy steady state, so the fleet-activity reading is the discriminator. The episode is
-edge-triggered with a **durable latch** (`~/catalyst/broker-degraded-latch.json`), so a broker
+fleet is the healthy steady state, so the fleet-activity reading is the discriminator. The episode
+is edge-triggered with a **durable latch** (`~/catalyst/broker-degraded-latch.json`), so a broker
 restart mid-episode resumes rather than re-emitting.
 
 **The detector is dormant by default and only meaningful on legacy-wave hosts.** Under
 **execution-core dispatch** nothing registers interests at all, so `interests.size === 0` is
 permanently true and the gate carries no information. That is a property of execution-core, **not**
 of every configuration named `phase-agents`: a **legacy-wave** host — one driving
-`/catalyst-legacy:orchestrate`, which invokes `plugins/dev/scripts/orchestrate-register-interests.sh`
-— does register interests (`pr_lifecycle` + `ticket_lifecycle` + `comms_lifecycle` unconditionally,
-plus a per-ticket `phase_lifecycle` when `dispatchMode` is `phase-agents`). There an empty interest
-table IS anomalous, and that is the deployment where enabling this is appropriate. These knobs are
-env vars on the `catalyst-broker` process:
+`/catalyst-legacy:orchestrate`, which invokes
+`plugins/dev/scripts/orchestrate-register-interests.sh` — does register interests (`pr_lifecycle` +
+`ticket_lifecycle` + `comms_lifecycle` unconditionally, plus a per-ticket `phase_lifecycle` when
+`dispatchMode` is `phase-agents`). There an empty interest table IS anomalous, and that is the
+deployment where enabling this is appropriate. These knobs are env vars on the `catalyst-broker`
+process:
 
 - `FILTER_BROKER_DEGRADED_ENABLED` (default **off**; set to exactly `1` to enable) — opt-in
   kill-switch. Unset (or any other value) means the detector evaluates nothing and emits nothing.
@@ -1364,26 +1386,26 @@ env vars on the `catalyst-broker` process:
   runtime control path that mutates it, so editing the env file (or exporting in a shell) does
   **not** reach a live broker. Restart it, or you will believe the detector is armed while it is
   still dormant. Flipping it **off** discards any in-progress debounce run, so a re-enable re-earns
-  the full sustained-tick threshold; an already-open episode survives the switch and still emits
-  its paired `recovered`.
+  the full sustained-tick threshold; an already-open episode survives the switch and still emits its
+  paired `recovered`.
 - `FILTER_BROKER_DEGRADED_GRACE_MS` (default `300000`, 5 min) — startup grace. An empty interest
-  table is not judged at all until the broker has been up this long, so a still-warming process never
-  trips.
+  table is not judged at all until the broker has been up this long, so a still-warming process
+  never trips.
 - `FILTER_BROKER_DEGRADED_SUSTAINED_TICKS` (default `5`) — consecutive anomalous watchdog ticks
   (~60s each) required before the degraded edge fires. The run must be contiguous: any non-anomalous
   tick resets it, so a single-tick blip cannot page.
 
-The fleet-activity reading is **tri-state** — active, proven idle, or *unknown* (the worker-table read
-failed). Only a proven-idle fleet closes an open episode (`recovered`, reason `fleet idle`); an
+The fleet-activity reading is **tri-state** — active, proven idle, or _unknown_ (the worker-table
+read failed). Only a proven-idle fleet closes an open episode (`recovered`, reason `fleet idle`); an
 unknown reading neither trips nor clears, so a transient DB failure cannot manufacture a false
 recovery followed by a duplicate degraded edge.
 
-**This is not a dead-broker detector**, and neither is the ingestion-silence detector above: both run
-inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an ingestion
-**stall** while the broker is **alive**. Detecting a fully-dead broker requires an **external,
-absence-based** check on the broker's own heartbeat/log series — e.g. a Loki `absent_over_time` alert
-on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because a fully-dead daemon is a
-*missing series*, which `count_over_time == 0` cannot assert).
+**This is not a dead-broker detector**, and neither is the ingestion-silence detector above: both
+run inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an
+ingestion **stall** while the broker is **alive**. Detecting a fully-dead broker requires an
+**external, absence-based** check on the broker's own heartbeat/log series — e.g. a Loki
+`absent_over_time` alert on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because
+a fully-dead daemon is a _missing series_, which `count_over_time == 0` cannot assert).
 
 ### Node admission state on the heartbeat (CTL-1322)
 
@@ -1433,52 +1455,54 @@ The distributed-coordination epic (ADR-022/023) adds a subsystem that durably or
 **coordination events** across hosts via a `coordination-publish` background process: it tails the
 unified event log, writes the ordered coordination subset to a local-first mirror
 (`~/catalyst/coordination.jsonl`, carrying a monotonic `local_seq`) synchronously before any network
-call, and — in `enforce` — exchanges those rows with a catalyst-cloud coordination hub (or, until the
-hub is wired, an interim Loki-tail transport).
+call, and — in `enforce` — exchanges those rows with a catalyst-cloud coordination hub (or, until
+the hub is wired, an interim Loki-tail transport).
 
 It ships behind the same **off→shadow→enforce** rollout discipline as the recovery family, but —
 unlike the board-health delegate — its floor is **`off`**, not `shadow`: coordination adds an
-always-on publisher process and, in enforce, network egress, so the safe default is fully inert until
-an operator promotes it.
+always-on publisher process and, in enforce, network egress, so the safe default is fully inert
+until an operator promotes it.
 
 The publisher is launched by `catalyst-stack` — after `otel-forward`, on **worker + monitor** nodes
 (gated `catalyst.node.class != developer`, following the reporting substrate) — as a self-managed
-nohup child ([`catalyst-stack`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-stack)
+nohup child
+([`catalyst-stack`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-stack)
 `start_coordination`). Because the daemon self-exits when the resolved mode is `off` (the default),
 `catalyst-stack` short-circuits before spawning it, so launching it unconditionally is safe and an
-unconfigured node is byte-identical to before: no publisher process, no PID file, no mirror. When the
-mode is `shadow`/`enforce`, the daemon comes up idempotently (a re-run of `catalyst-stack start` — or
-the keep-alive tick — never double-starts it); `catalyst-stack status` reports a `coordination` line
-(`off (inert)`, or `running … mode=<mode>`). A missing `bun` is non-fatal (a bun-less host resolves to
-`off` and never blocks the rest of the stack). **Enforce and the hub transport stay operator-gated** —
-this wiring only makes `shadow`/`enforce` take effect where they were previously dark.
+unconfigured node is byte-identical to before: no publisher process, no PID file, no mirror. When
+the mode is `shadow`/`enforce`, the daemon comes up idempotently (a re-run of `catalyst-stack start`
+— or the keep-alive tick — never double-starts it); `catalyst-stack status` reports a `coordination`
+line (`off (inert)`, or `running … mode=<mode>`). A missing `bun` is non-fatal (a bun-less host
+resolves to `off` and never blocks the rest of the stack). **Enforce and the hub transport stay
+operator-gated** — this wiring only makes `shadow`/`enforce` take effect where they were previously
+dark.
 
 Mode resolves from the env var (a single operator knob) over Layer-2 over the default. The `0`
 kill-switch and any unset/garbage value both resolve to `off`.
 
-| Key | Default | Notes |
-| --- | --- | --- |
-| `CATALYST_COORDINATION_MODE` _(env var)_ | `off` | `off` / `0` (kill-switch — strict no-op: no publisher, no mirror, no egress), `shadow` (run the publisher and write the local `~/catalyst/coordination.jsonl` mirror only — no outbound publish, no inbound pull), `enforce` (also exchange rows with the hub: outbound buffer + inbound merge; **operator-gated, never auto-enabled**). Unset or garbage falls back to `off`. Overrides Layer-2. |
-| `catalyst.coordination.mode` _(Layer-2)_ | `off` | Same three values; honored when the env var is unset. |
-| `CATALYST_COORDINATION_HUB_URL` _(env var)_ | _(none)_ | Base URL of the catalyst-cloud coordination changefeed used in `enforce`. Overrides Layer-2. When empty/unset the publisher uses the interim Loki-tail transport instead. |
-| `catalyst.coordination.hubUrl` _(Layer-2)_ | `null` | Same; honored when the env var is unset. |
+| Key                                         | Default  | Notes                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_COORDINATION_MODE` _(env var)_    | `off`    | `off` / `0` (kill-switch — strict no-op: no publisher, no mirror, no egress), `shadow` (run the publisher and write the local `~/catalyst/coordination.jsonl` mirror only — no outbound publish, no inbound pull), `enforce` (also exchange rows with the hub: outbound buffer + inbound merge; **operator-gated, never auto-enabled**). Unset or garbage falls back to `off`. Overrides Layer-2. |
+| `catalyst.coordination.mode` _(Layer-2)_    | `off`    | Same three values; honored when the env var is unset.                                                                                                                                                                                                                                                                                                                                             |
+| `CATALYST_COORDINATION_HUB_URL` _(env var)_ | _(none)_ | Base URL of the catalyst-cloud coordination changefeed used in `enforce`. Overrides Layer-2. When empty/unset the publisher uses the interim Loki-tail transport instead.                                                                                                                                                                                                                         |
+| `catalyst.coordination.hubUrl` _(Layer-2)_  | `null`   | Same; honored when the env var is unset.                                                                                                                                                                                                                                                                                                                                                          |
 
 **Cloud token (enforce delivery).** In `enforce` mode the publisher sends each batch to
 `<hubUrl>/coordination/publish` with an `Authorization: Bearer <token>` header. The **payload
 carries no tenant field** — the server derives tenant from the token. The token comes from the
 `cloud-token` secret-contract row (ADR-0008 leg-3 credential): `~/.config/catalyst/cloud-sync.env`
 must export the resolved var name (default `CATALYST_CLOUD_TOKEN`; the exact name is
-`CATALYST_CLOUD_TOKEN_ENV` → Layer-2 → `CATALYST_CLOUD_TOKEN`). `catalyst-stack start` sources
-this file in a subshell when spawning the daemon so the credential is inherited without leaking into
-the long-lived shell process.
+`CATALYST_CLOUD_TOKEN_ENV` → Layer-2 → `CATALYST_CLOUD_TOKEN`). `catalyst-stack start` sources this
+file in a subshell when spawning the daemon so the credential is inherited without leaking into the
+long-lived shell process.
 
 An enforce host with a valid `hubUrl` but **no** token degrades to inbound-only with a one-time
 warning — it never hammers the hub with 401s. Provisioning a token and restarting
 (`catalyst-stack start`) bounces the daemon (token presence is part of the restart fingerprint).
 
-**Shadow → enforce promotion (ADR-023 rollout gate).** Do not flip hosts to enforce until all of
-the following are true, verified by `bun coordination-publish/parity-check.ts` on each candidate
-host over a ≥3–5 day window:
+**Shadow → enforce promotion (ADR-023 rollout gate).** Do not flip hosts to enforce until all of the
+following are true, verified by `bun coordination-publish/parity-check.ts` on each candidate host
+over a ≥3–5 day window:
 
 1. Non-zero matched pairs (the mirror contains coordination rows that align with the `worker_state`
    projection — meaning the outbound stream is non-empty and well-formed).
@@ -1487,6 +1511,6 @@ host over a ≥3–5 day window:
 3. Each candidate has been spot-checked for false positives.
 
 Once criteria are met, flip **one host at a time** to `enforce`. Rollback = unset the mode +
-`catalyst-stack start` (the daemon self-exits on `off`, ADR-023 rule 5). The three-way exit
-contract of `parity-check.ts`: `0` = healthy, `1` = divergent, `2` = inconclusive (mirror empty
-or no matching pairs — not an error, just not yet evaluable).
+`catalyst-stack start` (the daemon self-exits on `off`, ADR-023 rule 5). The three-way exit contract
+of `parity-check.ts`: `0` = healthy, `1` = divergent, `2` = inconclusive (mirror empty or no
+matching pairs — not an error, just not yet evaluable).


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-12T05:57:00Z -->
<!-- Last updated: 2026-08-12T05:57:00Z -->
<!-- PR: #3280 -->
<!-- Previous commits: bf996495,847b2884,47fd3afb,e51e515c,cf708d65,7743d18e -->

## Summary

`CATALYST_DELEGATE_FIRST=shadow` was byte-identical to `off` — it produced zero evidence because no `appendEvent` emitter was threaded through the six call sites that invoke `routeStuckTicketToDelegate`. This PR closes both structural blockers identified in the CTL-1774 audit:

1. **Extracts a `delegate-event.mjs` leaf emitter** — a zero-import module that wraps the JSONL append into a typed `appendDelegateEvent(emitter, ticket, mode, reason)` function with a stable interface, analogous to `appendWorkerTransitionEvent`.
2. **Threads `appendDelegateEvent` through all six call sites** in `scheduler.mjs` (Sites 1–4), `monitor.mjs` (Site 5), and `stale-pr-rescue-timer.mjs` (Site 6). The emitter is injected via the existing opts pattern, defaulting to a no-op so off-mode callers are untouched.
3. **Adds a config ladder for `CATALYST_DELEGATE_FIRST`** in `config.mjs` — env → Layer-1 `.catalyst/config.json` → default `off`, matching the pattern used by `boardHealth`, `recoveryPass`, and `daemonWatchdog`.
4. **End-to-end shadow test** (`delegate-shadow-e2e.test.mjs`) proves that with a real (un-spied) emitter and a temp `CATALYST_DIR`, shadow mode writes exactly one `delegate.would-route` JSONL line per eligible ticket.

## Changes Made

### New modules
- **`delegate-event.mjs`** — leaf emitter; `appendDelegateEvent(emitter, ticket, mode, reason)` with try/catch (never throws), 121-line test suite covering all four mode branches.

### Wired call sites
- **`scheduler.mjs`** — `maybeEscalateDispatchFailures` (Site 1), dependency-cycle escalation (Sites 2 & 3), terminal-sweep escalation (Site 4) each receive `appendDelegateEvent` via the `opts` chain threading through `schedulerTick` → `runTick` → `startScheduler`.
- **`monitor.mjs`** — `dispatchTriage` default-label closure (Site 5); also threads through `sweepMissingTriage` and `handleStateChangedEvent`.
- **`stale-pr-rescue-timer.mjs`** — `defaultEscalate` (Site 6).

### Config ladder
- **`config.mjs`** — `readDelegateFirstConfig()` resolves `CATALYST_DELEGATE_FIRST` env → `catalyst.orchestration.delegateFirst.mode` Layer-1 → `"off"`. Returns `{ mode, source }`. Consumed by `delegate-first.mjs` `routeStuckTicketToDelegate` (replaces the bare `process.env` read).

### Tests (all green)
- `delegate-event.test.mjs` — 121 LOC, 14 assertions covering off/shadow/enforce/unknown
- `delegate-emit-wiring.test.mjs` — 303 LOC, 7 tests: red→green confirmed at each of the 6 call sites + `startScheduler` opts passthrough
- `delegate-shadow-e2e.test.mjs` — 112 LOC, proves the real emitter path with a temp CATALYST_DIR (no mocks)
- `delegate-first.test.mjs` — extended with 8 new assertions for the config-ladder read

### Docs
- **`docs/architecture.md`** — updated "Delegate-first escalation" section with the two-gap narrative, config-ladder resolution order, and event names.
- **`website/src/content/docs/reference/configuration.md`** — adds `catalyst.orchestration.delegateFirst.mode` with allowed values, default, precedence table, and example.

## How to Verify It

- [x] `node --check` passes on all 6 modified source files (delegate-event, delegate-first, config, scheduler, monitor, stale-pr-rescue-timer)
- [x] 42/42 delegate tests pass (delegate-event, delegate-first, delegate-emit-wiring, delegate-shadow-e2e)
- [x] `broker/namespace-parity.test.mjs` 8/8 — `delegate.*` names registered and not broker-protected
- [x] `stale-pr-rescue + monitor`: 214/216 pass; the 2 monitor failures reproduce identically on `origin/main` baseline (pre-existing env flaky, not regressions)
- [x] Reward-hacking scan: no `as any` / `@ts-ignore` / `forEach(async` / `void` tricks introduced
- [x] Security: best-effort local event-log append only; no secrets, no network, no shell exec of untrusted input; `appendDelegateEvent` never throws

## Verification (from verify phase)

- **Regression risk**: 1 / 10
- **typecheck**: skip — diff is `.mjs` (plain JS) + markdown; `node --check` passed on all 6 modified source files
- **node_check**: pass — `node --check` clean: delegate-event, delegate-first, config, scheduler, monitor, stale-pr-rescue-timer
- **delegate_tests**: pass — 42/42 pass across delegate-event, delegate-first, delegate-emit-wiring, delegate-shadow-e2e
- **namespace_parity**: pass — `broker/namespace-parity.test.mjs` 8/8; `delegate.*` names registered and not broker-protected
- **affected_suites**: pass — stale-pr-rescue + monitor: 214/216; the 2 monitor fails reproduce identically on `origin/main` baseline
- **scheduler_suite**: skip — `scheduler.test.mjs` SIGKILLed (137, resource exhaustion on busy host, known-flaky suite); `node --check` clean; the `maybeEscalateDispatchFailures` export is covered green by `delegate-emit-wiring.test.mjs`
- **reward_hacking**: pass
- **security**: pass
- **empty_branch**: pass — 6 commits ahead of `origin/main`

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1774