### PR TITLE
fix(dev): CAT-73 — resolve replica token presence from the writer's environment

### DIFF
--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -17,8 +17,15 @@ the token FIRST, activate the writer, wait for a verified seed, and only then fl
    `~/.config/catalyst/cloud-sync.env` (`chmod 600`).
 2. **Activate the writer**: `catalyst-stack adopt-cloud-sync`. Provisioning the token does not
    itself install or start the supervised writer.
-3. **Wait for a verified seed** — `catalyst doctor`'s `replica-fresh` PASS, or
-   `sqlite3 ~/catalyst/catalyst-replica.db 'SELECT COUNT(*) FROM issues'` > 0.
+3. **Wait for a verified seed** — `catalyst-stack verify-cloud-sync` (this is the authority: it
+   checks the schema, issue rows, a fresh writer lock, **and** a non-empty seed cursor). Equivalent
+   manual check — the row count alone is **not** sufficient, because a database with `issues` rows
+   but no `sync_meta` cursor is mid-reseed and every read still falls back to `linearis`:
+
+   ```bash
+   sqlite3 ~/catalyst/catalyst-replica.db \
+     "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;"
+   ```
 4. **Then set `CATALYST_LINEAR_REPLICA=on`** and restart execution-core on a worker — an
    already-running process does not construct a reader just because the flag changed.
 
@@ -37,8 +44,9 @@ The canonical seed-before-flip runbook, including every key's precedence, lives 
 
 ## Loki queries
 
-`service_name` is the only stream label here; every other field — including the event name — arrives
-as **structured metadata**, because `otel-forward` sends the body as a plain string and the event
+`service_name` and `service_namespace` are the stream labels here (`service_namespace` is
+`catalyst` for every emitter, and is the cross-signal join key); every other field — including the
+event name — arrives as **structured metadata**, because `otel-forward` sends the body as a plain string and the event
 attributes as OTLP log attributes (dots normalized to underscores). Do not `| json` these lines:
 there is no JSON body to parse, and `attributes["event.name"]` never matches.
 

--- a/plugins/dev/scripts/__tests__/docs-drift-references.test.sh
+++ b/plugins/dev/scripts/__tests__/docs-drift-references.test.sh
@@ -17,6 +17,17 @@ assert_doc_has() {
   fi
 }
 
+# CAT-73: the inverse — a claim a doc must NO LONGER make. A corrected statement is only
+# corrected once the wrong one is gone; assert_doc_has alone cannot see a leftover copy.
+assert_doc_lacks() {
+  local label="$1" file="$2" needle="$3"
+  if grep -qF -- "$needle" "$REPO_ROOT/$file"; then
+    FAILURES=$((FAILURES+1)); echo "  FAIL: $label (still present in $file): $needle"
+  else
+    PASSES=$((PASSES+1)); echo "  PASS: $label"
+  fi
+}
+
 assert_doc_has "orchestrator-overview mentions check-config-drift.sh" \
   "docs/orchestrator-overview.md" "check-config-drift.sh"
 assert_doc_has "setup-health-check doc covers Config-template drift" \
@@ -32,6 +43,24 @@ assert_doc_has "configuration ref documents CATALYST_COORDINATION_MODE (CTL-1488
   "website/src/content/docs/reference/configuration.md" "CATALYST_COORDINATION_MODE"
 assert_doc_has "configuration ref documents catalyst.coordination.hubUrl (CTL-1488)" \
   "website/src/content/docs/reference/configuration.md" "catalyst.coordination.hubUrl"
+
+# CAT-73: the seed-before-flip runbook must name the RESOLVED token variable, not
+# hardcode CATALYST_CLOUD_TOKEN — a host using the escape hatch is left unauthenticated.
+assert_doc_has "configuration runbook names the resolved token variable (CAT-73)" \
+  "website/src/content/docs/reference/configuration.md" 'TOKEN_VAR='
+assert_doc_has "configuration runbook cross-links the token-name escape hatch (CAT-73)" \
+  "website/src/content/docs/reference/configuration.md" 'CATALYST_CLOUD_TOKEN_ENV'
+# CAT-73: the documented pre-flip seed condition must require the sync_meta cursor, not
+# just issues rows — both production readers do (replica_fresh, SEED_COMPLETE_SELECT).
+assert_doc_has "linear-replica seed condition requires the sync_meta cursor (CAT-73)" \
+  "docs/linear-replica.md" "key='cursor'"
+assert_doc_has "linear-replica routes the seed check through verify-cloud-sync (CAT-73)" \
+  "docs/linear-replica.md" "verify-cloud-sync"
+# CAT-73: service_namespace is a stream label too (AGENTS.md is the authority).
+assert_doc_has "linear-replica names service_namespace a stream label (CAT-73)" \
+  "docs/linear-replica.md" "service_namespace"
+assert_doc_lacks "linear-replica no longer claims service_name is the only stream label (CAT-73)" \
+  "docs/linear-replica.md" "is the only stream label"
 
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -30,9 +30,27 @@ function deps(over = {}) {
     // fs/spawn. Healthy default = a real SQLite file carrying both required tables.
     isSqliteFile: () => true,
     readDbTables: () => ["issues", "sync_meta", "labels"],
+    // CAT-73: the launchd-faithful token-presence seam. Injected here (rather than
+    // letting defaultProbeTokenPresence fire) so the suite never shells out to
+    // bash/bun. Healthy default = the supervised writer can see the token.
+    probeTokenPresence: () => ({
+      available: true,
+      present: true,
+      name: TOKEN_ENV.envVar,
+      source: "cloud-sync.env",
+      permsWarning: false,
+    }),
     ...over,
   };
 }
+// CAT-73: the writer genuinely cannot see the token (the probe ran and said so).
+const PROBE_ABSENT = () => ({
+  available: true,
+  present: false,
+  name: TOKEN_ENV.envVar,
+  source: "default",
+  permsWarning: false,
+});
 const byName = (recs) => Object.fromEntries(recs.map((r) => [r.name, r]));
 const noFail = (recs) => recs.every((r) => r.status !== "fail");
 
@@ -53,9 +71,11 @@ describe("checkCloudSync", () => {
     expect(m["replica-read-flag"].status).toBe("pass");
   });
 
+  // CAT-73: the authority for these two is the PROBE (the environment the supervised
+  // writer sees), not `env` (this shell's). Both assertions are otherwise unchanged.
   test("token unset → replica-token WARN; the value never leaks", () => {
     const SECRET = "lin_should_never_appear";
-    const recs = checkCloudSync(deps({ env: { SOME_OTHER: SECRET } }));
+    const recs = checkCloudSync(deps({ env: { SOME_OTHER: SECRET }, probeTokenPresence: PROBE_ABSENT }));
     const m = byName(recs);
     expect(m["replica-token"].status).toBe("warn");
     expect(m["replica-token"].detail).toContain(TOKEN_ENV.envVar);
@@ -67,6 +87,70 @@ describe("checkCloudSync", () => {
     const recs = checkCloudSync(deps({ env: { [TOKEN_ENV.envVar]: SECRET } }));
     expect(JSON.stringify(recs)).not.toContain(SECRET);
     expect(byName(recs)["replica-token"].status).toBe("pass");
+  });
+
+  test("CAT-73: token visible to the writer but absent from this shell → PASS, tier PASS", () => {
+    const m = byName(checkCloudSync(deps({ env: {} })));
+    expect(m["replica-token"].status).toBe("pass");
+    expect(m["replica-token"].detail).toMatch(/cloud-sync\.env/);
+    expect(m["replica-tier"].status).toBe("pass");
+    expect(m["replica-tier"].detail).not.toMatch(/INERT|partially/i);
+  });
+
+  test("CAT-73: token in this shell only → WARN naming the writer's env, tier not PASS", () => {
+    const SECRET = "lin_should_never_appear";
+    const recs = checkCloudSync(deps({
+      env: { [TOKEN_ENV.envVar]: SECRET },
+      probeTokenPresence: PROBE_ABSENT,
+    }));
+    const m = byName(recs);
+    expect(m["replica-token"].status).toBe("warn");
+    expect(m["replica-token"].detail).toMatch(/this shell/i);
+    expect(m["replica-token"].detail).toMatch(/cloud-sync\.env/);
+    expect(m["replica-tier"].status).not.toBe("pass");
+    expect(JSON.stringify(recs)).not.toContain(SECRET);
+  });
+
+  test("CAT-73: probe unavailable → degraded wording, answers from this shell", () => {
+    const m = byName(checkCloudSync(deps({
+      env: { [TOKEN_ENV.envVar]: "x" },
+      probeTokenPresence: () => ({ available: false, reason: "probe exit 127" }),
+    })));
+    expect(m["replica-token"].detail).toMatch(/probe unavailable/i);
+    expect(m["replica-token"].detail).toMatch(/may not reflect/i);
+    expect(m["replica-token"].status).toBe("pass"); // shell answer, explicitly caveated
+  });
+
+  test("CAT-73: a throwing probe degrades instead of propagating", () => {
+    const recs = checkCloudSync(deps({
+      env: {},
+      probeTokenPresence: () => { throw new Error("probe threw"); },
+    }));
+    const m = byName(recs);
+    expect(m["replica-token"].status).toBe("warn");
+    expect(m["replica-token"].detail).toMatch(/probe unavailable/i);
+    expect(noFail(recs)).toBe(true);
+  });
+
+  test("CAT-73: probe's resolved name wins in the wording", () => {
+    const m = byName(checkCloudSync(deps({
+      probeTokenPresence: () => ({ available: true, present: true, name: "MY_TOKEN", source: "cloud-sync.env", permsWarning: false }),
+    })));
+    expect(m["replica-token"].detail).toContain("MY_TOKEN");
+    // A NAME divergence is real information, but must not become a second record.
+    expect(m["replica-token"].detail).toContain(TOKEN_ENV.envVar);
+    expect(m["replica-tier"].detail).not.toMatch(/INERT|partially/i);
+  });
+
+  test("CAT-73: perms warning folds into the detail, not a new record", () => {
+    const healthy = checkCloudSync(deps());
+    const recs = checkCloudSync(deps({
+      probeTokenPresence: () => ({ available: true, present: true, name: TOKEN_ENV.envVar, source: "cloud-sync.env", permsWarning: true }),
+    }));
+    const m = byName(recs);
+    expect(m["replica-token"].status).toBe("pass");
+    expect(m["replica-token"].detail).toMatch(/600/);
+    expect(recs).toHaveLength(healthy.length);
   });
 
   test("db absent → replica-fresh WARN (not connected)", () => {
@@ -128,7 +212,12 @@ describe("checkCloudSync", () => {
   });
 
   test("tier-inert summary names token and read flag gaps", () => {
-    const m = byName(checkCloudSync(deps({ mode: "off", env: {}, statFile: () => ({ size: 0, mtimeMs: NOW }) })));
+    const m = byName(checkCloudSync(deps({
+      mode: "off",
+      env: {},
+      probeTokenPresence: PROBE_ABSENT, // CAT-73: the writer's env is the token authority
+      statFile: () => ({ size: 0, mtimeMs: NOW }),
+    })));
     expect(m["replica-tier"].status).toBe("warn");
     expect(m["replica-tier"].detail).toMatch(/token/i);
     expect(m["replica-tier"].detail).toMatch(/CATALYST_LINEAR_REPLICA/);
@@ -194,14 +283,23 @@ describe("checkCloudSync", () => {
       () => ({ size: 10, mtimeMs: 0 }),
       () => { throw new Error("stat fail"); },
     ];
+    const probes = [
+      () => ({ available: true, present: true, name: TOKEN_ENV.envVar, source: "cloud-sync.env", permsWarning: false }),
+      () => ({ available: true, present: false, name: TOKEN_ENV.envVar, source: "default", permsWarning: true }),
+      () => ({ available: false, reason: "boom" }),
+      () => { throw new Error("probe threw"); },
+    ];
     for (const agentInstalled of bools)
       for (const processAlive of bools)
         for (const mode of ["on", "off"])
           for (const fileExists of bools)
             for (const statFile of stats)
-              for (const env of [{ [TOKEN_ENV.envVar]: "x" }, {}]) {
-                const recs = checkCloudSync(deps({ agentInstalled, processAlive, mode, fileExists, statFile, env }));
-                expect(recs.every((r) => r.status !== "fail")).toBe(true);
-              }
+              for (const env of [{ [TOKEN_ENV.envVar]: "x" }, {}])
+                // CAT-73: the probe axis — including a probe that THROWS, which
+                // checkCloudSync must contain rather than propagate into doctor's run.
+                for (const probeTokenPresence of probes) {
+                  const recs = checkCloudSync(deps({ agentInstalled, processAlive, mode, fileExists, statFile, env, probeTokenPresence }));
+                  expect(recs.every((r) => r.status !== "fail")).toBe(true);
+                }
   });
 });

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3083,11 +3083,100 @@ function defaultReadDbTables(path) {
   return r.stdout.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
 }
 
+// defaultProbeTokenPresence — CAT-73. Answers "can the SUPERVISED writer authenticate?",
+// not "does this shell happen to hold the token". `catalyst doctor` sources neither
+// ~/.config/catalyst/cluster.env nor ~/.config/catalyst/cloud-sync.env, but cloud-sync's
+// launch.sh sources both — so process.env is the wrong authority and produces both false
+// greens and false warns. Delegates to the launchd-faithful presence probe
+// (lib/cloud-sync-token-probe.sh), which scrubs the caller's CATALYST_*/XDG_CONFIG_HOME
+// overrides, sources the same two 0600 files in the same order, resolves the token NAME
+// through the same resolveNodeCloudTokenEnv ladder, and reports presence by NAME only —
+// the VALUE never crosses this boundary. Returns { available:false, reason } on ANY
+// failure so the caller degrades LOUDLY rather than silently falling back to process.env
+// (the CAT-154 learning: an omitted seam must not quietly answer from live host I/O).
+function defaultProbeTokenPresence({ hostName = process.env.CATALYST_HOST_NAME ?? "" } = {}) {
+  const probePath = resolve(dirname(fileURLToPath(import.meta.url)), "../lib/cloud-sync-token-probe.sh");
+  if (!existsSync(probePath)) return { available: false, reason: "probe script not found" };
+  let r;
+  try {
+    r = spawnSync("bash", ["-c", '. "$0"; cloud_sync_probe_token --host "$1"', probePath, hostName], {
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+  } catch (e) {
+    return { available: false, reason: `probe spawn failed: ${e?.code ?? "error"}` };
+  }
+  // NOTE: `reason` lands in doctor's output, so it never carries probe stdout/stderr —
+  // the probe is value-safe by construction, but this boundary does not rely on that.
+  if (r.error) return { available: false, reason: r.error.code === "ETIMEDOUT" ? "probe timed out" : "probe could not run" };
+  if (r.status !== 0) return { available: false, reason: `probe exit ${r.status}` };
+  if (typeof r.stdout !== "string" || r.stdout.trim().length === 0) return { available: false, reason: "probe produced no output" };
+  const kv = new Map();
+  for (const line of r.stdout.split("\n")) {
+    const eq = line.indexOf("="); // indexOf, not split: a name containing "=" must not corrupt the map
+    if (eq <= 0) continue;
+    kv.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+  }
+  const name = kv.get("name");
+  const present = kv.get("present");
+  if (!name || (present !== "yes" && present !== "no")) return { available: false, reason: "probe output malformed" };
+  return {
+    available: true,
+    present: present === "yes",
+    name,
+    source: kv.get("source") || "unknown",
+    permsWarning: kv.get("perms_warning") === "yes",
+  };
+}
+
+// resolveReplicaTokenPresence — CAT-73. The four-state token verdict, pure so the state
+// machine is testable without doctor's surrounding I/O. Never returns FAIL (see the
+// checkCloudSync contract below) and never touches the token VALUE.
+export function resolveReplicaTokenPresence({ probe, shellTokenSet, tokenEnv }) {
+  if (probe?.available) {
+    const tokenName = probe.name || tokenEnv.envVar;
+    const perms = probe.permsWarning ? " — WARNING: the token file is not mode 600" : "";
+    // A NAME divergence is real information, but must not become a second record.
+    const divergence = tokenName !== tokenEnv.envVar ? ` (doctor resolved ${tokenEnv.envVar} from this shell's config)` : "";
+    if (probe.present === true) {
+      return {
+        tokenSet: true,
+        tokenName,
+        status: STATUS.PASS,
+        detail: `${tokenName} is set in the writer's environment (source=${probe.source})${perms}${divergence}`,
+      };
+    }
+    if (shellTokenSet) {
+      return {
+        tokenSet: false,
+        tokenName,
+        status: STATUS.WARN,
+        detail: `${tokenName} is set in this shell but NOT visible to the supervised writer — launchd sources only ~/.config/catalyst/cluster.env and ~/.config/catalyst/cloud-sync.env; write it to ~/.config/catalyst/cloud-sync.env (chmod 600)${divergence}`,
+      };
+    }
+    return {
+      tokenSet: false,
+      tokenName,
+      status: STATUS.WARN,
+      detail: `${tokenName} not set — the writer cannot authenticate (idle no-op); provision it in a 0600 file the launcher sources (~/.config/catalyst/cloud-sync.env)${divergence}`,
+    };
+  }
+  // Degraded: say so IN the record. Never silently answer from the wrong environment.
+  const tokenName = tokenEnv.envVar;
+  return {
+    tokenSet: shellTokenSet,
+    tokenName,
+    status: shellTokenSet ? STATUS.PASS : STATUS.WARN,
+    detail: `launchd-faithful token probe unavailable (${probe?.reason ?? "unknown"}) — answering from this shell's environment, which may not reflect the writer's view: ${tokenName} ${shellTokenSet ? "is set" : "not set"}`,
+  };
+}
+
 // checkCloudSync — CTL-1394. Advisory health of the per-node supervised Linear-replica
 // writer + its read tier. EVERY condition is WARN/INFO/PASS, NEVER FAIL: doctor's exit code
 // is the FAIL count and gates catalyst-join activation — a FAIL here would block a node that
 // simply hasn't opted into the replica yet. All deps injectable so tests touch no
-// fs/pgrep/launchctl. NODE-SAFE: file-mtime freshness only (no bun:sqlite); rowcount /
+// fs/pgrep/launchctl — and, since CAT-73, no subprocess either: the production default for
+// probeTokenPresence shells out to bash, so the suite must inject it. NODE-SAFE: file-mtime freshness only (no bun:sqlite); rowcount /
 // MAX(updated_at) freshness is check-setup.sh's richer job.
 export function checkCloudSync(deps = {}) {
   const {
@@ -3100,7 +3189,10 @@ export function checkCloudSync(deps = {}) {
     statFile = (p) => statSync(p),
     mode = readLinearReplica().mode,
     tokenEnv = resolveNodeCloudTokenEnv(),
+    // CAT-73: `env` is NO LONGER the token authority — probeTokenPresence is. It is read
+    // only on the degraded path (probe unavailable), where the record says so explicitly.
     env = process.env,
+    probeTokenPresence = defaultProbeTokenPresence,
     now = Date.now(),
     staleMs = Number(process.env.CATALYST_REPLICA_STALE_MS) || 120_000,
     // The writer-lock heartbeat is the FEED-INDEPENDENT liveness signal: the live writer
@@ -3203,14 +3295,21 @@ export function checkCloudSync(deps = {}) {
     }
   }
 
-  // (c) token presence — by NAME only, NEVER the value.
-  const tokenVal = env[tokenEnv.envVar];
-  const tokenSet = typeof tokenVal === "string" && tokenVal.length > 0;
-  checks.push(
-    tokenSet
-      ? mkCheck("replica-token", STATUS.PASS, `${tokenEnv.envVar} is set (len>0, source=${tokenEnv.source})`)
-      : mkCheck("replica-token", STATUS.WARN, `${tokenEnv.envVar} not set — the writer cannot authenticate (idle no-op); provision it in a 0600 file the launcher sources`),
-  );
+  // (c) token presence — by NAME only, NEVER the value. CAT-73: the authority is the
+  // environment the SUPERVISED WRITER sees (launchd + the two 0600 files launch.sh
+  // sources), not this shell's — catalyst-doctor sources neither file.
+  let probe;
+  try {
+    probe = probeTokenPresence();
+  } catch (e) {
+    // A probe exception must never propagate into doctor's run.
+    probe = { available: false, reason: String(e?.message ?? e) };
+  }
+  const shellTokenVal = env[tokenEnv.envVar];
+  const shellTokenSet = typeof shellTokenVal === "string" && shellTokenVal.length > 0;
+  const { tokenSet, tokenName, status: tokenStatus, detail: tokenDetail } =
+    resolveReplicaTokenPresence({ probe, shellTokenSet, tokenEnv });
+  checks.push(mkCheck("replica-token", tokenStatus, tokenDetail));
 
   // (d) read-flag ↔ writer consistency.
   if (mode === "on") {
@@ -3229,10 +3328,10 @@ export function checkCloudSync(deps = {}) {
   const flagOff = mode !== "on";
   if (tokenMissing && flagOff) {
     checks.push(mkCheck("replica-tier", STATUS.WARN,
-      `replica tier INERT end-to-end: token ${tokenEnv.envVar} unset AND CATALYST_LINEAR_REPLICA off. Both must be fixed, token FIRST`));
+      `replica tier INERT end-to-end: token ${tokenName} unset AND CATALYST_LINEAR_REPLICA off. Both must be fixed, token FIRST`));
   } else if (tokenMissing || flagOff) {
     checks.push(mkCheck("replica-tier", STATUS.WARN,
-      `replica tier partially configured (${tokenMissing ? `token ${tokenEnv.envVar} unset` : "CATALYST_LINEAR_REPLICA off"}) — reads still fall back`));
+      `replica tier partially configured (${tokenMissing ? `token ${tokenName} unset` : "CATALYST_LINEAR_REPLICA off"}) — reads still fall back`));
   } else {
     checks.push(mkCheck("replica-tier", STATUS.PASS, "replica tier fully configured (token set + read flag on)"));
   }

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -702,15 +702,25 @@ plist; the launcher sources it from a `0600` file at run time.
 **Seed-before-flip runbook** (run on each host):
 
 1. **Operator credential step:** obtain the cloud credential from the operator who manages the
-   service. This repository does not contain it. Provision it in the launcher's `0600` environment
-   file:
+   service. This repository does not contain it.
+
+   Provision it under the **resolved** token variable name for this host. The name is
+   `CATALYST_CLOUD_TOKEN` unless this host sets the `CATALYST_CLOUD_TOKEN_ENV` env override or the
+   Layer-2 `catalyst.cloud.tokenEnv` key (see the escape-hatch row above) — on such a host,
+   exporting `CATALYST_CLOUD_TOKEN` does **not** authenticate the writer.
 
    ```bash
    mkdir -p ~/.config/catalyst
-   printf 'export CATALYST_CLOUD_TOKEN=%s\n' '<credential>' \
+   # The resolved name for this host: the escape hatch if set, else the default.
+   TOKEN_VAR="${CATALYST_CLOUD_TOKEN_ENV:-CATALYST_CLOUD_TOKEN}"
+   printf 'export %s=%s\n' "$TOKEN_VAR" '<credential>' \
      > ~/.config/catalyst/cloud-sync.env
    chmod 600 ~/.config/catalyst/cloud-sync.env
    ```
+
+   If the name is set via Layer-2 `catalyst.cloud.tokenEnv` rather than the env override, set
+   `TOKEN_VAR` to that value by hand. After step 2, `catalyst doctor`'s `replica-token` line
+   reports the name this host actually resolved — use it to confirm you provisioned the right one.
 
 2. Install and start the supervised writer:
 


### PR DESCRIPTION
## Summary

Closes the four accuracy gaps deferred from CAT-35 / PR #3144 round-2 review. One is behavioral and
load-bearing; three are single-location documentation corrections whose contradicting authority was
already in-repo.

**The core defect.** `checkCloudSync` (`execution-core/doctor.mjs`) read the cloud-token value from
`process.env`. The `catalyst doctor` invocation chain sources nothing, while `cloud-sync/launch.sh`
— the launcher that actually starts the replica writer — sources `~/.config/catalyst/cluster.env`
and `~/.config/catalyst/cloud-sync.env`. A host that followed the canonical runbook therefore had a
healthy, authenticated writer reported as `replica-token WARN` / `replica-tier … partially
configured`.

### Approach — probe, don't source

Rather than adding a sixth hand-rolled copy of the source-both-files chain (or injecting the secret
into the doctor process), this reuses the existing launchd-faithful presence probe
`lib/cloud-sync-token-probe.sh` and injects only its answer.

|  | source in `catalyst-doctor` | inject `env` in JS | **probe (chosen)** |
| --- | --- | --- | --- |
| Secret enters the doctor process | yes | yes | **no — only a boolean crosses** |
| Models the writer's real (launchd) view | no | no | **yes** |
| Reuses a tested primitive | no | no | **yes** |

`catalyst-doctor` (the bash entrypoint) is unmodified.

### Deliberate behavior change

A third verdict state falls out: token present in the **invoking shell but not in the writer's
environment**. That previously reported PASS — a false green, since the writer genuinely cannot
authenticate. It is now a WARN naming the precise remedy. Probe *unavailability* is likewise an
explicit, message-visible degraded state rather than a silent fall-through to `process.env`
(honouring the CAT-154 learning that an injectable seam's omission should fail loudly).

## Documentation corrections

- `website/.../reference/configuration.md` — the canonical runbook now names the resolved
  cloud-token variable and cross-links the token-name escape hatch.
- `docs/linear-replica.md` — the seed condition requires the `sync_meta` cursor and routes the seed
  check through `verify-cloud-sync`; `service_namespace` is correctly named a stream label (it
  previously claimed `service_name` was the only one).

## Verification

- `execution-core/__tests__/doctor-replica.test.mjs` — **27 pass / 0 fail** (454 assertions)
- `__tests__/cloud-sync-token-probe.test.sh` — **18 pass**
- `__tests__/docs-drift-references.test.sh` — all 8 new CAT-73 assertions pass

> Two assertions in `docs-drift-references.test.sh` fail on this branch, both **pre-existing on
> `main`** and untouched here: they reference
> `website/src/content/docs/reference/setup-health-check.md`, which does not exist on `main` either.
> Filed separately rather than fixed in-scope.

Plan: `thoughts/shared/plans/2026-08-11-cat-73.md`
