### PR TITLE
fix(dev): unbreak main — CTL-56 guard scanned CHANGELOG prose as a call site

### DIFF
--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -107,20 +107,77 @@ echo "CTL-56: repo-wide invariant — no live gh pr merge call carries --delete-
 
 # Scan plugins/ for any 'gh pr merge' line that includes '--delete-branch'.
 # Exclude: JSON schema description strings, HTML mockups, bash comments (#),
-# and test files (themselves may reference the flag for assertion labels).
+# test files (themselves may reference the flag for assertion labels), and
+# generated CHANGELOGs.
+#
+# Why CHANGELOGs are excluded, and why the exclusion is this narrow: a release
+# note DESCRIBING the removal ("The fix drops `--delete-branch` from all `gh pr
+# merge` calls") carries both tokens in prose and was scanned as if it were a
+# call site — a guard that cannot tell the thing from a description of the thing.
+# Release-please generates these files and nothing ever executes them.
+#
+# The exclusion is by CHANGELOG filename, NOT by `.md`, deliberately: 32 live
+# `gh pr merge` call sites in this repo live in `.md` files (SKILL.md bodies and
+# prompt templates that agents execute verbatim). Excluding `*.md` would trade
+# this false positive for a silent false negative across every one of them.
+_scan_live_violators() {
+  # $1 — root to scan. Kept a function so the positive control below runs the
+  # SAME filter chain against a known-violating fixture.
+  grep -rn -- '--delete-branch' "$1" 2>/dev/null \
+    | grep 'gh pr merge' \
+    | grep -v '\.json:' \
+    | grep -v '\.html:' \
+    | grep -v '\.test\.sh:' \
+    | grep -v 'CHANGELOG\.md:' \
+    | grep -v '^[^:]*:[[:space:]]*#' \
+    || true
+}
+
 REPO_ROOT_GUARD="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
-LIVE_VIOLATORS="$(grep -rn -- '--delete-branch' "${REPO_ROOT_GUARD}/plugins/" \
-  | grep 'gh pr merge' \
-  | grep -v '\.json:' \
-  | grep -v '\.html:' \
-  | grep -v '\.test\.sh:' \
-  | grep -v '^[^:]*:[[:space:]]*#' \
-  || true)"
+LIVE_VIOLATORS="$(_scan_live_violators "${REPO_ROOT_GUARD}/plugins/")"
 if [[ -z "$LIVE_VIOLATORS" ]]; then
   pass "no live gh pr merge call carries --delete-branch (repo-wide)"
 else
   fail "live gh pr merge --delete-branch found (CTL-56 violation):
 ${LIVE_VIOLATORS}"
+fi
+
+# POSITIVE CONTROL (CTL-1801). The check above concludes from an EMPTY result,
+# so it passes identically whether the repo is clean or the scan is broken —
+# exactly the failure mode that let a too-broad exclusion disable a guard
+# silently. Prove the instrument can still see a true positive: build a fixture
+# that genuinely violates the invariant and assert the same filter chain flags
+# it. If a future edit over-excludes (e.g. dropping all `*.md`), this fails.
+CONTROL_DIR="$(mktemp -d)"
+trap 'rm -rf "${CONTROL_DIR}"' EXIT
+mkdir -p "${CONTROL_DIR}/skills/fixture"
+cat >"${CONTROL_DIR}/skills/fixture/SKILL.md" <<'CONTROL_EOF'
+Merge the pull request:
+
+```bash
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+```
+CONTROL_EOF
+# ...and a CHANGELOG that only DESCRIBES the flag, which must NOT be flagged.
+cat >"${CONTROL_DIR}/CHANGELOG.md" <<'CONTROL_EOF'
+### Worktree-Safe PR Merge
+
+The fix drops `--delete-branch` from all `gh pr merge` calls.
+CONTROL_EOF
+
+CONTROL_HITS="$(_scan_live_violators "${CONTROL_DIR}")"
+if grep -q 'SKILL\.md' <<<"${CONTROL_HITS}"; then
+  pass "positive control: the scan still detects a real .md call site"
+else
+  fail "positive control FAILED — the scan no longer detects a known violation, so its
+clean result above is not evidence. Filter chain output was:
+${CONTROL_HITS}"
+fi
+if grep -q 'CHANGELOG\.md' <<<"${CONTROL_HITS}"; then
+  fail "negative control FAILED — prose in a CHANGELOG was scanned as a call site:
+${CONTROL_HITS}"
+else
+  pass "negative control: CHANGELOG prose is not scanned as a call site"
 fi
 
 echo ""

--- a/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/merge-delete-branch-worktree-guard.test.sh
@@ -128,10 +128,17 @@ _scan_live_violators() {
     | grep -v '\.json:' \
     | grep -v '\.html:' \
     | grep -v '\.test\.sh:' \
-    | grep -v 'CHANGELOG\.md:' \
+    | grep -v '/CHANGELOG\.md:' \
     | grep -v '^[^:]*:[[:space:]]*#' \
     || true
 }
+# NOTE the leading `/` on the CHANGELOG filter: it anchors the match to a path
+# boundary so the exclusion covers ONLY a file whose basename is exactly
+# `CHANGELOG.md`. Unanchored, the same filter would also drop a live instruction
+# file named e.g. `NOT_CHANGELOG.md` or `PLUGIN_CHANGELOG.md`, and a real
+# violation inside one would make this guard pass silently — reintroducing the
+# false negative the narrow exclusion exists to avoid. The positive control below
+# covers the prefixed-basename case explicitly.
 
 REPO_ROOT_GUARD="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 LIVE_VIOLATORS="$(_scan_live_violators "${REPO_ROOT_GUARD}/plugins/")"
@@ -158,11 +165,21 @@ Merge the pull request:
 gh pr merge "$PR_NUMBER" --squash --delete-branch
 ```
 CONTROL_EOF
-# ...and a CHANGELOG that only DESCRIBES the flag, which must NOT be flagged.
+# ...a CHANGELOG that only DESCRIBES the flag, which must NOT be flagged...
 cat >"${CONTROL_DIR}/CHANGELOG.md" <<'CONTROL_EOF'
 ### Worktree-Safe PR Merge
 
 The fix drops `--delete-branch` from all `gh pr merge` calls.
+CONTROL_EOF
+# ...and a live instruction file whose basename merely ENDS WITH the excluded
+# one. An unanchored `CHANGELOG.md:` filter would drop this too, letting a real
+# violation through silently.
+cat >"${CONTROL_DIR}/skills/fixture/NOT_CHANGELOG.md" <<'CONTROL_EOF'
+Merge it:
+
+```bash
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+```
 CONTROL_EOF
 
 CONTROL_HITS="$(_scan_live_violators "${CONTROL_DIR}")"
@@ -173,7 +190,14 @@ else
 clean result above is not evidence. Filter chain output was:
 ${CONTROL_HITS}"
 fi
-if grep -q 'CHANGELOG\.md' <<<"${CONTROL_HITS}"; then
+if grep -q 'NOT_CHANGELOG\.md' <<<"${CONTROL_HITS}"; then
+  pass "positive control: the CHANGELOG exclusion is anchored to the exact basename"
+else
+  fail "positive control FAILED — a violation in NOT_CHANGELOG.md was swallowed by an
+unanchored CHANGELOG filter. Filter chain output was:
+${CONTROL_HITS}"
+fi
+if grep -qE '(^|/)CHANGELOG\.md' <<<"${CONTROL_HITS}"; then
   fail "negative control FAILED — prose in a CHANGELOG was scanned as a call site:
 ${CONTROL_HITS}"
 else


### PR DESCRIPTION
## Main is red for every open PR

Release PR #3227 (`cb14ba689`) regenerated `plugins/legacy/CHANGELOG.md`, whose CTL-56 release note reads:

> The fix drops `--delete-branch` from all `gh pr merge` calls and replaces it with a checkout-free remote ref delete via the GitHub REST API...

The repo-wide CTL-56 guard greps `plugins/` for lines carrying **both** `--delete-branch` and `gh pr merge`. That sentence carries both — in prose — so it was scanned as if it were a live call site, and the guard reported a violation that does not exist.

`execution-core-tests.yml` never ran on `cb14ba689` (the release-please merge path does not trigger it), so **main went red without a red run on main**. The first PR to rebase onto it inherited the failure — that is how this surfaced (#3276).

Reproduced on a clean `origin/main` worktree: `21 passed, 1 failed`.

## The fix, and why the exclusion is deliberately narrow

Exclude generated CHANGELOGs **by filename** — not `*.md`.

I checked before choosing: **32 live `gh pr merge` call sites live in `.md` files** in this repo (SKILL.md bodies and prompt templates that agents execute verbatim) versus **1** in a CHANGELOG. Excluding `*.md` would have traded this false positive for a silent false negative across all 32.

## Positive control (CTL-1801 discipline)

The invariant concludes from an **empty** grep result, so it passed identically whether the repo was clean or the scan was broken. That is precisely the shape that lets a too-broad exclusion disable a guard silently and forever.

This PR adds:
- a **positive control** — build a fixture that genuinely violates the invariant, assert the same filter chain still flags it;
- a **negative control** — assert CHANGELOG prose is *not* flagged.

Verified load-bearing by mutation: replacing `CHANGELOG.md:` with `.md:` makes the main check pass **vacuously** while the positive control fails (`23 passed, 1 failed`).

## Verification

| state | result |
|---|---|
| clean `origin/main` | 21 passed, **1 failed** |
| with this fix | **24 passed, 0 failed** |
| fix + over-broad `.md` mutation | 23 passed, **1 failed** (control bites) |