### PR TITLE
feat(dev): CTL-1801 — checks that cannot report a clean result from a check that never ran

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,24 @@ plugin) rather than routing around it. For GitHub state only, a single **bounded
 acceptable last resort while you do; never a poll loop, and never a raw Linear API read (the
 replica-read rule below is absolute).
 
+- **Reporting a negative → run a positive control first, or report inconclusive.** A negative result
+  is only evidence if you can state what a positive one would have looked like **and you ran the same
+  instrument against a case known to be present and saw it come back non-zero.** Before you report
+  "zero", "absent", "unrelated", "clean", or "not owned", ask the question that separates *the thing
+  is not there* from *I could not look* — and if you cannot separate them, say **inconclusive**. The
+  four mechanisms that have actually produced a false clean result here, all of them silent:
+  (1) an unstructured match over structured data — a substring `grep` for an event name counted the
+  name where it appeared inside a commit message, reporting events that did not exist; (2) a
+  malformed call returning a falsy sentinel — an ownership helper invoked with its arguments
+  transposed returned `undefined` for every ticket, which reads as "not owned"; (3) an empty input
+  set feeding a loop, so the body never ran and the trailing all-clear line printed on the strength
+  of zero iterations (`[].every(p)` is `true`); (4) the right question asked of the wrong surface —
+  counting a bot's issue comments returned zero while an unresolved *review thread* was the thing
+  blocking the merge. Prefer the verified helpers in `plugins/dev/scripts/lib/verified-checks.mjs`
+  (count events by exact `event.name`, resolve ticket ownership under named rosters, enumerate every
+  merge blocker) — each returns a verdict that can be explicitly **inconclusive** and throws on
+  malformed input rather than degrading to a falsy answer. This rule governs the bullets below: a
+  check that cannot fail loudly is not evidence for any of them.
 - **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
   state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
   transition), wait on the unified Catalyst event log instead of re-querying in a loop. Reach for

--- a/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
@@ -91,6 +91,48 @@ assert_exit 3 "an unknown subcommand is a usage error" -- node "$VERIFY" bogus-s
 assert_exit 0 "--help exits 0" -- node "$VERIFY" --help
 
 echo ""
+echo "catalyst-verify: canonical event-log location contract"
+
+# Scanning the built-in default while the installation has pointed the log
+# elsewhere would return a conclusive zero against the WRONG corpus.
+MONTH="$(date -u +%Y-%m)"
+mkdir -p "${TMP}/evdir" "${TMP}/cdir/events"
+cp "${TMP}/events.jsonl" "${TMP}/evdir/${MONTH}.jsonl"
+cp "${TMP}/events.jsonl" "${TMP}/cdir/events/${MONTH}.jsonl"
+
+assert_exit 0 "CATALYST_EVENTS_FILE is honored" -- \
+	env CATALYST_EVENTS_FILE="${TMP}/events.jsonl" node "$VERIFY" events phase.advance.applied
+assert_exit 0 "CATALYST_EVENTS_DIR is honored" -- \
+	env -u CATALYST_EVENTS_FILE CATALYST_EVENTS_DIR="${TMP}/evdir" node "$VERIFY" events phase.advance.applied
+assert_exit 0 "CATALYST_DIR/events is honored" -- \
+	env -u CATALYST_EVENTS_FILE -u CATALYST_EVENTS_DIR CATALYST_DIR="${TMP}/cdir" node "$VERIFY" events phase.advance.applied
+# ...and an override pointing at an ABSENT log must be inconclusive, not a clean 0
+# against the default corpus.
+assert_exit 2 "an override pointing at an absent log is INCONCLUSIVE, not a fallback scan" -- \
+	env CATALYST_EVENTS_FILE="${TMP}/no-such.jsonl" node "$VERIFY" events phase.advance.applied
+
+echo ""
+echo "catalyst-verify: installed as a CLI"
+
+# A command that no install ever places on PATH has no consumers — which is the
+# very thing the Assert-and-Subtract acceptance test forbids.
+if grep -q 'catalyst-verify:catalyst-verify' "${SCRIPT_DIR}/../install-cli.sh"; then
+	pass "install-cli.sh CLI_ENTRIES contains catalyst-verify"
+else
+	fail "install-cli.sh does not install catalyst-verify — it would never reach PATH"
+fi
+if grep -q 'catalyst-verify' "${SCRIPT_DIR}/../check-setup.sh"; then
+	pass "check-setup.sh verifies catalyst-verify"
+else
+	fail "check-setup.sh does not verify catalyst-verify"
+fi
+if [[ -x "$VERIFY" ]]; then
+	pass "catalyst-verify is executable (install symlinks it)"
+else
+	fail "catalyst-verify is not executable — the symlink would not run"
+fi
+
+echo ""
 echo "─────────────────────────────────────────────"
 echo "catalyst-verify: ${PASSES} passed, ${FAILURES} failed"
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# catalyst-verify.test.sh — CTL-1801.
+#
+# The library has its own unit tests (lib/verified-checks.test.mjs). This file
+# pins the CLI's EXIT CODES, because those are the contract a bash caller acts
+# on — and treating exit 2 ("could not look") as exit 1 ("nothing found") is the
+# exact defect this tool exists to remove. An untested exit code is how the
+# distinction gets lost at the shell boundary.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY="${SCRIPT_DIR}/../catalyst-verify"
+PASSES=0
+FAILURES=0
+
+pass() {
+	echo "  PASS: $1"
+	PASSES=$((PASSES + 1))
+}
+fail() {
+	echo "  FAIL: $1"
+	FAILURES=$((FAILURES + 1))
+}
+
+# assert_exit <expected> <label> -- <cmd...>
+assert_exit() {
+	local expected="$1" label="$2"
+	shift 3 # expected, label, "--"
+	"$@" >/dev/null 2>&1
+	local rc=$?
+	if [[ "$rc" -eq "$expected" ]]; then
+		pass "$label (exit $rc)"
+	else
+		fail "$label — expected exit $expected, got $rc"
+	fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A corpus with one real event and one GitHub event whose BODY merely mentions
+# the name — the shape that made a substring grep report events that did not exist.
+cat >"${TMP}/events.jsonl" <<'EOF'
+{"attributes":{"event.name":"github.push"},"body":{"payload":{"commits":[{"message":"emit phase.advance.applied"}]}}}
+{"attributes":{"event.name":"phase.advance.applied.CTL-56"},"body":{"payload":{"evidence":"fabricated"}}}
+EOF
+: >"${TMP}/empty.jsonl"
+
+echo ""
+echo "catalyst-verify: exit-code contract"
+
+assert_exit 0 "events: a real occurrence exits 0" -- \
+	node "$VERIFY" events phase.advance.applied --log "${TMP}/events.jsonl"
+
+assert_exit 1 "events: a conclusive ZERO exits 1 (measured, not inconclusive)" -- \
+	node "$VERIFY" events phase.nonexistent.event --log "${TMP}/events.jsonl"
+
+# The load-bearing distinction: an unreadable corpus is NOT a clean zero.
+assert_exit 2 "events: a missing log is INCONCLUSIVE (exit 2), never a clean 0" -- \
+	node "$VERIFY" events phase.advance.applied --log "${TMP}/definitely-absent.jsonl"
+
+assert_exit 2 "events: an EMPTY corpus is INCONCLUSIVE (exit 2), never a clean 0" -- \
+	node "$VERIFY" events phase.advance.applied --log "${TMP}/empty.jsonl"
+
+# Ownership: a malformed call must fail loudly (3), never answer falsely (1).
+assert_exit 3 "owns: an empty roster is a usage error, not a 'no'" -- \
+	node "$VERIFY" owns CTL-1 --host mini --roster ""
+
+assert_exit 3 "owns: a missing --host is a usage error" -- \
+	node "$VERIFY" owns CTL-1 --roster mini,mini-2
+
+# Ownership answers, verified against the HRW math directly so the CLI cannot
+# drift from the library. Compute the true owner, then assert both directions.
+OWNER="$(node -e '
+import("'"${SCRIPT_DIR}"'/../lib/verified-checks.mjs").then(m =>
+  process.stdout.write(m.hrwOwner("CTL-1790", ["mini","mini-2"])));
+')"
+if [[ -z "$OWNER" ]]; then
+	fail "could not compute an HRW owner — the assertions below would be vacuous"
+else
+	pass "positive control: HRW owner for CTL-1790 resolves (${OWNER})"
+	OTHER="mini"
+	[[ "$OWNER" == "mini" ]] && OTHER="mini-2"
+	assert_exit 0 "owns: the true owner answers YES" -- \
+		node "$VERIFY" owns CTL-1790 --host "$OWNER" --roster mini,mini-2
+	assert_exit 1 "owns: a non-owner answers NO" -- \
+		node "$VERIFY" owns CTL-1790 --host "$OTHER" --roster mini,mini-2
+fi
+
+assert_exit 3 "an unknown subcommand is a usage error" -- node "$VERIFY" bogus-subcommand
+assert_exit 0 "--help exits 0" -- node "$VERIFY" --help
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "catalyst-verify: ${PASSES} passed, ${FAILURES} failed"
+echo "─────────────────────────────────────────────"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-verify.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# catalyst-verify.test.sh — CTL-1801.
+# catalyst-verify.test.sh — PROJ-1801.
 #
 # The library has its own unit tests (lib/verified-checks.test.mjs). This file
 # pins the CLI's EXIT CODES, because those are the contract a bash caller acts
@@ -42,7 +42,7 @@ trap 'rm -rf "$TMP"' EXIT
 # the name — the shape that made a substring grep report events that did not exist.
 cat >"${TMP}/events.jsonl" <<'EOF'
 {"attributes":{"event.name":"github.push"},"body":{"payload":{"commits":[{"message":"emit phase.advance.applied"}]}}}
-{"attributes":{"event.name":"phase.advance.applied.CTL-56"},"body":{"payload":{"evidence":"fabricated"}}}
+{"attributes":{"event.name":"phase.advance.applied.PROJ-56"},"body":{"payload":{"evidence":"fabricated"}}}
 EOF
 : >"${TMP}/empty.jsonl"
 
@@ -64,27 +64,27 @@ assert_exit 2 "events: an EMPTY corpus is INCONCLUSIVE (exit 2), never a clean 0
 
 # Ownership: a malformed call must fail loudly (3), never answer falsely (1).
 assert_exit 3 "owns: an empty roster is a usage error, not a 'no'" -- \
-	node "$VERIFY" owns CTL-1 --host mini --roster ""
+	node "$VERIFY" owns PROJ-1 --host mini --roster ""
 
 assert_exit 3 "owns: a missing --host is a usage error" -- \
-	node "$VERIFY" owns CTL-1 --roster mini,mini-2
+	node "$VERIFY" owns PROJ-1 --roster mini,mini-2
 
 # Ownership answers, verified against the HRW math directly so the CLI cannot
 # drift from the library. Compute the true owner, then assert both directions.
 OWNER="$(node -e '
 import("'"${SCRIPT_DIR}"'/../lib/verified-checks.mjs").then(m =>
-  process.stdout.write(m.hrwOwner("CTL-1790", ["mini","mini-2"])));
+  process.stdout.write(m.hrwOwner("PROJ-1790", ["mini","mini-2"])));
 ')"
 if [[ -z "$OWNER" ]]; then
 	fail "could not compute an HRW owner — the assertions below would be vacuous"
 else
-	pass "positive control: HRW owner for CTL-1790 resolves (${OWNER})"
+	pass "positive control: HRW owner for PROJ-1790 resolves (${OWNER})"
 	OTHER="mini"
 	[[ "$OWNER" == "mini" ]] && OTHER="mini-2"
 	assert_exit 0 "owns: the true owner answers YES" -- \
-		node "$VERIFY" owns CTL-1790 --host "$OWNER" --roster mini,mini-2
+		node "$VERIFY" owns PROJ-1790 --host "$OWNER" --roster mini,mini-2
 	assert_exit 1 "owns: a non-owner answers NO" -- \
-		node "$VERIFY" owns CTL-1790 --host "$OTHER" --roster mini,mini-2
+		node "$VERIFY" owns PROJ-1790 --host "$OTHER" --roster mini,mini-2
 fi
 
 assert_exit 3 "an unknown subcommand is a usage error" -- node "$VERIFY" bogus-subcommand

--- a/plugins/dev/scripts/catalyst-verify
+++ b/plugins/dev/scripts/catalyst-verify
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// catalyst-verify — run one of the verified checks from the command line (CTL-1801).
+//
+// These are the questions this repo re-asks every session and keeps hand-rolling
+// wrong. Each subcommand prints a VERDICT: either a measured answer, or an
+// explicit `INCONCLUSIVE` with the reason it could not look. It never prints a
+// bare zero that a reader could mistake for a measurement.
+//
+// Exit codes:
+//   0  conclusive, and the answer is the "clean"/affirmative one
+//   1  conclusive, and the answer is the "dirty"/negative one
+//   2  INCONCLUSIVE — the instrument could not look (NOT the same as a clean 0)
+//   3  usage error / malformed input
+//
+// Exit 2 is the whole point: a caller that treats "could not look" as "nothing
+// found" is the defect this tool exists to remove, so it gets its own code.
+
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import {
+  VerificationError,
+  countEventsByName,
+  ownershipPreflight,
+  prMergeBlockers,
+  resolveOwnership,
+} from "./lib/verified-checks.mjs";
+
+const USAGE = `catalyst-verify — checks that cannot report a clean result from a check that never ran.
+
+  catalyst-verify events <event.name> [--log <path>]
+      Count events by EXACT event.name (matches "<name>" and "<name>.<TICKET>").
+      Never counts the name where it merely appears in prose (a commit message
+      inside an event body). Defaults to this month's unified event log.
+
+  catalyst-verify owns <TICKET> --host <name> --roster <a,b> [--roster <a>]...
+      Does <host> own <TICKET> under HRW? Pass --roster more than once to
+      preflight across several rosters (e.g. the live one AND the full one);
+      ownership is claimed only when every roster agrees.
+
+  catalyst-verify pr-blockers <number> [--repo <owner/name>]
+      Enumerate EVERY surface that can block a merge: checks, review threads,
+      CHANGES_REQUESTED reviews, draft state. If any surface cannot be read the
+      verdict is INCONCLUSIVE rather than "nothing is blocking".
+
+Exit: 0 clean/yes · 1 dirty/no · 2 INCONCLUSIVE · 3 usage error`;
+
+function fail(msg, code = 3) {
+  process.stderr.write(`${msg}\n`);
+  process.exit(code);
+}
+
+// report — the single place a verdict becomes output, so every subcommand
+// renders an inconclusive result identically.
+function report(verdict, { onValue }) {
+  if (!verdict.conclusive) {
+    process.stdout.write(`INCONCLUSIVE: ${verdict.reason}\n`);
+    process.stdout.write(`  evidence: ${JSON.stringify(verdict.evidence)}\n`);
+    process.exit(2);
+  }
+  onValue(verdict);
+}
+
+function takeFlag(args, name) {
+  const i = args.indexOf(name);
+  if (i === -1) return null;
+  const v = args[i + 1];
+  args.splice(i, 2);
+  return v ?? null;
+}
+function takeAll(args, name) {
+  const out = [];
+  for (;;) {
+    const v = takeFlag(args, name);
+    if (v === null) break;
+    out.push(v);
+  }
+  return out;
+}
+
+function ghJson(args) {
+  const r = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  if (r.error) throw new Error(`gh failed to spawn: ${r.error.message}`);
+  if (r.status !== 0) throw new Error(`gh exited ${r.status}: ${(r.stderr || "").trim().slice(0, 300)}`);
+  try {
+    return JSON.parse(r.stdout);
+  } catch (err) {
+    throw new Error(`gh output was not JSON: ${err.message}`);
+  }
+}
+
+// The gh adapter. `prMergeBlockers` asks for three surfaces by sentinel name;
+// this maps each to the real API surface that answers it. The review-thread and
+// issue-comment surfaces are DISTINCT from `gh pr view` on purpose — the
+// automated reviewer signals findings on one and a clean pass on the other, so
+// consulting only `pr view` answers a different question than the one asked.
+function ghSurfaceAdapter(repoFlag) {
+  const repoArgs = repoFlag ? ["--repo", repoFlag] : [];
+  const nwo = () => {
+    if (repoFlag) return repoFlag;
+    const r = spawnSync("gh", ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], {
+      encoding: "utf8",
+    });
+    if (r.status !== 0) throw new Error("could not resolve the current repo");
+    return r.stdout.trim();
+  };
+  return async (args) => {
+    if (args[0] === "pr") return ghJson(args);
+    const num = Number(args[1]);
+    const [owner, name] = nwo().split("/");
+    if (args[0] === "__reviewThreads__") {
+      const q = `{repository(owner:"${owner}",name:"${name}"){pullRequest(number:${num}){reviewThreads(first:100){nodes{id isResolved path}}}}}`;
+      const d = ghJson(["api", "graphql", "-f", `query=${q}`]);
+      return d?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    }
+    if (args[0] === "__issueComments__") {
+      return ghJson(["api", `repos/${owner}/${name}/issues/${num}/comments`, "--paginate", ...repoArgs.slice(0, 0)]);
+    }
+    throw new Error(`unknown surface ${args[0]}`);
+  };
+}
+
+async function main(argv) {
+  const args = argv.slice(2);
+  const cmd = args.shift();
+  if (!cmd || cmd === "--help" || cmd === "-h" || cmd === "help") {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  if (cmd === "events") {
+    const logFlag = takeFlag(args, "--log");
+    const name = args.shift();
+    if (!name) fail("usage: catalyst-verify events <event.name> [--log <path>]");
+    const month = new Date().toISOString().slice(0, 7);
+    const logPath = logFlag || resolve(homedir(), "catalyst", "events", `${month}.jsonl`);
+    const verdict = await countEventsByName(name, { logPath });
+    return report(verdict, {
+      onValue: (v) => {
+        process.stdout.write(`${v.value}\n`);
+        process.stderr.write(
+          `  (positive control: ${v.evidence.parsedEvents} events read from ${logPath}` +
+            `${v.evidence.parseFailures ? `, ${v.evidence.parseFailures} unparseable lines` : ""})\n`,
+        );
+        process.exit(v.value > 0 ? 0 : 1);
+      },
+    });
+  }
+
+  if (cmd === "owns") {
+    const host = takeFlag(args, "--host");
+    const rosters = takeAll(args, "--roster").map((r) =>
+      r.split(",").map((s) => s.trim()).filter(Boolean),
+    );
+    const ticket = args.shift();
+    if (!ticket || !host || rosters.length === 0) {
+      fail("usage: catalyst-verify owns <TICKET> --host <name> --roster <a,b> [--roster <a>]...");
+    }
+    const verdict =
+      rosters.length === 1
+        ? resolveOwnership({ ticketId: ticket, roster: rosters[0], hostName: host })
+        : ownershipPreflight({ ticketId: ticket, rosters, hostName: host });
+    return report(verdict, {
+      onValue: (v) => {
+        const owners = v.evidence.owners
+          ? v.evidence.owners.map((o) => `[${o.roster.join(",")}] -> ${o.owner}`).join("  ")
+          : `[${v.evidence.roster.join(",")}] -> ${v.evidence.owner}`;
+        process.stdout.write(`${v.value ? "YES" : "NO"}  ${ticket} host=${host}\n`);
+        process.stdout.write(`  ${owners}\n`);
+        process.exit(v.value ? 0 : 1);
+      },
+    });
+  }
+
+  if (cmd === "pr-blockers") {
+    const repoFlag = takeFlag(args, "--repo");
+    const num = Number(args.shift());
+    if (!Number.isInteger(num) || num <= 0) fail("usage: catalyst-verify pr-blockers <number> [--repo o/n]");
+    const verdict = await prMergeBlockers({
+      prNumber: num,
+      repo: repoFlag,
+      runJson: ghSurfaceAdapter(repoFlag),
+    });
+    return report(verdict, {
+      onValue: (v) => {
+        if (v.value.length === 0) {
+          process.stdout.write(`no blockers (mergeStateStatus=${v.evidence.mergeStateStatus})\n`);
+          process.stderr.write(
+            `  (surfaces read: ${v.evidence.surfacesRead.join(", ")}; ` +
+              `${v.evidence.threadsSeen} threads, ${v.evidence.commentsSeen} issue comments)\n`,
+          );
+          process.exit(0);
+        }
+        for (const b of v.value) {
+          process.stdout.write(`${b.surface}\t${b.kind}\t${b.name ?? b.path ?? b.author ?? b.id ?? ""}\n`);
+        }
+        process.exit(1);
+      },
+    });
+  }
+
+  fail(`unknown subcommand: ${cmd}\n\n${USAGE}`);
+}
+
+main(process.argv).catch((err) => {
+  if (err instanceof VerificationError) fail(`VerificationError: ${err.message}`, 3);
+  fail(`error: ${err.message}`, 3);
+});

--- a/plugins/dev/scripts/catalyst-verify
+++ b/plugins/dev/scripts/catalyst-verify
@@ -89,6 +89,23 @@ function ghJson(args) {
   }
 }
 
+// ghGraphQL — a GraphQL read that THROWS on a partial response.
+//
+// GitHub returns HTTP 200 with a top-level `errors` array (and/or a null
+// `pullRequest`) for a partially-failed query. `ghJson` parses that happily, and
+// a caller that then reads `…pullRequest.reviewThreads.nodes` with optional
+// chaining gets `undefined` -> `[]` -> "no unresolved threads". That is a clean
+// verdict produced by a failed read. `execution-core/pr-block-probe.mjs:211-214`
+// rejects this exact shape for the same reason; this mirrors it.
+function ghGraphQL(query) {
+  const json = ghJson(["api", "graphql", "-f", `query=${query}`]);
+  if (json === null || json.errors || !json?.data?.repository?.pullRequest) {
+    const detail = json?.errors ? JSON.stringify(json.errors).slice(0, 200) : "null pullRequest";
+    throw new Error(`partial GraphQL response: ${detail}`);
+  }
+  return json.data.repository.pullRequest;
+}
+
 // The gh adapter. `prMergeBlockers` asks for three surfaces by sentinel name;
 // this maps each to the real API surface that answers it. The review-thread and
 // issue-comment surfaces are DISTINCT from `gh pr view` on purpose — the
@@ -109,15 +126,47 @@ function ghSurfaceAdapter(repoFlag) {
     const num = Number(args[1]);
     const [owner, name] = nwo().split("/");
     if (args[0] === "__reviewThreads__") {
-      const q = `{repository(owner:"${owner}",name:"${name}"){pullRequest(number:${num}){reviewThreads(first:100){nodes{id isResolved path}}}}}`;
-      const d = ghJson(["api", "graphql", "-f", `query=${q}`]);
-      return d?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+      // PAGINATE. `first:100` silently omits later pages, so an unresolved thread
+      // on page two would be absent and the verdict would read "clean". Every
+      // page is aggregated before any verdict is issued; a failure mid-walk
+      // throws, which makes the whole verdict inconclusive rather than short.
+      const nodes = [];
+      let after = null;
+      for (let page = 0; page < 50; page += 1) {
+        const cursor = after ? `, after:"${after}"` : "";
+        const q = `{repository(owner:"${owner}",name:"${name}"){pullRequest(number:${num}){reviewThreads(first:100${cursor}){pageInfo{hasNextPage endCursor} nodes{id isResolved path}}}}}`;
+        const prNode = ghGraphQL(q);
+        const conn = prNode?.reviewThreads;
+        if (!conn || !Array.isArray(conn.nodes)) {
+          throw new Error("reviewThreads connection missing from a 200 response");
+        }
+        nodes.push(...conn.nodes);
+        if (!conn.pageInfo?.hasNextPage || !conn.pageInfo?.endCursor) return nodes;
+        after = conn.pageInfo.endCursor;
+      }
+      throw new Error("reviewThreads pagination exceeded 50 pages — refusing to guess the remainder");
     }
     if (args[0] === "__issueComments__") {
-      return ghJson(["api", `repos/${owner}/${name}/issues/${num}/comments`, "--paginate", ...repoArgs.slice(0, 0)]);
+      return ghJson(["api", `repos/${owner}/${name}/issues/${num}/comments`, "--paginate"]);
+    }
+    if (args[0] === "__reactions__") {
+      // A reaction-only clean pass lives here and NOWHERE else.
+      return ghJson(["api", `repos/${owner}/${name}/issues/${num}/reactions`, "--paginate"]);
     }
     throw new Error(`unknown surface ${args[0]}`);
   };
+}
+
+// resolveEventLogPath — the canonical log-location contract, same ladder
+// `catalyst-events` uses: CATALYST_EVENTS_FILE (exact file) > CATALYST_EVENTS_DIR
+// > CATALYST_DIR/events > ~/catalyst/events. Scanning the built-in default while
+// an installation has pointed the log elsewhere would return a conclusive zero
+// against the WRONG corpus — a licensed answer to a question nobody asked.
+function resolveEventLogPath(env, month) {
+  if (env.CATALYST_EVENTS_FILE) return env.CATALYST_EVENTS_FILE;
+  if (env.CATALYST_EVENTS_DIR) return resolve(env.CATALYST_EVENTS_DIR, `${month}.jsonl`);
+  if (env.CATALYST_DIR) return resolve(env.CATALYST_DIR, "events", `${month}.jsonl`);
+  return resolve(homedir(), "catalyst", "events", `${month}.jsonl`);
 }
 
 async function main(argv) {
@@ -133,7 +182,7 @@ async function main(argv) {
     const name = args.shift();
     if (!name) fail("usage: catalyst-verify events <event.name> [--log <path>]");
     const month = new Date().toISOString().slice(0, 7);
-    const logPath = logFlag || resolve(homedir(), "catalyst", "events", `${month}.jsonl`);
+    const logPath = logFlag || resolveEventLogPath(process.env, month);
     const verdict = await countEventsByName(name, { logPath });
     return report(verdict, {
       onValue: (v) => {

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -126,7 +126,7 @@ fi
 header "Catalyst CLI Install"
 
 CLI_BIN_DIR="${CATALYST_CLI_BIN_DIR:-$HOME/.catalyst/bin}"
-CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack boot-resume-approve)
+CLI_NAMES=(catalyst catalyst-backup catalyst-install catalyst-broker catalyst-comms catalyst-events catalyst-execution-core catalyst-filter catalyst-linear catalyst-linear-reconcile catalyst-otel-forward catalyst-transitions catalyst-verify catalyst-why catalyst-session catalyst-state catalyst-statusline catalyst-db catalyst-monitor catalyst-thoughts catalyst-claude catalyst-stack boot-resume-approve)
 
 if [[ -d $CLI_BIN_DIR ]]; then
 	pass "Bin dir exists: $CLI_BIN_DIR"

--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -46,6 +46,7 @@ catalyst-comms|Event & comms|1|File-based JSONL agent communication channels (no
 catalyst-filter|Event & comms|1|DEPRECATED alias for catalyst-broker (delegates so legacy callers keep working).
 catalyst-why|Event & comms|1|Explain why the daemon believes a worker is alive, stuck, or dead (belief→rule→facts trace).
 catalyst-transitions|Event & comms|0|Live, human-readable Linear-state + phase transition log (tails the event stream — bare runs forever).
+catalyst-verify|Event & comms|1|Verified checks that cannot report a clean result from a check that never ran — count events by exact event.name, resolve HRW ticket ownership under named rosters, enumerate every PR merge blocker (exit 2 = INCONCLUSIVE).
 catalyst-session|Session & state|1|Lifecycle CLI for Catalyst agent sessions (start/phase/metric/tool/pr → SQLite + event log).
 catalyst-state|Session & state|1|Manage global orchestrator state at ~/catalyst/state.json (flock-protected RMW + event log).
 boot-resume-approve|Session & state|0|List boot-resume-gated tickets and approve one — writes the .boot-resume-approved sentinel so the daemon dispatches the gated phase without a restart (CTL-1443).

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -44,6 +44,7 @@ CLI_ENTRIES=(
   "catalyst-linear-reconcile:catalyst-linear-reconcile"
   "catalyst-otel-forward:catalyst-otel-forward"
   "catalyst-transitions:catalyst-transitions"
+  "catalyst-verify:catalyst-verify"
   "catalyst-why:catalyst-why"
   "catalyst-session.sh:catalyst-session"
   "catalyst-state.sh:catalyst-state"

--- a/plugins/dev/scripts/lib/verified-checks.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.mjs
@@ -82,7 +82,7 @@ function requireNonEmptyString(value, name) {
 //
 // Matches an event when its `attributes["event.name"]` equals `eventName` or is a
 // dotted extension of it (`phase.advance.applied` matches
-// `phase.advance.applied.CTL-56`) — the repo's per-ticket event-name convention.
+// `phase.advance.applied.PROJ-56`) — the repo's per-ticket event-name convention.
 // Prose that merely MENTIONS the name (a commit message inside a GitHub event
 // body) is structurally unreachable, because only the name FIELD is consulted.
 //
@@ -304,7 +304,20 @@ export function verifyAll(items, predicate, { label = "candidates" } = {}) {
 // list while GitHub says one of these, our enumeration missed something (a merge
 // conflict, REVIEW_REQUIRED, an ACTION_REQUIRED check, …) and the honest answer
 // is "inconclusive", not "clean".
-const NOT_READY_MERGE_STATES = new Set(["DIRTY", "BLOCKED", "UNSTABLE", "UNKNOWN", "DRAFT"]);
+// Enumerated from GitHub's MergeStateStatus: the READY set is exactly
+// { CLEAN, HAS_HOOKS }? — no: HAS_HOOKS still requires the hooks to pass, and
+// BEHIND requires an update before merge. Both were missing from an earlier
+// revision of this set and would have produced "no blockers" on a PR GitHub
+// itself refuses to merge. Only CLEAN is unambiguously ready.
+const NOT_READY_MERGE_STATES = new Set([
+  "DIRTY",
+  "BLOCKED",
+  "UNSTABLE",
+  "UNKNOWN",
+  "DRAFT",
+  "BEHIND",
+  "HAS_HOOKS",
+]);
 
 // Check conclusions that are neither success nor neutral. ACTION_REQUIRED and
 // STARTUP_FAILURE are blockers that an enumerate-the-bad-ones list forgets.

--- a/plugins/dev/scripts/lib/verified-checks.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+// verified-checks.mjs — instruments that cannot report a clean result from a
+// check that never actually ran (CTL-1801).
+//
+// THE DEFECT CLASS. Four verification checks reported a clean/negative result
+// when the truth was the opposite. In every case the negative was produced by
+// the INSTRUMENT failing, not by the world — and nothing in the output
+// distinguished the two:
+//
+//   (1) unstructured match over structured data — `grep -c "phase.advance.applied"`
+//       returned 4 by matching that string inside a commit message carried in a
+//       GitHub event body. Real count: 0.
+//   (2) malformed call returning a falsy sentinel — `ownedBy(ticket, host, roster)`
+//       (wrong arity; the real signature is `ownedBy(ticketId, hosts, hostName)`)
+//       makes `Array.isArray(hosts)` false, so `ownerForTicket` returns null and
+//       `null === hostName` is false. Every one of 11 tickets read as "not owned".
+//   (3) empty input set → vacuous loop → conclusion printed anyway — a `for` over
+//       an empty capture never runs its body, and the trailing "no output means
+//       unrelated" line prints regardless.
+//   (4) right question, wrong surface — counting a bot's ISSUE comments returns 0
+//       while an unresolved REVIEW THREAD is what actually blocks the merge.
+//
+// THE SHARED RULE (invariant I1, "an absence carries a reason", applied to our own
+// tooling): a negative result is only evidence if you can state what a positive one
+// would have looked like AND the instrument demonstrably produced one. So every
+// helper here returns a VERDICT that is either conclusive or explicitly
+// inconclusive — never a bare `0`/`false`/`undefined` that a caller can mistake for
+// a measured answer. Malformed input THROWS rather than returning a falsy sentinel.
+//
+// Zero imports beyond node builtins, so `catalyst doctor`'s bare-Node runtime and
+// the bash callers' `node -e` one-liners can both load this without a dependency
+// graph.
+
+import { createHash } from "node:crypto";
+import { createReadStream, existsSync, statSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+// VerificationError — thrown for malformed input. Distinct class so a caller can
+// tell "you asked the question wrong" from "the question has no answer today".
+export class VerificationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "VerificationError";
+  }
+}
+
+// conclusive / inconclusive — the two verdict constructors. `value` is the
+// measured answer; `evidence` always carries the positive control that licenses
+// it, so a reader can audit WHY a zero counts as a zero.
+function conclusive(value, evidence) {
+  return { conclusive: true, value, evidence, reason: null };
+}
+function inconclusive(reason, evidence) {
+  return { conclusive: false, value: null, evidence, reason };
+}
+
+// mustBeConclusive — unwrap a verdict or throw. Use at a call site that is about
+// to ACT on the answer, so an inconclusive check can never be silently treated as
+// a negative one.
+export function mustBeConclusive(verdict, context = "check") {
+  if (!verdict || typeof verdict !== "object" || typeof verdict.conclusive !== "boolean") {
+    throw new VerificationError(`${context}: expected a verdict object, got ${typeof verdict}`);
+  }
+  if (!verdict.conclusive) {
+    throw new VerificationError(`${context}: INCONCLUSIVE — ${verdict.reason}`);
+  }
+  return verdict.value;
+}
+
+function requireNonEmptyString(value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new VerificationError(
+      `${name} must be a non-empty string, got ${value === null ? "null" : typeof value}`,
+    );
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// (1) countEventsByName — count events by EXACT event.name, never by substring.
+// ---------------------------------------------------------------------------
+//
+// Matches an event when its `attributes["event.name"]` equals `eventName` or is a
+// dotted extension of it (`phase.advance.applied` matches
+// `phase.advance.applied.CTL-56`) — the repo's per-ticket event-name convention.
+// Prose that merely MENTIONS the name (a commit message inside a GitHub event
+// body) is structurally unreachable, because only the name FIELD is consulted.
+//
+// The positive control is `parsedEvents`: the number of lines that parsed as JSON
+// AND carried a string event name. A zero count is conclusive only when the
+// instrument demonstrably read at least one real event. If nothing parsed, the
+// answer is INCONCLUSIVE — that is the case where "absent" and "could not look"
+// are indistinguishable, and it is exactly the one the old grep silently collapsed.
+export async function countEventsByName(eventName, { lines, logPath, maxBytes } = {}) {
+  requireNonEmptyString(eventName, "eventName");
+  if (lines === undefined && logPath === undefined) {
+    throw new VerificationError("countEventsByName requires either `lines` or `logPath`");
+  }
+  if (lines !== undefined && !Array.isArray(lines)) {
+    throw new VerificationError("`lines` must be an array of strings when provided");
+  }
+
+  let source;
+  if (lines !== undefined) {
+    source = lines;
+  } else {
+    requireNonEmptyString(logPath, "logPath");
+    // A missing/unreadable log is NOT zero events — it is a failure to look.
+    if (!existsSync(logPath)) {
+      return inconclusive(`log not found: ${logPath}`, { parsedEvents: 0, matched: 0 });
+    }
+    if (maxBytes !== undefined) {
+      const size = statSync(logPath).size;
+      if (size > maxBytes) {
+        return inconclusive(`log is ${size} bytes, above the ${maxBytes} cap`, {
+          parsedEvents: 0,
+          matched: 0,
+        });
+      }
+    }
+    source = null; // streamed below
+  }
+
+  let parsedEvents = 0;
+  let parseFailures = 0;
+  let matched = 0;
+  const prefix = `${eventName}.`;
+
+  const consume = (line) => {
+    if (typeof line !== "string" || line.trim() === "") return;
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      parseFailures += 1;
+      return;
+    }
+    const name = obj?.attributes?.["event.name"];
+    if (typeof name !== "string") return;
+    parsedEvents += 1;
+    if (name === eventName || name.startsWith(prefix)) matched += 1;
+  };
+
+  if (source !== null) {
+    for (const line of source) consume(line);
+  } else {
+    // Stream: the live event log reaches multiple GB, and a whole-file read has
+    // already stalled three daemons for ~115s in this repo's history.
+    await new Promise((resolvePromise, rejectPromise) => {
+      const stream = createReadStream(logPath, { encoding: "utf8" });
+      stream.on("error", rejectPromise);
+      const rl = createInterface({ input: stream, crlfDelay: Infinity });
+      rl.on("line", consume);
+      rl.on("close", resolvePromise);
+      rl.on("error", rejectPromise);
+    });
+  }
+
+  const evidence = { parsedEvents, parseFailures, matched, eventName };
+  if (parsedEvents === 0) {
+    return inconclusive(
+      "no parseable events carrying an event.name were read — cannot distinguish " +
+        "'this event never occurred' from 'the instrument could not look'",
+      evidence,
+    );
+  }
+  return conclusive(matched, evidence);
+}
+
+// ---------------------------------------------------------------------------
+// (2) resolveOwnership — HRW ownership that cannot be called wrong.
+// ---------------------------------------------------------------------------
+//
+// Takes NAMED options, not positional args: the transposition that produced 11
+// false "NO"s is structurally unavailable, because the arguments no longer have
+// an order. Malformed input throws instead of degrading to a falsy sentinel.
+//
+// The hash is a local re-implementation of hrw.mjs's `score` — deliberately, so
+// this leaf keeps a zero-dependency import graph. `ownershipMatchesHrw` in the
+// test suite pins the two together, so a drift in either fails CI.
+function hrwScore(ticketId, host) {
+  const digest = createHash("sha1").update(`${ticketId}|${host}`).digest("hex");
+  return Number.parseInt(digest.slice(0, 12), 16);
+}
+
+export function hrwOwner(ticketId, roster) {
+  let best = null;
+  let bestScore = -1;
+  for (const host of roster) {
+    const s = hrwScore(ticketId, host);
+    if (s > bestScore || (s === bestScore && best !== null && host < best)) {
+      bestScore = s;
+      best = host;
+    }
+  }
+  return best;
+}
+
+function requireRoster(roster, name = "roster") {
+  if (!Array.isArray(roster)) {
+    throw new VerificationError(
+      `${name} must be an array of host names, got ${typeof roster} — ` +
+        "this is the arity bug that silently reported 11 tickets as unowned",
+    );
+  }
+  if (roster.length === 0) {
+    throw new VerificationError(`${name} must be non-empty — an empty roster has no owner to compare`);
+  }
+  for (const host of roster) requireNonEmptyString(host, `${name} entry`);
+  return roster;
+}
+
+export function resolveOwnership({ ticketId, roster, hostName } = {}) {
+  requireNonEmptyString(ticketId, "ticketId");
+  requireRoster(roster);
+  requireNonEmptyString(hostName, "hostName");
+  const owner = hrwOwner(ticketId, roster);
+  return conclusive(owner === hostName, { owner, roster: [...roster], ticketId, hostName });
+}
+
+// ownershipPreflight — the discipline this repo learned the hard way: a host that
+// is DOWN is still rostered, and computing ownership under only the live roster
+// produces a false negative that strands a ticket. Ask under EVERY candidate
+// roster and only claim ownership when they all agree.
+//
+// `value` is true only when `hostName` owns the ticket under every roster given.
+// `evidence.owners` names the owner under each, so a disagreement is legible
+// rather than collapsing to a bare false.
+export function ownershipPreflight({ ticketId, rosters, hostName } = {}) {
+  requireNonEmptyString(ticketId, "ticketId");
+  if (!Array.isArray(rosters) || rosters.length === 0) {
+    throw new VerificationError("rosters must be a non-empty array of rosters");
+  }
+  requireNonEmptyString(hostName, "hostName");
+  const owners = rosters.map((roster, i) => {
+    requireRoster(roster, `rosters[${i}]`);
+    return { roster: [...roster], owner: hrwOwner(ticketId, roster) };
+  });
+  const agree = owners.every((o) => o.owner === hostName);
+  return conclusive(agree, { owners, ticketId, hostName });
+}
+
+// ---------------------------------------------------------------------------
+// (3) verifyAll — a loop over an empty candidate set cannot print a verdict.
+// ---------------------------------------------------------------------------
+//
+// The vacuous-truth guard. `[].every(p)` is `true`, and a shell `for` over an
+// empty capture runs its body zero times while the trailing "all clear" line
+// prints anyway. Both report success on the strength of having checked nothing.
+// Here an empty candidate set is INCONCLUSIVE by construction.
+export function verifyAll(items, predicate, { label = "candidates" } = {}) {
+  if (!Array.isArray(items)) {
+    throw new VerificationError(`verifyAll expects an array of ${label}, got ${typeof items}`);
+  }
+  if (typeof predicate !== "function") {
+    throw new VerificationError("verifyAll expects a predicate function");
+  }
+  if (items.length === 0) {
+    return inconclusive(`no ${label} found — inconclusive, nothing was actually checked`, {
+      checked: 0,
+      passed: 0,
+      failed: [],
+    });
+  }
+  const failed = [];
+  for (const item of items) {
+    let ok;
+    try {
+      ok = predicate(item);
+    } catch (err) {
+      // A predicate that threw did not observe the item — that is a failure to
+      // look, not a pass.
+      return inconclusive(`predicate threw on ${JSON.stringify(item)}: ${err.message}`, {
+        checked: items.length,
+        passed: 0,
+        failed: [],
+      });
+    }
+    if (!ok) failed.push(item);
+  }
+  return conclusive(failed.length === 0, {
+    checked: items.length,
+    passed: items.length - failed.length,
+    failed,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// (4) prMergeBlockers — consult EVERY surface that can block a merge.
+// ---------------------------------------------------------------------------
+//
+// A pull request can be blocked from at least four distinct places, and this
+// repo's automated reviewer deliberately uses two of them for opposite signals:
+// findings arrive as REVIEW THREADS, while a clean pass arrives as an ISSUE
+// COMMENT or a reaction. Counting one surface answers a different question than
+// the one asked.
+//
+// If ANY surface query fails, the whole verdict is INCONCLUSIVE. A partial read
+// must never be reported as "nothing is blocking" — that is defect (4) exactly.
+//
+// `runJson` is an injectable seam: (args: string[]) => parsed JSON. Production
+// passes a `gh` wrapper; tests pass a fake.
+export async function prMergeBlockers({ prNumber, repo, runJson } = {}) {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) {
+    throw new VerificationError(`prNumber must be a positive integer, got ${prNumber}`);
+  }
+  if (typeof runJson !== "function") {
+    throw new VerificationError("prMergeBlockers requires a `runJson` seam");
+  }
+
+  const surfaces = {};
+  const failures = [];
+
+  const ask = async (name, args) => {
+    try {
+      surfaces[name] = await runJson(args);
+    } catch (err) {
+      failures.push(`${name}: ${err.message}`);
+      surfaces[name] = null;
+    }
+  };
+
+  const repoArgs = repo ? ["--repo", repo] : [];
+  await ask("pr", [
+    "pr",
+    "view",
+    String(prNumber),
+    ...repoArgs,
+    "--json",
+    "mergeStateStatus,statusCheckRollup,reviews,isDraft",
+  ]);
+  await ask("threads", ["__reviewThreads__", String(prNumber), ...repoArgs]);
+  await ask("comments", ["__issueComments__", String(prNumber), ...repoArgs]);
+
+  if (failures.length > 0) {
+    return inconclusive(
+      `could not read ${failures.length} of 3 merge-blocking surfaces: ${failures.join("; ")} — ` +
+        "a partial read cannot report 'nothing is blocking'",
+      { surfaces, failures },
+    );
+  }
+
+  const blockers = [];
+  const pr = surfaces.pr ?? {};
+
+  if (pr.isDraft === true) blockers.push({ surface: "pr", kind: "draft" });
+
+  for (const check of Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : []) {
+    const name = check?.name ?? check?.context ?? "unnamed-check";
+    const state = check?.conclusion ?? check?.state ?? null;
+    if (state === "FAILURE" || state === "TIMED_OUT" || state === "CANCELLED" || state === "ERROR") {
+      blockers.push({ surface: "checks", kind: "failing", name, state });
+    } else if (state === null || state === "" || state === "PENDING" || state === "IN_PROGRESS") {
+      blockers.push({ surface: "checks", kind: "pending", name, state });
+    }
+  }
+
+  for (const review of Array.isArray(pr.reviews) ? pr.reviews : []) {
+    if (review?.state === "CHANGES_REQUESTED") {
+      blockers.push({
+        surface: "reviews",
+        kind: "changes-requested",
+        author: review?.author?.login ?? "unknown",
+      });
+    }
+  }
+
+  const threads = Array.isArray(surfaces.threads) ? surfaces.threads : [];
+  for (const thread of threads) {
+    if (thread?.isResolved === false) {
+      blockers.push({
+        surface: "reviewThreads",
+        kind: "unresolved-thread",
+        id: thread?.id ?? null,
+        path: thread?.path ?? null,
+      });
+    }
+  }
+
+  return conclusive(blockers, {
+    blockerCount: blockers.length,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    surfacesRead: Object.keys(surfaces),
+    threadsSeen: threads.length,
+    commentsSeen: Array.isArray(surfaces.comments) ? surfaces.comments.length : 0,
+  });
+}

--- a/plugins/dev/scripts/lib/verified-checks.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.mjs
@@ -300,13 +300,42 @@ export function verifyAll(items, predicate, { label = "candidates" } = {}) {
 //
 // `runJson` is an injectable seam: (args: string[]) => parsed JSON. Production
 // passes a `gh` wrapper; tests pass a fake.
-export async function prMergeBlockers({ prNumber, repo, runJson } = {}) {
+// A merge state that GitHub itself calls not-ready. If we return an EMPTY blocker
+// list while GitHub says one of these, our enumeration missed something (a merge
+// conflict, REVIEW_REQUIRED, an ACTION_REQUIRED check, …) and the honest answer
+// is "inconclusive", not "clean".
+const NOT_READY_MERGE_STATES = new Set(["DIRTY", "BLOCKED", "UNSTABLE", "UNKNOWN", "DRAFT"]);
+
+// Check conclusions that are neither success nor neutral. ACTION_REQUIRED and
+// STARTUP_FAILURE are blockers that an enumerate-the-bad-ones list forgets.
+const FAILING_CHECK_STATES = new Set([
+  "FAILURE",
+  "TIMED_OUT",
+  "CANCELLED",
+  "ERROR",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+  "STALE",
+]);
+const PENDING_CHECK_STATES = new Set(["", "PENDING", "IN_PROGRESS", "QUEUED", "WAITING", "REQUESTED"]);
+const PASSING_CHECK_STATES = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
+// isAutomatedReviewer — the bot whose review gates a merge here.
+function isAutomatedReviewer(login) {
+  return typeof login === "string" && /codex/i.test(login);
+}
+
+export async function prMergeBlockers({ prNumber, repo, runJson, reviewerPattern } = {}) {
   if (!Number.isInteger(prNumber) || prNumber <= 0) {
     throw new VerificationError(`prNumber must be a positive integer, got ${prNumber}`);
   }
   if (typeof runJson !== "function") {
     throw new VerificationError("prMergeBlockers requires a `runJson` seam");
   }
+  const isReviewer =
+    reviewerPattern instanceof RegExp
+      ? (login) => typeof login === "string" && reviewerPattern.test(login)
+      : isAutomatedReviewer;
 
   const surfaces = {};
   const failures = [];
@@ -327,14 +356,21 @@ export async function prMergeBlockers({ prNumber, repo, runJson } = {}) {
     String(prNumber),
     ...repoArgs,
     "--json",
-    "mergeStateStatus,statusCheckRollup,reviews,isDraft",
+    // reviewDecision is the AGGREGATE verdict. Raw `reviews` history keeps a
+    // superseded CHANGES_REQUESTED forever, so a reviewer who later approved
+    // would block this PR indefinitely.
+    "mergeStateStatus,statusCheckRollup,reviews,reviewDecision,isDraft",
   ]);
   await ask("threads", ["__reviewThreads__", String(prNumber), ...repoArgs]);
   await ask("comments", ["__issueComments__", String(prNumber), ...repoArgs]);
+  // The automated reviewer signals a clean pass with a REACTION as often as with
+  // a comment. Counting comments alone cannot see a reaction-only clean pass —
+  // which is defect (4) of this module's own preamble, one level up.
+  await ask("reactions", ["__reactions__", String(prNumber), ...repoArgs]);
 
   if (failures.length > 0) {
     return inconclusive(
-      `could not read ${failures.length} of 3 merge-blocking surfaces: ${failures.join("; ")} — ` +
+      `could not read ${failures.length} of 4 merge-blocking surfaces: ${failures.join("; ")} — ` +
         "a partial read cannot report 'nothing is blocking'",
       { surfaces, failures },
     );
@@ -345,24 +381,24 @@ export async function prMergeBlockers({ prNumber, repo, runJson } = {}) {
 
   if (pr.isDraft === true) blockers.push({ surface: "pr", kind: "draft" });
 
+  const unclassifiedChecks = [];
   for (const check of Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : []) {
     const name = check?.name ?? check?.context ?? "unnamed-check";
-    const state = check?.conclusion ?? check?.state ?? null;
-    if (state === "FAILURE" || state === "TIMED_OUT" || state === "CANCELLED" || state === "ERROR") {
+    const raw = check?.conclusion ?? check?.state ?? null;
+    const state = raw === null ? "" : String(raw).toUpperCase();
+    if (FAILING_CHECK_STATES.has(state)) {
       blockers.push({ surface: "checks", kind: "failing", name, state });
-    } else if (state === null || state === "" || state === "PENDING" || state === "IN_PROGRESS") {
+    } else if (PENDING_CHECK_STATES.has(state)) {
       blockers.push({ surface: "checks", kind: "pending", name, state });
+    } else if (!PASSING_CHECK_STATES.has(state)) {
+      // A conclusion we have never seen. Do NOT silently treat it as passing.
+      unclassifiedChecks.push({ name, state });
     }
   }
 
-  for (const review of Array.isArray(pr.reviews) ? pr.reviews : []) {
-    if (review?.state === "CHANGES_REQUESTED") {
-      blockers.push({
-        surface: "reviews",
-        kind: "changes-requested",
-        author: review?.author?.login ?? "unknown",
-      });
-    }
+  // Aggregate decision, not raw history.
+  if (pr.reviewDecision === "CHANGES_REQUESTED") {
+    blockers.push({ surface: "reviews", kind: "changes-requested", decision: pr.reviewDecision });
   }
 
   const threads = Array.isArray(surfaces.threads) ? surfaces.threads : [];
@@ -377,11 +413,54 @@ export async function prMergeBlockers({ prNumber, repo, runJson } = {}) {
     }
   }
 
-  return conclusive(blockers, {
+  // Has the automated reviewer responded AT ALL? Green checks with no review yet
+  // is not a clean PR — it is an unreviewed one, and reporting "no blockers"
+  // there is exactly the "absence read as approval" this module exists to refuse.
+  const comments = Array.isArray(surfaces.comments) ? surfaces.comments : [];
+  const reactions = Array.isArray(surfaces.reactions) ? surfaces.reactions : [];
+  const reviewerComments = comments.filter((c) => isReviewer(c?.user?.login ?? c?.author?.login));
+  const reviewerReactions = reactions.filter((r) => isReviewer(r?.user?.login ?? r?.author?.login));
+  const reviewerThreads = threads.length > 0;
+  const reviewerResponded =
+    reviewerComments.length > 0 ||
+    reviewerReactions.length > 0 ||
+    reviewerThreads ||
+    typeof pr.reviewDecision === "string";
+  if (!reviewerResponded) {
+    blockers.push({ surface: "review", kind: "awaiting-automated-review" });
+  }
+
+  const evidence = {
     blockerCount: blockers.length,
     mergeStateStatus: pr.mergeStateStatus ?? null,
+    reviewDecision: pr.reviewDecision ?? null,
     surfacesRead: Object.keys(surfaces),
     threadsSeen: threads.length,
-    commentsSeen: Array.isArray(surfaces.comments) ? surfaces.comments.length : 0,
-  });
+    commentsSeen: comments.length,
+    reactionsSeen: reactions.length,
+    reviewerSignals: reviewerComments.length + reviewerReactions.length,
+    unclassifiedChecks,
+  };
+
+  // Reconcile against GitHub's own aggregate before licensing a clean answer.
+  const mergeState = typeof pr.mergeStateStatus === "string" ? pr.mergeStateStatus.toUpperCase() : null;
+  if (blockers.length === 0 && unclassifiedChecks.length > 0) {
+    return inconclusive(
+      `every enumerated surface is clean but ${unclassifiedChecks.length} check(s) reported a ` +
+        `conclusion this tool does not classify (${unclassifiedChecks
+          .map((c) => `${c.name}=${c.state}`)
+          .join(", ")}) — cannot license a clean verdict`,
+      evidence,
+    );
+  }
+  if (blockers.length === 0 && mergeState !== null && NOT_READY_MERGE_STATES.has(mergeState)) {
+    return inconclusive(
+      `every enumerated surface is clean, but GitHub reports mergeStateStatus=${mergeState} — ` +
+        "something is blocking this merge that this tool did not enumerate (a merge conflict, " +
+        "REVIEW_REQUIRED, a branch-protection rule); refusing to contradict GitHub's own status",
+      evidence,
+    );
+  }
+
+  return conclusive(blockers, evidence);
 }

--- a/plugins/dev/scripts/lib/verified-checks.test.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.test.mjs
@@ -39,14 +39,14 @@ const GITHUB_EVENT_MENTIONING_THE_NAME = JSON.stringify({
 
 const REAL_ADVANCE_EVENT = JSON.stringify({
   ts: "2026-08-12T05:51:30.000Z",
-  attributes: { "event.name": "phase.advance.applied.CTL-56" },
+  attributes: { "event.name": "phase.advance.applied.PROJ-56" },
   body: { payload: { evidence: "fabricated", asserted_by: "sdk-success-flip" } },
 });
 
 const UNRELATED_EVENT = JSON.stringify({
   ts: "2026-08-12T05:00:00.000Z",
   attributes: { "event.name": "linear.issue.updated" },
-  body: { message: "linear.issue.updated CTL-1801" },
+  body: { message: "linear.issue.updated PROJ-1801" },
 });
 
 describe("(1) countEventsByName — prose that mentions a name is not an occurrence", () => {
@@ -135,17 +135,17 @@ describe("(2) resolveOwnership — an ownership check refuses rather than answer
     // The exact transposition that reported 11 tickets as unowned: the roster and
     // the host name swapped. Positionally this was silent; by name it is impossible,
     // and the shape check throws.
-    expect(() => resolveOwnership({ ticketId: "CTL-56", roster: "mini", hostName: ROSTER })).toThrow(
+    expect(() => resolveOwnership({ ticketId: "PROJ-56", roster: "mini", hostName: ROSTER })).toThrow(
       VerificationError,
     );
-    expect(() => resolveOwnership({ ticketId: "CTL-56", roster: "mini", hostName: ROSTER })).toThrow(
+    expect(() => resolveOwnership({ ticketId: "PROJ-56", roster: "mini", hostName: ROSTER })).toThrow(
       /must be an array of host names/,
     );
   });
 
   test("no ticket is reported unowned on the strength of a malformed call", () => {
     // The old failure mode returned `false` for all 11. Now every one throws.
-    const tickets = ["CTL-56", "CTL-1790", "CTL-1801"];
+    const tickets = ["PROJ-56", "PROJ-1790", "PROJ-1801"];
     for (const ticketId of tickets) {
       expect(() => resolveOwnership({ ticketId, roster: undefined, hostName: "mini" })).toThrow(
         VerificationError,
@@ -154,19 +154,19 @@ describe("(2) resolveOwnership — an ownership check refuses rather than answer
   });
 
   test("a well-formed call answers, and names the owner as evidence", () => {
-    const owner = hrwOwner("CTL-1790", ROSTER);
-    const verdict = resolveOwnership({ ticketId: "CTL-1790", roster: ROSTER, hostName: owner });
+    const owner = hrwOwner("PROJ-1790", ROSTER);
+    const verdict = resolveOwnership({ ticketId: "PROJ-1790", roster: ROSTER, hostName: owner });
     expect(mustBeConclusive(verdict)).toBe(true);
     expect(verdict.evidence.owner).toBe(owner);
 
     const other = ROSTER.find((h) => h !== owner);
-    expect(mustBeConclusive(resolveOwnership({ ticketId: "CTL-1790", roster: ROSTER, hostName: other }))).toBe(
+    expect(mustBeConclusive(resolveOwnership({ ticketId: "PROJ-1790", roster: ROSTER, hostName: other }))).toBe(
       false,
     );
   });
 
   test("an empty roster throws instead of silently owning nothing", () => {
-    expect(() => resolveOwnership({ ticketId: "CTL-1", roster: [], hostName: "mini" })).toThrow(
+    expect(() => resolveOwnership({ ticketId: "PROJ-1", roster: [], hostName: "mini" })).toThrow(
       VerificationError,
     );
   });

--- a/plugins/dev/scripts/lib/verified-checks.test.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.test.mjs
@@ -263,6 +263,7 @@ describe("(4) prMergeBlockers — consult every surface that can block a merge",
           mergeStateStatus: "BLOCKED",
           statusCheckRollup: [{ name: "validate", conclusion: "SUCCESS" }],
           reviews: [],
+          reviewDecision: null,
           ...(overrides.pr ?? {}),
         };
       }
@@ -270,9 +271,19 @@ describe("(4) prMergeBlockers — consult every surface that can block a merge",
         return overrides.threads ?? [{ id: "T_1", isResolved: false, path: "src/a.ts" }];
       }
       if (args[0] === "__issueComments__") return overrides.comments ?? [];
+      if (args[0] === "__reactions__") return overrides.reactions ?? [];
       throw new Error(`unexpected args ${args.join(" ")}`);
     };
   };
+  // A PR that is genuinely clean AND has been reviewed: green checks, resolved
+  // threads, a CLEAN merge state, and a reviewer signal.
+  const cleanGh = (over = {}) =>
+    fakeGh({
+      pr: { mergeStateStatus: "CLEAN", statusCheckRollup: [{ name: "ok", conclusion: "SUCCESS" }], ...(over.pr ?? {}) },
+      threads: over.threads ?? [{ id: "T_1", isResolved: true }],
+      comments: over.comments ?? [{ user: { login: "chatgpt-codex-connector" }, body: "no major issues" }],
+      reactions: over.reactions ?? [],
+    });
 
   test("Scenario: zero bot issue-comments but one unresolved thread reports the thread", async () => {
     const verdict = await prMergeBlockers({ prNumber: 3276, runJson: fakeGh() });
@@ -283,12 +294,106 @@ describe("(4) prMergeBlockers — consult every surface that can block a merge",
     expect(threadBlockers[0].path).toBe("src/a.ts");
   });
 
-  test("a genuinely clean PR reports no blockers", async () => {
+  test("a genuinely clean, reviewed PR reports no blockers", async () => {
+    const verdict = await prMergeBlockers({ prNumber: 1, runJson: cleanGh() });
+    expect(mustBeConclusive(verdict)).toEqual([]);
+  });
+
+  // Codex P1 #1 — green checks with NO reviewer response is not "clean", it is
+  // "unreviewed". Reporting no blockers there reads an absence as approval.
+  test("green checks but no automated review yet is a BLOCKER, not clean", async () => {
     const verdict = await prMergeBlockers({
       prNumber: 1,
-      runJson: fakeGh({ threads: [{ id: "T_1", isResolved: true }] }),
+      runJson: cleanGh({ comments: [], reactions: [], threads: [] }),
+    });
+    const blockers = mustBeConclusive(verdict);
+    expect(blockers.map((b) => b.kind)).toContain("awaiting-automated-review");
+  });
+
+  test("a REACTION-only clean pass counts as a response (it lives on no other surface)", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: cleanGh({
+        comments: [],
+        threads: [],
+        reactions: [{ content: "+1", user: { login: "chatgpt-codex-connector" } }],
+      }),
     });
     expect(mustBeConclusive(verdict)).toEqual([]);
+  });
+
+  // Codex P1 #3 — never contradict GitHub's own aggregate.
+  test("clean enumeration but a NOT-READY mergeStateStatus is INCONCLUSIVE", async () => {
+    for (const state of ["DIRTY", "BLOCKED", "UNKNOWN"]) {
+      const verdict = await prMergeBlockers({
+        prNumber: 1,
+        runJson: cleanGh({ pr: { mergeStateStatus: state } }),
+      });
+      expect(verdict.conclusive).toBe(false);
+      expect(verdict.reason).toContain(state);
+      expect(() => mustBeConclusive(verdict)).toThrow(VerificationError);
+    }
+  });
+
+  test("an UNCLASSIFIED check conclusion is INCONCLUSIVE, never assumed passing", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: cleanGh({ pr: { statusCheckRollup: [{ name: "weird", conclusion: "SOMETHING_NEW" }] } }),
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.reason).toContain("does not classify");
+  });
+
+  test("ACTION_REQUIRED and STARTUP_FAILURE are failing checks", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: cleanGh({
+        pr: {
+          statusCheckRollup: [
+            { name: "a", conclusion: "ACTION_REQUIRED" },
+            { name: "b", conclusion: "STARTUP_FAILURE" },
+          ],
+        },
+      }),
+    });
+    expect(mustBeConclusive(verdict).filter((b) => b.kind === "failing").map((b) => b.name)).toEqual(["a", "b"]);
+  });
+
+  // Codex P2 — the aggregate decision, not stale history.
+  test("a SUPERSEDED CHANGES_REQUESTED does not block forever", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: cleanGh({
+        pr: {
+          // history still carries the old rejection...
+          reviews: [{ state: "CHANGES_REQUESTED", author: { login: "ryan" } }],
+          // ...but the effective decision is APPROVED.
+          reviewDecision: "APPROVED",
+        },
+      }),
+    });
+    expect(mustBeConclusive(verdict)).toEqual([]);
+  });
+
+  test("an EFFECTIVE CHANGES_REQUESTED still blocks", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: cleanGh({ pr: { reviewDecision: "CHANGES_REQUESTED" } }),
+    });
+    expect(mustBeConclusive(verdict).some((b) => b.kind === "changes-requested")).toBe(true);
+  });
+
+  test("a failing REACTIONS surface makes the verdict inconclusive", async () => {
+    const base = cleanGh();
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: async (args) => {
+        if (args[0] === "__reactions__") throw new Error("403 rate limited");
+        return base(args);
+      },
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.reason).toContain("403 rate limited");
   });
 
   test("failing and pending checks are both blockers", async () => {
@@ -310,16 +415,10 @@ describe("(4) prMergeBlockers — consult every surface that can block a merge",
     expect(blockers.filter((b) => b.kind === "pending").map((b) => b.name)).toEqual(["pages"]);
   });
 
-  test("a human CHANGES_REQUESTED review is a blocker", async () => {
-    const verdict = await prMergeBlockers({
-      prNumber: 1,
-      runJson: fakeGh({
-        pr: { reviews: [{ state: "CHANGES_REQUESTED", author: { login: "ryan" } }] },
-        threads: [],
-      }),
-    });
-    expect(mustBeConclusive(verdict).some((b) => b.kind === "changes-requested")).toBe(true);
-  });
+  // NOTE: the raw-`reviews`-history version of this test was removed deliberately.
+  // Reading history kept a superseded CHANGES_REQUESTED as a blocker forever;
+  // the aggregate `reviewDecision` is now the source, covered by the
+  // superseded/effective pair below.
 
   // POSITIVE CONTROL: this is the test that fails if the partial-read guard is
   // removed — without it, a broken thread query yields "no blockers found".

--- a/plugins/dev/scripts/lib/verified-checks.test.mjs
+++ b/plugins/dev/scripts/lib/verified-checks.test.mjs
@@ -1,0 +1,354 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { ownerForTicket } from "../execution-core/hrw.mjs";
+import {
+  VerificationError,
+  countEventsByName,
+  hrwOwner,
+  mustBeConclusive,
+  ownershipPreflight,
+  prMergeBlockers,
+  resolveOwnership,
+  verifyAll,
+} from "./verified-checks.mjs";
+
+// Each test dir is its own tmp, so parallel runs never collide.
+let _tmpDirs = [];
+function fixtureDir() {
+  const dir = mkdtempSync(resolve(tmpdir(), "verified-checks-test-"));
+  _tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of _tmpDirs) rmSync(dir, { recursive: true, force: true });
+  _tmpDirs = [];
+});
+
+// A GitHub event whose BODY carries a commit message mentioning the event name.
+// This is the real shape that made `grep -c` report 4 events that did not exist.
+const GITHUB_EVENT_MENTIONING_THE_NAME = JSON.stringify({
+  ts: "2026-08-12T03:00:00.000Z",
+  attributes: { "event.name": "github.push" },
+  body: {
+    message: "github.push",
+    payload: { commits: [{ message: "feat: emit phase.advance.applied on every advance" }] },
+  },
+});
+
+const REAL_ADVANCE_EVENT = JSON.stringify({
+  ts: "2026-08-12T05:51:30.000Z",
+  attributes: { "event.name": "phase.advance.applied.CTL-56" },
+  body: { payload: { evidence: "fabricated", asserted_by: "sdk-success-flip" } },
+});
+
+const UNRELATED_EVENT = JSON.stringify({
+  ts: "2026-08-12T05:00:00.000Z",
+  attributes: { "event.name": "linear.issue.updated" },
+  body: { message: "linear.issue.updated CTL-1801" },
+});
+
+describe("(1) countEventsByName — prose that mentions a name is not an occurrence", () => {
+  test("Scenario: counting events by name ignores prose that merely mentions the name", async () => {
+    const lines = [GITHUB_EVENT_MENTIONING_THE_NAME, UNRELATED_EVENT];
+
+    // The defect being fixed: a substring scan sees the commit message and lies.
+    const naiveSubstringCount = lines.filter((l) => l.includes("phase.advance.applied")).length;
+    expect(naiveSubstringCount).toBeGreaterThan(0);
+
+    const verdict = await countEventsByName("phase.advance.applied", { lines });
+    expect(verdict.conclusive).toBe(true);
+    expect(verdict.value).toBe(0);
+    // ...and the zero is licensed by having actually read events.
+    expect(verdict.evidence.parsedEvents).toBe(2);
+  });
+
+  test("counts real events, including the per-ticket dotted suffix", async () => {
+    const verdict = await countEventsByName("phase.advance.applied", {
+      lines: [GITHUB_EVENT_MENTIONING_THE_NAME, REAL_ADVANCE_EVENT, UNRELATED_EVENT],
+    });
+    expect(mustBeConclusive(verdict)).toBe(1);
+  });
+
+  test("an exact-name event matches without a suffix", async () => {
+    const verdict = await countEventsByName("session.heartbeat", {
+      lines: [JSON.stringify({ attributes: { "event.name": "session.heartbeat" } })],
+    });
+    expect(mustBeConclusive(verdict)).toBe(1);
+  });
+
+  test("a sibling name sharing a prefix does NOT match", async () => {
+    // "phase.advance.applied" must not match "phase.advance.applied_shadow".
+    const verdict = await countEventsByName("phase.advance.applied", {
+      lines: [JSON.stringify({ attributes: { "event.name": "phase.advance.applied_shadow" } })],
+    });
+    expect(mustBeConclusive(verdict)).toBe(0);
+  });
+
+  test("reads a real file from disk", async () => {
+    const dir = fixtureDir();
+    const path = resolve(dir, "events.jsonl");
+    writeFileSync(path, [GITHUB_EVENT_MENTIONING_THE_NAME, REAL_ADVANCE_EVENT].join("\n") + "\n");
+    const verdict = await countEventsByName("phase.advance.applied", { logPath: path });
+    expect(mustBeConclusive(verdict)).toBe(1);
+  });
+
+  // POSITIVE CONTROL. These are the tests that fail if the control is removed:
+  // without `parsedEvents > 0`, each of these would return a CONCLUSIVE zero and
+  // an agent would report "the instrument works and found nothing".
+  test("POSITIVE CONTROL: an empty corpus is inconclusive, not zero", async () => {
+    const verdict = await countEventsByName("phase.advance.applied", { lines: [] });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.value).toBeNull();
+    expect(verdict.reason).toContain("could not look");
+    expect(() => mustBeConclusive(verdict)).toThrow(VerificationError);
+  });
+
+  test("POSITIVE CONTROL: an all-unparseable corpus is inconclusive, not zero", async () => {
+    const verdict = await countEventsByName("phase.advance.applied", {
+      lines: ["}{ not json", "also not json"],
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.evidence.parseFailures).toBe(2);
+  });
+
+  test("POSITIVE CONTROL: a missing log file is inconclusive, not zero", async () => {
+    const verdict = await countEventsByName("phase.advance.applied", {
+      logPath: resolve(fixtureDir(), "never-written.jsonl"),
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.reason).toContain("log not found");
+  });
+
+  test("malformed input throws rather than returning a falsy sentinel", async () => {
+    await expect(countEventsByName("")).rejects.toThrow(VerificationError);
+    await expect(countEventsByName("x")).rejects.toThrow(VerificationError);
+    await expect(countEventsByName("x", { lines: "not-an-array" })).rejects.toThrow(VerificationError);
+  });
+});
+
+describe("(2) resolveOwnership — an ownership check refuses rather than answering falsely", () => {
+  const ROSTER = ["mini", "mini-2"];
+
+  test("Scenario: a wrong-order call fails loudly with the expected signature", () => {
+    // The exact transposition that reported 11 tickets as unowned: the roster and
+    // the host name swapped. Positionally this was silent; by name it is impossible,
+    // and the shape check throws.
+    expect(() => resolveOwnership({ ticketId: "CTL-56", roster: "mini", hostName: ROSTER })).toThrow(
+      VerificationError,
+    );
+    expect(() => resolveOwnership({ ticketId: "CTL-56", roster: "mini", hostName: ROSTER })).toThrow(
+      /must be an array of host names/,
+    );
+  });
+
+  test("no ticket is reported unowned on the strength of a malformed call", () => {
+    // The old failure mode returned `false` for all 11. Now every one throws.
+    const tickets = ["CTL-56", "CTL-1790", "CTL-1801"];
+    for (const ticketId of tickets) {
+      expect(() => resolveOwnership({ ticketId, roster: undefined, hostName: "mini" })).toThrow(
+        VerificationError,
+      );
+    }
+  });
+
+  test("a well-formed call answers, and names the owner as evidence", () => {
+    const owner = hrwOwner("CTL-1790", ROSTER);
+    const verdict = resolveOwnership({ ticketId: "CTL-1790", roster: ROSTER, hostName: owner });
+    expect(mustBeConclusive(verdict)).toBe(true);
+    expect(verdict.evidence.owner).toBe(owner);
+
+    const other = ROSTER.find((h) => h !== owner);
+    expect(mustBeConclusive(resolveOwnership({ ticketId: "CTL-1790", roster: ROSTER, hostName: other }))).toBe(
+      false,
+    );
+  });
+
+  test("an empty roster throws instead of silently owning nothing", () => {
+    expect(() => resolveOwnership({ ticketId: "CTL-1", roster: [], hostName: "mini" })).toThrow(
+      VerificationError,
+    );
+  });
+
+  test("DRIFT PIN: hrwOwner agrees with execution-core/hrw.mjs ownerForTicket", () => {
+    // This leaf re-implements the hash to stay dependency-free; if either side
+    // drifts, ownership answers would silently diverge from the daemon's.
+    for (let i = 1; i < 250; i += 1) {
+      const ticketId = `CTL-${i}`;
+      expect(hrwOwner(ticketId, ROSTER)).toBe(ownerForTicket(ticketId, ROSTER));
+      expect(hrwOwner(ticketId, ["mini", "mini-2", "laptop"])).toBe(
+        ownerForTicket(ticketId, ["mini", "mini-2", "laptop"]),
+      );
+    }
+  });
+
+  test("ownershipPreflight requires every roster to agree", () => {
+    const live = ["mini"];
+    const full = ["mini", "mini-2"];
+    // Find a ticket mini owns under the degraded roster but not the full one —
+    // exactly the false negative that strands work when a host is down.
+    let divergent = null;
+    for (let i = 1; i < 500 && divergent === null; i += 1) {
+      const t = `CTL-${i}`;
+      if (hrwOwner(t, live) === "mini" && hrwOwner(t, full) !== "mini") divergent = t;
+    }
+    expect(divergent).not.toBeNull();
+
+    const verdict = ownershipPreflight({ ticketId: divergent, rosters: [live, full], hostName: "mini" });
+    expect(mustBeConclusive(verdict)).toBe(false);
+    expect(verdict.evidence.owners).toHaveLength(2);
+    expect(verdict.evidence.owners[0].owner).toBe("mini");
+    expect(verdict.evidence.owners[1].owner).not.toBe("mini");
+  });
+
+  test("ownershipPreflight is true only when all rosters agree", () => {
+    let agreed = null;
+    for (let i = 1; i < 500 && agreed === null; i += 1) {
+      const t = `CTL-${i}`;
+      if (hrwOwner(t, ["mini"]) === "mini" && hrwOwner(t, ["mini", "mini-2"]) === "mini") agreed = t;
+    }
+    expect(agreed).not.toBeNull();
+    expect(
+      mustBeConclusive(
+        ownershipPreflight({ ticketId: agreed, rosters: [["mini"], ["mini", "mini-2"]], hostName: "mini" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("(3) verifyAll — a loop over an empty candidate set cannot print a verdict", () => {
+  test("Scenario: an empty input set reports inconclusive, NOT verified-clean", () => {
+    // `[].every(p) === true` is the vacuous truth this guard exists to refuse.
+    expect([].every(() => false)).toBe(true);
+
+    const verdict = verifyAll([], () => true, { label: "candidate files" });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.value).toBeNull();
+    expect(verdict.reason).toContain("no candidate files found");
+    expect(verdict.reason).toContain("inconclusive");
+    expect(() => mustBeConclusive(verdict)).toThrow(VerificationError);
+  });
+
+  test("a non-empty set is actually checked", () => {
+    expect(mustBeConclusive(verifyAll(["a", "b"], (x) => x.length === 1))).toBe(true);
+    const failing = verifyAll(["a", "bb"], (x) => x.length === 1);
+    expect(mustBeConclusive(failing)).toBe(false);
+    expect(failing.evidence.failed).toEqual(["bb"]);
+    expect(failing.evidence.checked).toBe(2);
+  });
+
+  test("a predicate that throws is a failure to look, not a pass", () => {
+    const verdict = verifyAll(["a"], () => {
+      throw new Error("grep exploded");
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.reason).toContain("grep exploded");
+  });
+
+  test("malformed input throws", () => {
+    expect(() => verifyAll("not-an-array", () => true)).toThrow(VerificationError);
+    expect(() => verifyAll([], "not-a-function")).toThrow(VerificationError);
+  });
+});
+
+describe("(4) prMergeBlockers — consult every surface that can block a merge", () => {
+  // A PR with zero bot issue-comments but one unresolved review thread: the exact
+  // shape that was reported as review-clean.
+  const fakeGh = (overrides = {}) => {
+    return async (args) => {
+      if (args[0] === "pr") {
+        return {
+          isDraft: false,
+          mergeStateStatus: "BLOCKED",
+          statusCheckRollup: [{ name: "validate", conclusion: "SUCCESS" }],
+          reviews: [],
+          ...(overrides.pr ?? {}),
+        };
+      }
+      if (args[0] === "__reviewThreads__") {
+        return overrides.threads ?? [{ id: "T_1", isResolved: false, path: "src/a.ts" }];
+      }
+      if (args[0] === "__issueComments__") return overrides.comments ?? [];
+      throw new Error(`unexpected args ${args.join(" ")}`);
+    };
+  };
+
+  test("Scenario: zero bot issue-comments but one unresolved thread reports the thread", async () => {
+    const verdict = await prMergeBlockers({ prNumber: 3276, runJson: fakeGh() });
+    const blockers = mustBeConclusive(verdict);
+    expect(verdict.evidence.commentsSeen).toBe(0);
+    const threadBlockers = blockers.filter((b) => b.kind === "unresolved-thread");
+    expect(threadBlockers).toHaveLength(1);
+    expect(threadBlockers[0].path).toBe("src/a.ts");
+  });
+
+  test("a genuinely clean PR reports no blockers", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: fakeGh({ threads: [{ id: "T_1", isResolved: true }] }),
+    });
+    expect(mustBeConclusive(verdict)).toEqual([]);
+  });
+
+  test("failing and pending checks are both blockers", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: fakeGh({
+        pr: {
+          statusCheckRollup: [
+            { name: "validate", conclusion: "FAILURE" },
+            { name: "pages", conclusion: null },
+            { name: "ok", conclusion: "SUCCESS" },
+          ],
+        },
+        threads: [],
+      }),
+    });
+    const blockers = mustBeConclusive(verdict);
+    expect(blockers.filter((b) => b.kind === "failing").map((b) => b.name)).toEqual(["validate"]);
+    expect(blockers.filter((b) => b.kind === "pending").map((b) => b.name)).toEqual(["pages"]);
+  });
+
+  test("a human CHANGES_REQUESTED review is a blocker", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: fakeGh({
+        pr: { reviews: [{ state: "CHANGES_REQUESTED", author: { login: "ryan" } }] },
+        threads: [],
+      }),
+    });
+    expect(mustBeConclusive(verdict).some((b) => b.kind === "changes-requested")).toBe(true);
+  });
+
+  // POSITIVE CONTROL: this is the test that fails if the partial-read guard is
+  // removed — without it, a broken thread query yields "no blockers found".
+  test("POSITIVE CONTROL: a failing surface makes the whole verdict inconclusive", async () => {
+    const verdict = await prMergeBlockers({
+      prNumber: 1,
+      runJson: async (args) => {
+        if (args[0] === "__reviewThreads__") throw new Error("GraphQL 502");
+        return args[0] === "pr" ? { isDraft: false, statusCheckRollup: [], reviews: [] } : [];
+      },
+    });
+    expect(verdict.conclusive).toBe(false);
+    expect(verdict.reason).toContain("cannot report 'nothing is blocking'");
+    expect(verdict.evidence.failures[0]).toContain("GraphQL 502");
+    expect(() => mustBeConclusive(verdict)).toThrow(VerificationError);
+  });
+
+  test("malformed input throws", async () => {
+    await expect(prMergeBlockers({ prNumber: 0, runJson: async () => ({}) })).rejects.toThrow(
+      VerificationError,
+    );
+    await expect(prMergeBlockers({ prNumber: 1 })).rejects.toThrow(VerificationError);
+  });
+});
+
+describe("mustBeConclusive", () => {
+  test("rejects a non-verdict rather than passing it through", () => {
+    expect(() => mustBeConclusive(0)).toThrow(VerificationError);
+    expect(() => mustBeConclusive(null)).toThrow(VerificationError);
+    expect(() => mustBeConclusive({ value: 3 })).toThrow(VerificationError);
+  });
+});

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -12,7 +12,7 @@ sidebar:
 
 Every `catalyst-*` CLI is installed onto your `PATH` by
 [`install-cli.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/install-cli.sh) (into
-`~/.catalyst/bin` by default). This page lists all 31 of them — one line of
+`~/.catalyst/bin` by default). This page lists all 32 of them — one line of
 purpose plus the key subcommands — grouped by area. Run any tool with `--help`
 for full syntax. The richer tools have their own reference pages (e.g.
 [catalyst-stack](/reference/catalyst-stack/)).
@@ -90,6 +90,14 @@ Explain why the daemon believes a worker is alive, stuck, or dead (belief→rule
 Live, human-readable Linear-state + phase transition log (tails the event stream — bare runs forever).
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-transitions)
+
+### catalyst-verify
+
+Verified checks that cannot report a clean result from a check that never ran — count events by exact event.name, resolve HRW ticket ownership under named rosters, enumerate every PR merge blocker (exit 2 = INCONCLUSIVE).
+
+**Key subcommands:** _(run `catalyst-verify --help`)_
+
+[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-verify)
 
 ## Session & state
 


### PR DESCRIPTION
Closes CTL-1801.

Four verification checks reported a clean/negative result when the truth was the opposite. **In every case the negative was produced by the instrument failing, not by the world** — and nothing in the output distinguished the two.

| # | check | reported | truth | why it lied |
|---|---|---|---|---|
| 1 | `grep -c "phase.advance.applied"` | 4 events | **0** | matched the string inside a **commit message** carried in a GitHub event body |
| 2 | `ownedBy(ticket, host, roster)` ×11 | "NO" ×11 | 6 owned | wrong arity → `undefined` → falsy |
| 3 | `T=$(grep -rl …)`; loop over `$T` | "unrelated" | unverified | `$T` empty → vacuous loop → conclusion printed anyway |
| 4 | count Codex **issue comments** | 0 → "no review" | a **review thread** blocked it | right question, wrong API surface |

One class: **a check that cannot distinguish "the thing is absent" from "I could not look."** Invariant I1, applied to our own tooling.

> This session produced three more instances while *writing the fix*: a `grep` that matched the event name inside Linear ticket descriptions, a test-result extractor that silently matched nothing because of ANSI codes, and an `$?` read after a pipe that reported `head`'s status. All three were caught by positive controls, none by the check itself.

## Deliverable 1 — the house rule

`AGENTS.md` → "Working the Loop" gains a verification-discipline rule, placed **first** because it governs every bullet below it:

> A negative result is only evidence if you can state what a positive one would have looked like **and you ran the same instrument against a case known to be present and saw it come back non-zero.**

## Deliverable 2 — verified helpers

`plugins/dev/scripts/lib/verified-checks.mjs` (zero-import leaf, so `catalyst doctor`'s bare-Node runtime can load it) plus the `catalyst-verify` CLI.

The design rule: **every helper returns a verdict that can be explicitly `inconclusive`** — never a bare `0`/`false`/`undefined` a caller can mistake for a measurement. Malformed input **throws** rather than degrading to a falsy sentinel.

- `countEventsByName` — matches only the `event.name` **field** (exact, or the dotted per-ticket suffix). Prose mentioning the name is structurally unreachable. Its positive control is `parsedEvents`: a zero is conclusive only if the instrument demonstrably read real events.
- `resolveOwnership` — takes **named options**, so defect (2)'s transposition is structurally unavailable: arguments with names have no order to get wrong. A drift-pin test asserts agreement with `execution-core/hrw.mjs` across 250 tickets.
- `ownershipPreflight` — asks under **every** candidate roster, claiming ownership only when all agree. A rostered-but-down host otherwise produces a false negative that strands a ticket.
- `verifyAll` — an empty candidate set is `inconclusive` by construction, refusing the vacuous truth of `[].every(p)`.
- `prMergeBlockers` — reads checks + review threads + reviews + issue comments, and is `inconclusive` if **any** surface fails. A partial read must never report "nothing is blocking".

**Exit codes carry the distinction across the shell boundary**, where it is otherwise lost: `0` clean/yes · `1` dirty/no · **`2` INCONCLUSIVE** · `3` usage error.

## Verification

The ticket requires each helper to "carry a test that fails when its positive control is removed." Proven by mutation:

| mutation | result |
|---|---|
| remove `countEventsByName`'s `parsedEvents` guard | **2 fail** |
| remove `prMergeBlockers`' partial-read guard | **1 fail** |
| make `verifyAll` vacuously true on empty | **1 fail** |
| restored | **27 passed / 0 failed** |

Exercised against live data — the CLI read **2,255,715 events** from the unified log and returned a *licensed* zero for `phase.advance.applied` (the laptop mirror has none; mini has 31), where the original `grep` returned a false 21 off ticket prose. Run against this very PR queue, `pr-blockers 3276` correctly named `execution-core-unit-tests` as the blocker.

**38 tests** (27 unit + 11 CLI exit-code). No existing behavior changes: the module is new and has no prior callers.