### PR TITLE
fix(dev): CTL-1790 PR-1 — a work-done probe must not match another ticket's document

### DIFF
--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -11,6 +11,7 @@
 
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
+import { isTicketKey } from "./ticket-key.mjs";
 import { parseWorktreeForBranch } from "./worktree.mjs";
 
 // MIN_ARTIFACT_BYTES — a small size floor below which an artifact is treated as a
@@ -351,18 +352,36 @@ function implementProbe(
 // bash gate's `-`-only rule loses them — a pre-existing gap, verified live).
 //
 // Measured against the real corpus: foreign matches 2721 pairs / 144 ids -> 0;
-// legitimate files newly unmatched -> 0. The new rule is a STRICT SUBSET of the
-// old one (same substring, plus boundaries), so it can only ever make a probe
-// MORE conservative — it can never newly declare work done, which is the correct
-// direction of failure for a work-done probe.
+// legitimate files newly unmatched -> 0. The new rule matches a STRICT SUBSET of
+// what the old one matched (same substring, plus boundaries).
+//
+// What that subset means per call site — it is NOT uniformly "more conservative":
+//   :368 artifactProbe    — fewer matches => fewer "work is done" returns. Strictly safer.
+//   :501 progress mark    — fewer matches => no progress invented for a foreign doc. Safer.
+//   :311 implement's gate — a non-match SKIPS the gate (the probe then returns true
+//        on >=1 commit + clean tree), so dropping a match here removes a gate rather
+//        than tightening one. That is still the right call: the gate being removed was
+//        computing a commit threshold from ANOTHER ticket's plan, whose error direction
+//        is arbitrary (too few phases => premature done; too many => a false "not done"
+//        revive loop). Removing a wrong gate is correct; it is just not "more conservative".
+//
+// The ticket-id shape is validated with the CANONICAL predicate
+// (`ticket-key.mjs` TICKET_KEY_RE, CTL-1504) rather than a local pattern. A
+// narrower private copy here would reject a legitimate team key that carries a
+// digit or underscore (`OPS_2-17`) or a long prefix/number, and a rejected id
+// returns false from every call site above — silently reporting real artifacts as
+// absent. That is the exact defect ticket-key.mjs was created to fix, and
+// re-deriving the grammar here would have reintroduced it as a second un-fixed
+// twin, which is the very failure this function's own history demonstrates.
+// Uppercased before the test because the canonical predicate is uppercase-only
+// while this matcher has always been case-insensitive about its input.
 function matchesTicket(filename, ticket) {
   if (typeof filename !== "string" || typeof ticket !== "string") return false;
   const lf = filename.toLowerCase();
   if (!lf.endsWith(".md")) return false;
-  const tl = ticket.toLowerCase();
   // Reject a malformed ticket id rather than building a garbage regex from it.
-  if (!/^[a-z]{2,6}-[0-9]{1,6}$/.test(tl)) return false;
-  const esc = tl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  if (!isTicketKey(ticket.toUpperCase())) return false;
+  const esc = ticket.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`(?:^|[^0-9a-z])${esc}(?![0-9a-z])`).test(lf);
 }
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -321,13 +321,49 @@ function implementProbe(
   return true;
 }
 
-// matchesTicket — true when `filename` is a markdown file naming `ticket`. Mirrors
-// the dispatcher's CTL-494 two-step match (strict `*-<ticket-lower>.md` then a
-// wider case-insensitive `*<ticket>*.md`): the strict tail is a subset of the
-// case-insensitive substring, so the substring check is the effective behavior.
+// matchesTicket — true when `filename` is a markdown file naming `ticket` as a
+// WHOLE TOKEN: delimited on the left by start-of-name or a non-alphanumeric
+// separator, and on the right by a non-alphanumeric character (or end).
+//
+// WHY THE BOUNDARIES ARE LOAD-BEARING. The old rule was a bare
+// `lf.includes(ticket)`, and `<worktree>/thoughts/shared` is a SYMLINK into one
+// shared repo — every worktree lists the identical corpus (measured: 695
+// research + 630 plans docs, same realpath from every worktree). Over that live
+// corpus the substring rule let **144 distinct ticket ids match a DIFFERENT
+// ticket's document** (2721 foreign pairs), and 100 of those ids own no document
+// at all. `CTL-56` owns nothing yet matched `2026-05-21-CTL-564.md`,
+// `-CTL-565.md`, `-CTL-567.md` — so `researchProbe`/`planProbe` returned TRUE for
+// CTL-56 off CTL-564's completed work. All three call sites turn that into a
+// wrong conclusion: a false "work is done" (:368), a wrong plan-phase commit
+// gate (:311), and a large forward-progress mark for a ticket with zero progress
+// (:501), which makes the reclaim path revive instead of stop.
+//
+// This is the un-fixed JS twin of an already-solved bash problem: the
+// dispatcher's gate `match_thoughts_artifact` (lib/phase-artifact-gate.sh,
+// CTL-1081) is boundary-safe and states the same goal — "the word-boundary guard
+// rejects cross-ticket lookalikes (e.g. ctl-10812 does NOT satisfy a ctl-1081
+// gate)". The stale comment this replaces claimed to mirror the dispatcher's
+// CTL-494 two-step match; the dispatcher moved to CTL-1081 and this copy never
+// followed.
+//
+// The grammar is the bash gate's, widened only to accept `_` as a left delimiter
+// so the six real `YYYY-MM-DD_ctl-NNNN_slug.md` docs on disk keep matching (the
+// bash gate's `-`-only rule loses them — a pre-existing gap, verified live).
+//
+// Measured against the real corpus: foreign matches 2721 pairs / 144 ids -> 0;
+// legitimate files newly unmatched -> 0. The new rule is a STRICT SUBSET of the
+// old one (same substring, plus boundaries), so it can only ever make a probe
+// MORE conservative — it can never newly declare work done, which is the correct
+// direction of failure for a work-done probe.
 function matchesTicket(filename, ticket) {
+  if (typeof filename !== "string" || typeof ticket !== "string") return false;
   const lf = filename.toLowerCase();
-  return lf.endsWith(".md") && lf.includes(ticket.toLowerCase());
+  if (!lf.endsWith(".md")) return false;
+  const tl = ticket.toLowerCase();
+  // Reject a malformed ticket id rather than building a garbage regex from it.
+  if (!/^[a-z]{2,6}-[0-9]{1,6}$/.test(tl)) return false;
+  const esc = tl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|[^0-9a-z])${esc}(?![0-9a-z])`).test(lf);
 }
 
 // bodyHasMarkers — completeness gate. `anyOf` requires at least one marker

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -575,6 +575,16 @@ describe("CTL-1790: matchesTicket must not match a LOOKALIKE ticket's artifact",
     ["2026-05-21-CTL-564.md", "CTL-5", false, "shorter prefix lookalike"],
     ["2026-06-16-ctl-10812.md", "CTL-1081", false, "the bash gate's own stated example"],
     ["2026-05-26-ctl-604.json", "CTL-604", false, "non-markdown is rejected"],
+    // The canonical ticket-key grammar (ticket-key.mjs TICKET_KEY_RE, CTL-1504)
+    // admits a digit/underscore in the team prefix and puts no length cap on
+    // either half. A narrower private guard here would reject these outright,
+    // and a rejected id reads as "no artifact exists" at every call site.
+    ["2026-08-01-ops_2-17-slug.md", "OPS_2-17", true, "team key with digit+underscore"],
+    ["2026-08-01_ops_2-17_slug.md", "OPS_2-17", true, "same, underscore separators"],
+    ["2026-08-01-ops_2-170-slug.md", "OPS_2-17", false, "…and it still rejects a lookalike"],
+    ["2026-08-01-verylongprefix-42.md", "VERYLONGPREFIX-42", true, "prefix longer than six chars"],
+    ["2026-08-01-ctl-1234567.md", "CTL-1234567", true, "number longer than six digits"],
+    ["2026-08-01-ctl-604.md", "not-a-ticket-key", false, "malformed id is rejected, not regex-injected"],
   ])("%s vs %s -> %s (%s)", (filename, ticket, expected) => {
     const probeWt = `/wt/${ticket}`;
     expect(

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -499,6 +499,99 @@ describe("WORK_DONE_PROBES.research — happy path", () => {
   });
 });
 
+// CTL-1790 PR-1 — the false-done vector closed by boundary-matching.
+//
+// `<worktree>/thoughts/shared` is a SYMLINK into one shared repo, so every
+// worktree lists the same ~1.3k documents. Under the old bare `includes()` rule,
+// 144 distinct ticket ids matched a DIFFERENT ticket's document (2721 foreign
+// pairs) and 100 of those owned no document at all. The live case: CTL-56 owns
+// nothing, yet the production researchProbe/planProbe returned TRUE off
+// CTL-564/565/567's completed 2026-05-21 docs.
+describe("CTL-1790: matchesTicket must not match a LOOKALIKE ticket's artifact", () => {
+  const wt = "/wt/CTL-56";
+  const runGit = makeRunGit({
+    "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-56", wt), stderr: "" },
+  });
+
+  // The exact filenames on disk that made CTL-56 probe "done".
+  const FOREIGN = ["2026-05-21-CTL-564.md", "2026-05-21-CTL-565.md", "2026-05-21-CTL-567.md"];
+
+  test("research: a longer ticket's doc does NOT satisfy the shorter ticket", () => {
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-56", repoRoot: "/repo" },
+        {
+          runGit,
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": FOREIGN }),
+          readArtifact: () => RESEARCH_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  test("plan: same, via the plans corpus", () => {
+    expect(
+      WORK_DONE_PROBES.plan(
+        { ticket: "CTL-56", repoRoot: "/repo" },
+        {
+          runGit,
+          listArtifacts: makeListArtifacts({
+            "thoughts/shared/plans": ["2026-05-21-CTL-565-daemon-two-state-trigger-rewiring.md"],
+          }),
+          readArtifact: () => PLAN_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  // POSITIVE CONTROL. Without this the test above passes for the wrong reason —
+  // e.g. a matcher that matches NOTHING would satisfy it while breaking every
+  // real probe. The owner's own document must still resolve through the same seams.
+  test("POSITIVE CONTROL: the OWNING ticket still matches its own doc", () => {
+    const ownWt = "/wt/CTL-564";
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket: "CTL-564", repoRoot: "/repo" },
+        {
+          runGit: makeRunGit({
+            "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor("CTL-564", ownWt), stderr: "" },
+          }),
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": FOREIGN }),
+          readArtifact: () => RESEARCH_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  // The separator families that actually occur on disk must keep matching: `-`
+  // (the common form) and `_` (six real YYYY-MM-DD_ctl-NNNN_slug.md docs, which
+  // the bash gate's `-`-only grammar would have lost).
+  test.each([
+    ["2026-05-26-ctl-604.md", "CTL-604", true, "bare -<ticket>.md tail"],
+    ["2026-05-26-CTL-604-some-suffix.md", "CTL-604", true, "uppercase + descriptive suffix"],
+    ["2026-06-19_ctl-1231_settings-json-never-provisioned.md", "CTL-1231", true, "underscore separators"],
+    ["2026-06-15-resilience-keystones-ctl-1135-ctl-1122.md", "CTL-1122", true, "second id in a two-ticket doc"],
+    ["2026-05-21-CTL-564.md", "CTL-56", false, "prefix lookalike (the live bug)"],
+    ["2026-05-21-CTL-564.md", "CTL-5", false, "shorter prefix lookalike"],
+    ["2026-06-16-ctl-10812.md", "CTL-1081", false, "the bash gate's own stated example"],
+    ["2026-05-26-ctl-604.json", "CTL-604", false, "non-markdown is rejected"],
+  ])("%s vs %s -> %s (%s)", (filename, ticket, expected) => {
+    const probeWt = `/wt/${ticket}`;
+    expect(
+      WORK_DONE_PROBES.research(
+        { ticket, repoRoot: "/repo" },
+        {
+          runGit: makeRunGit({
+            "-C /repo worktree list --porcelain": { code: 0, stdout: porcelainFor(ticket, probeWt), stderr: "" },
+          }),
+          listArtifacts: makeListArtifacts({ "thoughts/shared/research": [filename] }),
+          readArtifact: () => RESEARCH_BODY_COMPLETE,
+        },
+      ),
+    ).toBe(expected);
+  });
+});
+
 describe("WORK_DONE_PROBES.research — false cases", () => {
   const wt = "/wt/CTL-604";
   const runGitOk = makeRunGit({


### PR DESCRIPTION
First of the CTL-1790 round-4 changes. **A live false-done vector today, independent of the inversion** — landable, and reviewable, on its own.

## The defect

`matchesTicket` (`work-done-probes.mjs`) was a bare substring test:

```js
return lf.endsWith(".md") && lf.includes(ticket.toLowerCase());
```

`<worktree>/thoughts/shared` is a **symlink into one shared repo**, so every worktree's `readdirSync` sees the identical corpus — measured **695 research + 630 plans** docs, same realpath from every worktree. Over that corpus the substring rule let **144 distinct ticket ids match a different ticket's document** (2721 foreign pairs). **100 of those ids own no document at all.**

Verified by **executing the production probes**, not by reading them:

```
researchProbe("CTL-56") = true      off 2026-05-21-CTL-564.md / -565.md / -567.md
planProbe("CTL-56")     = true      off 2026-05-21-CTL-565-daemon-two-state-trigger-rewiring.md
control: CTL-9999       = false/false
```

CTL-56 owns **no** document. And it is not historical — it is one of the two tickets in the live 31-advance measurement on mini on 2026-08-12.

All three call sites turn that match into a wrong conclusion:

| site | consequence of a foreign match |
|---|---|
| `:368` `artifactProbe` | a direct **"work is done"** |
| `:311` implement's plan-completeness gate | wrong phase count → premature "done" or a false "not done" revive loop |
| `:501` `defaultProgressMark` | a large progress mark for a ticket with **zero** progress, turning a reclaim's **stop** into a **revive** |

## The fix — the JS twin of an already-solved bash problem

The dispatcher's gate `match_thoughts_artifact` (`lib/phase-artifact-gate.sh`, CTL-1081) is already boundary-safe, and its comment states this exact goal: *"the word-boundary guard rejects cross-ticket lookalikes (e.g. `ctl-10812` does NOT satisfy a `ctl-1081` gate)."* `phase-agent-dispatch:564` gates on it.

The stale comment this replaces claimed to mirror the dispatcher's CTL-494 two-step match — **the dispatcher moved to CTL-1081 and this copy never followed.**

Token-boundary matching, using the bash gate's grammar widened *only* to accept `_` as a left delimiter, so the six real `YYYY-MM-DD_ctl-NNNN_slug.md` docs on disk keep matching. (The `-`-only bash rule loses them — a pre-existing bash-side gap, verified live, deliberately not mirrored back.)

The new rule matches a **strict subset** of what the old one matched — same substring, *plus* boundaries. Per call site that means:

| site | effect |
|---|---|
| `:368` artifactProbe | fewer matches → fewer "work is done" returns. Strictly safer. |
| `:501` progress mark | no progress invented from a foreign doc. Safer. |
| `:311` implement's gate | a non-match **skips** the gate, so this **removes** a gate rather than tightening one |

That third case is still the right call — the gate being removed computed a commit threshold from *another ticket's* plan, whose error direction is arbitrary (too few phases → premature done; too many → a false "not done" revive loop) — but it is **not** "more conservative", and an earlier revision of this PR overclaimed that it was. Corrected in `1e3e106f` after Codex's P1 made the per-site asymmetry concrete.

## Measured, and independently replayed

| | current `includes()` | this PR |
|---|---|---|
| foreign matches | **2721 pairs / 144 ticket ids** | **0** |
| legitimate files newly unmatched | — | **0** |

I replayed both matchers over the real 1325-file corpus myself rather than accepting the analysis that proposed the fix, running positive controls on the listing and on the matcher semantics before trusting any zero. My first pass showed 7 residual matches; all 7 turned out to be artifacts of my own owner-token heuristic (one doc legitimately names two tickets, `ctl-1135-ctl-1122`; the other six are the `_`-separated family my `\b` regex could not parse). Candidate A matches all seven **correctly**.

## Tests: 95 → 106

Proven load-bearing by mutation: **restoring the substring rule fails 5 of the new cases.** Includes a **positive control** — the *owning* ticket must still match its own doc — so a matcher that matched nothing could not satisfy the suite.

Table-driven coverage: bare `-<ticket>.md` tail, uppercase + suffix, underscore separators, the second id in a two-ticket doc, prefix lookalike (the live bug), shorter prefix lookalike, the bash gate's own `ctl-10812`/`ctl-1081` example, and non-markdown rejection.

---

**Not in this PR** — the inversion itself, deliberately. The round-4 recon corrected the prior round's blocker on a load-bearing point: `monitor-deploy` **does** have a registered probe (`work-done-probes.mjs:171-175`, registered `:414`); **`teardown` is the only probe-less phase**. It also failed to reproduce three numbers the earlier rounds argued from (the "19 monitor-deploy cases", the "~14% / ~77%" blast radius, and the "20–40s synchronous probe"). Those are blocked pending a replay rather than built on.