### PR TITLE
fix(dev): CAT-219 window fence suppression events

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -710,6 +710,7 @@ jobs:
             event-log-window.test.mjs \
             event-log-read-guard.test.mjs \
             fence-guard.test.mjs \
+            fence-standoff.test.mjs \
             fence-guard-integration.test.mjs \
             terminal-done-cooldown.test.mjs \
             fleet-health-event.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,52 @@ outage (heartbeat read throws / everyone looks dead) degrades to the **full rost
 only its own HRW slice — never double-acts). The Linear-CAS claim (`cluster-claim.mjs` soft-CAS on
 `catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains the transition-race serializer.
 
+**Fence-standoff bound (CAT-173).** Two live hosts can each hold evidence that the other owns a
+ticket, causing every fence-guarded human escalation to be suppressed. Each escalation site records
+that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both
+the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an
+unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the
+notification bridge can surface the ticket without a Linear write.
+
+Only a MUTUAL standoff counts, and a standoff is by definition AMBIGUOUS — nobody can tell who owns
+the ticket. Just two `fenceGuard` verdicts are ambiguous in that sense and so accumulate toward the
+bound: `unverifiable` (the authoritative read neither confirmed nor refuted this host's generation)
+and `threw` (fail-closed on an error), alongside a non-fail-open `missing-generation`.
+
+The CONFIRMED-TAKEOVER verdicts are the opposite — positive evidence that a specific other host holds
+the claim, which is the correct outcome on the superseded host after a healthy takeover, where
+`fenceGuard` deliberately leaves the escalation to the current owner (whose own fence passes).
+There are TWO of them and BOTH are excluded: `foreign-owner` (the projection names a different owner
+host) and `superseded` (the authoritative read returned `stale: true`, i.e. a newer generation
+exists — the shape an ordinary healthy takeover takes on the old host, discovered via generation
+rather than owner identity). Counting either would let a lingering worker directory on the old host
+cross the bound and page an operator about a ticket the new owner is actively processing, so both are
+excluded from accounting and additionally CLEAR the ledger, letting a later genuine standoff start
+a fresh episode instead of inheriting a stale count and age.
+
+The record is GC-surviving and reaches the board two ways. When the ticket has **no** card,
+`synthesizeDurableEscalations` mints one. When it already has a card, that function's id dedupe
+drops the record, so `mergeDurableEscalationsIntoCards` runs first and stamps the escalation's
+reason onto the existing card — but only when that card carries no `attention` yet, so a live
+reason always wins. Both halves are needed: a terminal-sweep standoff has a live `failed`/`stalled`
+signal (hence a card, hence `deriveAttention`'s `phaseFailed` → `needs-human`) and only wanted the
+standoff-specific reason, whereas a stale-PR standoff on a `BEHIND` PR has a card with **no**
+attention at all — `BEHIND` is excluded from `PR_BLOCKER_STATES` as auto-rebasable and the fence
+suppressed the label — so before the merge pass its break-glass reached no operator surface,
+including the push bridge, which projects only board tickets.
+
+This changes no `fenceGuard` decision: every write suppressed before CAT-173 remains suppressed.
+It does change the **retry cadence** of those suppressed writes. Crossing the bound stamps a
+`.fence-standoff-cooldown` (default 6 h) that gates the same terminal-sweep probe+write block
+`.fence-suppressed` (15 min) already gated, so after a break-glass a healed standoff's `needs-human`
+label write — and the terminal-clear branch that retracts it on a late Done — is retried every 6 h
+rather than every 15 min. A break-glass whose delivery FAILS drops the 15-minute marker to retry on
+the next tick, bounded by `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` (default 5) so a persistently
+unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn. That bound is only enforceable
+while the attempt counter survives the tick, so a failed-delivery increment that cannot be persisted
+(full disk, read-only mount) fails CLOSED — reported as not-retryable rather than retryable-forever,
+since an unpersisted counter can never grow past the max.
+
 **Board-health ownership scope (CAT-57).** Board-health uses the same dispatch roster as the
 scheduler's new-work gate when assigning eligible tickets, rather than hashing over the raw roster.
 Its `dispatchLiveness` invariant judges only this host's owned queue, while preserving the raw and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -548,7 +548,9 @@ label application:
   ensures the chokepoint's coercion cannot overwrite it.
 
 New event names (registered in `broker/namespace-parity.test.mjs`): `escalation.explanation-absent`,
-`delegate.would-route`, `delegate.routed`, `delegate.route-fallback`.
+`escalation.fence-suppressed`, `delegate.would-route`, `delegate.routed`,
+`delegate.route-fallback`. A fence suppression is a deliberate no-write;
+`escalation.fence-suppressed` makes that decision operator-visible instead of silent.
 
 ### Runaway-loop guards (CTL-671)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -550,7 +550,17 @@ label application:
 New event names (registered in `broker/namespace-parity.test.mjs`): `escalation.explanation-absent`,
 `escalation.fence-suppressed`, `delegate.would-route`, `delegate.routed`,
 `delegate.route-fallback`. A fence suppression is a deliberate no-write;
-`escalation.fence-suppressed` makes that decision operator-visible instead of silent.
+`escalation.fence-suppressed` makes that decision operator-visible instead of silent. It emits at
+most once per `(ticket, site)` during `CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS` (15 minutes by
+default) and fails open when its marker is absent or malformed. Scheduler Pass 4 reaps
+`orchDir/.fence-suppressed-emits/` with a TTL equal to that window, so raising the emission window
+also raises marker retention.
+
+The stale-PR rescue escalation path is fence-guarded, but the daemon deliberately leaves its
+`gateway` seam latent. Threading the production gateway would make the authoritative fence read
+fail closed; an indeterminate Linear read such as a 401 could then silently suppress the human
+escalation. The timer's `self` value remains load-bearing both as the discriminator for a
+self-owned projection row and as the `host` dimension on `escalation.fence-suppressed`.
 
 ### Runaway-loop guards (CTL-671)
 

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -46,6 +46,7 @@ import { JANITOR_EVENT_TYPES } from "../execution-core/janitor-event-types.mjs";
 import { UNSTUCK_SWEEP_EVENT_TYPES } from "../execution-core/unstuck-sweep-event-types.mjs";
 import { LINEAR_READ_EVENT } from "../execution-core/linear-read-event.mjs"; // CTL-1403
 import { ALERT_BOOT_DEPENDENCY_UNUSABLE } from "../execution-core/dispatch-alert.mjs";
+import { FENCE_STANDOFF_EVENT } from "../execution-core/fence-standoff.mjs"; // CAT-173
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -86,6 +87,7 @@ const EXEC_CORE_EVENT_NAMES = [
   ...UNSTUCK_SWEEP_EVENT_TYPES,
   LINEAR_READ_EVENT, // CTL-1403 reads-by-source (catalyst.linear.read)
   ALERT_BOOT_DEPENDENCY_UNUSABLE,
+  FENCE_STANDOFF_EVENT,
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -66,6 +66,7 @@ const INLINE_EVENT_NAMES = [
   "fence.claimed.CTL-1",              // CTL-863 fence-event.mjs (exec-core-owned, projected-not-re-emitted)
   "fence.released.CTL-1",             // CTL-863 fence-event.mjs
   "escalation.explanation-absent",    // CTL-1609 label-guard.mjs (warn when explanation omitted)
+  "escalation.fence-suppressed",      // CAT-3 scheduler/stale-pr-rescue fence suppression visibility
   "delegate.would-route",             // CTL-1609 delegate-first.mjs (shadow mode — would enqueue)
   "delegate.routed",                  // CTL-1609 delegate-first.mjs (enforce mode — enqueued ok)
   "delegate.route-fallback",          // CTL-1609 delegate-first.mjs (enforce mode — queue full / failed)

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -2032,6 +2032,9 @@ function startReaperAndTimer({
       intervalSeconds: rescueCfg.intervalSeconds ?? RESCUE_DEFAULTS.intervalSeconds,
       orchDir,
       config: rescueCfg,
+      // CAT-219-GATEWAY-LATENT: do not thread a gateway here. Its authoritative
+      // read is fail-closed, so an indeterminate Linear read could silently
+      // suppress the human escalation this timer exists to surface.
       // CTL-1609 (Codex P1): the delegate ceiling for this timer's escalation
       // enqueues. Resolved lazily per escalation (not captured at boot) so an
       // autotuned maxParallel is honored without a daemon restart. Injected here

--- a/plugins/dev/scripts/execution-core/fence-guard-integration.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard-integration.test.mjs
@@ -162,6 +162,28 @@ describe("schedulerTick terminalDoneOnce fence guard (site 1, CTL-863)", () => {
     });
     expect(doneCalls).not.toContain("CTL-S1");
   });
+
+  test("completed tick reaps expired fence-event markers and preserves fresh ones", () => {
+    const dir = join(orchDir, ".fence-suppressed-emits");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "old.applied"), JSON.stringify({ emittedAt: 1 }));
+    writeFileSync(join(dir, "fresh.applied"), JSON.stringify({ emittedAt: 999_999 }));
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: () => ({ code: 0, stdout: "" }),
+      writeStatus: {
+        applyTerminalDone: () => ({ applied: true }),
+        applyPhaseStatus: () => ({ applied: true }),
+        applyLabel: () => ({ applied: true }),
+      },
+      liveBackgroundCount: () => 0,
+      teardownWorktree: () => true,
+      hosts: ["single-host"],
+      now: () => 1_000_000,
+    });
+    expect(existsSync(join(dir, "old.applied"))).toBe(false);
+    expect(existsSync(join(dir, "fresh.applied"))).toBe(true);
+  });
 });
 
 // ── Site 10: defaultEscalate (stale-pr-rescue-timer) suppressed by stale fence ─
@@ -439,5 +461,37 @@ describe("schedulerTick ctl-925 cycle escalation — HRW ownership gate", () => 
     // pick the escalation up rather than letting it strand.
     expect(ownerForTicket(member, [survivor])).toBe(survivor);
     expect(runAs(survivor, { survivors: [survivor] })).toContain(member);
+  });
+
+  test("foreign-owner suppression emits each cycle member with the injected host", () => {
+    const hostName = ownerForTicket(RING[0], ROSTER);
+    // Both fixture identifiers intentionally share the same owner under this roster.
+    expect(ownerForTicket(RING[1], ROSTER)).toBe(hostName);
+    const events = [];
+    schedulerTick(orchDir, {
+      readEligible: ring,
+      dispatch: () => ({ code: 0, stdout: "" }),
+      writeStatus: {
+        applyTerminalDone: () => ({ applied: true }),
+        applyPhaseStatus: () => ({ applied: true }),
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+        applyBlockedByRelation: () => ({ applied: true }),
+      },
+      liveBackgroundCount: () => 0,
+      teardownWorktree: () => true,
+      hosts: ROSTER,
+      hostName,
+      dispatchSurvivingRoster: ROSTER,
+      gateway: { getDescriptor: () => ({ ownerHost: "foreign-host", generation: 2 }) },
+      appendFenceSuppressedEvent: (event) => events.push(event),
+      now: () => 1_000,
+    });
+    expect(events.map((event) => event.ticket).sort()).toEqual([...RING].sort());
+    expect(events.every((event) => event.site === "ctl-925-cycle")).toBe(true);
+    expect(events.every((event) => event.host === hostName)).toBe(true);
+    for (const ticket of RING) {
+      expect(existsSync(join(orchDir, "workers", ticket))).toBe(false);
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/fence-guard.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.mjs
@@ -54,6 +54,17 @@ import { log } from "./config.mjs";
 // CATALYST_FENCE_FRESH_MS for tuning.
 const FENCE_FRESH_MS_DEFAULT = 240_000;
 
+// CAT-173: report why a guarded write was suppressed without changing the
+// guard's boolean decision. In particular, preserve the authoritative read's
+// distinction between a confirmed takeover and an unavailable read.
+export const FENCE_SUPPRESS_REASONS = Object.freeze({
+  FOREIGN_OWNER: "foreign-owner",
+  MISSING_GENERATION: "missing-generation",
+  SUPERSEDED: "superseded",
+  UNVERIFIABLE: "unverifiable",
+  THREW: "threw",
+});
+
 function resolveFenceFreshMs(env) {
   const raw = Number(env?.CATALYST_FENCE_FRESH_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : FENCE_FRESH_MS_DEFAULT;
@@ -206,8 +217,26 @@ export function fenceGuard(
     // the terminal-probe path. Optional; default no-op so existing callers are
     // unaffected.
     onMissingGeneration = null,
+    // CAT-173: optional observation hook for false verdicts. Like
+    // onMissingGeneration, hook failures are swallowed and cannot affect the
+    // already-decided guard result.
+    onSuppress = null,
   } = {},
 ) {
+  const suppress = (reason, generation = null) => {
+    if (typeof onSuppress === "function") {
+      try {
+        onSuppress({ ticket, reason, generation });
+      } catch (err) {
+        logger?.debug?.(
+          { ticket, err: err?.message },
+          "fenceGuard: onSuppress hook threw — continuing",
+        );
+      }
+    }
+    return false;
+  };
+
   // N=1 single-host gate: provably no peer → trust local unconditionally.
   if (!multiHost) return true;
 
@@ -290,7 +319,7 @@ export function fenceGuard(
             "SUPPRESSING the guarded write (fail-closed) even at an escalation site; " +
             "the current owner escalates this ticket itself.",
         );
-        return false;
+        return suppress(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
       }
       if (typeof onMissingGeneration === "function") {
         try {
@@ -311,7 +340,7 @@ export function fenceGuard(
         );
         return true;
       }
-      return false; // missing/null/NaN → fail-closed (mutating write sites)
+      return suppress(FENCE_SUPPRESS_REASONS.MISSING_GENERATION);
     }
 
     // Stage 1 opt-in: trust a FRESH cross-host-reconciled projection row.
@@ -320,15 +349,25 @@ export function fenceGuard(
     if (effectiveReadSource === "projection-first" && gateway) {
       const f = readFence(ticket);
       if (f && isFresh(f, env)) {
-        if (f.ownerHost !== self) return false; // foreign owner (incl. released→null) → suppress
-        return f.generation === generation; // higher/other gen → suppress
+        if (f.ownerHost !== self) {
+          return suppress(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER, f.generation ?? null);
+        }
+        if (f.generation === generation) return true;
+        return suppress(FENCE_SUPPRESS_REASONS.SUPERSEDED, generation);
       }
       // stale/absent projection → fall through to the authoritative read.
     }
 
     // Stage 0 default (and Stage 1 stale/absent fallback): authoritative read.
-    return escalate({ ticket, generation }).current === true;
+    const verdict = escalate({ ticket, generation });
+    if (verdict?.current === true) return true;
+    return suppress(
+      verdict?.stale === true
+        ? FENCE_SUPPRESS_REASONS.SUPERSEDED
+        : FENCE_SUPPRESS_REASONS.UNVERIFIABLE,
+      generation,
+    );
   } catch {
-    return false; // any error → fail-closed
+    return suppress(FENCE_SUPPRESS_REASONS.THREW); // any error → fail-closed
   }
 }

--- a/plugins/dev/scripts/execution-core/fence-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.test.mjs
@@ -7,7 +7,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { fenceGuard, readClusterGeneration, readSignalGeneration } from "./fence-guard.mjs";
+import {
+  fenceGuard,
+  FENCE_SUPPRESS_REASONS,
+  readClusterGeneration,
+  readSignalGeneration,
+} from "./fence-guard.mjs";
 
 // A helper to build a `readFence` seam that returns a fixed projection row.
 const fenceRow = (over = {}) => ({
@@ -18,12 +23,105 @@ const fenceRow = (over = {}) => ({
   ...over,
 });
 
+describe("fenceGuard — discriminated suppression verdict (CAT-173)", () => {
+  const base = { ticket: "PROJ-1", orchDir: "/tmp/x", multiHost: true, self: "hostA" };
+  const silent = { warn() {}, debug() {} };
+
+  test("confirmed-stale authoritative read reports SUPERSEDED", () => {
+    const seen = [];
+    const ok = fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: false, stale: true }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(ok).toBe(false);
+    expect(seen).toEqual([
+      { ticket: "PROJ-1", reason: FENCE_SUPPRESS_REASONS.SUPERSEDED, generation: 7 },
+    ]);
+  });
+
+  test("indeterminate authoritative read reports UNVERIFIABLE — distinct from SUPERSEDED", () => {
+    const seen = [];
+    fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: false, stale: false }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.UNVERIFIABLE);
+    expect(FENCE_SUPPRESS_REASONS.UNVERIFIABLE).not.toBe(FENCE_SUPPRESS_REASONS.SUPERSEDED);
+  });
+
+  test("known-foreign owner reports FOREIGN_OWNER", () => {
+    const seen = [];
+    fenceGuard({ ...base, gateway: {} }, {
+      readGen: () => null,
+      readFence: () => ({ ownerHost: "hostB", generation: 3 }),
+      proceedOnMissingGeneration: true,
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
+  });
+
+  test("missing generation at a MUTATING site reports MISSING_GENERATION", () => {
+    const seen = [];
+    fenceGuard(base, { readGen: () => null, onSuppress: (v) => seen.push(v), logger: silent });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.MISSING_GENERATION);
+  });
+
+  test("a throwing escalate reports THREW", () => {
+    const seen = [];
+    fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => { throw new Error("boom"); },
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.THREW);
+  });
+
+  test("onSuppress NEVER fires on a PASS, and a throwing hook cannot flip the verdict", () => {
+    const seen = [];
+    expect(fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: true, stale: false }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    })).toBe(true);
+    expect(seen).toEqual([]);
+
+    expect(fenceGuard(base, {
+      readGen: () => null,
+      proceedOnMissingGeneration: true,
+      onSuppress: () => { throw new Error("hook exploded"); },
+      logger: silent,
+    })).toBe(true);
+  });
+
+  test("single-host (multiHost:false) never fires the hook", () => {
+    const seen = [];
+    expect(fenceGuard({ ...base, multiHost: false }, {
+      readGen: () => 1,
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    })).toBe(true);
+    expect(seen).toEqual([]);
+  });
+
+  test("omitting onSuppress leaves every path byte-identical (default no-op)", () => {
+    expect(fenceGuard(base, { readGen: () => 7, escalate: () => ({ current: false, stale: true }), logger: silent })).toBe(false);
+    expect(fenceGuard(base, { readGen: () => 7, escalate: () => ({ current: true }), logger: silent })).toBe(true);
+  });
+});
+
 describe("fenceGuard — N=1 single-host gate (spec §C1)", () => {
   test("roster==1 (multiHost:false) trusts local unconditionally, no read at all", () => {
     let escalated = false;
     let fenceRead = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: false, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: false, gateway: {}, self: "mini" },
       {
         escalate: () => { escalated = true; return { current: true }; },
         readFence: () => { fenceRead = true; return null; },
@@ -38,7 +136,7 @@ describe("fenceGuard — N=1 single-host gate (spec §C1)", () => {
 describe("fenceGuard — multi-host default (Stage 0, readSource=linear → escalate)", () => {
   test("current generation via authoritative read → passes", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 5, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(true);
@@ -46,7 +144,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("stale generation via authoritative read → blocks", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 5, escalate: () => ({ current: false }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -54,7 +152,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("missing generation (null) → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => null, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -62,7 +160,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("NaN generation → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => NaN, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -70,7 +168,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("escalate throws → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 3, escalate: () => { throw new Error("spawn failed"); }, readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -78,7 +176,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("readGen throws → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => { throw new Error("ENOENT"); }, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -87,10 +185,10 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
   test("passes the correct ticket+generation to the authoritative read", () => {
     let captured = null;
     fenceGuard(
-      { ticket: "CTL-999", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-999", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 42, escalate: (args) => { captured = args; return { current: true }; }, readSource: "linear" },
     );
-    expect(captured).toEqual({ ticket: "CTL-999", generation: 42 });
+    expect(captured).toEqual({ ticket: "PROJ-999", generation: 42 });
   });
 
   test("Stage-0 default NEVER trusts the local projection — a fresh self-owned row still escalates", () => {
@@ -100,7 +198,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
     let escalated = false;
     let fenceRead = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => 5,
         readFence: () => { fenceRead = true; return fenceRow(); },
@@ -115,7 +213,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 });
 
 describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gated)", () => {
-  const base = { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" };
+  const base = { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" };
   // The N>1 guardrail hard-refuses projection-first on a multi-host roster unless
   // the Stage-1 capability marker is present; these tests exercise the Stage-1
   // projection LOGIC, so they arm the marker.
@@ -136,6 +234,7 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
   });
 
   test("fresh row showing a FOREIGN owner → suppress (the partitioned-zombie catch)", () => {
+    const seen = [];
     const result = fenceGuard(base, {
       readGen: () => 5,
       readFence: () => fenceRow({ ownerHost: "laptop", generation: 6 }), // peer took over
@@ -143,11 +242,14 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
       escalate: () => ({ current: true }), // even if Linear lied, we must not reach it
       readSource: "projection-first",
       env: STAGE1,
+      onSuppress: (verdict) => seen.push(verdict),
     });
     expect(result).toBe(false);
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
   });
 
   test("fresh self-owned row at a HIGHER generation → suppress", () => {
+    const seen = [];
     const result = fenceGuard(base, {
       readGen: () => 5,
       readFence: () => fenceRow({ ownerHost: "mini", generation: 6 }),
@@ -155,8 +257,10 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
       escalate: () => ({ current: true }),
       readSource: "projection-first",
       env: STAGE1,
+      onSuppress: (verdict) => seen.push(verdict),
     });
     expect(result).toBe(false);
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.SUPERSEDED);
   });
 
   test("STALE self-owned row → escalates (does NOT trust local; regression guard for findings 1/2/7)", () => {
@@ -260,7 +364,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
   test("proceedOnMissingGeneration:true + null generation → PROCEED (write) + loud warn, never a silent drop", () => {
     const warns = [];
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       {
         readGen: () => null,
         escalate: () => ({ current: false }),
@@ -275,7 +379,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
 
   test("default (proceedOnMissingGeneration:false) + null generation → fail-closed (mutating write sites unchanged)", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => null, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -283,7 +387,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
 
   test("proceedOnMissingGeneration does NOT loosen a readable-but-superseded generation (still suppresses)", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       {
         readGen: () => 5, // generation IS readable
         escalate: () => ({ current: false }), // authoritative says superseded
@@ -305,7 +409,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
     let escalated = false;
     const warns = [];
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null, // this host's cluster-generation.json is gone
         readFence: () => fenceRow({ ownerHost: "mini-2", generation: 9 }), // a peer owns it NOW
@@ -323,7 +427,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
   test("a foreign owner suppresses BEFORE onMissingGeneration fires (the call site's own fail-closed path arms its cooldown)", () => {
     let hookFired = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => fenceRow({ ownerHost: "mini-2", generation: 9 }),
@@ -342,7 +446,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
     for (const row of [null, fenceRow({ ownerHost: null }), fenceRow({ ownerHost: "" })]) {
       let hookFired = false;
       const result = fenceGuard(
-        { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+        { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
         {
           readGen: () => null,
           readFence: () => row,
@@ -359,7 +463,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
 
   test("a throwing projection read is UNKNOWN, not foreign → still fails open at an escalation site", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => { throw new Error("sqlite is down"); },
@@ -374,7 +478,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
   test("SELF-owned projection is unaffected — still borrows the generation and escalates", () => {
     let captured = null;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => fenceRow({ ownerHost: "mini", generation: 9 }),
@@ -383,7 +487,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
         proceedOnMissingGeneration: true,
       },
     );
-    expect(captured).toEqual({ ticket: "CTL-1", generation: 9 });
+    expect(captured).toEqual({ ticket: "PROJ-1", generation: 9 });
     expect(result).toBe(true);
   });
 });
@@ -409,7 +513,7 @@ describe("fenceGuard — generation SOURCE wiring (CTL-1157 A1 regression)", () 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "fence-src-"));
     orchDir = dir;
-    ticket = "CTL-1423";
+    ticket = "PROJ-1423";
     wdir = join(orchDir, "workers", ticket);
     mkdirSync(wdir, { recursive: true });
   });

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -1,0 +1,356 @@
+// fence-standoff.mjs — bounded escape from a mutual multi-host fencing standoff (CAT-173).
+//
+// This module changes no fence decision. It records repeated suppressions so a
+// caller can eventually surface the condition out-of-band, without a Linear
+// write or a fence dependency. Every I/O helper is fail-open and never throws.
+
+import { randomBytes } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
+import { FENCE_SUPPRESS_REASONS } from "./fence-guard.mjs";
+
+// A STANDOFF is mutual: every live host believes some OTHER host owns the ticket,
+// so nobody writes the escalation. That is the AMBIGUOUS class of verdict —
+// `unverifiable` (the authoritative read could neither confirm nor refute this
+// host's generation) and `threw` (fail-closed on an error). Only those can be a
+// standoff, because only there is it genuinely unknown who owns the ticket.
+//
+// The CONFIRMED-TAKEOVER verdicts are the opposite: positive evidence that a
+// specific other host holds the claim, which is the CORRECT outcome on the old
+// host after a healthy takeover. fenceGuard deliberately leaves the escalation to
+// the current owner there, and that owner's own fence passes, so it escalates
+// normally. There are TWO such verdicts, and both must be excluded:
+//   * `foreign-owner` — the projection names a different owner host outright.
+//   * `superseded`    — the authoritative read returned stale:true, i.e. a NEWER
+//                       generation exists. A healthy takeover bumps the generation,
+//                       so this is the shape an ordinary supersession takes on the
+//                       old host; it is confirmed takeover evidence just like
+//                       `foreign-owner`, only discovered via generation rather than
+//                       owner identity.
+//
+// Counting either would let a lingering failed / stale-PR worker directory on the
+// superseded host accumulate the bound over 45 minutes and page an operator about a
+// ticket the NEW owner is actively processing — turning correct zombie fencing into
+// a false page. Excluded from accounting entirely.
+const NON_STANDOFF_SUPPRESS_REASONS = new Set([
+  FENCE_SUPPRESS_REASONS.FOREIGN_OWNER,
+  FENCE_SUPPRESS_REASONS.SUPERSEDED,
+]);
+
+export const FENCE_STANDOFF_CAP_DEFAULT = 4;
+export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;
+export const FENCE_STANDOFF_COOLDOWN_MS_DEFAULT = 6 * 60 * 60_000;
+// How many consecutive FAILED deliveries may bypass the caller's ordinary
+// suppression cooldown before the retry falls back to that cooldown's cadence.
+// A transient disk/event blip is retried immediately; a PERSISTENT one must not
+// re-run the caller's per-tick probe forever (the CTL-1329 quota burn).
+export const FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT = 5;
+// Namespace specimen only — the `<ticket>` slot is filled per-emit by
+// buildFenceStandoffEvent. Uses the repo-neutral `PROJ` prefix so this
+// distributed plugin encodes no project-specific ticket namespace.
+export const FENCE_STANDOFF_EVENT = "escalation.fence-standoff.PROJ-1";
+
+function positiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveStandoffCap(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_CAP, FENCE_STANDOFF_CAP_DEFAULT);
+}
+
+export function resolveStandoffMinAgeMs(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_MIN_AGE_MS, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT);
+}
+
+export function resolveStandoffCooldownMs(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_COOLDOWN_MS, FENCE_STANDOFF_COOLDOWN_MS_DEFAULT);
+}
+
+export function resolveStandoffDeliveryRetryMax(env = process.env) {
+  return positiveNumber(
+    env?.CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX,
+    FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT,
+  );
+}
+
+function standoffDir(orchDir) {
+  return join(orchDir, ".fence-standoff");
+}
+
+function standoffPath(orchDir, ticket) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(String(ticket ?? ""))) {
+    throw new Error("fence-standoff: invalid ticket identifier");
+  }
+  return join(standoffDir(orchDir), `${ticket}.json`);
+}
+
+export function readFenceStandoff(orchDir, ticket) {
+  try {
+    const path = standoffPath(orchDir, ticket);
+    if (!existsSync(path)) return null;
+    const rec = JSON.parse(readFileSync(path, "utf8"));
+    return rec && typeof rec === "object" ? rec : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRecord(orchDir, ticket, rec) {
+  const dir = standoffDir(orchDir);
+  mkdirSync(dir, { recursive: true });
+  const path = standoffPath(orchDir, ticket);
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmp, JSON.stringify(rec, null, 2));
+  renameSync(tmp, path);
+  return rec;
+}
+
+export function recordFenceSuppression({ orchDir, ticket, site, reason, now }) {
+  const prior = readFenceStandoff(orchDir, ticket);
+  const rec = {
+    ticket,
+    site,
+    reason,
+    firstSuppressedAt: Number.isFinite(prior?.firstSuppressedAt) ? prior.firstSuppressedAt : now,
+    lastSuppressedAt: now,
+    count: Number.isFinite(prior?.count) ? prior.count + 1 : 1,
+    breakGlassAt: Number.isFinite(prior?.breakGlassAt) ? prior.breakGlassAt : null,
+    // Consecutive failed break-glass deliveries. Preserved across suppression
+    // ticks so a persistent failure can be bounded; reset only by
+    // clearFenceStandoff (the episode ending).
+    deliveryAttempts: Number.isFinite(prior?.deliveryAttempts) ? prior.deliveryAttempts : 0,
+  };
+  try {
+    return writeRecord(orchDir, ticket, rec);
+  } catch {
+    return rec;
+  }
+}
+
+export function markBreakGlass({ orchDir, ticket, now }) {
+  const prior = readFenceStandoff(orchDir, ticket);
+  if (!prior) return null;
+  const rec = {
+    ...prior,
+    breakGlassAt: Number.isFinite(prior.breakGlassAt) ? prior.breakGlassAt : now,
+  };
+  try {
+    return writeRecord(orchDir, ticket, rec);
+  } catch {
+    return rec;
+  }
+}
+
+// markDeliveryAttempt — count one FAILED break-glass delivery and report both the
+// new running total AND whether that total actually reached disk.
+//
+// The `persisted` half is load-bearing, not diagnostic. The retry bound is only
+// enforceable if the count SURVIVES the tick: when the ledger is unwritable the
+// next tick re-reads the OLD `deliveryAttempts`, recomputes the same total, and
+// would report "still under the bound" forever — so an unbounded caller re-runs
+// its terminal probe + fence check + delivery on EVERY tick against a full disk
+// or read-only mount. That is precisely the CTL-1329 per-tick burn this bound
+// exists to prevent, so a non-persisted attempt must fail CLOSED (see the
+// `deliveryRetryable` computation in maybeBreakGlass): delivery still retries,
+// on the caller's ordinary cooldown cadence instead of every tick.
+//
+// Never throws — bookkeeping must not interrupt a scheduler tick.
+export function markDeliveryAttempt({ orchDir, ticket, record }) {
+  const prior = Number.isFinite(record?.deliveryAttempts) ? record.deliveryAttempts : 0;
+  const attempts = prior + 1;
+  try {
+    writeRecord(orchDir, ticket, { ...record, deliveryAttempts: attempts });
+    return { attempts, persisted: true };
+  } catch {
+    return { attempts, persisted: false };
+  }
+}
+
+export function clearFenceStandoff(orchDir, ticket) {
+  try {
+    const path = standoffPath(orchDir, ticket);
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // Fail open: bookkeeping must never interrupt a scheduler tick.
+  }
+}
+
+export function evaluateStandoff(rec, { now, cap, minAgeMs }) {
+  if (!rec || !Number.isFinite(rec.count) || !Number.isFinite(rec.firstSuppressedAt)) {
+    return { breakGlass: false, firstBreakGlass: false, ageMs: 0 };
+  }
+  const ageMs = now - rec.firstSuppressedAt;
+  const breakGlass = rec.count >= cap && ageMs >= minAgeMs;
+  return { breakGlass, firstBreakGlass: breakGlass && !Number.isFinite(rec.breakGlassAt), ageMs };
+}
+
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+export function buildFenceStandoffEvent(
+  { ticket, site, reason, count, ageMs } = {},
+  {
+    now = () => new Date(),
+    newId = () => randomBytes(8).toString("hex"),
+    newTrace = () => randomBytes(16).toString("hex"),
+    newSpan = () => randomBytes(8).toString("hex"),
+  } = {},
+) {
+  if (!ticket) throw new Error("buildFenceStandoffEvent: ticket is required");
+  const ts = now().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return JSON.stringify({
+    ts,
+    id: newId(),
+    observedTs: ts,
+    severityText: "WARN",
+    severityNumber: 13,
+    traceId: newTrace(),
+    spanId: newSpan(),
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": `escalation.fence-standoff.${ticket}`,
+      "event.entity": "escalation",
+      "event.action": "fence-standoff",
+      "event.label": ticket,
+      "linear.issue.identifier": ticket,
+    },
+    body: { payload: { ticket, site, reason, count, ageMs } },
+  }) + "\n";
+}
+
+export function appendFenceStandoffEvent(payload, { append = defaultAppend, build = buildFenceStandoffEvent } = {}) {
+  try {
+    append(build(payload));
+    return true;
+  } catch (err) {
+    log.error({ err: err?.message, ticket: payload?.ticket }, "fence-standoff: append failed");
+    return false;
+  }
+}
+
+// maybeBreakGlass — shared best-effort suppression accounting for every
+// escalation site. The caller still owns its fence decision; this helper only
+// records a durable, out-of-band human signal once the count+age bound is met.
+export function maybeBreakGlass({
+  orchDir,
+  ticket,
+  site,
+  verdict,
+  phase = site,
+  now,
+  env = process.env,
+  appendEvent = appendFenceStandoffEvent,
+  recordEscalation = recordDurableEscalation,
+  logger = log,
+  detail = "",
+}) {
+  try {
+    standoffPath(orchDir, ticket); // validate containment before any sink path is built
+    // A confirmed takeover is not a standoff — the new owner escalates. Clear any
+    // ledger this host built up BEFORE the takeover so a later genuine standoff
+    // starts a fresh episode rather than inheriting a stale count/age.
+    if (NON_STANDOFF_SUPPRESS_REASONS.has(verdict?.reason)) {
+      clearFenceStandoff(orchDir, ticket);
+      return {
+        breakGlass: false,
+        firstBreakGlass: false,
+        ageMs: 0,
+        record: null,
+        skipped: verdict.reason,
+      };
+    }
+    const rec = recordFenceSuppression({
+      orchDir,
+      ticket,
+      site,
+      reason: verdict?.reason ?? "unknown",
+      now,
+    });
+    const evaluation = evaluateStandoff(rec, {
+      now,
+      cap: resolveStandoffCap(env),
+      minAgeMs: resolveStandoffMinAgeMs(env),
+    });
+    if (evaluation.firstBreakGlass) {
+      const durableResult = recordEscalation({
+        orchDir,
+        ticket,
+        phase,
+        reason:
+          `fence-standoff (${rec.reason}) at ${site}: ${ticket} is stuck but the ` +
+          `fence suppressed every needs-human write${detail ? `; ${detail}` : ""}. ` +
+          "Check cluster-generation.json divergence across hosts.",
+        labelConfirmed: false,
+        source: "fence-standoff",
+        now: new Date(now).toISOString(),
+      });
+      let persistedDurable = null;
+      try {
+        persistedDurable = JSON.parse(readFileSync(
+          join(orchDir, ".escalations", `${ticket}.json`),
+          "utf8",
+        ));
+      } catch {
+        persistedDurable = null;
+      }
+      const durableConfirmed = durableResult?.source === "fence-standoff"
+        && persistedDurable?.source === "fence-standoff"
+        && persistedDurable?.lastTs === new Date(now).toISOString();
+      const eventConfirmed = durableConfirmed && appendEvent({
+        ticket,
+        site,
+        reason: rec.reason,
+        count: rec.count,
+        ageMs: evaluation.ageMs,
+      });
+      // Persist the once-per-episode latch only after BOTH human-facing outputs
+      // confirm. A transient disk/event failure stays retryable next tick.
+      if (durableConfirmed && eventConfirmed === true) {
+        markBreakGlass({ orchDir, ticket, now });
+      } else {
+        // Delivery failed. Report it as retryable ONLY while the consecutive-failure
+        // count is under the bound: the caller drops its own suppression cooldown to
+        // retry next tick, and an unbounded version of that re-runs the caller's
+        // per-tick terminal probe + fence check forever on a PERSISTENTLY failing
+        // sink — the CTL-1329 burn that froze fleet dispatch. Past the bound the
+        // caller keeps its ordinary cooldown, so delivery still retries, just on the
+        // ordinary cadence instead of every tick.
+        const { attempts: deliveryAttempts, persisted } = markDeliveryAttempt({
+          orchDir,
+          ticket,
+          record: rec,
+        });
+        return {
+          ...evaluation,
+          firstBreakGlass: true,
+          record: rec,
+          deliveryPending: true,
+          deliveryAttempts,
+          // Fail CLOSED when the incremented count did not reach disk: an
+          // unpersisted counter can never grow, so treating it as retryable
+          // would drop the caller's cooldown on every tick forever.
+          deliveryRetryable:
+            persisted && deliveryAttempts <= resolveStandoffDeliveryRetryMax(env),
+        };
+      }
+      logger?.warn?.(
+        { ticket, site, reason: rec.reason, count: rec.count, ageMs: evaluation.ageMs },
+        "cat-173: FENCE STANDOFF — wrote a durable escalation without a Linear label",
+      );
+    }
+    return { ...evaluation, record: rec };
+  } catch (err) {
+    logger?.warn?.(
+      { ticket, site, err: err?.message },
+      "cat-173: standoff bookkeeping failed — continuing",
+    );
+    return { breakGlass: false, firstBreakGlass: false, ageMs: 0, record: null };
+  }
+}

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -1,0 +1,322 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
+import {
+  recordFenceSuppression, readFenceStandoff, clearFenceStandoff,
+  evaluateStandoff, markBreakGlass, buildFenceStandoffEvent,
+  maybeBreakGlass,
+  FENCE_STANDOFF_EVENT, FENCE_STANDOFF_CAP_DEFAULT, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT,
+  FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT,
+} from "./fence-standoff.mjs";
+
+describe("fence-standoff ledger (CAT-173)", () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "fs-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("first suppression seeds count:1 and anchors firstSuppressedAt", () => {
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 1000 });
+    expect(r.count).toBe(1);
+    expect(r.firstSuppressedAt).toBe(1000);
+    expect(r.lastSuppressedAt).toBe(1000);
+  });
+
+  test("repeat suppressions increment count and PRESERVE firstSuppressedAt (the age anchor)", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 1000 });
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 5000 });
+    expect(r.count).toBe(2);
+    expect(r.firstSuppressedAt).toBe(1000);
+    expect(r.lastSuppressedAt).toBe(5000);
+    expect(r.reason).toBe("unverifiable");
+  });
+
+  test("clearFenceStandoff is idempotent and safe on an absent record", () => {
+    clearFenceStandoff(dir, "NOPE");
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 1 });
+    clearFenceStandoff(dir, "PROJ-53");
+    clearFenceStandoff(dir, "PROJ-53");
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
+  });
+
+  test("a malformed record file degrades to null, never throws", () => {
+    mkdirSync(join(dir, ".fence-standoff"), { recursive: true });
+    writeFileSync(join(dir, ".fence-standoff", "PROJ-53.json"), "{not json");
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
+    expect(recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 9 }).count).toBe(1);
+  });
+
+  test("an unwritable orchDir fails open — returns a synthetic record, never throws", () => {
+    const r = recordFenceSuppression({ orchDir: "/proc/nonexistent-cat173", ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 3 });
+    expect(r.count).toBe(1);
+    expect(r.ticket).toBe("PROJ-53");
+  });
+
+  test("ticket identifiers cannot escape the ledger directory", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "../../escaped", site: "s", reason: "unverifiable", now: 3 });
+    clearFenceStandoff(dir, "../../escaped");
+    expect(existsSync(join(dir, "..", "..", "escaped.json"))).toBe(false);
+  });
+
+  test("markBreakGlass preserves the first break-glass timestamp", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 1 });
+    expect(markBreakGlass({ orchDir: dir, ticket: "PROJ-53", now: 9 }).breakGlassAt).toBe(9);
+    expect(markBreakGlass({ orchDir: dir, ticket: "PROJ-53", now: 12 }).breakGlassAt).toBe(9);
+  });
+});
+
+describe("evaluateStandoff — pure break-glass predicate (CAT-173)", () => {
+  const rec = (count, firstSuppressedAt, breakGlassAt = null) => ({ ticket: "PROJ-53", count, firstSuppressedAt, breakGlassAt });
+  const opts = { cap: 4, minAgeMs: 45 * 60_000 };
+
+  test("count reached but episode TOO YOUNG → no break-glass (a fast tick loop cannot trip it)", () => {
+    expect(evaluateStandoff(rec(9, 0), { now: 60_000, ...opts }).breakGlass).toBe(false);
+  });
+  test("old enough but UNDER the cap → no break-glass (one blip is not a standoff)", () => {
+    expect(evaluateStandoff(rec(2, 0), { now: 3 * 60 * 60_000, ...opts }).breakGlass).toBe(false);
+  });
+  test("cap AND age both satisfied → break-glass, flagged as the FIRST for this episode", () => {
+    expect(evaluateStandoff(rec(4, 0), { now: 46 * 60_000, ...opts })).toEqual({ breakGlass: true, firstBreakGlass: true, ageMs: 46 * 60_000 });
+  });
+  test("already broken glass this episode → still breakGlass, but firstBreakGlass:false (fires ONCE)", () => {
+    const v = evaluateStandoff(rec(50, 0, 46 * 60_000), { now: 99 * 60_000, ...opts });
+    expect(v.breakGlass).toBe(true);
+    expect(v.firstBreakGlass).toBe(false);
+  });
+  test("a null/garbage record is not a standoff", () => {
+    expect(evaluateStandoff(null, { now: 1e12, ...opts }).breakGlass).toBe(false);
+    expect(evaluateStandoff({}, { now: 1e12, ...opts }).breakGlass).toBe(false);
+  });
+  test("defaults are the documented bound: cap 4, min age 45m (3x the 15m fence cooldown)", () => {
+    expect(FENCE_STANDOFF_CAP_DEFAULT).toBe(4);
+    expect(FENCE_STANDOFF_MIN_AGE_MS_DEFAULT).toBe(45 * 60_000);
+  });
+});
+
+describe("buildFenceStandoffEvent (CAT-173)", () => {
+  test("event name is the per-ticket canonical form", () => {
+    const ev = JSON.parse(buildFenceStandoffEvent({ ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", count: 4, ageMs: 2_700_000 }, { now: () => new Date("2026-08-11T00:00:00Z") }));
+    expect(ev.attributes["event.name"]).toBe("escalation.fence-standoff.PROJ-53");
+    expect(ev.body.payload).toMatchObject({ ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", count: 4 });
+  });
+  test("FENCE_STANDOFF_EVENT is the registrable prefix form", () => {
+    expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.PROJ-1");
+  });
+  // AGENTS.md → Version Control: this plugin ships to other projects, so the
+  // shipped module must not encode a specific ticket prefix in its specimen.
+  test("FENCE_STANDOFF_EVENT carries no project-specific ticket prefix", () => {
+    expect(FENCE_STANDOFF_EVENT).not.toMatch(/\.(CTL|CAT)-\d+$/);
+  });
+});
+
+test("maybeBreakGlass emits and records exactly once after the bound", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-break-"));
+  const events = [];
+  const escalations = [];
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "PROJ-53",
+      site: "terminal-sweep",
+      verdict: { reason: "unverifiable" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "2", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: (event) => { events.push(event); return true; },
+      recordEscalation: (record) => { escalations.push(record); return recordDurableEscalation(record); },
+      logger: { warn() {} },
+    };
+    maybeBreakGlass({ ...opts, now: 1 });
+    maybeBreakGlass({ ...opts, now: 2 });
+    maybeBreakGlass({ ...opts, now: 3 });
+    expect(events).toHaveLength(1);
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]).toMatchObject({ labelConfirmed: false, source: "fence-standoff" });
+    expect(escalations[0].now).toBe("1970-01-01T00:00:00.002Z");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("maybeBreakGlass retries delivery before latching the episode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-"));
+  let eventAttempts = 0;
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "PROJ-53",
+      site: "terminal-sweep",
+      verdict: { reason: "unverifiable" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: () => { eventAttempts += 1; return eventAttempts > 1; },
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
+    expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryPending).toBe(true);
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBeNull();
+    expect(maybeBreakGlass({ ...opts, now: 2 }).deliveryPending).toBeUndefined();
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBe(2);
+    expect(eventAttempts).toBe(2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// CAT-173 review: the retry above lets the caller drop its own suppression cooldown
+// to re-try next tick. A PERSISTENTLY failing sink must stop earning that bypass, or
+// the caller's per-tick probe runs forever (the CTL-1329 quota burn).
+test("maybeBreakGlass stops reporting a persistently failing delivery as retryable", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-bound-"));
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "PROJ-53",
+      site: "terminal-sweep",
+      verdict: { reason: "unverifiable" },
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX: "3",
+      },
+      appendEvent: () => false, // never succeeds
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
+    const verdicts = [1, 2, 3, 4, 5].map((now) => maybeBreakGlass({ ...opts, now }));
+    expect(verdicts.map((v) => v.deliveryPending)).toEqual([true, true, true, true, true]);
+    expect(verdicts.map((v) => v.deliveryAttempts)).toEqual([1, 2, 3, 4, 5]);
+    expect(verdicts.map((v) => v.deliveryRetryable)).toEqual([true, true, true, false, false]);
+    // The episode is still unlatched, so delivery keeps being ATTEMPTED — only the
+    // caller's cooldown bypass is withdrawn.
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the delivery-retry bound defaults to 5 and survives across suppression ticks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-default-"));
+  try {
+    expect(FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT).toBe(5);
+    const opts = {
+      orchDir: dir,
+      ticket: "PROJ-53",
+      site: "terminal-sweep",
+      verdict: { reason: "unverifiable" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: () => false,
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
+    for (let i = 1; i <= 5; i++) expect(maybeBreakGlass({ ...opts, now: i }).deliveryRetryable).toBe(true);
+    expect(maybeBreakGlass({ ...opts, now: 6 }).deliveryRetryable).toBe(false);
+    // Ending the episode resets the counter — a later recurrence retries promptly again.
+    clearFenceStandoff(dir, "PROJ-53");
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 100 });
+    expect(maybeBreakGlass({ ...opts, now: 101 }).deliveryRetryable).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Codex #3241 round-1 P1 remediations ────────────────────────────────────
+
+// A CONFIRMED TAKEOVER is not a standoff. There are two verdicts that carry that
+// evidence and BOTH must be excluded from accounting: `foreign-owner` (the
+// projection names another owner host) and `superseded` (the authoritative read
+// returned stale:true — a newer generation exists, which is precisely the shape an
+// ordinary healthy takeover takes on the old host). Counting either would page an
+// operator about a ticket the NEW owner is actively working.
+describe.each(["foreign-owner", "superseded"])(
+  "%s is a confirmed takeover, not a standoff (CAT-173, Codex #3241 P1)",
+  (takeoverReason) => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "fs-foreign-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const opts = (now) => ({
+    orchDir: dir,
+    ticket: "PROJ-53",
+    site: "terminal-sweep",
+    verdict: { reason: takeoverReason },
+    now,
+    env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "0" },
+    appendEvent: () => true,
+    logger: { warn() {} },
+  });
+
+  test("a confirmed takeover is never counted, so it can never break glass", () => {
+    const events = [];
+    // Well past the cap+age bound: a counted reason would have paged several times.
+    for (let i = 1; i <= 10; i++) {
+      const r = maybeBreakGlass({ ...opts(i * 1000), appendEvent: (p) => { events.push(p); return true; } });
+      expect(r.breakGlass).toBe(false);
+      expect(r.skipped).toBe(takeoverReason);
+    }
+    expect(events).toEqual([]);
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
+  });
+
+  test("a takeover CLEARS a prior episode so a later standoff starts fresh", () => {
+    // Three genuine standoff suppressions accumulate...
+    for (let i = 1; i <= 3; i++) {
+      recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: i });
+    }
+    expect(readFenceStandoff(dir, "PROJ-53").count).toBe(3);
+    // ...then the ticket is legitimately taken over.
+    maybeBreakGlass(opts(4));
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
+    // A later genuine standoff must re-earn the bound from count 1, not inherit 3.
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 5 });
+    expect(r.count).toBe(1);
+    expect(r.firstSuppressedAt).toBe(5);
+  });
+
+  test("genuine standoff reasons are still counted (negative control)", () => {
+    // Only the AMBIGUOUS verdicts — where it is genuinely unknown who owns the
+    // ticket — may accumulate toward a break-glass.
+    for (const reason of ["unverifiable", "missing-generation", "threw"]) {
+      const d = mkdtempSync(join(tmpdir(), "fs-ctl-"));
+      try {
+        const r = maybeBreakGlass({ ...opts(1000), orchDir: d, verdict: { reason } });
+        expect(r.skipped).toBeUndefined();
+        expect(readFenceStandoff(d, "PROJ-53")?.count).toBe(1);
+      } finally {
+        rmSync(d, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+test("an UNPERSISTABLE delivery count fails closed, not retryable-forever (Codex #3241 P1)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-unwritable-"));
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "PROJ-53",
+      site: "terminal-sweep",
+      verdict: { reason: "unverifiable" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: () => false, // delivery keeps failing
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
+    // Baseline: a writable ledger reports the attempt as retryable.
+    expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryRetryable).toBe(true);
+
+    // Now make the ledger directory unwritable so the incremented count cannot
+    // reach disk. Without the fix the count silently resets every tick and
+    // deliveryRetryable stays true forever — the CTL-1329 per-tick burn.
+    const ledgerDir = join(dir, ".fence-standoff");
+    const mode = 0o500;
+    chmodSync(ledgerDir, mode);
+    try {
+      const r = maybeBreakGlass({ ...opts, now: 2 });
+      expect(r.deliveryPending).toBe(true);
+      expect(r.deliveryRetryable).toBe(false);
+    } finally {
+      chmodSync(ledgerDir, 0o700);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -622,8 +622,27 @@ export function defaultAppendFenceSuppressedEvent({
   });
 }
 
+export const DEFAULT_FENCE_SUPPRESSED_EMIT_WINDOW_MS = 15 * 60_000;
+
+function fenceSuppressedEmitWindowMs() {
+  const configured = Number(process.env.CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS);
+  return Number.isFinite(configured) && configured >= 0
+    ? configured
+    : DEFAULT_FENCE_SUPPRESSED_EMIT_WINDOW_MS;
+}
+
+function inFenceSuppressedEmitWindow(markerPath, now, windowMs = fenceSuppressedEmitWindowMs()) {
+  try {
+    const emittedAt = Number(JSON.parse(readFileSync(markerPath, "utf8"))?.emittedAt);
+    return Number.isFinite(emittedAt) && now - emittedAt < windowMs;
+  } catch {
+    return false;
+  }
+}
+
 // Keep observability-only markers outside workers/: an empty workers/<ticket>
 // directory is interpreted as started work until the orphan grace expires.
+// Markers are windowed so a resolved suppression can be observed if it recurs.
 export function emitFenceSuppressedEventOnce(
   orchDir,
   ticket,
@@ -632,7 +651,9 @@ export function emitFenceSuppressedEventOnce(
   appendFenceSuppressedEvent = defaultAppendFenceSuppressedEvent
 ) {
   const marker = join(orchDir, ".fence-suppressed-emits", `${ticket}-${site}.applied`);
-  if (existsSync(marker) || typeof appendFenceSuppressedEvent !== "function") return;
+  if (typeof appendFenceSuppressedEvent !== "function") return;
+  const now = Date.now();
+  if (inFenceSuppressedEmitWindow(marker, now)) return;
   const ok = appendFenceSuppressedEvent({
     ticket,
     site,
@@ -641,8 +662,29 @@ export function emitFenceSuppressedEventOnce(
   });
   if (ok !== false) {
     mkdirSync(dirname(marker), { recursive: true });
-    writeFileSync(marker, "");
+    writeFileSync(marker, JSON.stringify({ ticket, site, emittedAt: now }));
   }
+}
+
+export function gcFenceSuppressedEmits(
+  orchDir,
+  now,
+  windowMs = fenceSuppressedEmitWindowMs()
+) {
+  const dir = join(orchDir, ".fence-suppressed-emits");
+  let reaped = 0;
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith(".applied")) continue;
+      const marker = join(dir, entry.name);
+      if (inFenceSuppressedEmitWindow(marker, now, windowMs)) continue;
+      rmSync(marker, { force: true });
+      reaped += 1;
+    }
+  } catch {
+    return reaped;
+  }
+  return reaped;
 }
 
 // ─── CTL-932: turn-zero gate primitives ─────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -607,6 +607,44 @@ export function defaultAppendOrphanDetectedEvent({
   );
 }
 
+// CAT-3 — operator-visible record of a deliberately suppressed escalation write.
+// This uses the generic operator envelope because escalation.* is not phase-keyed.
+export function defaultAppendFenceSuppressedEvent({
+  ticket,
+  site,
+  host,
+  reason = "fence-suppressed",
+}) {
+  return defaultAppendOperatorEvent({
+    "event.name": "escalation.fence-suppressed",
+    payload: { ticket, site, host, reason },
+    attributes: { ticket, site, host, reason },
+  });
+}
+
+// Keep observability-only markers outside workers/: an empty workers/<ticket>
+// directory is interpreted as started work until the orphan grace expires.
+export function emitFenceSuppressedEventOnce(
+  orchDir,
+  ticket,
+  site,
+  host,
+  appendFenceSuppressedEvent = defaultAppendFenceSuppressedEvent
+) {
+  const marker = join(orchDir, ".fence-suppressed-emits", `${ticket}-${site}.applied`);
+  if (existsSync(marker) || typeof appendFenceSuppressedEvent !== "function") return;
+  const ok = appendFenceSuppressedEvent({
+    ticket,
+    site,
+    host,
+    reason: "fence-suppressed",
+  });
+  if (ok !== false) {
+    mkdirSync(dirname(marker), { recursive: true });
+    writeFileSync(marker, "");
+  }
+}
+
 // ─── CTL-932: turn-zero gate primitives ─────────────────────────────────────
 //
 // A wedged-never-started worker registered with CC but never resolved its
@@ -1510,6 +1548,7 @@ export function defaultAppendOperatorEvent(evt) {
         spanId: randomBytes(8).toString("hex"),
         resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
         attributes: {
+          ...(evt?.attributes ?? {}),
           "event.name": name,
         },
         body: { payload: evt?.payload ?? null },

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -47,6 +47,8 @@ import {
   defaultAppendBootResumePhaseRegressionEvent,
   // CTL-1044
   defaultAppendOperatorEvent,
+  // CAT-3
+  defaultAppendFenceSuppressedEvent,
   // 2026-08-03
   detectSessionRateLimitHit,
 } from "./recovery.mjs";
@@ -3750,6 +3752,86 @@ describe("defaultAppendOperatorEvent (CTL-1044)", () => {
         payload: { ticket: "CTL-FAIL" },
       }),
     ).toBe(false);
+  });
+});
+
+// CAT-3: escalation.fence-suppressed envelope. A fence suppression is a
+// deliberate no-write; the event is the ONLY operator-visible record of it, and
+// its whole value is the DIMENSIONS (ticket/site/host/reason). otel-forward
+// strips body.payload off-machine, so those dimensions have to survive as OTLP
+// ATTRIBUTES — if defaultAppendOperatorEvent stops merging evt.attributes the
+// event still lands, still passes namespace parity, and is silently useless.
+// These tests pin that merge so the regression cannot ship green.
+describe("escalation.fence-suppressed envelope (CAT-3)", () => {
+  let envCatalystDir;
+  let prevCatalystDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    envCatalystDir = mkdtempSync(join(tmpdir(), "cat3-fence-suppressed-"));
+    process.env.CATALYST_DIR = envCatalystDir;
+    mkdirSync(join(envCatalystDir, "events"), { recursive: true });
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(envCatalystDir, { recursive: true, force: true });
+  });
+
+  function readBackEnvelope() {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const lines = readFileSync(join(envCatalystDir, "events", `${ym}.jsonl`), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    return JSON.parse(lines[lines.length - 1]);
+  }
+
+  test("carries ticket/site/host/reason as ATTRIBUTES (survives the payload strip)", () => {
+    const ok = defaultAppendFenceSuppressedEvent({
+      ticket: "CAT-3",
+      site: "terminal-sweep",
+      host: "host-a",
+    });
+    expect(ok).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("escalation.fence-suppressed");
+    expect(env.attributes.ticket).toBe("CAT-3");
+    expect(env.attributes.site).toBe("terminal-sweep");
+    expect(env.attributes.host).toBe("host-a");
+    expect(env.attributes.reason).toBe("fence-suppressed");
+    // payload keeps the same dimensions for the on-machine log reader.
+    expect(env.body.payload).toEqual({
+      ticket: "CAT-3",
+      site: "terminal-sweep",
+      host: "host-a",
+      reason: "fence-suppressed",
+    });
+    expect(env.resource["service.name"]).toBe("catalyst.execution-core");
+  });
+
+  test("an explicit reason overrides the default", () => {
+    expect(
+      defaultAppendFenceSuppressedEvent({
+        ticket: "CAT-3",
+        site: "stale-pr-rescue",
+        host: "host-b",
+        reason: "foreign-owner",
+      }),
+    ).toBe(true);
+    expect(readBackEnvelope().attributes.reason).toBe("foreign-owner");
+  });
+
+  test("a caller-supplied attribute can never shadow event.name", () => {
+    expect(
+      defaultAppendOperatorEvent({
+        "event.name": "escalation.fence-suppressed",
+        attributes: { "event.name": "spoofed", ticket: "CAT-3" },
+        payload: { ticket: "CAT-3" },
+      }),
+    ).toBe(true);
+    const env = readBackEnvelope();
+    expect(env.attributes["event.name"]).toBe("escalation.fence-suppressed");
+    expect(env.attributes.ticket).toBe("CAT-3");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.test.mjs
@@ -49,6 +49,9 @@ import {
   defaultAppendOperatorEvent,
   // CAT-3
   defaultAppendFenceSuppressedEvent,
+  emitFenceSuppressedEventOnce,
+  gcFenceSuppressedEmits,
+  DEFAULT_FENCE_SUPPRESSED_EMIT_WINDOW_MS,
   // 2026-08-03
   detectSessionRateLimitHit,
 } from "./recovery.mjs";
@@ -68,6 +71,92 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(orchDir, { recursive: true, force: true });
+});
+
+describe("emitFenceSuppressedEventOnce windowing (CAT-219)", () => {
+  const ticket = "CAT-219";
+  const site = "terminal-sweep";
+  const marker = () =>
+    join(orchDir, ".fence-suppressed-emits", `${ticket}-${site}.applied`);
+
+  function seed(value) {
+    mkdirSync(join(orchDir, ".fence-suppressed-emits"), { recursive: true });
+    writeFileSync(marker(), value);
+  }
+
+  test("re-emits after the window elapses", () => {
+    seed(JSON.stringify({ emittedAt: Date.now() - 60 * 60_000 }));
+    const calls = [];
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", (event) => calls.push(event));
+    expect(calls).toEqual([
+      { ticket, site, host: "host-a", reason: "fence-suppressed" },
+    ]);
+  });
+
+  test("stays silent inside the window", () => {
+    seed(JSON.stringify({ emittedAt: Date.now() - 60_000 }));
+    const calls = [];
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", (event) => calls.push(event));
+    expect(calls).toHaveLength(0);
+  });
+
+  test("writes a timestamped marker and never manufactures a worker directory", () => {
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", () => true);
+    expect(typeof JSON.parse(readFileSync(marker(), "utf8")).emittedAt).toBe("number");
+    expect(existsSync(join(orchDir, "workers", ticket))).toBe(false);
+  });
+
+  test.each(["", "{not json"])("legacy or malformed marker fails open: %p", (value) => {
+    seed(value);
+    const calls = [];
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", (event) => calls.push(event));
+    expect(calls).toHaveLength(1);
+    expect(typeof JSON.parse(readFileSync(marker(), "utf8")).emittedAt).toBe("number");
+  });
+
+  test("environment override is read lazily", () => {
+    const prior = process.env.CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS;
+    try {
+      process.env.CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS = "100";
+      seed(JSON.stringify({ emittedAt: Date.now() - 101 }));
+      const calls = [];
+      emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", (event) => calls.push(event));
+      expect(calls).toHaveLength(1);
+    } finally {
+      if (prior === undefined) delete process.env.CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS;
+      else process.env.CATALYST_FENCE_SUPPRESSED_EMIT_WINDOW_MS = prior;
+    }
+  });
+
+  test("failed emit does not refresh an expired marker", () => {
+    const emittedAt = Date.now() - DEFAULT_FENCE_SUPPRESSED_EMIT_WINDOW_MS - 1;
+    seed(JSON.stringify({ emittedAt }));
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", () => false);
+    expect(JSON.parse(readFileSync(marker(), "utf8")).emittedAt).toBe(emittedAt);
+    const calls = [];
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, "host-a", (event) => calls.push(event));
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(readFileSync(marker(), "utf8")).emittedAt).toBeGreaterThan(emittedAt);
+  });
+});
+
+describe("gcFenceSuppressedEmits retention (CAT-219)", () => {
+  test("reaps expired, malformed, and legacy markers while preserving fresh markers", () => {
+    const dir = join(orchDir, ".fence-suppressed-emits");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "old.applied"), JSON.stringify({ emittedAt: 1 }));
+    writeFileSync(join(dir, "fresh.applied"), JSON.stringify({ emittedAt: 9_999 }));
+    writeFileSync(join(dir, "legacy.applied"), "");
+    writeFileSync(join(dir, "malformed.applied"), "{");
+    writeFileSync(join(dir, "keep.txt"), "");
+    expect(gcFenceSuppressedEmits(orchDir, 10_000, 100)).toBe(3);
+    expect(readdirSync(dir).sort()).toEqual(["fresh.applied", "keep.txt"]);
+  });
+
+  test("absent directory is a no-op", () => {
+    expect(() => gcFenceSuppressedEmits(orchDir, Date.now())).not.toThrow();
+    expect(gcFenceSuppressedEmits(orchDir, Date.now())).toBe(0);
+  });
 });
 
 // --- helpers --------------------------------------------------------------

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -222,6 +222,8 @@ import {
   defaultAppendPhaseAdvanceAppliedEvent, // CTL-1789: the positive half of the advancement gate
   defaultAppendRunawayEvent,
   defaultAppendOrphanDetectedEvent,
+  defaultAppendFenceSuppressedEvent,
+  emitFenceSuppressedEventOnce,
 } from "./recovery.mjs";
 import { resolvePhaseSessionId as defaultResolveSession } from "./session-resolve.mjs";
 // CTL-729: progress-watchdog imports.
@@ -3905,6 +3907,17 @@ function emitOrphanDetectedOnce(orchDir, ticket, signals, appendOrphanDetectedEv
   }
 }
 
+export function emitFenceSuppressedOnce(orchDir, ticket, site, self, appendFenceSuppressedEvent) {
+  try {
+    emitFenceSuppressedEventOnce(orchDir, ticket, site, self, appendFenceSuppressedEvent);
+  } catch (err) {
+    log.warn(
+      { ticket, site, err: err.message },
+      "cat-3: fence-suppressed emit threw — continuing tick"
+    );
+  }
+}
+
 // defaultJanitorKillIntentRecorder — CTL-1004 J2's kill seam, backed by the
 // CTL-936 intentDb (beliefs.db) already threaded into the tick. Mirrors
 // recovery.mjs's intentAwareKill EXACTLY: it BOTH issues the real stop
@@ -4414,6 +4427,7 @@ export function schedulerTick(
     appendFenceStandoffEvent = defaultAppendFenceStandoffEvent,
     // CAT-173: injectable terminal-sweep fence seam for scheduler integration tests.
     terminalFenceGuard = fenceGuard,
+    appendFenceSuppressedEvent = defaultAppendFenceSuppressedEvent,
     // CTL-537: sequencing seam. Default undefined → the new-work gate is skipped
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
@@ -6682,6 +6696,13 @@ export function schedulerTick(
                 logger: log,
                 detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
               });
+              emitFenceSuppressedOnce(
+                orchDir,
+                member,
+                "dependency-cycle",
+                self,
+                appendFenceSuppressedEvent
+              );
             }
           }
         }
@@ -7641,7 +7662,7 @@ export function schedulerTick(
           } else {
             log.warn(
               { ticket: member, reason: c925FenceVerdict?.reason ?? null },
-              "cat-173: fence suppressed eligible dependency-cycle escalation",
+              "ctl-863: stale fence — suppressing labelOnce(needs-human/ctl-925-cycle) write (zombie guard)"
             );
             maybeBreakGlass({
               orchDir,
@@ -7655,6 +7676,13 @@ export function schedulerTick(
               logger: log,
               detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
             });
+            emitFenceSuppressedOnce(
+              orchDir,
+              member,
+              "ctl-925-cycle",
+              self,
+              appendFenceSuppressedEvent
+            );
           }
         }
       }
@@ -8420,6 +8448,16 @@ export function schedulerTick(
                   /* best-effort — a missing marker already permits retry */
                 }
               }
+              // CAT-3: the log.warn + stampFenceSuppress above already cover this
+              // else-branch's original scope — this is the one genuinely new piece
+              // CAT-3 adds on top of CAT-173's standoff handling: per-site telemetry.
+              emitFenceSuppressedOnce(
+                orchDir,
+                ticket,
+                "terminal-sweep",
+                self,
+                appendFenceSuppressedEvent
+              );
             }
           } else {
             log.warn(

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -224,6 +224,7 @@ import {
   defaultAppendOrphanDetectedEvent,
   defaultAppendFenceSuppressedEvent,
   emitFenceSuppressedEventOnce,
+  gcFenceSuppressedEmits,
 } from "./recovery.mjs";
 import { resolvePhaseSessionId as defaultResolveSession } from "./session-resolve.mjs";
 // CTL-729: progress-watchdog imports.
@@ -8572,6 +8573,7 @@ export function schedulerTick(
   for (const { ticket, phase } of gcDispatchCooldowns(orchDir, eligibleIds, now())) {
     appendCooldownGcEvent({ ticket, orchId: ticket, target_phase: phase });
   }
+  gcFenceSuppressedEmits(orchDir, now());
 
   const didWork =
     dispatched.length > 0 || advanced.length > 0 || promotedCount > 0 || resumedCount > 0;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -121,6 +121,12 @@ import {
 import { collectBeliefsTick, getBeliefsDb, getEscalateHumanBelief } from "./beliefs/collector.mjs";
 import { buildRecoveryItems } from "./recovery-evidence.mjs";
 import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator re-arm
+import {
+  appendFenceStandoffEvent as defaultAppendFenceStandoffEvent,
+  clearFenceStandoff,
+  maybeBreakGlass,
+  resolveStandoffCooldownMs,
+} from "./fence-standoff.mjs"; // CAT-173: bounded out-of-band surfacing for fence standoffs
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
 import {
   isIntentEffective,
@@ -3336,6 +3342,35 @@ function escalationProbeCooldownPath(orchDir, ticket) {
   return join(orchDir, "workers", ticket, ".escalation-probe-cooldown");
 }
 
+// CAT-173: successful fence-standoff delivery has its own long cooldown. Keep it
+// separate from `.fence-suppressed`: terminalDoneOnce consumes that marker and
+// must remain free to write Done while standoff re-escalation is rate-bounded.
+function fenceStandoffCooldownPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".fence-standoff-cooldown");
+}
+
+function stampFenceStandoffCooldown(orchDir, ticket, nowMs, env = process.env) {
+  try {
+    writeFileSync(
+      fenceStandoffCooldownPath(orchDir, ticket),
+      JSON.stringify({ expiresAt: nowMs + resolveStandoffCooldownMs(env) }),
+    );
+  } catch {
+    /* best-effort — re-probe next tick */
+  }
+}
+
+function isFenceStandoffCooldownFresh(orchDir, ticket, nowMs) {
+  try {
+    const { expiresAt } = JSON.parse(
+      readFileSync(fenceStandoffCooldownPath(orchDir, ticket), "utf8"),
+    );
+    return Number.isFinite(expiresAt) && nowMs < expiresAt;
+  } catch {
+    return false;
+  }
+}
+
 // Best-effort: a failed write just means we re-probe next tick (no worse than before).
 function stampCooldownMarker(path, nowMs) {
   try {
@@ -4376,6 +4411,9 @@ export function schedulerTick(
     // CTL-868 — orphan-detected emitter (route B observability). Injectable; tests
     // pass a spy, production uses the canonical unified-event-log appender.
     appendOrphanDetectedEvent = defaultAppendOrphanDetectedEvent,
+    appendFenceStandoffEvent = defaultAppendFenceStandoffEvent,
+    // CAT-173: injectable terminal-sweep fence seam for scheduler integration tests.
+    terminalFenceGuard = fenceGuard,
     // CTL-537: sequencing seam. Default undefined → the new-work gate is skipped
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
@@ -6572,12 +6610,17 @@ export function schedulerTick(
         for (const member of anomaly.members) {
           if (triagedWaiting.includes(member)) {
             cycleMembers.add(member);
+            let cycleFenceVerdict = null;
             if (
               fenceGuard(
                 { ticket: member, orchDir, multiHost, gateway, self },
-                { proceedOnMissingGeneration: true }
+                {
+                  proceedOnMissingGeneration: true,
+                  onSuppress: (verdict) => { cycleFenceVerdict = verdict; },
+                }
               )
             ) {
+              clearFenceStandoff(orchDir, member);
               const dcResult = routeStuckTicketToDelegate(orchDir, member, {
                 site: "dependency-cycle",
                 reason: "dependency-cycle",
@@ -6624,9 +6667,21 @@ export function schedulerTick(
               }
             } else {
               log.warn(
-                { ticket: member },
+                { ticket: member, reason: cycleFenceVerdict?.reason ?? null },
                 "ctl-863: stale fence — suppressing labelOnce(needs-human/cycle) write (zombie guard)"
               );
+              maybeBreakGlass({
+                orchDir,
+                ticket: member,
+                site: "triaged-waiting-cycle",
+                verdict: cycleFenceVerdict,
+                phase: "dependency-cycle",
+                now: now(),
+                env,
+                appendEvent: appendFenceStandoffEvent,
+                logger: log,
+                detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
+              });
             }
           }
         }
@@ -7540,12 +7595,17 @@ export function schedulerTick(
           );
           // CTL-863 fence: external Linear write — a zombie host that lost its
           // claim must not label after takeover (mirrors the A.5 cycle site).
+          let c925FenceVerdict = null;
           if (
             fenceGuard(
               { ticket: member, orchDir, multiHost, gateway, self },
-              { proceedOnMissingGeneration: true }
+              {
+                proceedOnMissingGeneration: true,
+                onSuppress: (verdict) => { c925FenceVerdict = verdict; },
+              }
             )
           ) {
+            clearFenceStandoff(orchDir, member);
             const c925Result = routeStuckTicketToDelegate(orchDir, member, {
               site: "ctl-925-cycle",
               reason: "dependency-cycle",
@@ -7578,6 +7638,23 @@ export function schedulerTick(
                 source: "ctl-925-cycle",
               });
             }
+          } else {
+            log.warn(
+              { ticket: member, reason: c925FenceVerdict?.reason ?? null },
+              "cat-173: fence suppressed eligible dependency-cycle escalation",
+            );
+            maybeBreakGlass({
+              orchDir,
+              ticket: member,
+              site: "ctl-925-cycle",
+              verdict: c925FenceVerdict,
+              phase: "dependency-cycle",
+              now: now(),
+              env,
+              appendEvent: appendFenceStandoffEvent,
+              logger: log,
+              detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
+            });
           }
         }
       }
@@ -8183,7 +8260,8 @@ export function schedulerTick(
       // fence-check runs before we've proven a write is needed.
       if (
         isFenceSuppressFresh(orchDir, ticket, now()) ||
-        isEscalationProbeCooldownFresh(orchDir, ticket, now())
+        isEscalationProbeCooldownFresh(orchDir, ticket, now()) ||
+        isFenceStandoffCooldownFresh(orchDir, ticket, now())
       ) {
         // Still surface the orphan once for the dashboard (the probe/write is what we
         // skip, not the visibility signal).
@@ -8226,49 +8304,122 @@ export function schedulerTick(
           // latch so a finished ticket's escalated/cooldown ledger entry doesn't
           // linger (hygiene — the recovery router already drops terminal tickets).
           recoveryForgetIntent(ticket, { orchDir });
+          clearFenceStandoff(orchDir, ticket);
         } else {
-          // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
-          // label (CTL-1241: skipped when the belief engine owns the reclaim).
-          if (
-            fenceGuard(
-              { ticket, orchDir, multiHost, gateway, self },
-              {
-                proceedOnMissingGeneration: true,
-                // CTL-1329: a missing generation stays missing next tick regardless
-                // of whether THIS tick's escalation write succeeded, so arm a cooldown
-                // — otherwise proceeding here (instead of suppressing) reintroduces the
-                // unbounded per-tick terminal-probe burn CTL-1329 fixed, just on the
-                // write path instead of the read path. It is the escalation-side marker,
-                // NOT `.fence-suppressed`: terminalDoneOnce reads the latter, so arming
-                // that one here would hold a genuinely-completed pipeline non-terminal
-                // for a whole cooldown window when recovery finishes teardown.
-                onMissingGeneration: () => stampEscalationProbeCooldown(orchDir, ticket, now()),
+          // #1461 Fix 3 (final-review finding): exempt a ticket
+          // resolve-conflict-sweep is actively resolving (failureReason/
+          // stalledReason === RESOLVED_MARKER_REASON, imported from
+          // resolve-conflict-sweep.mjs) from immediate needs-human labeling —
+          // otherwise every candidate is flagged needs-human the same tick the
+          // fix is already in flight. A cap-exhausted stall
+          // (resolve-conflict-sweep.mjs's CAP_EXHAUSTED_REASON) is a NORMAL
+          // stalled reason and is NOT exempted — it surfaces exactly like
+          // remediate-cycle-cap-exhausted already does.
+          //
+          // The exemption is narrowly scoped to ONLY the needs-human label
+          // call below — it used to `continue`, which skipped the ENTIRE rest
+          // of this loop iteration: convergeStartedHeldLabels (CTL-1068
+          // orphaned held-label retraction), convergeDispositionLabel (CTL-764
+          // finding 5), and the CTL-695 terminal-worker reap nomination below
+          // all have nothing to do with needs-human labeling and must still
+          // run normally for a ticket under active resolve-conflict resolution.
+          const activeSignal = signalByTicket.get(ticket);
+          const activeReason =
+            activeSignal?.raw?.failureReason ?? activeSignal?.raw?.stalledReason ?? null;
+          if (activeReason !== RESOLVED_MARKER_REASON) {
+            // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
+            // label (CTL-1241: skipped when the belief engine owns the reclaim).
+            let fenceVerdict = null;
+            if (
+              terminalFenceGuard(
+                { ticket, orchDir, multiHost, gateway, self },
+                {
+                  proceedOnMissingGeneration: true,
+                  // CTL-1329: a missing generation stays missing next tick regardless
+                  // of whether THIS tick's escalation write succeeded, so arm a cooldown
+                  // — otherwise proceeding here (instead of suppressing) reintroduces the
+                  // unbounded per-tick terminal-probe burn CTL-1329 fixed, just on the
+                  // write path instead of the read path. It is the escalation-side marker,
+                  // NOT `.fence-suppressed`: terminalDoneOnce reads the latter, so arming
+                  // that one here would hold a genuinely-completed pipeline non-terminal
+                  // for a whole cooldown window when recovery finishes teardown.
+                  onMissingGeneration: () => stampEscalationProbeCooldown(orchDir, ticket, now()),
+                  onSuppress: (verdict) => {
+                    fenceVerdict = verdict;
+                  },
+                }
+              )
+            ) {
+              clearFenceStandoff(orchDir, ticket);
+              const stalledSig = signalByTicket.get(ticket);
+              const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
+                site: "terminal-sweep",
+                reason: stalledSig?.stalledReason ?? "stalled",
+                boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
+                applyLabel: writeStatus,
+                env,
+                log,
+                appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
+                explanation: {
+                  problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
+                  call_to_action: `decide whether to retry ${ticket} or close it`,
+                },
+                // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
+                // terminal-sweep cohort cannot enqueue past maxParallel.
+                deps: { orchDir, maxParallel },
+              });
+              // CTL-764 finding 8: emit worker.transition ONLY when the label write
+              // actually occurred. A persisted .linear-label-needs-human marker after a
+              // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
+              // label — recording a fresh needs-human transition there is a false escalation.
+              if (tsResult.labelled === true) {
+                recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
               }
-            )
-          ) {
-            const stalledSig = signalByTicket.get(ticket);
-            const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
-              site: "terminal-sweep",
-              reason: stalledSig?.stalledReason ?? "stalled",
-              boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
-              applyLabel: writeStatus,
-              env,
-              log,
-              appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
-              explanation: {
-                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
-                call_to_action: `decide whether to retry ${ticket} or close it`,
-              },
-              // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
-              // terminal-sweep cohort cannot enqueue past maxParallel.
-              deps: { orchDir, maxParallel },
-            });
-            // CTL-764 finding 8: emit worker.transition ONLY when the label write
-            // actually occurred. A persisted .linear-label-needs-human marker after a
-            // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
-            // label — recording a fresh needs-human transition there is a false escalation.
-            if (tsResult.labelled === true) {
-              recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
+            } else {
+              log.warn(
+                { ticket, reason: fenceVerdict?.reason ?? null },
+                "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
+              );
+              // CTL-1329: arm the cooldown so the next ticks skip this dir's probe+fence
+              // instead of re-burning Linear quota every tick until the dir is reaped.
+              stampFenceSuppress(orchDir, ticket, now());
+              const standoff = maybeBreakGlass({
+                orchDir,
+                ticket,
+                site: "terminal-sweep",
+                verdict: fenceVerdict,
+                phase: signalByTicket.get(ticket)?.phase ?? "terminal-sweep",
+                now: now(),
+                env,
+                appendEvent: (payload) => {
+                  try {
+                    return appendFenceStandoffEvent(payload);
+                  } catch {
+                    return false;
+                  }
+                },
+                logger: log,
+              });
+              if (standoff.breakGlass && !standoff.deliveryPending) {
+                stampFenceStandoffCooldown(orchDir, ticket, now(), env);
+              } else if (standoff.deliveryPending && standoff.deliveryRetryable === true) {
+                // Delivery is intentionally retryable on the next tick. The ordinary
+                // 15-minute suppression marker was stamped immediately above; remove
+                // it so it cannot accidentally become a delivery-retry latch.
+                //
+                // BOUNDED (CAT-173 review): only while maybeBreakGlass still reports the
+                // failure as retryable. Dropping the marker every tick on a PERSISTENTLY
+                // failing sink (unwritable `.escalations`, full disk) re-runs this block's
+                // terminal Linear probe + fence-check subprocess ~2x/sec forever — exactly
+                // the CTL-1329 burn that drained the OAuth bucket and froze fleet dispatch.
+                // Past the bound we leave the marker, so delivery still retries — once per
+                // 15-minute cooldown instead of every tick. Fail-closed on an absent flag.
+                try {
+                  unlinkSync(fenceSuppressMarkerPath(orchDir, ticket));
+                } catch {
+                  /* best-effort — a missing marker already permits retry */
+                }
+              }
             }
           } else {
             log.warn(
@@ -8990,6 +9141,8 @@ function runTick() {
       // CTL-1789: same shape — undefined keeps schedulerTick's default-on
       // defaultAppendPhaseAdvanceAppliedEvent; a test injects a spy.
       appendPhaseAdvanceAppliedEvent: runningOpts.appendPhaseAdvanceAppliedEvent,
+      appendFenceStandoffEvent:
+        runningOpts.appendFenceStandoffEvent ?? defaultAppendFenceStandoffEvent,
       // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
       // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
       // resolver the J4 census uses (never removes a dir whose worktree hosts a live

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5213,6 +5213,206 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
   });
 });
 
+describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
+  test("delivery failure does not extend fence suppression and retries next tick", () => {
+    const ticket = "PROJ-173-RETRY";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "unverifiable",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "unverifiable" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        throw new Error("injected append failure");
+      },
+    };
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-suppressed"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-standoff-cooldown"))).toBe(false);
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(2);
+  });
+
+  // CAT-173 review: the retry above must be BOUNDED. An unbounded one re-runs the
+  // terminal Linear probe + fence-check every tick on a persistently failing sink —
+  // the CTL-1329 burn. Past the bound the ordinary 15-minute marker is retained.
+  test("a persistently failing delivery stops bypassing the 15-minute cooldown", () => {
+    const ticket = "PROJ-173-RETRY-BOUND";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "unverifiable",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+        CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX: "3",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "unverifiable" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        throw new Error("injected persistent append failure");
+      },
+    };
+
+    for (let i = 0; i < 12; i++) schedulerTick(orchDir, opts);
+    // 4 probes: the first three failures are under the bound and drop the marker;
+    // the fourth retains it, so every later tick short-circuits before the fence.
+    expect(fenceCalls).toBe(4);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-suppressed"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-standoff-cooldown"))).toBe(false);
+  });
+
+  // CAT-173 verify finding #3: the POSITIVE path was unpinned — nothing asserted
+  // that a successful break-glass stamps the cooldown, nor that the cooldown then
+  // short-circuits the next tick's probe+write block.
+  test("a successful break-glass stamps the cooldown and short-circuits the next tick", () => {
+    const ticket = "PROJ-173-COOLDOWN";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "unverifiable",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    let appendCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "unverifiable" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        appendCalls += 1;
+        return true;
+      },
+    };
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(appendCalls).toBe(1);
+    const cooldownPath = join(orchDir, "workers", ticket, ".fence-standoff-cooldown");
+    expect(existsSync(cooldownPath)).toBe(true);
+    expect(JSON.parse(readFileSync(cooldownPath, "utf8")).expiresAt).toBe(nowMs + 21600000);
+    // The durable, unfenced human signal was written without a Linear label.
+    const durable = JSON.parse(
+      readFileSync(join(orchDir, ".escalations", `${ticket}.json`), "utf8"),
+    );
+    expect(durable.source).toBe("fence-standoff");
+    expect(durable.labelConfirmed).toBe(false);
+
+    // Second tick inside the window: zero fence calls, zero further escalations.
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(appendCalls).toBe(1);
+  });
+});
+
 // ── CTL-1079: retraction sweep reads from broker cache instead of live API ──
 // These tests use an exec spy + the real removeLabel (from linear-write.mjs)
 // to verify that gateway cache hits suppress the live `linearis issues read`

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -43,6 +43,7 @@ import {
   listStartedTickets,
   schedulerTick,
   readAllEligibleTickets,
+  emitFenceSuppressedOnce,
   hydrateOutOfSetBlockers,
   startScheduler,
   stopScheduler,
@@ -108,6 +109,60 @@ import { removeLabel as realRemoveLabel } from "./linear-write.mjs"; // CTL-1079
 import { bootResumePendingPath, bootResumeApprovedPath } from "./boot-resume.mjs"; // CTL-1367 P2-C: per-tick approval-poll dispatch wiring
 import { recordRemovalFailure } from "./label-guard.mjs"; // CTL-1605 Codex thread: drive needs-human into CTL-1078 backoff for the terminal-stale multi-label tests
 import { getDrainFlagPath, getEventLogPath } from "./config.mjs"; // CTL-1678: drain-disabled override integration test
+
+describe("emitFenceSuppressedOnce", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "fence-suppressed-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("emits once per ticket and site with the operator payload", () => {
+    const calls = [];
+    const emit = (payload) => {
+      calls.push(payload);
+      return true;
+    };
+    emitFenceSuppressedOnce(dir, "CAT-3", "terminal-sweep", "host-a", emit);
+    emitFenceSuppressedOnce(dir, "CAT-3", "terminal-sweep", "host-a", emit);
+    emitFenceSuppressedOnce(dir, "CAT-3", "dependency-cycle", "host-a", emit);
+    expect(calls).toEqual([
+      {
+        ticket: "CAT-3",
+        site: "terminal-sweep",
+        host: "host-a",
+        reason: "fence-suppressed",
+      },
+      {
+        ticket: "CAT-3",
+        site: "dependency-cycle",
+        host: "host-a",
+        reason: "fence-suppressed",
+      },
+    ]);
+  });
+
+  test("does not create a worker directory for an unstarted ticket", () => {
+    const calls = [];
+    const emit = (payload) => {
+      calls.push(payload);
+      return true;
+    };
+    for (let i = 0; i < 3; i += 1) {
+      emitFenceSuppressedOnce(dir, "CAT-3", "ctl-925-cycle", "host-a", emit);
+    }
+    expect(calls).toHaveLength(1);
+    expect(existsSync(join(dir, "workers", "CAT-3"))).toBe(false);
+  });
+
+  test("does not write a marker when the emitter returns false or throws", () => {
+    emitFenceSuppressedOnce(dir, "CAT-3", "terminal-sweep", "host-a", () => false);
+    emitFenceSuppressedOnce(dir, "CAT-3", "dependency-cycle", "host-a", () => {
+      throw new Error("boom");
+    });
+    expect(existsSync(join(dir, ".fence-suppressed-emits"))).toBe(false);
+  });
+});
 
 let orchDir;
 let catalystDir;

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -521,8 +521,11 @@ export function startStalePrRescueTimer({
   // (which already owns concurrency); importing readMaxParallel here would pull
   // scheduler.mjs's bun:sqlite graph into this timer. undefined → prior behavior.
   maxParallel = undefined,
+  // CAT-219: gateway is deliberately latent in production. `self` is load-bearing:
+  // it identifies self-owned projection rows and is the host dimension of emitted events.
   gateway = undefined,
   self = getHostName(),
+  appendFenceSuppressedEvent = defaultAppendFenceSuppressedEvent,
   // injectable seams
   jobLifecycle: jobLifecycleFn = jobLifecycle,
   prView = defaultPrView,
@@ -559,6 +562,7 @@ export function startStalePrRescueTimer({
         maxParallel,
         gateway,
         self,
+        appendFenceSuppressedEvent,
         jobLifecycleFn,
         prView,
         compareBehind,
@@ -587,6 +591,7 @@ async function runTick({
   maxParallel,
   gateway,
   self,
+  appendFenceSuppressedEvent,
   jobLifecycleFn,
   prView,
   compareBehind,
@@ -618,6 +623,7 @@ async function runTick({
         maxParallel,
         gateway,
         self,
+        appendFenceSuppressedEvent,
         nowMs,
         jobLifecycleFn,
         prView,
@@ -644,6 +650,7 @@ async function processTicket({
   maxParallel,
   gateway,
   self,
+  appendFenceSuppressedEvent,
   nowMs,
   jobLifecycleFn,
   prView,
@@ -716,6 +723,7 @@ async function processTicket({
         gateway,
         self,
         now: () => nowMs,
+        appendFenceSuppressedEvent,
       }
     );
     // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
@@ -863,6 +871,7 @@ async function processTicket({
         now: () => nowMs,
         gateway,
         self,
+        appendFenceSuppressedEvent,
       });
       // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
       // permanent skip in decideRescue, so it is written only when the needs-human

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -19,7 +19,11 @@ import {
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { jobLifecycle } from "./recovery.mjs";
+import {
+  jobLifecycle,
+  defaultAppendFenceSuppressedEvent,
+  emitFenceSuppressedEventOnce,
+} from "./recovery.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { fenceGuard } from "./fence-guard.mjs";
@@ -30,7 +34,7 @@ import {
 } from "./fence-standoff.mjs";
 import { recordDurableEscalation } from "./durable-escalation.mjs";
 import { appendFileSync } from "node:fs";
-import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
+import { log, getEventLogPath, getClusterHosts, getHostName } from "./config.mjs";
 import { DEFAULTS, classifyMergeTree, decideRescue } from "./stale-pr-rescue.mjs";
 // Default Linear transport for the escalation path. The daemon does not thread
 // a writer (scheduler.mjs threads its own), so without this default every
@@ -343,6 +347,7 @@ export function defaultEscalate(
     fenceGuardFn = fenceGuard,
     recordDurableEscalationFn = recordDurableEscalation,
     appendStandoffEvent = appendFenceStandoffEvent,
+    appendFenceSuppressedEvent = defaultAppendFenceSuppressedEvent,
   } = {}
 ) {
   let routed = false;
@@ -402,6 +407,20 @@ export function defaultEscalate(
         recordEscalation: recordDurableEscalationFn,
         detail: `stale PR #${detail?.prNumber ?? "?"}`,
       });
+      try {
+        emitFenceSuppressedEventOnce(
+          orchDir,
+          ticket,
+          "stale-pr-rescue",
+          self,
+          appendFenceSuppressedEvent
+        );
+      } catch (err) {
+        log.warn(
+          { ticket, err: err.message },
+          "cat-3: stale-pr-rescue fence-suppressed emit threw"
+        );
+      }
     }
   } else {
     log.warn(
@@ -502,6 +521,8 @@ export function startStalePrRescueTimer({
   // (which already owns concurrency); importing readMaxParallel here would pull
   // scheduler.mjs's bun:sqlite graph into this timer. undefined → prior behavior.
   maxParallel = undefined,
+  gateway = undefined,
+  self = getHostName(),
   // injectable seams
   jobLifecycle: jobLifecycleFn = jobLifecycle,
   prView = defaultPrView,
@@ -535,6 +556,9 @@ export function startStalePrRescueTimer({
         cfg,
         linearWrite,
         multiHost: tickMultiHost,
+        maxParallel,
+        gateway,
+        self,
         jobLifecycleFn,
         prView,
         compareBehind,
@@ -561,6 +585,8 @@ async function runTick({
   linearWrite,
   multiHost,
   maxParallel,
+  gateway,
+  self,
   jobLifecycleFn,
   prView,
   compareBehind,
@@ -590,6 +616,8 @@ async function runTick({
         linearWrite,
         multiHost,
         maxParallel,
+        gateway,
+        self,
         nowMs,
         jobLifecycleFn,
         prView,
@@ -614,6 +642,8 @@ async function processTicket({
   linearWrite,
   multiHost,
   maxParallel,
+  gateway,
+  self,
   nowMs,
   jobLifecycleFn,
   prView,
@@ -677,7 +707,16 @@ async function processTicket({
       // conflict fields but never prNumber, so the standoff detail rendered
       // "stale PR #?" and dropped the primary actionable identifier.
       { reason: "rescue_worker_stalled", prNumber: prInfo.number, ...rescueState },
-      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel, now: () => nowMs }
+      {
+        orchDir,
+        orchId: effectiveOrchId,
+        linearWrite,
+        multiHost,
+        maxParallel,
+        gateway,
+        self,
+        now: () => nowMs,
+      }
     );
     // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
     // decideRescue skips forever once escalatedAt exists, so latching on an
@@ -822,6 +861,8 @@ async function processTicket({
         multiHost,
         maxParallel,
         now: () => nowMs,
+        gateway,
+        self,
       });
       // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
       // permanent skip in decideRescue, so it is written only when the needs-human

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -23,6 +23,12 @@ import { jobLifecycle } from "./recovery.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { fenceGuard } from "./fence-guard.mjs";
+import {
+  appendFenceStandoffEvent,
+  clearFenceStandoff,
+  maybeBreakGlass,
+} from "./fence-standoff.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 import { appendFileSync } from "node:fs";
 import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
 import { DEFAULTS, classifyMergeTree, decideRescue } from "./stale-pr-rescue.mjs";
@@ -333,6 +339,10 @@ export function defaultEscalate(
     env = process.env,
     maxParallel = undefined,
     appendDelegateEvent = defaultAppendDelegateEvent,
+    now = () => Date.now(),
+    fenceGuardFn = fenceGuard,
+    recordDurableEscalationFn = recordDurableEscalation,
+    appendStandoffEvent = appendFenceStandoffEvent,
   } = {}
 ) {
   let routed = false;
@@ -344,12 +354,15 @@ export function defaultEscalate(
     // generation must LOUDLY proceed with the label rather than silently drop a
     // human escalation. A genuine supersession (readable generation, fresh
     // foreign owner / authoritative read says not-current) still suppresses.
-    if (
-      fenceGuard(
-        { ticket, orchDir, multiHost, gateway, self },
-        { proceedOnMissingGeneration: true }
-      )
-    ) {
+    let fenceVerdict = null;
+    if (fenceGuardFn(
+      { ticket, orchDir, multiHost, gateway, self },
+      {
+        proceedOnMissingGeneration: true,
+        onSuppress: (verdict) => { fenceVerdict = verdict; },
+      },
+    )) {
+      clearFenceStandoff(orchDir, ticket);
       const r = routeStuckTicketToDelegate(orchDir, ticket, {
         site: "stale-pr-rescue",
         reason: detail?.reason ?? "unresolvable-conflict",
@@ -374,9 +387,21 @@ export function defaultEscalate(
     } else {
       outcomeReason = "fence-suppressed";
       log.warn(
-        { ticket },
+        { ticket, reason: fenceVerdict?.reason ?? null },
         "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)"
       );
+      maybeBreakGlass({
+        orchDir,
+        ticket,
+        site: "stale-pr-rescue",
+        verdict: fenceVerdict,
+        phase: "pr",
+        now: now(),
+        env,
+        appendEvent: appendStandoffEvent,
+        recordEscalation: recordDurableEscalationFn,
+        detail: `stale PR #${detail?.prNumber ?? "?"}`,
+      });
     }
   } else {
     log.warn(
@@ -648,8 +673,11 @@ async function processTicket({
     }
     const stalledOutcome = escalate(
       ticket,
-      { reason: "rescue_worker_stalled", ...rescueState },
-      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel }
+      // CAT-173: thread the known PR number — rescueState carries attempt/behind/
+      // conflict fields but never prNumber, so the standoff detail rendered
+      // "stale PR #?" and dropped the primary actionable identifier.
+      { reason: "rescue_worker_stalled", prNumber: prInfo.number, ...rescueState },
+      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel, now: () => nowMs }
     );
     // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
     // decideRescue skips forever once escalatedAt exists, so latching on an
@@ -785,12 +813,15 @@ async function processTicket({
     }
 
     case "escalate": {
-      const outcome = escalate(ticket, decision.detail ?? {}, {
+      // CAT-173: decideRescue's detail supplies attempt/behind/conflict only —
+      // thread prNumber so the standoff/escalation reason names the actual PR.
+      const outcome = escalate(ticket, { prNumber: prInfo.number, ...(decision.detail ?? {}) }, {
         orchDir,
         orchId: effectiveOrchId,
         linearWrite,
         multiHost,
         maxParallel,
+        now: () => nowMs,
       });
       // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
       // permanent skip in decideRescue, so it is written only when the needs-human

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -1158,3 +1158,47 @@ describe("escalation durability — escalatedAt only on a confirmed escalation (
     expect(readRescueState(orchDir, "CTL-E4")?.escalatedAt).toBeTruthy();
   });
 });
+
+describe("defaultEscalate fence-suppressed event", () => {
+  let dir;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it("emits once without creating a worker directory", () => {
+    dir = mkdtempSync(join(tmpdir(), "stale-pr-fence-"));
+    const events = [];
+    const deps = {
+      orchDir: dir,
+      linearWrite: { applyLabel: () => ({ applied: true }) },
+      multiHost: true,
+      self: "host-a",
+      gateway: {
+        getDescriptor: () => ({ ownerHost: "host-b", generation: 2 }),
+      },
+      appendFenceSuppressedEvent: (event) => events.push(event),
+    };
+    const outcome = defaultEscalate("CAT-3", {}, deps);
+    defaultEscalate("CAT-3", {}, deps);
+    defaultEscalate("CAT-3", {}, deps);
+    expect(outcome).toEqual({ confirmed: false, routed: false, reason: "fence-suppressed" });
+    expect(events).toEqual([
+      {
+        ticket: "CAT-3",
+        site: "stale-pr-rescue",
+        host: "host-a",
+        reason: "fence-suppressed",
+      },
+    ]);
+    expect(existsSync(join(dir, "workers", "CAT-3"))).toBe(false);
+  });
+
+  it("does not emit for a missing Linear transport", () => {
+    dir = mkdtempSync(join(tmpdir(), "stale-pr-no-transport-"));
+    const events = [];
+    defaultEscalate("CAT-3", {}, {
+      orchDir: dir,
+      linearWrite: null,
+      appendFenceSuppressedEvent: (event) => events.push(event),
+    });
+    expect(events).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -11,7 +11,10 @@ import {
   buildRescueDispatchArgs,
   defaultMergeTree,
   defaultLinearWrite,
+  defaultEscalate,
 } from "./stale-pr-rescue-timer.mjs";
+import { readFenceStandoff } from "./fence-standoff.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 import * as linearWriteModule from "./linear-write.mjs";
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
@@ -625,6 +628,102 @@ describe("escalation default seam", () => {
 
     expect(labels).toEqual([{ ticket: "CTL-31", label: "needs-human" }]);
     expect(existsSync(join(orchDir, "workers", "CTL-31", ".linear-label-needs-human.applied"))).toBe(true);
+  });
+
+  it("fence-suppressed rescue records the episode and writes one durable escalation past the bound (CAT-173)", () => {
+    const orchDir = mkOrchDir();
+    const events = [];
+    let now = 1_000;
+    const fenceGuardFn = (_ctx, opts) => {
+      opts.onSuppress?.({ ticket: "PROJ-173", reason: "unverifiable", generation: 7 });
+      return false;
+    };
+    const deps = {
+      orchDir,
+      linearWrite: {},
+      multiHost: true,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "2",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+      },
+      now: () => now,
+      fenceGuardFn,
+      appendStandoffEvent: (payload) => {
+        events.push(payload);
+        return true;
+      },
+    };
+
+    const first = defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(first.reason).toBe("fence-suppressed");
+    expect(readFenceStandoff(orchDir, "PROJ-173")?.count).toBe(1);
+    expect(existsSync(join(orchDir, ".escalations", "PROJ-173.json"))).toBe(false);
+
+    now += 2;
+    const second = defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(second.reason).toBe("fence-suppressed");
+    const durable = JSON.parse(readFileSync(join(orchDir, ".escalations", "PROJ-173.json"), "utf8"));
+    expect(durable.source).toBe("fence-standoff");
+    expect(durable.reason).toMatch(/fence-standoff.*PR #173/);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ ticket: "PROJ-173", site: "stale-pr-rescue", count: 2 });
+
+    now += 2;
+    defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(events).toHaveLength(1);
+  });
+
+  it("retries break-glass until both the durable record and event append succeed (CAT-173 P1)", () => {
+    const orchDir = mkOrchDir();
+    let now = 2_000;
+    let durableAttempts = 0;
+    let eventAttempts = 0;
+    const deps = {
+      orchDir,
+      linearWrite: {},
+      multiHost: true,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+      },
+      now: () => now,
+      fenceGuardFn: (_ctx, opts) => {
+        opts.onSuppress?.({ ticket: "PROJ-174", reason: "unverifiable", generation: 8 });
+        return false;
+      },
+      recordDurableEscalationFn: (record) => {
+        durableAttempts += 1;
+        return durableAttempts > 1 ? recordDurableEscalation(record) : null;
+      },
+      appendStandoffEvent: () => {
+        eventAttempts += 1;
+        return eventAttempts > 1;
+      },
+    };
+
+    now += 2;
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(0);
+
+    now += 2;
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(0);
+
+    now += 2;
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(1);
+
+    now += 2;
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBe(now);
+    expect(eventAttempts).toBe(2);
+
+    now += 2;
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(eventAttempts).toBe(2);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -307,18 +307,21 @@ describe("startStalePrRescueTimer", () => {
     });
 
     const escalated = [];
+    const ceiling = () => 1;
     startStalePrRescueTimer({
       enabled: true,
       orchDir,
       intervalSeconds: 1,
       config: { stableSeconds: 300, behindThreshold: 10, maxAttempts: 1 },
+      maxParallel: ceiling,
       clock,
-      ...makeSeams({ escalate: (t) => escalated.push(t) }),
+      ...makeSeams({ escalate: (t, detail, opts) => escalated.push({ t, detail, opts }) }),
     });
     clock.advance(1_000);
     await new Promise(r => setTimeout(r, 20));
     expect(escalated.length).toBe(1);
-    expect(escalated[0]).toBe("CTL-6");
+    expect(escalated[0].t).toBe("CTL-6");
+    expect(escalated[0].opts.maxParallel).toBe(ceiling);
   });
 
   it("tick: MERGED → no action, rescue state ignored", async () => {
@@ -769,17 +772,20 @@ describe("timer-level decision paths (previously only covered in the pure core)"
     });
 
     const escalated = [];
+    const ceiling = () => 1;
     startStalePrRescueTimer({
       enabled: true, orchDir, intervalSeconds: 1, clock,
       config: { stableSeconds: 300, behindThreshold: 10, maxAttempts: 1 },
+      maxParallel: ceiling,
       ...makeSeams({
         worktreeExists: () => false,
-        escalate: (ticket, detail) => escalated.push({ ticket, detail }),
+        escalate: (ticket, detail, opts) => escalated.push({ ticket, detail, opts }),
       }),
     });
     clock.advance(1_000);
     await new Promise(r => setTimeout(r, 20));
     expect(escalated.length).toBe(1);
+    expect(escalated[0].opts.maxParallel).toBe(ceiling);
     const rs = readRescueState(orchDir, "CTL-41");
     expect(rs?.escalateReason).toBe("worktree_missing");
   });
@@ -815,6 +821,97 @@ describe("timer-level decision paths (previously only covered in the pure core)"
     const rs = readRescueState(orchDir, "CTL-42");
     expect(rs?.escalateReason).toBe("rescue_budget_exhausted");
     expect(rs?.rescueAttempts).toBe(1); // untouched
+  });
+});
+
+describe("CAT-219 latent gateway wiring", () => {
+  it("threads gateway, self, and the suppression sink through the real timer", async () => {
+    const priorDir = process.env.CATALYST_DIR;
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    process.env.CATALYST_DIR = orchDir;
+    try {
+      mkTicketDir(orchDir, "CAT-219");
+      writeSignal(orchDir, "CAT-219", "pr", {
+        status: "done",
+        bg_job_id: "dead",
+        pr: { number: 219, url: "https://github.com/org/repo/pull/219" },
+        worktreePath: "/gone/wt",
+      });
+      const events = [];
+      startStalePrRescueTimer({
+        enabled: true,
+        orchDir,
+        intervalSeconds: 1,
+        clock,
+        multiHost: true,
+        self: "host-a",
+        gateway: { getDescriptor: () => ({ ownerHost: "host-b", generation: 2 }) },
+        appendFenceSuppressedEvent: (event) => events.push(event),
+        ...makeSeams({ worktreeExists: () => false, escalate: defaultEscalate }),
+      });
+      clock.advance(1_000);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(events).toEqual([
+        {
+          ticket: "CAT-219",
+          site: "stale-pr-rescue",
+          host: "host-a",
+          reason: "fence-suppressed",
+        },
+      ]);
+    } finally {
+      if (priorDir === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = priorDir;
+    }
+  });
+
+  it("threads the suppression sink through rescue_worker_stalled", async () => {
+    const clock = fakeClock();
+    const orchDir = mkOrchDir();
+    mkTicketDir(orchDir, "CAT-219-STALLED");
+    writeSignal(orchDir, "CAT-219-STALLED", "pr", {
+      status: "done",
+      bg_job_id: "dead",
+      pr: { number: 220, url: "https://github.com/org/repo/pull/220" },
+      worktreePath: "/gone/wt",
+    });
+    writeRescueState(orchDir, "CAT-219-STALLED", {
+      status: "rescue-stalled",
+      rescueAttempts: 1,
+    });
+    const events = [];
+    startStalePrRescueTimer({
+      enabled: true,
+      orchDir,
+      intervalSeconds: 1,
+      clock,
+      multiHost: true,
+      self: "host-a",
+      gateway: { getDescriptor: () => ({ ownerHost: "host-b", generation: 2 }) },
+      appendFenceSuppressedEvent: (event) => events.push(event),
+      ...makeSeams({ escalate: defaultEscalate }),
+    });
+    clock.advance(1_000);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toEqual([
+      {
+        ticket: "CAT-219-STALLED",
+        site: "stale-pr-rescue",
+        host: "host-a",
+        reason: "fence-suppressed",
+      },
+    ]);
+  });
+
+  it("pins daemon gateway omission with the source marker", () => {
+    const source = readFileSync(join(import.meta.dir, "daemon.mjs"), "utf8");
+    const marker = source.indexOf("CAT-219-GATEWAY-LATENT");
+    const start = source.lastIndexOf("startStalePrRescueTimer({", marker);
+    const call = source.slice(start, source.indexOf("});", marker) + 3);
+    expect(call).toContain("CAT-219-GATEWAY-LATENT");
+    expect(call).toContain("maxParallel:");
+    expect(call).not.toMatch(/^\s*gateway\s*:/m);
   });
 });
 
@@ -1194,11 +1291,62 @@ describe("defaultEscalate fence-suppressed event", () => {
   it("does not emit for a missing Linear transport", () => {
     dir = mkdtempSync(join(tmpdir(), "stale-pr-no-transport-"));
     const events = [];
-    defaultEscalate("CAT-3", {}, {
-      orchDir: dir,
-      linearWrite: null,
-      appendFenceSuppressedEvent: (event) => events.push(event),
-    });
+    defaultEscalate(
+      "CAT-3",
+      {},
+      {
+        orchDir: dir,
+        linearWrite: null,
+        appendFenceSuppressedEvent: (event) => events.push(event),
+      },
+    );
     expect(events).toHaveLength(0);
+  });
+});
+
+describe("defaultEscalate delegate ceiling (CAT-219)", () => {
+  it("queue-full falls back to a needs-human label", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cat219-queue-full-"));
+    dirs.push(dir);
+    mkdirSync(join(dir, ".delegate-queue"), { recursive: true });
+    writeFileSync(
+      join(dir, ".delegate-queue", "OTHER-1.json"),
+      JSON.stringify({ ticket: "OTHER-1", status: "queued" }),
+    );
+    const priorFirst = process.env.CATALYST_DELEGATE_FIRST;
+    const priorRunner = process.env.CATALYST_DELEGATE_RUNNER;
+    const priorIntents = process.env.CATALYST_INTENTS_ENFORCE;
+    process.env.CATALYST_DELEGATE_FIRST = "enforce";
+    process.env.CATALYST_DELEGATE_RUNNER = "on";
+    delete process.env.CATALYST_INTENTS_ENFORCE;
+    const labels = [];
+    let ceilingCalls = 0;
+    try {
+      const outcome = defaultEscalate("CAT-219", {}, {
+        orchDir: dir,
+        linearWrite: {
+          applyLabel: (args) => {
+            labels.push(args);
+            return { applied: true };
+          },
+        },
+        multiHost: false,
+        maxParallel: () => {
+          ceilingCalls += 1;
+          return 1;
+        },
+      });
+      expect(ceilingCalls).toBe(1);
+      expect(labels.some((entry) => entry.ticket === "CAT-219" && entry.label === "needs-human"))
+        .toBe(true);
+      expect(outcome.confirmed).toBe(true);
+    } finally {
+      if (priorFirst === undefined) delete process.env.CATALYST_DELEGATE_FIRST;
+      else process.env.CATALYST_DELEGATE_FIRST = priorFirst;
+      if (priorRunner === undefined) delete process.env.CATALYST_DELEGATE_RUNNER;
+      else process.env.CATALYST_DELEGATE_RUNNER = priorRunner;
+      if (priorIntents === undefined) delete process.env.CATALYST_INTENTS_ENFORCE;
+      else process.env.CATALYST_INTENTS_ENFORCE = priorIntents;
+    }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
@@ -36,7 +36,7 @@ const synthesizeDurableEscalations = (boardMod as Record<string, unknown>)
 
 // Minimal durable record as recordDurableEscalation writes it.
 const durableRec = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
-  ticket: "CTL-9",
+  ticket: "PROJ-9",
   phase: "implement",
   reason: "Worker stuck > 24h, no progress",
   escalatedAt: new Date(100_000).toISOString(),
@@ -60,10 +60,26 @@ function mkPayload(tickets: BoardTicket[]): BoardPayload {
 }
 
 describe("synthesizeDurableEscalations — the pure card builder", () => {
+  it("a fence-standoff durable record round-trips as needs-human attention (CAT-173)", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec({
+        ticket: "PROJ-53",
+        reason: "fence-standoff: superseded on 2 hosts",
+        escalatedAt: "2026-08-11T00:00:00Z",
+        source: "fence-standoff",
+      })],
+      new Set<string>(),
+      Date.now(),
+    );
+    expect(cards[0].attention).toBe("needs-human");
+    expect(cards[0].humanQuestion).toMatch(/fence-standoff/);
+    expect(cards[0].attentionSince).toBe("2026-08-11T00:00:00Z");
+  });
+
   it("(a) a durable record with labelConfirmed:false and no existing card → attention card (Hole 1)", () => {
     const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
     expect(cards).toHaveLength(1);
-    expect(cards[0].id).toBe("CTL-9");
+    expect(cards[0].id).toBe("PROJ-9");
     expect(cards[0].attention).toBe("needs-human");
     // attentionSince anchored to the original escalatedAt (not lastTs / now).
     expect(cards[0].attentionSince).toBe(new Date(100_000).toISOString());
@@ -74,7 +90,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
     const model = deriveInbox(mkPayload(cards));
     expect(model.counts.attention).toBe(1);
     expect(model.counts.needsYou).toBe(1);
-    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("CTL-9");
+    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("PROJ-9");
   });
 
   it("(b) a durable record with labelConfirmed:true surfaces identically to labelConfirmed:false", () => {
@@ -92,7 +108,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
   it("(c) a ticket already carded (worker-dir / parked / queued) is NOT duplicated", () => {
     const cards = synthesizeDurableEscalations(
       [durableRec()],
-      new Set(["CTL-9"]),
+      new Set(["PROJ-9"]),
       600_000,
     );
     expect(cards).toHaveLength(0);
@@ -109,7 +125,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
 
   it("(d) terminal-aware: linfo carries Done linearState → NO card", () => {
     const linfo: Record<string, { linearState?: string }> = {
-      "CTL-9": { linearState: "Done" },
+      "PROJ-9": { linearState: "Done" },
     };
     const cards = synthesizeDurableEscalations(
       [durableRec()],
@@ -128,7 +144,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       600_000,
       {},
       {},
-      new Set(["CTL-9"]),
+      new Set(["PROJ-9"]),
     );
     expect(cards).toHaveLength(0);
   });
@@ -139,7 +155,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { linearState: "Canceled" } },
+      { "PROJ-9": { linearState: "Canceled" } },
     );
     expect(cards).toHaveLength(0);
   });
@@ -150,7 +166,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { linearState: "Implement" } },
+      { "PROJ-9": { linearState: "Implement" } },
     );
     expect(cards).toHaveLength(1);
   });
@@ -160,8 +176,8 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       [durableRec()],
       new Set<string>(),
       600_000,
-      { "CTL-9": "Replica title" },
-      { "CTL-9": { title: "Linfo title" } },
+      { "PROJ-9": "Replica title" },
+      { "PROJ-9": { title: "Linfo title" } },
     );
     expect(replica[0].title).toBe("Replica title");
 
@@ -170,23 +186,23 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { title: "Linfo title" } },
+      { "PROJ-9": { title: "Linfo title" } },
     );
     expect(linfoOnly[0].title).toBe("Linfo title");
 
     const bareId = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
-    expect(bareId[0].title).toBe("CTL-9");
+    expect(bareId[0].title).toBe("PROJ-9");
   });
 
   it("card has the correct type, team, and repo fields", () => {
     const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
     expect(cards[0].type).toBe("durable-escalation");
-    expect(cards[0].team).toBe("CTL");
+    expect(cards[0].team).toBe("PROJ");
     expect(classifyTicket(cards[0])).not.toBe("done");
   });
 
   it("existingIds may arrive as a plain array (also deduped)", () => {
-    const cards = synthesizeDurableEscalations([durableRec()], ["CTL-9"], 600_000);
+    const cards = synthesizeDurableEscalations([durableRec()], ["PROJ-9"], 600_000);
     expect(cards).toHaveLength(0);
   });
 
@@ -223,5 +239,82 @@ describe("assembleBoard wiring — durable escalation cards", () => {
     const nospace = (s: string) => s.replace(/\s+/g, "");
     expect(nospace(boardDataSrc)).toContain(nospace("synthesizeDurableEscalations("));
     expect(boardDataSrc).toContain("...durableTickets");
+  });
+});
+
+// ─── CAT-173 (Codex #3241 round-1 P1) ───────────────────────────────────────
+// The id dedupe in synthesizeDurableEscalations DROPS a record whose ticket
+// already has a card. Correct for terminal-sweep (that card already renders
+// needs-human via deriveAttention's phaseFailed path), but it silently swallowed
+// a fence-standoff break-glass on a BEHIND PR: the rescue timer only reaches
+// break-glass through an existing worker dir (so a card always exists), BEHIND is
+// excluded from PR_BLOCKER_STATES, and the fence suppressed the needs-human
+// label — leaving the escalation on no operator surface at all.
+const mergeDurableEscalationsIntoCards = (boardMod as Record<string, unknown>)
+  .mergeDurableEscalationsIntoCards as (
+  tickets: unknown,
+  records: unknown,
+  linfo?: unknown,
+  terminalIds?: unknown,
+) => BoardTicket[];
+
+describe("mergeDurableEscalationsIntoCards — CAT-173 standoff visibility", () => {
+  const card = (over: Record<string, unknown> = {}): BoardTicket =>
+    ({
+      id: "PROJ-9",
+      title: "a behind PR",
+      attention: null,
+      attentionSince: null,
+      humanQuestion: null,
+      ...over,
+    }) as unknown as BoardTicket;
+
+  it("fills attention on an existing attention-less card (the BEHIND-PR hole)", () => {
+    const tickets = [card()];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec({ source: "fence-standoff" })]);
+    expect(tickets[0].attention).toBe("needs-human");
+    expect(tickets[0].humanQuestion).toBe("Worker stuck > 24h, no progress");
+    // Anchored to the ORIGINAL escalation, not this tick.
+    expect(tickets[0].attentionSince).toBe(new Date(100_000).toISOString());
+  });
+
+  it("never overwrites an attention that is already set (live reason wins)", () => {
+    const tickets = [
+      card({ attention: "waiting-on-you", humanQuestion: "answer my question", attentionSince: "X" }),
+    ];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec()]);
+    expect(tickets[0].attention).toBe("waiting-on-you");
+    expect(tickets[0].humanQuestion).toBe("answer my question");
+    expect(tickets[0].attentionSince).toBe("X");
+  });
+
+  it("never pages on a terminal ticket", () => {
+    const bySet = [card()];
+    mergeDurableEscalationsIntoCards(bySet, [durableRec()], {}, new Set(["PROJ-9"]));
+    expect(bySet[0].attention).toBeNull();
+
+    const byLinfo = [card()];
+    mergeDurableEscalationsIntoCards(byLinfo, [durableRec()], { "PROJ-9": { linearState: "Done" } });
+    expect(byLinfo[0].attention).toBeNull();
+  });
+
+  it("ignores records with no matching card — synthesis owns those", () => {
+    const tickets = [card({ id: "PROJ-OTHER" })];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec()]);
+    expect(tickets[0].attention).toBeNull();
+    expect(tickets).toHaveLength(1);
+  });
+
+  it("is total on junk input and never throws", () => {
+    expect(() => mergeDurableEscalationsIntoCards(null, null)).not.toThrow();
+    expect(() => mergeDurableEscalationsIntoCards([card()], [null, {}, { ticket: "" }])).not.toThrow();
+  });
+
+  it("leaves the dedupe path intact: a merged card still yields no second card", () => {
+    const tickets = [card()];
+    const recs = [durableRec({ source: "fence-standoff" })];
+    mergeDurableEscalationsIntoCards(tickets, recs);
+    const extra = synthesizeDurableEscalations(recs, new Set(tickets.map((t) => t.id)), 600_000);
+    expect(extra).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -1524,6 +1524,53 @@ export function synthesizeParkedNeedsHumanTickets(
   return cards;
 }
 
+// mergeDurableEscalationsIntoCards — CAT-173: the complement of
+// synthesizeDurableEscalations, which by design DROPS a durable record whose ticket
+// already has a card (id dedupe). That dedupe is right for the terminal-sweep case:
+// such a ticket has a live failed/stalled signal, so deriveAttention's phaseFailed
+// path already renders it needs-human and a second card would double-list it.
+//
+// It is WRONG for a record whose existing card carries no attention at all. The
+// concrete hole: a fence-suppressed break-glass on a BEHIND PR whose rescue budget
+// is exhausted. The rescue timer only reaches that point via an existing worker
+// directory, so the ticket always has a card; BEHIND is deliberately excluded from
+// PR_BLOCKER_STATES (the pipeline may auto-rebase it); and the fence suppressed the
+// needs-human label, so nothing else marks it. The record was then deduped away —
+// leaving the break-glass on no operator surface at all, including the push bridge,
+// which projects only board tickets.
+//
+// So: fill the EXISTING card's attention instead of dropping the record. Never
+// overwrite an attention that is already set — a live reason is always better than
+// a durable record's replay of it.
+export function mergeDurableEscalationsIntoCards(
+  tickets,
+  records,
+  linfo = {},
+  terminalIds = new Set(),
+) {
+  if (!Array.isArray(tickets) || !Array.isArray(records)) return tickets;
+  const terminal = terminalIds instanceof Set ? terminalIds : new Set();
+  const byId = new Map();
+  for (const t of tickets) {
+    if (t && t.id != null && !byId.has(t.id)) byId.set(t.id, t);
+  }
+  for (const rec of records) {
+    if (!rec || !rec.ticket) continue;
+    const card = byId.get(rec.ticket);
+    if (!card) continue; // no existing card → synthesizeDurableEscalations owns it
+    // Terminal-aware, matching the synthesis path: never page on a Done/Canceled ticket.
+    if (terminal.has(rec.ticket) || isLinearTerminal(linfo?.[rec.ticket]?.linearState)) continue;
+    if (card.attention) continue; // already surfaced — keep the live reason
+    card.attention = "needs-human";
+    card.attentionSince = rec.escalatedAt ?? card.attentionSince ?? null;
+    card.humanQuestion =
+      typeof rec.reason === "string" && rec.reason.length > 0
+        ? rec.reason
+        : "Escalated for a human.";
+  }
+  return tickets;
+}
+
 // synthesizeDurableEscalations — CTL-1643: surface durable escalation records on
 // the board even when the worker dir has been GC'd (Hole 2) and even when the
 // needs-human label never confirmed in Linear (Hole 1). Mirrors the parked-synthesis
@@ -2362,6 +2409,15 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
     Object.keys(linfo).filter((id) => isLinearTerminal(linfo[id]?.linearState))
   );
   const durableEscalationRecords = readDurableEscalations(EC);
+  // CAT-173: fill attention on cards that already exist BEFORE the id dedupe below
+  // drops their records, so a fence-standoff break-glass on an otherwise
+  // attention-less card (e.g. a BEHIND PR) still reaches the board and push bridge.
+  tickets = mergeDurableEscalationsIntoCards(
+    tickets,
+    durableEscalationRecords,
+    linfo,
+    terminalLinearIds,
+  );
   const durableCardIds = new Set(tickets.map((t) => t.id));
   const durableTickets = synthesizeDurableEscalations(
     durableEscalationRecords,

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1092,6 +1092,36 @@ outage can never quarantine a healthy, resolvable, in-flight ticket.
 `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` is the Linear-independent backstop; the runaway knobs are
 observability only.
 
+### Fence-standoff human-surfacing bound (CAT-173)
+
+These execution-core environment variables bound how long repeated fence suppression can remain
+invisible to a human. The count and age must both be reached; the 45-minute floor spans three
+15-minute fence cooldowns, preventing a fast tick loop from paging on a transient blip.
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `CATALYST_FENCE_STANDOFF_CAP` | `4` | Consecutive suppressions required before out-of-band escalation. |
+| `CATALYST_FENCE_STANDOFF_MIN_AGE_MS` | `2700000` (45 min) | Minimum episode age before out-of-band escalation. |
+| `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` | `21600000` (6 h) | After a delivered break-glass, how long the terminal sweep skips this ticket's probe + fence check + `needs-human` write. |
+| `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` | `5` | Consecutive FAILED break-glass deliveries that may bypass the ordinary 15-minute suppression cooldown to retry on the very next tick. |
+
+Crossing the bound writes a durable board/push escalation and does not loosen the fence or perform
+a Linear write. Two cadence caveats:
+
+- The out-of-band escalation fires **once per episode**. `breakGlassAt` latches on the first
+  delivered break-glass and is reset only by `clearFenceStandoff` (a later fence PASS, or the
+  terminal branch of the sweep), so `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` paces the ticket's
+  *fence re-probe*, not a repeat page.
+- Because that cooldown gates the whole terminal-sweep probe+write block, a standoff that heals
+  after a break-glass has its `needs-human` Linear write — and the terminal-clear retraction on a
+  late Done — deferred by up to one cooldown window (6 h by default, versus the 15 min the
+  pre-existing `.fence-suppressed` marker imposed).
+- A break-glass whose durable-record or event write fails drops the 15-minute marker so delivery
+  retries next tick. `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` bounds that bypass: past it the
+  ordinary cooldown is retained, so a persistently unwritable sink degrades to a 15-minute retry
+  cadence instead of re-running the per-tick Linear probe + fence-check subprocess forever
+  (the CTL-1329 quota burn).
+
 ### Broker watchdog session eviction (CTL-1516)
 
 The broker's watchdog tick keeps per-session bookkeeping (`lastHeartbeat`, `workerToOrchestrator`)


### PR DESCRIPTION
Courtesy PR — mirrors a fix already merged on our fork (thagale/catalyst#101). Not intended to be merged here; opened for upstream visibility per our dual-PR convention.

Adds a delegate-queue ceiling fallback to `defaultEscalate()`: when the delegate queue is full, falls back to a plain needs-human label instead of dropping the escalation.

Built on top of CAT-3 (#3287) and CAT-173 (#3241), which this depends on.