### PR TITLE
docs(dev): CTL-1802 — record the duplicate-label-name trap in the linearis skill

### DIFF
--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -418,6 +418,55 @@ linearis issues update ENG-123 --labels "bug,P1" --label-mode overwrite
 linearis issues update ENG-123 --clear-labels
 ```
 
+> **`--labels` defaults to OVERWRITE.** Omitting `--label-mode` replaces every
+> label on the ticket, silently dropping the ones you did not name. Pass
+> `--label-mode add` unless you positively intend a full replacement.
+
+### Trap: a label name can exist on more than one team (CTL-1802)
+
+A team-scoped label is identified by `(name, team)`, and a workspace can hold
+**two different labels with the same name on different teams**. A migration or a
+team split leaves exactly that. When it happens, applying the label **by name**
+fails, even though the label plainly exists on the issue's team:
+
+```
+linearis issues update CTL-1802 --labels orchestrator
+  -> "LabelIds for incorrect team — The label 'orchestrator' is not
+      associated with the same team as the issue."
+```
+
+The failure is **name→id resolution**, not a missing vocabulary: the name
+resolved to the other team's twin. `labels list --team <TEAM>` is *correct* and
+lists only applicable labels, which is exactly why this is easy to misread as
+"discovery and write disagree" and misdiagnose as a stranded vocabulary.
+
+**Diagnose it — list every team that owns the name** (a plain `labels list`
+cannot show you this, because it only ever shows one team):
+
+```bash
+curl -s -X POST https://api.linear.app/graphql \
+  -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ issueLabels(filter:{name:{eq:\"orchestrator\"}},first:50){ nodes{ id name team{ key } } } }"}' \
+  | jq -r '.data.issueLabels.nodes[] | "\(.name)\tteam=\(.team.key // "WORKSPACE")\t\(.id)"'
+```
+
+**Apply by UUID** — the only unambiguous form when a name is duplicated:
+
+```bash
+linearis issues update CTL-1802 --labels 80a8e8f3-b960-4bb7-9e6a-f8b67b0dc62b --label-mode add
+```
+
+Two things that make this trap hard to see:
+
+- **Workspace-scoped labels are immune.** A label with no team (`team=WORKSPACE`)
+  has no twin to disambiguate against, so type vocabularies like
+  `bug`/`feature`/`chore` keep resolving by name while every component label
+  fails. Half your labels working is not evidence that the rest are broken
+  differently — it is evidence they are team-scoped.
+- **The error names the label, not the team.** It reads as "this label is on the
+  wrong team", when the truth is "the name you gave me resolved to a label on
+  the wrong team, and the right one exists too."
+
 ## Workflow: Cycle Review
 
 ### Get the active cycle

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -422,7 +422,7 @@ linearis issues update ENG-123 --clear-labels
 > label on the ticket, silently dropping the ones you did not name. Pass
 > `--label-mode add` unless you positively intend a full replacement.
 
-### Trap: a label name can exist on more than one team (CTL-1802)
+### Trap: a label name can exist on more than one team
 
 A team-scoped label is identified by `(name, team)`, and a workspace can hold
 **two different labels with the same name on different teams**. A migration or a
@@ -430,7 +430,7 @@ team split leaves exactly that. When it happens, applying the label **by name**
 fails, even though the label plainly exists on the issue's team:
 
 ```
-linearis issues update CTL-1802 --labels orchestrator
+linearis issues update PROJ-123 --labels orchestrator
   -> "LabelIds for incorrect team — The label 'orchestrator' is not
       associated with the same team as the issue."
 ```
@@ -440,10 +440,31 @@ resolved to the other team's twin. `labels list --team <TEAM>` is *correct* and
 lists only applicable labels, which is exactly why this is easy to misread as
 "discovery and write disagree" and misdiagnose as a stranded vocabulary.
 
-**Diagnose it — list every team that owns the name** (a plain `labels list`
-cannot show you this, because it only ever shows one team):
+**Step 1 — replica first (free, no API quota).** Confirm which team's issues
+actually carry the name, and get the label id, without touching Linear:
 
 ```bash
+sqlite3 -separator '  ' ~/catalyst/catalyst-replica.db "
+  SELECT l.name, l.id, i.team_key, COUNT(*) AS issues
+    FROM issue_labels il
+    JOIN labels l  ON l.id = il.label_id
+    JOIN issues i  ON i.id = il.issue_id
+   WHERE l.name = 'orchestrator'
+   GROUP BY l.name, l.id, i.team_key;"
+```
+
+This answers "which id is in use on MY team's issues", which is usually all you
+need — apply that id and move on.
+
+**Step 2 — only if step 1 is inconclusive.** The replica **cannot** prove a
+duplicate exists: its `labels` table carries no team column, and it mirrors only
+this team's issues, so a twin on another team is structurally invisible to it.
+That is a genuine gap, not a shortcut — so this is the documented
+single-bounded-check last resort, run **once** during a diagnosis, never in a
+loop or a script:
+
+```bash
+# LAST RESORT — one call, one label name, during an active diagnosis only.
 curl -s -X POST https://api.linear.app/graphql \
   -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
   -d '{"query":"{ issueLabels(filter:{name:{eq:\"orchestrator\"}},first:50){ nodes{ id name team{ key } } } }"}' \
@@ -453,7 +474,7 @@ curl -s -X POST https://api.linear.app/graphql \
 **Apply by UUID** — the only unambiguous form when a name is duplicated:
 
 ```bash
-linearis issues update CTL-1802 --labels 80a8e8f3-b960-4bb7-9e6a-f8b67b0dc62b --label-mode add
+linearis issues update PROJ-123 --labels <label-uuid> --label-mode add
 ```
 
 Two things that make this trap hard to see:


### PR DESCRIPTION
Closes CTL-1802.

Since the workspace migration, applying a component label to a new CTL ticket **by name** fails:

```
linearis issues update CTL-1802 --labels orchestrator
  -> "LabelIds for incorrect team — The label 'orchestrator' is not
      associated with the same team as the issue."
```

…while `linearis labels list --team CTL` lists `orchestrator` perfectly happily.

## The diagnosis is not the one the ticket assumed

The ticket's premise — *"the component vocabulary is bound to the old team"* — is **wrong**, in a way that makes the fix far cheaper. Measured 2026-08-12: every component label exists on team **CTL**, *and* a duplicate exists on team **MCP**:

```
broker        CTL a1eb7d59  |  MCP c67be19c
cli           CTL 371939d0  |  MCP bbc8b2f7
monitor       CTL 2590f30b  |  MCP d0f736bc
orchestrator  CTL 80a8e8f3  |  MCP df0d99ae
phase-agent   CTL ce0087c6  |  MCP 818d57f5
worktree      CTL c2fdc493  |  MCP 3985d5e0
estimation    CTL 4359ce04  |  MCP 13f8b357
```

So the failure is **name→id resolution**, not a missing vocabulary. Applying the CTL-team UUID succeeds:

```
--labels orchestrator                             -> rejected
--labels 80a8e8f3-b960-4bb7-9e6a-f8b67b0dc62b     -> OK (verified: orchestrator(CTL))
```

That also dissolves the two symptoms that made it look like something else:

- **"Discovery and write disagree"** — they don't. `labels list --team CTL` is *correct*; every label it lists really is applicable. The **write** picks the wrong twin.
- **"Type labels survived by luck"** — they survived structurally: `bug`/`feature`/`chore` are **workspace-scoped**, so they have no twin to disambiguate against. Half the labels working was evidence the rest are *team-scoped*, not that they are stranded.

## What this PR changes

`linearis` is a fork this repo does not push to, so the resolution fix cannot land there. This documents the trap in the `catalyst-dev:linearis` skill:

- the failure mode and why the error message misleads (it names the label, not the team);
- **the GraphQL query that reveals it** — a plain `labels list` structurally *cannot*, because it only ever shows one team;
- apply-by-UUID as the unambiguous form;
- **`--labels` defaults to OVERWRITE.** It silently dropped CTL-1802's `bug`/`Bug` on my first write; restored immediately with `--label-mode add`.

## Backfill (already applied)

All 12 post-migration roadmap tickets now carry a CTL-team component label, by UUID with `--label-mode add`, type labels intact:

```
CTL-1789 orchestrator   CTL-1793 cli          CTL-1797 monitor
CTL-1790 orchestrator   CTL-1794 orchestrator CTL-1798 orchestrator
CTL-1791 orchestrator   CTL-1795 broker       CTL-1801 cli
CTL-1792 monitor        CTL-1796 phase-agent  CTL-1802 orchestrator
```

**Not done deliberately:** deleting the MCP twins. Team MCP may legitimately use them, and that is a destructive cross-team write to make on purpose, not as a side effect of this fix.