### PR TITLE
fix(dev): CAT-85 make stat fixture host-independent

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -369,6 +369,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash lib/__tests__/linear-app-actor.test.sh
 
+      - name: portable stat helper tests (CAT-85)
+        working-directory: plugins/dev/scripts
+        run: bash lib/__tests__/portable-stat.test.sh
+
+      - name: portable stat regression guard (CAT-85)
+        working-directory: plugins/dev/scripts
+        run: |
+          command -v rg >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ripgrep)
+          bash lib/__tests__/stat-portability-guard.test.sh
+
       - name: worktree-salvage primitive + telemetry unit tests (CTL-1639)
         # lib/worktree-salvage.sh snapshots a worktree's unpushed commits +
         # uncommitted changes to ~/catalyst/salvage/ BEFORE any destructive

--- a/assets/brand-v2/build-og-card.sh
+++ b/assets/brand-v2/build-og-card.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$REPO_ROOT/plugins/dev/scripts/lib/portable-stat.sh"
 SRC="$SCRIPT_DIR/og-card.svg"
 PNG="$SCRIPT_DIR/og-card.png"
 
@@ -49,7 +50,7 @@ magick "$TMP" -background "#07090B" -alpha remove -alpha off -colorspace sRGB -s
 rm -f "$TMP"
 
 # Report size + dimensions.
-BYTES=$(stat -f %z "$PNG" 2>/dev/null || stat -c %s "$PNG")
+BYTES=$(portable_stat_size "$PNG") || { echo "ERROR: cannot read size of $PNG" >&2; exit 1; }
 KB=$((BYTES / 1024))
 log "og-card.png: ${BYTES} bytes (~${KB} KB)"
 if [ "$BYTES" -ge 307200 ]; then

--- a/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-backup.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # Shell tests for `catalyst-backup` (CTL-1369 PR2).
 #
 # Runs the CLI as a SUBPROCESS against a sandbox HOME (every path is env-overridable), so the
@@ -23,7 +24,7 @@ expect_file()     { if [[ -f "$2" ]]; then ok "$1"; else fail "$1" "missing file
 expect_absent()   { if [[ ! -e "$2" ]]; then ok "$1"; else fail "$1" "should not exist: $2"; fi; }
 # GNU stat uses `-c %a`; BSD/macOS stat uses `-f %Lp`. Try GNU first (on BSD `-c` errors out;
 # on GNU `-f` means file-system status and would wrongly succeed) so we get mode bits on both.
-perms() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+perms() { portable_stat_mode "$1"; }
 
 command -v jq >/dev/null 2>&1 || { echo "jq required for these tests — skipping"; exit 0; }
 
@@ -92,9 +93,9 @@ expect_eq "manifest captured >= 8 required artifacts" "yes" "$([[ "${CCOUNT:-0}"
 expect_eq "backed-up db is a valid sqlite snapshot" "2" "$(sqlite3 "$BUNDLE/runtime/catalyst.db" 'SELECT count(*) FROM sessions' 2>/dev/null)"
 
 echo "catalyst-backup — secret perms (bundle 0700, secret files 0600)"
-expect_eq "bundle dir is 0700"        "700" "$(perms "$BUNDLE")"
-expect_eq "config.json is 0600"       "600" "$(perms "$BUNDLE/config/config.json")"
-expect_eq "humanlayer.json is 0600"   "600" "$(perms "$BUNDLE/humanlayer/humanlayer.json")"
+expect_eq "bundle dir is 0700"        "0700" "$(perms "$BUNDLE")"
+expect_eq "config.json is 0600"       "0600" "$(perms "$BUNDLE/config/config.json")"
+expect_eq "humanlayer.json is 0600"   "0600" "$(perms "$BUNDLE/humanlayer/humanlayer.json")"
 
 echo "catalyst-backup — list"
 expect_contains "list shows the bundle"        "$(src_env "$BACKUP" list 2>/dev/null)" "$BUNDLE"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-verify-cloud-sync.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-verify-cloud-sync.test.sh
@@ -49,7 +49,7 @@ check "refusal leaves config unchanged" test "$BEFORE" = "$AFTER"
 
 fixture activate; seed_db; sqlite3 "$CATALYST_REPLICA_DB" "INSERT INTO issues VALUES('1'); INSERT INTO sync_meta VALUES('cursor','abc');"; touch "$CATALYST_REPLICA_DB.writer.lock"; printf '{"keep":true}\n' > "$CATALYST_LAYER2_CONFIG_FILE"; cmd_activate_replica >/dev/null
 check "activate merges mode" jq -e '.keep == true and .catalyst.linearReplica.mode == "on"' "$CATALYST_LAYER2_CONFIG_FILE"
-check "activate preserves secret config mode" test "$(_stat_field %Lp %a "$CATALYST_LAYER2_CONFIG_FILE")" = "600"
+check "activate preserves secret config mode" test "$(portable_stat_mode "$CATALYST_LAYER2_CONFIG_FILE")" = "0600"
 BEFORE="$(shasum "$CATALYST_LAYER2_CONFIG_FILE")"; cmd_activate_replica --dry-run >/dev/null; AFTER="$(shasum "$CATALYST_LAYER2_CONFIG_FILE")"
 check "dry-run changes nothing" test "$BEFORE" = "$AFTER"
 
@@ -68,7 +68,7 @@ check "activate normalizes legacy mode without clobbering config" jq -e '.keep =
 
 rm -f "$CATALYST_LAYER2_CONFIG_FILE"
 cmd_activate_replica >/dev/null
-check "activate creates secret config with restrictive mode" test "$(_stat_field %Lp %a "$CATALYST_LAYER2_CONFIG_FILE")" = "600"
+check "activate creates secret config with restrictive mode" test "$(portable_stat_mode "$CATALYST_LAYER2_CONFIG_FILE")" = "0600"
 
 printf '{malformed\n' > "$CATALYST_LAYER2_CONFIG_FILE"; BEFORE="$(shasum "$CATALYST_LAYER2_CONFIG_FILE")"; cmd_activate_replica >/dev/null 2>&1; EC=$?; AFTER="$(shasum "$CATALYST_LAYER2_CONFIG_FILE")"
 check "activate refuses malformed existing config" test "$EC" -ne 0

--- a/plugins/dev/scripts/__tests__/ensure-agent-house-rules.test.sh
+++ b/plugins/dev/scripts/__tests__/ensure-agent-house-rules.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # Tests for ensure-agent-house-rules.sh — the sentinel-based "Working the Loop" auto-seeder.
 # Run: bash plugins/dev/scripts/__tests__/ensure-agent-house-rules.test.sh
 
@@ -126,8 +127,8 @@ has "symlink: shared target updated" "$BEGIN" "$R/shared/CLAUDE.md"
 # something different on GNU/Linux and would return the wrong value)
 R="$SCRATCH/perm"; mkdir -p "$R"; printf '# CLAUDE.md\n\n## Setup\nx\n' >"$R/CLAUDE.md"; chmod 0640 "$R/CLAUDE.md"
 run "$R" --fix >/dev/null
-mode="$(stat -c '%a' "$R/CLAUDE.md" 2>/dev/null || stat -f '%Lp' "$R/CLAUDE.md" 2>/dev/null)"
-assert_eq "perm: mode preserved (640)" "640" "$mode"
+mode="$(portable_stat_mode "$R/CLAUDE.md")"
+assert_eq "perm: mode preserved (640)" "0640" "$mode"
 
 # 14. write into a read-only DIR → nonzero exit, unchanged. (The atomic path stages
 # a temp in the same dir and renames, so a read-only DIR is the real failure mode.)

--- a/plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
+++ b/plugins/dev/scripts/__tests__/research-curate-contradictions.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # Tests for plugins/dev/scripts/research-curate/{cluster,contradict,append-contradictions}.sh
 # plus the run.sh extensions added in CTL-468.
 #
@@ -299,7 +300,7 @@ echo '{"cluster_id":"c1","topic":"alpha+beta","contradictions":[{"between":["A",
   | bash "$APPEND" --date 2026-05-17 "$DEST7" >/dev/null 2>&1
 
 # Original content still present byte-for-byte
-HEAD_BYTES=$(head -c "$(stat -f%z "$DEST7" 2>/dev/null || stat -c%s "$DEST7")" "$DEST7" | head -8)
+HEAD_BYTES=$(head -c "$(portable_stat_size "$DEST7")" "$DEST7" | head -8)
 if grep -q "existing entry kept intact" "$DEST7"; then
   ok "append-contradictions.sh: original entries preserved"
 else

--- a/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
+++ b/plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # Shell tests for rotate_log_on_start (CTL-1755).
 # Run: bash plugins/dev/scripts/__tests__/rotate-log-on-start.test.sh
 
@@ -33,9 +34,7 @@ teardown() {
 # form — on GNU, `-f` means "filesystem status" (mutable, changes when `.1` is
 # created) and would silently return the wrong value instead of the inode. macOS
 # stat rejects `-c`, so it falls through to the BSD `-f` form there.
-inode_of() {
-	stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null
-}
+inode_of() { portable_stat_inode "$1"; }
 
 # -----------------------------------------------------------------------
 echo "Test 1: absent log → no-op"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-config-merge.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-config-merge.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # CTL-843: setup-catalyst.sh must merge per-project secrets, never drop unprompted keys.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -150,11 +151,11 @@ set -e
 if [[ $RC -ne 0 ]]; then
   fail "write_secrets_config exited non-zero"
 else
-  CFG_PERMS=$(stat -f "%OLp" "$CONF8" 2>/dev/null || stat -c "%a" "$CONF8" 2>/dev/null)
-  assert_eq "600" "$CFG_PERMS" "config file is chmod 600"
+  CFG_PERMS=$(portable_stat_mode "$CONF8")
+  assert_eq "0600" "$CFG_PERMS" "config file is chmod 600"
   if [[ -n "$BAK8" ]]; then
-    BAK_PERMS=$(stat -f "%OLp" "$BAK8" 2>/dev/null || stat -c "%a" "$BAK8" 2>/dev/null)
-    assert_eq "600" "$BAK_PERMS" "backup file is chmod 600"
+    BAK_PERMS=$(portable_stat_mode "$BAK8")
+    assert_eq "0600" "$BAK_PERMS" "backup file is chmod 600"
   else
     fail "no backup to check permissions on"
   fi

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -170,6 +170,7 @@ unset _SRC
 
 # shellcheck source=lib/catalyst-agent-path.sh
 source "$SCRIPT_DIR/lib/catalyst-agent-path.sh"
+source "$SCRIPT_DIR/lib/portable-stat.sh"
 # shellcheck source=lib/cloud-sync-token-probe.sh
 [[ -f "${SCRIPT_DIR}/lib/cloud-sync-token-probe.sh" ]] && . "${SCRIPT_DIR}/lib/cloud-sync-token-probe.sh"
 
@@ -2485,7 +2486,7 @@ cloud_sync_verify_report() {
   else _cloud_sync_verify_add agent UNKNOWN "agent not running"; fi
   local db_ok=no
   if [[ ! -e "$db" ]]; then _cloud_sync_verify_add replica-db FAIL "replica db absent"
-  else local size; size="$(_stat_field %z %s "$db")"; if (( size >= 65536 )); then db_ok=yes; _cloud_sync_verify_add replica-db PASS "replica db present"; else _cloud_sync_verify_add replica-db FAIL "replica db below 65536 bytes"; fi; fi
+  else local size; size="$(portable_stat_size "$db" || echo 0)"; if (( size >= 65536 )); then db_ok=yes; _cloud_sync_verify_add replica-db PASS "replica db present"; else _cloud_sync_verify_add replica-db FAIL "replica db below 65536 bytes"; fi; fi
   local schema_ok=yes table
   if [[ "$db_ok" == yes ]] && command -v sqlite3 >/dev/null 2>&1; then
     for table in $CLOUD_SYNC_REPLICA_TABLES; do sqlite3 "$db" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table';" 2>/dev/null | grep -q 1 || schema_ok=no; done
@@ -2494,7 +2495,7 @@ cloud_sync_verify_report() {
   local rows=0; [[ "$schema_ok" == yes ]] && rows="$(sqlite3 "$db" 'SELECT COUNT(*) FROM issues;' 2>/dev/null || echo 0)"
   [[ "${rows:-0}" =~ ^[0-9]+$ && "${rows:-0}" -gt 0 ]] && _cloud_sync_verify_add rows PASS "$rows issues" || _cloud_sync_verify_add rows FAIL "issues table empty"
   local lock="$db.writer.lock" stale_ms="${CATALYST_LINEAR_REPLICA_STALE_MS:-300000}" lock_ok=no age_ms=""
-  if [[ -f "$lock" ]]; then local mt now; mt="$(_stat_field %m %Y "$lock")"; now="$(date +%s)"; age_ms=$(( (now-mt)*1000 )); (( age_ms < stale_ms )) && lock_ok=yes; fi
+  if [[ -f "$lock" ]]; then local mt now; mt="$(portable_stat_mtime "$lock" || echo 0)"; now="$(date +%s)"; age_ms=$(( (now-mt)*1000 )); (( age_ms < stale_ms )) && lock_ok=yes; fi
   [[ "$lock_ok" == yes ]] && _cloud_sync_verify_add writer-lock PASS "writer heartbeat fresh" || _cloud_sync_verify_add writer-lock FAIL "writer lock absent or stale"
   local cursor=""; [[ "$schema_ok" == yes ]] && cursor="$(sqlite3 "$db" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;" 2>/dev/null || true)"
   [[ -n "$cursor" ]] && _cloud_sync_verify_add seed-cursor PASS "seed cursor present" || _cloud_sync_verify_add seed-cursor FAIL "seed cursor absent"

--- a/plugins/dev/scripts/channel-watcher/launch.sh
+++ b/plugins/dev/scripts/channel-watcher/launch.sh
@@ -13,6 +13,7 @@ _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
+source "${SCRIPT_DIR}/../lib/portable-stat.sh"
 
 log()  { printf '[catalyst-channel-watcher] %s\n' "$*"; }
 fail() { printf '[catalyst-channel-watcher] ERROR: %s\n' "$*" >&2; exit 1; }
@@ -25,7 +26,7 @@ _warn_if_readable() {
   local f="$1"
   [[ -r "$f" ]] || return 0
   local mode
-  mode="$(stat -f '%Lp' "$f" 2>/dev/null || stat -c '%a' "$f" 2>/dev/null || echo '')"
+  mode="$(portable_stat_mode "$f" || echo '')"
   [[ "$mode" =~ ^[0-7]+$ ]] || return 0
   local grp=$(( ${mode: -2:1} )) oth=$(( ${mode: -1:1} ))
   if (( (grp & 4) != 0 || (oth & 4) != 0 )); then

--- a/plugins/dev/scripts/ensure-agent-house-rules.sh
+++ b/plugins/dev/scripts/ensure-agent-house-rules.sh
@@ -53,6 +53,7 @@ say() { [[ $QUIET -eq 1 ]] || printf '%s\n' "$*"; }
 die() { echo "ensure-agent-house-rules: $1" >&2; exit "${2:-5}"; }
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/portable-stat.sh"
 BEGIN_MARK='<!-- catalyst-house-rules:begin -->'
 END_MARK='<!-- catalyst-house-rules:end -->'
 BRIDGE_LINE='@AGENTS.md'
@@ -155,7 +156,7 @@ write_through() {
 		local real; real="$(readlink_f "$dest")"
 		cat "$src" >"$real" || die "failed to write ${dest#"$REPO"/} via symlink (read-only?)"
 	elif [[ -f "$dest" ]]; then
-		local mode tmp; mode="$(stat -c '%a' "$dest" 2>/dev/null || stat -f '%Lp' "$dest" 2>/dev/null || echo '')"
+		local mode tmp; mode="$(portable_stat_mode "$dest" || echo '')"
 		tmp="$(mktemp "$(dirname "$dest")/.house-rules.XXXXXX" 2>/dev/null)" || die "cannot create temp next to ${dest#"$REPO"/} (read-only dir?)"
 		if ! cat "$src" >"$tmp"; then rm -f "$tmp"; die "failed to stage ${dest#"$REPO"/}"; fi
 		[[ -n "$mode" ]] && chmod "$mode" "$tmp" 2>/dev/null

--- a/plugins/dev/scripts/execution-core/cloud-sync/launch.sh
+++ b/plugins/dev/scripts/execution-core/cloud-sync/launch.sh
@@ -17,6 +17,7 @@ _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
+source "${SCRIPT_DIR}/../../lib/portable-stat.sh"
 
 log()  { printf '[catalyst-cloud-sync] %s\n' "$*"; }
 fail() { printf '[catalyst-cloud-sync] ERROR: %s\n' "$*" >&2; exit 1; }
@@ -42,7 +43,7 @@ _warn_if_readable() {
   # stat perms portably (BSD/macOS -f%Lp, GNU -c%a). Last two octal digits = group + other;
   # if either has the read bit (4) set, the secret is exposed to other local users.
   local mode
-  mode="$(stat -f '%Lp' "$f" 2>/dev/null || stat -c '%a' "$f" 2>/dev/null || echo '')"
+  mode="$(portable_stat_mode "$f" || echo '')"
   [[ "$mode" =~ ^[0-7]+$ ]] || return 0
   local grp=$(( ${mode: -2:1} )) oth=$(( ${mode: -1:1} ))
   if (( (grp & 4) != 0 || (oth & 4) != 0 )); then

--- a/plugins/dev/scripts/execution-core/join-token-cli.test.sh
+++ b/plugins/dev/scripts/execution-core/join-token-cli.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/portable-stat.sh"
 # join-token-cli.test.sh — catalyst-cluster join-token verb contract (CTL-1184).
 # Run: bash plugins/dev/scripts/execution-core/join-token-cli.test.sh
 
@@ -16,7 +17,7 @@ check "prints CATALYST_JOIN_TOKEN=jt_ line" \
 check "prints a TTL / expiry line" \
   'grep -qiE "ttl|expires" <<<"$OUT"'
 check "writes the 0600 store file" \
-  '[[ -f "$TMP/cluster/join-token.json" ]] && [[ "$(stat -f %Lp "$TMP/cluster/join-token.json")" == "600" ]]'
+  '[[ -f "$TMP/cluster/join-token.json" ]] && [[ "$(portable_stat_mode "$TMP/cluster/join-token.json")" == "0600" ]]'
 check "stored token matches printed token" \
   '[[ "$(grep -oE "jt_[0-9a-f]{64}" <<<"$OUT" | head -1)" == "$(grep -oE "jt_[0-9a-f]{64}" "$TMP/cluster/join-token.json" | head -1)" ]]'
 

--- a/plugins/dev/scripts/god-gather.sh
+++ b/plugins/dev/scripts/god-gather.sh
@@ -17,6 +17,9 @@
 
 set -uo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/portable-stat.sh"
+
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 CLAUDE_PROJECTS_DIR="${HOME}/.claude/projects"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -34,7 +37,7 @@ minutes_ago_iso() {
 
 # mtime of a path in seconds since epoch (macOS + Linux)
 path_mtime() {
-  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+  portable_stat_mtime "$1" || echo 0
 }
 
 # Elapsed seconds → human string

--- a/plugins/dev/scripts/health-responder.sh
+++ b/plugins/dev/scripts/health-responder.sh
@@ -103,6 +103,7 @@ _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
+source "${SCRIPT_DIR}/lib/portable-stat.sh"
 export PATH="${PATH}:${SCRIPT_DIR}"
 
 # CTL-1616 PR5: the secret-contract bash mirror — sourced here (once, at script load, NOT
@@ -366,16 +367,7 @@ is_dry() { [[ "$DRY_RUN" == "1" ]]; }
 # filesystem info to stdout before returning non-zero (Codex P2) — so the BSD
 # attempt's output must be validated and DISCARDED on failure, never
 # concatenated with the `-c` fallback's output.
-_mtime() {
-  local out
-  if out="$(stat -f %m "$1" 2>/dev/null)" && [[ "$out" =~ ^[0-9]+$ ]]; then
-    echo "$out"
-    return 0
-  fi
-  out="$(stat -c %Y "$1" 2>/dev/null)" || return 1
-  [[ "$out" =~ ^[0-9]+$ ]] || return 1
-  echo "$out"
-}
+_mtime() { portable_stat_mtime "$1"; }
 
 # Fail-open telemetry (orphan-sweep idiom): missing binary = silent no-op, and
 # a telemetry failure can never fail the responder.

--- a/plugins/dev/scripts/lib/__tests__/helpers/gnu-stat-stub.sh
+++ b/plugins/dev/scripts/lib/__tests__/helpers/gnu-stat-stub.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+_install_stat_stub() {
+  local mockbin="$1" dialect="$2" real_stat host_dialect
+  real_stat="$(command -v stat)"
+  if "$real_stat" -c %Y "$0" >/dev/null 2>&1; then host_dialect=gnu; else host_dialect=bsd; fi
+  mkdir -p "$mockbin"
+  cat > "$mockbin/stat" <<EOF
+#!/usr/bin/env bash
+dialect='$dialect'; real_stat='$real_stat'; host_dialect='$host_dialect'
+fmt="\${2-}"; path="\${3-}"
+if [[ "\$dialect" == gnu && "\${1-}" == -f ]]; then printf '  File: "%s"\n    ID: 1 Namelen: 255 Type: fake\n' "\$path"; exit 1; fi
+if [[ "\$dialect" == bsd && "\${1-}" == -c ]]; then echo 'stat: illegal option -- c' >&2; exit 1; fi
+case "\$dialect:\$fmt" in
+  gnu:%Y|bsd:%m) field=mtime ;;
+  gnu:%s|bsd:%z) field=size ;;
+  gnu:%a|bsd:%p) field=mode ;;
+  gnu:%u|bsd:%u) field=owner ;;
+  gnu:%i|bsd:%i) field=inode ;;
+  *) exit 1 ;;
+esac
+if [[ "\$host_dialect" == gnu ]]; then
+  case "\$field" in mtime) f=%Y;; size) f=%s;; mode) f=%a;; owner) f=%u;; inode) f=%i;; esac
+  exec "\$real_stat" -c "\$f" "\$path"
+else
+  case "\$field" in mtime) f=%m;; size) f=%z;; mode) f=%p;; owner) f=%u;; inode) f=%i;; esac
+  exec "\$real_stat" -f "\$f" "\$path"
+fi
+EOF
+  chmod +x "$mockbin/stat"
+}
+
+stub_gnu_stat() { _install_stat_stub "$1" gnu; }
+stub_bsd_stat() { _install_stat_stub "$1" bsd; }
+unstub_stat() { rm -f "$1/stat"; }

--- a/plugins/dev/scripts/lib/__tests__/portable-stat.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/portable-stat.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/../portable-stat.sh"
+source "$HERE/helpers/gnu-stat-stub.sh"
+SCRATCH="$(mktemp -d)"; trap 'rm -rf "$SCRATCH"' EXIT
+MOCKBIN="$SCRATCH/bin"; mkdir -p "$MOCKBIN"; ORIGINAL_PATH="$PATH"
+FILE="$SCRATCH/file"; : > "$FILE"; chmod 600 "$FILE"
+
+assert_digits() { [[ "$1" =~ ^[0-9]+$ ]]; }
+assert_digits "$(portable_stat_mtime "$FILE")"
+for dialect in gnu bsd; do
+  "stub_${dialect}_stat" "$MOCKBIN"; PATH="$MOCKBIN:$ORIGINAL_PATH"
+  out="$(portable_stat_mtime "$FILE")"; assert_digits "$out"; [[ "$out" != *File:* ]]
+  out="$(portable_stat_size "$FILE")"; : "$(( out / 1024 ))"
+  [[ "$(portable_stat_mode "$FILE")" == 0600 ]]
+  [[ "$(portable_stat_mode_oct "$FILE")" == 384 ]]
+  [[ "$(portable_stat_owner "$FILE")" == "$(id -u)" ]]
+  out="$(portable_stat_mtime "$SCRATCH/missing" 2>/dev/null || true)"; [[ -z "$out" ]]
+  [[ "$(portable_stat_mtime "$SCRATCH/missing" 2>/dev/null || echo 0)" == 0 ]]
+  PATH="$ORIGINAL_PATH"; unstub_stat "$MOCKBIN"
+done
+mkdir "$SCRATCH/sticky"; chmod 1777 "$SCRATCH/sticky"
+stub_bsd_stat "$MOCKBIN"; PATH="$MOCKBIN:$ORIGINAL_PATH"
+[[ "$(portable_stat_mode "$SCRATCH/sticky")" == 1777 ]]
+PATH="$ORIGINAL_PATH"; unstub_stat "$MOCKBIN"
+source "$HERE/../portable-stat.sh"
+( set -u; source "$HERE/../portable-stat.sh"; portable_stat_mtime "$FILE" >/dev/null )
+echo "portable-stat: PASS"

--- a/plugins/dev/scripts/lib/__tests__/secret-hygiene-check.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/secret-hygiene-check.test.sh
@@ -63,6 +63,17 @@ RC=$?
 assert_contains "$MSG" "config.json" "error message names the file"
 
 echo ""
+echo "check_secret_file_modes: unreadable mode probe → non-zero, names file"
+portable_stat_mode() { return 1; }
+MSG="$(check_secret_file_modes "$DIR_GOOD" 2>&1)"
+RC=$?
+[[ $RC -ne 0 ]] && pass "unreadable mode → non-zero exit" || fail "unreadable mode → should be non-zero"
+assert_contains "$MSG" "config-proj.json mode unreadable" "error names unreadable file"
+# Restore the helper after the injected failure.
+unset _CATALYST_PORTABLE_STAT_SH_LOADED
+source "${SCRIPT_DIR}/../portable-stat.sh"
+
+echo ""
 echo "check_secret_file_modes: empty dir / no config files → exit 0"
 DIR_EMPTY="${SCRATCH}/empty"
 mkdir -p "$DIR_EMPTY"

--- a/plugins/dev/scripts/lib/__tests__/secrets-hygiene.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/secrets-hygiene.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../portable-stat.sh"
 # Unit tests for lib/secrets-hygiene.sh (CTL-1203).
 #
 # Tests harden_secrets_dir, ensure_secrets_gitignore, and write_secret_file
@@ -33,9 +34,7 @@ assert_contains() {
 	fi
 }
 
-file_mode() {
-	stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
-}
+file_mode() { portable_stat_mode "$1"; }
 
 if [[ ! -f "$LIB" ]]; then
 	echo "FATAL: $LIB not found — implement it first" >&2
@@ -49,7 +48,7 @@ source "$LIB"
 echo "harden_secrets_dir: creates missing dir at mode 700"
 DIR1="${SCRATCH}/new-dir"
 harden_secrets_dir "$DIR1"
-assert_eq "700" "$(file_mode "$DIR1")" "new dir mode = 700"
+assert_eq "0700" "$(file_mode "$DIR1")" "new dir mode = 700"
 
 echo ""
 echo "harden_secrets_dir: tightens existing 755 dir to 700"
@@ -57,14 +56,14 @@ DIR2="${SCRATCH}/loose-dir"
 mkdir -p "$DIR2"
 chmod 755 "$DIR2"
 harden_secrets_dir "$DIR2"
-assert_eq "700" "$(file_mode "$DIR2")" "755→700 tightened"
+assert_eq "0700" "$(file_mode "$DIR2")" "755→700 tightened"
 
 echo ""
 echo "harden_secrets_dir: idempotent — second call still 700, exit 0"
 harden_secrets_dir "$DIR2"
 RC=$?
 assert_eq "0" "$RC" "second call exit 0"
-assert_eq "700" "$(file_mode "$DIR2")" "still 700 after second call"
+assert_eq "0700" "$(file_mode "$DIR2")" "still 700 after second call"
 
 # ─── ensure_secrets_gitignore ────────────────────────────────────────────────
 
@@ -104,14 +103,14 @@ WF_DIR="${SCRATCH}/write-dir"
 mkdir -p "$WF_DIR"
 WF_PATH="${WF_DIR}/config.json"
 write_secret_file '{"key":"value"}' "$WF_PATH"
-assert_eq "600" "$(file_mode "$WF_PATH")" "new file mode = 600"
+assert_eq "0600" "$(file_mode "$WF_PATH")" "new file mode = 600"
 assert_eq '{"key":"value"}' "$(cat "$WF_PATH")" "content matches"
 
 echo ""
 echo "write_secret_file: overwrites existing 644 file, result is 600"
 chmod 644 "$WF_PATH"
 write_secret_file '{"key":"updated"}' "$WF_PATH"
-assert_eq "600" "$(file_mode "$WF_PATH")" "overwrite → mode 600"
+assert_eq "0600" "$(file_mode "$WF_PATH")" "overwrite → mode 600"
 assert_eq '{"key":"updated"}' "$(cat "$WF_PATH")" "overwrite content matches"
 
 echo ""

--- a/plugins/dev/scripts/lib/__tests__/stat-portability-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/stat-portability-guard.test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+failures=0
+command -v rg >/dev/null 2>&1 || {
+  echo "FAIL: ripgrep is required by stat-portability-guard" >&2
+  exit 1
+}
+while IFS=: read -r file line text; do
+  case "$text" in *'#'*) continue;; esac
+  case "$file" in
+    plugins/dev/scripts/lib/portable-stat.sh|plugins/dev/scripts/lib/__tests__/helpers/gnu-stat-stub.sh) continue ;;
+    plugins/dev/scripts/phase-agent-watch-bg|plugins/dev/scripts/__tests__/catalyst-execution-core.test.sh|plugins/dev/scripts/__tests__/setup-linear-webhook.test.sh) continue ;;
+    plugins/dev/scripts/create-worktree.sh|plugins/dev/scripts/orphan-sweep.sh) continue ;;
+    plugins/dev/skills/linearis/SKILL.md|plugins/dev/skills/morning-briefing/SKILL.md) continue ;;
+  esac
+  printf 'unguarded stat dialect probe: %s:%s:%s\n' "$file" "$line" "$text" >&2
+  failures=$((failures + 1))
+done < <(cd "$ROOT" && rg -n '\bstat\s+-[cf]\b' --glob '!thoughts/**' --glob '!node_modules/**')
+[[ "$failures" -eq 0 ]]
+echo "stat-portability-guard: PASS"

--- a/plugins/dev/scripts/lib/cloud-sync-token-probe.sh
+++ b/plugins/dev/scripts/lib/cloud-sync-token-probe.sh
@@ -3,6 +3,7 @@
 
 _CSTP_SELF="${BASH_SOURCE[0]}"
 _CSTP_DIR="$(cd "$(dirname "$_CSTP_SELF")" && pwd)"
+source "${_CSTP_DIR}/portable-stat.sh"
 
 cloud_sync_probe_token() {
   local host_name="" arg
@@ -49,12 +50,12 @@ cloud_sync_probe_token() {
     if [[ -r "$cluster_file" ]]; then
       . "$cluster_file"
       source_name="cluster.env"
-      [[ "$(stat -f '%Lp' "$cluster_file" 2>/dev/null || stat -c '%a' "$cluster_file" 2>/dev/null || echo 600)" == "600" ]] || perms_warning="yes"
+      [[ "$(portable_stat_mode "$cluster_file" || echo 0600)" == "0600" ]] || perms_warning="yes"
     fi
     if [[ -r "$cloud_file" ]]; then
       . "$cloud_file"
       source_name="cloud-sync.env"
-      [[ "$(stat -f '%Lp' "$cloud_file" 2>/dev/null || stat -c '%a' "$cloud_file" 2>/dev/null || echo 600)" == "600" ]] || perms_warning="yes"
+      [[ "$(portable_stat_mode "$cloud_file" || echo 0600)" == "0600" ]] || perms_warning="yes"
     fi
     name="$(CFG_DIR="$config_dir" bun -e 'const m = await import(process.env.CFG_DIR + "/config.mjs"); process.stdout.write(m.resolveNodeCloudTokenEnv().envVar);' 2>/dev/null || printf 'CATALYST_CLOUD_TOKEN')"
     local present="no"

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -45,6 +45,7 @@ _CATALYST_LINEAR_READ_REPLICA_SH=1
 # shellcheck disable=SC2296
 __LRR_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
 __LRR_LIB_DIR="$(cd "$(dirname "$__LRR_SELF")" && pwd)"
+source "${__LRR_LIB_DIR}/portable-stat.sh"
 
 # _lrr_emit_fallback_event <ID> <reason> <source> — best-effort: append a WARN
 # `catalyst.replica.read_fallback` event to the unified log so every replica
@@ -135,7 +136,7 @@ _lrr_live_read() {
 # `--file-system` (it would NOT error, it prints filesystem text), so probing BSD
 # first would yield garbage on the Linux fleet. macOS lacks `-c`, so it errors
 # cleanly and falls through to `-f`.
-_lrr_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
+_lrr_mtime() { portable_stat_mtime "$1" || echo ""; }
 
 # replica_fresh [db] → rc 0 when the replica is safe to read:
 #   • sqlite3 available, and

--- a/plugins/dev/scripts/lib/portable-stat.sh
+++ b/plugins/dev/scripts/lib/portable-stat.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# The shared portable file-metadata seam (CAT-85).
+#
+# A single `stat -f ... || stat -c ...` capture is unsafe: GNU stat treats -f
+# as --file-system, writes a filesystem report to stdout, and can still fail.
+# The fallback output is then concatenated with that report. This caused the
+# CTL-1473, CTL-1628, CTL-1509, and CAT-21 incidents. Probe each dialect in a
+# separate capture and validate its shape before returning it.
+[[ -n "${_CATALYST_PORTABLE_STAT_SH_LOADED:-}" ]] && return 0
+_CATALYST_PORTABLE_STAT_SH_LOADED=1
+
+portable_stat() {
+  local gnu_fmt="$1" bsd_fmt="$2" path="$3" pattern="${4:-^[0-9]+$}" out
+  out="$(stat -c "$gnu_fmt" "$path" 2>/dev/null)" || out=""
+  if [[ ! "$out" =~ $pattern ]]; then
+    out="$(stat -f "$bsd_fmt" "$path" 2>/dev/null)" || out=""
+  fi
+  [[ "$out" =~ $pattern ]] || return 1
+  printf '%s\n' "$out"
+}
+
+portable_stat_mtime() { portable_stat '%Y' '%m' "$1"; }
+portable_stat_size() { portable_stat '%s' '%z' "$1"; }
+portable_stat_owner() { portable_stat '%u' '%u' "$1"; }
+portable_stat_inode() { portable_stat '%i' '%i' "$1"; }
+
+# BSD %Lp drops special bits, so use raw %p and mask permission/special bits.
+portable_stat_mode() {
+  local raw
+  raw="$(portable_stat '%a' '%p' "$1" '^[0-7]+$')" || return 1
+  printf '%04o\n' "$(( 8#$raw & 4095 ))"
+}
+
+portable_stat_mode_oct() {
+  local raw
+  raw="$(portable_stat '%a' '%p' "$1" '^[0-7]+$')" || return 1
+  printf '%s\n' "$(( 8#$raw & 4095 ))"
+}

--- a/plugins/dev/scripts/lib/secret-hygiene-check.sh
+++ b/plugins/dev/scripts/lib/secret-hygiene-check.sh
@@ -3,22 +3,30 @@
 # Each function prints FAIL: … to stderr on violation and returns non-zero.
 # bash-3.2 safe: no mapfile, no associative arrays.
 
-# Portable file-mode reader (BSD stat vs GNU stat).
-_shc_file_mode() {
-	stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
-}
+# Portable self-path: BASH_SOURCE under bash, prompt-expansion %x under zsh.
+# shellcheck disable=SC2296
+__SHC_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__SHC_LIB_DIR="$(cd "$(dirname "$__SHC_SELF")" && pwd)"
+source "${__SHC_LIB_DIR}/portable-stat.sh"
 
 # check_secret_file_modes [config_dir]
 # Fail if any config_dir/config*.json is group/other readable (perm bits & 077 set).
 check_secret_file_modes() {
 	local config_dir="${1:-${CATALYST_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/catalyst}}"
-	local rc=0 mode f
+	local rc=0 mode oct f
 	for f in "${config_dir}"/config*.json; do
 		[[ -f "$f" ]] || continue
-		mode="$(_shc_file_mode "$f")"
-		# Check if group or other bits are set (last two octal digits != 00)
-		local last2="${mode#?}"  # strip leading digit (owner)
-		if [[ "$last2" != "00" ]]; then
+		if ! mode="$(portable_stat_mode "$f")"; then
+			echo "FAIL: ${f} mode unreadable" >&2
+			rc=1
+			continue
+		fi
+		if ! oct="$(portable_stat_mode_oct "$f")"; then
+			echo "FAIL: ${f} mode unreadable" >&2
+			rc=1
+			continue
+		fi
+		if (( (oct & 63) != 0 )); then
 			echo "FAIL: ${f} is mode ${mode} (expected 600, group/other readable)" >&2
 			rc=1
 		fi

--- a/plugins/dev/scripts/lib/secrets-hygiene.sh
+++ b/plugins/dev/scripts/lib/secrets-hygiene.sh
@@ -2,10 +2,11 @@
 # Secret-hygiene primitives (CTL-1203). Source me; do not execute directly.
 # bash-3.2 safe: no mapfile, no associative arrays.
 
-# Portable file-mode reader (BSD stat vs GNU stat).
-_sh_file_mode() {
-	stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null
-}
+# Portable self-path: BASH_SOURCE under bash, prompt-expansion %x under zsh.
+# shellcheck disable=SC2296
+__SH_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__SH_LIB_DIR="$(cd "$(dirname "$__SH_SELF")" && pwd)"
+source "${__SH_LIB_DIR}/portable-stat.sh"
 
 # harden_secrets_dir <dir>
 # mkdir -p then chmod 700 the dir. Idempotent; no-op if already 700.

--- a/plugins/dev/scripts/migrate-dual-harness.sh
+++ b/plugins/dev/scripts/migrate-dual-harness.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/portable-stat.sh"
 # migrate-dual-harness.sh — migrate a single-harness repo (Claude-only monolithic
 # CLAUDE.md, or Codex-only AGENTS.md-with-no-bridge) to the dual-harness layout so
 # BOTH Claude Code and Codex load the same instructions and the same skills.
@@ -305,8 +307,8 @@ elif [[ -d "$CS" ]]; then
 				# silently drop group access / setgid semantics. The tree
 				# roots themselves are compared first (-mindepth 1 skips them
 				# in the loop, where the rel-path arithmetic needs a child).
-				cs_mode="$(stat -c %a "$CS" 2>/dev/null || stat -f %Lp "$CS" 2>/dev/null)"
-				as_mode="$(stat -c %a "$AS" 2>/dev/null || stat -f %Lp "$AS" 2>/dev/null)"
+				cs_mode="$(portable_stat_mode "$CS")"
+				as_mode="$(portable_stat_mode "$AS")"
 				if [[ "$cs_mode" != "$as_mode" ]]; then
 					SKILLS_ACTION="ambiguous"
 					SKILLS_MSG="byte-identical but the tree roots' modes differ: .claude/skills is mode ${cs_mode:-unreadable} but .agents/skills is ${as_mode:-unreadable}"
@@ -314,8 +316,8 @@ elif [[ -d "$CS" ]]; then
 				[[ "$SKILLS_ACTION" == "collapse" ]] && while IFS= read -r cs_file; do
 					rel_path="${cs_file#"$CS"/}"
 					as_file="$AS/$rel_path"
-					cs_mode="$(stat -c %a "$cs_file" 2>/dev/null || stat -f %Lp "$cs_file" 2>/dev/null)"
-					as_mode="$(stat -c %a "$as_file" 2>/dev/null || stat -f %Lp "$as_file" 2>/dev/null)"
+					cs_mode="$(portable_stat_mode "$cs_file")"
+					as_mode="$(portable_stat_mode "$as_file")"
 					if [[ "$cs_mode" != "$as_mode" ]]; then
 						SKILLS_ACTION="ambiguous"
 						SKILLS_MSG="byte-identical but modes differ: '${rel_path}' is mode ${cs_mode:-unreadable} under .claude/skills but ${as_mode:-unreadable} under .agents/skills"

--- a/plugins/dev/scripts/orchestrate-healthcheck
+++ b/plugins/dev/scripts/orchestrate-healthcheck
@@ -68,6 +68,7 @@ STATE_SCRIPT="${CATALYST_STATE_SCRIPT:-${SCRIPT_DIR}/catalyst-state.sh}"
 # CTL-607: current-phase guard helper (latest_phase_in_dir + PHASES mirror).
 # shellcheck source=lib/phase-sequence.sh
 . "${SCRIPT_DIR}/lib/phase-sequence.sh"
+. "${SCRIPT_DIR}/lib/portable-stat.sh"
 # CTL-511: phase-agent-emit-complete emits the broker-routable phase.<name>.failed
 # event when a phase signal is flipped to stalled. Test-overridable.
 EMIT_COMPLETE="${CATALYST_EMIT_COMPLETE:-${SCRIPT_DIR}/phase-agent-emit-complete}"
@@ -236,9 +237,8 @@ SUPPRESSED_TICKETS=() # CTL-509: workers left running by the git-activity guard
 PHASE_TERMINAL_STATES="done failed errored stopped stalled"
 
 mtime_of() {
-	# macOS `stat -f` vs GNU `stat -c` — fall back if neither accepts.
 	local f="$1"
-	stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo ""
+	portable_stat_mtime "$f" || echo ""
 }
 
 # CTL-509: resolve the worktree base for phase-mode workers. Precedence:

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -79,6 +79,7 @@ _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
+source "${SCRIPT_DIR}/lib/portable-stat.sh"
 export PATH="${PATH}:${SCRIPT_DIR}"
 
 # CTL-1417: self-protection guard — a final belt (fail-closed lsof + cwd check)
@@ -562,11 +563,7 @@ _wt_unpushed_count() {
 # mtime stream is polluted with filesystem-block numbers and `sort -nr | head -1`
 # returns garbage — the wf_* classify path produced no SAFE/KEEP verdict on Linux
 # (CI RED T67/T68). Detect the working flavour once at load time instead.
-if stat -c '%Y' /dev/null >/dev/null 2>&1; then
-  _stat_mtime() { stat -c '%Y' "$1" 2>/dev/null || echo 0; }
-else
-  _stat_mtime() { stat -f '%m' "$1" 2>/dev/null || echo 0; }
-fi
+_stat_mtime() { portable_stat_mtime "$1" || echo 0; }
 
 _wt_newest_mtime() {
   find "$1" -type f \

--- a/plugins/dev/scripts/ticket-retro/gather-retro.sh
+++ b/plugins/dev/scripts/ticket-retro/gather-retro.sh
@@ -30,6 +30,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/portable-stat.sh"
 COMPOUND_LOG="${SCRIPT_DIR}/../compound-log.sh"
 
 THOUGHTS_DIR="./thoughts"
@@ -177,7 +178,7 @@ LEARN_DIR="${THOUGHTS_DIR}/shared/learnings"
 if [ -d "$LEARN_DIR" ]; then
   find "$LEARN_DIR" -type f -name '*.md' 2>/dev/null | while IFS= read -r lf; do
     [ -n "$lf" ] || continue
-    mt=$(date -u -r "$lf" +%s 2>/dev/null || stat -c %Y "$lf" 2>/dev/null || echo 0)
+    mt=$(portable_stat_mtime "$lf" || echo 0)
     [ "$mt" -gt "$WINDOW_EPOCH" ] || continue
     title=$(grep -m1 '^title:' "$lf" 2>/dev/null | sed -E 's/^title:[[:space:]]*//; s/^"//; s/"$//')
     [ -z "$title" ] && title="$(basename "$lf" .md)"


### PR DESCRIPTION
Courtesy PR — mirrors a fix already merged on our fork (thagale/catalyst#90). Not intended to be merged here; opened for upstream visibility per our dual-PR convention.

Adds a portable `stat` helper (`lib/portable-stat.sh`) used by `secret-hygiene-check.sh` and `secrets-hygiene.sh` so mode/mtime checks work on both BSD and GNU stat, replacing a host-dependent fixture.