### PR TITLE
docs(dev): CTL-1798 — name the two legacy fallback modes instead of "both paths"

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,18 +47,25 @@ per-orchestrator local state in worktrees stays the source of truth for crash re
 only; the execution-core daemon writes none of it, so on an execution-core host the file is
 routinely **absent** (measured: no `~/catalyst/state.json`, `catalyst.db.orchestrators` = 0 rows).
 Absence is therefore not evidence the machinery is dead. `catalyst-state.sh` is nonetheless **not**
-removable, because it retains live callers in the two **legacy fallback modes** — wave-orchestration
-(`plugins/legacy/skills/orchestrate/SKILL.md`: `ensure-run-dir`, `register`, `update`, `worker`,
-`heartbeat`, `attention`, `resolve-attention`, `archive`, `event`) and oneshot
-(`plugins/legacy/skills/oneshot/SKILL.md`: `event`, `worker`, `attention`) — **and** in
-standalone/helper tooling outside the legacy plugin: `setup-orchestrator.sh` (`init`,
-`ensure-run-dir`), `emit-worker-status-change.sh`, `compound-log.sh`, `orchestrate-roll-usage.sh`,
-`orchestrate-status.sh`, and the `orchestrate-*` helper family, with `install-cli.sh` /
-`check-setup.sh` installing and verifying it as the `catalyst-state` CLI. Those two categories are
-what "retains live callers" means here — **execution-core is not one of them**: a search of
-`plugins/dev/scripts/execution-core` finds no `catalyst-state.sh` invocation at all (0 files;
-positive control — the same search over `plugins/legacy` returns 2). Read this paragraph as evidence
-about `catalyst-state.sh`'s **callers**, not as an execution-core dependency.
+removable, because it retains live callers in two places:
+
+1. **The legacy-wave path** — its coordinator `plugins/legacy/skills/orchestrate/SKILL.md`
+   (`ensure-run-dir`, `register`, `update`, `worker`, `heartbeat`, `attention`, `resolve-attention`,
+   `archive`, `event`) together with the `/oneshot` worker it dispatches under
+   `dispatchMode: "oneshot-legacy"` (`plugins/legacy/skills/oneshot/SKILL.md`: `event`, `worker`,
+   `attention`). These are **one path, not two modes**: `oneshot-legacy` is a worker-dispatch
+   strategy the wave coordinator selects, and those `worker`/`attention` calls are the worker half
+   of that same path. (Standalone `/oneshot` as a direct single-ticket lifecycle is documented
+   separately and is not a second orchestration mode.)
+2. **Standalone/helper tooling** outside the legacy plugin — `setup-orchestrator.sh` (`init`,
+   `ensure-run-dir`), `emit-worker-status-change.sh`, `compound-log.sh`, `orchestrate-roll-usage.sh`,
+   `orchestrate-status.sh`, and the `orchestrate-*` helper family, with `install-cli.sh` /
+   `check-setup.sh` installing and verifying it as the `catalyst-state` CLI.
+
+Those two are what "retains live callers" means here — **execution-core is not one of them**: a
+search of `plugins/dev/scripts/execution-core` finds no `catalyst-state.sh` invocation at all
+(0 files; positive control — the same search over `plugins/legacy` returns 2). Read this paragraph as
+evidence about `catalyst-state.sh`'s **callers**, not as an execution-core dependency.
 
 ```
 ~/catalyst/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,14 +46,19 @@ per-orchestrator local state in worktrees stays the source of truth for crash re
 **Liveness (audited CTL-1791, 2026-08-11).** `state.json` is written by the **legacy-wave** path
 only; the execution-core daemon writes none of it, so on an execution-core host the file is
 routinely **absent** (measured: no `~/catalyst/state.json`, `catalyst.db.orchestrators` = 0 rows).
-Absence is therefore not evidence the machinery is dead. `catalyst-state.sh` retains live callers on
-both paths and is **not** removable: `plugins/legacy/skills/orchestrate/SKILL.md` (`ensure-run-dir`,
-`register`, `update`, `worker`, `heartbeat`, `attention`, `resolve-attention`, `archive`, `event`)
-and `plugins/legacy/skills/oneshot/SKILL.md` (`event`, `worker`, `attention`) — the documented
-runtime fallback — plus, outside the legacy plugin, `setup-orchestrator.sh` (`init`,
+Absence is therefore not evidence the machinery is dead. `catalyst-state.sh` is nonetheless **not**
+removable, because it retains live callers in the two **legacy fallback modes** — wave-orchestration
+(`plugins/legacy/skills/orchestrate/SKILL.md`: `ensure-run-dir`, `register`, `update`, `worker`,
+`heartbeat`, `attention`, `resolve-attention`, `archive`, `event`) and oneshot
+(`plugins/legacy/skills/oneshot/SKILL.md`: `event`, `worker`, `attention`) — **and** in
+standalone/helper tooling outside the legacy plugin: `setup-orchestrator.sh` (`init`,
 `ensure-run-dir`), `emit-worker-status-change.sh`, `compound-log.sh`, `orchestrate-roll-usage.sh`,
 `orchestrate-status.sh`, and the `orchestrate-*` helper family, with `install-cli.sh` /
-`check-setup.sh` installing and verifying it as the `catalyst-state` CLI.
+`check-setup.sh` installing and verifying it as the `catalyst-state` CLI. Those two categories are
+what "retains live callers" means here — **execution-core is not one of them**: a search of
+`plugins/dev/scripts/execution-core` finds no `catalyst-state.sh` invocation at all (0 files;
+positive control — the same search over `plugins/legacy` returns 2). Read this paragraph as evidence
+about `catalyst-state.sh`'s **callers**, not as an execution-core dependency.
 
 ```
 ~/catalyst/


### PR DESCRIPTION
Closes CTL-1798. Deferred P2 from Codex round 2 on #3271 (house rule: round 2+ P2 defers to a follow-up ticket).

## The finding

`docs/architecture.md` said `catalyst-state.sh` *"retains live callers on **both paths**"*.

Read in place, "both paths" points at the legacy-wave and execution-core paths named in the *preceding* sentence — which flatly contradicts that same sentence, since it states the execution-core daemon writes none of this state.

## The fix

The enumerated callers are actually **two different categories**, and neither is execution-core:

1. the two **legacy fallback modes** — wave-orchestration (`orchestrate/SKILL.md`) and oneshot (`oneshot/SKILL.md`);
2. **standalone/helper tooling** outside the legacy plugin (`setup-orchestrator.sh`, `emit-worker-status-change.sh`, `compound-log.sh`, the `orchestrate-*` helper family, …).

Both are now named explicitly, "both paths" is gone, and the paragraph states outright what it is evidence *about* (`catalyst-state.sh`'s callers) and what it is **not** (an execution-core dependency).

## Verified, not asserted

```
grep -rl catalyst-state plugins/dev/scripts/execution-core/   -> 0 files
grep -rl catalyst-state plugins/legacy/                       -> 2 files   (positive control)
```

The zero is a measurement rather than a failed grep, because the same search returns non-zero where the callers do exist.

## Why this is more than a wording nit

The commit this follows exists **to correct an over-broad sentence in this same file** — `architecture.md:133`, whose "purely observational" scoped only worker-state *authority* but read as "no consumers", and on that reading seeded a proposal to delete a live detector.

A replacement sentence that is over-broad in the *other* direction — documenting a dependency that does not exist — is the same defect one line down.