### PR TITLE
test(dev): CAT-257 cover compound escalation fallback

### DIFF
--- a/plugins/dev/scripts/__tests__/escalate-helper-invariants.test.sh
+++ b/plugins/dev/scripts/__tests__/escalate-helper-invariants.test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+FAIL=0 CHECKED=0
+bad() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+for file in "$ROOT"/plugins/dev/scripts/lib/escalate-*.sh; do
+  [[ "$file" == *escalate-common.sh ]] && continue
+  CHECKED=$((CHECKED+1))
+  grep -q 'escalation-explain\.mjs' "$file" && bad "I1 $file: calls shim directly; use escalation_explain_json"
+  grep -qE '2>/dev/null[[:space:]]*\|\|[[:space:]]*echo' "$file" && bad "I2 $file: discarded stderr fallback"
+  grep -qE '\[\[? -x "\$\{?emit' "$file" && bad "I3 $file: hand-rolled emitter guard"
+  grep -q 'escalation_emit_terminal' "$file" || bad "I3 $file: no shared terminal emit"
+  grep -q -- '--argjson' "$file" && bad "I4 $file: raw --argjson"
+  grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*:-\{\}\}' "$file" && bad "I5 $file: unsafe brace fallback"
+  grep -q 'escalate-common.sh' "$file" || bad "I6 $file: shared primitives not sourced"
+  if command -v shellcheck >/dev/null; then shellcheck -e SC2317 "$file" || bad "I7 $file: shellcheck"; fi
+done
+[[ "$CHECKED" -ge 2 ]] || bad "I8: expected at least two helpers, found $CHECKED"
+echo "checked=$CHECKED failed=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-monitor-merge-permission-wall.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-monitor-merge-permission-wall.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/escalate-merge-permission.sh"
+SKILL="${REPO_ROOT}/plugins/dev/skills/phase-monitor-merge/SKILL.md"
+FAILURES=0; PASSES=0
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; }
+assert_eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$2', got '$1'"; }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — '$2' not found"; }
+TMPROOT="$(mktemp -d)"; trap 'rm -rf "$TMPROOT"' EXIT
+source "$LIB"
+mk_gh() { local dir="$TMPROOT/bin.$RANDOM"; mkdir -p "$dir"; { echo '#!/usr/bin/env bash'; printf 'printf %%s %q\n' "$1"; echo "exit $2"; } > "$dir/gh"; chmod +x "$dir/gh"; echo "$dir"; }
+probe_with() { local bin; bin="$(mk_gh "$1" "$2")"; PATH="$bin:$PATH" merge_permission_probe owner/repo; }
+describe_with() { local bin; bin="$(mk_gh "$1" "$2")"; PATH="$bin:$PATH" merge_permission_describe owner/repo; }
+assert_eq "$(probe_with '{"push":false,"maintain":false,"admin":false}' 0)" denied "read-only grant"
+assert_eq "$(probe_with '{"push":true,"maintain":false,"admin":false}' 0)" ok "push grant"
+assert_eq "$(probe_with '{"push":false,"maintain":false,"admin":true}' 0)" ok "admin grant"
+assert_eq "$(probe_with '' 1)" unknown "gh failure fails open"
+assert_eq "$(probe_with '{}' 0)" unknown "missing permissions fails open"
+assert_eq "$(describe_with '{"admin":false,"maintain":false,"push":false,"triage":true,"pull":true}' 0)" "denied TRIAGE" "triage grant is reported"
+assert_eq "$(describe_with '{"admin":false,"maintain":false,"push":false,"triage":false,"pull":true}' 0)" "denied READ" "read grant is reported"
+assert_eq "$(describe_with '{"admin":false,"maintain":false,"push":false,"triage":false,"pull":false}' 0)" "denied NONE" "no grant is reported"
+assert_eq "$(describe_with '{"admin":false,"maintain":true,"push":true}' 0)" "ok MAINTAIN" "maintain outranks write"
+assert_eq "$(describe_with '' 1)" "unknown UNKNOWN" "failed grant lookup is unknown"
+assert_denial() { if merge_denial_is_permission "$1"; then assert_eq 0 "$2" "$3"; else assert_eq 1 "$2" "$3"; fi; }
+assert_denial 'GraphQL: user does not have the correct permissions to execute `MergePullRequest`' 0 "GraphQL denial"
+assert_denial 'HTTP 403: Must have admin rights to Repository.' 0 "admin denial"
+assert_denial 'GraphQL: Pull request is not mergeable (mergePullRequest)' 1 "plain unmergeable"
+assert_denial 'HTTP 502: Bad gateway' 1 "transient failure"
+# --- escalation: exactly one emit, MANUAL (non-degraded) explanation ---
+# PLUGIN_ROOT is stubbed so the emit is recorded rather than appended to the
+# LIVE event log, and so "exactly once" is assertable.
+# shellcheck disable=SC2034  # consumed as globals by the sourced lib
+ORCH_ID="test"; TICKET="CAT-999"; PHASE="monitor-merge"
+ORCH_DIR="$TMPROOT/orch"; mkdir -p "$ORCH_DIR/workers/$TICKET"
+SIGNAL_FILE="$ORCH_DIR/workers/$TICKET/phase-${PHASE}.json"
+echo '{"ticket":"CAT-999","phase":"monitor-merge","status":"running"}' > "$SIGNAL_FILE"
+EMITLOG="$TMPROOT/emit.log"
+STUBROOT="$TMPROOT/stubroot"; mkdir -p "$STUBROOT/scripts/execution-core"
+cat > "$STUBROOT/scripts/phase-agent-emit-complete" <<EOS
+#!/usr/bin/env bash
+echo "\$*" >> "$EMITLOG"
+EOS
+chmod +x "$STUBROOT/scripts/phase-agent-emit-complete"
+cp "${REPO_ROOT}/plugins/dev/scripts/execution-core/escalation-explain.mjs" \
+   "${REPO_ROOT}/plugins/dev/scripts/execution-core/escalation-explanation.mjs" \
+   "$STUBROOT/scripts/execution-core/"
+# shellcheck disable=SC2034  # consumed as globals by the sourced lib
+COMMS=""
+# shellcheck disable=SC2034  # consumed as a global by the sourced lib
+CATALYST_COMMENT_POST_HELPER="/nonexistent"
+PLUGIN_ROOT="$STUBROOT" _escalate_merge_permission "coalesce-labs/catalyst" "3218" "READ" >/dev/null 2>&1
+
+assert_eq "$(wc -l < "$EMITLOG" | tr -d ' ')" "1" "emits exactly once (no attempts burned)"
+assert_contains "$(cat "$EMITLOG")" "--status failed" "emits status=failed"
+assert_contains "$(cat "$EMITLOG")" "merge_permission_denied" "emits the permission failureReason"
+SIG="$(cat "$SIGNAL_FILE")"
+assert_eq "$(jq -r '.status' <<<"$SIG")" "failed" "signal status=failed"
+assert_eq "$(jq -r '.failureReason' <<<"$SIG")" "merge_permission_denied" "signal failureReason set"
+assert_eq "$(jq -r '.explanation.escalation_type' <<<"$SIG")" "manual" "explanation is MANUAL, not authorization"
+assert_eq "$(jq -r '.explanation.degraded // "false"' <<<"$SIG")" "false" "explanation validates (not degraded)"
+assert_contains "$(jq -r '.explanation.problem' <<<"$SIG")" "coalesce-labs/catalyst" "problem names the repository"
+assert_contains "$(jq -r '.explanation.blocked_capability' <<<"$SIG")" "merge" "blocked_capability names the missing merge permission"
+CTA="$(jq -r '.explanation.call_to_action' <<<"$SIG")"
+assert_contains "$CTA" "merge" "CTA is actionable"
+if [[ "$(printf '%s' "$CTA" | tr '[:upper:]' '[:lower:]')" == *"authorize"*"retry"* ]]; then
+  fail "CTA must never ask the operator to authorize a retry"
+else
+  pass "CTA never asks the operator to authorize a retry"
+fi
+
+# CAT-257 compound regression: empty explanation + missing emitter must still
+# leave a terminal signal and must report both degraded links on stderr.
+printf 'process.stdout.write("");\n' > "$STUBROOT/scripts/execution-core/escalation-explain.mjs"
+rm -f "$STUBROOT/scripts/phase-agent-emit-complete"
+printf '{"ticket":"CAT-999","phase":"monitor-merge","status":"running"}\n' > "$SIGNAL_FILE"
+PLUGIN_ROOT="$STUBROOT" _escalate_merge_permission "coalesce-labs/catalyst" "3218" "TRIAGE" \
+  >/dev/null 2>"$TMPROOT/compound.err"
+assert_eq "$(jq -r .status "$SIGNAL_FILE")" failed "compound fallback leaves terminal signal"
+assert_contains "$(cat "$TMPROOT/compound.err")" "EMPTY stdout" "empty explanation is diagnosed"
+assert_contains "$(cat "$TMPROOT/compound.err")" "NOT executable" "missing emitter is diagnosed"
+assert_contains "$(cat "$TMPROOT/compound.err")" "no-progress" "missing emitter names recovery consequence"
+assert_eq "$(find "$TMPROOT" -name '*.tmp.*' | wc -l | tr -d ' ')" 0 "compound fallback leaves no temporary file"
+
+BODY="$(cat "$SKILL")"
+assert_contains "$BODY" "merge_permission_describe" "preflight wired"
+assert_contains "$BODY" "merge_denial_is_permission" "call-site classifier wired"
+assert_contains "$BODY" "MERGE_PERM_LIB_OK" "merge classifier is source-gated"
+assert_contains "$BODY" "merge_failed_unclassified" "unclassified merge failure emits terminal reason"
+assert_contains "$BODY" "merge_permission_describe" "preflight surfaces concrete grant"
+PRE_LINE="$(grep -n 'merge_permission_probe' "$SKILL" | head -1 | cut -d: -f1)"
+MERGE_LINE="$(grep -n 'if ! gh pr merge' "$SKILL" | head -1 | cut -d: -f1)"
+[[ "$PRE_LINE" -lt "$MERGE_LINE" ]] && pass "preflight precedes merge" || fail "preflight ordering"
+echo "passed=$PASSES failed=$FAILURES"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/lib/__tests__/escalate-common.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/escalate-common.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+LIB="$ROOT/plugins/dev/scripts/lib/escalate-common.sh"
+P=0 F=0
+pass() { P=$((P+1)); echo "  PASS: $1"; }
+fail() { F=$((F+1)); echo "  FAIL: $1"; }
+eq() { [[ "$1" == "$2" ]] && pass "$3" || fail "$3 — expected '$2', got '$1'"; }
+has() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 — missing '$2'"; }
+command -v node >/dev/null && command -v jq >/dev/null || { echo "SKIP: node/jq unavailable"; exit 0; }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/root/scripts/execution-core"
+PLUGIN_ROOT="$TMP/root"; source "$LIB"
+
+printf 'process.stderr.write("boom-from-stderr\\n"); process.exit(3);\n' > "$PLUGIN_ROOT/scripts/execution-core/escalation-explain.mjs"
+OUT="$(escalation_explain_json test --type manual 2>"$TMP/err")"
+eq "$OUT" '{}' "crash falls back to JSON"
+has "$(cat "$TMP/err")" "exited 3" "crash exit is visible"
+has "$(cat "$TMP/err")" "boom-from-stderr" "captured stderr is visible"
+
+printf 'process.stdout.write("");\n' > "$PLUGIN_ROOT/scripts/execution-core/escalation-explain.mjs"
+OUT="$(escalation_explain_json test 2>"$TMP/err")"
+eq "$OUT" '{}' "empty stdout falls back"
+has "$(cat "$TMP/err")" "EMPTY stdout" "empty stdout is visible"
+
+printf 'process.stdout.write("garbage");\n' > "$PLUGIN_ROOT/scripts/execution-core/escalation-explain.mjs"
+OUT="$(escalation_explain_json test 2>"$TMP/err")"
+eq "$OUT" '{}' "invalid JSON falls back"
+has "$(cat "$TMP/err")" "not valid JSON" "invalid JSON is visible"
+
+printf 'process.stdout.write(JSON.stringify({escalation_type:"manual"}));\n' > "$PLUGIN_ROOT/scripts/execution-core/escalation-explain.mjs"
+OUT="$(escalation_explain_json test 2>"$TMP/err")"
+eq "$(jq -r .escalation_type <<<"$OUT")" manual "valid JSON passes through"
+eq "$(cat "$TMP/err")" '' "success is silent"
+
+SIG="$TMP/signal.json"; printf '{"status":"running"}\n' > "$SIG"
+escalation_write_signal_explanation test "$SIG" failed reason '' 2>"$TMP/err" || true
+eq "$(jq -r .status "$SIG")" failed "empty explanation still writes terminal state"
+has "$(cat "$TMP/err")" "substituting {}" "empty explanation is visible"
+eq "$(find "$TMP" -name '*.tmp.*' | wc -l | tr -d ' ')" 0 "no temporary files remain"
+
+ERR="$(escalation_emit_terminal test monitor-merge CAT-999 reason 2>&1)"; RC=$?
+eq "$RC" 0 "missing emitter is fail-open"
+has "$ERR" "NOT executable" "missing emitter is visible"
+has "$ERR" "no-progress" "missing emitter names consequence"
+
+( set -euo pipefail; source "$LIB"; escalation_explain_json test >/dev/null 2>&1 )
+eq "$?" 0 "failure paths are set -e safe"
+if command -v shellcheck >/dev/null; then shellcheck -e SC2317 "$ROOT/plugins/dev/scripts/lib/escalate-common.sh" && pass "shellcheck" || fail "shellcheck"; fi
+echo "passed=$P failed=$F"
+[[ "$F" -eq 0 ]]

--- a/plugins/dev/scripts/lib/escalate-common.sh
+++ b/plugins/dev/scripts/lib/escalate-common.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# CAT-257: fail-open, never-silent primitives shared by escalation helpers.
+[ -n "${_CATALYST_ESCALATE_COMMON_LIB:-}" ] && return 0
+_CATALYST_ESCALATE_COMMON_LIB=1
+
+_escalate_warn() { printf 'escalate[%s]: %s\n' "${1:-?}" "${2:-}" >&2; }
+
+escalation_explain_json() {
+  local ctx="$1"; shift
+  local shim="${PLUGIN_ROOT:-}/scripts/execution-core/escalation-explain.mjs"
+  local errf="" out="" err="" rc=0
+  errf="$(mktemp "${TMPDIR:-/tmp}/escalate-explain.XXXXXX" 2>/dev/null || true)"
+  if [ -n "$errf" ]; then
+    out="$(node "$shim" "$@" 2>"$errf")" || rc=$?
+    err="$(tr '\n' ' ' < "$errf" 2>/dev/null || true)"
+    rm -f "$errf"
+  else
+    _escalate_warn "$ctx" "mktemp failed; running escalation-explain without stderr capture"
+    out="$(node "$shim" "$@")" || rc=$?
+  fi
+  if [ "$rc" -ne 0 ]; then
+    _escalate_warn "$ctx" "escalation-explain.mjs exited ${rc}; falling back to {} — stderr: ${err:-<empty>}"
+    out=""
+  elif [ -z "$out" ]; then
+    _escalate_warn "$ctx" "escalation-explain.mjs exited 0 with EMPTY stdout; falling back to {} — stderr: ${err:-<empty>}"
+  elif ! printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+    _escalate_warn "$ctx" "escalation-explain.mjs stdout is not valid JSON; falling back to {} — stdout: $(printf '%s' "$out" | head -c 200)"
+    out=""
+  fi
+  [ -n "$out" ] || out='{}'
+  printf '%s' "$out"
+}
+
+escalation_write_signal_explanation() {
+  local ctx="$1" sig="$2" state="$3" reason="$4" expl="$5"
+  if [ -z "$sig" ] || [ ! -f "$sig" ]; then
+    _escalate_warn "$ctx" "signal file missing (${sig:-<unset>}); terminal explanation NOT written"
+    return 1
+  fi
+  if [ -z "$expl" ]; then
+    _escalate_warn "$ctx" "empty explanation JSON; substituting {} (operator will see a DEGRADED decision ask)"
+    expl='{}'
+  elif ! printf '%s' "$expl" | jq -e . >/dev/null 2>&1; then
+    _escalate_warn "$ctx" "explanation JSON is unparseable; substituting {} (operator will see a DEGRADED decision ask)"
+    expl='{}'
+  fi
+  local ts tmp
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; tmp="${sig}.tmp.$$"
+  if jq --arg ts "$ts" --arg st "$state" --arg rsn "$reason" --argjson expl "$expl" \
+      '.status=$st | .failureReason=$rsn | .explanation=$expl | .updatedAt=$ts' \
+      "$sig" > "$tmp" 2>/dev/null && mv "$tmp" "$sig"; then
+    return 0
+  fi
+  rm -f "$tmp"
+  _escalate_warn "$ctx" "jq write of the terminal explanation FAILED; ${sig} left unchanged (phase-agent-emit-complete is the only remaining backstop for .status)"
+  return 1
+}
+
+escalation_emit_terminal() {
+  local ctx="$1" phase="$2" ticket="$3" reason="$4"
+  local emit="${PLUGIN_ROOT:-}/scripts/phase-agent-emit-complete" rc=0
+  if [ ! -x "$emit" ]; then
+    _escalate_warn "$ctx" "phase-agent-emit-complete NOT executable at ${emit}; NO terminal event emitted for ${ticket}/${phase} (reason=${reason}) — recovery will attribute this as no-progress"
+    return 0
+  fi
+  "$emit" --phase "$phase" --ticket "$ticket" --status failed --reason "$reason" || rc=$?
+  [ "$rc" -eq 0 ] || _escalate_warn "$ctx" "phase-agent-emit-complete exited ${rc} for ${ticket}/${phase} (reason=${reason})"
+  return 0
+}
+
+escalation_comms_attention() {
+  local ctx="$1" msg="$2" comms_path="${COMMS:-}"
+  [ -n "$comms_path" ] || return 0
+  if [ ! -x "$comms_path" ]; then
+    _escalate_warn "$ctx" "COMMS set to ${comms_path} but not executable; no attention message sent"
+    return 0
+  fi
+  "$comms_path" send "${ORCH_ID:-}" "$msg" --as "${TICKET:-}" --type attention --orch "${ORCH_ID:-}" >/dev/null 2>&1 || _escalate_warn "$ctx" "comms attention send failed"
+  return 0
+}
+
+escalation_label_needs_human() {
+  local ctx="$1" reason="$2" expl="$3"
+  local orch="${ORCH_DIR:-${CATALYST_ORCHESTRATOR_DIR:-}}" runtime
+  [ -n "$orch" ] || { _escalate_warn "$ctx" "no ORCH_DIR; needs-human label NOT applied"; return 0; }
+  runtime="$(command -v bun 2>/dev/null || true)"
+  [ -n "$runtime" ] || { _escalate_warn "$ctx" "bun not on PATH; needs-human label NOT applied"; return 0; }
+  "$runtime" "${PLUGIN_ROOT}/scripts/execution-core/label-needs-human.mjs" --ticket "${TICKET}" --orch-dir "$orch" --explanation "$expl" --reason "$reason" >/dev/null 2>&1 || _escalate_warn "$ctx" "label-needs-human.mjs failed; needs-human may be unapplied"
+  return 0
+}
+
+escalation_post_cta_comment() {
+  local ctx="$1" heading="$2" expl="$3" footer="$4" cta post body
+  cta="$(printf '%s' "$expl" | jq -r '.call_to_action // empty' 2>/dev/null || true)"
+  if [ -z "$cta" ]; then _escalate_warn "$ctx" "explanation carries no call_to_action; Linear comment NOT posted"; return 0; fi
+  post="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
+  if [ -z "$post" ] || [ ! -x "$post" ]; then post="$(command -v linear-comment-post.sh 2>/dev/null || true)"; fi
+  if [ -z "$post" ] || [ ! -x "$post" ]; then _escalate_warn "$ctx" "no executable linear-comment-post.sh; CTA NOT posted to Linear"; return 0; fi
+  body="$(printf '%s\n\n%s\n\n%s' "$heading" "$cta" "$footer")"
+  "$post" "${TICKET}" "$body" >/dev/null || _escalate_warn "$ctx" "linear-comment-post.sh failed"
+  return 0
+}

--- a/plugins/dev/scripts/lib/escalate-merge-permission.sh
+++ b/plugins/dev/scripts/lib/escalate-merge-permission.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# CAT-222: fail-open repository permission probe and terminal escalation.
+[ -n "${_CAT222_MERGE_PERM_LIB:-}" ] && return 0
+_CAT222_MERGE_PERM_LIB=1
+
+_CAT257_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./escalate-common.sh
+. "${_CAT257_LIB_DIR}/escalate-common.sh"
+
+merge_permission_describe() {
+  local repo="${1:-}" body out
+  [ -n "$repo" ] || { printf 'unknown UNKNOWN'; return 0; }
+  body="$(gh api "repos/${repo}" --jq '.permissions' 2>/dev/null || true)"
+  [ -n "$body" ] || { printf 'unknown UNKNOWN'; return 0; }
+  out="$(printf '%s' "$body" | jq -r '
+    if type != "object" or (has("push") and has("maintain") and has("admin") | not)
+    then "unknown UNKNOWN"
+    else
+      (if .admin == true then "ADMIN" elif .maintain == true then "MAINTAIN"
+       elif .push == true then "WRITE" elif (.triage // false) == true then "TRIAGE"
+       elif (.pull // false) == true then "READ" else "NONE" end) as $g
+      | (if .push == true or .maintain == true or .admin == true then "ok"
+         elif .push == false and .maintain == false and .admin == false then "denied"
+         else "unknown" end) as $v | "\($v) \($g)"
+    end' 2>/dev/null || true)"
+  case "$out" in "ok "*|"denied "*|"unknown "*) printf '%s' "$out";; *) printf 'unknown UNKNOWN';; esac
+}
+
+merge_permission_probe() {
+  local description; description="$(merge_permission_describe "${1:-}")"
+  printf '%s' "${description%% *}"
+}
+
+merge_denial_is_permission() {
+  local err="${1:-}"
+  [ -n "$err" ] || return 1
+  { grep -qi 'MergePullRequest' <<<"$err" && grep -qi 'permission' <<<"$err"; } ||
+    grep -qi 'must have admin rights' <<<"$err"
+}
+
+_escalate_merge_permission() {
+  local repo="$1" pr="$2" observed="${3:-UNKNOWN}" expl_json
+  expl_json="$(escalation_explain_json monitor-merge \
+    --ticket "$TICKET" --phase "$PHASE" --type manual \
+    --problem "GitHub repository ${repo} reports ${observed} permission; this worker cannot merge PR #${pr}" \
+    --call-to-action "Grant write access on ${repo}, or merge PR #${pr} manually." \
+    --blocked-capability "merge pull requests in ${repo}" \
+    --instructions "$(jq -nc --arg r "$repo" --arg p "$pr" '["grant the worker identity write access to \($r)","or merge PR #\($p) manually"]')" \
+    --remediation-then-retry "after access is granted, re-run phase-monitor-merge" \
+    --why-not-auto "the worker cannot grant its own repository permissions" \
+    --can-execute false --observed "$(jq -nc --arg repo "$repo" --arg permission "$observed" '{repo:$repo,permission:$permission}')")"
+  escalation_write_signal_explanation monitor-merge "$SIGNAL_FILE" failed merge_permission_denied "$expl_json" || true
+  escalation_emit_terminal monitor-merge "$PHASE" "$TICKET" merge_permission_denied
+  escalation_label_needs_human monitor-merge merge_permission_denied "$expl_json"
+  escalation_comms_attention monitor-merge "phase-monitor-merge failed: ${repo} reports ${observed} permission — cannot merge PR #${pr}"
+  escalation_post_cta_comment monitor-merge '**Merge permission blocked — operator action required**' "$expl_json" '_Posted automatically by phase-monitor-merge escalation (CAT-222/CAT-257)._'
+  return 0
+}

--- a/plugins/dev/scripts/lib/escalate-workflow-scope.sh
+++ b/plugins/dev/scripts/lib/escalate-workflow-scope.sh
@@ -9,74 +9,28 @@
 #
 # Usage: source this file and call _escalate_workflow_scope_push [BRANCH]
 
+_CAT257_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./escalate-common.sh
+. "${_CAT257_LIB_DIR}/escalate-common.sh"
+
 _escalate_workflow_scope_push() {
-  local branch="${1:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "$TICKET")}"
+  local branch="${1:-$(git rev-parse --abbrev-ref HEAD || echo "$TICKET")}"
   local expl_json
-  expl_json="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+  expl_json="$(escalation_explain_json pr \
     --ticket "$TICKET" --phase "$PHASE" \
     --type manual \
     --problem "git push was rejected: the branch modifies .github/workflows/ but the host token lacks the 'workflow' OAuth scope" \
     --call-to-action "Grant the daemon token 'workflow' scope (gh auth refresh -s workflow) or set CATALYST_WORKFLOW_GITHUB_TOKEN, then re-run phase-pr — or push branch ${TICKET} manually. Which?" \
     --blocked-capability "the host git token lacks the workflow OAuth scope" \
-    --instructions "$(jq -nc '["gh auth refresh -s workflow","or set CATALYST_WORKFLOW_GITHUB_TOKEN"]' 2>/dev/null || echo '[]')" \
+    --instructions "$(jq -nc '["gh auth refresh -s workflow","or set CATALYST_WORKFLOW_GITHUB_TOKEN"]' || echo '[]')" \
     --remediation-then-retry "re-run /catalyst-dev:phase-pr after the scope is granted" \
     --why-not-auto "the daemon cannot grant itself an OAuth scope (capability boundary)" \
     --can-execute false \
-    --observed "$(jq -nc --arg b "$branch" '{branch:$b, scope_missing:"workflow"}' 2>/dev/null || echo '{}')" \
-    2>/dev/null || echo '{}')"
-  [ -n "$expl_json" ] || expl_json='{}'
-  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  local tmp="${SIGNAL_FILE}.tmp.$$"
-  jq --arg ts "$ts" --argjson expl "$expl_json" \
-    '.status="failed" | .failureReason="push_rejected_no_workflow_scope" | .explanation=$expl | .updatedAt=$ts' \
-    "$SIGNAL_FILE" > "$tmp" && mv "$tmp" "$SIGNAL_FILE" || true
-  local emit="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
-  if [[ -x "$emit" ]]; then
-    "$emit" --phase "$PHASE" --ticket "$TICKET" --status failed \
-      --reason "push_rejected_no_workflow_scope"
-  fi
-  if [[ -n "${COMMS:-}" && -x "${COMMS:-}" ]]; then
-    "$COMMS" send "${ORCH_ID}" \
-      "phase-pr failed: push rejected — missing 'workflow' OAuth scope on branch ${branch}" \
-      --as "$TICKET" --type attention --orch "${ORCH_ID}" >/dev/null 2>&1 || true
-  fi
-
-  # Apply needs-human THROUGH the shared guard (CTL-1552): the belief-owner check
-  # + read-verify applyLabel + the once-marker in ONE place, replacing the prior
-  # raw label add and the hand-written once-marker (which skipped the guard and
-  # could desync marker vs. Linear). The CLI writes the once-marker itself via
-  # labelOnce, so orch-monitor's Needs-You inbox still lights. Best-effort,
-  # fail-open. Runs under bun (the execution-core runtime; applyLabel reaches
-  # bun:sqlite).
-  local _orch="${ORCH_DIR:-${CATALYST_ORCHESTRATOR_DIR:-}}"
-  if [[ -n "${_orch:-}" ]]; then
-    # bun ONLY — never node. label-needs-human.mjs transitively imports
-    # bun:sqlite, so node exits ERR_UNSUPPORTED_ESM_URL_SCHEME and the fail-open
-    # redirect below would silently leave the label AND its marker unapplied.
-    local _rt
-    _rt="$(command -v bun 2>/dev/null || true)"
-    if [[ -n "${_rt:-}" ]]; then
-      # Thread the MANUAL explanation already built above. Without it the guard
-      # writes a generic "unexplained failure" phase-recovery-pass.json, which the
-      # monitor prefers over the failed-phase signal — hiding the actionable
-      # OAuth-scope instructions from the Needs-You inbox.
-      "$_rt" "${PLUGIN_ROOT}/scripts/execution-core/label-needs-human.mjs" \
-        --ticket "${TICKET}" --orch-dir "${_orch}" \
-        --explanation "${expl_json}" \
-        --reason push_rejected_no_workflow_scope >/dev/null 2>&1 || true
-    fi
-  fi
-
-  # Post call_to_action to Linear as a comment so the operator sees the CTA.
-  local _cta
-  _cta="$(printf '%s' "$expl_json" | jq -r '.call_to_action // empty' 2>/dev/null || true)"
-  local _comment_post="${CATALYST_COMMENT_POST_HELPER:-${PLUGIN_ROOT}/scripts/lib/linear-comment-post.sh}"
-  if [[ -z "${_comment_post:-}" || ! -x "${_comment_post:-}" ]]; then
-    _comment_post="$(command -v linear-comment-post.sh 2>/dev/null || true)"
-  fi
-  if [[ -n "${_cta:-}" && -n "${_comment_post:-}" && -x "${_comment_post:-}" ]]; then
-    local _cta_body
-    _cta_body="$(printf '**Workflow scope push blocked — operator action required**\n\n%s\n\n_Posted automatically by phase-pr escalation (CTL-1181)._' "${_cta}")"
-    "$_comment_post" "${TICKET}" "${_cta_body}" >/dev/null 2>&1 || true
-  fi
+    --observed "$(jq -nc --arg b "$branch" '{branch:$b, scope_missing:"workflow"}' || echo '{}')")"
+  escalation_write_signal_explanation pr "$SIGNAL_FILE" failed push_rejected_no_workflow_scope "$expl_json" || true
+  escalation_emit_terminal pr "$PHASE" "$TICKET" push_rejected_no_workflow_scope
+  escalation_comms_attention pr "phase-pr failed: push rejected — missing 'workflow' OAuth scope on branch ${branch}"
+  escalation_label_needs_human pr push_rejected_no_workflow_scope "$expl_json"
+  escalation_post_cta_comment pr '**Workflow scope push blocked — operator action required**' "$expl_json" '_Posted automatically by phase-pr escalation (CTL-1181)._'
+  return 0
 }

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -82,6 +82,21 @@ fi
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 [[ -n "$REPO" ]] || { echo "phase-monitor-merge: cannot resolve repo" >&2; exit 1; }
 
+# CAT-222: an affirmative read-only grant is terminal; probe errors fail open.
+MERGE_PERMISSION_LIB="${PLUGIN_ROOT}/scripts/lib/escalate-merge-permission.sh"
+if [[ -r "$MERGE_PERMISSION_LIB" ]]; then
+  source "$MERGE_PERMISSION_LIB"
+  COMMS="${COMMS:-${PLUGIN_ROOT}/scripts/catalyst-comms}"
+  [[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
+  MERGE_PERMISSION_DESC="$(merge_permission_describe "$REPO")"
+  MERGE_PERMISSION="${MERGE_PERMISSION_DESC%% *}"
+  MERGE_PERMISSION_GRANT="${MERGE_PERMISSION_DESC##* }"
+  if [[ "$MERGE_PERMISSION" == "denied" ]]; then
+    _escalate_merge_permission "$REPO" "$PR_NUMBER" "$MERGE_PERMISSION_GRANT"
+    exit 1
+  fi
+fi
+
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 TMP="${SIGNAL_FILE}.tmp.$$"
 # CTL-496: persist catalystSessionId so orchestrate-roll-usage --phase can
@@ -420,16 +435,53 @@ if [[ "$REVIEWER_VERDICT_PRESENT" != true && -n "${HEAD_AGE_SEC:-}" ]]; then
   fi
   echo "phase-monitor-merge: reviewer-arrival window elapsed; proceeding to merge pr#${PR_NUMBER}" >&2
 fi
+# CAT-202: explicit --repo — a bare `gh pr merge` resolves against the
+# ambient `origin` remote, which can disagree with $REPO (the repo the PR was
+# actually opened on, resolved above from phase-pr.json's .pr.url).
+# CAT-222: wrapped so a permission-wall denial escalates instead of surfacing
+# as an opaque non-zero exit.
+# CAT-257: this bash block is independent from preflight, so source locally.
+MERGE_PERM_LIB_OK=false
+MERGE_PERMISSION_LIB="${PLUGIN_ROOT}/scripts/lib/escalate-merge-permission.sh"
+if [[ -r "$MERGE_PERMISSION_LIB" ]]; then
+  source "$MERGE_PERMISSION_LIB" && MERGE_PERM_LIB_OK=true
+fi
+[[ "$MERGE_PERM_LIB_OK" == true ]] || echo "phase-monitor-merge: ${MERGE_PERMISSION_LIB} not readable; merge-permission classification DISABLED (a permission wall will be reported as an unclassified merge failure)" >&2
+COMMS="${COMMS:-${PLUGIN_ROOT}/scripts/catalyst-comms}"
+[[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
 # CTL-56: capture head ref BEFORE merge so we can delete it checkout-free after confirm.
 HEAD_REF=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.ref' 2>/dev/null || true)
-# Merge via REST only (CTL-56: dropping the local branch-cleanup flag avoids the
-# `git checkout <base>` that fails inside a linked worktree when main is checked
-# out in the primary clone). The exit code is now meaningful; REST confirm below
-# is the authoritative success gate.
-gh pr merge "$PR_NUMBER" --squash
+MERGE_ERR_FILE="$(mktemp)"
+# CTL-56: deliberately no local branch-cleanup flag on this call — it triggers a
+# local `git checkout <base>` that fails inside a linked worktree when the base
+# branch is already checked out in the primary clone, and it auto-closes any
+# OTHER open PR sharing this head branch name (breaks the dual-PR courtesy-PR
+# policy). Branch cleanup happens below, checkout-free, via the REST ref-delete
+# after the merge is confirmed.
+if ! gh pr merge "$PR_NUMBER" --repo "${REPO}" --squash 2>"$MERGE_ERR_FILE"; then
+  MERGE_ERR="$(cat "$MERGE_ERR_FILE" 2>/dev/null || true)"
+  rm -f "$MERGE_ERR_FILE"
+  if [[ "$MERGE_PERM_LIB_OK" == true ]] && merge_denial_is_permission "$MERGE_ERR"; then
+    _escalate_merge_permission "$REPO" "$PR_NUMBER" "${MERGE_PERMISSION_GRANT:-UNKNOWN}"
+    exit 1
+  fi
+  echo "phase-monitor-merge: gh pr merge exited non-zero: ${MERGE_ERR}" >&2
+else
+  rm -f "$MERGE_ERR_FILE"
+fi
 # REST is authoritative — confirm via REST, never GraphQL
 MERGED_OK=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.merged' 2>/dev/null || echo "false")
-[[ "$MERGED_OK" = "true" ]] || { echo "phase-monitor-merge: merge not confirmed via REST" >&2; exit 1; }
+if [[ "$MERGED_OK" != "true" ]]; then
+  echo "phase-monitor-merge: merge not confirmed via REST${MERGE_ERR:+ — last merge error: ${MERGE_ERR}}" >&2
+  if [[ "$MERGE_PERM_LIB_OK" == true ]]; then
+    escalation_emit_terminal monitor-merge "$PHASE" "$TICKET" merge_failed_unclassified
+  elif [[ -x "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" ]]; then
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" --phase "$PHASE" --ticket "$TICKET" --status failed --reason merge_failed_unclassified
+  else
+    echo "phase-monitor-merge: phase-agent-emit-complete unavailable; NO terminal event for ${TICKET}/${PHASE}" >&2
+  fi
+  exit 1
+fi
 
 # CTL-1680: retry empty merge_commit_sha — GitHub can return it empty for a few
 # seconds after a squash merge while it computes the SHA. Bounded + sleeps (no


### PR DESCRIPTION
Courtesy PR — mirrors a fix already merged on our fork (thagale/catalyst#100). Not intended to be merged here; opened for upstream visibility per our dual-PR convention.

Hardens the merge-permission escalation path (`escalate-merge-permission.sh`, extracted into `escalate-common.sh`) with regression coverage for the compound-failure fallback and preflight ordering.