### PR TITLE
test(dev): CAT-264 await branches stdout completion

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -578,6 +578,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/merge-delete-branch-worktree-guard.test.sh
 
+      - name: catalyst-stack integration tests (CAT-264)
+        # CAT-264: this suite was red and absent from the explicit CI allowlist.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/catalyst-stack.test.sh
+
+      - name: execution-core CLI routing tests (CAT-264)
+        # CAT-264: guards complete JSON output as well as noun dispatch.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/execution-core-cli-routing.test.sh
+
       - name: Run stable unit tests
         # CTL-1789 round-1 P2 (Codex): assertion-evidence.test.mjs and
         # assertion-evidence-parity.test.mjs are added below. The parity
@@ -649,6 +659,7 @@ jobs:
             cli/beliefs-shadow-status.test.mjs \
             beliefs/shadow-store.test.mjs \
             beliefs/why.test.mjs \
+            cli/branches.test.mjs \
             abort-worker.test.mjs \
             assertion-evidence.test.mjs \
             assertion-evidence-parity.test.mjs \

--- a/plugins/dev/scripts/__tests__/catalyst-broker-stop.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-broker-stop.test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CLI="$ROOT/plugins/dev/scripts/catalyst-broker"
+failures=0; children=""
+ok() { echo "  PASS: $1"; }
+bad() { echo "  FAIL: $1 ($2)"; failures=$((failures + 1)); }
+tmp="$(mktemp -d)"; export CATALYST_DIR="$tmp"
+marker="cat163-broker-$PPID-$$"
+marker_script="$tmp/$marker-broker-index.mjs"
+printf '#!/usr/bin/env bash\nsleep 30 & wait\n' > "$marker_script"; chmod +x "$marker_script"
+export BROKER_PROC_PATTERN="$marker"
+cleanup() { local p; for p in $children; do kill -9 "$p" 2>/dev/null || true; wait "$p" 2>/dev/null || true; done; rm -rf "$tmp"; }
+trap cleanup EXIT
+spawn() { bash "$marker_script" & SPAWNED=$!; children="$children $SPAWNED"; sleep 0.1; }
+
+sleep 30 & imposter=$!; children="$children $imposter"; echo "$imposter" > "$tmp/broker.pid"
+out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$out" == *"not running"* ]] && kill -0 "$imposter" 2>/dev/null && [[ "$(cat "$tmp/broker.pid")" == "$imposter" ]]; then ok "recycled pid is not signalled and its pid file is preserved"; else bad "recycled pid is not signalled and its pid file is preserved" "$out rc=$rc"; fi
+rm -f "$tmp/broker.pid"
+
+spawn; orphan=$SPAWNED; rm -f "$tmp/broker.pid"
+out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$out" == *"orphan"* ]] && ! kill -0 "$orphan" 2>/dev/null; then ok "orphan is found and stopped"; else bad "orphan is found and stopped" "$out rc=$rc"; fi
+
+out="$($CLI stop 2>&1)"; rc=$?
+[[ $rc -eq 0 && "$out" == *"not running"* ]] && ok "absent daemon is a clean no-op" || bad "absent daemon is a clean no-op" "$out rc=$rc"
+
+spawn; first=$SPAWNED; spawn; second=$SPAWNED
+out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 1 && "$out" == *"ambiguous"* ]] && kill -0 "$first" 2>/dev/null && kill -0 "$second" 2>/dev/null; then ok "ambiguous matches are not signalled"; else bad "ambiguous matches are not signalled" "$out rc=$rc"; fi
+kill "$first" "$second" 2>/dev/null || true; wait "$first" "$second" 2>/dev/null || true
+
+spawn; orphan=$SPAWNED
+out="$($CLI status 2>&1)"
+[[ "$out" == *"running"* && "$out" == *"orphan"* ]] && ok "status reports orphan as running" || bad "status reports orphan as running" "$out"
+
+stub="$tmp/process-identity-stub.sh"
+cp "$ROOT/plugins/dev/scripts/lib/process-identity.sh" "$stub"
+printf '\ncpi_pid_gone() { return 1; }\n' >> "$stub"
+echo "$orphan" > "$tmp/broker.pid"
+out="$(CATALYST_PROCESS_IDENTITY_LIB="$stub" $CLI stop 2>&1)"; rc=$?
+[[ $rc -eq 1 && "$out" == *"not confirmed"* ]] && ok "unconfirmable stop fails distinctly" || bad "unconfirmable stop fails distinctly" "$out rc=$rc"
+
+stale_stub="$tmp/process-identity-stale-stub.sh"
+cp "$ROOT/plugins/dev/scripts/lib/process-identity.sh" "$stale_stub"
+printf '\ncpi_find_orphans() { echo 5999998; }\n' >> "$stale_stub"
+rm -f "$tmp/broker.pid"
+out="$(CATALYST_PROCESS_IDENTITY_LIB="$stale_stub" $CLI stop 2>&1)"; rc=$?
+[[ $rc -ne 0 && "$out" == *"refusing to signal"* ]] \
+  && ok "orphan stop refuses a pid that no longer matches the pattern" \
+  || bad "orphan stop refuses a pid that no longer matches the pattern" "$out rc=$rc"
+
+exit "$failures"

--- a/plugins/dev/scripts/__tests__/catalyst-execution-core-stop.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-execution-core-stop.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"; CLI="$ROOT/plugins/dev/scripts/catalyst-execution-core"
+failures=0; children=""; ok(){ echo "  PASS: $1"; }; bad(){ echo "  FAIL: $1 ($2)"; failures=$((failures+1)); }
+tmp="$(mktemp -d)"; export CATALYST_DIR="$tmp" CATALYST_SKIP_DEP_PREFLIGHT=1
+marker="cat163-execution-core-$PPID-$$"; marker_script="$tmp/$marker-daemon.mjs"
+printf '#!/usr/bin/env bash\nsleep 30 & wait\n' > "$marker_script"; chmod +x "$marker_script"; export EXECUTION_CORE_PROC_PATTERN="$marker"
+cleanup(){ local p; for p in $children; do kill -9 "$p" 2>/dev/null || true; wait "$p" 2>/dev/null || true; done; rm -rf "$tmp"; }; trap cleanup EXIT
+spawn(){ bash "$marker_script" & SPAWNED=$!; children="$children $SPAWNED"; sleep 0.1; }
+
+sleep 30 & imposter=$!; children="$children $imposter"; mkdir -p "$tmp/execution-core"; echo "$imposter" > "$tmp/execution-core/daemon.pid"
+out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$out" == *"not running"* ]] && kill -0 "$imposter" 2>/dev/null && [[ "$(cat "$tmp/execution-core/daemon.pid")" == "$imposter" ]]; then ok "recycled pid is not signalled and its pid file is preserved"; else bad "recycled pid is not signalled and its pid file is preserved" "$out rc=$rc"; fi
+rm -f "$tmp/execution-core/daemon.pid"
+spawn; orphan=$SPAWNED; rm -f "$tmp/execution-core/daemon.pid"; out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$out" == *"orphan"* ]] && ! kill -0 "$orphan" 2>/dev/null; then ok "orphan is found and stopped"; else bad "orphan is found and stopped" "$out rc=$rc"; fi
+out="$($CLI stop 2>&1)"; rc=$?; [[ $rc -eq 0 && "$out" == *"not running"* ]] && ok "absent daemon is a clean no-op" || bad "absent daemon is a clean no-op" "$out rc=$rc"
+spawn; first=$SPAWNED; spawn; second=$SPAWNED; out="$($CLI stop 2>&1)"; rc=$?
+if [[ $rc -eq 1 && "$out" == *"ambiguous"* ]] && kill -0 "$first" 2>/dev/null && kill -0 "$second" 2>/dev/null; then ok "ambiguous matches are not signalled"; else bad "ambiguous matches are not signalled" "$out rc=$rc"; fi
+kill "$first" "$second" 2>/dev/null || true; wait "$first" "$second" 2>/dev/null || true
+spawn; orphan=$SPAWNED; out="$($CLI status 2>&1)"; [[ "$out" == *"running"* && "$out" == *"orphan"* ]] && ok "status reports orphan as running" || bad "status reports orphan as running" "$out"
+stub="$tmp/process-identity-stub.sh"; sed '$a\
+cpi_pid_gone() { return 1; }' "$ROOT/plugins/dev/scripts/lib/process-identity.sh" > "$stub"
+echo "$orphan" > "$tmp/execution-core/daemon.pid"; out="$(CATALYST_PROCESS_IDENTITY_LIB="$stub" $CLI stop 2>&1)"; rc=$?
+[[ $rc -eq 1 && "$out" == *"not confirmed"* ]] && ok "unconfirmable stop fails distinctly" || bad "unconfirmable stop fails distinctly" "$out rc=$rc"
+stale_stub="$tmp/process-identity-stale-stub.sh"; cp "$ROOT/plugins/dev/scripts/lib/process-identity.sh" "$stale_stub"
+printf '\ncpi_find_orphans() { echo 5999998; }\n' >> "$stale_stub"
+rm -f "$tmp/execution-core/daemon.pid"; out="$(CATALYST_PROCESS_IDENTITY_LIB="$stale_stub" $CLI stop 2>&1)"; rc=$?
+[[ $rc -ne 0 && "$out" == *"refusing to signal"* ]] && ok "orphan stop refuses a pid that no longer matches the pattern" || bad "orphan stop refuses a pid that no longer matches the pattern" "$out rc=$rc"
+exit "$failures"

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -14,7 +14,37 @@ MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 FAILURES=0
 PASSES=0
 SCRATCH="$(mktemp -d)"
-trap 'rm -rf "$SCRATCH"' EXIT
+
+# CAT-264: snapshot the operator's real runtime before any test runs. The final
+# assertion makes hermeticity self-enforcing when future start/stop cases land.
+_live_runtime_fingerprint() {
+  local marker="${HOME}/catalyst/stack-halt.json"
+  if [[ -e "$marker" ]]; then
+    stat -f '%m:%z' "$marker" 2>/dev/null || stat -c '%Y:%s' "$marker" 2>/dev/null || echo unreadable
+  else
+    echo absent
+  fi
+}
+export -f _live_runtime_fingerprint
+LIVE_MARKER_SNAPSHOT="${SCRATCH}/live-runtime.snapshot"
+_live_runtime_fingerprint > "$LIVE_MARKER_SNAPSHOT"
+
+# CAT-264: every start/stop/restart case invokes the real catalyst-stack, which
+# post-CAT-163 writes or clears the operator halt marker, appends unified events,
+# and may stop runtime processes under ${CATALYST_DIR:-$HOME/catalyst}. Scope the
+# entire suite once so future cases inherit the same hermetic boundary.
+export CATALYST_DIR="${SCRATCH}/catalyst"
+mkdir -p "${CATALYST_DIR}"
+
+# Keep --print fixtures outside linked worktrees/temp roots so the CTL-1473
+# production guard does not mask host-name rendering assertions, without
+# littering the live $HOME/catalyst runtime directory.
+BAKE_ROOT="${CATALYST_STACK_TEST_BAKE_ROOT:-${HOME}/.cache/catalyst-stack-tests}"
+mkdir -p "${BAKE_ROOT}"
+BAKE="$(mktemp -d "${BAKE_ROOT}/bake.XXXXXX")"
+mkdir -p "${BAKE}/log-shipper"
+cp "${REPO_ROOT}/plugins/dev/scripts/log-shipper/config.alloy" "${BAKE}/log-shipper/config.alloy"
+trap 'rm -rf "$SCRATCH" "$BAKE"' EXIT
 
 run() {
   local name="$1"; shift
@@ -276,10 +306,17 @@ exit 0
 EOF
 chmod +x "$STUBDIR2/catalyst-execution-core"
 
-# git stub: records args, succeeds
+# git stub: records args and models the one-checkout hotpatch preflight.
 cat > "$STUBDIR2/git" <<EOF
 #!/usr/bin/env bash
 echo "\$@" >> "${SCRATCH}/git.args"
+case "\$*" in
+  *"rev-parse --show-toplevel"*) echo "${FAKE_REPO}" ;;
+  *"status --porcelain"*) [[ "\${GIT_MODE:-}" == dirty ]] && echo ' M dirty-file' ;;
+  *"rev-list --count origin/main..HEAD"*) [[ "\${GIT_MODE:-}" == ahead ]] && echo 1 || echo 0 ;;
+  *"rev-list --count HEAD..origin/main"*) echo 1 ;;
+  *"rev-parse HEAD"*) echo 0123456789abcdef0123456789abcdef01234567 ;;
+esac
 exit 0
 EOF
 chmod +x "$STUBDIR2/git"
@@ -292,28 +329,39 @@ exit 0
 EOF
 chmod +x "$STUBDIR2/rsync"
 
-run "restart --hotpatch calls git pull --ff-only" bash -c "
+run "hotpatch (one-checkout): restart --hotpatch calls git pull --ff-only" bash -c "
   rm -f '${SCRATCH}/git.args' '${SCRATCH}/rsync.args'
+  PATH='${STUBDIR2}:${REAL_PATH}' \
+    CATALYST_PLUGIN_DIRS='${FAKE_REPO}/plugins/dev' \
+    HOME='${SCRATCH}/fake_home' \
+    '${STACK}' restart --hotpatch >/dev/null 2>&1
+  grep -q 'fetch -q origin main' '${SCRATCH}/git.args' &&
+  grep -q 'pull --ff-only' '${SCRATCH}/git.args' &&
+  [[ ! -f '${SCRATCH}/rsync.args' ]]
+"
+
+run "hotpatch (--legacy-rsync): calls rsync with -ac" bash -c "
+  rm -f '${SCRATCH}/git.args' '${SCRATCH}/rsync.args' '${SCRATCH}/legacy.err'
   PATH='${STUBDIR2}:${REAL_PATH}' \
     CATALYST_REPO_DIR='${FAKE_REPO}' \
     HOME='${SCRATCH}/fake_home' \
-    '${STACK}' restart --hotpatch >/dev/null 2>&1
-  grep -q 'pull --ff-only' '${SCRATCH}/git.args'
-"
-
-run "restart --hotpatch calls rsync with -ac" bash -c "
+    '${STACK}' hotpatch --legacy-rsync >/dev/null 2>'${SCRATCH}/legacy.err'
   grep -q -- '-ac' '${SCRATCH}/rsync.args'
 "
 
-run "hotpatch rsync never uses --delete" bash -c "
-  ! grep -q -- '--delete' '${SCRATCH}/rsync.args'
+run "hotpatch (--legacy-rsync): warns that the path is deprecated" bash -c "
+  grep -qi 'deprecated' '${SCRATCH}/legacy.err'
 "
 
-run "hotpatch rsync excludes node_modules" bash -c "
+run "hotpatch (--legacy-rsync): rsync never uses --delete" bash -c "
+  [[ -f '${SCRATCH}/rsync.args' ]] && ! grep -q -- '--delete' '${SCRATCH}/rsync.args'
+"
+
+run "hotpatch (--legacy-rsync): rsync excludes node_modules" bash -c "
   grep -q 'node_modules' '${SCRATCH}/rsync.args'
 "
 
-run "hotpatch rsync targets catalyst-dev in destination" bash -c "
+run "hotpatch (--legacy-rsync): rsync targets catalyst-dev in destination" bash -c "
   grep -q 'catalyst-dev' '${SCRATCH}/rsync.args'
 "
 
@@ -323,8 +371,15 @@ make_stubs "$STUBDIR_GITFAIL"
 cp "$STUBDIR2/catalyst-execution-core" "$STUBDIR_GITFAIL/catalyst-execution-core"
 cat > "$STUBDIR_GITFAIL/git" <<EOF
 #!/usr/bin/env bash
-if echo "\$@" | grep -q "ff-only"; then exit 1; fi
 echo "\$@" >> "${SCRATCH}/git_gitfail.args"
+case "\$*" in
+  *"rev-parse --show-toplevel"*) echo "${FAKE_REPO}" ;;
+  *"status --porcelain"*) ;;
+  *"rev-list --count origin/main..HEAD"*) echo 0 ;;
+  *"rev-list --count HEAD..origin/main"*) echo 1 ;;
+  *"rev-parse HEAD"*) echo 0123456789abcdef0123456789abcdef01234567 ;;
+  *"pull --ff-only"*) exit 1 ;;
+esac
 exit 0
 EOF
 chmod +x "$STUBDIR_GITFAIL/git"
@@ -335,16 +390,32 @@ exit 0
 EOF
 chmod +x "$STUBDIR_GITFAIL/rsync"
 
-run "hotpatch aborts on non-ff pull before rsync" bash -c "
-  rm -f '${SCRATCH}/rsync_gitfail.args'
+run "hotpatch (one-checkout): aborts on non-ff pull after attempting it" bash -c "
+  rm -f '${SCRATCH}/git_gitfail.args' '${SCRATCH}/rsync_gitfail.args'
   set +e
   PATH='${STUBDIR_GITFAIL}:${REAL_PATH}' \
-    CATALYST_REPO_DIR='${FAKE_REPO}' \
+    CATALYST_PLUGIN_DIRS='${FAKE_REPO}/plugins/dev' \
     HOME='${SCRATCH}/fake_home' \
     '${STACK}' restart --hotpatch >/dev/null 2>&1
   rc=\$?
   set -e
-  [[ \$rc -ne 0 ]] && [[ ! -f '${SCRATCH}/rsync_gitfail.args' ]]
+  [[ \$rc -ne 0 ]] && grep -q 'pull --ff-only' '${SCRATCH}/git_gitfail.args' && [[ ! -f '${SCRATCH}/rsync_gitfail.args' ]]
+"
+
+run "hotpatch (one-checkout): dirty checkout aborts before fetch" bash -c "
+  rm -f '${SCRATCH}/git.args'
+  ! PATH='${STUBDIR2}:${REAL_PATH}' GIT_MODE=dirty \
+    CATALYST_PLUGIN_DIRS='${FAKE_REPO}/plugins/dev' HOME='${SCRATCH}/fake_home' \
+    '${STACK}' restart --hotpatch >/dev/null 2>&1
+  ! grep -q 'fetch -q origin main' '${SCRATCH}/git.args'
+"
+
+run "hotpatch (one-checkout): ahead checkout aborts before pull" bash -c "
+  rm -f '${SCRATCH}/git.args'
+  ! PATH='${STUBDIR2}:${REAL_PATH}' GIT_MODE=ahead \
+    CATALYST_PLUGIN_DIRS='${FAKE_REPO}/plugins/dev' HOME='${SCRATCH}/fake_home' \
+    '${STACK}' restart --hotpatch >/dev/null 2>&1
+  grep -q 'fetch -q origin main' '${SCRATCH}/git.args' && ! grep -q 'pull --ff-only' '${SCRATCH}/git.args'
 "
 
 run "start --hotpatch on live stack refuses with restart message" bash -c "
@@ -427,21 +498,27 @@ HOSTCFG_HOME="${SCRATCH}/host_home"
 mkdir -p "${HOSTCFG_HOME}/.config/catalyst"
 printf '{"catalyst":{"host":{"name":"mini"}}}' > "${HOSTCFG_HOME}/.config/catalyst/config.json"
 
+run "install-services --print host-name fixture is non-ephemeral and renders output" bash -c "
+  ! bash -c 'source \"${STACK}\"; _is_ephemeral_dir \"${BAKE}\"' >/dev/null 2>&1 &&
+  out=\$(HOME='${HOSTCFG_HOME}' CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>/dev/null) &&
+  [[ -n \"\$out\" ]]
+"
+
 run "install-services --print pins CATALYST_HOST_NAME key" bash -c "
-  HOME='${HOSTCFG_HOME}' '${STACK}' install-services --print 2>&1 | grep -q '<key>CATALYST_HOST_NAME</key>'
+  HOME='${HOSTCFG_HOME}' CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>&1 | grep -q '<key>CATALYST_HOST_NAME</key>'
 "
 
 run "install-services --print pins configured host name value" bash -c "
-  HOME='${HOSTCFG_HOME}' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
+  HOME='${HOSTCFG_HOME}' CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
 "
 
 run "install-services --print honors CATALYST_LAYER2_CONFIG_FILE" bash -c "
-  CATALYST_LAYER2_CONFIG_FILE='${HOSTCFG_HOME}/.config/catalyst/config.json' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
+  CATALYST_LAYER2_CONFIG_FILE='${HOSTCFG_HOME}/.config/catalyst/config.json' CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>&1 | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
 "
 
 run "install-services --print omits key when host.name unset" bash -c "
   emptyhome=\$(mktemp -d);
-  out=\$(HOME=\"\$emptyhome\" '${STACK}' install-services --print 2>/dev/null);
+  out=\$(HOME=\"\$emptyhome\" CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>/dev/null);
   printf '%s' \"\$out\" | grep -q 'ai.coalesce.catalyst-stack' && ! printf '%s' \"\$out\" | grep -q '<key>CATALYST_HOST_NAME</key>'
 "
 
@@ -572,7 +649,7 @@ run "install-services --print stack plist DOES set AbandonProcessGroup (CTL-1285
 "
 
 run "install-services --print log-shipper pins CATALYST_HOST_NAME from config" bash -c "
-  out=\$(HOME='${HOSTCFG_HOME}' '${STACK}' install-services --print 2>/dev/null)
+  out=\$(HOME='${HOSTCFG_HOME}' CATALYST_FORCE_BAKE_DIR='${BAKE}' '${STACK}' install-services --print 2>/dev/null)
   printf '%s\n' \"\$out\" | awk '/^<\?xml/{c++} c==3' | grep -A1 'CATALYST_HOST_NAME' | grep -q '<string>mini</string>'
 "
 
@@ -611,6 +688,10 @@ run "stop leaves the launchd-managed shipper running when its plist is present" 
   fh='${SCRATCH}/defer_home2'; mkdir -p \"\$fh/Library/LaunchAgents\" \"\$fh/catalyst\";
   printf '<plist/>' > \"\$fh/Library/LaunchAgents/ai.coalesce.catalyst-log-shipper.plist\";
   PATH='${STUBDIR}:${REAL_PATH}' HOME=\"\$fh\" '${STACK}' stop 2>&1 | grep -q 'leaving it running'
+"
+
+run "suite is hermetic: no writes to the live CATALYST_DIR" bash -c "
+  test \"\$(cat '${LIVE_MARKER_SNAPSHOT}')\" = \"\$(_live_runtime_fingerprint)\"
 "
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/__tests__/execution-core-cli-routing.test.sh
+++ b/plugins/dev/scripts/__tests__/execution-core-cli-routing.test.sh
@@ -44,6 +44,12 @@ chmod +x "$FAKE_GH"
 export CATALYST_GH_BIN="$FAKE_GH"
 # Point runs root at empty scratch so indexSignalsByBgJobId finds nothing.
 export CATALYST_DIR="$SCRATCH/catalyst"
+# Keep branch inventory independent of the checkout's ref count and clone depth.
+# The route test owns dispatch + complete JSON, not the repository inventory.
+FAKE_REPO="$SCRATCH/repo"
+git init -q -b main "$FAKE_REPO"
+git -C "$FAKE_REPO" -c user.name=test -c user.email=test@example.invalid \
+	commit --allow-empty -q -m init
 
 echo "test 1 (CTL-649): backcompat 'probe' routes to daemon probe (no daemon → nonzero)"
 if "$SCRIPT" probe; then
@@ -76,7 +82,7 @@ fi
 echo "test 5 (CTL-649): 'sessions list --json' routes to the sessions module"
 OUT="$("$SCRIPT" sessions list --json 2>/dev/null)"
 RC=$?
-if [ "$RC" = "0" ] && echo "$OUT" | grep -q '\[\]'; then
+if [ "$RC" = "0" ] && [[ "$OUT" == \[* ]]; then
 	pass "sessions list --json emits a JSON array"
 else
 	fail "sessions list --json emits a JSON array" "rc=$RC out=$OUT"
@@ -85,16 +91,17 @@ fi
 echo "test 5b (CTL-649): 'worktrees list --json' routes to the worktrees module"
 OUT="$("$SCRIPT" worktrees list --json 2>/dev/null)"
 RC=$?
-if [ "$RC" = "0" ] && echo "$OUT" | grep -q '\['; then
+if [ "$RC" = "0" ] && [[ "$OUT" == \[* ]]; then
 	pass "worktrees list --json routes to worktrees module"
 else
 	fail "worktrees list --json routes to worktrees module" "rc=$RC out=$OUT"
 fi
 
 echo "test 5c (CTL-649): 'branches list --json' routes to the branches module"
-OUT="$("$SCRIPT" branches list --json 2>/dev/null)"
+OUT="$("$SCRIPT" branches list --json --repo-root "$FAKE_REPO" 2>/dev/null)"
 RC=$?
-if [ "$RC" = "0" ] && echo "$OUT" | grep -q '\['; then
+if [ "$RC" = "0" ] && [[ "$OUT" == \[* ]] &&
+	{ ! command -v jq >/dev/null 2>&1 || printf '%s' "$OUT" | jq -e 'type == "array"' >/dev/null; }; then
 	pass "branches list --json routes to branches module"
 else
 	fail "branches list --json routes to branches module" "rc=$RC out=$OUT"

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -67,6 +67,9 @@ while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
 DAEMON_SCRIPT="${BROKER_DAEMON_SCRIPT:-$SCRIPT_DIR/broker/index.mjs}"
+BROKER_PROC_PATTERN="${BROKER_PROC_PATTERN:-broker/index.mjs}"
+# shellcheck source=lib/process-identity.sh
+source "${CATALYST_PROCESS_IDENTITY_LIB:-$SCRIPT_DIR/lib/process-identity.sh}"
 
 is_alive() { kill -0 "$1" 2>/dev/null; }
 
@@ -75,11 +78,27 @@ read_pid() {
     local pid
     pid="$(cat "$PID_FILE" 2>/dev/null)"
     if [[ "$pid" =~ ^[0-9]+$ ]] && is_alive "$pid"; then
-      echo "$pid"; return 0
+      if cpi_pid_is_ours "$pid" "$BROKER_PROC_PATTERN"; then
+        echo "$pid"; return 0
+      fi
+      echo "warning: pid file $PID_FILE names live pid $pid, but its identity does not match '$BROKER_PROC_PATTERN'; preserving pid file" >&2
+      return 1
     fi
     rm -f "$PID_FILE" 2>/dev/null
   fi
   return 1
+}
+
+find_orphan_pid() {
+  local matches count
+  matches="$(cpi_find_orphans "$BROKER_PROC_PATTERN")" || return 1
+  [[ -n "$matches" ]] || return 1
+  count="$(printf '%s\n' "$matches" | awk 'NF { n++ } END { print n+0 }')"
+  if [[ "$count" -gt 1 ]]; then
+    echo "error: ambiguous broker processes match '$BROKER_PROC_PATTERN'; refusing to signal any" >&2
+    return 2
+  fi
+  printf '%s\n' "$matches"
 }
 
 resolve_runtime() {
@@ -133,24 +152,30 @@ cmd_start() {
 }
 
 cmd_stop() {
-  local pid
+  local pid orphan=0 rc
   if ! pid=$(read_pid); then
-    echo "catalyst-broker not running"
-    return 0
+    pid="$(find_orphan_pid)"; rc=$?
+    if [[ $rc -eq 2 ]]; then return 1; fi
+    if [[ $rc -ne 0 ]]; then
+      echo "catalyst-broker not running"
+      return 0
+    fi
+    orphan=1
   fi
-  kill "$pid" 2>/dev/null || true
-  local waited=0
-  while [[ $waited -lt 30 ]] && is_alive "$pid"; do
-    sleep 0.1
-    waited=$((waited + 1))
-  done
-  is_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+  if [[ $orphan -eq 1 ]] && ! cpi_pid_is_ours "$pid" "$BROKER_PROC_PATTERN"; then
+    echo "error: pid $pid no longer matches '$BROKER_PROC_PATTERN'; refusing to signal" >&2
+    return 1
+  fi
+  if ! cpi_stop_pid "$pid"; then
+    echo "error: catalyst-broker stop not confirmed; pid $pid may still be running" >&2
+    return 1
+  fi
   rm -f "$PID_FILE" 2>/dev/null
-  echo "catalyst-broker stopped"
+  if [[ $orphan -eq 1 ]]; then echo "catalyst-broker orphan stopped (pid $pid)"; else echo "catalyst-broker stopped"; fi
 }
 
 cmd_restart() {
-  cmd_stop
+  cmd_stop || return 1
   cmd_start
 }
 
@@ -167,8 +192,11 @@ cmd_status() {
     esac
   done
 
-  local pid
-  if pid=$(read_pid); then
+  local pid orphan=0
+  if ! pid=$(read_pid); then
+    pid="$(find_orphan_pid 2>/dev/null)" && orphan=1 || pid=""
+  fi
+  if [[ -n "$pid" ]]; then
     if [[ $json -eq 1 ]]; then
       if [[ -f "$STATE_FILE" ]] && jq -e . "$STATE_FILE" >/dev/null 2>&1; then
         jq --argjson pid "$pid" '. + {running: true, pid: $pid}' "$STATE_FILE"
@@ -176,7 +204,7 @@ cmd_status() {
         jq -n --argjson pid "$pid" '{running: true, pid: $pid, keyHealth: null, gateway: null}'
       fi
     else
-      echo "running (pid $pid)"
+      if [[ $orphan -eq 1 ]]; then echo "running (orphan pid $pid)"; else echo "running (pid $pid)"; fi
     fi
     return 0
   fi

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -35,6 +35,9 @@ source "$SCRIPT_DIR/lib/catalyst-agent-path.sh"
 
 DAEMON_SCRIPT="${EXECUTION_CORE_DAEMON_SCRIPT:-$SCRIPT_DIR/execution-core/daemon.mjs}"
 RUNTIME="${EXECUTION_CORE_RUNTIME-}" # empty → resolve_runtime picks bun/node
+EXECUTION_CORE_PROC_PATTERN="${EXECUTION_CORE_PROC_PATTERN:-execution-core/daemon.mjs}"
+# shellcheck source=lib/process-identity.sh
+source "${CATALYST_PROCESS_IDENTITY_LIB:-$SCRIPT_DIR/lib/process-identity.sh}"
 
 is_alive() { kill -0 "$1" 2>/dev/null; }
 
@@ -43,12 +46,28 @@ read_pid() {
 		local pid
 		pid="$(cat "$PID_FILE" 2>/dev/null)"
 		if [[ $pid =~ ^[0-9]+$ ]] && is_alive "$pid"; then
-			echo "$pid"
-			return 0
+			if cpi_pid_is_ours "$pid" "$EXECUTION_CORE_PROC_PATTERN"; then
+				echo "$pid"
+				return 0
+			fi
+			echo "warning: pid file $PID_FILE names live pid $pid, but its identity does not match '$EXECUTION_CORE_PROC_PATTERN'; preserving pid file" >&2
+			return 1
 		fi
 		rm -f "$PID_FILE" 2>/dev/null
 	fi
 	return 1
+}
+
+find_orphan_pid() {
+	local matches count
+	matches="$(cpi_find_orphans "$EXECUTION_CORE_PROC_PATTERN")" || return 1
+	[[ -n "$matches" ]] || return 1
+	count="$(printf '%s\n' "$matches" | awk 'NF { n++ } END { print n+0 }')"
+	if [[ "$count" -gt 1 ]]; then
+		echo "error: ambiguous execution-core processes match '$EXECUTION_CORE_PROC_PATTERN'; refusing to signal any" >&2
+		return 2
+	fi
+	printf '%s\n' "$matches"
 }
 
 resolve_runtime() {
@@ -377,26 +396,32 @@ cmd_start() {
 }
 
 cmd_stop() {
-	local pid
+	local pid orphan=0 rc
 	if ! pid=$(read_pid); then
-		echo "catalyst-execution-core not running"
-		return 0
+		pid="$(find_orphan_pid)"; rc=$?
+		if [[ $rc -eq 2 ]]; then return 1; fi
+		if [[ $rc -ne 0 ]]; then
+			echo "catalyst-execution-core not running"
+			return 0
+		fi
+		orphan=1
 	fi
-	kill "$pid" 2>/dev/null || true
-	local waited=0
-	while [[ $waited -lt 30 ]] && is_alive "$pid"; do
-		sleep 0.1
-		waited=$((waited + 1))
-	done
-	is_alive "$pid" && kill -9 "$pid" 2>/dev/null || true
+	if [[ $orphan -eq 1 ]] && ! cpi_pid_is_ours "$pid" "$EXECUTION_CORE_PROC_PATTERN"; then
+		echo "error: pid $pid no longer matches '$EXECUTION_CORE_PROC_PATTERN'; refusing to signal" >&2
+		return 1
+	fi
+	if ! cpi_stop_pid "$pid"; then
+		echo "error: catalyst-execution-core stop not confirmed; pid $pid may still be running" >&2
+		return 1
+	fi
 	rm -f "$PID_FILE" 2>/dev/null
-	echo "catalyst-execution-core stopped"
+	if [[ $orphan -eq 1 ]]; then echo "catalyst-execution-core orphan stopped (pid $pid)"; else echo "catalyst-execution-core stopped"; fi
 }
 
 cmd_restart() {
 	# CTL-635: restart re-applies OTEL env hygiene for free — the scrub lives in
 	# cmd_start, which re-warms a fresh daemon (and its spare pool) on restart.
-	cmd_stop
+	cmd_stop || return 1
 	cmd_start
 }
 
@@ -439,13 +464,16 @@ cmd_status() {
 			echo "drain-disabled — this node ignores the drain flag (CATALYST_DRAIN_DISABLED=1)"
 		fi
 	}
-	local pid
-	if pid=$(read_pid); then
+	local pid orphan=0
+	if ! pid=$(read_pid); then
+		pid="$(find_orphan_pid 2>/dev/null)" && orphan=1 || pid=""
+	fi
+	if [[ -n "$pid" ]]; then
 		if [ "$want_json" -eq 1 ]; then
 			printf '{"running":true,"pid":%s,"draining":%s,"inFlightCount":%s,"flagPresent":%s,"drainDisabled":%s}\n' \
 				"$pid" "$draining" "$in_flight_count" "$flag_present" "$drain_disabled"
 		else
-			echo "running (pid $pid)"
+			if [[ $orphan -eq 1 ]]; then echo "running (orphan pid $pid)"; else echo "running (pid $pid)"; fi
 			_status_drain_note
 		fi
 		return 0

--- a/plugins/dev/scripts/execution-core/cli/branches.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.mjs
@@ -315,10 +315,16 @@ export function parseBranchArgs(argv) {
   return out;
 }
 
+export function writeOut(text, stdout = process.stdout) {
+  return new Promise((resolve, reject) => {
+    stdout.write(text, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
 async function cmdList({ json, staleDays, repoRoot }) {
   const rows = await buildRows({ repoRoot, staleDays: staleDays ?? DEFAULT_STALE_DAYS });
   if (json) {
-    process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    await writeOut(`${JSON.stringify(rows, null, 2)}\n`);
     return 0;
   }
   for (const r of rows) {

--- a/plugins/dev/scripts/execution-core/cli/branches.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.test.mjs
@@ -3,8 +3,37 @@
 // directly (git branch -D / git push origin --delete), NOT through the reaper.
 
 import { describe, it, expect } from "bun:test";
-import { classify, buildRows, runBranchesPrune, parseBranchArgs, gitLines } from "./branches.mjs";
+import {
+  classify,
+  buildRows,
+  runBranchesPrune,
+  parseBranchArgs,
+  gitLines,
+  writeOut,
+} from "./branches.mjs";
 import { ArgError } from "./args.mjs";
+
+describe("writeOut", () => {
+  it("waits for the write callback even when stdout.write returns true", async () => {
+    let completeWrite;
+    const stdout = {
+      write(_text, callback) {
+        completeWrite = callback;
+        return true;
+      },
+    };
+    let resolved = false;
+    const pending = writeOut("complete JSON", stdout).then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    completeWrite();
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});
 
 describe("branches classify", () => {
   it("WORKTREE_BACKED when checked out in some worktree", () => {

--- a/plugins/dev/scripts/lib/__tests__/process-identity.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/process-identity.test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../process-identity.sh
+source "$HERE/../process-identity.sh"
+
+failures=0
+ok() { echo "  PASS: $1"; }
+bad() { echo "  FAIL: $1"; failures=$((failures + 1)); }
+tmp="$(mktemp -d)"
+children=""
+cleanup() {
+  local p
+  for p in $children; do kill -9 "$p" 2>/dev/null || true; wait "$p" 2>/dev/null || true; done
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+sleep 30 & unrelated=$!; children="$children $unrelated"
+cpi_pid_is_ours "$unrelated" 'definitely-not-sleep' && bad "identity rejects unrelated pid" || ok "identity rejects unrelated pid"
+
+mkdir "$tmp/bin"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$tmp/bin/ps"
+chmod +x "$tmp/bin/ps"
+(PATH="$tmp/bin:$PATH"; cpi_pid_is_ours "$unrelated" sleep) && bad "identity fails closed when ps fails" || ok "identity fails closed when ps fails"
+
+cpi_pid_gone "$unrelated" && bad "live pid is not gone" || ok "live pid is not gone"
+cpi_pid_gone 5999999 && ok "nonexistent pid is gone" || bad "nonexistent pid is gone"
+
+self_matches="$(cpi_find_orphans "process-identity.test.sh" || true)"
+[[ -z "$self_matches" ]] && ok "orphan scan excludes caller and its forks" \
+  || bad "orphan scan excludes caller and its forks (self=$$ got: $(echo $self_matches))"
+
+marker="cpi-marker-$PPID-$$"
+marker_script="$tmp/$marker.sh"
+printf '#!/usr/bin/env bash\nexec -a "$0" sleep 30\n' > "$marker_script"
+chmod +x "$marker_script"
+bash "$marker_script" & marked=$!; children="$children $marked"
+sleep 0.1
+found="$(cpi_find_orphans "$marker")"
+[[ "$found" == "$marked" ]] && ok "orphan scan finds exactly marker process" || bad "orphan scan finds exactly marker process (got: $found)"
+
+cpi_stop_pid "$marked" 2 && ok "stop confirms real process gone" || bad "stop confirms real process gone"
+wait "$marked" 2>/dev/null || true
+
+shared="$tmp/orphan-process-identity.test.sh-probe.sh"
+printf '#!/usr/bin/env bash\nexec -a "$0" sleep 30\n' > "$shared"; chmod +x "$shared"
+bash "$shared" & shared_pid=$!; children="$children $shared_pid"
+sleep 0.1
+found="$(cpi_find_orphans "process-identity.test.sh")"
+[[ "$found" == "$shared_pid" ]] \
+  && ok "self forks excluded when the pattern matches the scanner too" \
+  || bad "self forks excluded when the pattern matches the scanner too (want $shared_pid, got: $(echo $found))"
+kill -9 "$shared_pid" 2>/dev/null || true; wait "$shared_pid" 2>/dev/null || true
+
+awkish="$tmp/$marker-awkish.sh"
+printf '#!/usr/bin/env bash\nexec -a "$0 awk placeholder" sleep 30\n' > "$awkish"; chmod +x "$awkish"
+bash "$awkish" "awk placeholder" & awkish_pid=$!; children="$children $awkish_pid"
+sleep 0.1
+found="$(cpi_find_orphans "$marker")"
+[[ "$found" == "$awkish_pid" ]] && ok "orphan whose argv contains 'awk ' is still found" \
+  || bad "orphan whose argv contains 'awk ' is still found (want $awkish_pid, got: $(echo $found))"
+kill -9 "$awkish_pid" 2>/dev/null || true; wait "$awkish_pid" 2>/dev/null || true
+
+real_ps="$(command -v ps)"
+mkdir "$tmp/selfstub"
+printf '#!/usr/bin/env bash\nfor a in "$@"; do [[ "$a" == "command=" ]] && exit 1; done\nexec %s "$@"\n' \
+  "$real_ps" > "$tmp/selfstub/ps"; chmod +x "$tmp/selfstub/ps"
+failopen="$tmp/$marker-failopen.sh"
+printf '#!/usr/bin/env bash\nexec -a "$0" sleep 30\n' > "$failopen"; chmod +x "$failopen"
+bash "$failopen" & failopen_pid=$!; children="$children $failopen_pid"
+sleep 0.1
+found="$(PATH="$tmp/selfstub:$PATH"; cpi_find_orphans "$marker")"
+[[ " $(echo $found) " == *" $failopen_pid "* ]] && ok "self-identity read failure fails open" \
+  || bad "self-identity read failure fails open (want $failopen_pid, got: $(echo $found))"
+kill -9 "$failopen_pid" 2>/dev/null || true; wait "$failopen_pid" 2>/dev/null || true
+
+sleep 30 & stubborn=$!; children="$children $stubborn"
+original_gone="$(declare -f cpi_pid_gone)"
+cpi_pid_gone() { return 1; }
+cpi_stop_pid "$stubborn" 1 && bad "stop fails when death cannot be confirmed" || ok "stop fails when death cannot be confirmed"
+eval "$original_gone"
+
+exit "$failures"

--- a/plugins/dev/scripts/lib/process-identity.sh
+++ b/plugins/dev/scripts/lib/process-identity.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Shared process identity/termination helpers. The -ww identity guard and
+# zombie-aware death proof originate in catalyst-monitor.sh:820-872.
+
+cpi_pid_is_ours() {
+  local pid="$1" pattern="$2" command
+  command="$(ps -ww -o command= -p "$pid" 2>/dev/null)" || return 1
+  [[ -n "$command" && "$command" == *"$pattern"* ]]
+}
+
+cpi_pid_gone() {
+  local pid="$1" state
+  kill -0 "$pid" 2>/dev/null || return 0
+  command -v ps >/dev/null 2>&1 || return 1
+  # kill -0 just proved the pid existed. If ps now fails, that may be a race
+  # with exit or a permission/tool failure; neither proves death, so fail closed.
+  state="$(ps -o state= -p "$pid" 2>/dev/null)" || return 1
+  state="${state//[[:space:]]/}"
+  [[ -z "$state" ]] && return 0
+  case "$state" in [Zz]*) return 0 ;; *) return 1 ;; esac
+}
+
+cpi_find_orphans() {
+  local pattern="$1" uid pid command self_cmd ancestors=" $$ " current="${PPID:-}"
+  uid="$(id -u)" || return 1
+  # Exclude scanner forks by their runtime command identity. The callers run
+  # this function inside command substitution and the ps pipeline forks again;
+  # those descendants inherit our argv but are not covered by the ancestor walk.
+  # Exact equality avoids the old broad `awk ` substring false negative. If ps
+  # cannot read our identity, fail open so a real orphan is not hidden.
+  self_cmd="$(ps -ww -o command= -p "$$" 2>/dev/null | awk '{ $1=$1; print }')"
+  while [[ "$current" =~ ^[0-9]+$ && "$current" -gt 1 ]]; do
+    ancestors="$ancestors$current "
+    current="$(ps -o ppid= -p "$current" 2>/dev/null)" || break
+    current="${current//[[:space:]]/}"
+  done
+  while read -r pid command; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    [[ " $ancestors " == *" $pid "* ]] && continue
+    [[ "$command" == *"$pattern"* ]] || continue
+    [[ -n "$self_cmd" && "$command" == "$self_cmd" ]] && continue
+    printf '%s\n' "$pid"
+  done < <(ps -ww -axo uid=,pid=,command= 2>/dev/null | awk -v uid="$uid" '$1 == uid { p=$2; $1=$2=""; sub(/^ +/, ""); print p, $0 }')
+}
+
+cpi_stop_pid() {
+  local pid="$1" wait_limit="${2:-30}" waited=0
+  kill "$pid" 2>/dev/null || true
+  while [[ "$waited" -lt "$wait_limit" ]] && ! cpi_pid_gone "$pid"; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if ! cpi_pid_gone "$pid"; then
+    kill -9 "$pid" 2>/dev/null || true
+    waited=0
+    while [[ "$waited" -lt "$wait_limit" ]] && ! cpi_pid_gone "$pid"; do
+      sleep 0.1
+      waited=$((waited + 1))
+    done
+  fi
+  cpi_pid_gone "$pid"
+}

--- a/plugins/dev/scripts/lib/stack-halt.sh
+++ b/plugins/dev/scripts/lib/stack-halt.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Durable operator-intent marker for catalyst-stack supervision (CAT-163).
+#
+# CROSS-FILE GLOBAL (CAT-264): STACK_HALT_STATE is assigned here and in
+# stack_halt_active() but read by catalyst-stack after it sources this library.
+# It carries why a falsy stack_halt_active returned: absent, expired, and
+# malformed all return 1. Do not delete or export it.
+# shellcheck disable=SC2034
+
+STACK_HALT_FILE="${CATALYST_DIR:-$HOME/catalyst}/stack-halt.json"
+STACK_HALT_TTL_SECS="${CATALYST_STACK_HALT_TTL_SECS:-86400}"
+# Tolerance for benign clock jitter between the write and a later read. A
+# haltedAt further ahead than this is treated as malformed, not as "age 0".
+STACK_HALT_SKEW_SECS="${CATALYST_STACK_HALT_SKEW_SECS:-300}"
+STACK_HALT_STATE="absent"
+STACK_HALT_AGE_SECS=0
+STACK_HALT_HALTED_AT=""
+STACK_HALT_REASON=""
+STACK_HALT_TTL_EFFECTIVE="$STACK_HALT_TTL_SECS"
+
+stack_halt_write() {
+  local reason="${1:-operator requested stop}" dir tmp now host by
+  dir="$(dirname "$STACK_HALT_FILE")"; mkdir -p "$dir" || return 1
+  tmp="${STACK_HALT_FILE}.tmp.$$"; now="$(date +%s)"
+  host="${CATALYST_HOST_NAME:-$(hostname -s 2>/dev/null || hostname)}"
+  by="${USER:-$(id -un 2>/dev/null || echo unknown)}"
+  jq -nc --argjson haltedAt "$now" --arg host "$host" --arg reason "$reason" \
+    --arg by "$by" --argjson ttlSecs "$STACK_HALT_TTL_SECS" \
+    '{haltedAt:$haltedAt,host:$host,reason:$reason,by:$by,ttlSecs:$ttlSecs}' > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$STACK_HALT_FILE"
+}
+
+stack_halt_clear() { rm -f "$STACK_HALT_FILE"; }
+
+stack_halt_active() {
+  STACK_HALT_STATE="absent"; STACK_HALT_AGE_SECS=0; STACK_HALT_HALTED_AT=""; STACK_HALT_REASON=""; STACK_HALT_TTL_EFFECTIVE="$STACK_HALT_TTL_SECS"
+  [[ -f "$STACK_HALT_FILE" ]] || return 1
+  local now halted ttl
+  now="$(date +%s)"; halted="$(jq -r '.haltedAt // empty' "$STACK_HALT_FILE" 2>/dev/null)"
+  # Integers only, and never further ahead than the skew allowance:
+  #  - a float or non-numeric haltedAt reaching $((now - halted)) is a FATAL bash
+  #    arithmetic-expansion error that aborts the CALLING shell, so every
+  #    `catalyst-stack status/stop/start --supervised` dies mid-run. jq's
+  #    `numbers` filter accepts floats, so it cannot be the gate.
+  #  - a future-dated haltedAt would pin the age clamp below at 0 forever, so
+  #    `age >= ttl` never fires and the host stays halted indefinitely —
+  #    contradicting the documented TTL invariant.
+  # Both route into the existing malformed self-heal (rename + treat as absent).
+  if [[ ! "$halted" =~ ^-?[0-9]+$ ]] || (( halted > now + STACK_HALT_SKEW_SECS )); then
+    STACK_HALT_STATE="malformed"
+    # Read-only callers (status/describe) classify but never rename: discarding the
+    # operator's halt intent must not be a side effect of merely looking at it.
+    [[ "${STACK_HALT_NO_HEAL:-0}" == 1 ]] \
+      || mv "$STACK_HALT_FILE" "${STACK_HALT_FILE}.invalid.$(date +%s)" 2>/dev/null || true
+    return 1
+  fi
+  ttl="$(jq -r '.ttlSecs // empty' "$STACK_HALT_FILE")"; [[ "$ttl" =~ ^[0-9]+$ ]] || ttl="$STACK_HALT_TTL_SECS"
+  STACK_HALT_TTL_EFFECTIVE="$ttl"
+  STACK_HALT_AGE_SECS=$((now - halted)); (( STACK_HALT_AGE_SECS < 0 )) && STACK_HALT_AGE_SECS=0
+  STACK_HALT_HALTED_AT="$halted"; STACK_HALT_REASON="$(jq -r '.reason // "operator requested stop"' "$STACK_HALT_FILE")"
+  if (( STACK_HALT_AGE_SECS >= ttl )); then STACK_HALT_STATE="expired"; return 1; fi
+  STACK_HALT_STATE="active"; return 0
+}
+
+stack_halt_describe() {
+  local STACK_HALT_NO_HEAL=1
+  if stack_halt_active; then
+    printf 'halted by operator at epoch %s (reason: %s, %ss remaining)' "$STACK_HALT_HALTED_AT" "$STACK_HALT_REASON" "$((STACK_HALT_TTL_EFFECTIVE - STACK_HALT_AGE_SECS))"
+  else
+    printf 'active'
+  fi
+}


### PR DESCRIPTION
Courtesy PR — mirrors a fix already merged on our fork (thagale/catalyst#102). Not intended to be merged here; opened for upstream visibility per our dual-PR convention.

Fixes a stdout-flush race in `branches` CLI JSON output, hardens `catalyst-broker`/`catalyst-execution-core` stop paths with orphan-process detection (via a new shared `lib/process-identity.sh`), and adds regression coverage for both.

Note: this PR omits one small piece of the original diff — a `checkStackAgent` platform-check tweak in `execution-core/doctor.mjs` — because that function doesn't exist yet on this branch's `doctor.mjs` (it depends on other unlanded work); the rest of the fix is self-contained and included in full.