### PR TITLE
feat(dev): CTL-1790 PR-2 — three-valued outcome verdict (foundation, NOT wired)

### DIFF
--- a/plugins/dev/scripts/execution-core/outcome-verdict.mjs
+++ b/plugins/dev/scripts/execution-core/outcome-verdict.mjs
@@ -1,0 +1,215 @@
+// outcome-verdict.mjs — the three-valued outcome verdict behind CTL-1790.
+//
+// THE PROBLEM THIS EXISTS TO SOLVE. When a phase worker exits cleanly WITHOUT
+// declaring an outcome, the pipeline fabricates a terminal `done` from the clean
+// process exit (`sdk-success-flip`). Measured live on host mini after CTL-1789
+// shipped: of 31 phase advancements, 16 were `declared` and **15 were
+// `fabricated`**. The pipeline was inferring success roughly half the time.
+//
+// Three prior attempts to simply invert that — treat an undeclared exit as
+// `failed` — were each blocked by a real defect. All three died on the SAME
+// thing, and it is the reason this module exists:
+//
+//   **A boolean probe conflates "I checked, the work is absent" with "I could
+//   not check."** Every probe in work-done-probes.mjs returns `false` for both.
+//   Inverting on `false` therefore manufactures terminal failures out of GitHub
+//   outages, unresolvable worktrees, absent probes, and circular probes.
+//
+// So the verdict is THREE-valued, and the whole safety property is one rule:
+//
+//   **UNKNOWN NEVER WRITES `failed`.** On UNKNOWN the caller reproduces today's
+//   behavior byte-for-byte (the flip still writes `done`) and emits telemetry.
+//   An inversion may only fire on a probe that is decisive AND non-circular AND
+//   on a phase the allowlist admits.
+//
+// This mirrors the house rule already stated verbatim at recovery.mjs:3027-3028
+// — "STRICTLY gated on snap.isFresh — a stale/cold snapshot skips the
+// cross-check and suppresses exactly as before."
+//
+// Zero imports beyond the probe registry, so a bare-Node caller can load it.
+
+import { hasProbe } from "./work-done-probes.mjs";
+
+export const VERDICT = Object.freeze({
+  DONE: "done",
+  NOT_DONE: "not-done",
+  UNKNOWN: "unknown",
+});
+
+// Why a verdict came back UNKNOWN. Every one of these is a case where an
+// absence is NOT evidence, and the caller must fall back to today's behavior.
+export const UNKNOWN_REASONS = Object.freeze({
+  NO_PROBE_FOR_PHASE: "no-probe-for-phase", // hasProbe(phase) === false — teardown
+  PHASE_EXEMPT: "phase-exempt", // phase not in INVERTIBLE_PHASES
+  CIRCULAR_PROBE: "circular-probe", // probe input === write target (monitor-deploy)
+  PROBE_INPUT_MISSING: "probe-input-missing", // worktree unresolvable / signal unreadable
+  PROBE_TRANSPORT_FAIL: "probe-transport-fail", // gh/git non-zero, parse failure, timeout
+  PROBE_THREW: "probe-threw",
+});
+
+// INVERTIBLE_PHASES — the ONLY phases the inversion may act on. The post-PR
+// phases are deliberately absent, and their absence is a safety property rather
+// than an oversight:
+//
+//   • `teardown` has NO probe at all (verified by executing hasProbe over the ten
+//     canonical phases, with the negative control hasProbe("not-a-phase") ===
+//     false). It is also the sole gate for ALL THREE Linear-Done writers — the
+//     teardown skill's own `linear-transition.sh --transition done`,
+//     `terminalDoneOnce` (gated on `signals[TERMINAL_PHASE] === "done"`), and the
+//     CTL-1371 reconciler seeded by that same skill. A fail-closed inversion here
+//     writes `failed`, teardown never reads `done`, and all three go dark at once:
+//     PR merged, ticket never Done, worktree never removed. The escalation sweep
+//     would then likely SUPPRESS the alarm, because isTicketTerminalOrMerged
+//     returns `{terminal:true, reason:"pr-merged"}` at teardown. A silent,
+//     permanent stall behind green health signals — precisely the round-2 blocker.
+//
+//   • `monitor-deploy`'s probe reads the SAME INODE its writer writes (the
+//     CTL-701 dual-use signal file). No replay can exist in which probe-input and
+//     write-target are independent, because they are one file. Circular by
+//     construction, not merely weak.
+//
+// Keeping this an ALLOWLIST (rather than a denylist) makes both hazards
+// structurally unreachable: a phase added to the pipeline later is exempt until
+// somebody deliberately admits it.
+export const INVERTIBLE_PHASES = new Set([
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+]);
+
+// Probe classes. `false` is allowed to mean NOT_DONE only for a probe that is
+// decisive and non-circular.
+export const PROBE_CLASS = Object.freeze({
+  LOCAL_DECISIVE: "local-decisive", // reads local artifacts; false means absent
+  NETWORK: "network", // reads GitHub; false means absent ONLY on a successful reply
+  CIRCULAR: "circular", // probe input is the write target — never decisive
+  NO_PROBE: "no-probe",
+});
+
+export const PHASE_PROBE_CLASS = Object.freeze({
+  triage: PROBE_CLASS.LOCAL_DECISIVE,
+  research: PROBE_CLASS.LOCAL_DECISIVE,
+  plan: PROBE_CLASS.LOCAL_DECISIVE,
+  implement: PROBE_CLASS.LOCAL_DECISIVE,
+  verify: PROBE_CLASS.LOCAL_DECISIVE,
+  review: PROBE_CLASS.LOCAL_DECISIVE,
+  remediate: PROBE_CLASS.LOCAL_DECISIVE,
+  pr: PROBE_CLASS.NETWORK,
+  "monitor-merge": PROBE_CLASS.NETWORK,
+  "monitor-deploy": PROBE_CLASS.CIRCULAR,
+  teardown: PROBE_CLASS.NO_PROBE,
+});
+
+export function probeClassFor(phase) {
+  return PHASE_PROBE_CLASS[phase] ?? PROBE_CLASS.NO_PROBE;
+}
+
+function unknown(reason, detail = null) {
+  return { verdict: VERDICT.UNKNOWN, reason, detail, invertible: false };
+}
+
+// classifyPhase — the cheap, IO-free gate. Answers "may the inversion act on
+// this phase at all?" before any probe is spawned, so an exempt phase costs
+// nothing and can never reach a probe that would block the daemon's event loop.
+export function classifyPhase(phase, { invertible = INVERTIBLE_PHASES } = {}) {
+  if (typeof phase !== "string" || phase === "") {
+    return unknown(UNKNOWN_REASONS.PHASE_EXEMPT, "phase is not a non-empty string");
+  }
+  const klass = probeClassFor(phase);
+  if (klass === PROBE_CLASS.CIRCULAR) {
+    return unknown(UNKNOWN_REASONS.CIRCULAR_PROBE, phase);
+  }
+  if (!hasProbe(phase)) {
+    return unknown(UNKNOWN_REASONS.NO_PROBE_FOR_PHASE, phase);
+  }
+  if (!invertible.has(phase)) {
+    return unknown(UNKNOWN_REASONS.PHASE_EXEMPT, phase);
+  }
+  return { verdict: null, reason: null, detail: null, invertible: true };
+}
+
+// evaluateOutcome — the verdict for one (ticket, phase) whose worker exited
+// clean WITHOUT declaring.
+//
+// `runProbe` is the injected seam: () => boolean. It is invoked ONLY when the
+// phase gate admits the phase, so an exempt phase never pays for a probe.
+//
+//   throws            -> UNKNOWN(probe-threw)        — never a failure
+//   non-boolean       -> UNKNOWN(probe-transport-fail) — a probe that cannot say
+//   true              -> DONE                        — the flip stands
+//   false             -> NOT_DONE                    — the ONLY path to `failed`
+//
+// A probe that returns a non-boolean is treated as unable to answer rather than
+// coerced: `undefined` is falsy, and coercing it would terminally fail work on a
+// malformed call — the exact arity-bug shape that produced eleven false
+// "not owned" answers elsewhere in this repo (CTL-1801).
+export function evaluateOutcome(
+  { phase, ticket } = {},
+  { runProbe, invertible = INVERTIBLE_PHASES } = {},
+) {
+  const gate = classifyPhase(phase, { invertible });
+  if (!gate.invertible) return { ...gate, phase, ticket };
+
+  if (typeof runProbe !== "function") {
+    return { ...unknown(UNKNOWN_REASONS.PROBE_INPUT_MISSING, "no runProbe seam"), phase, ticket };
+  }
+
+  let result;
+  try {
+    result = runProbe();
+  } catch (err) {
+    return {
+      ...unknown(UNKNOWN_REASONS.PROBE_THREW, err?.message ?? String(err)),
+      phase,
+      ticket,
+    };
+  }
+
+  if (typeof result !== "boolean") {
+    return {
+      ...unknown(UNKNOWN_REASONS.PROBE_TRANSPORT_FAIL, `probe returned ${typeof result}`),
+      phase,
+      ticket,
+    };
+  }
+
+  return {
+    verdict: result ? VERDICT.DONE : VERDICT.NOT_DONE,
+    reason: null,
+    detail: null,
+    invertible: true,
+    phase,
+    ticket,
+  };
+}
+
+// shouldWriteFailed — the single predicate a caller acts on. Deliberately narrow:
+// ONLY an explicit NOT_DONE, and ONLY in enforce mode. Everything else — UNKNOWN,
+// DONE, shadow, off — leaves today's behavior untouched.
+//
+// Written as a positive test against NOT_DONE rather than `!== DONE`, so a future
+// verdict value added to the enum cannot silently become a reason to fail work.
+export function shouldWriteFailed(outcome, mode) {
+  return mode === "enforce" && outcome?.verdict === VERDICT.NOT_DONE;
+}
+
+// describeOutcome — the telemetry payload. Carries the reason on UNKNOWN so a
+// shadow window can be read as "how often could we not tell, and why" — which is
+// the number the shadow→enforce exit criterion is actually about.
+export function describeOutcome(outcome, mode) {
+  return {
+    phase: outcome?.phase ?? null,
+    ticket: outcome?.ticket ?? null,
+    verdict: outcome?.verdict ?? VERDICT.UNKNOWN,
+    unknown_reason: outcome?.reason ?? null,
+    detail: outcome?.detail ?? null,
+    probe_class: probeClassFor(outcome?.phase),
+    mode: mode ?? "off",
+    would_write_failed: shouldWriteFailed(outcome, "enforce"),
+  };
+}

--- a/plugins/dev/scripts/execution-core/outcome-verdict.test.mjs
+++ b/plugins/dev/scripts/execution-core/outcome-verdict.test.mjs
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+import { hasProbe } from "./work-done-probes.mjs";
+import {
+  INVERTIBLE_PHASES,
+  PROBE_CLASS,
+  UNKNOWN_REASONS,
+  VERDICT,
+  classifyPhase,
+  describeOutcome,
+  evaluateOutcome,
+  probeClassFor,
+  shouldWriteFailed,
+} from "./outcome-verdict.mjs";
+
+const CANONICAL_PHASES = [
+  "triage",
+  "research",
+  "plan",
+  "implement",
+  "verify",
+  "review",
+  "pr",
+  "monitor-merge",
+  "monitor-deploy",
+  "teardown",
+];
+
+describe("the safety invariant: UNKNOWN never writes failed", () => {
+  // This is the whole design. Three prior rounds were blocked because a boolean
+  // probe conflates "absent" with "could not look"; if this test ever fails, the
+  // inversion has become capable of manufacturing terminal failures again.
+  test("no UNKNOWN reason, on any phase, can produce a failed write", () => {
+    for (const reason of Object.values(UNKNOWN_REASONS)) {
+      for (const phase of CANONICAL_PHASES) {
+        const outcome = { verdict: VERDICT.UNKNOWN, reason, phase };
+        expect(shouldWriteFailed(outcome, "enforce")).toBe(false);
+      }
+    }
+  });
+
+  test("only an explicit NOT_DONE in enforce mode writes failed", () => {
+    const notDone = { verdict: VERDICT.NOT_DONE, phase: "implement" };
+    expect(shouldWriteFailed(notDone, "enforce")).toBe(true);
+    for (const mode of ["off", "shadow", undefined, null, "", "ENFORCE"]) {
+      expect(shouldWriteFailed(notDone, mode)).toBe(false);
+    }
+    expect(shouldWriteFailed({ verdict: VERDICT.DONE }, "enforce")).toBe(false);
+    // A malformed/absent outcome must never be a reason to fail work.
+    expect(shouldWriteFailed(null, "enforce")).toBe(false);
+    expect(shouldWriteFailed(undefined, "enforce")).toBe(false);
+    expect(shouldWriteFailed({}, "enforce")).toBe(false);
+  });
+
+  test("a future verdict value cannot become a reason to fail work", () => {
+    // shouldWriteFailed tests POSITIVELY for NOT_DONE rather than `!== DONE`,
+    // so an enum value added later defaults to safe.
+    expect(shouldWriteFailed({ verdict: "some-future-state" }, "enforce")).toBe(false);
+  });
+});
+
+describe("phase allowlist — the post-PR phases are structurally exempt", () => {
+  test("teardown is UNKNOWN(no-probe-for-phase) and never invertible", () => {
+    // Grounding assertion: teardown genuinely has no probe. Positive control
+    // below proves hasProbe can say yes, so this zero is a measurement.
+    expect(hasProbe("teardown")).toBe(false);
+    expect(hasProbe("implement")).toBe(true); // positive control
+    const g = classifyPhase("teardown");
+    expect(g.invertible).toBe(false);
+    expect(g.reason).toBe(UNKNOWN_REASONS.NO_PROBE_FOR_PHASE);
+  });
+
+  test("monitor-deploy is UNKNOWN(circular-probe) even though it HAS a probe", () => {
+    // The distinction matters: monitor-deploy is exempt because its probe reads
+    // the same file its writer writes, NOT because a probe is missing.
+    expect(hasProbe("monitor-deploy")).toBe(true);
+    const g = classifyPhase("monitor-deploy");
+    expect(g.invertible).toBe(false);
+    expect(g.reason).toBe(UNKNOWN_REASONS.CIRCULAR_PROBE);
+    expect(probeClassFor("monitor-deploy")).toBe(PROBE_CLASS.CIRCULAR);
+  });
+
+  test("neither post-PR phase is in the allowlist", () => {
+    expect(INVERTIBLE_PHASES.has("monitor-deploy")).toBe(false);
+    expect(INVERTIBLE_PHASES.has("teardown")).toBe(false);
+  });
+
+  test("a phase invented later is exempt by default (allowlist, not denylist)", () => {
+    const g = classifyPhase("some-new-phase");
+    expect(g.invertible).toBe(false);
+    expect(g.reason).toBe(UNKNOWN_REASONS.NO_PROBE_FOR_PHASE);
+  });
+
+  test("the eight admitted phases are invertible", () => {
+    for (const p of INVERTIBLE_PHASES) {
+      expect(classifyPhase(p).invertible).toBe(true);
+    }
+    expect(INVERTIBLE_PHASES.size).toBe(8);
+  });
+
+  test("a malformed phase is exempt, not crashing", () => {
+    for (const bad of [null, undefined, "", 42, {}]) {
+      expect(classifyPhase(bad).invertible).toBe(false);
+    }
+  });
+});
+
+describe("evaluateOutcome — a probe that cannot answer is UNKNOWN, never NOT_DONE", () => {
+  const call = (phase, runProbe) => evaluateOutcome({ phase, ticket: "PROJ-1" }, { runProbe });
+
+  test("probe true -> DONE (the flip stands)", () => {
+    expect(call("implement", () => true).verdict).toBe(VERDICT.DONE);
+  });
+
+  test("probe false -> NOT_DONE (the only path to failed)", () => {
+    const o = call("implement", () => false);
+    expect(o.verdict).toBe(VERDICT.NOT_DONE);
+    expect(shouldWriteFailed(o, "enforce")).toBe(true);
+  });
+
+  test("probe THROWS -> UNKNOWN(probe-threw), not a failure", () => {
+    const o = call("implement", () => {
+      throw new Error("gh exited 128");
+    });
+    expect(o.verdict).toBe(VERDICT.UNKNOWN);
+    expect(o.reason).toBe(UNKNOWN_REASONS.PROBE_THREW);
+    expect(o.detail).toContain("gh exited 128");
+    expect(shouldWriteFailed(o, "enforce")).toBe(false);
+  });
+
+  test("probe returns a NON-BOOLEAN -> UNKNOWN, never coerced to false", () => {
+    // `undefined` is falsy. Coercing it would terminally fail work on a
+    // malformed call — the arity-bug shape that produced 11 false negatives
+    // elsewhere in this repo.
+    for (const bad of [undefined, null, 0, "", "false"]) {
+      const o = call("implement", () => bad);
+      expect(o.verdict).toBe(VERDICT.UNKNOWN);
+      expect(o.reason).toBe(UNKNOWN_REASONS.PROBE_TRANSPORT_FAIL);
+      expect(shouldWriteFailed(o, "enforce")).toBe(false);
+    }
+  });
+
+  test("a missing runProbe seam is UNKNOWN, not a failure", () => {
+    const o = evaluateOutcome({ phase: "implement", ticket: "PROJ-1" }, {});
+    expect(o.verdict).toBe(VERDICT.UNKNOWN);
+    expect(o.reason).toBe(UNKNOWN_REASONS.PROBE_INPUT_MISSING);
+  });
+
+  test("an EXEMPT phase never invokes the probe at all", () => {
+    // Cost matters: the probe spawns git/gh synchronously, and the daemon tick
+    // has a documented event-loop-stall history. An exempt phase must not pay.
+    let called = 0;
+    for (const phase of ["monitor-deploy", "teardown"]) {
+      const o = evaluateOutcome({ phase, ticket: "PROJ-1" }, { runProbe: () => { called += 1; return false; } });
+      expect(o.verdict).toBe(VERDICT.UNKNOWN);
+    }
+    expect(called).toBe(0);
+  });
+});
+
+describe("describeOutcome — the shadow-window telemetry", () => {
+  test("carries the reason so a shadow window can be read", () => {
+    const o = evaluateOutcome({ phase: "teardown", ticket: "PROJ-9" }, { runProbe: () => false });
+    const d = describeOutcome(o, "shadow");
+    expect(d).toMatchObject({
+      phase: "teardown",
+      ticket: "PROJ-9",
+      verdict: VERDICT.UNKNOWN,
+      unknown_reason: UNKNOWN_REASONS.NO_PROBE_FOR_PHASE,
+      probe_class: PROBE_CLASS.NO_PROBE,
+      mode: "shadow",
+      would_write_failed: false,
+    });
+  });
+
+  test("would_write_failed marks the shadow cases that enforce WOULD have failed", () => {
+    const o = evaluateOutcome({ phase: "monitor-merge", ticket: "PROJ-56" }, { runProbe: () => false });
+    const d = describeOutcome(o, "shadow");
+    expect(d.verdict).toBe(VERDICT.NOT_DONE);
+    // In shadow nothing is written, but the counter that drives the exit
+    // criterion is exactly this flag.
+    expect(d.would_write_failed).toBe(true);
+  });
+
+  test("never throws on a malformed outcome", () => {
+    expect(() => describeOutcome(null, "shadow")).not.toThrow();
+    expect(describeOutcome(null, "shadow").verdict).toBe(VERDICT.UNKNOWN);
+  });
+});
+
+describe("the measured 2026-08-12 sample replays correctly", () => {
+  // Decomposition of the live 16 declared / 15 fabricated on host mini:
+  // all 15 fabricated advances sit on two edges of ONE ticket —
+  //   14x monitor-merge -> monitor-deploy, and 1x monitor-deploy -> teardown.
+  // Under this design exactly ONE changes outcome, and it is a true positive:
+  // PR #3277 was still unmerged when the pipeline advanced past monitor-merge
+  // (it merged 36m34s later).
+  test("the monitor-merge advance on an unmerged PR becomes NOT_DONE", () => {
+    const o = evaluateOutcome(
+      { phase: "monitor-merge", ticket: "PROJ-56" },
+      { runProbe: () => false }, // gh: merged=false at 05:12:34Z
+    );
+    expect(o.verdict).toBe(VERDICT.NOT_DONE);
+    expect(shouldWriteFailed(o, "enforce")).toBe(true);
+  });
+
+  test("the monitor-deploy -> teardown advance is UNCHANGED (exempt)", () => {
+    const o = evaluateOutcome({ phase: "monitor-deploy", ticket: "PROJ-56" }, { runProbe: () => false });
+    expect(o.verdict).toBe(VERDICT.UNKNOWN);
+    expect(shouldWriteFailed(o, "enforce")).toBe(false);
+  });
+
+  test("a transient GitHub failure on that same edge is UNKNOWN, not a failure", () => {
+    // The difference between a true positive and a manufactured one is entirely
+    // whether the probe could look. Same phase, same ticket, opposite handling.
+    const o = evaluateOutcome(
+      { phase: "monitor-merge", ticket: "PROJ-56" },
+      { runProbe: () => { throw new Error("gh api 502"); } },
+    );
+    expect(o.verdict).toBe(VERDICT.UNKNOWN);
+    expect(shouldWriteFailed(o, "enforce")).toBe(false);
+  });
+});


### PR DESCRIPTION
> **DRAFT — do not merge yet.** This module has **no production caller**. Merging it as-is would ship a feature that has never produced an output, which is precisely what this project's acceptance test forbids. It merges once PR-3 wires it in shadow mode.

The structural decision behind the CTL-1790 inversion, extracted so it can be reviewed on its own after three blocked rounds.

## Why three values

Rounds 1–3 all died on the same thing: **a boolean probe conflates "I checked, the work is absent" with "I could not check."** Every probe in `work-done-probes.mjs` returns `false` for both, so inverting on `false` manufactures terminal failures out of GitHub outages, unresolvable worktrees, absent probes, and circular probes.

```
VERDICT = { DONE, NOT_DONE, UNKNOWN }
```

and the entire safety property is one rule:

> **UNKNOWN never writes `failed`.**

On UNKNOWN the caller reproduces today's behavior byte-for-byte (the flip still writes `done`) and emits telemetry. This mirrors the house rule already stated verbatim at `recovery.mjs:3027-3028` for the freshness gate.

`shouldWriteFailed` tests **positively** for `NOT_DONE` rather than `!== DONE`, so a verdict value added later cannot silently become a reason to fail work.

## The allowlist is a safety property, not an oversight

`INVERTIBLE_PHASES` admits eight phases. The two post-PR phases are exempt, for two *different* reasons:

- **`teardown`** has **no probe at all** (verified by executing `hasProbe` over all ten canonical phases, with the negative control `hasProbe("not-a-phase") === false`) **and** is the sole gate for all three Linear-Done writers. A fail-closed inversion there writes `failed`, `signals["teardown"]` never reads `done`, and **all three go dark at once** — PR merged, ticket never Done, worktree never removed. `isTicketTerminalOrMerged` would then likely *suppress* the alarm, since it returns `{terminal:true, reason:"pr-merged"}`. A silent permanent stall behind green health signals — **exactly the round-2 blocker**.
- **`monitor-deploy`** has a probe, but it reads the **same inode its writer writes** (the CTL-701 dual-use signal file). Circular by construction — no replay can exist in which probe-input and write-target are independent.

An **allowlist** (not a denylist) makes both structurally unreachable, and a phase added to the pipeline later is exempt until somebody deliberately admits it.

## Blast radius: 1 of 31, not 15 of 31

The live `16 declared / 15 fabricated` was never decomposed before. It is:

| ticket | advances | declared | fabricated |
|---|---|---|---|
| CTL-1774 | 9 | **9** (full pipeline) | 0 |
| CTL-56 | 22 | 7 | **15** |

All 15 sit on **two edges of one ticket** — 14× `monitor-merge → monitor-deploy` (13 of those a replay burst inside 55 s, re-reading one stale file) and 1× `monitor-deploy → teardown`.

Under this design exactly **one** changes outcome, and it is a **true positive**: the pipeline advanced past `monitor-merge` while PR #3277 was still unmerged — it merged **36 m 34 s later**. The 13 replays never occur because #1 stops the edge. The `monitor-deploy` one is exempt and unchanged, so **the Linear-Done backstop is provably untouched**.

So *"48% of advances are fabricated"* is **not** the blast radius. The gate is `fabricated ∧ phase-invertible ∧ probe-says-NOT-DONE` — 1/31 on the only sample that exists. That conjunction is why round 1's unconditional inversion was correctly blocked: it gated on the first conjunct alone.

Both cases are replayed as tests, including the discriminator that matters: the **same phase and ticket** with a throwing probe yields UNKNOWN, not a failure.

## Tests — 21

Covering: no UNKNOWN reason on any phase can produce a failed write (cross-product); only explicit NOT_DONE in enforce mode does; a non-boolean probe result is UNKNOWN rather than coerced (`undefined` is falsy — the arity-bug shape that produced 11 false negatives in CTL-1801); an exempt phase **never invokes the probe at all** (the daemon tick has a documented event-loop-stall history, so an exempt phase must not pay for a spawn).

## Next

- **PR-3** — wire in shadow at `flipSignalDoneOnSuccess`, which is already `async` at its call site, so an awaited probe blocks nothing. Threading `phase`/`ticket` through is the bulk of that change.
- **`enforce` is BLOCKED** on **CTL-1805** — the `monitor-merge → monitor-deploy` edge re-fired **13× in 55 s** from an unchanged signal file, and the mechanism is not yet established. That is 13 chances to write a terminal `failed` on a merged PR.

Full design, with a verification ledger stating how each claim was checked: `thoughts/shared/research/2026-08-12-ctl-1790-round4-design.md`.