### PR TITLE
fix(dev): CTL-1810 — bound every work-done probe spawn so a hung gh cannot wedge the scheduler tick

### DIFF
--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -26,12 +26,58 @@ const MIN_ARTIFACT_BYTES = 200;
 // derive phaseCount from the same schema element.
 const PLAN_PHASE_HEADER_RE = /^## Phase /gm;
 
-// defaultRunGit — `git <args>` with stdout/stderr captured. Returns
-// { code, stdout, stderr }; never throws.
-export function defaultRunGit(args, { spawn = spawnSync } = {}) {
-  const res = spawn("git", args, { encoding: "utf8" });
-  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
+// CTL-1810 — BOUND EVERY PROBE SPAWN.
+//
+// `defaultRunGit`/`defaultRunGh` were the only un-timed `spawnSync` seams left in
+// execution-core, and both are called SYNCHRONOUSLY from `schedulerTick` (a 30s
+// `setInterval`): resolveWorktree's `git worktree list`, ghPullRest's `gh api`, and the
+// implement/verify/review probes' `git rev-list`/`git status`. An unbounded child — hung
+// TLS, a GitHub incident, a credential-helper prompt, a stalled network mount — blocks the
+// daemon's event loop indefinitely, with no clock and nothing to break the wait. That is
+// the CTL-1524 failure mode (median event-loop delay 77.5s inside a synchronous drain
+// burst; see wt-cleanup-drain.mjs:19-30).
+//
+// Every sibling probe in this directory was already bounded — pr-block-probe.mjs:24 (20s),
+// github-quota-timer.mjs:43 (10s), github-auth-preflight.mjs:52 (10s) — and the first of
+// those states this rationale in its own header. These two were the gap.
+//
+// WHY A TIMEOUT NEEDS NO NEW ERROR PATH HERE. Unlike pr-block-probe's `realGh`, these two
+// seams contract to NEVER THROW; a timeout must degrade to the existing non-zero return, not
+// an exception thrown into the tick. `spawnSync` reports a timeout by setting `res.error`
+// (ETIMEDOUT) and leaving `status` null, which the pre-existing `if (res.error)` branch below
+// already converts to `{ code: 127 }`. Callers then see "probe failed", which every probe
+// already treats as "work NOT proven done" — the safe direction. The only addition is a
+// stderr string that names the timeout, so a bound that fires is diagnosable rather than
+// looking like a generic spawn failure.
+//
+// `CATALYST_GH_PROBE_TIMEOUT_MS` is deliberately the SAME knob (and the same 20s default)
+// pr-block-probe.mjs already uses, so "the gh probe timeout" stays one value fleet-wide.
+// Local `git` gets its own, tighter bound: measured warm-cache cost is 0.02-0.07s, so 10s is
+// already three orders of magnitude of headroom.
+const GIT_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GIT_PROBE_TIMEOUT_MS || 10000);
+const GH_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GH_PROBE_TIMEOUT_MS || 20000);
+
+// spawnResult — shared { code, stdout, stderr } normalizer for the two bounded seams.
+// Never throws. A timed-out child (ETIMEDOUT, or killed by the timeout's SIGTERM) is
+// reported as the same code:127 failure as any other spawn error, with a stderr that says
+// so explicitly.
+function spawnResult(bin, args, res, timeoutMs) {
+  if (res.error) {
+    const timedOut = res.error.code === "ETIMEDOUT" || res.signal === "SIGTERM";
+    return {
+      code: 127,
+      stdout: "",
+      stderr: timedOut ? `${bin} timed out after ${timeoutMs}ms: ${bin} ${args.join(" ")}` : res.error.message,
+    };
+  }
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// defaultRunGit — `git <args>` with stdout/stderr captured, bounded by `timeoutMs`.
+// Returns { code, stdout, stderr }; never throws.
+export function defaultRunGit(args, { spawn = spawnSync, timeoutMs = GIT_PROBE_TIMEOUT_MS } = {}) {
+  const res = spawn("git", args, { encoding: "utf8", timeout: timeoutMs });
+  return spawnResult("git", args, res, timeoutMs);
 }
 
 // defaultListArtifacts — `readdirSync(dir)` → filenames; [] on any error (missing
@@ -182,11 +228,11 @@ function monitorDeployProbe({ ticket, orchDir } = {}, { readFile = defaultReadFi
 // per research §4 — NOT `gh pr view --json state`, whose GraphQL state is
 // uppercase and would never compare equal to "open").
 
-// defaultRunGh — `gh <args>` with stdout/stderr captured; never throws.
-export function defaultRunGh(args, { spawn = spawnSync } = {}) {
-  const res = spawn("gh", args, { encoding: "utf8" });
-  if (res.error) return { code: 127, stdout: "", stderr: res.error.message };
-  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+// defaultRunGh — `gh <args>` with stdout/stderr captured, bounded by `timeoutMs`
+// (CTL-1810 — see the GIT_PROBE_TIMEOUT_MS block above for why). Never throws.
+export function defaultRunGh(args, { spawn = spawnSync, timeoutMs = GH_PROBE_TIMEOUT_MS } = {}) {
+  const res = spawn("gh", args, { encoding: "utf8", timeout: timeoutMs });
+  return spawnResult("gh", args, res, timeoutMs);
 }
 
 // prInfoFromSignal — read { number, url } from a worker-dir signal's .pr. null

--- a/plugins/dev/scripts/execution-core/work-done-probes.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.mjs
@@ -54,8 +54,25 @@ const PLAN_PHASE_HEADER_RE = /^## Phase /gm;
 // pr-block-probe.mjs already uses, so "the gh probe timeout" stays one value fleet-wide.
 // Local `git` gets its own, tighter bound: measured warm-cache cost is 0.02-0.07s, so 10s is
 // already three orders of magnitude of headroom.
-const GIT_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GIT_PROBE_TIMEOUT_MS || 10000);
-const GH_PROBE_TIMEOUT_MS = Number(process.env.CATALYST_GH_PROBE_TIMEOUT_MS || 20000);
+
+// positiveIntMs — an override is only honored if it is a POSITIVE INTEGER; anything
+// else falls back to the bounded default (Codex #3307 P2). Both failure modes are
+// real and both defeat the contract this block exists to create:
+//   • "0" is TRUTHY, so a naive `env || default` yields Number("0") === 0, and
+//     spawnSync treats timeout:0 as NO TIMEOUT — an operator "kill-switch" would
+//     silently restore the exact indefinitely-blocking probe this bounds. VERIFIED.
+//   • negative, fractional and non-numeric values make spawnSync throw
+//     ERR_OUT_OF_RANGE *before* spawnResult can run, breaking the seams' never-throw
+//     contract and putting an exception into schedulerTick. VERIFIED for -5, 1.5, NaN.
+// Falling back to the default is deliberate: there is no legitimate reason to want an
+// unbounded probe, so an unusable override degrades to bounded rather than to off.
+function positiveIntMs(raw, fallback) {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+const GIT_PROBE_TIMEOUT_MS = positiveIntMs(process.env.CATALYST_GIT_PROBE_TIMEOUT_MS, 10000);
+const GH_PROBE_TIMEOUT_MS = positiveIntMs(process.env.CATALYST_GH_PROBE_TIMEOUT_MS, 20000);
 
 // spawnResult — shared { code, stdout, stderr } normalizer for the two bounded seams.
 // Never throws. A timed-out child (ETIMEDOUT, or killed by the timeout's SIGTERM) is
@@ -75,9 +92,10 @@ function spawnResult(bin, args, res, timeoutMs) {
 
 // defaultRunGit — `git <args>` with stdout/stderr captured, bounded by `timeoutMs`.
 // Returns { code, stdout, stderr }; never throws.
-export function defaultRunGit(args, { spawn = spawnSync, timeoutMs = GIT_PROBE_TIMEOUT_MS } = {}) {
-  const res = spawn("git", args, { encoding: "utf8", timeout: timeoutMs });
-  return spawnResult("git", args, res, timeoutMs);
+export function defaultRunGit(args, { spawn = spawnSync, timeoutMs } = {}) {
+  const t = positiveIntMs(timeoutMs, GIT_PROBE_TIMEOUT_MS);
+  const res = spawn("git", args, { encoding: "utf8", timeout: t });
+  return spawnResult("git", args, res, t);
 }
 
 // defaultListArtifacts — `readdirSync(dir)` → filenames; [] on any error (missing
@@ -230,9 +248,10 @@ function monitorDeployProbe({ ticket, orchDir } = {}, { readFile = defaultReadFi
 
 // defaultRunGh — `gh <args>` with stdout/stderr captured, bounded by `timeoutMs`
 // (CTL-1810 — see the GIT_PROBE_TIMEOUT_MS block above for why). Never throws.
-export function defaultRunGh(args, { spawn = spawnSync, timeoutMs = GH_PROBE_TIMEOUT_MS } = {}) {
-  const res = spawn("gh", args, { encoding: "utf8", timeout: timeoutMs });
-  return spawnResult("gh", args, res, timeoutMs);
+export function defaultRunGh(args, { spawn = spawnSync, timeoutMs } = {}) {
+  const t = positiveIntMs(timeoutMs, GH_PROBE_TIMEOUT_MS);
+  const res = spawn("gh", args, { encoding: "utf8", timeout: t });
+  return spawnResult("gh", args, res, t);
 }
 
 // prInfoFromSignal — read { number, url } from a worker-dir signal's .pr. null

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -2,10 +2,12 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test work-done-probes.test.mjs
 
 import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
 import {
   WORK_DONE_PROBES,
   hasProbe,
   defaultRunGit,
+  defaultRunGh,
   resolveWorktree,
   defaultReadFile,
   readVerifyVerdict,
@@ -424,6 +426,99 @@ describe("defaultRunGit — spawn error is non-fatal", () => {
     expect(r.code).toBe(127);
     expect(r.stdout).toBe("");
     expect(r.stderr).toContain("ENOENT");
+  });
+});
+
+// CTL-1810 — the probe spawns are BOUNDED. These two seams run synchronously on the
+// scheduler tick, so an unbounded child wedges the daemon's event loop.
+describe("CTL-1810 — defaultRunGit/defaultRunGh bound every spawn", () => {
+  // T1/T2 — the bound is actually handed to spawnSync. Deleting `timeout:` from either
+  // seam fails these directly.
+  test("defaultRunGit passes a positive timeout to spawn", () => {
+    let seen = null;
+    defaultRunGit(["status", "--porcelain"], {
+      spawn: (_bin, _args, opts) => {
+        seen = opts;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(typeof seen.timeout).toBe("number");
+    expect(seen.timeout).toBeGreaterThan(0);
+  });
+
+  test("defaultRunGh passes a positive timeout to spawn", () => {
+    let seen = null;
+    defaultRunGh(["api", "repos/o/r/pulls/1"], {
+      spawn: (_bin, _args, opts) => {
+        seen = opts;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(typeof seen.timeout).toBe("number");
+    expect(seen.timeout).toBeGreaterThan(0);
+  });
+
+  test("an explicit timeoutMs overrides the default and reaches spawn", () => {
+    let seen = null;
+    defaultRunGh(["api", "x"], {
+      timeoutMs: 1234,
+      spawn: (_bin, _args, opts) => {
+        seen = opts;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(seen.timeout).toBe(1234);
+  });
+
+  // T3/T4 — a timeout degrades to the seams' existing never-throw failure contract,
+  // NOT to an exception thrown into schedulerTick, and says so in stderr.
+  test("an ETIMEDOUT child returns code 127 and names the timeout — it does not throw", () => {
+    const err = Object.assign(new Error("spawnSync git ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const r = defaultRunGit(["rev-list", "--count", "origin/main..HEAD"], {
+      timeoutMs: 5000,
+      spawn: () => ({ error: err, status: null }),
+    });
+    expect(r.code).toBe(127);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("timed out after 5000ms");
+  });
+
+  test("a child killed by the timeout's SIGTERM also reads as timed out", () => {
+    const r = defaultRunGh(["api", "repos/o/r/pulls/1"], {
+      timeoutMs: 7000,
+      spawn: () => ({ error: new Error("killed"), signal: "SIGTERM", status: null }),
+    });
+    expect(r.code).toBe(127);
+    expect(r.stderr).toContain("timed out after 7000ms");
+  });
+
+  // T5 — regression guard: a NON-timeout spawn error must still surface its own message,
+  // not be relabelled as a timeout.
+  test("a non-timeout spawn error keeps its original message", () => {
+    const r = defaultRunGit(["worktree", "list"], {
+      spawn: () => ({ error: new Error("ENOENT") }),
+    });
+    expect(r.stderr).toContain("ENOENT");
+    expect(r.stderr).not.toContain("timed out");
+  });
+
+  // T6 — THE LOAD-BEARING TEST. Everything above asserts against a stub, so all of it
+  // would still pass if spawnSync ignored the option. This one spawns a REAL child that
+  // hangs far longer than the bound and asserts the call returns anyway. Delete the
+  // `timeout:` from defaultRunGit and this test hangs for 30s instead of returning in
+  // ~0.3s — i.e. it is the test that goes red when the production line is removed.
+  test("a real hanging child returns within the bound (red if `timeout:` is removed)", () => {
+    const started = Date.now();
+    const r = defaultRunGit(["--exec-path"], {
+      timeoutMs: 300,
+      // Ignore the git args entirely — spawn a child that is guaranteed to outlive the
+      // bound. spawnSync's own timeout is what must terminate it.
+      spawn: (_bin, _args, opts) => spawnSync("sleep", ["30"], opts),
+    });
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeLessThan(5000);
+    expect(r.code).toBe(127);
+    expect(r.stderr).toContain("timed out after 300ms");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
+++ b/plugins/dev/scripts/execution-core/work-done-probes.test.mjs
@@ -1271,3 +1271,49 @@ describe("CTL-663: probe descriptions updated for plan-phase gate", () => {
     expect(WORK_DONE_PROBE_DESCRIPTIONS.remediate).toBe("commits ahead of origin/main + clean worktree");
   });
 });
+
+// Codex #3307 P2 — an override that cannot be honored must degrade to the BOUNDED
+// default, never to unbounded and never to a throw. Both failure modes are real:
+// spawnSync treats timeout:0 as NO TIMEOUT, and rejects negative/fractional/NaN with
+// ERR_OUT_OF_RANGE before our never-throw normalizer can run.
+describe("CTL-1810 — an unusable timeout override degrades to bounded, not to off", () => {
+  const seenTimeout = (timeoutMs) => {
+    let seen = null;
+    defaultRunGit(["status"], {
+      timeoutMs,
+      spawn: (_b, _a, opts) => {
+        seen = opts.timeout;
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    });
+    return seen;
+  };
+
+  // 0 is the dangerous one: it is a plausible "disable it" value AND spawnSync reads
+  // it as unbounded, so it would silently restore the defect this bounds.
+  test("0 does NOT reach spawn — it would mean 'no timeout'", () => {
+    const t = seenTimeout(0);
+    expect(t).toBeGreaterThan(0);
+  });
+
+  for (const bad of [-5, 1.5, NaN, "abc", null, "", "0"]) {
+    test(`unusable override ${JSON.stringify(bad)} falls back to a positive integer`, () => {
+      const t = seenTimeout(bad);
+      expect(Number.isInteger(t)).toBe(true);
+      expect(t).toBeGreaterThan(0);
+    });
+  }
+
+  test("a usable override is still honored exactly", () => {
+    expect(seenTimeout(1234)).toBe(1234);
+  });
+
+  // The seams must never throw, whatever the override — spawnSync's own
+  // ERR_OUT_OF_RANGE would otherwise land inside schedulerTick.
+  test("a real spawn with an unusable override never throws", () => {
+    expect(() => {
+      defaultRunGit(["--version"], { timeoutMs: -5 });
+      defaultRunGh(["--version"], { timeoutMs: NaN });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes CTL-1810.

## The defect

`defaultRunGit` and `defaultRunGh` (`plugins/dev/scripts/execution-core/work-done-probes.mjs`) were
the **only two un-timed `spawnSync` seams left in `execution-core`**:

```js
const res = spawn("git", args, { encoding: "utf8" });   // :31 — no timeout
const res = spawn("gh",  args, { encoding: "utf8" });   // :186 — no timeout
```

Both are called **synchronously from `schedulerTick`** (a 30 s `setInterval`): `resolveWorktree`'s
`git worktree list` (`:78`), `ghPullRest`'s `gh api` (`:211`), and the implement/verify/review probes'
`git rev-list` / `git status` (`:259`, `:263`, `:294`, `:299`, `:540`).

So one hung child — stalled TLS, a GitHub incident, a credential-helper prompt, a wedged network
mount — **blocks the daemon's event loop indefinitely**, with no clock and nothing to break the wait.
That is precisely the CTL-1524 failure mode, measured there at a **median event-loop delay of 77.5 s**
inside a synchronous drain burst (`wt-cleanup-drain.mjs:19-30`).

Every sibling probe in the same directory was already bounded, and the first of them states this
PR's rationale in its own header:

| file | timeout |
| -- | -- |
| `pr-block-probe.mjs:21,35` — *"wedge the whole daemon event loop. Bound every spawn"* | 20 s |
| `github-quota-timer.mjs:43` | 10 s |
| `github-auth-preflight.mjs:52` | 10 s |

These two were the gap. Surfaced as the companion one-liner to CTL-1790 PR-1 (`e785a6e4`), which
shipped without it; CTL-1790 has since been rewritten onto the goal-loop pivot and no longer carries
this, so it had no ticket until now.

## Why the fix needs no new error path

Unlike `pr-block-probe`'s `realGh`, these seams **contract to never throw** — a timeout must degrade
to the existing non-zero return, not an exception thrown into the tick. `spawnSync` reports a timeout
by setting `res.error` (ETIMEDOUT) and leaving `status` null, which the **pre-existing** `if (res.error)`
branch already converts to `{ code: 127 }`. Callers then see "probe failed", which every probe already
treats as **"work NOT proven done"** — the conservative direction. The only behavioural addition is a
stderr string naming the timeout, so a bound that fires is diagnosable rather than looking generic.

`CATALYST_GH_PROBE_TIMEOUT_MS` is deliberately the **same knob and the same 20 s default** that
`pr-block-probe.mjs` already uses, so "the gh probe timeout" stays one value fleet-wide. Local `git`
gets its own tighter bound (10 s; measured warm-cache cost is 0.02–0.07 s).

## Tests — including one that is mutation-verified

Six stub-level assertions (the bound reaches `spawn`; an explicit `timeoutMs` overrides; ETIMEDOUT and
SIGTERM both degrade to `code: 127` without throwing; a non-timeout error keeps its own message).

Those all pass against a stub even if `spawnSync` ignored the option, so there is a seventh that
spawns a **real** child outliving the bound:

```
bound REMOVED  → ✗ fails at 5004ms  ("this test timed out after 5000ms")
bound RESTORED → ✓ passes in 323ms
```

That is the test-the-subscriber-by-deleting-it rule applied to a guard rather than a handler.

## Not claimed

The widely-repeated *"20–40 s synchronous probe"* figure is **not** the justification and is not used
anywhere here — three independent attempts (including the round-4 design pass) failed to reproduce it.
The justification is the missing bound, which is structural and verified by reading the two call sites.

## Verification

- `bun test work-done-probes.test.mjs` → **119 pass, 0 fail**
- Full `execution-core` suite compared against a pristine `origin/main` worktree; this branch
  introduces no new failures (main is currently red at 61 pre-existing failures — tracked separately).
- No leaked child processes after the real-spawn test (`pgrep -fl "sleep 30"` → empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)