### PR TITLE
feat(dev): CTL-1790 — an undeclared clean exit records abandonment, not a fabricated success

### DIFF
--- a/plugins/dev/scripts/broker/namespace-contract.mjs
+++ b/plugins/dev/scripts/broker/namespace-contract.mjs
@@ -78,8 +78,12 @@ export const INTENTIONAL_PHASE_SLOT_EXCEPTIONS = Object.freeze([
 // CTL-512: skipped is the monitor-deploy terminal-no-deploy status. Routed
 // the same as complete (phase-advance is a no-op for monitor-deploy) so the
 // scheduler frees the wave slot.
+// CTL-1790: `abandoned` is the terminal for a worker that exited cleanly WITHOUT
+// declaring an outcome. It is a terminal like `failed` — it frees the ticket and
+// escalates — and it must NEVER be routed like `complete`/`skipped`, which advance
+// the phase.
 export const PHASE_EVENT_PATTERN =
-  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped|abandoned)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
 
 // isBrokerProtectedName — true if `name` falls in any broker-protected space.
 // Callers: shouldSkipEvent (router.mjs), parity tests.

--- a/plugins/dev/scripts/broker/projection.mjs
+++ b/plugins/dev/scripts/broker/projection.mjs
@@ -321,14 +321,18 @@ function localTicket(event, payload) {
 }
 
 // keep in sync with router.mjs PHASE_EVENT_PATTERN
+// CTL-1790 added `abandoned`; `skipped` was missing here since CTL-512 — this copy
+// had drifted from the contract it claims to mirror, so both are added together.
 const WORKER_PHASE_EVENT_PATTERN =
-  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
+  /^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped|abandoned)\.([A-Za-z][A-Za-z0-9_]*-\d+)$/;
 
 // phase.<name>.<status> → projected worker `status` value.
 const PHASE_STATUS_MAP = {
   complete: "phase-complete",
   failed: "phase-failed",
   "turn-cap-exhausted": "turn-cap-exhausted",
+  skipped: "phase-complete", // CTL-512: terminal-success for monitor-deploy
+  abandoned: "phase-failed", // CTL-1790: terminal, never advance-eligible
 };
 
 // orchestrator.worker.<action> events that map directly to a status with no

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -2077,7 +2077,12 @@ export function tryPhaseLifecycleRoute(event, interestsMap) {
           ? `Phase ${phaseName} turn-cap-exhausted on ${ticket}`
           : status === "skipped"
             ? `Phase ${phaseName} skipped on ${ticket}`
-            : `Phase ${phaseName} failed on ${ticket}`;
+            : // CTL-1790: without this arm an abandoned phase reads as a plain
+              // failure in the wake envelope, the broker log and the HUD — the
+              // trailing branch is a catch-all, not a `failed` test.
+              status === "abandoned"
+              ? `Phase ${phaseName} abandoned (worker exited without declaring) on ${ticket}`
+              : `Phase ${phaseName} failed on ${ticket}`;
     matches.push({
       interestId,
       reason,

--- a/plugins/dev/scripts/execution-core/assertion-evidence.mjs
+++ b/plugins/dev/scripts/execution-core/assertion-evidence.mjs
@@ -52,9 +52,22 @@ export const ASSERTED_BY = Object.freeze({
   RECOVERY_RECLAIM: "recovery-reclaim",
   // C (legacy wave orchestration) — orchestrate-revive's synthetic complete.
   REVIVE_SYNTHESIZED: "revive-synthesized",
-  // B — sdk-run-phase-agent.mjs flipSignalDoneOnSuccess. Shared by the SDK and
-  // codex-exec launch verbs (codex imports the same function).
+  // B — HISTORICAL. sdk-run-phase-agent.mjs's old `flipSignalDoneOnSuccess`, which
+  // wrote status:"done" for any worker that exited zero without declaring anything.
+  // CTL-1790 REMOVED that writer — no code emits this id any more.
+  //
+  // It is deliberately KEPT REGISTERED rather than renamed. Signal files and events
+  // written before CTL-1790 still carry it, and this file's parity suite states the
+  // cost of dropping an id: a value the registry does not contain classifies as
+  // `absent`/`unknown-writer`, "corrupting the advancement audit this ticket exists
+  // to produce". Deleting it would retroactively blind the CTL-1789 instrument to
+  // exactly the 15-of-31 fabricated advances that motivated CTL-1790. Keep forever.
   SDK_SUCCESS_FLIP: "sdk-success-flip",
+  // B — sdk-run-phase-agent.mjs flipSignalAbandonedOnUndeclaredExit (CTL-1790), the
+  // REPLACEMENT for the above. Shared by the SDK and codex-exec launch verbs (codex
+  // imports the same function). Asserts only that the process exited cleanly WITHOUT
+  // a declaration — it never asserts the work happened, and it never advances a phase.
+  SDK_ABANDONED: "sdk-abandoned",
   // B (non-success) — sdk-run-phase-agent.mjs defaultWriteSignalTerminal, the
   // stalled/failed/turn-cap-exhausted backstop. Never advance-eligible, stamped
   // so the marker's coverage of the SDK writer pair is not half-missing.
@@ -88,7 +101,8 @@ const DECLARED_WRITERS = new Set([ASSERTED_BY.PHASE_AGENT]);
 const FABRICATED_WRITERS = new Set([
   ASSERTED_BY.RECOVERY_RECLAIM,
   ASSERTED_BY.REVIVE_SYNTHESIZED,
-  ASSERTED_BY.SDK_SUCCESS_FLIP,
+  ASSERTED_BY.SDK_SUCCESS_FLIP, // historical (CTL-1790 removed the writer); see above
+  ASSERTED_BY.SDK_ABANDONED,
   ASSERTED_BY.SDK_BACKSTOP,
 ]);
 

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -23,7 +23,7 @@
 // EXPORTED sdk primitives: runPrelaunch (the Stage-A shared pre-launch: claim +
 // fenced "dispatched" signal + generation + rebase + prompt/env composition),
 // Semaphore + resolveMaxParallel (the process-wide concurrency cap),
-// scrubSecrets (token redaction), flipSignalDoneOnSuccess (the success-branch
+// scrubSecrets (token redaction), flipSignalAbandonedOnUndeclaredExit (the success-branch
 // signal backstop), defaultWriteSignalStalled (the stalled-signal flip) and
 // defaultEmitBackstop (the terminal-event backstop). Only the launch verb —
 // spawn `codex exec --json`, parse its JSONL, classify its errors — is new.
@@ -66,7 +66,7 @@ import { codexConfig, log } from "./config.mjs";
 import {
   defaultEmitBackstop,
   defaultWriteSignalStalled,
-  flipSignalDoneOnSuccess,
+  flipSignalAbandonedOnUndeclaredExit,
   resolveMaxParallel,
   runPrelaunch,
   scrubSecrets,
@@ -1766,9 +1766,11 @@ export async function codexRunPhaseAgent(
         };
       }
 
-      // success (exitCode === 0) — in-process backstop flip (no-op when the skill's
-      // own phase-agent-emit-complete already flipped it, or the generation is stale).
-      flipSignalDoneOnSuccess(signalFile, spec.generation);
+      // success (exitCode === 0) — CTL-1790: a clean exit is NOT a declared outcome.
+      // If the signal is still in-flight the skill never declared, so record
+      // ABANDONMENT (no-op when the skill's own phase-agent-emit-complete already
+      // declared, or when this generation is stale).
+      flipSignalAbandonedOnUndeclaredExit(signalFile, spec.generation, { ticket, phase });
       const usage = normalizeUsage(res.usage);
       emitEvent("execution-core.codex.phase-turns", { ticket, phase, usage });
       return {

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -1564,8 +1564,13 @@ describe("codexRunPhaseAgent — spawn contract (verbatim 0.144.1 success)", () 
     expect(events.find(([n]) => n === "execution-core.codex.phase-turns")[1].usage).toEqual(E1_USAGE);
     expect(reg.state.handles[0].deregistered).toBe(1);
     expect(reg.state.registered[0]).toMatchObject({ executor: "codex-exec", ticket: "CTL-100" });
-    // Success backstop flipped the still-dispatched signal to done.
-    expect(JSON.parse(readFileSync(signalFile, "utf8")).status).toBe("done");
+    // CTL-1790: codex-exec shares the SDK's undeclared-exit handler, so a clean exit
+    // whose skill never declared records ABANDONMENT here too — not a fabricated done.
+    // This assertion is the executor-parity guard: fixing only the SDK path fails it.
+    const sigAfter = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(sigAfter.status).not.toBe("done");
+    expect(sigAfter.status).toBe("failed");
+    expect(sigAfter.outcome).toBe("abandoned");
     rmSync(dir, { recursive: true, force: true });
   });
 });
@@ -1697,8 +1702,10 @@ describe("codexRunPhaseAgent — failure classification", () => {
     expect(r.classification).toBe("success");
     expect(spawned).toBe(1); // NOT re-spawned/retried as a rate-park
     expect(stalled).toHaveLength(0); // never written a stalled signal
-    // flipSignalDoneOnSuccess flipped the still-dispatched signal to done.
-    expect(JSON.parse(readFileSync(signalFile, "utf8")).status).toBe("done");
+    // CTL-1790: an undeclared clean exit is abandonment on the codex path too.
+    const sigAfter2 = JSON.parse(readFileSync(signalFile, "utf8"));
+    expect(sigAfter2.status).toBe("failed");
+    expect(sigAfter2.outcome).toBe("abandoned");
     // success telemetry, not a rate-park event.
     expect(events.map(([n]) => n)).toContain("execution-core.codex.phase-turns");
     expect(events.map(([n]) => n)).not.toContain("execution-core.codex.rate-park");

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -484,21 +484,33 @@ export function defaultWriteSignalStalled(signalFile, reason) {
 // SKILL was solely responsible for flipping its own signal to done (via the
 // phase-agent-emit-complete wrapper). That holds now that the two event-only
 // phases (triage, monitor-deploy) route their terminal emit through the wrapper,
-// but this is the in-process belt-and-suspenders net: on a clean success, if the
-// signal is STILL in-flight (dispatched|running) — the skill exited 0 without its
-// own flip — flip it to done here so occupancy (countSdkInflight) releases the
-// slot and deriveAdvancement sees a terminal status. Under executor=sdk there is
-// no bg reclaim path to synthesize the flip, so without this a success that
-// skipped its wrapper call would strand the slot.
+// but a worker can still exit 0 without ever declaring anything.
+//
+// CTL-1790 — WHAT THIS USED TO DO, AND WHY IT CHANGED. This function was
+// `flipSignalDoneOnSuccess`: on a clean exit with an in-flight signal it wrote
+// status:"done" and emitted nothing. That is where 15 of 31 measured August 2026
+// phase advancements came from — success INFERRED from a process exiting zero,
+// declared by nothing that did the work, and silent. Under the goal-loop contract a
+// worker declares its own outcome or nothing is recorded, so the fabricated success
+// is deleted outright.
+//
+// What is NOT deleted is the TERMINAL WRITE, and that distinction is the whole trap.
+// Removing this function altogether leaves the signal in-flight forever:
+// isTicketInFlight stays true, classifyWorker returns "unknown" so the CTL-574
+// reclaim never fires, and the terminal sweep never escalates — a stranded, invisible
+// ticket that silently re-dispatches on the next daemon restart. An event alone
+// cannot fix that: the readers that free the ticket read the SIGNAL FILE, not the
+// event log. So the fabrication becomes a declared non-outcome, written terminal.
 //
 // Distinct from defaultWriteSignalTerminal on purpose:
 //   - acts ONLY on an in-flight (dispatched|running) signal — it NEVER resurrects
-//     a parked (needs-input) hold into done, and never clobbers an already-terminal
-//     status (done/failed/skipped/turn-cap-exhausted);
+//     a parked (needs-input) hold, and never clobbers an already-terminal status
+//     (done/failed/skipped/turn-cap-exhausted);
 //   - honors the CTL-736 generation fence — a stale superseded worker must NOT
 //     write an outcome (see below);
-//   - writes status:"done" + completedAt (a SUCCESS terminal), no attentionReason
-//     (an attentionReason/failureReason would trip revive's escalate branch).
+//   - writes the recognized terminal status:"failed" with outcome:"abandoned" and
+//     failureReason:"ended-without-declaration", and NO completedAt — see the
+//     block at the write site for why each of those three is load-bearing.
 const SIGNAL_INFLIGHT_STATUSES = new Set(["dispatched", "running"]);
 
 // Plain-integer test shared by the generation fence — mirrors the bash
@@ -506,7 +518,8 @@ const SIGNAL_INFLIGHT_STATUSES = new Set(["dispatched", "running"]);
 // isCurrentGeneration semantics exactly.
 const isPlainInt = (v) => /^[0-9]+$/.test(String(v));
 
-export function flipSignalDoneOnSuccess(signalFile, generation) {
+export function flipSignalAbandonedOnUndeclaredExit(signalFile, generation, opts = {}) {
+  const { appendEventLog = defaultAppendEventLog, ticket, phase } = opts;
   if (!signalFile) return;
   try {
     let sig;
@@ -533,18 +546,54 @@ export function flipSignalDoneOnSuccess(signalFile, generation) {
       return;
     }
     const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-    sig.status = "done";
-    // CTL-1789: this flip fires on a CLEAN SDK EXIT, not on an agent declaring
-    // completion — the agent never ran its wrapper (if it had, `status` would
-    // already be terminal and the in-flight precondition above would have
-    // returned). Stamp it FABRICATED so the advancement audit can subtract it.
-    sig.assertedBy = ASSERTED_BY.SDK_SUCCESS_FLIP;
-    sig.completedAt = ts;
+    // ── CTL-1790: record ABANDONMENT, never a fabricated success. ──────────────
+    //
+    // `status` is the ALREADY-RECOGNIZED terminal `failed`, NOT a new `abandoned`
+    // token, and that choice is the load-bearing one. A new status value would have
+    // to be added to 29 separate status sets across exec-core, the broker, the
+    // orch-monitor readers and five hand-copied UI literals (three of which have no
+    // drift guard). A single miss fails in the WORST direction: `isTicketInFlight`
+    // (scheduler.mjs:1226) is a closed allow-list of `failed|stalled|aborted`, so an
+    // unrecognized terminal keeps the ticket "in flight" forever — never advanced,
+    // never reclaimed (classifyWorker → "unknown"), never escalated (the terminal
+    // sweep's anyFailed/anyStalled both stay false), excluded from the recovery pass,
+    // and silently re-dispatched on the next daemon restart (boot-resume.mjs:298).
+    // That is a permanently stranded, permanently INVISIBLE ticket — the exact defect
+    // class this ticket exists to remove, reproduced by its own fix.
+    //
+    // With `failed`, every one of those 29 sets already handles it, so a surface we
+    // have not upgraded yet degrades to "this phase failed" — which is TRUE, and loud.
+    // The abandonment itself rides additive fields plus its own event, and each
+    // display surface can be upgraded independently. Safety by construction; fidelity
+    // opt-in. (Two further traps, both verified: the UI's `isAbandoned()` in
+    // orch-monitor/ui/src/lib/computations.ts:28 returns FALSE for "abandoned" — its
+    // set is {superseded,canceled} — and catalyst-state.sh:469 already uses
+    // `abandoned` for orchestrator heartbeat-expiry GC.)
+    sig.status = "failed";
+    sig.outcome = "abandoned";
+    sig.failureReason = "ended-without-declaration";
+    // CTL-1789: this fires on a CLEAN SDK EXIT, not on an agent declaring anything —
+    // the agent never ran its wrapper (if it had, `status` would already be terminal
+    // and the in-flight precondition above would have returned). Stamp the writer so
+    // the advancement audit can attribute it.
+    sig.assertedBy = ASSERTED_BY.SDK_ABANDONED;
     sig.updatedAt = ts;
-    sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), done: ts };
+    // DELIBERATELY NO `completedAt`. computeLastPhaseAdvanceTs (signal-reader.mjs:85)
+    // reads `completedAt` on any TERMINAL status as a phase ADVANCE and publishes it
+    // as cross-host liveness — an abandoned phase advanced nothing, and claiming
+    // otherwise would feed the liveness plane a fabrication of a different shape.
+    sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), failed: ts };
     const tmp = `${signalFile}.tmp.${process.pid}`;
     writeFileSync(tmp, JSON.stringify(sig));
     renameSync(tmp, signalFile);
+    // SILENCE IS A DEFECT. The old flip wrote a terminal and emitted NOTHING, which
+    // is why 15 of 31 August advancements were invisible. Emit outside the
+    // read→fence→write block above so a logging failure can never affect the write.
+    const t = ticket ?? sig.ticket;
+    const p = phase ?? sig.phase;
+    if (t && p) {
+      appendEventLog({ phase: p, ticket: t, status: "abandoned", reason: "ended-without-declaration" });
+    }
   } catch {
     /* best-effort — the skill's own wrapper flip is the primary path */
   }
@@ -1207,11 +1256,12 @@ export async function sdkRunPhaseAgent(
       if (backstop) {
         emitBackstop({ phase, ticket, status: backstop.status, reason: backstop.reason, orchDir, signalFile }, { spawn });
       } else if (signalFile) {
-        // CTL-1410 Phase A: clean SDK success (no backstop) — in-process safety
-        // net that flips a still-in-flight signal to done. No-op when the phase
-        // SKILL already flipped it via the wrapper (the primary path), or when
-        // this run's generation is stale (superseded by a newer dispatch).
-        flipSignalDoneOnSuccess(signalFile, spec.generation);
+        // CTL-1410 Phase A / CTL-1790: the process exited 0 with no backstop. If
+        // the signal is STILL in-flight the phase SKILL never declared an outcome,
+        // so record ABANDONMENT — not a fabricated success. No-op when the skill
+        // already declared via the wrapper (the primary path), or when this run's
+        // generation is stale (superseded by a newer dispatch).
+        flipSignalAbandonedOnUndeclaredExit(signalFile, spec.generation, { ticket, phase });
       }
       return mapped;
     }

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -578,10 +578,15 @@ export function flipSignalAbandonedOnUndeclaredExit(signalFile, generation, opts
     // the advancement audit can attribute it.
     sig.assertedBy = ASSERTED_BY.SDK_ABANDONED;
     sig.updatedAt = ts;
-    // DELIBERATELY NO `completedAt`. computeLastPhaseAdvanceTs (signal-reader.mjs:85)
-    // reads `completedAt` on any TERMINAL status as a phase ADVANCE and publishes it
-    // as cross-host liveness — an abandoned phase advanced nothing, and claiming
-    // otherwise would feed the liveness plane a fabrication of a different shape.
+    // DELIBERATELY NO `completedAt`. computeLastPhaseAdvanceTs (signal-reader.mjs)
+    // reads it on any TERMINAL status as a phase ADVANCE and publishes it as
+    // cross-host liveness — an abandoned phase advanced nothing.
+    //
+    // Omitting it here is NECESSARY BUT NOT SUFFICIENT (Codex #3310 P2): that reader's
+    // value chain falls back to `updatedAt`, which the line above necessarily sets. The
+    // load-bearing half of this guard therefore lives in the READER, which now skips
+    // any signal carrying `outcome: "abandoned"`. Both halves are required; neither
+    // alone works.
     sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), failed: ts };
     const tmp = `${signalFile}.tmp.${process.pid}`;
     writeFileSync(tmp, JSON.stringify(sig));

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -4,7 +4,7 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test sdk-run-phase-agent.test.mjs
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { isTicketInFlight, deriveAdvancement } from "./scheduler.mjs";
 import { PHASE_EVENT_PATTERN } from "../broker/namespace-contract.mjs";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
@@ -1146,7 +1146,12 @@ describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 tr
     const dir = mkdtempSync(join(tmpdir(), "sdk-flip-"));
     const signalFile = join(dir, "phase-triage.json");
     writeFileSync(signalFile, JSON.stringify({ status: startStatus, ticket: "CTL-1", phase: "triage" }));
-    flipSignalAbandonedOnUndeclaredExit(signalFile);
+    // Codex #3310 P2: NEVER let a unit test reach defaultAppendEventLog — it appends to
+    // the REAL fleet log at getEventLogPath(). VERIFIED by probe: an un-injected call
+    // wrote `phase.triage.abandoned.CTL-1` into this machine's live
+    // ~/catalyst/events/2026-08.jsonl. A test that pollutes the event log can also WAKE
+    // the local dogfooding installation.
+    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, { appendEventLog: () => {} });
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     return after;
@@ -1190,7 +1195,7 @@ describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 tr
       signalFile,
       JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement", generation: 6 })
     );
-    flipSignalAbandonedOnUndeclaredExit(signalFile, 5);
+    flipSignalAbandonedOnUndeclaredExit(signalFile, 5, { appendEventLog: () => {} });
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     expect(after.status).toBe("dispatched");
@@ -1221,9 +1226,10 @@ describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 tr
 
   test("missing / empty / null signalFile never throws", () => {
     expect(() => {
-      flipSignalAbandonedOnUndeclaredExit("/nonexistent/dir/sig.json");
-      flipSignalAbandonedOnUndeclaredExit("");
-      flipSignalAbandonedOnUndeclaredExit(null);
+      const sink = { appendEventLog: () => {} };
+      flipSignalAbandonedOnUndeclaredExit("/nonexistent/dir/sig.json", undefined, sink);
+      flipSignalAbandonedOnUndeclaredExit("", undefined, sink);
+      flipSignalAbandonedOnUndeclaredExit(null, undefined, sink);
     }).not.toThrow();
   });
 
@@ -1235,7 +1241,7 @@ describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 tr
     const sig = { status: "dispatched", ticket: "CTL-1", phase: "implement" };
     if (sigGen !== undefined) sig.generation = sigGen;
     writeFileSync(signalFile, JSON.stringify(sig));
-    flipSignalAbandonedOnUndeclaredExit(signalFile, mine);
+    flipSignalAbandonedOnUndeclaredExit(signalFile, mine, { appendEventLog: () => {} });
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     return after.status;
@@ -1267,6 +1273,26 @@ describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 tr
 });
 
 describe("sdkRunPhaseAgent — CTL-1410 Phase A / CTL-1790 (a clean exit with no declaration is abandonment)", () => {
+  // Codex #3310 P2: these drive the REAL call site, which uses defaultAppendEventLog —
+  // and that appends to getEventLogPath(), i.e. the machine's LIVE fleet event log.
+  // VERIFIED by probe: an un-redirected call wrote `phase.triage.abandoned.CTL-1` into
+  // this machine's real ~/catalyst/events/2026-08.jsonl. Redirect CATALYST_DIR for the
+  // whole block (getEventLogPath re-resolves per call — same technique as the CTL-1488
+  // test below) so a unit test can neither pollute the log nor WAKE the local
+  // dogfooding installation.
+  let prevCatalystDir;
+  let evDir;
+  beforeEach(() => {
+    prevCatalystDir = process.env.CATALYST_DIR;
+    evDir = mkdtempSync(join(tmpdir(), "sdk-abandon-evdir-"));
+    process.env.CATALYST_DIR = evDir;
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(evDir, { recursive: true, force: true });
+  });
+
   test("success + signal still 'dispatched' → abandoned, NOT done (end to end)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
     const signalFile = join(dir, "phase-triage.json");
@@ -2046,7 +2072,9 @@ describe("CTL-1790 — the written terminal is recognized by the live predicates
       signalFile,
       JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement" })
     );
-    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, { ticket: "CTL-1", phase: "implement" });
+    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, {
+      ticket: "CTL-1", phase: "implement", appendEventLog: () => {},
+    });
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     return after;

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -5,6 +5,8 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test sdk-run-phase-agent.test.mjs
 
 import { describe, test, expect } from "bun:test";
+import { isTicketInFlight, deriveAdvancement } from "./scheduler.mjs";
+import { PHASE_EVENT_PATTERN } from "../broker/namespace-contract.mjs";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -19,7 +21,7 @@ import {
   scrubSecrets,
   defaultEmitBackstop,
   defaultAppendEventLog,
-  flipSignalDoneOnSuccess,
+  flipSignalAbandonedOnUndeclaredExit,
   runPrelaunch,
 } from "./sdk-run-phase-agent.mjs";
 import { ASSERTED_BY } from "./assertion-evidence.mjs"; // CTL-1789: terminal-writer attribution
@@ -1133,41 +1135,50 @@ describe("sdkRunPhaseAgent — CTL-1367 item 4 (backstop → stalled signal)", (
 // ── CTL-1410 Phase A: SDK success-branch signal flip ──────────────────────────
 // mapResult subtype==="success" returns backstop:null — historically the ONE
 // abstaining branch (the skill was solely responsible for its own flip). With the
-// event-only phases migrated onto the wrapper, this in-process net flips a
-// still-in-flight (dispatched|running) signal to done so occupancy releases and
-// deriveAdvancement sees a terminal status even if a skill skipped its wrapper
-// call. It must NEVER clobber a terminal status, resurrect a parked hold, nor
-// act on a stale generation (superseded worker).
+// event-only phases migrated onto the wrapper, this in-process net acts on a
+// still-in-flight (dispatched|running) signal. CTL-1790 changed WHAT it writes: it
+// used to fabricate `done`; it now records ABANDONMENT (a recognized terminal that
+// frees the ticket and escalates, but never advances). It must NEVER clobber a
+// terminal status, resurrect a parked hold, nor act on a stale generation.
 
-describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
+describe("flipSignalAbandonedOnUndeclaredExit — CTL-1410 Phase A / CTL-1790 truth table", () => {
   const flipCase = (startStatus) => {
     const dir = mkdtempSync(join(tmpdir(), "sdk-flip-"));
     const signalFile = join(dir, "phase-triage.json");
     writeFileSync(signalFile, JSON.stringify({ status: startStatus, ticket: "CTL-1", phase: "triage" }));
-    flipSignalDoneOnSuccess(signalFile);
+    flipSignalAbandonedOnUndeclaredExit(signalFile);
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     return after;
   };
 
-  test("dispatched (in-flight) → done + completedAt, no attentionReason", () => {
+  // CTL-1790 — THE core behavioural assertion. A clean exit with no declaration is
+  // NOT a success. Any regression to `done` re-opens the 15-of-31 fabricated-advance
+  // defect, so this test is the one that must go red if the fix is reverted.
+  test("dispatched (in-flight) → abandonment, NEVER done", () => {
     const after = flipCase("dispatched");
-    expect(after.status).toBe("done");
-    expect(typeof after.completedAt).toBe("string");
-    expect("attentionReason" in after).toBe(false);
-    expect("failureReason" in after).toBe(false);
+    expect(after.status).not.toBe("done");
+    expect(after.status).toBe("failed");
+    expect(after.outcome).toBe("abandoned");
+    expect(after.failureReason).toBe("ended-without-declaration");
+    // No completedAt: computeLastPhaseAdvanceTs (signal-reader.mjs:85) would read it
+    // on a TERMINAL status as a phase ADVANCE and publish it as cross-host liveness.
+    expect("completedAt" in after).toBe(false);
   });
 
   // CTL-1789: this flip is the canonical FABRICATED terminal — a clean SDK exit,
   // NOT the agent declaring completion. It must stamp its own writer id so the
   // advancement audit can subtract it from the declared advances. Without the
   // marker the signal is byte-indistinguishable from a wrapper-written one.
-  test("CTL-1789: a flipped terminal is stamped assertedBy=sdk-success-flip", () => {
+  test("CTL-1789/CTL-1790: the terminal is stamped assertedBy=sdk-abandoned", () => {
     const after = flipCase("dispatched");
-    expect(after.assertedBy).toBe("sdk-success-flip");
-    expect(after.assertedBy).toBe(ASSERTED_BY.SDK_SUCCESS_FLIP);
+    expect(after.assertedBy).toBe("sdk-abandoned");
+    expect(after.assertedBy).toBe(ASSERTED_BY.SDK_ABANDONED);
     // …and it is NOT the wrapper's declared id.
     expect(after.assertedBy).not.toBe(ASSERTED_BY.PHASE_AGENT);
+    // The retired id must stay REGISTERED so pre-CTL-1790 signals still classify as
+    // fabricated rather than unknown-writer — but nothing may write it any more.
+    expect(after.assertedBy).not.toBe(ASSERTED_BY.SDK_SUCCESS_FLIP);
   });
 
   test("CTL-1789: a bowed-out stale-generation flip stamps NOTHING", () => {
@@ -1179,20 +1190,23 @@ describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
       signalFile,
       JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement", generation: 6 })
     );
-    flipSignalDoneOnSuccess(signalFile, 5);
+    flipSignalAbandonedOnUndeclaredExit(signalFile, 5);
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     expect(after.status).toBe("dispatched");
     expect("assertedBy" in after).toBe(false);
   });
 
-  test("running (in-flight) → done", () => {
-    expect(flipCase("running").status).toBe("done");
+  test("running (in-flight) → the abandonment terminal", () => {
+    const after = flipCase("running");
+    expect(after.status).toBe("failed");
+    expect(after.outcome).toBe("abandoned");
   });
 
-  test("needs-input (parked) is NEVER resurrected to done", () => {
+  test("needs-input (parked) is NEVER resurrected", () => {
     const after = flipCase("needs-input");
     expect(after.status).toBe("needs-input");
+    expect("outcome" in after).toBe(false);
     expect("completedAt" in after).toBe(false);
   });
 
@@ -1200,15 +1214,16 @@ describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
     test(`already-terminal '${terminal}' is not clobbered`, () => {
       const after = flipCase(terminal);
       expect(after.status).toBe(terminal);
+      expect("outcome" in after).toBe(false);
       expect("completedAt" in after).toBe(false);
     });
   }
 
   test("missing / empty / null signalFile never throws", () => {
     expect(() => {
-      flipSignalDoneOnSuccess("/nonexistent/dir/sig.json");
-      flipSignalDoneOnSuccess("");
-      flipSignalDoneOnSuccess(null);
+      flipSignalAbandonedOnUndeclaredExit("/nonexistent/dir/sig.json");
+      flipSignalAbandonedOnUndeclaredExit("");
+      flipSignalAbandonedOnUndeclaredExit(null);
     }).not.toThrow();
   });
 
@@ -1220,7 +1235,7 @@ describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
     const sig = { status: "dispatched", ticket: "CTL-1", phase: "implement" };
     if (sigGen !== undefined) sig.generation = sigGen;
     writeFileSync(signalFile, JSON.stringify(sig));
-    flipSignalDoneOnSuccess(signalFile, mine);
+    flipSignalAbandonedOnUndeclaredExit(signalFile, mine);
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
     rmSync(dir, { recursive: true, force: true });
     return after.status;
@@ -1230,29 +1245,29 @@ describe("flipSignalDoneOnSuccess — CTL-1410 Phase A truth table", () => {
     expect(fenceCase(5, 6)).toBe("dispatched");
   });
 
-  test("current generation (mine == signal) flips", () => {
-    expect(fenceCase(6, 6)).toBe("done");
+  test("current generation (mine == signal) writes the terminal", () => {
+    expect(fenceCase(6, 6)).toBe("failed");
   });
 
   test("newer generation (mine > signal) flips (fail-open, matches isCurrentGeneration)", () => {
-    expect(fenceCase(7, 6)).toBe("done");
+    expect(fenceCase(7, 6)).toBe("failed");
   });
 
   test("missing own generation fails open (legacy/unfenced dispatch) — flips", () => {
-    expect(fenceCase(undefined, 6)).toBe("done");
+    expect(fenceCase(undefined, 6)).toBe("failed");
   });
 
   test("missing signal generation fails open — flips", () => {
-    expect(fenceCase(5, undefined)).toBe("done");
+    expect(fenceCase(5, undefined)).toBe("failed");
   });
 
   test("non-numeric generations fail open — flips", () => {
-    expect(fenceCase("garbage", "alsogarbage")).toBe("done");
+    expect(fenceCase("garbage", "alsogarbage")).toBe("failed");
   });
 });
 
-describe("sdkRunPhaseAgent — CTL-1410 Phase A (success flips in-flight signal to done)", () => {
-  test("success + signal still 'dispatched' → flipped to done (the safety net)", async () => {
+describe("sdkRunPhaseAgent — CTL-1410 Phase A / CTL-1790 (a clean exit with no declaration is abandonment)", () => {
+  test("success + signal still 'dispatched' → abandoned, NOT done (end to end)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "sdk-flip-e2e-"));
     const signalFile = join(dir, "phase-triage.json");
     const spec = makeSpec({ signalFile });
@@ -1266,8 +1281,12 @@ describe("sdkRunPhaseAgent — CTL-1410 Phase A (success flips in-flight signal 
     expect(r.code).toBe(0);
     expect(backstops).toHaveLength(0);
     const after = JSON.parse(readFileSync(signalFile, "utf8"));
-    expect(after.status).toBe("done");
-    expect(typeof after.completedAt).toBe("string");
+    // The whole point of CTL-1790: a zero exit code is not evidence of work.
+    expect(after.status).not.toBe("done");
+    expect(after.status).toBe("failed");
+    expect(after.outcome).toBe("abandoned");
+    expect(after.failureReason).toBe("ended-without-declaration");
+    expect("completedAt" in after).toBe(false);
     expect("attentionReason" in after).toBe(false);
     rmSync(dir, { recursive: true, force: true });
   });
@@ -2008,5 +2027,94 @@ describe("defaultAppendEventLog — CTL-1488 stamps the coordination stream clas
       else process.env.CATALYST_DIR = prev;
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── CTL-1790: the abandonment terminal must FREE the ticket and NOT advance it ──
+//
+// The truth-table block above pins what gets WRITTEN. These two pin what the rest of
+// the system DOES with it, by driving the real production predicates rather than
+// re-stating a status literal. They are the anti-wedge tests: the measured hazard of
+// this change is a terminal the readers do not recognize, which leaves the ticket
+// in-flight forever — never advanced, never reclaimed, never escalated, and silently
+// re-dispatched on the next daemon restart.
+describe("CTL-1790 — the written terminal is recognized by the live predicates", () => {
+  const writeAbandoned = () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-abandon-live-"));
+    const signalFile = join(dir, "phase-implement.json");
+    writeFileSync(
+      signalFile,
+      JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement" })
+    );
+    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, { ticket: "CTL-1", phase: "implement" });
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    rmSync(dir, { recursive: true, force: true });
+    return after;
+  };
+
+  // T1 — THE ANTI-WEDGE TEST. isTicketInFlight (scheduler.mjs) is a CLOSED allow-list
+  // of failed|stalled|aborted; a status outside it returns true forever. Driving the
+  // real function means this fails if the writer ever emits an unrecognized terminal
+  // (including a bare `abandoned`), and also fails if someone narrows the allow-list.
+  test("the ticket is no longer in flight — the slot and the claim are freed", () => {
+    const after = writeAbandoned();
+    expect(isTicketInFlight({ implement: after.status })).toBe(false);
+  });
+
+  // T2 — THE ticket's single hard requirement. An undeclared exit must not move the
+  // pipeline forward. Fails the moment the writer regresses to "done".
+  test("the pipeline does NOT advance off an undeclared exit", () => {
+    const after = writeAbandoned();
+    expect(deriveAdvancement({ implement: after.status })).toBeNull();
+    // and the control: a genuinely declared `done` DOES advance, so the assertion
+    // above is testing the status and not a broken call.
+    expect(deriveAdvancement({ implement: "done" })).not.toBeNull();
+  });
+
+  // T3 — silence is a defect: exactly one event, correctly named, is emitted.
+  test("exactly one phase.<phase>.abandoned.<ticket> event is emitted", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-abandon-ev-"));
+    const signalFile = join(dir, "phase-implement.json");
+    writeFileSync(
+      signalFile,
+      JSON.stringify({ status: "running", ticket: "CTL-1", phase: "implement" })
+    );
+    const seen = [];
+    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, {
+      ticket: "CTL-1",
+      phase: "implement",
+      appendEventLog: (e) => seen.push(e),
+    });
+    rmSync(dir, { recursive: true, force: true });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].status).toBe("abandoned");
+    expect(seen[0].phase).toBe("implement");
+    expect(seen[0].ticket).toBe("CTL-1");
+    expect(`phase.${seen[0].phase}.${seen[0].status}.${seen[0].ticket}`).toBe(
+      "phase.implement.abandoned.CTL-1"
+    );
+    // and it must be routable by the broker's contract, not a silently-dropped orphan
+    expect(PHASE_EVENT_PATTERN.test("phase.implement.abandoned.CTL-1")).toBe(true);
+  });
+
+  // T4 — a bow-out (parked / already-terminal / stale generation) emits NOTHING.
+  // An event without a matching write would be a fabrication of the opposite kind.
+  test("a bowed-out call writes nothing and emits nothing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "sdk-abandon-bow-"));
+    const signalFile = join(dir, "phase-implement.json");
+    writeFileSync(
+      signalFile,
+      JSON.stringify({ status: "dispatched", ticket: "CTL-1", phase: "implement", generation: 9 })
+    );
+    const seen = [];
+    flipSignalAbandonedOnUndeclaredExit(signalFile, 8, {
+      ticket: "CTL-1",
+      phase: "implement",
+      appendEventLog: (e) => seen.push(e),
+    });
+    const after = JSON.parse(readFileSync(signalFile, "utf8"));
+    rmSync(dir, { recursive: true, force: true });
+    expect(after.status).toBe("dispatched");
+    expect(seen).toHaveLength(0);
   });
 });

--- a/plugins/dev/scripts/execution-core/signal-reader.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.mjs
@@ -83,6 +83,16 @@ export function computeLastPhaseAdvanceTs(signals, { self, now = Date.now() } = 
       if (!signal || typeof signal !== "object") continue;
       const status = String(signal.status ?? "").toLowerCase();
       if (!TERMINAL.has(status) && status !== "complete" && status !== "completed") continue;
+      // CTL-1790 (Codex #3310 P2): an ABANDONED phase advanced nothing, so its
+      // timestamp must not publish as a phase advance. Omitting `completedAt` at the
+      // writer is NOT sufficient — the value chain below falls back to `updatedAt`,
+      // which the writer necessarily sets, so the abandonment would still surface as
+      // `lastAdvanceAt` and report productivity for a phase that explicitly did not
+      // advance. That is a fabrication of the same family this ticket removes, just
+      // in the liveness plane instead of the pipeline. Keyed on the additive
+      // `outcome` field so no other terminal's behaviour changes.
+      const outcome = String(signal.outcome ?? signal.raw?.outcome ?? "").toLowerCase();
+      if (outcome === "abandoned") continue;
       const host = signal.raw?.host?.name ?? signal.host?.name ?? null;
       if (host != null && host !== self) continue;
       const value = signal.completedAt ?? signal.raw?.completedAt ?? signal.updatedAt ?? signal.raw?.updatedAt;

--- a/plugins/dev/scripts/execution-core/signal-reader.test.mjs
+++ b/plugins/dev/scripts/execution-core/signal-reader.test.mjs
@@ -584,3 +584,34 @@ describe("hasFreshClaim (CTL-1367 P2-G)", () => {
     expect(hasFreshClaim(orchDir, "CTL-NOPE", "triage")).toBe(false);
   });
 });
+
+// CTL-1790 (Codex #3310 P2) — an ABANDONED phase advanced nothing, so it must not
+// publish as a phase advance. Omitting `completedAt` at the writer is not enough:
+// the value chain falls back to `updatedAt`, which the writer necessarily sets.
+describe("computeLastPhaseAdvanceTs — abandonment is not an advance", () => {
+  const abandoned = {
+    status: "failed",
+    outcome: "abandoned",
+    updatedAt: "2026-08-12T23:00:00Z",
+  };
+
+  test("a signal with outcome:'abandoned' contributes no advance timestamp", () => {
+    expect(computeLastPhaseAdvanceTs([abandoned], { now: Date.parse("2026-08-12T23:30:00Z") })).toBeNull();
+  });
+
+  // POSITIVE CONTROL — the same shape WITHOUT the outcome field must still count,
+  // proving the test above is exercising the exclusion and not a broken call.
+  test("an ordinary failed terminal still contributes its updatedAt", () => {
+    const { outcome, ...plainFailed } = abandoned;
+    expect(computeLastPhaseAdvanceTs([plainFailed], { now: Date.parse("2026-08-12T23:30:00Z") })).toBe(
+      "2026-08-12T23:00:00.000Z",
+    );
+  });
+
+  test("abandonment does not mask a genuine advance from another phase", () => {
+    const real = { status: "done", completedAt: "2026-08-12T22:00:00Z" };
+    expect(computeLastPhaseAdvanceTs([abandoned, real], { now: Date.parse("2026-08-12T23:30:00Z") })).toBe(
+      "2026-08-12T22:00:00.000Z",
+    );
+  });
+});


### PR DESCRIPTION
Closes CTL-1790.

## What this removes

`flipSignalDoneOnSuccess` wrote `status: "done"` into a phase signal whenever an SDK or codex-exec
worker exited zero **without declaring an outcome**, and emitted nothing at all. That is where
**15 of 31** measured August 2026 phase advancements came from: success inferred from a process
exiting quietly, declared by nothing that did the work, and silent.

Under the goal-loop contract a worker declares its own outcome or nothing is recorded. So the
fabrication goes.

## ⛔ What this deliberately does NOT remove — and why the obvious version of this PR is a bug

The one-line framing is *"delete the flip"*. Taken literally that strands work permanently and
invisibly. `isTicketInFlight` (`scheduler.mjs:1226`) is a **closed allow-list**:

```js
if (status === "failed" || status === "stalled" || status === "aborted") return false;
```

so a signal that never reaches a recognized terminal falls through to `return true` forever:

| effect | predicate |
| -- | -- |
| never reclaimed | `classifyWorker` (`recovery.mjs:362`) → `"unknown"` → `reclaimDeadWorkIfPossible:2340` → `noop` |
| never escalated | terminal sweep `scheduler.mjs:8167-8168` — `anyFailed`/`anyStalled` both stay false |
| excluded from the autonomy loop | recovery Pass 0r `scheduler.mjs:5667` filters `{needs-human, failed, stalled}` |
| silently re-dispatched on restart | `boot-resume.mjs:298` `!TERMINAL.has(s.status)` |
| leaks a per-project slot | `scheduler.mjs:1857` |

**An event cannot substitute for the terminal write** — every reader that frees a ticket reads the
**signal file**, not the event log. So the fabricated success becomes a *declared non-outcome*, still
written terminal.

### Correction to the ticket's own earlier reasoning

The prior ticket body claimed `countSdkInflight` counts such a signal and *"six exits wedge the node
at maxParallel:6"*. **That is false**, and it had never been executed before being written down:

```js
signal-reader.mjs:237  const SDK_INFLIGHT_STATUSES = new Set(["dispatched", "running"]);
signal-reader.mjs:259  if (!SDK_INFLIGHT_STATUSES.has(s.status)) continue;
```

A positive in-flight allow-list — safe by construction. The real failure strands rather than wedges.
Recorded in the ticket rather than quietly edited, because asserting a chain without executing it is
the defect class this initiative exists to remove.

## The encoding — `status: "failed"` + `outcome: "abandoned"`, not a new status token

```js
sig.status        = "failed";                      // recognized by every terminal set
sig.outcome       = "abandoned";
sig.failureReason = "ended-without-declaration";
sig.assertedBy    = ASSERTED_BY.SDK_ABANDONED;
// NO completedAt — signal-reader.mjs:85 reads it on a terminal status as a phase ADVANCE
//                  and publishes it as cross-host liveness.
```

A new `abandoned` **status value** would need adding to **29** status sets across exec-core, the
broker, the orch-monitor readers and **five hand-copied UI literals, three with no drift guard**. One
miss strands a ticket invisibly. With `failed`, all 29 already handle it, so any surface not yet
upgraded degrades to *"this phase failed"* — **true, and loud**. Safety by construction; display
fidelity opt-in.

Two verified traps make the literal token actively hazardous, not merely costly:

- `orch-monitor/ui/src/lib/computations.ts:28` — `ABANDONED_STATUSES = new Set(["superseded","canceled"])`.
  A function **named `isAbandoned()` returns `false` for `"abandoned"`**, so `isSettled()` does too and
  the dashboard would carry the worker as permanently unsettled. The names match; the behaviour doesn't.
- `catalyst-state.sh:469` already writes `.status = "abandoned"` for **orchestrator** heartbeat-expiry
  GC — two different things named `abandoned` in one event log.

The **event** is still `phase.<name>.abandoned.<ticket>`, registered in the CTL-1142 namespace.

## Silence is a defect

The old path wrote a terminal and emitted **nothing** — which is why the 15 fabrications were
invisible. This emits exactly one `phase.<name>.abandoned.<ticket>`, outside the read→fence→write
block so a logging failure can never affect the write. `router.mjs` gains its own reason arm (its
trailing branch is a catch-all, so without it an abandoned phase reads as a plain failure in the wake
envelope, broker log and HUD). `projection.mjs` gains the token **and the `skipped` it had been
missing since CTL-512** — that copy had drifted from the contract it claims to mirror.

## `SDK_SUCCESS_FLIP` is kept registered, not renamed

Signals and events written before this change still carry it. Dropping the id would classify them
`unknown-writer` — and per `assertion-evidence-parity.test.mjs`'s own header, that would *"corrupt the
advancement audit this ticket exists to produce"*, retroactively blinding the CTL-1789 instrument to
the very 15-of-31 fabrications that motivated this work. A new `SDK_ABANDONED` is added alongside it.
This also keeps the blast radius to two test files instead of five.

## Both executors

`codex-run-phase-agent.mjs:1771` imports and calls the same function. Its parity tests assert the new
contract, so fixing only the SDK path fails CI.

## Tests drive the real predicates, not status literals

```js
expect(isTicketInFlight({ implement: after.status })).toBe(false);   // anti-wedge
expect(deriveAdvancement({ implement: after.status })).toBeNull();   // must not advance
expect(deriveAdvancement({ implement: "done" })).not.toBeNull();     // positive control
```

Importing the production functions means these also fail if either allow-list is later narrowed, or if
the writer ever emits an unrecognized terminal — including a future bare `abandoned`.

## Verification

Targeted suites, all green: `sdk-run-phase-agent` 135/136, `codex-run-phase-agent` 72/72,
`assertion-evidence` + parity 32/32, broker `namespace-parity` 8/8. The single `sdk` failure is the
documented `CLAUDE_CODE_OAUTH_TOKEN` env false-fail, present identically on pristine `main`.

Full `execution-core` suite compared **by failing-test name** against a pristine `origin/main`
worktree (counts alone are unreliable — the same tree yielded 67 and 69 on two runs):

- baseline **64** unique failures, this branch **65**
- the single set difference is two load-sensitive **timeout** tests whose membership rotates:
  `CTL-671 "stops dispatching after THRESHOLD"` **passes on both trees in isolation** (3.37 s each
  against a 5000 ms limit; it tips over when `terminal-sweep` runs ~380 ms/tick under load), and
  `CTL-1667 "advancement sweep still advances…"` **fails on both trees in isolation**.
- **No failure is attributable to this change.**

⚠️ Worth flagging separately: `main` currently carries **64 failing execution-core tests**. That is
pre-existing and independent of this PR, but it means the suite cannot presently be used as a
pass/fail gate — only as a differential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)