### PR TITLE
fix(dev): CTL-1812 — stop the event mirror silently skipping 15% of the fleet's events

### DIFF
--- a/plugins/dev/scripts/event-mirror/index.test.ts
+++ b/plugins/dev/scripts/event-mirror/index.test.ts
@@ -43,9 +43,31 @@ describe("extractEventId", () => {
   test("reads attributes[event.id]", () => {
     expect(extractEventId(JSON.stringify({ attributes: { "event.id": "eid" } }))).toBe("eid");
   });
-  test("falls back to ts:name composite", () => {
+  // CTL-1812: this USED to return the `${ts}:${name}` composite. That is not an
+  // identity — two distinct events sharing a timestamp and a name collided, and the
+  // second was silently dropped as a duplicate. Measured: 35,931 real events suppressed
+  // across the two worker logs, 100% via this path. There is now no fallback id, and the
+  // caller's conservative path includes the line instead.
+  test("an event with no real id has NO fallback id — it must not be synthesised", () => {
     const line = JSON.stringify({ ts: "2026-08", attributes: { "event.name": "foo" } });
-    expect(extractEventId(line)).toBe("2026-08:foo");
+    expect(extractEventId(line)).toBeNull();
+  });
+
+  test("two DISTINCT events sharing ts and name are not collapsed", () => {
+    const a = JSON.stringify({ ts: "2026-08", attributes: { "event.name": "foo" }, body: { n: 1 } });
+    const b = JSON.stringify({ ts: "2026-08", attributes: { "event.name": "foo" }, body: { n: 2 } });
+    const state = newMirrorState();
+    const out = filterNewLines(state, [a, b], "2026-08.jsonl");
+    expect(out).toHaveLength(2);
+  });
+
+  // POSITIVE CONTROL — a real id still dedups, so the test above is proving the fallback
+  // was removed rather than that dedup stopped working altogether.
+  test("a real event id still dedups", () => {
+    const line = JSON.stringify({ id: "real-1", ts: "2026-08" });
+    const state = newMirrorState();
+    expect(filterNewLines(state, [line], "2026-08.jsonl")).toHaveLength(1);
+    expect(filterNewLines(state, [line], "2026-08.jsonl")).toHaveLength(0);
   });
   test("returns null for unparseable line", () => {
     expect(extractEventId("not json")).toBeNull();
@@ -260,5 +282,82 @@ describe("resolveHosts — roster resolution", () => {
     withEnv({ CATALYST_CLUSTER_JSON: join(tmp, "does-not-exist.json") }, () => {
       expect(resolveHosts()).toEqual([]);
     });
+  });
+});
+
+// ── CTL-1812: the cursor race that lost 341,356 events ────────────────────────
+//
+// `tail -c +N` always reads to EOF, so `bytesRead` is (EOF - cursor). The old code did
+// `hs.cursor += bytesRead`, a read-modify-write on shared state — two overlapping ticks
+// each added (EOF - cursor) to the SAME starting cursor and parked it at roughly
+// 2*EOF - cursor, far past the end of the remote file. While parked, `tail -c +N`
+// returns nothing and the mirror goes DARK: events are skipped with no fragment, no
+// error, and no unhealthy host. Measured consequence on this node: 167,118 of mini's
+// events (15.63%) and 174,238 of mini-2's (13.60%) simply absent.
+describe("CTL-1812 — overlapping ticks must not park the cursor past remote EOF", () => {
+  // A fake remote whose content grows, and which behaves exactly like `tail -c +N`:
+  // reads from `cursor` to EOF, returning nothing once the cursor is past the end.
+  const makeRemote = (content: string) => {
+    const fetchFn: FetchFn = async (_host, cursor) => {
+      const buf = Buffer.from(content, "utf8");
+      if (cursor >= buf.length) return { lines: [], bytesRead: 0 };
+      const slice = buf.subarray(cursor).toString("utf8");
+      return { lines: slice.split("\n").filter((l) => l.trim()), bytesRead: Buffer.byteLength(slice, "utf8") };
+    };
+    return fetchFn;
+  };
+
+  const lines = (n: number, tag: string) =>
+    Array.from({ length: n }, (_, i) => JSON.stringify({ id: `${tag}-${i}`, ts: "2026-08" })).join("\n") + "\n";
+
+  test("two CONCURRENT ticks leave the cursor at EOF, not past it", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mirror-race-"));
+    try {
+      const content = lines(50, "a");
+      const fetchFn = makeRemote(content);
+      const state = newMirrorState();
+      const localFile = join(dir, "2026-08.jsonl");
+
+      // Fire both ticks WITHOUT awaiting the first — the exact shape setInterval had.
+      await Promise.all([
+        mirrorTick({ hosts: ["h1"], state, fetchFn, localFile }),
+        mirrorTick({ hosts: ["h1"], state, fetchFn, localFile }),
+      ]);
+
+      const eof = Buffer.byteLength(content, "utf8");
+      // THE ASSERTION. With `cursor += bytesRead` this lands at ~2*eof and the mirror
+      // goes dark for everything written before the remote catches up.
+      expect(state.byHost["h1"].cursor).toBeLessThanOrEqual(eof);
+      expect(state.byHost["h1"].cursor).toBe(eof);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("after concurrent ticks, subsequently-appended events are still mirrored", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mirror-race2-"));
+    try {
+      const first = lines(20, "a");
+      const state = newMirrorState();
+      const localFile = join(dir, "2026-08.jsonl");
+
+      await Promise.all([
+        mirrorTick({ hosts: ["h1"], state, fetchFn: makeRemote(first), localFile }),
+        mirrorTick({ hosts: ["h1"], state, fetchFn: makeRemote(first), localFile }),
+      ]);
+
+      // The remote grows. A parked cursor would skip straight past these.
+      const grown = first + lines(20, "b");
+      await mirrorTick({ hosts: ["h1"], state, fetchFn: makeRemote(grown), localFile });
+
+      const body = readFileSync(localFile, "utf8");
+      // Every one of the later events must be present — this is the 341k-event property.
+      for (let i = 0; i < 20; i++) {
+        expect(body).toContain(`"b-${i}"`);
+      }
+      expect(state.byHost["h1"].cursor).toBe(Buffer.byteLength(grown, "utf8"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/dev/scripts/event-mirror/index.ts
+++ b/plugins/dev/scripts/event-mirror/index.ts
@@ -164,14 +164,26 @@ export async function mirrorTick(opts: MirrorTickOpts): Promise<TickResult> {
       }
       hs.currentFile = currentFile;
 
+      // CTL-1812: capture the offset this read STARTS at, and set the cursor
+      // ABSOLUTELY from it below. The previous `hs.cursor += bytesRead` was a
+      // read-modify-write on shared mutable state, and `tail -c +N` always reads to
+      // EOF — so two overlapping ticks each added (EOF - cursor) to the SAME cursor
+      // and parked it far past EOF. While parked, `tail -c +N` returns nothing and
+      // the mirror goes DARK: events are skipped silently, with no fragment and no
+      // error. MEASURED consequence: 341,356 events (15.6% of mini, 13.6% of mini-2)
+      // absent from this node's copy, and 200 mid-string fragments produced when the
+      // remote later grew past the parked cursor. Setting it absolutely makes the
+      // update idempotent — an overlapping tick now computes the SAME endpoint
+      // instead of doubling it.
+      const startCursor = hs.cursor;
       try {
-        const { lines, bytesRead } = await fetchFn(host, hs.cursor, currentFile);
+        const { lines, bytesRead } = await fetchFn(host, startCursor, currentFile);
         const survivors = filterNewLines(state, lines, currentFile);
         if (survivors.length > 0) {
           appendFileSync(localFile, survivors.map(l => l + "\n").join(""));
           totalAppended += survivors.length;
         }
-        hs.cursor += bytesRead;
+        hs.cursor = startCursor + bytesRead;
         hs.healthy = true;
         hs.lastSeenTs = new Date().toISOString();
         byHostResult[host] = { healthy: true, linesAppended: survivors.length };
@@ -234,9 +246,39 @@ if (import.meta.main) {
     persistState(state);
   };
 
+  // CTL-1812: RE-ENTRANCY GUARD. `setInterval(async ...)` does not await the previous
+  // callback, so a tick slower than intervalMs — which a catch-up read against a 1 GB
+  // remote log reliably is — starts while the last one is still in flight. That was the
+  // trigger for the cursor race above. The absolute-cursor fix makes an overlap
+  // HARMLESS; this makes it not happen, which also stops us re-reading (and buffering)
+  // the same gigabyte twice.
+  //
+  // A skipped tick costs only latency: the next one reads from the same cursor to EOF,
+  // so nothing is missed. That is the "an event means go look" property — the tick is
+  // idempotent by observation, so declining to run one cannot lose data.
+  let tickInFlight = false;
+  let ticksSkipped = 0;
+  const guardedTick = async () => {
+    if (tickInFlight) {
+      ticksSkipped += 1;
+      // Silence is a defect: a mirror permanently skipping ticks is a mirror falling
+      // behind, and it must be visible rather than inferred from missing events later.
+      console.warn(
+        `[catalyst-event-mirror] tick still in flight — skipped (${ticksSkipped} since start)`
+      );
+      return;
+    }
+    tickInFlight = true;
+    try {
+      await tick();
+    } catch (err) {
+      console.error("[catalyst-event-mirror] tick error:", err);
+    } finally {
+      tickInFlight = false;
+    }
+  };
+
   // Run immediately then on interval.
-  await tick().catch(err => console.error("[catalyst-event-mirror] tick error:", err));
-  setInterval(async () => {
-    await tick().catch(err => console.error("[catalyst-event-mirror] tick error:", err));
-  }, intervalMs);
+  await guardedTick();
+  setInterval(guardedTick, intervalMs);
 }

--- a/plugins/dev/scripts/event-mirror/lib/state.ts
+++ b/plugins/dev/scripts/event-mirror/lib/state.ts
@@ -49,10 +49,23 @@ export function extractEventId(line: string): string | null {
     if (typeof obj?.id === "string") return obj.id;
     if (typeof obj?.event_id === "string") return obj.event_id;
     if (typeof obj?.attributes?.["event.id"] === "string") return obj.attributes["event.id"];
-    // Fall back to the ts + event.name composite as a pseudo-id for events without an id field.
-    const ts = obj?.ts ?? obj?.time ?? null;
-    const name = obj?.attributes?.["event.name"] ?? obj?.event ?? null;
-    if (ts && name) return `${ts}:${name}`;
+    // CTL-1812: there is NO fallback id, deliberately.
+    //
+    // This used to return the `${ts}:${name}` composite, which is not an identity — two
+    // genuinely distinct events sharing a timestamp and an event name collide, and the
+    // second is silently discarded as a duplicate. MEASURED: replaying that rule over the
+    // authoritative worker logs suppressed 35,931 real events (14,660 mini + 21,271
+    // mini-2), 100% of them via this path and 0 via a real id.
+    //
+    // A CONTENT HASH was the obvious replacement and is also WRONG — measured before
+    // adopting it: mini's own August log contains 14,515 byte-identical duplicate lines
+    // (1.32% of 1,096,795). Those are real, separately-emitted events, so hashing would
+    // trade one silent-loss bug for a smaller one. Fewer lost events is still lost events.
+    //
+    // So we return null and let the caller's conservative path include the line. A
+    // duplicate is visible and harmless; a dropped event is neither. The dedup ring
+    // still does its job for every event that carries a REAL id, which is the population
+    // it was built for.
     return null;
   } catch {
     return null;


### PR DESCRIPTION
Closes CTL-1812.

## The defect — 341,356 events, silently, with every surface green

Measured on this monitor node against both workers' authoritative logs:

```
mini  : 1,069,008 ids →  167,118 ABSENT from the mirror (15.63%)
mini-2: 1,281,620 ids →  174,238 ABSENT                 (13.60%)
                         ───────
                         341,356 events silently missing
```

For `host.name=mini`, **2026-08-08 alone is missing 92,665 of 108,203 events (85.6%)**. First damage
`2026-08-06T14:59:18Z` — the day the mirror shipped. The laptop's July file contains **0**
`catalyst.event_mirror.tick` events and **0** damage.

`catalyst-events wait-for` on a monitor node has therefore been answering from a corpus missing
**one event in seven**, and nothing anywhere went red.

## The mechanism, reproduced from the shipped code

`tail -c +N` always reads to EOF, so `bytesRead` is `(EOF - cursor)`. The tick did:

```ts
hs.cursor += bytesRead;                       // read-modify-write on shared state
...
setInterval(async () => { await tick(); });   // never awaits the previous callback
```

A catch-up read against a 1 GB remote reliably outruns the interval, so two ticks overlap and **each
adds `(EOF - cursor)` to the same starting cursor**, parking it at roughly `2*EOF`.

While the cursor sits past EOF, `tail -c +N` returns nothing — **the mirror goes dark**, skipping
events with no fragment, no error, and no unhealthy host. It then **self-heals** once the remote grows
past the parked cursor, which is why it was never noticed, and it is where the 200 mid-string
fragments in the local log come from (the next read starts mid-line).

## Two fixes, addressing different halves

**1. The cursor is set ABSOLUTELY**, from the offset the read started at — so an overlapping tick
computes the *same* endpoint instead of doubling it. This is the correctness fix: overlap becomes
harmless.

**2. A re-entrancy guard** stops ticks overlapping at all, which also stops re-reading and buffering
the same gigabyte twice. A skipped tick costs only latency — the next reads from the same cursor to
EOF — and it **says so out loud** rather than skipping silently.

Belt and braces on purpose: (1) makes the data correct, (2) makes the resource behaviour sane. Either
alone would leave the other problem.

## The pseudo-id, and the fix I measured my way out of

`extractEventId` fell back to a `${ts}:${name}` composite. That is **not an identity** — two distinct
events sharing a timestamp and an event name collide, and the second is dropped as a duplicate.
Measured: **35,931 real events suppressed** (14,660 mini + 21,271 mini-2), **100% via that path, 0 via
a real id**.

A **content hash** was the obvious replacement, and I implemented it — then measured it before
trusting it:

```
mini 2026-08: 1,096,795 lines, 14,515 byte-identical duplicates (1.32%)
```

Those are real, separately-emitted events. Hashing would have **traded one silent-loss bug for a
smaller one**, which is still the disease. So there is now **no fallback id at all**: `extractEventId`
returns `null` and the caller's existing conservative path includes the line.

A duplicate is visible and harmless; a dropped event is neither. The dedup ring still does its job for
every event that carries a real id — the population it was built for.

## Mutation-verified

The regression tests fire **two concurrent `mirrorTick`s** against a fake remote that behaves exactly
like `tail -c +N`, then assert the cursor lands at EOF and that subsequently-appended events still
arrive.

Restoring `hs.cursor += bytesRead`:

```
Expected: <= 1440
Received:    2880          ← exactly 2x EOF, the doubling
Expected to contain: "b-0"
Received: ...only a-0 … a-19…   ← every later event absent from the mirror
```

That is the production defect reproduced in a unit test, and it is why these tests are worth having:
they go red for the actual mechanism, not for a proxy.

## Verification

- `event-mirror` suite: **23 pass, 0 fail** (was 19 before; +4 new, 2 rewritten).
- The two rewritten tests asserted the old pseudo-id behaviour and are replaced with ones asserting
  distinct events are not collapsed, plus a **positive control** proving a real id still dedups (so
  the change removed the fallback rather than breaking dedup outright).

## Not in this change

**Backfill.** The 341,356 missing events are recoverable — both worker logs are byte-clean and still
hold every one — but re-mirroring is an operational step, not a code change. It should follow this
merge, and it is the reason the fix is worth landing before any subscriber owns a state transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
