### PR TITLE
feat(dev): CTL-1808 — the fast-forward becomes a subscriber, not a call (part 1: the scanner)

### DIFF
--- a/plugins/dev/scripts/execution-core/checkout-sync.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.mjs
@@ -1,0 +1,267 @@
+// checkout-sync.mjs — CTL-1808. Keep every enrolled PRIMARY checkout at origin/<default>.
+//
+// ─── WHY THIS IS A SUBSCRIBER AND NOT A CALL ────────────────────────────────────
+//
+// The primary checkout must fast-forward when something merges. That was built the old
+// way — a helper (`pull-primary-worktree.sh`) invoked explicitly by the merge skill — and
+// it decayed exactly as that shape always decays: the helper acquired two callers plus a
+// third INLINE reimplementation inside one of them (`merge-pr/SKILL.md:458-461` runs its
+// own `git checkout $base && git pull` a few lines from where it calls the helper), while
+// the workflow moved out from under it. `phase-monitor-merge`, `phase-teardown`, PR triage,
+// recovery-pass, and every merge a human does by hand have never called it.
+//
+// On 2026-08-12 that produced four measured incidents in one day: two agents read stale
+// trees and each came within one inference of filing "this feature was never built" against
+// work that was merged, deployed, and in front of a live customer (one checkout 22 commits
+// behind, another 17); and a stale sibling clone hid a ratified ADR from three separate
+// agents, each of whom concluded the document did not exist.
+//
+// Adding the call to the paths that lack it reproduces the bug. So does moving it to a
+// shared "merge confirmed" seam — BOTH still couple the side effect to the merger, and the
+// sixth merge path written next month misses it again. So the merge emits nothing extra and
+// knows nothing; THIS runs on its own clock and reacts to the world.
+//
+// ─── THE RULE THAT SHAPES THE MECHANISM ─────────────────────────────────────────
+//
+// "Let the event wake the scan; never let it replace the scan." A periodic pass holds the
+// entire correctness intent; an event may only make it happen sooner. This module therefore
+// takes NO argument describing what merged — it cannot act on an event's contents even by
+// mistake — and it keeps NO record of work done: no consumed offset, no handled-merge
+// marker, no cursor. It asks the world every pass.
+//
+// That is not academic here. The local event log on a monitor node was MEASURED (CTL-1812)
+// to be missing 341,356 events — 15.6% of one worker's and 13.6% of the other's. A design
+// that is correct only when it receives the event would be wrong one time in seven on this
+// very machine. If every event were lost, this still converges within one interval.
+//
+// ─── WHAT IT MAY DO ─────────────────────────────────────────────────────────────
+//
+// The entire mutating vocabulary is `git fetch <one refspec>` and `git merge --ff-only`.
+// Explicitly never, on any path or flag: reset, checkout, clean, stash, rebase, gc, prune,
+// remote set-head, tag fetch, config write, or any deletion. If a situation needs a
+// decision, it is not this automation's to make — it refuses and says exactly what it found.
+
+import { createHash } from "node:crypto";
+
+// ── Outcomes ──────────────────────────────────────────────────────────────────
+// A closed vocabulary. `refused` always carries a `refused_reason`; `fetch-failed` is
+// deliberately NOT a refusal — transient infrastructure must never read as a human problem.
+export const ACTION = Object.freeze({
+  CURRENT: "current",
+  ADVANCED: "advanced",
+  REFUSED: "refused",
+  FETCH_FAILED: "fetch-failed",
+  SKIPPED: "skipped",
+  DIAGNOSTIC: "diagnostic-only",
+});
+
+// REFUSAL — every reason this automation declines to act. Each is a state a human must
+// resolve, and each is reported verbatim rather than summarised, because "refused" without
+// the reason is the silent failure this ticket exists to remove.
+export const REFUSAL = Object.freeze({
+  DETACHED: "detached-head",
+  WRONG_BRANCH: "primary-on-other-branch",
+  OP_IN_PROGRESS: "git-operation-in-progress",
+  LOCAL_COMMITS: "unpushed-local-commits",
+  FF_BLOCKED: "ff-blocked-by-local-changes",
+  NO_UPSTREAM: "no-upstream",
+  DEFAULT_UNRESOLVED: "default-branch-unresolved",
+  BROKEN_POINTER: "broken-worktree-pointer",
+  LINKED_WORKTREE: "not-a-primary-checkout",
+});
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+// slugForRoot — a stable, filesystem-safe id for a repo path, used for the per-repo lock
+// and alert-latch filenames. A hash rather than a sanitised path so two roots differing
+// only in a character the sanitiser would fold cannot collide onto one lock.
+export function slugForRoot(root) {
+  return createHash("sha256").update(String(root)).digest("hex").slice(0, 16);
+}
+
+// parseSymrefDefault — read the default branch from `git ls-remote --symref origin HEAD`.
+//
+// This is asked of the REMOTE every pass on purpose. The local `refs/remotes/origin/HEAD`
+// is a clone-time cache that no fetch updates; trusting it would reintroduce exactly the
+// class of defect this ticket is about — a stale local copy asserted as current fact.
+export function parseSymrefDefault(stdout) {
+  if (typeof stdout !== "string") return null;
+  for (const line of stdout.split("\n")) {
+    // `ref: refs/heads/main\tHEAD`
+    const m = /^ref:\s+refs\/heads\/(\S+)\s+HEAD$/.exec(line.trim());
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// classifyGitState — the guard set, as a PURE function of already-collected observations.
+// Returns null when every guard holds (safe to fast-forward), else the refusal.
+//
+// Note what is NOT here: a dirty worktree is not pre-refused. `merge --ff-only` aborts
+// precisely when it would clobber a local edit and otherwise fast-forwards while preserving
+// it, so pre-refusing on dirt would be this automation making a judgement call that git
+// makes better. Let the tool that owns the invariant enforce it.
+export function classifyGitState(obs) {
+  if (!obs || typeof obs !== "object") return REFUSAL.BROKEN_POINTER;
+  if (obs.brokenPointer) return REFUSAL.BROKEN_POINTER;
+  // G1 — a linked worktree has its own HEAD and belongs to phase-agent-dispatch's rebase
+  // layers. A second writer there is the genuinely dangerous version of this ticket.
+  if (obs.isLinkedWorktree) return REFUSAL.LINKED_WORKTREE;
+  // G3 — an interrupted git operation. The user's commits may exist only in the reflog.
+  if (obs.operationInProgress) return REFUSAL.OP_IN_PROGRESS;
+  // G2 — detached, or deliberately parked on another branch. Both are someone's workspace.
+  if (obs.detached) return REFUSAL.DETACHED;
+  if (obs.defaultBranch && obs.currentBranch !== obs.defaultBranch) return REFUSAL.WRONG_BRANCH;
+  if (!obs.hasUpstreamRef) return REFUSAL.NO_UPSTREAM;
+  // G4 — local commits that are not on the remote. `--ff-only` would refuse anyway; this
+  // reports it as the distinct, actionable state it is rather than as a merge failure.
+  if (obs.aheadBy > 0) return REFUSAL.LOCAL_COMMITS;
+  return null;
+}
+
+// summarize — fold per-repo results into the one-line verdict a human or a check reads.
+// Counts every action so a pass that did nothing is distinguishable from one that never ran.
+export function summarize(repos) {
+  const out = { total: repos.length, current: 0, advanced: 0, refused: 0, fetchFailed: 0, skipped: 0, diagnostic: 0, unreachableCommits: 0 };
+  for (const r of repos) {
+    if (r.action === ACTION.CURRENT) out.current += 1;
+    else if (r.action === ACTION.ADVANCED) out.advanced += 1;
+    else if (r.action === ACTION.REFUSED) out.refused += 1;
+    else if (r.action === ACTION.FETCH_FAILED) out.fetchFailed += 1;
+    else if (r.action === ACTION.SKIPPED) out.skipped += 1;
+    else if (r.action === ACTION.DIAGNOSTIC) out.diagnostic += 1;
+    out.unreachableCommits += Number(r.unreachable_commits ?? 0) || 0;
+  }
+  return out;
+}
+
+// resolveAllowlist — the enrolled primary checkouts, from three DECLARED sources.
+//
+// Never a filesystem walk for `.git`. A walk would sweep in harness worktrees under
+// `.claude/worktrees/`, the forensic archive, the marketplace cache, and third-party
+// clones — repos this automation has no business touching and whose states it would then
+// have to reason about. An allowlist is also what makes "zero repos" a detectable
+// misconfiguration rather than a quiet no-op.
+//
+// Sibling repos matter: the 2026-08-12 ADR incident was `catalyst-cloud`, NOT this repo.
+// A catalyst-only subscriber would have caught none of the four incidents.
+export function resolveAllowlist({ registryRoots = [], selfRoot = null, configuredRoots = [] } = {}) {
+  const seen = new Set();
+  const out = [];
+  for (const r of [...registryRoots, ...(selfRoot ? [selfRoot] : []), ...configuredRoots]) {
+    if (typeof r !== "string" || !r.trim()) continue;
+    const root = r.replace(/\/+$/, "");
+    if (seen.has(root)) continue;
+    seen.add(root);
+    out.push(root);
+  }
+  return out;
+}
+
+// ── The pass ──────────────────────────────────────────────────────────────────
+
+// syncRepo — one repo, one pass. Every effect is an injected seam so the whole decision
+// tree is testable without a git binary, a network, or a real checkout.
+//
+// ORDER IS LOAD-BEARING: resolve the default branch, FETCH, and only then evaluate the
+// guards — because `aheadBy` is measured against `origin/<default>`, and before the fetch
+// that ref is stale or absent. Evaluating it first asks git about a commit the local object
+// store does not have, which errors on precisely the repos that are behind: the main path.
+export async function syncRepo(root, deps) {
+  const {
+    lsRemoteDefault,     // (root) -> {ok, branch} | {ok:false}
+    offlineDefault,      // (root) -> branch | null   (origin/HEAD cache; DIAGNOSTIC ONLY)
+    fetchRef,            // (root, branch) -> {ok, stderr}
+    observe,             // (root, branch) -> observations for classifyGitState
+    mergeFf,             // (root, branch) -> {ok, stderr}
+    headSha,             // (root) -> sha | null
+    remoteSha,           // (root, branch) -> sha | null
+    behindCount,         // (root, branch) -> number
+    unreachableCount,    // (root) -> number
+  } = deps;
+
+  const base = { root, action: ACTION.REFUSED, refused_reason: null, behind_by: 0, unreachable_commits: 0 };
+
+  // 1. The default branch, from the remote. This is the only authority.
+  const sym = await lsRemoteDefault(root);
+  let branch = sym?.ok ? sym.branch : null;
+  let diagnosticOnly = false;
+  if (!branch) {
+    // The remote is unreachable. The local cache MAY tell us the branch — but a cached
+    // answer is exactly the kind of stale fact this ticket exists to stop trusting, so it
+    // may inform a REPORT and must never authorise a WRITE.
+    branch = offlineDefault(root);
+    if (!branch) return { ...base, refused_reason: REFUSAL.DEFAULT_UNRESOLVED };
+    diagnosticOnly = true;
+  }
+  base.branch = branch;
+
+  // 2. Fetch BEFORE the guards, so every subsequent comparison is against a current ref.
+  if (!diagnosticOnly) {
+    const f = await fetchRef(root, branch);
+    if (!f.ok) {
+      // Transient infrastructure is NOT a refusal and NOT a human's problem. It is reported,
+      // counted, and escalated only if it persists — never labelled needs-human.
+      return { ...base, action: ACTION.FETCH_FAILED, refused_reason: null, error: (f.stderr || "").split("\n")[0]?.slice(0, 200) ?? "" };
+    }
+  }
+
+  // 3. Guards, all against the just-fetched ref.
+  const obs = await observe(root, branch);
+  base.unreachable_commits = Number(await unreachableCount(root)) || 0;
+  const refusal = classifyGitState({ ...obs, defaultBranch: branch });
+  base.behind_by = Number(await behindCount(root, branch)) || 0;
+  if (refusal) return { ...base, refused_reason: refusal, detail: obs.detail ?? null };
+
+  if (diagnosticOnly) {
+    // Guards pass, but the branch came from a cache we do not trust to authorise a write.
+    return { ...base, action: ACTION.DIAGNOSTIC, refused_reason: null };
+  }
+
+  if (base.behind_by === 0) return { ...base, action: ACTION.CURRENT, refused_reason: null };
+
+  // 4. Act.
+  const before = await headSha(root);
+  const m = await mergeFf(root, branch);
+
+  // 5. THE ORACLE. The verdict is what the world says, never the exit code.
+  //
+  // This is not defensive padding. On a non-default branch `git pull --ff-only` exits 0 with
+  // "Already up to date." while N commits behind — so an exit-code verdict reports success it
+  // did not achieve, which is the one thing rule 4 forbids outright. Ask where HEAD actually is.
+  const after = await headSha(root);
+  const target = await remoteSha(root, branch);
+  if (after && target && after === target) {
+    return { ...base, action: ACTION.ADVANCED, refused_reason: null, old_sha: before, new_sha: after };
+  }
+  return {
+    ...base,
+    refused_reason: REFUSAL.FF_BLOCKED,
+    // git's own words, not our paraphrase — it names the files that blocked the merge.
+    detail: (m?.stderr || "").split("\n").slice(0, 3).join(" ").slice(0, 300),
+  };
+}
+
+// runPass — every enrolled repo, once. Never throws: a scanner that dies on one bad repo
+// stops protecting the others, and its silence would be indistinguishable from health.
+export async function runPass({ roots, deps, reason = "timer", now = () => new Date().toISOString(), host = "" }) {
+  const repos = [];
+  for (const root of roots) {
+    try {
+      repos.push(await syncRepo(root, deps));
+    } catch (err) {
+      repos.push({
+        root,
+        action: ACTION.FETCH_FAILED,
+        refused_reason: null,
+        behind_by: 0,
+        unreachable_commits: 0,
+        error: String(err?.message ?? err).slice(0, 200),
+      });
+    }
+  }
+  // The heartbeat is written on EVERY pass, acting or not. A scanner whose only output is a
+  // refusal is invisible when it dies — and a dead scanner never refuses. This status record
+  // is what makes "it stopped running" a detectable state rather than an absence of news.
+  return { ts: now(), host, reason, repos, summary: summarize(repos) };
+}

--- a/plugins/dev/scripts/execution-core/checkout-sync.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.mjs
@@ -104,6 +104,14 @@ export function parseSymrefDefault(stdout) {
 export function classifyGitState(obs) {
   if (!obs || typeof obs !== "object") return REFUSAL.BROKEN_POINTER;
   if (obs.brokenPointer) return REFUSAL.BROKEN_POINTER;
+  // A checkout we could not read a branch from is BROKEN, not "repurposed" (Codex #3316 P2).
+  // Without this, a null/partial observation spread into {} leaves currentBranch undefined,
+  // which compares unequal to the default and reports `primary-on-other-branch` — a
+  // plausible-but-wrong reason that sends a human to look at the wrong thing. Checked before
+  // the branch comparison precisely so it cannot be misread as that.
+  if (!obs.detached && (typeof obs.currentBranch !== "string" || !obs.currentBranch)) {
+    return REFUSAL.BROKEN_POINTER;
+  }
   // G1 — a linked worktree has its own HEAD and belongs to phase-agent-dispatch's rebase
   // layers. A second writer there is the genuinely dangerous version of this ticket.
   if (obs.isLinkedWorktree) return REFUSAL.LINKED_WORKTREE;
@@ -207,11 +215,15 @@ export async function syncRepo(root, deps) {
   }
 
   // 3. Guards, all against the just-fetched ref.
+  // `observe` may legitimately return null for a broken checkout, so nothing below may
+  // dereference it unguarded: a throw here is caught by runPass and recorded as the
+  // TRANSIENT `fetch-failed` class, which by design never escalates — exactly inverting the
+  // meaning of a broken pointer, which never fixes itself (Codex #3316 P2).
   const obs = await observe(root, branch);
   base.unreachable_commits = Number(await unreachableCount(root)) || 0;
-  const refusal = classifyGitState({ ...obs, defaultBranch: branch });
+  const refusal = classifyGitState({ ...(obs ?? {}), defaultBranch: branch });
   base.behind_by = Number(await behindCount(root, branch)) || 0;
-  if (refusal) return { ...base, refused_reason: refusal, detail: obs.detail ?? null };
+  if (refusal) return { ...base, refused_reason: refusal, detail: obs?.detail ?? null };
 
   if (diagnosticOnly) {
     // Guards pass, but the branch came from a cache we do not trust to authorise a write.

--- a/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
@@ -262,3 +262,57 @@ describe("summarize", () => {
     expect(s).toEqual({ total: 6, current: 1, advanced: 1, refused: 1, fetchFailed: 1, skipped: 1, diagnostic: 1, unreachableCommits: 3 });
   });
 });
+
+// Codex #3316 P2 — a broken checkout must stay ACTIONABLE.
+//
+// `observe()` returning null is a real state (a broken `.git` file pointer, a directory that
+// is not a repo). Two bugs conspired to turn it into the wrong answer: `obs.detail` threw,
+// runPass caught it, and the repo was recorded as `fetch-failed` — TRANSIENT infrastructure,
+// which by design never escalates to a human. A broken pointer is precisely the opposite:
+// it never fixes itself. Inverting those two classes defeats the distinction this module is
+// built around.
+describe("Codex #3316 P2 — a null observation is a broken pointer, not transient", () => {
+  const brokenDeps = {
+    lsRemoteDefault: async () => ({ ok: true, branch: "main" }),
+    offlineDefault: () => null,
+    fetchRef: async () => ({ ok: true, stderr: "" }),
+    observe: async () => null,
+    mergeFf: async () => ({ ok: true, stderr: "" }),
+    headSha: async () => "a",
+    remoteSha: async () => "b",
+    behindCount: async () => 1,
+    unreachableCount: async () => 0,
+  };
+
+  test("a null observation refuses as broken-worktree-pointer, and does not throw", async () => {
+    const out = await runPass({ roots: ["/broken"], deps: brokenDeps });
+    const r = out.repos[0];
+    expect(r.action).toBe(ACTION.REFUSED);
+    expect(r.refused_reason).toBe(REFUSAL.BROKEN_POINTER);
+  });
+
+  test("it is NOT recorded as the transient fetch-failed class", async () => {
+    const out = await runPass({ roots: ["/broken"], deps: brokenDeps });
+    // fetch-failed never escalates to a human; a broken pointer must.
+    expect(out.repos[0].action).not.toBe(ACTION.FETCH_FAILED);
+    expect(out.repos[0].error).toBeUndefined();
+  });
+
+  // The second defect, which the throw was masking: spreading null yields {}, so
+  // `currentBranch` was undefined and compared unequal to the default — classifying a broken
+  // checkout as "someone repurposed the primary". A plausible-but-wrong reason sends a human
+  // to look at the wrong thing, which is worse than no reason at all.
+  test("an observation with no branch is broken — never 'primary-on-other-branch'", () => {
+    expect(classifyGitState({ defaultBranch: "main" })).toBe(REFUSAL.BROKEN_POINTER);
+    expect(classifyGitState({ defaultBranch: "main", currentBranch: null })).toBe(REFUSAL.BROKEN_POINTER);
+  });
+
+  // POSITIVE CONTROL — a genuinely repurposed primary must STILL report the branch reason,
+  // so the test above is proving the null case is distinguished rather than that the
+  // wrong-branch refusal was removed.
+  test("a real repurposed primary still reports primary-on-other-branch", () => {
+    expect(classifyGitState({
+      defaultBranch: "main", currentBranch: "my-wip", hasUpstreamRef: true, aheadBy: 0,
+    })).toBe(REFUSAL.WRONG_BRANCH);
+  });
+});

--- a/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
@@ -1,0 +1,264 @@
+// checkout-sync.test.mjs — CTL-1808.
+//
+// Every seam is injected, so these run with no git binary, no network, and no real checkout.
+// The cases are the refusal table from the design, plus the three that adversarial review
+// said the design would otherwise have shipped broken.
+import { describe, test, expect } from "bun:test";
+import {
+  ACTION,
+  REFUSAL,
+  slugForRoot,
+  parseSymrefDefault,
+  classifyGitState,
+  resolveAllowlist,
+  summarize,
+  syncRepo,
+  runPass,
+} from "./checkout-sync.mjs";
+
+// A repo whose every observation is healthy and 2 commits behind. Individual tests override
+// exactly the one field under test, so a failure names the state that broke it.
+const healthy = (over = {}) => ({
+  lsRemoteDefault: async () => ({ ok: true, branch: "main" }),
+  offlineDefault: () => null,
+  fetchRef: async () => ({ ok: true, stderr: "" }),
+  observe: async () => ({
+    isLinkedWorktree: false,
+    brokenPointer: false,
+    operationInProgress: false,
+    detached: false,
+    currentBranch: "main",
+    hasUpstreamRef: true,
+    aheadBy: 0,
+  }),
+  mergeFf: async () => ({ ok: true, stderr: "" }),
+  headSha: (() => {
+    let calls = 0;
+    return async () => (calls++ === 0 ? "old-sha" : "new-sha");
+  })(),
+  remoteSha: async () => "new-sha",
+  behindCount: async () => 2,
+  unreachableCount: async () => 0,
+  ...over,
+});
+
+describe("parseSymrefDefault — the default branch comes from the REMOTE, every pass", () => {
+  test("reads the symref line", () => {
+    expect(parseSymrefDefault("ref: refs/heads/main\tHEAD\nabc123\tHEAD")).toBe("main");
+  });
+  test("handles a non-main default", () => {
+    expect(parseSymrefDefault("ref: refs/heads/trunk\tHEAD")).toBe("trunk");
+  });
+  test("returns null when there is no symref (so the caller can refuse rather than guess)", () => {
+    expect(parseSymrefDefault("abc123\tHEAD")).toBeNull();
+    expect(parseSymrefDefault("")).toBeNull();
+    expect(parseSymrefDefault(null)).toBeNull();
+  });
+});
+
+describe("classifyGitState — the guards", () => {
+  const ok = {
+    isLinkedWorktree: false, brokenPointer: false, operationInProgress: false,
+    detached: false, currentBranch: "main", defaultBranch: "main", hasUpstreamRef: true, aheadBy: 0,
+  };
+  test("all guards holding → no refusal", () => {
+    expect(classifyGitState(ok)).toBeNull();
+  });
+  test("a linked worktree is never touched — phase-agent-dispatch owns those", () => {
+    expect(classifyGitState({ ...ok, isLinkedWorktree: true })).toBe(REFUSAL.LINKED_WORKTREE);
+  });
+  test("an interrupted git operation refuses — the commits may exist only in the reflog", () => {
+    expect(classifyGitState({ ...ok, operationInProgress: true })).toBe(REFUSAL.OP_IN_PROGRESS);
+  });
+  test("detached HEAD refuses", () => {
+    expect(classifyGitState({ ...ok, detached: true })).toBe(REFUSAL.DETACHED);
+  });
+  test("a primary repurposed as a working branch refuses (measured live on mini-2)", () => {
+    expect(classifyGitState({ ...ok, currentBranch: "my-wip" })).toBe(REFUSAL.WRONG_BRANCH);
+  });
+  test("unpushed local commits refuse", () => {
+    expect(classifyGitState({ ...ok, aheadBy: 3 })).toBe(REFUSAL.LOCAL_COMMITS);
+  });
+  test("no upstream refuses", () => {
+    expect(classifyGitState({ ...ok, hasUpstreamRef: false })).toBe(REFUSAL.NO_UPSTREAM);
+  });
+  test("a malformed observation refuses rather than throwing", () => {
+    expect(classifyGitState(null)).toBe(REFUSAL.BROKEN_POINTER);
+  });
+
+  // A dirty tree is deliberately NOT a guard: `merge --ff-only` aborts exactly when it would
+  // clobber and otherwise preserves local edits. Pre-refusing would be this automation making
+  // a judgement call, which rule 3 forbids.
+  test("a dirty tree is NOT pre-refused — git owns that invariant", () => {
+    expect(classifyGitState({ ...ok, dirty: true, dirtyPaths: 4 })).toBeNull();
+  });
+});
+
+describe("syncRepo — outcomes", () => {
+  test("clean and behind → advanced, with both shas", async () => {
+    const r = await syncRepo("/r", healthy());
+    expect(r.action).toBe(ACTION.ADVANCED);
+    expect(r.old_sha).toBe("old-sha");
+    expect(r.new_sha).toBe("new-sha");
+    expect(r.behind_by).toBe(2);
+  });
+
+  test("already at origin → current, and no merge is attempted", async () => {
+    let merged = false;
+    const r = await syncRepo("/r", healthy({
+      behindCount: async () => 0,
+      mergeFf: async () => { merged = true; return { ok: true, stderr: "" }; },
+    }));
+    expect(r.action).toBe(ACTION.CURRENT);
+    expect(merged).toBe(false);
+  });
+
+  test("a fetch failure is transient — NOT a refusal, and never needs-human", async () => {
+    const r = await syncRepo("/r", healthy({
+      fetchRef: async () => ({ ok: false, stderr: "ssh: connect to host forge port 22: No route to host" }),
+    }));
+    expect(r.action).toBe(ACTION.FETCH_FAILED);
+    expect(r.refused_reason).toBeNull();
+    expect(r.error).toContain("No route to host");
+  });
+
+  test("the remote unreachable AND no cached default → refuses, does not guess", async () => {
+    const r = await syncRepo("/r", healthy({
+      lsRemoteDefault: async () => ({ ok: false }),
+      offlineDefault: () => null,
+    }));
+    expect(r.action).toBe(ACTION.REFUSED);
+    expect(r.refused_reason).toBe(REFUSAL.DEFAULT_UNRESOLVED);
+  });
+
+  // The cached origin/HEAD is a clone-time artefact no fetch updates. It may inform a REPORT
+  // and must never authorise a WRITE — trusting it would be the same stale-fact-as-current
+  // defect this whole ticket is about.
+  test("a cache-derived default branch downgrades the pass to diagnostic — it never merges", async () => {
+    let merged = false;
+    const r = await syncRepo("/r", healthy({
+      lsRemoteDefault: async () => ({ ok: false }),
+      offlineDefault: () => "main",
+      mergeFf: async () => { merged = true; return { ok: true, stderr: "" }; },
+    }));
+    expect(r.action).toBe(ACTION.DIAGNOSTIC);
+    expect(merged).toBe(false);
+  });
+
+  test("a refusal carries git's verbatim stderr, not a paraphrase", async () => {
+    const r = await syncRepo("/r", healthy({
+      mergeFf: async () => ({ ok: false, stderr: "error: Your local changes to the following files would be overwritten by merge:\n\tsrc/a.ts" }),
+      headSha: async () => "old-sha",
+      remoteSha: async () => "new-sha",
+    }));
+    expect(r.action).toBe(ACTION.REFUSED);
+    expect(r.refused_reason).toBe(REFUSAL.FF_BLOCKED);
+    expect(r.detail).toContain("src/a.ts");
+  });
+});
+
+// ── The three cases adversarial review said would otherwise ship broken ─────────
+
+describe("CTL-1808 — the review catches", () => {
+  // 1. FETCH BEFORE GUARDS. `aheadBy` is measured against origin/<default>; before the fetch
+  //    that ref is stale or absent, so asking first errors on exactly the repos that are
+  //    behind — the main path. Assert the ORDER, not just the outcome.
+  test("the fetch happens BEFORE any guard is evaluated", async () => {
+    const order = [];
+    await syncRepo("/r", healthy({
+      fetchRef: async () => { order.push("fetch"); return { ok: true, stderr: "" }; },
+      observe: async () => {
+        order.push("observe");
+        return { isLinkedWorktree: false, brokenPointer: false, operationInProgress: false, detached: false, currentBranch: "main", hasUpstreamRef: true, aheadBy: 0 };
+      },
+      behindCount: async () => { order.push("behind"); return 2; },
+    }));
+    expect(order[0]).toBe("fetch");
+    expect(order.indexOf("fetch")).toBeLessThan(order.indexOf("observe"));
+    expect(order.indexOf("fetch")).toBeLessThan(order.indexOf("behind"));
+  });
+
+  // 2. THE ORACLE BEATS THE EXIT CODE. `git pull --ff-only` on a non-default branch exits 0
+  //    with "Already up to date." while N behind. A verdict taken from the exit code reports
+  //    success it did not achieve — the exact thing rule 4 prohibits. Here: merge claims
+  //    success, but HEAD did not move to the target.
+  test("a merge that exits 0 without moving HEAD is REFUSED, not reported as advanced", async () => {
+    const r = await syncRepo("/r", healthy({
+      mergeFf: async () => ({ ok: true, stderr: "Already up to date." }), // claims success
+      headSha: async () => "stuck-sha",                                   // …but HEAD never moved
+      remoteSha: async () => "target-sha",
+    }));
+    expect(r.action).not.toBe(ACTION.ADVANCED);
+    expect(r.action).toBe(ACTION.REFUSED);
+  });
+
+  // 3. SILENCE IS A DEFECT / a dead scanner never refuses. Every pass must produce a record
+  //    even when nothing happened, or "it stopped running" is indistinguishable from "all well".
+  test("a pass over zero repos still produces a heartbeat record", async () => {
+    const out = await runPass({ roots: [], deps: healthy(), now: () => "2026-08-13T00:00:00Z", host: "h" });
+    expect(out.ts).toBe("2026-08-13T00:00:00Z");
+    expect(out.host).toBe("h");
+    expect(out.summary.total).toBe(0);
+  });
+
+  test("a pass where every repo is current still produces a record with counts", async () => {
+    const out = await runPass({ roots: ["/a", "/b"], deps: healthy({ behindCount: async () => 0 }) });
+    expect(out.summary).toMatchObject({ total: 2, current: 2, advanced: 0, refused: 0 });
+  });
+
+  // 4. One bad repo must not stop the scanner protecting the others.
+  test("a throwing repo is recorded and the pass continues", async () => {
+    const deps = healthy({
+      lsRemoteDefault: async (root) => {
+        if (root === "/bad") throw new Error("boom");
+        return { ok: true, branch: "main" };
+      },
+    });
+    const out = await runPass({ roots: ["/bad", "/good"], deps });
+    expect(out.repos).toHaveLength(2);
+    expect(out.repos[0].error).toContain("boom");
+    expect(out.repos[1].action).toBe(ACTION.ADVANCED);
+  });
+});
+
+describe("resolveAllowlist — declared sources only, never a filesystem walk", () => {
+  test("merges registry, self, and configured roots, de-duplicated and order-stable", () => {
+    expect(resolveAllowlist({
+      registryRoots: ["/a", "/b"], selfRoot: "/b", configuredRoots: ["/c", "/a"],
+    })).toEqual(["/a", "/b", "/c"]);
+  });
+  test("normalises trailing slashes so one repo cannot enrol twice", () => {
+    expect(resolveAllowlist({ registryRoots: ["/a/"], selfRoot: "/a" })).toEqual(["/a"]);
+  });
+  test("ignores blanks and non-strings rather than producing a bogus root", () => {
+    expect(resolveAllowlist({ registryRoots: ["", "  ", null, 7, "/a"] })).toEqual(["/a"]);
+  });
+  // Tonight's ADR incident was a SIBLING repo, not this one. A catalyst-only allowlist would
+  // have caught none of the four measured incidents.
+  test("a sibling repo enrols through the configured source", () => {
+    const roots = resolveAllowlist({ selfRoot: "/x/catalyst", configuredRoots: ["/x/catalyst-cloud"] });
+    expect(roots).toContain("/x/catalyst-cloud");
+  });
+});
+
+describe("slugForRoot — lock identity", () => {
+  test("is stable and path-safe", () => {
+    expect(slugForRoot("/a/b")).toBe(slugForRoot("/a/b"));
+    expect(slugForRoot("/a/b")).toMatch(/^[0-9a-f]{16}$/);
+  });
+  // A sanitiser that folded '/' and '-' would collide these onto one lock; a hash cannot.
+  test("distinct roots that a path-sanitiser would fold do NOT collide", () => {
+    expect(slugForRoot("/a/b")).not.toBe(slugForRoot("/a-b"));
+  });
+});
+
+describe("summarize", () => {
+  test("counts every action class and totals unreachable commits", () => {
+    const s = summarize([
+      { action: ACTION.CURRENT }, { action: ACTION.ADVANCED },
+      { action: ACTION.REFUSED, unreachable_commits: 3 },
+      { action: ACTION.FETCH_FAILED }, { action: ACTION.SKIPPED }, { action: ACTION.DIAGNOSTIC },
+    ]);
+    expect(s).toEqual({ total: 6, current: 1, advanced: 1, refused: 1, fetchFailed: 1, skipped: 1, diagnostic: 1, unreachableCommits: 3 });
+  });
+});


### PR DESCRIPTION
Part 1 of CTL-1808. **Additive — nothing is deleted yet** (see *Sequencing*).

Design: `thoughts/shared/research/2026-08-12-ctl-1808-fast-forward-subscriber-design.md`
(3 independent designs → 3 adversarial review lenses → synthesis).

## Why a subscriber and not another call site

The primary checkout must fast-forward when something merges. That was built the old way — a helper
invoked explicitly by the merge skill — and it decayed exactly as that shape always decays:

| | |
| -- | -- |
| `plugins/dev/scripts/pull-primary-worktree.sh` | the helper (49 lines) |
| `plugins/dev/skills/merge-pr/SKILL.md:478` | caller 1 |
| `plugins/legacy/skills/orchestrate/SKILL.md:1400` | caller 2 |
| `plugins/dev/skills/merge-pr/SKILL.md:458-461` | a **third, inline reimplementation** — inside caller 1 |

That last row is the duplication tell firing *inside a single file*: `git checkout $base_branch` /
`git pull origin $base_branch`, a few lines from where the same file calls the helper. Meanwhile
`phase-monitor-merge`, `phase-teardown`, PR triage, recovery-pass, and every merge a human does by
hand have **never** called it.

**Four measured incidents on 2026-08-12.** Two agents read stale trees and each came within one
inference of filing *"this feature was never built"* against work that was merged, deployed, and in
front of a live customer — one checkout 22 commits behind, the other 17. A fourth: a stale sibling
clone hid a **ratified ADR** from three separate agents, each of whom concluded the document did not
exist.

Adding the call to the paths that lack it reproduces the bug. So does moving it to a shared
"merge confirmed" seam — **both still couple the side effect to the merger**, and the sixth merge path
written next month misses it again.

## Shape

The **periodic pass holds the entire correctness intent**; an event may only make it happen sooner.

- The module takes **no argument describing what merged** — it cannot act on an event's payload even
  by mistake.
- It keeps **no record of work done**: no consumed offset, no handled-merge marker, no cursor. It asks
  the world every pass.

That is not academic. This node's event log was **measured missing 15.6% of one worker's events**
(CTL-1812, merged tonight). A design correct only when it *receives* the event would be wrong one time
in seven on this very machine. If every event were lost, this converges within one interval.

The entire mutating vocabulary is `git fetch <one refspec>` and `git merge --ff-only`. Never `reset`,
`checkout`, `clean`, `stash`, `rebase`, `gc`, `prune`, `remote set-head`, tag fetch, config write, or
any deletion.

## The two orderings that are load-bearing

Both were caught by **adversarial review of the design**, before any code existed:

**1. Fetch before guards.** `aheadBy` is measured against `origin/<default>`; before the fetch that ref
is stale or absent. Evaluating guards first asks git about a commit the local object store does not
have — which errors on precisely the repos that are **behind**, i.e. the main path.

**2. The oracle beats the exit code.** On a non-default branch `git pull --ff-only` exits **0** with
*"Already up to date."* while N commits behind. A verdict taken from the exit code reports success it
did not achieve. The verdict is `rev-parse HEAD == rev-parse origin/<default>`.

Both are **mutation-verified** — each mutation makes exactly its own test go red:

```
verdict from exit code   → ✗ "a merge that exits 0 without moving HEAD is REFUSED"
guards before the fetch  → ✗ "the fetch happens BEFORE any guard is evaluated"
```

## Three deliberate non-obvious choices

- **A dirty tree is NOT pre-refused.** `--ff-only` aborts exactly when it would clobber and otherwise
  preserves local edits. Pre-refusing on dirt would be this automation making a *decision* — and the
  rule is that if it needs a decision, it is not this automation. Let git enforce the invariant it owns.
- **A cache-derived default branch downgrades the pass to diagnostic-only.** `refs/remotes/origin/HEAD`
  is a clone-time artefact no fetch updates. It may inform a *report*; it must never authorise a
  *write* — trusting it is the same stale-fact-as-current defect this ticket is about.
- **A fetch failure is transient**, not a refusal, and never `needs-human`.

## Silence is a defect

Every pass produces a record **even when nothing happened**, because a dead scanner never refuses and
its silence would otherwise be indistinguishable from health. `runPass` returns a timestamped
heartbeat with per-action counts on every invocation, including a pass over zero repos — which is
itself the detectable signal for an allowlist that has silently resolved to nothing.

## Sequencing — why nothing is deleted in this PR

Deleting the helper and its three call sites **before** the timer is verified running on every node
would leave a window with **no puller at all**. So: this lands additively, the launchd agent +
`catalyst doctor` check land next, and the deletion comes once the timer is confirmed live on all
three node classes. Two mechanisms briefly coexisting is the cheaper mistake.

## Verification

`bun test checkout-sync.test.mjs` → **30 pass, 0 fail**, covering the full refusal table (detached,
repurposed primary, operation-in-progress, unpushed commits, no upstream, broken pointer, linked
worktree, unresolvable default, ff-blocked), the allowlist rules, and the four review catches.

Every seam is injected, so the suite runs with **no git binary, no network, and no real checkout**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
