### PR TITLE
fix(dev): CTL-1813 — a torn first line must not retire the month beside it

### DIFF
--- a/plugins/dev/scripts/__tests__/canonical-event-rotation.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event-rotation.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# CTL-1813: a malformed first line must quarantine itself, not retire the month beside it.
+#
+# `canonical_jsonl_append` rotates the live month file aside when its first line is not a
+# canonical event. That rotation exists for the v1 -> canonical MIGRATION, and for that it is
+# correct. But the old test was `jq -e 'has("attributes")'`, which exits non-zero for BOTH a
+# legacy line and an UNPARSEABLE one — so one torn line moved the whole month aside, and
+# because the destination was a fixed `.legacy`, a second torn line one rotation later
+# overwrote the only surviving copy.
+#
+# That composes with CTL-1809: our own bash appends TEAR above 1025 bytes (macOS BUFSIZ), so a
+# torn first line is a predictable product of the writer, not a rare accident.
+#
+# Driven against the REAL function, not a model of it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$(dirname "$SCRIPT_DIR")/lib/canonical-event.sh"
+[[ -f "$LIB" ]] || { echo "FAIL: canonical-event.sh not found at $LIB"; exit 1; }
+# shellcheck disable=SC1090
+source "$LIB"
+
+TMPS=()
+# NOTE the trailing `true`: without it the loop's last conditional decides this script's
+# EXIT STATUS, so a passing test can report failure. Cleanup must never be able to change
+# the verdict.
+cleanup() { local d; for d in "${TMPS[@]:-}"; do [[ -n "$d" ]] && rm -rf "$d"; done; true; }
+trap cleanup EXIT
+newdir() { local d; d="$(mktemp -d)"; TMPS+=("$d"); printf '%s' "$d"; }
+monthfile() { printf '%s/%s.jsonl' "$1" "$(date -u +%Y-%m)"; }
+fail() { echo "FAIL: $*"; exit 1; }
+
+# --- 1. A TORN first line must NOT rotate, and must lose nothing ---------------
+D="$(newdir)"; F="$(monthfile "$D")"
+printf 'not json at all\n' > "$F"
+for i in $(seq 1 20); do printf '{"attributes":{"event.name":"e%s"}}\n' "$i" >> "$F"; done
+
+WARN="$(newdir)/warn.txt"
+canonical_jsonl_append "$D" '{"attributes":{"event.name":"new"}}' 2>"$WARN"
+
+ROTATED="$(find "$D" -name '*legacy*' | wc -l | tr -d ' ')"
+[[ "$ROTATED" == "0" ]] || fail "a torn first line rotated the live log ($ROTATED files) — 20 events would have been retired"
+
+LIVE="$(grep -c 'event.name' "$F" || true)"
+[[ "$LIVE" == "21" ]] || fail "expected 21 live events preserved (20 + the append), found $LIVE"
+
+# Silence is a defect: refusing to rotate a DAMAGED log must be audible, or the damage is
+# invisible until someone goes looking.
+grep -q 'does not parse' "$WARN" || fail "refusing to rotate a damaged log was silent; stderr: $(cat "$WARN")"
+
+# --- 2. A GENUINE legacy first line still rotates -----------------------------
+# POSITIVE CONTROL for case 1: proves the rotation feature still works, so case 1 is testing
+# the parse distinction rather than a rotation that has simply been disabled.
+D2="$(newdir)"; F2="$(monthfile "$D2")"
+printf '{"ts":"x","event":"MONTH_A"}\n' > "$F2"
+canonical_jsonl_append "$D2" '{"attributes":{"event.name":"n1"}}' 2>/dev/null
+[[ "$(find "$D2" -name '*legacy*' | wc -l | tr -d ' ')" == "1" ]] \
+  || fail "a genuine legacy first line did NOT rotate — the migration path is broken"
+
+# --- 3. A SECOND rotation must not clobber the first --------------------------
+# The unrecoverable half of the defect: a fixed `.legacy` is a rescue slot of depth one.
+printf '{"ts":"y","event":"MONTH_B"}\n' > "$F2"
+canonical_jsonl_append "$D2" '{"attributes":{"event.name":"n2"}}' 2>/dev/null
+
+COUNT="$(find "$D2" -name '*legacy*' | wc -l | tr -d ' ')"
+[[ "$COUNT" == "2" ]] || fail "expected 2 distinct rotated files, found $COUNT — one rotation clobbered another"
+
+ALL="$(cat "$D2"/*legacy* 2>/dev/null || true)"
+grep -q MONTH_A <<<"$ALL" || fail "MONTH_A was destroyed by the second rotation"
+grep -q MONTH_B <<<"$ALL" || fail "MONTH_B is missing from the rotated copies"
+
+echo "PASS: a torn first line preserves the month; a legacy line still rotates; rotations cannot clobber each other"
+exit 0

--- a/plugins/dev/scripts/__tests__/canonical-event-rotation.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event-rotation.test.sh
@@ -26,16 +26,19 @@ TMPS=()
 # the verdict.
 cleanup() { local d; for d in "${TMPS[@]:-}"; do [[ -n "$d" ]] && rm -rf "$d"; done; true; }
 trap cleanup EXIT
-newdir() { local d; d="$(mktemp -d)"; TMPS+=("$d"); printf '%s' "$d"; }
+# NOTE: `newdir` is called inside a command substitution, which is a SUBSHELL — an array
+# append inside it never reaches the parent, so registering the path here would silently leak
+# every directory (Codex #3318 P2). The caller registers it instead.
+newdir() { mktemp -d; }
 monthfile() { printf '%s/%s.jsonl' "$1" "$(date -u +%Y-%m)"; }
 fail() { echo "FAIL: $*"; exit 1; }
 
 # --- 1. A TORN first line must NOT rotate, and must lose nothing ---------------
-D="$(newdir)"; F="$(monthfile "$D")"
+D="$(newdir)"; TMPS+=("$D"); F="$(monthfile "$D")"
 printf 'not json at all\n' > "$F"
 for i in $(seq 1 20); do printf '{"attributes":{"event.name":"e%s"}}\n' "$i" >> "$F"; done
 
-WARN="$(newdir)/warn.txt"
+WARNDIR="$(newdir)"; TMPS+=("$WARNDIR"); WARN="$WARNDIR/warn.txt"
 canonical_jsonl_append "$D" '{"attributes":{"event.name":"new"}}' 2>"$WARN"
 
 ROTATED="$(find "$D" -name '*legacy*' | wc -l | tr -d ' ')"
@@ -51,7 +54,7 @@ grep -q 'does not parse' "$WARN" || fail "refusing to rotate a damaged log was s
 # --- 2. A GENUINE legacy first line still rotates -----------------------------
 # POSITIVE CONTROL for case 1: proves the rotation feature still works, so case 1 is testing
 # the parse distinction rather than a rotation that has simply been disabled.
-D2="$(newdir)"; F2="$(monthfile "$D2")"
+D2="$(newdir)"; TMPS+=("$D2"); F2="$(monthfile "$D2")"
 printf '{"ts":"x","event":"MONTH_A"}\n' > "$F2"
 canonical_jsonl_append "$D2" '{"attributes":{"event.name":"n1"}}' 2>/dev/null
 [[ "$(find "$D2" -name '*legacy*' | wc -l | tr -d ' ')" == "1" ]] \

--- a/plugins/dev/scripts/__tests__/canonical-event.test.sh
+++ b/plugins/dev/scripts/__tests__/canonical-event.test.sh
@@ -311,10 +311,13 @@ CANONICAL_LINE="$(build_canonical_line \
   --event-name session.started)"
 canonical_jsonl_append "$SCRATCH" "$CANONICAL_LINE"
 
-if [[ -f "${LEGACY_FILE}.legacy" ]]; then
+# CTL-1813: the rotation destination is now UNIQUE — a fixed `.legacy` is a rescue slot of
+# depth one, and a second rotation clobbered the previous month's only copy. Resolve the
+# rotated sibling rather than assuming its exact name.
+if [[ -n "$(find "$SCRATCH" -name "$(basename "$LEGACY_FILE").legacy*" -print -quit 2>/dev/null)" ]]; then
   ok "canonical_jsonl_append rotates legacy file"
 else
-  fail "canonical_jsonl_append rotation" "no .legacy file at ${LEGACY_FILE}.legacy"
+  fail "canonical_jsonl_append rotation" "no rotated sibling of ${LEGACY_FILE}"
 fi
 
 NEW_LINE_COUNT="$(wc -l < "$LEGACY_FILE" | tr -d ' ')"

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -470,20 +470,34 @@ canonical_jsonl_append() {
           # A genuine legacy log. Rotate to a UNIQUE destination: a fixed `.legacy` is a
           # rescue slot of depth one, and the next rotation clobbers the previous month's
           # only copy.
-          # A destination that CANNOT COLLIDE. A timestamp plus pid is still not unique —
-          # the same process can rotate twice within one second — and a collision here means
-          # one rotation destroying another's rescue copy, which is the whole defect.
+          # A destination that cannot collide AND cannot be clobbered by a concurrent
+          # rotation. `[[ -e ]]` then `mv` is check-then-act: two writers can both see the
+          # name free, and POSIX rename() OVERWRITES, so the second would destroy the first's
+          # rescue copy — this ticket's own defect, one layer down (Codex #3318 P1).
+          #
+          # `ln` is the atomic primitive: hard-linking onto an existing path fails EEXIST
+          # rather than overwriting, so the name is RESERVED by the link itself. Unlink the
+          # source only once the link succeeded; if it fails we simply try the next name and
+          # the original is still in place.
           local stamp dest n
           stamp="$(date -u +%Y%m%dT%H%M%SZ)"
-          dest="${month_file}.legacy.${stamp}.$$"
-          n=1
-          while [[ -e "$dest" ]]; do
-            dest="${month_file}.legacy.${stamp}.$$.${n}"
+          n=0
+          while :; do
+            if [[ "$n" -eq 0 ]]; then dest="${month_file}.legacy.${stamp}.$$"
+            else dest="${month_file}.legacy.${stamp}.$$.${n}"; fi
+            if ln "$month_file" "$dest" 2>/dev/null; then
+              rm -f "$month_file" 2>/dev/null || true
+              printf '[catalyst] rotated legacy event log %s -> %s\n' "$month_file" "$dest" >&2
+              break
+            fi
             n=$((n + 1))
+            # Bounded: an unbounded loop here would spin forever if the directory were
+            # unwritable, and a rotation is never worth wedging an append path for.
+            if [[ "$n" -gt 50 ]]; then
+              printf '[catalyst] WARNING: could not reserve a rotation name for %s — leaving it in place\n' "$month_file" >&2
+              break
+            fi
           done
-          if mv "$month_file" "$dest" 2>/dev/null; then
-            printf '[catalyst] rotated legacy event log %s -> %s\n' "$month_file" "$dest" >&2
-          fi
         fi
       else
         # Silence is a defect: an unparseable first line means the log has been damaged, and

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -451,8 +451,45 @@ canonical_jsonl_append() {
   if [[ -f "$month_file" ]]; then
     local first
     first="$(head -n 1 "$month_file" 2>/dev/null || true)"
-    if [[ -n "$first" ]] && ! printf '%s' "$first" | jq -e 'has("attributes")' >/dev/null 2>&1; then
-      mv "$month_file" "${month_file}.legacy" 2>/dev/null || true
+    if [[ -n "$first" ]]; then
+      # CTL-1813: rotate ONLY for a genuine v1 line — a line that PARSES and simply lacks
+      # `attributes`. That migration is the entire purpose of this rotation.
+      #
+      # An UNPARSEABLE first line is a different thing and must NOT move the live log. The
+      # old test conflated them (`jq -e has("attributes")` exits non-zero for both), so one
+      # torn line retired the whole month: MEASURED against this function, a single truncated
+      # first line moved 499 live events aside, and a SECOND torn line one rotation later
+      # overwrote the only surviving copy, because the destination is a fixed name. A torn
+      # line is exactly what CTL-1809's bash-append tearing produces above 1025 bytes, so the
+      # two defects compose into unrecoverable loss.
+      #
+      # Quarantining the LINE is also not this function's job — it appends, it does not repair.
+      # Refusing to rotate keeps every event in place and leaves the damage visible.
+      if printf '%s' "$first" | jq -e . >/dev/null 2>&1; then
+        if ! printf '%s' "$first" | jq -e 'has("attributes")' >/dev/null 2>&1; then
+          # A genuine legacy log. Rotate to a UNIQUE destination: a fixed `.legacy` is a
+          # rescue slot of depth one, and the next rotation clobbers the previous month's
+          # only copy.
+          # A destination that CANNOT COLLIDE. A timestamp plus pid is still not unique —
+          # the same process can rotate twice within one second — and a collision here means
+          # one rotation destroying another's rescue copy, which is the whole defect.
+          local stamp dest n
+          stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+          dest="${month_file}.legacy.${stamp}.$$"
+          n=1
+          while [[ -e "$dest" ]]; do
+            dest="${month_file}.legacy.${stamp}.$$.${n}"
+            n=$((n + 1))
+          done
+          if mv "$month_file" "$dest" 2>/dev/null; then
+            printf '[catalyst] rotated legacy event log %s -> %s\n' "$month_file" "$dest" >&2
+          fi
+        fi
+      else
+        # Silence is a defect: an unparseable first line means the log has been damaged, and
+        # nothing else in this path would ever say so.
+        printf '[catalyst] WARNING: first line of %s does not parse as JSON — NOT rotating (events preserved in place)\n' "$month_file" >&2
+      fi
     fi
   fi
   printf '%s\n' "$line" >> "$month_file" 2>/dev/null || true

--- a/plugins/dev/scripts/orch-monitor/__tests__/event-writer.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/event-writer.test.ts
@@ -6,6 +6,15 @@ import { tmpdir } from "node:os";
 import { CanonicalEventWriter } from "../lib/event-writer";
 import type { CanonicalEvent } from "../lib/canonical-event";
 
+// CTL-1813: rotation destinations are now UNIQUE (a fixed `.legacy` is a rescue slot of
+// depth one — the next rotation clobbers the previous month's only copy). Tests therefore
+// look for ANY rotated sibling rather than one exact name.
+function rotatedFiles(dir: string, base: string): string[] {
+  if (!existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((f) => f.startsWith(`${base}.legacy`));
+}
+
+
 // bytesRequested — total `length` argument across readSync calls. The spy's
 // call tuple resolves to the 3-arg `readSync(fd, buffer, opts)` overload under
 // TS, so index positionally through `unknown[]` rather than fighting the
@@ -124,9 +133,10 @@ describe("CanonicalEventWriter", () => {
     );
     const writer = new CanonicalEventWriter({ baseDir: workdir, now: () => fixed });
     await writer.append(sampleEvent());
-    const legacyPath = join(workdir, "2026-05.jsonl.legacy");
-    expect(existsSync(legacyPath)).toBe(true);
-    expect(readFileSync(legacyPath, "utf8")).toContain('"event":"session-started"');
+    // CTL-1813: the destination is now unique, so resolve it rather than assuming the name.
+    const rotated = rotatedFiles(workdir, "2026-05.jsonl");
+    expect(rotated.length).toBe(1);
+    expect(readFileSync(join(workdir, rotated[0]), "utf8")).toContain('"event":"session-started"');
 
     const newContents = readFileSync(target, "utf8")
       .split("\n")
@@ -211,14 +221,14 @@ describe("CanonicalEventWriter", () => {
         readFileSyncSpy.mockRestore();
       }
       // …and the semantics are unchanged: a canonical first line is not rotated.
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(false);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(0);
     });
 
     it("still rotates a LEGACY first line in a multi-megabyte log (bounding did not blind it)", async () => {
       writeBigMonth(JSON.stringify({ ts: "2026-05-07T00:00:00Z", event: "session-started" }));
       const writer = new CanonicalEventWriter({ baseDir: workdir, now: () => fixed });
       await writer.append(sampleEvent());
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(true);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(1);
     });
 
     it("FAIL-SAFE: an undecidably long first line does NOT rotate, and says so", async () => {
@@ -236,18 +246,63 @@ describe("CanonicalEventWriter", () => {
         logger: { warn: (m) => warnings.push(m) },
       });
       await writer.append(sampleEvent());
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(false);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(0);
       expect(warnings.some((w) => w.includes("first-line probe exceeded"))).toBe(true);
       // The append still lands.
       expect(readFileSync(target(), "utf8")).toContain("github.pr.merged");
     });
 
-    it("a SHORT unparseable first line still rotates (the fail-safe is only for the cap)", async () => {
+    // ⛔ CTL-1813 REVERSES this case. It previously asserted that a short unparseable first
+    // line SHOULD rotate — "the fail-safe is only for the cap" — and that was a considered
+    // decision, not an oversight: CTL-1529 reasoned that an unreadably-large probe means "I
+    // could not look", while a short garbage line means the file really is junk.
+    //
+    // MEASUREMENT SINCE THEN FALSIFIES THAT PREMISE. CTL-1809 established that our own bash
+    // appends TEAR above 1025 bytes (macOS BUFSIZ), so a short unparseable first line is now
+    // a predictable product of the writer rather than evidence of a junk file. And the cost
+    // is total: driven against this writer, one torn first line rotated 349 live events
+    // aside, and a second torn line one rotation later overwrote the only surviving copy.
+    //
+    // CTL-1529's own words argue for the reversal — "'I could not read enough' must never be
+    // conflated with 'this is legacy', because only one of them destroys the path every
+    // reader is tailing." Damage is now in the first category too.
+    it("CTL-1813: a SHORT unparseable first line does NOT rotate — damage is not a legacy log", async () => {
       mkdirSync(workdir, { recursive: true });
       writeFileSync(target(), "not json at all\n");
-      const writer = new CanonicalEventWriter({ baseDir: workdir, now: () => fixed });
+      const warnings: string[] = [];
+      const writer = new CanonicalEventWriter({
+        baseDir: workdir,
+        now: () => fixed,
+        logger: { warn: (m) => warnings.push(m) },
+      });
       await writer.append(sampleEvent());
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(true);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(0);
+      // Silence is a defect: refusing must be audible, or a damaged log looks healthy.
+      expect(warnings.some((w) => w.includes("does not parse as JSON"))).toBe(true);
+      // Every pre-existing byte is still there, and the append still lands.
+      const body = readFileSync(target(), "utf8");
+      expect(body).toContain("not json at all");
+      expect(body).toContain("github.pr.merged");
+    });
+
+    // THE LOAD-BEARING ONE: two rotations must not destroy the first month.
+    it("CTL-1813: a second legacy rotation cannot clobber the first", async () => {
+      mkdirSync(workdir, { recursive: true });
+      // Round 1 — a genuine v1 line (parses, no `attributes`) rotates.
+      writeFileSync(target(), JSON.stringify({ ts: "x", event: "MONTH_A" }) + "\n");
+      await new CanonicalEventWriter({ baseDir: workdir, now: () => fixed }).append(sampleEvent());
+      // Round 2 — a NEW writer (fresh in-process `rotated` set, as a restart would have) sees
+      // another legacy line and rotates again.
+      writeFileSync(target(), JSON.stringify({ ts: "y", event: "MONTH_B" }) + "\n");
+      await new CanonicalEventWriter({ baseDir: workdir, now: () => fixed }).append(sampleEvent());
+
+      const rotated = rotatedFiles(workdir, "2026-05.jsonl");
+      expect(rotated.length).toBe(2);
+      // With a fixed `.legacy` destination the second rename overwrote the first, and
+      // MONTH_A was unrecoverable. Both must survive.
+      const all = rotated.map((f) => readFileSync(join(workdir, f), "utf8")).join("");
+      expect(all).toContain("MONTH_A");
+      expect(all).toContain("MONTH_B");
     });
 
     it("preserves the old split().find() semantics: leading blank lines are skipped", async () => {
@@ -257,7 +312,7 @@ describe("CanonicalEventWriter", () => {
       await writer.append(sampleEvent());
       // The first NON-EMPTY line is legacy ⇒ rotate (a naive "bytes before the
       // first \n" probe would have seen "" and skipped rotation).
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(true);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(1);
     });
 
     it("preserves the old semantics: a first line with NO trailing newline still classifies", async () => {
@@ -265,7 +320,7 @@ describe("CanonicalEventWriter", () => {
       writeFileSync(target(), JSON.stringify({ ts: "x", event: "legacy" })); // no "\n"
       const writer = new CanonicalEventWriter({ baseDir: workdir, now: () => fixed });
       await writer.append(sampleEvent());
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(true);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(1);
     });
 
     it("an empty file is not legacy (nothing to rotate)", async () => {
@@ -273,7 +328,7 @@ describe("CanonicalEventWriter", () => {
       writeFileSync(target(), "");
       const writer = new CanonicalEventWriter({ baseDir: workdir, now: () => fixed });
       await writer.append(sampleEvent());
-      expect(existsSync(join(workdir, "2026-05.jsonl.legacy"))).toBe(false);
+      expect(rotatedFiles(workdir, "2026-05.jsonl").length).toBe(0);
     });
   });
 

--- a/plugins/dev/scripts/orch-monitor/lib/event-writer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-writer.ts
@@ -134,8 +134,21 @@ function isLegacyFirstLine(filePath: string, logger?: EventWriterLogger): boolea
     if (typeof parsed !== "object" || parsed === null) return true;
     return !("attributes" in parsed);
   } catch {
-    // unparseable — treat as legacy/garbage; rotate it out of the way
-    return true;
+    // CTL-1813: an UNPARSEABLE first line is NOT a legacy log, and must never move the live
+    // one. This used to return true — "garbage; rotate it out of the way" — which meant a
+    // single torn line retired the whole month: measured against this writer, one truncated
+    // first line rotated 349 live events aside, and because the destination is a fixed
+    // `.legacy` name, a second torn line one rotation later overwrote the only surviving
+    // copy. A torn line is precisely what CTL-1809's bash-append tearing produces above 1025
+    // bytes, so the two defects compose into unrecoverable loss.
+    //
+    // Rotation exists for the v1 -> canonical migration, which is a line that PARSES and
+    // lacks `attributes`. Damage is a different thing: refuse, keep every event in place,
+    // and say so — the same fail-safe the >1 MiB probe branch above already takes.
+    logger?.warn?.(
+      `[event-writer] first line of ${filePath} does not parse as JSON — NOT rotating (events preserved in place)`,
+    );
+    return false;
   }
 }
 
@@ -161,7 +174,19 @@ export class CanonicalEventWriter {
     if (this.rotated.has(filePath)) return;
     this.rotated.add(filePath);
     if (!isLegacyFirstLine(filePath, this.logger)) return;
-    const legacyPath = `${filePath}.legacy`;
+    // CTL-1813: a destination that CANNOT COLLIDE. A fixed `.legacy` is a rescue slot of
+    // depth one — the next rotation renames over it and the previous month's only surviving
+    // copy is gone. Measured: two consecutive rotations left the first month unrecoverable.
+    //
+    // A timestamp alone is not sufficient, and the test for this caught it: two rotations
+    // inside the same millisecond produce the same name and the collision returns. So probe
+    // for a free name and never rename onto an existing file — the whole point is that no
+    // rotation may destroy a previous one.
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    let legacyPath = `${filePath}.legacy.${stamp}`;
+    for (let n = 1; existsSync(legacyPath); n += 1) {
+      legacyPath = `${filePath}.legacy.${stamp}.${n}`;
+    }
     try {
       renameSync(filePath, legacyPath);
       this.logger.warn?.(

--- a/plugins/dev/scripts/orch-monitor/lib/event-writer.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/event-writer.ts
@@ -20,7 +20,8 @@ import {
   mkdirSync,
   openSync,
   readSync,
-  renameSync,
+  linkSync,
+  unlinkSync,
 } from "node:fs";
 import { join } from "node:path";
 import type { CanonicalEvent } from "./canonical-event";
@@ -182,13 +183,33 @@ export class CanonicalEventWriter {
     // inside the same millisecond produce the same name and the collision returns. So probe
     // for a free name and never rename onto an existing file — the whole point is that no
     // rotation may destroy a previous one.
+    // `existsSync` then `renameSync` is check-then-act: two writers can both see the name
+    // free, and POSIX rename() OVERWRITES — so the second would destroy the first's rescue
+    // copy, which is this ticket's own defect one layer down (Codex #3318 P1).
+    //
+    // `linkSync` is the atomic primitive: it throws EEXIST rather than overwriting, so the
+    // link itself RESERVES the name. Unlink the source only once the link succeeded; if it
+    // fails we try the next name and the original is untouched.
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    let legacyPath = `${filePath}.legacy.${stamp}`;
-    for (let n = 1; existsSync(legacyPath); n += 1) {
-      legacyPath = `${filePath}.legacy.${stamp}.${n}`;
+    let legacyPath = "";
+    let reserved = false;
+    for (let n = 0; n <= 50 && !reserved; n += 1) {
+      legacyPath = n === 0 ? `${filePath}.legacy.${stamp}` : `${filePath}.legacy.${stamp}.${n}`;
+      try {
+        linkSync(filePath, legacyPath);
+        reserved = true;
+      } catch {
+        // EEXIST (a peer reserved it) or a real error — either way, try the next name.
+      }
+    }
+    if (!reserved) {
+      this.logger.warn?.(
+        `[event-writer] could not reserve a rotation name for ${filePath} — leaving it in place`,
+      );
+      return;
     }
     try {
-      renameSync(filePath, legacyPath);
+      unlinkSync(filePath);
       this.logger.warn?.(
         `[event-writer] rotated legacy file ${filePath} → ${legacyPath}`,
       );


### PR DESCRIPTION
Closes CTL-1813.

## The defect

Two writers rotated the **live** event log aside whenever its first line was not a canonical event,
and both sent it to a **single fixed `.legacy` name**:

```
plugins/dev/scripts/lib/canonical-event.sh                 (bash, all 18 bash producers)
plugins/dev/scripts/orch-monitor/lib/event-writer.ts       (bun)
```

Driven against the real code, not a model:

```
bash   — 500 good events, first line truncated → ONE append retires 499 of them
TS     — same probe                            → retires 349
round 2 — a second torn line, one rotation later → OVERWRITES the only surviving copy
```

A rescue slot of depth one. The second rotation makes the first month unrecoverable.

## The conflation is the bug

`jq -e 'has("attributes")'` exits non-zero for **both** a genuine v1 line and an **unparseable** one,
and the TS twin's `catch` returned *"legacy/garbage; rotate it out of the way"*.

Rotation exists for the **v1 → canonical migration** — a line that *parses* and lacks `attributes`.
Damage is a different thing, and it must not move a file every reader is tailing. Both writers now
parse first: **legacy rotates; unparseable refuses and says so.**

**Why this matters now:** it composes with CTL-1809. Our own bash appends **tear above 1025 bytes**
(macOS `BUFSIZ`), so a torn first line is a *predictable product of the writer*, not a rare accident.
Tear a line, lose a month.

## ⛔ This reverses a deliberate earlier decision — argued, not assumed

CTL-1529 explicitly asserted that a short unparseable first line **should** rotate: *"the fail-safe is
only for the cap."* Its reasoning was that an unreadably-large probe means *"I could not look"*, while
short garbage means the file really is junk. That was considered, not an oversight.

**Measurement since then falsifies the premise.** A short unparseable line is now a known output of
our own writer. And CTL-1529's own comment argues the reversal better than I can:

> *"'I could not read enough' must never be conflated with 'this is legacy', because only one of them
> destroys the path every reader is tailing."*

Damage belongs in that first category too. The test that encoded the old behaviour is rewritten with
this reasoning inline, so the next reader sees why it flipped.

## Collision-proof destinations — caught by the new test

A timestamp alone was **not** sufficient, and the test for it caught that: two rotations inside the
same millisecond produced the same name and the collision returned. Both writers now probe for a free
name and **never rename onto an existing file** — the entire point is that no rotation may destroy
another's rescue copy.

## Verification

- `__tests__/canonical-event-rotation.test.sh` — new, drives the **real** `canonical_jsonl_append`:
  a torn line rotates nothing and preserves all 21 events and warns; a genuine legacy line still
  rotates (**positive control**, so the refusal proves the parse distinction rather than a disabled
  feature); two rotations both survive with `MONTH_A` and `MONTH_B` intact.
- `orch-monitor/__tests__/event-writer.test.ts` — **16 pass, 0 fail** (was 15; baseline on pristine
  `main` is 15/15, so no pre-existing failure is masked).
- **Mutation-verified:** restoring the conflated check fails with *"a torn first line rotated the live
  log (1 files) — 20 events would have been retired"*, exit 1.

One incidental fix worth noting: the bash test's cleanup now ends in `true` and the script in
`exit 0`. Without them the EXIT trap's last conditional decided the exit status, and a **passing test
reported failure** — cleanup must never be able to change the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)