### PR TITLE
chore(dev): resolve @catalyst-cloud/schema to 0.1.5 so a published migration reaches the replica

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -211,7 +211,7 @@
 
     "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.3", "", { "dependencies": { "@catalyst-cloud/schema": "^0.1.3" } }, "sha512-7LyYJTG5fkjq9RA8OaCpCzP2b/gjPOYJJmCxRce++TPsIviQULpTiaffL7MuBfwGODf2dwGrO0ozeW7n8slTTQ=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-qZGbGvJuvputQlX2TCH5IYAGGVJjunh7tZc9tsp4YxoE82Bj34F+zjqgtCuMTAc6yzR7rNJv90ZjZBLDNoKYwg=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.5", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-00jtw6f9bUwwR3aeviECqNHfuMrlLK73cOym4wCLBdMJNLOBo0NYM7HlkH6ejWpqycq7EI2ECfys4wqzqnhT5g=="],
 
     "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-QJZFWZAfDdLCr4jvfS05BfuZDR5jr6bN4n/DN2vgMQB9pRTTrZAtk+mbvcK8M3NwfxyuPD0ICVM4Qe+/8jtnEg=="],
 


### PR DESCRIPTION
## The defect

Every replica on the fleet has been frozen at migration `0008_optimal_rattler` since 2026-08-10, while `@catalyst-cloud/schema` **0.1.5** (tail `0015_brainy_lady_ursula`) has been published. **Nothing is red** — the writer heartbeats, the cursor advances, and each host faithfully applies every migration in the bundle it has.

Measured on all three hosts today:

| | value |
| - | ----- |
| published `@catalyst-cloud/schema` | **0.1.5** |
| every host's `bun.lock` | **0.1.3** |
| every replica's applied tail | **`0008_optimal_rattler`** |
| `pull_requests.head_ref` | **absent** on both minis |
| anything red | **nothing** |

## Mechanism

```
cloud-sync.mjs -> @catalyst-cloud/sdk CatalystReplica.start()  (opens + migrates)
               -> the sdk's RESOLVED @catalyst-cloud/schema
               -> src/migrations.generated.ts
```

`sdk@0.8.2` declares `schema: ^0.1.3`, which **admits** 0.1.5 — but `bun.lock` pinned the resolution at `0.1.3` exactly, so `bun install --frozen-lockfile` re-installs 0.1.3 deterministically. That is what a lockfile is for.

schema@0.1.3's `migrations.generated.ts` ends at `0008_optimal_rattler`; 0.1.5's runs through `0015_brainy_lady_ursula`. The installed bundle's tail and the replica's tail are the same value **because one causes the other**.

**Positive control on the discriminator:** `head_ref` appears **0** times in 0.1.3's generated migrations and **1** time in 0.1.5's. So `pull_requests.head_ref` being absent is explained by the pin, not by a failed migration.

## Why the lockfile is edited surgically

`bun update @catalyst-cloud/schema` is the obvious fix and it is **a silent no-op for the daemon**:

- it ADDS a direct root dependency and hoists 0.1.5 there, while leaving nested `@catalyst-cloud/sdk/@catalyst-cloud/schema` pinned at **0.1.3**
- verified on disk — after running it, the sdk's store symlink still resolved **0.1.3**
- it prints `installed @catalyst-cloud/schema@0.1.5` and changes nothing for `cloud-sync`

Two other options were tested and rejected:

- **deleting the lockfile entry** and re-resolving works, but re-resolves ~35 unrelated packages (`ws`, `postcss`, `@types/node`, `@tanstack/*`, `lucide-react`, …)
- **an `overrides` pin** works but hard-codes an exact version, relocating the same staleness trap to 0.1.6

## Verification

Run with the command the fleet actually runs:

```
rm -rf node_modules && bun install --frozen-lockfile
```

| check | result |
| ----- | ------ |
| sdk-resolved schema version | **0.1.5** |
| `head_ref` in generated migrations | **present** |
| migration tail | **`0015_brainy_lady_ursula`** |
| lockfile diff | **1 line** |

## Scope

This unblocks migration **delivery**. It is **not a guard** — the durable fix (the SDK refusing to run a schema bundle older than the cloud's) is **CTC-471**. Applying the migrations on each host additionally requires restarting `cloud-sync`, which the stack reload never touches (**CTL-1659**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)