### PR TITLE
fix(dev): CTL-1832 — a triage escalation must carry its question, not an empty object

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -318,6 +318,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/canonical-event.test.sh
 
+      - name: SKILL.md ${PLUGIN_ROOT} assignment guard (CTL-1832)
+        # CTL-1832: a SKILL.md that EXPANDS ${PLUGIN_ROOT} must also ASSIGN it, or
+        # the expansion is empty and the command silently addresses a bogus path.
+        # This shipped twice: fatally in phase-monitor-deploy (CTL-1410, under
+        # `set -u`) and SILENTLY in phase-triage, where `2>/dev/null || echo '{}'`
+        # turned a broken escalation shim into an empty explanation with exit 0.
+        # The scan carries its own positive control, so a clean run is evidence.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/skill-plugin-root-assigned.test.sh
+
       - name: catalyst-stack shipper ephemeral-path guard test (CTL-1473)
         # CTL-1473: guards that install-services (--print and real) refuses to bake
         # an ephemeral config path (worktree or /tmp). Uses CATALYST_FORCE_BAKE_DIR +

--- a/plugins/dev/scripts/__tests__/skill-plugin-root-assigned.test.sh
+++ b/plugins/dev/scripts/__tests__/skill-plugin-root-assigned.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# CTL-1832: skill-invariant test. A SKILL.md that EXPANDS ${PLUGIN_ROOT} in live
+# shell must also ASSIGN it, or the expansion is empty and every command built
+# from it silently addresses the wrong path.
+#
+# This has now happened twice, in opposite directions:
+#   - phase-monitor-deploy (CTL-1410, pre-existing since CTL-550): fatal, because
+#     that body runs under `set -u` — the unbound expansion killed the success
+#     path outright.
+#   - phase-triage (CTL-1832): SILENT, because the call was wrapped in
+#     `2>/dev/null || echo '{}'` — so a broken escalation shim produced an empty
+#     explanation and exited 0, and the operator inbox rendered a bare
+#     `needs-human` label instead of a specific answerable question.
+#
+# The silent direction is the one worth a permanent guard: it cannot be noticed
+# by running the pipeline, only by reading the file.
+#
+# NOTE ON THE INSTRUMENT: mentions of ${PLUGIN_ROOT} inside a COMMENT are not
+# uses. phase-monitor-deploy still names the variable in its explanatory comment
+# describing the CTL-1410 fix; counting that would report a defect that is
+# already fixed. Comment lines are therefore stripped before matching.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+
+FAILURES=0
+PASSES=0
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; [ $# -ge 2 ] && echo "    $2"; }
+
+# live_plugin_root_uses <file> — count ${PLUGIN_ROOT} expansions that are NOT on
+# a comment line. Deliberately does not try to parse fenced blocks: a bare
+# mention outside a code fence is still prose that an agent may copy verbatim.
+live_plugin_root_uses() {
+	grep -v '^[[:space:]]*#' "$1" 2>/dev/null | grep -c '\${PLUGIN_ROOT}' || true
+}
+
+assigns_plugin_root() {
+	grep -cE '^[[:space:]]*(export[[:space:]]+)?PLUGIN_ROOT=' "$1" 2>/dev/null || true
+}
+
+echo "Test: every SKILL.md that expands \${PLUGIN_ROOT} also assigns it"
+OFFENDERS=""
+CHECKED=0
+while IFS= read -r f; do
+	CHECKED=$((CHECKED + 1))
+	uses=$(live_plugin_root_uses "$f")
+	[ "$uses" -gt 0 ] || continue
+	assigns=$(assigns_plugin_root "$f")
+	if [ "$assigns" -eq 0 ]; then
+		OFFENDERS="${OFFENDERS}
+    ${f#"$REPO_ROOT"/} (${uses} live use(s), 0 assignments)"
+	fi
+done < <(find "$REPO_ROOT/plugins" -name 'SKILL.md' -type f 2>/dev/null)
+
+if [ -z "$OFFENDERS" ]; then
+	pass "no SKILL.md expands an unassigned \${PLUGIN_ROOT} (${CHECKED} files scanned)"
+else
+	fail "SKILL.md files expand \${PLUGIN_ROOT} without assigning it" "$OFFENDERS"
+fi
+
+# ── POSITIVE CONTROL ─────────────────────────────────────────────────────────
+# The check above reports a clean result. A clean result is only evidence if the
+# same instrument returns a DIRTY result on a case known to be defective. Build
+# that case and assert the detector fires on it. If this control ever passes
+# silently, the scan above is vacuous and its "no offenders" means nothing.
+echo "Test: the detector actually fires on a known-defective file (positive control)"
+CTRL_DIR="$(mktemp -d)"
+trap 'rm -rf "$CTRL_DIR"' EXIT
+
+cat >"$CTRL_DIR/SKILL.md" <<'FIXTURE'
+# A skill that never assigns PLUGIN_ROOT
+```bash
+EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" --ticket "$T")"
+```
+FIXTURE
+
+ctrl_uses=$(live_plugin_root_uses "$CTRL_DIR/SKILL.md")
+ctrl_assigns=$(assigns_plugin_root "$CTRL_DIR/SKILL.md")
+if [ "$ctrl_uses" -gt 0 ] && [ "$ctrl_assigns" -eq 0 ]; then
+	pass "detector reports the defective fixture as an offender (uses=${ctrl_uses}, assigns=${ctrl_assigns})"
+else
+	fail "detector did NOT flag the defective fixture — the scan above is vacuous" \
+		"uses=${ctrl_uses} assigns=${ctrl_assigns} (expected uses>0, assigns=0)"
+fi
+
+# Second control, the other direction: a file that DOES assign must not be
+# flagged, so the check is not simply reporting every file as an offender.
+cat >"$CTRL_DIR/OK.md" <<'FIXTURE'
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+echo "${PLUGIN_ROOT}/scripts/thing"
+```
+FIXTURE
+
+ok_uses=$(live_plugin_root_uses "$CTRL_DIR/OK.md")
+ok_assigns=$(assigns_plugin_root "$CTRL_DIR/OK.md")
+if [ "$ok_uses" -gt 0 ] && [ "$ok_assigns" -gt 0 ]; then
+	pass "detector does not flag a file that assigns \${PLUGIN_ROOT} (uses=${ok_uses}, assigns=${ok_assigns})"
+else
+	fail "detector mis-reads a correct file" "uses=${ok_uses} assigns=${ok_assigns}"
+fi
+
+# ── The specific regression this ticket fixed ────────────────────────────────
+echo "Test: phase-triage's escalation shim resolves from CLAUDE_PLUGIN_ROOT"
+TRIAGE="$REPO_ROOT/plugins/dev/skills/phase-triage/SKILL.md"
+if grep -q 'CLAUDE_PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs' "$TRIAGE"; then
+	pass "phase-triage escalation-explain uses CLAUDE_PLUGIN_ROOT"
+else
+	fail "phase-triage escalation-explain does not resolve from CLAUDE_PLUGIN_ROOT"
+fi
+
+echo "Test: a failed escalation shim leaves a breadcrumb instead of silently emitting {}"
+if grep -q 'escalation-explain unavailable' "$TRIAGE"; then
+	pass "phase-triage warns on shim failure"
+else
+	fail "phase-triage still degrades to {} with no operator-visible signal"
+fi
+
+echo ""
+echo "─────────────────────────────────────────"
+echo "  Passed: $PASSES   Failed: $FAILURES"
+[ "$FAILURES" -eq 0 ] || exit 1

--- a/plugins/dev/skills/phase-triage/SKILL.md
+++ b/plugins/dev/skills/phase-triage/SKILL.md
@@ -467,12 +467,33 @@ ambiguous to classify, or a required external resource is unavailable), emit
 `failed` with a structured `explanation` block. Use the CLI shim:
 
 ```bash
-EXPL_JSON="$(node "${PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
-  --ticket "$TICKET" --phase triage \
-  --what-failed "{{ specific symptom }}" \
-  --why-gave-up "{{ reason autonomous triage cannot complete }}" \
-  --human-question "{{ one specific answerable question }}" \
-  2>/dev/null || echo '{}')"
+# CTL-1832: this invocation referenced ${PLUGIN_ROOT}, which this skill NEVER
+# assigns — the file's own idiom is CLAUDE_PLUGIN_ROOT (see the secret-contract
+# source earlier in this skill). The empty expansion handed node the bogus path
+# "/scripts/execution-core/escalation-explain.mjs"; `2>/dev/null` swallowed the
+# ENOENT and `|| echo '{}'` substituted an EMPTY explanation, exiting 0. So every
+# structured triage escalation silently degraded to {} — which is exactly the
+# failure CTL-1609's explanation chokepoint exists to prevent: with no
+# explanation it emits `escalation.explanation-absent`, coerces a degraded
+# fallback, and the operator inbox renders a bare `needs-human` label instead of
+# the specific question this section demands below.
+#
+# Same defect CTL-1410 fixed in phase-monitor-deploy (there it was fatal, under
+# that body's `set -u`); it was never back-ported here, where it degrades
+# silently instead — the worse direction.
+#
+# The '{}' fallback is KEPT so a broken shim can never block a triage escalation,
+# but the failure now leaves a breadcrumb on stderr rather than being invisible,
+# and stderr is no longer discarded.
+if ! EXPL_JSON="$(node "${CLAUDE_PLUGIN_ROOT}/scripts/execution-core/escalation-explain.mjs" \
+      --ticket "$TICKET" --phase triage \
+      --what-failed "{{ specific symptom }}" \
+      --why-gave-up "{{ reason autonomous triage cannot complete }}" \
+      --human-question "{{ one specific answerable question }}")" \
+   || [[ -z "$EXPL_JSON" ]]; then
+  echo "phase-triage: escalation-explain unavailable (CLAUDE_PLUGIN_ROOT=${CLAUDE_PLUGIN_ROOT:-<unset>}); escalating WITHOUT a structured explanation" >&2
+  EXPL_JSON='{}'
+fi
 ```
 
 The `human_question` MUST be specific and answerable — never:


### PR DESCRIPTION
Closes CTL-1832.

## The defect

`plugins/dev/skills/phase-triage/SKILL.md:470` invoked the structured-escalation shim through `${PLUGIN_ROOT}` — a variable **that skill never assigns**. Its only other plugin-root reference (`:386`, the secret-contract source) uses the *different* variable `CLAUDE_PLUGIN_ROOT`.

**Positive control on the claim:** `phase-verify/SKILL.md:77` DOES assign it (`PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-…}"`), so the instrument distinguishes assigned from unassigned rather than reporting the same thing everywhere.

## Why nothing was ever red

```
${PLUGIN_ROOT} -> ""                                   (unassigned)
node "/scripts/execution-core/escalation-explain.mjs"   (bogus path)
2>/dev/null                                             (ENOENT swallowed)
|| echo '{}'                                            (empty explanation)
exit 0
```

Every structured triage escalation degraded to `{}`. That is exactly the case **CTL-1609's explanation chokepoint** exists to catch: with no explanation, `labelNeedsHumanUnlessBeliefOwner` emits `escalation.explanation-absent`, coerces a `degraded: true` fallback, and the operator inbox renders a bare `needs-human` label — instead of the specific, answerable question this same skill spends three paragraphs demanding.

## This is the second instance of one defect

`phase-monitor-deploy/SKILL.md:347-351` carries a comment describing the identical bug, fixed by **CTL-1410** (pre-existing since CTL-550). There it was **fatal** — the unbound expansion died under that body's `set -u`. It was never back-ported here, where it **degrades silently** instead. The silent direction is worse: running the pipeline cannot reveal it, only reading the file can.

## The fix

- resolve from the file's own idiom, `CLAUDE_PLUGIN_ROOT`
- **keep** the `{}` fallback so a broken shim can never block an escalation
- stop discarding stderr, and emit an operator-visible breadcrumb when the shim is unavailable

## The guard generalizes it

Rather than patching one line, `__tests__/skill-plugin-root-assigned.test.sh` asserts that **every** `SKILL.md` expanding `${PLUGIN_ROOT}` also assigns it. **112 SKILL.md files scanned.**

It carries its own positive controls, because a clean result is only evidence if the instrument can return a dirty one:

| control | expectation |
| ------- | ----------- |
| synthetic defective fixture | MUST be flagged (uses=1, assigns=0) |
| synthetic correct fixture | MUST NOT be flagged (uses=1, assigns=1) |
| comment-only mentions | stripped — so phase-monitor-deploy's comment about the CTL-1410 fix is not re-reported as a live defect |

## Verification — the test was proven able to fail

Reverted the source fix with the test in place:

| | result |
| - | ------ |
| with fix | **5 passed, 0 failed**, exit 0 |
| without fix | **2 passed, 3 failed**, exit 1, naming `plugins/dev/skills/phase-triage/SKILL.md (1 live use(s), 0 assignments)` |

## CI wiring

Added explicitly to `execution-core-tests.yml`. That list is **hand-enumerated, not globbed** — an unlisted test file simply never runs, and the guard would have landed with no gate at all.

Found by a recon pass over M3 on 2026-08-13; unrelated to that milestone's scope, fixed here because it is cheap and the escalation path is load-bearing for the operator inbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)