### PR TITLE
fix(dev): CTL-1818 — count the events the forwarder throws away, on a surface that survives the throwing-away

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -630,6 +630,42 @@ mode, restarts the stuck daemon exactly once per breach episode.
   not just `kill -0`, and fail closed — a recycled pid is treated as a stale file, never a kill
   target. Covered by `__tests__/daemon-watchdog-supervision.test.sh`.
 
+### Forward-drop surface (CTL-1818)
+
+The watchdog above catches a **wedged** forwarder. A forwarder that is working perfectly and
+**discarding** events is a different failure, and none of the three existing instruments can see it:
+`emitDrop` (`otel-forward/lib/destinations/otlp.ts`) fires for `aged` or `terminal_4xx`, and an aged
+record **never rides the DLQ in the primary path** — so the watchdog's DLQ-size predicate stays flat,
+the checkpoint keeps advancing (a discard *is* read progress), and the
+`catalyst.observability.forward_dropped` event it writes ships through the very path that just
+discarded something. Measured on the fleet's mirrored `2026-08.jsonl` (coverage 08-08 → 08-13):
+**87,706 drop events carrying 7,623,269 discarded records, 100% `reason: "aged"`** — read by nothing
+in this repo, and by nothing in `catalyst-otel` either (the provisioned Grafana rule reads
+`forward_failed`, a different name).
+
+- **Where it is counted** — `recordDrop` (`otel-forward/lib/drop-surface.ts`) is called from
+  `emitDrop` **before** its `!eventLogPath` / `isSelfBatch` guards, both of which suppress the event
+  entirely. Counters are process-exact, per reason, in events (batches) **and** records.
+- **Three sinks, none of which ride the failing pipe** — (1) the exact in-memory counters;
+  (2) a durable marker `~/catalyst/otel-forward-drops.json` (atomic tmp+rename, `cumulative` totals
+  carried across restarts, ≤1 s write throttle bypassed on any alert transition); (3) the daemon's
+  pino `.log`, Alloy-shipped independently of its own OTLP egress. Deliberately **no** event sink —
+  an alarm sourced from the forwarded stream measures the survivors and reads clean during exactly
+  the outage it exists to detect.
+- **Sustained-rate alert** — pure `classifyDropWindow` over a bounded 60-bucket ring: breach when
+  window records `>= thresholdRecords`, alert when the breach persists `>= sustainMs` (defaults 5 min
+  / 1,000 records / 10 min, resolved env > `forwarders.otlp.dropSurface` > frozen default). Raise and
+  clear are **edge-triggered**, so a storm logs one `ERROR`, not one per batch; the forwarder's
+  existing 30 s lag timer re-evaluates so a host that recovered and went quiet does not latch raised
+  forever.
+- **ALERT-ONLY, by ruling.** This is *not* a third member of `classifyDaemonStuck`'s `tripped` list —
+  that list is wired straight to `restart()` in the CTL-1502 probe, and restarting a forwarder does
+  not fix a Loki-accept-window/backlog condition; it only loses the in-memory buffer. A Grafana rule
+  over the `.log` stream is the follow-up, and belongs in the `catalyst-otel` repo.
+- **One mechanism, two callers** — the CTL-1817 count-every/log-sparsely gate moved to
+  `otel-forward/lib/sparse-warn.ts` (semantics unchanged); the tailer's unknown-shape alarm and this
+  drop alarm each build their own gate so a flood of one cannot exhaust the other's key budget.
+
 ### Two-axis worker state & the recordTransition chokepoint (CTL-764)
 
 Every worker ticket has **two orthogonal axes** — never blurred:

--- a/plugins/dev/references/event-forwarding.md
+++ b/plugins/dev/references/event-forwarding.md
@@ -88,6 +88,44 @@ not duplicated here.
 with attribute `catalyst.observability.drop_reason` (`"aged"` or `"terminal_4xx"`) and
 `body.payload.count`. Loop-guarded by `isSelfBatch` (same as `forward_failed`).
 
+### Drop surface — `~/catalyst/otel-forward-drops.json` (CTL-1818)
+
+A discard is the one forwarder failure **no other instrument can see**:
+
+| signal          | how it is normally caught                                      | does it catch an aged drop?                                            |
+| --------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `forward_failed` | DLQ grows → CTL-1502 watchdog P1 (DLQ file size)               | **No** — an aged record never rides the DLQ, so the file stays flat     |
+| `forward_lag`    | checkpoint `lastForwardedTs` freezes → watchdog P2             | **No** — the checkpoint advances; a discard *is* read progress          |
+| `forward_dropped`| an event on the log…                                           | **No** — that event ships through the path that just discarded something |
+
+So the drop is accounted for **on the host**, out of band of the forwarder's own OTLP egress:
+
+- **Counters** — exact, per reason, in both events (batches) and records. Recorded in
+  `emitDrop` **before** its `!eventLogPath` / `isSelfBatch` guards, so a discard that emits no
+  event at all is still counted.
+- **Marker** — `~/catalyst/otel-forward-drops.json` (atomic tmp+rename, beside the checkpoint and
+  the DLQ). Carries host, pid, per-reason `process` and restart-carried `cumulative` totals, the
+  rolling-window verdict, and the alert latch. Read it directly:
+
+  ```bash
+  jq '{host, cumulative, window, alert}' ~/catalyst/otel-forward-drops.json
+  ```
+
+- **Alarm** — the daemon's pino `~/catalyst/otel-forward.log`, which Alloy ships to Loki
+  **independently** of this daemon's OTLP egress. A first-sighting warning per reason plus
+  exponentially-spaced heartbeats (the CTL-1817 count-every/log-sparsely gate,
+  `lib/sparse-warn.ts`), and one `ERROR` line when the discard rate stays above threshold for the
+  sustain window — naming the host and the reason.
+
+**Alert-only.** The sustained-loss alert raises a log line and latches the marker; it never
+restarts anything. An aged drop is a Loki-accept-window / backlog condition, and a restart does not
+fix it — it only loses the in-memory buffer. This is deliberately *not* a third predicate in
+`classifyDaemonStuck`, whose `tripped` list feeds `restart()` in the CTL-1502 probe.
+
+Thresholds (`windowMs`, `thresholdRecords`, `sustainMs`) resolve **env > `forwarders.otlp.dropSurface`
+> frozen default**; the authoritative schema and defaults live in
+`website/src/content/docs/reference/configuration.md`.
+
 The `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable overrides `endpoint` (port 4317 is
 automatically rewritten to 4318 for HTTP).
 

--- a/plugins/dev/scripts/otel-forward/index-drop-wiring.test.ts
+++ b/plugins/dev/scripts/otel-forward/index-drop-wiring.test.ts
@@ -1,0 +1,186 @@
+// index-drop-wiring.test.ts — CTL-1818. The two lines in index.ts that WIRE the drop surface
+// into the daemon, held load-bearing by BEHAVIOUR rather than by inspection.
+//
+// The unit suites next door exercise the drop surface by calling into it directly —
+// `resolveDropSurfaceConfig(...)` and `evaluateDropSurface({ ...io })` — so they pass whether or
+// not index.ts ever calls either one. Measured before this file existed: deleting each wiring
+// line in turn left the whole otel-forward suite at 236 pass / 0 fail. That is the
+// "tested the pure function, not the gate in front of it" hole, and these two probes close it:
+//
+//   index.ts  `configureDropSurface(cfg.otlp.dropSurface)` — without it the documented
+//     `forwarders.otlp.dropSurface` config layer is DEAD: the surface runs on env + the frozen
+//     defaults forever while website/src/content/docs/reference/configuration.md declares that
+//     layer authoritative, and an operator who raises the threshold on a noisy host is ignored.
+//   index.ts  `evaluateDropSurface()` on the 30 s lag tick — without it a host that recovered
+//     latches `alert.raised: true` FOREVER, in memory and in the marker file. The clear branch in
+//     lib/drop-surface.ts is reachable from this tick and from nothing else.
+//
+// ── Why a SUBPROCESS ──────────────────────────────────────────────────────────────────────────
+// Both facts are module-scope facts. `configureDropSurface` runs on `import` of index.ts, not on
+// any call, and `bun test` shares ONE module registry across every file in the run — so an
+// in-process import would observe whichever env/cwd the first importing test file happened to
+// leave behind, and would be silently order-dependent. A spawned probe with a pinned
+// CATALYST_DIR / CATALYST_EVENTS_DIR / CATALYST_CONFIG_PATH is deterministic and hermetic:
+// nothing it writes can land in the real ~/catalyst, and nothing in the developer's shell can
+// stand in for the config tier under test. (Same shape as execution-core's
+// config-pino-fallback.test.mjs, which spawns probes for the same module-load reason.)
+//
+// Run: cd plugins/dev/scripts/otel-forward && bun test index-drop-wiring.test.ts
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DROP_SURFACE_DEFAULTS } from "./lib/drop-surface.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const INDEX_TS = resolve(HERE, "index.ts");
+const DROP_SURFACE_TS = resolve(HERE, "lib/drop-surface.ts");
+
+// Deliberately unlike DROP_SURFACE_DEFAULTS (300_000 / 1_000 / 600_000) in ALL THREE fields, so
+// "the config file reached the surface" can never be confused with "the default happened to
+// match". Every value is also inside its own validity floor, so the resolver keeps it verbatim.
+const FILE_CFG = { windowMs: 111_000, thresholdRecords: 222, sustainMs: 333_000 };
+
+// The alert fixture, applied INSIDE the probe AFTER the config observation is captured, so the
+// two assertions stay independent: deleting the configure line must fail probe (1) alone, and
+// deleting the tick call must fail probe (2) alone.
+const ALERT_CFG = { windowMs: 60_000, thresholdRecords: 100, sustainMs: 30_000 };
+
+// Written to a temp dir and run by the same bun that runs this suite. It imports index.ts the way
+// production does: module scope executes, while the daemon loop behind `if (import.meta.main)`
+// does not, because the entry point is the probe rather than index.ts.
+const PROBE_SRC = `
+import { readFileSync } from "node:fs";
+
+const idx = await import(process.env.PROBE_INDEX);
+const ds = await import(process.env.PROBE_DROP_SURFACE);
+
+// (1) What index.ts applied to the surface at import time. Nothing has been called yet — if the
+// wiring line is gone this is the frozen default set, not the config file's block.
+const applied = ds.dropSurfaceSnapshot().config;
+
+// (2) Latch a sustained-loss alert on the surface, then run ONE tick body and watch it clear.
+// The injected clock is what makes this deterministic: the two drops sit at t=1s/t=40s (39s of
+// sustained breach against a 30s sustain window), and the tick then evaluates at the real
+// Date.now(), decades later, so the rolling window is provably drained rather than merely quiet.
+ds.resetDropSurfaceForTest();
+ds.configureDropSurface(JSON.parse(process.env.PROBE_ALERT_CFG));
+const quiet = { warn() {}, error() {}, info() {} };
+ds.recordDrop("aged", 150, { log: quiet, now: () => 1000 });
+ds.recordDrop("aged", 150, { log: quiet, now: () => 40000 });
+
+const markerBefore = JSON.parse(readFileSync(ds.getDropMarkerPath(), "utf8"));
+const raisedBeforeTick = ds.dropSurfaceSnapshot().alertRaised;
+
+idx.emitLag();
+
+const markerAfter = JSON.parse(readFileSync(ds.getDropMarkerPath(), "utf8"));
+const raisedAfterTick = ds.dropSurfaceSnapshot().alertRaised;
+
+process.stdout.write("PROBE_RESULT " + JSON.stringify({
+  applied,
+  raisedBeforeTick,
+  raisedAfterTick,
+  markerRaisedBeforeTick: markerBefore.alert.raised,
+  markerRaisedAfterTick: markerAfter.alert.raised,
+}) + "\\n");
+`;
+
+interface ProbeResult {
+  applied: { windowMs: number; thresholdRecords: number; sustainMs: number };
+  raisedBeforeTick: boolean;
+  raisedAfterTick: boolean;
+  markerRaisedBeforeTick: boolean;
+  markerRaisedAfterTick: boolean;
+}
+
+let dir = "";
+let status: number | null = null;
+let stderr = "";
+let parsed: ProbeResult | null = null;
+
+/** Fails LOUDLY with the probe's own stderr rather than throwing an opaque property error. */
+function probe(): ProbeResult {
+  if (!parsed) throw new Error(`probe produced no PROBE_RESULT (status=${status})\n${stderr}`);
+  return parsed;
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctl1818-wiring-"));
+  const configPath = join(dir, "config-ctl1818-probe.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      catalyst: {
+        projectKey: "ctl1818-probe",
+        // OTLP stays disabled: the probe is about the drop-surface wiring, and a constructed
+        // sender would be dead weight (no endpoint, nothing to flush).
+        observability: { forwarders: { otlp: { enabled: false, dropSurface: FILE_CFG } } },
+      },
+    }),
+  );
+  const probePath = join(dir, "probe.ts");
+  writeFileSync(probePath, PROBE_SRC);
+
+  // Built from scratch rather than spread over process.env, so a CATALYST_FORWARD_DROP_* left in
+  // the developer's shell cannot stand in for the config-file tier this probe is measuring, and
+  // an OTLP endpoint in the environment cannot make the tick's memory gauge post real samples.
+  const env: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? "",
+    HOME: process.env.HOME ?? "",
+    CATALYST_DIR: dir,
+    CATALYST_EVENTS_DIR: join(dir, "events"),
+    CATALYST_CONFIG_PATH: configPath,
+    LOG_LEVEL: "silent",
+    PROBE_INDEX: INDEX_TS,
+    PROBE_DROP_SURFACE: DROP_SURFACE_TS,
+    PROBE_ALERT_CFG: JSON.stringify(ALERT_CFG),
+  };
+
+  const run = spawnSync(process.execPath, [probePath], {
+    cwd: HERE,
+    env,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  status = run.status;
+  stderr = run.stderr ?? "";
+  // The daemon logs on its own logger, so PROBE_RESULT is picked out by marker rather than by
+  // assuming it is the only line on stdout.
+  const line = (run.stdout ?? "").split("\n").find((l) => l.startsWith("PROBE_RESULT "));
+  parsed = line ? (JSON.parse(line.slice("PROBE_RESULT ".length)) as ProbeResult) : null;
+});
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("index.ts wires the drop surface into the daemon (CTL-1818)", () => {
+  test("the probe imports the daemon cleanly and reports", () => {
+    // Guards the two assertions below against the vacuous pass: a probe that crashed on import
+    // must read as a failure here, not as an absent surface change somewhere downstream.
+    expect(stderr).not.toContain("error:");
+    expect(status).toBe(0);
+    expect(parsed).not.toBeNull();
+  });
+
+  test("the forwarders.otlp.dropSurface config layer reaches the surface on import", () => {
+    // index.ts `configureDropSurface(cfg.otlp.dropSurface)`. Delete it and the surface answers
+    // with the frozen defaults instead — the documented config layer silently does nothing.
+    expect(probe().applied).toEqual(FILE_CFG);
+    expect(probe().applied).not.toEqual({ ...DROP_SURFACE_DEFAULTS });
+  });
+
+  test("one lag tick clears a latched sustained-loss alert, in memory and in the marker", () => {
+    // index.ts `evaluateDropSurface()` inside emitLag(). The BEFORE assertions are the positive
+    // control: they prove the fixture genuinely latched an alert, so `false` afterwards is a real
+    // clear rather than an alert that was never raised. Delete the call and the alert stays
+    // raised forever — nothing else in the daemon re-evaluates once the drops stop.
+    expect(probe().raisedBeforeTick).toBe(true);
+    expect(probe().markerRaisedBeforeTick).toBe(true);
+    expect(probe().raisedAfterTick).toBe(false);
+    expect(probe().markerRaisedAfterTick).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -21,6 +21,8 @@ import {
 } from "./lib/normalize.ts";
 import { dlqDepth } from "./lib/dlq.ts";
 import { buildCanonicalEnvelope } from "./lib/canonical.ts";
+import { createSparseWarnGate } from "./lib/sparse-warn.ts";
+import { configureDropSurface, evaluateDropSurface } from "./lib/drop-surface.ts";
 
 const CATALYST_DIR = process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
 const EVENTS_DIR = process.env.CATALYST_EVENTS_DIR ?? join(CATALYST_DIR, "events");
@@ -100,6 +102,11 @@ const CONFIG_PATH =
 
 const cfg = loadForwarderConfig(CONFIG_PATH, PROJECT_KEY);
 const ck = readCheckpoint(CHECKPOINT_PATH);
+
+// CTL-1818: apply the configured drop-surface thresholds (env still wins — see
+// lib/drop-surface.ts's ladder). Done at module scope, not inside the `import.meta.main`
+// block, so a sender constructed by any importer measures against the same thresholds.
+configureDropSurface(cfg.otlp.dropSurface);
 
 // CTL-1817: `unrecognized` counts lines the TAILER filtered out for matching no known
 // envelope shape; `skippedNoAttributes` counts records that got past the tailer but were
@@ -226,6 +233,11 @@ function emitLag(): void {
   // CTL-1517: per-process RSS/heap OTel gauge on the same tick (fire-and-forget; never
   // throws, never blocks) so per-daemon memory becomes attributable in Prometheus.
   void emitProcessMemoryMetric({ serviceName: "catalyst.otel-forward", log });
+  // CTL-1818: re-evaluate the host-local drop surface on the same 30 s tick. Two things no
+  // drop-driven call can do: CLEAR a latched sustained-loss alert on a host that recovered
+  // and went quiet (nothing else re-evaluates once the drops stop), and keep the marker's
+  // rolling-window figures honest while nothing is being discarded. Best-effort, never throws.
+  evaluateDropSurface();
   // Skip on cold start before any event has been processed or delivered
   if (!lastLocalTs && !lastForwardedTs) return;
   try {
@@ -260,30 +272,12 @@ export function describeUnknownShape(line: string): string {
   }
 }
 
-// CTL-1817: COUNT EVERY OCCURRENCE, LOG SPARSELY.
-//
-// The counters above must be exact — they are the measurement. The log line is the alarm,
-// and an alarm that fires per-record is a liability: the observed v3 rate was ~17/day, but
-// an unknown future shape could be a `recovery.tick`-class emitter (326,940/month), which
-// would flood otel-forward.log and, through Alloy, Loki itself. Degrading the log surface
-// while reporting a log-surface defect would be its own bug.
-//
-// So: warn once per distinct event name (the diagnostic that actually tells an operator what
-// to fix), then only on exponentially-spaced totals so a sustained flood still shows a live
-// heartbeat with an accurate running count. The distinct-name set is capped — an attacker-ish
-// pathological case (a unique name per record, e.g. a ticket id in the name) must not grow
-// unboundedly in a long-lived daemon.
-const MAX_TRACKED_SHAPES = 50;
-const warnedShapes = new Set<string>();
-
-function shouldWarnForShape(name: string, total: number): boolean {
-  if (!warnedShapes.has(name) && warnedShapes.size < MAX_TRACKED_SHAPES) {
-    warnedShapes.add(name);
-    return true;
-  }
-  // 10, 100, 1000, … — a bounded heartbeat under sustained loss.
-  return total >= 10 && Math.log10(total) % 1 === 0;
-}
+// CTL-1817: COUNT EVERY OCCURRENCE, LOG SPARSELY. The gate itself moved to
+// lib/sparse-warn.ts in CTL-1818 (unchanged semantics: first sighting per distinct key, then
+// 10/100/1000… heartbeats, capped key set) so the drop surface reuses the SAME mechanism
+// rather than growing a second one beside it. This gate keeps its own key budget — a flood of
+// unknown envelope shapes must not exhaust the one the drop alarm depends on.
+const shouldWarnForShape = createSparseWarnGate({ maxTracked: 50 });
 
 // Wired into the tailer as onUnrecognized. This is the ONLY place that can see a line the
 // tailer's shouldForward filter discards, because such a line never reaches processLine.

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -223,7 +223,18 @@ const senders = {
     : null,
 };
 
-function emitLag(): void {
+/**
+ * The 30 s tick body. EXPORTED for the CTL-1818 wiring test, not for production use — the
+ * `lagTimer` in the `import.meta.main` block below is its only runtime caller.
+ *
+ * Why it has to be exported: the drop surface's alert-CLEAR branch (`lib/drop-surface.ts`) is
+ * reachable from `evaluateDropSurface()` and from nothing else, so a test that calls that
+ * function directly passes whether or not this daemon ever calls it — which is exactly how the
+ * call below survived deletion with a fully green suite. Exporting the tick lets the test assert
+ * the CALL (raise a latched alert, run one tick, watch it clear) rather than the callee in
+ * isolation. See index-drop-wiring.test.ts.
+ */
+export function emitLag(): void {
   // CTL-1280: deterministic liveness heartbeat to otel-forward.log (Alloy→Loki),
   // emitted UNCONDITIONALLY each tick — BEFORE the cold-start skip below — so an
   // idle/quiet forwarder still proves it is alive (it previously wrote only a
@@ -237,6 +248,9 @@ function emitLag(): void {
   // drop-driven call can do: CLEAR a latched sustained-loss alert on a host that recovered
   // and went quiet (nothing else re-evaluates once the drops stop), and keep the marker's
   // rolling-window figures honest while nothing is being discarded. Best-effort, never throws.
+  // Placed BEFORE the cold-start skip below for the same reason CTL-1280's heartbeat is: the
+  // skip is about the lag EVENT having nothing to report, and a forwarder with a latched drop
+  // alert must still be able to clear it. index-drop-wiring.test.ts asserts this call.
   evaluateDropSurface();
   // Skip on cold start before any event has been processed or delivered
   if (!lastLocalTs && !lastForwardedTs) return;

--- a/plugins/dev/scripts/otel-forward/lib/config.ts
+++ b/plugins/dev/scripts/otel-forward/lib/config.ts
@@ -11,6 +11,10 @@ export interface OtlpConfig {
   lokiAcceptWindowMs: number;
   /** CTL-1506: max elapsed time for HTTP retry window. Default 60s. */
   maxRetryElapsedMs: number;
+  /** CTL-1818: thresholds for the host-local drop surface. Declared structurally rather than
+   *  importing lib/drop-surface.ts's type, so the config leaf stays dependency-free; the
+   *  resolver there owns validation and the env-override ladder. */
+  dropSurface: { windowMs?: number; thresholdRecords?: number; sustainMs?: number };
 }
 export interface PosthogConfig { enabled: boolean; apiKey: string; host: string; batchSize: number; flushIntervalMs: number }
 export interface CloudflareAEConfig { enabled: boolean; accountId: string; apiToken: string; dataset: string; batchSize: number; flushIntervalMs: number }
@@ -20,7 +24,7 @@ export interface ForwarderConfig { otlp: OtlpConfig; posthog: PosthogConfig; clo
 // operator who enables OTLP without an explicit endpoint hits a real URL instead of the
 // relative "/v1/logs" (which fails every fetch and silently fills the DLQ).
 const DEFAULTS = {
-  otlp: { enabled: false, endpoint: "http://localhost:4318", batchSize: 100, flushIntervalMs: 5000, lokiAcceptWindowMs: 3_600_000, maxRetryElapsedMs: 60_000 },
+  otlp: { enabled: false, endpoint: "http://localhost:4318", batchSize: 100, flushIntervalMs: 5000, lokiAcceptWindowMs: 3_600_000, maxRetryElapsedMs: 60_000, dropSurface: {} },
   posthog: { enabled: false, apiKey: "", host: "https://us.i.posthog.com", batchSize: 50, flushIntervalMs: 10000 },
   cloudflareAE: { enabled: false, accountId: "", apiToken: "", dataset: "catalyst_events", batchSize: 100, flushIntervalMs: 5000 },
 };

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp-drop-surface.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp-drop-surface.test.ts
@@ -1,0 +1,168 @@
+// otlp-drop-surface.test.ts — CTL-1818. The wiring: every discard the OTLP sender makes
+// must land on the host-local surface, INCLUDING the discards that emit no event at all.
+//
+// `emitDrop` returns early on two conditions before it writes
+// `catalyst.observability.forward_dropped` — no `eventLogPath`, and `isSelfBatch` — so those
+// discards are today invisible on every surface: they never ride the DLQ (aged records are
+// dropped before send), the checkpoint keeps advancing, and no event is written either.
+// The accounting therefore has to happen BEFORE both guards; these tests pin that ordering.
+//
+// Run: cd plugins/dev/scripts/otel-forward && bun test lib/destinations/otlp-drop-surface.test.ts
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
+import { OtlpSender } from "./otlp.ts";
+import { dropSurfaceSnapshot, resetDropSurfaceForTest, configureDropSurface } from "../drop-surface.ts";
+
+const SAMPLE_EVENT: CanonicalEvent = {
+  ts: "2026-08-13T00:00:00Z",
+  id: "11111111-2222-4333-8444-555555555555",
+  observedTs: "2026-08-13T00:00:00Z",
+  severityText: "INFO",
+  severityNumber: 9,
+  traceId: null,
+  spanId: null,
+  resource: {
+    "service.name": "catalyst.session",
+    "service.namespace": "catalyst" as const,
+    "service.version": "8.2.0",
+    "host.name": "test-host",
+    "host.id": "test-id-0000",
+  },
+  attributes: { "event.name": "session.heartbeat" },
+  body: { message: "heartbeat", payload: null },
+};
+
+const makeAged = (): CanonicalEvent => ({
+  ...SAMPLE_EVENT,
+  ts: new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString(),
+});
+const makeFresh = (): CanonicalEvent => ({ ...SAMPLE_EVENT, ts: new Date().toISOString() });
+const makeAgedSelf = (): CanonicalEvent => ({
+  ...makeAged(),
+  resource: { ...SAMPLE_EVENT.resource, "service.name": "catalyst.otel-forward" },
+  attributes: { "event.name": "catalyst.observability.forward_dropped" },
+});
+
+describe("OtlpSender → host-local drop surface (CTL-1818)", () => {
+  let dir: string;
+  let savedCatalystDir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "otlp-drop-surface-"));
+    savedCatalystDir = process.env.CATALYST_DIR;
+    // Pin the default marker location into the temp dir so the suite can never clobber a
+    // real ~/catalyst/otel-forward-drops.json on a developer machine.
+    process.env.CATALYST_DIR = dir;
+    resetDropSurfaceForTest();
+    configureDropSurface({ windowMs: 60_000, thresholdRecords: 1_000_000, sustainMs: 60_000 });
+  });
+  afterEach(() => {
+    resetDropSurfaceForTest();
+    if (savedCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = savedCatalystDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("an aged drop with NO event log configured still increments the surface", async () => {
+    // The event sink is unavailable here, which is precisely the case emitDrop's first guard
+    // returns on today — leaving the discard with no surface whatsoever.
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 200 }))) as unknown as typeof fetch;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath: join(dir, "dlq-noeventlog.jsonl"),
+      lokiAcceptWindowMs: 3_600_000,
+      // deliberately no eventLogPath
+    });
+
+    await sender.flush([makeAged(), makeAged()]);
+
+    expect(dropSurfaceSnapshot().totals.aged).toEqual({ events: 1, records: 2 });
+    expect(existsSync(join(dir, "otel-forward-drops.json"))).toBe(true);
+  });
+
+  test("a self-batch aged drop is counted even though its event is loop-guarded away", async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 200 }))) as unknown as typeof fetch;
+    const eventLogPath = join(dir, "events-self.jsonl");
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath: join(dir, "dlq-self.jsonl"),
+      eventLogPath,
+      lokiAcceptWindowMs: 3_600_000,
+    });
+
+    await sender.flush([makeAgedSelf()]);
+
+    // isSelfBatch suppresses the event (no re-amplification) — the surface must not be
+    // suppressed with it, or the forwarder's own losses stay unmeasurable.
+    const emitted = existsSync(eventLogPath) ? readFileSync(eventLogPath, "utf8").trim() : "";
+    expect(emitted).toBe("");
+    expect(dropSurfaceSnapshot().totals.aged).toEqual({ events: 1, records: 1 });
+  });
+
+  test("the surface still updates when the OTLP endpoint is unreachable", async () => {
+    // The scenario an event-based consumer cannot satisfy: nothing can leave this host, so
+    // any alarm that rides the forwarded stream reads clean.
+    global.fetch = mock(() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:1",
+      dlqPath: join(dir, "dlq-unreachable.jsonl"),
+      eventLogPath: join(dir, "events-unreachable.jsonl"),
+      httpRetryPolicy: { maxElapsedMs: 0 },
+      lokiAcceptWindowMs: 3_600_000,
+    });
+
+    await sender.flush([makeAged(), makeFresh()]);
+
+    expect(dropSurfaceSnapshot().totals.aged).toEqual({ events: 1, records: 1 });
+  });
+
+  test("a terminal 4xx drop is counted under its own reason", async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 400 }))) as unknown as typeof fetch;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath: join(dir, "dlq-terminal.jsonl"),
+      eventLogPath: join(dir, "events-terminal.jsonl"),
+      httpRetryPolicy: { maxElapsedMs: 0 },
+      lokiAcceptWindowMs: Number.MAX_SAFE_INTEGER,
+    });
+
+    await sender.flush([makeFresh(), makeFresh()]);
+
+    expect(dropSurfaceSnapshot().totals.terminal_4xx).toEqual({ events: 1, records: 2 });
+  });
+
+  test("a delivered batch touches the surface at all — it stays at zero", async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 200 }))) as unknown as typeof fetch;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath: join(dir, "dlq-ok.jsonl"),
+      eventLogPath: join(dir, "events-ok.jsonl"),
+      lokiAcceptWindowMs: 3_600_000,
+    });
+
+    await sender.flush([makeFresh()]);
+
+    expect(dropSurfaceSnapshot().totals).toEqual({});
+  });
+
+  // POSITIVE CONTROL (the ticket's required scenario). With the recorder replaced by a
+  // no-op — the test-only bypass — the exact same aged discard leaves the surface unchanged.
+  // If this ever passes at the same time as the first test above, one of the two is lying.
+  test("with the drop recorder bypassed, the same aged discard changes nothing", async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(null, { status: 200 }))) as unknown as typeof fetch;
+    const sender = new OtlpSender({
+      endpoint: "http://127.0.0.1:4318",
+      dlqPath: join(dir, "dlq-bypass.jsonl"),
+      lokiAcceptWindowMs: 3_600_000,
+      dropRecorder: () => {}, // bypass
+    });
+
+    await sender.flush([makeAged(), makeAged()]);
+
+    expect(dropSurfaceSnapshot().totals).toEqual({});
+    expect(existsSync(join(dir, "otel-forward-drops.json"))).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.test.ts
@@ -3,6 +3,20 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildOtlpPayload } from "./otlp.ts";
+
+// CTL-1818: every discard this file provokes now also lands on the host-local drop surface,
+// whose marker defaults to `$CATALYST_DIR/otel-forward-drops.json`. Pin CATALYST_DIR into a
+// throwaway directory so a local `bun test` cannot overwrite a real ~/catalyst marker
+// belonging to a running forwarder. Re-asserted per test, not only at file scope: bun runs
+// every test file in one process, and the drop-surface suite restores CATALYST_DIR to
+// whatever it found — which is `undefined` (i.e. the real ~/catalyst) if that file's modules
+// happened to execute first. Asserting the surface is otlp-drop-surface.test.ts's job; here
+// it is only isolated.
+const TEST_CATALYST_DIR = mkdtempSync(join(tmpdir(), "otlp-test-catalyst-dir-"));
+process.env.CATALYST_DIR = TEST_CATALYST_DIR;
+beforeEach(() => {
+  process.env.CATALYST_DIR = TEST_CATALYST_DIR;
+});
 import { appendToDlq, dlqDepth, drainDlq } from "../dlq.ts";
 import type { CanonicalEvent } from "../../../orch-monitor/lib/canonical-event.ts";
 

--- a/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
+++ b/plugins/dev/scripts/otel-forward/lib/destinations/otlp.ts
@@ -10,6 +10,7 @@ import { appendToDlq, drainDlqBounded, DEFAULT_MAX_DRAIN_BATCHES, type DrainOutc
 import { partitionByAge } from "../age-filter.ts";
 import { log } from "../logger.ts";
 import { buildCanonicalEnvelope } from "../canonical.ts";
+import { recordDrop, type DropReason } from "../drop-surface.ts";
 
 const destLog = log.child({ destination: "otlp" });
 
@@ -179,6 +180,11 @@ export interface OtlpSenderOpts {
   /** CTL-1506 (Codex P1): shutdown signal. When aborted, in-flight retries stop and the
    *  batch is DLQ'd immediately, so a flush can't outlive the launcher's SIGKILL grace. */
   signal?: AbortSignal;
+  /** CTL-1818: accounting seam for a DISCARDED batch. Defaults to the host-local drop
+   *  surface (lib/drop-surface.ts) so the wiring cannot be forgotten at a call site; a test
+   *  passes a no-op to bypass it (the ticket's required positive control) or a spy to assert
+   *  the exact reason/count. Never used to CHANGE what is dropped — only to record it. */
+  dropRecorder?: (reason: DropReason, records: number) => void;
 }
 
 // CTL-1008 Phase 4: guard against re-amplifying our own failure events —
@@ -240,6 +246,15 @@ export class OtlpSender {
   }
 
   private emitDrop(reason: "aged" | "terminal_4xx", records: CanonicalEvent[]): void {
+    // CTL-1818: account for the discard on the host-local surface BEFORE the two guards
+    // below, both of which suppress the event entirely — no `eventLogPath` (nothing to write
+    // to) and `isSelfBatch` (the CTL-1008 loop guard). A discard suppressed there is today
+    // invisible on EVERY surface: aged records never ride the DLQ, so the CTL-1502 watchdog's
+    // DLQ-size predicate stays flat, and the checkpoint keeps advancing past them.
+    //
+    // This is deliberately unconditional and destination-local: the surface must survive the
+    // transport it reports on, so it can never be gated on the event log being writable.
+    (this.opts.dropRecorder ?? recordDrop)(reason, records.length);
     if (!this.opts.eventLogPath || isSelfBatch(records)) return;
     this.emitEvent(
       "catalyst.observability.forward_dropped",

--- a/plugins/dev/scripts/otel-forward/lib/drop-surface.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/drop-surface.test.ts
@@ -1,0 +1,323 @@
+// drop-surface.test.ts — CTL-1818. The host-local surface that makes a DISCARDED event
+// visible, and the sustained-loss alert built on it.
+//
+// Why this surface cannot be an event consumer: `emitDrop` already writes
+// `catalyst.observability.forward_dropped` to the event log — and that event is then
+// forwarded through the very path that just discarded something. An alarm sourced from the
+// forwarded stream measures the SURVIVORS and reads clean during exactly the outage it
+// exists to detect. So the assertions below are all about state that lives on THIS host:
+// process-exact counters, a durable marker under ~/catalyst/, and the daemon's pino log
+// (which Alloy ships independently of otel-forward's OTLP egress).
+//
+// Run: cd plugins/dev/scripts/otel-forward && bun test lib/drop-surface.test.ts
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { DropBucket } from "./drop-surface.ts";
+import {
+  DROP_SURFACE_DEFAULTS,
+  buildDropMarker,
+  classifyDropWindow,
+  configureDropSurface,
+  dropSurfaceSnapshot,
+  evaluateDropSurface,
+  getDropMarkerPath,
+  recordDrop,
+  resetDropSurfaceForTest,
+  resolveDropSurfaceConfig,
+} from "./drop-surface.ts";
+
+// A pino-shaped recorder so the alarm sink can be asserted without writing a real log.
+function makeLog() {
+  const calls: { level: string; obj: Record<string, unknown>; msg: string }[] = [];
+  const mk = (level: string) => (obj: Record<string, unknown>, msg: string) =>
+    calls.push({ level, obj, msg });
+  return { calls, warn: mk("warn"), error: mk("error"), info: mk("info") };
+}
+
+const CFG = { windowMs: 60_000, thresholdRecords: 100, sustainMs: 30_000 };
+
+describe("classifyDropWindow — the pure sustained-rate classifier", () => {
+  const bucket = (startMs: number, records: number, reason = "aged"): [number, DropBucket] => [
+    startMs,
+    { records, byReason: { [reason]: records } },
+  ];
+
+  test("under the threshold is not a breach", () => {
+    const v = classifyDropWindow([bucket(1_000, 99)], CFG, 10_000, null);
+    expect(v.windowRecords).toBe(99);
+    expect(v.breaching).toBe(false);
+    expect(v.breachSinceMs).toBeNull();
+    expect(v.sustained).toBe(false);
+  });
+
+  test("the threshold is inclusive (boundary-exact >=, mirroring classifyDaemonStuck)", () => {
+    const v = classifyDropWindow([bucket(1_000, 100)], CFG, 10_000, null);
+    expect(v.breaching).toBe(true);
+    expect(v.breachSinceMs).toBe(10_000); // breach starts now when there was no prior breach
+    expect(v.sustained).toBe(false); // ...but has not yet lasted the sustain window
+  });
+
+  test("a breach shorter than the sustain window does NOT alert", () => {
+    const v = classifyDropWindow([bucket(1_000, 500)], CFG, 20_000, 1_000);
+    expect(v.breaching).toBe(true);
+    expect(v.sustainedMs).toBe(19_000);
+    expect(v.sustained).toBe(false);
+  });
+
+  test("a breach that persists for the sustain window alerts, and names the reason", () => {
+    const v = classifyDropWindow(
+      [bucket(1_000, 400, "aged"), bucket(2_000, 10, "terminal_4xx")],
+      CFG,
+      31_000,
+      1_000,
+    );
+    expect(v.sustained).toBe(true);
+    expect(v.topReason).toBe("aged");
+    expect(v.byReason).toEqual({ aged: 400, terminal_4xx: 10 });
+  });
+
+  test("records outside the rolling window are excluded — an old storm cannot alert forever", () => {
+    // Bucket at t=1s, window 60s, now = 5 minutes later.
+    const v = classifyDropWindow([bucket(1_000, 10_000)], CFG, 300_000, 1_000);
+    expect(v.windowRecords).toBe(0);
+    expect(v.breaching).toBe(false);
+    expect(v.breachSinceMs).toBeNull(); // the breach is forgotten, so a later one is a new episode
+  });
+
+  test("a non-finite or negative count contributes 0 — a garbage reading never fabricates a breach", () => {
+    const v = classifyDropWindow(
+      [bucket(1_000, Number.NaN), bucket(2_000, -5_000)],
+      CFG,
+      10_000,
+      null,
+    );
+    expect(v.windowRecords).toBe(0);
+    expect(v.breaching).toBe(false);
+  });
+
+  test("no buckets at all is not a breach (an empty input must not read as clean-by-vacuity elsewhere)", () => {
+    const v = classifyDropWindow([], CFG, 10_000, 1_000);
+    expect(v.windowRecords).toBe(0);
+    expect(v.breaching).toBe(false);
+    expect(v.topReason).toBeNull();
+  });
+});
+
+describe("resolveDropSurfaceConfig — env > file > frozen default", () => {
+  const KEYS = [
+    "CATALYST_FORWARD_DROP_WINDOW_MS",
+    "CATALYST_FORWARD_DROP_THRESHOLD_RECORDS",
+    "CATALYST_FORWARD_DROP_SUSTAIN_MS",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test("defaults when nothing is supplied", () => {
+    expect(resolveDropSurfaceConfig()).toEqual({ ...DROP_SURFACE_DEFAULTS });
+  });
+
+  test("a file value overrides the default and env overrides the file", () => {
+    expect(resolveDropSurfaceConfig({ thresholdRecords: 7 }).thresholdRecords).toBe(7);
+    process.env.CATALYST_FORWARD_DROP_THRESHOLD_RECORDS = "42";
+    expect(resolveDropSurfaceConfig({ thresholdRecords: 7 }).thresholdRecords).toBe(42);
+  });
+
+  test("a malformed override is ignored rather than disabling the surface", () => {
+    process.env.CATALYST_FORWARD_DROP_WINDOW_MS = "not-a-number";
+    expect(resolveDropSurfaceConfig().windowMs).toBe(DROP_SURFACE_DEFAULTS.windowMs);
+    process.env.CATALYST_FORWARD_DROP_WINDOW_MS = "0"; // a zero-length window can never breach
+    expect(resolveDropSurfaceConfig().windowMs).toBe(DROP_SURFACE_DEFAULTS.windowMs);
+  });
+});
+
+describe("recordDrop — exact counters + a durable host-local marker", () => {
+  let dir: string;
+  let markerPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "drop-surface-"));
+    markerPath = join(dir, "otel-forward-drops.json");
+    resetDropSurfaceForTest();
+    configureDropSurface(CFG);
+  });
+  afterEach(() => {
+    resetDropSurfaceForTest();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const readMarker = () => JSON.parse(readFileSync(markerPath, "utf8"));
+
+  test("counts EVERY drop exactly, per reason, in both events and records", () => {
+    const log = makeLog();
+    let t = 1_000;
+    for (let i = 0; i < 250; i++) recordDrop("aged", 3, { markerPath, log, now: () => (t += 10) });
+    recordDrop("terminal_4xx", 7, { markerPath, log, now: () => t });
+
+    const snap = dropSurfaceSnapshot();
+    expect(snap.totals.aged).toEqual({ events: 250, records: 750 });
+    expect(snap.totals.terminal_4xx).toEqual({ events: 1, records: 7 });
+  });
+
+  test("the alarm is SPARSE even though the counter is exact (the CTL-1817 discipline)", () => {
+    const log = makeLog();
+    let t = 1_000;
+    for (let i = 0; i < 250; i++) recordDrop("aged", 1, { markerPath, log, now: () => (t += 10) });
+    // First occurrence + log10 heartbeats at 10/100 → far fewer lines than records.
+    const warns = log.calls.filter((c) => c.level === "warn");
+    expect(warns.length).toBeGreaterThan(0);
+    expect(warns.length).toBeLessThan(10);
+    expect(dropSurfaceSnapshot().totals.aged.events).toBe(250);
+  });
+
+  test("writes an operator-readable marker naming the host, reason and counts", () => {
+    const log = makeLog();
+    recordDrop("aged", 12, { markerPath, log, now: () => 5_000 });
+    expect(existsSync(markerPath)).toBe(true);
+    const m = readMarker();
+    expect(m.daemon).toBe("otel-forward");
+    expect(typeof m.host).toBe("string");
+    expect(m.host.length).toBeGreaterThan(0);
+    expect(m.process.aged).toEqual({ events: 1, records: 12 });
+    expect(m.cumulative.aged.records).toBe(12);
+    expect(m.lastDrop.reason).toBe("aged");
+    expect(m.window.windowMs).toBe(CFG.windowMs);
+    expect(m.alert.raised).toBe(false);
+  });
+
+  test("cumulative totals carry across a restart; process totals do not", () => {
+    const log = makeLog();
+    recordDrop("aged", 40, { markerPath, log, now: () => 1_000 });
+    // Simulate a daemon restart: process state resets, the marker on disk does not.
+    resetDropSurfaceForTest();
+    configureDropSurface(CFG);
+    recordDrop("aged", 2, { markerPath, log, now: () => 2_000 });
+
+    const m = readMarker();
+    expect(m.process.aged.records).toBe(2); // this process only
+    expect(m.cumulative.aged.records).toBe(42); // carried 40 + 2
+  });
+
+  test("never throws when the marker cannot be written — a tap is never load-bearing", () => {
+    const log = makeLog();
+    // A regular file where a directory would have to be — mkdir/rename cannot succeed here.
+    writeFileSync(join(dir, "not-a-dir-file"), "x");
+    const unwritable = join(dir, "not-a-dir-file", "drops.json");
+    expect(() =>
+      recordDrop("aged", 1, { markerPath: unwritable, log, now: () => 1_000 }),
+    ).not.toThrow();
+    // The in-memory counter is still exact — the file is the convenience, not the measurement.
+    expect(dropSurfaceSnapshot().totals.aged.events).toBe(1);
+  });
+});
+
+describe("sustained-loss alert — raised, latched, then cleared", () => {
+  let dir: string;
+  let markerPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "drop-alert-"));
+    markerPath = join(dir, "otel-forward-drops.json");
+    resetDropSurfaceForTest();
+    configureDropSurface(CFG); // window 60s, threshold 100 records, sustain 30s
+  });
+  afterEach(() => {
+    resetDropSurfaceForTest();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const readMarker = () => JSON.parse(readFileSync(markerPath, "utf8"));
+
+  test("a sustained breach raises exactly one alert naming the host and the reason", () => {
+    const log = makeLog();
+    // t=1s: cross the threshold. Not yet sustained.
+    recordDrop("aged", 150, { markerPath, log, now: () => 1_000 });
+    expect(readMarker().alert.raised).toBe(false);
+    expect(log.calls.filter((c) => c.level === "error").length).toBe(0);
+
+    // t=40s: still breaching (both drops inside the 60s window), 39s > 30s sustain.
+    recordDrop("aged", 150, { markerPath, log, now: () => 40_000 });
+    const errors = log.calls.filter((c) => c.level === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0].obj.reason).toBe("aged");
+    expect(typeof errors[0].obj.host).toBe("string");
+
+    const m = readMarker();
+    expect(m.alert.raised).toBe(true);
+    expect(m.alert.reason).toBe("aged");
+
+    // t=41s: still breaching — the alert must not re-fire per record (latched episode).
+    recordDrop("aged", 150, { markerPath, log, now: () => 41_000 });
+    expect(log.calls.filter((c) => c.level === "error").length).toBe(1);
+  });
+
+  test("the alert clears once the window drains — evaluated even when no new drop arrives", () => {
+    const log = makeLog();
+    recordDrop("aged", 150, { markerPath, log, now: () => 1_000 });
+    recordDrop("aged", 150, { markerPath, log, now: () => 40_000 });
+    expect(readMarker().alert.raised).toBe(true);
+
+    // No further drops. The lag timer's periodic evaluation is what clears the episode —
+    // without it the marker would latch "raised" forever on a host that has recovered.
+    evaluateDropSurface({ markerPath, log, now: () => 200_000 });
+    const m = readMarker();
+    expect(m.alert.raised).toBe(false);
+    expect(m.window.records).toBe(0);
+    expect(log.calls.filter((c) => c.level === "info").length).toBe(1);
+  });
+});
+
+describe("buildDropMarker — the shape an operator reads", () => {
+  test("carries host, pid, per-reason totals and the live window verdict", () => {
+    const marker = buildDropMarker({
+      nowIso: "2026-08-13T12:00:00.000Z",
+      host: "mini",
+      pid: 4242,
+      startedAt: "2026-08-13T11:00:00.000Z",
+      cfg: CFG,
+      totals: { aged: { events: 3, records: 300 } },
+      carried: { aged: { events: 1, records: 100 } },
+      verdict: {
+        windowRecords: 300,
+        byReason: { aged: 300 },
+        topReason: "aged",
+        breaching: true,
+        breachSinceMs: 1_000,
+        sustainedMs: 5_000,
+        sustained: false,
+      },
+      alert: { raised: false, sinceIso: null, reason: null },
+      lastDrop: { ts: "2026-08-13T12:00:00.000Z", reason: "aged", count: 100 },
+    });
+
+    expect(marker.host).toBe("mini");
+    expect(marker.pid).toBe(4242);
+    expect(marker.cumulative.aged).toEqual({ events: 4, records: 400 });
+    expect(marker.window.records).toBe(300);
+    expect(marker.window.thresholdRecords).toBe(CFG.thresholdRecords);
+    expect(marker.window.breaching).toBe(true);
+  });
+});
+
+describe("getDropMarkerPath — resolved per call so a pinned CATALYST_DIR is honored", () => {
+  test("lives beside the checkpoint and the DLQ under CATALYST_DIR", () => {
+    const saved = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = "/tmp/ctl1818-marker-dir";
+    expect(getDropMarkerPath()).toBe("/tmp/ctl1818-marker-dir/otel-forward-drops.json");
+    if (saved === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = saved;
+  });
+});

--- a/plugins/dev/scripts/otel-forward/lib/drop-surface.ts
+++ b/plugins/dev/scripts/otel-forward/lib/drop-surface.ts
@@ -1,0 +1,496 @@
+// drop-surface.ts — CTL-1818. The host-local surface for events this daemon DISCARDS.
+//
+// ⚠️ WHY THIS CANNOT BE AN EVENT CONSUMER. `OtlpSender.emitDrop` already appends
+// `catalyst.observability.forward_dropped` to the event log, and that event is then shipped
+// through the very path that just discarded something. An alarm sourced from the forwarded
+// stream measures the SURVIVORS and reads clean during exactly the outage it exists to
+// detect. Worse, the two guards at the top of `emitDrop` (`!eventLogPath`, `isSelfBatch`)
+// mean some discards emit no event at all. So the accounting lives HERE, on the host:
+//
+//   1. process-exact counters, per drop reason, in both events (batches) and records
+//   2. a durable marker `~/catalyst/otel-forward-drops.json` — atomic tmp+rename, carried
+//      across restarts, sitting beside the checkpoint and the DLQ so an operator finds it
+//      where they already look
+//   3. the daemon's pino `.log`, which Alloy tails and ships to Loki INDEPENDENTLY of this
+//      daemon's own OTLP egress (log-shipper/config.alloy:22)
+//
+// None of the three existing forwarder guardrails can see an aged drop:
+//   - `forward_failed` / the CTL-1502 watchdog's DLQ-size predicate — an aged record never
+//     rides the DLQ in the primary path (otlp.ts, "Aged records never ride the DLQ"), so the
+//     DLQ stays flat while records are thrown away;
+//   - the watchdog's forwarding-lag predicate — the checkpoint keeps advancing, because a
+//     discard IS forward progress as far as the read position is concerned;
+//   - `forward_dropped` itself — 87,706 of them on the fleet's mirrored 2026-08 log, read by
+//     nothing in this repo and by nothing in `catalyst-otel` either (the provisioned Grafana
+//     rule reads `forward_failed`, a different name).
+//
+// ⚠️ ALERT-ONLY BY DESIGN. This module raises an alarm; it never restarts or otherwise
+// actuates anything. A sustained aged-drop is a Loki-accept-window / backlog condition, and
+// bouncing the forwarder does not fix it — it only loses the in-memory buffer. In particular
+// this is deliberately NOT wired into `classifyDaemonStuck`, whose `tripped` list feeds
+// `restart()` in the CTL-1502 probe.
+
+import { mkdirSync, writeFileSync, renameSync, readFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { join, dirname } from "node:path";
+import { log as defaultLog } from "./logger.ts";
+import { createSparseWarnGate } from "./sparse-warn.ts";
+
+export type DropReason = "aged" | "terminal_4xx";
+
+export interface DropSurfaceConfig {
+  /** Rolling window the drop rate is measured over. */
+  windowMs: number;
+  /** Records discarded within the window that constitutes a breach (inclusive `>=`). */
+  thresholdRecords: number;
+  /** How long a breach must persist before the alert fires. */
+  sustainMs: number;
+}
+
+// Defaults chosen against MEASURED fleet behavior (mirrored `~/catalyst/events/2026-08.jsonl`,
+// coverage 2026-08-08 → 08-13, both worker hosts): 87,706 `forward_dropped` events carrying
+// 7,623,269 discarded records, 100% `reason: "aged"`. A quiet day on `mini` was ~234k
+// records/day ≈ 813 records per 5-minute window; the loss storms of 08-10/08-11 ran
+// ~2.0M records/day ≈ 6,900 per 5-minute window. 1,000 records per 5-minute window therefore
+// sits between the two regimes that are actually present in the data, rather than at a number
+// picked from nowhere. `windowMs`/`sustainMs` mirror the provisioned Grafana rule for
+// `forward_failed` (5-minute window, `for: 10m`) so an operator reasons in one unit.
+export const DROP_SURFACE_DEFAULTS: Readonly<DropSurfaceConfig> = Object.freeze({
+  windowMs: 300_000,
+  thresholdRecords: 1_000,
+  sustainMs: 600_000,
+});
+
+// The rolling window is kept as a small ring of time buckets rather than a list of samples,
+// so memory is O(BUCKET_COUNT) no matter how fast drops arrive — an unbounded sample array in
+// a long-lived daemon is the very shape this repo keeps getting bitten by.
+const BUCKET_COUNT = 60;
+
+// A marker write per discarded batch is cheap (a few hundred bytes, tmp+rename), but under a
+// storm it is pointless churn. Throttle it — EXCEPT on an alert state change, which is always
+// written immediately. The in-memory counters stay exact regardless; the file may lag by up
+// to this interval, and the periodic `evaluateDropSurface` tick refreshes it anyway.
+const MARKER_MIN_WRITE_INTERVAL_MS = 1_000;
+
+export interface DropWindowVerdict {
+  windowRecords: number;
+  byReason: Record<string, number>;
+  topReason: string | null;
+  breaching: boolean;
+  breachSinceMs: number | null;
+  sustainedMs: number;
+  sustained: boolean;
+}
+
+export interface DropBucket {
+  records: number;
+  byReason: Record<string, number>;
+}
+
+/** A count that is not a finite positive number contributes 0 — never NaN, never negative. */
+function safeCount(n: unknown): number {
+  const v = typeof n === "number" ? n : Number(n);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+}
+
+/**
+ * classifyDropWindow — pure. Sums the buckets that fall inside the rolling window, decides
+ * whether the rate is breaching, and carries the breach start forward so "sustained" is
+ * measured from the FIRST crossing rather than the latest sample.
+ *
+ * Boundary-exact `>=` on both the threshold and the sustain window (mirrors
+ * `classifyDaemonStuck`). A garbage reading can only ever push the sum DOWN (see
+ * `safeCount`), so a bad bucket can never fabricate a breach.
+ */
+export function classifyDropWindow(
+  buckets: Iterable<readonly [number, DropBucket]>,
+  cfg: DropSurfaceConfig,
+  nowMs: number,
+  prevBreachSinceMs: number | null,
+): DropWindowVerdict {
+  const cutoff = nowMs - cfg.windowMs;
+  let windowRecords = 0;
+  const byReason: Record<string, number> = {};
+  for (const [startMs, bucket] of buckets) {
+    if (!(startMs >= cutoff)) continue; // outside the window (and NaN-safe)
+    for (const [reason, count] of Object.entries(bucket?.byReason ?? {})) {
+      const n = safeCount(count);
+      if (n === 0) continue;
+      byReason[reason] = (byReason[reason] ?? 0) + n;
+      windowRecords += n;
+    }
+  }
+  let topReason: string | null = null;
+  for (const [reason, n] of Object.entries(byReason)) {
+    if (topReason === null || n > byReason[topReason]) topReason = reason;
+  }
+  // `windowRecords > 0` is not redundant: a `thresholdRecords: 0` configuration means "alert on
+  // any discard", and must still not read as breaching on a window in which nothing was discarded.
+  const breaching = windowRecords > 0 && windowRecords >= cfg.thresholdRecords;
+  const breachSinceMs = breaching ? (prevBreachSinceMs ?? nowMs) : null;
+  const sustainedMs = breachSinceMs === null ? 0 : Math.max(0, nowMs - breachSinceMs);
+  return {
+    windowRecords,
+    byReason,
+    topReason,
+    breaching,
+    breachSinceMs,
+    sustainedMs,
+    sustained: breaching && sustainedMs >= cfg.sustainMs,
+  };
+}
+
+// --- configuration ladder: env > forwarder config file > frozen default -------------------
+
+function envInt(name: string, fallback: number, min: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number(raw);
+  // A malformed or out-of-range override is IGNORED rather than silently disabling the
+  // surface — the failure direction has to be "keep measuring", not "go quiet".
+  return Number.isFinite(n) && n >= min ? Math.floor(n) : fallback;
+}
+
+export function resolveDropSurfaceConfig(fileCfg: Partial<DropSurfaceConfig> = {}): DropSurfaceConfig {
+  const pick = (key: keyof DropSurfaceConfig, min: number) => {
+    const v = fileCfg?.[key];
+    return typeof v === "number" && Number.isFinite(v) && v >= min ? Math.floor(v) : DROP_SURFACE_DEFAULTS[key];
+  };
+  return {
+    windowMs: envInt("CATALYST_FORWARD_DROP_WINDOW_MS", pick("windowMs", 1), 1),
+    thresholdRecords: envInt("CATALYST_FORWARD_DROP_THRESHOLD_RECORDS", pick("thresholdRecords", 0), 0),
+    sustainMs: envInt("CATALYST_FORWARD_DROP_SUSTAIN_MS", pick("sustainMs", 0), 0),
+  };
+}
+
+// --- module state -------------------------------------------------------------------------
+
+export interface DropTotals {
+  events: number;
+  records: number;
+}
+
+interface DropState {
+  startedAt: string;
+  totals: Record<string, DropTotals>;
+  /** Cumulative totals read once from a marker written by a PREVIOUS process. */
+  carried: Record<string, DropTotals> | null;
+  carriedSeeded: boolean;
+  buckets: Map<number, DropBucket>;
+  breachSinceMs: number | null;
+  alertRaised: boolean;
+  alertSinceIso: string | null;
+  alertReason: string | null;
+  lastDrop: { ts: string; reason: string; count: number } | null;
+  lastMarkerWriteMs: number;
+  warnGate: (key: string, total: number) => boolean;
+}
+
+function freshState(): DropState {
+  return {
+    startedAt: new Date().toISOString(),
+    totals: {},
+    carried: null,
+    carriedSeeded: false,
+    buckets: new Map(),
+    breachSinceMs: null,
+    alertRaised: false,
+    alertSinceIso: null,
+    alertReason: null,
+    lastDrop: null,
+    lastMarkerWriteMs: 0,
+    // Reasons are a closed two-value set today, so a small cap is plenty; it exists so a
+    // future caller passing an open-ended reason string cannot grow the set without bound.
+    warnGate: createSparseWarnGate({ maxTracked: 8 }),
+  };
+}
+
+let state: DropState = freshState();
+let cfg: DropSurfaceConfig = resolveDropSurfaceConfig();
+
+/** Apply the forwarder config file's `otlp.dropSurface` block (env still wins). */
+export function configureDropSurface(fileCfg: Partial<DropSurfaceConfig> = {}): void {
+  cfg = resolveDropSurfaceConfig(fileCfg);
+}
+
+/** Test seam — drop all process state and re-read the config ladder. */
+export function resetDropSurfaceForTest(): void {
+  state = freshState();
+  cfg = resolveDropSurfaceConfig();
+}
+
+/** In-memory view of the surface. Exact by construction; the marker file may lag it by ≤1 s. */
+export function dropSurfaceSnapshot(): {
+  startedAt: string;
+  totals: Record<string, DropTotals>;
+  alertRaised: boolean;
+  config: DropSurfaceConfig;
+} {
+  return {
+    startedAt: state.startedAt,
+    totals: JSON.parse(JSON.stringify(state.totals)),
+    alertRaised: state.alertRaised,
+    config: { ...cfg },
+  };
+}
+
+// --- the marker ----------------------------------------------------------------------------
+
+function catalystDir(): string {
+  return process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
+}
+
+/**
+ * Resolved PER CALL (the CTL-1502 predicates' discipline) so a pinned `CATALYST_DIR` is
+ * honored no matter when the module was imported. Sits beside
+ * `otel-forward.checkpoint.json` / `otel-forward-dlq-otlp.jsonl`.
+ */
+export function getDropMarkerPath(): string {
+  return join(catalystDir(), "otel-forward-drops.json");
+}
+
+export interface DropSurfaceIo {
+  now?: () => number;
+  markerPath?: string;
+  log?: { warn: Function; error: Function; info: Function };
+}
+
+function mergeTotals(
+  a: Record<string, DropTotals> | null,
+  b: Record<string, DropTotals>,
+): Record<string, DropTotals> {
+  const out: Record<string, DropTotals> = {};
+  for (const src of [a ?? {}, b]) {
+    for (const [reason, t] of Object.entries(src)) {
+      const prev = out[reason] ?? { events: 0, records: 0 };
+      out[reason] = {
+        events: prev.events + safeCount(t?.events),
+        records: prev.records + safeCount(t?.records),
+      };
+    }
+  }
+  return out;
+}
+
+/** buildDropMarker — pure. The exact JSON an operator (or a future HUD panel) reads. */
+export function buildDropMarker(args: {
+  nowIso: string;
+  host: string;
+  pid: number;
+  startedAt: string;
+  cfg: DropSurfaceConfig;
+  totals: Record<string, DropTotals>;
+  carried: Record<string, DropTotals> | null;
+  verdict: DropWindowVerdict;
+  alert: { raised: boolean; sinceIso: string | null; reason: string | null };
+  lastDrop: { ts: string; reason: string; count: number } | null;
+}) {
+  return {
+    daemon: "otel-forward",
+    ticket: "CTL-1818",
+    host: args.host,
+    pid: args.pid,
+    updatedAt: args.nowIso,
+    processStartedAt: args.startedAt,
+    /** Discards by THIS process — exact. */
+    process: args.totals,
+    /** Discards carried across restarts (seeded from a marker a previous process wrote). */
+    cumulative: mergeTotals(args.carried, args.totals),
+    window: {
+      windowMs: args.cfg.windowMs,
+      records: args.verdict.windowRecords,
+      byReason: args.verdict.byReason,
+      thresholdRecords: args.cfg.thresholdRecords,
+      breaching: args.verdict.breaching,
+      sustainMs: args.cfg.sustainMs,
+      sustainedMs: args.verdict.sustainedMs,
+    },
+    alert: {
+      raised: args.alert.raised,
+      since: args.alert.sinceIso,
+      reason: args.alert.reason,
+    },
+    lastDrop: args.lastDrop,
+  };
+}
+
+function seedCarried(path: string): void {
+  if (state.carriedSeeded) return;
+  state.carriedSeeded = true;
+  try {
+    const prior = JSON.parse(readFileSync(path, "utf8")) as { cumulative?: Record<string, DropTotals> };
+    // Only a well-shaped prior marker seeds the carry-forward; anything else starts clean
+    // rather than importing garbage into the operator-facing number.
+    if (prior?.cumulative && typeof prior.cumulative === "object") state.carried = prior.cumulative;
+  } catch {
+    /* no prior marker (or unreadable) — cumulative starts at this process's totals */
+  }
+}
+
+function writeMarker(io: DropSurfaceIo, verdict: DropWindowVerdict, nowMs: number): void {
+  try {
+    const path = io.markerPath ?? getDropMarkerPath();
+    seedCarried(path);
+    const marker = buildDropMarker({
+      nowIso: new Date(nowMs).toISOString(),
+      host: hostname(),
+      pid: process.pid,
+      startedAt: state.startedAt,
+      cfg,
+      totals: state.totals,
+      carried: state.carried,
+      verdict,
+      alert: { raised: state.alertRaised, sinceIso: state.alertSinceIso, reason: state.alertReason },
+      lastDrop: state.lastDrop,
+    });
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(marker, null, 2));
+    renameSync(tmp, path); // atomic — a reader never sees a half-written marker
+    state.lastMarkerWriteMs = nowMs;
+  } catch {
+    /* best-effort: the file is the convenience, the in-memory counter is the measurement */
+  }
+}
+
+function safeLog(io: DropSurfaceIo, level: "warn" | "error" | "info", obj: object, msg: string): void {
+  try {
+    const l = (io.log ?? defaultLog) as Record<string, Function>;
+    // Called through `.call(l, …)` — pino's level methods need the logger as their `this`
+    // receiver, and a bare extracted call would throw into the catch below, silently
+    // swallowing every record on the one sink that is independent of the OTLP egress
+    // (the same trap CTL-1502's alert module documents).
+    (l[level] ?? l.info ?? (() => {})).call(l, obj, msg);
+  } catch {
+    /* best-effort */
+  }
+}
+
+// --- evaluation -----------------------------------------------------------------------------
+
+function bucketMs(): number {
+  return Math.max(1_000, Math.ceil(cfg.windowMs / BUCKET_COUNT));
+}
+
+function pruneBuckets(nowMs: number): void {
+  const cutoff = nowMs - cfg.windowMs;
+  for (const startMs of state.buckets.keys()) {
+    if (startMs < cutoff) state.buckets.delete(startMs);
+  }
+}
+
+/**
+ * Prune → classify → apply the alert edges → refresh the marker. Shared by `recordDrop` and
+ * the periodic `evaluateDropSurface` tick; returns the verdict so the caller can log it.
+ */
+function evaluate(nowMs: number, io: DropSurfaceIo): DropWindowVerdict {
+  pruneBuckets(nowMs);
+  const verdict = classifyDropWindow(state.buckets.entries(), cfg, nowMs, state.breachSinceMs);
+  state.breachSinceMs = verdict.breachSinceMs;
+
+  let alertChanged = false;
+  if (verdict.sustained && !state.alertRaised) {
+    // RAISE — edge-triggered, once per episode. Alert-only: no restart, no actuation.
+    state.alertRaised = true;
+    state.alertSinceIso = new Date(nowMs).toISOString();
+    state.alertReason = verdict.topReason;
+    alertChanged = true;
+    safeLog(
+      io,
+      "error",
+      {
+        host: hostname(),
+        reason: verdict.topReason,
+        window_records: verdict.windowRecords,
+        window_ms: cfg.windowMs,
+        threshold_records: cfg.thresholdRecords,
+        sustained_ms: verdict.sustainedMs,
+        by_reason: verdict.byReason,
+        marker: io.markerPath ?? getDropMarkerPath(),
+      },
+      "otel-forward SUSTAINED EVENT LOSS — discard rate above threshold for the sustain window; these events were never delivered and never dead-lettered (CTL-1818)",
+    );
+  } else if (!verdict.breaching && state.alertRaised) {
+    // CLEAR — the window has drained. Without the periodic tick calling this, a host that
+    // recovered would latch "raised" forever, because nothing else re-evaluates.
+    state.alertRaised = false;
+    state.alertSinceIso = null;
+    state.alertReason = null;
+    alertChanged = true;
+    safeLog(
+      io,
+      "info",
+      { host: hostname(), window_ms: cfg.windowMs, marker: io.markerPath ?? getDropMarkerPath() },
+      "otel-forward discard rate back under threshold — sustained-loss alert cleared (CTL-1818)",
+    );
+  }
+
+  // An alert transition is ALWAYS written through immediately; routine counter updates are
+  // throttled so a discard storm cannot turn into a rewrite storm.
+  const due = nowMs - state.lastMarkerWriteMs >= MARKER_MIN_WRITE_INTERVAL_MS;
+  if (alertChanged || due) writeMarker(io, verdict, nowMs);
+  return verdict;
+}
+
+/**
+ * recordDrop — the ONE accounting call. Invoked from `OtlpSender.emitDrop` BEFORE its
+ * event-emission guards, so a discard is counted even when no `forward_dropped` event is
+ * written at all. Never throws: it runs on the discard path, and a tap must never be able to
+ * wedge the thing it measures.
+ */
+export function recordDrop(reason: DropReason | string, records: number, io: DropSurfaceIo = {}): void {
+  try {
+    const nowMs = io.now ? io.now() : Date.now();
+    const n = safeCount(records);
+    const prev = state.totals[reason] ?? { events: 0, records: 0 };
+    state.totals[reason] = { events: prev.events + 1, records: prev.records + n };
+    state.lastDrop = { ts: new Date(nowMs).toISOString(), reason, count: n };
+
+    const size = bucketMs();
+    const startMs = Math.floor(nowMs / size) * size;
+    const bucket = state.buckets.get(startMs) ?? { records: 0, byReason: {} };
+    bucket.records += n;
+    bucket.byReason[reason] = (bucket.byReason[reason] ?? 0) + n;
+    state.buckets.set(startMs, bucket);
+
+    const verdict = evaluate(nowMs, io);
+
+    // Sparse alarm on the pino log — the counter above is the measurement, this is the line
+    // an operator (or a Loki rule over the .log stream) actually sees.
+    const total = state.totals[reason].events;
+    if (state.warnGate(`drop:${reason}`, total)) {
+      safeLog(
+        io,
+        "warn",
+        {
+          host: hostname(),
+          reason,
+          drop_events_total: total,
+          drop_records_total: state.totals[reason].records,
+          window_records: verdict.windowRecords,
+          window_ms: cfg.windowMs,
+          marker: io.markerPath ?? getDropMarkerPath(),
+        },
+        "otel-forward DISCARDED events — never delivered, never dead-lettered; invisible to the DLQ-size and checkpoint-lag guardrails (CTL-1818)",
+      );
+    }
+  } catch {
+    /* never throw on the discard path */
+  }
+}
+
+/**
+ * evaluateDropSurface — the periodic tick (wired to the forwarder's existing 30 s lag timer).
+ * Two jobs no drop-driven call can do: clear a latched alert on a host that has recovered and
+ * gone quiet, and keep the marker's window figures honest while nothing is being discarded.
+ */
+export function evaluateDropSurface(io: DropSurfaceIo = {}): void {
+  try {
+    const nowMs = io.now ? io.now() : Date.now();
+    // Nothing has ever been recorded → no marker to write; do not create an empty one.
+    if (state.lastDrop === null) return;
+    evaluate(nowMs, io);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/plugins/dev/scripts/otel-forward/lib/sparse-warn.ts
+++ b/plugins/dev/scripts/otel-forward/lib/sparse-warn.ts
@@ -1,0 +1,39 @@
+// sparse-warn.ts — CTL-1817's "count every occurrence, log sparsely" gate, extracted
+// (CTL-1818) so the drop surface reuses the SAME mechanism instead of growing a second one
+// beside it.
+//
+// The counters a caller keeps must be exact — they are the measurement. The log line is the
+// alarm, and an alarm that fires per-record is a liability: the observed v3 rate was ~17/day,
+// but an unknown future shape could be a `recovery.tick`-class emitter (326,940/month), which
+// would flood otel-forward.log and, through Alloy, Loki itself. Degrading the log surface
+// while reporting a log-surface defect would be its own bug.
+//
+// So: warn once per distinct key (the diagnostic that actually tells an operator what to
+// fix), then only on exponentially-spaced totals so a sustained flood still shows a live
+// heartbeat with an accurate running count. The distinct-key set is capped — an attacker-ish
+// pathological case (a unique name per record, e.g. a ticket id in the name) must not grow
+// unboundedly in a long-lived daemon.
+//
+// Each caller builds its OWN gate rather than sharing one module-level set: a flood of
+// unknown envelope shapes must not exhaust the budget that the drop-reason alarm depends on.
+
+export interface SparseWarnGateOpts {
+  /** Cap on distinct keys that get a first-sighting warning. Default 50. */
+  maxTracked?: number;
+}
+
+/**
+ * Returns `shouldWarn(key, total)` — true on the first sighting of `key` (while under the
+ * cap), and thereafter only at 10, 100, 1000, … occurrences of the caller's running `total`.
+ */
+export function createSparseWarnGate({ maxTracked = 50 }: SparseWarnGateOpts = {}) {
+  const warned = new Set<string>();
+  return function shouldWarn(key: string, total: number): boolean {
+    if (!warned.has(key) && warned.size < maxTracked) {
+      warned.add(key);
+      return true;
+    }
+    // 10, 100, 1000, … — a bounded heartbeat under sustained loss.
+    return total >= 10 && Math.log10(total) % 1 === 0;
+  };
+}

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -525,6 +525,24 @@ default.** This section is the authoritative schema; the developer reference
 | `flushIntervalMs`    | `5000`                  | Per-forwarder flush cadence — each enabled destination runs its own timer at its own interval (CTL-1506). A destination's flushes are serialized independently: a tick arriving while its previous flush is still in flight is a no-op, so this is a floor.                                                                                                                                                |
 | `lokiAcceptWindowMs` | `3600000` (1 h)         | Age cutoff for Loki records (CTL-1506). Records older than this are dropped with a `forward_dropped` (`drop_reason: "aged"`) event before any send. Note the _effective_ send cutoff is slightly stricter — `lokiAcceptWindowMs − min(timeoutMs, lokiAcceptWindowMs/4)` — a delivery margin so a near-cutoff record can't age past the window mid-request. Tune to your Loki `reject_old_samples_max_age`. |
 | `maxRetryElapsedMs`  | `60000` (60 s)          | Max elapsed time for HTTP retry backoff on a retryable failure (`429`/`5xx`/network) before the batch is dead-lettered (CTL-1506). Terminal `4xx` (not `429`) is dropped immediately, never retried or DLQ'd.                                                                                                                                                                                              |
+| `dropSurface`        | see below               | Thresholds for the host-local drop surface (CTL-1818) — the counter/marker/alarm that makes a **discarded** event visible. Sub-keys below; each also has an env override, which wins.                                                                                                                                                                                                                       |
+
+#### `otlp.dropSurface` keys (CTL-1818)
+
+Every discard (`drop_reason: "aged"` or `"terminal_4xx"`) increments a host-local counter and is
+written to the marker `~/catalyst/otel-forward-drops.json`; a discard rate that stays above
+`thresholdRecords` for `sustainMs` raises one `ERROR` line on `~/catalyst/otel-forward.log`
+(Alloy-shipped, independent of the OTLP egress this daemon is itself responsible for). The alert is
+**alert-only** — it never restarts the forwarder.
+
+| Key                | Env override                               | Default          | Description                                                                                                                                                          |
+| ------------------ | ------------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `windowMs`         | `CATALYST_FORWARD_DROP_WINDOW_MS`          | `300000` (5 min) | Rolling window the discard rate is measured over. Matches the provisioned Grafana window for `forward_failed`, so both are reasoned about in one unit.                |
+| `thresholdRecords` | `CATALYST_FORWARD_DROP_THRESHOLD_RECORDS`  | `1000`           | Records discarded within the window that constitutes a breach (inclusive `>=`). Sits between the two regimes measured on the fleet: a quiet day ≈ 800/window, a loss storm ≈ 6,900/window. |
+| `sustainMs`        | `CATALYST_FORWARD_DROP_SUSTAIN_MS`         | `600000` (10 min)| How long the breach must persist before the alert fires, so a single burst self-heals without paging.                                                                |
+
+A malformed or out-of-range override is **ignored** (the surface keeps measuring at its previous
+value) rather than silently disabling the counter.
 
 PostHog and Cloudflare AE keys mirror the JSON above; see the developer reference for their delivery
 semantics.


### PR DESCRIPTION
Closes CTL-1818. Second ticket of **M1 — the event substrate is trustworthy** (sibling of #3325).

## The defect

`otel-forward` discards batches — `emitDrop`, reason `aged` or `terminal_4xx` — and **nothing measures it**. The two sibling signals are each covered by another instrument; this one is genuinely invisible:

| signal            | normally caught by                             | catches an aged drop?                                                    |
| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------ |
| `forward_failed`  | DLQ grows → CTL-1502 watchdog P1 (DLQ size)    | **No** — an aged record never rides the DLQ, so the file stays flat       |
| `forward_lag`     | checkpoint `lastForwardedTs` freezes → P2      | **No** — the checkpoint advances; a discard *is* read progress            |
| `forward_dropped` | an event on the log…                           | **No** — that event ships through the path that just discarded something  |

And two guards at the top of `emitDrop` (`!eventLogPath`, `isSelfBatch`) mean some discards emit **no event at all**, so they have no surface whatsoever.

## Measurement

Structured parse of the fleet's mirrored `~/catalyst/events/2026-08.jsonl` — name read as `attributes["event.name"] ?? event ?? name`, `grep` used only as a superset pre-filter and the decision made on the parsed name (8 substring-only lines were correctly rejected):

| scope                                     | drop events | discarded **records** |
| ----------------------------------------- | ----------: | --------------------: |
| fleet (mirror coverage 2026-08-08 → 08-13) | **87,706**  | **7,623,269**         |
| └ `mini-2`                                | 68,131      | 3,260,951             |
| └ `mini`                                  | 19,575      | 4,362,318             |
| by reason                                 | `aged` 87,706 · `terminal_4xx` **0** | |

Every health surface was green throughout. *Positive control for the instrument:* the same pre-filter over `recovery.tick` returns 557,150, and the parse returns non-zero for the name under test, so a zero here would have been a finding rather than a broken reader.

**Consumer search** (the negative claim): the only non-test occurrence of `catalyst.observability.forward_dropped` anywhere in this repo is the emitter itself, `otel-forward/lib/destinations/otlp.ts:245`. *Positive control for that search:* the same instrument over `reap-requested` returns the producer registry **and** its reaper consumer. In `catalyst-otel`, `provisioning/alerting/read-path-alerts.yaml` alerts on `forward_failed` — a **different name** — so `forward_dropped` has no external consumer either.

## The mechanism

`recordDrop` (`otel-forward/lib/drop-surface.ts`) is called from `emitDrop` **before** both early-return guards, so a discard is counted even when no event is written. Three sinks, none of which ride the pipe being reported on:

1. **Counters** — process-exact, per reason, in events (batches) **and** records.
2. **Marker** — `~/catalyst/otel-forward-drops.json`, atomic tmp+rename, `cumulative` totals carried across restarts, beside the checkpoint and the DLQ where an operator already looks:
   ```bash
   jq '{host, cumulative, window, alert}' ~/catalyst/otel-forward-drops.json
   ```
3. **Alarm** — the daemon's pino `.log`, which Alloy ships to Loki **independently** of this daemon's own OTLP egress.

There is deliberately **no event sink**: an alarm sourced from the forwarded stream measures the survivors and reads clean during exactly the outage it exists to detect.

The sustained-rate alert is a pure `classifyDropWindow` over a **bounded 60-bucket ring** (no unbounded sample list in a long-lived daemon): breach at `windowRecords >= thresholdRecords`, alert once the breach persists `>= sustainMs`. Raise and clear are **edge-triggered**, so a storm logs one `ERROR` rather than one per batch, and the forwarder's existing 30 s lag timer re-evaluates so a host that recovered and went quiet does not latch raised forever. Defaults (5 min / 1,000 records / 10 min) sit between the two regimes actually present in the measurement — a quiet day ≈ 813 records per 5-min window, the 08-10/08-11 storms ≈ 6,900 — and resolve **env > `forwarders.otlp.dropSurface` > frozen default**. A malformed override is ignored rather than silently disabling the counter.

**One mechanism, not two:** CTL-1817's count-every-occurrence/log-sparsely gate moved verbatim to `lib/sparse-warn.ts` as a factory. The tailer's unknown-shape alarm and this drop alarm each build their own gate, so a flood of one cannot exhaust the other's key budget.

## Alert-only, on purpose

This adds **no** predicate to `classifyDaemonStuck`. That function's `tripped` list is wired straight to `restart()` in the CTL-1502 probe (`daemon-watchdog-probe.mjs`), so a third member would **restart otel-forward** on a sustained aged drop. Restarting does not fix an aged drop — it is a Loki-accept-window / backlog condition — and would only lose the in-memory buffer. The ticket's AC asks that an alert fire; it never authorizes a restart. **No watchdog file is touched.**

## Verification

| suite                                                  | this branch                 | merge base (`cf37127`)      |
| ------------------------------------------------------ | --------------------------- | --------------------------- |
| `cd plugins/dev/scripts/otel-forward && bun test`      | **236 pass / 0 fail**, 18 files | 211 pass / 0 fail, 16 files |
| `bun run typecheck` (`tsc --noEmit`)                   | clean                       | clean                       |

The delta is exactly the +25 added here; no pre-existing red imported. Baseline measured by restoring the merge-base tree into this worktree, not by inference.

**Positive control** (required by the ticket's own AC, and run for real): reverting the single wiring line in `emitDrop` takes `otlp-drop-surface.test.ts` from 6 pass → **2 pass / 4 fail**. The 2 that stay green are the two that *should* be invariant — the delivered-batch case and the bypassed-recorder case. The line was then restored and the suite re-run green. The AC's "test-only bypass" is the injectable `dropRecorder` seam (default = the real recorder, so the wiring cannot be forgotten at a call site); no production kill-switch was added.

Also covered — the three cases no event-based consumer can satisfy: a discard with **no event log configured**, a **self-batch** discard whose event is loop-guarded away, and a discard while the **OTLP endpoint is unreachable**.

`lib/destinations/otlp.test.ts` gains a pinned `CATALYST_DIR` (re-asserted per test, since bun runs every file in one process). Found the hard way: the first full-suite run after wiring wrote a bogus marker into the real `~/catalyst/otel-forward-drops.json` on this machine. That file was removed and the suite now cannot reach it.

## Stale premises in the ticket, left uncorrected on purpose

1. **The catalog edit the ticket asks for must NOT be made.** CTL-1818 says `2026-08-13-event-automation-catalog.md` §5(a) "recommends deleting all three families … update that cut-list row so the delete is not actioned". That row has **already been corrected** and now reads **"⛔ REJECTED — do not delete"** for all three, because `forward_failed` has a **live external consumer**: `catalyst-otel/provisioning/alerting/read-path-alerts.yaml:252-276`, the only "the stack goes blind" guard in the stack (verified by reading both files). Making the edit as written would *reverse* that correction and greenlight deleting an event a provisioned Grafana alert reads. The rows are left intact. (The catalog lives in `thoughts/`, a separate repo, and is untouched by this PR either way.)

2. **The volume numbers do not disagree — they are differently scoped, and neither is a month.** The ticket's "19,569 a month (mini)" is the **`mini`-only** subset; the catalog's 87,216 is the **fleet** total of the same mirrored file. My measurement reproduces both (19,575 and 87,706, a day later). But the laptop's mirror only covers **2026-08-08 → 08-13**, so both figures are ~6 days of mirrored log presented as "/month" — the real monthly rate is several times higher. Neither figure counts **records**, which is where the loss actually lives: 7.6 M.

## Deferred (not in this PR)

- **A Grafana rule** over the `otel-forward.log` stream (`| msg =~ "SUSTAINED EVENT LOSS"`, or the `drop_records_total` field) belongs in the sister repo `catalyst-otel`; a malformed provisioned rule file crash-loops the **shared** Grafana, so it is described rather than written here.
- **A HUD / orch-monitor renderer** over `~/catalyst/otel-forward-drops.json` — the same follow-up the CTL-1502 watchdog marker is still waiting on (its Codex P2).
- **Root-causing the aged drops themselves.** This PR makes the loss visible; it does not reduce it. 7.6 M records in 6 days at 100% `aged` says records are reaching the sender well past `lokiAcceptWindowMs` — worth its own ticket now that there is a number to watch.
- **PostHog / Cloudflare AE** discards. The surface is destination-agnostic by construction (it records a reason and a count), but only the OTLP sender is wired here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
