### PR TITLE
fix(dev): CTL-1814 — stamp the orchestrator on fallback terminals, so worker state is not blind exactly when the primary path failed

### DIFF
--- a/plugins/dev/scripts/coordination-publish/parity-check.ts
+++ b/plugins/dev/scripts/coordination-publish/parity-check.ts
@@ -117,11 +117,18 @@ export function computeParity(input: {
   // Index ALL coordination rows by ticket in a SINGLE list per ticket, preserving input (wire)
   // order and tagging each with its orchestrator. A worker_state then matches the entries whose
   // orchestrator is its OWN (composite isolation, so multiple orchestrators/runs of a ticket never
-  // cross-contaminate) OR is identity-less. Identity-less rows (no catalyst.orchestrator.id) come
-  // from the SDK terminal emitter's defaultAppendEventLog fallback (sdk-run-phase-agent.mjs, when
-  // phase-agent-emit-complete is missing/fails) — a real terminal carrying the ticket but no
-  // orchestrator; matching them against every worker_state for the ticket keeps a failed
-  // identity-less terminal from silently disappearing. Keeping BOTH kinds in one ordered list (not
+  // cross-contaminate) OR is identity-less. Identity-less rows (no catalyst.orchestrator.id) are a
+  // real terminal carrying the ticket but no orchestrator; matching them against every worker_state
+  // for the ticket keeps a failed identity-less terminal from silently disappearing.
+  //   PROVENANCE (corrected, CTL-1814): this path used to name the SDK terminal emitter's
+  //   defaultAppendEventLog fallback (sdk-run-phase-agent.mjs) as the SOURCE of identity-less rows.
+  //   That emitter now stamps catalyst.orchestrator.id on every terminal it writes — resolved, or
+  //   the explicit "unresolved" sentinel — so it is no longer a producer of this shape. The branch
+  //   is KEPT because pre-CTL-1814 events already on the log are identity-less forever, and because
+  //   any future hand-rolled envelope can reintroduce the shape. Note the sentinel is deliberately
+  //   NOT folded in here: an unattributable terminal matching no worker_state surfaces as a coverage
+  //   gap, which is the loud outcome, not a silently absorbed one.
+  // Keeping BOTH kinds in one ordered list (not
   // two concatenated maps) is essential: selectTerminalOutcome's watermark tie-break is
   // last-processed-wins, so re-ordering an earlier identity-less row after a later keyed row would
   // flip the winner and fabricate a divergence (Codex P1, round 8).

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -304,7 +304,7 @@ function defaultEmitEvent(name, payload) {
 // --no-signal-update so the skill/pre-launch keeps ownership of the signal file).
 // Best-effort; never throws.
 export function defaultEmitBackstop(
-  { phase, ticket, status, reason, orchDir, signalFile },
+  { phase, ticket, status, reason, orchDir, signalFile, orchestrator },
   {
     spawn = spawnSync,
     writeSignalStalled = defaultWriteSignalStalled,
@@ -336,12 +336,25 @@ export function defaultEmitBackstop(
   // signal), then INSPECT the result instead of swallowing it — a missing/failing
   // emit binary falls back to a direct event-log append so the terminal event is
   // never silently dropped.
+  //
+  // CTL-1814: ONE resolved id, TWO consumers — the wrapper's `--orch-id` and the
+  // fallback append below. They must never drift. The fallback fires precisely
+  // when the wrapper did NOT cleanly succeed, INCLUDING the case where it already
+  // wrote its own copy of this terminal and then died; that duplicate is tolerated
+  // by design (phase-advance is idempotent) but only because both copies converge
+  // on ONE `(orchestrator, ticket)` worker_state row. Two different ids would split
+  // one phase across two rows instead. Defaulting to `ticket` reproduces the value
+  // this call site has always handed the wrapper — execution-core dispatch sets
+  // CATALYST_ORCHESTRATOR_ID to the ticket (phase-agent-dispatch / runPrelaunch),
+  // so orchestrator == ticket there; the parameter lets a caller that knows a
+  // different id supply it to BOTH consumers at once.
+  const orchId = resolveOrchestratorId(orchestrator ?? ticket);
   const args = [
     "--phase", phase,
     "--ticket", ticket,
     "--status", status,
     "--orch-dir", orchDir,
-    "--orch-id", ticket,
+    "--orch-id", orchId,
     "--no-signal-update",
   ];
   if (reason) args.push("--reason", reason);
@@ -373,7 +386,7 @@ export function defaultEmitBackstop(
     typeof res.status !== "number" ||
     res.status !== 0;
   if (emitFailed) {
-    appendEventLog({ phase, ticket, status, reason });
+    appendEventLog({ phase, ticket, status, reason, orchestrator: orchId });
   }
 }
 
@@ -519,7 +532,7 @@ const SIGNAL_INFLIGHT_STATUSES = new Set(["dispatched", "running"]);
 const isPlainInt = (v) => /^[0-9]+$/.test(String(v));
 
 export function flipSignalAbandonedOnUndeclaredExit(signalFile, generation, opts = {}) {
-  const { appendEventLog = defaultAppendEventLog, ticket, phase } = opts;
+  const { appendEventLog = defaultAppendEventLog, ticket, phase, orchestrator } = opts;
   if (!signalFile) return;
   try {
     let sig;
@@ -597,11 +610,62 @@ export function flipSignalAbandonedOnUndeclaredExit(signalFile, generation, opts
     const t = ticket ?? sig.ticket;
     const p = phase ?? sig.phase;
     if (t && p) {
-      appendEventLog({ phase: p, ticket: t, status: "abandoned", reason: "ended-without-declaration" });
+      appendEventLog({
+        phase: p,
+        ticket: t,
+        status: "abandoned",
+        reason: "ended-without-declaration",
+        // CTL-1814: the SIGNAL FILE is the authoritative local record of whose run
+        // this was — phase-agent-dispatch writes `orchestrator` into it at prelaunch
+        // — and this function has already parsed it, so attribution costs no extra
+        // I/O. Resolving it HERE rather than at the call sites is what carries the
+        // fix to the codex-exec launch verb too: codex-run-phase-agent.mjs imports
+        // this function and calls it with the same `{ ticket, phase }` the SDK path
+        // does, so neither call site needs to learn a new argument.
+        orchestrator: orchestrator ?? sig.orchestrator,
+      });
     }
   } catch {
     /* best-effort — the skill's own wrapper flip is the primary path */
   }
+}
+
+// ── CTL-1814: the orchestrator id this emitter must carry ───────────────────
+//
+// `catalyst.orchestrator.id` is HALF of the CTL-532 worker-state identity.
+// broker/projection.mjs reads it (`localOrchestrator` →
+// `event.orchestrator ?? attributes["catalyst.orchestrator.id"]`),
+// `reduceWorkerStateEvent` returns NULL the moment it is absent, and
+// `upsertWorkerState` — PRIMARY KEY `(orchestrator, ticket)` — then writes
+// nothing at all. So a terminal without it is not "degraded", it is INVISIBLE to
+// worker_state; and because this is the LAST-RESORT writer, it went invisible
+// precisely when the primary `phase-agent-emit-complete` path had already
+// failed, which is the worst moment to lose the record.
+//
+// UNRESOLVABLE IS A VALUE, NOT AN OMISSION. When no id resolves the attribute is
+// still written, carrying ORCHESTRATOR_UNRESOLVED. Omitting it would leave
+// "this event predates the contract" and "this emitter tried and could not
+// resolve one" reading identically (`undefined`) off the same key for every
+// downstream consumer. The sentinel also keeps the terminal PROJECTABLE: the
+// fold yields a row under a name that says out loud it is unattributed, which
+// is strictly louder than the row never existing.
+export const ORCHESTRATOR_UNRESOLVED = "unresolved";
+
+// resolveOrchestratorId — the id ladder, mirroring the value the PRIMARY path
+// would have used: an explicit caller value first, then CATALYST_ORCHESTRATOR_ID
+// (the same env `phase-agent-emit-complete` defaults its ORCH_ID from), then the
+// sentinel. Only a non-empty STRING resolves — a number/object/blank falls through
+// to the next rung rather than being coerced into an identity nobody can look up
+// (a `[object Object]` orchestrator is worse than an honest sentinel, because it
+// looks like a real key). Pure; never throws.
+export function resolveOrchestratorId(orchestrator, env = process.env) {
+  for (const candidate of [orchestrator, env?.CATALYST_ORCHESTRATOR_ID]) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return ORCHESTRATOR_UNRESOLVED;
 }
 
 // defaultAppendEventLog — CTL-1367 item 5. Last-resort terminal-event append when
@@ -609,7 +673,11 @@ export function flipSignalAbandonedOnUndeclaredExit(signalFile, generation, opts
 // v2 envelope `phase.<phase>.<status>.<ticket>` to the unified event log so the
 // terminal event is NEVER silently dropped (the broker routes on
 // attributes["event.name"]). Best-effort; never throws.
-export function defaultAppendEventLog({ phase, ticket, status, reason }) {
+//
+// CTL-1814: `orchestrator` completes the projection identity (see the block
+// above). It is resolved, never assumed — and always stamped, including the
+// unresolvable case.
+export function defaultAppendEventLog({ phase, ticket, status, reason, orchestrator }) {
   try {
     const path = getEventLogPath();
     mkdirSync(dirname(path), { recursive: true });
@@ -626,6 +694,9 @@ export function defaultAppendEventLog({ phase, ticket, status, reason }) {
         // CTL-1488: DIRECT canonical writer — bypasses buildCanonicalEvent, so stamp the stream class
         // or coordination-publish's fail-closed filter silently drops this terminal event.
         "event.stream_class": classifyEventStream(eventName),
+        // CTL-1814: without this the CTL-532 fold returns null and worker_state
+        // stays stale for exactly the four terminal statuses this emitter writes.
+        "catalyst.orchestrator.id": resolveOrchestratorId(orchestrator),
         "linear.issue.identifier": ticket,
         "catalyst.worker.ticket": ticket,
       },

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -7,6 +7,9 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { isTicketInFlight, deriveAdvancement } from "./scheduler.mjs";
 import { PHASE_EVENT_PATTERN } from "../broker/namespace-contract.mjs";
+// CTL-1814: the REAL CTL-532 reducer — the consumer this emitter was invisible to.
+// Asserting against a re-implementation of the fold would test nothing.
+import { reduceWorkerStateEvent } from "../broker/projection.mjs";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -2144,5 +2147,219 @@ describe("CTL-1790 — the written terminal is recognized by the live predicates
     rmSync(dir, { recursive: true, force: true });
     expect(after.status).toBe("dispatched");
     expect(seen).toHaveLength(0);
+  });
+});
+
+// ── CTL-1814: the fallback terminal must carry its orchestrator ──────────────
+//
+// defaultAppendEventLog is the LAST-RESORT terminal writer — it fires exactly when
+// the phase-agent-emit-complete wrapper is missing or died. Its hand-rolled v2
+// envelope never carried `catalyst.orchestrator.id`, which is HALF of the CTL-532
+// worker-state identity: broker/projection.mjs `reduceWorkerStateEvent` returns
+// null without it, and `upsertWorkerState` (PK `(orchestrator, ticket)`) then
+// writes nothing — so worker_state went stale precisely when the primary path had
+// already broken.
+//
+// These tests drive the REAL reducer over the REAL written line. The status list is
+// DERIVED from the broker's own PHASE_EVENT_PATTERN rather than re-typed, so a
+// future terminal status cannot be added to the contract without landing here.
+const CONTRACT_TERMINAL_STATUSES = (() => {
+  // The second capture group of PHASE_EVENT_PATTERN is the terminal-status
+  // alternation. Anchor on `complete` (its first member) rather than on group
+  // position so the match FAILS CLOSED if the pattern is restructured — a guard
+  // that silently matched the wrong group would derive an empty/wrong list and
+  // then pass by testing nothing.
+  const m = /\((complete\|[^)]+)\)/.exec(PHASE_EVENT_PATTERN.source);
+  if (!m) {
+    throw new Error(
+      "PHASE_EVENT_PATTERN no longer exposes a `(complete|…)` terminal-status alternation — " +
+        "this guard can no longer derive the status list, so fix the guard rather than deleting it",
+    );
+  }
+  return m[1].split("|");
+})();
+
+// The explicit sentinel this emitter must write when no orchestrator can be
+// resolved. Declared here as the CONTRACT the test pins — deliberately NOT imported
+// from the module under test, so a rename on the production side is a failure here
+// rather than a silently-agreeing tautology.
+const UNRESOLVED_ORCHESTRATOR = "unresolved";
+
+describe("CTL-1814 — the fallback terminal event carries its orchestrator", () => {
+  // Drive defaultAppendEventLog against a scratch CATALYST_DIR and return the
+  // parsed line it appended. getEventLogPath() re-resolves CATALYST_DIR per call,
+  // so nothing here can touch the real ~/catalyst event log.
+  const appendAndRead = (args, envOverrides = {}) => {
+    const prevDir = process.env.CATALYST_DIR;
+    const prevOrch = process.env.CATALYST_ORCHESTRATOR_ID;
+    const dir = mkdtempSync(join(tmpdir(), "sdk-ctl1814-"));
+    process.env.CATALYST_DIR = dir;
+    // The daemon that runs this code may itself have CATALYST_ORCHESTRATOR_ID set;
+    // clear it so each case exercises the rung it means to (test-env pollution).
+    delete process.env.CATALYST_ORCHESTRATOR_ID;
+    if (envOverrides.CATALYST_ORCHESTRATOR_ID !== undefined) {
+      process.env.CATALYST_ORCHESTRATOR_ID = envOverrides.CATALYST_ORCHESTRATOR_ID;
+    }
+    try {
+      defaultAppendEventLog(args);
+      const now = new Date();
+      const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+      const line = readFileSync(join(dir, "events", `${ym}.jsonl`), "utf8")
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .pop();
+      return JSON.parse(line);
+    } finally {
+      if (prevDir === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prevDir;
+      if (prevOrch === undefined) delete process.env.CATALYST_ORCHESTRATOR_ID;
+      else process.env.CATALYST_ORCHESTRATOR_ID = prevOrch;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  test("the derived status list is the full contract set (guard is looking at real data)", () => {
+    // Positive control for the derivation above: if this list ever comes back empty
+    // or truncated, every per-status test below would vacuously "pass" by not running.
+    expect(CONTRACT_TERMINAL_STATUSES).toEqual([
+      "complete",
+      "failed",
+      "turn-cap-exhausted",
+      "skipped",
+      "abandoned",
+    ]);
+  });
+
+  for (const status of CONTRACT_TERMINAL_STATUSES) {
+    test(`status=${status}: the written envelope folds to a non-null worker-state patch`, () => {
+      const ev = appendAndRead({
+        phase: "implement",
+        ticket: "CTL-1814",
+        status,
+        reason: "sdk-threw",
+        orchestrator: "ORCH-9",
+      });
+      expect(ev.attributes["event.name"]).toBe(`phase.implement.${status}.CTL-1814`);
+      expect(ev.attributes["catalyst.orchestrator.id"]).toBe("ORCH-9");
+
+      const folded = reduceWorkerStateEvent(ev);
+      expect(folded).not.toBeNull();
+      expect(folded.orchestrator).toBe("ORCH-9");
+      expect(folded.ticket).toBe("CTL-1814");
+      expect(folded.patch.phase).toBe("implement");
+      // A status the projection does not map yields `undefined` here, which
+      // upsertWorkerState would write as a NULL status — a folded row that says
+      // nothing. Assert a real mapped value, not merely a non-null envelope.
+      expect(folded.patch.status).toBeTruthy();
+    });
+  }
+
+  test("an UNRESOLVABLE orchestrator is written explicitly, never omitted", () => {
+    const ev = appendAndRead({ phase: "implement", ticket: "CTL-1814", status: "failed" });
+    // The distinction this ticket exists for: an emitter that never stamped the
+    // attribute and an emitter that stamped "I could not resolve one" must not both
+    // read as `undefined` on the same key. Asserted over the KEY SET rather than
+    // with toHaveProperty, whose dotted-path semantics would look for a nested
+    // `catalyst → orchestrator → id` object and report "unable to find property"
+    // even when the flat attribute is present.
+    expect(Object.keys(ev.attributes)).toContain("catalyst.orchestrator.id");
+    expect(ev.attributes["catalyst.orchestrator.id"]).toBe(UNRESOLVED_ORCHESTRATOR);
+    // …and the sentinel keeps the terminal PROJECTABLE — a row that names itself
+    // unattributed is strictly louder than no row at all.
+    const folded = reduceWorkerStateEvent(ev);
+    expect(folded).not.toBeNull();
+    expect(folded.orchestrator).toBe(UNRESOLVED_ORCHESTRATOR);
+  });
+
+  test("CATALYST_ORCHESTRATOR_ID is the second rung — the same env the wrapper defaults from", () => {
+    const ev = appendAndRead(
+      { phase: "verify", ticket: "CTL-1814", status: "failed" },
+      { CATALYST_ORCHESTRATOR_ID: "orch-from-env" },
+    );
+    expect(ev.attributes["catalyst.orchestrator.id"]).toBe("orch-from-env");
+  });
+
+  test("an explicit orchestrator outranks the env rung", () => {
+    const ev = appendAndRead(
+      { phase: "verify", ticket: "CTL-1814", status: "failed", orchestrator: "orch-explicit" },
+      { CATALYST_ORCHESTRATOR_ID: "orch-from-env" },
+    );
+    expect(ev.attributes["catalyst.orchestrator.id"]).toBe("orch-explicit");
+  });
+
+  test("a blank/non-string orchestrator falls through instead of being coerced into an id", () => {
+    for (const bogus of ["", "   ", 42, null, {}]) {
+      const ev = appendAndRead({
+        phase: "implement",
+        ticket: "CTL-1814",
+        status: "failed",
+        orchestrator: bogus,
+      });
+      expect(ev.attributes["catalyst.orchestrator.id"]).toBe(UNRESOLVED_ORCHESTRATOR);
+    }
+  });
+
+  test("defaultEmitBackstop's fallback uses the SAME id it handed the wrapper", () => {
+    // The fallback fires when the wrapper did NOT cleanly succeed — including the
+    // case where it wrote its own copy of this terminal and then died. A duplicate
+    // is tolerated by design (phase-advance is idempotent), but only because both
+    // copies converge on ONE worker_state row: two different orchestrator ids would
+    // split one phase across two rows. Pin that they cannot drift.
+    const spawned = [];
+    const appended = [];
+    defaultEmitBackstop(
+      { phase: "implement", ticket: "CTL-1814", status: "failed", reason: "sdk-threw", orchDir: "/ec" },
+      {
+        spawn: (_bin, args) => {
+          spawned.push(args);
+          return { status: 1, error: null }; // non-zero → the fallback append runs
+        },
+        writeSignalStalled: () => {},
+        appendEventLog: (e) => appended.push(e),
+      },
+    );
+    expect(appended).toHaveLength(1);
+    const wrapperOrchId = spawned[0][spawned[0].indexOf("--orch-id") + 1];
+    expect(wrapperOrchId).toBeTruthy();
+    expect(appended[0].orchestrator).toBe(wrapperOrchId);
+  });
+
+  test("the abandonment terminal is attributed from the signal file itself", () => {
+    // phase-agent-dispatch writes `orchestrator` into the phase signal at prelaunch,
+    // so the signal this function already parses is the authoritative local record of
+    // whose run it was — no new argument at either call site (sdk + codex-exec).
+    const dir = mkdtempSync(join(tmpdir(), "sdk-ctl1814-abandon-"));
+    const signalFile = join(dir, "phase-implement.json");
+    writeFileSync(
+      signalFile,
+      JSON.stringify({
+        status: "running",
+        ticket: "CTL-1814",
+        phase: "implement",
+        orchestrator: "orch-from-signal",
+      }),
+    );
+    const seen = [];
+    flipSignalAbandonedOnUndeclaredExit(signalFile, undefined, {
+      ticket: "CTL-1814",
+      phase: "implement",
+      appendEventLog: (e) => seen.push(e),
+    });
+    rmSync(dir, { recursive: true, force: true });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].orchestrator).toBe("orch-from-signal");
+  });
+
+  test("codex-exec reuses these emitters rather than forking its own copy", () => {
+    // The whole fix reaches the codex-exec launch verb only because that module
+    // IMPORTS both writers from here. If it ever inlines its own copies, the codex
+    // path silently regresses to orchestrator-less terminals with every test above
+    // still green — so assert the import edge, not just the behaviour.
+    const codexSrc = readFileSync(join(import.meta.dir, "codex-run-phase-agent.mjs"), "utf8");
+    const importBlock = /import\s*\{([^}]*)\}\s*from\s*"\.\/sdk-run-phase-agent\.mjs"/.exec(codexSrc);
+    expect(importBlock).not.toBeNull();
+    expect(importBlock[1]).toContain("defaultEmitBackstop");
+    expect(importBlock[1]).toContain("flipSignalAbandonedOnUndeclaredExit");
   });
 });


### PR DESCRIPTION
Closes CTL-1814.

## The defect

`defaultAppendEventLog` (`execution-core/sdk-run-phase-agent.mjs`) is the **last-resort** terminal writer — it hand-rolls a v2 envelope when the `phase-agent-emit-complete` wrapper is missing or dies, so a terminal event is "never silently dropped". Its envelope has **never carried `catalyst.orchestrator.id`**.

That attribute is **half** of the CTL-532 worker-state identity, and the fold is all-or-nothing on it:

```
broker/projection.mjs   localOrchestrator      → event.orchestrator
                                               ?? attributes["catalyst.orchestrator.id"] ?? null
broker/projection.mjs   reduceWorkerStateEvent → returns null when it is absent
broker/broker-state.mjs upsertWorkerState      → `if (!orchestrator || !ticket) return;`
                                                 (PRIMARY KEY (orchestrator, ticket))
```

So the terminal is not *degraded*, it is **invisible** — no row is written at all. The projection went dark **precisely when the primary path had already broken**, for every status this emitter writes: `complete`, `failed`, `turn-cap-exhausted`, `abandoned`.

## Measurement

`~/catalyst/events/2026-08.jsonl`, every terminal phase event (1,207 matched):

| carries `catalyst.orchestrator.id` | service | count |
| ---------------------------------- | ------- | ----: |
| yes | `catalyst.phase-agent` (the wrapper) | 1,185 |
| **no** | `catalyst.execution-core` — 20 × `phase.dispatch.failed.*`, **1 × this emitter's exact shape** | 22 |

The one identity-less event of this emitter's shape, verbatim:

```json
{"ts":"2026-08-13T00:39:47.610Z","resource":{"service.name":"catalyst.execution-core",…},
 "attributes":{"event.name":"phase.triage.abandoned.CTL-1","event.stream_class":"coordination",
 "linear.issue.identifier":"CTL-1","catalyst.worker.ticket":"CTL-1"},
 "body":{"message":"ended-without-declaration"}}
```

*Positive control for the "absent" reading:* the same jq pass over the same file returns **1,185** events **with** the attribute, so the instrument can see it when it is there. Event names were read as `attributes["event.name"] ?? event ?? name`.

The population is small because this path only fires when the wrapper fails — which is the argument for fixing it, not for deferring it.

## The fix

One resolution ladder, one attribute, both sibling writers.

- **`resolveOrchestratorId(orchestrator, env)`** — explicit caller value → `CATALYST_ORCHESTRATOR_ID` (the same env `phase-agent-emit-complete` defaults its `ORCH_ID` from) → the explicit sentinel. Only a **non-empty string** resolves; a number/object/blank falls through rather than being coerced into an identity nobody can look up (`[object Object]` is worse than an honest sentinel — it *looks* like a real key).

- **Unresolvable is a value, not an omission.** When nothing resolves, the attribute is still written, carrying `"unresolved"`. Omitting it would leave *"this event predates the contract"* and *"this emitter tried and could not resolve one"* reading identically (`undefined`) off the same key for every consumer — the exact conflation the ticket forbids. The sentinel also keeps the terminal **projectable**: a row named unattributed is strictly louder than no row at all.

- **`defaultEmitBackstop` resolves ONE `orchId` and hands it to BOTH consumers** — the wrapper's `--orch-id` and the fallback append — so they cannot drift. This matters: the fallback fires when the wrapper did *not* cleanly succeed, **including after it already wrote its own copy of this terminal and then died**. That duplicate is tolerated by design (phase-advance is idempotent) *only because both copies converge on one `(orchestrator, ticket)` row*; two different ids would split one phase across two rows. It defaults to `ticket`, the value this call site has always handed the wrapper (execution-core dispatch sets `CATALYST_ORCHESTRATOR_ID` to the ticket).

- **`flipSignalAbandonedOnUndeclaredExit` resolves from the phase SIGNAL FILE it has already parsed** — `phase-agent-dispatch` writes `orchestrator` into it at prelaunch, so attribution costs no extra I/O. Resolving *there* rather than at the call sites is what carries the fix to the **codex-exec** launch verb with **zero codex edits**: `codex-run-phase-agent.mjs` imports both writers from this module and calls them with the same arguments the SDK path does. A test asserts that import edge, so inlining a fork of either writer fails loudly instead of silently regressing the codex path.

## Verification

Command: `cd plugins/dev/scripts/execution-core && bun test sdk-run-phase-agent.test.mjs`
(`CLAUDE_CODE_OAUTH_TOKEN` unset — a shell token false-fails the pre-existing auth-guard test.)

| run | result |
| --- | ------ |
| test written **before** the fix | 138 pass / **11 fail** |
| after the fix | **149 pass / 0 fail** |
| **positive control** — fix reverted (`git checkout` the source), re-run | back to 138 pass / **11 fail**; restored → 149 / 0 |

Full CI stable list (the exact 182 files from `execution-core-tests.yml`):

| | pass | fail |
| --- | ---: | ---: |
| fix reverted | 6,325 | 16 — 11 CTL-1814 + 5 pre-existing |
| fix applied | 6,334–6,337 | 4–7 — pre-existing only |

The pre-existing failures are timing-flaky *locally* and vary run to run: `integration.test.mjs` AC1b/AC5, `scheduler.test.mjs` CTL-1329 fence guard, `linearis fallback`, `buildHeartbeatEnvelope` host.name (this host is `…-2.local`). **Every failing set with the fix applied is a subset of the failing set without it** — no red is introduced.

Also green: `broker/worker-state-projection.test.mjs` **60 / 0**, `coordination-publish` **88 / 0**.

### How the per-status test resists rot

The five per-status cases are **generated from the broker's own `PHASE_EVENT_PATTERN` alternation**, not a re-typed list, and the derivation regex anchors on `complete` so it **fails closed** if the pattern is restructured — a guard that derived an empty list would otherwise "pass" by testing nothing (there is a separate assertion pinning the derived list, as the control on the control). Each case drives the **real** `reduceWorkerStateEvent` over the **real** written line and asserts a *mapped* status, not merely a non-null envelope. A future terminal status added to the contract lands here automatically.

## Stale premise corrected

`coordination-publish/parity-check.ts` documented this emitter as the **source** of its identity-less coordination rows. That is no longer true, and a false premise left in place propagates. The branch is kept — pre-CTL-1814 events already on the log are identity-less forever — with corrected provenance, plus the note that the `"unresolved"` sentinel is deliberately **not** folded into it: an unattributable terminal surfacing as a coverage gap is the loud outcome, not a silently absorbed one.

## Sibling writers checked, per the ticket

**Not the same gap** (all three verified in source):

- `catalyst-state.sh` — `event_append` passes `--orch "$orch"` → `catalyst.orchestrator.id`.
- `emit-worker-status-change.sh` — emits a v1 envelope with a top-level `orchestrator` field, which `localOrchestrator` reads *first*.
- `lib/emit-reap-intent.sh` — `phase.*.reap-requested` never matches the projection's terminal-status set, so the fold ignores it by construction.

## Deferred (a fourth writer, deliberately left alone)

`recovery.mjs`'s `phase.dispatch.failed.<TICKET>` — **20 events in August, all orchestrator-less**, and `WORKER_PHASE_EVENT_PATTERN` *does* match it. Stamping it would make the projection write `phase: "dispatch"` (not a pipeline phase — it is an `INTENTIONAL_PHASE_SLOT_EXCEPTION`) over the row's real phase, i.e. the fix would corrupt what it set out to complete. Today's null return is accidentally correct. The right fix is **projection-side** — exclude slots outside `KNOWN_PHASES` from the worker-state fold — and belongs in its own ticket rather than riding this one.

Two further observations recorded but not acted on here:

- One August terminal from the *primary* wrapper (`phase.implement.complete.CTL-1506`, `catalyst.phase-agent`) also lacks the attribute — a dispatch that ran with `CATALYST_ORCHESTRATOR_ID` unset. Different emitter, different cause.
- `PHASE_STATUS_MAP` yields `phase-complete`/`phase-failed`/`turn-cap-exhausted`, none of which are in `WORKER_TERMINAL_STATUSES` (`done`/`failed`/`complete`), so **any** folded phase terminal keeps `hasActiveWorkers` true for 30 minutes. Pre-existing for all 1,185 primary-path events; this PR only brings the fallback to parity with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
