### PR TITLE
fix(dev): CTL-1795 — dual-emit the v2 envelope from every v1 site, so a consumer filtering on event.name stops seeing a smaller universe

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -328,6 +328,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/skill-plugin-root-assigned.test.sh
 
+      - name: dual-envelope test (CTL-1795 v1→superset, bash half)
+        # Covers canonical_dual_envelope_line / canonical_note_v1_only, the bash
+        # reap-intent producer, and catalyst-session.sh's agent.checkin/checkout.
+        # ALSO the cross-stack ATTR_MAP parity check: the bash mirror
+        # _CE_FLAT_ATTR_JQ vs the JS registry FLAT_ATTRIBUTE_MAP. Bash cannot
+        # import an ESM constant, so this suite is the only thing preventing the
+        # two hand-written mirrors from drifting.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/dual-envelope.test.sh
+
       - name: catalyst-stack shipper ephemeral-path guard test (CTL-1473)
         # CTL-1473: guards that install-services (--print and real) refuses to bake
         # an ephemeral config path (worktree or /tmp). Uses CATALYST_FORCE_BAKE_DIR +
@@ -720,6 +730,7 @@ jobs:
             event-log-window.test.mjs \
             event-log-read-guard.test.mjs \
             lib/canonical-event.test.mjs \
+            lib/dual-envelope.test.mjs \
             fence-guard.test.mjs \
             fence-guard-integration.test.mjs \
             terminal-done-cooldown.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,6 +97,27 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
   - **v1** (bash, `catalyst-state.sh event`): `{ts, event, orchestrator, worker, detail}`.
   - **v2 OTel** (`plugins/dev/scripts/orch-monitor/lib/webhook-events.ts` for `github.*`/`linear.*`;
     `catalyst-comms send` for `comms.message.posted`): `{ts, attributes, body, resource}`.
+  - **Superset (CTL-1795, phase 1)** — every v1 emit site now writes ONE line carrying BOTH the
+    top-level `event` and a full v2 `attributes`/`body`/`resource` block, built through the shared
+    builders `execution-core/lib/canonical-event.mjs` (`buildDualEnvelopeLine`) and
+    `lib/canonical-event.sh` (`canonical_dual_envelope_line`). Measured motivation: 159,009 v1
+    events across **31 distinct names** in 2026-08 were invisible to any consumer reading
+    `attributes["event.name"]`. It is **one** line, not two, because `getEventName` reads
+    `event.event` FIRST (`broker/event-name.mjs:16`) — a v1 line plus a v2 twin would be routed
+    twice, double-applying `handleAgentCheckin`'s `upsertAgent`/`_autoRegisterPrLifecycle`. Flat
+    fields are promoted to attributes by the same map otel-forward's `normalizeFlatEvent` uses, so
+    the OTLP attribute set is unchanged; unmapped fields land in `body.payload`; every v1 key also
+    survives verbatim. Phase 1 is **additive** — removing v1 emission and narrowing
+    `catalyst-events tail`/`wait-for` to v2 is an explicit follow-up one release later.
+  - **Declared asymmetry (jq-less hosts).** The bash v2 builder is a jq program, so two bash
+    fallbacks — `catalyst-state.sh`'s jq-less branch and `emit-worker-status-change.sh`'s
+    missing-`$STATE_SCRIPT` branch, both of which exist *because* the canonical path is
+    unavailable — emit v1 only; no jq-free JSON assembler is written for them. Same posture as the
+    jq-less deployment-mode resolver above: the divergence is made observable rather than silent,
+    via a `CATALYST_EVENT_ENVELOPE_V1_ONLY` breadcrumb plus one stderr line per process
+    (`canonical_note_v1_only`) — stderr because a separate CLI process cannot hand an exported var
+    back, and because it rides the Alloy-shipped daemon `.log` rather than the event log whose
+    degradation it reports.
   - Consumers: `catalyst-events tail` (stream), `catalyst-events wait-for` (blocking single-event).
     Both shapes handled. See `website/src/content/docs/observability/catalyst-events.md`.
 - **history/** — full snapshots archived on completion/failure/stale.

--- a/plugins/dev/scripts/__tests__/dual-envelope.test.sh
+++ b/plugins/dev/scripts/__tests__/dual-envelope.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Shell tests for the CTL-1795 bash half of the v1→superset dual envelope:
+#   lib/canonical-event.sh   canonical_dual_envelope_line / canonical_merge_v1 / canonical_note_v1_only
+#   lib/emit-reap-intent.sh  the bash reap-intent producer
+#   catalyst-session.sh      agent.checkin / agent.checkout (Ruling 2 — the census missed these)
+#
+# Plus the cross-stack ATTR_MAP parity check: the bash mirror _CE_FLAT_ATTR_JQ vs the JS
+# registry FLAT_ATTRIBUTE_MAP. Bash cannot import an ESM constant, so the two are hand-written
+# mirrors and this is what keeps them honest.
+#
+# Run: bash plugins/dev/scripts/__tests__/dual-envelope.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB="${SCRIPTS_DIR}/lib/canonical-event.sh"
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+FAILURES=0
+PASSES=0
+
+ok() {
+  PASSES=$((PASSES + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  echo "    $2"
+}
+
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then ok "$name"; else fail "$name" "expected '$expected' got '$actual'"; fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq unavailable — the canonical path under test requires it by design (CTL-1795 Ruling 3)"
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "=== canonical_dual_envelope_line ==="
+
+V1='{"ts":"2026-08-13T10:00:00Z","event":"phase.terminal.reap-requested","ticket":"CTL-1795","phase":"implement","bg_job_id":"abc12345","reason":"terminal-signal"}'
+LINE="$(canonical_dual_envelope_line "$V1")"
+
+# ONE line, not two — a v1 line plus a separate v2 twin would be double-routed by every
+# consumer using the v1-first getEventName extractor.
+expect_eq "emits exactly one line" "1" "$(printf '%s' "$LINE" | grep -c '' || true)"
+
+# The load-bearing invariant: both readers of the SAME line resolve the SAME name.
+expect_eq "top-level event survives" "phase.terminal.reap-requested" \
+  "$(printf '%s' "$LINE" | jq -r '.event')"
+expect_eq "attributes carry event.name" "phase.terminal.reap-requested" \
+  "$(printf '%s' "$LINE" | jq -r '.attributes["event.name"]')"
+expect_eq "the two extractors agree" "true" \
+  "$(printf '%s' "$LINE" | jq -r '(.event) == (.attributes["event.name"])')"
+
+# Existing v1 consumers must be untouched — the reaper reads e.ticket / e.bg_job_id / e.reason.
+expect_eq "v1 field ticket preserved" "CTL-1795" "$(printf '%s' "$LINE" | jq -r '.ticket')"
+expect_eq "v1 field bg_job_id preserved" "abc12345" "$(printf '%s' "$LINE" | jq -r '.bg_job_id')"
+expect_eq "v1 field reason preserved" "terminal-signal" "$(printf '%s' "$LINE" | jq -r '.reason')"
+
+# ATTR_MAP promotion, matching otel-forward's normalizeFlatEvent.
+expect_eq "ticket promoted to attribute" "CTL-1795" \
+  "$(printf '%s' "$LINE" | jq -r '.attributes["catalyst.worker.ticket"]')"
+expect_eq "phase promoted to attribute" "implement" \
+  "$(printf '%s' "$LINE" | jq -r '.attributes["catalyst.worker.phase"]')"
+expect_eq "bg_job_id promoted to attribute" "abc12345" \
+  "$(printf '%s' "$LINE" | jq -r '.attributes["catalyst.worker.bg_job_id"]')"
+expect_eq "unmapped field lands in body.payload" "terminal-signal" \
+  "$(printf '%s' "$LINE" | jq -r '.body.payload.reason')"
+expect_eq "ts is never duplicated into payload" "null" \
+  "$(printf '%s' "$LINE" | jq -r '.body.payload.ts // "null"')"
+
+# One timestamp, adopted verbatim from v1.
+expect_eq "canonical ts adopts the v1 ts" "2026-08-13T10:00:00Z" "$(printf '%s' "$LINE" | jq -r '.ts')"
+expect_eq "observedTs matches ts" "true" "$(printf '%s' "$LINE" | jq -r '.ts == .observedTs')"
+expect_eq "body.message is non-empty" "phase.terminal.reap-requested" \
+  "$(printf '%s' "$LINE" | jq -r '.body.message')"
+expect_eq "resource is present" "catalyst.execution-core" \
+  "$(printf '%s' "$LINE" | jq -r '.resource["service.name"]')"
+
+# The superset line must NOT trip the legacy rotation (which keys on has("attributes")).
+expect_eq "has attributes, so canonical_jsonl_append will not rotate" "true" \
+  "$(printf '%s' "$LINE" | jq -r 'has("attributes")')"
+
+# A flat field cannot displace event.name even when it maps onto that key.
+SPOOF='{"ts":"2026-08-13T10:00:00Z","event":"real.name","event.name":"spoofed"}'
+expect_eq "a flat field cannot displace event.name" "real.name" \
+  "$(canonical_dual_envelope_line "$SPOOF" | jq -r '.attributes["event.name"]')"
+
+echo "=== canonical_dual_envelope_line — fails CLOSED ==="
+
+if canonical_dual_envelope_line '{"ts":"x"}' >/dev/null 2>&1; then
+  fail "nameless record rejected" "expected non-zero exit"
+else
+  ok "nameless record rejected"
+fi
+if canonical_dual_envelope_line '{"ts":"x","event":""}' >/dev/null 2>&1; then
+  fail "empty-name record rejected" "expected non-zero exit"
+else
+  ok "empty-name record rejected"
+fi
+if canonical_dual_envelope_line '{"ts":"x","event":"e.v","attributes":{}}' >/dev/null 2>&1; then
+  fail "already-canonical record rejected" "expected non-zero exit (no double-wrap)"
+else
+  ok "already-canonical record rejected"
+fi
+if canonical_dual_envelope_line 'not json' >/dev/null 2>&1; then
+  fail "unparseable record rejected" "expected non-zero exit"
+else
+  ok "unparseable record rejected"
+fi
+
+echo "=== canonical_note_v1_only — the declared-asymmetry breadcrumb ==="
+
+BREADCRUMB_OUT="$(
+  unset CATALYST_EVENT_ENVELOPE_V1_ONLY __CE_V1_ONLY_WARNED
+  canonical_note_v1_only "jq-missing:test" 2>&1
+  canonical_note_v1_only "jq-missing:test" 2>&1 # second call must be silent
+  printf 'FLAG=%s REASON=%s\n' "${CATALYST_EVENT_ENVELOPE_V1_ONLY:-}" "${CATALYST_EVENT_ENVELOPE_V1_ONLY_REASON:-}"
+)"
+expect_eq "warns exactly once per process" "1" "$(printf '%s\n' "$BREADCRUMB_OUT" | grep -c 'RAW v1 event envelope' || true)"
+expect_eq "sets the env breadcrumb" "FLAG=1 REASON=jq-missing:test" \
+  "$(printf '%s\n' "$BREADCRUMB_OUT" | tail -n 1)"
+
+echo "=== cross-stack ATTR_MAP parity (bash mirror vs the JS registry) ==="
+
+# Parse FLAT_ATTRIBUTE_MAP out of the JS source and compare it, as a SET, to the bash mirror.
+# Anchored on the declaration so a rename fails CLOSED rather than silently comparing nothing.
+JS_SRC="${SCRIPTS_DIR}/execution-core/lib/canonical-event.mjs"
+if [[ ! -r "$JS_SRC" ]]; then
+  fail "JS registry readable" "missing $JS_SRC"
+else
+  JS_PAIRS="$(
+    awk '/^export const FLAT_ATTRIBUTE_MAP = Object.freeze\(\{/{f=1;next} f&&/^\}\);/{exit} f' "$JS_SRC" |
+      sed -n 's/^[[:space:]]*\([A-Za-z_][A-Za-z0-9_]*\):[[:space:]]*"\([^"]*\)".*$/\1=\2/p' | sort
+  )"
+  SH_PAIRS="$(printf '%s' "$_CE_FLAT_ATTR_JQ" | jq -r 'to_entries[] | "\(.key)=\(.value)"' | sort)"
+  # Positive control: the instrument must actually find rows, or "they match" is vacuous
+  # (two empty sets are equal). Six is the registry's real size.
+  expect_eq "parity instrument extracted the JS rows (positive control)" "6" \
+    "$(printf '%s\n' "$JS_PAIRS" | grep -c '=' || true)"
+  if [[ "$JS_PAIRS" == "$SH_PAIRS" ]]; then
+    ok "bash _CE_FLAT_ATTR_JQ matches JS FLAT_ATTRIBUTE_MAP exactly"
+  else
+    fail "bash _CE_FLAT_ATTR_JQ matches JS FLAT_ATTRIBUTE_MAP exactly" \
+      "$(printf 'js:\n%s\nsh:\n%s\n' "$JS_PAIRS" "$SH_PAIRS")"
+  fi
+fi
+
+echo "=== lib/emit-reap-intent.sh emits the superset line ==="
+
+REAP_DIR="$TMP/reap-events"
+mkdir -p "$REAP_DIR"
+(
+  export CATALYST_EVENTS_DIR="$REAP_DIR"
+  # shellcheck disable=SC1090
+  . "${SCRIPTS_DIR}/lib/emit-reap-intent.sh"
+  emit_reap_intent phase.yield.reap-requested --ticket CTL-1795 --phase implement --bg-job-id abc12345
+)
+REAP_FILE="${REAP_DIR}/$(date -u +%Y-%m).jsonl"
+if [[ ! -f "$REAP_FILE" ]]; then
+  fail "emit_reap_intent wrote an event" "no file at $REAP_FILE"
+else
+  expect_eq "emit_reap_intent wrote exactly one line" "1" "$(grep -c '' "$REAP_FILE" || true)"
+  REAP_LINE="$(head -n 1 "$REAP_FILE")"
+  expect_eq "emit_reap_intent keeps the v1 event field" "phase.yield.reap-requested" \
+    "$(printf '%s' "$REAP_LINE" | jq -r '.event')"
+  expect_eq "emit_reap_intent keeps the v1 ticket field" "CTL-1795" \
+    "$(printf '%s' "$REAP_LINE" | jq -r '.ticket')"
+  expect_eq "emit_reap_intent now carries attributes.event.name" "phase.yield.reap-requested" \
+    "$(printf '%s' "$REAP_LINE" | jq -r '.attributes["event.name"]')"
+  expect_eq "emit_reap_intent promotes ticket to the mapped attribute" "CTL-1795" \
+    "$(printf '%s' "$REAP_LINE" | jq -r '.attributes["catalyst.worker.ticket"]')"
+fi
+
+echo "=== catalyst-session.sh agent.checkin / agent.checkout (Ruling 2) ==="
+
+SESSION_SH="${SCRIPTS_DIR}/catalyst-session.sh"
+if [[ ! -x "$SESSION_SH" ]] || ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "  SKIP: catalyst-session.sh not runnable here (needs sqlite3)"
+else
+  SESS_HOME="$TMP/sess"
+  mkdir -p "$SESS_HOME"
+  SID="$(CATALYST_DIR="$SESS_HOME" "$SESSION_SH" start --skill phase-implement --ticket CTL-1795 2>/dev/null | tail -n 1)"
+  SESS_FILE="${SESS_HOME}/events/$(date -u +%Y-%m).jsonl"
+  if [[ -z "$SID" || ! -f "$SESS_FILE" ]]; then
+    fail "catalyst-session.sh start emitted events" "sid='$SID' file='$SESS_FILE'"
+  else
+    CHECKIN="$(jq -c 'select((.event // .attributes["event.name"]) == "agent.checkin")' "$SESS_FILE" | head -n 1)"
+    if [[ -z "$CHECKIN" ]]; then
+      fail "agent.checkin emitted" "no agent.checkin line in $SESS_FILE"
+    else
+      expect_eq "agent.checkin keeps top-level event" "agent.checkin" "$(printf '%s' "$CHECKIN" | jq -r '.event')"
+      expect_eq "agent.checkin now carries attributes.event.name" "agent.checkin" \
+        "$(printf '%s' "$CHECKIN" | jq -r '.attributes["event.name"]')"
+      # getEventPayload reads `.detail` FIRST, so the broker's behaviour is unchanged …
+      expect_eq "agent.checkin keeps .detail for the broker" "$SID" \
+        "$(printf '%s' "$CHECKIN" | jq -r '.detail.session_id')"
+      # … and body.payload is the SAME object, so the follow-up v1 removal is a no-op there.
+      expect_eq "agent.checkin body.payload equals detail" "true" \
+        "$(printf '%s' "$CHECKIN" | jq -r '.body.payload == .detail')"
+      expect_eq "agent.checkin is one line per emit" "1" \
+        "$(jq -c 'select((.event // .attributes["event.name"]) == "agent.checkin")' "$SESS_FILE" | grep -c '' || true)"
+    fi
+
+    CATALYST_DIR="$SESS_HOME" "$SESSION_SH" end "$SID" --status done >/dev/null 2>&1
+    CHECKOUT="$(jq -c 'select((.event // .attributes["event.name"]) == "agent.checkout")' "$SESS_FILE" | head -n 1)"
+    if [[ -z "$CHECKOUT" ]]; then
+      fail "agent.checkout emitted" "no agent.checkout line in $SESS_FILE"
+    else
+      expect_eq "agent.checkout keeps top-level event" "agent.checkout" "$(printf '%s' "$CHECKOUT" | jq -r '.event')"
+      expect_eq "agent.checkout now carries attributes.event.name" "agent.checkout" \
+        "$(printf '%s' "$CHECKOUT" | jq -r '.attributes["event.name"]')"
+      expect_eq "agent.checkout body.payload equals detail" "true" \
+        "$(printf '%s' "$CHECKOUT" | jq -r '.body.payload == .detail')"
+      expect_eq "agent.checkout is one line per emit" "1" \
+        "$(jq -c 'select((.event // .attributes["event.name"]) == "agent.checkout")' "$SESS_FILE" | grep -c '' || true)"
+    fi
+  fi
+fi
+
+echo
+echo "PASSES=$PASSES FAILURES=$FAILURES"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -236,6 +236,63 @@ emit_event() {
   __session_emit_canonical "$sid" "$type" "${payload:-null}" "$ts"
 }
 
+# __session_emit_agent_event NAME ACTION TS DETAIL_JSON SESSION_ID [TICKET] [ORCH]
+#
+# CTL-1795. `agent.checkin` / `agent.checkout` are the two places this script writes a RAW v1
+# line — hand-built here and handed straight to canonical_jsonl_append, which BYPASSES
+# catalyst-state.sh's event_append and therefore its v1→canonical translation. They are live
+# (302 checkins + 394 checkouts measured in 2026-08) and they feed the broker's agent-identity
+# and PR auto-correlation path, so they were invisible to any consumer reading
+# attributes["event.name"]. The ticket's own census missed them.
+#
+# Emits ONE superset line: the v1 `{ts,event,detail}` keys are preserved verbatim (the broker's
+# getEventPayload reads `event.detail` FIRST, so nothing about its behaviour changes) and a full
+# canonical block is merged over them. body.payload is the detail object ITSELF, not a wrapper
+# around it, precisely so that getEventPayload's `detail ?? body.payload` fallback returns the
+# same object once v1 emission is removed in the follow-up.
+#
+# entity/action mirror catalyst-state.sh's __orch_canonical_for, which already carries explicit
+# `agent.checkin`/`agent.checkout` cases — one translation for these names, not two.
+__session_emit_agent_event() {
+  local name="$1" action="$2" ts="$3" detail="$4" sid="$5" ticket="${6:-}" orch="${7:-}"
+  local v1 line superset
+  v1="$(jq -nc --arg ts "$ts" --arg ev "$name" --argjson detail "$detail" \
+    '{ts:$ts,event:$ev,detail:$detail}' 2>/dev/null)" || return 0
+  [[ -n "$v1" ]] || return 0
+
+  local extra_args=()
+  [[ -n "$ticket" && "$ticket" != "null" ]] && extra_args+=(--worker "$ticket")
+  [[ -n "$orch" && "$orch" != "null" ]] && extra_args+=(--orch "$orch")
+
+  line="$(build_canonical_line \
+    --ts "$ts" \
+    --severity INFO \
+    --service catalyst.session \
+    --event-name "$name" \
+    --entity agent \
+    --action "$action" \
+    --label "$sid" \
+    --message "$name" \
+    --session "$sid" \
+    "${extra_args[@]}" \
+    --payload-json "$detail" 2>/dev/null)" || line=""
+
+  if [[ -n "$line" ]]; then
+    superset="$(canonical_merge_v1 "$v1" "$line")" || superset=""
+  else
+    superset=""
+  fi
+
+  if [[ -z "$superset" ]]; then
+    # The declared asymmetry: no jq (or a canonical build that failed) means no v2 half is
+    # constructible from bash. Emit the v1 line anyway — losing a checkin/checkout would strand
+    # the broker's agent registry — and leave a breadcrumb so the degradation is observable.
+    canonical_note_v1_only "canonical-build-unavailable:${name}"
+    superset="$v1"
+  fi
+  canonical_jsonl_append "$EVENTS_DIR" "$superset" 2>/dev/null || true
+}
+
 # ─── Commands ───────────────────────────────────────────────────────────────
 
 cmd_start() {
@@ -325,9 +382,8 @@ cmd_start() {
       orchestrator:(if $orchestrator == "" then null else $orchestrator end),
       claimed_pr:null,
       cwd:$cwd}')
-  canonical_jsonl_append "$EVENTS_DIR" \
-    "$(jq -nc --arg ts "$checkin_ts" --argjson detail "$checkin_payload" \
-      '{ts:$ts,event:"agent.checkin",detail:$detail}' 2>/dev/null)" 2>/dev/null || true
+  __session_emit_agent_event "agent.checkin" "checkin" "$checkin_ts" "$checkin_payload" \
+    "$sid" "$ticket" "${workflow:-${CATALYST_ORCHESTRATOR_ID:-}}"
 
   echo "$sid"
 }
@@ -571,9 +627,12 @@ cmd_end() {
   # CTL-303: emit agent.checkout so the broker can clean up auto-correlated interests.
   # CTL-402: include reason so the broker can log and persist why the session ended.
   local checkout_ts; checkout_ts="$(now_iso)"
-  canonical_jsonl_append "$EVENTS_DIR" \
-    "$(jq -nc --arg ts "$checkout_ts" --arg sid "$sid" --arg st "$status" --arg reason "$reason" \
-      '{ts:$ts,event:"agent.checkout",detail:({session_id:$sid,status:$st}+if $reason!="" then {reason:$reason} else {} end)}' 2>/dev/null)" 2>/dev/null || true
+  local checkout_payload
+  checkout_payload="$(jq -nc --arg sid "$sid" --arg st "$status" --arg reason "$reason" \
+    '{session_id:$sid,status:$st}+if $reason!="" then {reason:$reason} else {} end' 2>/dev/null)" \
+    || checkout_payload=""
+  [[ -n "$checkout_payload" ]] && __session_emit_agent_event \
+    "agent.checkout" "checkout" "$checkout_ts" "$checkout_payload" "$sid"
 
   # CTL-157: emit claude_code.session.outcome to OTLP.
   local emit_bin="${CATALYST_EMIT_OTEL_BIN:-$SCRIPT_DIR/emit-otel-event.sh}"

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -185,6 +185,13 @@ event_append() {
   ensure_dirs
 
   if ! command -v jq >/dev/null 2>&1; then
+    # CTL-1795 DECLARED ASYMMETRY. build_canonical_line is a jq program, so on a jq-less host
+    # there is no canonical half to emit and this branch writes the caller's RAW v1 line. That
+    # is deliberate: a hand-rolled jq-free JSON assembler would be a second, untested serializer
+    # for the shape this repo has one builder for. The line is emitted rather than dropped (the
+    # event matters more than its envelope) and the breadcrumb makes the divergence observable
+    # instead of silent — same posture as lib/catalyst-deployment-mode.sh's jq-less resolver.
+    canonical_note_v1_only "jq-missing:event_append"
     local month_file="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
     echo "$input_json" >> "$month_file"
     return 0

--- a/plugins/dev/scripts/emit-worker-status-change.sh
+++ b/plugins/dev/scripts/emit-worker-status-change.sh
@@ -137,6 +137,20 @@ append_event() {
     # Fallback: write directly to the events file. Same path catalyst-state.sh
     # uses (CATALYST_EVENTS_DIR / YYYY-MM.jsonl, or CATALYST_EVENTS_FILE if
     # explicitly set, used by tests).
+    #
+    # CTL-1795 DECLARED ASYMMETRY. This branch exists precisely BECAUSE the canonical path is
+    # unavailable — $STATE_SCRIPT is what owns the v1→canonical translation, and it is not
+    # executable here — so the line goes out as RAW v1 with no attributes block. Emitting it
+    # beats dropping it; the breadcrumb (env var + one stderr line per process) is what keeps
+    # the divergence observable. canonical-event.sh is sourced lazily and only for the
+    # breadcrumb, so this path stays dependency-free when the helper is absent too.
+    if [ -r "${SCRIPT_DIR}/lib/canonical-event.sh" ]; then
+      # shellcheck source=lib/canonical-event.sh
+      . "${SCRIPT_DIR}/lib/canonical-event.sh" 2>/dev/null || true
+    fi
+    if command -v canonical_note_v1_only >/dev/null 2>&1; then
+      canonical_note_v1_only "state-script-unavailable:emit-worker-status-change"
+    fi
     local events_file
     if [ -n "${CATALYST_EVENTS_FILE:-}" ]; then
       events_file="$CATALYST_EVENTS_FILE"

--- a/plugins/dev/scripts/execution-core/lib/canonical-event.d.mts
+++ b/plugins/dev/scripts/execution-core/lib/canonical-event.d.mts
@@ -30,3 +30,32 @@ export function buildCanonicalEventLine(
   spec: CanonicalEventSpec,
   seams?: CanonicalEventSeams,
 ): string;
+
+/** The same envelope as an object, before serialization (CTL-1795). */
+export function buildCanonicalEvent(
+  spec: CanonicalEventSpec,
+  seams?: CanonicalEventSeams,
+): Record<string, unknown>;
+
+/**
+ * Which v1 flat fields are promoted to first-class OTel attributes (CTL-1795).
+ * Byte-identical to otel-forward's ATTR_MAP — see the note on the implementation.
+ */
+export const FLAT_ATTRIBUTE_MAP: Readonly<Record<string, string>>;
+
+export interface DualEnvelopeOpts {
+  serviceName?: string;
+  severityText?: string;
+  severityNumber?: number;
+}
+
+/**
+ * Build ONE superset JSONL line carrying both the v1 top-level `event` and a v2
+ * `attributes`/`body`/`resource` block (CTL-1795). Throws on a nameless record or one that
+ * is already canonical — callers fall back to the plain v1 line.
+ */
+export function buildDualEnvelopeLine(
+  flat: Record<string, unknown>,
+  opts?: DualEnvelopeOpts,
+  seams?: CanonicalEventSeams,
+): string;

--- a/plugins/dev/scripts/execution-core/lib/canonical-event.mjs
+++ b/plugins/dev/scripts/execution-core/lib/canonical-event.mjs
@@ -52,7 +52,22 @@ import { buildCatalystResource } from "./catalyst-resource.mjs";
  *   event is exactly the degenerate record this module exists to prevent, so it must not be
  *   constructible; the caller's try/catch turns it into a logged best-effort miss.
  */
-export function buildCanonicalEventLine(
+export function buildCanonicalEventLine(spec, seams) {
+  return JSON.stringify(buildCanonicalEvent(spec, seams)) + "\n";
+}
+
+/**
+ * buildCanonicalEvent — the same envelope as an OBJECT, before serialization.
+ *
+ * Extracted from buildCanonicalEventLine (CTL-1795) so the dual-envelope builder below can
+ * merge the v1 fields into it without a JSON.parse round-trip. buildCanonicalEventLine is
+ * now a one-line wrapper, so the two can never describe different shapes.
+ *
+ * @param {import("./canonical-event.d.mts").CanonicalEventSpec} spec
+ * @param {import("./canonical-event.d.mts").CanonicalEventSeams} [seams]
+ * @returns {object} the envelope object
+ */
+export function buildCanonicalEvent(
   {
     name,
     payload = undefined,
@@ -78,22 +93,138 @@ export function buildCanonicalEventLine(
   // invariant (2) holds even against a careless caller.
   const attrs = { "event.name": name, ...attributes };
   attrs["event.name"] = name;
-  return (
-    JSON.stringify({
-      ts,
-      id: newId(),
-      observedTs: ts,
-      severityText,
-      severityNumber,
-      traceId: newTrace(),
-      spanId: newSpan(),
-      resource: buildCatalystResource({ serviceName }),
-      attributes: attrs,
-      body: {
-        // Non-empty by construction — this is invariant (1) above.
-        message: name,
-        ...(payload !== undefined && payload !== null ? { payload } : {}),
-      },
-    }) + "\n"
+  return {
+    ts,
+    id: newId(),
+    observedTs: ts,
+    severityText,
+    severityNumber,
+    traceId: newTrace(),
+    spanId: newSpan(),
+    resource: buildCatalystResource({ serviceName }),
+    attributes: attrs,
+    body: {
+      // Non-empty by construction — this is invariant (1) above.
+      message: name,
+      ...(payload !== undefined && payload !== null ? { payload } : {}),
+    },
+  };
+}
+
+// ─── CTL-1795: the v1→superset dual envelope ────────────────────────────────────────────
+//
+// A SECOND shape is still live on the log alongside v3's now-fixed producers: **v1**, the flat
+// `{ts, event, ...snake_case fields}` envelope. Measured on mini over 2026-08 (2,544,842 events):
+// v2 2,384,622 · **v1 159,009 across 31 distinct names** · v3 1,006. Every one of those 159k is
+// invisible to a consumer that reads `attributes["event.name"]`, with no error — which is how the
+// design audit that produced this project missed 27 names on its own first pass.
+//
+// THE WIRE SHAPE IS ONE SUPERSET LINE, NOT TWO LINES. The line carries BOTH the top-level v1
+// `event` and a full v2 `attributes`/`body`/`resource` block. Two separate lines would be a
+// correctness bug, not merely wasteful: three readers extract the name **v1-first** —
+//   broker/event-name.mjs:16 · broker/projection.mjs:305 · broker/router.mjs (re-export)
+//     getEventName = event.event ?? event.attributes?.["event.name"]
+// so a v1 line and its v2 twin BOTH resolve to the same name and BOTH get routed. For
+// `agent.checkin`/`agent.checkout` that means `handleAgentCheckin`/`handleAgentCheckout` run
+// `upsertAgent` and `_autoRegisterPrLifecycle` twice per real event.
+//
+// The superset line is safe against every shape discriminator that reads this log, each verified
+// against the tree rather than assumed:
+//   · otel-forward `isFlatEvent` (lib/normalize.ts:20) requires `!("attributes" in o)`, so a
+//     superset line is NOT claimed by it and forwards as already-canonical — no re-normalization,
+//     and the producer's attributes reach OTLP intact.
+//   · `canonical_jsonl_append`'s legacy rotation (lib/canonical-event.sh) and orch-monitor's
+//     `event-writer.ts:136` both key on `has("attributes")`, so a superset line does NOT rotate
+//     the live month file aside.
+//   · `catalyst-state.sh:193` passes an attributes-bearing line straight through, untranslated.
+//
+// PHASE 1 IS ADDITIVE. v1 emission is NOT removed here and `catalyst-events tail`/`wait-for` are
+// NOT narrowed to v2 — that is an explicit follow-up one release later, once consumers are
+// confirmed reading v2. Re-emitting the plain v1 line is the revert.
+
+/**
+ * FLAT_ATTRIBUTE_MAP — which v1 flat fields are promoted to first-class OTel attributes.
+ *
+ * Deliberately byte-identical to otel-forward's `ATTR_MAP` (lib/normalize.ts:8-15), because
+ * that is what the forwarder produces for these events TODAY. Once a producer emits the
+ * superset shape the forwarder stops normalizing it (`isFlatEvent` no longer matches), so any
+ * divergence here would silently change the attribute set of 159k events/month arriving in
+ * Loki — a dashboard break landing at the same moment as a shape change, which is exactly the
+ * kind of coupled failure this ticket exists to prevent. Keep the two in lockstep; the
+ * dual-envelope test asserts the table contents literally.
+ */
+export const FLAT_ATTRIBUTE_MAP = Object.freeze({
+  ticket: "catalyst.worker.ticket",
+  phase: "catalyst.worker.phase",
+  bg_job_id: "catalyst.worker.bg_job_id",
+  branch: "catalyst.worker.branch",
+  orch_id: "catalyst.orchestrator.id",
+  dominant_phase: "catalyst.worker.dominant_phase",
+});
+
+/**
+ * buildDualEnvelopeLine — one JSONL line carrying BOTH envelope shapes for the same event.
+ *
+ * @param {object} flat  the v1 record the caller already builds: `{ts, event, ...fields}`.
+ *   `event` is the event NAME (required, non-empty string); `ts` is adopted verbatim by the
+ *   canonical half so the line can never carry two disagreeing timestamps. Every other key is
+ *   split by FLAT_ATTRIBUTE_MAP into attributes (mapped) or body.payload (everything else), so
+ *   nothing is dropped — and every key ALSO survives at the top level, untouched, for the
+ *   existing v1 readers (the reaper reads `e.event`/`e.bg_job_id`/`e.worktree_path` directly).
+ * @param {object} [opts] `{serviceName, severityText, severityNumber}` — same defaults as the
+ *   canonical builder.
+ * @param {import("./canonical-event.d.mts").CanonicalEventSeams} [seams]
+ * @returns {string} the JSONL line, newline-terminated
+ * @throws {Error} when `flat.event` is missing/not a non-empty string, or when `flat` ALREADY
+ *   carries an `attributes` block. Both fail CLOSED: the first is the nameless degenerate
+ *   record the canonical builder exists to prevent, and the second means the caller handed us
+ *   something already canonical, which we must not double-wrap. Callers keep their existing
+ *   try/catch and fall back to the plain v1 line, so a throw here degrades to today's behavior
+ *   rather than losing an event — losing a `*.reap-requested` means a worker is never reaped.
+ */
+export function buildDualEnvelopeLine(flat, opts = {}, seams = undefined) {
+  if (flat === null || typeof flat !== "object" || Array.isArray(flat)) {
+    throw new Error("buildDualEnvelopeLine: flat.event is required");
+  }
+  const name = flat.event;
+  if (typeof name !== "string" || name === "") {
+    throw new Error("buildDualEnvelopeLine: flat.event is required");
+  }
+  if ("attributes" in flat) {
+    throw new Error("buildDualEnvelopeLine: record is already canonical — refusing to double-wrap");
+  }
+
+  const attributes = {};
+  const payload = {};
+  for (const [key, value] of Object.entries(flat)) {
+    if (key === "ts" || key === "event") continue; // envelope fields, never payload
+    const mapped = FLAT_ATTRIBUTE_MAP[key];
+    if (mapped) attributes[mapped] = value;
+    else payload[key] = value;
+  }
+
+  const canonical = buildCanonicalEvent(
+    {
+      name,
+      attributes,
+      payload: Object.keys(payload).length > 0 ? payload : undefined,
+      serviceName: opts.serviceName,
+      severityText: opts.severityText,
+      severityNumber: opts.severityNumber,
+    },
+    seams,
   );
+
+  // ONE timestamp, adopted verbatim rather than re-derived. Round-tripping `flat.ts` through
+  // `new Date()` would throw on an unparseable value (and silently re-render a non-ISO one), so
+  // the string is copied as-is: the two halves of a superset line must never disagree about when
+  // the event happened.
+  if (typeof flat.ts === "string" && flat.ts !== "") {
+    canonical.ts = flat.ts;
+    canonical.observedTs = flat.ts;
+  }
+
+  // v1 keys FIRST so the line still reads as a v1 record at a glance and `event` stays early;
+  // canonical keys win any collision (only `ts` can collide, and it was just unified above).
+  return JSON.stringify({ ...flat, ...canonical }) + "\n";
 }

--- a/plugins/dev/scripts/execution-core/lib/dual-envelope.test.mjs
+++ b/plugins/dev/scripts/execution-core/lib/dual-envelope.test.mjs
@@ -1,0 +1,251 @@
+// dual-envelope.test.mjs — CTL-1795 phase 1. Every v1 emit site also emits the v2 shape, as
+// ONE SUPERSET LINE carrying both the top-level `event` and an `attributes` block.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test lib/dual-envelope.test.mjs
+//
+// WHY ONE LINE AND NOT TWO. Three in-tree readers extract the event name v1-FIRST:
+//   broker/event-name.mjs:16, broker/projection.mjs:305, broker/router.mjs (re-export)
+//     getEventName = event.event ?? event.attributes["event.name"]
+// so a v1 line and a v2 twin of the SAME event would both resolve to the same name and both
+// be routed. handleAgentCheckin/handleAgentCheckout run upsertAgent and _autoRegisterPrLifecycle
+// on each — two lines would double-apply them. A superset line is processed exactly once by
+// every existing consumer while being visible to an attributes-only reader for the first time.
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildDualEnvelopeLine, FLAT_ATTRIBUTE_MAP } from "./canonical-event.mjs";
+import { getEventName } from "../../broker/event-name.mjs";
+import { isFlatEvent, isPinoRecord } from "../../otel-forward/lib/normalize.ts";
+
+const parse = (line) => JSON.parse(line.trimEnd());
+
+const det = {
+  now: () => new Date("2026-08-13T10:00:00.000Z"),
+  newId: () => "id00",
+  newTrace: () => "trace0",
+  newSpan: () => "span0",
+};
+
+// A representative live v1 line: the single most common v1 event name in 2026-08
+// (138,425 of 159,009 measured v1 events on mini).
+const LIVE_V1 = Object.freeze({
+  ts: "2026-08-13T09:59:58Z",
+  event: "phase.terminal.reap-requested",
+  ticket: "CTL-1795",
+  phase: "implement",
+  bg_job_id: "abc12345",
+  worktree_path: "/Users/ryan/catalyst/wt/x",
+  reason: "terminal-signal",
+});
+
+describe("buildDualEnvelopeLine — the superset wire shape", () => {
+  test("emits exactly ONE line, not two", () => {
+    const out = buildDualEnvelopeLine(LIVE_V1, {}, det);
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.split("\n").filter((l) => l !== "")).toHaveLength(1);
+  });
+
+  test("carries BOTH top-level `event` and attributes['event.name'], and they AGREE", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    expect(e.event).toBe("phase.terminal.reap-requested");
+    expect(e.attributes["event.name"]).toBe("phase.terminal.reap-requested");
+    // The anti-double-processing invariant: the v1-first extractor and an attributes-only
+    // reader must resolve the SAME name from the SAME line.
+    expect(getEventName(e)).toBe(e.attributes["event.name"]);
+  });
+
+  test("every v1 top-level field survives byte-identically", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    for (const [k, v] of Object.entries(LIVE_V1)) expect(e[k]).toEqual(v);
+  });
+
+  test("attribute promotion matches otel-forward's normalizeFlatEvent ATTR_MAP", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    // Mapped keys become first-class OTel attributes …
+    expect(e.attributes["catalyst.worker.ticket"]).toBe("CTL-1795");
+    expect(e.attributes["catalyst.worker.phase"]).toBe("implement");
+    expect(e.attributes["catalyst.worker.bg_job_id"]).toBe("abc12345");
+    // … and everything else lands in body.payload, so nothing is dropped.
+    expect(e.body.payload).toEqual({
+      worktree_path: "/Users/ryan/catalyst/wt/x",
+      reason: "terminal-signal",
+    });
+    // `ts` and `event` are envelope fields, never payload.
+    expect(e.body.payload.ts).toBeUndefined();
+    expect(e.body.payload.event).toBeUndefined();
+  });
+
+  test("FLAT_ATTRIBUTE_MAP is exactly otel-forward's ATTR_MAP", () => {
+    expect({ ...FLAT_ATTRIBUTE_MAP }).toEqual({
+      ticket: "catalyst.worker.ticket",
+      phase: "catalyst.worker.phase",
+      bg_job_id: "catalyst.worker.bg_job_id",
+      branch: "catalyst.worker.branch",
+      orch_id: "catalyst.orchestrator.id",
+      dominant_phase: "catalyst.worker.dominant_phase",
+    });
+  });
+
+  test("one timestamp, not two — the canonical half adopts the v1 ts verbatim", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    expect(e.ts).toBe(LIVE_V1.ts);
+    expect(e.observedTs).toBe(LIVE_V1.ts);
+  });
+
+  test("body.message is non-empty, and the v2 half is otherwise complete", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    expect(e.body.message).toBe("phase.terminal.reap-requested");
+    expect(e.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(e.resource["service.namespace"]).toBe("catalyst");
+    expect(e.severityText).toBe("INFO");
+  });
+
+  test("serviceName and severity are overridable", () => {
+    const e = parse(
+      buildDualEnvelopeLine(LIVE_V1, { serviceName: "catalyst.session", severityText: "WARN", severityNumber: 13 },
+        det),
+    );
+    expect(e.resource["service.name"]).toBe("catalyst.session");
+    expect(e.severityText).toBe("WARN");
+    expect(e.severityNumber).toBe(13);
+  });
+
+  test("body.payload is omitted entirely when the v1 line carries no unmapped fields", () => {
+    const e = parse(buildDualEnvelopeLine({ ts: "2026-08-13T10:00:00Z", event: "orphans.reap-requested" }, {}, det));
+    expect("payload" in e.body).toBe(false);
+    expect(e.body.message).toBe("orphans.reap-requested");
+  });
+
+  test("fails CLOSED on a nameless v1 line — that IS the degenerate record", () => {
+    expect(() => buildDualEnvelopeLine({ ts: "x" }, {}, det)).toThrow(/event is required/);
+    expect(() => buildDualEnvelopeLine({ ts: "x", event: "" }, {}, det)).toThrow(/event is required/);
+    expect(() => buildDualEnvelopeLine({ ts: "x", event: 42 }, {}, det)).toThrow(/event is required/);
+    expect(() => buildDualEnvelopeLine(undefined, {}, det)).toThrow(/event is required/);
+  });
+
+  test("fails CLOSED on an input that is ALREADY canonical — never double-wrap", () => {
+    expect(() =>
+      buildDualEnvelopeLine({ ts: "x", event: "e.v", attributes: { "event.name": "e.v" } }, {}, det),
+    ).toThrow(/already canonical/);
+  });
+});
+
+describe("the superset line against the shape discriminators that read the log", () => {
+  test("otel-forward: NOT flat, NOT pino — so it forwards as already-canonical", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    // isFlatEvent requires !("attributes" in o) (normalize.ts:20). If the superset line were
+    // claimed by it, normalizeFlatEvent would REBUILD the envelope and discard the attributes
+    // the producer just guaranteed.
+    expect(isFlatEvent(e)).toBe(false);
+    expect(isPinoRecord(e)).toBe(false);
+  });
+
+  test("otel-forward: survives processLine's no-attributes drop", () => {
+    const e = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    expect(Boolean(e.attributes)).toBe(true);
+  });
+
+  test("broker: getEventName is unchanged from the pure-v1 line", () => {
+    const v1Only = { ...LIVE_V1 };
+    const superset = parse(buildDualEnvelopeLine(LIVE_V1, {}, det));
+    expect(getEventName(superset)).toBe(getEventName(v1Only));
+  });
+});
+
+// The producers, exercised through their REAL emit adapter — the adapter is what has to
+// change, so a test against the builder alone could never observe the wiring.
+describe("every live JS v1 emit site now writes the superset line", () => {
+  let dir;
+  let priorCatalystDir;
+
+  const readSoleEvent = () => {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const path = join(dir, "events", `${ym}.jsonl`);
+    expect(existsSync(path)).toBe(true);
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    // ONE line per emit — the two-line design would show up here as 2.
+    expect(lines).toHaveLength(1);
+    return parse(lines[0]);
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl1795-"));
+    mkdirSync(join(dir, "events"), { recursive: true });
+    priorCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (priorCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = priorCatalystDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reap-intent.mjs emitReapIntent (the 138k/month producer)", async () => {
+    const { emitReapIntent } = await import(`../reap-intent.mjs?cb=${Date.now()}-${Math.random()}`);
+    const ok = await emitReapIntent("phase.terminal.reap-requested", {
+      ticket: "CTL-1795",
+      phase: "implement",
+      bgJobId: "abc12345",
+      reason: "terminal-signal",
+    });
+    expect(ok).toBe(true);
+
+    const e = readSoleEvent();
+    // v1 half — the reaper reads e.event / e.bg_job_id / e.reason directly (reaper.mjs:327,331).
+    expect(e.event).toBe("phase.terminal.reap-requested");
+    expect(e.ticket).toBe("CTL-1795");
+    expect(e.bg_job_id).toBe("abc12345");
+    expect(e.reason).toBe("terminal-signal");
+    // v2 half — newly visible to an attributes-only reader.
+    expect(e.attributes["event.name"]).toBe("phase.terminal.reap-requested");
+    expect(e.attributes["catalyst.worker.ticket"]).toBe("CTL-1795");
+    expect(e.attributes["catalyst.worker.bg_job_id"]).toBe("abc12345");
+    expect(e.body.message).toBe("phase.terminal.reap-requested");
+    expect(e.body.payload).toEqual({ reason: "terminal-signal" });
+  });
+
+  test("unstuck-sweep.mjs emitUnstuckEvent", async () => {
+    const { emitUnstuckEvent } = await import(`../unstuck-sweep.mjs?cb=${Date.now()}-${Math.random()}`);
+    const ok = await emitUnstuckEvent("unstuck.escalated", { ticket: "CTL-1795", category: "unknown" });
+    expect(ok).toBe(true);
+
+    const e = readSoleEvent();
+    expect(e.event).toBe("unstuck.escalated");
+    expect(e.ticket).toBe("CTL-1795");
+    expect(e.attributes["event.name"]).toBe("unstuck.escalated");
+    expect(e.attributes["catalyst.worker.ticket"]).toBe("CTL-1795");
+    expect(e.body.payload).toEqual({ category: "unknown" });
+  });
+
+  test("reaper.mjs defaultEmit — the echo fallback for names OUTSIDE the closed vocabulary", async () => {
+    // `pr.merged.cleanup-failed` is NOT in REAP_INTENT_TYPES (1,560 measured in 2026-08), so
+    // emitReapIntent throws and defaultEmit falls through to its own direct append. That
+    // fallback was a second, independent hand-rolled v1 envelope.
+    const { defaultEmit } = await import(`../reaper.mjs?cb=${Date.now()}-${Math.random()}`);
+    await defaultEmit("pr.merged.cleanup-failed", { ticket: "CTL-1795", reason: "worktree-dirty" });
+
+    const e = readSoleEvent();
+    expect(e.event).toBe("pr.merged.cleanup-failed");
+    expect(e.ticket).toBe("CTL-1795");
+    expect(e.reason).toBe("worktree-dirty");
+    expect(e.attributes["event.name"]).toBe("pr.merged.cleanup-failed");
+    expect(e.attributes["catalyst.worker.ticket"]).toBe("CTL-1795");
+  });
+
+  test("a builder failure degrades to the plain v1 line — an event is NEVER lost", async () => {
+    // Emission is best-effort by contract (emitReapIntent returns false rather than throwing
+    // on a write failure). Losing a *.reap-requested means a worker is never reaped, so the
+    // dual-emit must degrade to v1 rather than drop. Exercised by feeding a flat record that
+    // the superset builder rejects: `attributes` is a legal reap-intent field name.
+    const { emitReapIntent } = await import(`../reap-intent.mjs?cb=${Date.now()}-${Math.random()}`);
+    const ok = await emitReapIntent("orphans.reap-requested", { attributes: "not-a-canonical-block" });
+    expect(ok).toBe(true);
+
+    const e = readSoleEvent();
+    expect(e.event).toBe("orphans.reap-requested");
+  });
+});

--- a/plugins/dev/scripts/execution-core/reap-intent.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.mjs
@@ -16,6 +16,10 @@ import { getEventLogPath, log } from "./config.mjs";
 // at this emitter and was silently lost. Importing the list (instead of
 // re-typing it) makes that class of bug structurally impossible.
 import { JANITOR_EVENT_TYPES } from "./janitor-event-types.mjs";
+// CTL-1795: the shared v1→superset envelope builder. This module is the single largest v1
+// producer on the log (138,425 `phase.terminal.reap-requested` alone in 2026-08 on mini), so
+// every event it writes was invisible to any consumer reading attributes["event.name"].
+import { buildDualEnvelopeLine } from "./lib/canonical-event.mjs";
 
 export const REAP_INTENT_TYPES = Object.freeze([
   "phase.yield.reap-requested",
@@ -111,7 +115,7 @@ export async function emitReapIntent(eventType, fields = {}) {
     const target = FIELD_MAP[k] ?? k;
     payload[target] = v;
   }
-  const line = JSON.stringify(payload) + "\n";
+  const line = dualEnvelopeOrV1(payload, eventType);
   const logPath = getEventLogPath();
   try {
     mkdirSync(dirname(logPath), { recursive: true });
@@ -120,5 +124,27 @@ export async function emitReapIntent(eventType, fields = {}) {
   } catch (err) {
     log.error({ err: err.message, eventType }, "emitReapIntent: append failed");
     return false;
+  }
+}
+
+/**
+ * dualEnvelopeOrV1 — serialize `payload` as the CTL-1795 superset line, degrading to the plain
+ * v1 line if the builder refuses it.
+ *
+ * The degradation matters: a `*.reap-requested` that never lands is a worker that is never
+ * reaped, so envelope enrichment must never be able to cost us the event. The builder throws
+ * only on a nameless record or one that already carries an `attributes` key — the latter is
+ * reachable from here because `attributes` is a legal (unmapped) reap-intent field name.
+ * Exported for the reaper's echo path, which needs the identical fallback.
+ */
+export function dualEnvelopeOrV1(payload, eventType) {
+  try {
+    return buildDualEnvelopeLine(payload, { serviceName: "catalyst.execution-core" });
+  } catch (err) {
+    log.warn(
+      { err: err?.message, eventType },
+      "dual-envelope build failed — falling back to the v1-only line (CTL-1795)",
+    );
+    return JSON.stringify(payload) + "\n";
   }
 }

--- a/plugins/dev/scripts/execution-core/reaper.mjs
+++ b/plugins/dev/scripts/execution-core/reaper.mjs
@@ -20,7 +20,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { scanEventsChunked } from "./event-tail.mjs";
 import { shortIdFromSessionId, isSelfSession } from "./claude-ids.mjs";
-import { emitReapIntent, REAP_INTENT_TYPES } from "./reap-intent.mjs";
+import { emitReapIntent, REAP_INTENT_TYPES, dualEnvelopeOrV1 } from "./reap-intent.mjs";
 import { lastSeenMsForSession } from "./session-recency.mjs";
 import { getAgentsCached, listClaudeAgentsResult } from "./claude-agents.mjs";
 import {
@@ -1142,7 +1142,11 @@ export async function defaultAgents() {
   return getAgentsCached().agents;
 }
 
-async function defaultEmit(eventType, fields) {
+// Exported for test observability (CTL-1795), matching the sibling timers
+// (stale-pr-rescue-timer.mjs:459, orphan-pr-sweep-timer.mjs:158). The echo fallback below is
+// the REAL adapter the daemon runs; a test against the injected `emit` seam would exercise the
+// test's own function and could never observe what this one writes to disk.
+export async function defaultEmit(eventType, fields) {
   try {
     return await emitReapIntent(eventType, fields);
   } catch (err) {
@@ -1156,7 +1160,11 @@ async function defaultEmit(eventType, fields) {
       const logPath = getEventLogPath();
       try {
         mkdirSync(dirname(logPath), { recursive: true });
-        appendFileSync(logPath, JSON.stringify(payload) + "\n");
+        // CTL-1795: the echo events are a SECOND hand-rolled v1 envelope, independent of
+        // emitReapIntent's — `pr.merged.cleanup-failed` alone was 1,560 events in 2026-08. They
+        // ride the same superset builder, with the same degrade-to-v1 fallback, so the two
+        // never drift.
+        appendFileSync(logPath, dualEnvelopeOrV1(payload, eventType));
       } catch (appendErr) {
         // A dropped *.cleanup-complete / *.reap-complete echo makes bootReplay
         // re-reap on next boot (it keys replay-skip on the echo's presence), so

--- a/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-sweep.mjs
@@ -18,6 +18,8 @@ import { spawnSync } from "node:child_process";
 import { log, getEventLogPath } from "./config.mjs";
 import { UNSTUCK_SWEEP_EVENT_TYPES } from "./unstuck-sweep-event-types.mjs";
 import { isTicketKey } from "./ticket-key.mjs";
+// CTL-1795: shared v1→superset envelope serializer (with its degrade-to-v1 fallback).
+import { dualEnvelopeOrV1 } from "./reap-intent.mjs";
 
 export { UNSTUCK_SWEEP_EVENT_TYPES };
 
@@ -48,7 +50,10 @@ export async function emitUnstuckEvent(eventType, fields = {}) {
     if (v === undefined || v === null || v === "") continue;
     payload[k] = v;
   }
-  const line = JSON.stringify(payload) + "\n";
+  // CTL-1795: the sweep's own hand-rolled v1 envelope — a THIRD independent copy of the shape.
+  // Same superset line, same degrade-to-v1 fallback as the reap-intent emitter, so an envelope
+  // build can never cost the sweep a verdict.
+  const line = dualEnvelopeOrV1(payload, eventType);
   const logPath = getEventLogPath();
   try {
     mkdirSync(dirname(logPath), { recursive: true });

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -413,6 +413,147 @@ build_canonical_line() {
     }'
 }
 
+# ─── CTL-1795: the v1→superset dual envelope (bash half) ─────────────────────
+#
+# Mirrors execution-core/lib/canonical-event.mjs's buildDualEnvelopeLine. A superset line
+# carries BOTH the top-level v1 `event` and a full v2 attributes/body/resource block, so a
+# consumer filtering on attributes["event.name"] stops silently seeing a smaller universe —
+# while every existing v1 reader keeps reading the same top-level fields it always did.
+#
+# ONE line, never two: broker/event-name.mjs's getEventName reads `event.event` FIRST, so a v1
+# line and a separate v2 twin would both resolve to the same name and both be routed —
+# `agent.checkin`/`agent.checkout` would run upsertAgent and _autoRegisterPrLifecycle twice.
+
+# canonical_merge_v1 V1_JSON CANONICAL_LINE
+#
+# Echo ONE superset JSONL line on stdout: the v1 object's keys first, then every canonical
+# field merged over them. jq's `+` is right-biased, so a canonical key always wins a collision;
+# `ts` is the only key both shapes carry, and it is then forced back to the v1 value so the two
+# halves of one line can never disagree about when the event happened.
+#
+# Returns 1 (and echoes nothing) when jq is missing or either input fails to parse — the caller
+# falls back to the plain v1 line and calls canonical_note_v1_only. Losing an event is never an
+# acceptable price for enriching its envelope.
+canonical_merge_v1() {
+  local v1="$1" canonical="$2"
+  command -v jq >/dev/null 2>&1 || return 1
+  [[ -n "$v1" && -n "$canonical" ]] || return 1
+  printf '%s' "$canonical" | jq -c --argjson v1 "$v1" '
+    (($v1.ts // .ts)) as $ts
+    | ($v1 + .)
+    | .ts = $ts
+    | .observedTs = $ts
+  ' 2>/dev/null || return 1
+}
+
+# _CE_FLAT_ATTR_JQ — the bash mirror of FLAT_ATTRIBUTE_MAP in
+# execution-core/lib/canonical-event.mjs (which is itself byte-identical to otel-forward's
+# ATTR_MAP in lib/normalize.ts). Bash cannot `import` an ESM constant, so this is a
+# hand-written mirror held honest MECHANICALLY by __tests__/dual-envelope.test.sh, which parses
+# both sides and asserts set equality — the same one-registry/hand-mirror/cross-stack-parity
+# discipline lib/secret-contract.sh and assertion-evidence-parity.test.mjs already use. Drift
+# here would silently give a bash-emitted event a different attribute set than the JS emitter
+# gives the SAME event name.
+_CE_FLAT_ATTR_JQ='{
+  "ticket": "catalyst.worker.ticket",
+  "phase": "catalyst.worker.phase",
+  "bg_job_id": "catalyst.worker.bg_job_id",
+  "branch": "catalyst.worker.branch",
+  "orch_id": "catalyst.orchestrator.id",
+  "dominant_phase": "catalyst.worker.dominant_phase"
+}'
+
+# canonical_dual_envelope_line V1_JSON [SERVICE] [SEVERITY]
+#
+# Echo ONE superset JSONL line built from a flat v1 record `{ts, event, ...fields}` — the bash
+# counterpart of buildDualEnvelopeLine in execution-core/lib/canonical-event.mjs, splitting the
+# flat fields by the SAME map so a bash-emitted and a JS-emitted event of the same name carry
+# the same attributes.
+#
+# Returns 1 and echoes nothing when jq is missing, the record is nameless, or the record is
+# already canonical — every caller falls back to its plain v1 line and calls
+# canonical_note_v1_only.
+canonical_dual_envelope_line() {
+  local v1="$1" service="${2:-catalyst.execution-core}" severity="${3:-INFO}"
+  command -v jq >/dev/null 2>&1 || return 1
+  [[ -n "$v1" ]] || return 1
+  # Fail closed on an already-canonical record: double-wrapping is the one shape this must
+  # never produce.
+  printf '%s' "$v1" | jq -e 'has("attributes") | not' >/dev/null 2>&1 || return 1
+
+  local name ts attrs payload
+  name="$(printf '%s' "$v1" | jq -r 'if (.event | type) == "string" then .event else "" end' 2>/dev/null)" || return 1
+  [[ -n "$name" ]] || return 1
+  ts="$(printf '%s' "$v1" | jq -r '.ts // ""' 2>/dev/null)" || return 1
+  [[ -n "$ts" ]] || ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # `ts` and `event` are envelope fields and never land in either bucket; a mapped key becomes
+  # an attribute; everything else lands in body.payload, so nothing is dropped.
+  attrs="$(printf '%s' "$v1" | jq -c --argjson m "$_CE_FLAT_ATTR_JQ" '
+    reduce (to_entries[]) as $e ({};
+      if $e.key == "ts" or $e.key == "event" then .
+      elif ($m[$e.key] // null) != null then .[$m[$e.key]] = $e.value
+      else . end)' 2>/dev/null)" || return 1
+  payload="$(printf '%s' "$v1" | jq -c --argjson m "$_CE_FLAT_ATTR_JQ" '
+    reduce (to_entries[]) as $e ({};
+      if $e.key == "ts" or $e.key == "event" or ($m[$e.key] // null) != null then .
+      else .[$e.key] = $e.value end)
+    | if length == 0 then null else . end' 2>/dev/null)" || return 1
+
+  # --message is REQUIRED here, not decorative: build_canonical_line omits body.message entirely
+  # when it is empty, and a record with no body.message AND no attributes is the degenerate
+  # OTLP LogRecord CTL-1817 exists to prevent. The mjs builder makes `message: name` an
+  # invariant; this is the bash statement of the same invariant.
+  local line
+  line="$(build_canonical_line \
+    --ts "$ts" \
+    --severity "$severity" \
+    --service "$service" \
+    --event-name "$name" \
+    --message "$name" \
+    --payload-json "${payload:-null}" 2>/dev/null)" || return 1
+  [[ -n "$line" ]] || return 1
+
+  # Merge the mapped attributes into the canonical block (event.name stays first and is
+  # reasserted so a flat field can never displace it), then merge the whole canonical envelope
+  # over the v1 keys.
+  printf '%s' "$line" | jq -c --argjson v1 "$v1" --argjson extra "$attrs" --arg name "$name" '
+    .attributes = ((.attributes + $extra) | ."event.name" = $name)
+    | ($v1 + .)
+    | .ts = ($v1.ts // .ts)
+    | .observedTs = .ts
+  ' 2>/dev/null || return 1
+}
+
+# canonical_note_v1_only REASON
+#
+# Record that this process just emitted a RAW v1 line because the canonical path was
+# unavailable. This is the DECLARED ASYMMETRY of CTL-1795: build_canonical_line requires jq, so
+# "every v1 emit site dual-emits" is structurally unachievable from bash on a jq-less host, and
+# the two remaining raw-v1 fallbacks (catalyst-state.sh's jq-less branch,
+# emit-worker-status-change.sh's missing-$STATE_SCRIPT branch) exist precisely BECAUSE the
+# canonical path is unavailable there. We do not hand-roll a jq-free JSON assembler for it; we
+# make the divergence observable instead of silent.
+#
+# Two breadcrumbs, because neither alone reaches both audiences:
+#   · an exported env var — same-shell, for an in-process caller and `catalyst doctor`; the same
+#     shape lib/catalyst-deployment-mode.sh uses for CATALYST_DEPLOYMENT_MODE_JQ_MISSING.
+#   · ONE stderr line per process — the durable, cross-process half. catalyst-state.sh runs as a
+#     separate CLI process, so an exported var dies with it and could never be read back. stderr
+#     lands in the caller's launchd-captured `.log`, which Alloy ships to Loki INDEPENDENTLY of
+#     the event log — an event-log-sourced signal could not report a degradation of the event log
+#     itself. Guarded to once per process so a hot emit path cannot flood the log.
+canonical_note_v1_only() {
+  local reason="${1:-unknown}"
+  export CATALYST_EVENT_ENVELOPE_V1_ONLY=1
+  export CATALYST_EVENT_ENVELOPE_V1_ONLY_REASON="$reason"
+  if [[ -z "${__CE_V1_ONLY_WARNED:-}" ]]; then
+    __CE_V1_ONLY_WARNED=1
+    printf '[catalyst] WARNING: emitted a RAW v1 event envelope (%s) — invisible to any consumer reading attributes["event.name"] (CTL-1795)\n' \
+      "$reason" >&2
+  fi
+}
+
 # _canonical_is_sentinel_leak BASE_DIR LINE
 # Returns 0 (true) if LINE is a sentinel-stamped event aimed at the default
 # production events dir (BASE_DIR resolves to $HOME/catalyst/events). Parity

--- a/plugins/dev/scripts/lib/emit-reap-intent.sh
+++ b/plugins/dev/scripts/lib/emit-reap-intent.sh
@@ -106,7 +106,35 @@ emit_reap_intent() {
 	mkdir -p "$dir" 2>/dev/null || return 1
 	local month_file
 	month_file="${dir}/$(date -u +%Y-%m).jsonl"
-	printf '%s\n' "$payload" >>"$month_file" 2>/dev/null || return 1
+
+	# CTL-1795: emit the superset envelope (v1 keys + a full canonical block) so this producer
+	# is visible to a consumer reading attributes["event.name"], exactly like its mjs twin
+	# execution-core/reap-intent.mjs. canonical-event.sh is sourced lazily — this file is a
+	# dependency-free leaf sourced by phase-agent-yield-check.sh / orchestrate-phase-advance /
+	# lib/worktree-presweep.sh, and it must keep working when the helper (or jq) is absent.
+	local line=""
+	if [[ -z ${__REAP_CANONICAL_TRIED:-} ]]; then
+		__REAP_CANONICAL_TRIED=1
+		local _rei_lib_dir
+		_rei_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")" && pwd)"
+		if [[ -r "${_rei_lib_dir}/canonical-event.sh" ]]; then
+			# shellcheck source=./canonical-event.sh
+			. "${_rei_lib_dir}/canonical-event.sh" 2>/dev/null || true
+		fi
+	fi
+	if command -v canonical_dual_envelope_line >/dev/null 2>&1; then
+		line="$(canonical_dual_envelope_line "$payload" "catalyst.execution-core" "INFO")" || line=""
+	fi
+	if [[ -z "$line" ]]; then
+		# The declared asymmetry — no jq or no canonical helper means no v2 half is constructible.
+		# Emit v1 anyway (a dropped reap-intent is a worker that is never reaped) and leave the
+		# breadcrumb so the divergence is observable rather than silent.
+		command -v canonical_note_v1_only >/dev/null 2>&1 &&
+			canonical_note_v1_only "canonical-build-unavailable:${event_type}"
+		line="$payload"
+	fi
+
+	printf '%s\n' "$line" >>"$month_file" 2>/dev/null || return 1
 	return 0
 }
 


### PR DESCRIPTION
Closes CTL-1795. **Phase 1 — additive only.** v1 emission is NOT removed and `catalyst-events tail`/`wait-for` are NOT narrowed to v2; that is the explicit follow-up one release later. Re-emitting the plain v1 line is the revert.

## The defect

Two envelope shapes coexist on `~/catalyst/events/YYYY-MM.jsonl`, so a consumer reading `attributes["event.name"]` silently sees a smaller universe. Re-measured on this machine's mirrored fleet log for 2026-08, parsed by **shape** — 2,544,842 events, 205 unparseable:

| envelope | discriminator | count |
| --- | --- | ---: |
| v2 | has `attributes` | 2,384,622 |
| **v1** | has `event` | **159,009** across **31 distinct names** |
| v3 | bare `name` | 1,006 |
| superset | both | 0 |

*Positive control for the instrument:* all four buckets come from one pass over the same parse and three return non-zero — an attributes-only reader sees neither v1 nor v3 at all, which is exactly why this was previously reported as "absent".

The 31 v1 names are dominated by `phase.terminal.reap-requested` (138,425), then the janitor/procOrphans/orphan families, `pr.merged.cleanup-failed` (1,560), `agent.checkout` (394), `agent.checkin` (302), and `unstuck.escalated`.

## The mechanism: ONE superset line, not two

Each v1 emit site now writes a single line carrying **both** the top-level `event` and a full v2 `attributes`/`body`/`resource` block, built through the shared builder CTL-1817 landed (`execution-core/lib/canonical-event.mjs`) and its bash counterpart.

**Two lines would be a correctness bug, not merely wasteful.** Three readers extract the name **v1-first**:

```js
// broker/event-name.mjs:16 · broker/projection.mjs:305 · router.mjs re-export
getEventName = (e) => e.event ?? e.attributes?.["event.name"] ?? ""
```

A v1 line and its v2 twin both resolve to the same name and both get routed — `handleAgentCheckin`/`handleAgentCheckout` would run `upsertAgent` and `_autoRegisterPrLifecycle` twice per real event.

The superset line was checked against every shape discriminator that reads this log, verified in-tree rather than assumed:

- **`isFlatEvent`** (`otel-forward/lib/normalize.ts:20`) requires `!("attributes" in o)`, so the line is not claimed by it and forwards as already-canonical — no re-normalization, and the producer's attributes reach OTLP intact.
- **The legacy rotation** in `canonical_jsonl_append` and orch-monitor's `event-writer.ts:136` both key on `has("attributes")`, so a superset line does **not** rotate the live month file aside.
- **`catalyst-state.sh:193`** passes an attributes-bearing line straight through, untranslated.

## Attribute promotion is frozen to the forwarder's map, on purpose

`FLAT_ATTRIBUTE_MAP` is byte-identical to otel-forward's `ATTR_MAP`, because that map is what the forwarder produces for these events **today**. Once a producer emits the superset shape the forwarder stops normalizing it, so any divergence would silently change the attribute set of 159k events/month arriving in Loki — a dashboard break landing at the same moment as a shape change. Unmapped fields go to `body.payload`; every v1 key also survives verbatim, so the reaper keeps reading `e.event` / `e.bg_job_id` / `e.reason` exactly as before.

For `agent.checkin`/`agent.checkout`, `body.payload` is the detail object **itself** rather than a wrapper, so `getEventPayload`'s `detail ?? body.payload` fallback (`router.mjs:971`) returns the same object once v1 emission is removed.

## Sites — five live producers, three of them independent hand-rolled copies

| site | note |
| --- | --- |
| `execution-core/reap-intent.mjs` | closed reap/janitor/procOrphans vocabulary; largest v1 producer |
| `execution-core/reaper.mjs` `defaultEmit` | echo fallback for names *outside* that vocabulary |
| `execution-core/unstuck-sweep.mjs` | a third independent copy of the same envelope |
| `catalyst-session.sh` checkin/checkout | **the ticket's census missed these** |
| `lib/emit-reap-intent.sh` | bash reap-intent producer, three callers |

`catalyst-session.sh` writes RAW v1 straight to `canonical_jsonl_append`, **bypassing** `event_append`'s v1→canonical translation, and feeds the broker's agent-identity and PR auto-correlation path. Under the one-line design there is no double-fire risk from including them.

Every site degrades to the plain v1 line if the builder refuses the record — a dropped `*.reap-requested` is a worker that is never reaped, so envelope enrichment must never be able to cost us the event.

## Declared asymmetry (not a gap)

`build_canonical_line` is a jq program, so "every v1 emit site dual-emits" is **structurally unachievable** from bash on a jq-less host. The two remaining raw-v1 fallbacks — `catalyst-state.sh`'s jq-less branch and `emit-worker-status-change.sh`'s missing-`$STATE_SCRIPT` branch — exist *precisely because* the canonical path is unavailable there. No jq-free JSON assembler was written for them. Instead `canonical_note_v1_only` makes the divergence observable rather than silent, documented in `docs/architecture.md` in the same shape that doc already uses for the jq-less deployment-mode resolver: an exported `CATALYST_EVENT_ENVELOPE_V1_ONLY` breadcrumb plus **one** stderr line per process.

stderr is load-bearing, not decorative: a separate CLI process cannot hand an exported var back to its caller, and stderr rides the Alloy-shipped daemon `.log` — independent of the event log whose degradation it is reporting.

## Cross-stack parity

The bash mirror `_CE_FLAT_ATTR_JQ` cannot `import` the JS `FLAT_ATTRIBUTE_MAP`, so `__tests__/dual-envelope.test.sh` parses both sides and asserts set equality — **with a positive control asserting the extractor found 6 rows**, since two empty sets are also equal. Same one-registry / hand-mirror / parity-suite discipline as `lib/secret-contract.sh` and `assertion-evidence-parity.test.mjs`. Both new suites are wired into the required `execution-core-tests` workflow.

## Tests

| suite | this branch | main (control) |
| --- | --- | --- |
| execution-core stable list + new suite | **6339 pass / 7 fail** | 6321 pass / 7 fail |
| `lib/dual-envelope.test.mjs` (new) | **18 pass / 0 fail** | 0 pass / 1 fail (RED) |
| `__tests__/dual-envelope.test.sh` (new) | **40 pass / 0 fail** | 13 pass / 27 fail (RED) |
| `__tests__/canonical-event.test.sh` | 97 / 0 | — |
| `lib/__tests__/emit-reap-intent.test.sh` | 19 / 0 | — |
| `test-catalyst-session.sh` | 20 / 0 | — |
| otel-forward | 120 / 7 | 120 / 7 (identical) |
| broker | 908 / 1 | same test fails on main |

Every branch failure is a **strict subset** of main's, verified by running the identical list in a pristine detached worktree at `cf37127`: three CTL-1329 fence-guard tests, `linearis fallback`, the SDK OAuth-token guard, and the heartbeat `host.name` test all fail on main too, plus one load-dependent integration timeout that passes standalone on **both** trees. The otel-forward errors are a missing `pino` in this machine's shared install, reproduced identically on main.

**Positive control that the new tests can fail:** the source diff was reverted to `main` with the new (untracked) tests left in place. The JS suite went to **0 pass / 1 fail** and the bash suite to **13 pass / 27 fail**; re-applying the diff returned them to 18/0 and 40/0.

## Stale premises found

- **The ticket's census is incomplete.** It scopes the v1 shape to `reap-intent.mjs`, but the log holds 31 distinct v1 names from **five** producers. `catalyst-session.sh`'s `agent.checkin`/`agent.checkout`, `unstuck-sweep.mjs`, and `reaper.mjs`'s echo fallback are all live and all missed.
- **`build_canonical_line` omits `body.message` entirely when `--message` is empty**, unlike the mjs builder which makes `message: name` an invariant. The first bash superset lines came out with `body.message: null` — the degenerate-record shape CTL-1817 exists to prevent. Caught by the new test, fixed by passing `--message` explicitly.
- **v3 is still on the log** (1,006 events in 2026-08) even though CTL-1817 merged — those events predate the fix reaching the fleet. Deployment matter, not a code regression.

## Deferred (explicitly not in this PR)

- Removing v1 emission and narrowing `catalyst-events tail`/`wait-for` to v2 — the ticket's own second acceptance criterion, one release later.
- Migrating the v1-field readers (`reaper.mjs` reads `e.event`/`e.bg_job_id` directly) onto the attributes/payload half. They keep working unchanged today; the superset line carries everything they will need.
- The resource block of these events loses the forwarder-synthesized `service.version: "0.0.0"` and `catalyst.node.name`, since the producer now supplies its own resource. `catalyst.node.name` is stamped **only** by `otel-forward/lib/canonical.ts` and resolves to the same value as `host.name`; its one consumer (`coordination-publish/lib/interim-loki-source.ts:57`) already falls back to `host.name`. This aligns these events with the other 2.38M producer-emitted v2 events, which carry neither key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
