### PR TITLE
fix(dev): CTL-1659 — a dependency fix that lands on main must reach the running cloud-sync writer

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -717,6 +717,9 @@ jobs:
             diagnostician.test.mjs \
             cloud-sync-telemetry.test.mjs \
             cloud-sync-log.test.mjs \
+            cloud-sync-deps.test.mjs \
+            cloud-sync-dep-skew-wiring.test.mjs \
+            doctor-cloud-sync-skew.test.mjs \
             dispatch.test.mjs \
             doctor.test.mjs \
             doctor-replica.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -666,6 +666,59 @@ in this repo, and by nothing in `catalyst-otel` either (the provisioned Grafana 
   `otel-forward/lib/sparse-warn.ts` (semantics unchanged); the tailer's unknown-shape alarm and this
   drop alarm each build their own gate so a flood of one cannot exhaust the other's key budget.
 
+### Installed-but-unloaded: cloud-sync dependency skew (CTL-1659)
+
+The **third** link in the CTL-1506 chain, and the one no existing mechanism covers. `plugin-refresh`
+emits `restart_needed` and deliberately stops ("restart stays a gated OPERATOR action — never
+automated here"); `decideStackReload` restarts exactly `monitor`, `execution-core`, `otel-forward`
+(cloud-sync in neither). Measured 2026-08-04: a dependency fix landed on main, the updater pulled it,
+the install succeeded, and **both minis' cloud-sync writers kept serving the old modules for days**
+— the CTC-328 delete-corruption guard sat correctly installed while the daemons ran unguarded, until
+a human kickstarted them. Nothing was red; `restart_needed` is a field in an event nobody watches.
+
+**It is deliberately NOT a fourth restart mechanism.** Adding cloud-sync to `decideStackReload` (the
+symmetric CTL-1506 move) fires only where the *broker* advances the checkout — a host whose
+`catalyst-updater` pulls without a broker never gets the push — and needs new kickstart plumbing plus
+a real per-component confirmation probe (cloud-sync has no pid file `readPidFor` knows, and
+CTL-1506's own P1 lesson is that a best-effort `return true` confirmation is exactly how a stale
+daemon hides). CTL-1502's watchdog is also the wrong reuse target: its predicates are **stuckness**
+for a daemon that cannot help itself, and its restart action is hardwired to `catalyst-monitor.sh`
+argv. Dep-skew is neither — the writer is healthy and fully capable of self-action — so it becomes a
+**second predicate on the CTL-1508 self-heal exit that already exists** in `cloud-sync.mjs`:
+
+| Piece                  | Already existed                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| Actuator               | launchd `KeepAlive={SuccessfulExit:false}`                                       |
+| Safe exit point        | the heartbeat tick, between applied frames                                        |
+| Bounded close          | `exitAfterClose` (CTL-1508)                                                       |
+| Restart-failed net     | `health-responder.sh`'s `no-respawn`, keyed on the breadcrumb this path writes    |
+| Loop terminator (new)  | a durable `{ts,count}` budget, `~/catalyst/cloud-sync.depskew.json`               |
+
+- **Boot record** (`cloud-sync-deps.mjs` `captureLoadedDeps` → `~/catalyst/cloud-sync.deps.json`):
+  what the process **actually resolved** — `createRequire().resolve()`'s path, the version from THAT
+  path's `package.json`, an entry-file digest, the serving root, and a SHA-256 of that root's
+  `bun.lock`. Deliberately not "what the lockfile said": a claim derived from the lockfile
+  re-manufactures the CTL-1646 shadowed-install lie. The **digest**, not the version string, is the
+  verdict — a repointed tarball / workspace link / git dep ships new bytes under the same semver.
+- **Predicate** (`cloud-sync-telemetry.mjs` `classifyDepSkew`, beside `classifyStall`, same
+  never-false-kill discipline): an unknown digest on either side never asserts; `sustainedTicks`
+  consecutive mismatches are required (bun rewrites `bun.lock` in place, so one tick can catch it
+  mid-write); an uptime floor holds a just-relaunched writer; the durable budget bounds the
+  pathological continuous-rewrite case, and its refusal is NAMED rather than folded into "no
+  restart". Modes `off`/`shadow`/`enforce`, **shadow by default**.
+- **Exit**: `writeSelfHealBreadcrumb(..., {reason:"dep-skew"})` + bounded `close()` + **exit 1**. The
+  ticket's own Option-1 wording ("exit cleanly and let KeepAlive relaunch") is mechanically wrong
+  here — exit **0** is the plist's "clean no-op, stay DOWN" contract, so a clean exit would
+  permanently stop the replica writer. The `reason` key is emitted only when supplied, so the stall
+  path's on-disk shape (which `health-responder.sh` parses with `jq`) is byte-identical.
+- **Alarm** rides the writer's existing structured heartbeat line in **every** mode
+  (`depSkewFields` → stderr → `cloud-sync.log` → Alloy → Loki, `service_name=catalyst.cloud-sync`),
+  because shadow-with-nobody-watching is precisely the failure being fixed. `catalyst doctor`'s
+  advisory `cloud-sync-skew` check grades the same record over three fail-closed links —
+  record-identity (pid must still name a live `cloud-sync.mjs`; a recycled pid is stale evidence),
+  loaded-vs-locked (the incident), installed-vs-locked (the partial install a restart does **not**
+  fix) — and can never PASS on absent, stale, or zero-comparison input.
+
 ### Two-axis worker state & the recordTransition chokepoint (CTL-764)
 
 Every worker ticket has **two orthogonal axes** — never blurred:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -718,6 +718,28 @@ argv. Dep-skew is neither — the writer is healthy and fully capable of self-ac
   record-identity (pid must still name a live `cloud-sync.mjs`; a recycled pid is stale evidence),
   loaded-vs-locked (the incident), installed-vs-locked (the partial install a restart does **not**
   fix) — and can never PASS on absent, stale, or zero-comparison input.
+- **Unified event log** (the ticket's AC1 clause "the restart is visible in the event log"). The
+  heartbeat line above is a **log** stream; it never reaches `catalyst-events wait-for`, the broker,
+  the HUD, or orch-monitor, all of which read `~/catalyst/events/YYYY-MM.jsonl`. So the dep-skew
+  path appends a **v2 envelope** to that file through the same `getEventLogPath()` +
+  `appendFileSync` call `emitWriterIdleEvent` (CAT-21) already used in `cloud-sync.mjs` — the
+  capability was present and merely unused here. Two names, not one name plus a payload flag,
+  because `otel-forward` strips `body.payload` off-machine and an alert must be able to select a
+  real restart from `attributes` alone:
+
+  | Event                                    | Emitted when                                                                                    |
+  | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+  | `catalyst.replica.dep_skew_restart`      | the writer IS exiting — budget spent, before `exitAfterClose`. At most once per process.        |
+  | `catalyst.replica.dep_skew_would_restart`| sustained skew that did NOT act: shadow mode (the default), exhausted budget, or an undurable ledger. `reason` names which. |
+
+  Both are built by the pure `depSkewEventEnvelope` (`cloud-sync-deps.mjs`) so the shape is
+  unit-testable without running the script-shaped writer, and both reuse `depSkewFields` for their
+  digest attributes so the event and the heartbeat line cannot drift. Emission is **fail-open** —
+  a failed append never blocks the self-heal exit — and the restart event is sequenced **before**
+  `exitAfterClose`, which can terminate the process at any point once called. Ordering rule: the
+  posture block emits only the *held* event (`wouldRestart && !restart`); the restart block owns
+  the acted one, so an event never claims a restart the ledger then declines. Registered in
+  `broker/namespace-parity.test.mjs` by import, not by re-typed literal.
 
 ### Two-axis worker state & the recordTransition chokepoint (CTL-764)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -714,10 +714,38 @@ argv. Dep-skew is neither — the writer is healthy and fully capable of self-ac
 - **Alarm** rides the writer's existing structured heartbeat line in **every** mode
   (`depSkewFields` → stderr → `cloud-sync.log` → Alloy → Loki, `service_name=catalyst.cloud-sync`),
   because shadow-with-nobody-watching is precisely the failure being fixed. `catalyst doctor`'s
-  advisory `cloud-sync-skew` check grades the same record over three fail-closed links —
+  advisory `cloud-sync-skew` check grades the same record over four fail-closed links —
   record-identity (pid must still name a live `cloud-sync.mjs`; a recycled pid is stale evidence),
-  loaded-vs-locked (the incident), installed-vs-locked (the partial install a restart does **not**
-  fix) — and can never PASS on absent, stale, or zero-comparison input.
+  boot-record-complete, loaded-vs-locked (the incident), installed-vs-locked (the partial install a
+  restart does **not** fix) — and can never PASS on absent, stale, or zero-comparison input.
+- **What each comparator is anchored on, and why the obvious anchor is not enough.**
+  `loaded-vs-locked` compares TWO digests, not one: the root lockfile's, AND each package's boot
+  `entryHash` re-hashed from its recorded `resolvedPath`. The entry digest is not redundant — a
+  repointed mutable artifact, a `bun link`ed workspace output, or an in-place rebuild changes the
+  bytes the running process holds while the lockfile TEXT and the package version stay
+  byte-identical, so the lockfile digest alone reports ok and the writer never restarts. (Capturing
+  a field as the discriminator and never reading it back is "a check that cannot fail" — the same
+  shape as `restart_needed`, one level in.) `installed-vs-locked` matches each package to **its own**
+  lock entry via the install-location key bun uses (`<id>` hoisted, `<parent>/<id>` nested,
+  chained deeper — `lockKeyForPackageJsonPath`), never to "any occurrence of this id in the file":
+  with the SDK locked at 0.8.2 at the root and 0.7.0 under a nested parent, an any-occurrence match
+  accepts a stale 0.7.0 root install, hiding exactly the shadowed/partial install the link exists to
+  detect. A path that cannot be associated with a lock entry (outside the recorded root, or a
+  workspace link) reports **inconclusive naming the elsewhere-resolutions**, never a permissive match.
+- **The restart-budget ledger read is TRI-STATE.** Absent (`ENOENT`) → full budget; a ledger that
+  exists but cannot be read or parsed → `RESTART_LEDGER_UNREADABLE`, and the classifier declines.
+  Collapsing the two into one `null` meant a corrupt or momentarily-unreadable ledger granted a full
+  budget and then overwrote the evidence — the durable loop terminator disarmed by the corruption it
+  exists to survive. Field types are checked before any coercion, since `Number(null)`/`Number([])`
+  are `0` (an "expired window" → full budget) and `Number(undefined) || 0` is `0` ("nothing spent
+  yet"); the gate runs BEFORE the expired-window shortcut so a bogus count cannot re-arm on an anchor
+  read out of the same untrusted file.
+- **The undurable-ledger decline is edge-triggered.** That branch sits inside `if (depSkew.restart)`,
+  outside the posture latch guarding the alert above it, so a sustained skew with an unwritable
+  ledger emitted an ERROR line plus a `dep_skew_would_restart` event on **every** 30 s heartbeat for
+  the whole incident. `_depSkewDeclinedPosture` latches the announcement (re-arming on any posture
+  change and when skew clears) while the write itself is still retried each tick — same
+  count-exactly / warn-sparsely discipline as CTL-1817/CTL-1823's `otel-forward/lib/sparse-warn.ts`.
 - **Unified event log** (the ticket's AC1 clause "the restart is visible in the event log"). The
   heartbeat line above is a **log** stream; it never reaches `catalyst-events wait-for`, the broker,
   the HUD, or orch-monitor, all of which read `~/catalyst/events/YYYY-MM.jsonl`. So the dep-skew

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -46,6 +46,10 @@ import { JANITOR_EVENT_TYPES } from "../execution-core/janitor-event-types.mjs";
 import { UNSTUCK_SWEEP_EVENT_TYPES } from "../execution-core/unstuck-sweep-event-types.mjs";
 import { LINEAR_READ_EVENT } from "../execution-core/linear-read-event.mjs"; // CTL-1403
 import { ALERT_BOOT_DEPENDENCY_UNUSABLE } from "../execution-core/dispatch-alert.mjs";
+// CTL-1659 — the cloud-sync dep-skew pair, imported from its owning module rather than
+// re-typed as a literal below, so a rename cannot leave this contract asserting over a name
+// nothing emits (the hand-copied-literal trap the ASSERTED_BY parity suite exists to prevent).
+import { DEP_SKEW_RESTART_EVENT, DEP_SKEW_WOULD_RESTART_EVENT } from "../execution-core/cloud-sync-deps.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -86,6 +90,8 @@ const EXEC_CORE_EVENT_NAMES = [
   ...UNSTUCK_SWEEP_EVENT_TYPES,
   LINEAR_READ_EVENT, // CTL-1403 reads-by-source (catalyst.linear.read)
   ALERT_BOOT_DEPENDENCY_UNUSABLE,
+  DEP_SKEW_RESTART_EVENT, // CTL-1659 cloud-sync.mjs — the writer restarting to load an installed dep fix
+  DEP_SKEW_WOULD_RESTART_EVENT, // CTL-1659 — sustained skew that did NOT act (shadow / budget / undurable ledger)
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
@@ -127,6 +127,43 @@ describe("cloud-sync.mjs dep-skew wiring", () => {
     expect(declineBlock).not.toContain("DEP_SKEW_RESTART_EVENT");
   });
 
+  // Round-2 finding 5. The decline branch sits INSIDE `if (depSkew.restart)` and therefore
+  // OUTSIDE the posture latch that guards the alert above it. With sustained skew in enforce
+  // mode and a ledger that stays unwritable (a full or read-only ~/catalyst), it ran on every
+  // heartbeat: one ERROR line plus one `dep_skew_would_restart` event every 30s for the whole
+  // incident — an alarm flooding the very two surfaces it exists to make legible. Same
+  // count-exactly / warn-sparsely shape as CTL-1817/CTL-1823's sparse-warn: the CONDITION is
+  // re-evaluated every tick, the ANNOUNCEMENT is edge-triggered.
+  test("the undurable-ledger DECLINE is latched, so a sustained incident announces once and not every 30s", () => {
+    const start = SRC.indexOf("if (spent === null)");
+    expect(start).toBeGreaterThan(-1);
+    const declineBlock = SRC.slice(start, SRC.indexOf("} else {", start));
+    // The guard, the assignment, and BOTH emissions must be inside it — a latch that covered
+    // only the pino line would still spam the unified event log, and vice versa.
+    const guard = declineBlock.indexOf("if (depSkewPosture !== _depSkewDeclinedPosture)");
+    expect(guard, "the decline must be gated on a posture latch, not run every tick").toBeGreaterThan(-1);
+    expect(declineBlock).toContain("_depSkewDeclinedPosture = depSkewPosture");
+    expect(declineBlock.indexOf("hlog.error("), "the ERROR line must sit inside the latch").toBeGreaterThan(guard);
+    expect(declineBlock.indexOf("emitDepSkewEvent({"), "the event emission must sit inside the latch").toBeGreaterThan(guard);
+    // The WRITE ATTEMPT must stay OUTSIDE the latch: retrying it each tick is what lets a
+    // repaired filesystem resume the self-heal. A latch over the retry would turn one
+    // transient EROFS into a permanent refusal.
+    expect(declineBlock).not.toContain("recordRestartAttempt(");
+    expect(SRC.slice(SRC.indexOf("if (depSkew.restart)"), start)).toContain("recordRestartAttempt(");
+  });
+
+  test("the decline latch is DECLARED and RE-ARMS when the skew clears (a latch that never resets is a permanent silence)", () => {
+    expect(SRC).toMatch(/let _depSkewDeclinedPosture = null;/);
+    // The re-arm rides the same `!depSkew.skewed` line as the alert latch, so the two can
+    // never drift into one resetting while the other stays stuck.
+    const rearm = SRC.match(/if \(!depSkew\.skewed\)[^\n]*\n?/)?.[0] ?? "";
+    expect(rearm).toContain("_depSkewAlertedPosture = null");
+    expect(rearm, "the decline latch must re-arm alongside the alert latch").toContain("_depSkewDeclinedPosture = null");
+    // POSITIVE CONTROL for this instrument: the pre-existing alert latch it is modelled on
+    // matches the same declaration shape, so a zero above is a measurement, not a bad regex.
+    expect(SRC).toMatch(/let _depSkewAlertedPosture = null;/);
+  });
+
   test("the durable restart budget is spent BEFORE the exit (the loop terminator is wired)", () => {
     const restartBlock = SRC.slice(SRC.indexOf("if (depSkew.restart)"));
     // Anchored on the CALL shapes, not the bare identifiers — both names also appear in this

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
@@ -1,0 +1,105 @@
+// cloud-sync-dep-skew-wiring.test.mjs — CTL-1659. A SOURCE-SCAN parity test over
+// cloud-sync.mjs, in the shape broker/namespace-parity.test.mjs uses for recovery.mjs.
+//
+// Why a source scan rather than a behavioural test. cloud-sync.mjs is script-shaped: it
+// imports the real @catalyst-cloud SDK at module scope, opens a socket, and ends in
+// `await new Promise(() => {})`. It cannot be imported by a test, which is exactly why its
+// pure helpers were factored into cloud-sync-telemetry.mjs / cloud-sync-deps.mjs in the
+// first place. But a fully-tested helper that no caller invokes is THE failure mode this
+// ticket exists to remove — `restart_needed` was a correct signal with no consumer, and
+// ADR-018's Phase 1 shipped a whole shadow-write mechanism whose only reader was a manual
+// CLI. So the wiring itself gets an assertion, and the assertion's own instrument is
+// positive-controlled below: a grep that cannot find a known-present anchor is not
+// evidence about the anchors it cannot find.
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "cloud-sync.mjs"), "utf8");
+
+describe("cloud-sync.mjs dep-skew wiring", () => {
+  test("POSITIVE CONTROL — the instrument finds anchors known to be present", () => {
+    // If these ever return 0 the scan is broken and every assertion below is vacuous.
+    expect(SRC).toContain("classifyStall"); // the CTL-1508 sibling predicate
+    expect(SRC).toContain("exitAfterClose"); // the CTL-1508 bounded exit
+    expect(SRC.length).toBeGreaterThan(1000);
+  });
+
+  test("the boot record is CAPTURED and WRITTEN — otherwise doctor has nothing to grade", () => {
+    expect(SRC).toContain("captureLoadedDeps");
+    expect(SRC).toContain("writeDepsBreadcrumb");
+    // Resolution goes through the real module resolver, so the record describes what was
+    // ACTUALLY loaded rather than what the lockfile claims (the CTL-1646 trap).
+    expect(SRC).toMatch(/resolveModule:\s*\(specifier\)\s*=>\s*depsRequire\.resolve\(specifier\)/);
+  });
+
+  test("the predicate is EVALUATED on the heartbeat tick, against a re-read lockfile digest", () => {
+    expect(SRC).toContain("classifyDepSkew");
+    expect(SRC).toMatch(/sha256File\(DEP_SKEW_LOCK_PATH\)/);
+  });
+
+  test("the skew fields ride the EXISTING freshness heartbeat line (the alertable surface)", () => {
+    // Not a separate opt-in line: shadow-mode detection that nobody can alert on is the
+    // status quo with better logging.
+    expect(SRC).toMatch(/freshnessFields\([\s\S]{0,400}?depSkewFields\(/);
+  });
+
+  test("the restart uses the EXISTING self-heal exit — breadcrumb + exit code 1, never 0", () => {
+    // exit 0 is the plist's "clean no-op, launchd leaves it DOWN" contract
+    // (KeepAlive={SuccessfulExit:false}); a literal clean exit would permanently stop the
+    // replica writer. The ticket's own Option-1 wording is wrong on exactly this point.
+    expect(SRC).toContain("reason: DEP_SKEW_REASON");
+    const restartBlock = SRC.slice(SRC.indexOf("if (depSkew.restart)"));
+    expect(restartBlock).toMatch(/exitAfterClose\(\{\s*closePromise: replica\.close\(\),\s*exitCode: 1/);
+    expect(restartBlock).not.toMatch(/exitCode:\s*0/);
+  });
+
+  test("no FOURTH restart mechanism is introduced — the daemon never shells out to restart itself", () => {
+    // The subtraction win of this design is that every actuator already exists: launchd
+    // KeepAlive restarts, health-responder.sh escalates, the heartbeat tick is the safe
+    // exit point. A self-restarting daemon that shells out would be a new mechanism.
+    //
+    // Matched STRUCTURALLY (an import, a call, a command line) rather than by the bare
+    // words "kickstart"/"launchctl", which appear legitimately in this file's prose — the
+    // unstructured-match-over-structured-data trap that has produced false results here.
+    expect(SRC).not.toMatch(/from\s+["']node:child_process["']/);
+    expect(SRC).not.toMatch(/\b(?:spawnSync|spawn|execSync|execFileSync|execFile)\s*\(/);
+    expect(SRC).not.toMatch(/launchctl\s+(?:kickstart|bootout|bootstrap)/);
+    // Positive control on those negatives: the same instruments DO match this file's real
+    // import and call shapes, so a zero above is a measurement rather than a broken regex.
+    expect(SRC).toMatch(/from\s+["']node:fs["']/);
+    expect(SRC).toMatch(/\bexitAfterClose\s*\(/);
+  });
+
+  test("the durable restart budget is spent BEFORE the exit (the loop terminator is wired)", () => {
+    const restartBlock = SRC.slice(SRC.indexOf("if (depSkew.restart)"));
+    expect(restartBlock.indexOf("recordRestartAttempt")).toBeGreaterThan(-1);
+    expect(restartBlock.indexOf("recordRestartAttempt")).toBeLessThan(restartBlock.indexOf("exitAfterClose"));
+  });
+
+  test("mode defaults to SHADOW and is operator-selectable", () => {
+    expect(SRC).toContain("resolveDepSkewMode(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW)");
+    // off is fully dormant: no capture, no breadcrumb, nothing written.
+    expect(SRC).toMatch(/if \(DEP_SKEW_MODE !== "off"\)/);
+  });
+});
+
+describe("stack-reload is deliberately NOT the trigger", () => {
+  test("cloud-sync stays out of decideStackReload's component list, by design", () => {
+    // Adding it there is the symmetric CTL-1506 move and was considered and rejected: it
+    // fires only on hosts where the BROKER advances the checkout (a host whose
+    // catalyst-updater pulls without a broker never gets the push), and it would need new
+    // kickstart plumbing plus a real per-component confirmation probe — cloud-sync has no
+    // pid file readPidFor knows, and CTL-1506's own P1 lesson is that a best-effort
+    // `return true` confirmation is how a stale daemon hides. The in-daemon predicate
+    // covers every host cloud-sync runs on, by construction, and its confirmation is free:
+    // the next boot overwrites the record. One trigger, not two.
+    const reload = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "..", "broker", "stack-reload.mjs"), "utf8");
+    expect(reload).not.toContain("cloud-sync");
+    // POSITIVE CONTROL for that negative — the same instrument on the same file finds the
+    // components that ARE listed. Without this, a typo'd path would "prove" the absence.
+    expect(reload).toContain("execution-core");
+    expect(reload).toContain("otel-forward");
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
@@ -72,10 +72,69 @@ describe("cloud-sync.mjs dep-skew wiring", () => {
     expect(SRC).toMatch(/\bexitAfterClose\s*\(/);
   });
 
+  // AC1's second clause — "And the restart is visible in the event log" — was REFUTED on the
+  // first cut of this PR: the restart block wrote a pino line to stderr and appended NOTHING
+  // to ~/catalyst/events/YYYY-MM.jsonl, so the surface `catalyst-events wait-for`, the broker,
+  // the HUD and orch-monitor all read had no record of it. These assertions are the standing
+  // guard against that regression, and they are checked against the block itself rather than
+  // the whole file — an emitter that exists somewhere in cloud-sync.mjs but is never called
+  // from the restart path is exactly the `restart_needed` failure with a new name.
+  test("the RESTART is appended to the unified event log, before the exit that would lose it", () => {
+    const restartBlock = SRC.slice(SRC.indexOf("if (depSkew.restart)"));
+    expect(restartBlock).toContain("DEP_SKEW_RESTART_EVENT");
+    const emit = restartBlock.indexOf("emitDepSkewEvent({ name: DEP_SKEW_RESTART_EVENT");
+    expect(emit).toBeGreaterThan(-1);
+    // Ordering is asserted against the CALLS (`name(` / `name({`), never the bare identifier:
+    // this file's prose names `exitAfterClose` and `recordRestartAttempt` in comments, and an
+    // offset taken from a comment is the unstructured-match-over-structured-data trap.
+    const exitCall = restartBlock.indexOf("exitAfterClose({");
+    const spendCall = restartBlock.indexOf("recordRestartAttempt(");
+    expect(exitCall).toBeGreaterThan(-1);
+    expect(spendCall).toBeGreaterThan(-1);
+    // exitAfterClose can terminate the process at any point after it is called, so an append
+    // sequenced after it is lost on exactly the runs that matter.
+    expect(emit).toBeLessThan(exitCall);
+    // …and after the budget is spent: announcing a restart the ledger then declines is the
+    // same lie `restart_needed` told.
+    expect(emit).toBeGreaterThan(spendCall);
+  });
+
+  test("the emitter appends to the UNIFIED LOG — the same file+call emitWriterIdleEvent uses", () => {
+    // A "telemetry" function that only writes a pino line would satisfy the test above while
+    // leaving the acceptance clause refuted, so the append itself is asserted structurally.
+    const emitter = SRC.slice(SRC.indexOf("function emitDepSkewEvent"), SRC.indexOf("function scrub"));
+    expect(emitter).toContain("getEventLogPath()");
+    expect(emitter).toMatch(/appendFileSync\(logPath, `\$\{JSON\.stringify\(envelope\)\}\\n`\)/);
+    expect(emitter).toContain("depSkewEventEnvelope"); // the unit-tested v2 envelope, not a hand-rolled one
+    // POSITIVE CONTROL for those anchors: the same instrument finds the KNOWN-WORKING
+    // emitter this one is modelled on. If `emitWriterIdleEvent` ever stops matching, the
+    // assertions above are measuring a moved target rather than a present one.
+    const known = SRC.slice(SRC.indexOf("function emitWriterIdleEvent"), SRC.indexOf("function emitDepSkewEvent"));
+    expect(known).toContain("getEventLogPath()");
+    expect(known).toMatch(/appendFileSync\(logPath, `\$\{JSON\.stringify\(envelope\)\}\\n`\)/);
+  });
+
+  test("the HELD posture is emitted too, and never claims a restart it did not perform", () => {
+    // Shadow is the shipping default, so the would-restart event is the one an operator sees
+    // in practice; without it the default configuration is silent on the unified log.
+    expect(SRC).toContain("DEP_SKEW_WOULD_RESTART_EVENT");
+    expect(SRC).toMatch(/if \(depSkew\.wouldRestart && !depSkew\.restart\)/);
+    // The undurable-ledger decline also emits — the posture block deferred to the restart
+    // block on `restart: true`, so without this an enforce-mode host with an unwritable
+    // ledger would emit nothing at all on the configuration that is trying to act.
+    const declineBlock = SRC.slice(SRC.indexOf("if (spent === null)"), SRC.indexOf("} else {", SRC.indexOf("if (spent === null)")));
+    expect(declineBlock).toContain("DEP_SKEW_WOULD_RESTART_EVENT");
+    expect(declineBlock).not.toContain("DEP_SKEW_RESTART_EVENT");
+  });
+
   test("the durable restart budget is spent BEFORE the exit (the loop terminator is wired)", () => {
     const restartBlock = SRC.slice(SRC.indexOf("if (depSkew.restart)"));
-    expect(restartBlock.indexOf("recordRestartAttempt")).toBeGreaterThan(-1);
-    expect(restartBlock.indexOf("recordRestartAttempt")).toBeLessThan(restartBlock.indexOf("exitAfterClose"));
+    // Anchored on the CALL shapes, not the bare identifiers — both names also appear in this
+    // block's prose, and an offset read out of a comment would still "pass" if the calls were
+    // reordered or removed.
+    expect(restartBlock.indexOf("recordRestartAttempt(")).toBeGreaterThan(-1);
+    expect(restartBlock.indexOf("exitAfterClose({")).toBeGreaterThan(-1);
+    expect(restartBlock.indexOf("recordRestartAttempt(")).toBeLessThan(restartBlock.indexOf("exitAfterClose({"));
   });
 
   test("mode defaults to SHADOW and is operator-selectable", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -14,8 +14,11 @@ import { describe, test, expect } from "bun:test";
 import {
   CRITICAL_DEPS,
   DEP_SKEW_REASON,
+  DEP_SKEW_RESTART_EVENT,
+  DEP_SKEW_WOULD_RESTART_EVENT,
   captureLoadedDeps,
   classifyRestartBudget,
+  depSkewEventEnvelope,
   depSkewFields,
   evaluateDepSkew,
   findLockRoot,
@@ -427,6 +430,55 @@ describe("dep-skew restart budget", () => {
     }
   });
 
+  // The fixtures above all carry `count >= maxRestarts`, so the COUNT branch alone returns
+  // allowed:false and the timestamp guard is never the thing under test — deleting the guard
+  // outright leaves that test green (measured: `if (!Number.isFinite(ts) || ts > now)` →
+  // `if (false)` survived the whole file at 44 pass / 0 fail). The discriminating input is a
+  // ledger whose timestamp is unusable while its COUNT is still under the cap: with the guard
+  // the ledger is refused, without it `now - NaN >= windowMs` is false (NaN comparisons are
+  // always false), `count 0 >= 1` is false, and the fail-closed refusal degrades into a
+  // FULL budget — the loop terminator silently disarmed on exactly the corrupt/clock-skewed
+  // ledger it exists to survive.
+  test("an unusable timestamp refuses the restart EVEN WHEN the count is under the cap (isolates the guard from the count branch)", () => {
+    const underCap = [
+      { ledger: { ts: "nope", count: 0 }, why: "non-numeric ts (Number('nope') → NaN)" },
+      { ledger: { ts: NaN, count: 0 }, why: "literal NaN ts" },
+      { ledger: { ts: NOW + 60_000, count: 0 }, why: "future-dated ts (clock skew / a tampered ledger)" },
+      { ledger: { count: 0 }, why: "ts absent entirely" },
+    ];
+    for (const { ledger, why } of underCap) {
+      const v = classifyRestartBudget({ ledger, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+      expect(v.allowed, `${why}: an unusable timestamp must NOT read as free budget`).toBe(false);
+      // The REASON separates the two branches: the timestamp guard says "no usable
+      // timestamp", the count branch says "exhausted". Asserting the text is what keeps this
+      // test honest about WHICH branch refused — an outcome-only assertion would pass again
+      // the moment someone widened the count branch to cover it.
+      expect(v.reason, `${why}: must be refused BY THE TIMESTAMP GUARD, not by the count cap`).toMatch(/no usable timestamp/i);
+      expect(v.count, `${why}: the guard reports an unknown count, never a fabricated 0`).toBeNull();
+    }
+  });
+
+  // POSITIVE CONTROL for the negative above: the same call shape, same maxRestarts, with a
+  // ledger whose timestamp IS usable and whose count is under the cap, DOES return free
+  // budget. Without this, a `classifyRestartBudget` that returned `allowed:false` for
+  // literally every input would satisfy every assertion in this describe block.
+  test("POSITIVE CONTROL — a well-formed in-window ledger under the cap still grants budget", () => {
+    const v = classifyRestartBudget({ ledger: { ts: NOW - 60_000, count: 0 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+    expect(v.allowed).toBe(true);
+    expect(v.count).toBe(0);
+    expect(v.reason).toBeNull();
+  });
+
+  // `ts === now` is the boundary the guard's `ts > now` draws: a ledger written in this very
+  // millisecond is legitimate, not future-dated, so it must fall through to the count branch.
+  // Pinned because tightening the comparison to `>=` would refuse a same-millisecond write.
+  test("a ledger stamped at exactly `now` is NOT future-dated — it falls through to the count branch", () => {
+    expect(classifyRestartBudget({ ledger: { ts: NOW, count: 0 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(true);
+    const held = classifyRestartBudget({ ledger: { ts: NOW, count: 1 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+    expect(held.allowed).toBe(false);
+    expect(held.reason).toMatch(/exhausted/i); // refused by the COUNT branch, proving the fall-through
+  });
+
   test("recordRestartAttempt increments within the window and resets past it", () => {
     const store = {};
     const io = {
@@ -474,5 +526,108 @@ describe("depSkewFields (the heartbeat-carried alert surface)", () => {
 describe("the self-heal exit reason", () => {
   test("dep-skew is a DISTINCT reason from the CTL-1508 stall, so the two paths stay separable", () => {
     expect(DEP_SKEW_REASON).toBe("dep-skew");
+  });
+});
+
+// ─── the unified-log event (AC1: "the restart is visible in the event log") ─────────────
+//
+// The acceptance clause this covers was REFUTED on the first cut of this PR: the dep-skew
+// restart wrote a pino line to stderr and nothing at all to ~/catalyst/events/YYYY-MM.jsonl,
+// so `catalyst-events wait-for`, the broker, the HUD and orch-monitor could not observe the
+// restart at all. The capability was present and simply unused — cloud-sync.mjs's
+// `emitWriterIdleEvent` already appends a v2 envelope to that exact file.
+describe("depSkewEventEnvelope (the unified event-log surface)", () => {
+  const base = {
+    host: "mini-2",
+    mode: "enforce",
+    reason: null,
+    bootLockHash: "sha256:0123456789abcdef",
+    currentLockHash: "sha256:fedcba9876543210",
+    lockPath: "/opt/plugin-source/bun.lock",
+    sustained: true,
+    wouldRestart: true,
+    ts: "2026-08-13T00:00:00Z",
+    id: "deadbeefdeadbeef",
+    traceId: "0".repeat(32),
+    spanId: "1".repeat(16),
+    resource: { "service.name": "catalyst.cloud-sync" },
+  };
+
+  test("is a V2 envelope — {ts, attributes, body, resource}, the shape catalyst-events reads", () => {
+    // v1 is the bash `{ts, event, orchestrator, worker, detail}` shape; a v2 consumer keys on
+    // attributes["event.name"], so an envelope missing `attributes` is an unreadable event.
+    const e = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, restart: true });
+    expect(e.ts).toBe("2026-08-13T00:00:00Z");
+    expect(e.observedTs).toBe(e.ts);
+    expect(e.resource).toEqual({ "service.name": "catalyst.cloud-sync" });
+    expect(e.attributes["event.name"]).toBe(DEP_SKEW_RESTART_EVENT);
+    expect(typeof e.body.message).toBe("string");
+    expect(e.severityText).toBe("WARN");
+    expect(e.severityNumber).toBe(13);
+    // It must survive the transport it will actually take.
+    expect(() => JSON.parse(JSON.stringify(e))).not.toThrow();
+    expect(JSON.stringify(e)).not.toContain("\n"); // one event, one JSONL line
+  });
+
+  test("the acted restart and the held would-restart are DISTINCT names and distinct actions", () => {
+    // Two names rather than one-name-plus-a-payload-field, because otel-forward strips
+    // `body.payload` off-machine: an alert rule that has to reach into the payload to tell a
+    // real restart from a shadow-mode observation cannot fire off-machine at all.
+    expect(DEP_SKEW_RESTART_EVENT).not.toBe(DEP_SKEW_WOULD_RESTART_EVENT);
+    const acted = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, restart: true });
+    const held = depSkewEventEnvelope({ name: DEP_SKEW_WOULD_RESTART_EVENT, ...base, mode: "shadow", reason: "dep-skew mode is shadow — would restart, mutating nothing", restart: false });
+    expect(acted.attributes["event.action"]).toBe("dep_skew_restart");
+    expect(held.attributes["event.action"]).toBe("dep_skew_would_restart");
+    expect(acted.attributes["catalyst.cloud_sync.deps.restart"]).toBe(true);
+    expect(held.attributes["catalyst.cloud_sync.deps.restart"]).toBe(false);
+    // The held event must NOT read as a restart in prose either — an operator scanning the
+    // log body is the second reader of this line.
+    expect(acted.body.message).toMatch(/restarting/i);
+    expect(held.body.message).toMatch(/NOT restarting/i);
+    expect(held.attributes["catalyst.cloud_sync.deps.reason"]).toMatch(/shadow/);
+  });
+
+  test("every load-bearing field rides ATTRIBUTES, because body.payload is stripped off-machine", () => {
+    const e = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, restart: true });
+    // Both digests, the mode, the sustained/would-restart verdict, the lockfile path and the
+    // host must all be answerable from `attributes` alone.
+    expect(e.attributes["catalyst.cloud_sync.deps.boot_lock_hash"]).toBe("0123456789ab");
+    expect(e.attributes["catalyst.cloud_sync.deps.current_lock_hash"]).toBe("fedcba987654");
+    expect(e.attributes["catalyst.cloud_sync.deps.mode"]).toBe("enforce");
+    expect(e.attributes["catalyst.cloud_sync.deps.sustained"]).toBe(true);
+    expect(e.attributes["catalyst.cloud_sync.deps.would_restart"]).toBe(true);
+    expect(e.attributes["catalyst.cloud_sync.deps.lock_path"]).toBe("/opt/plugin-source/bun.lock");
+    expect(e.attributes.host).toBe("mini-2");
+    expect(e.attributes["event.label"]).toBe("mini-2");
+    expect(e.body.payload).toBeUndefined();
+  });
+
+  test("the digest attributes come from depSkewFields, so the event and the heartbeat cannot drift", () => {
+    // Not a tautology: it pins that the envelope REUSES the shared field builder rather than
+    // hand-copying six key names that a later rename would silently split in two.
+    const e = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, restart: true });
+    const fields = depSkewFields({ mode: "enforce", bootLockHash: base.bootLockHash, currentLockHash: base.currentLockHash, skewed: true, sustained: true, wouldRestart: true });
+    for (const [k, v] of Object.entries(fields)) expect(e.attributes[k], `attribute ${k}`).toEqual(v);
+  });
+
+  test("carries no secret-shaped substring (it lands in a world-readable log file)", () => {
+    const e = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, restart: true });
+    expect(JSON.stringify(e)).not.toMatch(/token|secret|lin_|Bearer|sk-/i);
+  });
+
+  test("an unknown lock path degrades the message instead of printing 'undefined'", () => {
+    const e = depSkewEventEnvelope({ name: DEP_SKEW_RESTART_EVENT, ...base, lockPath: null, restart: true });
+    expect(e.body.message).not.toMatch(/undefined|null/);
+    expect(e.attributes["catalyst.cloud_sync.deps.lock_path"]).toBeNull();
+  });
+
+  test("the event names stay inside catalyst.replica.* — the family cloud-sync already owns", () => {
+    // Sibling of catalyst.replica.writer_idle, and clear of every CTL-1142 broker-protected
+    // prefix (`filter.`, `broker.daemon`, `session.heartbeat`, `phase.<slot>.<status>`).
+    for (const n of [DEP_SKEW_RESTART_EVENT, DEP_SKEW_WOULD_RESTART_EVENT]) {
+      expect(n).toMatch(/^catalyst\.replica\./);
+      expect(n.startsWith("filter.")).toBe(false);
+      expect(n.startsWith("broker.daemon")).toBe(false);
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -1,0 +1,478 @@
+// cloud-sync-deps.test.mjs — CTL-1659. The loaded-dependency identity record, the
+// three-link skew comparator, the dep-skew restart budget, and the pure daemon-side
+// predicate (classifyDepSkew, which lives beside classifyStall in cloud-sync-telemetry).
+//
+// The defect under test: a dependency fix lands on main, the updater pulls it, the
+// install succeeds — and the RUNNING cloud-sync writer keeps serving the old modules
+// indefinitely, with nothing red. Every assertion below therefore comes in pairs: the
+// negative ("no skew") is only evidence when the SAME instrument is shown producing the
+// positive ("skew") on a case known to carry it. A comparator that can only ever say
+// "clean" is exactly the failure mode this ticket exists to remove.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cloud-sync-deps
+import { describe, test, expect } from "bun:test";
+import {
+  CRITICAL_DEPS,
+  DEP_SKEW_REASON,
+  captureLoadedDeps,
+  classifyRestartBudget,
+  depSkewFields,
+  evaluateDepSkew,
+  findLockRoot,
+  lockedVersionsFor,
+  readDepsBreadcrumb,
+  recordRestartAttempt,
+  sha256File,
+  writeDepsBreadcrumb,
+} from "../cloud-sync-deps.mjs";
+import { classifyDepSkew, resolveDepSkewMode } from "../cloud-sync-telemetry.mjs";
+
+const NOW = 1_800_000_000_000;
+const ROOT = "/opt/plugin-source";
+const LOCK = `${ROOT}/bun.lock`;
+const SDK_ENTRY = `${ROOT}/node_modules/@catalyst-cloud/sdk/dist/node.js`;
+const SDK_PKG = `${ROOT}/node_modules/@catalyst-cloud/sdk/package.json`;
+
+// A minimal but REAL-SHAPED bun.lock excerpt (the "packages" map entry format bun
+// writes): `"<key>": ["<name>@<version>", …]`. Nested resolutions carry a slashed key.
+const LOCK_TEXT = `{
+  "lockfileVersion": 1,
+  "workspaces": { "": { "dependencies": { "@catalyst-cloud/sdk": "^0.8.2" } } },
+  "packages": {
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": {} }, "sha512-aaa=="],
+    "@catalyst-cloud/sdk/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.5", "", {}, "sha512-bbb=="],
+    "pino": ["pino@9.6.0", "", {}, "sha512-ccc=="],
+  }
+}`;
+
+// ─── fixtures ───────────────────────────────────────────────────────────────
+// A whole synthetic filesystem, so nothing here touches a real disk or resolver.
+function fs(over = {}) {
+  return {
+    [LOCK]: LOCK_TEXT,
+    [SDK_ENTRY]: "// sdk entry bytes v1\n",
+    [SDK_PKG]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.8.2" }),
+    ...over,
+  };
+}
+
+function deps(files, over = {}) {
+  return {
+    startDir: `${ROOT}/plugins/dev/scripts/execution-core`,
+    deps: [{ id: "@catalyst-cloud/sdk", specifier: "@catalyst-cloud/sdk/node" }],
+    resolveModule: (spec) => {
+      if (spec === "@catalyst-cloud/sdk/node") return SDK_ENTRY;
+      throw new Error(`Cannot find module '${spec}'`);
+    },
+    fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+    readText: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return files[p];
+    },
+    readJson: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return JSON.parse(files[p]);
+    },
+    pid: 4242,
+    now: () => NOW,
+    ...over,
+  };
+}
+
+describe("sha256File", () => {
+  test("hashes content, and DIFFERENT bytes produce a DIFFERENT digest (the discriminator)", () => {
+    const a = sha256File("/a", { readText: () => "alpha" });
+    const b = sha256File("/b", { readText: () => "beta" });
+    expect(a).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // Positive control for "identical bytes → identical digest": without this the
+    // inequality below could be produced by a hasher that just returns randomness.
+    expect(sha256File("/c", { readText: () => "alpha" })).toBe(a);
+    expect(b).not.toBe(a);
+  });
+
+  test("unreadable file → null (never a fabricated digest a comparison could pass on)", () => {
+    expect(sha256File("/nope", { readText: () => { throw new Error("ENOENT"); } })).toBeNull();
+  });
+});
+
+describe("findLockRoot", () => {
+  test("walks up to the directory holding bun.lock", () => {
+    const files = fs();
+    const r = findLockRoot(`${ROOT}/node_modules/@catalyst-cloud/sdk/dist`, {
+      fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+    });
+    expect(r).toEqual({ root: ROOT, lockPath: LOCK });
+  });
+
+  test("no lockfile anywhere above → null (not a guessed root)", () => {
+    expect(findLockRoot("/tmp/x/y", { fileExists: () => false })).toBeNull();
+  });
+});
+
+describe("captureLoadedDeps", () => {
+  test("records what was ACTUALLY resolved — path, version, entry hash — plus the root lockfile hash", () => {
+    const files = fs();
+    const rec = captureLoadedDeps(deps(files));
+    expect(rec.degraded).toBe(false);
+    expect(rec.pid).toBe(4242);
+    expect(rec.ts).toBe(NOW);
+    expect(rec.root).toBe(ROOT);
+    expect(rec.lockPath).toBe(LOCK);
+    expect(rec.lockHash).toBe(sha256File(LOCK, { readText: () => LOCK_TEXT }));
+    expect(rec.packages).toHaveLength(1);
+    const p = rec.packages[0];
+    expect(p.id).toBe("@catalyst-cloud/sdk");
+    expect(p.resolvedPath).toBe(SDK_ENTRY);
+    expect(p.packageJsonPath).toBe(SDK_PKG);
+    expect(p.version).toBe("0.8.2");
+    expect(p.entryHash).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  test("the version comes from the RESOLVED path's package.json, not from the lockfile", () => {
+    // The CTL-1646 shadowed-install class: the lockfile says one thing and the bytes
+    // on disk say another. A capture derived from the lockfile re-manufactures the lie.
+    const files = fs({ [SDK_PKG]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.7.0" }) });
+    expect(captureLoadedDeps(deps(files)).packages[0].version).toBe("0.7.0");
+  });
+
+  test("an unresolvable package degrades the record and NAMES the failure — never a silent clean record", () => {
+    const files = fs();
+    const rec = captureLoadedDeps(deps(files, { resolveModule: () => { throw new Error("Cannot find module"); } }));
+    expect(rec.degraded).toBe(true);
+    expect(rec.degradedReasons.join(" ")).toMatch(/@catalyst-cloud\/sdk/);
+    // Positive control: the same instrument on a resolvable package is NOT degraded.
+    expect(captureLoadedDeps(deps(files)).degraded).toBe(false);
+  });
+
+  test("an EMPTY critical-dep list is degraded, not a vacuous clean capture ([].every(p) === true)", () => {
+    const files = fs();
+    const rec = captureLoadedDeps(deps(files, { deps: [] }));
+    expect(rec.degraded).toBe(true);
+    expect(rec.degradedReasons.join(" ")).toMatch(/no critical dependencies/i);
+  });
+
+  test("no lockfile above the daemon → degraded with a null lockHash (nothing to compare against)", () => {
+    const files = fs();
+    delete files[LOCK];
+    const rec = captureLoadedDeps(deps(files));
+    expect(rec.lockHash).toBeNull();
+    expect(rec.degraded).toBe(true);
+  });
+
+  test("the shipped CRITICAL_DEPS registry is non-empty and names the SDK cloud-sync loads", () => {
+    expect(CRITICAL_DEPS.length).toBeGreaterThan(0);
+    expect(CRITICAL_DEPS.map((d) => d.id)).toContain("@catalyst-cloud/sdk");
+  });
+});
+
+describe("deps breadcrumb io", () => {
+  test("atomic tmp+rename, and reads back what was written", () => {
+    const written = {};
+    const renames = [];
+    const rec = captureLoadedDeps(deps(fs()));
+    expect(
+      writeDepsBreadcrumb("/tmp/deps.json", rec, {
+        writeFile: (p, c) => { written[p] = c; },
+        rename: (a, b) => { renames.push([a, b]); written[b] = written[a]; },
+      }),
+    ).toBe(true);
+    expect(renames).toEqual([["/tmp/deps.json.tmp", "/tmp/deps.json"]]);
+    const back = readDepsBreadcrumb("/tmp/deps.json", { readText: (p) => written[p] });
+    expect(back.lockHash).toBe(rec.lockHash);
+    expect(back.packages[0].version).toBe("0.8.2");
+  });
+
+  test("write failure is fail-open (false, never throws) — the breadcrumb must not block boot", () => {
+    expect(writeDepsBreadcrumb("/tmp/x", {}, { writeFile: () => { throw new Error("EROFS"); } })).toBe(false);
+  });
+
+  test("absent / malformed breadcrumb reads as null, never as an empty-but-valid record", () => {
+    expect(readDepsBreadcrumb("/nope", { readText: () => { throw new Error("ENOENT"); } })).toBeNull();
+    expect(readDepsBreadcrumb("/bad", { readText: () => "{not json" })).toBeNull();
+  });
+});
+
+describe("lockedVersionsFor", () => {
+  test("extracts every locked resolution for a package id (hoisted AND nested keys)", () => {
+    const v = lockedVersionsFor(LOCK_TEXT, "@catalyst-cloud/sdk");
+    expect(v.conclusive).toBe(true);
+    expect(v.versions).toEqual(["0.8.2"]);
+    const s = lockedVersionsFor(LOCK_TEXT, "@catalyst-cloud/schema");
+    expect(s.conclusive).toBe(true);
+    expect(s.versions).toEqual(["0.1.5"]);
+  });
+
+  test("a package absent from the lockfile is INCONCLUSIVE, never 'no skew'", () => {
+    const v = lockedVersionsFor(LOCK_TEXT, "@catalyst-cloud/nonexistent");
+    expect(v.conclusive).toBe(false);
+    expect(v.reason).toMatch(/not found/i);
+    // Positive control on the same instrument + same text: a present package IS conclusive.
+    expect(lockedVersionsFor(LOCK_TEXT, "pino").conclusive).toBe(true);
+  });
+});
+
+// ─── the three-link comparator ──────────────────────────────────────────────
+function evalDeps(files, over = {}) {
+  const record = captureLoadedDeps(deps(files));
+  return {
+    breadcrumb: record,
+    readText: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return files[p];
+    },
+    readJson: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return JSON.parse(files[p]);
+    },
+    processCommandForPid: (pid) => (pid === 4242 ? "bun /opt/plugin-source/plugins/dev/scripts/execution-core/cloud-sync.mjs" : null),
+    ...over,
+  };
+}
+const linkOf = (r, link) => r.verdicts.find((v) => v.link === link);
+
+describe("evaluateDepSkew — link 1: loaded vs locked", () => {
+  test("lockfile unchanged since boot → ok", () => {
+    const files = fs();
+    const r = evaluateDepSkew(evalDeps(files));
+    expect(linkOf(r, "loaded-vs-locked").status).toBe("ok");
+    expect(r.skew).toBe(false);
+  });
+
+  test("THE CTL-1659 INCIDENT: lockfile changed after boot → skew, naming both digests", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    files[LOCK] = LOCK_TEXT.replace("0.8.2", "0.8.3"); // a dep fix landed + installed
+    const r = evaluateDepSkew(args);
+    const v = linkOf(r, "loaded-vs-locked");
+    expect(v.status).toBe("skew");
+    expect(r.skew).toBe(true);
+    expect(v.detail).toMatch(/lockfile/i);
+  });
+
+  test("SAME version, DIFFERENT bytes still skews — the digest, not the version string, is the verdict", () => {
+    // A repointed tarball / workspace-link / git dep ships new bytes under the same
+    // semver. A version-equality comparator is permanently non-discriminating there.
+    const files = fs();
+    const args = evalDeps(files);
+    files[LOCK] = LOCK_TEXT.replace("sha512-aaa==", "sha512-zzz==");
+    expect(linkOf(evaluateDepSkew(args), "loaded-vs-locked").status).toBe("skew");
+  });
+
+  test("lockfile now unreadable → INCONCLUSIVE, never ok", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    delete files[LOCK];
+    const r = evaluateDepSkew(args);
+    expect(linkOf(r, "loaded-vs-locked").status).toBe("inconclusive");
+    expect(r.inconclusive).toBe(true);
+  });
+});
+
+describe("evaluateDepSkew — link 2: installed vs locked", () => {
+  test("installed version is one of the locked resolutions → ok", () => {
+    expect(linkOf(evaluateDepSkew(evalDeps(fs())), "installed-vs-locked").status).toBe("ok");
+  });
+
+  test("partial install / shadowed install: on-disk version not in the lockfile → skew NAMING package + both versions", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    files[SDK_PKG] = JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.7.0" });
+    const v = linkOf(evaluateDepSkew(args), "installed-vs-locked");
+    expect(v.status).toBe("skew");
+    expect(v.detail).toContain("@catalyst-cloud/sdk");
+    expect(v.detail).toContain("0.7.0"); // installed
+    expect(v.detail).toContain("0.8.2"); // locked
+  });
+
+  test("package.json missing on disk now (SIGKILL'd install residue) → INCONCLUSIVE, never ok", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    delete files[SDK_PKG];
+    expect(linkOf(evaluateDepSkew(args), "installed-vs-locked").status).toBe("inconclusive");
+  });
+
+  test("zero packages compared → INCONCLUSIVE (the vacuous-loop trap), never ok", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    args.breadcrumb = { ...args.breadcrumb, packages: [] };
+    const v = linkOf(evaluateDepSkew(args), "installed-vs-locked");
+    expect(v.status).toBe("inconclusive");
+    expect(v.detail).toMatch(/no package/i);
+  });
+});
+
+describe("evaluateDepSkew — link 3: breadcrumb ↔ process identity", () => {
+  test("pid names the live cloud-sync writer → ok", () => {
+    expect(linkOf(evaluateDepSkew(evalDeps(fs())), "record-identity").status).toBe("ok");
+  });
+
+  test("pid dead → INCONCLUSIVE and links 1/2 are NOT reported as ok (stale evidence)", () => {
+    const r = evaluateDepSkew(evalDeps(fs(), { processCommandForPid: () => null }));
+    expect(linkOf(r, "record-identity").status).toBe("inconclusive");
+    expect(r.inconclusive).toBe(true);
+    expect(r.verdicts.every((v) => v.status !== "ok")).toBe(true);
+  });
+
+  test("pid RECYCLED onto another program → INCONCLUSIVE (fail-closed identity, not bare kill -0)", () => {
+    const r = evaluateDepSkew(evalDeps(fs(), { processCommandForPid: () => "/usr/bin/vim notes.txt" }));
+    expect(linkOf(r, "record-identity").status).toBe("inconclusive");
+  });
+});
+
+describe("evaluateDepSkew — absent evidence", () => {
+  test("no breadcrumb at all → INCONCLUSIVE, never a clean bill of health", () => {
+    const r = evaluateDepSkew({ breadcrumb: null });
+    expect(r.inconclusive).toBe(true);
+    expect(r.skew).toBe(false);
+    expect(r.verdicts.every((v) => v.status !== "ok")).toBe(true);
+    // Positive control: the SAME function CAN return an all-ok result.
+    expect(evaluateDepSkew(evalDeps(fs())).verdicts.every((v) => v.status === "ok")).toBe(true);
+  });
+});
+
+// ─── the daemon-side predicate ──────────────────────────────────────────────
+describe("classifyDepSkew", () => {
+  const base = {
+    bootLockHash: "sha256:aaa",
+    currentLockHash: "sha256:bbb",
+    consecutiveMismatches: 2,
+    sustainedTicks: 2,
+    uptimeMs: 600_000,
+    uptimeFloorMs: 120_000,
+    mode: "enforce",
+    budgetAllowed: true,
+  };
+
+  test("sustained mismatch under enforce → restart", () => {
+    const c = classifyDepSkew(base);
+    expect(c.skewed).toBe(true);
+    expect(c.sustained).toBe(true);
+    expect(c.wouldRestart).toBe(true);
+    expect(c.restart).toBe(true);
+  });
+
+  test("identical hashes → no skew (the healthy steady state)", () => {
+    const c = classifyDepSkew({ ...base, currentLockHash: base.bootLockHash });
+    expect(c.skewed).toBe(false);
+    expect(c.restart).toBe(false);
+  });
+
+  test("an unknown hash on EITHER side never asserts skew — a failed read must not kill the writer", () => {
+    for (const over of [{ bootLockHash: null }, { currentLockHash: null }, { bootLockHash: "" }, { currentLockHash: undefined }]) {
+      const c = classifyDepSkew({ ...base, ...over });
+      expect(c.known).toBe(false);
+      expect(c.skewed).toBe(false);
+      expect(c.restart).toBe(false);
+    }
+    // Positive control: with both hashes known and different, the SAME call DOES assert.
+    expect(classifyDepSkew(base).skewed).toBe(true);
+  });
+
+  test("a single-tick mismatch (mid-write lockfile) does not act — sustained needs >= sustainedTicks", () => {
+    const c = classifyDepSkew({ ...base, consecutiveMismatches: 1 });
+    expect(c.skewed).toBe(true);
+    expect(c.sustained).toBe(false);
+    expect(c.restart).toBe(false);
+  });
+
+  test("uptime floor: a just-booted writer never self-restarts on skew", () => {
+    expect(classifyDepSkew({ ...base, uptimeMs: 5_000 }).restart).toBe(false);
+  });
+
+  test("shadow (the default) detects and would-restart but NEVER exits", () => {
+    const c = classifyDepSkew({ ...base, mode: "shadow" });
+    expect(c.wouldRestart).toBe(true);
+    expect(c.restart).toBe(false);
+  });
+
+  test("off is fully dormant — no would-restart, no restart", () => {
+    const c = classifyDepSkew({ ...base, mode: "off" });
+    expect(c.wouldRestart).toBe(false);
+    expect(c.restart).toBe(false);
+  });
+
+  test("an exhausted restart budget holds the exit and NAMES why (the loop terminator)", () => {
+    const c = classifyDepSkew({ ...base, budgetAllowed: false });
+    expect(c.wouldRestart).toBe(true);
+    expect(c.restart).toBe(false);
+    expect(c.reason).toMatch(/budget/i);
+  });
+
+  test("resolveDepSkewMode: recognized values pass through; anything else settles at the shadow default", () => {
+    expect(resolveDepSkewMode("enforce")).toBe("enforce");
+    expect(resolveDepSkewMode("off")).toBe("off");
+    expect(resolveDepSkewMode("shadow")).toBe("shadow");
+    for (const raw of [undefined, null, "", "ENFORCE!", "on", "true"]) expect(resolveDepSkewMode(raw)).toBe("shadow");
+  });
+});
+
+// ─── the restart budget (durable loop terminator) ───────────────────────────
+describe("dep-skew restart budget", () => {
+  test("first trip is allowed; the cap holds the second within the window", () => {
+    expect(classifyRestartBudget({ ledger: null, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(true);
+    const spent = { ts: NOW - 60_000, count: 1 };
+    const held = classifyRestartBudget({ ledger: spent, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+    expect(held.allowed).toBe(false);
+    expect(held.reason).toMatch(/budget|cap/i);
+  });
+
+  test("an expired window re-arms the budget (a success resets the counter as time passes)", () => {
+    const old = { ts: NOW - 21_600_001, count: 5 };
+    expect(classifyRestartBudget({ ledger: old, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(true);
+  });
+
+  test("a malformed / future-dated ledger is treated as spent, not as free budget (fail-closed)", () => {
+    for (const ledger of [{ ts: "nope", count: 1 }, { ts: NOW + 60_000, count: 1 }, { count: 3 }]) {
+      expect(classifyRestartBudget({ ledger, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(false);
+    }
+  });
+
+  test("recordRestartAttempt increments within the window and resets past it", () => {
+    const store = {};
+    const io = {
+      writeFile: (p, c) => { store[p] = c; },
+      rename: (a, b) => { store[b] = store[a]; },
+    };
+    const first = recordRestartAttempt("/tmp/led.json", { ledger: null, now: NOW, windowMs: 1000 }, io);
+    expect(first).toEqual({ ts: NOW, count: 1 });
+    const second = recordRestartAttempt("/tmp/led.json", { ledger: first, now: NOW + 500, windowMs: 1000 }, io);
+    expect(second.count).toBe(2);
+    expect(second.ts).toBe(NOW); // window anchor stays at the first attempt
+    const afterWindow = recordRestartAttempt("/tmp/led.json", { ledger: second, now: NOW + 5000, windowMs: 1000 }, io);
+    expect(afterWindow).toEqual({ ts: NOW + 5000, count: 1 });
+    expect(JSON.parse(store["/tmp/led.json"]).count).toBe(1);
+  });
+
+  test("a ledger that could NOT be persisted returns null — the loop terminator fails CLOSED", () => {
+    // If the budget is not durable there is no terminator, so the caller must decline the
+    // restart. Declining is never destructive: a skewed-but-running writer is exactly
+    // today's behavior, which the doctor check now names.
+    expect(recordRestartAttempt("/tmp/led.json", { ledger: null, now: NOW }, { writeFile: () => { throw new Error("EROFS"); } })).toBeNull();
+    // Positive control: the same call with a working writer DOES return a ledger.
+    expect(recordRestartAttempt("/tmp/led.json", { ledger: null, now: NOW }, { writeFile: () => {}, rename: () => {} })).toEqual({ ts: NOW, count: 1 });
+  });
+});
+
+describe("depSkewFields (the heartbeat-carried alert surface)", () => {
+  test("carries the mode, the verdict, and BOTH short digests — never a secret", () => {
+    const f = depSkewFields({ mode: "shadow", bootLockHash: "sha256:0123456789abcdef", currentLockHash: "sha256:fedcba9876543210", skewed: true, sustained: true, wouldRestart: true });
+    expect(f["catalyst.cloud_sync.deps.mode"]).toBe("shadow");
+    expect(f["catalyst.cloud_sync.deps.skewed"]).toBe(true);
+    expect(f["catalyst.cloud_sync.deps.would_restart"]).toBe(true);
+    expect(f["catalyst.cloud_sync.deps.boot_lock_hash"]).toBe("0123456789ab");
+    expect(f["catalyst.cloud_sync.deps.current_lock_hash"]).toBe("fedcba987654");
+    expect(JSON.stringify(f)).not.toMatch(/token|secret|lin_|Bearer/i);
+  });
+
+  test("unknown inputs stay null (never a bogus false that reads as 'no skew')", () => {
+    const f = depSkewFields({ mode: "shadow" });
+    expect(f["catalyst.cloud_sync.deps.skewed"]).toBeNull();
+    expect(f["catalyst.cloud_sync.deps.boot_lock_hash"]).toBeNull();
+  });
+});
+
+describe("the self-heal exit reason", () => {
+  test("dep-skew is a DISTINCT reason from the CTL-1508 stall, so the two paths stay separable", () => {
+    expect(DEP_SKEW_REASON).toBe("dep-skew");
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -16,14 +16,18 @@ import {
   DEP_SKEW_REASON,
   DEP_SKEW_RESTART_EVENT,
   DEP_SKEW_WOULD_RESTART_EVENT,
+  RESTART_LEDGER_UNREADABLE,
   captureLoadedDeps,
   classifyRestartBudget,
   depSkewEventEnvelope,
   depSkewFields,
   evaluateDepSkew,
   findLockRoot,
+  lockKeyForPackageJsonPath,
+  lockedVersionForKey,
   lockedVersionsFor,
   readDepsBreadcrumb,
+  readRestartLedger,
   recordRestartAttempt,
   sha256File,
   writeDepsBreadcrumb,
@@ -502,6 +506,267 @@ describe("dep-skew restart budget", () => {
     expect(recordRestartAttempt("/tmp/led.json", { ledger: null, now: NOW }, { writeFile: () => { throw new Error("EROFS"); } })).toBeNull();
     // Positive control: the same call with a working writer DOES return a ledger.
     expect(recordRestartAttempt("/tmp/led.json", { ledger: null, now: NOW }, { writeFile: () => {}, rename: () => {} })).toEqual({ ts: NOW, count: 1 });
+  });
+});
+
+// ─── the ledger READ is tri-state (absent ≠ unreadable) ─────────────────────
+//
+// Round-2 finding 1. `readRestartLedger` returned the SAME `null` for "no file" and for
+// "a file I could not read or parse", and `classifyRestartBudget(null)` grants a FULL
+// budget. So in enforce mode a corrupt or momentarily-unreadable ledger permitted another
+// restart past the cap and then overwrote the evidence — the durable loop terminator
+// disarmed by exactly the corruption it exists to survive. Each negative below is paired
+// with the positive control on the same instrument.
+const enoent = () => { throw Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" }); };
+
+describe("readRestartLedger — absent and unreadable are DIFFERENT answers", () => {
+  test("a genuinely ABSENT ledger (ENOENT) reads as null → full budget (the normal first trip)", () => {
+    expect(readRestartLedger("/nope", { readText: enoent })).toBeNull();
+    // …and that null is what grants budget, which is why the cases below must NOT be null.
+    expect(classifyRestartBudget({ ledger: readRestartLedger("/nope", { readText: enoent }), now: NOW, maxRestarts: 1 }).allowed).toBe(true);
+  });
+
+  test("a ledger that EXISTS but does not parse is UNREADABLE, and the budget is DECLINED", () => {
+    const led = readRestartLedger("/bad", { readText: () => "{not json" });
+    expect(led).not.toBeNull();
+    expect(led).toBe(RESTART_LEDGER_UNREADABLE);
+    const v = classifyRestartBudget({ ledger: led, now: NOW, maxRestarts: 1 });
+    expect(v.allowed, "a corrupt ledger must never read as free budget").toBe(false);
+    expect(v.reason).toMatch(/could not be read or parsed/i);
+    expect(v.count).toBeNull();
+  });
+
+  test("a NON-ENOENT read failure (EACCES/EIO) is UNREADABLE, not absent — 'I could not look' ≠ 'not there'", () => {
+    for (const code of ["EACCES", "EIO", undefined]) {
+      const led = readRestartLedger("/x", { readText: () => { throw Object.assign(new Error(code ?? "boom"), code ? { code } : {}); } });
+      expect(led, `code=${code}`).toBe(RESTART_LEDGER_UNREADABLE);
+      expect(classifyRestartBudget({ ledger: led, now: NOW, maxRestarts: 1 }).allowed, `code=${code}`).toBe(false);
+    }
+  });
+
+  test("valid JSON that is not a ledger OBJECT (null / array / scalar) is UNREADABLE, never absent", () => {
+    for (const text of ["null", "[]", "42", '"ts"']) {
+      expect(readRestartLedger("/x", { readText: () => text }), text).toBe(RESTART_LEDGER_UNREADABLE);
+    }
+  });
+
+  test("POSITIVE CONTROL — a well-formed ledger file reads back as its object and still grades normally", () => {
+    const led = readRestartLedger("/ok", { readText: () => JSON.stringify({ ts: NOW - 60_000, count: 0 }) });
+    expect(led).toEqual({ ts: NOW - 60_000, count: 0 });
+    expect(classifyRestartBudget({ ledger: led, now: NOW, maxRestarts: 1 }).allowed).toBe(true);
+  });
+});
+
+// ─── raw types before coercion ──────────────────────────────────────────────
+//
+// Round-2 finding 2, and it is the SAME defect class the round-1 remediation just fixed one
+// level up: a guard that looks right while the fixture cannot discriminate. Every case here
+// therefore keeps `count` UNDER the cap, so the count branch can never be the thing that
+// refuses, and asserts the REASON so the test names WHICH guard fired.
+describe("classifyRestartBudget — raw field TYPES are checked before any Number() coercion", () => {
+  test("a syntactically valid `{ts: null}` must not become an epoch anchor and re-arm a full budget", () => {
+    // Number(null) === 0 → finite → not future → `now - 0 >= windowMs` → "expired window"
+    // → allowed:true, count:0. A FULL budget handed out by a corrupt ledger.
+    const v = classifyRestartBudget({ ledger: { ts: null, count: 0 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+    expect(v.allowed, "`ts: null` coerces to 0 and reads as an expired window").toBe(false);
+    expect(v.reason).toMatch(/no usable timestamp/i);
+    expect(v.count).toBeNull();
+  });
+
+  test("every non-number `ts` that Number() would launder into a finite value is refused", () => {
+    // Each of these coerces to a finite number: [] → 0, true → 1, "0" → 0, "" → 0.
+    for (const ts of [null, [], true, false, "0", "", "1800000000000"]) {
+      const v = classifyRestartBudget({ ledger: { ts, count: 0 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+      expect(v.allowed, `ts=${JSON.stringify(ts)} must not read as a usable anchor`).toBe(false);
+      expect(v.reason, `ts=${JSON.stringify(ts)}`).toMatch(/no usable timestamp/i);
+    }
+  });
+
+  test("a missing or non-numeric `count` is refused BY THE COUNT GUARD, not coerced to zero", () => {
+    // Number(undefined) || 0 === 0 and Number(null) || 0 === 0 → "nothing spent yet".
+    for (const ledger of [{ ts: NOW - 60_000 }, { ts: NOW - 60_000, count: null }, { ts: NOW - 60_000, count: "1" }, { ts: NOW - 60_000, count: 1.5 }, { ts: NOW - 60_000, count: -1 }, { ts: NOW - 60_000, count: NaN }]) {
+      const v = classifyRestartBudget({ ledger, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+      expect(v.allowed, `count=${JSON.stringify(ledger.count)} must not read as "nothing spent yet"`).toBe(false);
+      // Naming the branch is what keeps this isolated: the timestamp here is perfectly
+      // usable, so a refusal blamed on the timestamp would mean the test is measuring the
+      // wrong guard.
+      expect(v.reason, `count=${JSON.stringify(ledger.count)}`).toMatch(/no usable count/i);
+      expect(v.count).toBeNull();
+    }
+  });
+
+  test("the type gate runs BEFORE the expired-window shortcut — a bogus count cannot re-arm on an untrusted anchor", () => {
+    // An expired window normally returns allowed:true without ever reading `count`; that
+    // shortcut must not be reachable from a ledger whose fields failed validation.
+    const v = classifyRestartBudget({ ledger: { ts: NOW - 21_600_001, count: "99" }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 });
+    expect(v.allowed).toBe(false);
+    expect(v.reason).toMatch(/no usable count/i);
+  });
+
+  test("POSITIVE CONTROL — the same shapes with real numbers still grant and still exhaust", () => {
+    expect(classifyRestartBudget({ ledger: { ts: NOW - 60_000, count: 0 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(true);
+    expect(classifyRestartBudget({ ledger: { ts: NOW - 60_000, count: 1 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(false);
+    expect(classifyRestartBudget({ ledger: { ts: NOW - 21_600_001, count: 9 }, now: NOW, windowMs: 21_600_000, maxRestarts: 1 }).allowed).toBe(true);
+  });
+
+  test("recordRestartAttempt applies the SAME gate — a coercible-but-invalid prior never seeds the next ledger", () => {
+    const io = { writeFile: () => {}, rename: () => {} };
+    // Number("7") === 7, so the old coercion would have written count 8 and carried the
+    // untrusted anchor forward. The gate resets to a fresh, honest window instead.
+    expect(recordRestartAttempt("/tmp/led.json", { ledger: { ts: NOW - 60_000, count: "7" }, now: NOW, windowMs: 21_600_000 }, io)).toEqual({ ts: NOW, count: 1 });
+    expect(recordRestartAttempt("/tmp/led.json", { ledger: RESTART_LEDGER_UNREADABLE, now: NOW, windowMs: 21_600_000 }, io)).toEqual({ ts: NOW, count: 1 });
+    // POSITIVE CONTROL: a valid in-window prior IS carried forward and incremented.
+    expect(recordRestartAttempt("/tmp/led.json", { ledger: { ts: NOW - 60_000, count: 7 }, now: NOW, windowMs: 21_600_000 }, io)).toEqual({ ts: NOW - 60_000, count: 8 });
+  });
+});
+
+// ─── the captured entry digest is actually COMPARED ─────────────────────────
+//
+// Round-2 finding 3, and the most important of the five: `captureLoadedDeps` records
+// `entryHash` expressly as the discriminator ("the VERDICT keys on the digest") and NO
+// comparator read it back. A repointed mutable artifact / workspace output changes the bytes
+// the running process holds while the lockfile TEXT and the package version are identical —
+// so loaded-vs-locked reported ok, doctor PASSed, and the writer never restarted.
+describe("evaluateDepSkew — the captured ENTRY DIGEST is compared, not merely recorded", () => {
+  test("THE UNCOMPARED-DISCRIMINATOR DEFECT: same lockfile, same version, DIFFERENT entry bytes → skew", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    // Nothing else moves: the lockfile text is byte-identical (so its digest matches) and
+    // package.json still says 0.8.2 (so installed-vs-locked is clean). ONLY the bytes the
+    // process loaded have changed underneath it.
+    files[SDK_ENTRY] = "// sdk entry bytes v2 — a repointed tarball, same semver\n";
+    const r = evaluateDepSkew(args);
+    const v = linkOf(r, "loaded-vs-locked");
+    expect(v.status, "changed entry bytes under an unchanged lockfile MUST skew").toBe("skew");
+    expect(r.skew).toBe(true);
+    expect(v.detail).toContain("@catalyst-cloud/sdk");
+    expect(v.detail).toMatch(/entry bytes changed/i);
+    expect(v.detail).toContain(SDK_ENTRY);
+    // The lockfile-digest half is genuinely clean here, which is what makes this a proof
+    // that the ENTRY digest is what produced the verdict.
+    expect(linkOf(r, "installed-vs-locked").status).toBe("ok");
+  });
+
+  test("the loaded entry file is unreadable NOW → INCONCLUSIVE, never ok (bytes UNKNOWN ≠ unchanged)", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    delete files[SDK_ENTRY];
+    const v = linkOf(evaluateDepSkew(args), "loaded-vs-locked");
+    expect(v.status).toBe("inconclusive");
+    expect(v.detail).toMatch(/unreadable now/i);
+  });
+
+  test("a boot record carrying NO entry digest is INCONCLUSIVE — an unmeasured discriminator is not a clean one", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    args.breadcrumb = { ...args.breadcrumb, packages: args.breadcrumb.packages.map((p) => ({ ...p, entryHash: null })) };
+    expect(linkOf(evaluateDepSkew(args), "loaded-vs-locked").status).toBe("inconclusive");
+  });
+
+  test("ZERO recorded packages cannot produce an ok loaded-vs-locked ([].every(p) === true)", () => {
+    const files = fs();
+    const args = evalDeps(files);
+    args.breadcrumb = { ...args.breadcrumb, packages: [] };
+    const v = linkOf(evaluateDepSkew(args), "loaded-vs-locked");
+    expect(v.status).toBe("inconclusive");
+    expect(v.detail).toMatch(/zero entry-digest comparisons/i);
+  });
+
+  test("POSITIVE CONTROL — unchanged bytes under an unchanged lockfile still report ok, naming the count", () => {
+    const v = linkOf(evaluateDepSkew(evalDeps(fs())), "loaded-vs-locked");
+    expect(v.status).toBe("ok");
+    expect(v.detail).toMatch(/entry digest\(s\) are unchanged/i);
+  });
+});
+
+// ─── the installed package is matched to ITS OWN lock resolution ────────────
+//
+// Round-2 finding 4. `locked.versions.includes(installed)` accepts ANY resolution anywhere
+// in the lockfile, so a stale ROOT install is excused by an unrelated NESTED entry that
+// happens to carry the same version — hiding the shadowed/partial install this link exists
+// to detect.
+const LOCK_TEXT_MULTI = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": {} }, "sha512-aaa=="],
+    "legacy-tool/@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.7.0", "", {}, "sha512-ddd=="],
+    "pino": ["pino@9.6.0", "", {}, "sha512-ccc=="],
+  }
+}`;
+
+describe("lockKeyForPackageJsonPath — install location → bun lock key", () => {
+  test("a hoisted install keys on the bare id; a nested one chains its parents", () => {
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/node_modules/pino/package.json`)).toBe("pino");
+    expect(lockKeyForPackageJsonPath(ROOT, SDK_PKG)).toBe("@catalyst-cloud/sdk");
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/node_modules/legacy-tool/node_modules/@catalyst-cloud/sdk/package.json`)).toBe("legacy-tool/@catalyst-cloud/sdk");
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/node_modules/@babel/core/node_modules/semver/package.json`)).toBe("@babel/core/semver");
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/node_modules/a/node_modules/b/node_modules/c/package.json`)).toBe("a/b/c");
+    expect(lockKeyForPackageJsonPath(`${ROOT}/`, SDK_PKG), "a trailing slash on the root is not a different root").toBe("@catalyst-cloud/sdk");
+  });
+
+  test("anything the path cannot answer returns null (→ the caller reports inconclusive), never a guess", () => {
+    // Outside the serving root; a workspace link that is not under node_modules at all
+    // (its bun key is the WORKSPACE's package name, which no path can supply); a dangling
+    // scope directory; a root that is not a string.
+    expect(lockKeyForPackageJsonPath(ROOT, "/elsewhere/node_modules/pino/package.json")).toBeNull();
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/plugins/dev/scripts/execution-core/package.json`)).toBeNull();
+    expect(lockKeyForPackageJsonPath(ROOT, `${ROOT}/node_modules/@scope/package.json`)).toBeNull();
+    expect(lockKeyForPackageJsonPath(null, SDK_PKG)).toBeNull();
+    expect(lockKeyForPackageJsonPath(ROOT, null)).toBeNull();
+    // POSITIVE CONTROL on the same instrument: a well-formed path DOES resolve, so the
+    // nulls above are measurements rather than a function that only ever returns null.
+    expect(lockKeyForPackageJsonPath(ROOT, SDK_PKG)).toBe("@catalyst-cloud/sdk");
+  });
+});
+
+describe("lockedVersionForKey — the ONE resolution at a specific install location", () => {
+  test("reads the exact key, and does NOT accept a sibling nesting of the same id", () => {
+    expect(lockedVersionForKey(LOCK_TEXT_MULTI, "@catalyst-cloud/sdk", "@catalyst-cloud/sdk")).toEqual({ conclusive: true, version: "0.8.2", reason: null });
+    expect(lockedVersionForKey(LOCK_TEXT_MULTI, "legacy-tool/@catalyst-cloud/sdk", "@catalyst-cloud/sdk").version).toBe("0.7.0");
+    // The old any-occurrence matcher conflates exactly these two.
+    expect(lockedVersionsFor(LOCK_TEXT_MULTI, "@catalyst-cloud/sdk").versions).toEqual(["0.7.0", "0.8.2"]);
+  });
+
+  test("an absent key or an underivable one is INCONCLUSIVE, never 'no drift'", () => {
+    expect(lockedVersionForKey(LOCK_TEXT_MULTI, "other/@catalyst-cloud/sdk", "@catalyst-cloud/sdk").conclusive).toBe(false);
+    expect(lockedVersionForKey(LOCK_TEXT_MULTI, null, "@catalyst-cloud/sdk").reason).toMatch(/could not be associated/i);
+    expect(lockedVersionForKey("", "@catalyst-cloud/sdk", "@catalyst-cloud/sdk").conclusive).toBe(false);
+  });
+});
+
+describe("evaluateDepSkew — installed-vs-locked matches the package to ITS OWN lock entry", () => {
+  test("A STALE ROOT INSTALL IS NOT EXCUSED BY A NESTED RESOLUTION OF THE SAME VERSION", () => {
+    // Root locks 0.8.2, a nested copy locks 0.7.0, the ROOT install is at 0.7.0. The
+    // any-occurrence matcher reports ok on the strength of the nested entry — precisely the
+    // shadowed/partial install this link exists to detect.
+    const files = fs({ [LOCK]: LOCK_TEXT_MULTI });
+    const args = evalDeps(files);
+    files[SDK_PKG] = JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.7.0" });
+    const v = linkOf(evaluateDepSkew(args), "installed-vs-locked");
+    expect(v.status, "0.7.0 at the ROOT is skew even though 0.7.0 is locked for a NESTED key").toBe("skew");
+    expect(v.detail).toContain("installed 0.7.0");
+    expect(v.detail).toContain("0.8.2");
+    expect(v.detail, "the detail must name the install location that was compared").toContain('"@catalyst-cloud/sdk"');
+  });
+
+  test("POSITIVE CONTROL — the SAME multi-version lockfile reports ok when the root install matches the root entry", () => {
+    // Without this, the assertion above would also be satisfied by a comparator that had
+    // simply started reporting skew for everything.
+    expect(linkOf(evaluateDepSkew(evalDeps(fs({ [LOCK]: LOCK_TEXT_MULTI }))), "installed-vs-locked").status).toBe("ok");
+  });
+
+  test("an install path that cannot be associated with a lock entry is INCONCLUSIVE, and NAMES the elsewhere-versions without accepting them", () => {
+    const files = fs({ [LOCK]: LOCK_TEXT_MULTI });
+    const args = evalDeps(files);
+    // A workspace-linked package: real on disk, outside node_modules, so its bun key is the
+    // workspace's name and no path can supply it.
+    const outside = `${ROOT}/packages/sdk/package.json`;
+    files[outside] = JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.7.0" });
+    args.breadcrumb = { ...args.breadcrumb, packages: args.breadcrumb.packages.map((p) => ({ ...p, packageJsonPath: outside })) };
+    const v = linkOf(evaluateDepSkew(args), "installed-vs-locked");
+    expect(v.status, "an unassociable path must not silently match some other resolution").toBe("inconclusive");
+    expect(v.detail).toMatch(/could not be associated/i);
+    expect(v.detail).toMatch(/locked elsewhere at 0\.7\.0, 0\.8\.2/);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
@@ -1,0 +1,146 @@
+// doctor-cloud-sync-skew.test.mjs — CTL-1659. Tests checkCloudSyncSkew() in doctor.mjs:
+// the on-demand half of "a dependency fix that lands on main should reach running daemons".
+//
+// The load-bearing invariants, in the order they matter:
+//   1. it can NEVER report PASS on absent or stale input (a check that cannot fail is
+//      not evidence — the whole reason `restart_needed` went unnoticed for weeks);
+//   2. it NEVER emits a FAIL record — it sits in the advisory checkCloudSync family,
+//      whose FAIL count gates catalyst-join activation;
+//   3. every deps is injected, so this suite touches no fs/ps/launchctl.
+// Run: cd plugins/dev/scripts/execution-core && bun test doctor-cloud-sync-skew
+import { describe, test, expect } from "bun:test";
+import { checkCloudSyncSkew } from "../doctor.mjs";
+
+const ROOT = "/opt/plugin-source";
+const LOCK = `${ROOT}/bun.lock`;
+const SDK_PKG = `${ROOT}/node_modules/@catalyst-cloud/sdk/package.json`;
+const LOCK_TEXT = `{
+  "packages": {
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", {}, "sha512-aaa=="],
+  }
+}`;
+// The digest the writer would have recorded at boot for LOCK_TEXT above.
+const BOOT_LOCK_HASH = "sha256:" + new Bun.CryptoHasher("sha256").update(LOCK_TEXT).digest("hex");
+
+function breadcrumb(over = {}) {
+  return {
+    ts: 1_800_000_000_000,
+    pid: 4242,
+    root: ROOT,
+    lockPath: LOCK,
+    lockHash: BOOT_LOCK_HASH,
+    degraded: false,
+    degradedReasons: [],
+    packages: [
+      {
+        id: "@catalyst-cloud/sdk",
+        specifier: "@catalyst-cloud/sdk/node",
+        resolvedPath: `${ROOT}/node_modules/@catalyst-cloud/sdk/dist/node.js`,
+        packageJsonPath: SDK_PKG,
+        version: "0.8.2",
+        entryHash: "sha256:deadbeef",
+      },
+    ],
+    ...over,
+  };
+}
+
+function deps(over = {}) {
+  const files = {
+    [LOCK]: LOCK_TEXT,
+    [SDK_PKG]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.8.2" }),
+    ...(over.files ?? {}),
+  };
+  delete over.files;
+  return {
+    agentInstalled: () => true,
+    processAlive: () => true,
+    depsPath: "/tmp/cloud-sync.deps.json",
+    readBreadcrumb: () => breadcrumb(),
+    readText: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return files[p];
+    },
+    readJson: (p) => {
+      if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+      return JSON.parse(files[p]);
+    },
+    processCommandForPid: (pid) => (pid === 4242 ? "bun /opt/plugin-source/plugins/dev/scripts/execution-core/cloud-sync.mjs" : null),
+    ...over,
+  };
+}
+
+const one = (recs) => { expect(recs).toHaveLength(1); return recs[0]; };
+const noFail = (recs) => recs.every((r) => r.status !== "fail");
+
+describe("checkCloudSyncSkew", () => {
+  test("healthy: boot record matches the current lockfile and the installed version → PASS", () => {
+    const r = one(checkCloudSyncSkew(deps()));
+    expect(r.name).toBe("cloud-sync-skew");
+    expect(r.status).toBe("pass");
+  });
+
+  test("THE INCIDENT: the lockfile changed after the writer booted → WARN naming the restart", () => {
+    const r = one(checkCloudSyncSkew(deps({ files: { [LOCK]: LOCK_TEXT.replace("0.8.2", "0.8.3") } })));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/lockfile|loaded/i);
+    expect(r.detail).toMatch(/restart|kickstart/i);
+  });
+
+  test("installed-vs-locked drift NAMES the package and BOTH versions (the ticket's alert contract)", () => {
+    const r = one(
+      checkCloudSyncSkew(deps({ files: { [SDK_PKG]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.7.0" }) } })),
+    );
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("@catalyst-cloud/sdk");
+    expect(r.detail).toContain("0.7.0");
+    expect(r.detail).toContain("0.8.2");
+  });
+
+  test("POSITIVE CONTROL — absent boot record can NEVER read as healthy", () => {
+    const r = one(checkCloudSyncSkew(deps({ readBreadcrumb: () => null })));
+    expect(r.status).toBe("warn");
+    expect(r.status).not.toBe("pass");
+    expect(r.detail).toMatch(/unknown|no boot record|absent/i);
+  });
+
+  test("POSITIVE CONTROL — a STALE boot record (pid is not the live writer) can never read as healthy", () => {
+    const dead = one(checkCloudSyncSkew(deps({ processCommandForPid: () => null })));
+    expect(dead.status).toBe("warn");
+    const recycled = one(checkCloudSyncSkew(deps({ processCommandForPid: () => "/usr/bin/vim notes.txt" })));
+    expect(recycled.status).toBe("warn");
+    // Control: the SAME check DOES return pass when the pid genuinely names the writer.
+    expect(one(checkCloudSyncSkew(deps())).status).toBe("pass");
+  });
+
+  test("a degraded boot record (a dep it could not resolve) is surfaced, never silently passed", () => {
+    const r = one(
+      checkCloudSyncSkew(deps({ readBreadcrumb: () => breadcrumb({ degraded: true, degradedReasons: ["@catalyst-cloud/sdk: Cannot find module"] }) })),
+    );
+    expect(r.status).toBe("warn");
+    expect(r.detail).toMatch(/degraded|resolve/i);
+  });
+
+  test("writer not installed → single INFO (nothing is loaded, so nothing can be skewed)", () => {
+    const r = one(checkCloudSyncSkew(deps({ agentInstalled: () => false, readBreadcrumb: () => null })));
+    expect(r.status).toBe("info");
+  });
+
+  test("NEVER FAILs — every branch stays advisory (the catalyst-join gate is the FAIL count)", () => {
+    const branches = [
+      deps(),
+      deps({ readBreadcrumb: () => null }),
+      deps({ processCommandForPid: () => null }),
+      deps({ agentInstalled: () => false }),
+      deps({ files: { [LOCK]: "corrupt" } }),
+      deps({ readText: () => { throw new Error("EIO"); } }),
+      deps({ readBreadcrumb: () => { throw new Error("boom"); } }),
+    ];
+    for (const d of branches) expect(noFail(checkCloudSyncSkew(d))).toBe(true);
+  });
+
+  test("a throwing dependency degrades to WARN instead of crashing the whole doctor run", () => {
+    const r = one(checkCloudSyncSkew(deps({ readBreadcrumb: () => { throw new Error("boom"); } })));
+    expect(r.status).toBe("warn");
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
@@ -14,13 +14,22 @@ import { checkCloudSyncSkew } from "../doctor.mjs";
 const ROOT = "/opt/plugin-source";
 const LOCK = `${ROOT}/bun.lock`;
 const SDK_PKG = `${ROOT}/node_modules/@catalyst-cloud/sdk/package.json`;
+const SDK_ENTRY = `${ROOT}/node_modules/@catalyst-cloud/sdk/dist/node.js`;
+const SDK_ENTRY_BYTES = "// sdk entry bytes v1\n";
 const LOCK_TEXT = `{
   "packages": {
     "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", {}, "sha512-aaa=="],
   }
 }`;
+const sha256 = (s) => "sha256:" + new Bun.CryptoHasher("sha256").update(s).digest("hex");
 // The digest the writer would have recorded at boot for LOCK_TEXT above.
-const BOOT_LOCK_HASH = "sha256:" + new Bun.CryptoHasher("sha256").update(LOCK_TEXT).digest("hex");
+const BOOT_LOCK_HASH = sha256(LOCK_TEXT);
+// …and for the ENTRY FILE it actually loaded. This fixture used to carry a placeholder
+// `entryHash: "sha256:deadbeef"` with no corresponding file on the synthetic disk, which
+// was harmless only because NO comparator read `entryHash` back — the round-2 defect. Now
+// that the loaded-vs-locked link compares it, the healthy fixture has to supply the real
+// bytes; a fixture that cannot present the discriminator cannot exercise the check.
+const BOOT_ENTRY_HASH = sha256(SDK_ENTRY_BYTES);
 
 function breadcrumb(over = {}) {
   return {
@@ -35,10 +44,10 @@ function breadcrumb(over = {}) {
       {
         id: "@catalyst-cloud/sdk",
         specifier: "@catalyst-cloud/sdk/node",
-        resolvedPath: `${ROOT}/node_modules/@catalyst-cloud/sdk/dist/node.js`,
+        resolvedPath: SDK_ENTRY,
         packageJsonPath: SDK_PKG,
         version: "0.8.2",
-        entryHash: "sha256:deadbeef",
+        entryHash: BOOT_ENTRY_HASH,
       },
     ],
     ...over,
@@ -49,6 +58,7 @@ function deps(over = {}) {
   const files = {
     [LOCK]: LOCK_TEXT,
     [SDK_PKG]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.8.2" }),
+    [SDK_ENTRY]: SDK_ENTRY_BYTES,
     ...(over.files ?? {}),
   };
   delete over.files;

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -1,0 +1,480 @@
+// cloud-sync-deps.mjs — CTL-1659. The loaded-dependency identity record for the
+// supervised catalyst-cloud-sync writer, plus the three-link skew comparator doctor
+// grades it with and the durable restart budget that bounds the self-heal loop.
+//
+// THE DEFECT. `plugin-refresh` emits `restart_needed` on daemon skew and deliberately
+// stops there ("restart stays a gated OPERATOR action — never automated here"), and the
+// broker's `decideStackReload` hard-codes exactly three components (monitor,
+// execution-core, otel-forward) — cloud-sync is in NEITHER. So on 2026-08-04 a dependency
+// fix landed on main, the updater pulled it, the install succeeded, and the RUNNING
+// cloud-sync daemon kept serving the OLD modules indefinitely: the CTC-328
+// delete-corruption guard sat correctly installed on both minis while the writers ran
+// unguarded, until a human kickstarted them. Nothing alerted. This is the same class as
+// CTL-1506's missing otel-forward entry — "a merged fix that never restarts is
+// indistinguishable from no fix" — one link further down the chain.
+//
+// WHY THE EVIDENCE IS A HASH OF WHAT WAS RESOLVED, NOT A CLAIM ABOUT IT. The trap this
+// module exists to avoid is the one that made the incident invisible in the first place:
+// `applied == installed` passes vacuously because BOTH go stale together. The
+// loaded-vs-locked analogue is a daemon that writes "I loaded what the lockfile said" at
+// boot — that re-manufactures the same lie (the CTL-1646 shadowed-install class). So the
+// boot record carries what the process ACTUALLY resolved: `createRequire(...).resolve()`'s
+// absolute path, the version read from THAT path's package.json, a digest of the resolved
+// entry file, the root the module was served from, and a SHA-256 of that root's lockfile.
+// Versions alone are permanently non-discriminating — a repointed tarball, a workspace
+// link, or a git dep ships new bytes under the same semver — so the VERDICT keys on the
+// digest and the versions ride along only because the alert has to name them.
+//
+// EVERY READER IS FAIL-CLOSED. A missing/unreadable/malformed input yields
+// `inconclusive`, never `ok`: an absent breadcrumb, a dead-or-recycled pid, an
+// unreadable lockfile, and an EMPTY package list ([].every(p) === true) must each be
+// unable to produce a clean bill of health. That is the property `restart_needed` lacked.
+//
+// Zero imports beyond node builtins (crypto/fs/path), so `catalyst doctor`'s bare-Node
+// runtime loads it without dragging in the bun:sqlite graph — the same constraint
+// doctor.mjs's other leaf imports honor.
+
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// The packages whose loaded identity is recorded. A REGISTRY rather than an inline
+// literal so a second critical dep is a one-line addition — and so `captureLoadedDeps`
+// can assert it is non-empty (an empty list would make every comparison vacuously clean,
+// which is the exact defect shape this module is built against).
+//
+// `specifier` is what cloud-sync.mjs actually imports (`@catalyst-cloud/sdk/node`), so
+// the resolve below follows the SAME export map the running daemon followed; `id` is the
+// package name used to look the resolution up in the lockfile.
+export const CRITICAL_DEPS = [
+  { id: "@catalyst-cloud/sdk", specifier: "@catalyst-cloud/sdk/node" },
+];
+
+// The discriminator stamped into the CTL-1508 self-heal breadcrumb when the writer exits
+// for dep-skew rather than for a stall. Both paths share one exit mechanism (breadcrumb +
+// bounded `exitAfterClose(exitCode: 1)`) — deliberately, so health-responder.sh's
+// `no-respawn` net covers this exit too with no change — and this field is what keeps the
+// two separable in an RCA.
+export const DEP_SKEW_REASON = "dep-skew";
+
+// The dep-skew alert name carried on the heartbeat line (and the field a Grafana rule
+// keys on). Shadow-with-nobody-watching is the failure being fixed, so the skew fields
+// ride the daemon's existing stderr→cloud-sync.log→Alloy→Loki path from day one.
+export const DEP_SKEW_ALERT = "replica_dep_skew";
+
+// ─── hashing + root discovery ───────────────────────────────────────────────
+
+// sha256File — content digest of a file, prefixed with the algorithm so a future
+// algorithm change is visible in the record rather than silently comparing apples to
+// pears. Unreadable → null (NEVER a fabricated digest a comparison could pass on: the
+// comparators treat a null on either side as inconclusive).
+export function sha256File(path, { readText = (p) => readFileSync(p, "utf8") } = {}) {
+  try {
+    return `sha256:${createHash("sha256").update(readText(path)).digest("hex")}`;
+  } catch {
+    return null;
+  }
+}
+
+// findLockRoot — walk up from `startDir` to the first directory holding a `bun.lock`.
+// This is the root that ACTUALLY served the module, which matters because the daemons run
+// from ~/catalyst/plugin-source, not from an operator's dev checkout: a doctor that
+// compared against its own cwd's lockfile would be comparing the wrong root entirely.
+// Returns null (not a guessed root) when there is no lockfile above the start.
+export function findLockRoot(startDir, { fileExists = existsSync } = {}) {
+  let dir = startDir;
+  while (typeof dir === "string" && dir.length > 0) {
+    const lockPath = join(dir, "bun.lock");
+    try {
+      if (fileExists(lockPath)) return { root: dir, lockPath };
+    } catch {
+      return null; // an exploding fileExists must not spin the walk
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null; // reached the filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+// findPackageJson — walk up from a resolved entry file to the package.json that OWNS it
+// (name === id). Walking to the first package.json is not enough: a package can ship a
+// nested `dist/package.json` (`{"type":"module"}` is a common one), and reading a version
+// out of that would silently record `undefined`.
+function findPackageJson(startDir, id, { fileExists, readJson }) {
+  let dir = startDir;
+  while (typeof dir === "string" && dir.length > 0) {
+    const candidate = join(dir, "package.json");
+    try {
+      if (fileExists(candidate)) {
+        const parsed = readJson(candidate);
+        if (parsed && parsed.name === id) return { path: candidate, version: parsed.version ?? null };
+      }
+    } catch {
+      /* unreadable/malformed → keep walking; a null result is handled by the caller */
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+  return null;
+}
+
+// ─── boot capture ───────────────────────────────────────────────────────────
+
+// captureLoadedDeps — build the boot record. Called ONCE, right after the writer reaches
+// 'live', from the process whose module identity it describes; every failure is recorded
+// as a named `degradedReason` and flips `degraded` rather than being swallowed, so a
+// record that could not measure what it claims to measure can never read as clean.
+export function captureLoadedDeps({
+  startDir,
+  deps = CRITICAL_DEPS,
+  resolveModule,
+  fileExists = existsSync,
+  readText = (p) => readFileSync(p, "utf8"),
+  readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
+  pid = process.pid,
+  now = Date.now,
+} = {}) {
+  const degradedReasons = [];
+  const packages = [];
+
+  // The vacuous-loop guard, stated first because everything below iterates this list:
+  // a zero-length registry would make every downstream comparison trivially "clean".
+  if (!Array.isArray(deps) || deps.length === 0) {
+    degradedReasons.push("no critical dependencies configured — nothing to compare");
+  }
+
+  for (const dep of Array.isArray(deps) ? deps : []) {
+    const id = dep?.id;
+    const specifier = dep?.specifier ?? id;
+    let resolvedPath = null;
+    try {
+      resolvedPath = resolveModule(specifier);
+    } catch (err) {
+      degradedReasons.push(`${id}: unresolvable (${err?.message ?? String(err)})`);
+      continue;
+    }
+    if (typeof resolvedPath !== "string" || resolvedPath.length === 0) {
+      degradedReasons.push(`${id}: resolver returned no path`);
+      continue;
+    }
+    const owner = findPackageJson(dirname(resolvedPath), id, { fileExists, readJson });
+    if (!owner) degradedReasons.push(`${id}: no owning package.json above ${resolvedPath}`);
+    const entryHash = sha256File(resolvedPath, { readText });
+    if (entryHash === null) degradedReasons.push(`${id}: entry file unreadable (${resolvedPath})`);
+    packages.push({
+      id,
+      specifier,
+      resolvedPath,
+      packageJsonPath: owner?.path ?? null,
+      version: owner?.version ?? null,
+      entryHash,
+    });
+  }
+
+  // The root is derived from the FIRST successfully resolved module — the root that
+  // actually served the bytes — and only falls back to the daemon's own directory when
+  // nothing resolved at all (in which case the record is already degraded).
+  const walkFrom = packages.find((p) => p.resolvedPath)?.resolvedPath;
+  const found =
+    (walkFrom ? findLockRoot(dirname(walkFrom), { fileExists }) : null) ??
+    (startDir ? findLockRoot(startDir, { fileExists }) : null);
+  if (!found) degradedReasons.push("no bun.lock found above the loaded modules — cannot anchor a lockfile digest");
+  const lockHash = found ? sha256File(found.lockPath, { readText }) : null;
+  if (found && lockHash === null) degradedReasons.push(`lockfile unreadable (${found.lockPath})`);
+
+  return {
+    ts: typeof now === "function" ? now() : now,
+    pid,
+    root: found?.root ?? null,
+    lockPath: found?.lockPath ?? null,
+    lockHash,
+    degraded: degradedReasons.length > 0,
+    degradedReasons,
+    packages,
+  };
+}
+
+// ─── breadcrumb io (atomic; fail-open) ──────────────────────────────────────
+// Read from ANOTHER process (doctor), so the write is tmp+rename — the same
+// writeSelfHealBreadcrumb idiom — and a torn read is structurally impossible.
+
+export function writeDepsBreadcrumb(path, record, { writeFile = writeFileSync, rename = renameSync } = {}) {
+  try {
+    const tmp = `${path}.tmp`;
+    writeFile(tmp, JSON.stringify(record));
+    rename(tmp, path);
+    return true;
+  } catch {
+    return false; // fail-open — recording module identity must never block the writer's boot
+  }
+}
+
+export function readDepsBreadcrumb(path, { readText = (p) => readFileSync(p, "utf8") } = {}) {
+  try {
+    const parsed = JSON.parse(readText(path));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null; // absent (the pre-rollout normal case) or malformed — both read as "unknown"
+  }
+}
+
+// ─── lockfile resolution lookup ─────────────────────────────────────────────
+
+const escapeRe = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// lockedVersionsFor — every version bun's lockfile resolves for `id`, hoisted or nested.
+// bun.lock is JSONC (trailing commas), so `JSON.parse` is not available; the `packages`
+// map's entry shape is stable and unambiguous instead:
+//     "<key>": ["<name>@<version>", "<resolution>", {…}, "<integrity>"]
+// where `<key>` is the package id for a hoisted resolution and `<parent>/<id>` for a
+// nested one. Anchoring on BOTH the key's final segment and the value's `name@` prefix is
+// what keeps this a structured match rather than the substring grep that has produced
+// false clean results here before.
+//
+// Returns a three-valued verdict: a package with no entry is INCONCLUSIVE ("I could not
+// look"), never an implicit "no skew".
+export function lockedVersionsFor(lockText, id) {
+  if (typeof lockText !== "string" || lockText.length === 0) {
+    return { conclusive: false, versions: [], reason: "lockfile text unavailable" };
+  }
+  const e = escapeRe(id);
+  const re = new RegExp(`"(?:[^"]*/)?${e}"\\s*:\\s*\\[\\s*"${e}@([^"]+)"`, "g");
+  const versions = [...new Set([...lockText.matchAll(re)].map((m) => m[1]))].sort();
+  if (versions.length === 0) {
+    return { conclusive: false, versions: [], reason: `${id} not found in the lockfile's packages map` };
+  }
+  return { conclusive: true, versions, reason: null };
+}
+
+// ─── the three-link comparator ──────────────────────────────────────────────
+//
+// Each link answers a question the others cannot, and each fails closed:
+//   record-identity      — does the boot record describe the process running RIGHT NOW?
+//                          A dead or RECYCLED pid makes links 2–4 stale evidence, so an
+//                          identity failure short-circuits them to inconclusive rather
+//                          than letting a fresh-looking file grade the wrong process.
+//   boot-record-complete — did the capture measure everything it claims to?
+//   loaded-vs-locked     — has the root lockfile changed since the daemon loaded its
+//                          modules? THIS is the CTL-1659 incident: installed-but-unloaded.
+//   installed-vs-locked  — does node_modules on disk match the lockfile's resolution? This
+//                          catches what a restart does NOT fix (the partial install from
+//                          the 180s SIGKILL ceiling, and the CTL-1646 shadowed install).
+
+export const SKEW_LINKS = ["record-identity", "boot-record-complete", "loaded-vs-locked", "installed-vs-locked"];
+
+const ok = (link, detail) => ({ link, status: "ok", detail });
+const skew = (link, detail) => ({ link, status: "skew", detail });
+const unknown = (link, detail) => ({ link, status: "inconclusive", detail });
+
+function summarize(verdicts) {
+  return {
+    verdicts,
+    skew: verdicts.some((v) => v.status === "skew"),
+    inconclusive: verdicts.some((v) => v.status === "inconclusive"),
+  };
+}
+
+export function evaluateDepSkew({
+  breadcrumb = null,
+  readText = (p) => readFileSync(p, "utf8"),
+  readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
+  processCommandForPid = () => null,
+  writerPattern = "cloud-sync.mjs",
+} = {}) {
+  if (!breadcrumb || typeof breadcrumb !== "object") {
+    return summarize(SKEW_LINKS.map((l) => unknown(l, "no boot record — the writer has not booted since dep-skew capture shipped, or the write failed")));
+  }
+
+  // Link 1 — identity, evaluated FIRST because it licenses the other three.
+  const pid = Number(breadcrumb.pid);
+  let cmd = null;
+  try {
+    cmd = Number.isInteger(pid) && pid > 0 ? processCommandForPid(pid) : null;
+  } catch {
+    cmd = null;
+  }
+  const identityOk = typeof cmd === "string" && cmd.includes(writerPattern);
+  if (!identityOk) {
+    const why =
+      !Number.isInteger(pid) || pid <= 0
+        ? "boot record carries no usable pid"
+        : cmd == null
+          ? `boot record pid ${pid} is not running`
+          : `boot record pid ${pid} has been recycled onto another program`;
+    // Stale evidence: report the remaining links as inconclusive rather than grading a
+    // fresh-looking file against the wrong process (fail-closed, the recycled-pid
+    // discipline catalyst-monitor.sh already applies to its pid files).
+    return summarize([
+      unknown("record-identity", `${why} — the boot record is stale evidence; skew is UNKNOWN`),
+      ...SKEW_LINKS.slice(1).map((l) => unknown(l, "not evaluated — the boot record does not describe the live writer")),
+    ]);
+  }
+  const verdicts = [ok("record-identity", `boot record describes the live writer (pid ${pid})`)];
+
+  // Link 2 — completeness of the capture itself.
+  verdicts.push(
+    breadcrumb.degraded
+      ? unknown("boot-record-complete", `boot record is degraded: ${(breadcrumb.degradedReasons ?? []).join("; ") || "reason not recorded"}`)
+      : ok("boot-record-complete", `${(breadcrumb.packages ?? []).length} package(s) recorded at boot`),
+  );
+
+  // Link 3 — loaded vs locked (the incident).
+  const lockPath = breadcrumb.lockPath;
+  const bootLockHash = breadcrumb.lockHash;
+  let lockText = null;
+  try {
+    lockText = typeof lockPath === "string" && lockPath.length > 0 ? readText(lockPath) : null;
+  } catch {
+    lockText = null;
+  }
+  const currentLockHash = lockText === null ? null : sha256File(lockPath, { readText: () => lockText });
+  if (typeof bootLockHash !== "string" || bootLockHash.length === 0) {
+    verdicts.push(unknown("loaded-vs-locked", "boot record carries no lockfile digest — nothing to compare against"));
+  } else if (currentLockHash === null) {
+    verdicts.push(unknown("loaded-vs-locked", `lockfile ${lockPath} is unreadable now — skew is UNKNOWN, not absent`));
+  } else if (currentLockHash !== bootLockHash) {
+    verdicts.push(
+      skew(
+        "loaded-vs-locked",
+        `the root lockfile changed since the writer loaded its modules (boot ${short(bootLockHash)} → now ${short(currentLockHash)}, ${lockPath}) — ` +
+          "the daemon is serving pre-change modules; restart it (launchctl kickstart -k) to load the installed fix",
+      ),
+    );
+  } else {
+    verdicts.push(ok("loaded-vs-locked", `loaded modules match the current lockfile (${short(bootLockHash)})`));
+  }
+
+  // Link 4 — installed vs locked (what a restart does NOT fix).
+  const packages = Array.isArray(breadcrumb.packages) ? breadcrumb.packages : [];
+  if (packages.length === 0) {
+    verdicts.push(unknown("installed-vs-locked", "no package identities recorded at boot — zero comparisons is not a clean result"));
+  } else {
+    const drifts = [];
+    const unknowns = [];
+    for (const p of packages) {
+      let installed = null;
+      try {
+        installed = typeof p.packageJsonPath === "string" ? readJson(p.packageJsonPath)?.version ?? null : null;
+      } catch {
+        installed = null;
+      }
+      if (installed == null) {
+        unknowns.push(`${p.id}: installed package.json unreadable (${p.packageJsonPath ?? "path not recorded"})`);
+        continue;
+      }
+      const locked = lockText === null ? { conclusive: false, versions: [], reason: "lockfile unreadable" } : lockedVersionsFor(lockText, p.id);
+      if (!locked.conclusive) {
+        unknowns.push(`${p.id}: ${locked.reason}`);
+        continue;
+      }
+      if (!locked.versions.includes(String(installed))) {
+        drifts.push(`${p.id} installed ${installed}, lockfile resolves ${locked.versions.join(", ")}`);
+      }
+    }
+    if (drifts.length > 0) {
+      verdicts.push(
+        skew(
+          "installed-vs-locked",
+          `node_modules does not match the lockfile: ${drifts.join("; ")} — a partial or shadowed install; re-run 'bun install --frozen-lockfile' (a restart alone will NOT fix this)`,
+        ),
+      );
+    } else if (unknowns.length > 0) {
+      verdicts.push(unknown("installed-vs-locked", `could not compare: ${unknowns.join("; ")}`));
+    } else {
+      verdicts.push(ok("installed-vs-locked", `${packages.length} package(s) match the lockfile's resolution`));
+    }
+  }
+
+  return summarize(verdicts);
+}
+
+// short — the first 12 hex chars of a digest, enough to distinguish two lockfiles in a
+// log line without making it unreadable. NAME-only data; a lockfile digest is not secret.
+function short(hash) {
+  return typeof hash === "string" ? hash.replace(/^sha256:/, "").slice(0, 12) : String(hash);
+}
+export { short as shortDigest };
+
+// ─── the durable restart budget (loop terminator) ───────────────────────────
+//
+// The self-heal predicate is self-clearing by construction — a relaunch re-captures the
+// CURRENT lockfile digest, so `boot === current` again on the next boot. The budget exists
+// for the pathological case that self-clearing cannot cover: a lockfile being rewritten
+// continuously (a broken install loop), where every relaunch immediately re-observes a
+// fresh mismatch. It is DURABLE (a file) rather than in-process because the whole point of
+// the mechanism is that the process exits — an in-memory latch would reset every restart,
+// which is precisely how "cleanup is load-bearing" fails.
+//
+// Same shape as health-responder.sh's attempt-cap markers: a window anchor plus a count,
+// where the passage of time re-arms the budget for free.
+
+export function readRestartLedger(path, { readText = (p) => readFileSync(p, "utf8") } = {}) {
+  try {
+    const parsed = JSON.parse(readText(path));
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null; // absent = never spent = full budget (the normal case)
+  }
+}
+
+// classifyRestartBudget — may this process spend a dep-skew restart? FAIL-CLOSED on a
+// malformed or future-dated ledger: a corrupt-but-numeric or clock-skewed `ts` must not
+// read as free budget (the same future-timestamp trap health-responder.sh hit, where a
+// negative age was permanently "within grace").
+export function classifyRestartBudget({ ledger = null, now = Date.now(), windowMs = 21_600_000, maxRestarts = 1 } = {}) {
+  if (ledger == null) return { allowed: true, count: 0, reason: null };
+  if (typeof ledger !== "object") return { allowed: false, count: null, reason: "restart budget ledger is malformed — declining the restart (fail-closed)" };
+  const ts = Number(ledger.ts);
+  if (!Number.isFinite(ts) || ts > now) {
+    return { allowed: false, count: null, reason: "restart budget ledger has no usable timestamp (malformed or future-dated) — declining the restart (fail-closed)" };
+  }
+  if (now - ts >= windowMs) return { allowed: true, count: 0, reason: null };
+  const count = Number(ledger.count) || 0;
+  if (count >= maxRestarts) {
+    return {
+      allowed: false,
+      count,
+      reason: `dep-skew restart budget exhausted (${count}/${maxRestarts} in the last ${Math.round(windowMs / 60_000)}m) — holding; the skew is surfaced by 'catalyst doctor' instead`,
+    };
+  }
+  return { allowed: true, count, reason: null };
+}
+
+// recordRestartAttempt — spend one unit of budget, atomically, BEFORE exiting. Returns the
+// written ledger, or NULL when the write failed. Null is deliberately fail-CLOSED at the
+// call site (the caller declines the restart): if the ledger is not durable the loop has
+// no terminator, and declining a restart is never destructive — a skewed-but-running
+// daemon is exactly today's behavior, which doctor now names.
+export function recordRestartAttempt(path, { ledger = null, now = Date.now(), windowMs = 21_600_000 } = {}, { writeFile = writeFileSync, rename = renameSync } = {}) {
+  const ts = Number(ledger?.ts);
+  const withinWindow = Number.isFinite(ts) && ts <= now && now - ts < windowMs;
+  const next = withinWindow ? { ts, count: (Number(ledger?.count) || 0) + 1 } : { ts: now, count: 1 };
+  try {
+    const tmp = `${path}.tmp`;
+    writeFile(tmp, JSON.stringify(next));
+    rename(tmp, path);
+    return next;
+  } catch {
+    return null; // not durable → the caller must NOT spend the restart
+  }
+}
+
+// ─── heartbeat fields ───────────────────────────────────────────────────────
+
+// depSkewFields — the skew observation, shaped for the writer's existing structured
+// heartbeat line (stderr → cloud-sync.log → Alloy → Loki, service_name=catalyst.cloud-sync).
+// Emitted from day one and in every mode, because "shadow with nobody watching" is the
+// exact failure this ticket exists to remove: `restart_needed` was already a field in an
+// event nobody watched. NAME-only data — digests and a mode, never a secret.
+export function depSkewFields({ mode = null, bootLockHash = null, currentLockHash = null, skewed = null, sustained = null, wouldRestart = null } = {}) {
+  return {
+    "catalyst.cloud_sync.deps.mode": mode ?? null,
+    "catalyst.cloud_sync.deps.skewed": skewed === null ? null : Boolean(skewed),
+    "catalyst.cloud_sync.deps.sustained": sustained === null ? null : Boolean(sustained),
+    "catalyst.cloud_sync.deps.would_restart": wouldRestart === null ? null : Boolean(wouldRestart),
+    "catalyst.cloud_sync.deps.boot_lock_hash": bootLockHash ? short(bootLockHash) : null,
+    "catalyst.cloud_sync.deps.current_lock_hash": currentLockHash ? short(currentLockHash) : null,
+  };
+}

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -478,3 +478,82 @@ export function depSkewFields({ mode = null, bootLockHash = null, currentLockHas
     "catalyst.cloud_sync.deps.current_lock_hash": currentLockHash ? short(currentLockHash) : null,
   };
 }
+
+// ─── the unified-log event (AC1: "the restart is visible in the event log") ──
+//
+// The heartbeat fields above ride stderr → cloud-sync.log → Alloy → Loki, which is a LOG
+// stream: queryable, but not the same surface `catalyst-events wait-for`, the broker, the
+// HUD, and orch-monitor read. AC1's second clause asks for the RESTART itself on
+// `~/catalyst/events/YYYY-MM.jsonl`, and the capability was already present in cloud-sync.mjs
+// and simply unused here — `emitWriterIdleEvent` writes a v2 envelope to that very file for
+// the tokenless-writer case. So the dep-skew self-heal gets the same treatment, for the same
+// reason the ticket exists: a restart nobody can observe is indistinguishable from no
+// restart, which is exactly how `restart_needed` failed.
+//
+// TWO names rather than one name with an action attribute, because the alert that matters is
+// "a writer restarted itself" and a Grafana/LogQL rule must be able to select it WITHOUT
+// filtering on a payload field (otel-forward strips `body.payload` off-machine — everything
+// load-bearing here therefore rides `attributes`):
+//   • `…dep_skew_restart`       — the writer IS exiting now; the budget was spent and the
+//                                 relaunch is launchd's. Emitted at most once per process.
+//   • `…dep_skew_would_restart` — sustained skew that did NOT act: shadow mode (the shipping
+//                                 default), an exhausted budget, or a ledger that could not be
+//                                 persisted. `reason` names which.
+export const DEP_SKEW_RESTART_EVENT = "catalyst.replica.dep_skew_restart";
+export const DEP_SKEW_WOULD_RESTART_EVENT = "catalyst.replica.dep_skew_would_restart";
+
+// depSkewEventEnvelope — the v2 OTel envelope, built PURELY so the shape is unit-testable
+// without running the script-shaped writer. Everything non-deterministic (`ts`, the ids, the
+// resource) is injected by the caller exactly as `emitWriterIdleEvent` supplies its own —
+// which also keeps this module's zero-import property (node crypto/fs/path only), the one
+// `catalyst doctor`'s bare-Node runtime depends on.
+//
+// The digest attributes come from `depSkewFields`, NOT from a second hand-written copy, so
+// the event-log surface and the heartbeat line can never drift apart in what they name.
+export function depSkewEventEnvelope({
+  name,
+  host = null,
+  mode = null,
+  reason = null,
+  bootLockHash = null,
+  currentLockHash = null,
+  lockPath = null,
+  sustained = null,
+  wouldRestart = null,
+  restart = false,
+  ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+  id = null,
+  traceId = null,
+  spanId = null,
+  resource = null,
+} = {}) {
+  const acted = restart === true;
+  return {
+    ts,
+    id,
+    observedTs: ts,
+    // WARN, matching the pino line this rides beside: a dep-skew episode is actionable but
+    // not an outage — the writer is serving, just serving pre-change code.
+    severityText: "WARN",
+    severityNumber: 13,
+    traceId,
+    spanId,
+    resource,
+    attributes: {
+      "event.name": name,
+      "event.entity": "replica",
+      "event.action": acted ? "dep_skew_restart" : "dep_skew_would_restart",
+      "event.label": host,
+      host,
+      ...depSkewFields({ mode, bootLockHash, currentLockHash, skewed: true, sustained, wouldRestart }),
+      "catalyst.cloud_sync.deps.restart": acted,
+      "catalyst.cloud_sync.deps.lock_path": lockPath,
+      "catalyst.cloud_sync.deps.reason": reason,
+    },
+    body: {
+      message: acted
+        ? `cloud-sync: restarting to load the installed dependency fix — the root lockfile changed since this writer loaded its modules (${lockPath ?? "lockfile path not recorded"})`
+        : `cloud-sync: dependency skew detected, NOT restarting (mode=${mode ?? "?"}): ${reason ?? "held"}`,
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -248,6 +248,68 @@ export function lockedVersionsFor(lockText, id) {
   return { conclusive: true, versions, reason: null };
 }
 
+// lockKeyForPackageJsonPath — bun's `packages` map is keyed by the INSTALL LOCATION, not by
+// the bare package name: a hoisted resolution is keyed `<id>` and a nested one
+// `<parent>/<id>`, with deeper nesting chaining the parents (`a/b/x`; measured in this
+// repo's own bun.lock as `@babel/core/semver`, `@eslint/eslintrc/ajv`, …). That key is
+// precisely the association `lockedVersionsFor` throws away, and throwing it away is a
+// fail-open: `versions.includes(installed)` accepts ANY resolution anywhere in the file, so
+// a ROOT install stranded at 0.7.0 while the root entry locks 0.8.2 reports "ok" on the
+// strength of some unrelated NESTED 0.7.0 — hiding the shadowed/partial install that is the
+// entire reason the installed-vs-locked link exists.
+//
+// Derived STRUCTURALLY from the recorded package directory relative to the serving root:
+// every hop must be a literal `node_modules` segment followed by a package name (two path
+// segments when the name is scoped). Anything that does not fit that shape returns null —
+// a path outside the recorded root, or a workspace package linked in from outside
+// `node_modules` (whose bun key is the WORKSPACE's package name, which the path alone
+// cannot supply). The caller renders a null key as INCONCLUSIVE and never falls back to the
+// permissive any-occurrence match: "I could not associate it" must not read as "it matches".
+export function lockKeyForPackageJsonPath(root, packageJsonPath) {
+  if (typeof root !== "string" || root.length === 0) return null;
+  if (typeof packageJsonPath !== "string" || packageJsonPath.length === 0) return null;
+  const dir = dirname(packageJsonPath);
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  if (!dir.startsWith(prefix)) return null;
+  const segs = dir.slice(prefix.length).split("/").filter((s) => s.length > 0);
+  const chain = [];
+  let i = 0;
+  while (i < segs.length) {
+    if (segs[i] !== "node_modules") return null;
+    i += 1;
+    if (i >= segs.length) return null;
+    let name = segs[i];
+    i += 1;
+    if (name.startsWith("@")) {
+      if (i >= segs.length) return null; // a scope with no package after it is not a package dir
+      name = `${name}/${segs[i]}`;
+      i += 1;
+    }
+    chain.push(name);
+  }
+  return chain.length > 0 ? chain.join("/") : null;
+}
+
+// lockedVersionForKey — the ONE resolution bun records at a specific install location.
+// Anchored on the exact key AND the value's `name@` prefix (the same structured-match
+// discipline `lockedVersionsFor` uses, minus the `(?:[^"]*/)?` wildcard that made it accept
+// every nesting). Three-valued: a key with no entry is INCONCLUSIVE, never "no drift".
+export function lockedVersionForKey(lockText, key, id) {
+  if (typeof lockText !== "string" || lockText.length === 0) {
+    return { conclusive: false, version: null, reason: "lockfile text unavailable" };
+  }
+  if (typeof key !== "string" || key.length === 0) {
+    return {
+      conclusive: false,
+      version: null,
+      reason: "the installed path could not be associated with a lockfile install location (outside the serving root, or a workspace link)",
+    };
+  }
+  const m = new RegExp(`"${escapeRe(key)}"\\s*:\\s*\\[\\s*"${escapeRe(id)}@([^"]+)"`).exec(lockText);
+  if (!m) return { conclusive: false, version: null, reason: `no "${key}" entry in the lockfile's packages map` };
+  return { conclusive: true, version: m[1], reason: null };
+}
+
 // ─── the three-link comparator ──────────────────────────────────────────────
 //
 // Each link answers a question the others cannot, and each fails closed:
@@ -320,7 +382,27 @@ export function evaluateDepSkew({
       : ok("boot-record-complete", `${(breadcrumb.packages ?? []).length} package(s) recorded at boot`),
   );
 
-  // Link 3 — loaded vs locked (the incident).
+  const packages = Array.isArray(breadcrumb.packages) ? breadcrumb.packages : [];
+
+  // Link 3 — loaded vs locked (the incident). TWO independent digests, both required, and
+  // a drift in EITHER is skew:
+  //   (a) the ROOT LOCKFILE's digest — did the resolution graph change since boot?
+  //   (b) each package's ENTRY-FILE digest — did the bytes the process actually loaded
+  //       change on disk since boot?
+  //
+  // (b) is not redundant with (a). `captureLoadedDeps` records `entryHash` expressly as the
+  // discriminator — this module's own header says "the VERDICT keys on the digest and the
+  // versions ride along only because the alert has to name them" — and until now NO
+  // comparator read it back. A repointed mutable artifact, a `bun link`ed workspace output,
+  // or an in-place rebuild changes the bytes the running process holds while the lockfile
+  // TEXT and the package version stay byte-identical: (a) alone reports ok, doctor PASSes,
+  // and the writer never restarts although it is serving pre-change code. A field captured
+  // as the discriminator and never compared is "a check that cannot fail" — the same defect
+  // class as `restart_needed`, one level further in.
+  //
+  // Fail-closed on both halves: an unknown digest on either side is INCONCLUSIVE (never
+  // ok), and ZERO recorded packages is inconclusive too — a loop that never ran is not a
+  // clean bill of health ([].every(p) === true is the trap this file is built against).
   const lockPath = breadcrumb.lockPath;
   const bootLockHash = breadcrumb.lockHash;
   let lockText = null;
@@ -330,27 +412,57 @@ export function evaluateDepSkew({
     lockText = null;
   }
   const currentLockHash = lockText === null ? null : sha256File(lockPath, { readText: () => lockText });
+  const loadedDrifts = [];
+  const loadedUnknowns = [];
   if (typeof bootLockHash !== "string" || bootLockHash.length === 0) {
-    verdicts.push(unknown("loaded-vs-locked", "boot record carries no lockfile digest — nothing to compare against"));
+    loadedUnknowns.push("boot record carries no lockfile digest — nothing to compare against");
   } else if (currentLockHash === null) {
-    verdicts.push(unknown("loaded-vs-locked", `lockfile ${lockPath} is unreadable now — skew is UNKNOWN, not absent`));
+    loadedUnknowns.push(`lockfile ${lockPath} is unreadable now — skew is UNKNOWN, not absent`);
   } else if (currentLockHash !== bootLockHash) {
+    loadedDrifts.push(`the root lockfile changed since the writer loaded its modules (boot ${short(bootLockHash)} → now ${short(currentLockHash)}, ${lockPath})`);
+  }
+  if (packages.length === 0) {
+    loadedUnknowns.push("no package identities recorded at boot — zero entry-digest comparisons is not a clean result");
+  }
+  for (const p of packages) {
+    const id = p?.id ?? "(unnamed package)";
+    if (typeof p?.entryHash !== "string" || p.entryHash.length === 0) {
+      loadedUnknowns.push(`${id}: no entry digest recorded at boot — the loaded bytes cannot be compared`);
+      continue;
+    }
+    if (typeof p?.resolvedPath !== "string" || p.resolvedPath.length === 0) {
+      loadedUnknowns.push(`${id}: no resolved entry path recorded at boot`);
+      continue;
+    }
+    const currentEntryHash = sha256File(p.resolvedPath, { readText });
+    if (currentEntryHash === null) {
+      loadedUnknowns.push(`${id}: entry file ${p.resolvedPath} is unreadable now — the loaded bytes are UNKNOWN, not unchanged`);
+      continue;
+    }
+    if (currentEntryHash !== p.entryHash) {
+      loadedDrifts.push(`${id} entry bytes changed on disk since the writer loaded them (boot ${short(p.entryHash)} → now ${short(currentEntryHash)}, ${p.resolvedPath})`);
+    }
+  }
+  if (loadedDrifts.length > 0) {
     verdicts.push(
       skew(
         "loaded-vs-locked",
-        `the root lockfile changed since the writer loaded its modules (boot ${short(bootLockHash)} → now ${short(currentLockHash)}, ${lockPath}) — ` +
-          "the daemon is serving pre-change modules; restart it (launchctl kickstart -k) to load the installed fix",
+        `${loadedDrifts.join("; ")} — the daemon is serving pre-change modules; restart it (launchctl kickstart -k) to load the installed fix`,
       ),
     );
+  } else if (loadedUnknowns.length > 0) {
+    verdicts.push(unknown("loaded-vs-locked", `could not compare: ${loadedUnknowns.join("; ")}`));
   } else {
-    verdicts.push(ok("loaded-vs-locked", `loaded modules match the current lockfile (${short(bootLockHash)})`));
+    verdicts.push(
+      ok("loaded-vs-locked", `loaded modules match the current lockfile (${short(bootLockHash)}) and all ${packages.length} entry digest(s) are unchanged on disk`),
+    );
   }
 
   // Link 4 — installed vs locked (what a restart does NOT fix).
-  const packages = Array.isArray(breadcrumb.packages) ? breadcrumb.packages : [];
   if (packages.length === 0) {
     verdicts.push(unknown("installed-vs-locked", "no package identities recorded at boot — zero comparisons is not a clean result"));
   } else {
+    const root = typeof breadcrumb.root === "string" ? breadcrumb.root : null;
     const drifts = [];
     const unknowns = [];
     for (const p of packages) {
@@ -364,13 +476,27 @@ export function evaluateDepSkew({
         unknowns.push(`${p.id}: installed package.json unreadable (${p.packageJsonPath ?? "path not recorded"})`);
         continue;
       }
-      const locked = lockText === null ? { conclusive: false, versions: [], reason: "lockfile unreadable" } : lockedVersionsFor(lockText, p.id);
-      if (!locked.conclusive) {
-        unknowns.push(`${p.id}: ${locked.reason}`);
+      if (lockText === null) {
+        unknowns.push(`${p.id}: lockfile unreadable`);
         continue;
       }
-      if (!locked.versions.includes(String(installed))) {
-        drifts.push(`${p.id} installed ${installed}, lockfile resolves ${locked.versions.join(", ")}`);
+      // The installed package is matched to ITS OWN lock entry, keyed by the install
+      // location, rather than to "any occurrence of this id anywhere in the lockfile".
+      const key = lockKeyForPackageJsonPath(root, p.packageJsonPath);
+      const locked = lockedVersionForKey(lockText, key, p.id);
+      if (!locked.conclusive) {
+        // Deliberately NOT a fallback onto `lockedVersionsFor`'s any-occurrence match —
+        // that permissive match IS the defect. The other resolutions still ride the REASON,
+        // so an operator gets the full diagnosis without the comparator accepting them.
+        const elsewhere = lockedVersionsFor(lockText, p.id);
+        const hint = elsewhere.conclusive
+          ? ` (the id IS locked elsewhere at ${elsewhere.versions.join(", ")}, under a different install location — not evidence about this one)`
+          : "";
+        unknowns.push(`${p.id}: ${locked.reason}${hint}`);
+        continue;
+      }
+      if (String(installed) !== locked.version) {
+        drifts.push(`${p.id} installed ${installed}, lockfile resolves ${locked.version} for "${key}"`);
       }
     }
     if (drifts.length > 0) {
@@ -410,28 +536,86 @@ export { short as shortDigest };
 // Same shape as health-responder.sh's attempt-cap markers: a window anchor plus a count,
 // where the passage of time re-arms the budget for free.
 
+// The ledger read is TRI-STATE, and the third state is the whole point. Collapsing
+// "no file" and "a file I could not read or parse" into one `null` hands
+// `classifyRestartBudget(null)` a FULL budget — so in enforce mode a corrupted or
+// momentarily-unreadable ledger PERMITS another restart past the cap and then
+// `recordRestartAttempt` overwrites the only surviving evidence of the previous one. The
+// durable loop terminator would be disarmed by exactly the corruption it exists to survive.
+//
+//   • `null`                      — genuinely ABSENT (ENOENT/ENOTDIR): never spent, full
+//                                   budget. This is the normal first-trip case.
+//   • `RESTART_LEDGER_UNREADABLE` — a ledger is (or may be) on disk and could not be read
+//                                   or parsed: the classifier declines, fail-closed.
+//   • the parsed object           — grade it on its contents.
+//
+// A read error carrying no `code` (an exotic fs, an injected reader) classifies as
+// UNREADABLE rather than absent, for the same reason the rest of this module fails closed:
+// "I could not look" is never "it is not there".
+export const RESTART_LEDGER_UNREADABLE = Object.freeze({ unreadable: true });
+
+const LEDGER_ABSENT_CODES = new Set(["ENOENT", "ENOTDIR"]);
+
 export function readRestartLedger(path, { readText = (p) => readFileSync(p, "utf8") } = {}) {
+  let raw;
   try {
-    const parsed = JSON.parse(readText(path));
-    return parsed && typeof parsed === "object" ? parsed : null;
+    raw = readText(path);
+  } catch (err) {
+    return LEDGER_ABSENT_CODES.has(err?.code) ? null : RESTART_LEDGER_UNREADABLE;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    // A bare `null`, a scalar, or an array is a file that EXISTS carrying something that is
+    // not a ledger — corruption, not absence, so it must not re-arm the budget either.
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed;
+    return RESTART_LEDGER_UNREADABLE;
   } catch {
-    return null; // absent = never spent = full budget (the normal case)
+    return RESTART_LEDGER_UNREADABLE;
   }
 }
 
+// readLedgerFields — the RAW-TYPE gate, run BEFORE any numeric coercion, because `Number()`
+// launders several distinct malformations into valid-looking numbers: `Number(null)` and
+// `Number([])` are 0, `Number(true)` is 1, `Number("5")` is 5, and `Number(undefined) || 0`
+// is 0. A syntactically valid ledger `{ts: null, count: 0}` therefore used to read as an
+// anchor at the epoch — an "expired window" — and re-armed a FULL budget; a missing or
+// non-numeric `count` coerced to zero and read as "nothing spent yet". Both are the
+// fail-OPEN direction inside a guard whose entire purpose is to fail closed. So the types
+// are CHECKED, never coerced: `typeof x === "number"` is the only test that rejects
+// null/""/[]/true/"5" before a coercion can rescue them, and `Number.isFinite` then rejects
+// NaN and ±Infinity.
+function readLedgerFields(ledger) {
+  if (ledger == null || typeof ledger !== "object" || Array.isArray(ledger)) return { ok: false, kind: "shape" };
+  // Identity would be enough within one module instance; the property check also covers a
+  // sentinel that crossed a module realm or a JSON round-trip.
+  if (ledger === RESTART_LEDGER_UNREADABLE || ledger.unreadable === true) return { ok: false, kind: "unreadable" };
+  if (typeof ledger.ts !== "number" || !Number.isFinite(ledger.ts)) return { ok: false, kind: "ts" };
+  if (typeof ledger.count !== "number" || !Number.isInteger(ledger.count) || ledger.count < 0) return { ok: false, kind: "count" };
+  return { ok: true, ts: ledger.ts, count: ledger.count };
+}
+
+const LEDGER_REFUSAL = {
+  unreadable: "restart budget ledger exists but could not be read or parsed — declining the restart (fail-closed; an unreadable ledger is not an empty one)",
+  shape: "restart budget ledger is malformed — declining the restart (fail-closed)",
+  ts: "restart budget ledger has no usable timestamp (malformed or future-dated) — declining the restart (fail-closed)",
+  count: "restart budget ledger has no usable count (absent or non-numeric) — declining the restart (fail-closed)",
+};
+
 // classifyRestartBudget — may this process spend a dep-skew restart? FAIL-CLOSED on a
-// malformed or future-dated ledger: a corrupt-but-numeric or clock-skewed `ts` must not
-// read as free budget (the same future-timestamp trap health-responder.sh hit, where a
-// negative age was permanently "within grace").
+// malformed, unreadable, or future-dated ledger: a corrupt-but-numeric or clock-skewed `ts`
+// must not read as free budget (the same future-timestamp trap health-responder.sh hit,
+// where a negative age was permanently "within grace"). Note the ordering: the type gate
+// runs BEFORE the expired-window shortcut, so a ledger with a bogus count cannot re-arm the
+// budget on the strength of an anchor read out of the same untrusted file. A corrupt ledger
+// therefore holds restarts until an operator removes it — which is never destructive: a
+// skewed-but-running writer is exactly today's behavior, and `catalyst doctor` names it.
 export function classifyRestartBudget({ ledger = null, now = Date.now(), windowMs = 21_600_000, maxRestarts = 1 } = {}) {
-  if (ledger == null) return { allowed: true, count: 0, reason: null };
-  if (typeof ledger !== "object") return { allowed: false, count: null, reason: "restart budget ledger is malformed — declining the restart (fail-closed)" };
-  const ts = Number(ledger.ts);
-  if (!Number.isFinite(ts) || ts > now) {
-    return { allowed: false, count: null, reason: "restart budget ledger has no usable timestamp (malformed or future-dated) — declining the restart (fail-closed)" };
-  }
+  if (ledger === null || ledger === undefined) return { allowed: true, count: 0, reason: null };
+  const fields = readLedgerFields(ledger);
+  if (!fields.ok) return { allowed: false, count: null, reason: LEDGER_REFUSAL[fields.kind] };
+  const { ts, count } = fields;
+  if (ts > now) return { allowed: false, count: null, reason: LEDGER_REFUSAL.ts };
   if (now - ts >= windowMs) return { allowed: true, count: 0, reason: null };
-  const count = Number(ledger.count) || 0;
   if (count >= maxRestarts) {
     return {
       allowed: false,
@@ -448,9 +632,14 @@ export function classifyRestartBudget({ ledger = null, now = Date.now(), windowM
 // no terminator, and declining a restart is never destructive — a skewed-but-running
 // daemon is exactly today's behavior, which doctor now names.
 export function recordRestartAttempt(path, { ledger = null, now = Date.now(), windowMs = 21_600_000 } = {}, { writeFile = writeFileSync, rename = renameSync } = {}) {
-  const ts = Number(ledger?.ts);
-  const withinWindow = Number.isFinite(ts) && ts <= now && now - ts < windowMs;
-  const next = withinWindow ? { ts, count: (Number(ledger?.count) || 0) + 1 } : { ts: now, count: 1 };
+  // The SAME raw-type gate the classifier uses, for the same reason: a prior whose fields
+  // cannot be trusted must not seed the next one. An unreadable/malformed prior anchors a
+  // FRESH window at `now` with count 1 rather than inheriting a coerced anchor — the
+  // conservative direction, since a fabricated older anchor would expire the window early
+  // and silently re-arm the budget on the next tick.
+  const prior = readLedgerFields(ledger);
+  const withinWindow = prior.ok && prior.ts <= now && now - prior.ts < windowMs;
+  const next = withinWindow ? { ts: prior.ts, count: prior.count + 1 } : { ts: now, count: 1 };
   try {
     const tmp = `${path}.tmp`;
     writeFile(tmp, JSON.stringify(next));

--- a/plugins/dev/scripts/execution-core/cloud-sync-telemetry.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-telemetry.mjs
@@ -86,6 +86,78 @@ export function classifyStall({ rows = null, stalledMs = 0, stallMs = 600_000, s
   };
 }
 
+// --- CTL-1659 dep-skew (the second self-heal condition) ------------------------------
+// The writer already owns a self-heal exit (breadcrumb + bounded exit 1 → launchd
+// KeepAlive relaunch). CTL-1659 adds a SECOND predicate to that same path rather than a
+// fourth external restart mechanism: the broker's `decideStackReload` hard-codes three
+// components and cloud-sync is not one of them, and CTL-1502's daemon-watchdog measures
+// STUCKNESS (DLQ bytes, frozen forwarding lag) for a daemon that cannot help itself, with
+// its restart action hardwired to `catalyst-monitor.sh` argv. Dep-skew is neither: the
+// daemon is healthy and fully capable of self-action, so the whole actuator chain it needs
+// — launchd KeepAlive, a safe exit point between applied frames, health-responder.sh's
+// `no-respawn` net keyed on the very breadcrumb it writes — already exists here.
+//
+// NOTE the exit code. The ticket's own wording ("exit cleanly and let KeepAlive relaunch")
+// is mechanically WRONG for this daemon: the plist pairs KeepAlive={SuccessfulExit:false}
+// with an exit-0 contract meaning "clean no-op, stay DOWN". A literal clean exit would
+// permanently stop the replica writer. The self-heal path is exit 1, always.
+
+export const DEP_SKEW_MODES = new Set(["off", "shadow", "enforce"]);
+
+// resolveDepSkewMode — off (fully dormant) | shadow (detect + log would-restart, mutate
+// nothing) | enforce (self-heal exit). Anything unrecognized settles at the SHADOW default:
+// both non-enforce modes are non-acting, so a typo can never turn a knob into a restarter.
+export function resolveDepSkewMode(raw) {
+  const v = String(raw ?? "").trim().toLowerCase();
+  return DEP_SKEW_MODES.has(v) ? v : "shadow";
+}
+
+// classifyDepSkew — decide whether the writer's loaded modules have fallen behind the
+// root lockfile far enough to justify spending its self-heal exit. Same never-false-kill
+// discipline as classifyStall: every guard below removes a way to restart a healthy
+// writer, and an UNKNOWN input never asserts.
+//   • either digest unknown (a failed read, a pre-rollout boot record) → known:false and
+//     nothing asserts — a failed measurement must never look like a positive one;
+//   • a single-tick mismatch does not act: `sustainedTicks` consecutive observations are
+//     required so a lockfile caught MID-WRITE (bun rewrites it in place during an install)
+//     cannot trip the predicate;
+//   • an uptime floor keeps a just-relaunched writer from immediately exiting again;
+//   • the durable restart budget (classifyRestartBudget) is the loop terminator for the
+//     pathological case self-clearing cannot cover, and its refusal is NAMED in `reason`
+//     rather than silently folded into "no restart".
+// `wouldRestart` is the shadow-mode observation (what enforce WOULD have done); `restart`
+// is the only field the daemon acts on.
+export function classifyDepSkew({
+  bootLockHash = null,
+  currentLockHash = null,
+  consecutiveMismatches = 0,
+  sustainedTicks = 2,
+  uptimeMs = 0,
+  uptimeFloorMs = 120_000,
+  mode = "shadow",
+  budgetAllowed = true,
+  budgetReason = null,
+} = {}) {
+  const known =
+    typeof bootLockHash === "string" && bootLockHash.length > 0 &&
+    typeof currentLockHash === "string" && currentLockHash.length > 0;
+  const skewed = known && bootLockHash !== currentLockHash;
+  const sustained = skewed && Number(consecutiveMismatches) >= Number(sustainedTicks);
+  const agedIn = Number(uptimeMs) >= Number(uptimeFloorMs);
+  const acting = mode !== "off";
+  const wouldRestart = acting && sustained && agedIn;
+  const restart = wouldRestart && mode === "enforce" && budgetAllowed === true;
+  let reason = null;
+  if (!known) reason = "lockfile digest unknown on at least one side — not asserting skew";
+  else if (!skewed) reason = null;
+  else if (!sustained) reason = `mismatch observed ${consecutiveMismatches}/${sustainedTicks} consecutive ticks — holding (the lockfile may be mid-write)`;
+  else if (!agedIn) reason = `writer uptime ${Math.round(Number(uptimeMs) / 1000)}s is below the ${Math.round(Number(uptimeFloorMs) / 1000)}s floor — holding`;
+  else if (!acting) reason = "dep-skew mode is off";
+  else if (mode !== "enforce") reason = `dep-skew mode is ${mode} — would restart, mutating nothing`;
+  else if (budgetAllowed !== true) reason = budgetReason ?? "dep-skew restart budget exhausted — holding";
+  return { known, skewed, sustained, wouldRestart, restart, mode, reason };
+}
+
 // readReplicaCounts — run the single freshness query against a read-model SqlExecutor
 // (`replica.sql`). Returns { rows, maxUpdatedMs }, both null on any failure (fail-open:
 // a locked / mid-apply DB must never throw out of the writer's telemetry timer).
@@ -149,10 +221,20 @@ export function exitAfterClose({ closePromise, exitCode, timeoutMs = 3_000, exit
 // writeSelfHealBreadcrumb — atomic tmp+rename (the writeBootMarker idiom, recovery.mjs):
 // CTL-1509's responder reads this file from another process, so it must never observe a
 // torn write. fs deps injectable for tests.
-export function writeSelfHealBreadcrumb(path, { cursor = null, stalledMs = null, sdkStatus = null } = {}, { writeFile = writeFileSync, rename = renameSync, now = Date.now } = {}) {
+//
+// CTL-1659: an OPTIONAL `reason` discriminator. The dep-skew self-heal rides this exact
+// path — same breadcrumb, same bounded exit 1 — deliberately, so health-responder.sh's
+// `no-respawn` condition (keyed on `expectRestart:true`) nets a failed dep-skew relaunch
+// with no change at all. The key is emitted ONLY when a caller supplies one, so the
+// stall path's on-disk shape stays byte-identical (the responder parses this file with
+// jq, and its consumers were written against the CTL-1508 shape); an absent `reason`
+// therefore means "stall", the original and still-default condition.
+export function writeSelfHealBreadcrumb(path, { cursor = null, stalledMs = null, sdkStatus = null, reason = null } = {}, { writeFile = writeFileSync, rename = renameSync, now = Date.now } = {}) {
   try {
     const tmp = `${path}.tmp`;
-    writeFile(tmp, JSON.stringify({ ts: now(), cursor, stalledMs, sdkStatus, expectRestart: true }));
+    const record = { ts: now(), cursor, stalledMs, sdkStatus, expectRestart: true };
+    if (typeof reason === "string" && reason.length > 0) record.reason = reason;
+    writeFile(tmp, JSON.stringify(record));
     rename(tmp, path);
     return true;
   } catch {

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -368,6 +368,22 @@ let _depSkewMismatches = 0;
 // Loki would be the earliest and weakest one, saying "no restart" about a run that went on
 // to restart. It re-arms (null) the moment skew clears.
 let _depSkewAlertedPosture = null;
+// A SECOND latch, for the undurable-ledger decline. That branch lives inside
+// `if (depSkew.restart)`, OUTSIDE the posture latch above, so with sustained skew in
+// enforce mode and a ledger that stays unwritable (a full or read-only ~/catalyst) it fires
+// on EVERY heartbeat: one ERROR line plus one `dep_skew_would_restart` event every 30s for
+// the whole incident — an alarm flooding the very surfaces (cloud-sync.log, the unified
+// event log) it exists to make legible. Same count-exactly / warn-sparsely discipline as
+// CTL-1817/CTL-1823 (otel-forward/lib/sparse-warn.ts): the condition is re-evaluated every
+// tick, the ANNOUNCEMENT is edge-triggered. Keyed on the same posture string as the alert
+// latch, so a genuine change (skew clears, the budget runs out, the run stops being
+// sustained) re-announces once; it re-arms (null) the moment skew clears.
+//
+// Deliberately latches only the EMISSIONS, never the write attempt: retrying
+// `recordRestartAttempt` each tick is what lets a repaired filesystem resume the self-heal,
+// and a latch that suppressed the retry would turn one transient EROFS into a permanent
+// refusal.
+let _depSkewDeclinedPosture = null;
 
 // CTL-1395: liveness + freshness telemetry. Every HEARTBEAT_INTERVAL_MS emit (a) the
 // CTL-1280 `daemon heartbeat` marker — feed-independent proof the writer is alive, → the
@@ -466,7 +482,7 @@ const emitTelemetry = () => {
     budgetReason: budget.reason,
   });
   const depSkewPosture = `${depSkew.skewed}:${depSkew.sustained}:${depSkew.wouldRestart}:${depSkew.restart}`;
-  if (!depSkew.skewed) _depSkewAlertedPosture = null; // re-arm the one-shot for the next episode
+  if (!depSkew.skewed) { _depSkewAlertedPosture = null; _depSkewDeclinedPosture = null; } // re-arm the one-shots for the next episode
   try {
     hlog.info(
       {
@@ -518,17 +534,26 @@ const emitTelemetry = () => {
     // running writer), which the doctor check and the alert above both name.
     const spent = recordRestartAttempt(getCloudSyncDepSkewLedgerPath(), { ledger: depSkewLedger, now, windowMs: DEP_SKEW_BUDGET_WINDOW_MS });
     if (spent === null) {
-      try { hlog.error({ event: "catalyst.replica.dep_skew", "catalyst.alert": DEP_SKEW_ALERT }, "cloud-sync: dep-skew restart DECLINED — the restart-budget ledger could not be persisted, so the loop has no terminator"); } catch { /* best-effort */ }
-      // The posture block above skipped its would-restart event (it saw `restart: true`, and
-      // deferred to this block), so without this line an enforce-mode host with an unwritable
-      // ledger would emit NOTHING to the unified log — silence on precisely the configuration
-      // that is trying to act and cannot. `reason` carries the ledger failure.
-      emitDepSkewEvent({
-        name: DEP_SKEW_WOULD_RESTART_EVENT,
-        currentLockHash,
-        depSkew: { ...depSkew, reason: "the dep-skew restart-budget ledger could not be persisted — declining the restart (the loop would have no terminator)" },
-        restart: false,
-      });
+      // EDGE-TRIGGERED, not per-tick. The write above is retried every heartbeat (that is
+      // how a repaired filesystem resumes the self-heal), but the ERROR line and the
+      // unified-log event are announced once per DECLINED POSTURE — otherwise a sustained
+      // skew with a permanently-unwritable ledger emits both every 30s for the duration of
+      // the incident, burying the one line an operator needs under thousands of copies of
+      // itself. The latch re-arms on any posture change and the moment skew clears.
+      if (depSkewPosture !== _depSkewDeclinedPosture) {
+        _depSkewDeclinedPosture = depSkewPosture;
+        try { hlog.error({ event: "catalyst.replica.dep_skew", "catalyst.alert": DEP_SKEW_ALERT }, "cloud-sync: dep-skew restart DECLINED — the restart-budget ledger could not be persisted, so the loop has no terminator"); } catch { /* best-effort */ }
+        // The posture block above skipped its would-restart event (it saw `restart: true`, and
+        // deferred to this block), so without this line an enforce-mode host with an unwritable
+        // ledger would emit NOTHING to the unified log — silence on precisely the configuration
+        // that is trying to act and cannot. `reason` carries the ledger failure.
+        emitDepSkewEvent({
+          name: DEP_SKEW_WOULD_RESTART_EVENT,
+          currentLockHash,
+          depSkew: { ...depSkew, reason: "the dep-skew restart-budget ledger could not be persisted — declining the restart (the loop would have no terminator)" },
+          restart: false,
+        });
+      }
     } else {
       // Same exit path as the CTL-1508 genuine-stall self-heal, with a `reason`
       // discriminator: breadcrumb (so health-responder.sh's no-respawn condition nets a

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -46,18 +46,47 @@
 //   • start() throws / fatal     → exit 1  (launchd restarts with backoff; a stale
 //                                   self-lock auto-reclaims after ~15s)
 //   • genuine stall (watchdog)   → self-heal breadcrumb + close() + exit 1  (restart)
+//   • dep-skew (CTL-1659)        → self-heal breadcrumb + close() + exit 1  (restart)
 // CTL-1508: BOTH close()-then-exit paths are bounded by CATALYST_CLOUD_SYNC_CLOSE_TIMEOUT_MS
 // (default 3s) via exitAfterClose — a close() wedged on a dead socket can no longer strand
 // the process in a half-dead never-exits state launchd cannot recover from.
+//
+// DEP-SKEW SELF-HEAL (CTL-1659): a dependency fix lands on main, the updater pulls it, the
+// install succeeds — and this process keeps serving the OLD modules until a human notices.
+// It went unnoticed for days on 2026-08-04 because nothing restarts this daemon on a dep
+// change: `plugin-refresh` deliberately stops at `restart_needed` ("restart stays a gated
+// OPERATOR action"), and the broker's `decideStackReload` hard-codes monitor/execution-core/
+// otel-forward — the same omission class CTL-1506 fixed one link up the chain. Rather than
+// add a FOURTH external restart mechanism, this is a SECOND predicate on the self-heal exit
+// that already exists three lines above: at boot we record what we actually resolved
+// (captureLoadedDeps), on each heartbeat we re-hash the root lockfile, and a SUSTAINED
+// mismatch takes the same breadcrumb + bounded exit-1 path the stall watchdog takes — which
+// means launchd KeepAlive is the actuator and health-responder.sh's `no-respawn` condition
+// already nets a failed relaunch, with no change to either. Ships SHADOW by default
+// (CATALYST_CLOUD_SYNC_DEP_SKEW=off|shadow|enforce); the skew fields ride the freshness
+// heartbeat line in every mode, so the signal is alertable in Loki from day one instead of
+// being another `restart_needed` nobody watches.
 import { CatalystReplica } from "@catalyst-cloud/sdk/node";
-import { getCloudSyncSelfHealPath, getEventLogPath, getHostName, getReplicaDbPath, resolveNodeCloudTokenEnv, HEARTBEAT_INTERVAL_MS } from "./config.mjs";
+import { getCloudSyncDepSkewLedgerPath, getCloudSyncDepsPath, getCloudSyncSelfHealPath, getEventLogPath, getHostName, getReplicaDbPath, resolveNodeCloudTokenEnv, HEARTBEAT_INTERVAL_MS } from "./config.mjs";
 import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
 import { emitProcessMemoryMetric } from "../lib/process-memory-metric.mjs"; // CTL-1517: per-process RSS/heap gauge
 import { sdkLogRecord } from "./cloud-sync-log.mjs";
-import { classifyStall, clearSelfHealBreadcrumb, exitAfterClose, freshnessFields, readReplicaCounts, writeSelfHealBreadcrumb } from "./cloud-sync-telemetry.mjs";
+import { classifyDepSkew, classifyStall, clearSelfHealBreadcrumb, exitAfterClose, freshnessFields, readReplicaCounts, resolveDepSkewMode, writeSelfHealBreadcrumb } from "./cloud-sync-telemetry.mjs";
+import {
+  DEP_SKEW_ALERT,
+  DEP_SKEW_REASON,
+  captureLoadedDeps,
+  classifyRestartBudget,
+  depSkewFields,
+  readRestartLedger,
+  recordRestartAttempt,
+  sha256File,
+  writeDepsBreadcrumb,
+} from "./cloud-sync-deps.mjs";
 import { createRequire } from "node:module";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
@@ -238,6 +267,65 @@ console.log(`${TAG} live — replica seeded + tailing the change feed (cursor=${
 // case and clearSelfHealBreadcrumb never throws.
 clearSelfHealBreadcrumb(getCloudSyncSelfHealPath());
 
+// --- CTL-1659: record what this process ACTUALLY loaded ------------------------------
+// Written ONCE, here, because reaching 'live' is the moment the modules are proven usable.
+// The record carries the RESOLVED module path, the version read from THAT path's
+// package.json, a digest of the entry file, the root that served it, and a SHA-256 of that
+// root's lockfile — deliberately NOT "what the lockfile said", which would re-manufacture
+// the claim under test (the CTL-1646 shadowed-install class). `bootLockHash` is also the
+// baseline the per-tick predicate below compares against.
+const DEP_SKEW_MODE = resolveDepSkewMode(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW);
+// Consecutive-tick threshold: bun rewrites bun.lock IN PLACE during an install, so a
+// single tick can catch it mid-write. Two consecutive observations (~1 min at the default
+// 30s heartbeat) is past any plausible write window.
+const DEP_SKEW_SUSTAINED_TICKS = Number(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW_TICKS) || 2;
+// Uptime floor — a just-relaunched writer never immediately exits again, so even a
+// pathological lockfile churn cannot restart faster than this.
+const DEP_SKEW_UPTIME_FLOOR_MS = Number(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW_UPTIME_MS) || 120_000;
+// Durable budget (the loop terminator). Default: at most ONE dep-skew restart per 6h. The
+// predicate is self-clearing — a relaunch re-captures the CURRENT digest, so boot ===
+// current again — and this covers only what self-clearing cannot: a lockfile being
+// rewritten continuously by a broken install loop.
+const DEP_SKEW_BUDGET_WINDOW_MS = Number(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW_WINDOW_MS) || 21_600_000;
+const DEP_SKEW_MAX_RESTARTS = Number(process.env.CATALYST_CLOUD_SYNC_DEP_SKEW_MAX_RESTARTS) || 1;
+const depsRequire = createRequire(import.meta.url);
+let _bootDeps = null;
+if (DEP_SKEW_MODE !== "off") {
+  try {
+    _bootDeps = captureLoadedDeps({
+      startDir: dirname(fileURLToPath(import.meta.url)),
+      resolveModule: (specifier) => depsRequire.resolve(specifier),
+    });
+    writeDepsBreadcrumb(getCloudSyncDepsPath(), _bootDeps);
+    hlog.info(
+      {
+        event: "catalyst.replica.deps_captured",
+        ...depSkewFields({ mode: DEP_SKEW_MODE, bootLockHash: _bootDeps.lockHash, skewed: false }),
+        "catalyst.cloud_sync.deps.root": _bootDeps.root,
+        "catalyst.cloud_sync.deps.degraded": _bootDeps.degraded,
+        "catalyst.cloud_sync.deps.packages": _bootDeps.packages.map((p) => `${p.id}@${p.version ?? "?"}`).join(","),
+        "host.name": getHostName(),
+      },
+      `cloud-sync: loaded-dependency boot record written (mode=${DEP_SKEW_MODE}${_bootDeps.degraded ? `, DEGRADED: ${_bootDeps.degradedReasons.join("; ")}` : ""})`,
+    );
+  } catch (err) {
+    // Fail-open by construction: recording module identity must never take down the
+    // writer. A missing record is UNKNOWN to doctor, never "clean" — that asymmetry is
+    // what keeps this safe to fail.
+    _bootDeps = null;
+    try { hlog.warn({ event: "catalyst.replica.deps_capture_failed" }, `cloud-sync: dependency boot record failed: ${scrub(err?.message ?? String(err))}`); } catch { /* best-effort */ }
+  }
+}
+const DEP_SKEW_BOOT_LOCK_HASH = _bootDeps?.lockHash ?? null;
+const DEP_SKEW_LOCK_PATH = _bootDeps?.lockPath ?? null;
+const BOOT_MS = Date.now();
+let _depSkewMismatches = 0;
+// The one-shot latch keys on the POSTURE, not on a bare boolean: an episode that escalates
+// (skewed → sustained → would-restart) must re-alert once per step, or the only line in
+// Loki would be the earliest and weakest one, saying "no restart" about a run that went on
+// to restart. It re-arms (null) the moment skew clears.
+let _depSkewAlertedPosture = null;
+
 // CTL-1395: liveness + freshness telemetry. Every HEARTBEAT_INTERVAL_MS emit (a) the
 // CTL-1280 `daemon heartbeat` marker — feed-independent proof the writer is alive, → the
 // uptime tile (same Loki heartbeat-freshness query as the other daemons) — and (b) a
@@ -305,12 +393,92 @@ const emitTelemetry = () => {
   // produces identically (Codex P1/P2).
   const { genuine, restart, displayStatus, sdkUnhealthy, frameSilent } = classifyStall({ rows, stalledMs, stallMs: STALL_MS, status: sdkStatus, lastFrameAt, now });
   if (!genuine) _stallAlerted = false; // re-arm the one-shot alert for the next genuine stall
+  // CTL-1659: re-hash the root lockfile the modules were served from. A digest read is
+  // O(file) on a ~200KB text file once per heartbeat — cheap, and it touches nothing the
+  // SDK owns. An unreadable lockfile yields null, which classifyDepSkew treats as UNKNOWN
+  // (never as skew), so a transient read error cannot kill a healthy writer.
+  const currentLockHash = DEP_SKEW_LOCK_PATH ? sha256File(DEP_SKEW_LOCK_PATH) : null;
+  if (DEP_SKEW_BOOT_LOCK_HASH && currentLockHash && currentLockHash !== DEP_SKEW_BOOT_LOCK_HASH) _depSkewMismatches += 1;
+  else _depSkewMismatches = 0; // any matching (or unknown) tick resets the run
+  // The budget is consulted BEFORE deciding, so its refusal is REPORTED in the same
+  // classification (and therefore in the alert line) rather than being discovered as a
+  // silent no-op after the alarm has already claimed a restart was coming. Read only when
+  // a mismatch run is actually open, so the healthy steady state costs no extra syscall.
+  const depSkewLedger = _depSkewMismatches > 0 ? readRestartLedger(getCloudSyncDepSkewLedgerPath()) : null;
+  const budget = classifyRestartBudget({
+    ledger: depSkewLedger,
+    now,
+    windowMs: DEP_SKEW_BUDGET_WINDOW_MS,
+    maxRestarts: DEP_SKEW_MAX_RESTARTS,
+  });
+  const depSkew = classifyDepSkew({
+    bootLockHash: DEP_SKEW_BOOT_LOCK_HASH,
+    currentLockHash,
+    consecutiveMismatches: _depSkewMismatches,
+    sustainedTicks: DEP_SKEW_SUSTAINED_TICKS,
+    uptimeMs: now - BOOT_MS,
+    uptimeFloorMs: DEP_SKEW_UPTIME_FLOOR_MS,
+    mode: DEP_SKEW_MODE,
+    budgetAllowed: budget.allowed,
+    budgetReason: budget.reason,
+  });
+  const depSkewPosture = `${depSkew.skewed}:${depSkew.sustained}:${depSkew.wouldRestart}:${depSkew.restart}`;
+  if (!depSkew.skewed) _depSkewAlertedPosture = null; // re-arm the one-shot for the next episode
   try {
     hlog.info(
-      freshnessFields({ rows, maxUpdatedMs, status: displayStatus, cursor, hostName: getHostName(), lastFrameAt, now }),
+      {
+        ...freshnessFields({ rows, maxUpdatedMs, status: displayStatus, cursor, hostName: getHostName(), lastFrameAt, now }),
+        // The skew observation rides the EXISTING heartbeat line in every mode, so a Loki
+        // rule can alarm on it without waiting for someone to run doctor. Shadow with
+        // nobody watching is precisely the failure this ticket exists to remove.
+        ...depSkewFields({
+          mode: DEP_SKEW_MODE,
+          bootLockHash: DEP_SKEW_BOOT_LOCK_HASH,
+          currentLockHash,
+          skewed: depSkew.known ? depSkew.skewed : null,
+          sustained: depSkew.known ? depSkew.sustained : null,
+          wouldRestart: depSkew.known ? depSkew.wouldRestart : null,
+        }),
+      },
       "cloud-sync: freshness",
     );
   } catch { /* best-effort — telemetry must never crash the writer */ }
+  if (depSkew.skewed && depSkewPosture !== _depSkewAlertedPosture) {
+    _depSkewAlertedPosture = depSkewPosture;
+    try {
+      hlog.warn(
+        {
+          event: "catalyst.replica.dep_skew",
+          "catalyst.alert": DEP_SKEW_ALERT,
+          ...depSkewFields({ mode: DEP_SKEW_MODE, bootLockHash: DEP_SKEW_BOOT_LOCK_HASH, currentLockHash, skewed: true, sustained: depSkew.sustained, wouldRestart: depSkew.wouldRestart }),
+          "catalyst.cloud_sync.deps.lock_path": DEP_SKEW_LOCK_PATH,
+          "catalyst.cloud_sync.deps.reason": depSkew.reason,
+          "host.name": getHostName(),
+        },
+        `cloud-sync: the root lockfile changed since this writer loaded its modules — the daemon is serving PRE-CHANGE code (mode=${DEP_SKEW_MODE}${depSkew.restart ? ", self-healing via restart" : `, no restart: ${depSkew.reason ?? "held"}`})`,
+      );
+    } catch { /* the alarm must never crash the writer */ }
+  }
+  if (depSkew.restart) {
+    // Spend the durable budget FIRST: if the ledger cannot be persisted there is no loop
+    // terminator, so we decline the restart rather than risk an unbounded relaunch cycle.
+    // Declining is never destructive — it leaves exactly today's behavior (a skewed but
+    // running writer), which the doctor check and the alert above both name.
+    const spent = recordRestartAttempt(getCloudSyncDepSkewLedgerPath(), { ledger: depSkewLedger, now, windowMs: DEP_SKEW_BUDGET_WINDOW_MS });
+    if (spent === null) {
+      try { hlog.error({ event: "catalyst.replica.dep_skew", "catalyst.alert": DEP_SKEW_ALERT }, "cloud-sync: dep-skew restart DECLINED — the restart-budget ledger could not be persisted, so the loop has no terminator"); } catch { /* best-effort */ }
+    } else {
+      // Same exit path as the CTL-1508 genuine-stall self-heal, with a `reason`
+      // discriminator: breadcrumb (so health-responder.sh's no-respawn condition nets a
+      // failed relaunch) + bounded close + exit 1. NEVER exit 0 — the plist pairs
+      // KeepAlive={SuccessfulExit:false} with an exit-0 "clean no-op, stay DOWN" contract,
+      // so a clean exit here would permanently stop the replica writer.
+      writeSelfHealBreadcrumb(getCloudSyncSelfHealPath(), { cursor, stalledMs: null, sdkStatus, reason: DEP_SKEW_REASON });
+      try { if (hbTimer) clearInterval(hbTimer); } catch { /* best-effort */ }
+      exitAfterClose({ closePromise: replica.close(), exitCode: 1, timeoutMs: CLOSE_TIMEOUT_MS });
+      return; // the stall block below must not also fire on the way out
+    }
+  }
   if (genuine && !_stallAlerted) {
     _stallAlerted = true;
     // The alarm that was missing for 18.5h — now gated on an independent liveness failure

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -65,7 +65,11 @@
 // already nets a failed relaunch, with no change to either. Ships SHADOW by default
 // (CATALYST_CLOUD_SYNC_DEP_SKEW=off|shadow|enforce); the skew fields ride the freshness
 // heartbeat line in every mode, so the signal is alertable in Loki from day one instead of
-// being another `restart_needed` nobody watches.
+// being another `restart_needed` nobody watches. The restart ALSO lands on the unified event
+// log (`catalyst.replica.dep_skew_restart`, with `…_would_restart` for a detected-but-held
+// posture) via the same append emitWriterIdleEvent already uses — the heartbeat line is a LOG
+// stream and reaches neither `catalyst-events wait-for`, the broker, the HUD, nor
+// orch-monitor, which is the ticket's "the restart is visible in the event log" clause.
 import { CatalystReplica } from "@catalyst-cloud/sdk/node";
 import { getCloudSyncDepSkewLedgerPath, getCloudSyncDepsPath, getCloudSyncSelfHealPath, getEventLogPath, getHostName, getReplicaDbPath, resolveNodeCloudTokenEnv, HEARTBEAT_INTERVAL_MS } from "./config.mjs";
 import { logDaemonHeartbeat } from "../lib/daemon-heartbeat.mjs";
@@ -75,8 +79,11 @@ import { classifyDepSkew, classifyStall, clearSelfHealBreadcrumb, exitAfterClose
 import {
   DEP_SKEW_ALERT,
   DEP_SKEW_REASON,
+  DEP_SKEW_RESTART_EVENT,
+  DEP_SKEW_WOULD_RESTART_EVENT,
   captureLoadedDeps,
   classifyRestartBudget,
+  depSkewEventEnvelope,
   depSkewFields,
   readRestartLedger,
   recordRestartAttempt,
@@ -142,6 +149,42 @@ function emitWriterIdleEvent({ host, tokenEnv, tokenSource, dbPath }) {
       },
       body: { message: `cloud-sync writer idle: no token in ${tokenEnv} (source=${tokenSource})` },
     };
+    const logPath = getEventLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// CTL-1659 — the AC1 clause "And the restart is visible in the event log". Deliberately the
+// SAME append that emitWriterIdleEvent performs (same file, same v2 envelope, same
+// fail-open `try`/`return false`): the unified log at ~/catalyst/events/YYYY-MM.jsonl is the
+// surface `catalyst-events wait-for`, the broker, the HUD and orch-monitor all read, and the
+// heartbeat line alone reaches none of them. The envelope itself is built by the pure
+// `depSkewEventEnvelope` in cloud-sync-deps.mjs so its shape is unit-testable without
+// running this script-shaped module. FAIL-OPEN, without exception: emitting the observation
+// must never be able to block or crash the self-heal exit it is describing — a lost event is
+// a lost event, a wedged writer is the incident.
+function emitDepSkewEvent({ name, currentLockHash, depSkew, restart }) {
+  try {
+    const envelope = depSkewEventEnvelope({
+      name,
+      host: getHostName(),
+      mode: DEP_SKEW_MODE,
+      reason: depSkew.reason,
+      bootLockHash: DEP_SKEW_BOOT_LOCK_HASH,
+      currentLockHash,
+      lockPath: DEP_SKEW_LOCK_PATH,
+      sustained: depSkew.sustained,
+      wouldRestart: depSkew.wouldRestart,
+      restart,
+      id: randomBytes(8).toString("hex"),
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.cloud-sync", host: getHostName() }),
+    });
     const logPath = getEventLogPath();
     mkdirSync(dirname(logPath), { recursive: true });
     appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
@@ -458,6 +501,15 @@ const emitTelemetry = () => {
         `cloud-sync: the root lockfile changed since this writer loaded its modules — the daemon is serving PRE-CHANGE code (mode=${DEP_SKEW_MODE}${depSkew.restart ? ", self-healing via restart" : `, no restart: ${depSkew.reason ?? "held"}`})`,
       );
     } catch { /* the alarm must never crash the writer */ }
+    // …and the same escalation step onto the UNIFIED EVENT LOG, gated on the same posture
+    // latch so a 30s heartbeat cannot spam it. Only the HELD case is emitted here: when
+    // `depSkew.restart` is true the restart block below owns the emission, because only
+    // AFTER the budget is spent is "restarting" a truthful claim — a ledger that cannot be
+    // persisted declines the exit, and an event announcing a restart that never happened is
+    // the same lie `restart_needed` told.
+    if (depSkew.wouldRestart && !depSkew.restart) {
+      emitDepSkewEvent({ name: DEP_SKEW_WOULD_RESTART_EVENT, currentLockHash, depSkew, restart: false });
+    }
   }
   if (depSkew.restart) {
     // Spend the durable budget FIRST: if the ledger cannot be persisted there is no loop
@@ -467,12 +519,29 @@ const emitTelemetry = () => {
     const spent = recordRestartAttempt(getCloudSyncDepSkewLedgerPath(), { ledger: depSkewLedger, now, windowMs: DEP_SKEW_BUDGET_WINDOW_MS });
     if (spent === null) {
       try { hlog.error({ event: "catalyst.replica.dep_skew", "catalyst.alert": DEP_SKEW_ALERT }, "cloud-sync: dep-skew restart DECLINED — the restart-budget ledger could not be persisted, so the loop has no terminator"); } catch { /* best-effort */ }
+      // The posture block above skipped its would-restart event (it saw `restart: true`, and
+      // deferred to this block), so without this line an enforce-mode host with an unwritable
+      // ledger would emit NOTHING to the unified log — silence on precisely the configuration
+      // that is trying to act and cannot. `reason` carries the ledger failure.
+      emitDepSkewEvent({
+        name: DEP_SKEW_WOULD_RESTART_EVENT,
+        currentLockHash,
+        depSkew: { ...depSkew, reason: "the dep-skew restart-budget ledger could not be persisted — declining the restart (the loop would have no terminator)" },
+        restart: false,
+      });
     } else {
       // Same exit path as the CTL-1508 genuine-stall self-heal, with a `reason`
       // discriminator: breadcrumb (so health-responder.sh's no-respawn condition nets a
       // failed relaunch) + bounded close + exit 1. NEVER exit 0 — the plist pairs
       // KeepAlive={SuccessfulExit:false} with an exit-0 "clean no-op, stay DOWN" contract,
       // so a clean exit here would permanently stop the replica writer.
+      //
+      // AC1's second clause, emitted HERE — after the budget is spent and before the exit,
+      // the one window in which "this writer is restarting for dep-skew" is both true and
+      // still recordable. Ordered ahead of clearInterval/exitAfterClose deliberately: the
+      // bounded close can exit the process at any point after it is called, so an append
+      // sequenced after it could be lost on exactly the runs that matter most.
+      emitDepSkewEvent({ name: DEP_SKEW_RESTART_EVENT, currentLockHash, depSkew, restart: true });
       writeSelfHealBreadcrumb(getCloudSyncSelfHealPath(), { cursor, stalledMs: null, sdkStatus, reason: DEP_SKEW_REASON });
       try { if (hbTimer) clearInterval(hbTimer); } catch { /* best-effort */ }
       exitAfterClose({ closePromise: replica.close(), exitCode: 1, timeoutMs: CLOSE_TIMEOUT_MS });

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2400,6 +2400,25 @@ export function getCloudSyncSelfHealPath() {
   return resolve(catalystDir(), "cloud-sync.selfheal.json");
 }
 
+// CTL-1659: path to the cloud-sync LOADED-DEPENDENCY boot record — what the writer
+// actually resolved at boot (module paths, versions, entry digests, the serving root and
+// that root's lockfile digest). Written once on reaching 'live', re-read by the writer's
+// own heartbeat (to detect a lockfile that moved underneath it) and by `catalyst doctor`
+// (which grades it from another process). Lives beside the writer's log/DB/self-heal
+// breadcrumb under ~/catalyst. Re-resolved per call (the catalystDir() idiom) so tests
+// redirect via CATALYST_DIR.
+export function getCloudSyncDepsPath() {
+  return resolve(catalystDir(), "cloud-sync.deps.json");
+}
+
+// CTL-1659: the durable dep-skew restart budget. Separate from the boot record because
+// the boot record is REWRITTEN every boot — a counter kept there would reset on exactly
+// the restart it is meant to count, which is how a loop terminator silently stops
+// terminating. Same attempt-cap shape health-responder.sh uses: {ts, count}.
+export function getCloudSyncDepSkewLedgerPath() {
+  return resolve(catalystDir(), "cloud-sync.depskew.json");
+}
+
 // --- Catalyst-Cloud token resolution (CTL-1394) ---
 // The supervised cloud-sync daemon reads its cloud token from a STANDARD env-var NAME —
 // `CATALYST_CLOUD_TOKEN` — on EVERY host (the same name cloud-token-env.mjs / CTL-1307

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -55,6 +55,9 @@ import {
   getReplicaDbPath,
   readLinearReplica,
   resolveNodeCloudTokenEnv,
+  // CTL-1659: the cloud-sync loaded-dependency boot record — doctor grades it from
+  // another process, so it needs the same path the writer writes.
+  getCloudSyncDepsPath,
   // CTL-1393: cluster-secret freshness check — clone dir + the durable
   // change-detection marker the daemon's auto-refresh writes.
   getClusterRepoDir,
@@ -66,6 +69,9 @@ import {
   resolveDeploymentMode,
 } from "./config.mjs";
 import { scanEventsSince } from "./event-tail.mjs"; // CTL-1529: bounded event-log scan
+// CTL-1659: the loaded-dependency skew comparator. A zero-import leaf (node:crypto/fs/path
+// only), like lib/secret-contract.mjs — safe under doctor's bare-Node runtime.
+import { evaluateDepSkew, readDepsBreadcrumb } from "./cloud-sync-deps.mjs";
 import { ownedBy } from "./hrw.mjs";
 import { readPeerHeartbeats } from "./cluster-heartbeat.mjs";
 // CTL-1616 PR2: the shared secret-contract engine, imported DIRECTLY from the
@@ -3245,6 +3251,104 @@ export function checkCloudSync(deps = {}) {
   return checks;
 }
 
+// defaultProcessCommandForPid — the full argv of a live pid, or null. Used ONLY to prove
+// a recorded pid still names the program that wrote the record. `kill -0` would answer
+// "some process holds this pid", which on a recycled pid is a fresh-looking lie — the same
+// fail-closed identity discipline catalyst-monitor.sh applies to its pid files.
+function defaultProcessCommandForPid(pid) {
+  try {
+    const r = spawnSync("ps", ["-ww", "-o", "command=", "-p", String(pid)], { encoding: "utf8", timeout: 5_000 });
+    if (r.error || r.status !== 0 || typeof r.stdout !== "string") return null;
+    const cmd = r.stdout.trim();
+    return cmd.length > 0 ? cmd : null;
+  } catch {
+    return null;
+  }
+}
+
+// checkCloudSyncSkew — CTL-1659. Is the RUNNING cloud-sync writer serving the modules the
+// current lockfile resolves? The measured incident (2026-08-04): a dependency fix landed
+// on main, the updater pulled it, the install succeeded, and the daemon kept serving the
+// OLD modules for days — because `plugin-refresh` stops at `restart_needed` by design and
+// the broker's `decideStackReload` hard-codes three components, cloud-sync among neither.
+// Nothing was red. This converts "invisible for weeks" into "named on the next doctor run"
+// — the property that was actually missing, and worth having even where a restart cannot
+// fix the drift (a partial install from the 180s SIGKILL ceiling).
+//
+// THREE THINGS IT WILL NOT DO, each one a way the check could otherwise report healthy
+// while the defect is present:
+//   • it never PASSes on absent input (no boot record → WARN "skew unknown"): a daemon
+//     that predates this feature, or whose breadcrumb write failed, is unmeasured, not
+//     clean. The first pipeline pass after deploy legitimately reads WARN.
+//   • it never PASSes on STALE input: the record's pid must still name a live
+//     cloud-sync.mjs, or the whole comparison is graded against the wrong process.
+//   • it never PASSes on ZERO comparisons ([].every(p) === true), and never derives the
+//     "loaded" side from the lockfile — that would re-manufacture the very claim under
+//     test (the CTL-1646 shadowed-install class).
+// Advisory by construction: WARN/INFO/PASS only, NEVER FAIL. It sits in the checkCloudSync
+// family, whose FAIL count gates catalyst-join activation. The ALARM is not this check —
+// doctor is on-demand, and an on-demand-only check reproduces "invisible until a human
+// looks"; the alerting surface is the writer's own heartbeat line (depSkewFields →
+// cloud-sync.log → Alloy → Loki).
+export function checkCloudSyncSkew(deps = {}) {
+  const {
+    label = CLOUD_SYNC_AGENT_LABEL,
+    laDir = defaultLaunchAgentsDir(),
+    agentInstalled = defaultAgentInstalled,
+    processAlive = defaultCloudSyncProcessAlive,
+    depsPath = getCloudSyncDepsPath(),
+    readBreadcrumb = (p) => readDepsBreadcrumb(p),
+    evaluate = evaluateDepSkew,
+    readText = (p) => readFileSync(p, "utf8"),
+    readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
+    processCommandForPid = defaultProcessCommandForPid,
+  } = deps;
+
+  // Wrapped whole: this check reads files and spawns `ps`, and a throw here would abort
+  // the entire doctor run. A failure to measure degrades to a WARN that says so.
+  try {
+    let record = null;
+    try {
+      record = readBreadcrumb(depsPath);
+    } catch (err) {
+      return [mkCheck("cloud-sync-skew", STATUS.WARN, `dependency-skew boot record unreadable (${depsPath}): ${err?.message ?? String(err)} — skew is UNKNOWN`)];
+    }
+
+    // Gate: no writer agent, no live writer, and no boot record → nothing is loaded on
+    // this node, so nothing can be skewed. One INFO, matching checkCloudSync's own gate
+    // so this check is safe to wire into every class.
+    const installed = agentInstalled(label, laDir);
+    if (!installed && !record) {
+      return [mkCheck("cloud-sync-skew", STATUS.INFO, "cloud-sync writer not installed on this node — no loaded modules to compare")];
+    }
+
+    if (!record) {
+      const alive = processAlive();
+      return [
+        mkCheck(
+          "cloud-sync-skew",
+          STATUS.WARN,
+          `no dependency-skew boot record at ${depsPath} — skew is UNKNOWN${alive ? " while a writer is running" : ""}. ` +
+            "Expected before the writer's first boot after CTL-1659 ships; it self-clears on the next restart (launchctl kickstart -k gui/$UID/" +
+            `${label}).`,
+        ),
+      ];
+    }
+
+    const result = evaluate({ breadcrumb: record, readText, readJson, processCommandForPid });
+    const bad = result.verdicts.filter((v) => v.status !== "ok");
+    if (bad.length === 0) {
+      return [mkCheck("cloud-sync-skew", STATUS.PASS, `loaded modules match the lockfile — ${result.verdicts.map((v) => v.link).join(", ")} all verified`)];
+    }
+    // WARN either way, but lead with the skew when there is one: a confirmed drift is
+    // actionable now, whereas an inconclusive link is a request to look again.
+    const lead = result.skew ? "DEPENDENCY SKEW" : "dependency skew UNKNOWN";
+    return [mkCheck("cloud-sync-skew", STATUS.WARN, `${lead}: ${bad.map((v) => `[${v.link}] ${v.detail}`).join(" | ")}`)];
+  } catch (err) {
+    return [mkCheck("cloud-sync-skew", STATUS.WARN, `dependency-skew check could not run: ${err?.message ?? String(err)} — skew is UNKNOWN, not absent`)];
+  }
+}
+
 // defaultClusterGit — a capturing git runner for the freshness check. Returns
 // { status, stdout }; never throws. Injectable so the check stays hermetic.
 function defaultClusterGit(args) {
@@ -5491,6 +5595,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkCloudTokenEnv(), // advisory
       () => checkClusterSecretFreshness(), // CTL-1393: warn if running on stale rotated secrets (advisory)
       () => checkCloudSync(), // CTL-1394: developer nodes read Linear from the local replica too (advisory)
+      () => checkCloudSyncSkew(), // CTL-1659: is the RUNNING writer serving the lockfile's modules? (advisory)
       () => checkConfigScopeLeak(), // advisory
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
       () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
@@ -5559,6 +5664,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkCloudTokenEnv(), // CTL-1307: cluster cloud token decrypted → projected to machine-level env (advisory)
     () => checkClusterSecretFreshness(), // CTL-1393: warn if the node is running on stale rotated secrets (advisory)
     () => checkCloudSync(), // CTL-1394: supervised cloud-sync daemon + read tier on the worker hot path (advisory)
+    () => checkCloudSyncSkew(), // CTL-1659: a merged dependency fix that never reached the running writer (advisory)
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)
     () => checkSdkDaemonEnv(), // CTL-1396 item A: under executor=sdk, the RUNNING daemon's process env must carry CLAUDE_CODE_OAUTH_TOKEN (not just the operator shell) + surface recent silent sdk→bg degrades
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -821,13 +821,29 @@ one:
 and the one-shot episode warning carries `"catalyst.alert": "replica_dep_skew"` with both short
 digests, the lockfile path, and the reason a restart was or was not taken.
 
-`catalyst doctor` grades the same boot record as the advisory `cloud-sync-skew` check, over three
-links that each fail **closed**: the record's pid must still name a live `cloud-sync.mjs` (a dead or
+`catalyst doctor` grades the same boot record as the advisory `cloud-sync-skew` check, over links
+that each fail **closed**: the record's pid must still name a live `cloud-sync.mjs` (a dead or
 recycled pid makes the whole comparison stale evidence); the boot lockfile digest is compared against
 the current one at the **recorded root** (the daemons run from `~/catalyst/plugin-source`, not your
-dev checkout); and the installed `node_modules` version is compared against the lockfile's resolution
-— which catches the partial install a restart does **not** fix. An absent boot record, an unreadable
-lockfile, or zero packages compared all report **WARN "skew unknown"**, never PASS.
+dev checkout); **each package's boot entry-file digest is re-hashed and compared** — a repointed
+mutable artifact or a rebuilt workspace output changes the bytes the process holds while the lockfile
+text and the package version stay byte-identical, so the digest is the only discriminator that can
+see it; and the installed `node_modules` version is compared against **that install location's own
+lockfile entry** — bun keys its `packages` map by install location (`<id>` hoisted,
+`<parent>/<id>` nested), so a stale root install is never excused by an unrelated nested resolution
+carrying the same version. An absent boot record, an unreadable lockfile or entry file, an install
+path that cannot be associated with a lock entry, and zero packages compared all report
+**WARN "skew unknown"**, never PASS.
+
+The durable restart budget (`~/catalyst/cloud-sync.depskew.json`) is read **tri-state**: genuinely
+absent (`ENOENT`) is a full budget, but a ledger that exists and cannot be read or parsed **declines**
+the restart, and every field is type-checked before any numeric coercion (`Number(null)` is `0`, which
+would otherwise read as an expired window and re-arm a full budget). A corrupt ledger therefore holds
+restarts until an operator removes it — never destructive, since a skewed-but-running writer is
+exactly the pre-CTL-1659 behavior, now named by the check above. When the ledger cannot be persisted
+at all, the write is retried on every heartbeat (so a repaired filesystem resumes the self-heal) but
+the ERROR line and its `dep_skew_would_restart` event are **edge-triggered per posture**, so a
+sustained incident announces once instead of flooding the log every 30 s.
 
 > **Rollout note.** A writer that has not restarted since this shipped has no boot record, so the
 > first `catalyst doctor` run after deploy legitimately reports `cloud-sync-skew` WARN "skew

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -780,6 +780,59 @@ authoritative acceptance check—an installed service alone is not proof of a us
 { "catalyst": { "linearReplica": { "mode": "on" } } }
 ```
 
+### Cloud-sync dependency skew (`CATALYST_CLOUD_SYNC_DEP_SKEW`, CTL-1659)
+
+Nothing in the fleet restarts the cloud-sync writer when a dependency changes. `plugin-refresh`
+deliberately stops at `restart_needed` ("restart stays a gated OPERATOR action"), and the broker's
+stack reload hard-codes three components — monitor, execution-core, otel-forward — of which
+cloud-sync is not one. On 2026-08-04 that meant a merged dependency fix installed correctly on both
+minis while the running writers kept serving the old modules for days, with nothing red anywhere: a
+merged fix that never restarts is indistinguishable from no fix.
+
+The writer therefore records what it **actually resolved** at boot (module paths, versions, entry
+digests, the root it was served from, and a SHA-256 of that root's `bun.lock`) to
+`~/catalyst/cloud-sync.deps.json`, re-hashes the lockfile on every heartbeat, and — in `enforce` —
+takes the **existing CTL-1508 self-heal exit** (self-heal breadcrumb with `reason:"dep-skew"` +
+bounded `close()` + **exit 1**) so launchd `KeepAlive` relaunches it on the new modules. It is not a
+new restart mechanism: launchd is the actuator, the heartbeat tick between applied frames is the safe
+exit point, and `health-responder.sh`'s existing `no-respawn` condition already nets a relaunch that
+never came. **Never exit 0** — that is the plist's "clean no-op, stay DOWN" contract, and a clean
+exit here would permanently stop the replica writer.
+
+| Key / env                                        | Purpose                                                                                                                                                                    | Default |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `CATALYST_CLOUD_SYNC_DEP_SKEW`                   | `off` (fully dormant — no boot record, no comparison), `shadow` (detect + emit the skew fields and a `would-restart` warning; mutate nothing), `enforce` (self-heal restart). Unrecognised values settle at `shadow`. | shadow  |
+| `CATALYST_CLOUD_SYNC_DEP_SKEW_TICKS`             | Consecutive mismatching heartbeats required before acting — `bun` rewrites `bun.lock` in place during an install, so one tick can catch it mid-write.                       | 2       |
+| `CATALYST_CLOUD_SYNC_DEP_SKEW_UPTIME_MS`         | Uptime floor: a just-relaunched writer never immediately exits again.                                                                                                       | 120000  |
+| `CATALYST_CLOUD_SYNC_DEP_SKEW_MAX_RESTARTS`      | Durable restart budget — the loop terminator for a lockfile being rewritten continuously by a broken install.                                                               | 1       |
+| `CATALYST_CLOUD_SYNC_DEP_SKEW_WINDOW_MS`         | The window that budget is measured over (`~/catalyst/cloud-sync.depskew.json`).                                                                                             | 21600000 |
+
+**The alarm is not `catalyst doctor`.** An on-demand-only check reproduces "invisible until a human
+looks" — the very property that made the incident last for days. The skew observation rides the
+writer's existing structured heartbeat line in **every** mode, so it is alertable in Loki from day
+one:
+
+```logql
+{service_name="catalyst.cloud-sync"} | json
+  | __error__=""
+  | `catalyst.cloud_sync.deps.skewed` = "true"
+```
+
+and the one-shot episode warning carries `"catalyst.alert": "replica_dep_skew"` with both short
+digests, the lockfile path, and the reason a restart was or was not taken.
+
+`catalyst doctor` grades the same boot record as the advisory `cloud-sync-skew` check, over three
+links that each fail **closed**: the record's pid must still name a live `cloud-sync.mjs` (a dead or
+recycled pid makes the whole comparison stale evidence); the boot lockfile digest is compared against
+the current one at the **recorded root** (the daemons run from `~/catalyst/plugin-source`, not your
+dev checkout); and the installed `node_modules` version is compared against the lockfile's resolution
+— which catches the partial install a restart does **not** fix. An absent boot record, an unreadable
+lockfile, or zero packages compared all report **WARN "skew unknown"**, never PASS.
+
+> **Rollout note.** A writer that has not restarted since this shipped has no boot record, so the
+> first `catalyst doctor` run after deploy legitimately reports `cloud-sync-skew` WARN "skew
+> unknown". It self-clears on the writer's next boot.
+
 ## Deployment mode (`catalyst.deployment.mode`, CTL-1617)
 
 `catalyst.deployment.mode` is the ONE declared answer to a question the system otherwise infers from


### PR DESCRIPTION
Closes CTL-1659. Follow-up to CTL-1646 (which fixed the _install_ being shadowed) — this is the next link in the same chain.

## The defect

Nothing in the fleet restarts `catalyst-cloud-sync` when a dependency changes, and nothing says so:

- `plugin-refresh.mjs:654` emits `restart_needed` and **deliberately stops** — _"Daemon restart stays a gated OPERATOR action — never automated here."_
- `decideStackReload` hard-codes exactly three components — `monitor`, `execution-core`, `otel-forward`.

| measurement | value |
| ----------- | ----- |
| `grep -c 'cloud-sync'` over `broker/stack-reload.mjs` | **0** |
| _positive control, same file + instrument:_ `grep -c 'execution-core'` | **5** |
| `grep -c 'require.resolve\|import.meta.resolve'` over `cloud-sync*.mjs` | **0** |
| _positive control, same files + instrument:_ `grep -c 'createRequire'` | **2** |

Observed on the fleet **2026-08-04**: a dependency fix landed on main, the updater pulled it, the install succeeded — and both minis' writers kept serving the **old** modules for days. The CTC-328 delete-corruption guard sat correctly installed while the daemons ran unguarded, until a human kickstarted them. Nothing alerted. The same shape recurred last week (#3337: schema pinned at 0.1.3 while 0.1.5 was published — applying it _"additionally requires restarting `cloud-sync`, which the stack reload never touches"_).

## Mechanism — a second predicate on an exit that already exists

Deliberately **not** a fourth restart mechanism. Every actuator this needs was already in `cloud-sync.mjs`:

| piece | already existed |
| ----- | --------------- |
| actuator | launchd `KeepAlive={SuccessfulExit:false}` |
| safe exit point | the heartbeat tick, between applied frames |
| bounded close | `exitAfterClose` (CTL-1508) |
| restart-failed net | `health-responder.sh`'s `no-respawn`, keyed on the breadcrumb this path writes |
| loop terminator | **new** — a durable `{ts,count}` budget |

**Boot record** (`cloud-sync-deps.mjs` → `~/catalyst/cloud-sync.deps.json`) carries what the process **actually resolved**: `createRequire().resolve()`'s path, the version read from _that path's_ `package.json`, an entry-file digest, the serving root, and a SHA-256 of that root's `bun.lock`. Deliberately **not** "what the lockfile said" — a claim derived from the lockfile re-manufactures the CTL-1646 shadowed-install lie. The **digest**, not the version string, is the verdict: a repointed tarball / workspace link / git dep ships new bytes under one semver.

**Predicate** (`classifyDepSkew`, beside `classifyStall`, same never-false-kill discipline): an unknown digest on either side never asserts; N consecutive mismatches are required (bun rewrites `bun.lock` **in place** during an install, so one tick can catch it mid-write); an uptime floor holds a just-relaunched writer; the durable budget bounds the continuous-rewrite case, and its refusal is **named**, not folded into silence.

**Exit**: breadcrumb with `reason:"dep-skew"` + bounded `close()` + **exit 1**. The ticket's Option-1 wording ("exit cleanly and let KeepAlive relaunch") is mechanically wrong for this daemon — exit **0** is the plist's _"clean no-op, stay DOWN"_ contract, so a clean exit would **permanently stop the replica writer**. The `reason` key is emitted only when supplied, so the stall path's on-disk shape (parsed with `jq` by `health-responder.sh`) stays byte-identical.

Modes `off`/`shadow`/`enforce`, **shadow by default**; unrecognized values settle at shadow (both non-enforce modes are non-acting).

## The alarm is not `doctor`

An on-demand-only check reproduces "invisible until a human looks" — the very property that made the incident last for days, and the reason `restart_needed` was useless. The skew fields therefore ride the writer's **existing** heartbeat line in every mode (stderr → `cloud-sync.log` → Alloy → Loki), so a Grafana rule can key on them from day one:

```logql
{service_name="catalyst.cloud-sync"} | json | __error__="" | `catalyst.cloud_sync.deps.skewed` = "true"
```

`catalyst doctor` grades the same record as the advisory `cloud-sync-skew` check, over three links that each fail **closed**:

1. **record-identity** — the pid must still name a live `cloud-sync.mjs`. A dead or **recycled** pid makes the whole comparison stale evidence (`ps -o command=`, not `kill -0`).
2. **loaded-vs-locked** — boot lockfile digest vs the current one **at the recorded root** (daemons run from `~/catalyst/plugin-source`, not your dev checkout).
3. **installed-vs-locked** — `node_modules` on disk vs the lockfile's resolution; catches the partial install a restart does **not** fix.

Absent record, unreadable lockfile, and zero comparisons (`[].every(p) === true`) all report **WARN "skew unknown"** — the check cannot report healthy on the strength of missing input.

## Verification

| suite | result |
| ----- | ------ |
| the 3 new test files | **62 pass / 0 fail** |
| doctor + cloud-sync + config (13 files) | **786 pass / 0 fail** |
| `bash __tests__/health-responder.test.sh` (breadcrumb shape) | **149 passed, 0 failed** |
| `bash catalyst-doctor.test.sh` | pass (exit 0) |
| `bun build cloud-sync.mjs --target=node` | 211 modules, resolves |
| `npm run build` (website) | 438 pages, complete |

**Positive control for the wiring test** — with `cloud-sync.mjs` reverted to its pre-fix state, **6 of 9** wiring assertions FAIL; restored, **9/9** pass. A test that passes before the fix is not a test of the fix.

**Live control on the comparator** (real repo, real resolver, real `bun.lock`):

| scenario | result |
| -------- | ------ |
| unchanged world | `skew=false, inconclusive=false` |
| same record, lockfile moved sdk `0.8.2 → 0.8.3` | `skew=true` — names both digests **and** both versions |
| same record, dead pid | `inconclusive=true`, **zero** `ok` verdicts |

**Pre-existing failures, not caused by this change** — each reproduced at baseline with `config.mjs` reverted to `HEAD`: `fence-guard-integration` (2–4, timing-flaky) and `linear-cli` _"mode off → linearis"_ (1). The `sdk-run-phase-agent` OAuth refusal is the documented shell-env pollution — **136 pass / 0 fail** with `CLAUDE_CODE_OAUTH_TOKEN` unset.

The three new files are added to the required `execution-core-tests` stable list.

## Deferred / out of scope

- **Adding cloud-sync to `decideStackReload`** — the symmetric CTL-1506 move — was considered and **rejected**, and a test asserts it stays out. It fires only where the _broker_ advances the checkout (a host whose `catalyst-updater` pulls without a broker never gets the push), and it needs new kickstart plumbing plus a real per-component confirmation probe: cloud-sync has no pid file `readPidFor` knows, and CTL-1506's own P1 lesson is that a best-effort `return true` confirmation is exactly how a stale daemon hides. The in-daemon predicate covers **every** host cloud-sync runs on, by construction, and its confirmation is free — the next boot overwrites the record. One trigger, not two.
- **Reusing CTL-1502's daemon-watchdog registry** — also rejected. Its predicates are **stuckness** (DLQ bytes, frozen forwarding lag) for a daemon that cannot help itself, and its restart action is hardwired to `catalyst-monitor.sh` argv with no way to bounce a LaunchAgent job. Dep-skew is not stuckness: the writer is healthy and fully capable of self-action.
- **The enforce flip.** Ships shadow. Flip to `enforce` after one observed clean `would_restart` on the fleet — shadow-forever would degenerate this into "the status quo with better logging".
- **Rollout note.** A writer that has not restarted since this ships has no boot record, so the first `catalyst doctor` run legitimately reports `cloud-sync-skew` WARN "skew unknown". It self-clears on the next boot. Do not alarm on it until a writer has cycled.
- **`CRITICAL_DEPS` currently registers one package** (`@catalyst-cloud/sdk` — what `cloud-sync.mjs` imports). It is a registry precisely so a second is a one-line addition; `captureLoadedDeps` fails **degraded** on an empty list rather than reporting a vacuously clean capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
