### PR TITLE
fix(dev): CTL-1825 — measure code currency at every executing root, so a 24-behind node cannot report zero

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -503,6 +503,31 @@ jobs:
         working-directory: plugins/dev/scripts/broker
         run: bun test worker-state-projection.test.mjs
 
+      - name: catalyst-agent tests (CTL-1825)
+        # catalyst-agent had NO CI coverage at all before CTL-1825
+        # (`grep catalyst-agent .github/workflows/` returned nothing — positive
+        # control: the same grep for `otel-forward` returned the step below), and
+        # it is a launchd-managed telemetry daemon whose gauges an operator is
+        # meant to TRUST. CTL-1825 is the failure that follows from not running
+        # them: the code-currency gauge measured the wrong tree and read a healthy
+        # 0 for a year, and no test would have failed if it had regressed either.
+        #
+        # The whole suite runs: measured 270 pass / 0 fail on this branch and
+        # 251 / 0 at the merge base — the delta is exactly the +19 added here, so
+        # there is no pre-existing red to import. It needs no install: the agent is
+        # `node:*`-only by design, which the build-resolution check above enforces.
+        working-directory: plugins/dev/scripts/catalyst-agent
+        run: bun test
+
+      - name: Verify catalyst-agent import graph (bare-node loadability, CTL-1825)
+        # The agent runs under plain `node` from a launchd plist with NO
+        # node_modules. CTL-1825 gave it its one execution-core import
+        # (checkout-sync.mjs's root enumeration); this step fails if that leaf ever
+        # grows a dependency the agent's runtime cannot load — the same guard the
+        # cloud-sync / catalyst-linear steps above apply to their entry points.
+        working-directory: plugins/dev/scripts/catalyst-agent
+        run: bun build --target=node catalyst-agent.mjs --outfile=/dev/null
+
       - name: otel-forward tests (CTL-1529 round 3)
         # otel-forward had NO CI coverage at all before this
         # (`grep otel-forward .github/workflows/` returned nothing), and it is a
@@ -692,6 +717,7 @@ jobs:
             tick-timing.test.mjs \
             tracing.test.mjs \
             cloud-token-env.test.mjs \
+            checkout-sync.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \
             comms-drain.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -512,10 +512,10 @@ jobs:
         # them: the code-currency gauge measured the wrong tree and read a healthy
         # 0 for a year, and no test would have failed if it had regressed either.
         #
-        # The whole suite runs: measured 270 pass / 0 fail on this branch and
-        # 251 / 0 at the merge base — the delta is exactly the +19 added here, so
+        # The whole suite runs: measured 273 pass / 0 fail on this branch and
+        # 251 / 0 at the merge base — the delta is exactly the tests added here, so
         # there is no pre-existing red to import. It needs no install: the agent is
-        # `node:*`-only by design, which the build-resolution check above enforces.
+        # `node:*`-only by design, which the import-graph check below enforces.
         working-directory: plugins/dev/scripts/catalyst-agent
         run: bun test
 
@@ -523,10 +523,23 @@ jobs:
         # The agent runs under plain `node` from a launchd plist with NO
         # node_modules. CTL-1825 gave it its one execution-core import
         # (checkout-sync.mjs's root enumeration); this step fails if that leaf ever
-        # grows a dependency the agent's runtime cannot load — the same guard the
-        # cloud-sync / catalyst-linear steps above apply to their entry points.
+        # grows a dependency the agent's runtime cannot load.
+        #
+        # Run with `node`, NOT `bun`, and NOT via a bundler. This step first shipped
+        # as `bun build --target=node catalyst-agent.mjs --outfile=/dev/null`, which
+        # CANNOT FAIL for the class it claims to catch — measured: with a
+        # side-effectful `import { Database } from "bun:sqlite"` added to
+        # build-info.mjs that command exits 0 (a bundler resolves `bun:*` as an
+        # external), while `node` on the same tree dies with
+        # ERR_UNSUPPORTED_ESM_URL_SCHEME. The instrument has to be the runtime the
+        # agent actually runs under. `check-import-graph.mjs` imports every agent
+        # module under bare node — not just the entry, since the four domain
+        # samplers are reached only through lazy `import()` — and separately audits
+        # the source graph so a stray node_modules on the runner cannot let a bare
+        # npm specifier pass here and fail on a launchd tick. Its own non-vacuity
+        # gates fail it closed if the enumeration ever goes empty.
         working-directory: plugins/dev/scripts/catalyst-agent
-        run: bun build --target=node catalyst-agent.mjs --outfile=/dev/null
+        run: node check-import-graph.mjs
 
       - name: otel-forward tests (CTL-1529 round 3)
         # otel-forward had NO CI coverage at all before this

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -538,6 +538,12 @@ jobs:
         # the source graph so a stray node_modules on the runner cannot let a bare
         # npm specifier pass here and fail on a launchd tick. Its own non-vacuity
         # gates fail it closed if the enumeration ever goes empty.
+        #
+        # That source audit is the half that carries the contract, because THIS job
+        # runs `bun install` many steps above: on the runner `pino` and every other
+        # hoisted package RESOLVES, so the load probe alone cannot fail for a newly
+        # added npm dependency. The audit records every external-import occurrence
+        # (not one row per package name) and exempts exactly one import by identity.
         working-directory: plugins/dev/scripts/catalyst-agent
         run: node check-import-graph.mjs
 

--- a/plugins/dev/scripts/catalyst-agent/README.md
+++ b/plugins/dev/scripts/catalyst-agent/README.md
@@ -18,7 +18,12 @@ up uniformly.
   `check-import-graph.mjs`, a required step in `execution-core-tests.yml`, which imports
   every agent module under plain `node` (not a bundler: `bun build --target=node` resolves
   `bun:*` as an external and exits 0 on a graph `node` cannot load) and separately audits
-  the source for any non-`node:` specifier.
+  the source for any non-`node:` specifier. The source audit is the half that carries the
+  contract — CI installs node_modules before the step runs, so on the runner a bare npm
+  specifier resolves and the load probe cannot see it. It records **every** occurrence of
+  an external specifier and exempts exactly one import by identity (`pino`, dynamic, in
+  `config.mjs`, inside a `try {} catch`); a second `pino` import of any shape fails, and so
+  does deleting the guarded one.
 
 ## Domains
 

--- a/plugins/dev/scripts/catalyst-agent/README.md
+++ b/plugins/dev/scripts/catalyst-agent/README.md
@@ -7,8 +7,15 @@ up uniformly.
 
 - **Zero npm deps** — `node:*` builtins only; runs unchanged under `node>=18`
   and `bun`.
-- **Does not import from execution-core** — it is a separate process with its own
-  config, envelope builder, and emit transports.
+- **Does not import execution-core's runtime** — it is a separate process with its own
+  config, envelope builder, and emit transports. There is exactly **one** exception, and
+  it is a pure `node:*`-only leaf carrying data the agent must not have a second copy of:
+  `execution-core/checkout-sync.mjs`'s `resolveExecutingRoots` (CTL-1808), the enumeration
+  of checkouts this host runs code from. The currency gauge below measures that set, and a
+  second enumeration written here would drift from the one the sync pass acts on. Nothing
+  in that leaf reaches `execution-core/config.mjs` or its `bun:sqlite` graph, so the agent
+  still loads under bare `node` with no `node_modules` (guarded by the import-graph check
+  in `execution-core-tests.yml`).
 
 ## Domains
 
@@ -20,10 +27,49 @@ up uniformly.
 
 Each toggle defaults **on**; set it to `0` to disable that domain.
 
-Each tick runs the enabled domains in order (usage → host → processes). The
-sampler modules (`usage.mjs` + `accounts.mjs`, `host.mjs`, `processes.mjs`) are
-imported lazily and adapted to a uniform `runOnce(config)`; a domain that throws
-is isolated so it never stops the others.
+A fourth domain (`version`, toggle `CATALYST_AGENT_VERSION`) emits **metrics**
+rather than events — see [Code currency](#code-currency) below.
+
+Each tick runs the enabled domains in order (usage → host → processes →
+version). The sampler modules (`usage.mjs` + `accounts.mjs`, `host.mjs`,
+`processes.mjs`, `version.mjs`) are imported lazily and adapted to a uniform
+`runOnce(config)`; a domain that throws is isolated so it never stops the others.
+
+## Code currency
+
+| metric                            | shape                                                                       |
+| --------------------------------- | --------------------------------------------------------------------------- |
+| `catalyst.build.info`             | always `1`; label `vcs.ref.head.revision` = the **agent's own** commit       |
+| `catalyst.vcs.commits_behind`     | **one series per executing checkout**, label `catalyst.checkout.root` = path |
+| `catalyst.vcs.commits_behind.max` | one value: the **stalest** checkout on this host                            |
+
+`commits_behind` is measured once per checkout this host actually executes code
+from, resolved through CTL-1808's `resolveExecutingRoots`:
+
+```
+registry repoRoots  ∪  this checkout  ∪  Layer-2 catalyst.checkouts[]  ∪  <CATALYST_DIR>/plugin-source
+```
+
+**Why not just this checkout (CTL-1825).** It used to be `git -C <the directory
+build-info.mjs lives in>`, which answers "is the tree the agent lives in
+current?" — a different question from "is the code this host runs current?"
+whenever those trees differ, and on this fleet they differ by design: workers
+execute from `~/catalyst/plugin-source`, the laptop's plist runs the agent out of
+the dev checkout. Measured 2026-08-13 on the laptop, the gauge read a healthy
+**0** while `~/catalyst/plugin-source` was **24** commits behind. A gauge that can
+only report 0 is worse than no gauge.
+
+Two rules follow, and both are enforced by tests: a stale root is **its own
+non-zero series** (never averaged away or overwritten), and the single aggregate
+is the **MAXIMUM** across roots, never the agent's own. A root git cannot read
+drops its own point — it never contributes a 0 that reads as "current".
+
+Enrol a sibling checkout this host keeps current but is not enrolled to dispatch
+into by adding it to Layer-2 (`~/.config/catalyst/config.json`):
+
+```json
+{ "catalyst": { "checkouts": ["/Users/me/code/catalyst-cloud"] } }
+```
 
 ## Run
 

--- a/plugins/dev/scripts/catalyst-agent/README.md
+++ b/plugins/dev/scripts/catalyst-agent/README.md
@@ -10,12 +10,15 @@ up uniformly.
 - **Does not import execution-core's runtime** — it is a separate process with its own
   config, envelope builder, and emit transports. There is exactly **one** exception, and
   it is a pure `node:*`-only leaf carrying data the agent must not have a second copy of:
-  `execution-core/checkout-sync.mjs`'s `resolveExecutingRoots` (CTL-1808), the enumeration
+  `execution-core/checkout-sync.mjs`'s `classifyExecutingRoots` (CTL-1808), the enumeration
   of checkouts this host runs code from. The currency gauge below measures that set, and a
   second enumeration written here would drift from the one the sync pass acts on. Nothing
   in that leaf reaches `execution-core/config.mjs` or its `bun:sqlite` graph, so the agent
-  still loads under bare `node` with no `node_modules` (guarded by the import-graph check
-  in `execution-core-tests.yml`).
+  still loads under bare `node` with no `node_modules` — guarded by
+  `check-import-graph.mjs`, a required step in `execution-core-tests.yml`, which imports
+  every agent module under plain `node` (not a bundler: `bun build --target=node` resolves
+  `bun:*` as an external and exits 0 on a graph `node` cannot load) and separately audits
+  the source for any non-`node:` specifier.
 
 ## Domains
 
@@ -40,15 +43,29 @@ version). The sampler modules (`usage.mjs` + `accounts.mjs`, `host.mjs`,
 | metric                            | shape                                                                       |
 | --------------------------------- | --------------------------------------------------------------------------- |
 | `catalyst.build.info`             | always `1`; label `vcs.ref.head.revision` = the **agent's own** commit       |
-| `catalyst.vcs.commits_behind`     | **one series per executing checkout**, label `catalyst.checkout.root` = path |
-| `catalyst.vcs.commits_behind.max` | one value: the **stalest** checkout on this host                            |
+| `catalyst.vcs.commits_behind`     | **one series per executing Catalyst checkout**, label `catalyst.checkout.root` = path |
+| `catalyst.vcs.commits_behind.max` | one value: the **stalest** Catalyst checkout on this host                    |
 
 `commits_behind` is measured once per checkout this host actually executes code
-from, resolved through CTL-1808's `resolveExecutingRoots`:
+from, resolved through CTL-1808's `classifyExecutingRoots`:
 
 ```
 registry repoRoots  ∪  this checkout  ∪  Layer-2 catalyst.checkouts[]  ∪  <CATALYST_DIR>/plugin-source
 ```
+
+**Which of those roots (CTL-1825 round 2).** That enumeration also carries the
+enrolled **product** repos the CTL-1808 sync pass fast-forwards, and those are a
+different repository's distance from a different `main`. Measured on the laptop,
+nine of eleven roots were product repos and the stalest — `personal-os`, 58 behind
+its own main — became this host's reported maximum, so a metric named for Catalyst
+currency reported 58 for a personal repository and the pre-existing
+`max by (host_name)(catalyst_vcs_commits_behind) > 20` alert fires on it. So each
+root is classified and **only the `catalyst` role is measured**: the agent's own
+tree and `<CATALYST_DIR>/plugin-source` (Catalyst by construction), plus any
+enrolled or Layer-2-declared root carrying `.claude-plugin/marketplace.json` — the
+Catalyst repo is itself enrolled (ADR-028), so the exclusion has to be by what a
+tree IS, not by which source named it. One enumeration, two views: the sync pass
+still fast-forwards every root.
 
 **Why not just this checkout (CTL-1825).** It used to be `git -C <the directory
 build-info.mjs lives in>`, which answers "is the tree the agent lives in

--- a/plugins/dev/scripts/catalyst-agent/build-info.mjs
+++ b/plugins/dev/scripts/catalyst-agent/build-info.mjs
@@ -4,25 +4,56 @@
 //                            semconv `service.version`; the running artifact)
 //   vcs.ref.head.revision    git commit short-SHA of the agent's checkout (OTel
 //                            semconv VCS `vcs.ref.head.revision`)
-//   commits-behind-main      how far HEAD is behind origin/main (drift)
+//   commits-behind-main      how far each EXECUTING checkout is behind origin/main
 //
 // version + commit are IMMUTABLE for the process lifetime, so they are resolved
 // ONCE and cached. commits-behind changes as main advances, so it is recomputed
 // per call (with an optional network fetch). All resolvers degrade to null on
 // any error (missing git, detached checkout, offline) — telemetry must never
 // crash the agent.
+//
+// ─── CTL-1825: WHERE the currency question is asked ────────────────────────────
+//
+// commits-behind used to be measured with `git -C MODULE_DIR`, i.e. against the
+// tree containing THIS FILE. That answers "is the tree the agent lives in
+// current?", which is a different question from "is the code this host runs
+// current?" whenever those trees differ — and on this fleet they differ BY
+// DESIGN: worker nodes execute from `~/catalyst/plugin-source`, while the
+// laptop's `com.catalyst.agent` plist runs the agent out of the dev working
+// checkout. Measured 2026-08-13 on the laptop:
+//
+//   git -C ~/code-repos/.../catalyst  rev-list --count HEAD..origin/main  →  0
+//   git -C ~/catalyst/plugin-source   rev-list --count HEAD..origin/main  → 24
+//
+// The gauge read a healthy 0 while the tree actually running health-responder,
+// orphan-sweep and log-shipper was 24 behind — not merely imprecise, but
+// structurally incapable of being non-zero on a host whose agent checkout is the
+// one being kept current. A gauge that can only report 0 is worse than no gauge:
+// it is affirmative evidence of currency where none exists.
+//
+// So the measurement is now taken once per EXECUTING ROOT, and the roots come
+// from CTL-1808's `resolveExecutingRoots` — the same enumeration the checkout-sync
+// pass fast-forwards. Deliberately one enumeration and not two: a root the syncer
+// keeps current that the gauge cannot see (or the reverse) is the same silent gap
+// in a new place. The revision/version signals stay MODULE_DIR-scoped, correctly
+// — those describe the running artifact, which IS this tree.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 import { execFileSync } from "node:child_process";
+// The ONE execution-core import the standalone agent makes (see README): a pure,
+// node:*-only leaf carrying the checkout enumeration. It pulls in no config, no
+// emit transport, and no npm dependency, so the agent still runs unchanged under
+// bare `node` with no node_modules.
+import { resolveExecutingRoots } from "../execution-core/checkout-sync.mjs";
 
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 
-// Run a git command in the agent's own checkout (git -C walks up to the repo
-// root). Returns trimmed stdout, or null on any failure.
-function git(args) {
+// Run a git command in a given checkout (git -C walks up to the repo root).
+// Returns trimmed stdout, or null on any failure.
+function gitAt(root, args) {
   try {
-    const out = execFileSync("git", ["-C", MODULE_DIR, ...args], {
+    const out = execFileSync("git", ["-C", root, ...args], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       timeout: 15000,
@@ -32,6 +63,10 @@ function git(args) {
     return null;
   }
 }
+
+// Run a git command in the agent's OWN checkout — the running artifact's identity
+// (version, revision), which is genuinely a property of this tree.
+const git = (args) => gitAt(MODULE_DIR, args);
 
 let _version; // undefined = unresolved · null = resolved-absent · string = value
 /** OTel semconv `service.version` — semver from the agent's plugin.json. Cached. */
@@ -55,16 +90,59 @@ export function vcsRevision() {
 }
 
 /**
- * commitsBehindMain — how many commits HEAD is behind origin/main. Fetches first
- * (network) unless {fetch:false}. Returns a non-negative integer, or null when
- * git / the remote / the network is unavailable (omit the gauge rather than lie).
+ * executingRoots — the checkouts this host actually runs code from. A thin pass-through
+ * to CTL-1808's `resolveExecutingRoots` (registry repoRoots ∪ this checkout ∪ Layer-2
+ * `catalyst.checkouts[]` ∪ `<CATALYST_DIR>/plugin-source`), re-exported here so the
+ * sampler has one import and so this file names the dependency explicitly rather than
+ * reaching across the tree at its call site. NOT cached: an operator who enrols a repo
+ * mid-flight should see it on the next tick, and the agent runs `--once` anyway.
  */
-export function commitsBehindMain({ fetch = true } = {}) {
-  if (fetch) git(["fetch", "--quiet", "origin", "main"]);
-  const n = git(["rev-list", "--count", "HEAD..origin/main"]);
-  if (n === null) return null;
-  const v = Number(n);
-  return Number.isFinite(v) && v >= 0 ? v : null;
+export function executingRoots(opts) {
+  return resolveExecutingRoots(opts);
+}
+
+/**
+ * commitsBehindByRoot — how many commits each executing root is behind origin/main,
+ * ONE measurement per root. Fetches each root first (network) unless {fetch:false}.
+ *
+ * Returns `[{root, behind}]`, `behind` a non-negative integer or **null** when git /
+ * the remote / the network is unavailable for that root. Null is preserved per-root
+ * rather than collapsed: an unreadable checkout must drop its own series, not
+ * contribute a 0 that reads as "current", and not suppress the roots that DID measure.
+ *
+ * COST — this went from one fetch per tick to one per root. Measured on the laptop
+ * (11 roots, real network): **8.6s**, against a 300s StartInterval. The worst case is
+ * bounded by `roots × 2 × 15s` (the two git timeouts) with no network at all, and even
+ * then nothing piles up: launchd will not start a second `--once` of the same label
+ * while one is running, so a slow tick costs a sample, never a process.
+ *
+ * Deliberately NO per-sweep time budget. A budget would have to cut the sweep short
+ * somewhere, and the enumeration puts `<CATALYST_DIR>/plugin-source` LAST — so the one
+ * root this ticket exists to measure is exactly the one a budget would starve first.
+ * A blind spot in the same place, reintroduced by the guard against a cost that measures
+ * 8.6s, is a bad trade.
+ */
+export function commitsBehindByRoot({ fetch = true, roots = executingRoots(), gitIn = gitAt } = {}) {
+  return (roots ?? []).map((root) => {
+    if (fetch) gitIn(root, ["fetch", "--quiet", "origin", "main"]);
+    const n = gitIn(root, ["rev-list", "--count", "HEAD..origin/main"]);
+    const v = n === null ? NaN : Number(n);
+    return { root, behind: Number.isFinite(v) && v >= 0 ? v : null };
+  });
+}
+
+/**
+ * commitsBehindMain — the host's single code-currency number: the MAXIMUM commits-behind
+ * across every executing root. Never the agent's own root, and never an average — a fleet
+ * is only as current as its stalest tree, and any aggregate that a current root can pull
+ * down is the same false-zero this ticket removed. Returns null when NO root resolved
+ * (omit the gauge rather than lie).
+ */
+export function commitsBehindMain(opts = {}) {
+  const measured = commitsBehindByRoot(opts)
+    .map((r) => r.behind)
+    .filter((n) => typeof n === "number");
+  return measured.length === 0 ? null : Math.max(...measured);
 }
 
 // Test-only: clear the version/commit caches so a test can re-resolve.

--- a/plugins/dev/scripts/catalyst-agent/build-info.mjs
+++ b/plugins/dev/scripts/catalyst-agent/build-info.mjs
@@ -32,11 +32,24 @@
 // it is affirmative evidence of currency where none exists.
 //
 // So the measurement is now taken once per EXECUTING ROOT, and the roots come
-// from CTL-1808's `resolveExecutingRoots` — the same enumeration the checkout-sync
+// from CTL-1808's `classifyExecutingRoots` — the same enumeration the checkout-sync
 // pass fast-forwards. Deliberately one enumeration and not two: a root the syncer
 // keeps current that the gauge cannot see (or the reverse) is the same silent gap
 // in a new place. The revision/version signals stay MODULE_DIR-scoped, correctly
 // — those describe the running artifact, which IS this tree.
+//
+// ─── …and WHICH of those roots the gauge answers for ──────────────────────────
+//
+// One enumeration, two VIEWS. The syncer fast-forwards every enumerated root,
+// including sibling and product repos — that breadth is the point of CTL-1808. This
+// gauge measures only the roots whose role is `catalyst`, because its name, and the
+// alert that reads it, are about CATALYST code currency. Measured on the laptop
+// 2026-08-13, nine of eleven enumerated roots were enrolled PRODUCT repos, and the
+// stalest — `personal-os`, 58 behind its own main — was the maximum, so
+// `catalyst.vcs.commits_behind.max` reported 58 for a personal repository and the
+// pre-existing `max by (host_name)(catalyst_vcs_commits_behind) > 20` alert fires
+// on it. That is a number that does not mean what its name says, which is the same
+// defect family as the false zero above, just pointing the other way.
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
@@ -45,7 +58,7 @@ import { execFileSync } from "node:child_process";
 // node:*-only leaf carrying the checkout enumeration. It pulls in no config, no
 // emit transport, and no npm dependency, so the agent still runs unchanged under
 // bare `node` with no node_modules.
-import { resolveExecutingRoots } from "../execution-core/checkout-sync.mjs";
+import { classifyExecutingRoots, resolveExecutingRoots, CHECKOUT_ROLE } from "../execution-core/checkout-sync.mjs";
 
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -102,7 +115,28 @@ export function executingRoots(opts) {
 }
 
 /**
- * commitsBehindByRoot — how many commits each executing root is behind origin/main,
+ * catalystRoots — the `catalyst`-role subset of the enumeration above: the checkouts of
+ * THIS repository that this host executes (its own tree, `<CATALYST_DIR>/plugin-source`, and
+ * any enrolled or Layer-2-declared root carrying the Catalyst marker). This — not
+ * `executingRoots` — is what the currency gauge measures, and it is the default `roots` for
+ * every function below.
+ *
+ * Excluding the enrolled PRODUCT repos is a scope decision, argued in the header: they are
+ * a different repository's distance from a different `main`, so folding them into a metric
+ * named `catalyst.vcs.commits_behind` makes its max mean something other than its name. It
+ * also stops the agent issuing a `git fetch` against nine unrelated repositories on every
+ * launchd tick, which is a side effect a telemetry sampler has no business having.
+ *
+ * NOT cached, for the same reason `executingRoots` is not.
+ */
+export function catalystRoots(opts) {
+  return classifyExecutingRoots(opts)
+    .filter((c) => c.role === CHECKOUT_ROLE.CATALYST)
+    .map((c) => c.root);
+}
+
+/**
+ * commitsBehindByRoot — how many commits each Catalyst checkout is behind origin/main,
  * ONE measurement per root. Fetches each root first (network) unless {fetch:false}.
  *
  * Returns `[{root, behind}]`, `behind` a non-negative integer or **null** when git /
@@ -110,11 +144,13 @@ export function executingRoots(opts) {
  * rather than collapsed: an unreadable checkout must drop its own series, not
  * contribute a 0 that reads as "current", and not suppress the roots that DID measure.
  *
- * COST — this went from one fetch per tick to one per root. Measured on the laptop
- * (11 roots, real network): **8.6s**, against a 300s StartInterval. The worst case is
- * bounded by `roots × 2 × 15s` (the two git timeouts) with no network at all, and even
- * then nothing piles up: launchd will not start a second `--once` of the same label
- * while one is running, so a slow tick costs a sample, never a process.
+ * COST — this went from one fetch per tick to one per root, and the `catalyst`-role
+ * scoping brings it back down: measured on the laptop, 11 enumerated roots (real
+ * network) took **8.6s**, of which nine were product repos the gauge no longer touches.
+ * Against a 300s StartInterval either is affordable; the worst case is bounded by
+ * `roots × 2 × 15s` (the two git timeouts) with no network at all, and even then nothing
+ * piles up: launchd will not start a second `--once` of the same label while one is
+ * running, so a slow tick costs a sample, never a process.
  *
  * Deliberately NO per-sweep time budget. A budget would have to cut the sweep short
  * somewhere, and the enumeration puts `<CATALYST_DIR>/plugin-source` LAST — so the one
@@ -122,7 +158,7 @@ export function executingRoots(opts) {
  * A blind spot in the same place, reintroduced by the guard against a cost that measures
  * 8.6s, is a bad trade.
  */
-export function commitsBehindByRoot({ fetch = true, roots = executingRoots(), gitIn = gitAt } = {}) {
+export function commitsBehindByRoot({ fetch = true, roots = catalystRoots(), gitIn = gitAt } = {}) {
   return (roots ?? []).map((root) => {
     if (fetch) gitIn(root, ["fetch", "--quiet", "origin", "main"]);
     const n = gitIn(root, ["rev-list", "--count", "HEAD..origin/main"]);
@@ -133,10 +169,10 @@ export function commitsBehindByRoot({ fetch = true, roots = executingRoots(), gi
 
 /**
  * commitsBehindMain — the host's single code-currency number: the MAXIMUM commits-behind
- * across every executing root. Never the agent's own root, and never an average — a fleet
- * is only as current as its stalest tree, and any aggregate that a current root can pull
- * down is the same false-zero this ticket removed. Returns null when NO root resolved
- * (omit the gauge rather than lie).
+ * across every Catalyst checkout it executes. Never the agent's own root alone, and never
+ * an average — a fleet is only as current as its stalest tree, and any aggregate that a
+ * current root can pull down is the same false-zero this ticket removed. Returns null when
+ * NO root resolved (omit the gauge rather than lie).
  */
 export function commitsBehindMain(opts = {}) {
   const measured = commitsBehindByRoot(opts)

--- a/plugins/dev/scripts/catalyst-agent/build-info.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/build-info.test.mjs
@@ -1,0 +1,177 @@
+// build-info.test.mjs (CTL-1825) — the code-currency gauge measures the roots
+// the fleet's daemons actually execute from, not the tree this file happens to
+// live in.
+//
+// The defect this suite exists to prevent: `commitsBehindMain` ran
+// `git -C MODULE_DIR rev-list --count HEAD..origin/main`, so it answered "is the
+// tree containing build-info.mjs current?". On this fleet that is a DIFFERENT
+// tree from the one the daemons run: worker nodes execute from
+// `~/catalyst/plugin-source`, and the laptop's `com.catalyst.agent` plist runs
+// the agent out of the dev working checkout. Measured 2026-08-13 on the laptop:
+// the agent's checkout 0 behind, `~/catalyst/plugin-source` 24 behind, gauge 0.
+//
+// Every git call is injected, so these run with no git binary, no network, and
+// no real checkout.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test build-info.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { commitsBehindByRoot, commitsBehindMain, executingRoots } from "./build-info.mjs";
+
+// THE LAPTOP, 2026-08-13 — the exact fixture the ticket measured. The agent's own
+// checkout is current; the tree that actually runs health-responder / orphan-sweep /
+// log-shipper is 24 commits behind.
+const AGENT_CHECKOUT = "/Users/ryan/code-repos/github/coalesce-labs/catalyst";
+const PLUGIN_SOURCE = "/Users/ryan/catalyst/plugin-source";
+const LAPTOP = { [AGENT_CHECKOUT]: 0, [PLUGIN_SOURCE]: 24 };
+
+// A git seam that answers `rev-list --count` from a {root: n} table. A root absent
+// from the table behaves like a root git cannot read: null, never a silent 0.
+function gitFor(table, { onFetch = () => {} } = {}) {
+  return (root, args) => {
+    if (args[0] === "fetch") {
+      onFetch(root);
+      return "";
+    }
+    if (args[0] === "rev-list") {
+      const n = table[root];
+      return n === undefined ? null : String(n);
+    }
+    return null;
+  };
+}
+
+describe("commitsBehindByRoot — one measurement per executing root", () => {
+  test("returns a series per root, each labelled by the root it measured", () => {
+    const series = commitsBehindByRoot({
+      fetch: false,
+      roots: [AGENT_CHECKOUT, PLUGIN_SOURCE],
+      gitIn: gitFor(LAPTOP),
+    });
+    expect(series).toEqual([
+      { root: AGENT_CHECKOUT, behind: 0 },
+      { root: PLUGIN_SOURCE, behind: 24 },
+    ]);
+  });
+
+  test("a root git cannot read reports null, never a false 0", () => {
+    const series = commitsBehindByRoot({
+      fetch: false,
+      roots: [AGENT_CHECKOUT, "/repos/no-remote"],
+      gitIn: gitFor(LAPTOP),
+    });
+    expect(series).toEqual([
+      { root: AGENT_CHECKOUT, behind: 0 },
+      { root: "/repos/no-remote", behind: null },
+    ]);
+  });
+
+  test("a negative or non-numeric rev-list answer degrades to null", () => {
+    const series = commitsBehindByRoot({
+      fetch: false,
+      roots: ["/a", "/b"],
+      gitIn: (root) => (root === "/a" ? "-3" : "not-a-number"),
+    });
+    expect(series).toEqual([{ root: "/a", behind: null }, { root: "/b", behind: null }]);
+  });
+
+  test("fetches every root when asked, and none when told not to", () => {
+    const fetched = [];
+    commitsBehindByRoot({
+      fetch: true,
+      roots: [AGENT_CHECKOUT, PLUGIN_SOURCE],
+      gitIn: gitFor(LAPTOP, { onFetch: (r) => fetched.push(r) }),
+    });
+    expect(fetched).toEqual([AGENT_CHECKOUT, PLUGIN_SOURCE]);
+
+    const skipped = [];
+    commitsBehindByRoot({
+      fetch: false,
+      roots: [AGENT_CHECKOUT],
+      gitIn: gitFor(LAPTOP, { onFetch: (r) => skipped.push(r) }),
+    });
+    expect(skipped).toEqual([]);
+  });
+
+  test("no resolvable roots at all → an empty series (the caller emits nothing)", () => {
+    expect(commitsBehindByRoot({ fetch: false, roots: [], gitIn: gitFor(LAPTOP) })).toEqual([]);
+  });
+});
+
+describe("commitsBehindMain — the single aggregate is the MAXIMUM across roots", () => {
+  test("a stale root sets the aggregate; the current one cannot hide it", () => {
+    const max = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT, PLUGIN_SOURCE], gitIn: gitFor(LAPTOP) });
+    expect(max).toBe(24);
+  });
+
+  test("root ORDER cannot change the answer (it is a max, not a first or a last)", () => {
+    const forward = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT, PLUGIN_SOURCE], gitIn: gitFor(LAPTOP) });
+    const reverse = commitsBehindMain({ fetch: false, roots: [PLUGIN_SOURCE, AGENT_CHECKOUT], gitIn: gitFor(LAPTOP) });
+    expect(forward).toBe(24);
+    expect(reverse).toBe(24);
+  });
+
+  test("an unreadable root does not suppress a readable stale one", () => {
+    const max = commitsBehindMain({
+      fetch: false,
+      roots: ["/repos/unreadable", PLUGIN_SOURCE],
+      gitIn: gitFor(LAPTOP),
+    });
+    expect(max).toBe(24);
+  });
+
+  test("every root unresolvable → null, so the gauge is omitted rather than reported as 0", () => {
+    expect(commitsBehindMain({ fetch: false, roots: ["/x", "/y"], gitIn: () => null })).toBeNull();
+    expect(commitsBehindMain({ fetch: false, roots: [], gitIn: () => null })).toBeNull();
+  });
+});
+
+// ─── POSITIVE CONTROL (ticket-mandated) ────────────────────────────────────────
+//
+// This is the scenario the ticket requires to FAIL if the fix is reverted. It runs
+// the SAME instrument twice over the SAME laptop fixture — once restricted to the
+// agent's own checkout (exactly what `git -C MODULE_DIR` measured before this
+// change), once over the full executing set — and asserts the two disagree.
+//
+// If `commitsBehindMain` goes back to measuring the module directory alone, the
+// second call collapses onto the first and returns 0, and the inequality below
+// fails. That is what makes the passing scenarios above non-vacuous: the fixture
+// is demonstrably capable of producing a wrong answer.
+describe("positive control — the gauge can observe the defect", () => {
+  test("MODULE_DIR-only measurement reports 0 on a host whose OTHER root is 24 behind", () => {
+    const preFix = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT], gitIn: gitFor(LAPTOP) });
+    const fixed = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT, PLUGIN_SOURCE], gitIn: gitFor(LAPTOP) });
+
+    // The pre-fix answer — affirmative evidence of currency where none exists.
+    expect(preFix).toBe(0);
+    // The fixed answer — the tree the daemons actually run.
+    expect(fixed).toBe(24);
+    // …and they MUST differ, or neither assertion above is measuring anything.
+    expect(fixed).not.toBe(preFix);
+  });
+});
+
+describe("executingRoots — the agent reads CTL-1808's enumeration, it does not invent one", () => {
+  test("registry ∪ self ∪ Layer-2 checkouts[] ∪ plugin-source, de-duplicated", () => {
+    const roots = executingRoots({
+      env: { CATALYST_DIR: "/cat", HOME: "/home/u" },
+      readJson: (path) => {
+        if (path === "/cat/execution-core/registry.json") return { projects: [{ team: "CTL", repoRoot: "/repos/catalyst" }] };
+        if (path === "/home/u/.config/catalyst/config.json") return { catalyst: { checkouts: ["/repos/extra"] } };
+        return null;
+      },
+      selfRoot: "/dev/checkout",
+      exists: () => true,
+    });
+    expect(roots).toEqual(["/repos/catalyst", "/dev/checkout", "/repos/extra", "/cat/plugin-source"]);
+  });
+
+  // The real resolver on a real box: whatever it returns, the tree this test file
+  // lives in must be in it — the agent always measures at least itself.
+  test("the real resolver includes this checkout", () => {
+    const roots = executingRoots();
+    expect(Array.isArray(roots)).toBe(true);
+    expect(roots.length).toBeGreaterThan(0);
+    expect(roots.some((r) => import.meta.dir.startsWith(r))).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/build-info.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/build-info.test.mjs
@@ -16,7 +16,10 @@
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test build-info.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { commitsBehindByRoot, commitsBehindMain, executingRoots } from "./build-info.mjs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { commitsBehindByRoot, commitsBehindMain, executingRoots, catalystRoots } from "./build-info.mjs";
 
 // THE LAPTOP, 2026-08-13 — the exact fixture the ticket measured. The agent's own
 // checkout is current; the tree that actually runs health-responder / orphan-sweep /
@@ -126,19 +129,20 @@ describe("commitsBehindMain — the single aggregate is the MAXIMUM across roots
   });
 });
 
-// ─── POSITIVE CONTROL (ticket-mandated) ────────────────────────────────────────
+// ─── NOT the positive control (kept, honestly labelled) ────────────────────────
 //
-// This is the scenario the ticket requires to FAIL if the fix is reverted. It runs
-// the SAME instrument twice over the SAME laptop fixture — once restricted to the
-// agent's own checkout (exactly what `git -C MODULE_DIR` measured before this
-// change), once over the full executing set — and asserts the two disagree.
-//
-// If `commitsBehindMain` goes back to measuring the module directory alone, the
-// second call collapses onto the first and returns 0, and the inequality below
-// fails. That is what makes the passing scenarios above non-vacuous: the fixture
-// is demonstrably capable of producing a wrong answer.
-describe("positive control — the gauge can observe the defect", () => {
-  test("MODULE_DIR-only measurement reports 0 on a host whose OTHER root is 24 behind", () => {
+// This block used to be labelled "positive control — the gauge can observe the
+// defect". It is not one, and saying so was the same error the ticket is about:
+// affirmative evidence of coverage where none exists. Both calls INJECT `roots`,
+// so between them they only assert that a Math.max over a list differs from a
+// Math.max over a subset of it — arithmetic that holds whatever the production
+// enumeration does. PROVEN, not assumed: with the whole per-root API kept and only
+// the root enumeration reverted to `[MODULE_DIR]`, every assertion here still
+// passed. It is retained because the arithmetic IS worth pinning (the aggregate
+// must move when a stale root joins the set); it is simply not the control.
+// The real one is the block below it.
+describe("aggregate arithmetic over an injected root set (NOT the positive control)", () => {
+  test("adding a 24-behind root to a set of current ones moves the aggregate to 24", () => {
     const preFix = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT], gitIn: gitFor(LAPTOP) });
     const fixed = commitsBehindMain({ fetch: false, roots: [AGENT_CHECKOUT, PLUGIN_SOURCE], gitIn: gitFor(LAPTOP) });
 
@@ -148,6 +152,147 @@ describe("positive control — the gauge can observe the defect", () => {
     expect(fixed).toBe(24);
     // …and they MUST differ, or neither assertion above is measuring anything.
     expect(fixed).not.toBe(preFix);
+  });
+});
+
+// ─── POSITIVE CONTROL (ticket-mandated) ────────────────────────────────────────
+//
+// The ticket's scenario, implemented literally:
+//
+//   Given the pre-fix implementation measuring MODULE_DIR only
+//   When it runs on the laptop (agent checkout current, plugin-source 24 behind)
+//   Then it reports 0
+//
+// The load-bearing difference from the block above: the FIXED call passes NO
+// `roots`, so it runs the production default — `catalystRoots()` →
+// `classifyExecutingRoots()` → registry read, self-root `.git` walk, Layer-2 read,
+// plugin-source, existence filter, role classification. Only the git seam is
+// injected, because the ticket is about WHICH trees are asked, not about git.
+//
+// The laptop is reproduced on disk rather than described: a scratch CATALYST_DIR
+// whose `plugin-source` really exists, with HOME pointed at the same scratch tree
+// so no real Layer-2 config leaks in. `plugin-source` is deliberately left WITHOUT
+// a Catalyst marker file — it is a Catalyst root structurally, and if that rule
+// ever regresses this control goes red rather than quietly measuring one tree.
+//
+// Revert the enumeration to the module directory (the pre-fix shape) and this
+// fails twice over: the stale root leaves the enumeration, and the aggregate
+// collapses to 0.
+describe("positive control — the gauge can observe the defect (production default path)", () => {
+  test("pre-fix shape reports 0 where the production enumeration reports 24", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "ctl1825-control-"));
+    const catalystDir = join(tmp, "catalyst");
+    const pluginSource = join(catalystDir, "plugin-source");
+    mkdirSync(pluginSource, { recursive: true });
+
+    const saved = { CATALYST_DIR: process.env.CATALYST_DIR, HOME: process.env.HOME, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME };
+    process.env.CATALYST_DIR = catalystDir;
+    process.env.HOME = tmp;
+    delete process.env.XDG_CONFIG_HOME;
+    try {
+      // The laptop, exactly: the tree the daemons run from is 24 behind, every
+      // other Catalyst checkout on the host (the agent's own included) is current.
+      const gitIn = (root, args) => (args[0] === "rev-list" ? (root === pluginSource ? "24" : "0") : "");
+
+      // NON-VACUITY, asserted before the measurement: the production enumeration
+      // must actually contain the stale root AND more than it alone, or the
+      // comparison below would be a tautology. This is the assertion that fails
+      // first if the enumeration ever collapses back to one directory.
+      const roots = catalystRoots();
+      expect(roots).toContain(pluginSource);
+      expect(roots.length).toBeGreaterThan(1);
+
+      // The pre-fix shape: `git -C <the directory build-info.mjs lives in>` — one
+      // root, the agent's own tree, which is exactly what the old code measured.
+      const preFix = commitsBehindMain({ fetch: false, roots: [import.meta.dir], gitIn });
+      // The fixed shape: no roots argument at all — the production default.
+      const fixed = commitsBehindMain({ fetch: false, gitIn });
+
+      expect(preFix).toBe(0); // affirmative evidence of currency where none exists
+      expect(fixed).toBe(24); // the tree the daemons actually run
+      expect(fixed).not.toBe(preFix);
+    } finally {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── SCOPE: whose currency is this? (CTL-1825 round 2) ─────────────────────────
+//
+// The enumeration deliberately spans every checkout this host runs, including the
+// enrolled PRODUCT repos the CTL-1808 sync pass fast-forwards. Measured on the
+// laptop 2026-08-13, nine of eleven roots were product repos and the stalest —
+// `personal-os`, 58 commits behind its OWN main — was this host's reported maximum,
+// so `catalyst.vcs.commits_behind.max` said 58 for a personal repository and the
+// pre-existing `max by (host_name)(catalyst_vcs_commits_behind) > 20` alert fires
+// on it. These two tests are the pair: the product repo must not drive the gauge,
+// and the exclusion must be by what the tree IS — not by "registry roots never
+// count", which would drop the Catalyst repo itself (it is enrolled, ADR-028).
+describe("scope — a Catalyst currency gauge is not driven by an enrolled product repo", () => {
+  // One scratch host: a registry naming `project`, plus a real plugin-source. The
+  // caller decides whether `project` carries the Catalyst marker.
+  function scratchHost({ markProjectAsCatalyst }) {
+    const tmp = mkdtempSync(join(tmpdir(), "ctl1825-scope-"));
+    const catalystDir = join(tmp, "catalyst");
+    const pluginSource = join(catalystDir, "plugin-source");
+    const project = join(tmp, "repos", "personal-os");
+    mkdirSync(pluginSource, { recursive: true });
+    mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+    mkdirSync(project, { recursive: true });
+    writeFileSync(
+      join(catalystDir, "execution-core", "registry.json"),
+      JSON.stringify({ projects: [{ team: "POS", repoRoot: project }] }),
+    );
+    if (markProjectAsCatalyst) {
+      mkdirSync(join(project, ".claude-plugin"), { recursive: true });
+      writeFileSync(join(project, ".claude-plugin", "marketplace.json"), "{}");
+    }
+    const saved = { CATALYST_DIR: process.env.CATALYST_DIR, HOME: process.env.HOME, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME };
+    process.env.CATALYST_DIR = catalystDir;
+    process.env.HOME = tmp;
+    delete process.env.XDG_CONFIG_HOME;
+    // 58 behind, exactly as measured; every Catalyst checkout current.
+    const gitIn = (root, args) => (args[0] === "rev-list" ? (root === project ? "58" : "0") : "");
+    const restore = () => {
+      for (const [k, v] of Object.entries(saved)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      rmSync(tmp, { recursive: true, force: true });
+    };
+    return { tmp, project, pluginSource, gitIn, restore };
+  }
+
+  test("a 58-behind enrolled product repo is neither measured nor the aggregate", () => {
+    const h = scratchHost({ markProjectAsCatalyst: false });
+    try {
+      // Non-vacuity: the enumeration DID see the product repo — it is enrolled and
+      // it exists — so its absence below is a role decision, not a missing fixture.
+      expect(executingRoots()).toContain(h.project);
+
+      const series = commitsBehindByRoot({ fetch: false, gitIn: h.gitIn });
+      expect(series.map((c) => c.root)).not.toContain(h.project);
+      expect(series.map((c) => c.root)).toContain(h.pluginSource);
+      // The alert's number. 58 here would fire `> 20` on a personal repository.
+      expect(commitsBehindMain({ fetch: false, gitIn: h.gitIn })).toBe(0);
+    } finally {
+      h.restore();
+    }
+  });
+
+  test("…but an enrolled root that IS a Catalyst checkout is measured (ADR-028 enrols this repo)", () => {
+    const h = scratchHost({ markProjectAsCatalyst: true });
+    try {
+      const series = commitsBehindByRoot({ fetch: false, gitIn: h.gitIn });
+      expect(series.map((c) => c.root)).toContain(h.project);
+      expect(commitsBehindMain({ fetch: false, gitIn: h.gitIn })).toBe(58);
+    } finally {
+      h.restore();
+    }
   });
 });
 

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.mjs
@@ -164,7 +164,8 @@ export function defaultImporters(pending = []) {
           await processes.sampleProcesses({ topN: config.topN });
         },
       })),
-    // Domain 4 (CTL-1235) — catalyst.build.info + catalyst.vcs.commits_behind.
+    // Domain 4 (CTL-1235) — catalyst.build.info + catalyst.vcs.commits_behind
+    // (one series per executing checkout) + catalyst.vcs.commits_behind.max.
     // Emits the running version/commit + drift-from-main as OTLP gauges. Uses its
     // own config-aware metric emit (like host), so nothing is collected here.
     version: () =>

--- a/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/catalyst-agent.test.mjs
@@ -12,6 +12,10 @@ import { join } from "node:path";
 import { runDomain, runOnce, main, defaultImporters, writeHeartbeat } from "./catalyst-agent.mjs";
 import { readAgentConfig, getHeartbeatPath } from "./config.mjs";
 
+// The three domains whose importers the tests below inject. `versionEnabled` is
+// deliberately absent (falsy → skipped): these fixtures supply no `version`
+// importer, and the real one would `git fetch` every executing root. The version
+// gate has its own coverage — see the toggle pair in the defaultImporters block.
 const ALL_ON = {
   usageEnabled: true,
   hostEnabled: true,
@@ -310,7 +314,14 @@ describe("main — --loop lifecycle", () => {
 // ─── defaultImporters / makeBuilderEmit — the REAL --once wiring (finding 9) ───
 
 describe("defaultImporters — real sampler composition (event-log emit)", () => {
-  const ENVS = ["CATALYST_DIR", "CATALYST_AGENT_EMIT", "CATALYST_AGENT_USAGE", "CATALYST_AGENT_HOST", "CATALYST_AGENT_PROCESS"];
+  const ENVS = [
+    "CATALYST_DIR",
+    "CATALYST_AGENT_EMIT",
+    "CATALYST_AGENT_USAGE",
+    "CATALYST_AGENT_HOST",
+    "CATALYST_AGENT_PROCESS",
+    "CATALYST_AGENT_VERSION",
+  ];
   let saved = {};
   function setEnv(env) {
     for (const k of ENVS) { saved[k] = process.env[k]; delete process.env[k]; }
@@ -390,6 +401,13 @@ describe("defaultImporters — real sampler composition (event-log emit)", () =>
       CATALYST_AGENT_EMIT: "otlp",
       CATALYST_AGENT_USAGE: "0", // no keychain/usage network
       CATALYST_AGENT_PROCESS: "0", // host only
+      // The version domain does not go through the monkeypatched fetch: its tick
+      // runs a REAL `git fetch --quiet origin main` per executing Catalyst root
+      // (build-info's commitsBehindByRoot, one 15s-bounded git call each since
+      // CTL-1825). That is real network inside a 5s bun timeout — the very thing
+      // "only the host domain enabled (no other network)" above rules out — so the
+      // domain is switched off here rather than raced against.
+      CATALYST_AGENT_VERSION: "0",
     });
     process.env.CATALYST_AGENT_OTLP_ENDPOINT = "http://127.0.0.1:4318";
     const realFetch = globalThis.fetch;
@@ -409,6 +427,11 @@ describe("defaultImporters — real sampler composition (event-log emit)", () =>
       // The decisive assertion: the POST completed before runOnce returned, so a
       // subsequent process.exit(0) (the --once entrypoint) would NOT drop it.
       expect(finished).toBe(true);
+      // Hermeticity, asserted rather than assumed. runOnce writes results.version
+      // ONLY inside `if (config.versionEnabled)`, so an absent key is proof the
+      // git-fetching domain was never entered — not merely that it happened to
+      // finish inside the timeout. The mirror of the positive control below.
+      expect(results.version).toBeUndefined();
     } finally {
       globalThis.fetch = realFetch;
       delete process.env.CATALYST_AGENT_OTLP_ENDPOINT;
@@ -416,16 +439,43 @@ describe("defaultImporters — real sampler composition (event-log emit)", () =>
     }
   });
 
+  test("positive control: with CATALYST_AGENT_VERSION unset the version domain DOES run", async () => {
+    // The mirror of the assertion above, and what makes it evidence: the same
+    // observable (results.version) under the same runOnce, with the toggle left
+    // unset. If it were absent here too, the test above would be passing because
+    // the domain is dead rather than because the toggle switched it off. Importers
+    // are injected, so the domain "running" costs no git and no network — what is
+    // under test is the env → readAgentConfig → runOnce gate, not the sampler.
+    const dir = mkdtempSync(join(tmpdir(), "ctl1825-version-on-"));
+    setEnv({ CATALYST_DIR: dir, CATALYST_AGENT_EMIT: "eventlog" }); // VERSION deliberately unset
+    const ran = [];
+    const stub = (name) => async () => ({ runOnce: async () => { ran.push(name); } });
+    try {
+      const config = readAgentConfig();
+      expect(config.versionEnabled).toBe(true);
+      const results = await runOnce({
+        config,
+        importers: { usage: stub("usage"), host: stub("host"), process: stub("process"), version: stub("version") },
+      });
+      expect(ran).toContain("version");
+      expect(results.version).toBe(true);
+    } finally {
+      restoreEnv();
+    }
+  });
+
   test("every importer resolves to a module with an async runOnce (lazy import + adapter shape)", async () => {
-    // Structural wiring check for ALL three domains, with NO network: the usage
-    // importer's runOnce would hit the live keychain + usage API if executed on a
-    // dev host, so we deliberately do NOT call it here — we assert the lazy import
-    // resolves and yields the uniform { runOnce } adapter (the import.meta.url path
-    // + two-level .then chain for usage). The deep enumerate→tick→emit and
+    // Structural wiring check for ALL four domains, with NO network: the usage
+    // importer's runOnce would hit the live keychain + usage API, and version's
+    // would `git fetch` every executing root, if executed on a dev host — so we
+    // deliberately do NOT call either here. We assert the lazy import resolves and
+    // yields the uniform { runOnce } adapter (the import.meta.url path + two-level
+    // .then chain for usage). The deep enumerate→tick→emit and
     // sampleHost/sampleProcesses signatures are validated by the host & process
-    // event-log tests above and by the per-module unit suites.
+    // event-log tests above and by the per-module unit suites (sampleVersion's own
+    // composition is covered with injected seams in version.test.mjs).
     const importers = defaultImporters();
-    for (const key of ["usage", "host", "process"]) {
+    for (const key of ["usage", "host", "process", "version"]) {
       const mod = await importers[key]();
       expect(typeof mod.runOnce).toBe("function");
       // Each adapter's runOnce is async (returns a promise) so runOnce/runDomain

--- a/plugins/dev/scripts/catalyst-agent/check-import-graph.mjs
+++ b/plugins/dev/scripts/catalyst-agent/check-import-graph.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+// check-import-graph.mjs (CTL-1825) — prove the agent's module graph is loadable by the
+// runtime that actually runs it: plain `node`, from a launchd plist, with no node_modules.
+//
+// ─── WHY THIS FILE EXISTS AND WHAT IT REPLACES ────────────────────────────────
+//
+// CTL-1825 gave the agent its one execution-core import (`checkout-sync.mjs`'s root
+// enumeration), and shipped a CI step to guard the "bare node, zero npm deps" rule that
+// import stretches:
+//
+//     bun build --target=node catalyst-agent.mjs --outfile=/dev/null
+//
+// That guard CANNOT FAIL for the class it claims to catch. Measured, not assumed: adding a
+// side-effectful `import { Database } from "bun:sqlite"` to `build-info.mjs` leaves that
+// command at exit 0, emitting a bundle that still contains the `bun:sqlite` specifier —
+// while `node -e 'import("./build-info.mjs")'` on the same tree fails with
+// ERR_UNSUPPORTED_ESM_URL_SCHEME. A bundler resolves `bun:*` as an external and a tree-shaken
+// import is dropped entirely, so `bun build` answers "can this be bundled", which is not the
+// question. A guard that cannot fail is worse than no guard — it is affirmative evidence of
+// safety where none exists, which is the exact defect CTL-1825 is about. So it is replaced,
+// not patched, by the two checks below, which use the real runtime as the instrument.
+//
+// ─── THE TWO CHECKS ───────────────────────────────────────────────────────────
+//
+// 1. LOADABILITY. Every agent module is `import()`ed under this process's runtime (CI runs it
+//    with `node`). Anything the runtime cannot resolve — `bun:*`, a missing sibling, a syntax
+//    error, a transitive import into `execution-core/config.mjs`'s `bun:sqlite` graph — throws
+//    here exactly as it would at 3am on a launchd tick. Every `*.mjs` in this directory is
+//    imported directly, not just the entry point, because the four domain samplers are reached
+//    only through LAZY `import()` at tick time: importing `catalyst-agent.mjs` alone would
+//    exercise none of them, and `build-info.mjs` (the CTL-1825 edge) is behind one of them.
+//
+// 2. SPECIFIER AUDIT. The transitive static-import graph is walked and every non-relative
+//    specifier must be `node:`-prefixed. This is not redundant with (1): check (1) is only as
+//    strict as the machine it runs on, and a stray `node_modules` anywhere above the checkout
+//    would let a bare npm specifier resolve in CI while the launchd runtime — which has none —
+//    fails. The audit is a statement about the SOURCE, so it holds on any machine.
+//
+// Both checks are gated on their own non-vacuity (see ASSERTIONS below): a walk that visits
+// nothing passes every "no bad specifier found" test there is, and reporting that as a clean
+// result would reproduce this ticket's defect inside the guard for it.
+//
+// Run: node check-import-graph.mjs      (exit 0 = clean, 1 = violation, 2 = the check itself
+//                                        could not run)
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, relative, resolve } from "node:path";
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+const SELF = fileURLToPath(import.meta.url);
+
+// Floors for the non-vacuity gates. Deliberately well below the real counts (currently 10
+// agent modules and 12 graph files) so ordinary growth never trips them — they exist to catch
+// an enumeration that has silently gone to zero or near-zero, not to pin exact numbers.
+const MIN_AGENT_MODULES = 6;
+const MIN_GRAPH_FILES = 8;
+
+// The cross-directory leaves CTL-1825 introduced. The walk MUST reach both: they are the only
+// files outside this directory in the agent's graph, and they are the whole reason this check
+// is stricter than it used to need to be. If a refactor drops the edge, this check must stop
+// claiming to guard it rather than silently guarding nothing.
+const REQUIRED_GRAPH_MEMBERS = ["execution-core/checkout-sync.mjs", "lib/secret-contract.mjs"];
+
+// Static `import`/`export ... from` specifiers, plus dynamic `import("literal")`. Anchored at
+// a line start (after optional indentation) so a specifier quoted inside a `//` comment — of
+// which this codebase has many — is not counted as an edge. Dynamic imports built from a
+// non-literal (`import(new URL("./host.mjs", import.meta.url).href)`, which is how the agent
+// loads its domain samplers) are invisible to any static scan; check (1) covers those by
+// importing every module in this directory directly.
+const SPECIFIER_PATTERNS = [
+  { kind: "static", re: /(?:^|\n)[ \t]*import\s+(?:[^'"();]*?\sfrom\s+)?['"]([^'"]+)['"]/g },
+  { kind: "static", re: /(?:^|\n)[ \t]*export\s+[^'"();]*?\sfrom\s+['"]([^'"]+)['"]/g },
+  { kind: "dynamic", re: /import\(\s*['"]([^'"]+)['"]\s*\)/g },
+];
+
+// The one declared npm dependency, and it is OPTIONAL by construction. `config.mjs` wraps
+// `await import("pino")` in a try/catch and substitutes a console shim with the same surface;
+// the shim IS the agent's expected steady state, since the launchd runtime has no
+// node_modules (CTL-1418 turned the fallback notice down to debug for exactly that reason).
+//
+// The distinction the allowlist encodes is real and not a courtesy: a STATIC bare specifier
+// aborts module load outright and nothing downstream gets a say, while a dynamic one is an
+// expression whose failure the caller can catch — and here does. Anything else, static or
+// dynamic, fails: an unguarded second npm import is how "zero npm deps" stops being true
+// without anyone noticing.
+const OPTIONAL_DYNAMIC_DEPS = new Set(["pino"]);
+
+function specifiersIn(source) {
+  const out = [];
+  for (const { kind, re } of SPECIFIER_PATTERNS) {
+    re.lastIndex = 0;
+    for (const m of source.matchAll(re)) out.push({ spec: m[1], kind });
+  }
+  return out;
+}
+
+// agentModules — every module this directory ships, tests and this file excluded.
+function agentModules() {
+  return readdirSync(DIR)
+    .filter((f) => f.endsWith(".mjs") && !f.endsWith(".test.mjs"))
+    .map((f) => join(DIR, f))
+    .filter((p) => p !== SELF)
+    .sort();
+}
+
+// walkGraph — follow relative specifiers transitively from every agent module, recording each
+// visited file and every non-relative specifier seen along the way.
+function walkGraph(entries) {
+  const visited = new Set();
+  const external = new Map(); // specifier → {kind, file} of the first importer seen
+  const queue = [...entries];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    let source;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch (err) {
+      throw new Error(`unreadable module in the agent graph: ${file} (${err?.message})`);
+    }
+    for (const { spec, kind } of specifiersIn(source)) {
+      if (spec.startsWith("./") || spec.startsWith("../")) {
+        queue.push(resolve(dirname(file), spec));
+      } else if (!external.has(spec)) {
+        external.set(spec, { kind, file });
+      }
+    }
+  }
+  return { visited, external };
+}
+
+const problems = [];
+const rel = (p) => relative(DIR, p);
+
+let modules;
+try {
+  modules = agentModules();
+} catch (err) {
+  console.error(`check-import-graph: cannot enumerate agent modules: ${err?.message}`);
+  process.exit(2);
+}
+
+// ── ASSERTIONS: non-vacuity first ─────────────────────────────────────────────
+// Everything below is a "nothing bad found" test, and every such test passes trivially on an
+// empty input set (`[].every(p)` is `true`). These gates are what make a clean result mean
+// "looked and found nothing" rather than "could not look".
+if (modules.length < MIN_AGENT_MODULES) {
+  problems.push(
+    `enumerated only ${modules.length} agent module(s) (floor ${MIN_AGENT_MODULES}) — the check would pass vacuously`,
+  );
+}
+
+// ── CHECK 1: loadability under THIS runtime ───────────────────────────────────
+for (const file of modules) {
+  try {
+    await import(pathToFileURL(file).href);
+  } catch (err) {
+    problems.push(`${rel(file)} does not load under ${process.release?.name ?? "this runtime"}: ${err?.message}`);
+  }
+}
+
+// ── CHECK 2: source-level specifier audit ─────────────────────────────────────
+let graph;
+try {
+  graph = walkGraph(modules);
+} catch (err) {
+  console.error(`check-import-graph: ${err?.message}`);
+  process.exit(2);
+}
+
+if (graph.visited.size < MIN_GRAPH_FILES) {
+  problems.push(
+    `walked only ${graph.visited.size} file(s) (floor ${MIN_GRAPH_FILES}) — the specifier audit would pass vacuously`,
+  );
+}
+for (const member of REQUIRED_GRAPH_MEMBERS) {
+  const reached = [...graph.visited].some((f) => f.replaceAll("\\", "/").endsWith(`/${member}`));
+  if (!reached) {
+    problems.push(`the walk never reached ${member} — the edge this check exists to guard is unguarded`);
+  }
+}
+// The scanner itself must have parsed something: zero external specifiers across a graph this
+// size means the regexes matched nothing, not that the agent imports nothing (every module in
+// it imports from `node:`).
+if (graph.external.size === 0) {
+  problems.push("the specifier scan found no imports at all — it is not parsing this graph");
+}
+for (const [spec, { kind, file }] of graph.external) {
+  if (spec.startsWith("node:")) continue;
+  if (kind === "dynamic" && OPTIONAL_DYNAMIC_DEPS.has(spec)) continue;
+  problems.push(
+    `${rel(file)} ${kind}-imports "${spec}" — the agent's runtime is bare node with no ` +
+      `node_modules, so only node:* is loadable (an optional dependency must be a guarded ` +
+      `dynamic import declared in OPTIONAL_DYNAMIC_DEPS)`,
+  );
+}
+
+if (problems.length > 0) {
+  console.error("check-import-graph: FAIL");
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+console.log(
+  `check-import-graph: OK — ${modules.length} agent modules load under ${process.release?.name ?? "this runtime"}; ` +
+    `${graph.visited.size} files walked; ${graph.external.size} external specifiers, all node:*`,
+);

--- a/plugins/dev/scripts/catalyst-agent/check-import-graph.mjs
+++ b/plugins/dev/scripts/catalyst-agent/check-import-graph.mjs
@@ -31,14 +31,22 @@
 //    exercise none of them, and `build-info.mjs` (the CTL-1825 edge) is behind one of them.
 //
 // 2. SPECIFIER AUDIT. The transitive static-import graph is walked and every non-relative
-//    specifier must be `node:`-prefixed. This is not redundant with (1): check (1) is only as
-//    strict as the machine it runs on, and a stray `node_modules` anywhere above the checkout
-//    would let a bare npm specifier resolve in CI while the launchd runtime — which has none —
-//    fails. The audit is a statement about the SOURCE, so it holds on any machine.
+//    specifier must be `node:`-prefixed. This is not redundant with (1) — it is the check that
+//    carries the dependency-free contract, and (1) cannot. Check (1) is only as strict as the
+//    machine it runs on, and the CI job that runs this file installs the workspace's
+//    node_modules SEVERAL STEPS EARLIER, so on the runner `pino` (and every other hoisted
+//    package) RESOLVES: an `import ... from "pino"` added to any agent module loads fine under
+//    (1) and dies on a launchd tick. The audit is a statement about the SOURCE, so it holds on
+//    any machine, node_modules present or not.
 //
 // Both checks are gated on their own non-vacuity (see ASSERTIONS below): a walk that visits
 // nothing passes every "no bad specifier found" test there is, and reporting that as a clean
 // result would reproduce this ticket's defect inside the guard for it.
+//
+// The audit keeps EVERY occurrence of an external specifier, not one row per specifier name.
+// Keyed by name alone, the allowed dynamic `pino` import would occupy the only slot `pino` has
+// and hide every later import of it — the same "first sample stands in for the population"
+// shape as the gauge this ticket is about.
 //
 // Run: node check-import-graph.mjs      (exit 0 = clean, 1 = violation, 2 = the check itself
 //                                        could not run)
@@ -85,19 +93,181 @@ const SPECIFIER_PATTERNS = [
 // expression whose failure the caller can catch — and here does. Anything else, static or
 // dynamic, fails: an unguarded second npm import is how "zero npm deps" stops being true
 // without anyone noticing.
-const OPTIONAL_DYNAMIC_DEPS = new Set(["pino"]);
+//
+// So each row pins ONE import by its IDENTITY, never by its name: file, kind, and proof that
+// it sits inside a `try {} catch` that can absorb the failure. A row is spent by the first
+// occurrence that matches it in full, and a spent row exempts nothing else — a second
+// `import("pino")`, guarded or not, in config.mjs or anywhere else, has no row left to inherit
+// and fails. An UNMATCHED row fails too: if the guarded import is deleted or moved, this file
+// must stop advertising an exemption it is no longer describing.
+const OPTIONAL_DYNAMIC_DEPS = [
+  { spec: "pino", kind: "dynamic", file: "config.mjs", guard: "try/catch" },
+];
+
+function lineOf(source, index) {
+  let line = 1;
+  for (let i = 0; i < index; i++) if (source[i] === "\n") line++;
+  return line;
+}
 
 function specifiersIn(source) {
   const out = [];
   for (const { kind, re } of SPECIFIER_PATTERNS) {
     re.lastIndex = 0;
-    for (const m of source.matchAll(re)) out.push({ spec: m[1], kind });
+    for (const m of source.matchAll(re)) {
+      // The static patterns anchor on the preceding newline, so step past it to land on the
+      // `import`/`export` keyword itself — the index is what the line number and the
+      // guard-range containment test below are both computed from.
+      const index = m.index + (m[0].startsWith("\n") ? 1 : 0);
+      out.push({ spec: m[1], kind, index, line: lineOf(source, index) });
+    }
   }
-  return out;
+  return out.sort((a, b) => a.index - b.index);
+}
+
+// ── Guard proof ───────────────────────────────────────────────────────────────
+// An exemption is only granted to an import whose failure something actually catches, so the
+// scanner has to answer "is this occurrence lexically inside a `try {} catch`?". Both helpers
+// below fail CLOSED: anything they cannot parse confidently reports "not guarded", which
+// DENIES the exemption and fails the check loudly, rather than granting one it cannot justify.
+
+// blankNonCode — replace the CONTENTS of comments, strings, and template literals with spaces,
+// preserving length (so indices still line up) and newlines (so line numbers still do). Brace
+// arithmetic then sees only code: a `}` inside a string or a `// try {` in a comment cannot
+// move the depth. `reliable` is false when the braces do not balance, which is the signal that
+// something (an unhandled construct, a regex literal containing a quote) desynced the scan.
+function blankNonCode(source) {
+  const out = [...source];
+  const blank = (i) => {
+    if (i < out.length && out[i] !== "\n") out[i] = " ";
+  };
+  const stack = [{ template: false, depth: 0, substitution: false }];
+  let i = 0;
+  while (i < source.length) {
+    const top = stack[stack.length - 1];
+    const c = source[i];
+    const d = source[i + 1];
+    if (top.template) {
+      if (c === "\\") {
+        blank(i);
+        blank(i + 1);
+        i += 2;
+      } else if (c === "`") {
+        blank(i);
+        i += 1;
+        stack.pop();
+      } else if (c === "$" && d === "{") {
+        // A `${}` substitution is code, but its braces are the template's, not the program's —
+        // blank them and track the nesting on the stack so they never reach the depth counter.
+        blank(i);
+        blank(i + 1);
+        i += 2;
+        stack.push({ template: false, depth: 0, substitution: true });
+      } else {
+        blank(i);
+        i += 1;
+      }
+      continue;
+    }
+    if (c === "/" && d === "/") {
+      while (i < source.length && source[i] !== "\n") blank(i++);
+      continue;
+    }
+    if (c === "/" && d === "*") {
+      blank(i);
+      blank(i + 1);
+      i += 2;
+      while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) blank(i++);
+      blank(i);
+      blank(i + 1);
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      blank(i++);
+      while (i < source.length) {
+        if (source[i] === "\\") {
+          blank(i);
+          blank(i + 1);
+          i += 2;
+          continue;
+        }
+        if (source[i] === c || source[i] === "\n") {
+          blank(i++);
+          break;
+        }
+        blank(i++);
+      }
+      continue;
+    }
+    if (c === "`") {
+      blank(i++);
+      stack.push({ template: true });
+      continue;
+    }
+    if (c === "{") {
+      top.depth += 1;
+      i += 1;
+      continue;
+    }
+    if (c === "}") {
+      if (top.depth === 0 && top.substitution) {
+        blank(i++);
+        stack.pop();
+        continue;
+      }
+      top.depth -= 1;
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  const balanced = stack.length === 1 && stack[0].depth === 0;
+  return { text: out.join(""), reliable: balanced };
+}
+
+// tryCatchRanges — the [openBrace, closeBrace] span of every `try { … }` that is followed by a
+// `catch`. A `try/finally` is deliberately NOT a range: `finally` runs the cleanup and then
+// re-throws, so it does not make a failed import survivable.
+function tryCatchRanges(blanked) {
+  const ranges = [];
+  for (const m of blanked.matchAll(/\btry\s*\{/g)) {
+    const open = m.index + m[0].length - 1;
+    let depth = 0;
+    let close = -1;
+    for (let i = open; i < blanked.length; i++) {
+      if (blanked[i] === "{") depth += 1;
+      else if (blanked[i] === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          close = i;
+          break;
+        }
+      }
+    }
+    if (close === -1) continue; // unterminated — no range, so nothing inside it is guarded
+    if (!/^\s*catch\b/.test(blanked.slice(close + 1, close + 32))) continue;
+    ranges.push([open, close]);
+  }
+  return ranges;
+}
+
+// guardRanges — the file's catchable spans, or NONE if the blanking pass desynced. An
+// unreliable scan therefore reports every occurrence as unguarded, which denies the exemption.
+function guardRanges(source) {
+  const { text, reliable } = blankNonCode(source);
+  return reliable ? tryCatchRanges(text) : [];
+}
+
+const inRanges = (ranges, index) => ranges.some(([open, close]) => index > open && index < close);
+
+// isGuarded — is the import at `index` inside a `try {} catch` that can absorb its failure?
+export function isGuarded(source, index) {
+  return inRanges(guardRanges(source), index);
 }
 
 // agentModules — every module this directory ships, tests and this file excluded.
-function agentModules() {
+export function agentModules() {
   return readdirSync(DIR)
     .filter((f) => f.endsWith(".mjs") && !f.endsWith(".test.mjs"))
     .map((f) => join(DIR, f))
@@ -106,10 +276,12 @@ function agentModules() {
 }
 
 // walkGraph — follow relative specifiers transitively from every agent module, recording each
-// visited file and every non-relative specifier seen along the way.
-function walkGraph(entries) {
+// visited file and EVERY non-relative specifier occurrence seen along the way. Occurrences, not
+// a specifier→importer map: two imports of the same package are two facts to validate, and the
+// second is exactly what an evasion looks like.
+export function walkGraph(entries) {
   const visited = new Set();
-  const external = new Map(); // specifier → {kind, file} of the first importer seen
+  const external = [];
   const queue = [...entries];
   while (queue.length > 0) {
     const file = queue.pop();
@@ -121,89 +293,167 @@ function walkGraph(entries) {
     } catch (err) {
       throw new Error(`unreadable module in the agent graph: ${file} (${err?.message})`);
     }
-    for (const { spec, kind } of specifiersIn(source)) {
+    // Guard ranges are per-file and only ever needed for a bare specifier, so pay for the
+    // blanking pass once, and only in a file that actually has one.
+    let ranges = null;
+    const guardedAt = (index) => {
+      if (ranges === null) ranges = guardRanges(source);
+      return inRanges(ranges, index);
+    };
+    for (const { spec, kind, index, line } of specifiersIn(source)) {
       if (spec.startsWith("./") || spec.startsWith("../")) {
         queue.push(resolve(dirname(file), spec));
-      } else if (!external.has(spec)) {
-        external.set(spec, { kind, file });
+        continue;
       }
+      const bare = !spec.startsWith("node:");
+      external.push({ spec, kind, file, line, guarded: bare ? guardedAt(index) : false });
     }
   }
+  // Stable order so the reported violation is the same one on every run and every machine —
+  // the walk itself is queue-ordered, which is an implementation detail.
+  external.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
   return { visited, external };
 }
 
-const problems = [];
 const rel = (p) => relative(DIR, p);
 
-let modules;
-try {
-  modules = agentModules();
-} catch (err) {
-  console.error(`check-import-graph: cannot enumerate agent modules: ${err?.message}`);
-  process.exit(2);
-}
-
-// ── ASSERTIONS: non-vacuity first ─────────────────────────────────────────────
-// Everything below is a "nothing bad found" test, and every such test passes trivially on an
-// empty input set (`[].every(p)` is `true`). These gates are what make a clean result mean
-// "looked and found nothing" rather than "could not look".
-if (modules.length < MIN_AGENT_MODULES) {
-  problems.push(
-    `enumerated only ${modules.length} agent module(s) (floor ${MIN_AGENT_MODULES}) — the check would pass vacuously`,
+// denialReason — why this particular occurrence gets no exemption. Named precisely, because
+// "add it to the allowlist" is the wrong fix for most of these and the message has to say so.
+function denialReason(occ, relFile, spentRow) {
+  const row = OPTIONAL_DYNAMIC_DEPS.find((e) => e.spec === occ.spec);
+  if (!row) return `"${occ.spec}" is not a declared optional dependency`;
+  if (occ.kind !== row.kind) {
+    return (
+      `the declared "${occ.spec}" exemption covers a ${row.kind} import only — a static bare ` +
+      `specifier aborts module load outright, so no fallback downstream ever runs`
+    );
+  }
+  if (relFile !== row.file) return `the declared "${occ.spec}" exemption is pinned to ${row.file}`;
+  if (!occ.guarded) {
+    return `this import is not inside a ${row.guard} that could absorb its failure`;
+  }
+  return (
+    `the declared "${occ.spec}" exemption is already spent by ${spentRow} — one row exempts ` +
+    `exactly one import, so a second one cannot inherit it`
   );
 }
 
-// ── CHECK 1: loadability under THIS runtime ───────────────────────────────────
-for (const file of modules) {
+// classifyExternals — the verdict on EVERY recorded occurrence, plus the stale-row check.
+// Pure and exported so a test can assert the counts without staging a whole tree.
+export function classifyExternals(occurrences, relOf = (p) => p) {
+  const problems = [];
+  const exempted = [];
+  const spent = OPTIONAL_DYNAMIC_DEPS.map(() => null);
+  for (const occ of occurrences) {
+    if (occ.spec.startsWith("node:")) continue;
+    const relFile = relOf(occ.file);
+    const where = `${relFile}:${occ.line}`;
+    const row = OPTIONAL_DYNAMIC_DEPS.findIndex(
+      (e, i) =>
+        spent[i] === null &&
+        e.spec === occ.spec &&
+        e.kind === occ.kind &&
+        e.file === relFile &&
+        occ.guarded === true,
+    );
+    if (row >= 0) {
+      spent[row] = where;
+      exempted.push(occ);
+      continue;
+    }
+    const already = OPTIONAL_DYNAMIC_DEPS.findIndex((e) => e.spec === occ.spec);
+    problems.push(
+      `${where} ${occ.kind}-imports "${occ.spec}" — the agent's runtime is bare node with no ` +
+        `node_modules, so only node:* is loadable; ` +
+        denialReason(occ, relFile, already >= 0 ? spent[already] : null),
+    );
+  }
+  // The other direction: a row that matched nothing is a claim this file can no longer back.
+  for (const [i, e] of OPTIONAL_DYNAMIC_DEPS.entries()) {
+    if (spent[i] !== null) continue;
+    problems.push(
+      `the declared "${e.spec}" exemption (${e.kind} import in ${e.file}, inside a ${e.guard}) ` +
+        `matched no import in the graph — it was moved, reshaped, or deleted, and this check is ` +
+        `advertising a guard it is no longer describing`,
+    );
+  }
+  return { problems, exempted };
+}
+
+async function main() {
+  const problems = [];
+
+  let modules;
   try {
-    await import(pathToFileURL(file).href);
+    modules = agentModules();
   } catch (err) {
-    problems.push(`${rel(file)} does not load under ${process.release?.name ?? "this runtime"}: ${err?.message}`);
+    console.error(`check-import-graph: cannot enumerate agent modules: ${err?.message}`);
+    process.exit(2);
   }
-}
 
-// ── CHECK 2: source-level specifier audit ─────────────────────────────────────
-let graph;
-try {
-  graph = walkGraph(modules);
-} catch (err) {
-  console.error(`check-import-graph: ${err?.message}`);
-  process.exit(2);
-}
+  // ── ASSERTIONS: non-vacuity first ───────────────────────────────────────────
+  // Everything below is a "nothing bad found" test, and every such test passes trivially on an
+  // empty input set (`[].every(p)` is `true`). These gates are what make a clean result mean
+  // "looked and found nothing" rather than "could not look".
+  if (modules.length < MIN_AGENT_MODULES) {
+    problems.push(
+      `enumerated only ${modules.length} agent module(s) (floor ${MIN_AGENT_MODULES}) — the check would pass vacuously`,
+    );
+  }
 
-if (graph.visited.size < MIN_GRAPH_FILES) {
-  problems.push(
-    `walked only ${graph.visited.size} file(s) (floor ${MIN_GRAPH_FILES}) — the specifier audit would pass vacuously`,
+  // ── CHECK 1: loadability under THIS runtime ─────────────────────────────────
+  for (const file of modules) {
+    try {
+      await import(pathToFileURL(file).href);
+    } catch (err) {
+      problems.push(`${rel(file)} does not load under ${process.release?.name ?? "this runtime"}: ${err?.message}`);
+    }
+  }
+
+  // ── CHECK 2: source-level specifier audit ───────────────────────────────────
+  let graph;
+  try {
+    graph = walkGraph(modules);
+  } catch (err) {
+    console.error(`check-import-graph: ${err?.message}`);
+    process.exit(2);
+  }
+
+  if (graph.visited.size < MIN_GRAPH_FILES) {
+    problems.push(
+      `walked only ${graph.visited.size} file(s) (floor ${MIN_GRAPH_FILES}) — the specifier audit would pass vacuously`,
+    );
+  }
+  for (const member of REQUIRED_GRAPH_MEMBERS) {
+    const reached = [...graph.visited].some((f) => f.replaceAll("\\", "/").endsWith(`/${member}`));
+    if (!reached) {
+      problems.push(`the walk never reached ${member} — the edge this check exists to guard is unguarded`);
+    }
+  }
+  // The scanner itself must have parsed something: zero external specifiers across a graph this
+  // size means the regexes matched nothing, not that the agent imports nothing (every module in
+  // it imports from `node:`).
+  if (graph.external.length === 0) {
+    problems.push("the specifier scan found no imports at all — it is not parsing this graph");
+  }
+  const audit = classifyExternals(graph.external, rel);
+  problems.push(...audit.problems);
+
+  if (problems.length > 0) {
+    console.error("check-import-graph: FAIL");
+    for (const p of problems) console.error(`  - ${p}`);
+    process.exit(1);
+  }
+  const exempt = audit.exempted.map((o) => `${rel(o.file)}:${o.line} ${o.spec}`).join(", ");
+  console.log(
+    `check-import-graph: OK — ${modules.length} agent modules load under ${process.release?.name ?? "this runtime"}; ` +
+      `${graph.visited.size} files walked; ${graph.external.length} external import occurrences, ` +
+      `all node:* except ${audit.exempted.length} declared-optional (${exempt})`,
   );
 }
-for (const member of REQUIRED_GRAPH_MEMBERS) {
-  const reached = [...graph.visited].some((f) => f.replaceAll("\\", "/").endsWith(`/${member}`));
-  if (!reached) {
-    problems.push(`the walk never reached ${member} — the edge this check exists to guard is unguarded`);
-  }
-}
-// The scanner itself must have parsed something: zero external specifiers across a graph this
-// size means the regexes matched nothing, not that the agent imports nothing (every module in
-// it imports from `node:`).
-if (graph.external.size === 0) {
-  problems.push("the specifier scan found no imports at all — it is not parsing this graph");
-}
-for (const [spec, { kind, file }] of graph.external) {
-  if (spec.startsWith("node:")) continue;
-  if (kind === "dynamic" && OPTIONAL_DYNAMIC_DEPS.has(spec)) continue;
-  problems.push(
-    `${rel(file)} ${kind}-imports "${spec}" — the agent's runtime is bare node with no ` +
-      `node_modules, so only node:* is loadable (an optional dependency must be a guarded ` +
-      `dynamic import declared in OPTIONAL_DYNAMIC_DEPS)`,
-  );
-}
 
-if (problems.length > 0) {
-  console.error("check-import-graph: FAIL");
-  for (const p of problems) console.error(`  - ${p}`);
-  process.exit(1);
-}
-console.log(
-  `check-import-graph: OK — ${modules.length} agent modules load under ${process.release?.name ?? "this runtime"}; ` +
-    `${graph.visited.size} files walked; ${graph.external.size} external specifiers, all node:*`,
-);
+// Run only when executed, so the helpers above can be unit-tested by importing this file.
+// Compared as RESOLVED paths, not as URLs: CI invokes this as `node check-import-graph.mjs`
+// from the agent directory, so `argv[1]` is relative — a `file://${argv[1]}` comparison would
+// never match and the whole check would silently no-op while still exiting 0.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(SELF)) await main();

--- a/plugins/dev/scripts/catalyst-agent/check-import-graph.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/check-import-graph.test.mjs
@@ -1,0 +1,249 @@
+// check-import-graph.test.mjs (CTL-1825) — the guard that enforces the agent's "bare node, no
+// node_modules" contract must itself be able to FAIL.
+//
+// The defect this suite exists to prevent: the audit keyed its external-import table by
+// SPECIFIER, so the first `pino` it saw — the allowed, try/catch-guarded dynamic one in
+// config.mjs — occupied the only row `pino` had, and a `import pinoStatic from "pino"` in any
+// file walked afterwards was never recorded at all. The blanket `OPTIONAL_DYNAMIC_DEPS.has(spec)`
+// exemption accepted any new unguarded `import("pino")` on top of that. Neither evasion could be
+// caught by the runtime load probe either: the CI job installs the workspace's node_modules
+// several steps before this check runs, so on the runner `pino` RESOLVES and both mutations load
+// fine — then die on a launchd tick.
+//
+// Measured against the pre-fix guard on this staged tree: a static `pino` import in accounts.mjs
+// exit 0, an unguarded `import("pino")` in host.mjs exit 0, unmutated exit 0. Post-fix: 1, 1, 0.
+// Whether the old guard noticed a static import at all was pure walk order — the same mutation
+// in build-info.mjs (visited BEFORE config.mjs, so it claimed the specifier's one row first) did
+// fail. Coverage that depends on stack order is not coverage.
+//
+// The staged tree below reproduces that CI premise exactly — a faithful copy of the agent with
+// a resolvable `pino` in node_modules — so a passing positive control means the harness is not
+// simply failing everything.
+//
+// Run: cd plugins/dev/scripts/catalyst-agent && bun test check-import-graph.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyExternals, isGuarded, walkGraph, agentModules } from "./check-import-graph.mjs";
+
+const DIR = dirname(fileURLToPath(import.meta.url));
+
+// A stand-in for the real package. Its only job is to make the specifier RESOLVE, which is the
+// state the CI runner is in when this check runs — the whole reason the source audit, not the
+// load probe, is the check that carries the contract.
+const PINO_STUB = `const logger = {
+  info() {}, warn() {}, error() {}, debug() {}, fatal() {}, trace() {}, child: () => logger,
+};
+export default function pino() { return logger; }
+`;
+
+// stageTree — a copy of the agent directory that the check can be run against for real, with
+// the two cross-directory leaves (execution-core/, lib/) symlinked so the walk still reaches
+// them. `mutate(agentDir)` applies the evasion under test before the check runs.
+function stageTree(mutate) {
+  const root = mkdtempSync(join(tmpdir(), "check-import-graph-"));
+  const scripts = join(root, "scripts");
+  const agent = join(scripts, "catalyst-agent");
+  mkdirSync(agent, { recursive: true });
+  for (const f of readdirSync(DIR)) {
+    if (!f.endsWith(".mjs") || f.endsWith(".test.mjs")) continue;
+    copyFileSync(join(DIR, f), join(agent, f));
+  }
+  symlinkSync(resolve(DIR, "..", "execution-core"), join(scripts, "execution-core"));
+  symlinkSync(resolve(DIR, "..", "lib"), join(scripts, "lib"));
+  const pinoDir = join(scripts, "node_modules", "pino");
+  mkdirSync(pinoDir, { recursive: true });
+  writeFileSync(
+    join(pinoDir, "package.json"),
+    JSON.stringify({ name: "pino", version: "0.0.0-stub", type: "module", exports: "./index.mjs" }),
+  );
+  writeFileSync(join(pinoDir, "index.mjs"), PINO_STUB);
+  if (mutate) mutate(agent);
+  return { root, agent };
+}
+
+const append = (agent, file, text) => {
+  const p = join(agent, file);
+  writeFileSync(p, `${readFileSync(p, "utf8")}\n${text}\n`);
+};
+
+// runGuard — exit code + output of the real check, run by the real runtime, against the staged
+// tree. `node`, not `process.execPath`: this guard is a statement about node specifically.
+function runGuard(mutate) {
+  const { root, agent } = stageTree(mutate);
+  try {
+    const r = spawnSync("node", ["check-import-graph.mjs"], { cwd: agent, encoding: "utf8" });
+    // Fail loudly rather than skipping — a check that cannot be run is not a check that passed.
+    expect(r.error).toBeUndefined();
+    return { code: r.status, out: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("check-import-graph — positive control", () => {
+  test("the real, unmodified tree passes", () => {
+    const r = spawnSync("node", ["check-import-graph.mjs"], { cwd: DIR, encoding: "utf8" });
+    expect(r.error).toBeUndefined();
+    expect(r.stdout + r.stderr).toContain("check-import-graph: OK");
+    expect(r.status).toBe(0);
+  });
+
+  test("the staged copy passes too, with pino installed exactly as CI has it", () => {
+    const r = runGuard(null);
+    expect(r.out).toContain("check-import-graph: OK");
+    expect(r.code).toBe(0);
+  });
+});
+
+describe("check-import-graph — the two evasions the first-occurrence keying allowed", () => {
+  // Evasion (a). accounts.mjs is walked AFTER config.mjs, so before the fix `pino` already had
+  // its one row (the guarded dynamic one) by the time this import was read and it was never
+  // recorded at all; the load probe resolved it out of the installed node_modules. Measured:
+  // exit 0. On launchd it is ERR_MODULE_NOT_FOUND at module load, before anything can catch it.
+  test("a STATIC import of pino in a module walked after the allowed dynamic one is rejected", () => {
+    const r = runGuard((agent) => append(agent, "accounts.mjs", 'import pinoStatic from "pino";\nexport { pinoStatic };'));
+    expect(r.out).toMatch(/accounts\.mjs:\d+ static-imports "pino"/);
+    expect(r.out).toContain("covers a dynamic import only");
+    expect(r.code).toBe(1);
+  });
+
+  // The same mutation in the file that OWNS the exemption. The pre-fix guard also failed this
+  // one, but only by accident — within a single file the static pattern is scanned before the
+  // dynamic one, so the static import happened to claim the row first. Pinned here so the
+  // behaviour no longer depends on which regex runs first.
+  test("a STATIC import of pino in config.mjs itself is rejected", () => {
+    const r = runGuard((agent) => append(agent, "config.mjs", 'import pinoStatic from "pino";\nexport { pinoStatic };'));
+    expect(r.out).toMatch(/config\.mjs:\d+ static-imports "pino"/);
+    expect(r.code).toBe(1);
+  });
+
+  // Evasion (b). Before the fix the exemption was a bare `Set.has(spec)` test applied to
+  // whichever occurrence happened to be recorded, so an unguarded dynamic import of the same
+  // package anywhere in the graph was waved through.
+  test("a new UNGUARDED dynamic import of pino in another module is rejected", () => {
+    const r = runGuard((agent) => append(agent, "host.mjs", 'export const sneak = () => import("pino");'));
+    expect(r.out).toMatch(/host\.mjs:\d+ dynamic-imports "pino"/);
+    expect(r.out).toContain("pinned to config.mjs");
+    expect(r.code).toBe(1);
+  });
+
+  test("an unguarded dynamic import of pino in config.mjs itself is rejected — the exemption is not file-wide", () => {
+    const r = runGuard((agent) => append(agent, "config.mjs", 'export const sneak = () => import("pino");'));
+    expect(r.out).toMatch(/config\.mjs:\d+ dynamic-imports "pino"/);
+    expect(r.out).toContain("not inside a try/catch");
+    expect(r.code).toBe(1);
+  });
+
+  test("even a SECOND guarded dynamic import of pino is rejected — one row, one import", () => {
+    const r = runGuard((agent) =>
+      append(
+        agent,
+        "config.mjs",
+        'export async function sneak() {\n  try {\n    return await import("pino");\n  } catch {\n    return null;\n  }\n}',
+      ),
+    );
+    expect(r.out).toMatch(/already spent by config\.mjs:\d+/);
+    expect(r.code).toBe(1);
+  });
+
+  test("deleting the guarded import fails the check instead of silently guarding nothing", () => {
+    const r = runGuard((agent) => {
+      const p = join(agent, "config.mjs");
+      writeFileSync(p, readFileSync(p, "utf8").replace('await import("pino")', "{ default: null }"));
+    });
+    expect(r.out).toContain("matched no import in the graph");
+    expect(r.code).toBe(1);
+  });
+});
+
+describe("walkGraph — every occurrence is retained, not one row per specifier", () => {
+  test("the real graph reports more occurrences than it has distinct specifiers", () => {
+    const { external } = walkGraph(agentModules());
+    const distinct = new Set(external.map((o) => o.spec));
+    // The old map-by-specifier shape could only ever report `distinct.size` rows; the literal
+    // gap between these two numbers is the population it was discarding.
+    expect(external.length).toBeGreaterThan(distinct.size);
+  });
+
+  test("two imports of one specifier in one file are two occurrences", () => {
+    const root = mkdtempSync(join(tmpdir(), "walkgraph-"));
+    try {
+      const f = join(root, "two.mjs");
+      writeFileSync(f, 'import a from "pino";\nexport const b = () => import("pino");\n');
+      const { external } = walkGraph([f]);
+      expect(external.length).toBe(2);
+      expect(external.map((o) => o.kind).sort()).toEqual(["dynamic", "static"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("isGuarded — the exemption's proof obligation", () => {
+  const at = (src, needle) => src.indexOf(needle);
+
+  test("an import inside try/catch is guarded", () => {
+    const src = 'try {\n  const x = await import("pino");\n} catch {}\n';
+    expect(isGuarded(src, at(src, 'import("pino")'))).toBe(true);
+  });
+
+  test("an import after the catch block is not", () => {
+    const src = 'try {\n  noop();\n} catch {}\nconst x = await import("pino");\n';
+    expect(isGuarded(src, at(src, 'import("pino")'))).toBe(false);
+  });
+
+  test("try/finally is not a guard — finally cleans up and the failure still propagates", () => {
+    const src = 'try {\n  const x = await import("pino");\n} finally {\n  done();\n}\n';
+    expect(isGuarded(src, at(src, 'import("pino")'))).toBe(false);
+  });
+
+  test("a brace inside a string or comment cannot fake a guard", () => {
+    const src = 'const s = "try {";\n// try {\nconst x = await import("pino");\n';
+    expect(isGuarded(src, at(src, 'import("pino")'))).toBe(false);
+  });
+
+  test("a template literal's ${} braces do not desync the scan", () => {
+    const src = 'try {\n  const s = `a${b ? "}" : "{"}c`;\n  const x = await import("pino");\n} catch {}\n';
+    expect(isGuarded(src, at(src, 'import("pino")'))).toBe(true);
+  });
+});
+
+describe("classifyExternals — the verdict, without staging a tree", () => {
+  const occ = (over) => ({ spec: "pino", kind: "dynamic", file: "config.mjs", line: 1, guarded: true, ...over });
+
+  test("the one declared import is exempt and everything else is a problem", () => {
+    const { problems, exempted } = classifyExternals([
+      occ({}),
+      occ({ line: 2 }),
+      occ({ kind: "static", line: 3 }),
+      occ({ file: "host.mjs", line: 4 }),
+      occ({ guarded: false, line: 5 }),
+      { spec: "node:fs", kind: "static", file: "config.mjs", line: 6, guarded: false },
+    ]);
+    expect(exempted.length).toBe(1);
+    expect(problems.length).toBe(4);
+  });
+
+  test("an occurrence set with no declared import at all is a problem, not a clean pass", () => {
+    const { problems, exempted } = classifyExternals([
+      { spec: "node:os", kind: "static", file: "config.mjs", line: 1, guarded: false },
+    ]);
+    expect(exempted.length).toBe(0);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("matched no import in the graph");
+  });
+});

--- a/plugins/dev/scripts/catalyst-agent/config.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/config.test.mjs
@@ -19,6 +19,7 @@ const ENVS = [
   "CATALYST_AGENT_USAGE",
   "CATALYST_AGENT_HOST",
   "CATALYST_AGENT_PROCESS",
+  "CATALYST_AGENT_VERSION",
   "CATALYST_DIR",
 ];
 let saved = {};
@@ -49,6 +50,7 @@ describe("readAgentConfig — defaults", () => {
     expect(cfg.usageEnabled).toBe(true);
     expect(cfg.hostEnabled).toBe(true);
     expect(cfg.processEnabled).toBe(true);
+    expect(cfg.versionEnabled).toBe(true);
   });
 });
 
@@ -137,6 +139,7 @@ describe("readAgentConfig — domain toggles", () => {
     expect(cfg.usageEnabled).toBe(false);
     expect(cfg.hostEnabled).toBe(true);
     expect(cfg.processEnabled).toBe(true);
+    expect(cfg.versionEnabled).toBe(true);
   });
 
   test("CATALYST_AGENT_HOST=0 disables host only", () => {
@@ -145,6 +148,7 @@ describe("readAgentConfig — domain toggles", () => {
     expect(cfg.hostEnabled).toBe(false);
     expect(cfg.usageEnabled).toBe(true);
     expect(cfg.processEnabled).toBe(true);
+    expect(cfg.versionEnabled).toBe(true);
   });
 
   test("CATALYST_AGENT_PROCESS=0 disables process only", () => {
@@ -153,13 +157,30 @@ describe("readAgentConfig — domain toggles", () => {
     expect(cfg.processEnabled).toBe(false);
     expect(cfg.usageEnabled).toBe(true);
     expect(cfg.hostEnabled).toBe(true);
+    expect(cfg.versionEnabled).toBe(true);
+  });
+
+  // The version domain is the ONE whose tick reaches the network unconditionally
+  // (build-info's per-root `git fetch --quiet origin main`, CTL-1825), so its
+  // toggle is what a test that must not touch the network sets — see the CTL-812
+  // OTLP-drain test in catalyst-agent.test.mjs. Left uncovered, a regression that
+  // stopped honoring it would surface only as an intermittent 5s timeout there.
+  test("CATALYST_AGENT_VERSION=0 disables version only", () => {
+    process.env.CATALYST_AGENT_VERSION = "0";
+    const cfg = readAgentConfig();
+    expect(cfg.versionEnabled).toBe(false);
+    expect(cfg.usageEnabled).toBe(true);
+    expect(cfg.hostEnabled).toBe(true);
+    expect(cfg.processEnabled).toBe(true);
   });
 
   test("any non-zero value keeps a domain enabled", () => {
     process.env.CATALYST_AGENT_USAGE = "1";
     process.env.CATALYST_AGENT_HOST = "true";
+    process.env.CATALYST_AGENT_VERSION = "1";
     expect(readAgentConfig().usageEnabled).toBe(true);
     expect(readAgentConfig().hostEnabled).toBe(true);
+    expect(readAgentConfig().versionEnabled).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/catalyst-agent/version.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.mjs
@@ -9,14 +9,34 @@
 //   catalyst.build.info        gauge=1, labels: vcs.ref.head.revision (commit)
 //                              — the classic *_build_info anchor; service.version
 //                                + host.name come from the shared resource.
-//   catalyst.vcs.commits_behind gauge=N — commits HEAD is behind origin/main
-//                              (0 = on the latest main). Omitted when unresolvable.
+//   catalyst.vcs.commits_behind gauge=N — commits HEAD is behind origin/main,
+//                              ONE SERIES PER EXECUTING CHECKOUT, labelled
+//                              catalyst.checkout.root. Omitted when unresolvable.
+//   catalyst.vcs.commits_behind.max gauge=N — the host's single currency number:
+//                              the MAXIMUM across those roots.
+//
+// CTL-1825 — why per-root and why a max. The drift gauge used to be one
+// unlabelled number measured against the agent's own module directory, so on a
+// host whose agent runs from a different tree than its daemons (every node on
+// this fleet) it reported the currency of a tree nobody executes. It read 0 on
+// the laptop while `~/catalyst/plugin-source` — the tree running
+// health-responder, orphan-sweep and log-shipper — was 24 commits behind.
+//
+// Two consequences for what is EMITTED. (a) Every executing root gets its own
+// series, labelled by its path, so a stale root is visible rather than averaged
+// away or overwritten. (b) Where a single number is unavoidable, it is the
+// MAXIMUM across roots — a host is only as current as its stalest checkout, and
+// any aggregate a current root can pull down reintroduces the false zero. It is
+// a SEPARATE metric name, not an unlabelled point on the per-root gauge, because
+// a point with and without `catalyst.checkout.root` on one metric is two
+// conflicting series in Prometheus, and the sum of a gauge over roots is
+// meaningless anyway.
 import { otlpMetric, emitMetrics } from "./emit.mjs";
 import { readAgentConfig, log } from "./config.mjs";
 import {
   serviceVersion as defaultServiceVersion,
   vcsRevision as defaultVcsRevision,
-  commitsBehindMain as defaultCommitsBehindMain,
+  commitsBehindByRoot as defaultCommitsBehindByRoot,
 } from "./build-info.mjs";
 
 // defaultEmitMetrics — config-aware OTLP metric emit (mirrors host.mjs). A no-op
@@ -33,13 +53,35 @@ async function defaultEmitMetrics(metrics) {
 export async function sampleVersion({
   serviceVersion = defaultServiceVersion,
   vcsRevision = defaultVcsRevision,
-  commitsBehindMain = defaultCommitsBehindMain,
+  commitsBehindByRoot = defaultCommitsBehindByRoot,
   emitMetricsFn = defaultEmitMetrics,
   nowMs = () => Date.now(),
 } = {}) {
   const t = String(nowMs() * 1_000_000); // ms → unix-nanos
   const revision = vcsRevision();
-  const behind = commitsBehindMain();
+
+  // One measurement per executing checkout. A root whose drift is null keeps its
+  // entry here (so the --once result map reports what could not be measured) but
+  // contributes no data point — otlpMetric drops a non-numeric value, which is
+  // what keeps an unreadable checkout from emitting a 0 that reads as current.
+  //
+  // Guarded: the enumeration now reads a registry and a config file, and this
+  // module's standing rule is that telemetry never crashes the agent. Degrading to
+  // an empty series set drops BOTH drift metrics (never a false 0) while build_info
+  // — which does not depend on the enumeration at all — still emits.
+  let checkouts = [];
+  try {
+    // An entry without a string root is discarded rather than emitted: an unlabelled
+    // point on a per-root gauge collides with every other one, and last-write-wins on
+    // a collision is the original defect wearing a label's clothes.
+    checkouts = (commitsBehindByRoot() ?? []).filter((c) => typeof c?.root === "string" && c.root);
+  } catch (err) {
+    log.warn({ err: err?.message }, "catalyst-agent: executing-checkout enumeration failed");
+  }
+  const measured = checkouts.map((c) => c.behind).filter((n) => typeof n === "number" && Number.isFinite(n));
+  // The host's single currency number. `null` when NOTHING measured, so the gauge
+  // is absent rather than falsely 0 — the same degradation rule as each series.
+  const behind = measured.length === 0 ? null : Math.max(...measured);
 
   const metrics = [
     // build_info: a constant 1 whose labels carry the build identity. The commit
@@ -55,14 +97,33 @@ export async function sampleVersion({
       kind: "gauge",
       points: [{ value: 1, attrs: { "vcs.ref.head.revision": revision }, timeUnixNano: t }],
     }),
-    // commits-behind drift. otlpMetric drops the point when behind is null, so
-    // the metric is simply absent on a host that can't resolve it (no false 0).
+    // commits-behind drift, one point per executing checkout. otlpMetric drops a
+    // point whose value is null, so an unreadable root disappears from the series
+    // set (no false 0) while the roots that DID measure still emit; when no root
+    // resolves at all, otlpMetric returns null and the metric is absent entirely.
     otlpMetric({
       // Empty unit (a plain count): unit "1" would append "_ratio" →
       // `catalyst_vcs_commits_behind_ratio`. Empty → `catalyst_vcs_commits_behind`.
       name: "catalyst.vcs.commits_behind",
       unit: "",
-      description: "Commits HEAD is behind origin/main (0 = up to date with main).",
+      description:
+        "Commits HEAD is behind origin/main for one executing checkout (0 = up to date with main); labelled by that checkout's path.",
+      kind: "gauge",
+      points: checkouts.map((c) => ({
+        value: c.behind,
+        // The path is the identity of the series. Without it the points collide
+        // and whichever arrives last wins — which is a per-root gauge that still
+        // cannot show a stale root, i.e. the defect with extra steps.
+        attrs: { "catalyst.checkout.root": c.root },
+        timeUnixNano: t,
+      })),
+    }),
+    // The one aggregate: the STALEST root, never the agent's own and never a mean.
+    otlpMetric({
+      name: "catalyst.vcs.commits_behind.max",
+      unit: "",
+      description:
+        "Commits behind origin/main of the STALEST executing checkout on this host (the host's single code-currency number).",
       kind: "gauge",
       points: [{ value: behind, timeUnixNano: t }],
     }),
@@ -75,5 +136,8 @@ export async function sampleVersion({
   }
 
   // Returned for tests / the --once result map; not used in production.
-  return { version: serviceVersion(), revision, commitsBehind: behind };
+  // `commitsBehind` is the MAX (the host's answer); `checkouts` is the per-root
+  // breakdown, so `--once` shows an operator WHICH tree is stale, not just that
+  // one is.
+  return { version: serviceVersion(), revision, commitsBehind: behind, checkouts };
 }

--- a/plugins/dev/scripts/catalyst-agent/version.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.mjs
@@ -10,7 +10,7 @@
 //                              — the classic *_build_info anchor; service.version
 //                                + host.name come from the shared resource.
 //   catalyst.vcs.commits_behind gauge=N — commits HEAD is behind origin/main,
-//                              ONE SERIES PER EXECUTING CHECKOUT, labelled
+//                              ONE SERIES PER EXECUTING CATALYST CHECKOUT, labelled
 //                              catalyst.checkout.root. Omitted when unresolvable.
 //   catalyst.vcs.commits_behind.max gauge=N — the host's single currency number:
 //                              the MAXIMUM across those roots.
@@ -31,6 +31,15 @@
 // a point with and without `catalyst.checkout.root` on one metric is two
 // conflicting series in Prometheus, and the sum of a gauge over roots is
 // meaningless anyway.
+//
+// Scope (CTL-1825 round 2). "Executing root" here means executing CATALYST
+// checkout — `build-info.mjs`'s `catalystRoots`, not the whole CTL-1808
+// enumeration. The enumeration also carries the enrolled PRODUCT repos the sync
+// pass fast-forwards, and on the laptop the stalest of those (`personal-os`, 58
+// behind its own main) became this host's reported maximum, firing an alert named
+// for Catalyst node currency on a personal repository. Both metrics below are
+// therefore Catalyst-checkout-scoped, which is what makes their names true and the
+// pre-existing `max by (host_name)(catalyst_vcs_commits_behind) > 20` alert correct.
 import { otlpMetric, emitMetrics } from "./emit.mjs";
 import { readAgentConfig, log } from "./config.mjs";
 import {
@@ -107,7 +116,7 @@ export async function sampleVersion({
       name: "catalyst.vcs.commits_behind",
       unit: "",
       description:
-        "Commits HEAD is behind origin/main for one executing checkout (0 = up to date with main); labelled by that checkout's path.",
+        "Commits HEAD is behind origin/main for one executing Catalyst checkout (0 = up to date with main); labelled by that checkout's path.",
       kind: "gauge",
       points: checkouts.map((c) => ({
         value: c.behind,
@@ -123,7 +132,7 @@ export async function sampleVersion({
       name: "catalyst.vcs.commits_behind.max",
       unit: "",
       description:
-        "Commits behind origin/main of the STALEST executing checkout on this host (the host's single code-currency number).",
+        "Commits behind origin/main of the STALEST executing Catalyst checkout on this host (the host's single code-currency number).",
       kind: "gauge",
       points: [{ value: behind, timeUnixNano: t }],
     }),

--- a/plugins/dev/scripts/catalyst-agent/version.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/version.test.mjs
@@ -1,11 +1,18 @@
 // version.test.mjs (CTL-1235) — Domain 4: the build-identity sampler.
 //
 // sampleVersion is exercised through injected seams (serviceVersion /
-// vcsRevision / commitsBehindMain / emitMetricsFn) so there is no real git or
+// vcsRevision / commitsBehindByRoot / emitMetricsFn) so there is no real git or
 // network. Covers: the build_info gauge shape + commit label, the commits_behind
 // gauge value, null-degradation (drift unresolvable → metric dropped, no false
 // 0), and emit-failure resilience. A light real-resolver check confirms
 // build-info.mjs reads the actual plugin.json + git.
+//
+// CTL-1825 changed the drift seam from `commitsBehindMain` (ONE number, measured
+// against the agent's own module directory) to `commitsBehindByRoot` (one
+// measurement per executing root). The assertions below are the same ones, now
+// stated per-root, plus the two the ticket added: a stale root is visible as its
+// own series, and the single aggregate is the MAXIMUM across roots. The
+// per-root cases live in build-info.test.mjs; this file covers what is EMITTED.
 //
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test version.test.mjs
 
@@ -13,21 +20,29 @@ import { describe, test, expect } from "bun:test";
 import { sampleVersion } from "./version.mjs";
 import { serviceVersion, vcsRevision } from "./build-info.mjs";
 
-// Pull the single data point's attributes into a plain {key:value} map.
-function attrMap(metric) {
+// Pull one data point's attributes into a plain {key:value} map.
+function attrMap(metric, i = 0) {
   const out = {};
-  for (const a of metric?.gauge?.dataPoints?.[0]?.attributes ?? []) {
+  for (const a of metric?.gauge?.dataPoints?.[i]?.attributes ?? []) {
     out[a.key] = a.value?.stringValue ?? a.value?.asDouble ?? a.value?.asInt;
   }
   return out;
 }
 const byName = (metrics, name) => metrics.find((m) => m?.name === name);
+// {root -> value} for a per-root gauge, so a test asserts the whole series set at once.
+function seriesByRoot(metric) {
+  const out = {};
+  (metric?.gauge?.dataPoints ?? []).forEach((p, i) => {
+    out[attrMap(metric, i)["catalyst.checkout.root"]] = p.asDouble;
+  });
+  return out;
+}
 
 describe("sampleVersion — build-identity metric set", () => {
   const stubs = {
     serviceVersion: () => "9.9.9",
     vcsRevision: () => "abc1234",
-    commitsBehindMain: () => 0,
+    commitsBehindByRoot: () => [{ root: "/repos/catalyst", behind: 0 }],
     nowMs: () => 1000,
   };
 
@@ -47,10 +62,16 @@ describe("sampleVersion — build-identity metric set", () => {
 
   test("emits catalyst.vcs.commits_behind with the drift count", async () => {
     let captured = [];
-    await sampleVersion({ ...stubs, commitsBehindMain: () => 7, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    await sampleVersion({
+      ...stubs,
+      commitsBehindByRoot: () => [{ root: "/repos/catalyst", behind: 7 }],
+      emitMetricsFn: async (m) => (captured = m.filter(Boolean)),
+    });
     const behind = byName(captured, "catalyst.vcs.commits_behind");
     expect(behind).toBeTruthy();
     expect(behind.gauge.dataPoints[0].asDouble).toBe(7);
+    // …and the point says WHICH tree it measured (CTL-1825).
+    expect(attrMap(behind)["catalyst.checkout.root"]).toBe("/repos/catalyst");
   });
 
   test("timeUnixNano is ms→nanos", async () => {
@@ -61,9 +82,23 @@ describe("sampleVersion — build-identity metric set", () => {
 
   test("commits_behind unresolvable (null) → metric dropped, no false 0", async () => {
     let captured = [];
-    await sampleVersion({ ...stubs, commitsBehindMain: () => null, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    await sampleVersion({
+      ...stubs,
+      commitsBehindByRoot: () => [{ root: "/repos/catalyst", behind: null }],
+      emitMetricsFn: async (m) => (captured = m.filter(Boolean)),
+    });
     expect(byName(captured, "catalyst.vcs.commits_behind")).toBeUndefined();
+    // The aggregate goes with it — an unmeasurable fleet must not report a healthy max.
+    expect(byName(captured, "catalyst.vcs.commits_behind.max")).toBeUndefined();
     // build_info still emits — the build identity is independent of drift.
+    expect(byName(captured, "catalyst.build.info")).toBeTruthy();
+  });
+
+  test("no executing roots at all → both drift metrics dropped", async () => {
+    let captured = [];
+    await sampleVersion({ ...stubs, commitsBehindByRoot: () => [], emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    expect(byName(captured, "catalyst.vcs.commits_behind")).toBeUndefined();
+    expect(byName(captured, "catalyst.vcs.commits_behind.max")).toBeUndefined();
     expect(byName(captured, "catalyst.build.info")).toBeTruthy();
   });
 
@@ -82,8 +117,114 @@ describe("sampleVersion — build-identity metric set", () => {
   });
 
   test("returns the resolved identity for the --once result map", async () => {
-    const r = await sampleVersion({ ...stubs, commitsBehindMain: () => 2, emitMetricsFn: async () => {} });
-    expect(r).toEqual({ version: "9.9.9", revision: "abc1234", commitsBehind: 2 });
+    const r = await sampleVersion({
+      ...stubs,
+      commitsBehindByRoot: () => [{ root: "/repos/catalyst", behind: 2 }],
+      emitMetricsFn: async () => {},
+    });
+    expect(r).toEqual({
+      version: "9.9.9",
+      revision: "abc1234",
+      commitsBehind: 2,
+      checkouts: [{ root: "/repos/catalyst", behind: 2 }],
+    });
+  });
+});
+
+// ─── CTL-1825 — the gauge measures where code actually runs ────────────────────
+//
+// The laptop fixture from the ticket: the agent's own checkout current, the tree
+// the daemons run (`~/catalyst/plugin-source`) 24 commits behind.
+describe("sampleVersion — code currency is measured where code actually runs", () => {
+  const AGENT_CHECKOUT = "/Users/ryan/code-repos/github/coalesce-labs/catalyst";
+  const PLUGIN_SOURCE = "/Users/ryan/catalyst/plugin-source";
+  const laptop = {
+    serviceVersion: () => "9.9.9",
+    vcsRevision: () => "abc1234",
+    commitsBehindByRoot: () => [
+      { root: AGENT_CHECKOUT, behind: 0 },
+      { root: PLUGIN_SOURCE, behind: 24 },
+    ],
+    nowMs: () => 1000,
+  };
+
+  test("one series per executing root, labelled by that root's path", async () => {
+    let captured = [];
+    await sampleVersion({ ...laptop, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    const behind = byName(captured, "catalyst.vcs.commits_behind");
+    expect(behind.gauge.dataPoints).toHaveLength(2);
+    expect(seriesByRoot(behind)).toEqual({ [AGENT_CHECKOUT]: 0, [PLUGIN_SOURCE]: 24 });
+  });
+
+  test("a stale root cannot be hidden by a current one", async () => {
+    let captured = [];
+    await sampleVersion({ ...laptop, emitMetricsFn: async (m) => (captured = m.filter(Boolean)) });
+    // The stale root is its own non-zero series…
+    expect(seriesByRoot(byName(captured, "catalyst.vcs.commits_behind"))[PLUGIN_SOURCE]).toBe(24);
+    // …and the single aggregate is the MAXIMUM across roots, never the agent's own.
+    const max = byName(captured, "catalyst.vcs.commits_behind.max");
+    expect(max).toBeTruthy();
+    expect(max.unit).toBe("");
+    expect(max.gauge.dataPoints).toHaveLength(1);
+    expect(max.gauge.dataPoints[0].asDouble).toBe(24);
+    // The aggregate carries no root label — it is the whole host's answer.
+    expect(attrMap(max)["catalyst.checkout.root"]).toBeUndefined();
+  });
+
+  test("the --once result map reports the MAX, plus the per-root breakdown", async () => {
+    const r = await sampleVersion({ ...laptop, emitMetricsFn: async () => {} });
+    expect(r.commitsBehind).toBe(24);
+    expect(r.checkouts).toEqual([
+      { root: AGENT_CHECKOUT, behind: 0 },
+      { root: PLUGIN_SOURCE, behind: 24 },
+    ]);
+  });
+
+  test("an enumeration that THROWS drops the drift metrics but never the tick", async () => {
+    let captured = [];
+    await expect(
+      sampleVersion({
+        ...laptop,
+        commitsBehindByRoot: () => { throw new Error("registry unreadable"); },
+        emitMetricsFn: async (m) => (captured = m.filter(Boolean)),
+      }),
+    ).resolves.toBeTruthy();
+    expect(byName(captured, "catalyst.vcs.commits_behind")).toBeUndefined();
+    expect(byName(captured, "catalyst.vcs.commits_behind.max")).toBeUndefined();
+    // build_info does not depend on the enumeration, so it still emits.
+    expect(byName(captured, "catalyst.build.info")).toBeTruthy();
+  });
+
+  test("an entry with no root is discarded, not emitted as an unlabelled point", async () => {
+    let captured = [];
+    await sampleVersion({
+      ...laptop,
+      commitsBehindByRoot: () => [{ root: null, behind: 99 }, { root: PLUGIN_SOURCE, behind: 24 }],
+      emitMetricsFn: async (m) => (captured = m.filter(Boolean)),
+    });
+    const behind = byName(captured, "catalyst.vcs.commits_behind");
+    // An unlabelled point would collide with every labelled one — last write wins,
+    // which is the original defect with a label bolted on.
+    expect(behind.gauge.dataPoints).toHaveLength(1);
+    expect(seriesByRoot(behind)).toEqual({ [PLUGIN_SOURCE]: 24 });
+    // …and the discarded entry does not reach the aggregate either.
+    expect(byName(captured, "catalyst.vcs.commits_behind.max").gauge.dataPoints[0].asDouble).toBe(24);
+  });
+
+  test("an unmeasurable root drops only its own point, not the whole gauge", async () => {
+    let captured = [];
+    await sampleVersion({
+      ...laptop,
+      commitsBehindByRoot: () => [
+        { root: AGENT_CHECKOUT, behind: null },
+        { root: PLUGIN_SOURCE, behind: 24 },
+      ],
+      emitMetricsFn: async (m) => (captured = m.filter(Boolean)),
+    });
+    const behind = byName(captured, "catalyst.vcs.commits_behind");
+    expect(behind.gauge.dataPoints).toHaveLength(1);
+    expect(seriesByRoot(behind)).toEqual({ [PLUGIN_SOURCE]: 24 });
+    expect(byName(captured, "catalyst.vcs.commits_behind.max").gauge.dataPoints[0].asDouble).toBe(24);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/checkout-sync.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.mjs
@@ -183,9 +183,12 @@ export function resolveAllowlist({ registryRoots = [], selfRoot = null, configur
 // follows. It lives HERE, next to the fold, because the moment a second consumer needs
 // "which checkouts does this host run?" it either imports this or writes its own, and two
 // readers of the same question drift. CTL-1825's currency gauge is that second consumer:
-// it measures exactly this set, so a root that the sync pass would fast-forward is also a
-// root the gauge reports on — one enumeration, two uses, no chance of one covering a tree
-// the other cannot see.
+// it measures this set, so a root the sync pass would fast-forward is a root the gauge can
+// see — one enumeration, two uses, no chance of one covering a tree the other cannot.
+//
+// The two consumers take DIFFERENT VIEWS of the one enumeration, not different enumerations:
+// the sync pass acts on every root, the gauge measures the `catalyst` role only. See
+// `classifyExecutingRoots` below for why, and for the measurement that forced the split.
 
 // defaultReadJson — parse a JSON file, or null for absent/unreadable/malformed. Total:
 // an operator's typo in Layer-2 must not take out the enumeration (and with it every
@@ -217,6 +220,63 @@ function defaultSelfRoot(exists) {
   }
 }
 
+// ── Role: a Catalyst checkout, or an enrolled project repo? ────────────────────
+//
+// CTL-1825 round 2. The enumeration answers "which checkouts does this host run?", and the
+// SYNC pass wants every one of them — the 2026-08-12 ADR incident was `catalyst-cloud`, a
+// sibling, so a catalyst-only subscriber would have caught none of the four incidents. The
+// currency GAUGE asks a narrower question over the same set: "is the CATALYST code this host
+// executes current?"
+//
+// That difference is not academic. Measured on the laptop, 2026-08-13: of eleven enumerated
+// roots, NINE are enrolled product repos, and the stalest of them — `personal-os`, 58 commits
+// behind its own main — was the maximum. So `catalyst.vcs.commits_behind.max` reported 58 for
+// a personal repository, and the pre-existing Grafana alert
+// `max by (host_name)(catalyst_vcs_commits_behind) > 20` fires on it. A gauge named for
+// Catalyst currency that is driven by an unrelated enrolled project is the same defect class
+// as the false zero this ticket removed: the number does not mean what its name says.
+//
+// So each root carries a ROLE, and the gauge measures the `catalyst` partition. The role is
+// decided by what the tree IS, never by which source named it — the registry legitimately
+// enrols this very repository (ADR-028's CAT registration), and Layer-2 `catalyst.checkouts[]`
+// is a config NAMESPACE rather than a claim about the repo (its own documented example is
+// `catalyst-cloud`, a sibling).
+export const CHECKOUT_ROLE = Object.freeze({ CATALYST: "catalyst", PROJECT: "project" });
+
+// The marker that identifies a checkout of THIS repository: the marketplace manifest every
+// Catalyst checkout carries at its root and no other repo on this fleet does. Verified
+// against the live registry 2026-08-13 — of the nine enrolled repoRoots plus
+// `~/catalyst/plugin-source`, exactly two carry it (the Catalyst repo and plugin-source) and
+// eight do not, which is the partition wanted. A file, not a directory: a stray empty
+// `.claude-plugin/` must not promote a product repo into the currency gauge.
+export const CATALYST_CHECKOUT_MARKER = join(".claude-plugin", "marketplace.json");
+
+/**
+ * classifyExecutingRoots — the enumeration below, each root tagged with its CHECKOUT_ROLE.
+ *
+ * Two roots are `catalyst` STRUCTURALLY, marker or no marker, because excluding either is
+ * precisely the CTL-1825 defect: `selfRoot` (this module IS Catalyst code, so the tree it was
+ * loaded from is a Catalyst checkout by construction) and `<CATALYST_DIR>/plugin-source` (the
+ * tree every daemon on a worker node runs FROM — the one root this whole ticket exists to
+ * measure). Every other root is promoted only by the marker.
+ *
+ * The fail direction is deliberate and asymmetric: an unrecognised tree that really is a
+ * Catalyst checkout costs one extra measured series and a slightly pessimistic max, while a
+ * Catalyst checkout wrongly excluded is a currency gauge that cannot see a stale root — which
+ * is the entire ticket. Misclassify toward measuring.
+ */
+export function classifyExecutingRoots(opts = {}) {
+  const { exists = existsSync } = opts;
+  const { roots, structuralCatalyst } = collectExecutingRoots(opts);
+  return roots.map((root) => ({
+    root,
+    role:
+      structuralCatalyst.has(root) || exists(join(root, CATALYST_CHECKOUT_MARKER))
+        ? CHECKOUT_ROLE.CATALYST
+        : CHECKOUT_ROLE.PROJECT,
+  }));
+}
+
 /**
  * resolveExecutingRoots — every checkout this host actually executes code from, from four
  * DECLARED sources, in order:
@@ -237,8 +297,18 @@ function defaultSelfRoot(exists) {
  * `requireExists` (default true) drops a root that is not on this host: a registry copied
  * between hosts routinely names a repoRoot that exists on neither (CTL-854), and measuring
  * it costs a git timeout to learn nothing. Set false to inspect the undiluted enumeration.
+ *
+ * The path-only view of `classifyExecutingRoots` — the sync pass acts on every root
+ * regardless of role, so it takes this one.
  */
-export function resolveExecutingRoots({
+export function resolveExecutingRoots(opts = {}) {
+  return collectExecutingRoots(opts).roots;
+}
+
+// collectExecutingRoots — the shared collection both views above are built from. Returns the
+// folded root list plus the set of roots that are Catalyst checkouts by construction rather
+// than by probe, so the classifier does not have to re-derive which source named what.
+function collectExecutingRoots({
   env = process.env,
   readJson = defaultReadJson,
   // `exists` is destructured BEFORE `selfRoot` so the default below can thread it —
@@ -277,10 +347,19 @@ export function resolveExecutingRoots({
 
   // 4. plugin-source, always last so an explicit declaration of the same path keeps its
   // earlier position (resolveAllowlist is order-stable and first-wins).
-  configuredRoots.push(join(catalystDir, "plugin-source"));
+  const pluginSource = join(catalystDir, "plugin-source");
+  configuredRoots.push(pluginSource);
 
   const roots = resolveAllowlist({ registryRoots, selfRoot, configuredRoots });
-  return requireExists ? roots.filter((r) => exists(r)) : roots;
+  // Normalised the SAME way resolveAllowlist normalises, or `/cat/plugin-source/` in the
+  // config and `/cat/plugin-source` in the fold would compare unequal and the one root this
+  // ticket exists to measure would silently classify as a product repo.
+  const norm = (r) => String(r).replace(/\/+$/, "");
+  const structuralCatalyst = new Set([norm(pluginSource), ...(selfRoot ? [norm(selfRoot)] : [])]);
+  return {
+    roots: requireExists ? roots.filter((r) => exists(r)) : roots,
+    structuralCatalyst,
+  };
 }
 
 // ── The pass ──────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/checkout-sync.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.mjs
@@ -42,6 +42,16 @@
 // decision, it is not this automation's to make — it refuses and says exactly what it found.
 
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+// The canonical Layer-2 path chain (CTL-1616 §2). Imported, never re-derived: a second
+// copy of that ladder is how one process reads `$XDG_CONFIG_HOME/catalyst/config.json`
+// while another reads `~/.config/catalyst/config.json` and they disagree about what is
+// configured. `secret-contract.mjs` is a zero-npm-dep node:* leaf, so importing it keeps
+// this module loadable under bare node (the catalyst-agent's runtime — CTL-1825).
+import { resolveLayer2Path } from "../lib/secret-contract.mjs";
 
 // ── Outcomes ──────────────────────────────────────────────────────────────────
 // A closed vocabulary. `refused` always carries a `refused_reason`; `fetch-failed` is
@@ -164,6 +174,113 @@ export function resolveAllowlist({ registryRoots = [], selfRoot = null, configur
     out.push(root);
   }
   return out;
+}
+
+// ── The declared sources, collected ───────────────────────────────────────────
+//
+// resolveAllowlist above takes the three source LISTS. Collecting them — reading the
+// registry, finding this checkout, reading Layer-2, naming plugin-source — is what
+// follows. It lives HERE, next to the fold, because the moment a second consumer needs
+// "which checkouts does this host run?" it either imports this or writes its own, and two
+// readers of the same question drift. CTL-1825's currency gauge is that second consumer:
+// it measures exactly this set, so a root that the sync pass would fast-forward is also a
+// root the gauge reports on — one enumeration, two uses, no chance of one covering a tree
+// the other cannot see.
+
+// defaultReadJson — parse a JSON file, or null for absent/unreadable/malformed. Total:
+// an operator's typo in Layer-2 must not take out the enumeration (and with it every
+// OTHER root's measurement), which is what a throw here would do.
+function defaultReadJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// defaultSelfRoot — the checkout THIS file is running out of, found by walking up to the
+// nearest `.git`. Deliberately not a hardcoded ancestor count (`../../../..`): the same
+// module is loaded from `~/catalyst/plugin-source`, from a dev clone, and from a linked
+// worktree, and only the walk gets all three right. A linked worktree's `.git` is a FILE,
+// so `exists` (not a directory check) is the right probe — a worktree IS a checkout that
+// executes code, and answering with the primary instead would measure the wrong tree.
+//
+// Uncached on purpose: the walk is a handful of stat calls, and a cache shared across an
+// injected and a real `exists` is a footgun that buys nothing in a one-shot process.
+function defaultSelfRoot(exists) {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (;;) {
+    if (exists(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null; // reached the filesystem root
+    dir = parent;
+  }
+}
+
+/**
+ * resolveExecutingRoots — every checkout this host actually executes code from, from four
+ * DECLARED sources, in order:
+ *
+ *   1. registry `repoRoots`  — `<CATALYST_DIR>/execution-core/registry.json`, the enrolled
+ *                              projects the daemon dispatches into
+ *   2. this checkout         — the tree this module was loaded from
+ *   3. Layer-2 `catalyst.checkouts[]` — machine-local declarations (siblings a given host
+ *                              keeps current but is not enrolled to dispatch into)
+ *   4. `<CATALYST_DIR>/plugin-source` — the tree every daemon on a worker node runs FROM,
+ *                              which is frequently NOT any of the above (this is the whole
+ *                              of CTL-1825: on the laptop it was 24 commits behind while
+ *                              the agent's own checkout was current)
+ *
+ * Still an allowlist, never a filesystem walk — see resolveAllowlist. Every input is
+ * injectable so the enumeration is testable without a registry, a config file, or a repo.
+ *
+ * `requireExists` (default true) drops a root that is not on this host: a registry copied
+ * between hosts routinely names a repoRoot that exists on neither (CTL-854), and measuring
+ * it costs a git timeout to learn nothing. Set false to inspect the undiluted enumeration.
+ */
+export function resolveExecutingRoots({
+  env = process.env,
+  readJson = defaultReadJson,
+  // `exists` is destructured BEFORE `selfRoot` so the default below can thread it —
+  // default parameters evaluate left to right, and the other order is a TDZ error.
+  exists = existsSync,
+  // undefined ⇒ resolve the real one; an explicit null ⇒ this host contributes none.
+  selfRoot = defaultSelfRoot(exists),
+  requireExists = true,
+} = {}) {
+  // Total against every source: a throwing reader (EACCES, a mocked failure) must cost
+  // that ONE source, never the whole set.
+  const read = (path) => {
+    try {
+      return readJson(path);
+    } catch {
+      return null;
+    }
+  };
+
+  const home = typeof env?.HOME === "string" && env.HOME ? env.HOME : homedir();
+  const catalystDir = typeof env?.CATALYST_DIR === "string" && env.CATALYST_DIR ? env.CATALYST_DIR : join(home, "catalyst");
+
+  // 1. The registry, read straight from disk rather than through registry.mjs — that
+  // module imports execution-core/config.mjs (and its bun:sqlite graph), which the bare-node
+  // consumers of this enumeration cannot load. Same file, same shape, same key.
+  const registry = read(join(catalystDir, "execution-core", "registry.json"));
+  const registryRoots = Array.isArray(registry?.projects)
+    ? registry.projects.map((p) => p?.repoRoot).filter((r) => typeof r === "string")
+    : [];
+
+  // 3. Layer-2 `catalyst.checkouts[]`. A non-array value is IGNORED, not coerced: spreading
+  // a bare string would enrol one root per character.
+  const layer2 = read(resolveLayer2Path(env));
+  const declared = (layer2?.catalyst ?? layer2)?.checkouts;
+  const configuredRoots = Array.isArray(declared) ? declared.filter((r) => typeof r === "string") : [];
+
+  // 4. plugin-source, always last so an explicit declaration of the same path keeps its
+  // earlier position (resolveAllowlist is order-stable and first-wins).
+  configuredRoots.push(join(catalystDir, "plugin-source"));
+
+  const roots = resolveAllowlist({ registryRoots, selfRoot, configuredRoots });
+  return requireExists ? roots.filter((r) => exists(r)) : roots;
 }
 
 // ── The pass ──────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
@@ -12,6 +12,9 @@ import {
   classifyGitState,
   resolveAllowlist,
   resolveExecutingRoots,
+  classifyExecutingRoots,
+  CHECKOUT_ROLE,
+  CATALYST_CHECKOUT_MARKER,
   summarize,
   syncRepo,
   runPass,
@@ -354,6 +357,107 @@ describe("resolveExecutingRoots — collect the four declared sources, then fold
         path === "/home/u/.config/catalyst/config.json" ? { catalyst: { checkouts: "/one/path" } } : null,
     }));
     expect(roots).toEqual(["/cat/plugin-source"]);
+  });
+});
+
+// CTL-1825 round 2 — ONE enumeration, TWO views.
+//
+// The sync pass acts on every enumerated root (the 2026-08-12 ADR incident was a sibling
+// repo, so breadth is the point). The currency gauge answers a narrower question over the
+// same set — "is the CATALYST code this host runs current?" — and on the laptop the whole
+// set gave it the wrong answer: nine of eleven roots were enrolled PRODUCT repos, and the
+// stalest of those (`personal-os`, 58 behind its own main) became the host's reported
+// maximum, firing an alert named for Catalyst node currency on a personal repository.
+//
+// The role is decided by what a tree IS, never by which source named it: the registry
+// legitimately enrols this very repository (ADR-028), and Layer-2 `catalyst.checkouts[]` is
+// a config namespace, not a claim (its documented example is `catalyst-cloud`, a sibling).
+describe("classifyExecutingRoots — Catalyst checkout vs enrolled product repo", () => {
+  // `exists` answers two different questions here (is the root present? does it carry the
+  // marker?), so the seam takes an explicit set of present paths rather than a blanket true.
+  const seams = ({ present = [], ...over } = {}) => ({
+    env: { CATALYST_DIR: "/cat", HOME: "/home/u" },
+    readJson: () => null,
+    selfRoot: null,
+    exists: (p) => present.includes(p),
+    ...over,
+  });
+
+  test("an enrolled repoRoot with no Catalyst marker is a product repo", () => {
+    const roots = classifyExecutingRoots(seams({
+      present: ["/repos/personal-os", "/cat/plugin-source"],
+      readJson: (path) =>
+        path === "/cat/execution-core/registry.json" ? { projects: [{ team: "POS", repoRoot: "/repos/personal-os" }] } : null,
+    }));
+    expect(roots).toEqual([
+      { root: "/repos/personal-os", role: CHECKOUT_ROLE.PROJECT },
+      { root: "/cat/plugin-source", role: CHECKOUT_ROLE.CATALYST },
+    ]);
+  });
+
+  // The exclusion above must be by CONTENT. "Registry roots are never Catalyst" would drop
+  // this repository, which is enrolled — and dropping a Catalyst checkout from the currency
+  // gauge is the CTL-1825 defect itself, just reached by a different route.
+  test("an enrolled repoRoot that carries the Catalyst marker IS a Catalyst checkout", () => {
+    const roots = classifyExecutingRoots(seams({
+      present: ["/repos/catalyst", `/repos/catalyst/${CATALYST_CHECKOUT_MARKER}`, "/cat/plugin-source"],
+      readJson: (path) =>
+        path === "/cat/execution-core/registry.json" ? { projects: [{ team: "CTL", repoRoot: "/repos/catalyst" }] } : null,
+    }));
+    expect(roots.find((r) => r.root === "/repos/catalyst")?.role).toBe(CHECKOUT_ROLE.CATALYST);
+  });
+
+  // The two roots that are Catalyst by construction. Both are marker-less in this fixture on
+  // purpose: if the structural rule regresses, the gauge stops measuring the one tree the
+  // ticket exists to measure, and it does so silently.
+  test("selfRoot and <CATALYST_DIR>/plugin-source are Catalyst with no marker present", () => {
+    const roots = classifyExecutingRoots(seams({
+      present: ["/dev/checkout", "/cat/plugin-source"],
+      selfRoot: "/dev/checkout",
+    }));
+    expect(roots).toEqual([
+      { root: "/dev/checkout", role: CHECKOUT_ROLE.CATALYST },
+      { root: "/cat/plugin-source", role: CHECKOUT_ROLE.CATALYST },
+    ]);
+  });
+
+  // Layer-2 `catalyst.checkouts[]` is a config NAMESPACE, not an assertion about the repo —
+  // the key's own documented example is `catalyst-cloud`. Declaring a sibling there must not
+  // fold its drift into a metric named for Catalyst currency.
+  test("a Layer-2 declared sibling is a product repo unless it carries the marker", () => {
+    const declared = (checkouts, present) =>
+      classifyExecutingRoots(seams({
+        present: ["/cat/plugin-source", ...present],
+        readJson: (path) => (path === "/home/u/.config/catalyst/config.json" ? { catalyst: { checkouts } } : null),
+      }));
+    expect(declared(["/repos/catalyst-cloud"], ["/repos/catalyst-cloud"])
+      .find((r) => r.root === "/repos/catalyst-cloud")?.role).toBe(CHECKOUT_ROLE.PROJECT);
+    expect(declared(["/repos/second-clone"], ["/repos/second-clone", `/repos/second-clone/${CATALYST_CHECKOUT_MARKER}`])
+      .find((r) => r.root === "/repos/second-clone")?.role).toBe(CHECKOUT_ROLE.CATALYST);
+  });
+
+  // A trailing slash in the registry or in Layer-2 is normalised by resolveAllowlist, so the
+  // structural set has to be normalised the same way or plugin-source compares unequal to
+  // itself and silently demotes to a product repo.
+  test("a trailing slash on plugin-source does not demote it", () => {
+    const roots = classifyExecutingRoots(seams({
+      present: ["/cat/plugin-source"],
+      readJson: (path) =>
+        path === "/home/u/.config/catalyst/config.json" ? { catalyst: { checkouts: ["/cat/plugin-source/"] } } : null,
+    }));
+    expect(roots).toEqual([{ root: "/cat/plugin-source", role: CHECKOUT_ROLE.CATALYST }]);
+  });
+
+  // The path-only view stays exactly the enumeration, roles or no roles — the sync pass
+  // must keep seeing every root, including the product repos it exists to fast-forward.
+  test("resolveExecutingRoots is the same set, unfiltered by role", () => {
+    const opts = seams({
+      present: ["/repos/personal-os", "/cat/plugin-source"],
+      readJson: (path) =>
+        path === "/cat/execution-core/registry.json" ? { projects: [{ team: "POS", repoRoot: "/repos/personal-os" }] } : null,
+    });
+    expect(resolveExecutingRoots(opts)).toEqual(classifyExecutingRoots(opts).map((r) => r.root));
+    expect(resolveExecutingRoots(opts)).toContain("/repos/personal-os");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/checkout-sync.test.mjs
@@ -11,6 +11,7 @@ import {
   parseSymrefDefault,
   classifyGitState,
   resolveAllowlist,
+  resolveExecutingRoots,
   summarize,
   syncRepo,
   runPass,
@@ -238,6 +239,121 @@ describe("resolveAllowlist — declared sources only, never a filesystem walk", 
   test("a sibling repo enrols through the configured source", () => {
     const roots = resolveAllowlist({ selfRoot: "/x/catalyst", configuredRoots: ["/x/catalyst-cloud"] });
     expect(roots).toContain("/x/catalyst-cloud");
+  });
+});
+
+// CTL-1825 — the SAME enumeration, now reachable by a second consumer.
+//
+// resolveAllowlist takes the three source LISTS already collected; nothing shipped that
+// collected them, so catalyst-agent's currency gauge would have had to invent its own reader
+// for the registry / Layer-2 / plugin-source. That second reader is how two answers to
+// "which checkouts does this host run?" start drifting, so the collection lives HERE, in the
+// module that owns the question, and folds into resolveAllowlist rather than beside it.
+describe("resolveExecutingRoots — collect the four declared sources, then fold through resolveAllowlist", () => {
+  // Every source is injected: no registry file, no Layer-2 config, no filesystem on the box
+  // running the test has any effect on the answer.
+  const seams = (over = {}) => ({
+    env: { CATALYST_DIR: "/cat", HOME: "/home/u" },
+    readJson: () => null,
+    selfRoot: null,
+    exists: () => true,
+    ...over,
+  });
+
+  test("registry repoRoots ∪ this checkout ∪ Layer-2 checkouts[] ∪ plugin-source, in that order", () => {
+    const roots = resolveExecutingRoots(seams({
+      readJson: (path) => {
+        if (path === "/cat/execution-core/registry.json") {
+          return { projects: [{ team: "CTL", repoRoot: "/repos/catalyst" }, { team: "CTC", repoRoot: "/repos/catalyst-cloud" }] };
+        }
+        if (path === "/home/u/.config/catalyst/config.json") {
+          return { catalyst: { checkouts: ["/repos/extra"] } };
+        }
+        return null;
+      },
+      selfRoot: "/dev/checkout",
+    }));
+    expect(roots).toEqual([
+      "/repos/catalyst",
+      "/repos/catalyst-cloud",
+      "/dev/checkout",
+      "/repos/extra",
+      "/cat/plugin-source",
+    ]);
+  });
+
+  test("plugin-source tracks CATALYST_DIR, and falls back to $HOME/catalyst when unset", () => {
+    expect(resolveExecutingRoots(seams({ env: { HOME: "/home/u" } }))).toContain("/home/u/catalyst/plugin-source");
+    expect(resolveExecutingRoots(seams({ env: { CATALYST_DIR: "/vol/cat", HOME: "/home/u" } })))
+      .toContain("/vol/cat/plugin-source");
+  });
+
+  // The whole point of CTL-1825: the tree the agent lives in and the tree the daemons run
+  // from are DIFFERENT trees on this fleet, and both must be in the set.
+  test("the agent's own checkout and ~/catalyst/plugin-source are both present, de-duplicated", () => {
+    const roots = resolveExecutingRoots(seams({ selfRoot: "/dev/checkout" }));
+    expect(roots).toContain("/dev/checkout");
+    expect(roots).toContain("/cat/plugin-source");
+    // …and when they ARE the same tree (a worker node), one entry, not two.
+    const same = resolveExecutingRoots(seams({ selfRoot: "/cat/plugin-source" }));
+    expect(same.filter((r) => r === "/cat/plugin-source")).toHaveLength(1);
+  });
+
+  test("a malformed registry / Layer-2 file contributes nothing rather than throwing", () => {
+    const roots = resolveExecutingRoots(seams({
+      readJson: () => { throw new Error("EACCES"); },
+      selfRoot: "/dev/checkout",
+    }));
+    expect(roots).toEqual(["/dev/checkout", "/cat/plugin-source"]);
+  });
+
+  test("a registry entry whose repoRoot is absent on THIS host is dropped (CTL-854)", () => {
+    const roots = resolveExecutingRoots(seams({
+      readJson: (path) =>
+        path === "/cat/execution-core/registry.json"
+          ? { projects: [{ team: "CTL", repoRoot: "/repos/present" }, { team: "X", repoRoot: "/repos/gone" }] }
+          : null,
+      exists: (p) => p !== "/repos/gone",
+    }));
+    expect(roots).toContain("/repos/present");
+    expect(roots).not.toContain("/repos/gone");
+  });
+
+  test("existence filtering is opt-out, so the pure enumeration is still inspectable", () => {
+    const roots = resolveExecutingRoots(seams({
+      readJson: (path) =>
+        path === "/cat/execution-core/registry.json" ? { projects: [{ team: "X", repoRoot: "/repos/gone" }] } : null,
+      exists: () => false,
+      requireExists: false,
+    }));
+    expect(roots).toContain("/repos/gone");
+  });
+
+  // The self-root is FOUND (walk up to the nearest `.git`), not computed from a fixed
+  // ancestor count — the same file is loaded from plugin-source, a dev clone, and a
+  // linked worktree, and only the walk is right in all three.
+  test("omitting selfRoot walks up to the nearest .git, through the injected `exists`", () => {
+    const probed = [];
+    const roots = resolveExecutingRoots({
+      env: { CATALYST_DIR: "/cat", HOME: "/home/u" },
+      readJson: () => null,
+      // Nothing has a `.git` and nothing exists → the walk runs to the filesystem root
+      // and contributes nothing, rather than throwing or looping.
+      exists: (p) => { probed.push(p); return false; },
+    });
+    expect(roots).toEqual([]);
+    // It probed for `.git`, and — finding none — walked all the way to the filesystem
+    // root and stopped there rather than spinning.
+    expect(probed.filter((p) => p.endsWith("/.git")).length).toBeGreaterThan(1);
+    expect(probed).toContain("/.git");
+  });
+
+  test("Layer-2 checkouts[] that is not an array of paths is ignored, not spread", () => {
+    const roots = resolveExecutingRoots(seams({
+      readJson: (path) =>
+        path === "/home/u/.config/catalyst/config.json" ? { catalyst: { checkouts: "/one/path" } } : null,
+    }));
+    expect(roots).toEqual(["/cat/plugin-source"]);
   });
 });
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -615,14 +615,29 @@ A path that does not exist on this host is dropped — a registry copied between
 names a `repoRoot` that exists on neither (CTL-854). A non-array value is **ignored**, never
 coerced: spreading a bare string would enrol one root per character.
 
-**Consumers.** The `catalyst-agent` code-currency gauge measures each root and emits
-`catalyst.vcs.commits_behind` one series per root (label `catalyst.checkout.root`), plus
-`catalyst.vcs.commits_behind.max` — the stalest root, which is the host's single currency
-number. Before CTL-1825 that gauge measured only the directory the agent's own module lived
-in, so on a host whose agent and daemons run from different trees (every node on this fleet)
-it reported a healthy `0` for a tree nobody executes. The checkout-sync pass consumes the same
-enumeration, deliberately: a root one keeps current that the other cannot see is the same
-silent gap in a new place.
+**Consumers, and the two views of the one enumeration.** The checkout-sync pass acts on
+**every** root — that breadth is the point, since the 2026-08-12 incident that motivated
+CTL-1808 was a sibling repo. The `catalyst-agent` code-currency gauge measures only the
+roots whose **role** is `catalyst` (`classifyExecutingRoots`), emitting
+`catalyst.vcs.commits_behind` one series per such root (label `catalyst.checkout.root`) plus
+`catalyst.vcs.commits_behind.max` — the stalest of them, which is the host's single currency
+number. Deliberately the same enumeration for both: a root one keeps current that the other
+cannot see is the same silent gap in a new place.
+
+Two failures shaped that. Before CTL-1825 the gauge measured only the directory the agent's
+own module lived in, so on a host whose agent and daemons run from different trees (every node
+on this fleet) it reported a healthy `0` for a tree nobody executes. Measuring the *whole*
+enumeration then overshot the other way: on the laptop, nine of eleven roots were enrolled
+**product** repos, and the stalest of those (`personal-os`, 58 commits behind its own `main`)
+became the reported maximum — a metric named for Catalyst currency answering for a personal
+repository, and firing `max by (host_name)(catalyst_vcs_commits_behind) > 20` on it.
+
+A root is `catalyst` when it is the agent's own tree or `<CATALYST_DIR>/plugin-source` (both
+by construction, marker or not — excluding either is the original defect), or when it carries
+`.claude-plugin/marketplace.json`. The role therefore follows what a tree **is**, never which
+source named it: this repository is itself an enrolled `repoRoot` (ADR-028), and
+`catalyst.checkouts[]` is a config namespace rather than a claim about the repo — its own
+example above is `catalyst-cloud`, a sibling.
 
 ## Node class (`catalyst.node.class`, CTL-1344)
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -585,6 +585,45 @@ token is decrypted but not yet projected to the machine-level env. The operator 
 adding/rotating the secret in the `catalyst-cluster` repo lives in the `docs/cluster-onboarding.md`
 developer guide ("Provisioning the shared cloud token").
 
+## Executing checkouts (`catalyst.checkouts`, CTL-1825)
+
+`catalyst.checkouts` is a **Layer-2, machine-local** array of absolute paths — extra git
+checkouts this host executes code from or keeps current, beyond the ones already declared
+elsewhere. Default: unset (an empty list).
+
+It is the third of four sources in the **executing-root enumeration**
+(`execution-core/checkout-sync.mjs` → `resolveExecutingRoots`), which is the single answer to
+"which checkouts does this host run?":
+
+```
+registry repoRoots  ∪  this checkout  ∪  Layer-2 catalyst.checkouts[]  ∪  <CATALYST_DIR>/plugin-source
+```
+
+| source                            | where it comes from                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| registry `repoRoot`s              | `<CATALYST_DIR>/execution-core/registry.json` — the enrolled projects the daemon dispatches into |
+| this checkout                     | the tree the resolving module was loaded from (nearest ancestor with a `.git`)          |
+| `catalyst.checkouts[]`            | **this key** — siblings a given host keeps current but is not enrolled to dispatch into |
+| `<CATALYST_DIR>/plugin-source`    | the tree every daemon on a worker node actually runs FROM                               |
+
+```json
+{ "catalyst": { "checkouts": ["/Users/me/code/catalyst-cloud", "/Users/me/code/catalyst-otel"] } }
+```
+
+Order-stable and de-duplicated (trailing slashes normalised, so one repo cannot enrol twice).
+A path that does not exist on this host is dropped — a registry copied between hosts routinely
+names a `repoRoot` that exists on neither (CTL-854). A non-array value is **ignored**, never
+coerced: spreading a bare string would enrol one root per character.
+
+**Consumers.** The `catalyst-agent` code-currency gauge measures each root and emits
+`catalyst.vcs.commits_behind` one series per root (label `catalyst.checkout.root`), plus
+`catalyst.vcs.commits_behind.max` — the stalest root, which is the host's single currency
+number. Before CTL-1825 that gauge measured only the directory the agent's own module lived
+in, so on a host whose agent and daemons run from different trees (every node on this fleet)
+it reported a healthy `0` for a tree nobody executes. The checkout-sync pass consumes the same
+enumeration, deliberately: a root one keeps current that the other cannot see is the same
+silent gap in a new place.
+
 ## Node class (`catalyst.node.class`, CTL-1344)
 
 `catalyst.node.class` names **what kind of machine this is**. It is the front door to per-class


### PR DESCRIPTION
Closes CTL-1825.

## The defect

`catalyst.vcs.commits_behind` was computed against **the emitting agent's own module directory**, not against the checkouts the fleet's daemons actually run from:

```js
// plugins/dev/scripts/catalyst-agent/build-info.mjs:19,25 (before)
const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
execFileSync("git", ["-C", MODULE_DIR, "rev-list", "--count", "HEAD..origin/main"], …)
```

That answers *"is the tree containing `build-info.mjs` current?"* — a different question from *"is the code this host runs current?"* whenever those trees differ. On this fleet they differ **by design**: worker nodes execute from `~/catalyst/plugin-source`, and the laptop's `com.catalyst.agent` plist runs the agent out of the **dev working checkout**.

The number was not merely imprecise. It was **structurally incapable of being non-zero** on a host whose agent checkout is the one being kept current. A gauge that can only report 0 is worse than no gauge: it is affirmative evidence of currency where none exists.

## Mechanism

The measurement is taken once per **executing root**, and the roots come from CTL-1808's own module rather than a second enumeration invented here. `execution-core/checkout-sync.mjs` gains `resolveExecutingRoots`, which collects the four declared sources and folds them through the existing `resolveAllowlist`:

```
registry repoRoots  ∪  this checkout  ∪  Layer-2 catalyst.checkouts[]  ∪  <CATALYST_DIR>/plugin-source
```

It lives next to the fold on purpose. `resolveAllowlist` only ever took the three source **lists**; nothing shipped that collected them (the module has zero importers today), so the gauge would otherwise have grown its own reader for the registry / Layer-2 / plugin-source — and a root the sync pass fast-forwards that the gauge cannot see, or the reverse, is the same silent gap in a new place.

Two rules govern what is emitted, both enforced by tests:

| | |
| --- | --- |
| **one series per root** | labelled `catalyst.checkout.root`, so a stale root is visible rather than averaged away or overwritten. An *unlabelled* point would collide with every labelled one and last-write-wins — the defect with a label bolted on. |
| **any single aggregate is the MAXIMUM** | never the agent's own. A separate metric, `catalyst.vcs.commits_behind.max` — a point with *and* without the root label on ONE metric is two conflicting Prometheus series, and the sum of this gauge over roots is meaningless. |

Degradation stays per-root, in the direction the file already commits to: a root git cannot read drops its **own** point (never a 0 that reads as "current") without suppressing the roots that did measure; when nothing measures, both drift metrics are absent rather than 0.

`service.version` / `vcs.ref.head.revision` stay MODULE_DIR-scoped, correctly — those describe the running *artifact*, which IS this tree.

### The one execution-core import

The standalone agent's rule is that it never imports execution-core. The exception is narrow and now stated in its README: `checkout-sync.mjs` is a `node:*`-only leaf that reaches neither `execution-core/config.mjs` nor its `bun:sqlite` graph. Verified under bare `node` v25.8.2 with no `node_modules` — the agent loads and resolves 11 roots. A new required CI step guards that it stays that way.

## Verification

| suite | base (`81380821`) | this branch |
| ----- | ----------------- | ----------- |
| catalyst-agent (full) | 251 pass / 0 fail | **270 pass / 0 fail** |
| execution-core CI stable list | 6278 pass / 12 fail | **6321 pass / 11 fail** |
| `checkout-sync.test.mjs` | 34 / 0 | **42 / 0** |

The 11–12 stable-list failures are **pre-existing** — known-flaky timing suites (`integration-ctl-539`, `fence-guard`), the SDK OAuth env-pollution case, host-name assertions, and the `linear-read-replica` suite. Measured base-vs-branch with only `checkout-sync.mjs` swapped: failures did not increase (12 → 11; the count varies between runs because those suites are timing-flaky). *Positive control that the instrument sees my file at all:* the same list run with the base `checkout-sync.mjs` runs 187 files, with mine 188.

### Positive control (ticket-mandated)

Reverting `commitsBehindMain` to the MODULE_DIR-only implementation and re-running the suite:

```
expect(fixed).toBe(24);
              ^
error: expect(received).toBe(expected)
Expected: 24
Received: 0
```

5 of 12 cases fail. The control asserts the pre-fix answer **is** 0 on the same fixture *and* that the two answers differ — so the passing scenarios are not vacuous.

### Live, on this host

Real `git fetch`, 11 roots, **8.6s** total (against a 300s `StartInterval`):

```
pre-fix (agent checkout only):   0
fixed   (all roots, MAX):       58
```

```
    1  …/coalesce-labs/catalyst-cloud
   58  …/ryanrozich/personal-os
    0  …/coalesce-labs/catalyst        ← the ONLY root the old gauge measured
    …
   25  /Users/ryan/catalyst/plugin-source   ← the tree the daemons run
```

`plugin-source` reads 25 today against the ticket's 24 measured yesterday; `main` advanced by one commit in between.

## Also in this PR

- **`catalyst-agent` had ZERO CI coverage.** `grep catalyst-agent .github/workflows/` → **0** (*positive control on the same instrument:* `otel-forward` → **8**). Its suite and a bare-node import-graph check are now required steps. `checkout-sync.test.mjs` joins the stable list — likewise unwired, so CTL-1808's decision core could regress unobserved.
- `catalyst.checkouts[]` is documented in `website/src/content/docs/reference/configuration.md`, the canonical config-schema home.

## Deferred (not in this PR — sister repo)

`catalyst-otel` needs **one** dashboard expression re-pointed at the new `_max` metric. `dashboards/catalyst-node-sync.json`'s build-info join reads `catalyst_vcs_commits_behind == 0` to mean "this host is current"; with per-root series that now means "this host has **at least one** current root". Every other consumer already wraps the gauge in `max(...)` / `max by (host_name)(...)` and keeps working unchanged — and the `> 20` alert in `provisioning/alerting/read-path-alerts.yaml` becomes correct for the first time, because it is now maxing over roots that exist. One raw-series panel will render N legend entries per host instead of 1.

**Cardinality note:** this metric goes from 1 series per host to one per executing root (11 on this laptop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
