### PR TITLE
fix(dev): CTL-1831 — prove the install RELINKED, so a merged lockfile is not installed in name only

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -524,6 +524,24 @@ jobs:
         working-directory: plugins/dev/scripts/broker
         run: bun test worker-state-projection.test.mjs tailer-torn.test.mjs
 
+      - name: plugin-refresh + lock-resolution-audit tests (CTL-1831)
+        # `grep plugin-refresh .github/workflows/` returned only two COMMENTS
+        # before this step — plugin-refresh.test.mjs (97 tests guarding the
+        # merge-to-main checkout refresh, the deps install, the stale-index.lock
+        # clear and the pull-owner cutover) had never run in CI at all. Positive
+        # control: the same grep for `worker-state-projection` returned the `run:`
+        # line directly above. CTL-1831 adds the install-must-relink guard to that
+        # same file plus its own audit suite, and an unlisted suite is a guard that
+        # lands with no gate — this job's list is hand-enumerated, not globbed.
+        #
+        # Both files run: measured 151 pass / 0 fail on this branch and 97 / 0 for
+        # plugin-refresh.test.mjs at the merge base, so there is no pre-existing
+        # red to import. They cannot join the `bun test` allowlist below — that
+        # step's working-directory is execution-core, and plugin-refresh.test.mjs
+        # reaches router.mjs, which needs the BROKER package's own pino.
+        working-directory: plugins/dev/scripts/broker
+        run: bun test plugin-refresh.test.mjs lock-resolution-audit.test.mjs
+
       - name: catalyst-agent tests (CTL-1825)
         # catalyst-agent had NO CI coverage at all before CTL-1825
         # (`grep catalyst-agent .github/workflows/` returned nothing — positive

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -534,11 +534,16 @@ jobs:
         # same file plus its own audit suite, and an unlisted suite is a guard that
         # lands with no gate — this job's list is hand-enumerated, not globbed.
         #
-        # Both files run: measured 151 pass / 0 fail on this branch and 97 / 0 for
-        # plugin-refresh.test.mjs at the merge base, so there is no pre-existing
-        # red to import. They cannot join the `bun test` allowlist below — that
-        # step's working-directory is execution-core, and plugin-refresh.test.mjs
-        # reaches router.mjs, which needs the BROKER package's own pino.
+        # Both files run: measured 175 tests / 0 fail on this branch, so there is
+        # no pre-existing red to import. (Instrument: `bun test
+        # plugin-refresh.test.mjs lock-resolution-audit.test.mjs` from this step's
+        # working-directory, bun 1.3.5, macOS arm64, single run — the count is
+        # deterministic, no spread. On a checkout WITHOUT the broker package's
+        # pino installed, one of the 175 fails to load rather than failing an
+        # assertion; CI installs it, so CI sees 175/0.) They cannot join the
+        # `bun test` allowlist below — that step's working-directory is
+        # execution-core, and plugin-refresh.test.mjs reaches router.mjs, which
+        # needs the BROKER package's own pino.
         working-directory: plugins/dev/scripts/broker
         run: bun test plugin-refresh.test.mjs lock-resolution-audit.test.mjs
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -808,23 +808,48 @@ covered a FAILING install; a no-op produced no signal at all.
   `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`); resolving only
   the immediate parent finds whichever copy is root-visible, which is a different tree. A BARE key is
   judged from the workspace roots plus every lockfile entry that DECLARES the id, minus any site
-  carrying its OWN nested key for that id — a declarer (`<declarer>/<id>`) or a workspace member root
-  (`<member>/<id>`, of which this repo really has three: `orch-monitor-ui/react`,
-  `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`). Shedding the member **root** is not
-  sufficient: entitlement to that member's nested version belongs to the whole SUBTREE reached
+  whose resolution of that id is governed by a nested entry — its own (`<declarer>/<id>`), an
+  ANCESTOR's, or a workspace member root's (`<member>/<id>`, of which this repo really has three:
+  `orch-monitor-ui/react`, `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`).
+  Entitlement climbs with resolution, so the governing entry is the one keyed by the longest prefix
+  of the site's install path that carries `<prefix>/<id>`; testing only the site's OWN key misses
+  the sibling shape bun really produces (measured: `@opentelemetry/exporter-trace-otlp-http/
+  @opentelemetry/sdk-trace-base` and `…/@opentelemetry/resources` are siblings under the exporter
+  with no `…/sdk-trace-base/@opentelemetry/resources` key, so sdk-trace-base is entitled to
+  resources 2.8.0 by its PARENT while the bare entry is 2.10.0). Shedding the member **root** is not
+  sufficient either: entitlement to that member's nested version belongs to the whole SUBTREE reached
   through it, so a declarer is located only from the roots that survived the shed. Locating it by
   first hit across every root is the bare-key twin of the one-hop bug the deep path fixes — bun's
-  isolated linker writes a separate **peer-disambiguated** store entry per peer set (measured:
-  `.bun/@dnd-kit+core@6.3.1/` resolves react 18.3.1, `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/`
-  resolves 19.2.8) while the lockfile records ONE bare `@dnd-kit/core` entry covering both, so
-  `packages.has("@dnd-kit/core/react")` is false and the nested-key exclusion cannot see the
-  difference. Measured on this repo's real `bun.lock` + `node_modules`, a bare `react` move reported
-  `mismatched=1, expected 18.3.1, found ["19.2.8"], 16 importers` on a correct tree — every one of
-  those 16 located through `orch-monitor-ui` — and a real `bun install --force` (1168 packages,
-  4.21 s) does **not** clear it, because the placement is lockfile-determined: a permanent ERROR plus
-  a re-extract on every refresh carrying that move. A declarer reachable ONLY through a shed root is
-  named in the INCONCLUSIVE reason, never folded into "could not locate" and never silently matched.
-  Because selection already sheds
+  isolated linker writes a separate **peer-disambiguated** store entry per peer set while the
+  lockfile records ONE bare entry covering all of them, so `packages.has("<declarer>/<id>")` is false
+  and the nested-key exclusion cannot see the difference. Reproducible on this checkout: a single
+  bare `eslint@9.39.5` lock entry with no nested key anywhere, two store copies
+  (`.bun/eslint@9.39.5+1a1acd4c2fa5b1a4` and `+5e91b0bf22d6303b`) resolving
+  `@eslint-community/eslint-utils` to two different store dirs — same version, different peer set,
+  one lock key. Measured on this repo's real `bun.lock` + `node_modules`, a bare `react` move
+  reported `mismatched=1, expected 18.3.1, found ["19.2.8"], 16 importers` on a correct tree — every
+  one of those 16 located through `orch-monitor-ui` — and a real `bun install --force`
+  (1168 packages, 4.21 s) does **not** clear it, because the placement is lockfile-determined: a
+  permanent ERROR plus a re-extract on every refresh carrying that move. A declarer reachable ONLY
+  through a shed root is named in the INCONCLUSIVE reason, never folded into "could not locate" and
+  never silently matched.
+- **Selecting the right root is only half of it — the site must be located as the COPY ITS OWN LOCK
+  KEY NAMES.** A site is EXCLUDED by its key but was LOCATED by its id, so a nested declarer was
+  found at whatever the first bare hit from a root happened to be. Measured on the real tree, which
+  is CORRECT on disk: `@opentelemetry/sdk-logs/@opentelemetry/resources` is locked at 2.8.0, has no
+  nested core key, is selected as a site for a bare `@opentelemetry/core` move, and was then located
+  at the 2.10.0 `@opentelemetry/resources` copy — the copy of the entry the exclusion had just shed —
+  whose core is legitimately 2.10.0. That emitted `deps_relink_failed, expected 2.8.0,
+  found ["2.10.0"], 2 importers` on a tree no install can repair. Six such sites; over all 689 bare
+  ids, **5** had at least one — 1 produced that live false ERROR and **4** (`@opentelemetry/api`,
+  `@opentelemetry/semantic-conventions`, `@opentelemetry/resources`, `csstype`) read `matched` ONLY
+  because the wrong copy happened to agree, a latent FALSE CLEAN in the other direction. One defect,
+  both failure modes. Every site is therefore located by walking its own lock key as an install path
+  with the located copy's version checked against the governing entry at EVERY hop; a hop that lands
+  on a version the lockfile does not record for that path is not evidence in either direction — it
+  can neither raise a mismatch nor contribute to a match, and it is named on the verdict as
+  `wrongCopy` rather than dropped. (A `workspace:` hop is exempt from the version check alone: a link
+  records `<name>@workspace:<path>`, not a semver.) Because selection already sheds
   every site entitled to a different version, a SELECTED site holding anything but the locked version
   is a **mismatch** — including a version the lockfile records elsewhere for the same id. Excusing
   those as a benign `alternate` hid the defect the audit exists to catch: with bare `x` moving

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -810,7 +810,21 @@ covered a FAILING install; a no-op produced no signal at all.
   judged from the workspace roots plus every lockfile entry that DECLARES the id, minus any site
   carrying its OWN nested key for that id — a declarer (`<declarer>/<id>`) or a workspace member root
   (`<member>/<id>`, of which this repo really has three: `orch-monitor-ui/react`,
-  `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`). Because selection already sheds
+  `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`). Shedding the member **root** is not
+  sufficient: entitlement to that member's nested version belongs to the whole SUBTREE reached
+  through it, so a declarer is located only from the roots that survived the shed. Locating it by
+  first hit across every root is the bare-key twin of the one-hop bug the deep path fixes — bun's
+  isolated linker writes a separate **peer-disambiguated** store entry per peer set (measured:
+  `.bun/@dnd-kit+core@6.3.1/` resolves react 18.3.1, `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/`
+  resolves 19.2.8) while the lockfile records ONE bare `@dnd-kit/core` entry covering both, so
+  `packages.has("@dnd-kit/core/react")` is false and the nested-key exclusion cannot see the
+  difference. Measured on this repo's real `bun.lock` + `node_modules`, a bare `react` move reported
+  `mismatched=1, expected 18.3.1, found ["19.2.8"], 16 importers` on a correct tree — every one of
+  those 16 located through `orch-monitor-ui` — and a real `bun install --force` (1168 packages,
+  4.21 s) does **not** clear it, because the placement is lockfile-determined: a permanent ERROR plus
+  a re-extract on every refresh carrying that move. A declarer reachable ONLY through a shed root is
+  named in the INCONCLUSIVE reason, never folded into "could not locate" and never silently matched.
+  Because selection already sheds
   every site entitled to a different version, a SELECTED site holding anything but the locked version
   is a **mismatch** — including a version the lockfile records elsewhere for the same id. Excusing
   those as a benign `alternate` hid the defect the audit exists to catch: with bare `x` moving

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -802,14 +802,29 @@ covered a FAILING install; a no-op produced no signal at all.
   structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk.
   A NESTED key (`chalk/ansi-styles`) is judged from its own parent only — judging it from the
   workspace root would compare against a legitimately different hoisted copy and force a needless
-  re-extract. A BARE key is judged from the workspace roots plus every lockfile entry that DECLARES
-  the id. An observed version the lockfile records ELSEWHERE for the same id is an `alternate`, not
-  a mismatch; only a version recorded NOWHERE proves the tree was not materialized from this
-  lockfile.
+  re-extract. The key minus its last element is an install PATH, walked hop by hop from a workspace
+  root, because this repo's own lockfile nests deeper than one level (measured: 48 nested keys, 5
+  deeper than one hop, max chain 4 —
+  `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`); resolving only
+  the immediate parent finds whichever copy is root-visible, which is a different tree. A BARE key is
+  judged from the workspace roots plus every lockfile entry that DECLARES the id, minus any site
+  carrying its OWN nested key for that id — a declarer (`<declarer>/<id>`) or a workspace member root
+  (`<member>/<id>`, of which this repo really has three: `orch-monitor-ui/react`,
+  `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`). Because selection already sheds
+  every site entitled to a different version, a SELECTED site holding anything but the locked version
+  is a **mismatch** — including a version the lockfile records elsewhere for the same id. Excusing
+  those as a benign `alternate` hid the defect the audit exists to catch: with bare `x` moving
+  1.0.0 → 2.0.0 while a nested `a/x` legitimately stays 1.0.0, a stale workspace-root link at 1.0.0
+  was labelled an alternate, `refreshPluginCheckout` ignores alternates, and no force ever ran.
 - **Every verdict is three-valued and fails closed.** An unusable lockfile, an empty site list, an
-  unlocatable importer, or a throwing probe each yield a named INCONCLUSIVE — never a clean pass
-  (`[].every(p)` is `true`, and a zero-site loop printing an all-clear is a false-clean mechanism
-  this repo has shipped before).
+  unlocatable importer, a broken hop in an install path, or a throwing probe each yield a named
+  INCONCLUSIVE — never a clean pass (`[].every(p)` is `true`, and a zero-site loop printing an
+  all-clear is a false-clean mechanism this repo has shipped before). That applies to the
+  **post-`--force` re-audit** too: only a CONCLUSIVE re-audit with neither mismatches nor per-entry
+  inconclusives may record the dir in `deps_relinked`. An empty `mismatched` from a re-audit that
+  threw is byte-identical to a repaired tree, so claiming repair off it would be a
+  check-that-cannot-fail inside the fix for a check-that-cannot-fail; the doubt is emitted as
+  `deps_audit_inconclusive` with `forced: true` (the detection pass carries `forced: false`).
 
 | Event                                     | Severity | Emitted when                                                                                     |
 | ----------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -778,15 +778,25 @@ covered a FAILING install; a no-op produced no signal at all.
   just reset to `origin/main`, so the lockfile IS authoritative.
 - **The discriminator is the IMPORTING package's resolved dependency, not the hoisted top-level
   copy.** `cloud-sync.mjs` imports the schema THROUGH the SDK, and under bun's isolated linker there
-  is frequently no top-level copy at all (measured on this repo:
-  `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` while
-  the SDK resolves it fine). A top-level probe reports "absent" or "fine" and never sees the stale
-  copy the daemons load.
-- **Resolution, not enumeration.** bun's `.bun` store keeps stale entries after an upgrade (measured
-  on this checkout: `@catalyst-cloud+schema@0.1.3` and `@0.1.5` both present, and
-  `@catalyst-cloud+sdk@0.8.1` alongside `0.8.2`), so a version's presence on disk says nothing about
-  what any importer loads. Only a resolve from the importer's own directory answers that — and it is
-  layout-agnostic, giving identical answers under the hoisted and isolated linkers.
+  is frequently no top-level copy at all (measured on this repo, both instruments agreeing:
+  `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` and the
+  disk probe returns null, while resolving it from the SDK's own directory returns 0.1.5). A
+  top-level probe reports "absent" or "fine" and never sees the stale copy the daemons load.
+- **Placement, not enumeration — and read off the DISK, never through the module loader.** bun's
+  `.bun` store keeps stale entries after an upgrade (measured on this checkout:
+  `@catalyst-cloud+schema@0.1.3` and `@0.1.5` both present, and `@catalyst-cloud+sdk@0.8.1`
+  alongside `0.8.2`), so a version's presence in the store says nothing about what any importer
+  loads; only the entry the importer's own `node_modules` ladder lands on does. The probe
+  (`plugin-refresh.mjs` `defaultResolvePackageFn`) walks that ladder with `readFileSync`, which is
+  layout-agnostic — under the hoisted linker the rung IS the package, under the isolated linker it
+  is a symlink into `.bun/`, and the read follows either. It deliberately does **not** use
+  `createRequire().resolve()`: **Node/bun module resolution is cached PROCESS-WIDE and a fresh
+  `createRequire` does not clear it**, so the first cut of this detector answered from cache rather
+  than disk (measured identically under node v25.8.2 and bun 1.3.5 — link flipped to 0.1.3, resolve
+  still reported 0.1.5). Inside the long-lived updater/broker daemons that meant the post-`--force`
+  re-audit reported a FALSE `deps_relink_failed` on every genuine repair, `deps_relinked` was always
+  `[]`, and a process that had once audited a good tree reported CLEAN on a tree that later went
+  stale. A question about bytes on disk gets answered by reading the disk.
 - **Scope of the audit** (`broker/lock-resolution-audit.mjs`, a leaf whose only I/O is an injected
   `resolvePackageFn` seam): just the entries whose resolution the pulled range MOVED, read off a
   structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -759,6 +759,60 @@ one is not counted here, which is the deliberate fail direction for a detector w
 at zero. The asymmetry with the two GATE counters (`unrecognized`, `skippedNoAttributes`) is
 intended and unchanged: those sit on the tail path, run once per line, and were always exact.
 
+### Installed-in-name-only: the install that exits 0 without relinking (CTL-1831)
+
+The link BEFORE the one below, and the one that makes a correct lockfile on `main` never reach any
+host's disk in the first place. `plugin-refresh.mjs` installs with `bun install --frozen-lockfile`,
+falling back to a plain `bun install`. **Neither relinks an existing `node_modules` when only a
+TRANSITIVE resolution changed** — bun prints `no changes` and exits 0, so a successful install and a
+no-op install are byte-identical to the caller. Measured on `mini` 2026-08-13, immediately after
+#3337 moved the root `bun.lock` from `@catalyst-cloud/schema@0.1.3` to `0.1.5`: plugin-source HEAD
+and `bun.lock` were both correct, and `--frozen-lockfile` **and** the plain fallback each left the
+SDK's resolved schema at 0.1.3; only `bun install --force` relinked it. The fleet was unblocked that
+day only by an operator running `--force` by hand on three hosts. `deps_install_failed` already
+covered a FAILING install; a no-op produced no signal at all.
+
+- **Detect, then force — never force always.** A blanket `--force` re-extracts 1168 packages (3-8 s
+  measured) on every refresh, so the refresh instead AUDITS the tree after the normal install and
+  escalates only on a proven mismatch. `--frozen-lockfile` stays the right default: the checkout was
+  just reset to `origin/main`, so the lockfile IS authoritative.
+- **The discriminator is the IMPORTING package's resolved dependency, not the hoisted top-level
+  copy.** `cloud-sync.mjs` imports the schema THROUGH the SDK, and under bun's isolated linker there
+  is frequently no top-level copy at all (measured on this repo:
+  `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` while
+  the SDK resolves it fine). A top-level probe reports "absent" or "fine" and never sees the stale
+  copy the daemons load.
+- **Resolution, not enumeration.** bun's `.bun` store keeps stale entries after an upgrade (measured
+  on this checkout: `@catalyst-cloud+schema@0.1.3` and `@0.1.5` both present, and
+  `@catalyst-cloud+sdk@0.8.1` alongside `0.8.2`), so a version's presence on disk says nothing about
+  what any importer loads. Only a resolve from the importer's own directory answers that — and it is
+  layout-agnostic, giving identical answers under the hoisted and isolated linkers.
+- **Scope of the audit** (`broker/lock-resolution-audit.mjs`, a leaf whose only I/O is an injected
+  `resolvePackageFn` seam): just the entries whose resolution the pulled range MOVED, read off a
+  structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk.
+  A NESTED key (`chalk/ansi-styles`) is judged from its own parent only — judging it from the
+  workspace root would compare against a legitimately different hoisted copy and force a needless
+  re-extract. A BARE key is judged from the workspace roots plus every lockfile entry that DECLARES
+  the id. An observed version the lockfile records ELSEWHERE for the same id is an `alternate`, not
+  a mismatch; only a version recorded NOWHERE proves the tree was not materialized from this
+  lockfile.
+- **Every verdict is three-valued and fails closed.** An unusable lockfile, an empty site list, an
+  unlocatable importer, or a throwing probe each yield a named INCONCLUSIVE — never a clean pass
+  (`[].every(p)` is `true`, and a zero-site loop printing an all-clear is a false-clean mechanism
+  this repo has shipped before).
+
+| Event                                     | Severity | Emitted when                                                                                     |
+| ----------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `plugin.checkout.deps_install_noop`       | WARN     | the install exited 0 and the tree still disagrees with the lockfile — emitted at DETECTION, before any remediation, so the record survives a failed force |
+| `plugin.checkout.deps_relink_failed`      | ERROR    | still mismatched after `--force`; nothing further on this path will fix it                       |
+| `plugin.checkout.deps_audit_inconclusive` | WARN     | the audit could not conclude — "could not look" made distinguishable from "the tree is correct"  |
+| `plugin.checkout.deps_install_failed`     | WARN     | pre-existing; now also carries `forced: true` when the remediation install itself throws         |
+
+`plugin.checkout.updated` gains `deps_relinked` — the dirs a forced relink actually repaired. The
+audit only runs for dirs whose install SUCCEEDED (a tree that was never built has nothing to audit),
+and it is fail-open end to end: a throwing audit degrades to an inconclusive event and never takes
+down the refresh that already succeeded.
+
 ### Installed-but-unloaded: cloud-sync dependency skew (CTL-1659)
 
 The **third** link in the CTL-1506 chain, and the one no existing mechanism covers. `plugin-refresh`

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -298,7 +298,23 @@ function normalizeWorkspaceRoots(workspaceRoots) {
  *     root (`<member>/<id>`, which this repo's lockfile really has three of:
  *     `orch-monitor-ui/react`, `orch-monitor-ui/@types/react`,
  *     `orch-monitor-ui/typescript`, and `plugins/dev/scripts/orch-monitor/ui` is
- *     a literal workspace member the caller passes as a root).
+ *     a literal workspace member the caller passes as a root). Shedding the
+ *     member ROOT is not enough on its own: entitlement to the member's nested
+ *     version belongs to the whole subtree reached THROUGH that root, so a
+ *     declarer is located only from the roots that survived the shed. Locating
+ *     it by first hit across every root is the bare-key twin of the one-hop bug
+ *     the deep path already fixes — bun's isolated linker writes a separate,
+ *     peer-disambiguated store entry per peer set (measured here:
+ *     `.bun/@dnd-kit+core@6.3.1/` -> react 18.3.1,
+ *     `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/` -> react 19.2.8) while the
+ *     lockfile records ONE bare `@dnd-kit/core` entry for both, so
+ *     `packages.has("@dnd-kit/core/react")` is false and the nested-key
+ *     exclusion cannot see the difference. Measured on this repo's real tree, a
+ *     bare `react` move reported 16 false mismatched importers, every one of
+ *     them located through `orch-monitor-ui`, and `bun install --force` cannot
+ *     clear it because the placement is lockfile-determined. A declarer
+ *     reachable ONLY through a shed root is reported by name in the
+ *     inconclusive reason, never folded into "could not locate".
  *
  * Because site selection already sheds every site entitled to a different
  * version, a SELECTED site that resolves anything other than the locked version
@@ -398,6 +414,7 @@ export function auditLockResolution({
     // ── site selection (see the doc comment above) ──
     const sites = [];
     const unlocatable = [];
+    const shedThroughNestedRoot = [];
     if (chain.length > 1) {
       // The key minus its last element is an install PATH, not a single parent.
       // Walk it hop by hop — root -> chain[0] -> chain[1] -> … — so the importer
@@ -427,10 +444,14 @@ export function auditLockResolution({
       if (importerDir) sites.push({ importer, dir: importerDir });
       else unlocatable.push(importer);
     } else {
-      for (const root of roots) {
-        // A member root with its own `<member>/<id>` key resolves THAT entry,
-        // not this bare one — the same exclusion the declarer loop below applies.
-        if (rootShadowedByOwnNestedKey(root, entry.id)) continue;
+      // The roots ENTITLED to the bare resolution. A member root carrying its
+      // own `<member>/<id>` key resolves THAT entry, not this bare one — and
+      // that entitlement is a property of the whole subtree reached through
+      // the root, not of the root directory alone. So this one list governs
+      // BOTH kinds of site below: the roots probed directly, and the roots a
+      // declarer may be LOCATED from.
+      const bareRoots = roots.filter((root) => !rootShadowedByOwnNestedKey(root, entry.id));
+      for (const root of bareRoots) {
         sites.push({ importer: `workspace:${root.dir}`, dir: root.dir });
       }
       for (const pkg of parsed.packages.values()) {
@@ -439,12 +460,35 @@ export function auditLockResolution({
         // A declarer with its own nested key for this id resolves THAT entry, not
         // this bare one — probing it would compare against the wrong resolution.
         if (parsed.packages.has(`${pkg.key}/${entry.id}`)) continue;
+        // Locate the declarer only from a bare-entitled root. Taking the first
+        // hit across ALL roots is the bare-key twin of the one-hop bug the deep
+        // path already fixes: bun's isolated linker writes a SEPARATE,
+        // peer-disambiguated store entry per peer set (measured on this repo:
+        // `.bun/@dnd-kit+core@6.3.1/` resolves react 18.3.1 while
+        // `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/` resolves 19.2.8), and the
+        // lockfile records ONE bare `@dnd-kit/core` entry for both — so
+        // `parsed.packages.has("@dnd-kit/core/react")` is false and the nested-key
+        // exclusion above cannot see the distinction. A declarer found through a
+        // shed member root IS the copy peered to that member's nested version;
+        // comparing it against the bare one reported 16 false mismatched importers
+        // for `react` on this repo's real tree, an ERROR no `--force` can clear
+        // because the placement is lockfile-determined.
         let located = null;
-        for (const root of roots) {
+        for (const root of bareRoots) {
           located = resolve(root.dir, pkg.id);
           if (located) break;
         }
-        if (located) sites.push({ importer: pkg.id, dir: located.dir });
+        if (located) {
+          sites.push({ importer: pkg.id, dir: located.dir });
+          continue;
+        }
+        // Not reachable from any bare-entitled root. Separate "shed on purpose"
+        // from "could not look" — folding the two together would let a wholly
+        // shed site list read as an absent dependency in the inconclusive reason.
+        const reachableOnlyViaShedRoot = roots.some(
+          (root) => rootShadowedByOwnNestedKey(root, entry.id) && resolve(root.dir, pkg.id),
+        );
+        if (reachableOnlyViaShedRoot) shedThroughNestedRoot.push(pkg.id);
         else unlocatable.push(pkg.id);
       }
     }
@@ -462,7 +506,10 @@ export function auditLockResolution({
         ...entry,
         reason:
           `no importer on disk resolves ${entry.id}` +
-          (unlocatable.length > 0 ? ` (could not locate: ${unlocatable.join(", ")})` : ""),
+          (unlocatable.length > 0 ? ` (could not locate: ${unlocatable.join(", ")})` : "") +
+          (shedThroughNestedRoot.length > 0
+            ? ` (reachable only through a workspace member that nests ${entry.id}: ${shedThroughNestedRoot.join(", ")})`
+            : ""),
       });
       continue;
     }

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -1,0 +1,406 @@
+// lock-resolution-audit.mjs — did the install actually RELINK, or merely exit 0?
+// (CTL-1831)
+//
+// MEASURED 2026-08-13 on `mini`, immediately after #3337 moved the root bun.lock
+// from @catalyst-cloud/schema@0.1.3 to 0.1.5. The refresh pulled the merge
+// correctly — plugin-source HEAD and bun.lock were both right — and then:
+//
+//   bun install --frozen-lockfile   (what plugin-refresh runs)  -> 0.1.3, "no changes", exit 0
+//   bun install                     (its fallback)              -> 0.1.3, "no changes", exit 0
+//   bun install --force                                         -> 0.1.5
+//
+// Bun will not relink an existing node_modules when only a TRANSITIVE resolution
+// changed, and both no-op commands exit 0 — so "the install succeeded" and "the
+// install changed nothing" are byte-identical to the caller. plugin-refresh
+// already surfaces install FAILURE as deps_install_failed; a no-op produced no
+// signal at all, which is why a correct lockfile reached every host's disk and
+// still never reached the running code (the CTL-1506 chain's second link; the
+// fleet was unblocked that day only by running --force by hand on three hosts).
+//
+// THE DISCRIMINATOR, and why it is not the obvious one: the check must read the
+// IMPORTING package's resolved dependency, NOT the hoisted top-level copy.
+// cloud-sync.mjs imports @catalyst-cloud/schema THROUGH the SDK, and under bun's
+// isolated linker there is frequently no top-level copy at all (measured in this
+// repo: `require.resolve("@catalyst-cloud/schema")` from the workspace root is
+// MODULE_NOT_FOUND while the SDK resolves it fine). A top-level probe would have
+// reported "absent" or "fine" and never seen the stale 0.1.3 the daemons loaded.
+//
+// Resolution — not directory enumeration — is the only honest instrument here.
+// bun's `.bun` store keeps STALE entries after an upgrade (measured on this
+// checkout: @catalyst-cloud+schema@0.1.3 and @0.1.5 both present, and
+// @catalyst-cloud+sdk@0.8.1 alongside 0.8.2), so "0.1.3 exists on disk" says
+// nothing about what any importer loads. Only a resolve from the importer's own
+// directory answers that, and it is layout-agnostic: it works identically under
+// the hoisted and isolated linkers because both are built to make resolution
+// give the right answer.
+//
+// The single filesystem interaction is the injected `resolvePackageFn(fromDir,
+// id) -> {dir, version} | null` seam, so the whole audit is deterministically
+// testable without a real node_modules. Mirrors the seam-injection convention of
+// plugin-refresh.mjs / cloud-sync-deps.mjs.
+
+// ─── lock key parsing ────────────────────────────────────────────────────────
+
+/**
+ * splitLockKey — bun keys its `packages` map by install LOCATION: `<id>` for a
+ * hoisted resolution, `<parent>/<id>` for a nested one, chaining deeper
+ * (measured in this repo's own bun.lock:
+ * `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`).
+ *
+ * A naive `split("/")` cannot tell a scoped package name from a nesting hop, so
+ * this consumes a leading `@` segment together with the segment after it.
+ * Returns null — never a guessed chain — for a dangling scope or a non-string,
+ * because a caller that cannot identify the importer must report inconclusive
+ * rather than probe the wrong directory.
+ *
+ * @returns {string[]|null}
+ */
+export function splitLockKey(key) {
+  if (typeof key !== "string" || key.length === 0) return null;
+  const parts = key.split("/");
+  const chain = [];
+  for (let i = 0; i < parts.length; i += 1) {
+    const seg = parts[i];
+    if (seg.length === 0) return null;
+    if (seg.startsWith("@")) {
+      if (i + 1 >= parts.length) return null; // a scope with no package after it
+      chain.push(`${seg}/${parts[i + 1]}`);
+      i += 1;
+    } else {
+      chain.push(seg);
+    }
+  }
+  return chain.length > 0 ? chain : null;
+}
+
+// A `packages` entry line, as bun writes it:
+//     "<key>": ["<name>@<version>", "<resolution>", {<meta>}, "<integrity>"],
+// Anchored at the start of the line so the `"optionalPeers": ["…"]` array that
+// lives INSIDE an entry (and any other mid-line `"key": ["`) cannot match.
+const ENTRY_RE = /^\s*"([^"]+)"\s*:\s*\[\s*"([^"]+)"/;
+
+// The `"packages": {` block opener and its 2-space closing brace. Scanning only
+// inside that block keeps the `workspaces` / `overrides` blocks out of the map.
+const PACKAGES_OPEN_RE = /^\s{0,4}"packages"\s*:\s*\{\s*$/;
+const BLOCK_CLOSE_RE = /^\s{0,3}\}/;
+
+// A workspace member is recorded as `<name>@workspace:<path>` — a link, not an
+// installed artifact. It has no resolution to materialize, so it never
+// contributes a change the audit could verify on disk.
+const WORKSPACE_VERSION_PREFIX = "workspace:";
+
+/**
+ * parseLockPackages — the lockfile's `packages` map as structured data.
+ *
+ * STRUCTURED, not a substring grep: each entry is anchored on the line-leading
+ * key AND the value's first array element, and the id/version split is taken at
+ * the LAST `@` so a scoped name (`@catalyst-cloud/schema@0.1.5`) survives. An
+ * unstructured match over structured data is one of the four mechanisms that has
+ * produced a false clean result in this repo before.
+ *
+ * Three-valued: text that is empty, non-string, or has no `packages` block is
+ * INCONCLUSIVE with a reason — never an empty map, which every downstream
+ * comparison would read as "nothing changed, all clean".
+ *
+ * @returns {{conclusive:boolean, reason:string|null,
+ *            packages: Map<string,{key:string,id:string,version:string,
+ *                                  workspaceLink:boolean, declaredDeps:string[]|null}>}}
+ */
+export function parseLockPackages(lockText) {
+  const packages = new Map();
+  if (typeof lockText !== "string" || lockText.length === 0) {
+    return { conclusive: false, reason: "lockfile text unavailable", packages };
+  }
+  const lines = lockText.split("\n");
+  let inBlock = false;
+  let sawBlock = false;
+  for (const line of lines) {
+    if (!inBlock) {
+      if (PACKAGES_OPEN_RE.test(line)) {
+        inBlock = true;
+        sawBlock = true;
+      }
+      continue;
+    }
+    if (BLOCK_CLOSE_RE.test(line)) {
+      inBlock = false;
+      continue;
+    }
+    const m = ENTRY_RE.exec(line);
+    if (!m) continue;
+    const [, key, first] = m;
+    const at = first.lastIndexOf("@");
+    if (at <= 0) continue; // no `name@version` shape — not a package entry
+    const id = first.slice(0, at);
+    const version = first.slice(at + 1);
+    packages.set(key, {
+      key,
+      id,
+      version,
+      workspaceLink: version.startsWith(WORKSPACE_VERSION_PREFIX),
+      declaredDeps: declaredDepsOf(line),
+    });
+  }
+  if (!sawBlock) {
+    return { conclusive: false, reason: 'no "packages" block found in the lockfile text', packages };
+  }
+  return { conclusive: true, reason: null, packages };
+}
+
+// declaredDepsOf — the dependency ids an entry declares, read out of its metadata
+// object (the third array element). Returns null — meaning "could not look" —
+// when the object cannot be located or parsed, so the caller can render that as
+// inconclusive rather than as "this package declares nothing".
+//
+// The object is extracted by brace matching rather than by regex, because a
+// dependency RANGE can itself contain braces-free but quoted content and the
+// entry's trailing integrity string must not be swallowed. Brace matching is
+// safe here for the same reason bun can write the file at all: the metadata
+// object is emitted as plain JSON on one line.
+function declaredDepsOf(line) {
+  const open = line.indexOf("{");
+  if (open === -1) return [];
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < line.length; i += 1) {
+    if (line[i] === "{") depth += 1;
+    else if (line[i] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) return null;
+  let meta;
+  try {
+    meta = JSON.parse(line.slice(open, close + 1));
+  } catch {
+    return null;
+  }
+  const out = [];
+  for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
+    const block = meta?.[field];
+    if (block && typeof block === "object" && !Array.isArray(block)) out.push(...Object.keys(block));
+  }
+  return [...new Set(out)];
+}
+
+// ─── change detection ────────────────────────────────────────────────────────
+
+/**
+ * changedResolutions — the entries whose resolution the pulled range MOVED.
+ *
+ * Only entries that are new or whose version changed: those are the ones that
+ * must be materialized on disk by the install that follows. A REMOVED entry
+ * needs nothing materialized (the leftover copy is unreachable debris, and bun's
+ * store keeps it around regardless), and a `workspace:` link is not an installed
+ * artifact at all.
+ *
+ * Restricting the audit to the CHANGED entries is what keeps it cheap enough to
+ * run on every refresh: a merge typically moves a handful of resolutions, versus
+ * the 1168 packages a blanket `--force` re-extracts (3-8 s measured).
+ *
+ * Three-valued: if either side cannot be parsed the result is INCONCLUSIVE with
+ * a reason and an EMPTY entry list — a caller must be able to tell "nothing
+ * changed" from "I could not look".
+ *
+ * @returns {{conclusive:boolean, reason:string|null,
+ *            entries:{key:string,id:string,from:string|null,to:string}[]}}
+ */
+export function changedResolutions(oldLockText, newLockText) {
+  const before = parseLockPackages(oldLockText);
+  const after = parseLockPackages(newLockText);
+  if (!before.conclusive || !after.conclusive) {
+    const which = !before.conclusive ? `previous lockfile (${before.reason})` : `new lockfile (${after.reason})`;
+    return { conclusive: false, reason: `cannot compare resolutions: ${which}`, entries: [] };
+  }
+  const entries = [];
+  for (const [key, now] of after.packages) {
+    if (now.workspaceLink) continue;
+    const then = before.packages.get(key);
+    if (then && then.version === now.version) continue;
+    entries.push({ key, id: now.id, from: then?.version ?? null, to: now.version });
+  }
+  return { conclusive: true, reason: null, entries };
+}
+
+// ─── the on-disk audit ───────────────────────────────────────────────────────
+
+/**
+ * auditLockResolution — for every resolution the pulled range moved, does the
+ * IMPORTING package on disk actually resolve the locked version?
+ *
+ * Importer selection is what keeps this both precise and free of false alarms:
+ *
+ *   - a NESTED key (`chalk/ansi-styles`) names its own importer. It is judged
+ *     from that parent's directory ONLY. Judging it from the workspace root
+ *     would compare against the hoisted copy — a legitimately different version
+ *     — and force a needless 1168-package re-extract on every refresh.
+ *   - a BARE key is the single graph-wide resolution for that id, so every
+ *     importer must agree. Sites are the workspace roots plus every lockfile
+ *     entry that DECLARES the id, each located by resolving it from a workspace
+ *     root. A declarer that carries its own nested key for the id is excluded —
+ *     it resolves the other entry, not this one.
+ *
+ * An observed version that the lockfile records ELSEWHERE for the same id is an
+ * `alternate`, not a mismatch: a legitimate second resolution must not trigger a
+ * force. Only a version the lockfile records NOWHERE for that id proves the tree
+ * was not materialized from this lockfile — which is exactly the measured
+ * incident (after #3337 the lockfile recorded 0.1.5 and only 0.1.5, and the disk
+ * held 0.1.3).
+ *
+ * FAIL-CLOSED THROUGHOUT. An unusable lockfile, an empty site list, an
+ * unlocatable importer, or a throwing resolver each produce an explicit
+ * INCONCLUSIVE — never a clean pass. `[].every(p)` is `true`, and a zero-site
+ * loop that prints an all-clear on the strength of zero iterations is one of the
+ * false-clean mechanisms this repo has actually shipped.
+ *
+ * @param {object}   opts
+ * @param {string[]} opts.workspaceRoots  dirs to resolve from (lock dir + literal members)
+ * @param {string?}  opts.oldLockText     lockfile content at the pre-pull sha
+ * @param {string?}  opts.newLockText     lockfile content on disk now
+ * @param {Function} opts.resolvePackageFn (fromDir, id) => {dir, version} | null
+ */
+export function auditLockResolution({
+  workspaceRoots = [],
+  oldLockText = null,
+  newLockText = null,
+  resolvePackageFn,
+} = {}) {
+  const empty = { checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+
+  const change = changedResolutions(oldLockText, newLockText);
+  if (!change.conclusive) return { ...empty, conclusive: false, reason: change.reason };
+  if (change.entries.length === 0) return { ...empty, conclusive: true, reason: null };
+
+  // The vacuity guard, asserted BEFORE the per-entry loop: with no site to probe
+  // every entry would fall through the loop body and the audit would report a
+  // clean tree it never looked at.
+  const roots = Array.isArray(workspaceRoots) ? workspaceRoots.filter((r) => typeof r === "string" && r) : [];
+  if (roots.length === 0) {
+    return { ...empty, conclusive: false, reason: "no workspace root to resolve from — nothing could be probed" };
+  }
+  if (typeof resolvePackageFn !== "function") {
+    return { ...empty, conclusive: false, reason: "no package resolver supplied — nothing could be probed" };
+  }
+
+  const parsed = parseLockPackages(newLockText);
+  const lockedVersionsById = new Map();
+  for (const entry of parsed.packages.values()) {
+    if (entry.workspaceLink) continue;
+    if (!lockedVersionsById.has(entry.id)) lockedVersionsById.set(entry.id, new Set());
+    lockedVersionsById.get(entry.id).add(entry.version);
+  }
+
+  // resolve/locate memo — one probe per (fromDir, id) across the whole audit.
+  const memo = new Map();
+  const resolve = (fromDir, id) => {
+    const cacheKey = `${fromDir} ${id}`;
+    if (memo.has(cacheKey)) return memo.get(cacheKey);
+    let out = null;
+    try {
+      const r = resolvePackageFn(fromDir, id);
+      out = r && typeof r.version === "string" && r.version ? r : null;
+    } catch {
+      out = null; // a throwing probe is "could not look", never "not there"
+    }
+    memo.set(cacheKey, out);
+    return out;
+  };
+
+  const matched = [];
+  const mismatched = [];
+  const alternates = [];
+  const inconclusive = [];
+
+  for (const entry of change.entries) {
+    const chain = splitLockKey(entry.key);
+    if (!chain) {
+      inconclusive.push({ ...entry, reason: `lockfile key "${entry.key}" is not a parseable install location` });
+      continue;
+    }
+
+    // ── site selection (see the doc comment above) ──
+    const sites = [];
+    const unlocatable = [];
+    if (chain.length > 1) {
+      const parentId = chain[chain.length - 2];
+      let located = null;
+      for (const root of roots) {
+        located = resolve(root, parentId);
+        if (located) break;
+      }
+      if (located) sites.push({ importer: parentId, dir: located.dir });
+      else unlocatable.push(parentId);
+    } else {
+      for (const root of roots) sites.push({ importer: `workspace:${root}`, dir: root });
+      for (const pkg of parsed.packages.values()) {
+        if (pkg.workspaceLink) continue;
+        if (!Array.isArray(pkg.declaredDeps) || !pkg.declaredDeps.includes(entry.id)) continue;
+        // A declarer with its own nested key for this id resolves THAT entry, not
+        // this bare one — probing it would compare against the wrong resolution.
+        if (parsed.packages.has(`${pkg.key}/${entry.id}`)) continue;
+        let located = null;
+        for (const root of roots) {
+          located = resolve(root, pkg.id);
+          if (located) break;
+        }
+        if (located) sites.push({ importer: pkg.id, dir: located.dir });
+        else unlocatable.push(pkg.id);
+      }
+    }
+
+    // ── probe every site ──
+    const observations = [];
+    for (const site of sites) {
+      const got = resolve(site.dir, entry.id);
+      if (!got) continue; // not reachable from this importer — not evidence either way
+      observations.push({ importer: site.importer, version: got.version, path: got.dir ?? null });
+    }
+
+    if (observations.length === 0) {
+      inconclusive.push({
+        ...entry,
+        reason:
+          `no importer on disk resolves ${entry.id}` +
+          (unlocatable.length > 0 ? ` (could not locate: ${unlocatable.join(", ")})` : ""),
+      });
+      continue;
+    }
+
+    const lockedElsewhere = lockedVersionsById.get(entry.id) ?? new Set();
+    const wrong = observations.filter((o) => o.version !== entry.to && !lockedElsewhere.has(o.version));
+    const other = observations.filter((o) => o.version !== entry.to && lockedElsewhere.has(o.version));
+
+    if (wrong.length > 0) {
+      mismatched.push({
+        ...entry,
+        expected: entry.to,
+        found: [...new Set(wrong.map((o) => o.version))],
+        importers: [...new Set(wrong.map((o) => o.importer))],
+        paths: [...new Set(wrong.map((o) => o.path).filter(Boolean))],
+      });
+    } else if (other.length > 0) {
+      alternates.push({
+        ...entry,
+        expected: entry.to,
+        found: [...new Set(other.map((o) => o.version))],
+        importers: [...new Set(other.map((o) => o.importer))],
+      });
+    } else {
+      matched.push({ ...entry, importers: [...new Set(observations.map((o) => o.importer))] });
+    }
+  }
+
+  return {
+    conclusive: true,
+    reason: null,
+    checked: change.entries.length,
+    matched,
+    mismatched,
+    alternates,
+    inconclusive,
+  };
+}

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -25,19 +25,29 @@
 // MODULE_NOT_FOUND while the SDK resolves it fine). A top-level probe would have
 // reported "absent" or "fine" and never seen the stale 0.1.3 the daemons loaded.
 //
-// Resolution — not directory enumeration — is the only honest instrument here.
+// Placement — not directory enumeration — is the only honest instrument here.
 // bun's `.bun` store keeps STALE entries after an upgrade (measured on this
 // checkout: @catalyst-cloud+schema@0.1.3 and @0.1.5 both present, and
 // @catalyst-cloud+sdk@0.8.1 alongside 0.8.2), so "0.1.3 exists on disk" says
-// nothing about what any importer loads. Only a resolve from the importer's own
-// directory answers that, and it is layout-agnostic: it works identically under
-// the hoisted and isolated linkers because both are built to make resolution
-// give the right answer.
+// nothing about what any importer loads. Only the entry the importer's own
+// node_modules ladder lands on answers that, and reading that ladder is
+// layout-agnostic: under the hoisted linker the rung IS the package, under the
+// isolated linker it is a symlink into `.bun/`, and a plain file read follows
+// either.
 //
 // The single filesystem interaction is the injected `resolvePackageFn(fromDir,
 // id) -> {dir, version} | null` seam, so the whole audit is deterministically
 // testable without a real node_modules. Mirrors the seam-injection convention of
 // plugin-refresh.mjs / cloud-sync-deps.mjs.
+//
+// CONTRACT ON THAT SEAM, and the trap the first implementation fell into: it
+// must answer from the DISK ON EVERY CALL. `createRequire().resolve()` looks
+// like the obvious implementation and is disqualified — Node/bun module
+// resolution is cached PROCESS-WIDE and a fresh `createRequire` does not clear
+// it, so inside a long-lived daemon the post-`--force` re-audit re-reads the
+// pre-force answer and a process that once saw a good tree never sees it go
+// stale. See `plugin-refresh.mjs` `defaultResolvePackageFn` for the ladder walk
+// that satisfies this.
 
 // ─── lock key parsing ────────────────────────────────────────────────────────
 

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -239,36 +239,90 @@ export function changedResolutions(oldLockText, newLockText) {
 // ─── the on-disk audit ───────────────────────────────────────────────────────
 
 /**
+ * normalizeWorkspaceRoots — accept a bare dir string OR `{dir, name}`, and drop
+ * anything that is neither. `name` is the root's own package name; it is what
+ * makes the bare-key member-nesting exclusion PRECISE (shed exactly the member
+ * whose `<name>/<id>` key exists) instead of blunt.
+ *
+ * A string entry is kept, with `name: null` — "present, name unknown" — rather
+ * than rejected, because the caller contract predates the name and every unit
+ * test passes bare dirs. The fallback for an unnamed root is deliberately blunt
+ * (see rootShadowedByOwnNestedKey): it cannot tell WHICH member nests an id, so
+ * it sheds every unnamed root for that id. Shedding is the safe direction — a
+ * site list that empties reports INCONCLUSIVE, never a clean pass.
+ *
+ * @returns {{dir:string, name:string|null}[]}
+ */
+function normalizeWorkspaceRoots(workspaceRoots) {
+  if (!Array.isArray(workspaceRoots)) return [];
+  const out = [];
+  for (const root of workspaceRoots) {
+    if (typeof root === "string" && root) {
+      out.push({ dir: root, name: null });
+      continue;
+    }
+    if (root && typeof root === "object" && typeof root.dir === "string" && root.dir) {
+      out.push({ dir: root.dir, name: typeof root.name === "string" && root.name ? root.name : null });
+    }
+  }
+  return out;
+}
+
+/**
  * auditLockResolution — for every resolution the pulled range moved, does the
  * IMPORTING package on disk actually resolve the locked version?
  *
  * Importer selection is what keeps this both precise and free of false alarms:
  *
- *   - a NESTED key (`chalk/ansi-styles`) names its own importer. It is judged
- *     from that parent's directory ONLY. Judging it from the workspace root
- *     would compare against the hoisted copy — a legitimately different version
- *     — and force a needless 1168-package re-extract on every refresh.
+ *   - a NESTED key (`chalk/ansi-styles`) names its own importer: the WHOLE key
+ *     minus the last element is an install PATH, and the importer is reached by
+ *     resolving each element of that path in sequence from a workspace root.
+ *     Resolving only the immediate parent is wrong for anything deeper than one
+ *     hop — this repo's own bun.lock really carries
+ *     `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`
+ *     (measured: 48 nested keys, 5 of them deeper than one hop, max chain 4) —
+ *     because the parent named by that path is `brace-expansion` UNDER
+ *     `minimatch` UNDER `typescript-estree`, not whichever `brace-expansion`
+ *     happens to be visible from the root. A root-visible parent that is a
+ *     separately hoisted copy makes the audit probe the wrong tree; an absent
+ *     one makes it inconclusive. It is judged from that located parent ONLY —
+ *     judging it from the workspace root would compare against the hoisted copy,
+ *     a legitimately different version, and force a needless 1168-package
+ *     re-extract on every refresh.
  *   - a BARE key is the single graph-wide resolution for that id, so every
  *     importer must agree. Sites are the workspace roots plus every lockfile
  *     entry that DECLARES the id, each located by resolving it from a workspace
- *     root. A declarer that carries its own nested key for the id is excluded —
- *     it resolves the other entry, not this one.
+ *     root. A site that carries its OWN nested key for the id is excluded — it
+ *     resolves that entry, not this bare one. That exclusion applies to BOTH
+ *     kinds of site: to a declarer (`<declarer>/<id>`) and to a workspace member
+ *     root (`<member>/<id>`, which this repo's lockfile really has three of:
+ *     `orch-monitor-ui/react`, `orch-monitor-ui/@types/react`,
+ *     `orch-monitor-ui/typescript`, and `plugins/dev/scripts/orch-monitor/ui` is
+ *     a literal workspace member the caller passes as a root).
  *
- * An observed version that the lockfile records ELSEWHERE for the same id is an
- * `alternate`, not a mismatch: a legitimate second resolution must not trigger a
- * force. Only a version the lockfile records NOWHERE for that id proves the tree
- * was not materialized from this lockfile — which is exactly the measured
- * incident (after #3337 the lockfile recorded 0.1.5 and only 0.1.5, and the disk
- * held 0.1.3).
+ * Because site selection already sheds every site entitled to a different
+ * version, a SELECTED site that resolves anything other than the locked version
+ * is a MISMATCH — including a version the lockfile records elsewhere for the
+ * same id. Excusing those as a benign "alternate" hid the exact defect this
+ * module exists to catch: with bare `x` moving 1.0.0 -> 2.0.0 while a nested
+ * `a/x` legitimately stays at 1.0.0, a stale workspace-root link at 1.0.0 was
+ * labelled an alternate, `refreshPluginCheckout` ignores alternates, no force
+ * ever ran, and the bare resolution stayed stale.
  *
  * FAIL-CLOSED THROUGHOUT. An unusable lockfile, an empty site list, an
- * unlocatable importer, or a throwing resolver each produce an explicit
- * INCONCLUSIVE — never a clean pass. `[].every(p)` is `true`, and a zero-site
+ * unlocatable importer, a broken hop part-way along an install path, or a
+ * throwing resolver each produce an explicit INCONCLUSIVE — never a clean pass
+ * and never a probe of a half-walked directory. `[].every(p)` is `true`, and a zero-site
  * loop that prints an all-clear on the strength of zero iterations is one of the
  * false-clean mechanisms this repo has actually shipped.
  *
- * @param {object}   opts
- * @param {string[]} opts.workspaceRoots  dirs to resolve from (lock dir + literal members)
+ * @param {object} opts
+ * @param {(string|{dir:string,name:string|null})[]} opts.workspaceRoots
+ *        dirs to resolve from (lock dir + literal members). An entry may be a
+ *        bare dir string or `{dir, name}`; `name` is the root's own package
+ *        name, which is what lets the bare-key exclusion above name the ONE
+ *        member root a `<member>/<id>` key shadows. See normalizeWorkspaceRoots
+ *        for the deliberately blunt fallback when a name is not supplied.
  * @param {string?}  opts.oldLockText     lockfile content at the pre-pull sha
  * @param {string?}  opts.newLockText     lockfile content on disk now
  * @param {Function} opts.resolvePackageFn (fromDir, id) => {dir, version} | null
@@ -279,7 +333,7 @@ export function auditLockResolution({
   newLockText = null,
   resolvePackageFn,
 } = {}) {
-  const empty = { checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+  const empty = { checked: 0, matched: [], mismatched: [], inconclusive: [] };
 
   const change = changedResolutions(oldLockText, newLockText);
   if (!change.conclusive) return { ...empty, conclusive: false, reason: change.reason };
@@ -288,7 +342,7 @@ export function auditLockResolution({
   // The vacuity guard, asserted BEFORE the per-entry loop: with no site to probe
   // every entry would fall through the loop body and the audit would report a
   // clean tree it never looked at.
-  const roots = Array.isArray(workspaceRoots) ? workspaceRoots.filter((r) => typeof r === "string" && r) : [];
+  const roots = normalizeWorkspaceRoots(workspaceRoots);
   if (roots.length === 0) {
     return { ...empty, conclusive: false, reason: "no workspace root to resolve from — nothing could be probed" };
   }
@@ -297,12 +351,22 @@ export function auditLockResolution({
   }
 
   const parsed = parseLockPackages(newLockText);
-  const lockedVersionsById = new Map();
-  for (const entry of parsed.packages.values()) {
-    if (entry.workspaceLink) continue;
-    if (!lockedVersionsById.has(entry.id)) lockedVersionsById.set(entry.id, new Set());
-    lockedVersionsById.get(entry.id).add(entry.version);
-  }
+
+  // The lockfile's workspace members, by package name — the possible parents of
+  // a `<member>/<id>` key, which is how a member root legitimately resolves a
+  // version other than the bare one.
+  const memberNames = [];
+  for (const pkg of parsed.packages.values()) if (pkg.workspaceLink) memberNames.push(pkg.id);
+
+  // rootShadowedByOwnNestedKey — does this workspace root resolve `id` through
+  // its OWN nested lock entry rather than the bare one? Named root: ask exactly
+  // that root's key. Unnamed root: we cannot tell which member nests the id, so
+  // if ANY member does, shed every unnamed root for this entry (safe direction —
+  // see normalizeWorkspaceRoots).
+  const rootShadowedByOwnNestedKey = (root, id) =>
+    root.name
+      ? parsed.packages.has(`${root.name}/${id}`)
+      : memberNames.some((member) => parsed.packages.has(`${member}/${id}`));
 
   // resolve/locate memo — one probe per (fromDir, id) across the whole audit.
   const memo = new Map();
@@ -322,7 +386,6 @@ export function auditLockResolution({
 
   const matched = [];
   const mismatched = [];
-  const alternates = [];
   const inconclusive = [];
 
   for (const entry of change.entries) {
@@ -336,16 +399,40 @@ export function auditLockResolution({
     const sites = [];
     const unlocatable = [];
     if (chain.length > 1) {
-      const parentId = chain[chain.length - 2];
-      let located = null;
+      // The key minus its last element is an install PATH, not a single parent.
+      // Walk it hop by hop — root -> chain[0] -> chain[1] -> … — so the importer
+      // located is the copy the path actually names. Resolving only
+      // chain[length-2] from a root finds whichever copy is root-visible, which
+      // for a deep key is either absent (inconclusive) or a separately hoisted
+      // copy in a different tree (the wrong probe, silently).
+      const parentPath = chain.slice(0, -1);
+      const importer = parentPath.join("/");
+      let importerDir = null;
       for (const root of roots) {
-        located = resolve(root, parentId);
-        if (located) break;
+        let cursor = root.dir;
+        let walked = true;
+        for (const hop of parentPath) {
+          const step = resolve(cursor, hop);
+          if (!step || typeof step.dir !== "string" || !step.dir) {
+            walked = false;
+            break;
+          }
+          cursor = step.dir;
+        }
+        if (walked) {
+          importerDir = cursor;
+          break;
+        }
       }
-      if (located) sites.push({ importer: parentId, dir: located.dir });
-      else unlocatable.push(parentId);
+      if (importerDir) sites.push({ importer, dir: importerDir });
+      else unlocatable.push(importer);
     } else {
-      for (const root of roots) sites.push({ importer: `workspace:${root}`, dir: root });
+      for (const root of roots) {
+        // A member root with its own `<member>/<id>` key resolves THAT entry,
+        // not this bare one — the same exclusion the declarer loop below applies.
+        if (rootShadowedByOwnNestedKey(root, entry.id)) continue;
+        sites.push({ importer: `workspace:${root.dir}`, dir: root.dir });
+      }
       for (const pkg of parsed.packages.values()) {
         if (pkg.workspaceLink) continue;
         if (!Array.isArray(pkg.declaredDeps) || !pkg.declaredDeps.includes(entry.id)) continue;
@@ -354,7 +441,7 @@ export function auditLockResolution({
         if (parsed.packages.has(`${pkg.key}/${entry.id}`)) continue;
         let located = null;
         for (const root of roots) {
-          located = resolve(root, pkg.id);
+          located = resolve(root.dir, pkg.id);
           if (located) break;
         }
         if (located) sites.push({ importer: pkg.id, dir: located.dir });
@@ -380,9 +467,14 @@ export function auditLockResolution({
       continue;
     }
 
-    const lockedElsewhere = lockedVersionsById.get(entry.id) ?? new Set();
-    const wrong = observations.filter((o) => o.version !== entry.to && !lockedElsewhere.has(o.version));
-    const other = observations.filter((o) => o.version !== entry.to && lockedElsewhere.has(o.version));
+    // Site selection above already shed every site entitled to a different
+    // version (a nested key is judged only at the importer its install path
+    // names; a bare key skips any declarer or member root carrying its own
+    // nested key). So the locked version is the ONLY correct answer at a site
+    // that survived, and "this version is recorded elsewhere in the lockfile" is
+    // no longer an excuse — that excuse is what let the stale bare resolution
+    // ride through as a benign `alternate` and never get forced.
+    const wrong = observations.filter((o) => o.version !== entry.to);
 
     if (wrong.length > 0) {
       mismatched.push({
@@ -391,13 +483,6 @@ export function auditLockResolution({
         found: [...new Set(wrong.map((o) => o.version))],
         importers: [...new Set(wrong.map((o) => o.importer))],
         paths: [...new Set(wrong.map((o) => o.path).filter(Boolean))],
-      });
-    } else if (other.length > 0) {
-      alternates.push({
-        ...entry,
-        expected: entry.to,
-        found: [...new Set(other.map((o) => o.version))],
-        importers: [...new Set(other.map((o) => o.importer))],
       });
     } else {
       matched.push({ ...entry, importers: [...new Set(observations.map((o) => o.importer))] });
@@ -410,7 +495,6 @@ export function auditLockResolution({
     checked: change.entries.length,
     matched,
     mismatched,
-    alternates,
     inconclusive,
   };
 }

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -304,17 +304,31 @@ function normalizeWorkspaceRoots(workspaceRoots) {
  *     declarer is located only from the roots that survived the shed. Locating
  *     it by first hit across every root is the bare-key twin of the one-hop bug
  *     the deep path already fixes — bun's isolated linker writes a separate,
- *     peer-disambiguated store entry per peer set (measured here:
- *     `.bun/@dnd-kit+core@6.3.1/` -> react 18.3.1,
- *     `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/` -> react 19.2.8) while the
- *     lockfile records ONE bare `@dnd-kit/core` entry for both, so
- *     `packages.has("@dnd-kit/core/react")` is false and the nested-key
- *     exclusion cannot see the difference. Measured on this repo's real tree, a
- *     bare `react` move reported 16 false mismatched importers, every one of
- *     them located through `orch-monitor-ui`, and `bun install --force` cannot
- *     clear it because the placement is lockfile-determined. A declarer
- *     reachable ONLY through a shed root is reported by name in the
- *     inconclusive reason, never folded into "could not locate".
+ *     peer-disambiguated store entry per peer set while the lockfile records ONE
+ *     bare entry covering all of them, so `packages.has("<declarer>/<id>")` is
+ *     false and the nested-key exclusion cannot see the difference. Reproducible
+ *     on this checkout: the lockfile holds a single bare `eslint@9.39.5` entry
+ *     with NO nested key anywhere, and the store holds two copies of it
+ *     (`.bun/eslint@9.39.5+1a1acd4c2fa5b1a4` and `+5e91b0bf22d6303b`), which
+ *     resolve `@eslint-community/eslint-utils` to two DIFFERENT store dirs
+ *     (`…+5e91b0bf22d6303b` vs `…+bd61bba68491e3a8`) — same version, different
+ *     peer set, one lock key. Measured on this repo's real tree, a bare `react`
+ *     move reported 16 false mismatched importers, every one of them located
+ *     through `orch-monitor-ui`, and `bun install --force` cannot clear it
+ *     because the placement is lockfile-determined. A declarer reachable ONLY
+ *     through a shed root is reported by name in the inconclusive reason, never
+ *     folded into "could not locate".
+ *
+ *     Selecting the right ROOT is only half of it: the declarer must also be
+ *     located as the COPY ITS OWN LOCK KEY NAMES. A site is excluded by
+ *     `pkg.key` but was located by `pkg.id`, so a nested declarer was found at
+ *     whatever the first bare hit from a root happened to be — frequently the
+ *     copy of the entry that exclusion had just shed. It is therefore located by
+ *     walking its own key as an install path, version-checked at every hop
+ *     (`walkInstallPath`, which carries the measurement). A hop that lands on a
+ *     version the lockfile does not record for that path is NOT evidence about
+ *     this key, in either direction: it can neither raise a mismatch nor
+ *     contribute to a match, and it is named on the verdict as `wrongCopy`.
  *
  * Because site selection already sheds every site entitled to a different
  * version, a SELECTED site that resolves anything other than the locked version
@@ -374,6 +388,35 @@ export function auditLockResolution({
   const memberNames = [];
   for (const pkg of parsed.packages.values()) if (pkg.workspaceLink) memberNames.push(pkg.id);
 
+  /**
+   * governingEntryFor — the lockfile entry that decides what `id` resolves to
+   * FROM a copy installed at `parentChain`, or null if the lockfile records no
+   * resolution for it at all.
+   *
+   * Resolution climbs, so entitlement climbs with it: the governing entry is the
+   * one keyed by the LONGEST prefix of `parentChain` that carries `<prefix>/<id>`
+   * — the copy's own nested key first, then each ancestor's, and only if no
+   * ancestor nests it does the BARE `<id>` entry govern.
+   *
+   * Asking only about the copy's OWN key (`<parentChain>/<id>`) is a real
+   * false-ERROR source, MEASURED on this repo's tree. bun nests one level from a
+   * top-level entry: `@opentelemetry/exporter-trace-otlp-http/@opentelemetry/
+   * sdk-trace-base` (2.8.0) and `@opentelemetry/exporter-trace-otlp-http/
+   * @opentelemetry/resources` (2.8.0) are SIBLINGS under the exporter, and there
+   * is no `…/sdk-trace-base/@opentelemetry/resources` key. So sdk-trace-base@2.8.0
+   * is entitled to resources 2.8.0 by its PARENT's key, while the bare
+   * `@opentelemetry/resources` entry is 2.10.0. An own-key-only test selects it
+   * as a site for the bare 2.10.0 move and reports `expected 2.10.0, found
+   * ["2.8.0"]` on a tree that is correct on disk.
+   */
+  const governingEntryFor = (parentChain, id) => {
+    for (let i = parentChain.length; i >= 1; i -= 1) {
+      const nested = parsed.packages.get(`${parentChain.slice(0, i).join("/")}/${id}`);
+      if (nested) return nested;
+    }
+    return parsed.packages.get(id) ?? null;
+  };
+
   // rootShadowedByOwnNestedKey — does this workspace root resolve `id` through
   // its OWN nested lock entry rather than the bare one? Named root: ask exactly
   // that root's key. Unnamed root: we cannot tell which member nests the id, so
@@ -383,6 +426,17 @@ export function auditLockResolution({
     root.name
       ? parsed.packages.has(`${root.name}/${id}`)
       : memberNames.some((member) => parsed.packages.has(`${member}/${id}`));
+
+  // siteEntitledElsewhere — does a copy installed at `parentChain` resolve `id`
+  // through some nested entry rather than the bare one? Then it is judged at
+  // that entry, not here, and probing it would compare against the wrong
+  // resolution. Key identity, not version equality, is the test: two entries
+  // that happen to carry the same version are still two entries, and shedding is
+  // the safe direction (a site list that empties reports INCONCLUSIVE).
+  const siteEntitledElsewhere = (parentChain, id) => {
+    const governing = governingEntryFor(parentChain, id);
+    return governing !== null && governing.key !== id;
+  };
 
   // resolve/locate memo — one probe per (fromDir, id) across the whole audit.
   const memo = new Map();
@@ -400,6 +454,78 @@ export function auditLockResolution({
     return out;
   };
 
+  /**
+   * walkInstallPath — locate the copy an install PATH names, hop by hop from
+   * `rootDir`, CHECKING AT EVERY HOP that the copy landed on is the one the
+   * lockfile records for that path.
+   *
+   * The check is the whole point, and the discriminator was already in hand and
+   * unused: `resolvePackageFn` returns the located package's OWN version, and a
+   * site selected by lock key K but located at a copy whose version disagrees
+   * with K is a probe of a DIFFERENT copy — an observation that is not evidence
+   * about K, in either direction.
+   *
+   * MEASURED on this repo's real bun.lock + node_modules (node v25.8.2 / bun
+   * 1.3.5, macOS 26.5): the lockfile records `@opentelemetry/resources` at
+   * 2.8.0 under six parents AND at 2.10.0 as its own bare entry, and both store
+   * copies exist and are both correct:
+   *
+   *   .bun/@opentelemetry+resources@2.8.0+e40b…/…  -> @opentelemetry/core 2.8.0
+   *   .bun/@opentelemetry+resources@2.10.0+e40b…/… -> @opentelemetry/core 2.10.0
+   *
+   * Locating `@opentelemetry/sdk-logs/@opentelemetry/resources` by a bare
+   * `resolve(root, "@opentelemetry/resources")` takes the FIRST hit from the
+   * root — the 2.10.0 copy, i.e. the copy of the very entry the nested-key
+   * exclusion had just shed — and then judged its core@2.10.0 against the bare
+   * lock's 2.8.0. That produced `deps_relink_failed, expected 2.8.0,
+   * found ["2.10.0"]` on a tree that is CORRECT on disk, so no install could
+   * ever repair it: a permanent ERROR, the same shape as the react incident
+   * reached by a different route. Measured over all 689 bare ids, 5 ids had at
+   * least one such site: `@opentelemetry/core` (6 sites) produced the live false
+   * ERROR, and `@opentelemetry/api` (6), `@opentelemetry/semantic-conventions`
+   * (6), `@opentelemetry/resources` (2) and `csstype` (2) read `matched` ONLY
+   * because the wrong copy happened to agree — a latent FALSE CLEAN in the other
+   * direction. One defect, both failure modes.
+   *
+   * Walking the declarer's OWN key path fixes both: root ->
+   * `@opentelemetry/exporter-trace-otlp-http` -> `@opentelemetry/resources`
+   * lands on the 2.8.0 copy and judges THAT.
+   *
+   * Three failure kinds, kept distinct because they mean different things to an
+   * operator: `absent` (a hop is not on disk — could not look), `wrong-copy`
+   * (the hop resolved a version the lockfile does not record for that path — we
+   * looked at the wrong thing), `unanchored` (no lock entry governs the path, so
+   * right and wrong cannot be told apart). All three are non-evidence; NONE of
+   * them may become a silent `matched`.
+   *
+   * A `workspace:` hop is exempt from the version check ONLY: a workspace link
+   * has no installed version to compare (its recorded "version" is the literal
+   * `workspace:<path>`), and it is identified by name, not by version.
+   */
+  const walkInstallPath = (rootDir, pathChain) => {
+    let cursor = rootDir;
+    for (let i = 0; i < pathChain.length; i += 1) {
+      const at = pathChain.slice(0, i + 1).join("/");
+      const step = resolve(cursor, pathChain[i]);
+      if (!step || typeof step.dir !== "string" || !step.dir) return { ok: false, kind: "absent", at };
+      const governing = governingEntryFor(pathChain.slice(0, i), pathChain[i]);
+      if (!governing) return { ok: false, kind: "unanchored", at };
+      if (!governing.workspaceLink && step.version !== governing.version) {
+        return { ok: false, kind: "wrong-copy", at, want: governing.version, got: step.version };
+      }
+      cursor = step.dir;
+    }
+    return { ok: true, dir: cursor };
+  };
+
+  // A walk that failed for a reason OTHER than "the hop is simply not there" —
+  // rendered for the inconclusive reason so the operator can tell "I could not
+  // look" from "I looked at the wrong copy".
+  const describeBadWalk = (label, walk) =>
+    walk.kind === "wrong-copy"
+      ? `${label} (install path ${walk.at}: the lockfile records ${walk.want} there, the located copy is ${walk.got})`
+      : `${label} (install path ${walk.at}: no lockfile entry governs it)`;
+
   const matched = [];
   const mismatched = [];
   const inconclusive = [];
@@ -415,33 +541,31 @@ export function auditLockResolution({
     const sites = [];
     const unlocatable = [];
     const shedThroughNestedRoot = [];
+    const wrongCopy = [];
     if (chain.length > 1) {
       // The key minus its last element is an install PATH, not a single parent.
       // Walk it hop by hop — root -> chain[0] -> chain[1] -> … — so the importer
       // located is the copy the path actually names. Resolving only
       // chain[length-2] from a root finds whichever copy is root-visible, which
       // for a deep key is either absent (inconclusive) or a separately hoisted
-      // copy in a different tree (the wrong probe, silently).
+      // copy in a different tree (the wrong probe, silently). Every hop is
+      // version-checked against the lock entry governing it (walkInstallPath),
+      // so a hop that lands on a peer copy the path does not name is rejected
+      // rather than followed into the wrong subtree.
       const parentPath = chain.slice(0, -1);
       const importer = parentPath.join("/");
       let importerDir = null;
+      let badWalk = null;
       for (const root of roots) {
-        let cursor = root.dir;
-        let walked = true;
-        for (const hop of parentPath) {
-          const step = resolve(cursor, hop);
-          if (!step || typeof step.dir !== "string" || !step.dir) {
-            walked = false;
-            break;
-          }
-          cursor = step.dir;
-        }
-        if (walked) {
-          importerDir = cursor;
+        const walk = walkInstallPath(root.dir, parentPath);
+        if (walk.ok) {
+          importerDir = walk.dir;
           break;
         }
+        if (!badWalk && walk.kind !== "absent") badWalk = walk;
       }
       if (importerDir) sites.push({ importer, dir: importerDir });
+      else if (badWalk) wrongCopy.push(describeBadWalk(importer, badWalk));
       else unlocatable.push(importer);
     } else {
       // The roots ENTITLED to the bare resolution. A member root carrying its
@@ -457,39 +581,67 @@ export function auditLockResolution({
       for (const pkg of parsed.packages.values()) {
         if (pkg.workspaceLink) continue;
         if (!Array.isArray(pkg.declaredDeps) || !pkg.declaredDeps.includes(entry.id)) continue;
-        // A declarer with its own nested key for this id resolves THAT entry, not
-        // this bare one — probing it would compare against the wrong resolution.
-        if (parsed.packages.has(`${pkg.key}/${entry.id}`)) continue;
-        // Locate the declarer only from a bare-entitled root. Taking the first
-        // hit across ALL roots is the bare-key twin of the one-hop bug the deep
-        // path already fixes: bun's isolated linker writes a SEPARATE,
-        // peer-disambiguated store entry per peer set (measured on this repo:
-        // `.bun/@dnd-kit+core@6.3.1/` resolves react 18.3.1 while
-        // `.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/` resolves 19.2.8), and the
-        // lockfile records ONE bare `@dnd-kit/core` entry for both — so
-        // `parsed.packages.has("@dnd-kit/core/react")` is false and the nested-key
-        // exclusion above cannot see the distinction. A declarer found through a
-        // shed member root IS the copy peered to that member's nested version;
-        // comparing it against the bare one reported 16 false mismatched importers
-        // for `react` on this repo's real tree, an ERROR no `--force` can clear
-        // because the placement is lockfile-determined.
-        let located = null;
-        for (const root of bareRoots) {
-          located = resolve(root.dir, pkg.id);
-          if (located) break;
-        }
-        if (located) {
-          sites.push({ importer: pkg.id, dir: located.dir });
+        const declarerPath = splitLockKey(pkg.key);
+        if (!declarerPath) {
+          unlocatable.push(pkg.key);
           continue;
         }
-        // Not reachable from any bare-entitled root. Separate "shed on purpose"
-        // from "could not look" — folding the two together would let a wholly
-        // shed site list read as an absent dependency in the inconclusive reason.
+        // A declarer whose resolution of this id is governed by a nested entry —
+        // its OWN or any ANCESTOR's — resolves THAT entry, not this bare one;
+        // probing it would compare against the wrong resolution. Testing only
+        // the declarer's own key misses the sibling case bun really produces
+        // (see governingEntryFor for the measurement).
+        if (siteEntitledElsewhere(declarerPath, entry.id)) continue;
+        // Locate the declarer only from a bare-entitled root, and locate it by
+        // walking its OWN lock key as an install path — never by a bare
+        // `resolve(root.dir, pkg.id)` first hit.
+        //
+        // Two distinct bugs are excluded here, and only the first was closed
+        // before. (1) Root SELECTION: taking the first hit across ALL roots is
+        // the bare-key twin of the one-hop bug the deep path already fixes —
+        // bun's isolated linker writes a SEPARATE, peer-disambiguated store
+        // entry per peer set (reproducible here: one bare `eslint@9.39.5` lock
+        // entry with no nested key anywhere, two store copies of it) while the
+        // lockfile records ONE bare entry for all of them, so
+        // `parsed.packages.has("<declarer>/<id>")` is false and the nested-key
+        // exclusion above cannot see the distinction; that reported 16 false
+        // mismatched importers for `react`. (2) COPY selection, the
+        // defect this walk closes: a declarer is EXCLUDED above by `pkg.key`
+        // but was LOCATED by `pkg.id`, so a nested declarer
+        // (`@opentelemetry/sdk-logs/@opentelemetry/resources`, locked 2.8.0)
+        // was located at the first bare hit for `@opentelemetry/resources` —
+        // the 2.10.0 copy, the copy of the entry just shed — and its
+        // core@2.10.0 judged against the bare lock's 2.8.0. See walkInstallPath
+        // for the full measurement; both routes end in an ERROR no `--force`
+        // can clear, because the placement is lockfile-determined.
+        let located = null;
+        let badWalk = null;
+        for (const root of bareRoots) {
+          const walk = walkInstallPath(root.dir, declarerPath);
+          if (walk.ok) {
+            located = walk;
+            break;
+          }
+          if (!badWalk && walk.kind !== "absent") badWalk = walk;
+        }
+        if (located) {
+          sites.push({ importer: pkg.key, dir: located.dir });
+          continue;
+        }
+        // Located nowhere as the copy its key names. Three reasons, kept apart:
+        // we probed the WRONG copy (not evidence about this key), the site was
+        // shed on purpose, or we simply could not look. Folding any of them
+        // together would let a wholly-unjudged site list read as an absent
+        // dependency in the inconclusive reason.
+        if (badWalk) {
+          wrongCopy.push(describeBadWalk(pkg.key, badWalk));
+          continue;
+        }
         const reachableOnlyViaShedRoot = roots.some(
           (root) => rootShadowedByOwnNestedKey(root, entry.id) && resolve(root.dir, pkg.id),
         );
-        if (reachableOnlyViaShedRoot) shedThroughNestedRoot.push(pkg.id);
-        else unlocatable.push(pkg.id);
+        if (reachableOnlyViaShedRoot) shedThroughNestedRoot.push(pkg.key);
+        else unlocatable.push(pkg.key);
       }
     }
 
@@ -504,11 +656,15 @@ export function auditLockResolution({
     if (observations.length === 0) {
       inconclusive.push({
         ...entry,
+        ...(wrongCopy.length > 0 ? { wrongCopy } : {}),
         reason:
           `no importer on disk resolves ${entry.id}` +
           (unlocatable.length > 0 ? ` (could not locate: ${unlocatable.join(", ")})` : "") +
           (shedThroughNestedRoot.length > 0
             ? ` (reachable only through a workspace member that nests ${entry.id}: ${shedThroughNestedRoot.join(", ")})`
+            : "") +
+          (wrongCopy.length > 0
+            ? ` (probed the wrong copy — not evidence about this lock key: ${wrongCopy.join("; ")})`
             : ""),
       });
       continue;
@@ -523,16 +679,25 @@ export function auditLockResolution({
     // ride through as a benign `alternate` and never get forced.
     const wrong = observations.filter((o) => o.version !== entry.to);
 
+    // A site excluded as a wrong-copy probe is carried on the verdict even when
+    // other sites DID answer. Dropping it silently is how the latent false-clean
+    // stayed invisible: four ids read `matched` on this repo's real tree only
+    // because a copy the lock key never selected happened to agree.
     if (wrong.length > 0) {
       mismatched.push({
         ...entry,
+        ...(wrongCopy.length > 0 ? { wrongCopy } : {}),
         expected: entry.to,
         found: [...new Set(wrong.map((o) => o.version))],
         importers: [...new Set(wrong.map((o) => o.importer))],
         paths: [...new Set(wrong.map((o) => o.path).filter(Boolean))],
       });
     } else {
-      matched.push({ ...entry, importers: [...new Set(observations.map((o) => o.importer))] });
+      matched.push({
+        ...entry,
+        ...(wrongCopy.length > 0 ? { wrongCopy } : {}),
+        importers: [...new Set(observations.map((o) => o.importer))],
+      });
     }
   }
 

--- a/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
@@ -467,13 +467,17 @@ describe("auditLockResolution", () => {
   //
   // MEASURED on this repo's real bun.lock + node_modules (node v25.8.2 / bun
   // 1.3.5, macOS 26.5, Ryans-MBP-2.rozich). bun's isolated linker writes a
-  // SEPARATE, peer-disambiguated store entry per peer set, and both are on disk:
+  // SEPARATE, peer-disambiguated store entry per peer set. Reproducible on this
+  // checkout — one bare lock entry, two store copies, different peer sets:
   //
-  //   node_modules/.bun/@dnd-kit+core@6.3.1/…                  -> react 18.3.1
-  //   node_modules/.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/… -> react 19.2.8
+  //   lock: "eslint": ["eslint@9.39.5", …]   (no nested `*/eslint` key at all)
+  //   .bun/eslint@9.39.5+1a1acd4c2fa5b1a4/…  -> @eslint-community/eslint-utils
+  //                                             @…+5e91b0bf22d6303b
+  //   .bun/eslint@9.39.5+5e91b0bf22d6303b/…  -> @eslint-community/eslint-utils
+  //                                             @…+bd61bba68491e3a8
   //
-  // The lockfile records ONE bare `@dnd-kit/core` entry covering both, so
-  // `packages.has("@dnd-kit/core/react")` is FALSE and the declarer's own
+  // The lockfile records ONE bare entry covering both copies, so
+  // `packages.has("<declarer>/<id>")` is FALSE and the declarer's own
   // nested-key exclusion cannot see the distinction. A declarer located by
   // first hit across every root lands on whichever copy some root can see —
   // measured, all 16 of `react`'s declarers are reachable ONLY through
@@ -742,6 +746,309 @@ describe("auditLockResolution", () => {
     expect(a.mismatched).toEqual([]);
     expect(a.inconclusive).toHaveLength(1);
     expect(a.inconclusive[0].reason).toContain("outer/mid");
+  });
+
+  // ── the declarer is EXCLUDED by its key but was LOCATED by its id ──
+  //
+  // MEASURED on this repo's real bun.lock + node_modules (node v25.8.2 / bun
+  // 1.3.5, macOS 26.5). The tree is CORRECT on disk — both store copies exist
+  // and both match the lockfile:
+  //
+  //   .bun/@opentelemetry+resources@2.8.0+e40b…/…/@opentelemetry/core  = 2.8.0
+  //   .bun/@opentelemetry+resources@2.10.0+e40b…/…/@opentelemetry/core = 2.10.0
+  //
+  // The bare `@opentelemetry/resources` declarer IS correctly shed (the lockfile
+  // carries `@opentelemetry/resources/@opentelemetry/core`). But
+  // `@opentelemetry/sdk-logs/@opentelemetry/resources` — locked at 2.8.0, with
+  // no nested core key of its own — is SELECTED, and was then located by
+  // `resolve(root, "@opentelemetry/resources")`: a first hit from a bare root,
+  // which lands on the 2.10.0 copy, i.e. the copy of the entry just shed. Six
+  // such sites; a bare `@opentelemetry/core` move reported
+  //
+  //   ERROR plugin.checkout.deps_relink_failed  expected=2.8.0 found=["2.10.0"]
+  //
+  // on a tree no install can repair — a permanent ERROR, the react incident's
+  // shape reached by a different route. Over all 689 bare ids, 5 had at least
+  // one such site: 1 produced that live false ERROR and 4 read `matched` ONLY
+  // because the wrong copy happened to agree (the latent false-clean below).
+
+  const WRONGCOPY_LOCK = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst" },
+  },
+  "packages": {
+    "core": ["core@2.8.0", "", {}, "sha512-aaa=="],
+
+    "resources": ["resources@2.10.0", "", { "dependencies": { "core": "2.10.0" } }, "sha512-bbb=="],
+
+    "resources/core": ["core@2.10.0", "", {}, "sha512-ccc=="],
+
+    "sdk-logs": ["sdk-logs@0.219.0", "", { "dependencies": { "resources": "2.8.0" } }, "sha512-ddd=="],
+
+    "sdk-logs/resources": ["resources@2.8.0", "", { "dependencies": { "core": "2.8.0" } }, "sha512-eee=="],
+  }
+}
+`;
+  // Only the BARE core entry moves. `resources/core` legitimately stays 2.10.0.
+  const WRONGCOPY_MOVED = WRONGCOPY_LOCK.replace('"core@2.8.0"', '"core@2.8.1"');
+
+  // The two store copies of `resources` the lockfile records separately.
+  const RES_210 = `${ROOT}/node_modules/.bun/resources@2.10.0+h/node_modules/resources`;
+  const RES_28 = `${ROOT}/node_modules/.bun/resources@2.8.0+h/node_modules/resources`;
+  const SDKLOGS_DIR = `${ROOT}/node_modules/.bun/sdk-logs@0.219.0+h/node_modules/sdk-logs`;
+
+  test("THE WRONG COPY: a declarer selected by its lock key is located by walking THAT key, not by a bare first hit", () => {
+    // Exactly the measured shape. `sdk-logs/resources` (locked 2.8.0) is a
+    // selected site for the bare core move; the bare first hit for `resources`
+    // from the root is the 2.10.0 copy, whose core is legitimately 2.10.0.
+    // Judging THAT against the moved bare 2.8.1 is the permanent false ERROR.
+    // Restoring `located = resolve(root.dir, pkg.id)` in the declarer loop
+    // fails this test.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: WRONGCOPY_LOCK,
+      newLockText: WRONGCOPY_MOVED,
+      resolvePackageFn: stubResolver({
+        // The decoy: a bare `resources` hit from the root is the 2.10.0 copy.
+        [`${ROOT}|resources`]: { dir: RES_210, version: "2.10.0" },
+        [`${RES_210}|core`]: { dir: "/store/core@2.10.0", version: "2.10.0" },
+        // The copy `sdk-logs/resources` actually names, reachable only through
+        // sdk-logs — and correctly relinked to the moved core.
+        [`${ROOT}|sdk-logs`]: { dir: SDKLOGS_DIR, version: "0.219.0" },
+        [`${SDKLOGS_DIR}|resources`]: { dir: RES_28, version: "2.8.0" },
+        [`${RES_28}|core`]: { dir: "/store/core@2.8.1", version: "2.8.1" },
+        [`${SDKLOGS_DIR}|core`]: { dir: "/store/core@2.8.1", version: "2.8.1" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    // The site is named by its lock KEY, so the two `resources` declarers are
+    // distinguishable in the report at all.
+    expect(a.matched[0].importers).toContain("sdk-logs/resources");
+    expect(a.matched[0].importers).not.toContain("resources");
+  });
+
+  test("THE LATENT FALSE CLEAN: the wrong copy AGREEING is not evidence either — the right copy is still judged", () => {
+    // The other direction of the same defect, and the half that fixing the
+    // ERROR alone would leave open. Same wiring, but now the decoy 2.10.0 copy
+    // coincidentally resolves the MOVED core (2.8.1) while the copy
+    // `sdk-logs/resources` really names is stale at 2.8.0. Probing the wrong
+    // copy reports a clean tree; probing the right one reports the real defect.
+    // Measured: 4 ids on this repo's real tree read `matched` only because a
+    // copy the lock key never selected happened to agree.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: WRONGCOPY_LOCK,
+      newLockText: WRONGCOPY_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|resources`]: { dir: RES_210, version: "2.10.0" },
+        [`${RES_210}|core`]: { dir: "/store/core@2.8.1", version: "2.8.1" }, // coincidental agreement
+        [`${ROOT}|sdk-logs`]: { dir: SDKLOGS_DIR, version: "0.219.0" },
+        [`${SDKLOGS_DIR}|resources`]: { dir: RES_28, version: "2.8.0" },
+        [`${RES_28}|core`]: { dir: "/store/core@2.8.0", version: "2.8.0" }, // the REAL stale placement
+        [`${SDKLOGS_DIR}|core`]: { dir: "/store/core@2.8.1", version: "2.8.1" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].expected).toBe("2.8.1");
+    expect(a.mismatched[0].found).toEqual(["2.8.0"]);
+    expect(a.mismatched[0].importers).toEqual(["sdk-logs/resources"]);
+  });
+
+  test("a declarer whose own key path lands on a DISAGREEING copy is not evidence — inconclusive, naming the wrong copy", () => {
+    // The walk cannot reach the copy the key names: `sdk-logs` on disk is a
+    // stale 0.9.9, not the 0.219.0 the lockfile records, so everything below it
+    // is a different subtree. That observation says nothing about the bare core
+    // move — it must not be a mismatch and must not be a silent match.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: WRONGCOPY_LOCK,
+      newLockText: WRONGCOPY_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|sdk-logs`]: { dir: SDKLOGS_DIR, version: "0.9.9" }, // NOT the locked 0.219.0
+        [`${SDKLOGS_DIR}|resources`]: { dir: RES_28, version: "2.8.0" },
+        [`${RES_28}|core`]: { dir: "/store/core@0.0.1", version: "0.0.1" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("probed the wrong copy");
+    expect(a.inconclusive[0].reason).toContain("install path sdk-logs");
+    expect(a.inconclusive[0].reason).toContain("0.219.0");
+    expect(a.inconclusive[0].reason).toContain("0.9.9");
+    expect(a.inconclusive[0].wrongCopy).toHaveLength(1);
+  });
+
+  test("a wrong-copy site is carried on the verdict even when other sites DID answer — never silently dropped", () => {
+    // The root answers correctly, so the entry is `matched`. The shed-for-wrong-
+    // copy declarer must still be NAMED on that verdict: dropping it silently is
+    // exactly how the latent false-clean stayed invisible for four ids.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: WRONGCOPY_LOCK,
+      newLockText: WRONGCOPY_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|core`]: { dir: "/store/core@2.8.1", version: "2.8.1" },
+        [`${ROOT}|sdk-logs`]: { dir: SDKLOGS_DIR, version: "0.9.9" }, // wrong copy
+        [`${SDKLOGS_DIR}|resources`]: { dir: RES_28, version: "2.8.0" },
+        [`${RES_28}|core`]: { dir: "/store/core@2.8.0", version: "2.8.0" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    expect(a.matched[0].importers).toEqual([`workspace:${ROOT}`]);
+    expect(a.matched[0].wrongCopy).toHaveLength(1);
+    expect(a.matched[0].wrongCopy[0]).toContain("sdk-logs/resources");
+  });
+
+  // ── entitlement climbs: an ANCESTOR's nested key governs too ──
+  //
+  // MEASURED on this repo's real lockfile: bun nests one level from a top-level
+  // entry, so `@opentelemetry/exporter-trace-otlp-http/@opentelemetry/
+  // sdk-trace-base` (2.8.0) and `@opentelemetry/exporter-trace-otlp-http/
+  // @opentelemetry/resources` (2.8.0) are SIBLINGS under the exporter and there
+  // is no `…/sdk-trace-base/@opentelemetry/resources` key at all. sdk-trace-base
+  // is entitled to resources 2.8.0 by its PARENT's key while the bare
+  // `@opentelemetry/resources` entry is 2.10.0.
+
+  const ANCESTOR_LOCK = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst" },
+  },
+  "packages": {
+    "resources": ["resources@2.10.0", "", {}, "sha512-aaa=="],
+
+    "exporter": ["exporter@0.219.0", "", { "dependencies": { "resources": "2.8.0", "sdk-trace-base": "2.8.0" } }, "sha512-bbb=="],
+
+    "exporter/resources": ["resources@2.8.0", "", {}, "sha512-ccc=="],
+
+    "exporter/sdk-trace-base": ["sdk-trace-base@2.8.0", "", { "dependencies": { "resources": "2.8.0" } }, "sha512-ddd=="],
+  }
+}
+`;
+  const ANCESTOR_MOVED = ANCESTOR_LOCK.replace('"resources@2.10.0"', '"resources@2.10.1"');
+  const EXPORTER_DIR = `${ROOT}/node_modules/.bun/exporter@0.219.0+h/node_modules/exporter`;
+  const STB_DIR = `${ROOT}/node_modules/.bun/sdk-trace-base@2.8.0+h/node_modules/sdk-trace-base`;
+
+  test("a declarer entitled by an ANCESTOR's nested key is shed too — not only by its own", () => {
+    // `exporter/sdk-trace-base` has no nested resources key of its own, so an
+    // own-key-only exclusion selects it, and the walk then correctly locates its
+    // legitimate 2.8.0 resources and reports `expected 2.10.1, found ["2.8.0"]`
+    // on a correct tree. Narrowing governingEntryFor to the declarer's own key
+    // (dropping the ancestor loop) fails this test.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: ANCESTOR_LOCK,
+      newLockText: ANCESTOR_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|resources`]: { dir: "/store/resources@2.10.1", version: "2.10.1" },
+        [`${ROOT}|exporter`]: { dir: EXPORTER_DIR, version: "0.219.0" },
+        [`${EXPORTER_DIR}|sdk-trace-base`]: { dir: STB_DIR, version: "2.8.0" },
+        [`${STB_DIR}|resources`]: { dir: "/store/resources@2.8.0", version: "2.8.0" },
+        [`${EXPORTER_DIR}|resources`]: { dir: "/store/resources@2.8.0", version: "2.8.0" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    expect(a.matched[0].importers).toEqual([`workspace:${ROOT}`]);
+  });
+
+  test("the ancestor shed does not swallow a declarer no ancestor nests — the positive control", () => {
+    // Same lockfile, but the audited move is on `sdk-trace-base`, which NO
+    // ancestor key nests (`exporter/sdk-trace-base` is the declarer's own
+    // identity here, not a nested resolution of the audited id). A shed that
+    // fired on any nested key anywhere would lose this site and read
+    // inconclusive; the stale copy must surface as a mismatch instead.
+    const stbMoved = ANCESTOR_LOCK.replace('"exporter@0.219.0"', '"exporter@0.219.1"');
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: ANCESTOR_LOCK,
+      newLockText: stbMoved,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|exporter`]: { dir: EXPORTER_DIR, version: "0.219.0" }, // genuinely stale
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].expected).toBe("0.219.1");
+    expect(a.mismatched[0].found).toEqual(["0.219.0"]);
+  });
+
+  test("a DEEP key's hop that lands on a disagreeing copy stops the walk — never followed into the wrong subtree", () => {
+    // `outer` on disk is a stale 9.9.9, not the locked 1.0.0, so its mid/leaf is
+    // a different tree entirely. Following it reports a confident mismatch off a
+    // subtree the install path never named. Deleting the version check in
+    // walkInstallPath turns this inconclusive into exactly that false mismatch.
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: DEEP_LOCK,
+      newLockText: DEEP_LOCK_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|outer`]: { dir: OUTER_DIR, version: "9.9.9" }, // NOT the locked 1.0.0
+        [`${OUTER_DIR}|mid`]: { dir: MID_UNDER_OUTER, version: "1.0.0" },
+        [`${MID_UNDER_OUTER}|leaf`]: { dir: "/store/leaf@7.7.7", version: "7.7.7" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("probed the wrong copy");
+    expect(a.inconclusive[0].reason).toContain("install path outer");
+  });
+
+  test("a hop no lockfile entry governs is INCONCLUSIVE — right and wrong copy cannot be told apart", () => {
+    // bun's keys are prefix-closed on every lockfile measured here (745 keys, 48
+    // nested, 0 missing prefixes), so this shape should not occur — which is
+    // precisely why it must fail CLOSED rather than be waved through. `ghost` is
+    // a hop with no entry of its own.
+    const orphanLock = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "leaf": ["leaf@2.0.0", "", {}, "sha512-aaa=="],
+
+    "ghost/leaf": ["leaf@1.0.0", "", {}, "sha512-bbb=="],
+  }
+}
+`;
+    const orphanMoved = orphanLock.replace('"leaf@1.0.0"', '"leaf@1.0.1"');
+    const GHOST_DIR = `${ROOT}/node_modules/.bun/ghost@1.0.0+h/node_modules/ghost`;
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: orphanLock,
+      newLockText: orphanMoved,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|ghost`]: { dir: GHOST_DIR, version: "1.0.0" },
+        [`${GHOST_DIR}|leaf`]: { dir: "/store/leaf@1.0.1", version: "1.0.1" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("no lockfile entry governs it");
+  });
+
+  test("a workspace: hop is exempt from the version check — a link has no installed version to compare", () => {
+    // A member root's lock entry records `ui@workspace:ui`, never a semver, so
+    // comparing the member's package.json version against it rejects EVERY
+    // key nested under a workspace member. Dropping the workspaceLink exemption
+    // in walkInstallPath turns this matched into an inconclusive.
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_LOCK.replace('"react@19.2.8"', '"react@19.2.9"'),
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|ui`]: { dir: UI_DIR, version: "0.0.0" }, // the member's own manifest version
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.9", version: "19.2.9" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    expect(a.matched[0].importers).toEqual(["ui"]);
   });
 
   test("no importer resolves the id on disk → INCONCLUSIVE, never a clean pass", () => {

--- a/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
@@ -344,10 +344,17 @@ describe("auditLockResolution", () => {
     expect(a.mismatched[0].importers).toEqual(["chalk"]);
   });
 
-  test("an observed version the lockfile records ELSEWHERE for the same id is an alternate, not a mismatch", () => {
-    // The lockfile keeps ansi-styles@6.2.3 hoisted AND ansi-styles@4.3.0 under
-    // chalk. If some importer legitimately resolves the other recorded version we
-    // must not force: a false positive costs a full re-extract on every refresh.
+  test("THE HIDDEN DEFECT: a wrong version at a SELECTED site is a mismatch even when the lockfile records it elsewhere", () => {
+    // The lockfile keeps ansi-styles@6.2.3 bare AND ansi-styles@4.3.0 under
+    // chalk; the BARE entry moves 6.2.3 -> 6.2.4. The workspace root must hold
+    // the bare resolution — chalk's nested copy is judged at chalk, not here —
+    // so a root still on 4.3.0 is precisely the stale placement this module
+    // exists to catch.
+    //
+    // Excusing it as a benign `alternate` (because 4.3.0 is recorded SOMEWHERE)
+    // was the bug: refreshPluginCheckout ignores alternates, never forces, and
+    // leaves the bare resolution stale forever. Restoring the
+    // `&& !lockedElsewhere.has(o.version)` filter on `wrong` fails this test.
     const newText = LOCK_0_1_5.replace('"ansi-styles@6.2.3"', '"ansi-styles@6.2.4"');
     const a = auditLockResolution({
       workspaceRoots: [ROOT],
@@ -358,9 +365,209 @@ describe("auditLockResolution", () => {
         [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
       }),
     });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].expected).toBe("6.2.4");
+    expect(a.mismatched[0].found).toContain("4.3.0");
+  });
+
+  // ── the false positive the `alternate` excuse was really shielding ──
+  //
+  // A workspace MEMBER root legitimately resolves its own nested copy. This repo
+  // really has three such keys (orch-monitor-ui/react, orch-monitor-ui/@types/react,
+  // orch-monitor-ui/typescript) and plugins/dev/scripts/orch-monitor/ui is a
+  // literal member passed in as a root — so this is a live shape, not a
+  // hypothetical. The honest fix is to shed the site, not to excuse the version.
+
+  const MEMBER_NEST_LOCK = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst" },
+  },
+  "packages": {
+    "catalyst-execution-core": ["catalyst-execution-core@workspace:plugins/dev/scripts/execution-core"],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-aaa=="],
+
+    "catalyst-execution-core/ansi-styles": ["ansi-styles@4.3.0", "", {}, "sha512-bbb=="],
+  }
+}
+`;
+  const MEMBER_NEST_MOVED = MEMBER_NEST_LOCK.replace('"ansi-styles@6.2.3"', '"ansi-styles@6.2.4"');
+  const MEMBER_DIR = `${ROOT}/plugins/dev/scripts/execution-core`;
+
+  test("a member root with its OWN nested key for the id is SHED, not judged against the bare resolution", () => {
+    // The member is entitled to 4.3.0 by `catalyst-execution-core/ansi-styles`.
+    // Probing it would report a mismatch and force a needless re-extract on
+    // every refresh that moves the bare entry. Deleting the
+    // rootShadowedByOwnNestedKey guard fails this test.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: MEMBER_DIR, name: "catalyst-execution-core" },
+      ],
+      oldLockText: MEMBER_NEST_LOCK,
+      newLockText: MEMBER_NEST_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@6.2.4", version: "6.2.4" },
+        [`${MEMBER_DIR}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
+      }),
+    });
     expect(a.mismatched).toEqual([]);
-    expect(a.alternates).toHaveLength(1);
-    expect(a.alternates[0].found).toContain("4.3.0");
+    expect(a.matched).toHaveLength(1);
+    // The shed member must NOT be credited as a site that agreed, either.
+    expect(a.matched[0].importers).toEqual([`workspace:${ROOT}`]);
+  });
+
+  test("a NAMED member root without a nested key for the id is still judged — the guard sheds one member, not all of them", () => {
+    // The positive control for the test above: same wiring, but the member's
+    // nested key names a DIFFERENT package, so nothing shields it and its stale
+    // copy must surface. A guard that shed every member root passes the previous
+    // test and fails this one.
+    const otherNest = MEMBER_NEST_LOCK.replace(
+      '"catalyst-execution-core/ansi-styles": ["ansi-styles@4.3.0"',
+      '"catalyst-execution-core/chalk": ["chalk@4.3.0"',
+    );
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: MEMBER_DIR, name: "catalyst-execution-core" },
+      ],
+      oldLockText: otherNest,
+      newLockText: otherNest.replace('"ansi-styles@6.2.3"', '"ansi-styles@6.2.4"'),
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@6.2.4", version: "6.2.4" },
+        [`${MEMBER_DIR}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
+      }),
+    });
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].importers).toEqual([`workspace:${MEMBER_DIR}`]);
+  });
+
+  test("an UNNAMED root falls back to shedding every root the nesting could apply to — inconclusive, never a false force", () => {
+    // A caller that passes bare dir strings gives the audit no way to tell WHICH
+    // member nests the id. Shedding is the safe direction: the site list empties
+    // and the entry reports INCONCLUSIVE. A fallback that instead kept the roots
+    // would report a mismatch here and force on every refresh.
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT, MEMBER_DIR],
+      oldLockText: MEMBER_NEST_LOCK,
+      newLockText: MEMBER_NEST_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@6.2.4", version: "6.2.4" },
+        [`${MEMBER_DIR}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+  });
+
+  // ── deep install paths: the importer is reached hop by hop ──
+  //
+  // This repo's own bun.lock carries chains deeper than one nesting level
+  // (measured: 48 nested keys, 5 of them deeper than one hop, max chain 4 —
+  // `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`).
+  // Resolving only the IMMEDIATE parent from a workspace root finds whichever
+  // copy is root-visible, which is a different tree.
+
+  const DEEP_LOCK = `{
+  "lockfileVersion": 1,
+  "packages": {
+    "outer": ["outer@1.0.0", "", { "dependencies": { "mid": "^1" } }, "sha512-aaa=="],
+
+    "outer/mid": ["mid@1.0.0", "", { "dependencies": { "leaf": "^1" } }, "sha512-bbb=="],
+
+    "outer/mid/leaf": ["leaf@1.0.0", "", {}, "sha512-ccc=="],
+
+    "mid": ["mid@2.0.0", "", { "dependencies": { "leaf": "^2" } }, "sha512-ddd=="],
+
+    "leaf": ["leaf@2.0.0", "", {}, "sha512-eee=="],
+  }
+}
+`;
+  // Only the DEEP entry moves: outer/mid/leaf 1.0.0 -> 1.0.1.
+  const DEEP_LOCK_MOVED = DEEP_LOCK.replace('"leaf@1.0.0"', '"leaf@1.0.1"');
+
+  const OUTER_DIR = `${ROOT}/node_modules/.bun/outer@1.0.0+h/node_modules/outer`;
+  const MID_UNDER_OUTER = `${ROOT}/node_modules/.bun/mid@1.0.0+h/node_modules/mid`;
+  const MID_HOISTED = `${ROOT}/node_modules/.bun/mid@2.0.0+h/node_modules/mid`;
+
+  test("a DEEP key probes the parent its install path names, not a separately hoisted copy of that parent", () => {
+    // Both `mid@1.0.0` (under outer) and `mid@2.0.0` (hoisted) exist. The key
+    // `outer/mid/leaf` names the FORMER. Resolving `mid` straight from the root
+    // lands on the hoisted 2.0.0, whose leaf is 2.0.0 — the wrong tree, reported
+    // as a defect in a tree that is perfectly correct.
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: DEEP_LOCK,
+      newLockText: DEEP_LOCK_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|outer`]: { dir: OUTER_DIR, version: "1.0.0" },
+        [`${OUTER_DIR}|mid`]: { dir: MID_UNDER_OUTER, version: "1.0.0" },
+        [`${ROOT}|mid`]: { dir: MID_HOISTED, version: "2.0.0" }, // the decoy
+        [`${MID_UNDER_OUTER}|leaf`]: { dir: "/store/leaf@1.0.1", version: "1.0.1" },
+        [`${MID_HOISTED}|leaf`]: { dir: "/store/leaf@2.0.0", version: "2.0.0" },
+      }),
+    });
+    expect(a.checked).toBe(1);
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    expect(a.matched[0].importers).toEqual(["outer/mid"]);
+  });
+
+  test("a DEEP key whose located parent is genuinely stale IS a mismatch — the walk still fails loudly", () => {
+    // The positive control for the walk: identical wiring, but the copy the
+    // install path names is stale. An implementation that located nothing would
+    // report inconclusive here instead of a mismatch.
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: DEEP_LOCK,
+      newLockText: DEEP_LOCK_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|outer`]: { dir: OUTER_DIR, version: "1.0.0" },
+        [`${OUTER_DIR}|mid`]: { dir: MID_UNDER_OUTER, version: "1.0.0" },
+        [`${MID_UNDER_OUTER}|leaf`]: { dir: "/store/leaf@1.0.0", version: "1.0.0" },
+      }),
+    });
+    expect(a.inconclusive).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].importers).toEqual(["outer/mid"]);
+    expect(a.mismatched[0].found).toContain("1.0.0");
+  });
+
+  test("a DEEP key's parent that is NOT visible from the root is still located by walking the chain", () => {
+    // No hoisted `mid` at all — the only way to reach the importer is
+    // root -> outer -> mid. Resolving the immediate parent from the root returns
+    // null here, and the entry would be written off as "could not locate".
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: DEEP_LOCK,
+      newLockText: DEEP_LOCK_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|outer`]: { dir: OUTER_DIR, version: "1.0.0" },
+        [`${OUTER_DIR}|mid`]: { dir: MID_UNDER_OUTER, version: "1.0.0" },
+        [`${MID_UNDER_OUTER}|leaf`]: { dir: "/store/leaf@1.0.1", version: "1.0.1" },
+      }),
+    });
+    expect(a.inconclusive).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+  });
+
+  test("a broken hop in the chain is INCONCLUSIVE naming the install path, never a clean pass", () => {
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: DEEP_LOCK,
+      newLockText: DEEP_LOCK_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|outer`]: { dir: OUTER_DIR, version: "1.0.0" },
+        // `mid` resolves from nowhere — the walk cannot complete.
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("outer/mid");
   });
 
   test("no importer resolves the id on disk → INCONCLUSIVE, never a clean pass", () => {

--- a/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
@@ -463,6 +463,180 @@ describe("auditLockResolution", () => {
     expect(a.inconclusive).toHaveLength(1);
   });
 
+  // ── shedding the member ROOT is not enough: its whole SUBTREE is shed ──
+  //
+  // MEASURED on this repo's real bun.lock + node_modules (node v25.8.2 / bun
+  // 1.3.5, macOS 26.5, Ryans-MBP-2.rozich). bun's isolated linker writes a
+  // SEPARATE, peer-disambiguated store entry per peer set, and both are on disk:
+  //
+  //   node_modules/.bun/@dnd-kit+core@6.3.1/…                  -> react 18.3.1
+  //   node_modules/.bun/@dnd-kit+core@6.3.1+005eabf3d8b6ef06/… -> react 19.2.8
+  //
+  // The lockfile records ONE bare `@dnd-kit/core` entry covering both, so
+  // `packages.has("@dnd-kit/core/react")` is FALSE and the declarer's own
+  // nested-key exclusion cannot see the distinction. A declarer located by
+  // first hit across every root lands on whichever copy some root can see —
+  // measured, all 16 of `react`'s declarers are reachable ONLY through
+  // `orch-monitor-ui`, the one member the lockfile shows nesting react at
+  // 19.2.8. That produced `mismatched=1, expected 18.3.1, found ["19.2.8"], 16
+  // importers` on a tree that is in fact correct, and `bun install --force`
+  // (1168 packages, 4.21 s) does NOT clear it because the placement is
+  // lockfile-determined.
+
+  const SUBTREE_LOCK = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst" },
+  },
+  "packages": {
+    "ui": ["ui@workspace:ui"],
+
+    "react": ["react@18.3.1", "", {}, "sha512-aaa=="],
+
+    "ui/react": ["react@19.2.8", "", {}, "sha512-bbb=="],
+
+    "dnd": ["dnd@6.3.1", "", { "peerDependencies": { "react": "*" } }, "sha512-ccc=="],
+  }
+}
+`;
+  const SUBTREE_MOVED = SUBTREE_LOCK.replace('"react@18.3.1"', '"react@18.3.2"');
+  const UI_DIR = `${ROOT}/ui`;
+  // The two peer-disambiguated store copies of the SAME bare `dnd` entry.
+  const DND_BARE = `${ROOT}/node_modules/.bun/dnd@6.3.1/node_modules/dnd`;
+  const DND_PEERED = `${ROOT}/node_modules/.bun/dnd@6.3.1+005eabf3d8b6ef06/node_modules/dnd`;
+
+  test("THE FALSE ERROR: a declarer reachable ONLY through a member root that nests the id is shed with that root", () => {
+    // Exactly the measured shape: `dnd` is invisible from the bare-entitled root
+    // and resolves only from `ui`, where it is the react-19 peered copy. The
+    // tree is correct — root react is the moved 18.3.2 — so this must be
+    // MATCHED. Locating the declarer from `roots` instead of `bareRoots` (the
+    // `for (const root of bareRoots)` line in the declarer loop) reports a
+    // mismatch here, which is the permanent, unforceable ERROR this test exists
+    // to prevent.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: UI_DIR, name: "ui" },
+      ],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|react`]: { dir: "/store/react@18.3.2", version: "18.3.2" },
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+        // `dnd` is NOT visible from the bare-entitled root — only from `ui`.
+        [`${UI_DIR}|dnd`]: { dir: DND_PEERED, version: "6.3.1" },
+        [`${DND_PEERED}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    // Only the bare-entitled root is credited; the shed subtree is not a site.
+    expect(a.matched[0].importers).toEqual([`workspace:${ROOT}`]);
+  });
+
+  test("a declarer visible from BOTH roots is probed at the BARE-entitled copy, not the peered one", () => {
+    // The positive control for the test above, and the guard against buying
+    // silence by simply dropping declarers: here `dnd` IS reachable from the
+    // bare-entitled root, so it stays a site — and the copy probed must be the
+    // bare one (react 18.3.2), not `ui`'s peered copy. A fix that skipped every
+    // declarer a shed root can also see would lose this site entirely and this
+    // assertion on `importers` would fail.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: UI_DIR, name: "ui" },
+      ],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|react`]: { dir: "/store/react@18.3.2", version: "18.3.2" },
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+        [`${ROOT}|dnd`]: { dir: DND_BARE, version: "6.3.1" },
+        [`${UI_DIR}|dnd`]: { dir: DND_PEERED, version: "6.3.1" },
+        [`${DND_BARE}|react`]: { dir: "/store/react@18.3.2", version: "18.3.2" },
+        [`${DND_PEERED}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+    expect(a.matched[0].importers).toEqual([`workspace:${ROOT}`, "dnd"]);
+  });
+
+  test("THE TRUE POSITIVE SURVIVES: a bare-entitled declarer still on the OLD version is a mismatch", () => {
+    // Same wiring as the control above, but the bare copy of `dnd` genuinely
+    // resolves the pre-move react. Shedding must not have widened into an
+    // excuse: this is the stale placement the module exists to force on.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: UI_DIR, name: "ui" },
+      ],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|react`]: { dir: "/store/react@18.3.2", version: "18.3.2" },
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+        [`${ROOT}|dnd`]: { dir: DND_BARE, version: "6.3.1" },
+        [`${UI_DIR}|dnd`]: { dir: DND_PEERED, version: "6.3.1" },
+        [`${DND_BARE}|react`]: { dir: "/store/react@18.3.1", version: "18.3.1" },
+        [`${DND_PEERED}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].expected).toBe("18.3.2");
+    expect(a.mismatched[0].found).toEqual(["18.3.1"]);
+    expect(a.mismatched[0].importers).toEqual(["dnd"]);
+  });
+
+  test("a wholly-shed site list is INCONCLUSIVE naming the shed declarers — not folded into 'could not locate'", () => {
+    // Nothing survives selection: the bare-entitled root cannot see react at
+    // all, and the only declarer lives under the shed member. That is "I could
+    // not look", and it must SAY which member subtree swallowed the site —
+    // reporting `dnd` as merely unlocatable would read as an absent dependency
+    // and hide that the audit deliberately declined to judge it.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: UI_DIR, name: "ui" },
+      ],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+        [`${UI_DIR}|dnd`]: { dir: DND_PEERED, version: "6.3.1" },
+        [`${DND_PEERED}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("reachable only through a workspace member that nests react");
+    expect(a.inconclusive[0].reason).toContain("dnd");
+    expect(a.inconclusive[0].reason).not.toContain("could not locate");
+  });
+
+  test("a declarer absent from EVERY root is still plain 'could not locate' — the shed reason is not a catch-all", () => {
+    // The positive control for the reason above: `dnd` is on disk nowhere, so
+    // the shed clause must NOT claim a member subtree swallowed it. A shed
+    // check that reported every unlocatable declarer as shed passes the
+    // previous test and fails this one.
+    const a = auditLockResolution({
+      workspaceRoots: [
+        { dir: ROOT, name: "catalyst" },
+        { dir: UI_DIR, name: "ui" },
+      ],
+      oldLockText: SUBTREE_LOCK,
+      newLockText: SUBTREE_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${UI_DIR}|react`]: { dir: "/store/react@19.2.8", version: "19.2.8" },
+      }),
+    });
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].reason).toContain("could not locate: dnd");
+    expect(a.inconclusive[0].reason).not.toContain("reachable only through");
+  });
+
   // ── deep install paths: the importer is reached hop by hop ──
   //
   // This repo's own bun.lock carries chains deeper than one nesting level

--- a/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
@@ -1,0 +1,434 @@
+// Unit tests for lock-resolution-audit.mjs (CTL-1831).
+//
+// The defect these lock down, measured on `mini` 2026-08-13 right after #3337
+// moved bun.lock from @catalyst-cloud/schema@0.1.3 to 0.1.5:
+//
+//   bun install --frozen-lockfile  -> 0.1.3 on disk, "no changes", exit 0
+//   bun install                    -> 0.1.3 on disk, "no changes", exit 0
+//   bun install --force            -> 0.1.5 on disk
+//
+// Bun does not relink an existing node_modules when only a TRANSITIVE resolution
+// changed, and both no-op commands exit 0 — so a successful-looking install is
+// byte-indistinguishable from one that changed nothing. This module is the
+// discriminator: it compares the lockfile's resolution against what the IMPORTING
+// package actually resolves on disk.
+//
+// Every filesystem interaction is the single injected `resolvePackageFn` seam, so
+// the whole audit is deterministically testable without a real node_modules.
+//
+// Run: bun test plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  splitLockKey,
+  parseLockPackages,
+  changedResolutions,
+  auditLockResolution,
+} from "./lock-resolution-audit.mjs";
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+//
+// Shaped exactly like this repo's own bun.lock: a 2-space `"packages": {` block
+// whose entries are 4-space-indented `"<key>": ["<name>@<version>", …]` lines.
+
+// `trustedDependencies` is deliberately present: it is a TOP-LEVEL key whose
+// value is an array whose first element carries an `@`, so it matches the entry
+// shape exactly. Without the packages-block gate it would be admitted as a
+// package named `trustedDependencies` — the fixture has to contain a line that
+// the gate is the ONLY thing rejecting, or the "only the packages block is
+// scanned" assertion cannot fail.
+const LOCK_0_1_3 = `{
+  "lockfileVersion": 1,
+  "trustedDependencies": ["esbuild@0.21.5"],
+  "workspaces": {
+    "": { "name": "catalyst" },
+  },
+  "packages": {
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.3", "", { "dependencies": { "@catalyst-cloud/schema": "^0.1.3" } }, "sha512-aaa=="],
+
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.3", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-bbb=="],
+
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": { "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" } }, "sha512-ccc=="],
+
+    "catalyst-execution-core": ["catalyst-execution-core@workspace:plugins/dev/scripts/execution-core"],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-ddd=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-eee=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-fff=="],
+  }
+}
+`;
+
+// The ONLY difference from LOCK_0_1_3: the schema entry moves to 0.1.5. Nothing
+// declares schema at the top level, so this is a transitive-only resolution change
+// — the exact shape bun refuses to relink.
+const LOCK_0_1_5 = LOCK_0_1_3.replace('"@catalyst-cloud/schema@0.1.3"', '"@catalyst-cloud/schema@0.1.5"');
+
+// A stub resolver: `table` maps "<fromDir>|<id>" to {dir, version}. Anything not in
+// the table is unresolvable (null) — the same three-valued shape the real
+// createRequire-backed resolver reports.
+function stubResolver(table) {
+  const calls = [];
+  const fn = (fromDir, id) => {
+    calls.push({ fromDir, id });
+    return table[`${fromDir}|${id}`] ?? null;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const ROOT = "/co";
+
+// ─── splitLockKey ────────────────────────────────────────────────────────────
+//
+// bun keys the packages map by install LOCATION: `<id>` hoisted, `<parent>/<id>`
+// nested, chaining deeper. Scoped names contain a `/` of their own, so a naive
+// split on "/" cannot tell `@scope/pkg` from `parent/child`.
+
+describe("splitLockKey", () => {
+  test("a bare unscoped key is a one-element chain", () => {
+    expect(splitLockKey("chalk")).toEqual(["chalk"]);
+  });
+
+  test("a bare SCOPED key is ONE element, not two", () => {
+    expect(splitLockKey("@catalyst-cloud/schema")).toEqual(["@catalyst-cloud/schema"]);
+  });
+
+  test("a nested key splits parent from child", () => {
+    expect(splitLockKey("chalk/ansi-styles")).toEqual(["chalk", "ansi-styles"]);
+  });
+
+  test("a deep chain mixing scoped and unscoped segments splits correctly", () => {
+    expect(
+      splitLockKey("@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match"),
+    ).toEqual([
+      "@typescript-eslint/typescript-estree",
+      "minimatch",
+      "brace-expansion",
+      "balanced-match",
+    ]);
+  });
+
+  test("a dangling scope with no package after it is null, never a guessed chain", () => {
+    expect(splitLockKey("@scope")).toBeNull();
+    expect(splitLockKey("chalk/@scope")).toBeNull();
+  });
+
+  test("an empty / non-string key is null", () => {
+    expect(splitLockKey("")).toBeNull();
+    expect(splitLockKey(null)).toBeNull();
+  });
+});
+
+// ─── parseLockPackages ───────────────────────────────────────────────────────
+
+describe("parseLockPackages", () => {
+  test("parses id + version off a bare entry", () => {
+    const p = parseLockPackages(LOCK_0_1_5);
+    expect(p.conclusive).toBe(true);
+    const schema = p.packages.get("@catalyst-cloud/schema");
+    expect(schema.id).toBe("@catalyst-cloud/schema");
+    expect(schema.version).toBe("0.1.5");
+  });
+
+  test("parses a NESTED entry's id off the value, not the key", () => {
+    const p = parseLockPackages(LOCK_0_1_5);
+    const nested = p.packages.get("chalk/ansi-styles");
+    expect(nested.id).toBe("ansi-styles");
+    expect(nested.version).toBe("4.3.0");
+  });
+
+  test("records each entry's declared dependency ids", () => {
+    const p = parseLockPackages(LOCK_0_1_5);
+    expect(p.packages.get("@catalyst-cloud/sdk").declaredDeps).toEqual([
+      "@catalyst-cloud/replicate",
+      "@catalyst-cloud/schema",
+    ]);
+  });
+
+  test("a workspace: entry is recorded as a workspace link, not an installable version", () => {
+    const p = parseLockPackages(LOCK_0_1_5);
+    expect(p.packages.get("catalyst-execution-core").workspaceLink).toBe(true);
+  });
+
+  test("only the packages block is scanned — a top-level entry-shaped key is not a package", () => {
+    const p = parseLockPackages(LOCK_0_1_5);
+    expect(p.packages.has("trustedDependencies")).toBe(false);
+    expect(p.packages.has("")).toBe(false);
+    expect(p.packages.size).toBe(7);
+  });
+
+  test("empty / non-string text is INCONCLUSIVE with a reason, never an empty clean map", () => {
+    for (const bad of ["", null, undefined, 42]) {
+      const p = parseLockPackages(bad);
+      expect(p.conclusive).toBe(false);
+      expect(typeof p.reason).toBe("string");
+    }
+  });
+
+  test("text with no packages block at all is INCONCLUSIVE, not zero-entries-clean", () => {
+    const p = parseLockPackages('{\n  "lockfileVersion": 1,\n}\n');
+    expect(p.conclusive).toBe(false);
+    expect(p.reason).toContain("packages");
+  });
+});
+
+// ─── changedResolutions ──────────────────────────────────────────────────────
+
+describe("changedResolutions", () => {
+  test("THE INCIDENT: a transitive-only version move is reported", () => {
+    const c = changedResolutions(LOCK_0_1_3, LOCK_0_1_5);
+    expect(c.conclusive).toBe(true);
+    expect(c.entries).toEqual([
+      { key: "@catalyst-cloud/schema", id: "@catalyst-cloud/schema", from: "0.1.3", to: "0.1.5" },
+    ]);
+  });
+
+  test("an identical lockfile yields zero entries (conclusively)", () => {
+    const c = changedResolutions(LOCK_0_1_5, LOCK_0_1_5);
+    expect(c.conclusive).toBe(true);
+    expect(c.entries).toEqual([]);
+  });
+
+  // WITH_LEFT_PAD is LOCK_0_1_5 plus one extra entry, so the add/remove pair
+  // below can be driven in BOTH directions off the same two texts. (Deriving the
+  // "removed" case by string-replacing an entry that is not in the text is a
+  // no-op that compares a text with itself — an assertion that cannot fail.)
+  const WITH_LEFT_PAD = LOCK_0_1_5.replace(
+    '    "chalk": [',
+    '    "left-pad": ["left-pad@1.3.0", "", {}, "sha512-ggg=="],\n\n    "chalk": [',
+  );
+
+  test("the added-entry fixture really differs from the base (control for the pair below)", () => {
+    expect(WITH_LEFT_PAD).not.toBe(LOCK_0_1_5);
+    expect(parseLockPackages(WITH_LEFT_PAD).packages.has("left-pad")).toBe(true);
+    expect(parseLockPackages(LOCK_0_1_5).packages.has("left-pad")).toBe(false);
+  });
+
+  test("an ADDED entry is reported with from:null", () => {
+    const c = changedResolutions(LOCK_0_1_5, WITH_LEFT_PAD);
+    expect(c.entries).toEqual([{ key: "left-pad", id: "left-pad", from: null, to: "1.3.0" }]);
+  });
+
+  test("a REMOVED entry is not reported — nothing needs materializing for it", () => {
+    const c = changedResolutions(WITH_LEFT_PAD, LOCK_0_1_5);
+    expect(c.entries).toEqual([]);
+  });
+
+  test("a workspace: entry that changes path is NOT an installable resolution change", () => {
+    const moved = LOCK_0_1_5.replace(
+      "catalyst-execution-core@workspace:plugins/dev/scripts/execution-core",
+      "catalyst-execution-core@workspace:plugins/dev/scripts/exec-core",
+    );
+    expect(changedResolutions(LOCK_0_1_5, moved).entries).toEqual([]);
+  });
+
+  test("an unparseable side is INCONCLUSIVE with a reason — never a silent zero", () => {
+    const c = changedResolutions(null, LOCK_0_1_5);
+    expect(c.conclusive).toBe(false);
+    expect(typeof c.reason).toBe("string");
+    expect(c.entries).toEqual([]);
+  });
+});
+
+// ─── auditLockResolution ─────────────────────────────────────────────────────
+
+describe("auditLockResolution", () => {
+  // The three importer dirs the stubs use, in bun's isolated-linker shape:
+  // node_modules/.bun/<name>@<version>+<hash>/node_modules/<name>.
+  const SDK_DIR = `${ROOT}/node_modules/.bun/@catalyst-cloud+sdk@0.8.2+h/node_modules/@catalyst-cloud/sdk`;
+  const REPLICATE_DIR = `${ROOT}/node_modules/.bun/@catalyst-cloud+replicate@0.1.3+h/node_modules/@catalyst-cloud/replicate`;
+
+  // A tree that has been correctly relinked: both importers see 0.1.5.
+  const RELINKED = {
+    [`${ROOT}|@catalyst-cloud/sdk`]: { dir: SDK_DIR, version: "0.8.2" },
+    [`${ROOT}|@catalyst-cloud/replicate`]: { dir: REPLICATE_DIR, version: "0.1.3" },
+    [`${SDK_DIR}|@catalyst-cloud/schema`]: { dir: "/store/schema@0.1.5", version: "0.1.5" },
+    [`${REPLICATE_DIR}|@catalyst-cloud/schema`]: { dir: "/store/schema@0.1.5", version: "0.1.5" },
+  };
+
+  // The measured post-no-op-install tree: the lockfile says 0.1.5, both importers
+  // still resolve 0.1.3.
+  const STALE = {
+    ...RELINKED,
+    [`${SDK_DIR}|@catalyst-cloud/schema`]: { dir: "/store/schema@0.1.3", version: "0.1.3" },
+    [`${REPLICATE_DIR}|@catalyst-cloud/schema`]: { dir: "/store/schema@0.1.3", version: "0.1.3" },
+  };
+
+  test("THE INCIDENT: lockfile 0.1.5, importers still on 0.1.3 → mismatched", () => {
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: stubResolver(STALE),
+    });
+    expect(a.conclusive).toBe(true);
+    expect(a.checked).toBe(1);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].id).toBe("@catalyst-cloud/schema");
+    expect(a.mismatched[0].expected).toBe("0.1.5");
+    expect(a.mismatched[0].found).toContain("0.1.3");
+    // The importer must be NAMED — an operator reading the event has to know which
+    // package's resolved dependency is stale, not just that "something" is.
+    expect(a.mismatched[0].importers).toContain("@catalyst-cloud/sdk");
+  });
+
+  test("after a forced relink the same audit is clean", () => {
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: stubResolver(RELINKED),
+    });
+    expect(a.conclusive).toBe(true);
+    expect(a.checked).toBe(1);
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+  });
+
+  test("the check reads the IMPORTER's resolution, not a hoisted top-level copy", () => {
+    // A hoisted 0.1.5 exists at the workspace root while the SDK still resolves
+    // 0.1.3 through its own node_modules. A check that read the top-level copy
+    // would report clean here; this one must not.
+    const hoistedFresh = {
+      ...STALE,
+      [`${ROOT}|@catalyst-cloud/schema`]: { dir: "/store/schema@0.1.5", version: "0.1.5" },
+    };
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: stubResolver(hoistedFresh),
+    });
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].found).toContain("0.1.3");
+  });
+
+  test("a NESTED key is judged from its parent only — a different hoisted copy is not a mismatch", () => {
+    // chalk/ansi-styles moves 4.3.0 -> 4.3.1 while a hoisted ansi-styles@6.2.3
+    // legitimately stays. Judging the nested entry from the workspace root would
+    // report 6.2.3 as a mismatch and force a needless 1168-package re-extract.
+    const oldText = LOCK_0_1_5;
+    const newText = LOCK_0_1_5.replace('"ansi-styles@4.3.0"', '"ansi-styles@4.3.1"');
+    const CHALK_DIR = `${ROOT}/node_modules/.bun/chalk@5.6.2+h/node_modules/chalk`;
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: oldText,
+      newLockText: newText,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|chalk`]: { dir: CHALK_DIR, version: "5.6.2" },
+        [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@6.2.3", version: "6.2.3" },
+        [`${CHALK_DIR}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.1", version: "4.3.1" },
+      }),
+    });
+    expect(a.checked).toBe(1);
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toHaveLength(1);
+  });
+
+  test("a nested key whose parent still resolves the OLD version IS a mismatch", () => {
+    const newText = LOCK_0_1_5.replace('"ansi-styles@4.3.0"', '"ansi-styles@4.3.1"');
+    const CHALK_DIR = `${ROOT}/node_modules/.bun/chalk@5.6.2+h/node_modules/chalk`;
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_5,
+      newLockText: newText,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|chalk`]: { dir: CHALK_DIR, version: "5.6.2" },
+        [`${CHALK_DIR}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
+      }),
+    });
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].importers).toEqual(["chalk"]);
+  });
+
+  test("an observed version the lockfile records ELSEWHERE for the same id is an alternate, not a mismatch", () => {
+    // The lockfile keeps ansi-styles@6.2.3 hoisted AND ansi-styles@4.3.0 under
+    // chalk. If some importer legitimately resolves the other recorded version we
+    // must not force: a false positive costs a full re-extract on every refresh.
+    const newText = LOCK_0_1_5.replace('"ansi-styles@6.2.3"', '"ansi-styles@6.2.4"');
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_5,
+      newLockText: newText,
+      resolvePackageFn: stubResolver({
+        // Root resolves the OTHER version the lockfile still records (4.3.0).
+        [`${ROOT}|ansi-styles`]: { dir: "/store/ansi-styles@4.3.0", version: "4.3.0" },
+      }),
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.alternates).toHaveLength(1);
+    expect(a.alternates[0].found).toContain("4.3.0");
+  });
+
+  test("no importer resolves the id on disk → INCONCLUSIVE, never a clean pass", () => {
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: stubResolver({}), // nothing resolves at all
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.matched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+    expect(a.inconclusive[0].id).toBe("@catalyst-cloud/schema");
+    expect(typeof a.inconclusive[0].reason).toBe("string");
+  });
+
+  test("a missing OLD lockfile text is reported as inconclusive with a reason and audits nothing", () => {
+    const resolver = stubResolver(STALE);
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: null,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: resolver,
+    });
+    expect(a.conclusive).toBe(false);
+    expect(typeof a.reason).toBe("string");
+    expect(a.checked).toBe(0);
+    // Nothing was probed — an audit that could not look must not touch the disk.
+    expect(resolver.calls).toHaveLength(0);
+  });
+
+  test("an empty workspaceRoots list is INCONCLUSIVE — a zero-site loop cannot judge anything", () => {
+    // [].every(p) is true; a site list that is empty must not read as "all clean".
+    const a = auditLockResolution({
+      workspaceRoots: [],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: stubResolver(STALE),
+    });
+    expect(a.conclusive).toBe(false);
+    expect(a.mismatched).toEqual([]);
+    expect(typeof a.reason).toBe("string");
+  });
+
+  test("zero changed entries → conclusive, checked 0, and no disk probes", () => {
+    const resolver = stubResolver(STALE);
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_5,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: resolver,
+    });
+    expect(a.conclusive).toBe(true);
+    expect(a.checked).toBe(0);
+    expect(a.mismatched).toEqual([]);
+    expect(resolver.calls).toHaveLength(0);
+  });
+
+  test("a throwing resolvePackageFn degrades to inconclusive, never crashes the refresh", () => {
+    const a = auditLockResolution({
+      workspaceRoots: [ROOT],
+      oldLockText: LOCK_0_1_3,
+      newLockText: LOCK_0_1_5,
+      resolvePackageFn: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(a.mismatched).toEqual([]);
+    expect(a.inconclusive).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -16,7 +16,11 @@
 //   3. runs `git fetch --no-tags origin main && git reset --hard origin/main`
 //      in each root (self-healing: the clone is disposable per CTL-992, so
 //      reset --hard is always safe regardless of working-tree dirt — CTL-1106)
-//   4. emits plugin.checkout.updated (new HEAD sha + daemon-skew restart_needed)
+//   4. runs `bun install` in each dir whose package.json/bun.lock moved, then
+//      AUDITS whether the install actually relinked (CTL-1831 — a bun install
+//      that skips a transitive-only resolution change still exits 0), forcing a
+//      relink only on a proven mismatch
+//   5. emits plugin.checkout.updated (new HEAD sha + daemon-skew restart_needed)
 //      on success, or plugin.checkout.refresh_failed (WARN) on a genuine
 //      network/auth failure — never failing silently.
 //
@@ -35,10 +39,12 @@
 
 import { readFileSync, existsSync, rmSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { homedir } from "node:os";
-import { resolve, join } from "node:path";
+import { resolve, join, dirname } from "node:path";
 import { getEventName } from "./event-name.mjs"; // CTL-1348: leaf, not the heavy router
 import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
+import { auditLockResolution } from "./lock-resolution-audit.mjs"; // CTL-1831
 
 // Throttle window: at most one pull per N seconds per checkout root. A merge
 // often arrives as both a github.pr.merged AND a github.push to main within the
@@ -184,26 +190,162 @@ export function clearStaleIndexLock({
 const BUN_INSTALL_TIMEOUT_MS =
   Number(process.env.CATALYST_PLUGIN_REFRESH_BUN_TIMEOUT_MS) || 180_000;
 
+/**
+ * bunInstallArgv — the argv for one `bun install` variant. Extracted as a pure
+ * helper (CTL-1831) so the flags themselves are assertable: the ONLY difference
+ * between an install that relinks a transitive-only resolution change and one
+ * that exits 0 having done nothing is `--force`, and that distinction had no
+ * test anywhere.
+ */
+export function bunInstallArgv({ force = false, frozen = true } = {}) {
+  if (force) return ["install", "--force"];
+  return frozen ? ["install", "--frozen-lockfile"] : ["install"];
+}
+
 // defaultBunInstallFn — run `bun install` in a package dir. Frozen first (the
 // checkout was just reset to origin/main, so the lockfile is authoritative);
 // fall back to a plain install if frozen rejects. Throws on non-zero exit, which
 // the caller catches and surfaces as deps_install_failed (non-fatal).
-function defaultBunInstallFn(pkgDir) {
+//
+// CTL-1831: `force:true` is the RELINK variant, and it is deliberately NOT the
+// default — measured, `--force` re-extracts 1168 packages (3-8 s) even when
+// nothing changed, so paying it on every refresh is the wrong trade. The caller
+// escalates to it only after the post-install resolution audit PROVES the tree
+// on disk disagrees with the lockfile.
+function defaultBunInstallFn(pkgDir, { force = false } = {}) {
+  const run = (argv) =>
+    execFileSync("bun", argv, {
+      cwd: pkgDir, encoding: "utf8", timeout: BUN_INSTALL_TIMEOUT_MS,
+      killSignal: "SIGKILL", env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+    });
+  if (force) {
+    run(bunInstallArgv({ force: true }));
+    return;
+  }
   try {
-    execFileSync("bun", ["install", "--frozen-lockfile"], {
-      cwd: pkgDir, encoding: "utf8", timeout: BUN_INSTALL_TIMEOUT_MS,
-      killSignal: "SIGKILL", env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-    });
+    run(bunInstallArgv({ frozen: true }));
   } catch {
-    execFileSync("bun", ["install"], {
-      cwd: pkgDir, encoding: "utf8", timeout: BUN_INSTALL_TIMEOUT_MS,
-      killSignal: "SIGKILL", env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-    });
+    run(bunInstallArgv({ frozen: false }));
   }
 }
 
 // Files whose change means deps may need (re)installing in their containing dir.
 const DEP_MANIFEST_RE = /(^|\/)(package\.json|bun\.lock)$/;
+
+// The lockfile alone — the subset of DEP_MANIFEST_RE whose change can move a
+// RESOLUTION, and therefore the only one the CTL-1831 audit has anything to
+// verify. A package.json-only change (a script rename, a field edit) resolves to
+// the same versions, so auditing it would spend probes to prove nothing.
+const LOCKFILE_RE = /(^|\/)bun\.lock$/;
+
+/**
+ * changedLockfiles — pure helper (CTL-1831): map a `git diff --name-only` output
+ * to the bun.lock files the pulled range touched, each with the absolute dir
+ * that owns it. Order-preserving and deduped. Exported for direct unit testing
+ * (no I/O — path logic only).
+ *
+ * @returns {{rel:string, dir:string}[]}
+ */
+export function changedLockfiles(root, diffOutput) {
+  const out = [];
+  const seen = new Set();
+  for (const line of String(diffOutput || "").split("\n")) {
+    const rel = line.trim();
+    if (!rel || !LOCKFILE_RE.test(rel)) continue;
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    const dirRel = rel.includes("/") ? rel.slice(0, rel.lastIndexOf("/")) : ".";
+    out.push({ rel, dir: dirRel === "." ? root : resolve(root, dirRel) });
+  }
+  return out;
+}
+
+/**
+ * workspaceRootsFor — the directories the CTL-1831 audit may resolve FROM: the
+ * lockfile's own dir plus each literal workspace member that has a package.json.
+ *
+ * The member dirs matter because bun's isolated linker gives the workspace root
+ * no copy of a package it does not itself depend on (measured on this repo:
+ * `require.resolve("@catalyst-cloud/schema")` from the root is MODULE_NOT_FOUND
+ * while it resolves fine from execution-core), so a root-only site list would
+ * report "no importer resolves it" for exactly the packages that matter.
+ *
+ * Glob entries ("packages/*") are SKIPPED, not expanded — same discipline as
+ * workspaceMemberNodeModules. The fail direction is safe here: a skipped member
+ * can only SHRINK the site set, and an entry with no reachable site is reported
+ * INCONCLUSIVE, never clean.
+ */
+export function workspaceRootsFor(lockDir, { readFileFn = readFileSync, existsFn = existsSync } = {}) {
+  const roots = [lockDir];
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileFn(resolve(lockDir, "package.json"), "utf8"));
+  } catch {
+    return roots;
+  }
+  const entries = Array.isArray(manifest?.workspaces) ? manifest.workspaces : [];
+  for (const entry of entries) {
+    if (typeof entry !== "string" || entry === "" || entry.includes("*")) continue;
+    const memberDir = resolve(lockDir, entry);
+    if (!existsFn(join(memberDir, "package.json"))) continue;
+    roots.push(memberDir);
+  }
+  return roots;
+}
+
+/**
+ * defaultResolvePackageFn — what `<id>` ACTUALLY resolves to when required from
+ * `fromDir`, as `{dir, version}` or null.
+ *
+ * Resolution, not directory enumeration, is the instrument: bun's `.bun` store
+ * keeps stale entries after an upgrade (measured on this checkout,
+ * @catalyst-cloud+schema@0.1.3 and @0.1.5 both present), so a package's presence
+ * on disk says nothing about what an importer loads. It is also the only
+ * layout-agnostic probe — identical answers under the hoisted and isolated
+ * linkers.
+ *
+ * `<id>/package.json` is tried first and the bare specifier second, because a
+ * package with an `exports` map may not expose its own manifest. Either way the
+ * version is read from the package.json that OWNS the resolved file (name ===
+ * id), walking up — a package can ship a nested `dist/package.json`, and reading
+ * a version out of THAT would silently record undefined (the same trap
+ * cloud-sync-deps.mjs's findPackageJson documents).
+ */
+function defaultResolvePackageFn(fromDir, id) {
+  let req;
+  try {
+    req = createRequire(join(fromDir, "package.json"));
+  } catch {
+    return null;
+  }
+  let entry = null;
+  try {
+    entry = req.resolve(`${id}/package.json`);
+  } catch {
+    /* an exports map may hide the manifest — fall through to the bare specifier */
+  }
+  if (!entry) {
+    try {
+      entry = req.resolve(id);
+    } catch {
+      return null;
+    }
+  }
+  let dir = dirname(entry);
+  for (;;) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+      if (parsed?.name === id && typeof parsed.version === "string" && parsed.version) {
+        return { dir, version: parsed.version };
+      }
+    } catch {
+      /* absent/malformed — keep walking up to the owning manifest */
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
 
 // changedPackageDirs — pure helper: map a `git diff --name-only` output to
 // unique absolute package dirs that need `bun install`. Exported for direct
@@ -537,6 +679,14 @@ export function refreshPluginCheckout({
   // falls through to staleLockStatus's real statSync default in production.
   statFn = undefined,
   rmFn = defaultRmFn,
+  // CTL-1831 seams: the post-install "did the install actually RELINK?" audit.
+  // All four are injectable so the wiring (signal → force → re-audit) is testable
+  // without a real node_modules; the audit's own logic has direct unit coverage
+  // in lock-resolution-audit.test.mjs.
+  auditFn = auditLockResolution,
+  workspaceRootsFn = workspaceRootsFor,
+  resolvePackageFn = defaultResolvePackageFn,
+  readFileFn = (p) => readFileSync(p, "utf8"),
 }) {
   if (!root) return { pulled: false, throttled: false, changed: false, failed: false, root, oldSha: null, newSha: null, restartNeeded: false };
 
@@ -671,6 +821,7 @@ export function refreshPluginCheckout({
   // triggers the monitor restart). Install failures are surfaced as WARN events
   // and never block the checkout-updated signal (reset already succeeded).
   const depsInstalled = [];
+  const depsRelinked = [];
   const staleNodeModulesPruned = [];
   if (oldSha) {
     let diffOut = "";
@@ -711,6 +862,121 @@ export function refreshPluginCheckout({
         });
       }
     }
+
+    // CTL-1831: an install that exits 0 is NOT evidence that it relinked
+    // anything. Measured on `mini` immediately after #3337 moved bun.lock from
+    // @catalyst-cloud/schema@0.1.3 to 0.1.5: `--frozen-lockfile` and the plain
+    // fallback BOTH reported "no changes", exited 0, and left the SDK's resolved
+    // schema at 0.1.3; only `--force` relinked it. So the loop above could
+    // succeed on every host while the correct lockfile never reached the running
+    // code — the second link of the CTL-1506 chain, and the one that had no
+    // detector at all (deps_install_failed covers only a FAILING install).
+    //
+    // The audit compares the lockfile's moved resolutions against what the
+    // IMPORTING package resolves on disk, and only a proven mismatch escalates
+    // to `--force`. Detect-then-force, never force-always: a blanket --force
+    // re-extracts 1168 packages (3-8 s measured) on every refresh.
+    //
+    // Scoped to dirs whose install SUCCEEDED: a tree that was never built has
+    // nothing to audit, and forcing on top of a failed install would replace one
+    // loud failure with a slower one.
+    const installedDirs = new Set(depsInstalled);
+    for (const lock of changedLockfiles(root, diffOut)) {
+      if (!installedDirs.has(lock.dir)) continue;
+      let oldLockText = null;
+      try { oldLockText = gitFn(root, ["show", `${oldSha}:${lock.rel}`]); } catch { oldLockText = null; }
+      let newLockText = null;
+      try { newLockText = readFileFn(join(lock.dir, "bun.lock")); } catch { newLockText = null; }
+      const auditArgs = {
+        workspaceRoots: workspaceRootsFn(lock.dir),
+        oldLockText,
+        newLockText,
+        resolvePackageFn,
+      };
+      let audit;
+      try {
+        audit = auditFn(auditArgs);
+      } catch (err) {
+        // The audit is a guardrail, not a gate: a throw here must degrade to a
+        // named inconclusive, never take down the refresh that already succeeded.
+        audit = { conclusive: false, reason: `audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+      }
+
+      if (audit.mismatched.length > 0) {
+        // THE SIGNAL the no-op install never produced. Emitted at DETECTION,
+        // before any remediation, so the record exists even if the force below
+        // throws or fails to fix it.
+        emitFn({
+          event: "plugin.checkout.deps_install_noop",
+          orchestrator: null,
+          worker: null,
+          severity: "WARN",
+          detail: {
+            checkout: root,
+            package_dir: lock.dir,
+            lockfile: lock.rel,
+            checked: audit.checked,
+            mismatched: audit.mismatched,
+          },
+        });
+        try {
+          bunInstallFn(lock.dir, { force: true });
+        } catch (err) {
+          emitFn({
+            event: "plugin.checkout.deps_install_failed",
+            orchestrator: null,
+            worker: null,
+            severity: "WARN",
+            detail: { checkout: root, package_dir: lock.dir, forced: true, error: err?.message ?? String(err) },
+          });
+          continue;
+        }
+        let after;
+        try {
+          after = auditFn(auditArgs);
+        } catch (err) {
+          after = { conclusive: false, reason: `re-audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+        }
+        if (after.mismatched.length > 0) {
+          // --force is the strongest lever this path has. Still stale after it
+          // means the drift is not bun's relink heuristic (a shadowing member
+          // node_modules, a registry serving the wrong bytes, a read-only tree),
+          // so it is ERROR: nothing further here will fix it.
+          emitFn({
+            event: "plugin.checkout.deps_relink_failed",
+            orchestrator: null,
+            worker: null,
+            severity: "ERROR",
+            detail: {
+              checkout: root,
+              package_dir: lock.dir,
+              lockfile: lock.rel,
+              mismatched: after.mismatched,
+            },
+          });
+        } else {
+          depsRelinked.push(lock.dir);
+        }
+      } else if (!audit.conclusive || audit.inconclusive.length > 0) {
+        // "I could not look" must be distinguishable from "the tree is correct".
+        // A silent inconclusive is exactly how the original defect stayed
+        // invisible for a year of refreshes.
+        emitFn({
+          event: "plugin.checkout.deps_audit_inconclusive",
+          orchestrator: null,
+          worker: null,
+          severity: "WARN",
+          detail: {
+            checkout: root,
+            package_dir: lock.dir,
+            lockfile: lock.rel,
+            reason: audit.reason ?? null,
+            checked: audit.checked,
+            inconclusive: audit.inconclusive,
+          },
+        });
+      }
+    }
   }
 
   emitFn({
@@ -724,6 +990,7 @@ export function refreshPluginCheckout({
       loaded_commit: loadedCommit,
       restart_needed: restartNeeded,
       deps_installed: depsInstalled,
+      deps_relinked: depsRelinked, // CTL-1831: dirs a forced relink actually repaired
       stale_node_modules_pruned: staleNodeModulesPruned,
     },
   });

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -273,21 +273,42 @@ export function changedLockfiles(root, diffOutput) {
  * workspaceMemberNodeModules. The fail direction is safe here: a skipped member
  * can only SHRINK the site set, and an entry with no reachable site is reported
  * INCONCLUSIVE, never clean.
+ *
+ * Each root carries its own package `name` when the manifest declares one,
+ * because the audit's bare-key site selection has to shed exactly the member
+ * root that owns a `<member>/<id>` nested key. This repo's bun.lock really has
+ * three (`orch-monitor-ui/react`, `orch-monitor-ui/@types/react`,
+ * `orch-monitor-ui/typescript`) and `plugins/dev/scripts/orch-monitor/ui` is a
+ * literal member passed here as a root — so without the name, a version move on
+ * `react` would read that member's legitimately-nested copy as a stale bare
+ * resolution and force a needless re-extract. `name` is null when the manifest
+ * is absent, unparseable, or nameless; the audit's fallback for a nameless root
+ * is blunt but safe (it sheds the root rather than trusting it).
+ *
+ * @returns {{dir:string, name:string|null}[]}
  */
 export function workspaceRootsFor(lockDir, { readFileFn = readFileSync, existsFn = existsSync } = {}) {
-  const roots = [lockDir];
-  let manifest;
-  try {
-    manifest = JSON.parse(readFileFn(resolve(lockDir, "package.json"), "utf8"));
-  } catch {
-    return roots;
-  }
+  const nameOf = (parsed) => (typeof parsed?.name === "string" && parsed.name ? parsed.name : null);
+  const manifestAt = (dir) => {
+    try {
+      return JSON.parse(readFileFn(resolve(dir, "package.json"), "utf8"));
+    } catch {
+      return null; // absent/unreadable/malformed — no name, and no members
+    }
+  };
+  // One read of the root manifest, used for BOTH its name and its members.
+  const manifest = manifestAt(lockDir);
+  const roots = [{ dir: lockDir, name: nameOf(manifest) }];
+  if (manifest === null) return roots;
   const entries = Array.isArray(manifest?.workspaces) ? manifest.workspaces : [];
   for (const entry of entries) {
     if (typeof entry !== "string" || entry === "" || entry.includes("*")) continue;
     const memberDir = resolve(lockDir, entry);
+    // Membership stays keyed on the package.json EXISTING, exactly as before —
+    // a member whose manifest is present but unparseable is still a resolvable
+    // dir, it just contributes no name.
     if (!existsFn(join(memberDir, "package.json"))) continue;
-    roots.push(memberDir);
+    roots.push({ dir: memberDir, name: nameOf(manifestAt(memberDir)) });
   }
   return roots;
 }
@@ -915,7 +936,7 @@ export function refreshPluginCheckout({
       } catch (err) {
         // The audit is a guardrail, not a gate: a throw here must degrade to a
         // named inconclusive, never take down the refresh that already succeeded.
-        audit = { conclusive: false, reason: `audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+        audit = { conclusive: false, reason: `audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], inconclusive: [] };
       }
 
       if (audit.mismatched.length > 0) {
@@ -951,7 +972,7 @@ export function refreshPluginCheckout({
         try {
           after = auditFn(auditArgs);
         } catch (err) {
-          after = { conclusive: false, reason: `re-audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], alternates: [], inconclusive: [] };
+          after = { conclusive: false, reason: `re-audit threw: ${err?.message ?? String(err)}`, checked: 0, matched: [], mismatched: [], inconclusive: [] };
         }
         if (after.mismatched.length > 0) {
           // --force is the strongest lever this path has. Still stale after it
@@ -970,8 +991,33 @@ export function refreshPluginCheckout({
               mismatched: after.mismatched,
             },
           });
-        } else {
+        } else if (after.conclusive && after.inconclusive.length === 0) {
           depsRelinked.push(lock.dir);
+        } else {
+          // A re-audit that could not LOOK is not evidence of repair. The
+          // synthesized throw-result above, and an audit whose entries came back
+          // per-entry inconclusive, both carry an EMPTY `mismatched` — identical
+          // to a genuinely clean tree. Claiming `deps_relinked` off that emptiness
+          // would be a check-that-cannot-fail sitting inside the fix for a
+          // check-that-cannot-fail: the refresh would report a known mismatch
+          // repaired with no positive evidence, and say nothing about the doubt.
+          // Only a CONCLUSIVE re-audit with neither mismatches nor per-entry
+          // inconclusives proves the force worked.
+          emitFn({
+            event: "plugin.checkout.deps_audit_inconclusive",
+            orchestrator: null,
+            worker: null,
+            severity: "WARN",
+            detail: {
+              checkout: root,
+              package_dir: lock.dir,
+              lockfile: lock.rel,
+              forced: true, // the POST-force re-audit, not the detection pass
+              reason: after.reason ?? null,
+              checked: after.checked,
+              inconclusive: after.inconclusive,
+            },
+          });
         }
       } else if (!audit.conclusive || audit.inconclusive.length > 0) {
         // "I could not look" must be distinguishable from "the tree is correct".
@@ -986,6 +1032,7 @@ export function refreshPluginCheckout({
             checkout: root,
             package_dir: lock.dir,
             lockfile: lock.rel,
+            forced: false, // the DETECTION pass, not a post-force re-audit
             reason: audit.reason ?? null,
             checked: audit.checked,
             inconclusive: audit.inconclusive,

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -37,9 +37,8 @@
 // deterministically testable without real load, timers, network, or a checkout.
 // Mirrors the gc-liveness.mjs / autotune.mjs seam-injection convention.
 
-import { readFileSync, existsSync, rmSync } from "node:fs";
+import { readFileSync, existsSync, rmSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { resolve, join, dirname } from "node:path";
 import { getEventName } from "./event-name.mjs"; // CTL-1348: leaf, not the heavy router
@@ -294,52 +293,69 @@ export function workspaceRootsFor(lockDir, { readFileFn = readFileSync, existsFn
 }
 
 /**
- * defaultResolvePackageFn — what `<id>` ACTUALLY resolves to when required from
+ * defaultResolvePackageFn — what `<id>` ACTUALLY resolves to when imported from
  * `fromDir`, as `{dir, version}` or null.
  *
- * Resolution, not directory enumeration, is the instrument: bun's `.bun` store
- * keeps stale entries after an upgrade (measured on this checkout,
- * @catalyst-cloud+schema@0.1.3 and @0.1.5 both present), so a package's presence
- * on disk says nothing about what an importer loads. It is also the only
- * layout-agnostic probe — identical answers under the hoisted and isolated
- * linkers.
+ * Directory PLACEMENT read off the disk, not `createRequire().resolve()`. The
+ * first cut of this probe used module resolution and was unusable for the exact
+ * reason this whole module exists: **Node/bun module resolution is cached
+ * PROCESS-WIDE, and a fresh `createRequire` does not clear that cache**. Measured
+ * identically under node v25.8.2 and bun 1.3.5 (macOS 26.5, arm64), isolated-
+ * linker layout, one process:
  *
- * `<id>/package.json` is tried first and the bare specifier second, because a
- * package with an `exports` map may not expose its own manifest. Either way the
- * version is read from the package.json that OWNS the resolved file (name ===
- * id), walking up — a package can ship a nested `dist/package.json`, and reading
- * a version out of THAT would silently record undefined (the same trap
- * cloud-sync-deps.mjs's findPackageJson documents).
+ *     before:              symlink -> 0.1.5 | resolve -> 0.1.5
+ *     after flip to 0.1.3: symlink -> 0.1.3 | resolve -> 0.1.5   <- STALE
+ *
+ * Held as a standing regression by the "THE DEFECT: a SECOND call in the SAME
+ * process sees the relink" test in plugin-refresh.test.mjs.
+ *
+ * In the long-lived updater daemon (`updater.mjs`'s setInterval) and the broker
+ * that consequence is total: the post-`--force` RE-audit answers from the cache
+ * the pre-force audit populated, so a SUCCESSFUL relink reported
+ * `deps_relink_failed` (an ERROR the docs describe as unfixable) and
+ * `deps_relinked` was permanently `[]`; and once a process had audited one good
+ * tree it reported CLEAN on a tree that had since gone stale — the detector
+ * blind to its own incident. A question about BYTES ON DISK must be answered by
+ * reading the disk.
+ *
+ * The walk is node's own `node_modules` ladder — `<dir>/node_modules/<id>`,
+ * rising to the filesystem root — which is what makes it layout-agnostic: under
+ * the hoisted linker the entry IS the package, under bun's isolated linker it is
+ * a symlink into `.bun/<id>@<version>/`, and `readFileSync` follows either. (The
+ * ladder is not pruned at a `node_modules` segment the way NODE_MODULES_PATHS
+ * prunes it; the extra probe is a miss on a path that cannot exist, and every
+ * directory the spec DOES visit is still visited, in the same order.)
+ *
+ * Version comes from the addressed `<id>/package.json` itself — no walking up to
+ * an "owning" manifest, since the path already names the package — and `dir` is
+ * realpath'd so a mismatch report names the store entry rather than the link.
+ * A realpath failure keeps the literal path: the version is the verdict, and
+ * losing the cosmetic path must not turn a real answer into a null (which the
+ * audit reads as "could not look").
+ *
+ * @param {string} fromDir importer directory to resolve from
+ * @param {string} id      package id, e.g. `@catalyst-cloud/schema`
  */
-function defaultResolvePackageFn(fromDir, id) {
-  let req;
-  try {
-    req = createRequire(join(fromDir, "package.json"));
-  } catch {
-    return null;
-  }
-  let entry = null;
-  try {
-    entry = req.resolve(`${id}/package.json`);
-  } catch {
-    /* an exports map may hide the manifest — fall through to the bare specifier */
-  }
-  if (!entry) {
-    try {
-      entry = req.resolve(id);
-    } catch {
-      return null;
-    }
-  }
-  let dir = dirname(entry);
+export function defaultResolvePackageFn(fromDir, id, { readFileFn = readFileSync, realpathFn = realpathSync } = {}) {
+  if (typeof fromDir !== "string" || !fromDir) return null;
+  if (typeof id !== "string" || !id) return null;
+  let dir = resolve(fromDir);
   for (;;) {
+    const candidate = join(dir, "node_modules", ...id.split("/"));
+    let parsed = null;
     try {
-      const parsed = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
-      if (parsed?.name === id && typeof parsed.version === "string" && parsed.version) {
-        return { dir, version: parsed.version };
-      }
+      parsed = JSON.parse(readFileFn(join(candidate, "package.json"), "utf8"));
     } catch {
-      /* absent/malformed — keep walking up to the owning manifest */
+      parsed = null; // absent/unreadable/malformed here — keep climbing the ladder
+    }
+    if (parsed && typeof parsed.version === "string" && parsed.version) {
+      let real = candidate;
+      try {
+        real = realpathFn(candidate);
+      } catch {
+        /* keep the literal path — the version is the verdict */
+      }
+      return { dir: real, version: parsed.version };
     }
     const parent = dirname(dir);
     if (parent === dir) return null;

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -30,6 +30,9 @@ import {
   startPluginDriftCheck,
   handlePluginRefreshEvent,
   changedPackageDirs,
+  changedLockfiles,
+  bunInstallArgv,
+  workspaceRootsFor,
   workspaceMemberNodeModules,
   PLUGIN_REFRESH_THROTTLE_MS,
   PLUGIN_DRIFT_CHECK_INTERVAL_MS,
@@ -1750,5 +1753,397 @@ describe("refreshPluginCheckout — stale-lock pre-pull clear (CTL-1415)", () =>
     expect(removed).toEqual([]);
     expect(emitted.some((e) => e.event === "plugin.checkout.stale_lock_cleared")).toBe(false);
     expect(gitFn.calls.some((c) => c.args[0] === "fetch")).toBe(true);
+  });
+});
+
+// ─── install-must-relink (CTL-1831) ─────────────────────────────────────────
+//
+// MEASURED on `mini` 2026-08-13, right after #3337 moved bun.lock from
+// @catalyst-cloud/schema@0.1.3 to 0.1.5. The refresh pulled the merge correctly
+// (plugin-source HEAD and bun.lock both right) and the daemons STILL loaded
+// 0.1.3, because bun does not relink an existing node_modules when only a
+// TRANSITIVE resolution changed — and both `--frozen-lockfile` and the plain
+// fallback exit 0 while doing nothing. `deps_install_failed` covers a FAILING
+// install; a no-op produced no signal at all. These tests pin the signal, the
+// forced relink, and — critically — that the force fires ONLY on a proven
+// mismatch (a blanket --force re-extracts 1168 packages, 3-8 s measured, on
+// every single refresh).
+
+describe("changedLockfiles (CTL-1831)", () => {
+  test("maps a root bun.lock change to the checkout root", () => {
+    expect(changedLockfiles("/repo", "bun.lock\n")).toEqual([{ rel: "bun.lock", dir: "/repo" }]);
+  });
+
+  test("maps a nested bun.lock change to its own dir", () => {
+    expect(changedLockfiles("/repo", "plugins/dev/scripts/orch-monitor/ui/bun.lock\n")).toEqual([
+      {
+        rel: "plugins/dev/scripts/orch-monitor/ui/bun.lock",
+        dir: "/repo/plugins/dev/scripts/orch-monitor/ui",
+      },
+    ]);
+  });
+
+  test("a package.json-only change yields no lockfile to audit", () => {
+    expect(changedLockfiles("/repo", "package.json\nsrc/index.ts\n")).toEqual([]);
+  });
+
+  test("does not match a file merely ENDING in bun.lock", () => {
+    expect(changedLockfiles("/repo", "vendor/notbun.lock\n")).toEqual([]);
+  });
+
+  test("dedupes a repeated path and tolerates empty input", () => {
+    expect(changedLockfiles("/repo", "bun.lock\nbun.lock\n")).toHaveLength(1);
+    expect(changedLockfiles("/repo", "")).toEqual([]);
+    expect(changedLockfiles("/repo", null)).toEqual([]);
+  });
+});
+
+describe("bunInstallArgv (CTL-1831)", () => {
+  test("frozen is the default — the checkout was just reset, so the lockfile IS authoritative", () => {
+    expect(bunInstallArgv()).toEqual(["install", "--frozen-lockfile"]);
+  });
+
+  test("the non-frozen fallback drops the flag rather than adding another", () => {
+    expect(bunInstallArgv({ frozen: false })).toEqual(["install"]);
+  });
+
+  test("force is the only argv that actually relinks a transitive-only change", () => {
+    expect(bunInstallArgv({ force: true })).toEqual(["install", "--force"]);
+  });
+});
+
+describe("workspaceRootsFor (CTL-1831)", () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "ctl1831-roots-"));
+  });
+
+  test("the lock dir itself is always a root, even with no manifest", () => {
+    expect(workspaceRootsFor(dir)).toEqual([dir]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("literal workspace members with a package.json are added", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ workspaces: ["pkg/a", "pkg/b"] }));
+    mkdirSync(join(dir, "pkg", "a"), { recursive: true });
+    writeFileSync(join(dir, "pkg", "a", "package.json"), "{}");
+    // pkg/b has no package.json → not a member dir anything can resolve from.
+    expect(workspaceRootsFor(dir)).toEqual([dir, join(dir, "pkg", "a")]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a GLOB entry is skipped, not expanded", () => {
+    // `packages/y` is a REAL package dir that only the glob could reach — the
+    // literal list names `packages/x` alone. Without a decoy the glob entry
+    // resolves to a path named "*" that has no package.json and is dropped for
+    // the wrong reason, so the assertion would pass whether or not the glob
+    // guard exists.
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ workspaces: ["packages/*", "packages/x"] }));
+    mkdirSync(join(dir, "packages", "x"), { recursive: true });
+    writeFileSync(join(dir, "packages", "x", "package.json"), "{}");
+    mkdirSync(join(dir, "packages", "y"), { recursive: true });
+    writeFileSync(join(dir, "packages", "y", "package.json"), "{}");
+    expect(workspaceRootsFor(dir)).toEqual([dir, join(dir, "packages", "x")]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", () => {
+  beforeEach(() => __clearThrottleForTest());
+
+  const OLD_LOCK = "OLD-LOCK-TEXT";
+  const NEW_LOCK = "NEW-LOCK-TEXT";
+
+  // git stub that also answers `show <sha>:<path>` with the pre-pull lockfile.
+  function makeAuditGitFn({ diffOutput = "bun.lock\n" } = {}) {
+    const calls = [];
+    const gitFn = (root, args) => {
+      calls.push({ root, args });
+      const sub = args[0];
+      if (sub === "rev-parse") {
+        const seen = calls.filter((c) => c.args[0] === "rev-parse").length;
+        return seen === 1 ? "oldsha" : "newsha";
+      }
+      if (sub === "diff") return diffOutput;
+      if (sub === "show") return OLD_LOCK;
+      return "";
+    };
+    gitFn.calls = calls;
+    return gitFn;
+  }
+
+  const MISMATCH = {
+    conclusive: true,
+    reason: null,
+    checked: 1,
+    matched: [],
+    mismatched: [
+      {
+        key: "@catalyst-cloud/schema",
+        id: "@catalyst-cloud/schema",
+        from: "0.1.3",
+        to: "0.1.5",
+        expected: "0.1.5",
+        found: ["0.1.3"],
+        importers: ["@catalyst-cloud/sdk"],
+        paths: [],
+      },
+    ],
+    alternates: [],
+    inconclusive: [],
+  };
+  const CLEAN = {
+    conclusive: true,
+    reason: null,
+    checked: 1,
+    matched: [{}],
+    mismatched: [],
+    alternates: [],
+    inconclusive: [],
+  };
+
+  // baseArgs — everything refreshPluginCheckout needs to reach the audit.
+  function baseArgs(overrides = {}) {
+    return {
+      root: "/repo",
+      now: 0,
+      emitFn: () => {},
+      readFileFn: () => NEW_LOCK,
+      workspaceRootsFn: () => ["/repo"],
+      resolvePackageFn: () => null,
+      ...overrides,
+    };
+  }
+
+  test("a CLEAN audit runs the install exactly once — no --force, no noop event", () => {
+    const installs = [];
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: (dir, opts) => installs.push({ dir, opts }),
+        auditFn: () => CLEAN,
+      }),
+    );
+    expect(installs).toHaveLength(1);
+    expect(installs[0].opts?.force).toBeFalsy();
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_install_noop")).toBe(false);
+  });
+
+  test("THE DEFECT: a mismatch after a 0-exit install emits deps_install_noop (WARN) naming the importer", () => {
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => MISMATCH,
+      }),
+    );
+    const ev = emitted.find((e) => e.event === "plugin.checkout.deps_install_noop");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.package_dir).toBe("/repo");
+    expect(ev.detail.mismatched[0].id).toBe("@catalyst-cloud/schema");
+    expect(ev.detail.mismatched[0].importers).toContain("@catalyst-cloud/sdk");
+  });
+
+  test("a mismatch triggers a SECOND install with force:true", () => {
+    const installs = [];
+    let audits = 0;
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        bunInstallFn: (dir, opts) => installs.push({ dir, opts }),
+        auditFn: () => (++audits === 1 ? MISMATCH : CLEAN),
+      }),
+    );
+    expect(installs).toHaveLength(2);
+    expect(installs[1]).toEqual({ dir: "/repo", opts: { force: true } });
+  });
+
+  test("a successful relink lands in plugin.checkout.updated → deps_relinked", () => {
+    const emitted = [];
+    let audits = 0;
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => (++audits === 1 ? MISMATCH : CLEAN),
+      }),
+    );
+    const upd = emitted.find((e) => e.event === "plugin.checkout.updated");
+    expect(upd.detail.deps_relinked).toEqual(["/repo"]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_relink_failed")).toBe(false);
+  });
+
+  test("a force that does NOT fix it emits deps_relink_failed (ERROR) and claims no relink", () => {
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => MISMATCH, // still mismatched after the force
+      }),
+    );
+    const fail = emitted.find((e) => e.event === "plugin.checkout.deps_relink_failed");
+    expect(fail).toBeDefined();
+    expect(fail.severity).toBe("ERROR");
+    expect(emitted.find((e) => e.event === "plugin.checkout.updated").detail.deps_relinked).toEqual([]);
+  });
+
+  test("a THROWING forced install surfaces deps_install_failed(forced) and never crashes the refresh", () => {
+    const emitted = [];
+    let installs = 0;
+    const res = refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {
+          installs += 1;
+          if (installs === 2) throw new Error("bun install --force exploded");
+        },
+        auditFn: () => MISMATCH,
+      }),
+    );
+    const fail = emitted.find(
+      (e) => e.event === "plugin.checkout.deps_install_failed" && e.detail.forced === true,
+    );
+    expect(fail).toBeDefined();
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_relink_failed")).toBe(false);
+    expect(res.changed).toBe(true);
+  });
+
+  test("an INCONCLUSIVE audit is surfaced and does NOT force — 'could not look' is not 'stale'", () => {
+    const installs = [];
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: (dir, opts) => installs.push({ dir, opts }),
+        auditFn: () => ({
+          conclusive: false,
+          reason: "previous lockfile unavailable",
+          checked: 0,
+          matched: [],
+          mismatched: [],
+          alternates: [],
+          inconclusive: [],
+        }),
+      }),
+    );
+    const ev = emitted.find((e) => e.event === "plugin.checkout.deps_audit_inconclusive");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.reason).toBe("previous lockfile unavailable");
+    expect(installs).toHaveLength(1);
+  });
+
+  test("a per-entry inconclusive verdict is surfaced too, even on a conclusive audit", () => {
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => ({
+          conclusive: true,
+          reason: null,
+          checked: 1,
+          matched: [],
+          mismatched: [],
+          alternates: [],
+          inconclusive: [{ key: "x", id: "x", to: "1.0.0", reason: "no importer on disk resolves x" }],
+        }),
+      }),
+    );
+    const ev = emitted.find((e) => e.event === "plugin.checkout.deps_audit_inconclusive");
+    expect(ev).toBeDefined();
+    expect(ev.detail.inconclusive[0].id).toBe("x");
+  });
+
+  test("a THROWING audit degrades to inconclusive — the guardrail cannot take down the refresh", () => {
+    const emitted = [];
+    const installs = [];
+    const res = refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: (dir, opts) => installs.push({ dir, opts }),
+        auditFn: () => {
+          throw new Error("resolver blew up");
+        },
+      }),
+    );
+    const ev = emitted.find((e) => e.event === "plugin.checkout.deps_audit_inconclusive");
+    expect(ev).toBeDefined();
+    expect(ev.detail.reason).toContain("resolver blew up");
+    expect(installs).toHaveLength(1);
+    expect(res.changed).toBe(true);
+  });
+
+  test("the pre-pull lockfile is read with `git show <oldSha>:<rel>`", () => {
+    const gitFn = makeAuditGitFn({ diffOutput: "plugins/dev/scripts/orch-monitor/ui/bun.lock\n" });
+    let seen = null;
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn,
+        bunInstallFn: () => {},
+        auditFn: (a) => {
+          seen = a;
+          return CLEAN;
+        },
+      }),
+    );
+    expect(
+      gitFn.calls.some(
+        (c) =>
+          c.args[0] === "show" && c.args[1] === "oldsha:plugins/dev/scripts/orch-monitor/ui/bun.lock",
+      ),
+    ).toBe(true);
+    expect(seen.oldLockText).toBe(OLD_LOCK);
+    expect(seen.newLockText).toBe(NEW_LOCK);
+  });
+
+  test("no bun.lock in the diff → the audit never runs (package.json-only change)", () => {
+    let audits = 0;
+    const installs = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn({ diffOutput: "plugins/dev/scripts/orch-monitor/ui/package.json\n" }),
+        bunInstallFn: (dir, opts) => installs.push({ dir, opts }),
+        auditFn: () => {
+          audits += 1;
+          return MISMATCH;
+        },
+      }),
+    );
+    expect(audits).toBe(0);
+    expect(installs).toHaveLength(1);
+  });
+
+  test("an install that FAILED is never audited or forced — the tree was never built", () => {
+    let audits = 0;
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {
+          throw new Error("frozen lockfile rejected");
+        },
+        auditFn: () => {
+          audits += 1;
+          return MISMATCH;
+        },
+      }),
+    );
+    expect(audits).toBe(0);
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_install_failed")).toBe(true);
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_install_noop")).toBe(false);
   });
 });

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -1820,7 +1820,7 @@ describe("workspaceRootsFor (CTL-1831)", () => {
   });
 
   test("the lock dir itself is always a root, even with no manifest", () => {
-    expect(workspaceRootsFor(dir)).toEqual([dir]);
+    expect(workspaceRootsFor(dir)).toEqual([{ dir, name: null }]);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -1829,7 +1829,35 @@ describe("workspaceRootsFor (CTL-1831)", () => {
     mkdirSync(join(dir, "pkg", "a"), { recursive: true });
     writeFileSync(join(dir, "pkg", "a", "package.json"), "{}");
     // pkg/b has no package.json → not a member dir anything can resolve from.
-    expect(workspaceRootsFor(dir)).toEqual([dir, join(dir, "pkg", "a")]);
+    expect(workspaceRootsFor(dir)).toEqual([
+      { dir, name: null },
+      { dir: join(dir, "pkg", "a"), name: null },
+    ]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("each root carries its own package NAME — the discriminator the bare-key audit sheds a nested member with", () => {
+    // Without the name the audit cannot tell WHICH member root a `<member>/<id>`
+    // lock key shadows, and falls back to shedding every nameless root. Mutating
+    // either `manifestNameAt` call site to `null` fails this assertion.
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "the-root", workspaces: ["pkg/named", "pkg/nameless", "pkg/broken"] }),
+    );
+    mkdirSync(join(dir, "pkg", "named"), { recursive: true });
+    writeFileSync(join(dir, "pkg", "named", "package.json"), JSON.stringify({ name: "member-ui" }));
+    mkdirSync(join(dir, "pkg", "nameless"), { recursive: true });
+    writeFileSync(join(dir, "pkg", "nameless", "package.json"), "{}");
+    // A member whose manifest EXISTS but does not parse is still a resolvable
+    // dir — membership stays keyed on existence, the name is what degrades.
+    mkdirSync(join(dir, "pkg", "broken"), { recursive: true });
+    writeFileSync(join(dir, "pkg", "broken", "package.json"), "{ not json");
+    expect(workspaceRootsFor(dir)).toEqual([
+      { dir, name: "the-root" },
+      { dir: join(dir, "pkg", "named"), name: "member-ui" },
+      { dir: join(dir, "pkg", "nameless"), name: null },
+      { dir: join(dir, "pkg", "broken"), name: null },
+    ]);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -1853,7 +1881,10 @@ describe("workspaceRootsFor (CTL-1831)", () => {
     writeFileSync(join(dir, "packages", "y", "package.json"), "{}");
     mkdirSync(join(dir, "packages", "*"), { recursive: true });
     writeFileSync(join(dir, "packages", "*", "package.json"), "{}");
-    expect(workspaceRootsFor(dir)).toEqual([dir, join(dir, "packages", "x")]);
+    expect(workspaceRootsFor(dir)).toEqual([
+      { dir, name: null },
+      { dir: join(dir, "packages", "x"), name: null },
+    ]);
     rmSync(dir, { recursive: true, force: true });
   });
 });
@@ -2169,7 +2200,6 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
         paths: [],
       },
     ],
-    alternates: [],
     inconclusive: [],
   };
   const CLEAN = {
@@ -2178,7 +2208,6 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
     checked: 1,
     matched: [{}],
     mismatched: [],
-    alternates: [],
     inconclusive: [],
   };
 
@@ -2259,6 +2288,104 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
     expect(emitted.some((e) => e.event === "plugin.checkout.deps_relink_failed")).toBe(false);
   });
 
+  // ── the post-force re-audit must be CONCLUSIVE before it may claim repair ──
+  //
+  // A re-audit that throws, or one whose entries come back per-entry
+  // inconclusive, carries an EMPTY `mismatched` — byte-identical to a genuinely
+  // repaired tree. Reading that emptiness as success is a check-that-cannot-fail
+  // sitting inside the fix for a check-that-cannot-fail: the refresh would
+  // announce a known mismatch repaired with no positive evidence, and emit no
+  // doubt at all. Mutating the guard back to `else { depsRelinked.push(...) }`
+  // fails both tests below.
+
+  test("a post-force re-audit that THROWS claims no relink and says so, loudly", () => {
+    const emitted = [];
+    let audits = 0;
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => {
+          audits += 1;
+          if (audits === 1) return MISMATCH;
+          throw new Error("package manifest momentarily unreadable");
+        },
+      }),
+    );
+    expect(emitted.find((e) => e.event === "plugin.checkout.updated").detail.deps_relinked).toEqual([]);
+    const ev = emitted.find(
+      (e) => e.event === "plugin.checkout.deps_audit_inconclusive" && e.detail.forced === true,
+    );
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.reason).toContain("package manifest momentarily unreadable");
+    // Not silently reclassified as a relink FAILURE either — we do not know that.
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_relink_failed")).toBe(false);
+  });
+
+  test("a post-force re-audit with PER-ENTRY inconclusives claims no relink", () => {
+    // conclusive:true and mismatched:[] — the shape that looks cleanest of all,
+    // and still proves nothing: no importer could be read for the entry.
+    const emitted = [];
+    let audits = 0;
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () =>
+          ++audits === 1
+            ? MISMATCH
+            : {
+                conclusive: true,
+                reason: null,
+                checked: 1,
+                matched: [],
+                mismatched: [],
+                inconclusive: [
+                  {
+                    key: "@catalyst-cloud/schema",
+                    id: "@catalyst-cloud/schema",
+                    to: "0.1.5",
+                    reason: "no importer on disk resolves @catalyst-cloud/schema",
+                  },
+                ],
+              },
+      }),
+    );
+    expect(emitted.find((e) => e.event === "plugin.checkout.updated").detail.deps_relinked).toEqual([]);
+    const ev = emitted.find(
+      (e) => e.event === "plugin.checkout.deps_audit_inconclusive" && e.detail.forced === true,
+    );
+    expect(ev).toBeDefined();
+    expect(ev.detail.inconclusive[0].id).toBe("@catalyst-cloud/schema");
+  });
+
+  test("the detection-pass and post-force inconclusives are distinguishable by `forced`", () => {
+    // Both emit the same event name; an operator (and any alert) has to be able
+    // to tell "could not look BEFORE remediating" from "could not confirm the
+    // remediation". Dropping either `forced` literal fails this.
+    const emitted = [];
+    refreshPluginCheckout(
+      baseArgs({
+        gitFn: makeAuditGitFn(),
+        emitFn: (e) => emitted.push(e),
+        bunInstallFn: () => {},
+        auditFn: () => ({
+          conclusive: false,
+          reason: "previous lockfile unavailable",
+          checked: 0,
+          matched: [],
+          mismatched: [],
+          inconclusive: [],
+        }),
+      }),
+    );
+    const ev = emitted.find((e) => e.event === "plugin.checkout.deps_audit_inconclusive");
+    expect(ev.detail.forced).toBe(false);
+  });
+
   test("a force that does NOT fix it emits deps_relink_failed (ERROR) and claims no relink", () => {
     const emitted = [];
     refreshPluginCheckout(
@@ -2311,7 +2438,6 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
           checked: 0,
           matched: [],
           mismatched: [],
-          alternates: [],
           inconclusive: [],
         }),
       }),
@@ -2336,7 +2462,6 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
           checked: 1,
           matched: [],
           mismatched: [],
-          alternates: [],
           inconclusive: [{ key: "x", id: "x", to: "1.0.0", reason: "no importer on disk resolves x" }],
         }),
       }),

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -16,7 +16,7 @@
 // Run: bun test plugins/dev/scripts/broker/plugin-refresh.test.mjs
 
 import { describe, test, expect, beforeEach } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -33,6 +33,7 @@ import {
   changedLockfiles,
   bunInstallArgv,
   workspaceRootsFor,
+  defaultResolvePackageFn,
   workspaceMemberNodeModules,
   PLUGIN_REFRESH_THROTTLE_MS,
   PLUGIN_DRIFT_CHECK_INTERVAL_MS,
@@ -1832,19 +1833,298 @@ describe("workspaceRootsFor (CTL-1831)", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("a GLOB entry is skipped, not expanded", () => {
-    // `packages/y` is a REAL package dir that only the glob could reach — the
-    // literal list names `packages/x` alone. Without a decoy the glob entry
-    // resolves to a path named "*" that has no package.json and is dropped for
-    // the wrong reason, so the assertion would pass whether or not the glob
-    // guard exists.
+  test("a GLOB entry is skipped, not expanded — and not merely dropped for the wrong reason", () => {
+    // TWO decoys, killing two different mutations, because either one alone
+    // leaves the assertion passing on broken code:
+    //
+    //   packages/*  — a directory LITERALLY named "*" (a legal filename), with a
+    //     package.json. Deleting the `entry.includes("*")` guard does not add
+    //     glob EXPANSION, so without this decoy the literal path `packages/*`
+    //     simply has no package.json and is dropped by the existsFn check on the
+    //     next line — the right answer for the wrong reason, and the guard
+    //     survives its own mutation. With the decoy, dropping the guard admits
+    //     `<dir>/packages/*` as a root and the assertion fails.
+    //   packages/y  — a real package dir reachable ONLY by expanding the glob, so
+    //     an implementation that started expanding globs also fails.
     writeFileSync(join(dir, "package.json"), JSON.stringify({ workspaces: ["packages/*", "packages/x"] }));
     mkdirSync(join(dir, "packages", "x"), { recursive: true });
     writeFileSync(join(dir, "packages", "x", "package.json"), "{}");
     mkdirSync(join(dir, "packages", "y"), { recursive: true });
     writeFileSync(join(dir, "packages", "y", "package.json"), "{}");
+    mkdirSync(join(dir, "packages", "*"), { recursive: true });
+    writeFileSync(join(dir, "packages", "*", "package.json"), "{}");
     expect(workspaceRootsFor(dir)).toEqual([dir, join(dir, "packages", "x")]);
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ─── defaultResolvePackageFn (CTL-1831) ──────────────────────────────────────
+//
+// The one component of the audit that touches disk, and — until this block — the
+// one with no coverage at all: every audit test injects a fake resolvePackageFn
+// and every refresh test injects a fake auditFn, so the production probe was
+// exercised by nothing. It shipped answering from Node's PROCESS-WIDE module
+// resolution cache, which made the post-force RE-audit report a FALSE
+// deps_relink_failed on every real repair and made a long-lived daemon
+// permanently blind to a tree that went stale after its first clean audit.
+// These tests run against a REAL temp tree in the isolated-linker layout the
+// incident occurred in.
+
+// isolatedTree — a minimal bun isolated-linker layout:
+//   node_modules/.bun/<pkg>@<ver>/node_modules/<pkg>/     the real copies
+//   node_modules/<pkg>                        -> symlink into the store
+// linkTo(pkg, ver) repoints that symlink, which is exactly what an install does
+// when it relinks a moved resolution.
+function isolatedTree(versionsByPkg) {
+  const root = mkdtempSync(join(tmpdir(), "ctl1831-tree-"));
+  const store = join(root, "node_modules", ".bun");
+  mkdirSync(store, { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "host", version: "1.0.0" }));
+  for (const [pkg, versions] of Object.entries(versionsByPkg)) {
+    for (const version of versions) {
+      const dir = join(store, `${pkg.replace("/", "+")}@${version}`, "node_modules", ...pkg.split("/"));
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "package.json"), JSON.stringify({ name: pkg, version }));
+    }
+  }
+  const linkTo = (fromDir, pkg, version) => {
+    const at = join(fromDir, "node_modules", ...pkg.split("/"));
+    mkdirSync(join(at, ".."), { recursive: true });
+    try {
+      rmSync(at, { force: true, recursive: false });
+    } catch {
+      /* first link — nothing to remove */
+    }
+    symlinkSync(join(store, `${pkg.replace("/", "+")}@${version}`, "node_modules", ...pkg.split("/")), at, "dir");
+  };
+  const storeDirOf = (pkg, version) =>
+    join(store, `${pkg.replace("/", "+")}@${version}`, "node_modules", ...pkg.split("/"));
+  return { root, store, linkTo, storeDirOf, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe("defaultResolvePackageFn (CTL-1831)", () => {
+  test("reads the version off the entry the importer's node_modules actually points at", () => {
+    const t = isolatedTree({ "@scope/dep": ["0.1.3", "0.1.5"] });
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    const got = defaultResolvePackageFn(t.root, "@scope/dep");
+    expect(got.version).toBe("0.1.5");
+    // dir is the realpath'd STORE entry, not the link — a mismatch report has to
+    // name the bytes, since both versions sit in the store simultaneously.
+    expect(got.dir).toBe(realpathSync(t.storeDirOf("@scope/dep", "0.1.5")));
+    t.cleanup();
+  });
+
+  test("THE DEFECT: a SECOND call in the SAME process sees the relink — no resolution cache in the path", () => {
+    // This is F2 at the unit altitude, and the assertion the shipped probe could
+    // not pass: createRequire().resolve() answers from a process-wide cache that
+    // a fresh createRequire does not clear. Measured pre-fix, one process:
+    //   before: symlink 0.1.5 -> resolve 0.1.5 | after flip: symlink 0.1.3 -> resolve 0.1.5
+    const t = isolatedTree({ "@scope/dep": ["0.1.3", "0.1.5"] });
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    expect(defaultResolvePackageFn(t.root, "@scope/dep").version).toBe("0.1.5");
+    t.linkTo(t.root, "@scope/dep", "0.1.3");
+    expect(defaultResolvePackageFn(t.root, "@scope/dep").version).toBe("0.1.3");
+    // …and back again, so the test cannot pass on an implementation that merely
+    // caches the LAST answer rather than the first.
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    expect(defaultResolvePackageFn(t.root, "@scope/dep").version).toBe("0.1.5");
+    t.cleanup();
+  });
+
+  test("the incident's own shape: the schema resolved THROUGH the SDK, with no top-level copy", () => {
+    // Under the isolated linker the workspace root has no @scope/schema at all,
+    // so a top-level probe reports "absent" and never sees what the daemon loads.
+    const t = isolatedTree({ "@scope/sdk": ["0.8.2"], "@scope/schema": ["0.1.3", "0.1.5"] });
+    t.linkTo(t.root, "@scope/sdk", "0.8.2");
+    const sdkDir = t.storeDirOf("@scope/sdk", "0.8.2");
+    t.linkTo(sdkDir, "@scope/schema", "0.1.3");
+    expect(defaultResolvePackageFn(t.root, "@scope/schema")).toBeNull();
+    const sdk = defaultResolvePackageFn(t.root, "@scope/sdk");
+    expect(defaultResolvePackageFn(sdk.dir, "@scope/schema").version).toBe("0.1.3");
+    t.cleanup();
+  });
+
+  test("climbs the node_modules ladder — a nested importer resolves the parent's copy", () => {
+    const t = isolatedTree({ "@scope/dep": ["0.1.5"] });
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    const deep = join(t.root, "packages", "a", "src");
+    mkdirSync(deep, { recursive: true });
+    expect(defaultResolvePackageFn(deep, "@scope/dep").version).toBe("0.1.5");
+    t.cleanup();
+  });
+
+  test("an id with no entry anywhere up the ladder is null — not a guessed version", () => {
+    const t = isolatedTree({ "@scope/dep": ["0.1.5"] });
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    expect(defaultResolvePackageFn(t.root, "@scope/absent")).toBeNull();
+    t.cleanup();
+  });
+
+  test("a manifest with no usable version is null — the audit reads that as 'could not look'", () => {
+    const t = isolatedTree({});
+    const at = join(t.root, "node_modules", "broken");
+    mkdirSync(at, { recursive: true });
+    writeFileSync(join(at, "package.json"), JSON.stringify({ name: "broken" })); // no version
+    expect(defaultResolvePackageFn(t.root, "broken")).toBeNull();
+    writeFileSync(join(at, "package.json"), "{not json");
+    expect(defaultResolvePackageFn(t.root, "broken")).toBeNull();
+    t.cleanup();
+  });
+
+  test("a realpath failure keeps the literal path — the VERSION is the verdict, never nulled", () => {
+    const t = isolatedTree({ "@scope/dep": ["0.1.5"] });
+    t.linkTo(t.root, "@scope/dep", "0.1.5");
+    const got = defaultResolvePackageFn(t.root, "@scope/dep", {
+      realpathFn: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(got.version).toBe("0.1.5");
+    expect(got.dir).toBe(join(t.root, "node_modules", "@scope", "dep"));
+    t.cleanup();
+  });
+
+  test("a missing or non-string argument is null, never a probe of the wrong directory", () => {
+    expect(defaultResolvePackageFn("", "dep")).toBeNull();
+    expect(defaultResolvePackageFn(null, "dep")).toBeNull();
+    expect(defaultResolvePackageFn("/tmp", "")).toBeNull();
+    expect(defaultResolvePackageFn("/tmp", undefined)).toBeNull();
+  });
+});
+
+// ─── the audit end-to-end, against a REAL tree (CTL-1831) ────────────────────
+//
+// Every other refresh test injects auditFn, so the wiring was proven while the
+// thing being wired was not. These drive the SHIPPED refreshPluginCheckout with
+// resolvePackageFn / workspaceRootsFn / readFileFn / auditFn ALL at their
+// production defaults; only gitFn and bunInstallFn are faked, because the alt
+// is a network fetch and a 5 s 1168-package extract.
+
+describe("refreshPluginCheckout — audit against a REAL node_modules (CTL-1831)", () => {
+  const SCHEMA = "@scope/schema";
+  const SDK = "@scope/sdk";
+
+  // A bun.lock `packages` block in the real emitted shape (see this repo's own
+  // bun.lock): `"<key>": ["<name>@<version>", "<resolution>", {<meta>}, "<sha>"],`
+  const lockText = (schemaVersion) =>
+    [
+      "{",
+      '  "lockfileVersion": 1,',
+      '  "packages": {',
+      `    "${SCHEMA}": ["${SCHEMA}@${schemaVersion}", "", {}, "sha512-aaa"],`,
+      `    "${SDK}": ["${SDK}@0.8.2", "", { "dependencies": { "${SCHEMA}": "^0.1.3" } }, "sha512-bbb"],`,
+      "  }",
+      "}",
+      "",
+    ].join("\n");
+
+  // The incident's tree: the SDK is the only importer of the schema, and the
+  // schema link under the SDK is what a relink moves.
+  function incidentTree(schemaOnDisk) {
+    const t = isolatedTree({ [SDK]: ["0.8.2"], [SCHEMA]: ["0.1.3", "0.1.5"] });
+    t.linkTo(t.root, SDK, "0.8.2");
+    t.linkTo(t.storeDirOf(SDK, "0.8.2"), SCHEMA, schemaOnDisk);
+    writeFileSync(join(t.root, "bun.lock"), lockText("0.1.5")); // post-pull lockfile
+    return t;
+  }
+
+  function runRefresh(t, { forceRelinksTo = null } = {}) {
+    __clearThrottleForTest();
+    const emitted = [];
+    const installs = [];
+    let revParse = 0;
+    return {
+      emitted,
+      installs,
+      res: refreshPluginCheckout({
+        root: t.root,
+        now: Date.now(),
+        loadedCommit: null,
+        emitFn: (e) => emitted.push(e),
+        memberNodeModulesFn: () => [],
+        pruneFn: () => {},
+        gitFn: (_root, args) => {
+          if (args[0] === "rev-parse") return (revParse += 1) === 1 ? "oldsha" : "newsha";
+          if (args[0] === "diff") return "bun.lock\n";
+          if (args[0] === "show") return lockText("0.1.3"); // pre-pull lockfile
+          return "";
+        },
+        bunInstallFn: (_dir, opts) => {
+          installs.push(opts ?? null);
+          // Model bun exactly: the plain install is the measured NO-OP; only
+          // --force moves the link.
+          if (opts?.force && forceRelinksTo) t.linkTo(t.storeDirOf(SDK, "0.8.2"), SCHEMA, forceRelinksTo);
+        },
+      }),
+    };
+  }
+
+  test("a stale tree is DETECTED through the real resolver — deps_install_noop names the found version", () => {
+    const t = incidentTree("0.1.3");
+    const { emitted } = runRefresh(t);
+    const noop = emitted.find((e) => e.event === "plugin.checkout.deps_install_noop");
+    expect(noop).toBeDefined();
+    expect(noop.detail.mismatched[0].id).toBe(SCHEMA);
+    expect(noop.detail.mismatched[0].found).toEqual(["0.1.3"]);
+    expect(noop.detail.mismatched[0].expected).toBe("0.1.5");
+    expect(noop.detail.mismatched[0].importers).toContain(SDK);
+    t.cleanup();
+  });
+
+  test("a REPAIR reports success: force fires, the re-audit sees the new bytes, deps_relinked is non-empty", () => {
+    // F1. Pre-fix this emitted deps_relink_failed (ERROR, documented as
+    // unfixable) with deps_relinked:[] even though the force HAD relinked the
+    // tree — the re-audit was answering from the cache the first audit filled.
+    const t = incidentTree("0.1.3");
+    const { emitted, installs } = runRefresh(t, { forceRelinksTo: "0.1.5" });
+    expect(installs).toEqual([null, { force: true }]);
+    expect(emitted.some((e) => e.event === "plugin.checkout.deps_relink_failed")).toBe(false);
+    expect(emitted.find((e) => e.event === "plugin.checkout.updated").detail.deps_relinked).toEqual([t.root]);
+    t.cleanup();
+  });
+
+  test("a force that genuinely does not fix it still reports deps_relink_failed", () => {
+    // The other side of the same edge: the ERROR must stay reachable, or the fix
+    // above would have bought a detector that can never say no.
+    const t = incidentTree("0.1.3");
+    const { emitted } = runRefresh(t, { forceRelinksTo: null });
+    const fail = emitted.find((e) => e.event === "plugin.checkout.deps_relink_failed");
+    expect(fail).toBeDefined();
+    expect(fail.severity).toBe("ERROR");
+    expect(emitted.find((e) => e.event === "plugin.checkout.updated").detail.deps_relinked).toEqual([]);
+    t.cleanup();
+  });
+
+  test("TWO refreshes in ONE process: a clean pass does not blind the next one to a tree that went stale", () => {
+    // F2. Pre-fix, pass 2 returned CLEAN with a single non-forced install — the
+    // long-lived updater/broker daemon (setInterval) could never see an incident
+    // that began after its first successful audit.
+    const t = incidentTree("0.1.5"); // pass 1: the tree is CORRECT
+    const first = runRefresh(t);
+    expect(first.installs).toEqual([null]);
+    expect(first.emitted.some((e) => e.event === "plugin.checkout.deps_install_noop")).toBe(false);
+
+    t.linkTo(t.storeDirOf(SDK, "0.8.2"), SCHEMA, "0.1.3"); // the tree goes stale
+    const second = runRefresh(t, { forceRelinksTo: "0.1.5" });
+    const noop = second.emitted.find((e) => e.event === "plugin.checkout.deps_install_noop");
+    expect(noop).toBeDefined();
+    expect(noop.detail.mismatched[0].found).toEqual(["0.1.3"]);
+    expect(second.installs).toEqual([null, { force: true }]);
+    t.cleanup();
+  });
+
+  test("a correct tree stays quiet — no noop, no force, no inconclusive", () => {
+    // The positive control for every negative above: the same instrument on a
+    // tree known to be right returns a clean verdict, so a CLEAN result means
+    // "looked and found nothing", not "could not look".
+    const t = incidentTree("0.1.5");
+    const { emitted, installs } = runRefresh(t);
+    expect(installs).toEqual([null]);
+    const names = emitted.map((e) => e.event);
+    expect(names).not.toContain("plugin.checkout.deps_install_noop");
+    expect(names).not.toContain("plugin.checkout.deps_audit_inconclusive");
+    expect(names).toContain("plugin.checkout.updated");
+    t.cleanup();
   });
 });
 


### PR DESCRIPTION
Closes CTL-1831.

## The defect

`plugin-refresh.mjs` installs deps with `bun install --frozen-lockfile`, falling back to a plain `bun install`. **Neither relinks an existing `node_modules` when only a TRANSITIVE resolution changed.** Bun prints `Checked N installs … (no changes)` and exits 0 — so a successful install and an install that changed nothing are byte-identical to the caller.

**Measured on `mini` 2026-08-13**, immediately after #3337 moved the root `bun.lock` from `@catalyst-cloud/schema@0.1.3` to `0.1.5`. The refresh pulled the merge correctly — plugin-source HEAD `81380821` and `bun.lock` both right — and then, in the same directory:

| command | sdk-resolved schema |
| --- | --- |
| `bun install --frozen-lockfile` (what the refresh runs) | **0.1.3** — "no changes", exit 0 |
| `bun install` (its fallback) | **0.1.3** — "no changes", exit 0 |
| `bun install --force` | **0.1.5** |

The fleet was unblocked that day only by an operator running `--force` by hand on all three hosts. `deps_install_failed` already covered a FAILING install; a no-op produced **no signal at all**, which is why a correct lockfile reached every host's disk and still never reached the running code. This is the second link of the CTL-1506 chain (1 = the lockfile pin, fixed by #3337; 3 = the daemon restart, CTL-1659; 4 = detection, CTC-471 / CTL-1825).

## The mechanism

**Detect, then force — never force always.** A blanket `--force` re-extracts 1168 packages (3-8 s measured) on every refresh, so the refresh now AUDITS the tree *after* the normal install and escalates to `--force` only on a proven mismatch. `--frozen-lockfile` stays the default: the checkout was just reset to `origin/main`, so the lockfile IS authoritative.

**The discriminator is the IMPORTING package's resolved dependency, not the hoisted top-level copy.** `cloud-sync.mjs` imports the schema THROUGH the SDK, and under bun's isolated linker there is frequently no top-level copy at all — verified on this checkout, `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` while the SDK resolves it fine. A top-level probe would report "absent" or "fine" and never see the stale 0.1.3 the daemons load.

**Resolution, not enumeration.** bun's `.bun` store keeps stale entries after an upgrade — verified on this checkout, `@catalyst-cloud+schema@0.1.3` **and** `@0.1.5` are both present, as are `@catalyst-cloud+sdk@0.8.1` and `@0.8.2`. A version's presence on disk therefore says nothing about what any importer loads. Only a resolve from the importer's own directory answers that, and it is layout-agnostic: identical under the hoisted and isolated linkers.

New leaf **`broker/lock-resolution-audit.mjs`** — single injected `resolvePackageFn(fromDir, id)` seam, so the whole audit is testable without a real `node_modules`. It reads the entries whose resolution the pulled range MOVED, off a structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk:

- a **NESTED** key (`chalk/ansi-styles`) is judged from its own parent ONLY — judging it from the workspace root compares against a legitimately different hoisted copy and forces a needless re-extract;
- a **BARE** key is judged from the workspace roots plus every lockfile entry that DECLARES the id — that is what makes the SDK, not the root, the probe site for the incident above;
- an observed version the lockfile records ELSEWHERE for the same id is an `alternate`, not a mismatch. Only a version recorded NOWHERE proves the tree was not materialized from this lockfile — exactly the measured case (after #3337 the lockfile recorded 0.1.5 and only 0.1.5).

Every verdict is three-valued and fails closed: an unusable lockfile, an empty site list, an unlocatable importer, or a throwing probe each yield a **named INCONCLUSIVE**, never a clean pass. The empty-site guard is asserted BEFORE the per-entry loop, because `[].every(p)` is `true` and a zero-site loop printing an all-clear is a false-clean mechanism this repo has shipped before.

### Signals

| Event | Severity | Emitted when |
| --- | --- | --- |
| `plugin.checkout.deps_install_noop` | WARN | the install exited 0 and the tree still disagrees with the lockfile — emitted at DETECTION, before any remediation, so the record survives a failed force |
| `plugin.checkout.deps_relink_failed` | ERROR | still mismatched after `--force`; nothing further on this path fixes it |
| `plugin.checkout.deps_audit_inconclusive` | WARN | the audit could not conclude — "could not look" made distinguishable from "the tree is correct" |
| `plugin.checkout.deps_install_failed` | WARN | pre-existing; now also carries `forced: true` when the remediation install itself throws |

`plugin.checkout.updated` gains `deps_relinked`. The audit runs only for dirs whose install SUCCEEDED (a tree that was never built has nothing to audit) and is fail-open end to end — a throwing audit degrades to an inconclusive event and never takes down a refresh that already worked.

## Verification — literal numbers

**Command:** `cd plugins/dev/scripts/broker && bun test plugin-refresh.test.mjs lock-resolution-audit.test.mjs`

| | plugin-refresh.test.mjs | lock-resolution-audit.test.mjs | combined |
| --- | --- | --- | --- |
| merge base (`2e6cc7199`) | 97 pass / 0 fail, 205 expect() | — (new) | 97 / 0 |
| this branch | 121 pass / 0 fail | 32 pass / 0 fail | **151 pass / 0 fail, 334 expect()** |

Delta is exactly the 54 tests added here (24 wiring + 32 audit, minus 2 reworked in place — see below). Also green: `bun test barrel-exports.test.mjs` (3/0), `execution-core: bun test updater/plugin-pull-defer.test.mjs` (13/0), `bun test event-log-read-guard.test.mjs` (40/0), and the CI import-graph checks `bun build daemon.mjs`/`updater/updater.mjs --target=node` (both bundle clean).

**One pre-existing red, imported not introduced:** the whole-broker `bun test` reports 962 pass / 1 fail — `fence-held-fold.test.mjs › the broker stamps held_since for exactly the labels heldFor classifies` (`heldFor(["waiting"])` returns `"queued"`). Measured at the merge base by swapping this diff's three broker files back to `origin/main` and re-running that one suite: **13 pass / 1 fail there too.** It touches `orch-monitor/lib/board-data.mjs`'s `heldFor`, which this diff does not go near, and it is not in any CI allowlist. Out of scope here.

## Mutation proof

Every new assertion was proven able to fail by mutating the exact behaviour it targets, running both suites, and restoring. A revert that dies with "Cannot find module" proves nothing, so all 40 mutations below change behaviour, not existence. Baseline for every row: **151 pass / 0 fail.**

<details><summary>40 mutations — audit module (31) and refresh wiring (28 anchors, some shared)</summary>

| # | Mutation | Result | Killed |
| --- | --- | --- | --- |
| M1 | `splitLockKey`: don't consume the scope pair | 144/5 | scoped-key, deep-chain, + 3 audit |
| M2 | `splitLockKey`: guess a chain for a dangling scope | 148/1 | dangling-scope |
| M3 | `parseLockPackages`: split id/version at the FIRST `@` | 139/10 | 3 parse + incident + 6 audit |
| M4 | `parseLockPackages`: scan the whole file, not the packages block | 148/1 | packages-block-only |
| M5 | empty text reads as conclusive-clean | 146/3 | 3 inconclusive tests |
| M6 | no packages block reads as conclusive-clean | 148/1 | no-block-inconclusive |
| M7 | never record declared deps | 145/4 | declared-deps + 3 audit |
| M8 | a workspace link looks installable | 147/2 | workspace-link ×2 |
| M9 | `changedResolutions`: report only ADDED, never a move | 139/10 | the incident + 9 |
| M10 | an unparseable side no longer blocks | 147/2 | 2 inconclusive |
| M11 | workspace links treated as installable changes | 148/1 | workspace-path-move |
| M12 | drop the empty-site vacuity guard | 148/1 | empty-workspaceRoots |
| M13a/b/c | eager probe / miscount `checked` / probe on a no-op audit | 148/1, 146/3, 148/1 | throwing-resolver, 3 counts, zero-entries-no-probes |
| M14 | judge a NESTED key from the roots, not its parent | 147/2 | both nested tests |
| M15 | probe the disk on an audit that could not look | 148/1 | missing-old-lockfile |
| M16 | unprobeable entry falls through to matched | 147/2 | 2 inconclusive |
| M17 | never classify anything as a mismatch | 146/3 | incident, hoisted, nested-stale |
| M18 | a legitimate alternate reported as a mismatch | 148/1 | alternates |
| M19 | a throwing probe fabricates a version | 148/1 | throwing-resolver |
| M20 | probe only the workspace roots (the hoisted copy) | 146/3 | incident, relinked, **hoisted-vs-importer** |
| M21 | a mismatch does not name the importer | 147/2 | incident, nested-stale |
| M22 | a mismatch does not report the version found | 147/2 | incident, hoisted |
| M23 | an inconclusive verdict carries no reason | 148/1 | no-importer |
| M24 | corrupt an unscoped chain segment | 144/5 | 3 splitLockKey + 2 audit |
| M25 | an unusable key yields a guessed chain | 148/1 | empty-key |
| M26 | take the id from the KEY instead of the value | 145/4 | nested-id + 3 audit |
| M27 | an alternate does not report what was found | 148/1 | alternates |
| M28 | report every entry, changed or not | 139/11 | 5 changedResolutions + 6 audit |
| M29 | an added entry reports a fabricated previous version | 149/1 | added-entry |
| M30b | report REMOVED entries too | 149/1 | removed-entry |
| M31 | admit no lockfile entries at all | 133/17 | 17 |
| P1 | unanchored lockfile match | 149/1 | `notbun.lock` |
| P2 | every lockfile maps to the checkout root | 148/2 | nested-dir, git-show |
| P3 | audit package.json changes too | 148/2 | pkg-json-only ×2 |
| P4 / P5 | no dedupe / no null tolerance | 149/1 each | dedupe-and-empty |
| P6 | corrupt the relative path | 147/3 | root-dir, nested-dir, git-show |
| P7 / P8 / P9 | `bunInstallArgv`: drop `--force` / never frozen / always frozen | 149/1 each | one argv test each |
| P10 | lock dir is not a workspace root | 147/3 | all 3 roots tests |
| P11 | expand a glob entry to a real child dir | 149/1 | glob-skipped |
| P12 | add members with no package.json | 149/1 | literal-members |
| P13 | a detected no-op emits nothing | 149/1 | **THE DEFECT** |
| P14 | the remediation install is not forced | 149/1 | force:true |
| P15 | a mismatch is never acted on | 145/5 | 5 wiring tests |
| P16 | claim a relink the force did not achieve | 149/1 | relink-failed |
| P17 | a still-stale tree after `--force` is silent | 149/1 | relink-failed |
| P18 | a throwing forced install is swallowed | 149/1 | throwing-force |
| P19 | an inconclusive audit is silent | 148/2 | both inconclusive |
| P20 | audit a dir whose install failed | 149/1 | failed-install |
| P21 | read the POST-pull lockfile as the baseline | 149/1 | git-show |
| P22 | never read the current lockfile | 149/1 | git-show |
| P23 | blanket `--force` on the FIRST install | 149/1 | clean-audit-one-install |
| P24 / P25 | downgrade noop to INFO / relink-failed to WARN | 149/1 each | severity assertions |
| P26 | force on every audit outcome | 142/9 | 4 new + 5 pre-existing CTL-1223/1628 |
| P27 | drop `deps_relinked` from the updated event | 149/2 | 2 wiring |
| P28 | a throwing audit reads as conclusively clean | 150/1 | throwing-audit |

</details>

**Two mutations SURVIVED on the first pass and the tests were rewritten, not the mutations:**

1. `parseLockPackages` "only the packages block is scanned" — the fixture contained no top-level line matching the entry shape, so removing the block gate changed nothing. Fixed by adding a real `"trustedDependencies": ["esbuild@0.21.5"]` line, which the gate is now the only thing rejecting. M4 then killed it.
2. `workspaceRootsFor` "a GLOB entry is skipped, not expanded" — `resolve(dir, "packages/*")` has no `package.json`, so the entry was dropped for the wrong reason whether or not the glob guard existed. Fixed by adding a decoy `packages/y` that only an expanding implementation could reach. P11 then killed it.

A third assertion, `changedResolutions` "a REMOVED entry is not reported", was **vacuous as written** — it string-replaced an entry that was not in the fixture, so it compared a text with itself. It now drives an add/remove pair off one shared fixture, with an explicit non-vacuity control asserting the two texts really differ. M30b kills it.

## CI wiring

`grep plugin-refresh .github/workflows/` returned only two **comments** before this PR: `plugin-refresh.test.mjs` — 97 tests guarding the merge-to-main refresh, the deps install, the stale-index.lock clear and the pull-owner cutover — had **never run in CI at all**. Positive control: the same grep for `worker-state-projection` returns its `run:` line. The allowlist in `execution-core-tests.yml` is hand-enumerated, not globbed, so both suites are wired in explicitly as one new step (they cannot join the `bun test` list below it — that step's working-directory is `execution-core`, and `plugin-refresh.test.mjs` reaches `router.mjs`, which needs the broker package's own `pino`).

## Acceptance criteria

Both AC scenarios are implemented as written; neither needed rewriting.

- *"a transitive-only resolution change is actually installed"* → `lock-resolution-audit.test.mjs › THE INCIDENT` + the four `refreshPluginCheckout` wiring tests (`deps_install_noop` → `force:true` → re-audit → `deps_relinked`).
- *"the check is made against the importing package's resolved dependency, NOT the hoisted top-level copy"* → `the check reads the IMPORTER's resolution, not a hoisted top-level copy`, whose fixture puts a FRESH 0.1.5 at the workspace root and a STALE 0.1.3 under the SDK; mutation **M20** (probe only the roots) turns it red, so the test genuinely discriminates.
- The AC's own *"positive control — MUST FAIL if the fix is reverted"* scenario is the mutation table above: P13/P14/P15 revert the detection, the force, and the whole branch respectively, and each turns the suite red.

## Deferred scope

- **Deeply nested importers.** A bare key's declarers are located by resolving them from a workspace root. A declarer reachable only three levels down resolves to nothing and is reported INCONCLUSIVE (named, with the unlocatable ids) rather than probed. Walking the full lockfile graph would close that; the incident class does not need it, and an honest inconclusive is the correct fail direction.
- **`alternate` is deliberately lenient.** If the moved version's predecessor is still recorded somewhere else in the lockfile for the same id, an importer resolving it is reported as an alternate and does **not** force. That trades a rare missed relink for never paying a 3-8 s false-positive re-extract on every refresh.
- **Nothing reads the new events yet.** They land on `~/catalyst/events/YYYY-MM.jsonl` and ride otel-forward to Loki like the rest of `plugin.checkout.*`. A Grafana rule on `deps_install_noop` / `deps_relink_failed` belongs in `catalyst-otel`, and the currency gauge that would make them actionable is CTL-1825.
- **Link 3 is still open.** A relinked `node_modules` does not restart the daemon holding the old modules — that is CTL-1659, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
