### PR TITLE
fix(dev): CTL-1809 — make a bash event append exactly one write(2), so a concurrent producer cannot splice two events into one line

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -503,7 +503,7 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/deployment-mode-parity.test.sh
 
-      - name: Broker worker-state projection test (CTL-1529)
+      - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),
         # and `grep worker-state-projection .github/workflows/` used to return NOTHING —
@@ -514,8 +514,15 @@ jobs:
         # CTL-1628: the root workspace install above already covers broker's deps
         # (bun resolves the workspace root's node_modules from this cwd), so no
         # per-package install here anymore.
+        #
+        # CTL-1809: this list is HAND-MAINTAINED — an unlisted broker test simply never
+        # runs, which is the same trap CTL-1529 documents one paragraph up. tailer-torn
+        # guards the broker's live-tail torn-line counter; it is named explicitly rather
+        # than globbed because the rest of the broker suite has a pre-existing failure
+        # (fence-held-fold, red on origin/main) that a `bun test` glob here would import
+        # into this job as a new red.
         working-directory: plugins/dev/scripts/broker
-        run: bun test worker-state-projection.test.mjs
+        run: bun test worker-state-projection.test.mjs tailer-torn.test.mjs
 
       - name: catalyst-agent tests (CTL-1825)
         # catalyst-agent had NO CI coverage at all before CTL-1825

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -318,6 +318,20 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/canonical-event.test.sh
 
+      - name: event-append atomicity test (CTL-1809)
+        # The bash append seam must be exactly ONE write(2) per event: `printf >>` is
+        # ⌈n/BUFSIZ⌉ write() calls (BUFSIZ = 1024 on macOS, 8192 on glibc), so a line over
+        # that tears when a concurrent producer appends between them. Runs 8 concurrent
+        # producers x 150 lines at 1,025 B and at the real 19,086 B fleet maximum, and
+        # asserts BOTH halves of the contract — every line parses, AND every line's contents
+        # belong to exactly one event (a splice can parse perfectly; the RCA reproduced one).
+        # Carries its own positive control: the same harness on a naive `printf >>` must go
+        # RED, so a green run is evidence rather than a machine that happens not to tear.
+        # Also covers the hard 256 KiB cap + tombstone, the all-producers convergence scan,
+        # and catalyst-events' torn-line batch-abort fix.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/event-append-atomicity.test.sh
+
       - name: SKILL.md ${PLUGIN_ROOT} assignment guard (CTL-1832)
         # CTL-1832: a SKILL.md that EXPANDS ${PLUGIN_ROOT} must also ASSIGN it, or
         # the expansion is empty and the command silently addresses a bogus path.

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -712,6 +712,12 @@ jobs:
         #   out at 9 s locally under load (bun default 5 000 ms). The test
         #   relies on real-time event-log delivery latency.
         #   Memory ref: project_execution_core_daemon_flaky_test
+        #
+        #   CTL-1809 NOTE: because monitor.test.mjs is excluded, a monitor case added
+        #   there would never run here. monitor-torn.test.mjs is therefore a SEPARATE
+        #   file in the list below — it drives readNewEvents directly and calls
+        #   stopMonitor() before every append, so it arms no timer and no watcher
+        #   (measured max 1.6 s per case locally, vs bun's 5 000 ms default).
         run: |
           bun test \
             beliefs/advance-rules.test.mjs \
@@ -796,6 +802,7 @@ jobs:
             event-cursor.test.mjs \
             event-scan.test.mjs \
             event-tail.test.mjs \
+            monitor-torn.test.mjs \
             event-log-window.test.mjs \
             event-log-read-guard.test.mjs \
             lib/canonical-event.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,46 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
     (`canonical_note_v1_only`) — stderr because a separate CLI process cannot hand an exported var
     back, and because it rides the Alloy-shipped daemon `.log` rather than the event log whose
     degradation it reports.
+  - **One write(2) per bash append (CTL-1809).** Every bash producer appends through the single
+    seam `canonical_atomic_append_line` (`lib/canonical-event.sh`), which pipes the line through
+    `/bin/dd obs=1048576` — dd accumulates the whole line into one output block and issues exactly
+    one `write(2)` up to 1 MiB (`0+1 records out` for a 256 KiB input at `obs=1m`, vs `4+1` at
+    `obs=64k`). The replaced `printf '%s\n' … >>` is NOT atomic: `O_APPEND` makes the file *offset*
+    atomic, not a multi-`write(2)` sequence, and bash's builtin printf flushes through stdio in
+    BUFSIZ chunks (1024 on macOS, 8192 on glibc), so a line past BUFSIZ is ⌈n/BUFSIZ⌉ writes and a
+    concurrent producer's append lands between them. Measured at 8 producers × 150 lines:
+    658/1200 damaged at 1,025 B and 1,196/1200 at 19,086 B. Under the CTL-1795 superset envelope
+    two producers' *median* line already sits past the macOS threshold (`catalyst.phase-agent`
+    averages 1,075 B; `catalyst.worktree-salvage` 919 B), so this was latent, not theoretical.
+    `/bin/dd` is absolute because a restricted-`PATH` phase-agent worker is exactly where a
+    PATH-resolved helper becomes a silent no-op; there is deliberately no size branch and no
+    printf fallback in the primitive. **Hard cap 262,144 bytes** (byte length, 4.2× the observed
+    all-time fleet max of 62,597 B, inside dd's proven-atomic range): over it, the write is
+    REFUSED — never truncated or split — with a stderr WARNING carrying the size and event name,
+    plus a `catalyst.event.oversized` tombstone appended in-band. The tombstone carries its **own**
+    name, never the dropped event's: re-emitting the original name with a gutted payload would fire
+    that event's `wait-for` subscribers and the broker's phase-lifecycle router on fabricated
+    content. The **JS** writers are untouched — `appendFileSync` is already atomic far past this cap.
+    Seven bash sites converge on the seam (`canonical_jsonl_append`, `catalyst-state.sh`'s jq-less
+    branch, `emit-worker-status-change.sh`, `lib/emit-reap-intent.sh`, `lib/phase-emit-complete.sh`,
+    `catalyst-events`'s `wait.*` emitter, and `catalyst-stack`'s `_emit_checkout_updated` — the last
+    a whole-function stdout redirect rather than a `printf`, which is why it is the easiest to miss).
+    The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud**
+    one; `__tests__/event-append-atomicity.test.sh` scans for any silent raw append and recognizes
+    the exemption only by that warning.
+  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at three
+    readers — `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`),
+    `execution-core/event-tail.mjs` (`tornLineCount()`), and `catalyst-events`' filter
+    (`torn_lines_total` on stderr). Every one **advances past** the line: a torn line is permanently
+    corrupt, so parking a cursor on it would wedge the reader forever
+    (`event-tail.mjs:12-17`). `catalyst-events` was worse than skipping — plain
+    `jq -c "select(...)"` ABORTS at the first unparseable line (exit 5), so every valid event after
+    a torn one in the same wake batch was silently lost and a `wait-for` sharing that batch timed
+    out; it now uses `jq -R 'fromjson?'`. These counters are a **lower bound**, never proof of
+    cleanliness: the RCA reproduced a splice that parses as valid JSON with a matching declared
+    length and three different events' contents, which no parser can detect. A monitor node's count
+    legitimately EXCEEDS a worker's — event-mirror is a transport, not a repair layer, and a torn
+    line has no extractable id for its dedup ring to suppress.
   - Consumers: `catalyst-events tail` (stream), `catalyst-events wait-for` (blocking single-event).
     Both shapes handled. See `website/src/content/docs/observability/catalyst-events.md`.
 - **history/** — full snapshots archived on completion/failure/stale.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,10 +125,21 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
     `obs=64k`). The replaced `printf '%s\n' … >>` is NOT atomic: `O_APPEND` makes the file *offset*
     atomic, not a multi-`write(2)` sequence, and bash's builtin printf flushes through stdio in
     BUFSIZ chunks (1024 on macOS, 8192 on glibc), so a line past BUFSIZ is ⌈n/BUFSIZ⌉ writes and a
-    concurrent producer's append lands between them. Measured at 8 producers × 150 lines:
-    658/1200 damaged at 1,025 B and 1,196/1200 at 19,086 B. Under the CTL-1795 superset envelope
-    two producers' *median* line already sits past the macOS threshold (`catalyst.phase-agent`
-    averages 1,075 B; `catalyst.worktree-salvage` 919 B), so this was latent, not theoretical.
+    concurrent producer's append lands between them. Measured with
+    `__tests__/event-append-atomicity.test.sh` case 3 (the same 8-producer × 150-line harness run
+    through the naive `printf >>`), over 20 runs on two hosts — a 12-core M2 laptop (macOS 26.5,
+    bash 5.3) and a 10-core Mac mini (macOS 26.6, bash 3.2): **28–134 of 1,200** lines damaged at
+    1,025 B and **165–523 of 1,200** at 19,086 B. Those are ranges, not point values — the count
+    is load- and host-dependent and swung ~5× run to run on one host, so it is not a regression
+    threshold. What reproduces is the direction: the 19 KB line tore more often than the 1 KB line
+    in 20 of 20 runs (2.6–7.2×). Under the CTL-1795 superset envelope
+    a large share of one bash producer's lines already sits past the 1,024 B macOS threshold, so
+    this was latent, not theoretical. Measured on mini's `2026-08.jsonl` (through 2026-08-13):
+    `catalyst.phase-agent` n=671, mean 1,094 B, median 1,021 B, max 2,870 B — **40.8% of its lines
+    exceed 1,024 B**; `catalyst.worktree-salvage` n=4,891, mean 910 B, median 900 B, max 1,216 B —
+    1.9% exceed it. Note neither *median* clears the threshold (phase-agent's sits 3 bytes under
+    it); the exposure is the upper tail, not the typical line, and the mean is above the median in
+    both because that tail is what drags it there.
     `/bin/dd` is absolute because a restricted-`PATH` phase-agent worker is exactly where a
     PATH-resolved helper becomes a silent no-op; there is deliberately no size branch and no
     printf fallback in the primitive. **Hard cap 262,144 bytes** (byte length, 4.2× the observed
@@ -145,10 +156,19 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
     The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud**
     one; `__tests__/event-append-atomicity.test.sh` scans for any silent raw append and recognizes
     the exemption only by that warning.
-  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at three
+  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at four
     readers — `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`),
-    `execution-core/event-tail.mjs` (`tornLineCount()`), and `catalyst-events`' filter
-    (`torn_lines_total` on stderr). Every one **advances past** the line: a torn line is permanently
+    `execution-core/event-tail.mjs` (`tornLineCount()`), `broker/tailer.mjs`'s **live** tail, and
+    `catalyst-events`' filter (`torn_lines_total` on stderr). The broker is the load-bearing one —
+    it routes every `filter.wake`, every phase-lifecycle terminal, the ingestion-recency map and
+    the worker-state projection — and it is covered in two halves that must not be confused: its
+    **boot replay** goes through `tailParsedEvents` (counted inside `event-tail.mjs`), while its
+    **live** `readNewEvents` loop hand-rolls its own `JSON.parse` and calls the same module's
+    exported `noteTornLine` directly. Sharing one process counter (and one sparse-warn key budget)
+    across those two is deliberate: they are one detector reading one file. The
+    "one flood must not exhaust another detector's budget" rule applies **across** readers —
+    separate processes, separate files — not within a single process's view of one log.
+    Every reader **advances past** the line: a torn line is permanently
     corrupt, so parking a cursor on it would wedge the reader forever
     (`event-tail.mjs:12-17`). `catalyst-events` was worse than skipping — plain
     `jq -c "select(...)"` ABORTS at the first unparseable line (exit 5), so every valid event after

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,18 +156,38 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
     The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud**
     one; `__tests__/event-append-atomicity.test.sh` scans for any silent raw append and recognizes
     the exemption only by that warning.
-  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at four
-    readers — `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`),
-    `execution-core/event-tail.mjs` (`tornLineCount()`), `broker/tailer.mjs`'s **live** tail, and
-    `catalyst-events`' filter (`torn_lines_total` on stderr). The broker is the load-bearing one —
-    it routes every `filter.wake`, every phase-lifecycle terminal, the ingestion-recency map and
-    the worker-state projection — and it is covered in two halves that must not be confused: its
-    **boot replay** goes through `tailParsedEvents` (counted inside `event-tail.mjs`), while its
-    **live** `readNewEvents` loop hand-rolls its own `JSON.parse` and calls the same module's
-    exported `noteTornLine` directly. Sharing one process counter (and one sparse-warn key budget)
-    across those two is deliberate: they are one detector reading one file. The
+  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at the
+    readers listed below. This is a LIST OF THE COVERED SITES, not a census of every reader of the
+    log — read it as "these are instrumented", never as "these are all of them":
+    `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`), `execution-core/event-tail.mjs`
+    (`tornLineCount()`), `broker/tailer.mjs`'s **live** tail, `execution-core/monitor.mjs`'s
+    **live** `readNewEvents`, and `catalyst-events`' filter (`torn_lines_total` on stderr).
+    (`grep -n 'noteTornLine' plugins/dev/scripts` is the instrument that enumerates the JS half;
+    the count it returns is the number to trust, not this sentence.)
+
+    Two of those are **hand-rolled live tails of the same file, and they are peers** — the broker's
+    `readNewEvents` (`broker/tailer.mjs`) and the monitor's (`execution-core/monitor.mjs`), both
+    resolving `getEventLogPath()` to `~/catalyst/events/YYYY-MM.jsonl`, each driven for its whole
+    process lifetime. Neither is "the" load-bearing one. The broker routes every `filter.wake`,
+    every phase-lifecycle terminal, the ingestion-recency map and the worker-state projection; the
+    monitor routes `handleStateChangedEvent` → **dispatchTriage**, `handleIssueUpdatedEvent` → the
+    eligible projection fold, and `handleCommentCreatedEvent` → **onComment** (the CTL-768
+    comment-wake needs-input clear + worker redispatch). A torn line on either drops real work.
+
+    The broker is additionally covered in two halves that must not be confused: its **boot replay**
+    goes through `tailParsedEvents` (counted inside `event-tail.mjs`), while its **live**
+    `readNewEvents` loop hand-rolls its own `JSON.parse` and calls the same module's exported
+    `noteTornLine` directly — as the monitor's now does too. Sharing one process counter (and one
+    sparse-warn key budget) across those is deliberate: they are one detector reading one file. The
     "one flood must not exhaust another detector's budget" rule applies **across** readers —
     separate processes, separate files — not within a single process's view of one log.
+
+    Only COMPLETE lines are counted. Every hand-rolled reader holds its trailing fragment back
+    (`leftover`/`leftoverBuf`) until a newline arrives, because a poll landing mid-append sees a
+    nonempty final fragment that is a healthy in-flight write, not damage — and since the byte
+    cursor has already advanced, counting it would also let the record's suffix be counted a
+    second time on the next poll. A torn-line counter that counts healthy writes is not a
+    torn-line counter.
     Every reader **advances past** the line: a torn line is permanently
     corrupt, so parking a cursor on it would wedge the reader forever
     (`event-tail.mjs:12-17`). `catalyst-events` was worse than skipping — plain

--- a/plugins/dev/hooks/emit-lifecycle-event.sh
+++ b/plugins/dev/hooks/emit-lifecycle-event.sh
@@ -49,9 +49,15 @@ fi
 # status=failed because an unclean exit is always a failure from the broker's
 # perspective; reason field distinguishes this path from a normal end call.
 ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# CTL-1809: the TRAILING `2>/dev/null` (the one after the closing paren) applied to
+# canonical_jsonl_append itself, not to jq, and has been removed. It is the easiest of the
+# five to miss precisely because the call spans six lines and the inner jq redirect looks
+# like the same thing. The inner one stays — jq's parse noise is not actionable; the
+# primitive's refused-line / failed-write WARNING is. `|| true` stays too: a Stop hook must
+# never fail the session it is closing.
 canonical_jsonl_append "$EVENTS_DIR" \
   "$(jq -nc \
     --arg ts "$ts" \
     --arg sid "$CATALYST_SESSION_ID" \
     '{ts:$ts,event:"agent.checkout",detail:{session_id:$sid,status:"failed",reason:"lifecycle-hook-stop"}}' \
-    2>/dev/null)" 2>/dev/null || true
+    2>/dev/null)" || true

--- a/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
+++ b/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
@@ -296,4 +296,91 @@ grep -q 'torn_lines_total' "$ERRF" \
   || fail "the skipped line was silent — no counted operator-visible warning. stderr: $(cat "$ERRF")"
 pass "catalyst-events: torn line counted and skipped, the rest of the batch survives"
 
+# --- 8. No caller may re-silence the primitive's stderr ----------------------
+# The primitive reports a refused (over-cap) line and a failed dd on stderr and NOTHING else
+# — that WARNING is the whole loud-failure contract, and canonical-event.sh's own former
+# `2>/dev/null || true` is the silence this ticket removed. A caller that re-adds `2>/dev/null`
+# around the append undoes it locally: the event is still dropped, and the drop is silent
+# again. `|| true` is fine and expected (the emit is best-effort at most call sites); it is
+# only the stderr mute that is banned.
+#
+# Two shapes to catch, and the second is why this scan is not a plain grep:
+#   (a) `canonical_jsonl_append "$d" "$l" 2>/dev/null || true`     — on the call line;
+#   (b) a six-line call whose TRAILING `2>/dev/null` sits after the closing paren of an
+#       inner `$(jq …)` that has its OWN legitimate redirect. A line-oriented grep either
+#       misses (b) entirely or flags every builder's jq noise as a violation.
+# So: join backslash-continuations into one logical line, strip balanced `$(…)` spans (where
+# the legitimate inner redirects live), and only then look for a surviving `2>/dev/null`.
+scan_silenced_appends() {
+  awk '
+    # Depth-aware removal of $( … ) spans, so an inner jq redirect is not mistaken for the
+    # append being muted. Errs toward stripping MORE on an unbalanced span, i.e. toward a
+    # false NEGATIVE — which is exactly what decoy (c) below is positive control for.
+    function strip_cmdsub(s,   out, i, c, depth, n) {
+      out = ""; depth = 0; n = length(s)
+      for (i = 1; i <= n; i++) {
+        c = substr(s, i, 1)
+        if (depth == 0 && c == "$" && substr(s, i + 1, 1) == "(") { depth = 1; i++; continue }
+        if (depth > 0) {
+          if (c == "(") depth++
+          else if (c == ")") depth--
+          continue
+        }
+        out = out c
+      }
+      return out
+    }
+    FNR == 1 { acc = ""; startline = 0 }
+    {
+      line = $0
+      if (acc == "") startline = FNR
+      # Join a backslash-continuation onto the accumulator and wait for the real end.
+      if (line ~ /\\[[:space:]]*$/) { sub(/\\[[:space:]]*$/, "", line); acc = acc line; next }
+      acc = acc line
+      if (acc ~ /canonical_(atomic_append_line|jsonl_append)[[:space:]]/) {
+        bare = strip_cmdsub(acc)
+        if (bare ~ /2>[[:space:]]*\/dev\/null/)
+          printf "%s:%d:%s\n", FILENAME, startline, acc
+      }
+      acc = ""
+    }
+  ' "$@" 2>/dev/null || true
+}
+# Discover callers rather than hard-code them: a new file that calls the primitive must be
+# covered the day it lands, not the day someone remembers to add it to a list. plugins/dev,
+# not just scripts/, because the Stop hook (hooks/emit-lifecycle-event.sh) is a caller and
+# was one of the five.
+PLUGIN_DIR="$(dirname "$SCRIPTS_DIR")"
+CALLER_FILES=()
+while IFS= read -r f; do
+  case "$f" in */__tests__/*) continue ;; esac
+  CALLER_FILES+=("$f")
+done < <(grep -rlE 'canonical_(atomic_append_line|jsonl_append)[[:space:]]' "$PLUGIN_DIR" 2>/dev/null || true)
+[[ ${#CALLER_FILES[@]} -gt 0 ]] \
+  || fail "found NO callers of the append primitive — the discovery glob is broken, so a clean result here would be meaningless"
+SILENCED="$(scan_silenced_appends "${CALLER_FILES[@]}")"
+[[ -z "$SILENCED" ]] || fail "a caller re-silences the atomic append primitive's stderr — a loud fallback a caller mutes is a silent fallback (CTL-1809):
+$SILENCED"
+
+# POSITIVE CONTROLS, one per way this scan can fail silently.
+D="$(newdir)"; TMPS+=("$D")
+# (a) the plain single-line mute must be reported, or the scan is blind.
+printf 'canonical_jsonl_append "$d" "$l" 2>/dev/null || true\n' > "$D/silenced-simple.sh"
+[[ -n "$(scan_silenced_appends "$D/silenced-simple.sh")" ]] \
+  || fail "the silenced-append scan cannot detect a plain 2>/dev/null — the clean result above is meaningless"
+# (b) a builder's inner jq redirect must NOT be reported, or the scan is really "match
+#     everything" and (a) passed for the wrong reason.
+{ printf 'canonical_jsonl_append "$d" \\\n'
+  printf '  "$(jq -nc --arg t "$ts" %s 2>/dev/null)" || true\n' "'{ts:\$t}'"; } > "$D/ok-inner-jq.sh"
+[[ -z "$(scan_silenced_appends "$D/ok-inner-jq.sh")" ]] \
+  || fail "the scan flags a legitimate inner jq redirect — it would force callers to un-mute jq noise"
+# (c) the multi-line TRAILING mute — the emit-lifecycle-event.sh shape, the one of the five
+#     that a line-oriented grep misses. If this decoy is not reported, the scan is only
+#     covering shape (a) and shape (b)'s file could hide a real mute.
+{ printf 'canonical_jsonl_append "$d" \\\n'
+  printf '  "$(jq -nc --arg t "$ts" %s 2>/dev/null)" 2>/dev/null || true\n' "'{ts:\$t}'"; } > "$D/silenced-trailing.sh"
+[[ -n "$(scan_silenced_appends "$D/silenced-trailing.sh")" ]] \
+  || fail "the scan misses a TRAILING 2>/dev/null on a continued call — the exact shape of the fifth re-silenced call site"
+pass "no caller re-silences the primitive (${#CALLER_FILES[@]} callers scanned, controlled 3 ways)"
+
 echo "PASS: event-append-atomicity (CTL-1809)"

--- a/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
+++ b/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
@@ -180,6 +180,40 @@ jq -e '.attributes["catalyst.event.oversized.bytes"] > 262144' < "$F4" >/dev/nul
 [[ "$(wc -l < "$F4" | tr -d ' ')" == "1" ]] || fail "expected exactly one tombstone line"
 pass "tombstone: catalyst.event.oversized, own name, records the dropped name and size"
 
+# --- 4b. The tombstone survives a hostile host name --------------------------
+# The tombstone is hand-built with printf because the cap must hold on the jq-less path, so
+# there is no escaper — every interpolated string has to be scrubbed by hand. TWO of them are
+# externally supplied, and the host name was the one that was not: `catalyst_host_name`
+# returns CATALYST_HOST_NAME (or Layer-2 `catalyst.host.name`) VERBATIM, and nothing upstream
+# validates it. A host named `bad"host` produced `"host.name":"bad"host"` — invalid JSON, so
+# `jq -e` fails and every reader discards the line. The one record whose entire job is to
+# preserve the dropped event would silently lose it.
+#
+# Asserted on the SHIPPED function with a hostile value covering all three ways to break the
+# template: a bare quote, a backslash (which would escape the following quote), and a newline
+# (which would split one line into two).
+D="$(newdir)"; TMPS+=("$D"); F4B="$D/e.jsonl"; : > "$F4B"
+HOSTILE_HOST='bad"host\evil
+second-line'
+CATALYST_HOST_NAME="$HOSTILE_HOST" canonical_atomic_append_line "$F4B" "$BIG_LINE" 2>/dev/null || true
+[[ "$(wc -l < "$F4B" | tr -d ' ')" == "1" ]] \
+  || fail "a hostile host name split the tombstone across $(wc -l < "$F4B" | tr -d ' ') lines"
+jq -e '.attributes["event.name"] == "catalyst.event.oversized"' < "$F4B" >/dev/null \
+  || fail "the tombstone did not parse under CATALYST_HOST_NAME='$HOSTILE_HOST' — readers discard it, so the drop is unrecorded. got: $(cat "$F4B")"
+jq -e '.attributes["catalyst.event.oversized.name"] == "phase.implement.complete.CTL-9999"' < "$F4B" >/dev/null \
+  || fail "the hostile-host tombstone parsed but lost the dropped event's name"
+# The scrub must not silently blank the field either — an empty host.name is a different way
+# to lose the evidence.
+jq -e '.resource["host.name"] | length > 0' < "$F4B" >/dev/null \
+  || fail "the tombstone's host.name was scrubbed to empty"
+# POSITIVE CONTROL: the same instrument on the UNSCRUBBED interpolation must FAIL, or the
+# three assertions above pass on any implementation, including one that never escapes.
+CTRL="$D/ctrl.jsonl"
+printf '{"resource":{"host.name":"%s"}}\n' "$HOSTILE_HOST" > "$CTRL"
+jq -e '.resource["host.name"]' < "$CTRL" >/dev/null 2>&1 \
+  && fail "the control (raw interpolation of the hostile host name) PARSED — this check cannot detect the defect it exists for"
+pass "tombstone: hostile CATALYST_HOST_NAME is scrubbed, one line, still parses (control: raw interpolation does not)"
+
 # --- 5. Cap boundary: exactly at the cap is ACCEPTED --------------------------
 # Off-by-one guard in the direction that matters. 262,144 B is 4.2x the all-time observed
 # fleet maximum (62,597 B) and is inside the range dd is proven atomic over, so a line at
@@ -277,17 +311,41 @@ mkdir -p "$(dirname "$EV")"
   printf '{"attributes":{"event.name":"after.torn"}}\n'
 } > "$EV"
 ERRF="$D/tail.err"; OUTF="$D/tail.out"
-# `tail` is a live tail — it never returns on its own. Start it, let it emit its one
-# --since-line 0 backlog batch, then kill it. The deadline is a fixed sleep in the
-# foreground, so nothing here can outlive this test even if the kill fails.
+# `tail` is a live tail — `cmd_tail`'s poll branch is a literal `while :; do sleep 1; …`, so
+# it NEVER returns on its own. This is a REQUIRED CI job, so the deadline may not live in the
+# parent: a foreground `sleep 2` is a pause, not a bound, and if the kill below is never
+# delivered the job blocks forever and the child outlives the harness (AGENTS.md "Spawning a
+# background process"). Two structural guards, both of which hold with every cleanup line
+# below deleted:
+#
+#   · `set -m` puts the tail in its OWN process group, so `kill -<pgid>` reaches the helpers
+#     it forks as well as the tail itself. This is not belt-and-braces: `cmd_tail`'s fswatch
+#     branch runs `fswatch -o "$file" | while read …`, whose two members are children of the
+#     tail — a pid-only kill orphans an `fswatch` watching a deleted temp dir forever.
+#     Measured with the same three-process fixture: pid-only kill leaks the grandchild
+#     (1 leaked), group kill leaks none (0).
+#   · The watchdog carries the deadline IN A CHILD that only sleeps and signals, and it
+#     ESCALATES: `cmd_tail` installs `trap 'exit 0' TERM …`, and a trapped signal is a signal
+#     that can be missed, so TERM at 20 s is followed by an untrappable KILL at 25 s. That
+#     bounds the `wait` below at ~25 s no matter what. The watchdog is itself bounded by its
+#     own two sleeps, so it cannot outlive this test even if its own cleanup never runs.
+set -m
 CATALYST_EVENTS_DIR="$D/events" "${SCRIPTS_DIR}/catalyst-events" tail \
   --since-line 0 --filter '.attributes["event.name"] | test("torn")' \
   >"$OUTF" 2>"$ERRF" &
 TAILPID=$!
+set +m
+( sleep 20; kill -TERM -"$TAILPID" 2>/dev/null; sleep 5; kill -KILL -"$TAILPID" 2>/dev/null ) &
+TAILWDPID=$!
 sleep 2
-kill "$TAILPID" 2>/dev/null || true
+kill -TERM -"$TAILPID" 2>/dev/null || true
 wait "$TAILPID" 2>/dev/null || true
+kill "$TAILWDPID" 2>/dev/null || true
+wait "$TAILWDPID" 2>/dev/null || true
+# Fail CLOSED, positively: `kill -0 … && echo` prints nothing when the PROBE errors, which is
+# how a script self-certifies a cleanup that never happened.
 ps -p "$TAILPID" >/dev/null 2>&1 && fail "LEAKED catalyst-events tail pid $TAILPID"
+ps -p "$TAILWDPID" >/dev/null 2>&1 && fail "LEAKED tail watchdog pid $TAILWDPID"
 grep -q 'after.torn' "$OUTF" \
   || fail "a torn line swallowed the rest of the batch — 'after.torn' never reached the consumer. got: $(cat "$OUTF")"
 grep -q 'before.torn' "$OUTF" \

--- a/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
+++ b/plugins/dev/scripts/__tests__/event-append-atomicity.test.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# CTL-1809 (Defect B): a bash append to the event log must be exactly ONE write(2).
+#
+# `printf '%s\n' "$line" >> "$file"` looks atomic and is not. O_APPEND makes the file OFFSET
+# atomic; it does NOT make a multi-write(2) sequence atomic. bash's builtin printf flushes
+# through stdio in BUFSIZ-sized chunks (1024 on macOS, 8192 on glibc), so a line longer than
+# BUFSIZ is ⌈n/BUFSIZ⌉ separate write() calls and a concurrent producer's append lands
+# BETWEEN them. The result is a spliced line: one event's head followed by another's tail.
+#
+# The nastiest product of that splice is NOT an unparseable line. The RCA reproduced a line
+# that PARSES as valid JSON, whose declared length matches, and whose contents are three
+# different events — so a parse-only assertion is not sufficient. Every case below therefore
+# asserts BOTH halves of the acceptance criterion: every line parses, AND every line's
+# contents belong to exactly one event. The second half is enforced by giving each producer
+# its own single fill character; a spliced line contains two.
+#
+# Sizes are not arbitrary. 1,025 B is one byte past macOS BUFSIZ; 19,086 B is the real
+# largest `catalyst.worktree-rebase` line measured on mini. Both demonstrably tear today —
+# case 3 is the committed proof of that, and it is what keeps cases 1 and 2 honest.
+#
+# Driven against the REAL shipped function (lib/canonical-event.sh), never a model of it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+LIB="${SCRIPTS_DIR}/lib/canonical-event.sh"
+[[ -f "$LIB" ]] || { echo "FAIL: canonical-event.sh not found at $LIB"; exit 1; }
+# shellcheck disable=SC1090
+source "$LIB"
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+
+# The primitive hard-codes /bin/dd — an ABSOLUTE path, deliberately, because a phase-agent
+# worker or launchd job runs with a restricted PATH and a PATH-resolved helper that fails to
+# resolve is the silent no-op this whole guard exists to prevent. Asserted here rather than
+# skipped: if /bin/dd is ever absent on a supported host, every bash append on that host is
+# broken and this suite must say so in one line instead of leaving the reader to infer it
+# from "expected 1200 lines, found 0". (Present on stock macOS and on Ubuntu, where /bin is
+# a usrmerge symlink to /usr/bin.)
+[[ -x /bin/dd ]] || { echo "FAIL: /bin/dd is missing — the atomic append primitive cannot work on this host"; exit 1; }
+
+TMPS=()
+# NOTE the trailing `true`: without it the loop's last conditional decides this script's EXIT
+# STATUS, so a passing test could report failure. Cleanup must never change the verdict.
+cleanup() { local d; for d in "${TMPS[@]:-}"; do [[ -n "$d" ]] && rm -rf "$d"; done; true; }
+trap cleanup EXIT
+newdir() { mktemp -d; }
+fail() { echo "FAIL: $*"; exit 1; }
+pass() { echo "  ok — $*"; }
+
+PRODUCERS=8
+LINES_PER=150
+
+# The naive append this ticket replaces — byte-for-byte the pre-CTL-1809 shape of
+# canonical-event.sh's last line. Case 3 runs the identical harness through it; if it ever
+# stops tearing, cases 1 and 2 have stopped proving anything and this suite says so.
+naive_append() { printf '%s\n' "$2" >> "$1"; }
+
+# run_harness FILE SIZE APPEND_FN
+# PRODUCERS concurrent subshells x LINES_PER lines, each line EXACTLY $SIZE bytes (the
+# trailing newline the appender adds is on top of that). Producer N fills its padding with
+# the single character N, which is what makes a splice detectable even when it parses.
+run_harness() {
+  local file="$1" size="$2" fn="$3"
+  : > "$file"
+  local pids=() p
+  for p in $(seq 1 "$PRODUCERS"); do
+    (
+      local prefix suffix npad padchar pad line i
+      padchar="$p"
+      for i in $(seq 1 "$LINES_PER"); do
+        prefix="{\"producer\":${p},\"seq\":${i},\"fill\":\""
+        suffix="\",\"producer_echo\":${p}}"
+        npad=$(( size - ${#prefix} - ${#suffix} ))
+        pad="$(printf '%*s' "$npad" '' | tr ' ' "$padchar")"
+        line="${prefix}${pad}${suffix}"
+        [[ ${#line} -eq $size ]] || { echo "harness bug: built ${#line} bytes, wanted $size" >&2; exit 1; }
+        "$fn" "$file" "$line"
+      done
+    ) &
+    pids+=($!)
+  done
+  # Bounded by construction: each child runs a fixed LINES_PER-iteration loop and exits. No
+  # `while :` anywhere, so there is nothing here that can outlive the test.
+  for p in "${pids[@]}"; do wait "$p"; done
+}
+
+# count_damage FILE — echoes "<unparseable> <spliced>".
+#   unparseable = lines that fail JSON.parse
+#   spliced     = lines that PARSE but whose contents come from more than one producer
+#                 (fill character not homogeneous, or not matching the declared producer,
+#                 or producer != producer_echo). This is the detector the RCA's
+#                 valid-JSON splice defeats a plain parse check with.
+count_damage() {
+  local file="$1"
+  local unparseable spliced
+  unparseable="$(jq -R 'try (fromjson | empty) catch 1' < "$file" | wc -l | tr -d ' ')"
+  spliced="$(jq -R '
+      (try fromjson catch null) as $o
+      | select($o != null)
+      | select(
+          ($o.producer != $o.producer_echo)
+          or (($o.fill | explode | unique | length) != 1)
+          or (($o.fill | explode | .[0]) != (48 + $o.producer))
+        )
+      | 1' < "$file" | wc -l | tr -d ' ')"
+  printf '%s %s' "$unparseable" "$spliced"
+}
+
+expected_lines=$(( PRODUCERS * LINES_PER ))
+
+# --- 1. 1,025 B x 8 producers through the primitive: clean --------------------
+D="$(newdir)"; TMPS+=("$D"); F1="$D/e.jsonl"
+run_harness "$F1" 1025 canonical_atomic_append_line
+read -r U1 S1 <<<"$(count_damage "$F1")"
+N1="$(wc -l < "$F1" | tr -d ' ')"
+[[ "$N1" == "$expected_lines" ]] || fail "1025B: expected $expected_lines lines, found $N1 (a line was dropped or split)"
+[[ "$U1" == "0" ]] || fail "1025B: $U1 unparseable lines through the atomic primitive"
+[[ "$S1" == "0" ]] || fail "1025B: $S1 lines carry contents from more than one event"
+pass "1025 B x ${PRODUCERS} producers: ${N1} lines, 0 unparseable, 0 spliced"
+
+# --- 2. 19,086 B x 8 producers through the primitive: clean -------------------
+D="$(newdir)"; TMPS+=("$D"); F2="$D/e.jsonl"
+run_harness "$F2" 19086 canonical_atomic_append_line
+read -r U2 S2 <<<"$(count_damage "$F2")"
+N2="$(wc -l < "$F2" | tr -d ' ')"
+[[ "$N2" == "$expected_lines" ]] || fail "19086B: expected $expected_lines lines, found $N2"
+[[ "$U2" == "0" ]] || fail "19086B: $U2 unparseable lines through the atomic primitive"
+[[ "$S2" == "0" ]] || fail "19086B: $S2 lines carry contents from more than one event"
+pass "19086 B x ${PRODUCERS} producers: ${N2} lines, 0 unparseable, 0 spliced"
+
+# --- 3. POSITIVE CONTROL: the same harness on a naive `printf >>` must TEAR ----
+# This is the AC's third clause made permanent ("replace the append primitive with a naive
+# printf >> and the concurrency test goes red"). Without it, cases 1 and 2 would still pass
+# on a machine or a bash build where nothing tears — a green that proves nothing. Asserted
+# at BOTH sizes so a platform whose BUFSIZ is 8192 (glibc) still exercises the control at
+# 19,086 B rather than reporting a false clean.
+D="$(newdir)"; TMPS+=("$D"); FN1="$D/naive1025.jsonl"; FN2="$D/naive19086.jsonl"
+run_harness "$FN1" 1025 naive_append
+run_harness "$FN2" 19086 naive_append
+read -r UN1 SN1 <<<"$(count_damage "$FN1")"
+read -r UN2 SN2 <<<"$(count_damage "$FN2")"
+DAMAGE_1025=$(( UN1 + SN1 ))
+DAMAGE_19086=$(( UN2 + SN2 ))
+[[ "$DAMAGE_19086" -gt 0 ]] \
+  || fail "positive control DID NOT TEAR at 19086 B — cases 1 and 2 are therefore not evidence of anything"
+pass "positive control: naive printf >> damaged ${DAMAGE_1025} lines at 1025 B and ${DAMAGE_19086} at 19086 B"
+
+# --- 4. Over the cap: fails loudly, drops nothing silently, leaves a tombstone -
+D="$(newdir)"; TMPS+=("$D"); F4="$D/e.jsonl"; : > "$F4"
+BIG_PAD="$(printf '%*s' 300000 '' | tr ' ' 'z')"
+BIG_LINE="{\"attributes\":{\"event.name\":\"phase.implement.complete.CTL-9999\"},\"pad\":\"${BIG_PAD}\"}"
+WARN="$D/warn.txt"
+set +e
+canonical_atomic_append_line "$F4" "$BIG_LINE" 2>"$WARN"
+RC=$?
+set -e
+[[ "$RC" -ne 0 ]] || fail "an oversized append returned 0 — a caller cannot tell the event was dropped"
+grep -q "300" "$WARN" || fail "the oversized warning does not report the size; stderr: $(cat "$WARN")"
+grep -q 'phase.implement.complete.CTL-9999' "$WARN" \
+  || fail "the oversized warning does not name the event; stderr: $(cat "$WARN")"
+# Never silently truncated or split: the file must not contain any fragment of the payload.
+grep -q 'zzzz' "$F4" && fail "an oversized event was written (truncated or split) instead of refused"
+pass "oversized append: rc=$RC, size and event name on stderr, nothing written from the payload"
+
+# The tombstone: the drop must be durable and in-band, not only a stderr line that no
+# event-log consumer can see.
+TOMB_NAME="$(jq -r '.attributes["event.name"]' < "$F4")"
+[[ "$TOMB_NAME" == "catalyst.event.oversized" ]] \
+  || fail "expected a catalyst.event.oversized tombstone in the log, found event.name=$TOMB_NAME"
+# The tombstone must carry its OWN name. Re-emitting the dropped event's name with a gutted
+# payload would fire `catalyst-events wait-for` subscribers and the broker's phase-lifecycle
+# router on fabricated content — strictly worse than the absence it is reporting.
+jq -e '.attributes["event.name"] != "phase.implement.complete.CTL-9999"' < "$F4" >/dev/null \
+  || fail "the tombstone re-used the dropped event's name — it would fire that event's subscribers"
+jq -e '.attributes["catalyst.event.oversized.name"] == "phase.implement.complete.CTL-9999"' < "$F4" >/dev/null \
+  || fail "the tombstone does not record which event was dropped"
+jq -e '.attributes["catalyst.event.oversized.bytes"] > 262144' < "$F4" >/dev/null \
+  || fail "the tombstone does not record the dropped size"
+[[ "$(wc -l < "$F4" | tr -d ' ')" == "1" ]] || fail "expected exactly one tombstone line"
+pass "tombstone: catalyst.event.oversized, own name, records the dropped name and size"
+
+# --- 5. Cap boundary: exactly at the cap is ACCEPTED --------------------------
+# Off-by-one guard in the direction that matters. 262,144 B is 4.2x the all-time observed
+# fleet maximum (62,597 B) and is inside the range dd is proven atomic over, so a line at
+# the cap is a line the primitive must still write.
+D="$(newdir)"; TMPS+=("$D"); F5="$D/e.jsonl"; : > "$F5"
+EXACT_PREFIX='{"attributes":{"event.name":"cap.boundary"},"pad":"'
+EXACT_SUFFIX='"}'
+EXACT_PAD="$(printf '%*s' $(( 262144 - ${#EXACT_PREFIX} - ${#EXACT_SUFFIX} )) '' | tr ' ' 'y')"
+EXACT_LINE="${EXACT_PREFIX}${EXACT_PAD}${EXACT_SUFFIX}"
+[[ ${#EXACT_LINE} -eq 262144 ]] || fail "harness bug: boundary line is ${#EXACT_LINE} bytes"
+canonical_atomic_append_line "$F5" "$EXACT_LINE" || fail "a line exactly at the cap was refused"
+jq -e '.attributes["event.name"] == "cap.boundary"' < "$F5" >/dev/null \
+  || fail "the at-cap line did not land intact"
+pass "cap boundary: 262144 B accepted and intact"
+
+# --- 6. Every bash producer converges on the one primitive --------------------
+# The primitive only helps the sites that call it, so a raw `>>` append to the event log
+# added later would silently keep the old torn path. This scan enumerates append redirects
+# to an event-log destination across the shipped bash producers.
+#
+# Three sites legitimately keep a raw append: dependency-free leaves that source
+# canonical-event.sh lazily and must still emit when it is absent. Those are recognized ONLY
+# by the loud warning that must immediately precede them — so the exemption cannot be
+# claimed by a silent append, and adding a genuinely new raw append still fails this test.
+UNGUARDED_SENTINEL='WITHOUT the atomic primitive'
+scan_unguarded_appends() {
+  # FNR, not NR: awk's NR is CUMULATIVE across the whole argument list, so using it would
+  # both misreport line numbers and — far worse — let a loud-fallback warning at the end of
+  # one file exempt a silent append near the start of the NEXT one. `guard` is reset at each
+  # file boundary for the same reason.
+  awk -v sentinel="$UNGUARDED_SENTINEL" '
+    FNR == 1 { guard = 0 }
+    index($0, sentinel) { guard = FNR }
+    />>/ && /(month_file|events_file|CATALYST_EVENTS_FILE|[$]dest|\.jsonl)/ {
+      if (guard == 0 || FNR - guard > 3) printf "%s:%d:%s\n", FILENAME, FNR, $0
+    }
+  ' "$@" 2>/dev/null || true
+}
+RAW="$(scan_unguarded_appends \
+  "${SCRIPTS_DIR}/lib/canonical-event.sh" \
+  "${SCRIPTS_DIR}/lib/emit-reap-intent.sh" \
+  "${SCRIPTS_DIR}/lib/phase-emit-complete.sh" \
+  "${SCRIPTS_DIR}/catalyst-state.sh" \
+  "${SCRIPTS_DIR}/catalyst-events" \
+  "${SCRIPTS_DIR}/catalyst-stack" \
+  "${SCRIPTS_DIR}/emit-worker-status-change.sh")"
+[[ -z "$RAW" ]] || fail "a bash producer appends to the event log without the atomic primitive and without a loud fallback warning:
+$RAW"
+# POSITIVE CONTROL for the scan above. A scan that matches nothing because its pattern is
+# wrong is indistinguishable from a clean tree — the exact shape of check that has shipped
+# as a false clean in this repo. Two decoys, because the scan has two halves that can each
+# fail silently: (a) an UNGUARDED raw append must be reported, or the scan is blind;
+# (b) a GUARDED one must not be, or the exemption is really "match nothing" and half (a)
+# would be reported for the wrong reason.
+D="$(newdir)"; TMPS+=("$D")
+printf 'printf "%%s" "$line" >> "$month_file"\n' > "$D/decoy-bare.sh"
+[[ -n "$(scan_unguarded_appends "$D/decoy-bare.sh")" ]] \
+  || fail "the raw-append scan cannot detect an unguarded raw append — the clean result above is meaningless"
+{ printf 'echo "WARNING: %s here"\n' "$UNGUARDED_SENTINEL"
+  printf 'printf "%%s" "$line" >> "$month_file"\n'; } > "$D/decoy-guarded.sh"
+[[ -z "$(scan_unguarded_appends "$D/decoy-guarded.sh")" ]] \
+  || fail "the scan does not honour the loud-fallback exemption it claims to"
+pass "no bash producer bypasses the primitive silently (scan positive-controlled both ways)"
+
+# --- 6b. The loud fallback actually fires ------------------------------------
+# The exemption above is only defensible if the warning is real. A fallback branch that
+# ships un-exercised is the second code path this ticket's design notes ban everywhere else,
+# so it gets exercised here against the REAL shipped file: copy lib/emit-reap-intent.sh
+# somewhere with no canonical-event.sh sibling — which is exactly how it resolves the helper
+# (`_rei_lib_dir` from BASH_SOURCE) — and require both the warning AND the event.
+D="$(newdir)"; TMPS+=("$D")
+mkdir -p "$D/lonely" "$D/ev"
+cp "${SCRIPTS_DIR}/lib/emit-reap-intent.sh" "$D/lonely/"
+FBERR="$D/fb.err"
+CATALYST_EVENTS_DIR="$D/ev" bash "$D/lonely/emit-reap-intent.sh" \
+  orphans.reap-requested --orch-id test-orch 2>"$FBERR" || true
+grep -q "$UNGUARDED_SENTINEL" "$FBERR" \
+  || fail "the helper-absent fallback did not warn — the scan's exemption covers a silent path. stderr: $(cat "$FBERR")"
+[[ -s "$D/ev/$(date -u +%Y-%m).jsonl" ]] \
+  || fail "the helper-absent fallback warned but dropped the event — it must still emit"
+pass "loud fallback: warns on stderr and still emits when canonical-event.sh is absent"
+
+# --- 7. catalyst-events must not lose a whole batch to one torn line ----------
+# `jq -c "select(...)"` ABORTS at the first line that does not parse (exit 5), so every
+# valid event AFTER a torn line in the same wake batch was silently lost and a `wait-for`
+# whose awaited event shared that batch timed out. The loop cursor is a line COUNT, so the
+# abort is batch-scoped rather than a permanent wedge — which is exactly why it was never
+# noticed.
+D="$(newdir)"; TMPS+=("$D")
+EV="$D/events/$(date -u +%Y-%m).jsonl"
+mkdir -p "$(dirname "$EV")"
+{
+  printf '{"attributes":{"event.name":"before.torn"}}\n'
+  printf 'TORN{"attributes":{"event.na\n'
+  printf '{"attributes":{"event.name":"after.torn"}}\n'
+} > "$EV"
+ERRF="$D/tail.err"; OUTF="$D/tail.out"
+# `tail` is a live tail — it never returns on its own. Start it, let it emit its one
+# --since-line 0 backlog batch, then kill it. The deadline is a fixed sleep in the
+# foreground, so nothing here can outlive this test even if the kill fails.
+CATALYST_EVENTS_DIR="$D/events" "${SCRIPTS_DIR}/catalyst-events" tail \
+  --since-line 0 --filter '.attributes["event.name"] | test("torn")' \
+  >"$OUTF" 2>"$ERRF" &
+TAILPID=$!
+sleep 2
+kill "$TAILPID" 2>/dev/null || true
+wait "$TAILPID" 2>/dev/null || true
+ps -p "$TAILPID" >/dev/null 2>&1 && fail "LEAKED catalyst-events tail pid $TAILPID"
+grep -q 'after.torn' "$OUTF" \
+  || fail "a torn line swallowed the rest of the batch — 'after.torn' never reached the consumer. got: $(cat "$OUTF")"
+grep -q 'before.torn' "$OUTF" \
+  || fail "the batch did not emit at all — the harness, not the fix, is what this case measured. got: $(cat "$OUTF")"
+grep -q 'torn_lines_total' "$ERRF" \
+  || fail "the skipped line was silent — no counted operator-visible warning. stderr: $(cat "$ERRF")"
+pass "catalyst-events: torn line counted and skipped, the rest of the batch survives"
+
+echo "PASS: event-append-atomicity (CTL-1809)"

--- a/plugins/dev/scripts/broker/tailer-torn.test.mjs
+++ b/plugins/dev/scripts/broker/tailer-torn.test.mjs
@@ -1,0 +1,129 @@
+// CTL-1809: the broker's LIVE event-log tail must COUNT a torn line, not drop it silently.
+// Run: bun test plugins/dev/scripts/broker/tailer-torn.test.mjs
+//
+// The broker is the load-bearing reader of ~/catalyst/events/YYYY-MM.jsonl: every
+// filter.wake, every phase-lifecycle terminal, the ingestion-recency map and the worker-state
+// projection all come off this one loop. Its BOOT replay goes through
+// execution-core/event-tail.mjs (counted since CTL-1809), but readNewEvents hand-rolls its own
+// read loop and its `catch { continue; }` was silent — so the counted half ran once per
+// process and the uncounted half ran for the process's whole life.
+//
+// The survivor assertion is deliberately NOT a mock. It observes processEvent's real
+// recordLastSeen fold (__getLastSeenByServiceForTest), so "the events either side of the torn
+// line still reached the router" is measured at the router, not at a stub the test wrote.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { seedTailer, readNewEvents } from "./tailer.mjs";
+import { __clearIngestionRecencyForTest, __getLastSeenByServiceForTest } from "./router.mjs";
+import { getEventLogPath } from "./config.mjs";
+import { tornLineCount, resetTornLineCount } from "../execution-core/event-tail.mjs";
+
+let tmpDir;
+let logPath;
+let stderrChunks;
+let realStderrWrite;
+
+// One valid v2 envelope. `resource["service.name"]` + a parseable `ts` are exactly what
+// recordLastSeen keys on, which is what makes arrival at the router observable.
+function envelope(service, ts) {
+  return JSON.stringify({
+    ts,
+    attributes: { "event.name": "catalyst.test.tailer-torn" },
+    resource: { "service.name": service },
+  });
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "broker-tailer-torn-"));
+  process.env.CATALYST_DIR = tmpDir;
+  logPath = getEventLogPath();
+  mkdirSync(join(tmpDir, "events"), { recursive: true });
+  __clearIngestionRecencyForTest();
+  resetTornLineCount();
+  // Capture stderr rather than let the warning escape into the suite output.
+  stderrChunks = [];
+  realStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  };
+});
+
+afterEach(() => {
+  process.stderr.write = realStderrWrite;
+  resetTornLineCount();
+  __clearIngestionRecencyForTest();
+  rmSync(tmpDir, { recursive: true, force: true });
+  // CTL-1086: restore to the hermetic preload value rather than deleting.
+  const hermetic = process.env.CATALYST_HERMETIC_DIR;
+  if (hermetic) {
+    process.env.CATALYST_DIR = hermetic;
+  } else {
+    delete process.env.CATALYST_DIR;
+  }
+});
+
+// Seed the tailer onto this test's log at offset 0, then drain it once. readNewEvents
+// short-circuits (and only re-seeds the offset) when logPath !== lastLogPath, so the path
+// must be seeded before the drain or the first call reads nothing.
+function drainFrom(contents) {
+  writeFileSync(logPath, contents);
+  seedTailer({ logPath, byteOffset: 0 });
+  readNewEvents();
+}
+
+describe("CTL-1809 — broker live tail counts torn lines", () => {
+  test("a torn line between two valid events is counted, and both survivors still route", () => {
+    expect(tornLineCount()).toBe(0); // positive control: the counter starts cold.
+
+    drainFrom(
+      `${envelope("catalyst.before-torn", "2026-08-13T00:00:00.000Z")}\n` +
+        `TORN{"attributes":{"event.na\n` +
+        `${envelope("catalyst.after-torn", "2026-08-13T00:00:01.000Z")}\n`
+    );
+
+    // The tear is now audible.
+    expect(tornLineCount()).toBe(1);
+
+    // …and it did not swallow the batch. Measured at the router's own last-seen fold.
+    const seen = __getLastSeenByServiceForTest();
+    expect(seen.has("catalyst.before-torn")).toBe(true);
+    expect(seen.has("catalyst.after-torn")).toBe(true);
+  });
+
+  test("the drop is operator-visible on stderr, naming the counter", () => {
+    drainFrom(`NOT JSON AT ALL\n`);
+
+    expect(tornLineCount()).toBe(1);
+    const err = stderrChunks.join("");
+    expect(err).toContain("TORN event-log line");
+    expect(err).toContain("torn_lines_total=1");
+  });
+
+  test("a clean batch counts zero — the detector is not counting healthy lines", () => {
+    // The negative control for the two cases above: if this ever counted, `1` would prove
+    // nothing about torn lines specifically.
+    drainFrom(
+      `${envelope("catalyst.clean-a", "2026-08-13T00:00:00.000Z")}\n` +
+        `${envelope("catalyst.clean-b", "2026-08-13T00:00:01.000Z")}\n`
+    );
+
+    expect(tornLineCount()).toBe(0);
+    expect(__getLastSeenByServiceForTest().has("catalyst.clean-b")).toBe(true);
+  });
+
+  test("a trailing partial line is NOT counted — it is an in-flight write, not damage", () => {
+    // readNewEvents pops the trailing partial into leftoverBuf and never parses it. Counting
+    // it would make the detector alarm on every healthy actively-written log, which is a
+    // detector nobody reads. Same carve-out as scanEventsChunked's `carry`.
+    drainFrom(
+      `${envelope("catalyst.complete", "2026-08-13T00:00:00.000Z")}\n` + `{"attributes":{"eve`
+    );
+
+    expect(tornLineCount()).toBe(0);
+    expect(__getLastSeenByServiceForTest().has("catalyst.complete")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/broker/tailer.mjs
+++ b/plugins/dev/scripts/broker/tailer.mjs
@@ -9,7 +9,7 @@
 import { watch, openSync, fstatSync, readSync, closeSync, mkdirSync } from "node:fs";
 // CTL-1529: bounded boot replay. tailParsedEvents returns the last N parsed events
 // in file order from a small window near EOF.
-import { tailParsedEvents } from "../execution-core/event-tail.mjs";
+import { tailParsedEvents, noteTornLine } from "../execution-core/event-tail.mjs";
 import { resolve, basename } from "node:path";
 import { getEventLogPath, log, CATALYST_DIR, LOOKBACK_LINES } from "./config.mjs";
 import {
@@ -59,7 +59,11 @@ export function getLastByteOffset() {
   return lastByteOffset;
 }
 
-function readNewEvents() {
+// CTL-1809: exported as a test seam, in the shape seedTailer already established. The live
+// path is driven by an fs.watch callback, so without this the only way to exercise it is to
+// start a real watcher and race a timer — which is how a flaky test that proves nothing gets
+// written. Production still reaches it only through startTailing's watcher.
+export function readNewEvents() {
   const logPath = getEventLogPath();
 
   if (logPath !== lastLogPath) {
@@ -99,6 +103,23 @@ function readNewEvents() {
       try {
         event = JSON.parse(line);
       } catch {
+        // CTL-1809: the broker's LIVE tail is the load-bearing reader of this log — it
+        // routes every filter.wake, every phase-lifecycle terminal, and the ingestion-recency
+        // and worker-state projections — and this drop was completely silent. Its BOOT replay
+        // (tailParsedEvents above) has been counted since CTL-1809; without this the covered
+        // half was the one that runs once per process and the uncounted half was the one that
+        // runs for the process's whole life.
+        //
+        // `line` is a COMPLETE line: leftoverBuf popped the trailing partial off `lines`
+        // before this loop, so an unparseable line here is real damage and not a read that
+        // raced a writer mid-append. Shares event-tail.mjs's process counter deliberately —
+        // one detector per process per log (see noteTornLine).
+        //
+        // COUNT AND ADVANCE. lastByteOffset was already moved to stat.size above, and that is
+        // correct: a torn line is permanently corrupt, so re-reading it would wedge the
+        // broker on damage that never resolves. The counter is a LOWER BOUND — a splice that
+        // happens to parse is invisible here, which is why the write side is the fix.
+        noteTornLine(line);
         continue;
       }
       // CTL-1330 Tier 1: time each route; surface ONLY slow routes (default

--- a/plugins/dev/scripts/catalyst-events
+++ b/plugins/dev/scripts/catalyst-events
@@ -46,6 +46,26 @@ esac
 CATALYST_DIR="${CATALYST_DIR:-$HOME/catalyst}"
 EVENTS_DIR="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}"
 
+# CTL-1809: this CLI is a READER that also emits a handful of `wait.*` events, so it is a
+# bash producer too and must append through the one atomic seam. Sourced best-effort — the
+# reader half must keep working on a host where the helper is missing, and the one emitter
+# below degrades loudly rather than silently.
+#
+# The symlink walk is not decoration: install-cli.sh installs this script as a symlink on
+# the PATH, so a bare `dirname "$BASH_SOURCE"` resolves to the symlink's directory, `lib/`
+# is not there, and the helper would silently never load on exactly the installed path that
+# matters. Same walk the --version block above already does, for the same reason.
+_CE_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_CE_SRC" ]]; do
+  _CE_D="$(cd -P "$(dirname "$_CE_SRC")" && pwd)" && _CE_SRC="$(readlink "$_CE_SRC")"
+  [[ "$_CE_SRC" != /* ]] && _CE_SRC="$_CE_D/$_CE_SRC"
+done
+_CE_LIB="$(cd -P "$(dirname "$_CE_SRC")" && pwd)/lib/canonical-event.sh"
+if [[ -r "$_CE_LIB" ]]; then
+  # shellcheck source=lib/canonical-event.sh
+  . "$_CE_LIB" 2>/dev/null || true
+fi
+
 # Resolve the current month's events file. Re-resolved each loop iteration so
 # month rollover is handled transparently.
 events_file_path() {
@@ -57,14 +77,58 @@ events_file_path() {
 }
 
 # Apply a jq predicate filter to a stream. With no filter, pass through.
-# The filter is wrapped in `select(...)` so callers write predicates, not full
-# jq programs. Lines that don't parse as JSON are silently skipped.
+# The filter is wrapped in `select(...)` so callers write predicates, not full jq programs.
+#
+# CTL-1809. The comment that used to sit here said "Lines that don't parse as JSON are
+# silently skipped." That was FALSE, and it was a sixth check-that-cannot-fail: plain
+# `jq -c "select(...)"` treats an unparseable line as a fatal parse error and ABORTS
+# (verified: exit 5), so every valid event AFTER a torn line in the same wake batch was
+# never emitted, and a `wait-for` whose awaited event shared a batch with an upstream torn
+# line simply timed out. Because the tail loop's cursor is a line COUNT rather than a byte
+# offset, the abort is batch-scoped instead of a permanent wedge — which is precisely why it
+# went unnoticed for so long. It was worse than skip-and-advance, not equivalent to it.
+#
+# `-R` + `fromjson` reads each line as raw text and decides per line, so one torn line costs
+# exactly one event. `torn_lines_total` is the named counter — carried in jq's `foreach`
+# state so each warning reports the running total for the batch and an operator can alert on
+# the rate. The line is written to stderr, which rides the caller's `.log` (Alloy → Loki)
+# rather than the event log whose damage it is reporting.
+#
+# COUNT-AND-ADVANCE is deliberate. A torn line is permanently corrupt: parking the cursor on
+# it would wedge the reader forever on damage that will never resolve, contradicting the
+# invariant every other reader on this log already ships
+# (execution-core/event-tail.mjs:12-17 — "their bytes are already behind the byte cursor and
+# will never be revisited").
+#
+# The counter is a LOWER BOUND, never proof of cleanliness. The CTL-1809 RCA reproduced a
+# splice that parses as valid JSON with a matching declared length and three different
+# events' contents — invisible to this and to every other parser. The write side is the fix;
+# this is a tripwire.
+#
+# Note the unfiltered branch is plain `cat`: it makes no parse decision and drops nothing,
+# so there is no skipped line there to count.
 apply_filter() {
   local filter="$1"
   if [[ -z "$filter" ]]; then
     cat
   else
-    jq -c --unbuffered "select($filter)" 2>/dev/null
+    jq -nRc --unbuffered "
+      foreach (inputs | select(length > 0)) as \$raw (
+        { n: 0, ok: false, obj: null };
+        (\$raw | try { ok: true, obj: fromjson } catch { ok: false, obj: null }) as \$p
+        | if \$p.ok then { n: .n, ok: true, obj: \$p.obj }
+          else { n: (.n + 1), ok: false, obj: null } end;
+        if .ok then .obj | select($filter)
+        else
+          (\"[catalyst] WARNING: catalyst-events skipped an unparseable event-log line (torn_lines_total=\(.n)); first 80 bytes: \" + (\$raw[0:80]) + \"\n\")
+          | stderr | empty
+        end
+      )
+    "
+    # NOTE: no `2>/dev/null` here, unlike the call this replaced. That redirect existed to
+    # hide jq's own parse errors — the very signal this change turns into a counted warning.
+    # Re-adding it would restore the silence while leaving the counter code in place, i.e. a
+    # counter that can never be observed.
   fi
 }
 
@@ -202,7 +266,14 @@ _emit_wait_event() {
        + $extra)}' 2>/dev/null)" || return 0
   local dest; dest="$(events_file_path)"
   mkdir -p "$(dirname "$dest")" 2>/dev/null || true
-  printf '%s\n' "$event_json" >> "$dest" 2>/dev/null || true
+  # CTL-1809: one write(2). Loud fallback if the helper could not be sourced — see the
+  # source block near the top of this file.
+  if command -v canonical_atomic_append_line >/dev/null 2>&1; then
+    canonical_atomic_append_line "$dest" "$event_json" || true
+  else
+    printf '[catalyst] WARNING: canonical-event.sh unavailable — appending a wait event WITHOUT the atomic primitive; this write can tear above BUFSIZ (CTL-1809)\n' >&2
+    printf '%s\n' "$event_json" >> "$dest" 2>/dev/null || true
+  fi
 }
 
 cmd_wait_for() {

--- a/plugins/dev/scripts/catalyst-session.sh
+++ b/plugins/dev/scripts/catalyst-session.sh
@@ -290,7 +290,12 @@ __session_emit_agent_event() {
     canonical_note_v1_only "canonical-build-unavailable:${name}"
     superset="$v1"
   fi
-  canonical_jsonl_append "$EVENTS_DIR" "$superset" 2>/dev/null || true
+  # CTL-1809: NO `2>/dev/null` here. The append primitive's only report of a refused
+  # oversized line or a failed dd is a stderr WARNING; muting it locally reproduces exactly
+  # the silence this ticket removed from canonical-event.sh's own call site. `|| true` stays —
+  # the emit is still best-effort and must not fail the caller — but the reason is now audible
+  # in the caller's launchd-captured `.log`.
+  canonical_jsonl_append "$EVENTS_DIR" "$superset" || true
 }
 
 # ─── Commands ───────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -922,7 +922,12 @@ _emit_checkout_updated() {
     command -v jq >/dev/null 2>&1 || exit 0
     local events_dir="${CATALYST_DIR:-$HOME/catalyst}/events"
     mkdir -p "$events_dir" 2>/dev/null || exit 0
-    build_canonical_line \
+    # CTL-1809: this used to redirect build_canonical_line's STDOUT straight at the log —
+    # a whole-function `>>` that looks nothing like the `printf … >>` at the other emit
+    # sites, which is exactly why it is the easiest one to miss when auditing them. Capture
+    # to a variable first so the line goes out through the one atomic seam.
+    local line
+    line="$(build_canonical_line \
       --ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
       --severity INFO \
       --service catalyst.stack \
@@ -931,8 +936,9 @@ _emit_checkout_updated() {
       --label "$checkout" \
       --message "plugin checkout updated ${old:0:8} → ${new:0:8}" \
       --payload-json "$(jq -nc --arg c "$checkout" --arg o "$old" --arg n "$new" \
-        '{checkout:$c, old_commit:$o, new_commit:$n}')" \
-      >> "${events_dir}/$(date -u +%Y-%m).jsonl"
+        '{checkout:$c, old_commit:$o, new_commit:$n}')")" || exit 0
+    [[ -n "$line" ]] || exit 0
+    canonical_atomic_append_line "${events_dir}/$(date -u +%Y-%m).jsonl" "$line" || exit 0
   ) || true
 }
 

--- a/plugins/dev/scripts/catalyst-state.sh
+++ b/plugins/dev/scripts/catalyst-state.sh
@@ -193,7 +193,11 @@ event_append() {
     # instead of silent — same posture as lib/catalyst-deployment-mode.sh's jq-less resolver.
     canonical_note_v1_only "jq-missing:event_append"
     local month_file="${EVENTS_DIR}/$(date -u +%Y-%m).jsonl"
-    echo "$input_json" >> "$month_file"
+    # CTL-1809: the jq-less branch bypasses canonical_jsonl_append (whose sentinel and
+    # rotation checks are jq programs and would mis-report here), but it must NOT bypass the
+    # atomic append. The primitive is jq-free by construction precisely so this path keeps
+    # the one-write(2) guarantee that the rest of the emit sites get.
+    canonical_atomic_append_line "$month_file" "$input_json" || return 1
     return 0
   fi
 

--- a/plugins/dev/scripts/emit-worker-status-change.sh
+++ b/plugins/dev/scripts/emit-worker-status-change.sh
@@ -158,7 +158,17 @@ append_event() {
       events_file="${CATALYST_EVENTS_DIR:-$CATALYST_DIR/events}/$(date -u +%Y-%m).jsonl"
       mkdir -p "$(dirname "$events_file")"
     fi
-    printf '%s\n' "$event_json" >> "$events_file"
+    # CTL-1809: one write(2). canonical-event.sh was already sourced just above (for the
+    # v1-only breadcrumb), so the primitive is normally in scope here. The fallback is kept
+    # because this branch's whole premise is "the canonical helpers may be unavailable" —
+    # but it is LOUD, because a silent printf here is indistinguishable from a working
+    # append until two producers overlap on a large line.
+    if command -v canonical_atomic_append_line >/dev/null 2>&1; then
+      canonical_atomic_append_line "$events_file" "$event_json" || return 1
+    else
+      printf '[catalyst] WARNING: canonical-event.sh unavailable — appending a worker-status event WITHOUT the atomic primitive; this write can tear above BUFSIZ (CTL-1809)\n' >&2
+      printf '%s\n' "$event_json" >> "$events_file"
+    fi
   fi
 }
 

--- a/plugins/dev/scripts/execution-core/event-tail.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.mjs
@@ -6,6 +6,70 @@ import { StringDecoder } from "node:string_decoder";
 
 const DEFAULT_CHUNK = 1 << 20; // 1 MiB — bounds peak memory regardless of file size.
 
+// ─── CTL-1809: torn-line counter ─────────────────────────────────────────────
+//
+// parseEventTailChunk's `catch { continue; }` below is a DROP, and until now it was a
+// completely silent one: this module backs the daemon's live tail, event-scan's incremental
+// counters, the reaper's boot replay, reaper-metrics and transcript-tail, and not one of
+// them could distinguish a damaged event log from a quiet one.
+//
+// COUNT AND ADVANCE, deliberately. A torn line is permanently corrupt — parking the byte
+// cursor on it would wedge every reader above on damage that will never resolve. The
+// module's own contract at the top of parseEventTailChunk already states the invariant
+// ("their bytes are already behind the byte cursor and will never be revisited"); this only
+// makes the drop audible.
+//
+// The count is a LOWER BOUND on corruption, never proof of cleanliness: the CTL-1809 RCA
+// reproduced a splice that parses as valid JSON with a matching declared length and three
+// different events inside it, which no parser can detect. The write side
+// (lib/canonical-event.sh's one-write(2) primitive) is the fix; this is the tripwire.
+//
+// Module-level rather than a parameter: parseEventTailChunk is positional and called from
+// five readers, and a per-call callback would have to be threaded through all of them to
+// report anything. Zero-dependency by design — this is a leaf module, so the warning goes
+// straight to stderr (which lands in the caller's launchd-captured `.log`, Alloy-shipped to
+// Loki INDEPENDENTLY of the event log whose damage it reports).
+let tornLineTotal = 0;
+const tornWarned = new Set();
+
+/** Process-total torn (unparseable) complete lines seen by parseEventTailChunk. */
+export function tornLineCount() {
+  return tornLineTotal;
+}
+
+/** Test seam — resets the process counter and the sparse-warn key set. */
+export function resetTornLineCount() {
+  tornLineTotal = 0;
+  tornWarned.clear();
+}
+
+// Count every occurrence, log sparsely — the same discipline as
+// otel-forward/lib/sparse-warn.ts, hand-rolled here because this module must stay
+// dependency-free (it is imported by the daemon, the reaper and standalone scan CLIs).
+// First sighting per distinct 60-byte prefix, capped at 20 keys, then 10/100/1000…
+// heartbeats on the running total so a sustained tear still reports a live, accurate count
+// without flooding the log surface it is reporting on.
+function noteTornLine(line) {
+  tornLineTotal += 1;
+  const key = line.slice(0, 60);
+  let warn = false;
+  if (!tornWarned.has(key) && tornWarned.size < 20) {
+    tornWarned.add(key);
+    warn = true;
+  } else if (tornLineTotal >= 10 && Math.log10(tornLineTotal) % 1 === 0) {
+    warn = true;
+  }
+  if (!warn) return;
+  try {
+    process.stderr.write(
+      `[catalyst] WARNING: TORN event-log line — did not parse as JSON; counted and skipped ` +
+        `(torn_lines_total=${tornLineTotal}, bytes=${line.length}): ${key}\n`
+    );
+  } catch {
+    /* a reporting hook must never break the tail */
+  }
+}
+
 // parseEventTailChunk — (moved from daemon.mjs, unchanged). Stitches `leftover`
 // (the partial line carried from the previous read) onto the front of `chunk`,
 // returns parsed events for the COMPLETE lines and the new trailing partial
@@ -33,6 +97,10 @@ export function parseEventTailChunk(chunk, leftover = "", lineFilter = null) {
     try {
       events.push(JSON.parse(line));
     } catch {
+      // CTL-1809: count and warn before skipping. This is a COMPLETE line (the trailing
+      // partial was popped off above), so an unparseable one here is real damage, not a
+      // read that raced a writer.
+      noteTornLine(line);
       continue; // skip a malformed complete line, keep tailing
     }
   }
@@ -134,6 +202,11 @@ export function scanEventsChunked({
         onEvent(JSON.parse(carry));
       } catch {
         /* genuinely partial mid-write line — skip, same as the old split path */
+        // CTL-1809 deliberately does NOT count this one. `carry` is the text after the last
+        // newline, i.e. a line a writer may be in the middle of appending right now. Feeding
+        // it to the torn counter would report a healthy in-flight write as log corruption on
+        // every scan of an actively-written log — a detector that alarms constantly is one
+        // nobody reads. Only COMPLETE lines (the loop in parseEventTailChunk) are counted.
       }
     }
     return { endOffset: size, leftover: carry };

--- a/plugins/dev/scripts/execution-core/event-tail.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.mjs
@@ -49,7 +49,17 @@ export function resetTornLineCount() {
 // First sighting per distinct 60-byte prefix, capped at 20 keys, then 10/100/1000…
 // heartbeats on the running total so a sustained tear still reports a live, accurate count
 // without flooding the log surface it is reporting on.
-function noteTornLine(line) {
+//
+// EXPORTED because a process can hold more than one reader of the SAME log and must not
+// hold more than one count of it. The broker is exactly that case: its BOOT replay comes
+// through tailParsedEvents (counted here), while its LIVE tail — the path that carries
+// essentially every routed event — hand-rolls its own read loop in broker/tailer.mjs and
+// calls this directly. Sharing the counter and the sparse-warn key budget is correct there:
+// the two paths are one detector reading one file, so a torn line seen at boot and the same
+// prefix seen live should not each spend a key. The "one flood must not exhaust another
+// detector's budget" rule applies ACROSS readers (separate processes / separate files), not
+// within one process's view of one log.
+export function noteTornLine(line) {
   tornLineTotal += 1;
   const key = line.slice(0, 60);
   let warn = false;

--- a/plugins/dev/scripts/execution-core/event-tail.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-tail.test.mjs
@@ -14,7 +14,13 @@ import { describe, test, expect } from "bun:test";
 import { writeFileSync, appendFileSync, mkdtempSync, statSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { parseEventTailChunk, scanEventsChunked, tailParsedEvents } from "./event-tail.mjs";
+import {
+  parseEventTailChunk,
+  scanEventsChunked,
+  tailParsedEvents,
+  tornLineCount,
+  resetTornLineCount,
+} from "./event-tail.mjs";
 
 // parseEventTailChunk — preserve the daemon.mjs contract verbatim.
 describe("parseEventTailChunk", () => {
@@ -188,5 +194,57 @@ describe("tailParsedEvents (CTL-1514)", () => {
     const got = tailParsedEvents({ path, maxLines: 1 });
     expect(got).toHaveLength(1);
     expect(got[0].big.length).toBe(2 * 1024 * 1024);
+  });
+});
+
+// ─── CTL-1809: the torn-line drop must be counted, not silent ────────────────
+//
+// parseEventTailChunk's `catch { continue }` drops an unparseable COMPLETE line. That drop
+// is correct — a torn line is permanently corrupt, and parking the byte cursor on it would
+// wedge the daemon tail, the reaper's boot replay and every scan CLI on damage that will
+// never resolve. But it used to be INVISIBLE, so a damaged event log and a quiet one read
+// identically from every reader built on this module.
+describe("torn-line counter (CTL-1809)", () => {
+  test("counts each unparseable complete line and still advances past it", () => {
+    resetTornLineCount();
+    const { events } = parseEventTailChunk(
+      '{"event":"a"}\nTORN{"attributes":{"event.na\n{"event":"b"}\n',
+      ""
+    );
+    // ADVANCES: the valid event AFTER the torn line is still returned. This is the half that
+    // separates count-and-advance from park-the-cursor — a reader that stalled on the torn
+    // line would never reach {"event":"b"}.
+    expect(events).toEqual([{ event: "a" }, { event: "b" }]);
+    expect(tornLineCount()).toBe(1);
+  });
+
+  test("a clean chunk leaves the counter untouched (with a positive control)", () => {
+    resetTornLineCount();
+    parseEventTailChunk('{"event":"a"}\n{"event":"b"}\n', "");
+    expect(tornLineCount()).toBe(0);
+    // POSITIVE CONTROL: same instrument, same call, one torn line added. Without it, a
+    // counter wired to nothing at all would also report 0 above and look correct.
+    parseEventTailChunk("TORN\n", "");
+    expect(tornLineCount()).toBe(1);
+  });
+
+  test("the trailing PARTIAL line is not counted — only complete lines are", () => {
+    resetTornLineCount();
+    // No trailing newline: `{"event":"b` is a write in flight, not corruption. Counting it
+    // would make the detector alarm continuously against any actively-written log.
+    const { events, leftover } = parseEventTailChunk('{"event":"a"}\n{"event":"b', "");
+    expect(events).toEqual([{ event: "a" }]);
+    expect(leftover).toBe('{"event":"b');
+    expect(tornLineCount()).toBe(0);
+  });
+
+  test("counts through scanEventsChunked — the path the daemon and reaper actually use", () => {
+    resetTornLineCount();
+    const path = join(mkdtempSync(join(tmpdir(), "ctl1809-")), "e.jsonl");
+    writeFileSync(path, '{"event":"a"}\nTORN{"att\n{"event":"b"}\n');
+    const seen = [];
+    scanEventsChunked({ path, onEvent: (e) => seen.push(e) });
+    expect(seen).toEqual([{ event: "a" }, { event: "b" }]);
+    expect(tornLineCount()).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor-torn.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor-torn.test.mjs
@@ -1,0 +1,192 @@
+// CTL-1809: the daemon monitor's LIVE event-log tail must COUNT a torn line, not drop it
+// silently. Run: cd plugins/dev/scripts/execution-core && bun test monitor-torn.test.mjs
+//
+// This is the SECOND uncovered live tail of the unified event log, structurally identical to
+// the broker's (covered by broker/tailer-torn.test.mjs). Both read the same file —
+// monitor.mjs's readNewEvents and broker/tailer.mjs's readNewEvents each call
+// getEventLogPath(), and execution-core/config.mjs's and broker/config.mjs's implementations
+// resolve to the same `$CATALYST_DIR/events/YYYY-MM.jsonl`.
+//
+// It is not a side path. startTailing drives readNewEvents from an fs.watch callback AND a
+// setInterval poll for the daemon's whole life, and it routes:
+//   handleStateChangedEvent   → dispatchTriage
+//   handleIssueUpdatedEvent   → the eligible projection fold
+//   handleCommentCreatedEvent → onComment (CTL-768 comment-wake / needs-input clear)
+// A torn line therefore silently drops a triage dispatch or a human's reply.
+//
+// Deliberately a separate file rather than a case in monitor.test.mjs: that suite is EXCLUDED
+// from the required execution-core job (documented there as flaky — it drives real timers and
+// fs.watch). A case added there would never run in CI, which is the same "covered on paper"
+// shape this ticket is about. Every drive below calls stopMonitor() before appending, so this
+// file arms no timer and no watcher.
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startMonitor, stopMonitor, readNewEvents, __resetForTests } from "./monitor.mjs";
+import { dropProject } from "./eligible-set.mjs";
+import { tornLineCount, resetTornLineCount } from "./event-tail.mjs";
+
+let catalystDir;
+let prevCatalystDir;
+let stderrChunks;
+let realStderrWrite;
+const enrolledTeams = new Set();
+const registryEntries = [];
+
+function writeRegistry() {
+  writeFileSync(
+    join(catalystDir, "execution-core", "registry.json"),
+    JSON.stringify({ projects: registryEntries }, null, 2)
+  );
+}
+
+function enroll(team, eligibleQuery) {
+  const repoRoot = mkdtempSync(join(catalystDir, `repo-${team}-`));
+  registryEntries.push({ team, repoRoot, eligibleQuery: eligibleQuery ?? null });
+  writeRegistry();
+  enrolledTeams.add(team);
+  return repoRoot;
+}
+
+// A linearis stub that reports no eligible tickets, so startMonitor's boot reconcile +
+// sweepMissingTriage dispatch nothing and every dispatch counted below came off the tail.
+function execEmpty() {
+  return () => ({ code: 0, stdout: JSON.stringify({ nodes: [] }), stderr: "" });
+}
+
+function eventLogPath() {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return join(catalystDir, "events", `${ym}.jsonl`);
+}
+
+function appendEventLog(text) {
+  mkdirSync(join(catalystDir, "events"), { recursive: true });
+  appendFileSync(eventLogPath(), text);
+}
+
+// One linear.issue.updated event. The survivor observable is deliberately the
+// handleIssueUpdatedEvent → onUpdate fold rather than handleStateChangedEvent → dispatchTriage:
+// the fold is pure and in-process, while the →Triage path runs the real applyTriageStatus
+// (a linearis spawn per event) and is exactly why monitor.test.mjs's burst cases are the ones
+// excluded from CI as timing-flaky. Same tail, same loop, same per-line `catch` — measured at
+// a production handler, not a stub, with no wall-clock dependency.
+const updateEvent = (ticket) =>
+  JSON.stringify({
+    event: "linear.issue.updated",
+    detail: { ticket, teamKey: "ENG", toState: "Ready" },
+  });
+
+// Boot the monitor with tailerOpts populated, then immediately disarm its timers/watcher.
+// stopMonitor clears reconcileTimer / tailerPollTimer / coordinationPollTimer and closes both
+// watchers; it does NOT clear tailerOpts, so a direct readNewEvents() below still runs the
+// full production handler chain with no wall-clock dependency anywhere in this file.
+function bootQuiescent(onUpdate) {
+  enroll("ENG", { status: "Ready" });
+  startMonitor({
+    exec: execEmpty(),
+    reconcileIntervalMs: 60_000,
+    tailerPollMs: 0,
+    resumeFromCursor: false,
+    orchDir: join(catalystDir, "execution-core"),
+    onUpdate,
+    readMaxParallelFn: () => 10,
+    liveBackgroundCount: () => 0, // plenty of free slots — the budget never gates these drives
+  });
+  stopMonitor();
+}
+
+beforeEach(() => {
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "exec-core-torn-"));
+  process.env.CATALYST_DIR = catalystDir;
+  mkdirSync(join(catalystDir, "execution-core"), { recursive: true });
+  __resetForTests();
+  resetTornLineCount();
+  enrolledTeams.clear();
+  registryEntries.length = 0;
+  // Capture the sparse-warn output rather than let it escape into suite output.
+  stderrChunks = [];
+  realStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = (chunk) => {
+    stderrChunks.push(String(chunk));
+    return true;
+  };
+});
+
+afterEach(() => {
+  process.stderr.write = realStderrWrite;
+  stopMonitor();
+  __resetForTests();
+  resetTornLineCount();
+  for (const t of enrolledTeams) dropProject(t);
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+  rmSync(catalystDir, { recursive: true, force: true });
+});
+
+describe("CTL-1809 — monitor live tail counts torn lines", () => {
+  test("a torn line between two valid events is counted, and both survivors still route", () => {
+    expect(tornLineCount()).toBe(0); // positive control: the counter starts cold.
+    const onUpdate = mock(() => {});
+    bootQuiescent(onUpdate);
+    expect(onUpdate.mock.calls.length).toBe(0); // boot routed nothing.
+
+    appendEventLog(
+      `${updateEvent("ENG-1")}\n` + `TORN{"attributes":{"event.na\n` + `${updateEvent("ENG-2")}\n`
+    );
+    readNewEvents();
+
+    // The tear is now audible…
+    expect(tornLineCount()).toBe(1);
+    // …and it did not swallow the batch. Measured at the real handleIssueUpdatedEvent fold.
+    expect(onUpdate.mock.calls.map((c) => c[0].identifier)).toEqual(["ENG-1", "ENG-2"]);
+  });
+
+  test("the drop is operator-visible on stderr, naming the counter", () => {
+    bootQuiescent(mock(() => {}));
+    appendEventLog("NOT JSON AT ALL\n");
+    readNewEvents();
+
+    expect(tornLineCount()).toBe(1);
+    const err = stderrChunks.join("");
+    expect(err).toContain("TORN event-log line");
+    expect(err).toContain("torn_lines_total=1");
+  });
+
+  test("a clean batch counts zero — the detector is not counting healthy lines", () => {
+    // Negative control for the two cases above: if this ever counted, `1` would prove nothing
+    // about torn lines specifically.
+    const onUpdate = mock(() => {});
+    bootQuiescent(onUpdate);
+    appendEventLog(`${updateEvent("ENG-3")}\n${updateEvent("ENG-4")}\n`);
+    readNewEvents();
+
+    expect(tornLineCount()).toBe(0);
+    expect(onUpdate.mock.calls.length).toBe(2);
+  });
+
+  test("a trailing partial line is NOT counted — it is an in-flight write, not damage", () => {
+    // readNewEvents pops the trailing partial into leftoverBuf and never parses it. Counting
+    // it would make the detector alarm on every healthy actively-written log.
+    const onUpdate = mock(() => {});
+    bootQuiescent(onUpdate);
+    appendEventLog(`${updateEvent("ENG-5")}\n{"event":"linear.issue.upda`);
+    readNewEvents();
+
+    expect(tornLineCount()).toBe(0);
+    expect(onUpdate.mock.calls.length).toBe(1);
+  });
+
+  test("the counter is SHARED with the broker's detector, not a second one", () => {
+    // noteTornLine is module-level in event-tail.mjs on purpose: one detector per process per
+    // log. If monitor.mjs ever grows its own private counter, this reads 0 while the module's
+    // own count reads 1 — the exact drift that makes two numbers for one file untrustworthy.
+    bootQuiescent(mock(() => {}));
+    appendEventLog(`{{{ not json\n`);
+    readNewEvents();
+    expect(tornLineCount()).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -150,6 +150,11 @@ import {
 } from "./reconcile-health-event.mjs";
 import { checkFleetFreeze } from "./fleet-freeze-alert.mjs"; // CTL-1420: fleet-frozen-for-admission alert
 import { recordReplicaRead } from "./replica-health.mjs"; // CAT-35
+// CTL-1809: the shared torn-line detector. readNewEvents below hand-rolls its own read loop
+// over the SAME unified event log the broker tails, so it needs the same tripwire — and it
+// must share the counter rather than start a second one. See noteTornLine's own comment: one
+// detector per process per log.
+import { noteTornLine } from "./event-tail.mjs";
 
 const MONITOR_BOOT_TS = Date.now();
 
@@ -1760,6 +1765,23 @@ export function readNewEvents({ foldOnly = false } = {}) {
       try {
         event = JSON.parse(line);
       } catch {
+        // CTL-1809: this is the daemon monitor's LIVE tail of the unified event log —
+        // structurally the same reader as broker/tailer.mjs's readNewEvents, on the same file
+        // (getEventLogPath), and it was silent in exactly the same way. It is not a minor
+        // path: startTailing drives it from both an fs.watch callback and a setInterval poll
+        // for the daemon's whole life, and it routes handleStateChangedEvent → dispatchTriage,
+        // handleIssueUpdatedEvent → the projection fold, and handleCommentCreatedEvent →
+        // onComment (the CTL-768 comment-wake needs-input clear + worker redispatch). A torn
+        // line here silently drops a dispatch or a human's reply.
+        //
+        // `line` is a COMPLETE line: leftoverBuf popped the trailing partial off `lines`
+        // before this loop, so an unparseable line here is real damage, not a read that raced
+        // a writer mid-append.
+        //
+        // COUNT AND ADVANCE. lastByteOffset (and the durable saveCursor) already moved to
+        // stat.size above, deliberately: a torn line is permanently corrupt, so parking on it
+        // would wedge the monitor forever on damage that never resolves.
+        noteTornLine(line);
         continue; // skip a malformed line, keep tailing
       }
       // CTL-731: handleStateChangedEvent gates its dispatch side-effects on

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -580,8 +580,23 @@ _canonical_is_sentinel_leak() {
 # flushes through stdio in BUFSIZ-sized chunks — 1024 on macOS, 8192 on glibc, an
 # undocumented implementation detail that differs by platform — so a line longer than
 # BUFSIZ becomes ⌈n/BUFSIZ⌉ separate write() calls and a concurrent producer's append lands
-# BETWEEN them. Measured against this repo's own harness at 8 producers × 150 lines:
-# 658/1200 lines damaged at 1,025 B and 1,196/1200 at 19,086 B.
+# BETWEEN them.
+#
+# Instrument: `__tests__/event-append-atomicity.test.sh` case 3 — the same 8-producer ×
+# 150-line harness as cases 1 and 2, run through the naive `printf >>` instead of this
+# primitive, counting unparseable + spliced lines out of 1,200. Measured over 20 runs on two
+# hosts: 15 on a 12-core M2 laptop (macOS 26.5, bash 5.3) and 5 on a 10-core Mac mini (macOS
+# 26.6, bash 3.2, the fleet's stock-macOS shape):
+#
+#     1,025 B  →   28–134 of 1,200 damaged   (2–11%)
+#    19,086 B  →  165–523 of 1,200 damaged  (14–44%)
+#
+# A RANGE, not a point value, and deliberately so: the count is load- and host-dependent and
+# swung ~5× run to run on one host (the 523 came from a run that overlapped other work). Do
+# not read a single number off this as a target or a regression threshold. What DOES reproduce
+# is the direction — the 19 KB line tore more often than the 1 KB line in 20 of 20 runs, by
+# 2.6–7.2× — and case 3 asserts only that the naive path tears at all, which is the property
+# that keeps cases 1 and 2 honest.
 #
 # The relevant constant is stdio BUFSIZ, NOT PIPE_BUF — the destination is a regular file,
 # not a pipe, so the familiar "a write below PIPE_BUF is atomic" reasoning does not apply

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -657,9 +657,18 @@ _canonical_event_name_of() {
 # A name-specific waiter therefore still misses its event; nothing in the fleet is within 4×
 # of the cap, so this is a tripwire for a pathological producer, not a routing policy.
 #
-# Hand-built with printf, not jq: the cap must hold on the jq-less path too. The dropped
-# event's name is the only untrusted text here and is scrubbed to the event-name charset
-# before embedding, since there is no jq available to escape it.
+# Hand-built with printf, not jq: the cap must hold on the jq-less path too. There is
+# therefore no escaper available, so EVERY externally-supplied string interpolated below is
+# scrubbed to a JSON-safe charset first. Two of them, not one:
+#
+#   · the dropped event's name (`$name`);
+#   · the HOST name (`$host`). `catalyst_host_name` returns `CATALYST_HOST_NAME` — or Layer-2
+#     `catalyst.host.name` — verbatim, and neither is validated anywhere upstream. A host
+#     named `bad"host` produced `"host.name":"bad"host"`, which fails `jq -e`, so every reader
+#     discards the tombstone: the durable record silently loses exactly the event it exists to
+#     preserve, on the one line that reports a drop. Scrubbed with the SAME charset as the
+#     event name (a legal DNS label is a strict subset of it), so neither `"` nor `\` nor a
+#     control byte can reach the printf template.
 _canonical_append_oversized_tombstone() {
   local file="$1" name="$2" bytes="$3"
   # Recursion guard: the tombstone is appended through the same primitive. It is fixed-size
@@ -669,6 +678,8 @@ _canonical_append_oversized_tombstone() {
   local ts host safe tomb
   ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
   host="$(catalyst_host_name 2>/dev/null || echo unknown)"
+  host="$(printf '%s' "$host" | LC_ALL=C tr -c 'A-Za-z0-9._:-' '_' | cut -c1-120)"
+  [[ -n "$host" ]] || host="unknown"
   safe="$(printf '%s' "$name" | LC_ALL=C tr -c 'A-Za-z0-9._:-' '_' | cut -c1-120)"
   tomb="$(printf '{"ts":"%s","observedTs":"%s","severityText":"ERROR","severityNumber":17,"body":{"message":"event dropped: %s bytes exceeds the %s-byte append cap"},"attributes":{"event.name":"catalyst.event.oversized","event.entity":"event","event.action":"dropped","catalyst.event.oversized.name":"%s","catalyst.event.oversized.bytes":%s,"catalyst.event.oversized.cap":%s},"resource":{"service.name":"catalyst.event-append","host.name":"%s"}}' \
     "$ts" "$ts" "$bytes" "$CATALYST_EVENT_LINE_MAX_BYTES" "$safe" "$bytes" "$CATALYST_EVENT_LINE_MAX_BYTES" "$host")"

--- a/plugins/dev/scripts/lib/canonical-event.sh
+++ b/plugins/dev/scripts/lib/canonical-event.sh
@@ -573,6 +573,121 @@ _canonical_is_sentinel_leak() {
      "$(cd "$default_dir" 2>/dev/null && pwd -P || echo "$default_dir")" ]]
 }
 
+# ─── CTL-1809: the one atomic append seam ────────────────────────────────────
+#
+# `printf '%s\n' "$line" >> "$file"` LOOKS atomic and is not. O_APPEND makes the file
+# OFFSET atomic; it does not make a multi-`write(2)` sequence atomic. bash's builtin printf
+# flushes through stdio in BUFSIZ-sized chunks — 1024 on macOS, 8192 on glibc, an
+# undocumented implementation detail that differs by platform — so a line longer than
+# BUFSIZ becomes ⌈n/BUFSIZ⌉ separate write() calls and a concurrent producer's append lands
+# BETWEEN them. Measured against this repo's own harness at 8 producers × 150 lines:
+# 658/1200 lines damaged at 1,025 B and 1,196/1200 at 19,086 B.
+#
+# The relevant constant is stdio BUFSIZ, NOT PIPE_BUF — the destination is a regular file,
+# not a pipe, so the familiar "a write below PIPE_BUF is atomic" reasoning does not apply
+# here at all.
+#
+# `/bin/dd obs=1048576` accumulates the entire piped line into ONE output block and issues
+# exactly one write(2) for any input up to 1 MiB. dd's own accounting is the direct proof: a
+# 262,145-byte input reports `0+1 records out` at obs=1m (one partial output block = one
+# write) versus `4+1 records out` at obs=64k. Pipe-side chunking is irrelevant — only dd's
+# OUTPUT write touches the log.
+#
+# THREE deliberate non-choices, each of which was the failure mode of an obvious alternative:
+#
+#   · `/bin/dd`, not `dd`. Phase-agent workers and launchd jobs run with a restricted PATH,
+#     and a PATH-resolved helper that fails to resolve is precisely the silent no-op this
+#     guard exists to prevent. An absolute path present on stock macOS and Linux satisfies
+#     that structurally, with no fallback branch to be loud about.
+#   · No interpreter. A bun/node append helper costs 10–20× dd's per-emit time AND
+#     reintroduces the PATH-resolution failure above. Measured here: 3.8 ms/emit for dd vs
+#     0.2 ms for raw printf. The bash-writer census is ~200k events/month fleet-wide
+#     (~0.077/s), i.e. ~13 CPU-minutes/month. The JS writers — which carry the high-rate
+#     families like `recovery.tick` — already use `appendFileSync` and are atomic far past
+#     this cap, so they are deliberately untouched.
+#   · No size branch. "printf if small, dd if big" is a second code path that ships
+#     un-exercised, and it would be exercised only on the large lines that actually tear.
+#     Every bash append goes through dd unconditionally.
+#
+# Hard cap: 262,144 bytes, measured with `wc -c` (BYTES, not characters — a multi-byte
+# payload must not slip past a character count). That is 4.2× the all-time observed fleet
+# maximum (62,597 B) and inside the range dd is empirically proven atomic over. A cap above
+# the proven-atomic bound would be a lie and a cap near the observed max would drop real
+# events, which is also why it is deliberately NOT env-overridable.
+CATALYST_EVENT_LINE_MAX_BYTES=262144
+
+# _canonical_event_name_of LINE
+# Best-effort name for a line we are about to refuse. Reads all three envelope
+# discriminators in the house order — attributes["event.name"] ?? event ?? name — because a
+# refused line may be in any of them and an anonymous tally is not actionable. Uses sed
+# rather than jq: this must work on the jq-less catalyst-state.sh path too, and it is a COLD
+# path (only a cap breach reaches it), so the fork is free.
+_canonical_event_name_of() {
+  local line="$1" n=""
+  n="$(printf '%s' "$line" | LC_ALL=C sed -n 's/.*"event\.name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [[ -n "$n" ]] || n="$(printf '%s' "$line" | LC_ALL=C sed -n 's/.*"event"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  [[ -n "$n" ]] || n="$(printf '%s' "$line" | LC_ALL=C sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  printf '%s' "${n:-(unknown)}"
+}
+
+# _canonical_append_oversized_tombstone FILE NAME BYTES
+# Durable, in-band record that an event was refused. The stderr WARNING alone rides the
+# caller's `.log` (Alloy → Loki), which is the right OUT-of-band channel for "the event log
+# itself is degraded" — but it is invisible to every consumer that reads the event log, i.e.
+# to the surface where the gap actually appears.
+#
+# The tombstone carries its OWN event name. Re-emitting the dropped event's name with a
+# gutted payload would fire `catalyst-events wait-for` subscribers and the broker's
+# phase-lifecycle router on fabricated content — strictly worse than the absence it reports.
+# A name-specific waiter therefore still misses its event; nothing in the fleet is within 4×
+# of the cap, so this is a tripwire for a pathological producer, not a routing policy.
+#
+# Hand-built with printf, not jq: the cap must hold on the jq-less path too. The dropped
+# event's name is the only untrusted text here and is scrubbed to the event-name charset
+# before embedding, since there is no jq available to escape it.
+_canonical_append_oversized_tombstone() {
+  local file="$1" name="$2" bytes="$3"
+  # Recursion guard: the tombstone is appended through the same primitive. It is fixed-size
+  # plus a 120-char name so it cannot itself breach the cap — but a guard that does not
+  # depend on that arithmetic staying true is cheaper than one that does.
+  [[ -z "${__CE_IN_TOMBSTONE:-}" ]] || return 0
+  local ts host safe tomb
+  ts="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+  host="$(catalyst_host_name 2>/dev/null || echo unknown)"
+  safe="$(printf '%s' "$name" | LC_ALL=C tr -c 'A-Za-z0-9._:-' '_' | cut -c1-120)"
+  tomb="$(printf '{"ts":"%s","observedTs":"%s","severityText":"ERROR","severityNumber":17,"body":{"message":"event dropped: %s bytes exceeds the %s-byte append cap"},"attributes":{"event.name":"catalyst.event.oversized","event.entity":"event","event.action":"dropped","catalyst.event.oversized.name":"%s","catalyst.event.oversized.bytes":%s,"catalyst.event.oversized.cap":%s},"resource":{"service.name":"catalyst.event-append","host.name":"%s"}}' \
+    "$ts" "$ts" "$bytes" "$CATALYST_EVENT_LINE_MAX_BYTES" "$safe" "$bytes" "$CATALYST_EVENT_LINE_MAX_BYTES" "$host")"
+  __CE_IN_TOMBSTONE=1 canonical_atomic_append_line "$file" "$tomb" || true
+}
+
+# canonical_atomic_append_line FILE LINE
+# Append LINE + "\n" to FILE in exactly one write(2). Returns 0 on success, non-zero when
+# the line was refused (over the cap) or dd itself failed.
+#
+# Failure is LOUD and does NOT degrade to printf. A silent degrade would put the tear back
+# on exactly the large lines this exists for. Note also that the old call site's
+# `2>/dev/null || true` is why nothing on this path was ever audible — these warnings must
+# reach the caller's stderr, so no caller may re-silence them.
+canonical_atomic_append_line() {
+  local file="$1" line="$2"
+  [[ -n "$file" ]] || return 1
+  local bytes
+  bytes="$(printf '%s' "$line" | LC_ALL=C wc -c | tr -d ' ')"
+  if [[ "$bytes" -gt "$CATALYST_EVENT_LINE_MAX_BYTES" ]]; then
+    local name
+    name="$(_canonical_event_name_of "$line")"
+    printf '[catalyst] WARNING: refusing to append a %s-byte event (cap %s) — event.name=%s; dropped, NOT truncated (CTL-1809)\n' \
+      "$bytes" "$CATALYST_EVENT_LINE_MAX_BYTES" "$name" >&2
+    _canonical_append_oversized_tombstone "$file" "$name" "$bytes"
+    return 1
+  fi
+  if ! printf '%s\n' "$line" | /bin/dd obs=1048576 2>/dev/null >>"$file"; then
+    printf '[catalyst] WARNING: atomic append to %s FAILED — event lost (CTL-1809)\n' "$file" >&2
+    return 1
+  fi
+  return 0
+}
+
 # canonical_jsonl_append BASE_DIR LINE
 # Append a JSONL line to ${BASE_DIR}/YYYY-MM.jsonl. Rotates the existing file
 # to *.legacy on first canonical write if the first existing line lacks an
@@ -647,5 +762,9 @@ canonical_jsonl_append() {
       fi
     fi
   fi
-  printf '%s\n' "$line" >> "$month_file" 2>/dev/null || true
+  # CTL-1809: one write(2), not ⌈n/BUFSIZ⌉ of them. The old `2>/dev/null || true` here is
+  # deliberately gone — silencing the primitive's stderr would re-hide the two conditions it
+  # exists to report (a refused oversized event, a failed write). The `|| true` stays in
+  # spirit: this function's contract is best-effort, so a refusal must not abort the caller.
+  canonical_atomic_append_line "$month_file" "$line" || true
 }

--- a/plugins/dev/scripts/lib/emit-reap-intent.sh
+++ b/plugins/dev/scripts/lib/emit-reap-intent.sh
@@ -134,7 +134,17 @@ emit_reap_intent() {
 		line="$payload"
 	fi
 
-	printf '%s\n' "$line" >>"$month_file" 2>/dev/null || return 1
+	# CTL-1809: one write(2) per event. This file is a dependency-free leaf that sources
+	# canonical-event.sh LAZILY (above) and must keep working when the helper is absent — so
+	# the fallback is kept, but made LOUD. A silent printf fallback here would be the exact
+	# shape of degradation the atomic seam exists to remove: it would look identical to a
+	# working append right up until two producers overlapped on a large line.
+	if command -v canonical_atomic_append_line >/dev/null 2>&1; then
+		canonical_atomic_append_line "$month_file" "$line" || return 1
+	else
+		printf '[catalyst] WARNING: canonical-event.sh unavailable — appending a reap intent WITHOUT the atomic primitive; this write can tear above BUFSIZ (CTL-1809)\n' >&2
+		printf '%s\n' "$line" >>"$month_file" 2>/dev/null || return 1
+	fi
 	return 0
 }
 

--- a/plugins/dev/scripts/lib/linear-read-replica.sh
+++ b/plugins/dev/scripts/lib/linear-read-replica.sh
@@ -72,7 +72,13 @@ _lrr_emit_fallback_event() {
     --session "${CATALYST_SESSION_ID:-}" \
     --message "Linear single-ticket read fell back to linearis ($reason) for $id" \
     --payload-json "$(jq -nc --arg s "$source" '{source:$s}')" 2>/dev/null)" || return 0
-  canonical_jsonl_append "$events_dir" "$line" 2>/dev/null || true
+  # CTL-1809: the `2>/dev/null` above belongs to build_canonical_line (a jq program whose
+  # noise is not actionable); the append below must NOT be muted. Its stderr is the only
+  # report that the event was refused over the byte cap or lost to a failed write, and this
+  # helper is on the canonical agent read path — a silent drop here is a hole in the very
+  # "every client reads the replica" accounting the event exists to prove. Still `|| true`:
+  # a diagnostic tap must never fail its caller (CTL-988).
+  canonical_jsonl_append "$events_dir" "$line" || true
 }
 
 # _lrr_emit_read_event <ID> <source> <result> [age_ms] — CTL-1403 reads-by-source.
@@ -113,7 +119,9 @@ _lrr_emit_read_event() {
     ${age_args[@]+"${age_args[@]}"} \
     --session "${CATALYST_SESSION_ID:-}" \
     --message "linear read $id source=$source result=$result" 2>/dev/null)" || return 0
-  canonical_jsonl_append "$events_dir" "$line" 2>/dev/null || true
+  # CTL-1809: same split as _lrr_emit_fallback_event above — the builder's jq noise stays
+  # muted, the append's refusal/failure WARNING does not. Still `|| true` (CTL-988).
+  canonical_jsonl_append "$events_dir" "$line" || true
 }
 
 # _lrr_live_read <ID> → run the linearis fallback, CAPPED so a 429-stalled / hung

--- a/plugins/dev/scripts/lib/phase-emit-complete.sh
+++ b/plugins/dev/scripts/lib/phase-emit-complete.sh
@@ -112,10 +112,15 @@ emit_phase_complete() {
     --message "$message" \
     --payload-json "$enriched_payload")" || return 1
 
-  # Test override: write the single line directly to the file.
+  # CATALYST_EVENTS_FILE override: write the single line directly to that file. It bypasses
+  # canonical_jsonl_append's month resolution and rotation, but NOT the atomic primitive —
+  # CTL-1809. This producer is `catalyst.phase-agent`, whose lines now AVERAGE 1,075 B under
+  # the CTL-1795 superset envelope (max 3,105 B), i.e. its median already sits past the
+  # 1,025-byte macOS tear threshold; it is one of the two producers most exposed to this bug,
+  # not a test-only curiosity.
   if [[ -n "${CATALYST_EVENTS_FILE:-}" ]]; then
     mkdir -p "$(dirname "$CATALYST_EVENTS_FILE")" 2>/dev/null || true
-    printf '%s\n' "$line" >> "$CATALYST_EVENTS_FILE" || return 1
+    canonical_atomic_append_line "$CATALYST_EVENTS_FILE" "$line" || return 1
     return 0
   fi
 

--- a/plugins/dev/scripts/lib/thoughts-sync-gate.sh
+++ b/plugins/dev/scripts/lib/thoughts-sync-gate.sh
@@ -106,7 +106,10 @@ if [[ "$SYNC_MODE" == "shadow" ]]; then
       --event-name "$EVENT_NAME" 2>/dev/null || true)"
     if [[ -n "$LINE" ]]; then
       EVENTS_BASE="${CATALYST_DIR:-${HOME}/catalyst}/events"
-      canonical_jsonl_append "$EVENTS_BASE" "$LINE" 2>/dev/null || true
+      # CTL-1809: no `2>/dev/null` — the primitive's refused-line / failed-write WARNING is
+      # the only report that this event was dropped, and a muted loud fallback is a silent
+      # one. `|| true` still keeps the shadow-mode gate non-blocking.
+      canonical_jsonl_append "$EVENTS_BASE" "$LINE" || true
     fi
   fi
   exit 0

--- a/plugins/dev/scripts/otel-forward/index.ts
+++ b/plugins/dev/scripts/otel-forward/index.ts
@@ -114,7 +114,13 @@ configureDropSurface(cfg.otlp.dropSurface);
 // undifferentiated `skipped`, which no surface reads — so a whole event family could vanish
 // with every health signal green. They are reported on the pino log (Alloy-shipped,
 // independent of this daemon's own OTLP egress), never as an event on the pipe they describe.
-let stats = { processed: 0, skipped: 0, unrecognized: 0, skippedNoAttributes: 0 };
+// CTL-1809: `torn` counts lines that did not parse as JSON AT ALL — the product of a bash
+// producer's multi-write(2) append being interleaved by a concurrent producer. It is a
+// strictly different failure from `unrecognized` (parses fine, matches no known envelope
+// shape) and must not be folded into it: one says a producer emitted a shape we cannot map,
+// the other says the log was damaged in transit. It is deliberately NOT added to `skipped`
+// either — `skipped` counts records that reached processLine, and a torn line never does.
+let stats = { processed: 0, skipped: 0, unrecognized: 0, skippedNoAttributes: 0, torn: 0 };
 
 // CTL-1060 Phase 3: lag tracking state. lastLocalTs = newest event ts seen from the log.
 // lastForwardedTs = newest event ts confirmed delivered to OTLP/Loki (seeded from checkpoint).
@@ -305,6 +311,40 @@ export function noteUnrecognizedLine(line: string): void {
   );
 }
 
+// CTL-1809: its own gate, not shouldWarnForShape's. A torn line's "key" is a raw byte
+// prefix, so a sustained tear produces a near-unique key per line — sharing the shape gate
+// would exhaust the 50-key budget that the unknown-envelope alarm depends on within 50
+// lines, silencing a completely different detector. Same reason CTL-1818 gave each caller
+// its own gate in the first place.
+const shouldWarnForTear = createSparseWarnGate({ maxTracked: 20 });
+
+// Wired into the tailer as onUnparseable. The tailer's JSON.parse catch is the ONLY place in
+// this process that can see a torn line — it never reaches shouldForward's shape test, let
+// alone processLine.
+//
+// The counter is a LOWER BOUND on corruption, never proof of cleanliness. The CTL-1809 RCA
+// reproduced a splice that parses as valid JSON, whose declared length matches, and whose
+// contents are three different events; nothing here or in any other parser can see that.
+// The write side (lib/canonical-event.sh's one-write(2) primitive) is the fix — this is the
+// tripwire that says the fix is not holding somewhere.
+//
+// Note for whoever reads these numbers across hosts: a MONITOR node's count will legitimately
+// exceed a worker's. event-mirror is a transport, not a repair layer — a torn line has no
+// extractable event id, so its dedup ring cannot suppress it and it is always appended
+// (event-mirror/lib/state.ts), faithfully propagating worker-host damage plus any duplicates
+// from a cursor-0 re-read.
+export function noteUnparseableLine(line: string): void {
+  stats.torn++;
+  // A torn line has no name to report, by definition — a bounded raw prefix is the only
+  // identity available, and it is what an operator greps the source log for.
+  const prefix = line.slice(0, 60);
+  if (!shouldWarnForTear(`t:${prefix}`, stats.torn)) return;
+  log.warn(
+    { prefix, torn_total: stats.torn, bytes: line.length },
+    "TORN event-log line — did not parse as JSON; counted and skipped, never forwarded (CTL-1809)",
+  );
+}
+
 export function processLine(line: string): void {
   try {
     let ev = JSON.parse(line) as CanonicalEvent;
@@ -418,6 +458,7 @@ if (import.meta.main) {
     offset: ck?.offset ?? 0,
     onLine: processLine,
     onUnrecognized: noteUnrecognizedLine, // CTL-1817: make the tailer's silent drop loud
+    onUnparseable: noteUnparseableLine, // CTL-1809: make the tailer's silent TORN line loud
     signal: ac.signal,
   });
 
@@ -529,5 +570,8 @@ if (import.meta.main) {
     });
   }
   await flushAll();
-  log.info({ processed: stats.processed, skipped: stats.skipped }, "stopped");
+  // CTL-1809: `torn` on the shutdown line too — the sparse gate above means a long, slow
+  // tear may only ever have logged its first sighting, so this is the one place the
+  // process-total is guaranteed to be reported.
+  log.info({ processed: stats.processed, skipped: stats.skipped, torn: stats.torn }, "stopped");
 }

--- a/plugins/dev/scripts/otel-forward/lib/tail-torn.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail-torn.test.ts
@@ -16,7 +16,7 @@
 //
 // Run: cd plugins/dev/scripts/otel-forward && bun test lib/tail-torn.test.ts
 import { describe, test, expect } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, writeFileSync, appendFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,6 +129,118 @@ describe("CTL-1809 — a torn line is counted, skipped, and does not wedge the t
     const r = await runTailer([clean("a"), TORN, clean("b")], false);
     expect(r.forwarded).toHaveLength(2); // still advances — the skip was never the bug
     expect(r.torn).toHaveLength(0); // …but the damage is unobservable
+  });
+});
+
+// ── the in-flight write is not a tear ────────────────────────────────────────────────────────
+// A poll landing while a producer is mid-append reads a final fragment with no newline yet.
+// That is a HEALTHY write, and counting it made the detector wrong twice over: it reported a
+// tear that never happened, and — because `offset` had already advanced to EOF — the next poll
+// saw the record's SUFFIX as a fresh line and could count the same record a second time. Every
+// other reader on this log (execution-core/event-tail.mjs's parseEventTailChunk,
+// broker/tailer.mjs's readNewEvents) already holds the fragment back; this one now does too.
+//
+// Driven as SEQUENTIAL DRAINS over one growing file, because a single drain cannot show the
+// defect: the interleaving IS the test.
+async function drainSteps(
+  steps: string[]
+): Promise<{ forwarded: string[]; torn: string[]; endOffset: number; size: number }> {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1809-partial-"));
+  const filePath = join(dir, "2026-08.jsonl");
+  writeFileSync(filePath, "");
+  const forwarded: string[] = [];
+  const torn: string[] = [];
+  const ac = new AbortController();
+  let endOffset = -1;
+  let size = -1;
+  try {
+    const tailer = createTailer({
+      filePath,
+      offset: 0,
+      onLine: (l) => forwarded.push(l),
+      onUnparseable: (l: string) => torn.push(l),
+      signal: ac.signal,
+    });
+    for (const chunk of steps) {
+      appendFileSync(filePath, chunk);
+      await tailer.drain();
+    }
+    endOffset = tailer.currentOffset();
+    size = statSync(filePath).size;
+  } finally {
+    ac.abort();
+    rmSync(dir, { recursive: true, force: true });
+  }
+  return { forwarded, torn, endOffset, size };
+}
+
+describe("CTL-1809 — a mid-append read is not a tear", () => {
+  test("a record split across two polls is forwarded ONCE and never counted torn", async () => {
+    const record = clean("split.across.polls");
+    const cut = Math.floor(record.length / 2);
+    // Poll 1 lands mid-append: the producer has written only the first half, no newline.
+    // Poll 2 sees the rest.
+    const r = await drainSteps([record.slice(0, cut), record.slice(cut) + "\n"]);
+
+    expect(r.torn).toHaveLength(0); // it was never damaged
+    expect(r.forwarded).toHaveLength(1); // …and it was not lost either
+    expect(JSON.parse(r.forwarded[0]).attributes["event.name"]).toBe("split.across.polls");
+    // The suffix was not re-counted as a second line on the later poll.
+    expect(r.forwarded.filter((l) => l.includes("split.across.polls"))).toHaveLength(1);
+  });
+
+  test("a complete line ahead of the in-flight one is delivered immediately, not held", async () => {
+    // The fragment must be held WITHOUT stalling the lines that did finish — holding the whole
+    // read back would turn a partial write into forwarding latency for everything behind it.
+    const done = clean("finished");
+    const half = clean("still.writing").slice(0, 20);
+    const r = await drainSteps([`${done}\n${half}`]);
+
+    expect(r.torn).toHaveLength(0);
+    expect(r.forwarded).toHaveLength(1);
+    expect(JSON.parse(r.forwarded[0]).attributes["event.name"]).toBe("finished");
+    // ADVANCE is unchanged: the byte cursor still sits at EOF even with a fragment held, so
+    // the held bytes are carried in memory, not re-read.
+    expect(r.endOffset).toBe(r.size);
+  });
+
+  test("POSITIVE CONTROL: a torn line is still counted across the same sequential drives", async () => {
+    // Without this, the two zeros above would also be produced by a harness whose onUnparseable
+    // hook is simply never reachable on this code path.
+    const r = await drainSteps([`${clean("a")}\n${TORN}\n${clean("b")}\n`]);
+    expect(r.torn).toHaveLength(1);
+    expect(r.forwarded).toHaveLength(2);
+  });
+
+  test("a fragment held across a TRUNCATION is dropped, not stitched onto the new first line", async () => {
+    // Rotation-in-place: the held bytes belong to a file that no longer exists. Prepending them
+    // would MANUFACTURE a torn line out of two healthy ones.
+    const dir = mkdtempSync(join(tmpdir(), "ctl1809-trunc-"));
+    const filePath = join(dir, "2026-08.jsonl");
+    const forwarded: string[] = [];
+    const torn: string[] = [];
+    const ac = new AbortController();
+    try {
+      writeFileSync(filePath, clean("before.truncate").slice(0, 30)); // fragment, no newline
+      const tailer = createTailer({
+        filePath,
+        offset: 0,
+        onLine: (l) => forwarded.push(l),
+        onUnparseable: (l: string) => torn.push(l),
+        signal: ac.signal,
+      });
+      await tailer.drain(); // holds the fragment
+      writeFileSync(filePath, ""); // truncate → size < offset
+      await tailer.drain(); // resets offset AND the held fragment
+      writeFileSync(filePath, `${clean("after.truncate")}\n`);
+      await tailer.drain();
+    } finally {
+      ac.abort();
+      rmSync(dir, { recursive: true, force: true });
+    }
+    expect(torn).toHaveLength(0);
+    expect(forwarded).toHaveLength(1);
+    expect(JSON.parse(forwarded[0]).attributes["event.name"]).toBe("after.truncate");
   });
 });
 

--- a/plugins/dev/scripts/otel-forward/lib/tail-torn.test.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail-torn.test.ts
@@ -1,0 +1,190 @@
+// tail-torn.test.ts — CTL-1809. The tailer's JSON.parse catch is the ONLY place in this
+// process that can see a TORN line, and until now it swallowed one silently.
+//
+// A torn line is not the same failure as CTL-1817's unrecognized envelope. Unrecognized
+// means a producer emitted a shape the mapper cannot read — the bytes are intact. Torn means
+// the LOG ITSELF was damaged in transit: a bash producer's `printf >>` above stdio BUFSIZ is
+// ⌈n/BUFSIZ⌉ separate write(2) calls, and a concurrent producer's append lands between them.
+// The two must stay separately counted; conflating them would report a write-path defect as a
+// producer-shape defect and send whoever reads the number to the wrong file.
+//
+// The behaviour under test is COUNT AND ADVANCE. The ticket's AC asked for the opposite ("does
+// not advance a durable cursor past the line it could not read"); that was overruled, because a
+// torn line is permanently corrupt and parking the cursor on it would wedge the forwarder —
+// and every other daemon on this log — forever. See execution-core/event-tail.mjs:12-17 for the
+// shipped invariant this matches.
+//
+// Run: cd plugins/dev/scripts/otel-forward && bun test lib/tail-torn.test.ts
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { createTailer } from "./tail.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const INDEX_TS = resolve(HERE, "..", "index.ts");
+
+interface TailRun {
+  forwarded: string[];
+  unrecognized: string[];
+  torn: string[];
+  endOffset: number;
+  size: number;
+  /** result of a SECOND drain with no new bytes — proves the cursor did not rewind */
+  redrainForwarded: string[];
+}
+
+// Drive the real tailer over a real file and collect all three outcomes, then drain again.
+async function runTailer(lines: string[], wireTornHook = true): Promise<TailRun> {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1809-tail-"));
+  const filePath = join(dir, "2026-08.jsonl");
+  writeFileSync(filePath, lines.join("\n") + "\n");
+
+  const forwarded: string[] = [];
+  const unrecognized: string[] = [];
+  const torn: string[] = [];
+  const redrainForwarded: string[] = [];
+  let endOffset = -1;
+  const size = statSync(filePath).size;
+  const ac = new AbortController();
+  try {
+    let collecting = forwarded;
+    const tailer = createTailer({
+      filePath,
+      offset: 0,
+      onLine: (l) => collecting.push(l),
+      onUnrecognized: (l) => unrecognized.push(l),
+      ...(wireTornHook ? { onUnparseable: (l: string) => torn.push(l) } : {}),
+      signal: ac.signal,
+    });
+    await tailer.drain();
+    endOffset = tailer.currentOffset();
+    collecting = redrainForwarded;
+    await tailer.drain();
+  } finally {
+    ac.abort();
+    rmSync(dir, { recursive: true, force: true });
+  }
+  return { forwarded, unrecognized, torn, endOffset, size, redrainForwarded };
+}
+
+// A torn line, shaped like the real thing: the RCA measured that all 200 production fragments
+// end in `}` and none start with `{` — they are TAIL fragments whose head was never written.
+const TORN = '.name":"phase.implement.complete.CTL-1"},"resource":{"service.name":"x"}}';
+
+const clean = (name: string) =>
+  JSON.stringify({ ts: "2026-08-13T10:00:00Z", attributes: { "event.name": name }, body: {} });
+
+describe("CTL-1809 — a torn line is counted, skipped, and does not wedge the tail", () => {
+  test("a torn line is reported once, never forwarded, and not misfiled as unrecognized", async () => {
+    const r = await runTailer([TORN]);
+    expect(r.forwarded).toHaveLength(0);
+    expect(r.torn).toHaveLength(1);
+    expect(r.torn[0]).toBe(TORN);
+    // The separation that matters: this is a damaged LOG, not an unreadable ENVELOPE.
+    expect(r.unrecognized).toHaveLength(0);
+  });
+
+  test("ADVANCE: every valid line after a torn one still reaches the pipeline", async () => {
+    const r = await runTailer([clean("before.torn"), TORN, clean("after.torn")]);
+    expect(r.torn).toHaveLength(1);
+    expect(r.forwarded).toHaveLength(2);
+    expect(r.forwarded.map((l) => JSON.parse(l).attributes["event.name"])).toEqual([
+      "before.torn",
+      "after.torn",
+    ]);
+  });
+
+  test("ADVANCE: the byte cursor lands at EOF and a re-drain replays nothing", async () => {
+    // The concrete failure the rewritten AC avoids. If the tailer parked on the torn line, the
+    // offset would stop short of EOF and every subsequent drain would re-read the same bytes —
+    // a forwarder that never makes progress again, on damage that will never resolve.
+    const r = await runTailer([clean("a"), TORN, clean("b")]);
+    expect(r.endOffset).toBe(r.size);
+    expect(r.redrainForwarded).toHaveLength(0);
+  });
+
+  test("several torn lines in one read are each counted", async () => {
+    const r = await runTailer([TORN, clean("mid"), TORN, TORN, clean("end")]);
+    expect(r.torn).toHaveLength(3);
+    expect(r.forwarded).toHaveLength(2);
+  });
+
+  test("a clean batch reports no torn lines (negative case, positively controlled)", async () => {
+    const r = await runTailer([clean("a"), clean("b"), clean("c")]);
+    expect(r.forwarded).toHaveLength(3);
+    expect(r.torn).toHaveLength(0);
+    // POSITIVE CONTROL: the same harness, same hook, with one torn line added. Without it, a
+    // hook wired to nothing would also report 0 above and read as correct.
+    const ctrl = await runTailer([clean("a"), TORN]);
+    expect(ctrl.torn).toHaveLength(1);
+  });
+
+  // POSITIVE CONTROL for the whole file — the pre-fix world. With no hook wired, the torn line
+  // is still dropped and NOTHING anywhere observes it. That is exactly the state that let a
+  // 200-fragment corpus sit unreported on the monitor node for a week.
+  test("without the hook the drop is invisible — which is the defect", async () => {
+    const r = await runTailer([clean("a"), TORN, clean("b")], false);
+    expect(r.forwarded).toHaveLength(2); // still advances — the skip was never the bug
+    expect(r.torn).toHaveLength(0); // …but the damage is unobservable
+  });
+});
+
+// ── index.ts wiring ──────────────────────────────────────────────────────────────────────────
+// The hook above is inert unless index.ts passes it to createTailer AND noteUnparseableLine
+// actually counts. The counter half is exercised behaviourally by a spawned probe (index.ts's
+// `stats` is module-private and its module scope loads config, so an in-process import would be
+// order-dependent across bun's shared registry — the same reason index-drop-wiring.test.ts
+// spawns). The `createTailer({...})` call itself lives inside `if (import.meta.main)`, i.e. only
+// on the daemon path, so it is asserted by source with its own positive control rather than
+// left unasserted.
+describe("CTL-1809 — index.ts wiring", () => {
+  test("noteUnparseableLine counts and warns with a running total", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1809-probe-"));
+    const probe = join(dir, "probe.ts");
+    writeFileSync(
+      probe,
+      `const idx = await import(process.env.PROBE_INDEX);\n` +
+        // Distinct prefixes so each gets a first-sighting warning from the sparse gate; a
+        // shared prefix would legitimately be suppressed and prove nothing about the count.
+        `idx.noteUnparseableLine("TORN-A" + "x".repeat(80));\n` +
+        `idx.noteUnparseableLine("TORN-B" + "x".repeat(80));\n`
+    );
+    try {
+      const res = spawnSync(process.execPath, [probe], {
+        encoding: "utf8",
+        // cwd inside the package so index.ts's own `pino` import resolves — same reason
+        // index-drop-wiring.test.ts pins cwd to its own directory.
+        cwd: resolve(HERE, ".."),
+        env: {
+          ...process.env,
+          PROBE_INDEX: INDEX_TS,
+          CATALYST_DIR: dir,
+          CATALYST_EVENTS_DIR: join(dir, "events"),
+          CATALYST_CONFIG_PATH: join(dir, "config.json"),
+        },
+      });
+      const out = `${res.stdout}${res.stderr}`;
+      expect(out).toContain('"torn_total":1');
+      expect(out).toContain('"torn_total":2');
+      expect(out).toContain("TORN event-log line");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the tailer is constructed WITH onUnparseable", async () => {
+    const src = await Bun.file(INDEX_TS).text();
+    const call = src.slice(src.indexOf("createTailer({"));
+    const body = call.slice(0, call.indexOf("});") + 3);
+    expect(body).toContain("onUnparseable: noteUnparseableLine");
+    // POSITIVE CONTROL for the slice above: it must also see the CTL-1817 hook that is known
+    // to be present, and must NOT see a key that is known to be absent. Without both, a slice
+    // that silently captured the wrong region (or the empty string) would pass by containing
+    // nothing and failing nothing.
+    expect(body).toContain("onUnrecognized: noteUnrecognizedLine");
+    expect(body).not.toContain("onDefinitelyNotAKeyThatExists");
+  });
+});

--- a/plugins/dev/scripts/otel-forward/lib/tail.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail.ts
@@ -22,6 +22,17 @@ export interface TailerOpts {
    * warning so the drop is loud instead of silent. See shouldForward below.
    */
   onUnrecognized?: (line: string) => void;
+  /**
+   * CTL-1809: called with the raw line when it does not parse as JSON at all — a TORN line,
+   * i.e. the product of a bash producer's multi-write(2) append being interleaved by a
+   * concurrent producer. Distinct from onUnrecognized, which fires for a line that parses
+   * fine but matches no known envelope shape. Both are drops; only this one means the log
+   * itself was damaged on the way in.
+   *
+   * Optional so every existing caller is unchanged; index.ts wires it to a counter +
+   * sparse warning. See shouldForward's catch below.
+   */
+  onUnparseable?: (line: string) => void;
 }
 
 export interface Tailer {
@@ -71,6 +82,22 @@ export function createTailer(opts: TailerOpts): Tailer {
       }
       return recognized;
     } catch {
+      // CTL-1809: THIS IS THE TORN-LINE SEAM. Until now this catch swallowed an unparseable
+      // line with no counter and no log line anywhere in the process — so a damaged event
+      // log and a quiet one were byte-for-byte indistinguishable from here, which is how a
+      // measured 200-fragment corpus on the monitor node went unreported for a week.
+      //
+      // COUNT AND SKIP. A torn line can never be forwarded (it has no readable envelope),
+      // and it is permanently corrupt — parking `offset` on it would wedge this tailer, and
+      // with it the whole forwarder, on damage that will never resolve. The byte cursor has
+      // already advanced past it by the time we get here (readNewLines sets `offset = size`
+      // before splitting), which is the same never-revisit contract every other reader on
+      // this log ships.
+      try {
+        opts.onUnparseable?.(line);
+      } catch {
+        /* best-effort — a reporting hook must never break the tail loop */
+      }
       return false;
     }
   }

--- a/plugins/dev/scripts/otel-forward/lib/tail.ts
+++ b/plugins/dev/scripts/otel-forward/lib/tail.ts
@@ -47,6 +47,12 @@ export function createTailer(opts: TailerOpts): Tailer {
   const monthFn = opts.monthFn ?? (() => defaultMonthPath(opts.eventsDir ?? ""));
   let currentPath = opts.filePath ?? monthFn();
   let offset = opts.offset;
+  // CTL-1809: the trailing bytes of a read that did not end on a newline. A poll landing
+  // while a producer is mid-append sees a nonempty final fragment with no "\n" yet — that is
+  // a healthy in-flight write, not damage. Held here and stitched onto the front of the next
+  // read, which is the same `leftover` contract execution-core/event-tail.mjs's
+  // parseEventTailChunk and broker/tailer.mjs's readNewEvents already ship.
+  let leftover = "";
 
   // Accept canonical OTel envelopes (have `attributes`), flat reap-intent
   // records (have `event` but no `attributes`), and pino operational logs
@@ -93,6 +99,13 @@ export function createTailer(opts: TailerOpts): Tailer {
       // already advanced past it by the time we get here (readNewLines sets `offset = size`
       // before splitting), which is the same never-revisit contract every other reader on
       // this log ships.
+      //
+      // Every line reaching here is a COMPLETE line: readNewLines pops the trailing fragment
+      // into `leftover` before this loop, so an in-flight append can no longer be counted as
+      // a tear. It used to be: the fragment was passed straight in, `stats.torn` ticked on a
+      // perfectly healthy write, and because `offset` had already advanced the NEXT poll
+      // counted the rest of the same record again. A torn-line counter that counts healthy
+      // in-flight writes is not a torn-line counter.
       try {
         opts.onUnparseable?.(line);
       } catch {
@@ -106,7 +119,10 @@ export function createTailer(opts: TailerOpts): Tailer {
     if (!existsSync(currentPath)) return;
     const size = statSync(currentPath).size;
     if (size < offset) {
+      // Truncation/rotation in place: the held fragment belonged to bytes that no longer
+      // exist, so stitching it onto the new file's first line would manufacture a tear.
       offset = 0;
+      leftover = "";
       return;
     }
     if (size === offset) return;
@@ -119,8 +135,14 @@ export function createTailer(opts: TailerOpts): Tailer {
       closeSync(fd);
     }
     offset = size;
-    const text = buf.toString("utf8");
-    for (const line of text.split("\n")) {
+    const text = leftover + buf.toString("utf8");
+    const lines = text.split("\n");
+    // The final element is the trailing partial line — empty when the read ended exactly on a
+    // newline. Hold it back until a newline arrives rather than handing it to shouldForward,
+    // whose catch would report it as a tear AND leave its suffix to be counted a second time
+    // on the next poll (the offset has already advanced).
+    leftover = lines.pop() ?? "";
+    for (const line of lines) {
       if (line.length > 0 && shouldForward(line)) opts.onLine(line);
     }
   }
@@ -135,6 +157,9 @@ export function createTailer(opts: TailerOpts): Tailer {
       if (expected !== currentPath) {
         currentPath = expected;
         offset = 0;
+        // Month rollover: any fragment held from the previous month's file must not be
+        // prepended to the new file's first line.
+        leftover = "";
       }
       readNewLines();
       await new Promise<void>((resolve) => {


### PR DESCRIPTION
Closes CTL-1809 (Defect B). Defects A (event-mirror tick re-entrancy) and C (rewrite-and-rename) stay in their own tickets — the RCA is explicit that merging them loses the distinction between *proven-firing* and *latent*.

## The defect

`printf '%s\n' "$line" >> "$file"` looks atomic and is not. `O_APPEND` makes the file **offset** atomic; it does not make a multi-`write(2)` sequence atomic. bash's builtin printf flushes through stdio in BUFSIZ-sized chunks — **1024 on macOS, 8192 on glibc**, an undocumented implementation detail that differs by platform — so a line longer than BUFSIZ is ⌈n/BUFSIZ⌉ separate `write()` calls and a concurrent producer's append lands **between** them.

The relevant constant is stdio **BUFSIZ, not PIPE_BUF**. The destination is a regular file, so the familiar "a write below PIPE_BUF is atomic" reasoning never applied here at all.

The worst product of a splice is **not** an unparseable line. The RCA reproduced a line that **parses as valid JSON**, whose declared length matches exactly, and whose contents are three different events. No parser, no counter, no length check can detect that. That is why this has to be prevented at the write side, not validated at the read side.

**Latent, not theoretical — corrected.** The original wording here ("two bash producers' *median* line already sits past the macOS threshold") was **overstated, and contradicted by the very figures it cited** — 919 B is below 1,024 B, and the two numbers quoted were means, not medians. Re-measured on mini's `2026-08.jsonl` (through 2026-08-13): `catalyst.phase-agent` n=671, mean 1,094 B, **median 1,021 B**, max 2,870 B; `catalyst.worktree-salvage` n=4,891, mean 910 B, **median 900 B**, max 1,216 B. **Neither median clears 1,024 B** — phase-agent's sits 3 bytes under it. The real exposure is the upper tail, and it is larger than the median claim implied: **40.8% of `catalyst.phase-agent` lines already exceed 1,024 B** (1.9% for `worktree-salvage`). Latent, not theoretical — but via the tail, not the typical line.

## The mechanism

One seam — `canonical_atomic_append_line` (`lib/canonical-event.sh`) — pipes the line through `/bin/dd obs=1048576`. dd accumulates the whole piped input into a single output block and issues exactly one `write(2)` for anything up to 1 MiB. **dd's own accounting is the direct proof:**

```
$ printf '%*s\n' 262144 '' | /bin/dd obs=1048576 >/dev/null
512+1 records in
0+1 records out          ← ONE output write of 262,145 bytes

$ printf '%*s\n' 262144 '' | /bin/dd obs=65536 >/dev/null
4+1 records out          ← five writes
```

Pipe-side chunking is irrelevant — only dd's **output** write touches the log.

Three deliberate non-choices, each the failure mode of an obvious alternative:

| Choice | Why not the alternative |
| --- | --- |
| `/bin/dd`, not `dd` | Phase-agent workers and launchd jobs run with a restricted `PATH`; a PATH-resolved helper that fails to resolve is precisely the silent no-op this guard exists to prevent. An absolute path satisfies that structurally — no fallback branch to be loud about. |
| No interpreter | A bun/node helper costs 10–20× dd's per-emit time **and** reintroduces that PATH failure. Measured **3.8 ms/emit** for dd vs 0.2 ms raw printf, against a bash-writer census of **~200k events/month fleet-wide (~0.077/s) ≈ 13 CPU-minutes/month**. JS writers carry the high-rate families (`recovery.tick`, 326,940/mo), already use `appendFileSync`, and are atomic far past this cap — deliberately untouched. |
| No size branch | "printf if small, dd if big" is a second code path that ships un-exercised, and it would be exercised *only* on the large lines that actually tear. |

**Hard cap 262,144 bytes** (`wc -c` — bytes, not characters, so a multi-byte payload cannot slip past). 4.2× the observed all-time fleet max (62,597 B) and inside the range dd is empirically proven atomic over: a cap above the proven bound would be a lie, one near the observed max would drop real events. Over the cap the write is **refused — never truncated, never split** — returning non-zero with a stderr WARNING naming size and event, plus a `catalyst.event.oversized` **tombstone** appended in-band so the loss is durable and alertable rather than only visible on a `.log`.

The tombstone carries its **own** name. Re-emitting the dropped event's name with a gutted payload would fire that event's `wait-for` subscribers and the broker's phase-lifecycle router on fabricated content — strictly worse than the absence it reports.

### Seven bash sites, two more than the pre-work audit found

`canonical_jsonl_append` · `catalyst-state.sh`'s jq-less branch (the primitive is jq-free by construction, so that path keeps the guarantee) · `emit-worker-status-change.sh` · `lib/emit-reap-intent.sh` · **`lib/phase-emit-complete.sh`** · **`catalyst-events`' own `wait.*` emitter** · `catalyst-stack`'s `_emit_checkout_updated` — the last a whole-function *stdout redirect* rather than a `printf`, which is exactly why it is the easiest one to miss.

The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud** one. `event-append-atomicity.test.sh` scans for any silent raw append and recognizes the exemption *only* by that warning, so a genuinely new raw append still fails.

## Read side: a tripwire, never a proof

Torn lines are now **counted** at four readers. Separate readers keep separate sparse-warn gates so one flood cannot exhaust another detector's key budget — but the broker's two halves deliberately **share** one counter and one key budget, because they are one detector reading one file:

| Reader | Counter |
| --- | --- |
| `otel-forward/lib/tail.ts` (the `JSON.parse` catch) | `onUnparseable` → `stats.torn` |
| `execution-core/event-tail.mjs` | `tornLineCount()` |
| `catalyst-events`' filter | `torn_lines_total` on stderr |
| **`broker/tailer.mjs`'s LIVE tail** (the miss above) | shares `event-tail.mjs`'s exported `noteTornLine` |

**`catalyst-events` was worse than skipping — a P1 found during this work.** `jq -c "select(...)"` treats an unparseable line as a fatal parse error and **aborts** (verified: exit 5), so every valid event *after* a torn line in the same wake batch was silently lost, and a `wait-for` whose awaited event shared that batch simply timed out. Because the loop cursor is a line *count*, the abort was batch-scoped rather than a permanent wedge — which is precisely why it went unnoticed. The comment claiming lines "are silently skipped" was **false**: a check-that-cannot-fail in the form of a wrong comment. Now `jq -R 'fromjson?'`, deciding per line.

These counters are a **lower bound**, never proof of cleanliness — the valid-JSON splice above is invisible to all of them. Documented at each counter, along with the fact that a **monitor node's count legitimately exceeds a worker's**: event-mirror is a transport, not a repair layer, and a torn line has no extractable id for its dedup ring to suppress.

## ⚠️ An acceptance criterion I had to rewrite

The ticket's fourth AC reads:

> **And** it does **not** advance a durable cursor past the line it could not read

**That AC is wrong and is not implemented.** It directly contradicts the invariant this repo already ships at `execution-core/event-tail.mjs:12-17` — *"their bytes are already behind the byte cursor and will never be revisited"* — and it would wedge every daemon that wakes on this log. A torn line is **permanently corrupt**: parking a cursor on it does not buy a retry, it buys a forwarder, a reaper boot-replay and a daemon tail that never make progress again.

Rewritten to: *increments a named counter, emits an operator-visible line, **and advances past it***. Asserted directly rather than assumed — `tail-torn.test.ts` checks the byte cursor lands at EOF and that a re-drain replays nothing.

~~I walked all ten reader classes; none justifies stalling.~~ **That claim was overstated and is withdrawn — the census was incomplete.** Re-deriving it found the log's single most load-bearing reader missing from it: **`broker/tailer.mjs`'s live tail**, which routes every `filter.wake`, every phase-lifecycle terminal, the ingestion-recency map and the worker-state projection — and dropped torn lines on a bare `catch { continue; }`. The broker was half-covered in the most misleading way possible: its **boot replay** goes through `event-tail.mjs` and *was* counted, while the **live** loop that runs for the process's entire life was not. Now fixed (see the reader table above). The conclusion that no reader justifies stalling still holds for all of them, including this one; the one that was *worse* than count-and-advance was `catalyst-events`, fixed above.

## Verification — literal numbers

**`plugins/dev/scripts/__tests__/event-append-atomicity.test.sh`** — 9 cases, all green:

```
ok — 1025 B x 8 producers: 1200 lines, 0 unparseable, 0 spliced
ok — 19086 B x 8 producers: 1200 lines, 0 unparseable, 0 spliced
ok — positive control: naive printf >> damaged 57 lines at 1025 B and 246 at 19086 B   (load-dependent; see range below)
ok — oversized append: rc=1, size and event name on stderr, nothing written from the payload
ok — tombstone: catalyst.event.oversized, own name, records the dropped name and size
ok — cap boundary: 262144 B accepted and intact
ok — no bash producer bypasses the primitive silently (scan positive-controlled both ways)
ok — loud fallback: warns on stderr and still emits when canonical-event.sh is absent
ok — catalyst-events: torn line counted and skipped, the rest of the batch survives
```

Both halves of the AC are asserted: every line parses **and** every line's contents belong to exactly one event — each producer fills its padding with its own single character, so a splice is caught even when it parses. The AC's own third clause ("replace the primitive with a naive `printf >>` → red") is a **permanent committed case**, not a one-off check: measured over **20 runs on two hosts** (15 on a 12-core M2 laptop, macOS 26.5 / bash 5.3; 5 on a 10-core Mac mini, macOS 26.6 / bash 3.2): **28–134 of 1,200 damaged at 1,025 B** and **165–523 of 1,200 at 19,086 B**. A range, not a point value — the count is load- and host-dependent and swung ~5× run to run, so it is not a regression threshold. The direction is what reproduces: the 19 KB line tore more than the 1 KB line in **20 of 20** runs (2.6–7.2×). The earlier figure committed to `canonical-event.sh` and `docs/architecture.md` (658/1200 and 1196/1200) **did not reproduce and has been replaced in both**.

**Mutation proofs** — every new assertion, mutated behaviourally (never structurally) and reverted:

| Mutation | Result |
| --- | --- |
| `dd` → naive `printf` | case 1 RED: **66 unparseable** (was 0) |
| cap check → `-gt 99999999` | RED: oversized append returned 0 |
| tombstone name → the original's | RED: `found event.name=REUSED_ORIGINAL_NAME` |
| `-gt` → `-ge` at the cap | RED: at-cap line refused |
| `apply_filter` → the shipped `jq -c` | RED: `after.torn` never reached the consumer — **the P1 reproduced** |
| `canonical_jsonl_append` → raw `printf` | RED: convergence scan names the exact line |
| fallback warning deleted | RED: exemption withdrawn, site reported |
| `noteTornLine(line)` removed | event-tail **23 pass/0 fail → 20 pass/3 fail** |
| `opts.onUnparseable?.(line)` removed | tail-torn **8 pass/0 fail → 4 pass/4 fail** |
| `stats.torn++` removed | RED: 7 pass / 1 fail |
| `onUnparseable:` wiring removed | RED: 7 pass / 1 fail |

Fixing one of these mutations also surfaced a real bug in my own scan: awk's `NR` is cumulative across files, so a loud-fallback warning at the end of one file would have exempted a silent append near the start of the next. Now `FNR`, with `guard` reset at each file boundary.

**Suites** (exact commands):

- `cd plugins/dev/scripts/otel-forward && bun test` → **255 pass / 0 fail** (247 at baseline with my source changes, + my 8).
- `cd plugins/dev/scripts/execution-core && bun test event-tail.test.mjs event-scan.test.mjs event-cursor.test.mjs event-log-window.test.mjs event-log-read-guard.test.mjs` → **213 pass / 0 fail**.
- 13 of 14 related bash suites pass (`canonical-event`, `canonical-event-rotation`, `canonical-event-sentinel-guard`, `dual-envelope`, `catalyst-events`, `catalyst-events.signal`, `catalyst-state`, `catalyst-state-attention`, `emit-worker-status-change`, `phase-agent-emit-complete`, `phase-emit-complete-zsh`, `emit-reap-intent`, `event-append-atomicity`).

**Pre-existing failures, measured not assumed.** Both were re-run against a pristine `git worktree` of `origin/main`:

| Suite | origin/main | this branch |
| --- | --- | --- |
| `catalyst-stack.test.sh` | 59/68, 9 failed | 59/68, 9 failed |
| `execution-core/daemon.test.mjs` | 173 pass / 1 fail | 173 pass / 1 fail |

Identical on both sides — not imported by this change.

**CI wiring.** The new bash test is enumerated in `.github/workflows/execution-core-tests.yml`; that list is hand-maintained, so an unlisted test simply never runs and the guard would land with no gate. The new `.ts` test is picked up by the existing globbed `bun test` step. YAML validated with a parser, and the edit is a single inserted step.

## Deferred / out of scope

- **Alerting is emit-only here**, per ruling. No Grafana rule file in this repo. The counters surface as stderr `.log` lines (Alloy → Loki) and via otel-forward's existing drop surface; a rule of shape `sum by (host_name) (count_over_time(<torn selector>[1h])) > 0` — plus the usual `absent_over_time` caveat for a dead forwarder — belongs in `catalyst-otel`.
- **CTL-1818 keeps the forwarder DROP counter**; this adds a separate `torn` counter and does not touch `emitDrop` or `recordDrop`.
- **JS writers unchanged** — `appendFileSync` is already atomic to ≥4 MiB.
- **Defects A and C** are separate tickets, including the re-mirror that recovers the 341,356 events missing from the monitor node.
- **No writer lock, no serialization daemon, no repair/quarantine inside the primitive** — `canonical_jsonl_append`'s CTL-1813 boundary ("it appends, it does not repair") is preserved.

## Review remediation (round 2)

Four verifier findings addressed in `8e0f00b9c`. The core write-side fix and all 11 behavioural mutation proofs are unchanged.

| # | Finding | Resolution |
| --- | --- | --- |
| F1 | A committed measurement that did not reproduce, in two permanent documents | Replaced the point values with a measured range + instrument + two named hosts + the run-to-run spread, in both `lib/canonical-event.sh` and `docs/architecture.md` |
| F2 | Read-side census incomplete — one load-bearing reader missed | `broker/tailer.mjs`'s LIVE tail now counts torn lines via `event-tail.mjs`'s newly exported `noteTornLine`; 4 new tests, mutation-proven |
| F3 | Five call sites re-silenced the primitive's stderr | All five un-muted; new harness case 8 discovers callers and guards the shape permanently |
| F4 | Two overstated headline claims | The "ten reader classes" census claim and the "median line past the threshold" claim, both corrected above with re-measured figures |

**Mutation controls for the new assertions** (behavioural, on the exact line, reverted after):

| Mutation | Before → after |
| --- | --- |
| `noteTornLine(line)` removed from `tailer.mjs`'s live catch | tailer-torn **4 pass / 0 fail → 2 pass / 2 fail** (the two negative-control cases correctly stay green) |
| Re-add `2>/dev/null` to `emit-lifecycle-event.sh` (the multi-line trailing shape) | harness case 8 **RED**, naming `emit-lifecycle-event.sh:58` |
| Re-add `2>/dev/null` to `linear-read-replica.sh` (single-line shape) | harness case 8 **RED**, naming both lines 81 and 124 |

**Suites after remediation:**

- `plugins/dev/scripts/broker` → **912 pass / 1 fail** across 913 tests, stable over 3 runs. The one failure is `fence-held-fold.test.mjs`, **proven pre-existing**: `origin/main` gives an identical 13 pass / 1 fail on that file in isolation (full baseline suite there: 908 pass / 2 fail / 1 intermittent unhandled error).
- `broker/tailer-torn.test.mjs` → **4 pass / 0 fail** (new).
- `otel-forward` → **255 pass / 0 fail**. `execution-core` event suites → **213 pass / 0 fail**.
- 14 related bash suites PASS, including the extended `event-append-atomicity.test.sh` (**10 cases**, up from 9).
- `test-session-instrumentation.sh` fails 14 assertions — **proven pre-existing**, byte-identical count on `origin/main`; every failing assertion is a SKILL.md pattern check and no SKILL.md is touched by this PR.

**CI wiring.** The broker step runs **named files**, not a glob, so `tailer-torn.test.mjs` was added to it explicitly — otherwise it would never have run. It is named rather than globbed on purpose: a `bun test` glob there would import the pre-existing `fence-held-fold` failure into this job as a new red.

## Deploy note

Daemons and hooks run from `~/catalyst/plugin-source`, not the repo — **merged ≠ applied**. After merge, verify on each host against the *deployed* copy: run the harness against a scratch `BASE_DIR` sourcing the deployed lib (expect 0 torn), then once more with the deployed function shadowed by naive printf (expect torn > 0). "0 torn in prod" is not the success signal — it was already 0 on the authoritative worker logs *before* this fix, because the detector could not see splices. The signal is the harness clean **and** the naive-printf control still red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

