### PR TITLE
fix(dev): CTL-1835 — close the four residual gaps from #3349, and prove each closure

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -526,24 +526,35 @@ jobs:
 
       - name: plugin-refresh + lock-resolution-audit tests (CTL-1831)
         # `grep plugin-refresh .github/workflows/` returned only two COMMENTS
-        # before this step — plugin-refresh.test.mjs (97 tests guarding the
-        # merge-to-main checkout refresh, the deps install, the stale-index.lock
-        # clear and the pull-owner cutover) had never run in CI at all. Positive
-        # control: the same grep for `worker-state-projection` returned the `run:`
-        # line directly above. CTL-1831 adds the install-must-relink guard to that
+        # before this step — plugin-refresh.test.mjs (guarding the merge-to-main
+        # checkout refresh, the deps install, the stale-index.lock clear and the
+        # pull-owner cutover) had never run in CI at all. Positive control: the
+        # same grep for `worker-state-projection` returned the `run:` line
+        # directly above. CTL-1831 adds the install-must-relink guard to that
         # same file plus its own audit suite, and an unlisted suite is a guard that
         # lands with no gate — this job's list is hand-enumerated, not globbed.
         #
-        # Both files run: measured 175 tests / 0 fail on this branch, so there is
-        # no pre-existing red to import. (Instrument: `bun test
-        # plugin-refresh.test.mjs lock-resolution-audit.test.mjs` from this step's
-        # working-directory, bun 1.3.5, macOS arm64, single run — the count is
-        # deterministic, no spread. On a checkout WITHOUT the broker package's
-        # pino installed, one of the 175 fails to load rather than failing an
-        # assertion; CI installs it, so CI sees 175/0.) They cannot join the
-        # `bun test` allowlist below — that step's working-directory is
-        # execution-core, and plugin-refresh.test.mjs reaches router.mjs, which
-        # needs the BROKER package's own pino.
+        # Both files run: measured 196 tests / 0 fail (139 plugin-refresh + 57
+        # lock-resolution-audit), so there is no pre-existing red to import.
+        # INSTRUMENT: `bun test plugin-refresh.test.mjs
+        # lock-resolution-audit.test.mjs` from this step's working-directory,
+        # bun 1.3.5, Darwin arm64 26.5.2, single run — the count is deterministic,
+        # no spread. On a checkout WITHOUT the broker package's pino installed,
+        # exactly one of the 196 fails to LOAD (`Cannot find package 'pino' from
+        # config.mjs`) rather than failing an assertion, giving 195/1; CI runs
+        # `bun install` here, so CI sees 196/0. Both figures re-measured on this
+        # branch by stashing and restoring node_modules.
+        #
+        # CTL-1835: the previous revision of this comment cited "97 tests" for
+        # plugin-refresh.test.mjs and "175 tests" for the pair. Neither
+        # reproduced at the commit that shipped them — the head commit measured
+        # 137 and 189. Counts here are a snapshot of a hand-enumerated suite and
+        # go stale on every added test; re-measure with the instrument above
+        # rather than trusting the number, and correct it when it drifts.
+        #
+        # They cannot join the `bun test` allowlist below — that step's
+        # working-directory is execution-core, and plugin-refresh.test.mjs reaches
+        # router.mjs, which needs the BROKER package's own pino.
         working-directory: plugins/dev/scripts/broker
         run: bun test plugin-refresh.test.mjs lock-resolution-audit.test.mjs
 
@@ -622,7 +633,7 @@ jobs:
       - name: orphan-sweep installer test (CTL-1531)
         # The installer resolves the SWEEP_PROC_WIDEN rollout value that ends up
         # in the LaunchAgent's EnvironmentVariables — i.e. whether the widened
-        # process killer runs in shadow or enforce on every host. Its 7 I13
+        # process killer runs in shadow or enforce on every host. Its 11 I13
         # assertions guard the precedence chain (env → .catalyst/config.json →
         # the value already installed → shadow) and, crucially, that a routine
         # `catalyst-stack install-services` does NOT silently revert an operator's
@@ -634,6 +645,10 @@ jobs:
         # this suite SKIPS here (loudly, rc=0) and its 38 assertions only execute
         # on a developer Mac. Wiring it in still catches a syntax/gate break; it
         # is NOT full CI coverage. A macos-latest job would close that.
+        # (CTL-1835 re-measured both counts above: INSTRUMENT `bash
+        # __tests__/install-orphan-sweep.test.sh` from this working-directory on
+        # Darwin arm64 26.5.2 -> "Results: 38 passed, 0 failed", of which 11 lines
+        # are I13. The 38 reproduced; "7 I13" did not and was corrected to 11.)
         run: bash __tests__/install-orphan-sweep.test.sh
 
       - name: orphan-sweep installer ephemeral-path guard test (CTL-1306)

--- a/plugins/dev/scripts/broker/lock-resolution-audit.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.mjs
@@ -99,6 +99,29 @@ const BLOCK_CLOSE_RE = /^\s{0,3}\}/;
 // contributes a change the audit could verify on disk.
 const WORKSPACE_VERSION_PREFIX = "workspace:";
 
+// MEMO_KEY_SEP — the separator joining (fromDir, id) into the resolve memo key.
+//
+// It has to be a code unit that cannot occur in EITHER half, or two distinct
+// (fromDir, id) pairs collide and one probe silently answers for the other. A
+// path separator is exactly the wrong choice: `("/a", "b/c")` and `("/a/b",
+// "c")` would then share a key, and the memo would hand the first pair's
+// resolution to the second — a false answer from the module whose entire job is
+// to be trustworthy about what is on disk. U+0000 cannot appear in a filesystem
+// path or an npm package id, so it is the safe joiner.
+//
+// WRITTEN AS THE ESCAPE `\0`, NEVER AS A LITERAL NUL BYTE IN THIS SOURCE.
+// A literal NUL made file(1) classify this module as `data` and made plain
+// grep(1) return a SILENT ZERO on it — no error, no warning, no matches — i.e.
+// a check-that-cannot-fail instrument sitting inside the fleet's only defence
+// against a silently stale install (CTL-1835, follow-up to CTL-1831). The
+// escape produces the identical string value (`\0` in a template literal IS
+// U+0000), so behaviour is unchanged. BOTH halves of that contract — the
+// separator's VALUE and this file being plain TEXT — are locked by
+// lock-resolution-audit.test.mjs; neither assertion alone is sufficient, since
+// a later "cleanup" could swap the value for a visible character (reintroducing
+// the collision) or re-inline the byte (reintroducing the silent zero).
+export const MEMO_KEY_SEP = "\0";
+
 /**
  * parseLockPackages — the lockfile's `packages` map as structured data.
  *
@@ -439,9 +462,12 @@ export function auditLockResolution({
   };
 
   // resolve/locate memo — one probe per (fromDir, id) across the whole audit.
+  // Keyed by the two strings joined on MEMO_KEY_SEP (U+0000); see that
+  // declaration for why the separator is that value and why it must be written
+  // as the `\0` ESCAPE and never as a literal NUL byte in this source.
   const memo = new Map();
   const resolve = (fromDir, id) => {
-    const cacheKey = `${fromDir} ${id}`;
+    const cacheKey = `${fromDir}${MEMO_KEY_SEP}${id}`;
     if (memo.has(cacheKey)) return memo.get(cacheKey);
     let out = null;
     try {

--- a/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
+++ b/plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
@@ -19,11 +19,13 @@
 // Run: bun test plugins/dev/scripts/broker/lock-resolution-audit.test.mjs
 
 import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   splitLockKey,
   parseLockPackages,
   changedResolutions,
   auditLockResolution,
+  MEMO_KEY_SEP,
 } from "./lock-resolution-audit.mjs";
 
 // ─── fixtures ────────────────────────────────────────────────────────────────
@@ -904,6 +906,47 @@ describe("auditLockResolution", () => {
     expect(a.matched[0].wrongCopy[0]).toContain("sdk-logs/resources");
   });
 
+  test("a wrong-copy site is carried on a MISMATCHED verdict too — the verdict an operator acts on", () => {
+    // CTL-1835 gap 1. `wrongCopy` was asserted on the `matched` verdict (above)
+    // and inside the `inconclusive` REASON string, but never on `mismatched` —
+    // measured as the single surviving mutant of round 4's 17-mutation pass on
+    // CTL-1831: deleting the spread from the mismatched branch left the suite
+    // GREEN while its siblings went RED.
+    //
+    // Mismatched is the verdict that costs something: it triggers a
+    // `bun install --force` re-extract and, if that does not clear it, a
+    // permanent `deps_relink_failed` ERROR. An operator reading that ERROR needs
+    // to know some sites were EXCLUDED as wrong-copy probes rather than judged —
+    // otherwise the report reads as a complete census of the importers when it
+    // is not, which is the same "could not look" / "not there" conflation the
+    // three-valued verdict exists to prevent.
+    //
+    // Same wiring as the matched case, with one byte changed: the workspace root
+    // answers the STALE 2.8.0 instead of the moved 2.8.1, so the entry lands in
+    // `mismatched` while `sdk-logs/resources` is still shed as a wrong-copy probe
+    // (sdk-logs on disk is 0.9.9, not the locked 0.219.0).
+    const a = auditLockResolution({
+      workspaceRoots: [{ dir: ROOT, name: "catalyst" }],
+      oldLockText: WRONGCOPY_LOCK,
+      newLockText: WRONGCOPY_MOVED,
+      resolvePackageFn: stubResolver({
+        [`${ROOT}|core`]: { dir: "/store/core@2.8.0", version: "2.8.0" }, // STALE — the real defect
+        [`${ROOT}|sdk-logs`]: { dir: SDKLOGS_DIR, version: "0.9.9" }, // wrong copy
+        [`${SDKLOGS_DIR}|resources`]: { dir: RES_28, version: "2.8.0" },
+        [`${RES_28}|core`]: { dir: "/store/core@2.8.0", version: "2.8.0" },
+      }),
+    });
+    expect(a.matched).toEqual([]);
+    expect(a.mismatched).toHaveLength(1);
+    expect(a.mismatched[0].expected).toBe("2.8.1");
+    expect(a.mismatched[0].found).toEqual(["2.8.0"]);
+    expect(a.mismatched[0].importers).toEqual([`workspace:${ROOT}`]);
+    // The guard: deleting `...(wrongCopy.length > 0 ? { wrongCopy } : {})` from
+    // the mismatched branch of auditLockResolution fails exactly here.
+    expect(a.mismatched[0].wrongCopy).toHaveLength(1);
+    expect(a.mismatched[0].wrongCopy[0]).toContain("sdk-logs/resources");
+  });
+
   // ── entitlement climbs: an ANCESTOR's nested key governs too ──
   //
   // MEASURED on this repo's real lockfile: bun nests one level from a top-level
@@ -1118,5 +1161,83 @@ describe("auditLockResolution", () => {
     });
     expect(a.mismatched).toEqual([]);
     expect(a.inconclusive).toHaveLength(1);
+  });
+});
+
+// ─── CTL-1835: the memo separator, and this module staying plain TEXT ─────────
+//
+// The resolve memo keys on `${fromDir}${MEMO_KEY_SEP}${id}`. That separator was
+// written as a LITERAL NUL BYTE in the source, which had a consequence that went
+// unnoticed for the length of CTL-1831. Measured on the pre-fix file:
+//
+//   $ file   plugins/dev/scripts/broker/lock-resolution-audit.mjs   -> "data"
+//   $ grep -c  wrongCopy <that file>                                -> (nothing)
+//   $ grep -ac wrongCopy <that file>                                -> 9
+//
+// One 0x00 byte made grep(1) report a SILENT ZERO — no error, no warning, no
+// distinguishing exit code — on the one module that is the fleet's only defence
+// against a silently stale install. A silent-zero instrument living inside the
+// silent-failure detector. Two INDEPENDENT properties keep that fixed and both
+// are load-bearing: the separator's VALUE (a visible character reintroduces key
+// collisions) and this file's TEXTNESS (a re-inlined byte reintroduces the blind
+// grep). Asserting either one alone leaves the other free to regress.
+describe("memo key separator (CTL-1835)", () => {
+  const SRC_PATH = new URL("./lock-resolution-audit.mjs", import.meta.url);
+  const srcBytes = readFileSync(SRC_PATH);
+  const countNul = (buf) => buf.reduce((n, b) => n + (b === 0 ? 1 : 0), 0);
+
+  test("the separator is U+0000 — the one code unit neither a path nor a package id can contain", () => {
+    expect(MEMO_KEY_SEP).toHaveLength(1);
+    expect(MEMO_KEY_SEP.charCodeAt(0)).toBe(0);
+    expect(MEMO_KEY_SEP).toBe("\u0000");
+  });
+
+  test("joining on it keeps (fromDir, id) pairs that a path separator would collide DISTINCT", () => {
+    // Why the VALUE matters, stated as the behaviour it buys rather than as the
+    // constant restated back to itself. Both pairs below are real shapes — every
+    // scoped package id contains a `/`, and so does every directory — so a `/`
+    // separator (or an empty one) makes the memo hand the first pair's cached
+    // resolution to the second, a false answer about what is on disk.
+    const viaScopeDir = `/x/node_modules/@scope${MEMO_KEY_SEP}name`;
+    const viaScopedId = `/x/node_modules${MEMO_KEY_SEP}@scope/name`;
+    expect(viaScopeDir).not.toBe(viaScopedId);
+    // The collision being avoided, spelled out: with "/" the two keys ARE equal,
+    // so this test fails the moment the separator becomes a path character.
+    expect(`/x/node_modules/@scope` + "/" + `name`).toBe(`/x/node_modules` + "/" + `@scope/name`);
+  });
+
+  test("the memo actually USES the constant — a hardcoded separator in the template is not allowed", () => {
+    // Without this, MEMO_KEY_SEP could be exported, asserted, and entirely unused
+    // while the template literal quietly carried some other separator: the two
+    // tests above would still pass. POSITIVE CONTROL that this read is looking at
+    // the right lines at all — the memo's own guard is asserted present by the
+    // same instrument, so a moved/renamed memo fails loudly instead of silently
+    // matching nothing.
+    const src = srcBytes.toString("utf8");
+    expect(src).toContain("if (memo.has(cacheKey)) return memo.get(cacheKey);");
+    expect(src).toContain("const cacheKey = `${fromDir}${MEMO_KEY_SEP}${id}`;");
+  });
+
+  test("the source file contains NO literal NUL byte — grep(1) on it must not return a silent zero", () => {
+    // POSITIVE CONTROL FIRST. Otherwise "zero NULs found" is indistinguishable
+    // from "the scanner cannot see a NUL", which is the very defect class this
+    // module exists to prevent and the exact way the original byte hid. The
+    // control is the real thing asserted absent: the pre-fix line, rebuilt with
+    // an actual 0x00 in it — written as the `\u0000` ESCAPE so that constructing
+    // the control does not itself put a literal NUL back into this test file.
+    const preFixLine = Buffer.from(
+      "    const cacheKey = `${fromDir}" + "\u0000" + "${id}`;\n",
+      "utf8",
+    );
+    expect(countNul(preFixLine)).toBe(1);
+
+    // The assertion itself, by the instrument just controlled.
+    expect(countNul(srcBytes)).toBe(0);
+
+    // And THIS file, which is where the byte most easily comes back: writing
+    // this very test is what re-introduced three literal NULs during CTL-1835,
+    // because a NUL pastes invisibly and nothing downstream complains. A blind
+    // grep over the test suite is the same hazard one file over.
+    expect(countNul(readFileSync(new URL(import.meta.url)))).toBe(0);
   });
 });

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -1498,10 +1498,13 @@ describe("workspaceMemberNodeModules", () => {
   // its fixture registers `/co/packages/a/...` but the un-guarded code path
   // probes the LITERAL `/co/packages/*/...`, which the fixture never registers —
   // so it returns [] with or without the guard. Measured: deleting
-  // `|| entry.includes("*")` at workspaceMemberNodeModules leaves the suite at
-  // 137 pass / 0 fail. (Its SIBLING guard in workspaceRootsFor is genuinely
-  // covered; only this one was blind.) The two tests below fail when it is
-  // dropped, from the two independent directions.
+  // `|| entry.includes("*")` at workspaceMemberNodeModules left the THEN-CURRENT
+  // suite — this file alone, before the two tests below existed — at 137 pass /
+  // 0 fail (bun 1.3.5, Darwin arm64 26.5.2, at origin/main 3f60190c6). With the
+  // two tests below present the same deletion gives 137 pass / 2 fail, which is
+  // the point; re-measure rather than trust either number. (Its SIBLING guard in
+  // workspaceRootsFor is genuinely covered; only this one was blind.) The two
+  // tests below fail when it is dropped, from the two independent directions.
   test("a glob entry is skipped at the ENTRY level — no path containing '*' is ever probed", () => {
     // The load-bearing meaning of "SKIPPED, not expanded": the pattern must
     // never enter path construction at all. This holds on every filesystem,

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -1494,6 +1494,66 @@ describe("workspaceMemberNodeModules", () => {
     expect(workspaceMemberNodeModules("/co", glob)).toEqual([]);
   });
 
+  // CTL-1835 gap 3. The assertion directly above is a CHECK THAT CANNOT FAIL:
+  // its fixture registers `/co/packages/a/...` but the un-guarded code path
+  // probes the LITERAL `/co/packages/*/...`, which the fixture never registers —
+  // so it returns [] with or without the guard. Measured: deleting
+  // `|| entry.includes("*")` at workspaceMemberNodeModules leaves the suite at
+  // 137 pass / 0 fail. (Its SIBLING guard in workspaceRootsFor is genuinely
+  // covered; only this one was blind.) The two tests below fail when it is
+  // dropped, from the two independent directions.
+  test("a glob entry is skipped at the ENTRY level — no path containing '*' is ever probed", () => {
+    // The load-bearing meaning of "SKIPPED, not expanded": the pattern must
+    // never enter path construction at all. This holds on every filesystem,
+    // including the normal one where no literal `*` directory exists — which is
+    // precisely why the returned-value assertion above could not see the guard.
+    const probed = [];
+    const fs = {
+      readFileFn: () => JSON.stringify({ workspaces: ["packages/*", "plugins/dev"] }),
+      existsFn: (path) => {
+        probed.push(String(path));
+        return true; // everything exists — maximum opportunity to construct a bad path
+      },
+    };
+    const out = workspaceMemberNodeModules("/co", fs);
+
+    // POSITIVE CONTROL: the recorder is wired and the literal sibling entry DID
+    // travel the full path-construction route. Without this, "no '*' probed"
+    // would be indistinguishable from "nothing was probed at all".
+    expect(probed).toContain("/co/plugins/dev/package.json");
+    expect(probed.length).toBeGreaterThan(1);
+
+    // The guard: with it dropped, `/co/packages/*/package.json` is probed here.
+    expect(probed.filter((p) => p.includes("*"))).toEqual([]);
+    // ...and the glob never reaches the caller's prune list. (`plugins/dev` is
+    // absent because existsFn:true also gives it its own bun.lock, i.e. it reads
+    // as standalone-managed — the point of this test is the probe log.)
+    expect(out.filter((p) => p.includes("*"))).toEqual([]);
+  });
+
+  test("a directory LITERALLY named '*' on disk is still not pruned — the rm -rf fan-out guard", () => {
+    // The rare-but-real filesystem state the previous test cannot express: `*` is
+    // a legal POSIX filename, and `mkdir packages/*` under a shell that found no
+    // match creates it for real. In that tree the un-guarded code returns
+    // `/co/packages/*/node_modules` and the caller rm -rf's it — deleting a
+    // directory no workspace member ever claimed.
+    const files = new Set([
+      "/co/package.json",
+      "/co/bun.lock",
+      "/co/packages/*/package.json",
+      "/co/packages/*/node_modules",
+    ]);
+    const fs = {
+      readFileFn: () => JSON.stringify({ workspaces: ["packages/*"] }),
+      existsFn: (path) => files.has(String(path)),
+    };
+    // POSITIVE CONTROL: this fixture really does describe an existing literal
+    // glob dir, so [] below means "the guard shed it", not "nothing was there".
+    expect(fs.existsFn("/co/packages/*/node_modules")).toBe(true);
+
+    expect(workspaceMemberNodeModules("/co", fs)).toEqual([]);
+  });
+
   test("an unreadable root package.json yields [] rather than a throw — refresh must not die on it", () => {
     expect(
       workspaceMemberNodeModules("/co", {


### PR DESCRIPTION
Closes CTL-1835. Follow-up to CTL-1831 (#3349, merged as `3f60190c6`): the four residual gaps that PR's round-4 adversarial pass found and deliberately did not chase, so they were recorded rather than lost.

The functional change is **two lines**. Everything else is the coverage that proves them.

## The four gaps

### 1. One unguarded mutation — `wrongCopy` dropped from the `mismatched` verdict

Round 4 ran 17 mutations; 16 went RED, **M7 did not**. Its siblings *are* guarded (M6 on `matched` → RED, M8 on the `inconclusive` reason → RED), so the field was covered on two of its three verdicts and blind on the third.

Proven closed with a **negative control**, which is the only way to show the new test is what closes it:

| M7 — delete `lock-resolution-audit.mjs:715` | result |
| --- | --- |
| against `origin/main`'s test file | **52 pass / 0 fail — GREEN** (the gap was real) |
| against this branch's test file | **56 / 1 — RED** |

### 2. A stale test-count citation

Corrected `175` → **196 (139 + 57)**, removed a stale `97`, and `7 I13` → **11**; the `38` reproduced and was kept. Each now names its instrument, bun version and host. The head commit measured **189**, not 175.

### 3. `plugin-refresh.mjs:437` — a second glob guard was mutation-uncovered

Pre-existing (CTL-1628), explicitly out of #3349's scope so it would not be mistaken for coverage.

| drop `\|\| entry.includes("*")` at `:437` | result |
| --- | --- |
| against `origin/main`'s test file | **137 pass / 0 fail — GREEN** (reproduces the documented uncovered state exactly) |
| against this branch's test file | **137 / 2 — RED** (both new tests, from two independent directions) |

**No source change to `plugin-refresh.mjs`** — the fix is entirely new tests, so this PR does not touch the region CTL-1834 is concurrently editing.

### 4. `grep` silently returned nothing on `lock-resolution-audit.mjs` — root-caused, not documented around

The ticket asked to either fix the cause or add a warning comment. The cause turned out to be **one byte**.

`file` classified the source as `data`, so **plain `grep` returned zero without saying why** — a silent-zero instrument sitting inside the module that is the fleet's only defence against a silent stale install. It had already cost one agent a false negative mid-analysis.

Cause: **exactly one literal NUL byte at offset 23048, line 444**, an intentional memo-key separator written as a raw byte instead of an escape:

```js
const cacheKey = `${fromDir}<NUL>${id}`;
```

Fixed by hoisting it to `export const MEMO_KEY_SEP = "\0"`. The string value is byte-identical; only the *source encoding* changes.

| check | before | after |
| --- | --- | --- |
| `file` | `data` | **`Unicode text, UTF-8 text`** |
| `grep -c 'wrongCopy'` | *(silent zero)* | **9** |
| `grep -ac 'wrongCopy'` | 9 | 9 — now agree |

The separator's *identity* is asserted, not just its behaviour, because a later "cleanup" to a visible character would silently reintroduce a collision. With `/` as the separator, `(fromDir="a", id="b/c")` and `(fromDir="a/b", id="c")` produce the **same** key and the memo returns the wrong cached resolution. Verified both directions: distinct under `\0`, equal under `/`.

## Verification

40 mutations run, **40 RED, 0 GREEN** — every added production line, all 23 new assertions (each expected value perturbed so it *must* fail), and 8 fixture-erosion probes.

The harness was proven capable of RED before any green was trusted, because **round 4 of the parent PR caught and discarded a broken mutation harness** that silently mis-parsed ANSI and reported every mutation GREEN. This one strips ANSI, fails closed on unparseable output, and checks file md5s per run.

## Notes

- **Gap 4's hazard bit while fixing gap 4**: writing the tests put three literal NUL bytes into the test file — they paste invisibly and nothing complains. Caught by byte-scanning, not by reading. The NUL guard now covers the test file too, since that is demonstrably where the byte comes back.
- **Two instruments returned false zeros during this work**, both caught by positive control: `git grep -E '\b137\b'` returned 0 while plain `grep` returned 41 (POSIX ERE has no `\b`), and a `cd`-broken `git show` produced empty files that prettier then cheerfully passed. Both are exactly the defect class this ticket is about.
- **Declined, with reason**: two other citations in `execution-core-tests.yml` (`273`/`120` "on this branch") do not reproduce today, but they record a historical *branch-vs-merge-base delta* justifying why those steps exist. Overwriting them with today's values would destroy their meaning, and that file is a known merge-conflict hot spot with CTL-1834 in flight. Left as-is deliberately.
- **One pre-existing broker-suite failure** (`held-label literals stay in lock-step with the board`) is unrelated: reproduced at HEAD with these changes stashed (1004 pass / 1 fail at HEAD vs 1011 / 1 fail here — the delta is exactly the 7 tests added).
- No new test files, so the hand-enumerated CI list needed no additions; both files were already registered. YAML re-validated as parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
