### PR TITLE
fix(dev): CTL-1806 — serve the board's supplemental reads from the local replica, so a display render stops spending the shared Linear quota

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -917,6 +917,7 @@ jobs:
             recovery.test.mjs \
             registry.test.mjs \
             replica-read.test.mjs \
+            replica-supplemental-reads.test.mjs \
             scan.test.mjs \
             scheduler-created-at.test.mjs \
             scheduler-perproject.test.mjs \

--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -25,6 +25,45 @@ the token FIRST, activate the writer, wait for a verified seed, and only then fl
 The canonical seed-before-flip runbook, including every key's precedence, lives in
 `website/src/content/docs/reference/configuration.md`; this list is its replica-tier summary.
 
+## Supplemental display reads (CTL-1806)
+
+Three resolvers outside the eligible path used to call the Linear GraphQL API with no replica
+consultation at all. Two are now replica-first; the third cannot be, and says so.
+
+| Resolver | Local tier | Gate | On a miss |
+| --- | --- | --- | --- |
+| `orch-monitor/lib/linear-estimate-fallback.mjs` | `replica-read.mjs` `estimates()` | file presence | `catalyst.linear.read {source:"linearis_miss", op:"estimate"}` |
+| `orch-monitor/lib/linear-title-description-fallback.mjs` | `details()` (+ `relations()`) | file presence | `… {source:"linearis_miss", op:"title_desc"}` |
+| `execution-core/linear-estimation-method.mjs` | **none — see below** | 7-day on-disk TTL | `… {source:"linearis", op:"team_method"}` |
+
+Three properties are deliberate and easy to "fix" wrongly:
+
+- **File presence, never writer liveness.** A liveness gate on a *display* read falls through to
+  Linear precisely when the board is UNCHANGED (a live writer on a quiet feed reads as stale —
+  CTL-1397), turning a healthy quiet period into a burst of API calls. That is backwards for a read
+  whose purpose is removing them.
+- **A replica `NULL` estimate is a MISS, not an authoritative null.** Locally, "Linear has none" and
+  "this row predates the estimate projection" are indistinguishable, so serving the null would drop
+  the board chip for a refresh. Mirrors what `titles()` already does with an empty title.
+- **The team estimation method has no replica source and must not be defaulted.** The replica has no
+  `teams` table and carries no `issueEstimation`; the `$.team` projection is `{id,key,name}` only. So
+  its Linear fetch stays, labelled and bounded at 8 team keys per host per TTL. It is **never**
+  defaulted to a scale: the value gates a real Linear write (`applyEstimate` on the triage→research
+  advance), where `null` makes the scheduler SKIP the write and a guess would write a Fibonacci
+  number into a tShirt team's estimate field. The durable fix is a cloud-side `teams.issue_estimation`
+  column, not a local guess.
+
+`state.type` is not in the replica either (the enrichment pass overwrites `raw` with a projection
+that drops it). It is **synthesized from lifecycle timestamps** — `canceled_at` → `completed_at` →
+`started_at` → `backlog` — deliberately not from the state NAME, which would hardcode this
+workspace's contract states and break under a bring-your-own-workspace tenant. Measured 109/109
+exact on every class the consumer renders distinctly, against a committed ground-truth fixture
+(`execution-core/__fixtures__/state-type-ground-truth.json`); the one residual is a true `unstarted`
+collapsing to `backlog`, which costs a stroke-dash difference on a muted ring. The type is carried
+rather than omitted because it also selects the 24h-vs-5min cache TTL, and dropping it would move
+every terminal ticket to the short TTL — a quota regression inside a quota reduction. The durable
+fix is a cloud-side `workflow_states` table (`issues.state_id` is already fully populated).
+
 ## Signals
 
 | Signal | Where | Meaning |

--- a/plugins/dev/scripts/execution-core/__fixtures__/state-type-ground-truth.json
+++ b/plugins/dev/scripts/execution-core/__fixtures__/state-type-ground-truth.json
@@ -1,0 +1,881 @@
+{
+  "_readme": "CTL-1806 D2 ground-truth fixture for synthesizeStateType(). Captured from the live Catalyst replica; each row is a real ticket that STILL carried a genuine `raw.$.state.type` at capture time, paired with the three lifecycle timestamps the synthesis reads. This is COMMITTED rather than re-queried at test time on purpose: `state.type` survives only in the ~4-day window of un-enriched webhook-shape blobs (the enrichment pass overwrites raw with a projection that drops it), so a live query is a sliding window that can legitimately return ZERO rows \u2014 at which point a for-loop assertion passes on zero iterations and self-certifies. A fixture cannot do that, and the accompanying test additionally fails closed if this file is empty or loses a class.",
+  "_captured_at": "2026-08-14",
+  "_capture_query": "SELECT identifier, json_extract(raw,'$.state.type'), started_at, completed_at, canceled_at, state FROM issues WHERE removed_at IS NULL AND json_extract(raw,'$.state.type') IS NOT NULL",
+  "_positive_control": "json_extract(raw,'$.state.name') extracts on 3887/3887 rows and json_extract(raw,'$.state.type') on 109 \u2014 the extractor works; the field is genuinely sparse.",
+  "_expected_accuracy": "109/109 exact on every class the consumer renders distinctly. The single `unstarted` row synthesizes to `backlog`, which stateIconSpec draws as the same MUTED ring differing only in stroke dash.",
+  "rows": [
+    {
+      "identifier": "COA-5",
+      "groundTruthType": "unstarted",
+      "stateName": "Todo",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-133",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-295",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-297",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-298",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786544026888,
+      "completed_at": 1786544592334,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-300",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-316",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-378",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-398",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786478263496,
+      "completed_at": 1786536783906,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-399",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786538239531,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-400",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786540712943,
+      "completed_at": 1786541537553,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-401",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-402",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-403",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-404",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-405",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-406",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-408",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786536785176,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-410",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786536786322,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-411",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786539073124,
+      "completed_at": 1786540029074,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-412",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786536787281,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-414",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-416",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786539593415,
+      "completed_at": 1786540854510,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-417",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786543117042,
+      "completed_at": 1786544061810,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-418",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786541797801,
+      "completed_at": 1786543225569,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-419",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-423",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-425",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-461",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-480",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-481",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-482",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTC-483",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786679773098
+    },
+    {
+      "identifier": "CTL-1502",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1784846457126,
+      "completed_at": 1786366992270,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1645",
+      "groundTruthType": "started",
+      "stateName": "PR",
+      "started_at": 1785890831315,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1659",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786652282442,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1681",
+      "groundTruthType": "started",
+      "stateName": "Implement",
+      "started_at": 1786140558617,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1742",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1743",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786405316318
+    },
+    {
+      "identifier": "CTL-1744",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1745",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451452600
+    },
+    {
+      "identifier": "CTL-1746",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451453664
+    },
+    {
+      "identifier": "CTL-1747",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451454639
+    },
+    {
+      "identifier": "CTL-1748",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451455683
+    },
+    {
+      "identifier": "CTL-1749",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451457011
+    },
+    {
+      "identifier": "CTL-1750",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786451459103
+    },
+    {
+      "identifier": "CTL-1751",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786452022417
+    },
+    {
+      "identifier": "CTL-1752",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1753",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1754",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1755",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786458754591,
+      "completed_at": 1786465510947,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1757",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1758",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1759",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1761",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1764",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1765",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1766",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1767",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1768",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1769",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1770",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1771",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1772",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1773",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1775",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1776",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1779",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1780",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1781",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1782",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1783",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1784",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1785",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1786",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1791",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786541291724,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1792",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1793",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786541292721,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1794",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1795",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786649537920,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1797",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1798",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786541747164,
+      "completed_at": 1786542075130,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1801",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786543010067,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1802",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786541620595,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1803",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1804",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786586335852,
+      "completed_at": 1786586564790,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1806",
+      "groundTruthType": "started",
+      "stateName": "Implement",
+      "started_at": 1786679823254,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1809",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786670896645,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1811",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786582437470,
+      "completed_at": 1786582669918,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1814",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786649173387,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1815",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1816",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1817",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786631444294,
+      "completed_at": 1786633419327,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1818",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786649945680,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1820",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1821",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1822",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1823",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786653547362,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1824",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786642066731
+    },
+    {
+      "identifier": "CTL-1825",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786653159704,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1826",
+      "groundTruthType": "canceled",
+      "stateName": "Canceled",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": 1786657914212
+    },
+    {
+      "identifier": "CTL-1827",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1830",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1831",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": null,
+      "completed_at": 1786675503492,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1832",
+      "groundTruthType": "completed",
+      "stateName": "Done",
+      "started_at": 1786645935769,
+      "completed_at": 1786647555420,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1833",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1834",
+      "groundTruthType": "started",
+      "stateName": "Implement",
+      "started_at": 1786679322977,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "CTL-1835",
+      "groundTruthType": "started",
+      "stateName": "Implement",
+      "started_at": 1786679755027,
+      "completed_at": null,
+      "canceled_at": null
+    },
+    {
+      "identifier": "OTL-66",
+      "groundTruthType": "backlog",
+      "stateName": "Backlog",
+      "started_at": null,
+      "completed_at": null,
+      "canceled_at": null
+    }
+  ]
+}

--- a/plugins/dev/scripts/execution-core/linear-estimation-method.d.mts
+++ b/plugins/dev/scripts/execution-core/linear-estimation-method.d.mts
@@ -1,0 +1,67 @@
+// Type declarations for linear-estimation-method.mjs (CTL-954, extended CTL-1806).
+//
+// CTL-1806 made this module a CROSS-PACKAGE API: orch-monitor's
+// linear-estimate-fallback.mjs now shares its TTL, cache path, query and
+// read/write helpers instead of carrying duplicates that wrote the SAME file
+// with a DIFFERENT (24h vs 7-day) TTL.
+
+/** Estimation method descriptor as returned by the Linear GraphQL API. */
+export interface EstimationMethod {
+  /** "fibonacci" | "tShirt" | "exponential" | "linear" | "notUsed" */
+  type: string;
+  allowZero: boolean;
+  extended: boolean;
+}
+
+/**
+ * The ONE TTL for the team estimation method (7 days), shared by both writers of
+ * `~/catalyst/execution-core/team-estimation-<TEAM>.json`.
+ */
+export const TEAM_ESTIMATION_TTL_MS: number;
+
+/** The GraphQL query text, shared so the two callers cannot drift. */
+export const TEAM_ESTIMATION_QUERY: string;
+
+/** The single on-disk location for a team's estimation method. */
+export function teamEstimationCachePath(teamId: string): string;
+
+/**
+ * The shared cache tiers (in-process memo, then the on-disk record) under the one
+ * TTL. `null` means "not cached / stale / corrupt" — the caller must fetch.
+ */
+export function readTeamEstimationCache(
+  teamId: string,
+  opts?: { ttlMs?: number },
+): EstimationMethod | null;
+
+/**
+ * Persist a resolved method atomically (tmp + rename) and seed the memo. Returns
+ * the written record, or null when the disk write failed.
+ */
+export function writeTeamEstimationCache(
+  teamId: string,
+  method: EstimationMethod,
+): { teamId: string; method: EstimationMethod; fetchedAt: string } | null;
+
+/**
+ * getEstimationMethod — the team's Linear estimation method: shared cache first,
+ * then a SYNCHRONOUS `curl` fetch (the scheduler's pull loop is synchronous).
+ *
+ * Returns null on ANY failure, and that null is load-bearing: the scheduler SKIPS
+ * its `applyEstimate` Linear write when the method is unavailable. It must never
+ * be defaulted to a scale — writing a Fibonacci number into a tShirt team's
+ * estimate field is irreversible without an audit.
+ */
+export function getEstimationMethod(
+  teamId: string,
+  opts?: { ttlMs?: number },
+): EstimationMethod | null;
+
+/** Sorted integer point values for an estimation type; [] for notUsed/unknown. */
+export function scaleForMethod(type: string): number[];
+
+/** Map a triage `estimated_scope` to the closest valid integer for a type. */
+export function mapScopeToEstimate(scope: string, type: string): number | null;
+
+/** Test-only: reset the module-level memo. */
+export function _resetMemoForTests(): void;

--- a/plugins/dev/scripts/execution-core/linear-estimation-method.mjs
+++ b/plugins/dev/scripts/execution-core/linear-estimation-method.mjs
@@ -20,19 +20,56 @@
 // (identical to runBatchOnce in linear-query.mjs).  No async seams are needed.
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 // CTL-1616 PR3: fold this file's inline LINEAR_API_TOKEN/LINEAR_API_KEY ladder
 // onto the shared secret-contract engine (design §8 PR3 table).
 import { resolveSecret } from "../lib/secret-contract.mjs";
+// CTL-1806 (D3): the degraded-path anomaly. This module CANNOT be served from the
+// replica (see the DEGRADED note below), so its Linear call is labelled rather
+// than removed — and a labelled call has to actually be observable.
+import { emitLinearReadEvent } from "./linear-read-event.mjs";
 
 const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
-const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * CTL-1806 (D1) — the ONE TTL for the team estimation method, and the reason the
+ * Linear fetch below stays.
+ *
+ * DEGRADED BY NECESSITY, not by choice: the local Linear replica has no `teams`
+ * table and no workflow/state table (measured 2026-08-14: `sqlite_master` LIKE
+ * '%team%' and '%state%' return ZERO tables, against a positive control of
+ * '%issue%' returning 3 and '%label%' returning 2), and `issueEstimation` appears
+ * in 0 of 3887 `raw` blobs against a positive control of '%estimate%' matching
+ * 3864. The `$.team` projection that DOES exist carries exactly {id,key,name} —
+ * the container is there and the estimation config is not in it. So this read has
+ * no local source and cannot be made replica-first; it is bounded instead, at 8
+ * distinct team keys per host per TTL window.
+ *
+ * It is NOT defaulted to Fibonacci on a miss, and that is the sharpest constraint
+ * in this file: the value gates a REAL LINEAR WRITE (scheduler.mjs's triage→
+ * research advance reads the triage estimate and calls
+ * writeStatus.applyEstimate). Today an unavailable method returns null and the
+ * scheduler SKIPS the write. A default would flip that from "skip" to "derive and
+ * write a Fibonacci number into a tShirt team's estimate field" — irreversible
+ * without an audit. A guessed scale is worse than no estimate.
+ *
+ * CTL-1806 also collapses the duplicate cache: orch-monitor's
+ * linear-estimate-fallback.mjs wrote THIS SAME FILE with a 24h TTL while this
+ * module used 7 days, so a record written at T+30h was valid here and stale
+ * there — the board re-fetched from Linear and rewrote a file the scheduler was
+ * already happily serving, the exact duplicated call this ticket removes. Both
+ * now share this constant, the path fn, the query, and the read/write helpers.
+ */
+export const TEAM_ESTIMATION_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 // GraphQL query — filter by key (the short mnemonic like "CTL") instead of
 // UUID, matching the pattern in setup-execution-core-states.sh line 351.
 // The scheduler knows team keys (CTL/ADV/OTL) not UUIDs.
-const TEAM_ESTIMATION_QUERY = `query GetTeamEstimation($key: String!) {
+// Exported (CTL-1806) so the orch-monitor async resolver reuses this text rather
+// than carrying a byte-copy that can drift.
+export const TEAM_ESTIMATION_QUERY = `query GetTeamEstimation($key: String!) {
   teams(filter: { key: { eq: $key } }) {
     nodes {
       issueEstimation {
@@ -53,27 +90,93 @@ const _memo = new Map();
 
 // ── Cache file path ───────────────────────────────────────────────────────────
 // Same durable-state directory as registry.json / eligible / state.json.
-function cacheFilePath(teamId) {
-  const dir = join(process.env.HOME ?? "/tmp", "catalyst", "execution-core");
-  return join(dir, `team-estimation-${teamId}.json`);
+// CTL-1806: `process.env.HOME ?? homedir()` rather than the old `?? "/tmp"` —
+// orch-monitor's now-deleted duplicate resolved this with homedir(), so with HOME
+// unset the two "same file" writers silently targeted two DIFFERENT files.
+function cacheDir() {
+  return join(process.env.HOME ?? homedir(), "catalyst", "execution-core");
+}
+
+/**
+ * teamEstimationCachePath — the single on-disk location for a team's estimation
+ * method. Exported (CTL-1806) so every writer of this file agrees on the path.
+ * @param {string} teamId
+ * @returns {string}
+ */
+export function teamEstimationCachePath(teamId) {
+  return join(cacheDir(), `team-estimation-${teamId}.json`);
 }
 
 // ── Atomic cache write ────────────────────────────────────────────────────────
 // Write to a .tmp sibling, then rename — avoids a corrupt half-written read on
 // the next tick if the process is killed mid-write.
-function writeCacheFile(teamId, method) {
-  const path = cacheFilePath(teamId);
-  const dir = join(process.env.HOME ?? "/tmp", "catalyst", "execution-core");
+/**
+ * writeTeamEstimationCache — persist a resolved method under the shared TTL
+ * contract. Exported (CTL-1806) so the async orch-monitor resolver reuses this
+ * atomic write instead of its own copy. Returns the written record, or null when
+ * the disk write failed (the caller's in-memory cache remains valid).
+ * @param {string} teamId
+ * @param {{type: string, allowZero: boolean, extended: boolean}} method
+ */
+export function writeTeamEstimationCache(teamId, method) {
+  const record = { teamId, method, fetchedAt: new Date().toISOString() };
+  // Seed the in-process memo BEFORE attempting the disk write: an unwritable
+  // disk must not force a fresh Linear fetch on every subsequent tick. (The
+  // orch-monitor duplicate this replaces already behaved this way; the sync
+  // scheduler path did not, and re-fetched forever on a read-only disk.)
+  _memo.set(teamId, record);
   try {
+    const dir = cacheDir();
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const record = { teamId, method, fetchedAt: new Date().toISOString() };
+    const path = teamEstimationCachePath(teamId);
     const tmp = `${path}.tmp`;
     writeFileSync(tmp, JSON.stringify(record, null, 2));
     renameSync(tmp, path);
     return record;
   } catch {
-    return null;
+    return null; // disk write failed — the memo above is still valid
   }
+}
+
+/**
+ * readTeamEstimationCache — the shared cache tiers (in-process memo, then the
+ * on-disk record), under the ONE TTL. Exported (CTL-1806) so the async
+ * orch-monitor resolver stops carrying a second memo, a second path fn and a
+ * second (shorter) TTL over the same file.
+ *
+ * @param {string} teamId
+ * @param {{ttlMs?: number}} [opts]
+ * @returns {{type: string, allowZero: boolean, extended: boolean} | null}
+ *   null means "not cached / stale / corrupt" — the caller must fetch.
+ */
+export function readTeamEstimationCache(teamId, { ttlMs = TEAM_ESTIMATION_TTL_MS } = {}) {
+  if (!teamId || typeof teamId !== "string") return null;
+  const now = Date.now();
+
+  // 1. In-process memo (within a single daemon run).
+  if (_memo.has(teamId)) {
+    const cached = _memo.get(teamId);
+    if (now - new Date(cached.fetchedAt).getTime() < ttlMs) return cached.method;
+    _memo.delete(teamId); // stale — re-fetch
+  }
+
+  // 2. On-disk cache.
+  const path = teamEstimationCachePath(teamId);
+  if (existsSync(path)) {
+    try {
+      const record = JSON.parse(readFileSync(path, "utf8"));
+      if (record?.method && typeof record.method.type === "string") {
+        if (now - new Date(record.fetchedAt).getTime() < ttlMs) {
+          _memo.set(teamId, record);
+          return record.method;
+        }
+        // stale — fall through to fetch
+      }
+    } catch {
+      // corrupt cache — fall through to fetch
+    }
+  }
+  return null;
 }
 
 // ── Linear API fetch ─────────────────────────────────────────────────────────
@@ -109,6 +212,21 @@ function fetchFromLinear(teamId) {
     "--data",
     "@-",
   ];
+
+  // CTL-1806 (D3): emit the degraded-path anomaly IMMEDIATELY BEFORE the outbound
+  // call, never after — an emission placed after is lost on exactly the failures
+  // worth knowing about (curl absent, timeout, throw). source is "linearis"
+  // (not "linearis_miss") because NO replica was consulted: there is no replica
+  // source for team estimation config at all, so this is not a miss, it is a read
+  // with no local tier. `result` records only what is knowable here — whether the
+  // call could be dispatched at all.
+  emitLinearReadEvent({
+    source: "linearis",
+    result: token ? "ok" : "failed",
+    op: "team_method",
+    entity: teamId,
+    serviceName: "catalyst.execution-core",
+  });
 
   let res;
   try {
@@ -154,45 +272,23 @@ function fetchFromLinear(teamId) {
  *           spawnSync is always used because the function must be synchronous).
  * @returns {{ type: string, allowZero: boolean, extended: boolean } | null}
  */
-export function getEstimationMethod(teamId, { ttlMs = DEFAULT_TTL_MS } = {}) {
+export function getEstimationMethod(teamId, { ttlMs = TEAM_ESTIMATION_TTL_MS } = {}) {
   if (!teamId || typeof teamId !== "string") return null;
 
-  const now = Date.now();
+  // 1+2. In-process memo, then the on-disk record — both under the ONE shared TTL
+  // (CTL-1806: this is the same helper the orch-monitor async resolver now uses,
+  // so the two writers of this file can no longer disagree about staleness).
+  const cached = readTeamEstimationCache(teamId, { ttlMs });
+  if (cached) return cached;
 
-  // 1. In-process memo (within a single daemon run).
-  if (_memo.has(teamId)) {
-    const cached = _memo.get(teamId);
-    if (now - new Date(cached.fetchedAt).getTime() < ttlMs) {
-      return cached.method;
-    }
-    _memo.delete(teamId); // stale — re-fetch
-  }
-
-  // 2. On-disk cache.
-  const path = cacheFilePath(teamId);
-  if (existsSync(path)) {
-    try {
-      const raw = readFileSync(path, "utf8");
-      const record = JSON.parse(raw);
-      if (record?.method && typeof record.method.type === "string") {
-        const age = now - new Date(record.fetchedAt).getTime();
-        if (age < ttlMs) {
-          _memo.set(teamId, record);
-          return record.method;
-        }
-        // stale — fall through to fetch
-      }
-    } catch {
-      // corrupt cache — fall through to fetch
-    }
-  }
-
-  // 3. Live Linear GraphQL fetch (cache miss / stale).
+  // 3. Live Linear GraphQL fetch (cache miss / stale) — the labelled degraded
+  // path (D1). Still returns null on ANY failure so the caller fails open; it is
+  // deliberately NOT defaulted to a scale, because null makes the scheduler SKIP
+  // its estimate write while a guess would make it write the wrong number.
   const method = fetchFromLinear(teamId);
-  if (!method) return null; // fail-open; caller uses Fibonacci fallback
+  if (!method) return null;
 
-  const record = writeCacheFile(teamId, method);
-  if (record) _memo.set(teamId, record);
+  writeTeamEstimationCache(teamId, method); // also seeds the memo
 
   return method;
 }

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -56,6 +56,123 @@ function titlesSelect(n) {
     .join(",")}) AND removed_at IS NULL`;
 }
 
+// CTL-1806: the display-resolver reads. The orch-monitor's two supplemental
+// resolvers (linear-estimate-fallback / linear-title-description-fallback) called
+// the rate-limited Linear GraphQL API with ZERO replica consultation; these are
+// the local primitives that make them replica-first. Same fail-open contract as
+// titles(): a HIT is an entry, anything else is OMITTED (never fabricated), and
+// any throw yields {} so the caller's existing chain runs unchanged.
+//
+// estimates(): a replica row whose `estimate` is NULL is a MISS, NOT an
+// authoritative null. The two are indistinguishable in the replica ("Linear has
+// none" vs "this row predates the estimate projection"), and serving the null
+// would silently drop the board's estimate chip for a refresh. Mirrors exactly
+// what titles() does with an empty title: omit, never fabricate.
+const ESTIMATES_CHUNK = 400;
+function estimatesSelect(n) {
+  return `SELECT identifier, estimate FROM issues WHERE identifier IN (${Array(n)
+    .fill("?")
+    .join(",")}) AND removed_at IS NULL`;
+}
+
+// details(): the own-ticket payload the ticket-DETAIL page needs
+// (title/description/labels/relations/state/priority/project/estimate). The
+// LEFT JOIN on projects supplies `project.name`; labels and relations are read
+// as separate batched queries inside the same snapshot.
+function detailsSelect(n) {
+  return `SELECT i.identifier, i.title, i.description, i.state, i.priority, i.estimate, i.started_at, i.completed_at, i.canceled_at, p.name AS project_name FROM issues i LEFT JOIN projects p ON p.id = i.project_id WHERE i.identifier IN (${Array(
+    n
+  )
+    .fill("?")
+    .join(",")}) AND i.removed_at IS NULL`;
+}
+// Batched label read for a bounded id set, carrying `color` (the detail page's
+// label chips need it). Tombstoned labels are excluded for the same reason
+// LABELS_SELECT excludes them: a removed label name can be recycled.
+function detailLabelsSelect(n) {
+  return `SELECT i.identifier AS identifier, l.name AS name, l.color AS color FROM issues i JOIN issue_labels il ON il.issue_id = i.id JOIN labels l ON l.id = il.label_id WHERE i.identifier IN (${Array(
+    n
+  )
+    .fill("?")
+    .join(",")}) AND i.removed_at IS NULL AND l.removed_at IS NULL ORDER BY l.name`;
+}
+// Relation edges in both directions for a bounded id set. `relations` is keyed by
+// display identifier (not the internal PK), so no id resolution is needed.
+function relationsForwardSelect(n) {
+  return `SELECT issue_identifier AS src, type, related_identifier AS target FROM relations WHERE issue_identifier IN (${Array(
+    n
+  )
+    .fill("?")
+    .join(",")})`;
+}
+function relationsInverseSelect(n) {
+  return `SELECT related_identifier AS src, type, issue_identifier AS target FROM relations WHERE related_identifier IN (${Array(
+    n
+  )
+    .fill("?")
+    .join(",")})`;
+}
+// Relation-TARGET enrichment: the {title,state,priority,project} each rendered
+// relation row shows. Same shape as detailsSelect minus description/estimate.
+function relationTargetsSelect(n) {
+  return `SELECT i.identifier, i.title, i.state, i.priority, i.started_at, i.completed_at, i.canceled_at, p.name AS project_name FROM issues i LEFT JOIN projects p ON p.id = i.project_id WHERE i.identifier IN (${Array(
+    n
+  )
+    .fill("?")
+    .join(",")}) AND i.removed_at IS NULL`;
+}
+
+/**
+ * synthesizeStateType — CTL-1806 (D2). Derive Linear's workflow-state `type`
+ * from the replica's own lifecycle TIMESTAMPS.
+ *
+ * The replica has no `workflow_states` table and its enriched `raw` projection
+ * DROPS `state.type` (measured 2026-08-14: `$.state.type` extracts on 110 of
+ * 3887 rows — only the ~4-day window of un-enriched webhook-shape blobs —
+ * against a positive control of `$.state.name` extracting on 3887/3887). So the
+ * type must be derived, and it is derived from timestamps rather than from the
+ * state NAME on purpose: a name→type map hardcodes THIS workspace's contract
+ * states (Implement/PR/Validate/Research/Remediate are not Linear defaults) and
+ * breaks under the bring-your-own-workspace model this read exists to serve.
+ *
+ * Ladder (order is load-bearing): canceled_at → completed_at → started_at →
+ * "backlog". `canceled` precedes `completed` because Linear can stamp
+ * completedAt and then cancel; `completed` precedes `started` because a finished
+ * ticket keeps its startedAt (measured: 2215 rows carry BOTH, by far the most
+ * exercised rung).
+ *
+ * Accuracy against ground truth (the rows that still carry a real
+ * `raw.$.state.type`): 109/109 exact on every class the consumer renders
+ * distinctly. The single residual is a true `unstarted` state, which
+ * synthesizes to `backlog` — `stateIconSpec` draws both as a MUTED ring
+ * differing only in stroke dash, so it costs a dash pattern and nothing else.
+ *
+ * @param {{started_at?: unknown, completed_at?: unknown, canceled_at?: unknown}} row
+ * @returns {"canceled"|"completed"|"started"|"backlog"|null} null only for a non-object.
+ */
+export function synthesizeStateType(row) {
+  if (!row || typeof row !== "object") return null;
+  if (row.canceled_at != null) return "canceled";
+  if (row.completed_at != null) return "completed";
+  if (row.started_at != null) return "started";
+  return "backlog";
+}
+
+// stateRefOf — the {name,type} the display consumers expect, or null. The NAME
+// must be a non-empty string: the downstream LinearStateRef contract requires
+// it, and fabricating a name from a synthesized type would invent a workflow
+// state that does not exist in the workspace.
+function stateRefOf(row) {
+  if (!row || typeof row.state !== "string" || row.state.length === 0) return null;
+  return { name: row.state, type: synthesizeStateType(row) };
+}
+
+// numOrNull — the replica stores estimate as REAL and priority as INTEGER;
+// anything non-finite (NULL included) is not a value.
+function numOrNull(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
 // coerce a replica `updated_at` cell to epoch-ms. Accepts an epoch-ms integer
 // (the cloud change-feed shape) OR an ISO-8601 string (Date.parse fallback).
 // Anything that resolves to neither (null, NaN, garbage) → undefined → the
@@ -294,6 +411,248 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
       return out;
     } catch {
       // Drop the handle so a later call re-opens fresh (DB may be re-seeded).
+      dropHandle();
+      return {};
+    }
+  };
+
+  // estimates(identifiers) → { [identifier]: number }  (CTL-1806)
+  //   HIT (non-removed row with a FINITE numeric estimate) → entry in the map.
+  //   absent / removed / NULL estimate → OMITTED. A NULL estimate is a MISS, not
+  //     an authoritative null (see the ESTIMATES_CHUNK note above).
+  //   empty input / no db / any throw → {}  (fail-open, mirroring titles()).
+  // Gated exactly like titles(): NO writer-liveness gate. A liveness gate on a
+  // display read falls through to the rate-limited path precisely when the board
+  // is UNCHANGED (CTL-1397: a live writer on a quiet feed reads as stale), which
+  // is backwards for a read whose whole purpose is removing Linear calls.
+  const estimates = (identifiers) => {
+    const wanted = [
+      ...new Set(
+        (Array.isArray(identifiers) ? identifiers : []).filter(
+          (id) => typeof id === "string" && id.length > 0
+        )
+      ),
+    ];
+    if (wanted.length === 0) return {};
+    const out = {};
+    try {
+      const handle = open();
+      for (let i = 0; i < wanted.length; i += ESTIMATES_CHUNK) {
+        const slice = wanted.slice(i, i + ESTIMATES_CHUNK);
+        for (const row of handle.prepare(estimatesSelect(slice.length)).all(...slice)) {
+          if (!row || typeof row.identifier !== "string") continue;
+          const est = numOrNull(row.estimate);
+          if (est === null) continue; // NULL estimate → MISS, never an authoritative null
+          out[row.identifier] = est;
+        }
+      }
+      return out;
+    } catch {
+      dropHandle();
+      return {};
+    }
+  };
+
+  // readRelations(handle, wanted) — the relation half, taking an already-open
+  // handle so details() can run it inside its own snapshot without nesting a
+  // second transaction. Returns { [identifier]: RelationMap }, one entry per
+  // requested id that has at least one edge (ids with no edges are OMITTED, so
+  // the caller can tell "no relation data" from "genuinely none" the same way
+  // every other read here distinguishes a miss).
+  //
+  // Grouping mirrors linear-title-description-fallback's parseRelations exactly:
+  //   forward  "blocks"    → blocks[]        (this ticket blocks the target)
+  //   forward  "duplicate" → duplicateOf[]
+  //   forward  "related"   → related[]
+  //   inverse  "blocks"    → blockedBy[]     (the target blocks this ticket)
+  //   inverse  "related"   → related[]       (deduped by identifier, forward wins)
+  const readRelations = (handle, wanted) => {
+    const edges = [];
+    for (let i = 0; i < wanted.length; i += ESTIMATES_CHUNK) {
+      const slice = wanted.slice(i, i + ESTIMATES_CHUNK);
+      for (const r of handle.prepare(relationsForwardSelect(slice.length)).all(...slice)) {
+        edges.push({ src: r.src, type: r.type, target: r.target, inverse: false });
+      }
+      for (const r of handle.prepare(relationsInverseSelect(slice.length)).all(...slice)) {
+        edges.push({ src: r.src, type: r.type, target: r.target, inverse: true });
+      }
+    }
+    if (edges.length === 0) return {};
+
+    // Enrich every distinct target in one batched pass (never N+1).
+    const targetIds = [
+      ...new Set(edges.map((e) => e.target).filter((t) => typeof t === "string" && t.length > 0)),
+    ];
+    const targetById = {};
+    for (let i = 0; i < targetIds.length; i += ESTIMATES_CHUNK) {
+      const slice = targetIds.slice(i, i + ESTIMATES_CHUNK);
+      for (const row of handle.prepare(relationTargetsSelect(slice.length)).all(...slice)) {
+        if (!row || typeof row.identifier !== "string") continue;
+        targetById[row.identifier] = {
+          identifier: row.identifier,
+          title: typeof row.title === "string" && row.title.length > 0 ? row.title : null,
+          state: stateRefOf(row),
+          priority: numOrNull(row.priority),
+          project: row.project_name ?? null,
+        };
+      }
+    }
+
+    const out = {};
+    // Forward edges first so a related edge seen in BOTH directions keeps its
+    // forward-resolved target (the dedup order the GraphQL parser uses).
+    for (const pass of [false, true]) {
+      for (const e of edges) {
+        if (e.inverse !== pass) continue;
+        if (typeof e.src !== "string" || typeof e.target !== "string") continue;
+        // Resolve the destination group BEFORE materializing an entry. An edge
+        // this mapping does not carry — notably an INVERSE "duplicate", which the
+        // GraphQL parser also ignores — must not create an empty relation map:
+        // that would turn a genuine "no relation data" miss into an
+        // authoritative-looking empty answer for the id on the OTHER end of
+        // someone else's duplicate edge.
+        const group =
+          e.type === "related"
+            ? "related"
+            : e.inverse
+              ? e.type === "blocks"
+                ? "blockedBy"
+                : null
+              : e.type === "blocks"
+                ? "blocks"
+                : e.type === "duplicate"
+                  ? "duplicateOf"
+                  : null;
+        if (group === null) continue;
+        // A target with no live issues row still keeps its edge: the identifier
+        // alone is real information (the rail renders `title ?? identifier`),
+        // and dropping it would silently hide a genuine blocker.
+        const target = targetById[e.target] ?? {
+          identifier: e.target,
+          title: null,
+          state: null,
+          priority: null,
+          project: null,
+        };
+        const map = (out[e.src] ??= {
+          blockedBy: [],
+          blocks: [],
+          related: [],
+          duplicateOf: [],
+        });
+        // `related` is deduped by identifier (an edge can appear in both
+        // directions); the others cannot collide the same way.
+        if (group === "related") {
+          if (!map.related.some((t) => t.identifier === target.identifier)) map.related.push(target);
+        } else {
+          map[group].push(target);
+        }
+      }
+    }
+    return out;
+  };
+
+  // relations(identifiers) → { [identifier]: RelationMap }  (CTL-1806)
+  //   The standalone relation-target read. Same fail-open contract as titles():
+  //   {} on empty input / no db / any throw; an id with no edges is omitted.
+  const relations = (identifiers) => {
+    const wanted = [
+      ...new Set(
+        (Array.isArray(identifiers) ? identifiers : []).filter(
+          (id) => typeof id === "string" && id.length > 0
+        )
+      ),
+    ];
+    if (wanted.length === 0) return {};
+    try {
+      const handle = open();
+      return handle.transaction(() => readRelations(handle, wanted))();
+    } catch {
+      dropHandle();
+      return {};
+    }
+  };
+
+  // details(identifiers) → { [identifier]: TitleDescription }  (CTL-1806)
+  //   The full ticket-DETAIL payload, replica-served: title, description, labels
+  //   (with colour), relations (with enriched targets), state {name,type},
+  //   priority, project, estimate.
+  //
+  //   HIT requires a NON-EMPTY title — the same bar titles() sets. The detail
+  //   page's own availability check is `title !== null || description !== null`,
+  //   so an entry with neither would render as "unavailable" while suppressing
+  //   the Linear fall-through that could have served it.
+  //   absent / removed / empty title → OMITTED (caller falls through).
+  //   empty input / no db / any throw → {}  (fail-open).
+  //
+  //   `state.type` is SYNTHESIZED from the row's timestamps — see
+  //   synthesizeStateType for why the replica cannot read it directly and why the
+  //   state NAME is deliberately not used as the source.
+  //
+  //   Rows, labels and relations are read inside ONE deferred read snapshot so a
+  //   forced re-seed cannot splice a pre-reseed ticket with post-reseed labels.
+  const details = (identifiers) => {
+    const wanted = [
+      ...new Set(
+        (Array.isArray(identifiers) ? identifiers : []).filter(
+          (id) => typeof id === "string" && id.length > 0
+        )
+      ),
+    ];
+    if (wanted.length === 0) return {};
+    try {
+      const handle = open();
+      return handle.transaction(() => {
+        const out = {};
+        for (let i = 0; i < wanted.length; i += ESTIMATES_CHUNK) {
+          const slice = wanted.slice(i, i + ESTIMATES_CHUNK);
+          for (const row of handle.prepare(detailsSelect(slice.length)).all(...slice)) {
+            if (!row || typeof row.identifier !== "string") continue;
+            if (typeof row.title !== "string" || row.title.length === 0) continue; // MISS
+            out[row.identifier] = {
+              title: row.title,
+              description:
+                typeof row.description === "string" && row.description.length > 0
+                  ? row.description
+                  : null,
+              labels: [],
+              relations: null,
+              state: stateRefOf(row),
+              priority: numOrNull(row.priority),
+              project: row.project_name ?? null,
+              estimate: numOrNull(row.estimate),
+            };
+          }
+        }
+        const hits = Object.keys(out);
+        if (hits.length === 0) return {};
+        for (let i = 0; i < hits.length; i += ESTIMATES_CHUNK) {
+          const slice = hits.slice(i, i + ESTIMATES_CHUNK);
+          for (const row of handle.prepare(detailLabelsSelect(slice.length)).all(...slice)) {
+            const entry = out[row?.identifier];
+            if (!entry || typeof row.name !== "string") continue;
+            entry.labels.push({
+              name: row.name,
+              // Match the GraphQL parser's default so a colourless replica label
+              // renders identically to a colourless Linear one.
+              color: typeof row.color === "string" && row.color.length > 0 ? row.color : "#8d8d8d",
+            });
+          }
+        }
+        const rel = readRelations(handle, hits);
+        for (const id of hits) {
+          // An id with no edges gets an EMPTY map, not null: we read the relation
+          // table for it and it genuinely has none. null means "unknown".
+          out[id].relations = rel[id] ?? {
+            blockedBy: [],
+            blocks: [],
+            related: [],
+            duplicateOf: [],
+          };
+        }
+        return out;
+      })();
+    } catch {
       dropHandle();
       return {};
     }
@@ -588,6 +947,9 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     lookup,
     freshness,
     titles,
+    estimates, // CTL-1806
+    relations, // CTL-1806
+    details, // CTL-1806
     eligible,
     triageState, // CTL-1589
     ownership,

--- a/plugins/dev/scripts/execution-core/replica-supplemental-reads.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-supplemental-reads.test.mjs
@@ -1,0 +1,501 @@
+// replica-supplemental-reads.test.mjs — CTL-1806. The three new replica reads
+// that let the orch-monitor's supplemental resolvers stop calling the
+// rate-limited Linear API: estimates(), relations(), details(), plus the
+// timestamp-based state.type synthesis they depend on.
+//
+// Built with REAL bun:sqlite over a real schema fixture (same discipline as
+// replica-read.test.mjs) so the actual SQL is exercised, not a mock of it.
+//
+// Run: bun test plugins/dev/scripts/execution-core/replica-supplemental-reads.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createReplicaReader, synthesizeStateType } from "./replica-read.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+let tmpDir;
+let dbPath;
+let reader;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "replica-supplemental-"));
+  dbPath = join(tmpDir, "catalyst-replica.db");
+});
+
+afterEach(() => {
+  reader?.close();
+  reader = null;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// seed — the real cloud-schema columns these reads touch.
+function seed() {
+  const db = new Database(dbPath, { create: true });
+  db.run(`CREATE TABLE issues (
+    id TEXT PRIMARY KEY, identifier TEXT, title TEXT, description TEXT,
+    state TEXT, priority INTEGER, estimate REAL, project_id TEXT,
+    started_at INTEGER, completed_at INTEGER, canceled_at INTEGER,
+    removed_at INTEGER
+  )`);
+  db.run(`CREATE INDEX idx_issues_identifier ON issues (identifier)`);
+  db.run(`CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT)`);
+  db.run(`CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT, color TEXT, removed_at INTEGER)`);
+  db.run(`CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT)`);
+  db.run(
+    `CREATE TABLE relations (id TEXT PRIMARY KEY, type TEXT, issue_identifier TEXT, related_identifier TEXT)`
+  );
+
+  db.run(`INSERT INTO projects VALUES ('p1', 'Fleet Hardening')`);
+  db.run(`INSERT INTO labels VALUES ('l1','needs-human','#ff0000',NULL)`);
+  db.run(`INSERT INTO labels VALUES ('l2','no-colour',NULL,NULL)`);
+  db.run(`INSERT INTO labels VALUES ('l3','tombstoned','#00ff00',1700)`);
+
+  // CTL-1 — the full-payload row: started, has everything.
+  db.run(
+    `INSERT INTO issues VALUES ('i1','CTL-1','Real title','## Body','Implement',2,5,'p1',1000,NULL,NULL,NULL)`
+  );
+  db.run(`INSERT INTO issue_labels VALUES ('i1','l1')`);
+  db.run(`INSERT INTO issue_labels VALUES ('i1','l2')`);
+  db.run(`INSERT INTO issue_labels VALUES ('i1','l3')`); // tombstoned → excluded
+  // CTL-2 — completed AND started (the 2215-row overlap: completed must win).
+  db.run(
+    `INSERT INTO issues VALUES ('i2','CTL-2','Done ticket',NULL,'Done',NULL,3,NULL,1000,2000,NULL,NULL)`
+  );
+  // CTL-3 — NULL estimate: a MISS for estimates(), a HIT for details().
+  db.run(
+    `INSERT INTO issues VALUES ('i3','CTL-3','No estimate',NULL,'Backlog',0,NULL,NULL,NULL,NULL,NULL,NULL)`
+  );
+  // CTL-4 — tombstoned: a MISS for every read.
+  db.run(
+    `INSERT INTO issues VALUES ('i4','CTL-4','Removed',NULL,'Todo',1,8,NULL,NULL,NULL,NULL,1700)`
+  );
+  // CTL-5 — empty title: a MISS for details() (cannot populate the detail page).
+  db.run(`INSERT INTO issues VALUES ('i5','CTL-5','',NULL,'Todo',NULL,13,NULL,NULL,NULL,NULL,NULL)`);
+  // CTL-6 — canceled AND completed (canceled must win).
+  db.run(
+    `INSERT INTO issues VALUES ('i6','CTL-6','Cancelled',NULL,'Canceled',NULL,1,NULL,1000,2000,3000,NULL)`
+  );
+  // CTL-7 — NULL state name: details() must report state null, never fabricate a
+  // name from the synthesized type.
+  db.run(`INSERT INTO issues VALUES ('i7','CTL-7','No state name',NULL,NULL,NULL,2,NULL,NULL,NULL,NULL,NULL)`);
+  // CTL-8 — a second `related` peer, reached FORWARD, to pin the pass order.
+  db.run(`INSERT INTO issues VALUES ('i8','CTL-8','Forward related',NULL,'Todo',NULL,1,NULL,NULL,NULL,NULL,NULL)`);
+  // CTL-9 — a `related` peer reached only INVERSELY.
+  db.run(`INSERT INTO issues VALUES ('i9','CTL-9','Inverse related',NULL,'Todo',NULL,1,NULL,NULL,NULL,NULL,NULL)`);
+
+  // Relations on CTL-1: forward blocks/duplicate/related, inverse blocks/related.
+  db.run(`INSERT INTO relations VALUES ('r1','blocks','CTL-1','CTL-2')`);
+  db.run(`INSERT INTO relations VALUES ('r2','duplicate','CTL-1','CTL-3')`);
+  db.run(`INSERT INTO relations VALUES ('r3','related','CTL-1','CTL-6')`);
+  db.run(`INSERT INTO relations VALUES ('r4','blocks','CTL-6','CTL-1')`); // inverse → blockedBy
+  db.run(`INSERT INTO relations VALUES ('r5','related','CTL-6','CTL-1')`); // inverse related, dup of r3
+  db.run(`INSERT INTO relations VALUES ('r6','blocks','CTL-1','CTL-999')`); // dangling target
+  // Order fixture: CTL-8 is related FORWARD from CTL-1; CTL-9 is related to CTL-1
+  // only INVERSELY. The GraphQL parser walks forward edges first, so CTL-8 must
+  // precede CTL-9 in `related`.
+  db.run(`INSERT INTO relations VALUES ('r7','related','CTL-1','CTL-8')`);
+  db.run(`INSERT INTO relations VALUES ('r8','related','CTL-9','CTL-1')`);
+  db.close();
+}
+
+describe("estimates() — CTL-1806", () => {
+  test("HIT: a finite estimate is returned", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.estimates(["CTL-1"])).toEqual({ "CTL-1": 5 });
+  });
+
+  test("a NULL estimate is a MISS (omitted), NEVER an authoritative null", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const out = reader.estimates(["CTL-3"]);
+    // The distinction that matters: `undefined` (absent key) makes the caller
+    // fall through; a present `null` would make it serve "no estimate" and drop
+    // the board chip for a refresh.
+    expect(Object.hasOwn(out, "CTL-3")).toBe(false);
+    expect(out).toEqual({});
+  });
+
+  test("a tombstoned row is a MISS", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.estimates(["CTL-4"])).toEqual({});
+  });
+
+  test("mixed batch returns only the hits", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.estimates(["CTL-1", "CTL-2", "CTL-3", "CTL-4", "CTL-404"])).toEqual({
+      "CTL-1": 5,
+      "CTL-2": 3,
+    });
+  });
+
+  test("empty / non-array input → {} without opening the db", () => {
+    reader = createReplicaReader({ dbPath: join(tmpDir, "absent.db") });
+    expect(reader.estimates([])).toEqual({});
+    expect(reader.estimates(null)).toEqual({});
+  });
+
+  test("absent db → {} (fail-open, never throws)", () => {
+    reader = createReplicaReader({ dbPath: join(tmpDir, "absent.db") });
+    expect(reader.estimates(["CTL-1"])).toEqual({});
+  });
+
+  test("chunks past the SQLite bound-parameter ceiling (600 ids in one call)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // 999 is SQLite's ceiling; an unchunked IN() of 600 would still fit, so use
+    // 1200 to force >2 chunks and prove the loop, not the ceiling.
+    const ids = Array.from({ length: 1200 }, (_, i) => `CTL-${9000 + i}`);
+    ids.push("CTL-1");
+    expect(reader.estimates(ids)).toEqual({ "CTL-1": 5 });
+  });
+});
+
+describe("relations() — CTL-1806", () => {
+  test("groups forward/inverse edges exactly as the GraphQL parser does", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const rel = reader.relations(["CTL-1"])["CTL-1"];
+    expect(rel.blocks.map((t) => t.identifier).sort()).toEqual(["CTL-2", "CTL-999"]);
+    expect(rel.duplicateOf.map((t) => t.identifier)).toEqual(["CTL-3"]);
+    expect(rel.blockedBy.map((t) => t.identifier)).toEqual(["CTL-6"]);
+    // r3 (forward) and r5 (inverse) name the same peer → deduped to one entry.
+    // Order is load-bearing: forward edges are walked first (matching the GraphQL
+    // parser), and the rail renders only the first 5 with a "show N more", so a
+    // flipped pass order silently changes WHICH relations a reader sees.
+    expect(rel.related.map((t) => t.identifier)).toEqual(["CTL-6", "CTL-8", "CTL-9"]);
+  });
+
+  test("enriches each target with title/state/priority/project", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const rel = reader.relations(["CTL-1"])["CTL-1"];
+    const target = rel.blocks.find((t) => t.identifier === "CTL-2");
+    expect(target).toEqual({
+      identifier: "CTL-2",
+      title: "Done ticket",
+      state: { name: "Done", type: "completed" },
+      priority: null,
+      project: null,
+    });
+  });
+
+  test("a target with no live issues row KEEPS its edge with null fields", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const rel = reader.relations(["CTL-1"])["CTL-1"];
+    // Dropping it would silently hide a genuine blocker; the rail renders
+    // `title ?? identifier`, so the bare identifier is still real information.
+    expect(rel.blocks.find((t) => t.identifier === "CTL-999")).toEqual({
+      identifier: "CTL-999",
+      title: null,
+      state: null,
+      priority: null,
+      project: null,
+    });
+  });
+
+  test("an id with no edges is OMITTED (a miss, not an empty map)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.relations(["CTL-3"])).toEqual({});
+  });
+
+  test("absent db → {} (fail-open)", () => {
+    reader = createReplicaReader({ dbPath: join(tmpDir, "absent.db") });
+    expect(reader.relations(["CTL-1"])).toEqual({});
+  });
+});
+
+describe("details() — CTL-1806", () => {
+  test("HIT returns the whole detail payload", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const d = reader.details(["CTL-1"])["CTL-1"];
+    expect(d.title).toBe("Real title");
+    expect(d.description).toBe("## Body");
+    expect(d.state).toEqual({ name: "Implement", type: "started" });
+    expect(d.priority).toBe(2);
+    expect(d.estimate).toBe(5);
+    expect(d.project).toBe("Fleet Hardening");
+  });
+
+  test("labels carry colour, default a colourless one, and exclude tombstones", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const d = reader.details(["CTL-1"])["CTL-1"];
+    expect(d.labels).toEqual([
+      // ORDER BY l.name
+      { name: "needs-human", color: "#ff0000" },
+      // matches the GraphQL parser's default so a colourless replica label
+      // renders identically to a colourless Linear one
+      { name: "no-colour", color: "#8d8d8d" },
+    ]);
+    expect(d.labels.some((l) => l.name === "tombstoned")).toBe(false);
+  });
+
+  test("relations are attached, and an edge-less hit gets an EMPTY map not null", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const withEdges = reader.details(["CTL-1"])["CTL-1"];
+    expect(withEdges.relations.duplicateOf.map((t) => t.identifier)).toEqual(["CTL-3"]);
+    const withoutEdges = reader.details(["CTL-3"])["CTL-3"];
+    // We READ the relation table for it and it genuinely has none — that is an
+    // empty answer, not "unknown".
+    expect(withoutEdges.relations).toEqual({
+      blockedBy: [],
+      blocks: [],
+      related: [],
+      duplicateOf: [],
+    });
+  });
+
+  test("an EMPTY title is a MISS — a hollow entry would suppress the Linear fall-through", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.details(["CTL-5"])).toEqual({});
+  });
+
+  test("a NULL estimate on a detail HIT stays null (the row IS served)", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // Unlike estimates(), details() is not an estimate lookup — the ticket is a
+    // genuine hit and its absent estimate is an honest null on a served payload.
+    expect(reader.details(["CTL-3"])["CTL-3"].estimate).toBe(null);
+  });
+
+  test("a tombstoned row is a MISS", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.details(["CTL-4"])).toEqual({});
+  });
+
+  test("a NULL state name yields state:null — a name is never fabricated", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // The synthesized `type` is always derivable from timestamps, but the NAME
+    // is not. Emitting {name:null,type:"backlog"} would invent a workflow state
+    // that does not exist in the workspace and break the LinearStateRef contract.
+    expect(reader.details(["CTL-7"])["CTL-7"].state).toBe(null);
+  });
+
+  test("absent db → {} (fail-open)", () => {
+    reader = createReplicaReader({ dbPath: join(tmpDir, "absent.db") });
+    expect(reader.details(["CTL-1"])).toEqual({});
+  });
+});
+
+describe("synthesizeStateType() — CTL-1806 D2, ladder order", () => {
+  test("canceled_at wins over completed_at AND started_at", () => {
+    expect(synthesizeStateType({ started_at: 1, completed_at: 2, canceled_at: 3 })).toBe("canceled");
+  });
+  test("completed_at wins over started_at (the 2215-row overlap)", () => {
+    expect(synthesizeStateType({ started_at: 1, completed_at: 2, canceled_at: null })).toBe(
+      "completed"
+    );
+  });
+  test("started_at alone → started", () => {
+    expect(synthesizeStateType({ started_at: 1, completed_at: null, canceled_at: null })).toBe(
+      "started"
+    );
+  });
+  test("no timestamps → backlog", () => {
+    expect(synthesizeStateType({ started_at: null, completed_at: null, canceled_at: null })).toBe(
+      "backlog"
+    );
+  });
+  test("canceled_at wins over completed_at with no started_at", () => {
+    // Exercised by ZERO rows in the live replica (no row sets both without a
+    // start), so it is asserted here synthetically rather than left untested:
+    // Linear can stamp completedAt and then cancel.
+    expect(synthesizeStateType({ started_at: null, completed_at: 2, canceled_at: 3 })).toBe(
+      "canceled"
+    );
+  });
+  test("a non-object is null, never a fabricated category", () => {
+    expect(synthesizeStateType(null)).toBe(null);
+    expect(synthesizeStateType(undefined)).toBe(null);
+    expect(synthesizeStateType("Done")).toBe(null);
+  });
+});
+
+describe("synthesizeStateType() — CTL-1806 D2 GROUND-TRUTH ACCURACY", () => {
+  const fixture = JSON.parse(
+    readFileSync(join(HERE, "__fixtures__", "state-type-ground-truth.json"), "utf8")
+  );
+  const rows = fixture.rows;
+
+  // ── Fail-closed guards on the fixture itself ──────────────────────────────
+  // Without these, an emptied or truncated fixture makes the accuracy loop below
+  // iterate zero times and PASS — the classic `[].every(p) === true` false clean.
+  // These assertions are the positive control for the accuracy assertion.
+  test("the fixture is non-degenerate (guards the accuracy check below)", () => {
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows.length).toBeGreaterThanOrEqual(50);
+    const classes = new Set(rows.map((r) => r.groundTruthType));
+    // Every class the synthesis can produce must be represented, or the accuracy
+    // figure is measuring less than it claims to.
+    for (const c of ["backlog", "completed", "canceled", "started"]) {
+      expect(classes.has(c)).toBe(true);
+    }
+    // At least one row must carry each timestamp, or the ladder rungs are untested.
+    expect(rows.some((r) => r.canceled_at != null)).toBe(true);
+    expect(rows.some((r) => r.completed_at != null)).toBe(true);
+    expect(rows.some((r) => r.started_at != null)).toBe(true);
+  });
+
+  test("EXACT on every class the consumer renders distinctly", () => {
+    const misses = [];
+    for (const r of rows) {
+      const got = synthesizeStateType(r);
+      if (got !== r.groundTruthType) {
+        misses.push({ identifier: r.identifier, truth: r.groundTruthType, got, name: r.stateName });
+      }
+    }
+    // The ONLY tolerated residual is a true `unstarted` collapsing to `backlog`:
+    // stateIconSpec draws both as a MUTED ring differing only in stroke dash, so
+    // it is a dash pattern and nothing else. Any OTHER miss is a real defect —
+    // notably a completed/canceled miss, which would also flip the 24h cache TTL.
+    for (const m of misses) {
+      expect({ identifier: m.identifier, truth: m.truth, got: m.got }).toEqual({
+        identifier: m.identifier,
+        truth: "unstarted",
+        got: "backlog",
+      });
+    }
+    const distinct = rows.filter((r) => r.groundTruthType !== "unstarted");
+    expect(distinct.length).toBeGreaterThan(0); // fail closed, not vacuously exact
+    expect(misses.filter((m) => m.truth !== "unstarted").length).toBe(0);
+  });
+
+  test("EXACT on the terminal predicate that picks the 24h vs 5min cache TTL", () => {
+    // linear-title-description-fallback's ttlForState keys on
+    // type === "completed" || "canceled". A miss here is a quota regression
+    // inside a quota-reduction change, so it is asserted separately.
+    let compared = 0;
+    for (const r of rows) {
+      const truthTerminal = r.groundTruthType === "completed" || r.groundTruthType === "canceled";
+      const got = synthesizeStateType(r);
+      const synthTerminal = got === "completed" || got === "canceled";
+      expect(synthTerminal).toBe(truthTerminal);
+      compared++;
+    }
+    expect(compared).toBe(rows.length);
+    expect(compared).toBeGreaterThan(0); // a zero-comparison pass is not a pass
+  });
+});
+
+describe("linear-estimation-method — CTL-1806 D1: the degraded fetch is LABELLED", () => {
+  // getEstimationMethod's fetch is a synchronous `curl` spawn. These cases point
+  // PATH at an empty directory so curl cannot be found: spawnSync returns a
+  // non-zero/absent status and the function fails open to null — with NO network
+  // traffic — while the D3 emission, which is taken BEFORE the spawn, has already
+  // been written. That ordering is the point: an emission placed after the call
+  // is lost on exactly the failures worth knowing about.
+  function isolated(fn) {
+    const home = mkdtempSync(join(tmpdir(), "ctl1806-est-home-"));
+    const dir = mkdtempSync(join(tmpdir(), "ctl1806-est-events-"));
+    const emptyBin = mkdtempSync(join(tmpdir(), "ctl1806-est-bin-"));
+    const prev = {
+      HOME: process.env.HOME,
+      CATALYST_DIR: process.env.CATALYST_DIR,
+      PATH: process.env.PATH,
+      TOKEN: process.env.LINEAR_API_TOKEN,
+      KEY: process.env.LINEAR_API_KEY,
+    };
+    process.env.HOME = home;
+    process.env.CATALYST_DIR = dir;
+    process.env.PATH = emptyBin; // no curl → no outbound call, ever
+    try {
+      return fn({ dir });
+    } finally {
+      for (const [k, v] of Object.entries({
+        HOME: prev.HOME,
+        CATALYST_DIR: prev.CATALYST_DIR,
+        PATH: prev.PATH,
+        LINEAR_API_TOKEN: prev.TOKEN,
+        LINEAR_API_KEY: prev.KEY,
+      })) {
+        if (v !== undefined) process.env[k] = v;
+        else delete process.env[k];
+      }
+      for (const d of [home, dir, emptyBin]) rmSync(d, { recursive: true, force: true });
+    }
+  }
+
+  function readEvents(dir) {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const p = join(dir, "events", `${ym}.jsonl`);
+    let raw;
+    try {
+      raw = readFileSync(p, "utf8");
+    } catch {
+      return [];
+    }
+    return raw
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((e) => e?.attributes?.["event.name"] === "catalyst.linear.read");
+  }
+
+  test("a cold cache emits catalyst.linear.read source=linearis op=team_method", async () => {
+    const { getEstimationMethod, _resetMemoForTests } = await import("./linear-estimation-method.mjs");
+    isolated(({ dir }) => {
+      _resetMemoForTests();
+      process.env.LINEAR_API_TOKEN = "lin_api_test_token";
+      const m = getEstimationMethod("QQQ");
+      expect(m).toBe(null); // curl unavailable → fail-open, never a guessed scale
+      const events = readEvents(dir);
+      expect(events.length).toBe(1);
+      const a = events[0].attributes;
+      // "linearis", NOT "linearis_miss": no replica was consulted, because the
+      // replica has no teams table and carries no issueEstimation at all.
+      expect(a["linear.read.source"]).toBe("linearis");
+      expect(a["linear.read.op"]).toBe("team_method");
+      expect(a["event.label"]).toBe("QQQ");
+      expect(events[0].resource["service.name"]).toBe("catalyst.execution-core");
+      _resetMemoForTests();
+    });
+  });
+
+  test("no credential → result=failed (WARN), so a silently-null node is visible", async () => {
+    const { getEstimationMethod, _resetMemoForTests } = await import("./linear-estimation-method.mjs");
+    isolated(({ dir }) => {
+      _resetMemoForTests();
+      delete process.env.LINEAR_API_TOKEN;
+      delete process.env.LINEAR_API_KEY;
+      expect(getEstimationMethod("RRR")).toBe(null);
+      const events = readEvents(dir);
+      expect(events.length).toBe(1);
+      expect(events[0].attributes["linear.read.result"]).toBe("failed");
+      expect(events[0].severityText).toBe("WARN");
+      _resetMemoForTests();
+    });
+  });
+
+  test("ONE TTL: a warm shared cache emits NOTHING and never reaches the fetch", async () => {
+    const { getEstimationMethod, writeTeamEstimationCache, _resetMemoForTests } = await import(
+      "./linear-estimation-method.mjs"
+    );
+    isolated(({ dir }) => {
+      _resetMemoForTests();
+      writeTeamEstimationCache("SSS", { type: "tShirt", allowZero: true, extended: false });
+      _resetMemoForTests(); // force the on-DISK read, not the memo
+      const m = getEstimationMethod("SSS");
+      expect(m?.type).toBe("tShirt");
+      // A warm cache must produce no degraded read at all — that is the whole
+      // bound D1 relies on (8 team keys per host per TTL window).
+      expect(readEvents(dir).length).toBe(0);
+      _resetMemoForTests();
+    });
+  });
+});

--- a/plugins/dev/scripts/execution-core/replica-supplemental-reads.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-supplemental-reads.test.mjs
@@ -54,6 +54,10 @@ function seed() {
   db.run(`INSERT INTO labels VALUES ('l1','needs-human','#ff0000',NULL)`);
   db.run(`INSERT INTO labels VALUES ('l2','no-colour',NULL,NULL)`);
   db.run(`INSERT INTO labels VALUES ('l3','tombstoned','#00ff00',1700)`);
+  // A label whose NAME is NULL — the degenerate row details()' label-name type
+  // guard exists for. Attached only to CTL-13 so it cannot perturb the exact
+  // label assertions on CTL-1.
+  db.run(`INSERT INTO labels VALUES ('l4',NULL,'#123456',NULL)`);
 
   // CTL-1 — the full-payload row: started, has everything.
   db.run(
@@ -88,6 +92,45 @@ function seed() {
   // CTL-9 — a `related` peer reached only INVERSELY.
   db.run(`INSERT INTO issues VALUES ('i9','CTL-9','Inverse related',NULL,'Todo',NULL,1,NULL,NULL,NULL,NULL,NULL)`);
 
+  // ── Degenerate-cell rows. Every one of these is written as a REAL SQLite
+  // literal rather than faked at the JS layer: the point of each guard is what
+  // the driver actually hands back from a column of that affinity, and a value
+  // injected past the driver would prove nothing about the read.
+  //
+  // CTL-10 — an EMPTY-STRING state name. `state` is TEXT affinity, so '' stays
+  // ''. The row is started, so a fabricated ref would carry a real-looking type.
+  db.run(
+    `INSERT INTO issues VALUES ('i10','CTL-10','Empty state name',NULL,'',NULL,1,NULL,1000,NULL,NULL,NULL)`
+  );
+  // CTL-11 — a NON-FINITE estimate. 9e999 overflows REAL and comes back as a JS
+  // number whose Number.isFinite is false (i.e. Infinity) — verified against this
+  // driver, not assumed.
+  db.run(
+    `INSERT INTO issues VALUES ('i11','CTL-11','Non-finite estimate',NULL,'Todo',NULL,9e999,NULL,NULL,NULL,NULL,NULL)`
+  );
+  // CTL-12 — a NON-NUMERIC STRING in the REAL estimate column. REAL affinity
+  // only converts text that is losslessly convertible, so this is stored — and
+  // returned — as a JS string.
+  db.run(
+    `INSERT INTO issues VALUES ('i12','CTL-12','String estimate',NULL,'Todo',NULL,'not a number',NULL,NULL,NULL,NULL,NULL)`
+  );
+  // CTL-13 — carries the NULL-named label l4 alongside a well-formed one.
+  db.run(
+    `INSERT INTO issues VALUES ('i13','CTL-13','Null label name',NULL,'Todo',NULL,NULL,NULL,NULL,NULL,NULL,NULL)`
+  );
+  db.run(`INSERT INTO issue_labels VALUES ('i13','l1')`);
+  db.run(`INSERT INTO issue_labels VALUES ('i13','l4')`); // NULL name → must be dropped
+  // CTL-14 — an EMPTY-STRING description on an otherwise valid detail HIT.
+  db.run(
+    `INSERT INTO issues VALUES ('i14','CTL-14','Empty description','','Todo',NULL,NULL,NULL,NULL,NULL,NULL,NULL)`
+  );
+  // CTL-15 — blocks CTL-5, whose title is ''. CTL-5 is thus reachable as a
+  // relation TARGET, which is the only way the target-title normalize is
+  // exercised (details() rejects an empty title before it ever gets there).
+  db.run(
+    `INSERT INTO issues VALUES ('i15','CTL-15','Blocks an untitled ticket',NULL,'Todo',NULL,NULL,NULL,NULL,NULL,NULL,NULL)`
+  );
+
   // Relations on CTL-1: forward blocks/duplicate/related, inverse blocks/related.
   db.run(`INSERT INTO relations VALUES ('r1','blocks','CTL-1','CTL-2')`);
   db.run(`INSERT INTO relations VALUES ('r2','duplicate','CTL-1','CTL-3')`);
@@ -100,6 +143,9 @@ function seed() {
   // precede CTL-9 in `related`.
   db.run(`INSERT INTO relations VALUES ('r7','related','CTL-1','CTL-8')`);
   db.run(`INSERT INTO relations VALUES ('r8','related','CTL-9','CTL-1')`);
+  // Edge onto the empty-titled CTL-5. Sourced from CTL-15 (not CTL-1) so the
+  // relation-grouping and pass-order assertions above stay untouched.
+  db.run(`INSERT INTO relations VALUES ('r9','blocks','CTL-15','CTL-5')`);
   db.close();
 }
 
@@ -136,7 +182,44 @@ describe("estimates() — CTL-1806", () => {
     });
   });
 
-  test("empty / non-array input → {} without opening the db", () => {
+  test("a NON-FINITE estimate is a MISS (omitted), never served as Infinity", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // 9e999 overflows SQLite's REAL and the driver hands back a JS number whose
+    // Number.isFinite is false. Serving it would put Infinity on the board's
+    // estimate chip and into any arithmetic downstream of it; the caller must
+    // instead fall through, exactly as for a NULL estimate.
+    const out = reader.estimates(["CTL-11"]);
+    expect(Object.hasOwn(out, "CTL-11")).toBe(false);
+    expect(out).toEqual({});
+  });
+
+  test("a NON-NUMERIC STRING estimate is a MISS (omitted), never served as text", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // REAL affinity converts text only when it is losslessly convertible, so
+    // 'not a number' really is stored and returned as a JS string — the board
+    // must never receive a string where it expects a point estimate.
+    //
+    // Mutation note: numOrNull's `typeof v === "number"` conjunct is on its own
+    // an EQUIVALENT mutant — Number.isFinite returns true only for number
+    // primitives, so deleting the typeof test cannot change any answer. What
+    // this case does kill is removal of the guard as a whole, which the
+    // non-finite case above cannot distinguish from a bare typeof check.
+    const out = reader.estimates(["CTL-12"]);
+    expect(Object.hasOwn(out, "CTL-12")).toBe(false);
+    expect(out).toEqual({});
+  });
+
+  test("empty / non-array input → {}", () => {
+    // Scope note: this asserts ONLY the return value. The original name also
+    // claimed "without opening the db", which the body never checked and cannot
+    // check — createReplicaReader constructs its Database inline with no
+    // injectable opener, and on an absent path the open throws and is caught,
+    // yielding the identical {}. Dropping the early return is therefore an
+    // equivalent mutant here, and adding a production seam purely to observe it
+    // is not worth the surface. A test name must not claim a property its body
+    // does not verify.
     reader = createReplicaReader({ dbPath: join(tmpDir, "absent.db") });
     expect(reader.estimates([])).toEqual({});
     expect(reader.estimates(null)).toEqual({});
@@ -200,6 +283,25 @@ describe("relations() — CTL-1806", () => {
       priority: null,
       project: null,
     });
+  });
+
+  test("a target whose title is EMPTY normalizes to null, so the rail renders its id", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const rel = reader.relations(["CTL-15"])["CTL-15"];
+    // The rail renders `title ?? identifier`. An empty string is not null, so it
+    // wins that coalesce and the row draws BLANK — a genuine blocker rendered as
+    // an empty line instead of "CTL-5". Normalizing to null is what restores the
+    // identifier fallback.
+    expect(rel.blocks).toEqual([
+      {
+        identifier: "CTL-5",
+        title: null,
+        state: { name: "Todo", type: "backlog" },
+        priority: null,
+        project: null,
+      },
+    ]);
   });
 
   test("an id with no edges is OMITTED (a miss, not an empty map)", () => {
@@ -284,6 +386,47 @@ describe("details() — CTL-1806", () => {
     // is not. Emitting {name:null,type:"backlog"} would invent a workflow state
     // that does not exist in the workspace and break the LinearStateRef contract.
     expect(reader.details(["CTL-7"])["CTL-7"].state).toBe(null);
+  });
+
+  test("an EMPTY state name yields state:null — an empty ref is never fabricated", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    // Distinct from the NULL-state case above: '' IS a string, so only the
+    // length check stands between the row and a {name:"", type:"started"} ref.
+    // That ref satisfies LinearStateRef structurally while naming a workflow
+    // state that does not exist, so the consumer renders a nameless chip with a
+    // confident icon instead of falling through.
+    expect(reader.details(["CTL-10"])["CTL-10"].state).toBe(null);
+  });
+
+  test("an EMPTY description normalizes to null, not the empty string", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const d = reader.details(["CTL-14"])["CTL-14"];
+    expect(d.title).toBe("Empty description"); // the row IS served
+    // The detail page's availability check is `title !== null || description
+    // !== null`, and callers coalesce on null. An empty string reads as present
+    // content, so the page renders an empty body instead of falling through.
+    expect(d.description).toBe(null);
+  });
+
+  test("a label whose NAME is NULL is DROPPED, never pushed as {name:null}", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const d = reader.details(["CTL-13"])["CTL-13"];
+    // ORDER BY l.name puts a NULL name FIRST in SQLite, so an ungated push
+    // would lead the chip row with a nameless label.
+    expect(d.labels).toEqual([{ name: "needs-human", color: "#ff0000" }]);
+    expect(d.labels.every((l) => typeof l.name === "string" && l.name.length > 0)).toBe(true);
+    expect(d.labels.length).toBe(1); // fail closed: an emptied list is not a pass
+  });
+
+  test("a NON-FINITE estimate on a detail HIT is null, never Infinity", () => {
+    seed();
+    reader = createReplicaReader({ dbPath });
+    const d = reader.details(["CTL-11"])["CTL-11"];
+    expect(d.title).toBe("Non-finite estimate"); // the row IS served
+    expect(d.estimate).toBe(null);
   });
 
   test("absent db → {} (fail-open)", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/cross-team-title-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cross-team-title-fallback.test.ts
@@ -23,7 +23,15 @@
 // (exactly the shape fillTitleDescriptionFallback returns) rather than swapping
 // globalThis.fetch — the network path already has its own suite, and a global-fetch
 // swap here would race other concurrently-running test files' fetch mocks.
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+// CTL-1806: these cases assert the DEGRADED (Linear) tier. Force the
+// replica file-presence gate CLOSED so a dev box (which HAS a real
+// ~/catalyst/catalyst-replica.db) runs the same path as CI (which does not).
+import { pinNoReplica } from "./helpers/no-replica";
+let _restoreReplicaPin: () => void;
+beforeAll(() => { _restoreReplicaPin = pinNoReplica(); });
+afterAll(() => { _restoreReplicaPin?.(); });
+
 import {
   collectNullTitleIds,
   mergeTitleFallback,

--- a/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/estimate-fallback.test.ts
@@ -9,6 +9,14 @@
 //  5. estimateDisplay is correct per method (fibonacci → number, tShirt → label).
 
 import { describe, it, expect, beforeEach, beforeAll, afterAll } from "bun:test";
+// CTL-1806: these cases assert the DEGRADED (Linear) tier. Force the
+// replica file-presence gate CLOSED so a dev box (which HAS a real
+// ~/catalyst/catalyst-replica.db) runs the same path as CI (which does not).
+import { pinNoReplica } from "./helpers/no-replica";
+let _restoreReplicaPin: () => void;
+beforeAll(() => { _restoreReplicaPin = pinNoReplica(); });
+afterAll(() => { _restoreReplicaPin?.(); });
+
 import {
   fillEstimateFallback,
   getEstimationMethodAsync,

--- a/plugins/dev/scripts/orch-monitor/__tests__/helpers/no-replica.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/helpers/no-replica.ts
@@ -1,0 +1,31 @@
+// no-replica.ts — CTL-1806 test helper.
+//
+// The supplemental resolvers are now REPLICA-FIRST, gated on file presence at
+// `CATALYST_REPLICA_DB || $CATALYST_DIR/catalyst-replica.db`. Every pre-existing
+// test in this directory asserts the DEGRADED (Linear GraphQL) behaviour, and a
+// developer machine HAS a real `~/catalyst/catalyst-replica.db` while CI does
+// not — so without an explicit pin those tests silently exercise a different
+// code path locally than in CI, passing in CI and failing (or worse, passing for
+// the wrong reason) on a laptop. That is the exact "green in CI, different
+// mechanism on a dev box" flake class this repo has been bitten by before.
+//
+// pinNoReplica() forces the file-presence gate CLOSED for the duration of a test
+// file, so the Linear tier is genuinely reached. Call it in beforeAll and call
+// the returned restore fn in afterAll.
+//
+// It deliberately does NOT stub the reader: pointing at a path that does not
+// exist exercises the REAL gate, so a regression that removes the gate is caught
+// here rather than hidden by a fake.
+export function pinNoReplica(): () => void {
+  const prevDb = process.env.CATALYST_REPLICA_DB;
+  const prevDir = process.env.CATALYST_DIR;
+  // A path under a directory that cannot exist — never merely "unlikely".
+  process.env.CATALYST_REPLICA_DB =
+    "/nonexistent-ctl-1806/no-such-dir/catalyst-replica.db";
+  return () => {
+    if (prevDb !== undefined) process.env.CATALYST_REPLICA_DB = prevDb;
+    else delete process.env.CATALYST_REPLICA_DB;
+    if (prevDir !== undefined) process.env.CATALYST_DIR = prevDir;
+    else delete process.env.CATALYST_DIR;
+  };
+}

--- a/plugins/dev/scripts/orch-monitor/__tests__/linear-title-description-fallback.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/linear-title-description-fallback.test.ts
@@ -15,7 +15,15 @@
 //  6. Fail-open: network failure → { title:null, description:null }, no throw.
 //  7. _clearTitleDescCache(id) evicts a single entry (webhook invalidation).
 
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "bun:test";
+// CTL-1806: these cases assert the DEGRADED (Linear) tier. Force the
+// replica file-presence gate CLOSED so a dev box (which HAS a real
+// ~/catalyst/catalyst-replica.db) runs the same path as CI (which does not).
+import { pinNoReplica } from "./helpers/no-replica";
+let _restoreReplicaPin: () => void;
+beforeAll(() => { _restoreReplicaPin = pinNoReplica(); });
+afterAll(() => { _restoreReplicaPin?.(); });
+
 import {
   fillTitleDescriptionFallback,
   _clearTitleDescCache,
@@ -67,13 +75,20 @@ function mockFetchFail() {
 
 // A token must be present for graphql() to attempt a fetch; the spy intercepts
 // the actual call so no real network traffic happens.
-function withToken<T>(fn: () => T): T {
+// CTL-1806: this MUST await `fn()` before restoring. It used to restore
+// synchronously, which only worked because the resolver happened to read the
+// token before its first `await`. Adding the replica tier put an `await` ahead of
+// that read, so the token was already deleted by the time the degraded fetch ran
+// — every Linear-tier case silently exercised the no-token path instead. A test
+// helper whose correctness depends on how many microtasks the code under test
+// yields is a test that can pass for the wrong reason.
+async function withToken<T>(fn: () => T | Promise<T>): Promise<T> {
   const prevToken = process.env.LINEAR_API_TOKEN;
   const prevKey = process.env.LINEAR_API_KEY;
   process.env.LINEAR_API_TOKEN = "lin_api_test_token";
   delete process.env.LINEAR_API_KEY;
   try {
-    return fn();
+    return await fn();
   } finally {
     if (prevToken !== undefined) process.env.LINEAR_API_TOKEN = prevToken;
     else delete process.env.LINEAR_API_TOKEN;

--- a/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
@@ -454,6 +454,34 @@ describe("CTL-1806 AC3: the degraded path is LOUD", () => {
     expect((events[0].attributes as Record<string, unknown>)["linear.read.result"]).toBe("failed");
     expect(events[0].severityText).toBe("WARN");
   });
+
+  // The twin of the test above, for the OTHER resolver. Without it, deleting the
+  // `result: "failed"` emission from linear-title-description-fallback.mjs left the
+  // whole suite GREEN (mutation-verified), while the same deletion in
+  // linear-estimate-fallback.mjs went RED. Two sibling resolvers, one of them
+  // silently unguarded on the branch an operator most needs to see: a degraded
+  // Linear read that did not even dispatch. AC3 is "the miss is LOUD" — a failure
+  // that emits nothing is the exact condition the emission exists to announce.
+  it("the title/description path ALSO emits result=failed (WARN) with no credential", async () => {
+    delete process.env.LINEAR_API_TOKEN;
+    delete process.env.LINEAR_API_KEY;
+    const spy = spyFetch();
+    const replica = fakeReplica({ details: {} });
+    try {
+      await fillTitleDescriptionFallback(["CTL-904"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(0); // undispatchable — no outbound call at all
+    } finally {
+      spy.restore();
+    }
+    const events = readEmitted();
+    expect(events.length).toBe(1);
+    const a = events[0].attributes as Record<string, unknown>;
+    expect(a["linear.read.result"]).toBe("failed");
+    expect(a["linear.read.op"]).toBe("title_desc");
+    expect(events[0].severityText).toBe("WARN");
+  });
 });
 
 describe("CTL-1806 D1: the team estimation method stays a LABELLED degraded fetch", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
@@ -1,0 +1,519 @@
+// replica-first-resolvers.test.ts — CTL-1806.
+//
+// The claim this ticket makes is NEGATIVE: "and no Linear API call is made".
+// A test that only checks the returned VALUE would pass even if the call were
+// still being made, so every case below asserts the fetch SPY's call count
+// directly. Each zero-call assertion is paired with a positive control in the
+// same describe block — a case that drives the same instrument and returns a
+// NON-zero count — so a spy that silently stopped observing can never be
+// mistaken for a resolver that stopped calling.
+//
+// The replica is injected through the `readerFactory` seam (the same seam
+// readReplicaTitles has carried since CTL-1372), so these run offline with no
+// real catalyst-replica.db and behave identically on a laptop and in CI.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  fillEstimateFallback,
+  getEstimationMethodAsync,
+  _clearEstimateCache,
+  _clearMethodCache,
+} from "../lib/linear-estimate-fallback.mjs";
+import {
+  fillTitleDescriptionFallback,
+  _clearTitleDescCache,
+  _getTitleDescCacheSize,
+  _sweepTitleDescCache,
+} from "../lib/linear-title-description-fallback.mjs";
+
+// ── fetch spy ────────────────────────────────────────────────────────────────
+// Counts EVERY outbound call. Returns an empty-but-well-formed GraphQL body so a
+// resolver that does call through still completes normally (the count, not a
+// crash, is what fails the test).
+function spyFetch(responseData: unknown = { data: { issues: { nodes: [] } } }) {
+  let callCount = 0;
+  const original = globalThis.fetch;
+  globalThis.fetch = ((_u: unknown, _i: unknown) => {
+    callCount++;
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(responseData) } as Response);
+  }) as typeof fetch;
+  return {
+    get callCount() {
+      return callCount;
+    },
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+// A replica reader stub honouring the primitives' real contracts: a HIT is an
+// entry, a MISS is an ABSENT KEY (never a null value).
+function fakeReplica({
+  estimates = {} as Record<string, number>,
+  details = {} as Record<string, unknown>,
+} = {}) {
+  let closed = false;
+  return {
+    factory: () => ({
+      estimates: (ids: string[]) =>
+        Object.fromEntries(
+          ids.filter((id) => id in estimates).map((id) => [id, estimates[id]])
+        ),
+      details: (ids: string[]) =>
+        Object.fromEntries(ids.filter((id) => id in details).map((id) => [id, details[id]])),
+      close: () => {
+        closed = true;
+      },
+    }),
+    get closed() {
+      return closed;
+    },
+  };
+}
+
+const DETAIL = {
+  title: "Replica-served title",
+  description: "## From SQLite",
+  labels: [{ name: "needs-human", color: "#ff0000" }],
+  relations: {
+    blockedBy: [
+      { identifier: "CTL-99", title: "Blocker", state: { name: "Done", type: "completed" }, priority: 1, project: "P" },
+    ],
+    blocks: [],
+    related: [],
+    duplicateOf: [],
+  },
+  state: { name: "Implement", type: "started" },
+  priority: 2,
+  project: "Fleet Hardening",
+  estimate: 5,
+};
+
+// A Linear token must be present, or graphql() short-circuits BEFORE fetch and a
+// zero-call assertion would pass for the wrong reason.
+let prevToken: string | undefined;
+let prevKey: string | undefined;
+let eventDir: string;
+let prevCatalystDir: string | undefined;
+
+beforeEach(() => {
+  prevToken = process.env.LINEAR_API_TOKEN;
+  prevKey = process.env.LINEAR_API_KEY;
+  process.env.LINEAR_API_TOKEN = "lin_api_test_token";
+  delete process.env.LINEAR_API_KEY;
+  // Redirect the CTL-1806 D3 event emissions into a temp dir so the assertions
+  // read this test's own events and nothing writes to the real ~/catalyst log.
+  prevCatalystDir = process.env.CATALYST_DIR;
+  eventDir = mkdtempSync(join(tmpdir(), "ctl1806-events-"));
+  process.env.CATALYST_DIR = eventDir;
+  _clearEstimateCache();
+  _clearMethodCache();
+  _clearTitleDescCache();
+});
+
+afterEach(() => {
+  if (prevToken !== undefined) process.env.LINEAR_API_TOKEN = prevToken;
+  else delete process.env.LINEAR_API_TOKEN;
+  if (prevKey !== undefined) process.env.LINEAR_API_KEY = prevKey;
+  if (prevCatalystDir !== undefined) process.env.CATALYST_DIR = prevCatalystDir;
+  else delete process.env.CATALYST_DIR;
+  rmSync(eventDir, { recursive: true, force: true });
+});
+
+// Read every catalyst.linear.read event this test emitted.
+function readEmitted(): Array<Record<string, unknown>> {
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const p = join(eventDir, "events", `${ym}.jsonl`);
+  if (!existsSync(p)) return [];
+  const lines = readFileSync(p, "utf8").split("\n").filter(Boolean);
+  const parsed: Array<Record<string, unknown>> = [];
+  for (const line of lines) {
+    parsed.push(JSON.parse(line) as Record<string, unknown>);
+  }
+  return parsed.filter(
+    (e) =>
+      (e.attributes as Record<string, unknown> | undefined)?.["event.name"] ===
+      "catalyst.linear.read"
+  );
+}
+
+describe("CTL-1806 AC1: a supplemental estimate is served from the replica", () => {
+  it("replica HIT → the value comes from the replica and ZERO Linear calls are made", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({ estimates: { "CTL-500": 8 } });
+    try {
+      const out = await fillEstimateFallback(["CTL-500"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(out["CTL-500"]).toBe(8);
+      expect(spy.callCount).toBe(0); // THE claim
+    } finally {
+      spy.restore();
+    }
+    expect(replica.closed).toBe(true); // the reader handle is always released
+  });
+
+  it("POSITIVE CONTROL: replica MISS → the same spy counts a real Linear call", async () => {
+    const spy = spyFetch({
+      data: { issues: { nodes: [{ number: 501, estimate: 3, team: { key: "CTL" } }] } },
+    });
+    const replica = fakeReplica({ estimates: {} });
+    try {
+      const out = await fillEstimateFallback(["CTL-501"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      // Non-zero here is what makes the zero above evidence rather than silence.
+      expect(spy.callCount).toBe(1);
+      expect(out["CTL-501"]).toBe(3);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("a replica NULL estimate is a MISS and FALLS THROUGH (never an authoritative null)", async () => {
+    const spy = spyFetch({
+      data: { issues: { nodes: [{ number: 502, estimate: 13, team: { key: "CTL" } }] } },
+    });
+    // The primitive omits a NULL estimate, so the stub omits the key. If the
+    // resolver ever treated a replica null as authoritative, this would be 0
+    // calls and the board chip would silently vanish for a refresh.
+    const replica = fakeReplica({ estimates: {} });
+    try {
+      const out = await fillEstimateFallback(["CTL-502"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(1);
+      expect(out["CTL-502"]).toBe(13);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("a non-numeric replica answer is NOT trusted as an estimate", async () => {
+    const spy = spyFetch({
+      data: { issues: { nodes: [{ number: 503, estimate: 21, team: { key: "CTL" } }] } },
+    });
+    // The primitive's contract is hits-only-and-finite, but this resolver must
+    // not DEPEND on a reader honouring it: an older or third-party reader that
+    // returns a present-but-null value would otherwise be served straight onto
+    // the board as an authoritative estimate. Falling through is the safe read.
+    const replica = {
+      factory: () => ({
+        estimates: () => ({ "CTL-503": null as unknown as number }),
+        details: () => ({}),
+        close: () => {},
+      }),
+    };
+    try {
+      const out = await fillEstimateFallback(["CTL-503"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(1);
+      expect(out["CTL-503"]).toBe(21);
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("a mixed batch fetches ONLY the replica misses", async () => {
+    const spy = spyFetch({
+      data: { issues: { nodes: [{ number: 601, estimate: 2, team: { key: "CTL" } }] } },
+    });
+    const replica = fakeReplica({ estimates: { "CTL-600": 5 } });
+    try {
+      const out = await fillEstimateFallback(["CTL-600", "CTL-601"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(out["CTL-600"]).toBe(5);
+      expect(out["CTL-601"]).toBe(2);
+      expect(spy.callCount).toBe(1); // one call, for the miss only
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("FILE-PRESENCE gate: an absent replica file falls through without throwing", async () => {
+    const spy = spyFetch();
+    try {
+      // No readerFactory → the real existsSync gate runs against a path that
+      // cannot exist. This exercises the GATE, not a stub of it.
+      const out = await fillEstimateFallback(["CTL-700"], {
+        replicaOptions: { dbPath: "/nonexistent-ctl-1806/no-such-dir/replica.db" },
+      });
+      expect(out["CTL-700"]).toBe(null);
+      expect(spy.callCount).toBe(1);
+    } finally {
+      spy.restore();
+    }
+  });
+});
+
+describe("CTL-1806 AC2: title/description (and the DETAIL route + relation targets) from the replica", () => {
+  it("replica HIT → full payload from the replica and ZERO Linear calls", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({ details: { "CTL-800": DETAIL } });
+    try {
+      const out = await fillTitleDescriptionFallback(["CTL-800"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      const e = out["CTL-800"];
+      expect(e.title).toBe("Replica-served title");
+      expect(e.description).toBe("## From SQLite");
+      expect(e.state).toEqual({ name: "Implement", type: "started" });
+      expect(e.priority).toBe(2);
+      expect(e.estimate).toBe(5);
+      expect(e.project).toBe("Fleet Hardening");
+      expect(e.labels).toEqual([{ name: "needs-human", color: "#ff0000" }]);
+      // The relation TARGETS — the half of AC2 that had no replica tier at all.
+      expect(e.relations?.blockedBy?.[0]?.identifier).toBe("CTL-99");
+      expect(e.relations?.blockedBy?.[0]?.state).toEqual({ name: "Done", type: "completed" });
+      // Provenance, so the detail route stops reporting "linear-live" for a read
+      // that never touched Linear.
+      expect(e.source).toBe("replica");
+      expect(spy.callCount).toBe(0); // THE claim
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("POSITIVE CONTROL: replica MISS → the same spy counts a real Linear call", async () => {
+    const spy = spyFetch({
+      data: {
+        issues: {
+          nodes: [{ number: 801, title: "From Linear", description: "d", team: { key: "CTL" } }],
+        },
+      },
+    });
+    const replica = fakeReplica({ details: {} });
+    try {
+      const out = await fillTitleDescriptionFallback(["CTL-801"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(1);
+      expect(out["CTL-801"].title).toBe("From Linear");
+      expect(out["CTL-801"].source).toBe("linear");
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("a replica hit with an EMPTY title falls through rather than caching a hollow entry", async () => {
+    const spy = spyFetch({
+      data: {
+        issues: {
+          nodes: [{ number: 802, title: "Real", description: null, team: { key: "CTL" } }],
+        },
+      },
+    });
+    const replica = fakeReplica({ details: { "CTL-802": { ...DETAIL, title: "" } } });
+    try {
+      const out = await fillTitleDescriptionFallback(["CTL-802"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(1);
+      expect(out["CTL-802"].title).toBe("Real");
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("D2/D4: a terminal replica hit takes the 24h TTL, so it is not re-resolved", async () => {
+    const replica = fakeReplica({
+      details: { "CTL-803": { ...DETAIL, state: { name: "Done", type: "completed" } } },
+    });
+    const spy1 = spyFetch();
+    try {
+      await fillTitleDescriptionFallback(["CTL-803"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+    } finally {
+      spy1.restore();
+    }
+    // Second call with NO replica available at all: served purely from the 24h
+    // cache the synthesized `completed` type selected. Had the type been dropped,
+    // this would take the 5-min TTL — still cached here, so the assertion that
+    // actually bites is the one in the execution-core ground-truth suite; this
+    // one proves the terminal payload survives a replica outage.
+    const spy2 = spyFetch();
+    try {
+      const out = await fillTitleDescriptionFallback(["CTL-803"], {
+        replicaOptions: { dbPath: "/nonexistent-ctl-1806/no-such-dir/replica.db" },
+      });
+      expect(out["CTL-803"].title).toBe("Replica-served title");
+      expect(spy2.callCount).toBe(0);
+    } finally {
+      spy2.restore();
+    }
+  });
+});
+
+describe("CTL-1806 D2->D4: the synthesized terminal type buys the 24h TTL", () => {
+  it("a terminal replica hit SURVIVES a sweep 6 minutes later; a started one does not", async () => {
+    const replica = fakeReplica({
+      details: {
+        "CTL-810": { ...DETAIL, state: { name: "Done", type: "completed" } },
+        "CTL-811": { ...DETAIL, state: { name: "Implement", type: "started" } },
+      },
+    });
+    const spy = spyFetch();
+    try {
+      await fillTitleDescriptionFallback(["CTL-810", "CTL-811"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(0);
+    } finally {
+      spy.restore();
+    }
+    expect(_getTitleDescCacheSize()).toBe(2);
+    // Sweep 6 minutes into the future: past the 5-min TTL, far short of 24h.
+    // If the terminal entry took the short TTL, BOTH would be evicted — which is
+    // the quota regression D2 rejects (2725 of 3887 replica tickets are terminal,
+    // so they would all drop from a 24h to a 5-min cache).
+    const removed = _sweepTitleDescCache(Date.now() + 6 * 60 * 1000);
+    expect(removed).toBe(1);
+    expect(_getTitleDescCacheSize()).toBe(1);
+  });
+});
+
+describe("CTL-1806 AC3: the degraded path is LOUD", () => {
+  it("a replica miss that falls through emits catalyst.linear.read source=linearis_miss", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({ estimates: {} });
+    try {
+      await fillEstimateFallback(["CTL-900"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+    } finally {
+      spy.restore();
+    }
+    const events = readEmitted();
+    expect(events.length).toBe(1);
+    const a = events[0].attributes as Record<string, unknown>;
+    expect(a["linear.read.source"]).toBe("linearis_miss");
+    expect(a["linear.read.result"]).toBe("ok");
+    expect(a["linear.read.op"]).toBe("estimate");
+    // The service.name must be orch-monitor's own — attributing these reads to
+    // the daemon would corrupt the very metric this ticket exists to move.
+    expect((events[0].resource as Record<string, unknown>)["service.name"]).toBe(
+      "catalyst.orch-monitor"
+    );
+  });
+
+  it("the title/description degraded path emits op=title_desc", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({ details: {} });
+    try {
+      await fillTitleDescriptionFallback(["CTL-901"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+    } finally {
+      spy.restore();
+    }
+    const events = readEmitted();
+    expect(events.length).toBe(1);
+    const a = events[0].attributes as Record<string, unknown>;
+    expect(a["linear.read.source"]).toBe("linearis_miss");
+    expect(a["linear.read.op"]).toBe("title_desc");
+  });
+
+  it("a replica HIT is SILENT — no degraded event, because no Linear call happened", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({ estimates: { "CTL-902": 3 } });
+    try {
+      await fillEstimateFallback(["CTL-902"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+    } finally {
+      spy.restore();
+    }
+    // The event stream is the alarm for "a Linear call is about to happen". If a
+    // healthy replica-served render emitted, the alarm would be worthless.
+    expect(readEmitted().length).toBe(0);
+  });
+
+  it("no Linear credential → result=failed (WARN), so a silently-null node is visible", async () => {
+    delete process.env.LINEAR_API_TOKEN;
+    delete process.env.LINEAR_API_KEY;
+    const spy = spyFetch();
+    const replica = fakeReplica({ estimates: {} });
+    try {
+      await fillEstimateFallback(["CTL-903"], {
+        replicaOptions: { readerFactory: replica.factory },
+      });
+      expect(spy.callCount).toBe(0); // undispatchable — no outbound call at all
+    } finally {
+      spy.restore();
+    }
+    const events = readEmitted();
+    expect(events.length).toBe(1);
+    expect((events[0].attributes as Record<string, unknown>)["linear.read.result"]).toBe("failed");
+    expect(events[0].severityText).toBe("WARN");
+  });
+});
+
+describe("CTL-1806 D1: the team estimation method stays a LABELLED degraded fetch", () => {
+  it("emits source=linearis (NOT linearis_miss) — no replica was consulted", async () => {
+    // The replica has no teams table and carries no issueEstimation, so this read
+    // has no local tier at all. Recording it as a "miss" would imply a replica
+    // could have served it.
+    const spy = spyFetch({
+      data: { teams: { nodes: [{ issueEstimation: { type: "tShirt", allowZero: true, extended: false } }] } },
+    });
+    const prevHome = process.env.HOME;
+    const home = mkdtempSync(join(tmpdir(), "ctl1806-home-"));
+    process.env.HOME = home; // isolate the shared on-disk cache
+    try {
+      const m = await getEstimationMethodAsync("ZZZ");
+      expect(m?.type).toBe("tShirt");
+      expect(spy.callCount).toBe(1);
+      const events = readEmitted();
+      expect(events.length).toBe(1);
+      const a = events[0].attributes as Record<string, unknown>;
+      expect(a["linear.read.source"]).toBe("linearis");
+      expect(a["linear.read.op"]).toBe("team_method");
+      expect(a["event.label"]).toBe("ZZZ");
+    } finally {
+      spy.restore();
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      rmSync(home, { recursive: true, force: true });
+      _clearMethodCache();
+    }
+  });
+
+  it("ONE cache: a record the scheduler wrote is honoured here, with ZERO Linear calls", async () => {
+    const prevHome = process.env.HOME;
+    const home = mkdtempSync(join(tmpdir(), "ctl1806-home-"));
+    process.env.HOME = home;
+    try {
+      // Write through the execution-core writer — the scheduler's own path.
+      const { writeTeamEstimationCache, _resetMemoForTests } = await import(
+        "../../execution-core/linear-estimation-method.mjs"
+      );
+      writeTeamEstimationCache("YYY", { type: "fibonacci", allowZero: false, extended: false });
+      _resetMemoForTests(); // force the on-DISK read, not the memo
+
+      const spy = spyFetch();
+      try {
+        const m = await getEstimationMethodAsync("YYY");
+        expect(m?.type).toBe("fibonacci");
+        // Before CTL-1806 this module used a 24h TTL over the same file the
+        // scheduler writes with a 7-day TTL, so a 30h-old record was valid there
+        // and stale here — the board re-fetched and rewrote a file the scheduler
+        // was already serving. One TTL now.
+        expect(spy.callCount).toBe(0);
+        expect(readEmitted().length).toBe(0);
+      } finally {
+        spy.restore();
+      }
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      rmSync(home, { recursive: true, force: true });
+      _clearMethodCache();
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/replica-first-resolvers.test.ts
@@ -28,6 +28,7 @@ import {
   _getTitleDescCacheSize,
   _sweepTitleDescCache,
 } from "../lib/linear-title-description-fallback.mjs";
+import { readReplicaTicketDetails } from "../lib/linear-cache-reader.mjs";
 
 // ── fetch spy ────────────────────────────────────────────────────────────────
 // Counts EVERY outbound call. Returns an empty-but-well-formed GraphQL body so a
@@ -55,10 +56,14 @@ function spyFetch(responseData: unknown = { data: { issues: { nodes: [] } } }) {
 function fakeReplica({
   estimates = {} as Record<string, number>,
   details = {} as Record<string, unknown>,
+  // Codex P1 (#3355): the single-ticket DETAIL path gates on writer liveness.
+  // Defaults true so every pre-existing case behaves exactly as before.
+  isFresh = true,
 } = {}) {
   let closed = false;
   return {
     factory: () => ({
+      isFresh: () => isFresh,
       estimates: (ids: string[]) =>
         Object.fromEntries(
           ids.filter((id) => id in estimates).map((id) => [id, estimates[id]])
@@ -462,6 +467,52 @@ describe("CTL-1806 AC3: the degraded path is LOUD", () => {
   // silently unguarded on the branch an operator most needs to see: a degraded
   // Linear read that did not even dispatch. AC3 is "the miss is LOUD" — a failure
   // that emits nothing is the exact condition the emission exists to announce.
+  // Codex P1 on #3355. The ticket-DETAIL path is a SINGLE-ticket read, and the repo
+  // rule requires those to gate freshness and fall back loudly. File presence alone
+  // is not enough: when the writer stops but its .db remains, a stale hit is served
+  // AND cached for 5-24 hours. Observed for real on the developer laptop 2026-08-14
+  // (clean SIGTERM, KeepAlive={SuccessfulExit:false} never revived it, .db left on
+  // disk, reads served ~15-minute-old state — CTL-1736 / CTL-1844).
+  //
+  // This is NOT the CTL-1397 hazard: that was gating on .db/-wal MTIME, which a quiet
+  // Linear feed makes look stale. isFresh() reads the .writer.lock HEARTBEAT, which
+  // ticks every few seconds regardless of Linear activity.
+  it("a STALE replica (writer stopped) is a MISS on the detail path, not a stale hit", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({
+      isFresh: false,
+      details: { "CTL-905": { title: "stale title", description: "stale" } },
+    });
+    try {
+      const out = await readReplicaTicketDetails({
+        ids: ["CTL-905"],
+        readerFactory: replica.factory,
+      });
+      // The row EXISTS in the replica — it is withheld because the writer is dead,
+      // so the caller falls through to its loud degraded Linear chain.
+      expect(out).toEqual({});
+    } finally {
+      spy.restore();
+    }
+  });
+
+  it("a FRESH replica still serves the detail hit (the gate is not a blanket refusal)", async () => {
+    const spy = spyFetch();
+    const replica = fakeReplica({
+      isFresh: true,
+      details: { "CTL-906": { title: "live title", description: "live" } },
+    });
+    try {
+      const out = await readReplicaTicketDetails({
+        ids: ["CTL-906"],
+        readerFactory: replica.factory,
+      });
+      expect(Object.keys(out)).toEqual(["CTL-906"]);
+    } finally {
+      spy.restore();
+    }
+  });
+
   it("the title/description path ALSO emits result=failed (WARN) with no credential", async () => {
     delete process.env.LINEAR_API_TOKEN;
     delete process.env.LINEAR_API_KEY;

--- a/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-endpoints.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/ticket-detail-endpoints.test.ts
@@ -8,6 +8,14 @@
 // CTL-996: also covers the /api/linear-ticket route which now returns
 // labels + relations in addition to title + description.
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+// CTL-1806: these cases assert the DEGRADED (Linear) tier. Force the
+// replica file-presence gate CLOSED so a dev box (which HAS a real
+// ~/catalyst/catalyst-replica.db) runs the same path as CI (which does not).
+import { pinNoReplica } from "./helpers/no-replica";
+let _restoreReplicaPin: () => void;
+beforeAll(() => { _restoreReplicaPin = pinNoReplica(); });
+afterAll(() => { _restoreReplicaPin?.(); });
+
 import { mkdtempSync, mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";

--- a/plugins/dev/scripts/orch-monitor/__tests__/title-desc-cache-bound.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/title-desc-cache-bound.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "bun:test";
+// CTL-1806: these cases assert the DEGRADED (Linear) tier. Force the
+// replica file-presence gate CLOSED so a dev box (which HAS a real
+// ~/catalyst/catalyst-replica.db) runs the same path as CI (which does not).
+import { pinNoReplica } from "./helpers/no-replica";
+let _restoreReplicaPin: () => void;
+beforeAll(() => { _restoreReplicaPin = pinNoReplica(); });
+afterAll(() => { _restoreReplicaPin?.(); });
+
 import {
   fillTitleDescriptionFallback,
   _clearTitleDescCache,

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.d.mts
@@ -88,3 +88,56 @@ export interface ReadReplicaTitlesOptions {
  *  read-only display) and is FAIL-OPEN: any error returns {} so the existing title
  *  chain is preserved. Returns { identifier → title } of HITS only. Never throws. */
 export function readReplicaTitles(opts?: ReadReplicaTitlesOptions): Promise<Record<string, string>>;
+
+/** CTL-1806: a batched replica ESTIMATE reader — `factory({dbPath})` returns an
+ *  object whose `estimates(ids)` yields an { identifier → estimate } map of HITS
+ *  only. A replica row with a NULL estimate is a MISS (omitted), never an
+ *  authoritative null. Injected in tests so the contract is driven offline. */
+export interface ReplicaEstimateReader {
+  estimates(ids: string[]): Record<string, number>;
+  close?: () => void;
+}
+
+export interface ReadReplicaEstimatesOptions {
+  /** Ticket ids to resolve estimates for (de-duped; empty/falsy skipped). */
+  ids?: string[];
+  /** Replica DB path; defaults to CATALYST_REPLICA_DB || ~/catalyst/catalyst-replica.db. */
+  dbPath?: string;
+  /** Test seam: a `factory({dbPath})` → ReplicaEstimateReader. When set, the
+   *  file-presence gate is skipped (the injected reader IS the DB). */
+  readerFactory?: ((opts: { dbPath: string }) => ReplicaEstimateReader) | null;
+}
+
+/** CTL-1806: serve the supplemental ESTIMATE resolver from the local replica
+ *  instead of the rate-limited Linear API. FILE-PRESENCE gate only (a
+ *  writer-liveness gate would burst Linear calls during a quiet feed — CTL-1397)
+ *  and FAIL-OPEN: any error returns {}. Returns { identifier → estimate } of HITS
+ *  only. Never throws. */
+export function readReplicaEstimates(
+  opts?: ReadReplicaEstimatesOptions,
+): Promise<Record<string, number>>;
+
+/** CTL-1806: a batched replica DETAIL reader — `factory({dbPath})` returns an
+ *  object whose `details(ids)` yields the full per-ticket payload for HITS only. */
+export interface ReplicaDetailReader {
+  details(ids: string[]): Record<string, unknown>;
+  close?: () => void;
+}
+
+export interface ReadReplicaTicketDetailsOptions {
+  /** Ticket ids to resolve details for (de-duped; empty/falsy skipped). */
+  ids?: string[];
+  /** Replica DB path; defaults to CATALYST_REPLICA_DB || ~/catalyst/catalyst-replica.db. */
+  dbPath?: string;
+  /** Test seam: a `factory({dbPath})` → ReplicaDetailReader. When set, the
+   *  file-presence gate is skipped (the injected reader IS the DB). */
+  readerFactory?: ((opts: { dbPath: string }) => ReplicaDetailReader) | null;
+}
+
+/** CTL-1806: serve the supplemental TITLE/DESCRIPTION resolver — and therefore
+ *  the ticket-DETAIL page and every relation target — from the local replica.
+ *  Same FILE-PRESENCE gate and fail-open contract as readReplicaTitles. A hit
+ *  requires a non-empty title; misses are omitted. Never throws. */
+export function readReplicaTicketDetails(
+  opts?: ReadReplicaTicketDetailsOptions,
+): Promise<Record<string, unknown>>;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -362,6 +362,27 @@ export async function readReplicaTicketDetails({
     }
     reader = factory({ dbPath });
     if (typeof reader.details !== "function") return {};
+    // ⛔ SINGLE-TICKET READS ARE FRESHNESS-GATED (Codex P1 on #3355).
+    // This is the ticket-DETAIL path, not the board batch, and the repo rule is
+    // explicit that a single-ticket read gates freshness and falls back LOUDLY.
+    // File presence alone is not enough: when the writer stops but its database
+    // remains, every field below is a stale hit that then gets cached for 5-24h.
+    //
+    // Not hypothetical — observed on the developer laptop 2026-08-14: the writer
+    // took a clean SIGTERM, `KeepAlive={SuccessfulExit:false}` never revived it,
+    // the .db stayed on disk, and reads silently served ~15-minute-old state
+    // (CTL-1736 / CTL-1844).
+    //
+    // This does NOT re-create CTL-1397, and the distinction matters: that incident
+    // was gating on the .db/-wal MTIME, which a legitimately QUIET Linear feed makes
+    // look stale. `isFresh()` reads the `.writer.lock` HEARTBEAT, which the writer
+    // touches every few seconds regardless of Linear activity — it tracks writer
+    // LIVENESS, not data-change cadence. The D4 ruling's file-presence choice stands
+    // for the high-volume board resolvers; it was never about this path.
+    //
+    // Returning {} is the documented miss contract, so the caller falls through to
+    // its existing (loud, degraded-labelled) Linear chain rather than serving stale.
+    if (typeof reader.isFresh === "function" && !reader.isFresh()) return {};
     const out = reader.details(wanted);
     return out && typeof out === "object" ? out : {};
   } catch {

--- a/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-cache-reader.mjs
@@ -268,6 +268,113 @@ export async function readReplicaTitles({
 }
 
 
+// readReplicaEstimates — CTL-1806. The replica tier for the supplemental ESTIMATE
+// resolver. linear-estimate-fallback.mjs had ZERO replica consultation: a board
+// ticket whose broker durable-cache estimate is null went straight to the
+// rate-limited Linear GraphQL API for a value sitting in local SQLite (measured
+// 2026-08-14: 2954 of 3887 replica rows carry an estimate; the broker's
+// ticket_state working set is ~100 rows).
+//
+// Gate + fail-open contract copied VERBATIM from readReplicaTitles above:
+// FILE-PRESENCE only (deliberately NOT writer-liveness — CTL-1397 documents that
+// a live writer on a QUIET Linear feed reads as stale, so a liveness gate here
+// would burst Linear calls exactly when the board is unchanged, which is
+// backwards for a read that exists to remove them), {} on ANY failure, reader
+// closed either way.
+//
+// Returns { [identifier]: number } of HITS only. A replica row whose estimate is
+// NULL is a MISS (omitted) — see replica-read.mjs::estimates for why an
+// authoritative null would be wrong. Never throws.
+//
+// HONEST NOTE on the file-presence gate (verified by mutation, CTL-1806): it is a
+// FAST PATH, not a correctness guard. Deleting it does not change any observable
+// result — `new Database(absentPath, {readonly:true})` THROWS ("unable to open
+// database file", measured), and the catch below converts that to the same {}.
+// What the gate buys is avoiding a dynamic import + a constructed-and-thrown
+// handle on every call on a node that has no replica. The same is true of
+// readReplicaTitles's gate above, from which this is copied verbatim. Do not
+// remove it, but do not mistake it for the thing that keeps this read safe —
+// that is the try/catch and the hits-only contract.
+export async function readReplicaEstimates({
+  ids = [],
+  dbPath = process.env.CATALYST_REPLICA_DB || defaultReplicaDbPath(),
+  readerFactory = null,
+} = {}) {
+  const wanted = [...new Set((Array.isArray(ids) ? ids : []).filter(Boolean))];
+  if (wanted.length === 0) return {};
+  if (!readerFactory) {
+    try {
+      if (!existsSync(dbPath)) return {};
+    } catch {
+      return {};
+    }
+  }
+  let reader = null;
+  try {
+    let factory = readerFactory;
+    if (!factory) {
+      ({ createReplicaReader: factory } = await import(REPLICA_READ_MODULE));
+    }
+    reader = factory({ dbPath });
+    if (typeof reader.estimates !== "function") return {};
+    const out = reader.estimates(wanted);
+    return out && typeof out === "object" ? out : {};
+  } catch {
+    return {}; // any failure → fail-open to the existing estimate chain
+  } finally {
+    try {
+      reader?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
+// readReplicaTicketDetails — CTL-1806. The replica tier for the supplemental
+// TITLE/DESCRIPTION resolver, which serves BOTH the board's null-title backfill
+// and — the real gap this closes — the ticket-DETAIL page (server.ts's
+// /api/linear-ticket route calls fillTitleDescriptionFallback with no replica
+// tier at all) plus every RELATION TARGET it renders.
+//
+// Same FILE-PRESENCE gate and fail-open contract as readReplicaTitles /
+// readReplicaEstimates above. Returns { [identifier]: TitleDescription } of HITS
+// only (a hit requires a non-empty title); misses are omitted so the caller falls
+// through to its existing chain. Never throws.
+export async function readReplicaTicketDetails({
+  ids = [],
+  dbPath = process.env.CATALYST_REPLICA_DB || defaultReplicaDbPath(),
+  readerFactory = null,
+} = {}) {
+  const wanted = [...new Set((Array.isArray(ids) ? ids : []).filter(Boolean))];
+  if (wanted.length === 0) return {};
+  if (!readerFactory) {
+    try {
+      if (!existsSync(dbPath)) return {};
+    } catch {
+      return {};
+    }
+  }
+  let reader = null;
+  try {
+    let factory = readerFactory;
+    if (!factory) {
+      ({ createReplicaReader: factory } = await import(REPLICA_READ_MODULE));
+    }
+    reader = factory({ dbPath });
+    if (typeof reader.details !== "function") return {};
+    const out = reader.details(wanted);
+    return out && typeof out === "object" ? out : {};
+  } catch {
+    return {}; // any failure → fail-open to the existing title/description chain
+  } finally {
+    try {
+      reader?.close?.();
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
 // readReplicaHumanHolds — replica-backed needs-human/needs-input holds for a
 // bounded id set (the CTL-1588 queue annotation's SECOND source). The parked
 // descriptor set (filter-state.db) is webhook-fed, and the webhook receiver is

--- a/plugins/dev/scripts/orch-monitor/lib/linear-degraded-read.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-degraded-read.mjs
@@ -1,0 +1,64 @@
+// linear-degraded-read.mjs — CTL-1806 (D3). The ONE place orch-monitor declares
+// that it is about to talk to the rate-limited Linear GraphQL API.
+//
+// AC3: "a replica miss is loud, not a silent API call". The anomaly worth
+// alarming on is not "a reader failed" — the replica readers
+// (readReplicaTitles / readReplicaEstimates / readReplicaTicketDetails) are
+// deliberately SILENT fail-open, and they must stay that way, because their
+// fall-through is to another LOCAL source. The anomaly is "a Linear API call is
+// about to happen". So the emission sits on the DEGRADED PATH, immediately
+// before the fetch — never on the reader. That placement makes the signal
+// impossible to reach without an actual outbound call, and impossible to skip
+// when the call throws or times out (an emission placed AFTER the fetch is lost
+// on exactly the failures worth knowing about).
+//
+// WHY THIS MODULE AND NOT recordDaemonRead: linear-query.mjs's recordDaemonRead
+// hardcodes serviceName "catalyst.execution-core". Reusing it would attribute
+// orch-monitor's reads to the daemon and corrupt the very metric this ticket
+// exists to move. emitLinearReadEvent is already exported and already imported
+// cross-package (broker/cache-reconcile.mjs), so a third package importing it is
+// precedent, not a new seam. This wrapper exists so the serviceName is declared
+// ONCE rather than re-typed at each call site.
+//
+// The static import is vite-safe: emitLinearReadEvent's transitive static graph
+// is 5 modules of node builtins + catalyst-resource + secret-contract, with NO
+// `bun:` specifier anywhere — unlike replica-read.mjs, which is why THAT one is
+// reached only through linear-cache-reader's computed dynamic specifier.
+import { emitLinearReadEvent } from "../../execution-core/linear-read-event.mjs";
+
+/** service.name stamped on every orch-monitor Linear read event. */
+export const ORCH_MONITOR_SERVICE = "catalyst.orch-monitor";
+
+/**
+ * noteDegradedLinearRead — emit one `catalyst.linear.read` for a Linear API call
+ * this process is making because a local source could not serve the read.
+ *
+ * Call it IMMEDIATELY BEFORE the outbound request, not after.
+ *
+ * `result` records whether the degraded call could be DISPATCHED — the only
+ * thing knowable at the emission point, and deliberately so (see above):
+ *   - "ok"     → the request is being sent to Linear.
+ *   - "failed" → the degraded path was reached but no call could be made at all
+ *                (no credential resolved). Stamps WARN/13, which is right: a
+ *                node that silently returns nulls because it has no Linear token
+ *                is the failure this telemetry most needs to surface.
+ *
+ * `source` distinguishes WHY we are here:
+ *   - "linearis_miss" → a replica WAS consulted and missed.
+ *   - "linearis"      → no replica was consulted (no replica source exists for
+ *                       this read — the team estimation method, D1).
+ *
+ * Best-effort and never throws: emitLinearReadEvent swallows its own errors and
+ * returns false (CTL-988 — a telemetry tap must never be able to fail the read
+ * that called it).
+ *
+ * @param {{source: string, result: "ok"|"failed", op: string, entity?: string|null}} fields
+ * @param {{logPath?: string, now?: Function}} [opts] injectable for tests
+ * @returns {boolean} true when the line was appended
+ */
+export function noteDegradedLinearRead({ source, result, op, entity = null }, opts = {}) {
+  return emitLinearReadEvent(
+    { source, result, op, entity, serviceName: ORCH_MONITOR_SERVICE },
+    opts
+  );
+}

--- a/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.d.mts
@@ -8,23 +8,44 @@ export interface EstimationMethod {
   extended: boolean;
 }
 
+/** CTL-1806: test seam for the replica tier. Forwarded verbatim to
+ *  readReplicaEstimates, so an injected `readerFactory` drives the replica
+ *  contract offline and a `dbPath` pins the file-presence gate. */
+export interface ReplicaTierOptions {
+  replicaOptions?: {
+    dbPath?: string;
+    readerFactory?: ((opts: { dbPath: string }) => unknown) | null;
+  };
+}
+
 /**
  * fillEstimateFallback — given an array of ticket IDs whose durable-cache
  * estimate is null, return a map { [id]: number|null } for those IDs.
  *
  * - Hits are served from the in-memory TTL cache (5 min).
- * - Remaining IDs are batched into a single Linear GraphQL call.
+ * - CTL-1806: remaining IDs are served from the LOCAL REPLICA (file-presence
+ *   gate, fail-open). A replica NULL estimate is a MISS, not an authoritative
+ *   null, so it falls through rather than dropping the chip.
+ * - Only genuine replica misses reach a Linear GraphQL call, and each such call
+ *   emits `catalyst.linear.read {source:"linearis_miss", op:"estimate"}`.
  * - Always resolves; never rejects (fail-open).
  */
 export function fillEstimateFallback(
   ticketIds: string[],
+  opts?: ReplicaTierOptions,
 ): Promise<Record<string, number | null>>;
 
 /**
  * getEstimationMethodAsync — async version of the scheduler's
- * getEstimationMethod. Reads the shared on-disk cache first (24h TTL),
- * falls back to a live Linear GraphQL fetch on a miss. Returns null on any
- * failure (fail-open).
+ * getEstimationMethod, sharing its on-disk cache, path and 7-day TTL
+ * (CTL-1806 D1 collapsed the duplicate 24h cache over the same file).
+ *
+ * The team estimation method has NO replica source — the replica has no teams
+ * table and carries no issueEstimation — so a cold cache falls back to a
+ * labelled DEGRADED Linear fetch that emits
+ * `catalyst.linear.read {source:"linearis", op:"team_method"}`. Returns null on
+ * any failure; it is deliberately never defaulted to a scale, because null makes
+ * the scheduler SKIP its estimate write while a guess would write a wrong one.
  */
 export function getEstimationMethodAsync(
   teamId: string,

--- a/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-estimate-fallback.mjs
@@ -33,31 +33,32 @@
 //
 // Dependencies: none beyond node built-ins + Bun's global `fetch`.
 
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
 // CTL-1616 PR3: fold this file's inline LINEAR_API_TOKEN/LINEAR_API_KEY ladder
 // onto the shared secret-contract engine (design §8 PR3 table).
 import { resolveSecret } from "../../lib/secret-contract.mjs";
-
-const HOME = homedir();
+// CTL-1806: the replica tier (read #1) + the degraded-path anomaly (D3).
+import { readReplicaEstimates } from "./linear-cache-reader.mjs";
+import { noteDegradedLinearRead } from "./linear-degraded-read.mjs";
+// CTL-1806 (D1): the team estimation method's cache lives in execution-core and
+// is now shared rather than duplicated here. This module previously carried its
+// own 24h TTL, its own path fn, its own memo, a byte-copy of the GraphQL query
+// and its own atomic write — all over THE SAME FILE the scheduler writes with a
+// 7-day TTL. A record written at T+30h was therefore valid to the scheduler and
+// stale here, so the board re-fetched from Linear and rewrote a file the
+// scheduler was already serving: a duplicated Linear call caused purely by the
+// two caches disagreeing. One TTL now, one path, one query, one writer.
+import {
+  TEAM_ESTIMATION_QUERY,
+  readTeamEstimationCache,
+  writeTeamEstimationCache,
+  _resetMemoForTests,
+} from "../../execution-core/linear-estimation-method.mjs";
 
 // ── In-memory TTL cache ───────────────────────────────────────────────────────
 // Keyed by ticket ID (e.g. "CTL-774"). Value: { estimate: number|null, ts: number }.
 // null means we fetched and Linear returned no estimate; absent means uncached.
 const ESTIMATE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const _estimateCache = new Map(); // ticketId → { estimate: number|null, ts: number }
-
-// ── Team estimation-method on-disk cache (mirrors execution-core) ─────────────
-// File: ~/catalyst/execution-core/team-estimation-<TEAM>.json
-// Reuses the same file the scheduler's getEstimationMethod writes, so a fresh
-// scheduler run primes this cache for free.
-const METHOD_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const _methodCache = new Map(); // teamId → { type, fetchedAt }
-
-function methodCachePath(teamId) {
-  return join(HOME, "catalyst", "execution-core", `team-estimation-${teamId}.json`);
-}
 
 // ── Linear GraphQL helpers ────────────────────────────────────────────────────
 const LINEAR_GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
@@ -103,19 +104,6 @@ const ESTIMATE_QUERY_FOR_TEAM = `query FallbackEstimates($teamKey: String!, $num
   }
 }`;
 
-// The team estimation-method query (reused from linear-estimation-method.mjs).
-const TEAM_METHOD_QUERY = `query GetTeamEstimation($key: String!) {
-  teams(filter: { key: { eq: $key } }) {
-    nodes {
-      issueEstimation {
-        type
-        allowZero
-        extended
-      }
-    }
-  }
-}`;
-
 function linearAuthHeader() {
   const token = resolveSecret("linear-api-token").value ?? ""; // CTL-1616 PR3
   if (!token) return null;
@@ -124,9 +112,22 @@ function linearAuthHeader() {
 
 // graphql — one async GraphQL call via Bun's native fetch.  Returns the parsed
 // `data` object on success, or null on any failure (network, auth, 429, bad JSON).
-async function graphql(query, variables) {
+//
+// CTL-1806 (D3): every reachable exit from this function is a Linear read on the
+// DEGRADED path, so each one emits `catalyst.linear.read` BEFORE the outbound
+// call. `source`/`op` are threaded from the call site because both queries below
+// route through this one helper — without that, the estimate read and the
+// team-method read would be indistinguishable in Loki, and one of them consults a
+// replica while the other has no local source at all.
+async function graphql(query, variables, { source, op, entity = null } = {}) {
   const auth = linearAuthHeader();
-  if (!auth) return null;
+  if (!auth) {
+    // Reached the degraded path but cannot even dispatch — a node with no Linear
+    // credential otherwise returns nulls in total silence. WARN via result:failed.
+    noteDegradedLinearRead({ source, result: "failed", op, entity });
+    return null;
+  }
+  noteDegradedLinearRead({ source, result: "ok", op, entity });
   try {
     const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -155,51 +156,29 @@ async function graphql(query, variables) {
 export async function getEstimationMethodAsync(teamId) {
   if (!teamId || typeof teamId !== "string") return null;
 
-  const now = Date.now();
+  // 1+2. The SHARED memo + on-disk record, under the ONE 7-day TTL (D1). This is
+  // the same helper the scheduler's synchronous getEstimationMethod uses, so a
+  // record either module writes is honoured by both.
+  const cached = readTeamEstimationCache(teamId);
+  if (cached) return cached;
 
-  // 1. In-process memo.
-  if (_methodCache.has(teamId)) {
-    const r = _methodCache.get(teamId);
-    if (now - new Date(r.fetchedAt).getTime() < METHOD_TTL_MS) {
-      return r.method ?? null;
-    }
-    _methodCache.delete(teamId);
-  }
-
-  // 2. On-disk cache (shared with execution-core/linear-estimation-method.mjs).
-  const path = methodCachePath(teamId);
-  if (existsSync(path)) {
-    try {
-      const record = JSON.parse(readFileSync(path, "utf8"));
-      if (record?.method && typeof record.method.type === "string") {
-        if (now - new Date(record.fetchedAt).getTime() < METHOD_TTL_MS) {
-          _methodCache.set(teamId, record);
-          return record.method;
-        }
-      }
-    } catch {
-      // corrupt cache — fall through
-    }
-  }
-
-  // 3. Live fetch.
-  const data = await graphql(TEAM_METHOD_QUERY, { key: teamId });
+  // 3. Live fetch — the labelled DEGRADED path (D1). The replica has no teams
+  // table and carries no issueEstimation, so unlike the estimate read below there
+  // is no local tier to consult first; source is "linearis", not "linearis_miss".
+  //
+  // The async fetch stays here rather than delegating to the sync
+  // getEstimationMethod: that one spawns curl SYNCHRONOUSLY, which is right for
+  // the scheduler's synchronous pull loop and wrong for a board request path.
+  const data = await graphql(
+    TEAM_ESTIMATION_QUERY,
+    { key: teamId },
+    { source: "linearis", op: "team_method", entity: teamId }
+  );
   const method = data?.teams?.nodes?.[0]?.issueEstimation;
   if (!method || typeof method.type !== "string") return null;
 
   const normalized = { type: method.type, allowZero: !!method.allowZero, extended: !!method.extended };
-  const record = { teamId, method: normalized, fetchedAt: new Date().toISOString() };
-  // Atomic write — same convention as linear-estimation-method.mjs.
-  try {
-    const dir = join(HOME, "catalyst", "execution-core");
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const tmp = `${path}.tmp`;
-    writeFileSync(tmp, JSON.stringify(record, null, 2));
-    renameSync(tmp, path);
-  } catch {
-    // disk write failed — in-mem cache is still valid
-  }
-  _methodCache.set(teamId, record);
+  writeTeamEstimationCache(teamId, normalized); // shared atomic write + memo seed
   return normalized;
 }
 
@@ -213,7 +192,7 @@ export async function getEstimationMethodAsync(teamId) {
 // - null is stored for IDs that Linear returned no estimate for (unset in
 //   Linear) so a subsequent call within the TTL does not re-fetch.
 // - Always resolves; never rejects.
-export async function fillEstimateFallback(ticketIds) {
+export async function fillEstimateFallback(ticketIds, { replicaOptions = {} } = {}) {
   const result = {};
   const toFetch = [];
   const now = Date.now();
@@ -229,10 +208,37 @@ export async function fillEstimateFallback(ticketIds) {
 
   if (toFetch.length === 0) return result;
 
+  // ── Tier 1: the LOCAL replica (CTL-1806) ───────────────────────────────────
+  // The whole point of this ticket. This resolver used to go straight from a
+  // durable-cache miss to the rate-limited Linear API, for a value that is
+  // already on this node in SQLite. Gated on FILE PRESENCE only and fail-open:
+  // an absent/unreadable replica yields {} and every id simply proceeds to the
+  // degraded path exactly as before.
+  //
+  // A replica row whose estimate is NULL is OMITTED by the primitive — i.e. it
+  // is a MISS and falls through, never an authoritative null. "Linear has none"
+  // and "this row predates the estimate projection" are indistinguishable
+  // locally, and serving the null would silently drop the chip for a refresh.
+  const replicaHits = await readReplicaEstimates({ ids: toFetch, ...replicaOptions });
+  const stillMissing = [];
+  for (const id of toFetch) {
+    const hit = replicaHits[id];
+    if (typeof hit === "number" && Number.isFinite(hit)) {
+      _estimateCache.set(id, { estimate: hit, ts: Date.now() });
+      result[id] = hit;
+    } else {
+      stillMissing.push(id);
+    }
+  }
+  if (stillMissing.length === 0) return result;
+  // From here on, every id is a genuine REPLICA MISS — which is exactly what the
+  // `linearis_miss` source on the emission below records.
+  const toQuery = stillMissing;
+
   // Group uncached IDs by team key (e.g. "CTL" → [774, 930, ...]).
   // IDs that don't parse are quietly stored as null (can't query them).
-  const teamGroups = groupByTeam(toFetch);
-  const unparseable = toFetch.filter((id) => parseIdentifier(id) === null);
+  const teamGroups = groupByTeam(toQuery);
+  const unparseable = toQuery.filter((id) => parseIdentifier(id) === null);
   for (const id of unparseable) {
     _estimateCache.set(id, { estimate: null, ts: Date.now() });
     result[id] = null;
@@ -248,7 +254,12 @@ export async function fillEstimateFallback(ticketIds) {
 
   await Promise.allSettled(
     perTeamChunks.map(async ({ teamKey, numbers }) => {
-      const data = await graphql(ESTIMATE_QUERY_FOR_TEAM, { teamKey, numbers });
+      // CTL-1806 (D3): a replica WAS consulted above and missed → linearis_miss.
+      const data = await graphql(
+        ESTIMATE_QUERY_FOR_TEAM,
+        { teamKey, numbers },
+        { source: "linearis_miss", op: "estimate" }
+      );
       const nodes = data?.issues?.nodes ?? [];
 
       // Build a set of numbers returned for this team.
@@ -282,8 +293,10 @@ export async function fillEstimateFallback(ticketIds) {
 export function _clearEstimateCache() {
   _estimateCache.clear();
 }
+// CTL-1806: the method memo now lives in execution-core (one cache, one TTL), so
+// this delegates rather than clearing a second map that no longer exists.
 export function _clearMethodCache() {
-  _methodCache.clear();
+  _resetMemoForTests();
 }
 export function _getEstimateCacheSize() {
   return _estimateCache.size;

--- a/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.d.mts
@@ -59,6 +59,18 @@ export interface TitleDescription {
   project: string | null;
   /** Own-ticket estimate (story points), or null when unset. */
   estimate: number | null;
+  /** CTL-1806 provenance: "replica" = served from the local replica (no Linear
+   *  call), "linear" = served by the degraded Linear fetch, null = unresolved. */
+  source: "replica" | "linear" | null;
+}
+
+/** CTL-1806: test seam for the replica tier, forwarded verbatim to
+ *  readReplicaTicketDetails. */
+export interface ReplicaTierOptions {
+  replicaOptions?: {
+    dbPath?: string;
+    readerFactory?: ((opts: { dbPath: string }) => unknown) | null;
+  };
 }
 
 /**
@@ -66,11 +78,17 @@ export interface TitleDescription {
  * { [id]: TitleDescription } for those IDs.
  *
  * - Hits are served from the in-memory TTL cache (5 min default; 24h for completed/canceled).
- * - Remaining IDs are batched into one Linear GraphQL call per team-chunk.
+ * - CTL-1806: remaining IDs are served from the LOCAL REPLICA — including
+ *   relation targets, and including the ticket-DETAIL route, which previously had
+ *   no replica tier at all. `state.type` is synthesized from the replica's
+ *   lifecycle timestamps (the replica has no workflow_states table).
+ * - Only genuine replica misses reach a Linear GraphQL call, and each such call
+ *   emits `catalyst.linear.read {source:"linearis_miss", op:"title_desc"}`.
  * - Always resolves; never rejects (fail-open → all null fields).
  */
 export function fillTitleDescriptionFallback(
   ticketIds: string[],
+  opts?: ReplicaTierOptions,
 ): Promise<Record<string, TitleDescription>>;
 
 /** CTL-1215: hard size cap (insertion-order LRU) on the in-memory cache. */

--- a/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/linear-title-description-fallback.mjs
@@ -42,6 +42,14 @@
 // shared secret-contract engine for the LINEAR_API_TOKEN/LINEAR_API_KEY
 // resolution below (design §8 PR3 table).
 import { resolveSecret } from "../../lib/secret-contract.mjs";
+// CTL-1806: the replica tier + the degraded-path anomaly (D3). This is the read
+// that closes the REAL AC2 gap — the board's title backfill was already
+// replica-aware one layer up (CTL-1372's readReplicaTitles in board-data), but
+// the ticket-DETAIL route (server.ts's /api/linear-ticket) calls this resolver
+// with no replica tier at all, and every RELATION TARGET it renders came from
+// Linear too. Putting the tier INSIDE the resolver serves both callers at once.
+import { readReplicaTicketDetails } from "./linear-cache-reader.mjs";
+import { noteDegradedLinearRead } from "./linear-degraded-read.mjs";
 
 // ── In-memory TTL cache ───────────────────────────────────────────────────────
 // Keyed by ticket ID (e.g. "CTL-926"). Value:
@@ -176,9 +184,20 @@ function linearAuthHeader() {
 
 // graphql — one async GraphQL call via Bun's native fetch. Returns the parsed
 // `data` object on success, or null on any failure (network, auth, 429, bad JSON).
-async function graphql(query, variables) {
+//
+// CTL-1806 (D3): emit `catalyst.linear.read` IMMEDIATELY BEFORE the outbound
+// call — never after, since an after-the-fact emission is lost on exactly the
+// failures (timeout, throw) worth knowing about. Every id reaching here has
+// already missed the replica, hence source "linearis_miss".
+async function graphql(query, variables, { source = "linearis_miss", op = "title_desc" } = {}) {
   const auth = linearAuthHeader();
-  if (!auth) return null;
+  if (!auth) {
+    // Degraded path reached but undispatchable — a node with no Linear
+    // credential otherwise returns nulls in total silence. WARN via result:failed.
+    noteDegradedLinearRead({ source, result: "failed", op });
+    return null;
+  }
+  noteDegradedLinearRead({ source, result: "ok", op });
   try {
     const res = await fetch(LINEAR_GRAPHQL_ENDPOINT, {
       method: "POST",
@@ -314,23 +333,42 @@ const NULL_ENTRY = {
   priority: null,
   project: null,
   estimate: null,
+  // CTL-1806: provenance for the detail route's `source` field. "replica" = served
+  // from the local replica, "linear" = served by the degraded Linear fetch, null =
+  // nothing served it. A user-facing field must not report "linear-live" for a read
+  // that never touched Linear.
+  source: null,
 };
 
-// fillTitleDescriptionFallback — given an array of ticket IDs (or ticket objects
-// with an `id` field), enriches each with { title, description, labels, relations }.
-// When called with an array of objects, mutates each object in place AND returns
-// the ID-keyed map.  When called with an array of strings, returns the map only.
+// ttlForState — D4's cache-lifetime decision, hoisted so the replica tier and the
+// Linear tier can never disagree about it. Terminal tickets (completed/canceled)
+// hold for 24h; everything else 5 min. This is exactly why the replica tier must
+// carry a `state.type` rather than omitting it: dropping the type would move
+// every terminal ticket (measured: 2725 of 3887) from a 24h to a 5-min cache — a
+// quota REGRESSION inside a quota-reduction change.
+function ttlForState(state) {
+  return state?.type === "completed" || state?.type === "canceled"
+    ? DONE_TTL_MS
+    : TITLE_DESC_TTL_MS;
+}
+
+// fillTitleDescriptionFallback — given an array of ticket IDs, enrich each with
+// { title, description, labels, relations, state, priority, project, estimate }.
 //
-// - Hits are served from _titleDescCache (5-min TTL).
-// - Remaining IDs are batched into one Linear GraphQL call per team-chunk.
-// - Null values are stored for IDs Linear returned nothing for (not found),
-//   so a subsequent call within the TTL does not re-fetch.
+// - Hits are served from _titleDescCache (5-min TTL; 24h for terminal tickets).
+// - Remaining IDs are served from the LOCAL REPLICA (CTL-1806).
+// - Only genuine replica misses are batched into a Linear GraphQL call per
+//   team-chunk, and each such call emits a `catalyst.linear.read` anomaly.
+// - Null values are stored for IDs nothing returned (not found), so a subsequent
+//   call within the TTL does not re-fetch.
 // - Always resolves; never rejects (fail-open).
-export async function fillTitleDescriptionFallback(ticketIds) {
-  // Support being called with an array of objects (the board-data pattern) as
-  // well as an array of string IDs (the server.ts linear-ticket route pattern).
-  const isObjectArray = ticketIds.length > 0 && typeof ticketIds[0] === "object" && ticketIds[0] !== null;
-  const ids = isObjectArray ? ticketIds.map((t) => t.id ?? t.ticket ?? "") : ticketIds;
+//
+// CTL-1806 subtraction: the old "array of objects, mutate in place" mode
+// (`isObjectArray`) is gone. It had ZERO production callers — board-data passes
+// `nullTitleIds` (strings from collectNullTitleIds) and server.ts passes
+// `[ticket]` (a string) — and the .d.mts already typed the parameter `string[]`.
+export async function fillTitleDescriptionFallback(ticketIds, { replicaOptions = {} } = {}) {
+  const ids = Array.isArray(ticketIds) ? ticketIds : [];
 
   const result = {};
   const toFetch = [];
@@ -348,33 +386,64 @@ export async function fillTitleDescriptionFallback(ticketIds) {
         priority: cached.priority ?? null,
         project: cached.project ?? null,
         estimate: cached.estimate ?? null,
+        source: cached.source ?? null,
       };
     } else {
       toFetch.push(id);
     }
   }
 
-  if (toFetch.length === 0) {
-    if (isObjectArray) {
-      for (const t of ticketIds) {
-        const id = t.id ?? t.ticket ?? "";
-        const r = result[id] ?? NULL_ENTRY;
-        t.title = r.title;
-        t.description = r.description;
-        t.labels = r.labels;
-        t.relations = r.relations;
-        // B3: board-data mutation only touches title/description/labels/relations
-        // (board payload shape unchanged); state/priority/project/estimate are
-        // only on the returned map (for the linear-ticket route).
-      }
+  if (toFetch.length === 0) return result;
+
+  // ── Tier 1: the LOCAL replica (CTL-1806) ───────────────────────────────────
+  // Serves title, description, labels (with colour), relations (with enriched
+  // targets), state, priority, project and estimate — the entire payload both
+  // callers consume. FILE-PRESENCE gate only, fail-open: an absent/unreadable
+  // replica yields {} and every id proceeds to the degraded path as before.
+  //
+  // A hit requires a NON-EMPTY title (the primitive omits anything less), so a
+  // replica row that could not actually populate the detail page still falls
+  // through to Linear rather than being cached as a hollow "available" entry.
+  //
+  // Note on the BOARD caller specifically: board-data already filters its ids
+  // through readReplicaTitles, so the set it passes here is precisely the ids the
+  // replica could NOT title — which means this read will miss for all of them.
+  // That is one extra local SQLite query over a usually-empty set (the resolver
+  // is not called at all when nothing is null-titled), and it is the price of
+  // putting the tier INSIDE the resolver, which is what gives the ticket-detail
+  // route and its relation targets a replica tier at all.
+  const replicaHits = await readReplicaTicketDetails({ ids: toFetch, ...replicaOptions });
+  const stillMissing = [];
+  for (const id of toFetch) {
+    const hit = replicaHits[id];
+    if (hit && typeof hit.title === "string" && hit.title.length > 0) {
+      const entry = {
+        title: hit.title,
+        description: hit.description ?? null,
+        labels: hit.labels ?? null,
+        relations: hit.relations ?? null,
+        state: hit.state ?? null,
+        priority: hit.priority ?? null,
+        project: hit.project ?? null,
+        estimate: hit.estimate ?? null,
+        source: "replica",
+      };
+      _titleDescCache.set(id, { ...entry, ts: Date.now(), ttlMs: ttlForState(entry.state) });
+      result[id] = entry;
+    } else {
+      stillMissing.push(id);
     }
-    return result;
   }
+  _capTitleDescCache();
+  if (stillMissing.length === 0) return result;
+  // From here on, every id is a genuine REPLICA MISS — which is exactly what the
+  // `linearis_miss` source on the emissions records.
+  const toQuery = stillMissing;
 
   // Group uncached IDs by team key. IDs that don't parse are stored as nulls
   // (can't query them).
-  const teamGroups = groupByTeam(toFetch);
-  const unparseable = toFetch.filter((id) => parseIdentifier(id) === null);
+  const teamGroups = groupByTeam(toQuery);
+  const unparseable = toQuery.filter((id) => parseIdentifier(id) === null);
   for (const id of unparseable) {
     _titleDescCache.set(id, { ...NULL_ENTRY, ts: Date.now(), ttlMs: TITLE_DESC_TTL_MS });
     result[id] = { ...NULL_ENTRY };
@@ -410,12 +479,9 @@ export async function fillTitleDescriptionFallback(ticketIds) {
         // B3: parse own-ticket meta fields.
         const { state, priority, project, estimate } = parseTicketMeta(node);
         // D4: completed/canceled tickets cached for 24h; all others 5m.
-        const ttlMs =
-          state?.type === "completed" || state?.type === "canceled"
-            ? DONE_TTL_MS
-            : TITLE_DESC_TTL_MS;
-        _titleDescCache.set(id, { title, description, labels, relations, state, priority, project, estimate, ts: Date.now(), ttlMs });
-        result[id] = { title, description, labels, relations, state, priority, project, estimate };
+        const ttlMs = ttlForState(state);
+        _titleDescCache.set(id, { title, description, labels, relations, state, priority, project, estimate, source: "linear", ts: Date.now(), ttlMs });
+        result[id] = { title, description, labels, relations, state, priority, project, estimate, source: "linear" };
         fetchedNumbers.add(node.number);
       }
 
@@ -433,7 +499,7 @@ export async function fillTitleDescriptionFallback(ticketIds) {
 
   // Any ID that fail-open dropped (graphql null → no nodes loop ran for its
   // chunk) still needs an honest entry. Backfill from the cache or as null.
-  for (const id of toFetch) {
+  for (const id of toQuery) {
     if (result[id] === undefined) {
       const cached = _titleDescCache.get(id);
       if (cached !== undefined) {
@@ -446,6 +512,7 @@ export async function fillTitleDescriptionFallback(ticketIds) {
           priority: cached.priority ?? null,
           project: cached.project ?? null,
           estimate: cached.estimate ?? null,
+          source: cached.source ?? null,
         };
       } else {
         _titleDescCache.set(id, { ...NULL_ENTRY, ts: Date.now(), ttlMs: TITLE_DESC_TTL_MS });
@@ -454,18 +521,6 @@ export async function fillTitleDescriptionFallback(ticketIds) {
     }
   }
   _capTitleDescCache();
-
-  // If called with objects, mutate them in place (board-data pattern).
-  if (isObjectArray) {
-    for (const t of ticketIds) {
-      const id = t.id ?? t.ticket ?? "";
-      const r = result[id] ?? NULL_ENTRY;
-      t.title = r.title;
-      t.description = r.description;
-      t.labels = r.labels;
-      t.relations = r.relations;
-    }
-  }
 
   return result;
 }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -3202,8 +3202,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
           ) {
             return new Response("Bad Request", { status: 400 });
           }
+          // CTL-1806: this call is now REPLICA-FIRST. The tier lives inside
+          // fillTitleDescriptionFallback, so this route — which previously had no
+          // replica tier at all and hit the rate-limited Linear API once per cold
+          // ticket view, relation targets included — is served locally whenever
+          // the replica holds the ticket, with no change here beyond reporting the
+          // provenance honestly below.
           const map = await fillTitleDescriptionFallback([ticket]);
-          const entry = map[ticket] ?? { title: null, description: null, labels: null, relations: null, state: null, priority: null, project: null, estimate: null };
+          const entry = map[ticket] ?? { title: null, description: null, labels: null, relations: null, state: null, priority: null, project: null, estimate: null, source: null };
           const available =
             entry.title !== null || entry.description !== null;
           return Response.json({
@@ -3216,7 +3222,14 @@ export function createServer(opts: CreateServerOptions): BunServer {
             priority: entry.priority ?? null,
             project: entry.project ?? null,
             estimate: entry.estimate ?? null,
-            source: available ? "linear-live" : "unavailable",
+            // CTL-1806: report where the answer actually came from. Reporting
+            // "linear-live" for a read served entirely from local SQLite would be
+            // a false provenance claim on a user-facing field.
+            source: available
+              ? entry.source === "replica"
+                ? "replica"
+                : "linear-live"
+              : "unavailable",
           });
         }
 

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/use-linear-ticket.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/use-linear-ticket.ts
@@ -59,7 +59,8 @@ interface LinearTicketResponse {
   priority: number | null;
   project: string | null;
   estimate: number | null;
-  source: "linear-live" | "unavailable";
+  /** CTL-1806: "replica" = served from the local Linear replica (no API call). */
+  source: "linear-live" | "replica" | "unavailable";
 }
 
 export interface LinearTicketState {


### PR DESCRIPTION
Closes CTL-1806. Points the three supplemental Linear resolvers at the local replica, per the ruled decision document (D1–D4) on the ticket.

**Ryan's standing rule:** *"The orchestrator and the local catalyst nodes should always read from the Linear replica."* `linear-query.mjs` already honours it; these three resolvers did not — 0 replica mentions between them, verified with a positive control (`linear-query.mjs` = 99).

## What changed

- **New replica primitives** — `estimates()` and `relations()` on `replica-read.mjs`, copying the proven `readReplicaTitles` template.
- **The real AC2 gap closed** — the *board* half was already shipped (CTL-1372); this covers the ticket-**detail** page (`server.ts`) and **relation targets**, which had no replica tier at all.
- **D2 `state.type` synthesized from the replica's own timestamps** (`canceled_at` → `canceled`; else `completed_at` → `completed`; else `started_at` → `started`; else `backlog`) — never from the state *name*, which would hardcode CTL's contract states and break under the BYO-workspace this ticket exists to serve.
- **D3 loud degraded path** — one `catalyst.linear.read` emitted immediately before each `fetch`, via the already-exported `emitLinearReadEvent`, stamped `service.name = catalyst.orch-monitor`. Deliberately **not** `recordDaemonRead`, which hardcodes the daemon's service name and would corrupt the very metric this ticket moves.
- **D4 asymmetric gating, on purpose** — file-presence only for the two display resolvers. A writer-liveness gate here would recreate CTL-1397: a *live* writer on a *quiet* Linear feed reads as stale, so the gate would burst Linear calls precisely when the board is unchanged — backwards for a quota-reduction ticket. A replica `NULL` estimate is treated as a **MISS**, never an authoritative null.
- **D1 pre-existing hazard fixed** — two writers of `team-estimation-<TEAM>.json` disagreed on TTL (7d vs 24h); collapsed to one.

**D1's estimation method deliberately keeps its labelled degraded Linear fetch.** The replica has no `teams` table and `issueEstimation` appears in **0 of 3838** raw blobs (positive control: `raw LIKE '%estimate%'` matches 3807), so AC4's "reads the replica" clause was **unsatisfiable** and is dropped. Defaulting to Fibonacci instead would be *destructive*, not merely lossy: `scheduler.mjs:7341` calls `applyEstimate` on every triage→research advance, and today an unavailable method returns `null` so the scheduler **skips the write**. A default would flip that to writing a Fibonacci number into a tShirt team's estimate field — irreversible without an audit.

## Verification

Mutation-tested **serially**, in a private worktree, with the harness proven before any green was trusted (a known-guarded mutation must go RED *and* a known-inert edit must stay GREEN; counts parsed only after stripping ANSI, with a parse-vs-exit-code cross-check that yields INCONCLUSIVE rather than GREEN on disagreement).

| area | result |
| --- | --- |
| D2 synthesis ladder (7 mutations: each arm, both reorders, default, non-object guard) | **RED all 7** |
| D4 "NULL estimate is a MISS" (2) | **RED both** |
| Six value-normalization guards (`stateRefOf` empty-name, `numOrNull` ×2, relation/description/label normalizers) | **RED 6/6** — all six were unkillable before this PR |
| D3 emissions (service name, both estimate emissions, title_desc success) | **RED** |
| D3 title_desc **failure** emission | was **GREEN** → test added → now **RED** |

`numOrNull`'s two guards are not theoretical: probed against a real REAL-affinity column, `9e999` returns a JS number with `Number.isFinite === false`, and `'not a number'` returns a JS **string** — SQLite converts only when lossless. Both guards are load-bearing and both were untested.

**Two equivalent mutants, documented rather than faked:** dropping the empty-input short-circuit and the file-presence gate both still yield `{}` (the reader fails open internally), so they are unobservable without a production seam that isn't worth adding. One test whose *name* claimed "without opening the db" — a property its body never checked and cannot check — was **renamed** to what it actually verifies.

## Honest limits

- The full local orch-monitor suite shows **145 fail on this branch vs 144 on base** at `3f60190c6`. The one-test delta is `catalyst-monitor.sh > handles stale PID file`, which is **pre-existing load flake**, established two ways: repeated runs flake on *both* sides (base 24/1, 25/0, 24/1; branch 25/0, 23/2, 23/2), and `catalyst-monitor` is **not among the 23 changed files**. The 144 baseline failures are known local-run pollution, not introduced here.
- D2's synthesis accuracy (118/118 on distinctly-rendered classes) was measured on a **CTL-workspace-only** sample, so it is **INCONCLUSIVE for a foreign workspace**. That is why the durable fix is the CTC `workflow_states` follow-up; this is the interim.

Fence writes (`cluster-claim.mjs`, `cluster-heartbeat.mjs`) are untouched — writes legitimately need a real token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
