### PR TITLE
fix(meta): manifest the 17 bash attribute keys that rotted main red

### DIFF
--- a/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
+++ b/plugins/dev/scripts/orch-monitor/docs/otel-attribute-audit.md
@@ -10,10 +10,10 @@ Do **not** edit this file directly.
 
 | Classification | Count |
 | --- | --- |
-| ✓ Conforming | 20 |
+| ✓ Conforming | 34 |
 | → Rename-to | 37 |
-| ● Legitimately Custom | 40 |
-| **Total** | 97 |
+| ● Legitimately Custom | 43 |
+| **Total** | 114 |
 
 ## Classification by Emitter
 
@@ -74,16 +74,33 @@ Do **not** edit this file directly.
 
 | Key | Source | Classification | Target | Cluster | Note |
 | --- | --- | --- | --- | --- | --- |
+| `attributes` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `bg_job_id` | `canonical-event.sh:460` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.worker.bg_job_id; never reaches OTLP under this name |
+| `body` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `branch` | `canonical-event.sh:461` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.worker.branch; never reaches OTLP under this name |
+| `catalyst.event.oversized.bytes` | `canonical-event.sh:684` | ● custom |  |  | CTL-1809 |
+| `catalyst.event.oversized.cap` | `canonical-event.sh:684` | ● custom |  |  | CTL-1809 |
+| `catalyst.event.oversized.name` | `canonical-event.sh:684` | ● custom |  |  | CTL-1809 |
 | `catalyst.executor` | `canonical-event.sh:406` | ● custom |  |  | CTL-1457 |
 | `catalyst.ticket.type` | `canonical-event.sh:349` | ● custom |  |  | CTL-1023 |
 | `claude.ratelimit.five_hour_pct` | `canonical-event.sh:343` | ● custom |  |  | CTL-760 |
 | `claude.ratelimit.seven_day_opus_pct` | `canonical-event.sh:345` | ● custom |  |  | CTL-763 |
 | `claude.ratelimit.seven_day_pct` | `canonical-event.sh:344` | ● custom |  |  | CTL-760 |
 | `claude.ratelimit.seven_day_sonnet_pct` | `canonical-event.sh:346` | ● custom |  |  | CTL-763 |
+| `dominant_phase` | `canonical-event.sh:463` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.worker.dominant_phase; never reaches OTLP under this name |
 | `linear.read.age_ms` | `canonical-event.sh:375` | ● custom |  |  | CTL-1403 |
 | `linear.read.op` | `canonical-event.sh:374` | ● custom |  |  | CTL-1403 |
 | `linear.read.result` | `canonical-event.sh:373` | ● custom |  |  | CTL-1403 |
 | `linear.read.source` | `canonical-event.sh:372` | ● custom |  |  | CTL-1403 |
+| `message` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: body.message |
+| `observedTs` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `orch_id` | `canonical-event.sh:462` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.orchestrator.id; never reaches OTLP under this name |
+| `phase` | `canonical-event.sh:459` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.worker.phase; never reaches OTLP under this name |
+| `resource` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `severityNumber` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `severityText` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
+| `ticket` | `canonical-event.sh:458` | ✓ conforming |  |  | CTL-1795 flat→OTel map: promoted to catalyst.worker.ticket; never reaches OTLP under this name |
+| `ts` | `canonical-event.sh:684` | ✓ conforming |  |  | CTL-1809 tombstone: OTLP log-record field |
 
 ### MJS (execution-core / catalyst-agent)
 

--- a/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/otel-attribute-audit.ts
@@ -117,6 +117,42 @@ export const AUDIT_MANIFEST: AttributeAuditEntry[] = [
   // legitimately-custom (catalyst.* namespace). Emitted at canonical-event.sh:406.
   { key: "catalyst.executor", emitter: "sh", source: "canonical-event.sh:406", classification: "legitimately-custom", note: "CTL-1457" },
 
+  // ── CTL-1795: the flat→OTel promotion map (_CE_FLAT_ATTR_JQ) ──────────────
+  // extractShellAttributeKeys matches every `"key":` in the file, so it captures
+  // the LEFT side of this map as well as emitted attributes. These six are the
+  // v1 flat field NAMES being renamed; the right-hand targets below are what
+  // actually reaches OTLP. Recorded as rename-to with the target the map already
+  // applies — the rename is shipped, not pending (same convention as the
+  // phase.attempt pair below, which kept rename-to after CTL-764 promoted it).
+  { key: "ticket", emitter: "sh", source: "canonical-event.sh:458", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.worker.ticket; never reaches OTLP under this name" },
+  { key: "phase", emitter: "sh", source: "canonical-event.sh:459", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.worker.phase; never reaches OTLP under this name" },
+  { key: "bg_job_id", emitter: "sh", source: "canonical-event.sh:460", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.worker.bg_job_id; never reaches OTLP under this name" },
+  { key: "branch", emitter: "sh", source: "canonical-event.sh:461", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.worker.branch; never reaches OTLP under this name" },
+  { key: "orch_id", emitter: "sh", source: "canonical-event.sh:462", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.orchestrator.id; never reaches OTLP under this name" },
+  { key: "dominant_phase", emitter: "sh", source: "canonical-event.sh:463", classification: "conforming", note: "CTL-1795 flat→OTel map: promoted to catalyst.worker.dominant_phase; never reaches OTLP under this name" },
+
+  // ── CTL-1809: the oversized-line tombstone envelope ───────────────────────
+  // _canonical_append_oversized_tombstone builds a COMPLETE v2 log record inline,
+  // so the extractor sees the OTLP structural fields too. These eight are the
+  // log-record shape defined by OTel itself, not catalyst attributes — conforming
+  // by construction. (They appear only here because every other bash emit path
+  // builds its envelope through jq helpers whose structural keys are TS-owned.)
+  { key: "ts",             emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "observedTs",     emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "severityText",   emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "severityNumber", emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "body",           emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "message",        emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: body.message" },
+  { key: "attributes",     emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+  { key: "resource",       emitter: "sh", source: "canonical-event.sh:684", classification: "conforming", note: "CTL-1809 tombstone: OTLP log-record field" },
+
+  // The tombstone's own three attributes. It carries its OWN event name rather
+  // than the dropped event's, so a refused line cannot fire that event's
+  // wait-for subscribers on fabricated content — these describe the drop.
+  { key: "catalyst.event.oversized.name",  emitter: "sh", source: "canonical-event.sh:684", classification: "legitimately-custom", note: "CTL-1809" },
+  { key: "catalyst.event.oversized.bytes", emitter: "sh", source: "canonical-event.sh:684", classification: "legitimately-custom", note: "CTL-1809" },
+  { key: "catalyst.event.oversized.cap",   emitter: "sh", source: "canonical-event.sh:684", classification: "legitimately-custom", note: "CTL-1809" },
+
   // §4h: Phase attempt tracking (CTL-761) — rename-to cluster F. CTL-764 promoted
   // these to the TS interface (worker-transition-event emits them), so they are
   // now ts-emitted; the sh extractor excludes any key present in the TS interface.


### PR DESCRIPTION
**This unblocks every open PR in the repo.** `otel-attribute-audit — emitter=sh (canonical-event.sh) > no_missing_audit_entry` fails on **clean `origin/main`** (`890c12d91`), so it fails on every branch regardless of content.

## Why nobody saw it

`quality` is a **PR-only** check. Measured on `check-runs` for four consecutive main commits:

| commit | `quality` |
| --- | --- |
| `890c12d91` chore: release main | **NOT RUN** |
| `725922a8e` CTL-1835 | **NOT RUN** |
| `3f60190c6` CTL-1831 | **NOT RUN** |
| `388edf41b` CTL-1809 | **NOT RUN** |

So main can go red with no red run on main — the same silent-rot class as the release-please path skip. Filed separately as **CTL-1840** so the class gets closed, not just this instance.

## The fix

`extractShellAttributeKeys` deliberately captures **every** `"key":` in `canonical-event.sh` minus TS-interface-owned keys — its docstring says the remainder "is what the bash emitter contributes beyond the TS schema." So the manifest is meant to document all of them. Two merged changes added keys without entries:

- **CTL-1795's flat→OTel promotion map** — the six *left-side* v1 field names (`ticket`, `phase`, `bg_job_id`, `branch`, `orch_id`, `dominant_phase`). Classified **`conforming`**, deliberately not `rename-to`: nothing emits them under those names, so claiming a pending rename would be untrue *and* would require a `remediationCluster` for work that already shipped. Each note records the target it is promoted to.
- **CTL-1809's oversized-line tombstone** — it builds a complete v2 record inline, so the extractor also sees eight OTLP **log-record structural fields** (`ts`, `observedTs`, `severityText`, `severityNumber`, `body`, `message`, `attributes`, `resource` — conforming by construction) plus the tombstone's own three `catalyst.event.oversized.*` attributes (legitimately-custom).

`docs/otel-attribute-audit.md` regenerated with `bun run audit:gen` (the Phase-3 staleness gate).

## The gate is repaired, not silenced

The obvious failure mode for a fix like this is to make the check pass by widening it until it can never fail. Proven otherwise — inserting an unmanifested key into `canonical-event.sh`:

```
probe key inserted: 1
✗ otel-attribute-audit — Phase 2 > emitter=sh > no_missing_audit_entry
 22 pass / 1 fail
```

Restored: **23 pass / 1 skip / 0 fail**.

(First attempt at that proof inserted **0** keys because of a bad `perl` guard, and reported a meaningless GREEN — caught by asserting the probe count before trusting the result.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)