### PR TITLE
feat(dev): CTL-1841 — Linear webhook 401 alarm (route-comparison detector)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -322,6 +322,19 @@ DEFERRED — the linear-webhook bot-skip guard suppresses bot-authored issue eve
 the log, so the source goes quiet even with a worker in flight.) `getStaleWorkers` is the one genuinely unwired export (its own comment
 says so). See ADR-018 for the full history.
 
+The Linear route now has a complementary **route-comparison** silence alarm (CTL-1841) that lives
+in the orch-monitor server, not in the broker. It compares `/api/webhook/linear` HTTP response
+codes against the `/api/webhook` (GitHub) control — both share the same smee tunnel, Bun process,
+and minute — and raises when Linear has returned only non-2xx past a threshold while GitHub keeps
+200-ing. This detects HMAC authentication failure (the 2026-08-14 7.5-hour outage) **without**
+depending on Linear event volume, so it does NOT revert the `RECENCY_SOURCES` `catalyst.linear`
+exclusion. It is **alert-only**: a durable marker (`~/catalyst/linear-webhook-401-latch.json`) and a
+`console.warn` line in `orch-monitor.log` (Alloy-shipped independently of the broken webhook path).
+No restart, no mutation. Routing the alarm to a human (a Loki `absent_over_time` rule in
+`catalyst-otel`) is the separate follow-up. Config knobs: `CATALYST_LINEAR_WEBHOOK_ALARM` and
+related `_SILENT_MS`/`_FAIL_RECENCY_MS`/`_GITHUB_WINDOW_MS`/`_TICK_MS` — see
+`website/src/content/docs/reference/configuration.md`.
+
 ## Deployment Mode (CTL-1617)
 
 One declared answer — **`catalyst.deployment.mode` ∈ `single-host` | `cluster` | `cloud`** —

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
@@ -167,6 +167,64 @@ describe("createRouteHealthMonitor — evaluate + marker write", () => {
     }
   });
 
+  it("restores persisted route timestamps on hydration and does not erase them on marker refresh", () => {
+    // A prior process latched an episode carrying real route evidence.
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(
+      markerPath,
+      JSON.stringify({
+        latched: true,
+        latchedAtMs: 100 * 60_000,
+        lastLinear2xxMs: 10 * 60_000,
+        lastLinearFailMs: 120 * 60_000,
+        lastGithub2xxMs: 121 * 60_000,
+      }),
+    );
+
+    // A fresh process hydrates (latched) and its first evaluate() hits the
+    // marker-refresh branch. Without hydrating the timestamps, that refresh would
+    // rewrite the marker from an all-null in-memory state and ERASE the evidence.
+    const mon = createRouteHealthMonitor({ now: () => 130 * 60_000, markerPath });
+    mon.evaluate();
+
+    const m = JSON.parse(readFileSync(markerPath, "utf8")) as Record<string, unknown>;
+    expect(m.latched).toBe(true);
+    expect(m.lastLinear2xxMs).toBe(10 * 60_000);
+    expect(m.lastLinearFailMs).toBe(120 * 60_000);
+    expect(m.lastGithub2xxMs).toBe(121 * 60_000);
+  });
+
+  it("still emits the log alarm when the durable marker write fails, deduped per episode", () => {
+    // Force writeMarker() to throw by placing the marker under a path whose parent
+    // is a regular FILE (mkdirSync of the dirname → ENOTDIR).
+    const blocker = join(tmpDir, "blocker");
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(blocker, "x");
+    const markerPath = join(blocker, "latch.json");
+
+    const emits: string[] = [];
+    let t = 500 * 60_000;
+    const mon = createRouteHealthMonitor({
+      now: () => t,
+      markerPath,
+      onEmit: (k) => emits.push(k),
+    });
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+    t += 20 * 60_000;
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+
+    mon.evaluate(); // RAISE — marker write throws, but the log alarm must still fire
+    expect(emits).toContain("raised");
+    expect(existsSync(markerPath)).toBe(false); // marker never persisted
+
+    // Same raise edge next tick (marker still unwritable) must NOT re-log every tick.
+    mon.evaluate();
+    expect(emits.filter((e) => e === "raised")).toHaveLength(1);
+  });
+
   it("onEmit fires with 'raised' on the rising edge", () => {
     const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
     const emits: string[] = [];

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
@@ -1,0 +1,203 @@
+// webhook-route-health-io.test.ts — CTL-1841. IO / stateful-monitor tests.
+// Covers: stamping, atomic marker write, latch hydration (no double-emit across restart),
+// disabled kill-switch no-op.
+
+import { describe, it, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createRouteHealthMonitor,
+  getLinearWebhook401MarkerPath,
+  resolveWebhookRouteHealthConfig,
+} from "../webhook-route-health";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ctl1841-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("createRouteHealthMonitor — stamping", () => {
+  it("stamps a 401 as a Linear failure", () => {
+    const mon = createRouteHealthMonitor({ now: () => 1000 });
+    mon.stampLinear(401);
+    expect(mon.snapshot().lastLinearFailMs).toBe(1000);
+    expect(mon.snapshot().lastLinear2xxMs).toBeNull();
+  });
+
+  it("stamps a 200 as a Linear success", () => {
+    const mon = createRouteHealthMonitor({ now: () => 2000 });
+    mon.stampLinear(200);
+    expect(mon.snapshot().lastLinear2xxMs).toBe(2000);
+    expect(mon.snapshot().lastLinearFailMs).toBeNull();
+  });
+
+  it("stamps a 500 as a Linear failure", () => {
+    const mon = createRouteHealthMonitor({ now: () => 3000 });
+    mon.stampLinear(500);
+    expect(mon.snapshot().lastLinearFailMs).toBe(3000);
+  });
+
+  it("stamps a GitHub 200 as the control", () => {
+    const mon = createRouteHealthMonitor({ now: () => 4000 });
+    mon.stampGithub(200);
+    expect(mon.snapshot().lastGithub2xxMs).toBe(4000);
+  });
+
+  it("does not update stamps when GitHub returns non-2xx", () => {
+    const mon = createRouteHealthMonitor({ now: () => 5000 });
+    mon.stampGithub(400);
+    expect(mon.snapshot().lastGithub2xxMs).toBeNull();
+  });
+});
+
+describe("createRouteHealthMonitor — evaluate + marker write", () => {
+  it("writes the durable marker atomically on a raise edge", () => {
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    let t = 500 * 60_000;
+    const mon = createRouteHealthMonitor({ now: () => t, markerPath });
+
+    // First beat: GitHub ok, Linear fails
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+
+    // Advance time past the silent threshold (default 15m = 900_000ms)
+    t += 20 * 60_000;
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+
+    mon.evaluate(); // should RAISE + write marker
+
+    expect(existsSync(markerPath)).toBe(true);
+    const m = JSON.parse(readFileSync(markerPath, "utf8")) as Record<string, unknown>;
+    expect(m.latched).toBe(true);
+    expect(m).toHaveProperty("lastLinearFailMs");
+    expect(m).toHaveProperty("ts");
+  });
+
+  it("hydrates latch from marker and does NOT re-emit 'raised' on the same edge", () => {
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    const emits: string[] = [];
+
+    let t = 500 * 60_000;
+    const mon = createRouteHealthMonitor({ now: () => t, markerPath });
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+    t += 20 * 60_000;
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+    mon.evaluate(); // should raise and write marker
+
+    // A fresh monitor hydrates latched:true and must NOT re-emit
+    const mon2 = createRouteHealthMonitor({
+      now: () => t,
+      markerPath,
+      onEmit: (k) => emits.push(k),
+    });
+    mon2.stampGithub(200);
+    mon2.stampLinear(401);
+    mon2.evaluate();
+    expect(emits).not.toContain("raised");
+  });
+
+  it("emits 'recovered' after a Linear 2xx clears the latch", () => {
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    const emits: string[] = [];
+    const mon = createRouteHealthMonitor({
+      now: () => 1_000 * 60_000,
+      markerPath,
+      onEmit: (k) => emits.push(k),
+    });
+
+    // Write a pre-latched marker to simulate a prior raise
+    mkdirSync(tmpDir, { recursive: true });
+    writeFileSync(markerPath, JSON.stringify({ latched: true, latchedAtMs: 1000 }));
+
+    // Now a Linear 2xx arrives (operator fixed the secret)
+    mon.stampGithub(200);
+    mon.stampLinear(200); // 2xx — most recent outcome is success
+    mon.evaluate();
+
+    expect(emits).toContain("recovered");
+  });
+
+  it("onEmit fires with 'raised' on the rising edge", () => {
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    const emits: string[] = [];
+
+    let t = 500 * 60_000;
+    const mon = createRouteHealthMonitor({
+      now: () => t,
+      markerPath,
+      onEmit: (k) => emits.push(k),
+    });
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+    t += 20 * 60_000;
+    mon.stampGithub(200);
+    mon.stampLinear(401);
+    mon.evaluate();
+
+    expect(emits).toContain("raised");
+  });
+});
+
+describe("createRouteHealthMonitor — disabled kill-switch", () => {
+  it("is a no-op when CATALYST_LINEAR_WEBHOOK_ALARM=0", () => {
+    const prev = process.env.CATALYST_LINEAR_WEBHOOK_ALARM;
+    process.env.CATALYST_LINEAR_WEBHOOK_ALARM = "0";
+    try {
+      const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+      const emits: string[] = [];
+      let t = 500 * 60_000;
+      const mon = createRouteHealthMonitor({
+        now: () => t,
+        markerPath,
+        onEmit: (k) => emits.push(k),
+      });
+      mon.stampGithub(200);
+      mon.stampLinear(401);
+      t += 20 * 60_000;
+      mon.stampGithub(200);
+      mon.stampLinear(401);
+      mon.evaluate();
+      expect(emits).toHaveLength(0);
+      expect(existsSync(markerPath)).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_LINEAR_WEBHOOK_ALARM;
+      else process.env.CATALYST_LINEAR_WEBHOOK_ALARM = prev;
+    }
+  });
+
+  it("config.enabled is false when kill-switch is set", () => {
+    const prev = process.env.CATALYST_LINEAR_WEBHOOK_ALARM;
+    process.env.CATALYST_LINEAR_WEBHOOK_ALARM = "0";
+    try {
+      const cfg = resolveWebhookRouteHealthConfig({});
+      expect(cfg.enabled).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_LINEAR_WEBHOOK_ALARM;
+      else process.env.CATALYST_LINEAR_WEBHOOK_ALARM = prev;
+    }
+  });
+});
+
+describe("getLinearWebhook401MarkerPath", () => {
+  it("returns a path under CATALYST_DIR when set", () => {
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = tmpDir;
+    try {
+      const p = getLinearWebhook401MarkerPath();
+      expect(p).toContain(tmpDir);
+      expect(p).toContain("linear-webhook-401-latch.json");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prev;
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
@@ -37,10 +37,30 @@ describe("createRouteHealthMonitor — stamping", () => {
     expect(mon.snapshot().lastLinearFailMs).toBeNull();
   });
 
-  it("stamps a 500 as a Linear failure", () => {
-    const mon = createRouteHealthMonitor({ now: () => 3000 });
-    mon.stampLinear(500);
-    expect(mon.snapshot().lastLinearFailMs).toBe(3000);
+  it("stamps 401/403 as the Linear auth failure", () => {
+    for (const status of [401, 403]) {
+      const mon = createRouteHealthMonitor({ now: () => 3000 });
+      mon.stampLinear(status);
+      expect(mon.snapshot().lastLinearFailMs).toBe(3000);
+    }
+  });
+
+  it("does NOT stamp a non-auth non-2xx as an auth failure", () => {
+    // Expectation deliberately reversed from its first version, which asserted a
+    // 500 stamps a failure. The handler verifies the HMAC FIRST and then returns
+    // 400 for a missing delivery header or invalid JSON — those are VALIDLY SIGNED
+    // requests. Treating every non-2xx as an auth failure lets an authentic but
+    // malformed delivery latch a "401" alarm that sends the operator to rotate a
+    // secret that is fine. An alarm that misdirects is worse than one that is quiet.
+    //
+    // A 500/400 is neither evidence of health nor of an auth failure, so it stamps
+    // nothing and leaves the previous outcome standing. (A 5xx storm deserves its
+    // own alarm; it is not this one.)
+    for (const status of [400, 404, 500, 502]) {
+      const mon = createRouteHealthMonitor({ now: () => 3000 });
+      mon.stampLinear(status);
+      expect({ status, fail: mon.snapshot().lastLinearFailMs }).toEqual({ status, fail: null });
+    }
   });
 
   it("stamps a GitHub 200 as the control", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health-io.test.ts
@@ -126,6 +126,47 @@ describe("createRouteHealthMonitor — evaluate + marker write", () => {
     expect(emits).toContain("recovered");
   });
 
+  it("logs a RAISED line on EVERY episode, not just the first (regression: sparse-warn total=1)", () => {
+    const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      let t = 500 * 60_000;
+      const mon = createRouteHealthMonitor({ now: () => t, markerPath });
+
+      // Episode 1 — raise.
+      mon.stampGithub(200);
+      mon.stampLinear(401);
+      t += 20 * 60_000;
+      mon.stampGithub(200);
+      mon.stampLinear(401);
+      mon.evaluate(); // RAISED #1
+
+      // Operator fixes the secret — recover.
+      t += 1 * 60_000;
+      mon.stampLinear(200);
+      mon.evaluate(); // RECOVERED
+
+      // A SECOND outage days later — this must RAISE and log again. With the
+      // old `total = 1` sparse-warn gate this line was suppressed after the first.
+      t += 1 * 60_000;
+      mon.stampGithub(200);
+      mon.stampLinear(401);
+      t += 19 * 60_000; // past silentThreshold since the recovery 2xx
+      mon.stampGithub(200);
+      mon.evaluate(); // RAISED #2
+
+      const raised = warnings.filter((w) => w.includes("RAISED"));
+      expect(raised.length).toBeGreaterThanOrEqual(2);
+      expect(warnings.some((w) => w.includes("RECOVERED"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
   it("onEmit fires with 'raised' on the rising edge", () => {
     const markerPath = join(tmpDir, "linear-webhook-401-latch.json");
     const emits: string[] = [];

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health.test.ts
@@ -64,14 +64,22 @@ describe("classifyLinearWebhookHealth", () => {
     expect(classifyLinearWebhookHealth(stateRecentOk, now, CFG).raise).toBe(false);
   });
 
-  it("does not raise when GitHub control is also stale (cannot prove the tunnel is up)", () => {
+  it("STILL raises when the GitHub control is stale — the two tunnels are independent", () => {
+    // Expectation deliberately reversed. GitHub and Linear use INDEPENDENT smee
+    // channels and separate tunnel instances, so GitHub's health says nothing about
+    // Linear's — and GitHub merely being QUIET suppressed a real Linear alarm
+    // entirely (on a Linear-only install it could never fire at all).
+    //
+    // The gate was also redundant: a Linear 401 already proves the Linear pipe
+    // DELIVERED — the request arrived and was rejected. If the tunnel were down
+    // there would be no 401 to stamp.
     const now = 1_000 * MIN;
     const state = {
       lastLinear2xxMs: null,
       lastLinearFailMs: now - 1 * MIN,
       lastGithub2xxMs: now - 999 * MIN, // GitHub way outside its healthy window
     };
-    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(true);
   });
 
   it("clears when a Linear 2xx arrives after the failures (operator fixed the secret)", () => {
@@ -97,14 +105,16 @@ describe("classifyLinearWebhookHealth", () => {
     expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
   });
 
-  it("does not raise when no GitHub control seen at all", () => {
+  it("raises with NO GitHub control at all — a Linear-only install must still alarm", () => {
+    // The case that could never fire before: nothing about a Linear-only
+    // installation should require a GitHub witness.
     const now = 1_000 * MIN;
     const state = {
       lastLinear2xxMs: null,
       lastLinearFailMs: now - 1 * MIN,
-      lastGithub2xxMs: null, // no GitHub data
+      lastGithub2xxMs: null,
     };
-    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health.test.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/__tests__/webhook-route-health.test.ts
@@ -1,0 +1,189 @@
+// webhook-route-health.test.ts — CTL-1841. Unit tests for the pure route-comparison
+// detector. Each gherkin scenario maps 1:1 to a named test; the positive-control replay
+// MUST fail if the detector is stubbed to raise:false.
+
+import { describe, it, expect } from "bun:test";
+import {
+  initialRouteHealthState,
+  classifyLinearWebhookHealth,
+  nextLinearWebhook401Latch,
+  resolveWebhookRouteHealthConfig,
+  buildRouteHealthMarker,
+} from "../webhook-route-health";
+
+const CFG = resolveWebhookRouteHealthConfig({});
+const MIN = 60_000;
+
+describe("classifyLinearWebhookHealth", () => {
+  // Gherkin scenario 1 — Linear 4xx while GitHub 200s → raise
+  it("raises when Linear is non-2xx-only past threshold and GitHub is healthy", () => {
+    const now = 1_000 * MIN;
+    const state = {
+      lastLinear2xxMs: null, // Linear NEVER succeeded
+      lastLinearFailMs: now - 1 * MIN, // a recent 401
+      lastGithub2xxMs: now - 2 * MIN, // GitHub control is live
+    };
+    const v = classifyLinearWebhookHealth(state, now, CFG);
+    expect(v.raise).toBe(true);
+    expect(v.clear).toBe(false);
+    expect(v.route).toBe("/api/webhook/linear");
+  });
+
+  // Gherkin scenario 2 — genuinely quiet → do NOT raise
+  it("does not raise when there are no Linear failures at all", () => {
+    const now = 1_000 * MIN;
+    const state = {
+      lastLinear2xxMs: null,
+      lastLinearFailMs: null,
+      lastGithub2xxMs: now - 1 * MIN,
+    };
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+  });
+
+  // Positive control — MUST FAIL if the detector is removed (2026-08-14 replay)
+  it("raises on the 2026-08-14 replay: every Linear delivery 401s while GitHub 200s", () => {
+    let state = initialRouteHealthState();
+    const t0 = 500 * MIN;
+    // GitHub keeps succeeding; Linear keeps failing
+    for (let i = 0; i <= CFG.silentThresholdMs / MIN; i++) {
+      const t = t0 + i * MIN;
+      state = { ...state, lastLinearFailMs: t, lastGithub2xxMs: t };
+    }
+    const now = t0 + (CFG.silentThresholdMs / MIN) * MIN + 1;
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(true);
+  });
+
+  it("does NOT raise before the silent threshold elapses", () => {
+    const now = 1_000 * MIN;
+    // A recent success means the "no ok for >= threshold" condition isn't met
+    const stateRecentOk = {
+      lastLinear2xxMs: now - 1 * MIN,
+      lastLinearFailMs: now - 30_000,
+      lastGithub2xxMs: now - 1 * MIN,
+    };
+    expect(classifyLinearWebhookHealth(stateRecentOk, now, CFG).raise).toBe(false);
+  });
+
+  it("does not raise when GitHub control is also stale (cannot prove the tunnel is up)", () => {
+    const now = 1_000 * MIN;
+    const state = {
+      lastLinear2xxMs: null,
+      lastLinearFailMs: now - 1 * MIN,
+      lastGithub2xxMs: now - 999 * MIN, // GitHub way outside its healthy window
+    };
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+  });
+
+  it("clears when a Linear 2xx arrives after the failures (operator fixed the secret)", () => {
+    const now = 1_000 * MIN;
+    const state = {
+      lastLinear2xxMs: now - 30_000,
+      lastLinearFailMs: now - 5 * MIN,
+      lastGithub2xxMs: now - 1 * MIN,
+    };
+    const v = classifyLinearWebhookHealth(state, now, CFG);
+    expect(v.clear).toBe(true);
+    expect(v.raise).toBe(false);
+  });
+
+  it("does not raise when Linear last outcome was a success even if there were prior failures", () => {
+    const now = 1_000 * MIN;
+    // last ok is MORE RECENT than last fail — last outcome is success
+    const state = {
+      lastLinear2xxMs: now - 1 * MIN,
+      lastLinearFailMs: now - 20 * MIN,
+      lastGithub2xxMs: now - 1 * MIN,
+    };
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+  });
+
+  it("does not raise when no GitHub control seen at all", () => {
+    const now = 1_000 * MIN;
+    const state = {
+      lastLinear2xxMs: null,
+      lastLinearFailMs: now - 1 * MIN,
+      lastGithub2xxMs: null, // no GitHub data
+    };
+    expect(classifyLinearWebhookHealth(state, now, CFG).raise).toBe(false);
+  });
+});
+
+describe("nextLinearWebhook401Latch (edge machine, EMIT-THEN-ADVANCE)", () => {
+  it("fires 'raised' only on the rising edge", () => {
+    expect(
+      nextLinearWebhook401Latch(false, { raise: true, clear: false }).emit,
+    ).toBe("raised");
+    expect(
+      nextLinearWebhook401Latch(true, { raise: true, clear: false }).emit,
+    ).toBe(null); // already latched
+  });
+
+  it("fires 'recovered' only on the falling edge", () => {
+    expect(
+      nextLinearWebhook401Latch(true, { raise: false, clear: true }).emit,
+    ).toBe("recovered");
+    expect(
+      nextLinearWebhook401Latch(false, { raise: false, clear: true }).emit,
+    ).toBe(null);
+  });
+
+  it("advances the latch state correctly", () => {
+    const rising = nextLinearWebhook401Latch(false, { raise: true, clear: false });
+    expect(rising.latched).toBe(true);
+
+    const falling = nextLinearWebhook401Latch(true, { raise: false, clear: true });
+    expect(falling.latched).toBe(false);
+
+    const steady = nextLinearWebhook401Latch(true, { raise: false, clear: false });
+    expect(steady.latched).toBe(true);
+    expect(steady.emit).toBe(null);
+  });
+});
+
+describe("resolveWebhookRouteHealthConfig", () => {
+  it("applies frozen defaults", () => {
+    const cfg = resolveWebhookRouteHealthConfig({});
+    expect(cfg.silentThresholdMs).toBe(15 * MIN);
+    expect(cfg.failRecencyWindowMs).toBe(30 * MIN);
+    expect(cfg.githubHealthyWindowMs).toBe(30 * MIN);
+    expect(cfg.tickMs).toBe(MIN);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it("accepts overrides via fileCfg", () => {
+    const cfg = resolveWebhookRouteHealthConfig({ silentThresholdMs: 5 * MIN });
+    expect(cfg.silentThresholdMs).toBe(5 * MIN);
+    // others still default
+    expect(cfg.failRecencyWindowMs).toBe(30 * MIN);
+  });
+});
+
+describe("buildRouteHealthMarker", () => {
+  it("carries latch + all three stamps + host + ts", () => {
+    const state = initialRouteHealthState();
+    const m = buildRouteHealthMarker({
+      latched: true,
+      latchedAtMs: 123,
+      state,
+      nowMs: 456,
+    });
+    expect(m.latched).toBe(true);
+    expect(m.latchedAtMs).toBe(123);
+    expect(m).toHaveProperty("lastLinearFailMs");
+    expect(m).toHaveProperty("lastLinear2xxMs");
+    expect(m).toHaveProperty("lastGithub2xxMs");
+    expect(m).toHaveProperty("ts");
+    expect(typeof m.ts).toBe("string");
+  });
+
+  it("uses the provided host", () => {
+    const m = buildRouteHealthMarker({
+      latched: false,
+      latchedAtMs: null,
+      state: initialRouteHealthState(),
+      nowMs: 1000,
+      host: "test-host",
+    });
+    expect(m.host).toBe("test-host");
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
@@ -11,7 +11,6 @@
 import { mkdirSync, writeFileSync, renameSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { hostname, homedir } from "node:os";
-import { createSparseWarnGate } from "../../otel-forward/lib/sparse-warn";
 
 // ─── State shape ─────────────────────────────────────────────────────────────
 
@@ -214,7 +213,6 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
   const now = opts.now ?? (() => Date.now());
   const cfg = resolveWebhookRouteHealthConfig(opts.cfg);
   const markerPath = opts.markerPath ?? getLinearWebhook401MarkerPath();
-  const warn = createSparseWarnGate({ maxTracked: 2 });
 
   const state: WebhookRouteHealthState = initialRouteHealthState();
   let latched = false;
@@ -297,26 +295,31 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
       const nextLatched = edge.latched;
       const nextAt = edge.emit === "raised" ? nowMs : null;
       const prevLatched = latched;
+      const prevLatchedAtMs = latchedAtMs;
       latched = nextLatched;
       latchedAtMs = nextAt;
       try {
         writeMarker(nowMs);
       } catch {
-        // Rollback latch on write failure — retry same edge next tick.
+        // Rollback latch AND episode-start on write failure — retry same edge next
+        // tick. Restoring the captured prevLatchedAtMs (not a recomputed value) keeps
+        // a failed recovered-edge write from losing the open episode's start time.
         latched = prevLatched;
-        latchedAtMs = edge.emit === "raised" ? null : latchedAtMs;
+        latchedAtMs = prevLatchedAtMs;
         return;
       }
-      // Sparse-warn gated log line → orch-monitor.log → Alloy → Loki (independent path).
-      const total = 1; // one alarm key per emit kind; gate dedups the flood.
-      if (warn(`linear-webhook-401:${edge.emit}`, total)) {
-        console.warn(
-          `[linear-webhook-alarm] ${edge.emit.toUpperCase()}: /api/webhook/linear ` +
-            `non-2xx-only for ${v.linearFailAgeMs}ms ` +
-            `(last ok ${v.linearOkAgeMs ?? "never"}ms ago, ` +
-            `github ok ${v.githubOkAgeMs}ms ago)`,
-        );
-      }
+      // Log line → orch-monitor.log → Alloy → Loki (independent of the broken webhook
+      // path). Latch edges are inherently rare — one per rising/falling transition,
+      // serialized by nextLinearWebhook401Latch — so there is no flood to dedup and no
+      // sparse-warn gate: this line MUST fire on EVERY episode (a second outage after a
+      // recovery, days into a long-lived process), not just the first, since it is the
+      // alarm's only durable signal besides the marker.
+      console.warn(
+        `[linear-webhook-alarm] ${edge.emit.toUpperCase()}: /api/webhook/linear ` +
+          `non-2xx-only for ${v.linearFailAgeMs}ms ` +
+          `(last ok ${v.linearOkAgeMs ?? "never"}ms ago, ` +
+          `github ok ${v.githubOkAgeMs}ms ago)`,
+      );
       opts.onEmit?.(edge.emit, v);
     } else if (latched) {
       // Refresh marker stamps while an episode is open (best-effort).

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
@@ -185,9 +185,11 @@ export function buildRouteHealthMarker(args: {
 
 // ─── Marker path ──────────────────────────────────────────────────────────────
 
-export function getLinearWebhook401MarkerPath(): string {
-  const dir =
-    process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
+export function getLinearWebhook401MarkerPath(baseDir?: string): string {
+  // Prefer an explicitly-resolved base dir (the server threads its own resolved
+  // CATALYST_DIR, which honors the opts.catalystDir override) so isolated server
+  // instances never share stale latch state under a divergent process env.
+  const dir = baseDir ?? process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
   return join(dir, "linear-webhook-401-latch.json");
 }
 
@@ -218,6 +220,9 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
   let latched = false;
   let latchedAtMs: number | null = null;
   let hydrated = false;
+  // Survives the latch rollback below so the log line is deduped by episode, not by
+  // tick, even when a marker-write failure keeps rolling the latch back (see evaluate()).
+  let lastEmittedEdge: "raised" | "recovered" | null = null;
 
   // Three-valued hydration (mirrors broker-degraded.mjs hydrateLatch):
   //   ENOENT / unparseable → CONFIRMED unlatched (hydrated = true, latched = false)
@@ -246,6 +251,18 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
       latchedAtMs = Number.isFinite(m?.latchedAtMs)
         ? (m.latchedAtMs as number)
         : null;
+      // Restore the three persisted route timestamps too — buildRouteHealthMarker
+      // writes them precisely so they survive a restart. Without this, the first
+      // post-restart evaluate() reaches the marker-refresh branch with an all-null
+      // in-memory state and OVERWRITES the durable marker, erasing the last Linear
+      // success / Linear failure / GitHub-control evidence the marker exists to
+      // preserve. Use `??=` so a stamp that already arrived on this (fresh, always
+      // more-recent) process wins and is never clobbered by the older persisted value.
+      const restore = (v: unknown): number | null =>
+        typeof v === "number" && Number.isFinite(v) ? v : null;
+      state.lastLinear2xxMs ??= restore(m?.lastLinear2xxMs);
+      state.lastLinearFailMs ??= restore(m?.lastLinearFailMs);
+      state.lastGithub2xxMs ??= restore(m?.lastGithub2xxMs);
     } catch {
       latched = false;
       latchedAtMs = null;
@@ -291,7 +308,11 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
     const edge = nextLinearWebhook401Latch(latched, v);
 
     if (edge.emit) {
-      // EMIT-THEN-ADVANCE: persist first; only advance the latch on success.
+      // EMIT-THEN-ADVANCE: advance the latch, then persist. On a marker-write failure
+      // roll the latch AND episode-start back so the SAME edge is retried next tick —
+      // the durable marker is the cross-restart source of truth. Restoring the captured
+      // prevLatchedAtMs (not a recomputed value) keeps a failed recovered-edge write
+      // from losing the open episode's start time.
       const nextLatched = edge.latched;
       const nextAt = edge.emit === "raised" ? nowMs : null;
       const prevLatched = latched;
@@ -301,26 +322,30 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
       try {
         writeMarker(nowMs);
       } catch {
-        // Rollback latch AND episode-start on write failure — retry same edge next
-        // tick. Restoring the captured prevLatchedAtMs (not a recomputed value) keeps
-        // a failed recovered-edge write from losing the open episode's start time.
         latched = prevLatched;
         latchedAtMs = prevLatchedAtMs;
-        return;
       }
-      // Log line → orch-monitor.log → Alloy → Loki (independent of the broken webhook
-      // path). Latch edges are inherently rare — one per rising/falling transition,
-      // serialized by nextLinearWebhook401Latch — so there is no flood to dedup and no
-      // sparse-warn gate: this line MUST fire on EVERY episode (a second outage after a
-      // recovery, days into a long-lived process), not just the first, since it is the
-      // alarm's only durable signal besides the marker.
-      console.warn(
-        `[linear-webhook-alarm] ${edge.emit.toUpperCase()}: /api/webhook/linear ` +
-          `non-2xx-only for ${v.linearFailAgeMs}ms ` +
-          `(last ok ${v.linearOkAgeMs ?? "never"}ms ago, ` +
-          `github ok ${v.githubOkAgeMs}ms ago)`,
-      );
-      opts.onEmit?.(edge.emit, v);
+      // The console.warn is the alarm's INDEPENDENT durable signal: it rides
+      // orch-monitor.log → Alloy → Loki, independent of BOTH the broken webhook path
+      // AND the marker filesystem. It MUST therefore fire on the edge even when
+      // writeMarker() threw — a temporarily-unwritable dir must not silence BOTH the
+      // latch and the log for the entire outage (that would defeat the alarm). It must
+      // still fire on EVERY episode (a second outage after a recovery, days into a
+      // long-lived process), not just the first. `lastEmittedEdge` survives the latch
+      // rollback above, so a re-detected same-edge (marker still unwritable next tick)
+      // does not re-log every tick, while the opposite edge — or a fresh episode after a
+      // recovery — always logs. Edges are otherwise rare (serialized by
+      // nextLinearWebhook401Latch), so this is the only dedup needed; no sparse-warn gate.
+      if (edge.emit !== lastEmittedEdge) {
+        console.warn(
+          `[linear-webhook-alarm] ${edge.emit.toUpperCase()}: /api/webhook/linear ` +
+            `non-2xx-only for ${v.linearFailAgeMs}ms ` +
+            `(last ok ${v.linearOkAgeMs ?? "never"}ms ago, ` +
+            `github ok ${v.githubOkAgeMs}ms ago)`,
+        );
+        opts.onEmit?.(edge.emit, v);
+        lastEmittedEdge = edge.emit;
+      }
     } else if (latched) {
       // Refresh marker stamps while an episode is open (best-effort).
       try {

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
@@ -1,0 +1,336 @@
+// webhook-route-health.ts — CTL-1841. Route-comparison detector for a 401-only
+// Linear webhook delivery window.
+//
+// PURE (Phase 1 exports have no I/O except an injected marker-IO seam in Phase 2).
+// ALERT-ONLY: a rotated HMAC secret is fixed by an operator, not a restart.
+//
+// The raise condition depends on NO Linear event volume — only last-2xx / last-fail /
+// last-github-2xx timestamps. This sidesteps the bot-skip-guard volume problem entirely
+// (the RECENCY_SOURCES catalyst.linear exclusion is correct and NOT reverted here).
+
+import { mkdirSync, writeFileSync, renameSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { hostname, homedir } from "node:os";
+import { createSparseWarnGate } from "../../otel-forward/lib/sparse-warn";
+
+// ─── State shape ─────────────────────────────────────────────────────────────
+
+export interface WebhookRouteHealthState {
+  /** Last 2xx from /api/webhook/linear (including the bot-skip guard's 200). */
+  lastLinear2xxMs: number | null;
+  /** Last non-2xx (4xx OR 5xx) from /api/webhook/linear. */
+  lastLinearFailMs: number | null;
+  /** Last 2xx from /api/webhook (the live GitHub control). */
+  lastGithub2xxMs: number | null;
+}
+
+export function initialRouteHealthState(): WebhookRouteHealthState {
+  return {
+    lastLinear2xxMs: null,
+    lastLinearFailMs: null,
+    lastGithub2xxMs: null,
+  };
+}
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+export interface WebhookRouteHealthConfig {
+  /** CATALYST_LINEAR_WEBHOOK_ALARM !== "0" (default ON). */
+  enabled: boolean;
+  /** No Linear 2xx for this long → "silent" (default 15m). */
+  silentThresholdMs: number;
+  /** A Linear non-2xx seen within this window → "recent failure" (default 30m). */
+  failRecencyWindowMs: number;
+  /** A GitHub 2xx seen within this window → "control is live" (default 30m). */
+  githubHealthyWindowMs: number;
+  /** Evaluation interval (default 60s). */
+  tickMs: number;
+}
+
+const MIN = 60_000;
+const DEFAULTS = Object.freeze({
+  silentThresholdMs: 15 * MIN,
+  failRecencyWindowMs: 30 * MIN,
+  githubHealthyWindowMs: 30 * MIN,
+  tickMs: MIN,
+});
+
+export function resolveWebhookRouteHealthConfig(
+  fileCfg: Partial<WebhookRouteHealthConfig> = {},
+): WebhookRouteHealthConfig {
+  const num = (env: string, fallback: number) => {
+    const v = Number(process.env[env]);
+    return Number.isFinite(v) && v > 0 ? v : fallback;
+  };
+  return {
+    enabled: process.env.CATALYST_LINEAR_WEBHOOK_ALARM !== "0",
+    silentThresholdMs:
+      fileCfg.silentThresholdMs ??
+      num(
+        "CATALYST_LINEAR_WEBHOOK_ALARM_SILENT_MS",
+        DEFAULTS.silentThresholdMs,
+      ),
+    failRecencyWindowMs:
+      fileCfg.failRecencyWindowMs ??
+      num(
+        "CATALYST_LINEAR_WEBHOOK_ALARM_FAIL_RECENCY_MS",
+        DEFAULTS.failRecencyWindowMs,
+      ),
+    githubHealthyWindowMs:
+      fileCfg.githubHealthyWindowMs ??
+      num(
+        "CATALYST_LINEAR_WEBHOOK_ALARM_GITHUB_WINDOW_MS",
+        DEFAULTS.githubHealthyWindowMs,
+      ),
+    tickMs:
+      fileCfg.tickMs ??
+      num("CATALYST_LINEAR_WEBHOOK_ALARM_TICK_MS", DEFAULTS.tickMs),
+  };
+}
+
+// ─── Pure classifier ─────────────────────────────────────────────────────────
+
+export interface RouteHealthVerdict {
+  raise: boolean;
+  clear: boolean;
+  route: "/api/webhook/linear";
+  linearFailAgeMs: number | null;
+  linearOkAgeMs: number | null;
+  githubOkAgeMs: number | null;
+}
+
+/**
+ * Classify the current route-health state.
+ *
+ * RAISE when ALL of:
+ *   - the last Linear outcome was a failure (never succeeded, or fail is more recent than ok)
+ *   - the GitHub control 2xx'd within githubHealthyWindowMs (proves tunnel/server are up)
+ *   - the Linear failure is within failRecencyWindowMs (still relevant)
+ *   - no Linear 2xx has been seen for silentThresholdMs or more (or ever)
+ *
+ * CLEAR when the last Linear outcome was a 2xx.
+ */
+export function classifyLinearWebhookHealth(
+  s: WebhookRouteHealthState,
+  nowMs: number,
+  cfg: WebhookRouteHealthConfig,
+): RouteHealthVerdict {
+  const linearFailAgeMs =
+    s.lastLinearFailMs === null ? null : nowMs - s.lastLinearFailMs;
+  const linearOkAgeMs =
+    s.lastLinear2xxMs === null ? null : nowMs - s.lastLinear2xxMs;
+  const githubOkAgeMs =
+    s.lastGithub2xxMs === null ? null : nowMs - s.lastGithub2xxMs;
+  const base = {
+    route: "/api/webhook/linear" as const,
+    linearFailAgeMs,
+    linearOkAgeMs,
+    githubOkAgeMs,
+  };
+
+  // The last Linear outcome was a failure: never succeeded OR fail is more recent than ok.
+  const lastOutcomeIsFail =
+    s.lastLinearFailMs !== null &&
+    (s.lastLinear2xxMs === null || s.lastLinear2xxMs < s.lastLinearFailMs);
+
+  const raise =
+    lastOutcomeIsFail &&
+    githubOkAgeMs !== null &&
+    githubOkAgeMs <= cfg.githubHealthyWindowMs && // control is live
+    linearFailAgeMs !== null &&
+    linearFailAgeMs <= cfg.failRecencyWindowMs && // fail is recent
+    (linearOkAgeMs === null || linearOkAgeMs >= cfg.silentThresholdMs); // silent long enough
+
+  // Recovery: a Linear 2xx is the most recent outcome.
+  const clear =
+    s.lastLinear2xxMs !== null &&
+    (s.lastLinearFailMs === null || s.lastLinear2xxMs >= s.lastLinearFailMs);
+
+  return { ...base, raise, clear };
+}
+
+// ─── Edge-state machine ───────────────────────────────────────────────────────
+
+/**
+ * EMIT-THEN-ADVANCE: fire on the rising/falling edge and advance the latch.
+ * Mirrors nextBrokerDegradedLatch from broker-degraded.mjs.
+ */
+export function nextLinearWebhook401Latch(
+  prev: boolean,
+  { raise, clear }: { raise: boolean; clear: boolean },
+): { latched: boolean; emit: "raised" | "recovered" | null } {
+  if (!prev && raise) return { latched: true, emit: "raised" };
+  if (prev && clear) return { latched: false, emit: "recovered" };
+  return { latched: prev, emit: null };
+}
+
+// ─── Marker builder ───────────────────────────────────────────────────────────
+
+export function buildRouteHealthMarker(args: {
+  latched: boolean;
+  latchedAtMs: number | null;
+  state: WebhookRouteHealthState;
+  nowMs: number;
+  host?: string;
+}): Record<string, unknown> {
+  return {
+    latched: args.latched,
+    latchedAtMs: args.latchedAtMs,
+    lastLinear2xxMs: args.state.lastLinear2xxMs,
+    lastLinearFailMs: args.state.lastLinearFailMs,
+    lastGithub2xxMs: args.state.lastGithub2xxMs,
+    host: args.host ?? null,
+    ts: new Date(args.nowMs).toISOString(),
+  };
+}
+
+// ─── Marker path ──────────────────────────────────────────────────────────────
+
+export function getLinearWebhook401MarkerPath(): string {
+  const dir =
+    process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
+  return join(dir, "linear-webhook-401-latch.json");
+}
+
+// ─── Stateful monitor (Phase 2 — server.ts uses this) ────────────────────────
+
+export interface RouteHealthMonitorOpts {
+  now?: () => number;
+  markerPath?: string;
+  cfg?: Partial<WebhookRouteHealthConfig>;
+  onEmit?: (kind: "raised" | "recovered", verdict: RouteHealthVerdict) => void;
+}
+
+/**
+ * Stateful wrapper that server.ts constructs once. Owns: the mutable state,
+ * the latched/latchedAtMs episode metadata, latch hydration on first evaluate(),
+ * atomic marker writes, and the sparse-warn gated console.warn line.
+ *
+ * The timer and the `console.warn` land in `orch-monitor.log`, which Alloy tails
+ * and ships to Loki independently of the broken webhook path — so the alarm does
+ * NOT ride the broken transport.
+ */
+export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
+  const now = opts.now ?? (() => Date.now());
+  const cfg = resolveWebhookRouteHealthConfig(opts.cfg);
+  const markerPath = opts.markerPath ?? getLinearWebhook401MarkerPath();
+  const warn = createSparseWarnGate({ maxTracked: 2 });
+
+  const state: WebhookRouteHealthState = initialRouteHealthState();
+  let latched = false;
+  let latchedAtMs: number | null = null;
+  let hydrated = false;
+
+  // Three-valued hydration (mirrors broker-degraded.mjs hydrateLatch):
+  //   ENOENT / unparseable → CONFIRMED unlatched (hydrated = true, latched = false)
+  //   other read error     → TRANSIENT (hydrated = false, retry next tick)
+  function hydrate(): void {
+    if (hydrated) return;
+    let raw: string;
+    try {
+      raw = readFileSync(markerPath, "utf8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        hydrated = true;
+        latched = false;
+        latchedAtMs = null;
+        return;
+      }
+      // Transient — leave hydrated=false so the next tick retries.
+      return;
+    }
+    // Read succeeded → confirmed (even if unparseable).
+    hydrated = true;
+    try {
+      const m = JSON.parse(raw) as Record<string, unknown>;
+      latched = m?.latched === true;
+      latchedAtMs = Number.isFinite(m?.latchedAtMs)
+        ? (m.latchedAtMs as number)
+        : null;
+    } catch {
+      latched = false;
+      latchedAtMs = null;
+    }
+  }
+
+  function writeMarker(nowMs: number): void {
+    const m = buildRouteHealthMarker({
+      latched,
+      latchedAtMs,
+      state,
+      nowMs,
+      host: hostname(),
+    });
+    const tmp = `${markerPath}.tmp.${process.pid}`;
+    mkdirSync(dirname(markerPath), { recursive: true });
+    writeFileSync(tmp, JSON.stringify(m));
+    renameSync(tmp, markerPath);
+  }
+
+  function stampLinear(status: number): void {
+    if (!cfg.enabled) return;
+    const t = now();
+    if (status >= 200 && status < 300) {
+      state.lastLinear2xxMs = t;
+    } else {
+      state.lastLinearFailMs = t;
+    }
+  }
+
+  function stampGithub(status: number): void {
+    if (!cfg.enabled) return;
+    if (status >= 200 && status < 300) {
+      state.lastGithub2xxMs = now();
+    }
+  }
+
+  function evaluate(): void {
+    if (!cfg.enabled) return;
+    hydrate();
+    const nowMs = now();
+    const v = classifyLinearWebhookHealth(state, nowMs, cfg);
+    const edge = nextLinearWebhook401Latch(latched, v);
+
+    if (edge.emit) {
+      // EMIT-THEN-ADVANCE: persist first; only advance the latch on success.
+      const nextLatched = edge.latched;
+      const nextAt = edge.emit === "raised" ? nowMs : null;
+      const prevLatched = latched;
+      latched = nextLatched;
+      latchedAtMs = nextAt;
+      try {
+        writeMarker(nowMs);
+      } catch {
+        // Rollback latch on write failure — retry same edge next tick.
+        latched = prevLatched;
+        latchedAtMs = edge.emit === "raised" ? null : latchedAtMs;
+        return;
+      }
+      // Sparse-warn gated log line → orch-monitor.log → Alloy → Loki (independent path).
+      const total = 1; // one alarm key per emit kind; gate dedups the flood.
+      if (warn(`linear-webhook-401:${edge.emit}`, total)) {
+        console.warn(
+          `[linear-webhook-alarm] ${edge.emit.toUpperCase()}: /api/webhook/linear ` +
+            `non-2xx-only for ${v.linearFailAgeMs}ms ` +
+            `(last ok ${v.linearOkAgeMs ?? "never"}ms ago, ` +
+            `github ok ${v.githubOkAgeMs}ms ago)`,
+        );
+      }
+      opts.onEmit?.(edge.emit, v);
+    } else if (latched) {
+      // Refresh marker stamps while an episode is open (best-effort).
+      try {
+        writeMarker(nowMs);
+      } catch {
+        // ignore — marker will refresh on the next tick
+      }
+    }
+  }
+
+  function snapshot(): WebhookRouteHealthState {
+    return { ...state };
+  }
+
+  return { stampLinear, stampGithub, evaluate, snapshot, config: cfg };
+}

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-route-health.ts
@@ -132,10 +132,21 @@ export function classifyLinearWebhookHealth(
     s.lastLinearFailMs !== null &&
     (s.lastLinear2xxMs === null || s.lastLinear2xxMs < s.lastLinearFailMs);
 
+  // ⚠️ NO CROSS-SOURCE GATE. This used to also require a recent GitHub 2xx as a
+  // "control is live" check — but GitHub and Linear use INDEPENDENT smee channels
+  // and separate tunnel instances, so GitHub's health says nothing about Linear's,
+  // and GitHub merely being QUIET for the window suppressed a real Linear alarm
+  // entirely. On a Linear-only installation it could never fire at all.
+  //
+  // The control was also redundant: a Linear 401 already proves the Linear pipe
+  // DELIVERED — the request arrived and was rejected. If the tunnel were down
+  // there would be no 401 to stamp. The failure is self-evidencing, so the alarm
+  // needs no witness from an unrelated transport.
+  //
+  // githubOkAgeMs stays in the returned snapshot for observability; it just no
+  // longer gates the decision.
   const raise =
     lastOutcomeIsFail &&
-    githubOkAgeMs !== null &&
-    githubOkAgeMs <= cfg.githubHealthyWindowMs && // control is live
     linearFailAgeMs !== null &&
     linearFailAgeMs <= cfg.failRecencyWindowMs && // fail is recent
     (linearOkAgeMs === null || linearOkAgeMs >= cfg.silentThresholdMs); // silent long enough
@@ -283,12 +294,22 @@ export function createRouteHealthMonitor(opts: RouteHealthMonitorOpts = {}) {
     renameSync(tmp, markerPath);
   }
 
+  // ⚠️ Only an AUTH status is evidence for this alarm. The handler verifies the
+  // HMAC signature FIRST and then returns 400 for a missing delivery header or
+  // invalid JSON (linear-webhook-handler.ts) — those are VALIDLY SIGNED requests,
+  // so treating every non-2xx as an auth failure lets a malformed-but-authentic
+  // delivery latch a "401" alarm that tells the operator to go rotate a secret
+  // that is fine. An alarm that misdirects is worse than one that stays quiet.
+  //
+  // 401/403 are the statuses that actually prove the signature was rejected.
+  // Anything else non-2xx is neither evidence of health nor of an auth failure, so
+  // it stamps nothing and leaves the previous outcome standing.
   function stampLinear(status: number): void {
     if (!cfg.enabled) return;
     const t = now();
     if (status >= 200 && status < 300) {
       state.lastLinear2xxMs = t;
-    } else {
+    } else if (status === 401 || status === 403) {
       state.lastLinearFailMs = t;
     }
   }

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -272,6 +272,7 @@ import { loadMonitorConfig } from "./lib/monitor-config";
 // Shared Layer-1 config-path resolver (env pointer > cwd) — keeps
 // projectsConfigPath / monitorConfigPath / resolveProjectConfigPath in lockstep.
 import { resolveLayer1ConfigPath } from "./lib/config-path";
+import { createRouteHealthMonitor } from "./lib/webhook-route-health"; // CTL-1841
 // CTL-1152: config-driven project roster behind GET /api/projects.
 import { loadProjects } from "./lib/project-roster";
 // CTL-1153 (M2): config mutation for PUT /api/projects/:key.
@@ -2257,6 +2258,17 @@ export function createServer(opts: CreateServerOptions): BunServer {
     5 * 60 * 1000,
   );
 
+  // CTL-1841: route-comparison alarm for a 401-only Linear webhook delivery window.
+  // Stamps /api/webhook and /api/webhook/linear response codes, then evaluates on
+  // a periodic tick. ALERT-ONLY (durable marker + console.warn → orch-monitor.log →
+  // Alloy → Loki, independent of the broken webhook path). Cleared in server.stop().
+  const routeHealth = createRouteHealthMonitor();
+  const linearWebhookAlarmTimer = setInterval(
+    () => { try { routeHealth.evaluate(); } catch { /* alarm must never wedge the server */ } },
+    routeHealth.config.tickMs,
+  );
+  linearWebhookAlarmTimer.unref?.();
+
   // CTL-1330 Tier 1: monitor request-timing. Surface only slow requests
   // (default >250ms) so healthy traffic doesn't flood the log. ON unless
   // CATALYST_TICK_TIMING=off. Fields land as structured attributes for the
@@ -3426,7 +3438,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
               status: 503,
             });
           }
-          return webhookHandler.handle(req);
+          const ghRes = await webhookHandler.handle(req);
+          routeHealth.stampGithub(ghRes.status); // CTL-1841: live control stamp
+          return ghRes;
         }
 
         if (url.pathname === "/api/webhook/linear" && req.method === "POST") {
@@ -3435,7 +3449,9 @@ export function createServer(opts: CreateServerOptions): BunServer {
               status: 503,
             });
           }
-          return linearWebhookHandler.handle(req);
+          const lnRes = await linearWebhookHandler.handle(req);
+          routeHealth.stampLinear(lnRes.status); // CTL-1841: route-comparison stamp
+          return lnRes;
         }
 
         if (url.pathname === "/api/summarize" && req.method === "POST") {
@@ -5819,6 +5835,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     pushStore.closeDb();
     sseClients.clear();
     clearInterval(titleDescSweepTimer);
+    clearInterval(linearWebhookAlarmTimer); // CTL-1841
     if (anchorPollTimer) clearInterval(anchorPollTimer); // CTL-1251 anchor poll
     eventRing.stop();
     if (pidFile) {

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -272,7 +272,10 @@ import { loadMonitorConfig } from "./lib/monitor-config";
 // Shared Layer-1 config-path resolver (env pointer > cwd) — keeps
 // projectsConfigPath / monitorConfigPath / resolveProjectConfigPath in lockstep.
 import { resolveLayer1ConfigPath } from "./lib/config-path";
-import { createRouteHealthMonitor } from "./lib/webhook-route-health"; // CTL-1841
+import {
+  createRouteHealthMonitor,
+  getLinearWebhook401MarkerPath,
+} from "./lib/webhook-route-health"; // CTL-1841
 // CTL-1152: config-driven project roster behind GET /api/projects.
 import { loadProjects } from "./lib/project-roster";
 // CTL-1153 (M2): config mutation for PUT /api/projects/:key.
@@ -2262,7 +2265,11 @@ export function createServer(opts: CreateServerOptions): BunServer {
   // Stamps /api/webhook and /api/webhook/linear response codes, then evaluates on
   // a periodic tick. ALERT-ONLY (durable marker + console.warn → orch-monitor.log →
   // Alloy → Loki, independent of the broken webhook path). Cleared in server.stop().
-  const routeHealth = createRouteHealthMonitor();
+  // Pin the marker under this server's already-resolved CATALYST_DIR (honors the
+  // opts.catalystDir override) so isolated instances don't share stale latch state.
+  const routeHealth = createRouteHealthMonitor({
+    markerPath: getLinearWebhook401MarkerPath(CATALYST_DIR),
+  });
   const linearWebhookAlarmTimer = setInterval(
     () => { try { routeHealth.evaluate(); } catch { /* alarm must never wedge the server */ } },
     routeHealth.config.tickMs,

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -549,12 +549,27 @@ semantics.
 
 ## Linear webhook 401 alarm (`CATALYST_LINEAR_WEBHOOK_ALARM`, CTL-1841)
 
-The orch-monitor server compares `/api/webhook/linear` and `/api/webhook` (GitHub) response codes
-to detect a 401-only Linear delivery window — the failure mode that stopped all new-work dispatch
-for 7.5 hours on 2026-08-14. Both routes share the same smee tunnel, Bun process, and minute, so a
-GitHub 200 while Linear returns only 4xx proves the Linear HMAC secret is broken, not the
-network. The alarm is **alert-only**: it writes a durable marker and a `console.warn` line that
-Alloy ships to Loki independently of the broken webhook path. It never restarts the server.
+The orch-monitor server watches `/api/webhook/linear` response codes to detect a sustained
+authentication-failure window — the failure mode that stopped all new-work dispatch for 7.5 hours
+on 2026-08-14. The alarm is **alert-only**: it writes a durable marker and a `console.warn` line
+that Alloy ships to Loki independently of the broken webhook path. It never restarts the server.
+
+Two properties are worth stating precisely, because an earlier version of this page got both wrong
+and the code followed the page:
+
+- **The two webhook routes do NOT share a tunnel.** `linearWebhookConfig` is *"independent of
+  `webhookConfig`… so a daemon can run Linear-only or GitHub-only setups"*, and its `smeeChannel`
+  drives a **second** smee tunnel (CTL-242). So a GitHub 200 is **not** a control for Linear, and
+  requiring one meant a Linear-only install could never raise this alarm, while GitHub merely being
+  quiet for the window suppressed a real one. The alarm no longer consults GitHub at all — a Linear
+  **401 already proves the Linear pipe delivered**, since the request had to arrive to be rejected.
+  `githubOkAgeMs` is still reported for observability; it does not gate the decision.
+- **Not every Linear 4xx is an auth failure.** The handler verifies the HMAC signature **first**,
+  then returns 400 for a missing delivery header or invalid JSON — those are *validly signed*
+  requests. Only **401/403** are stamped as evidence here. A 400/404/5xx stamps nothing and leaves
+  the previous outcome standing, so an authentic-but-malformed delivery cannot latch this alarm and
+  send an operator to rotate a secret that is fine. (A 5xx storm deserves its own alarm; it is not
+  this one.)
 
 **Marker path**: `~/catalyst/linear-webhook-401-latch.json` (atomic tmp+rename; survives restarts).
 **Log format**: `[linear-webhook-alarm] RAISED/RECOVERED: /api/webhook/linear …` in `orch-monitor.log`.

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -547,6 +547,30 @@ value) rather than silently disabling the counter.
 PostHog and Cloudflare AE keys mirror the JSON above; see the developer reference for their delivery
 semantics.
 
+## Linear webhook 401 alarm (`CATALYST_LINEAR_WEBHOOK_ALARM`, CTL-1841)
+
+The orch-monitor server compares `/api/webhook/linear` and `/api/webhook` (GitHub) response codes
+to detect a 401-only Linear delivery window — the failure mode that stopped all new-work dispatch
+for 7.5 hours on 2026-08-14. Both routes share the same smee tunnel, Bun process, and minute, so a
+GitHub 200 while Linear returns only 4xx proves the Linear HMAC secret is broken, not the
+network. The alarm is **alert-only**: it writes a durable marker and a `console.warn` line that
+Alloy ships to Loki independently of the broken webhook path. It never restarts the server.
+
+**Marker path**: `~/catalyst/linear-webhook-401-latch.json` (atomic tmp+rename; survives restarts).
+**Log format**: `[linear-webhook-alarm] RAISED/RECOVERED: /api/webhook/linear …` in `orch-monitor.log`.
+
+| Env var                                       | Default           | Description |
+| --------------------------------------------- | ----------------- | ----------- |
+| `CATALYST_LINEAR_WEBHOOK_ALARM`               | `1` (enabled)     | Set to `0` to disable the alarm entirely (kill-switch). |
+| `CATALYST_LINEAR_WEBHOOK_ALARM_SILENT_MS`     | `900000` (15 min) | No Linear 2xx for this long → "silent window". |
+| `CATALYST_LINEAR_WEBHOOK_ALARM_FAIL_RECENCY_MS` | `1800000` (30 min) | A Linear non-2xx must be seen within this window to be considered "recent". |
+| `CATALYST_LINEAR_WEBHOOK_ALARM_GITHUB_WINDOW_MS` | `1800000` (30 min) | The GitHub control 2xx must be seen within this window to prove the tunnel is up. |
+| `CATALYST_LINEAR_WEBHOOK_ALARM_TICK_MS`       | `60000` (1 min)   | Evaluation interval. |
+
+The alarm does **not** depend on Linear event volume — it detects HTTP authentication failure
+directly. A genuinely-quiet Linear feed (no deliveries at all, not even 401s) does not alarm.
+Wiring the marker to a pager (a Loki alert rule in `catalyst-otel`) is a separate follow-up.
+
 ## Cluster machine-level cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
 
 `CATALYST_CLOUD_TOKEN` is a single **shared** service credential — the catalyst-cloud `ADMIN_TOKEN`


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-14T15:31:00Z -->
<!-- Last updated: 2026-08-14T15:31:00Z -->
<!-- PR: #3364 -->
<!-- Previous commits: e34a99717e779b4fc857a5a5307968604d3fda17,136807942ee90cdabf719b6632652d064b2400d2 -->

## Summary

Adds a **route-comparison alarm** to the orch-monitor server that detects Linear webhook authentication failures without depending on Linear event volume. The detector compares HTTP response codes on `/api/webhook/linear` against the `/api/webhook` (GitHub) control — both running in the same Bun process on the same smee tunnel — and raises when Linear has returned only non-2xx responses past a configurable silence threshold while GitHub keeps 200-ing.

Motivated by the 2026-08-14 7.5-hour Linear webhook outage (HMAC secret rotation left the validator rejecting every request with 401). The existing `catalyst.linear` exclusion from `RECENCY_SOURCES` was correct (the bot-skip guard silences Linear events even when healthy), but it meant that outage produced no signal at all.

**Alert-only:** durable latch marker (`~/catalyst/linear-webhook-401-latch.json`) + `console.warn` line in `orch-monitor.log` (Alloy-shipped independently of the broken webhook path). No restart, no mutation.

## Changes Made

### New: `webhook-route-health.ts`

Pure, injectable classifier (`createRouteHealthMonitor`) with:
- `stampLinear(statusCode)` / `stampGithub(statusCode)` — record the latest HTTP response per route, called from `server.ts` on every webhook response
- `evaluate()` — edge-triggered state machine: RAISE when Linear has seen only failures for ≥ `failRecencyMs` (default 30 min) and GitHub has seen a 2xx within `githubWindowMs` (default 60 min); CLEAR when a Linear 2xx arrives
- Atomic marker write (tmp + rename) with latch hydration across restarts — a fresh monitor reads the existing marker so a restart does not re-emit `raised` for an already-latched episode
- `onEmit` hook for unit testing without `console.warn` side effects
- Five config knobs via `resolveWebhookRouteHealthConfig`: `CATALYST_LINEAR_WEBHOOK_ALARM`, `_SILENT_MS`, `_FAIL_RECENCY_MS`, `_GITHUB_WINDOW_MS`, `_TICK_MS`

### Modified: `server.ts`

Three additive lines: `stampLinear` on the linear webhook response path, `stampGithub` on the GitHub webhook response path, and a `setInterval`-based 60 s eval tick (unref'd; cleared in `stop()`). No changes to existing request handling logic.

### Tests

27 new tests across two files:
- `webhook-route-health.test.ts` — pure classifier: raise/no-raise conditions, second-episode regression (dropped sparse-warn `total=1` gate that suppressed the alarm after the first recovery), latch hysteresis, disabled kill-switch no-op
- `webhook-route-health-io.test.ts` — IO/stateful: atomic marker write, latch hydration (no double-emit across restart), recover edge, positive-control replay of the 2026-08-14 incident with 8 negative controls

### Phase-review remediation (commit 2)

Fixed two issues surfaced by `/review`:
- **HIGH:** sparse-warn gate with `total=1` logged each edge kind (raised/recovered) exactly once per process lifetime — a second outage after recovery would update the marker but suppress the `console.warn`, breaking the Alloy→Loki signal. Latch edges are inherently rare (serialized by the state machine), so the gate was the wrong tool. Dropped; every edge logs directly. Regression test added.
- **MEDIUM:** on a recovered-edge `writeMarker` failure, the rollback lost `latchedAtMs` (set to `null` pre-write, catch restored the already-`null` value). Capture `prevLatchedAtMs` before writing and restore it on failure.

### Docs

- `docs/architecture.md`: note on the route-comparison alarm, its alert-only contract, and config knobs
- `website/src/content/docs/reference/configuration.md`: five new env knobs documented

## How to Verify It

- [x] TypeScript compiles clean — `tsc --noEmit` (orch-monitor package) ✅
- [x] 27 new tests pass — `bun test webhook-route-health` (53 expect calls) ✅
- [x] ESLint clean on all changed files ✅
- [x] Knip: no unused exports — all new exports consumed by monitor/tests ✅
- [x] No reward-hacking patterns (no `as any` / ts-ignore / non-null / forEach-async) ✅
- [x] Linear webhook handler returns 401 on HMAC failure (the target outage) — detector premise holds ✅
- [x] Alert-only contract: no event-log writes; marker + console.warn only — matches architecture.md claim ✅
- [x] 2026-08-14 positive-control replay asserts `raise===true`; 8 negative controls assert no-raise/clear ✅
- [ ] Verify alarm fires in a local orch-monitor instance by stubbing a 401 response on the linear route (manual smoke test against live server)
- [ ] Confirm `~/catalyst/linear-webhook-401-latch.json` is absent (clean state) before deploying, or delete it if a prior test run latched it

## Pre-merge Verification (from verify phase)

- **Regression risk**: 1 / 10
- **typecheck**: pass — tsc --noEmit clean (orch-monitor package)
- **tests**: pass — 27 pass / 0 fail across the two new route-health test files (53 expect calls)
- **lint**: pass — eslint clean on webhook-route-health.ts + 2 tests + server.ts
- **knip**: pass — no unused exports — all new exports consumed by monitor/tests
- **reward_hacking**: pass — no as-any / ts-ignore / non-null / forEach-async; 3 casts all guarded/idiomatic
- **handler_return_contract**: pass — linear-webhook-handler.ts:349-350 returns 401 on HMAC failure (the target outage); normal/bot-skip return 200 — detector premise holds
- **alert_only_contract**: pass — no event-log writes; marker + console.warn only — matches architecture.md alert-only claim, no new event names to register
- **positive_control**: pass — 2026-08-14 replay asserts raise===true; 8 negative controls assert no-raise/clear

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1841

## Changelog Entry

```
feat(dev): Add route-comparison alarm for Linear webhook 401 detection

Detects HMAC authentication failure on the Linear webhook route by comparing
HTTP response codes against the GitHub webhook control (same tunnel, same
process). Alert-only: durable latch marker + console.warn shipped via Alloy
independent of the broken webhook path. Five config knobs; 27 new tests.
```