### PR TITLE
feat(dev): CTL-1836 — give the installer a cloud path, and make it refuse to guess the tenant

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -332,6 +332,19 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/event-append-atomicity.test.sh
 
+      - name: setup-catalyst.sh cloud replica provisioning (CTL-1836)
+        # CTL-1836: the installer's --cloud-token path. The load-bearing case is the
+        # REFUSAL: cloud-sync.mjs:125 defaults CATALYST_CLOUD_ACCOUNT to "tenant-0"
+        # (the maintainer's own tenant), so a token supplied without an account must
+        # fail loudly rather than silently point a new user's host at somebody else's
+        # workspace. Equally load-bearing is the no-op: with no cloud flags, setup must
+        # be byte-identical to before the flag existed.
+        # Carries its own precondition assertion — case 5 starts from a 0644 env file
+        # and proves it is tightened to 0600, because the naive mode check passes for
+        # free (mktemp creates 0600 and mv preserves it, verified by mutation).
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/setup-cloud-replica.test.sh
+
       - name: SKILL.md ${PLUGIN_ROOT} assignment guard (CTL-1832)
         # CTL-1832: a SKILL.md that EXPANDS ${PLUGIN_ROOT} must also ASSIGN it, or
         # the expansion is empty and the command silently addresses a bogus path.

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -116,6 +116,11 @@ on:
       - "plugins/legacy/skills/orchestrate/**"
       # CTL-1628: the root bun workspace lockfile/manifest — a change here affects
       # every member package's install (incl. execution-core, broker, otel-forward).
+      # CTL-1836: the root installer, whose cloud-replica provisioning is covered by
+      # __tests__/setup-cloud-replica.test.sh below. Without this path a setup-only
+      # change would neither trigger the workflow on push nor mark a PR relevant —
+      # the tested implementation would bypass its own regression test.
+      - "setup-catalyst.sh"
       - "package.json"
       - "bun.lock"
       - "turbo.json"
@@ -155,6 +160,8 @@ jobs:
               - "plugins/dev/scripts/migrate-dual-harness.sh"
               - "plugins/dev/scripts/check-project-setup.sh"
               - ".github/workflows/execution-core-tests.yml"
+              # CTL-1836: root installer — see the matching note in on.push.paths.
+              - "setup-catalyst.sh"
               - "package.json"
               - "bun.lock"
               - "turbo.json"

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -36,6 +36,21 @@ bad() {
 	echo "  FAIL — $1"
 }
 
+# file_mode PATH -> the octal permission bits, portably.
+# ⛔ ORDER MATTERS AND BSD-FIRST IS WRONG. On Linux `stat -f` is --file-system, which
+# SUCCEEDS and prints filesystem info, so a `stat -f ... || stat -c ...` chain never
+# reaches the fallback and yields garbage like `File: "/tmp/..."`. GNU (-c) is tried
+# first for exactly that reason — the same ordering AGENTS.md's replica freshness-gate
+# snippet uses. Returns empty when neither form works, so callers fail loudly rather
+# than comparing against a non-numeric string.
+file_mode() {
+	local m
+	m="$(stat -c %a "$1" 2>/dev/null)" || m=""
+	[[ $m =~ ^[0-7]+$ ]] || m="$(stat -f %Lp "$1" 2>/dev/null)" || m=""
+	[[ $m =~ ^[0-7]+$ ]] || m=""
+	printf '%s' "$m"
+}
+
 # Run setup_cloud_replica in a subshell with a fake HOME, sourcing the real script.
 # setup-catalyst.sh already guards main() behind a sourced-detection test;
 # CATALYST_SETUP_LIB_ONLY is its explicit belt-and-braces form.
@@ -90,7 +105,7 @@ if [[ $rc == "0" ]]; then ok "token + account → returns 0"; else bad "token + 
 if [[ -f "$ENV_FILE" ]]; then
 	ok "token + account → cloud-sync.env written"
 
-	mode=$(stat -f %Lp "$ENV_FILE" 2>/dev/null || stat -c %a "$ENV_FILE" 2>/dev/null)
+	mode=$(file_mode "$ENV_FILE")
 	if [[ $mode == "600" ]]; then ok "cloud-sync.env is 0600"; else bad "cloud-sync.env mode is $mode, expected 600"; fi
 	# ⚠️ NOTE: the assertion above is NOT sufficient on its own and must not be
 	# trusted alone. mktemp creates its file 0600 by default and mv preserves the
@@ -152,9 +167,9 @@ H5=$(mktemp -d)
 mkdir -p "$H5/.config/catalyst"
 : >"$H5/.config/catalyst/cloud-sync.env"
 chmod 644 "$H5/.config/catalyst/cloud-sync.env"
-pre_mode=$(stat -f %Lp "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null || stat -c %a "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null)
+pre_mode=$(file_mode "$H5/.config/catalyst/cloud-sync.env")
 rc=$(run_case "$H5" "tok_test_abc" "tenant-9")
-post_mode=$(stat -f %Lp "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null || stat -c %a "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null)
+post_mode=$(file_mode "$H5/.config/catalyst/cloud-sync.env")
 if [[ $pre_mode == "644" ]]; then
 	ok "precondition established: env file started 0644 (proves this case can discriminate)"
 else

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -112,14 +112,14 @@ if [[ -f "$ENV_FILE" ]]; then
 	# mode, so this passes even with EVERY chmod removed — mutation-verified.
 	# Case 5 below is what actually makes the permission behaviour load-bearing.
 
-	if grep -q '^CATALYST_CLOUD_ACCOUNT=tenant-7$' "$ENV_FILE"; then
+	if grep -q '^export CATALYST_CLOUD_ACCOUNT=tenant-7$' "$ENV_FILE"; then
 		ok "account pinned EXPLICITLY (never left to the tenant-0 default)"
 	else
 		bad "account not pinned explicitly in cloud-sync.env"
 	fi
 
 	# The legacy host is being retired; a new user must not be pointed at it.
-	if grep -q '^CATALYST_CLOUD_BASE_URL=' "$ENV_FILE"; then
+	if grep -q '^export CATALYST_CLOUD_BASE_URL=' "$ENV_FILE"; then
 		ok "base URL pinned explicitly"
 	else
 		bad "base URL not pinned — new install would inherit the LEGACY default"
@@ -130,7 +130,7 @@ if [[ -f "$ENV_FILE" ]]; then
 		ok "cloud-sync.env does not pin the legacy base URL"
 	fi
 
-	if grep -q '^CATALYST_CLOUD_TOKEN=tok_test_abc$' "$ENV_FILE"; then
+	if grep -q '^export CATALYST_CLOUD_TOKEN=tok_test_abc$' "$ENV_FILE"; then
 		ok "token written"
 	else
 		bad "token missing from cloud-sync.env"
@@ -150,7 +150,7 @@ H4=$(mktemp -d)
 	set +e
 	setup_cloud_replica >/dev/null 2>&1
 )
-if grep -q '^CATALYST_CLOUD_BASE_URL=https://example.invalid/api/v1$' "$H4/.config/catalyst/cloud-sync.env" 2>/dev/null; then
+if grep -q '^export CATALYST_CLOUD_BASE_URL=https://example.invalid/api/v1$' "$H4/.config/catalyst/cloud-sync.env" 2>/dev/null; then
 	ok "explicit CATALYST_CLOUD_BASE_URL override is honoured"
 else
 	bad "base URL override ignored"
@@ -182,12 +182,69 @@ else
 fi
 # And it must be REPLACED, not appended to: a stale token line surviving alongside
 # the new one would leave the writer reading whichever the shell sourced last.
-if [[ $(grep -c '^CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) == "1" ]]; then
+if [[ $(grep -c '^export CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) == "1" ]]; then
 	ok "env file replaced, not appended (exactly one token line)"
 else
-	bad "env file has $(grep -c '^CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) token lines — expected exactly 1"
+	bad "env file has $(grep -c '^export CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) token lines — expected exactly 1"
 fi
 rm -rf "$H5"
+
+# ── Case 6: EVERY line must be exported (Codex P1 on #3365) ─────────────────
+# launch.sh SOURCES this file and then execs bun. A bare `FOO=bar` in a sourced
+# file is shell-local — not in the child's environment — so the writer would see no
+# token, take its tokenless idle path, and process.exit(0). Under
+# KeepAlive={SuccessfulExit:false} that clean exit is PERMANENT: launchd never
+# restarts it and the only symptom is a replica that quietly stops advancing.
+# This is not theoretical bookkeeping — it is the exact silent-death shape of
+# CTL-1844, which cost hours to diagnose on a live host.
+H6=$(mktemp -d)
+rc=$(run_case "$H6" "tok_export_check" "tenant-3")
+E6="$H6/.config/catalyst/cloud-sync.env"
+if [[ -f $E6 ]]; then
+	assigns=$(grep -cE '^[A-Za-z_][A-Za-z0-9_]*=' "$E6" || true)
+	exports=$(grep -cE '^export [A-Za-z_][A-Za-z0-9_]*=' "$E6" || true)
+	if [[ $assigns -eq 0 && $exports -gt 0 ]]; then
+		ok "every assignment is exported ($exports exported, 0 bare) — the writer's child process sees them"
+	else
+		bad "$assigns BARE assignment(s) present — a sourced non-exported var never reaches bun (silent idle exit)"
+	fi
+	# Prove the child really would see it, rather than trusting the text: source the
+	# file in a subshell and check the variable is in the ENVIRONMENT, not just set.
+	if (
+		# shellcheck disable=SC1090
+		. "$E6"
+		env | grep -q '^CATALYST_CLOUD_TOKEN=tok_export_check$'
+	); then
+		ok "sourcing the file puts the token in the ENVIRONMENT (env|grep, not just set)"
+	else
+		bad "after sourcing, the token is not in env — bun would receive no token"
+	fi
+else
+	bad "case 6: no env file written"
+fi
+rm -rf "$H6"
+
+# ── Case 7: the configured token NAME is honoured (CTL-1668, Codex P2) ──────
+# Writing a fixed name while the writer resolves a custom one produces the same
+# silent idle as case 6.
+H7=$(mktemp -d)
+(
+	export HOME="$H7" CATALYST_SETUP_LIB_ONLY=1
+	export CATALYST_CLOUD_TOKEN_ENV="MY_CUSTOM_CLOUD_TOKEN"
+	export MY_CUSTOM_CLOUD_TOKEN="tok_custom_name"
+	export CATALYST_CLOUD_ACCOUNT="tenant-4"
+	# shellcheck disable=SC1090
+	source "$SETUP" >/dev/null 2>&1
+	set +e
+	setup_cloud_replica >/dev/null 2>&1
+)
+E7="$H7/.config/catalyst/cloud-sync.env"
+if grep -q '^export MY_CUSTOM_CLOUD_TOKEN=tok_custom_name$' "$E7" 2>/dev/null; then
+	ok "token written under the CONFIGURED name, not the hardcoded default"
+else
+	bad "configured token name ignored — writer would resolve a name the file never sets"
+fi
+rm -rf "$H7"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# CTL-1836: setup-catalyst.sh must be able to provision the Catalyst Cloud replica,
+# and must REFUSE to guess the tenant when it cannot.
+#
+# The refusal is the load-bearing case, not the happy path. cloud-sync.mjs:125 and
+# cloud-sync/launch.sh:68 both default CATALYST_CLOUD_ACCOUNT to "tenant-0" — the
+# Catalyst maintainer's own tenant. An external user who omits the account would
+# silently point their host at somebody else's workspace; with a per-tenant key that
+# fails CLOSED (the mirror forces the account to match the key) but surfaces as an
+# opaque 403 with no hint. So a token WITHOUT an account must be a loud failure here,
+# never a default.
+#
+# The second load-bearing case is the no-op: with no cloud flags at all, this function
+# must not touch anything. Existing installs must be byte-identical to before.
+#
+# Driven against the REAL shipped function by sourcing setup-catalyst.sh with a guard
+# that stops it before main() runs — never a re-implementation of it.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/setup-catalyst.sh"
+[[ -f "$SETUP" ]] || {
+	echo "FAIL: setup-catalyst.sh not found at $SETUP"
+	exit 1
+}
+
+PASS=0
+FAIL=0
+ok() {
+	PASS=$((PASS + 1))
+	echo "  ok   — $1"
+}
+bad() {
+	FAIL=$((FAIL + 1))
+	echo "  FAIL — $1"
+}
+
+# Run setup_cloud_replica in a subshell with a fake HOME, sourcing the real script.
+# setup-catalyst.sh already guards main() behind a sourced-detection test;
+# CATALYST_SETUP_LIB_ONLY is its explicit belt-and-braces form.
+run_case() {
+	local home="$1" token="$2" account="$3"
+	(
+		export HOME="$home"
+		export CATALYST_SETUP_LIB_ONLY=1
+		export CATALYST_CLOUD_TOKEN="$token"
+		export CATALYST_CLOUD_ACCOUNT="$account"
+		# shellcheck disable=SC1090
+		source "$SETUP" >/dev/null 2>&1
+		# setup-catalyst.sh sets -e; re-disable AFTER sourcing so a deliberate
+		# non-zero return is reportable instead of killing this subshell.
+		set +e
+		setup_cloud_replica >/dev/null 2>&1
+		echo "$?"
+	)
+}
+
+echo "CTL-1836 — setup-catalyst.sh cloud replica provisioning"
+
+# ── Case 1: no token → complete no-op (existing installs untouched) ──────────
+H1=$(mktemp -d)
+rc=$(run_case "$H1" "" "")
+if [[ $rc == "0" ]]; then ok "no token → returns 0 (no-op)"; else bad "no token → expected rc 0, got $rc"; fi
+if [[ ! -e "$H1/.config/catalyst/cloud-sync.env" ]]; then
+	ok "no token → writes NO cloud-sync.env"
+else
+	bad "no token → wrote cloud-sync.env, which would change existing-install behaviour"
+fi
+rm -rf "$H1"
+
+# ── Case 2: token WITHOUT account → loud refusal, nothing written ────────────
+# This is the tenant-0 footgun. It must fail, and it must not leave a half-written
+# credential behind.
+H2=$(mktemp -d)
+rc=$(run_case "$H2" "tok_test_abc" "")
+if [[ $rc != "0" ]]; then ok "token without account → non-zero exit (refuses to guess the tenant)"; else bad "token without account → returned 0; it defaulted instead of refusing"; fi
+if [[ ! -e "$H2/.config/catalyst/cloud-sync.env" ]]; then
+	ok "token without account → no cloud-sync.env written"
+else
+	bad "token without account → wrote a credential file despite refusing"
+fi
+rm -rf "$H2"
+
+# ── Case 3: token + account → env file written, 0600, explicit values ────────
+H3=$(mktemp -d)
+rc=$(run_case "$H3" "tok_test_abc" "tenant-7")
+ENV_FILE="$H3/.config/catalyst/cloud-sync.env"
+if [[ $rc == "0" ]]; then ok "token + account → returns 0"; else bad "token + account → expected rc 0, got $rc"; fi
+if [[ -f "$ENV_FILE" ]]; then
+	ok "token + account → cloud-sync.env written"
+
+	mode=$(stat -f %Lp "$ENV_FILE" 2>/dev/null || stat -c %a "$ENV_FILE" 2>/dev/null)
+	if [[ $mode == "600" ]]; then ok "cloud-sync.env is 0600"; else bad "cloud-sync.env mode is $mode, expected 600"; fi
+	# ⚠️ NOTE: the assertion above is NOT sufficient on its own and must not be
+	# trusted alone. mktemp creates its file 0600 by default and mv preserves the
+	# mode, so this passes even with EVERY chmod removed — mutation-verified.
+	# Case 5 below is what actually makes the permission behaviour load-bearing.
+
+	if grep -q '^CATALYST_CLOUD_ACCOUNT=tenant-7$' "$ENV_FILE"; then
+		ok "account pinned EXPLICITLY (never left to the tenant-0 default)"
+	else
+		bad "account not pinned explicitly in cloud-sync.env"
+	fi
+
+	# The legacy host is being retired; a new user must not be pointed at it.
+	if grep -q '^CATALYST_CLOUD_BASE_URL=' "$ENV_FILE"; then
+		ok "base URL pinned explicitly"
+	else
+		bad "base URL not pinned — new install would inherit the LEGACY default"
+	fi
+	if grep -q 'api\.catalyst-cloud\.coalescelabs\.ai' "$ENV_FILE"; then
+		bad "cloud-sync.env pins the LEGACY base URL"
+	else
+		ok "cloud-sync.env does not pin the legacy base URL"
+	fi
+
+	if grep -q '^CATALYST_CLOUD_TOKEN=tok_test_abc$' "$ENV_FILE"; then
+		ok "token written"
+	else
+		bad "token missing from cloud-sync.env"
+	fi
+else
+	bad "token + account → no cloud-sync.env written"
+fi
+rm -rf "$H3"
+
+# ── Case 4: CATALYST_CLOUD_BASE_URL override is honoured ─────────────────────
+H4=$(mktemp -d)
+(
+	export HOME="$H4" CATALYST_SETUP_LIB_ONLY=1 CATALYST_CLOUD_TOKEN="t" CATALYST_CLOUD_ACCOUNT="a"
+	export CATALYST_CLOUD_BASE_URL="https://example.invalid/api/v1"
+	# shellcheck disable=SC1090
+	source "$SETUP" >/dev/null 2>&1
+	set +e
+	setup_cloud_replica >/dev/null 2>&1
+)
+if grep -q '^CATALYST_CLOUD_BASE_URL=https://example.invalid/api/v1$' "$H4/.config/catalyst/cloud-sync.env" 2>/dev/null; then
+	ok "explicit CATALYST_CLOUD_BASE_URL override is honoured"
+else
+	bad "base URL override ignored"
+fi
+rm -rf "$H4"
+
+# ── Case 5: a PRE-EXISTING world-readable env file must be tightened ─────────
+# This is the case that makes the permission behaviour real. A 0644 cloud-sync.env
+# left behind by an earlier manual step is a credential readable by every local
+# user. Setup must replace it with a 0600 file, not append to it or leave the mode
+# alone. Unlike the mode check in case 3 (which mktemp satisfies for free), this
+# one fails if the write stops going through the tmp+mv path.
+H5=$(mktemp -d)
+mkdir -p "$H5/.config/catalyst"
+: >"$H5/.config/catalyst/cloud-sync.env"
+chmod 644 "$H5/.config/catalyst/cloud-sync.env"
+pre_mode=$(stat -f %Lp "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null || stat -c %a "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null)
+rc=$(run_case "$H5" "tok_test_abc" "tenant-9")
+post_mode=$(stat -f %Lp "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null || stat -c %a "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null)
+if [[ $pre_mode == "644" ]]; then
+	ok "precondition established: env file started 0644 (proves this case can discriminate)"
+else
+	bad "precondition NOT established: pre-mode was $pre_mode, not 644 — case 5 proves nothing"
+fi
+if [[ $post_mode == "600" ]]; then
+	ok "a pre-existing 0644 cloud-sync.env is tightened to 0600"
+else
+	bad "pre-existing 0644 env file left at $post_mode — credential readable by other local users"
+fi
+# And it must be REPLACED, not appended to: a stale token line surviving alongside
+# the new one would leave the writer reading whichever the shell sourced last.
+if [[ $(grep -c '^CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) == "1" ]]; then
+	ok "env file replaced, not appended (exactly one token line)"
+else
+	bad "env file has $(grep -c '^CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) token lines — expected exactly 1"
+fi
+rm -rf "$H5"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1561,7 +1561,15 @@ EOF
 setup_cloud_replica() {
 	# Flags win over env. Absent → this whole function is a no-op and setup is
 	# byte-identical to before CTL-1836.
-	local token="${CLOUD_TOKEN:-${CATALYST_CLOUD_TOKEN:-}}"
+	# CTL-1668: also LOOK UP the token under the configured name, not just the
+	# default — otherwise a host using a custom name has its valid token treated as
+	# absent and provisioning is silently skipped (Codex P2 on #3365).
+	local _tv="${CATALYST_CLOUD_TOKEN_ENV:-}"
+	if [[ -z $_tv ]] && [[ -r "$HOME/.config/catalyst/config.json" ]] && command -v jq >/dev/null 2>&1; then
+		_tv="$(jq -r '.catalyst.cloud.tokenEnv // empty' "$HOME/.config/catalyst/config.json" 2>/dev/null || true)"
+	fi
+	[[ -n $_tv ]] || _tv="CATALYST_CLOUD_TOKEN"
+	local token="${CLOUD_TOKEN:-${!_tv:-}}"
 	local account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT:-}}"
 	[[ -n $token ]] || return 0
 
@@ -1590,6 +1598,28 @@ setup_cloud_replica() {
 	# relies on the default is pointed at a host that is going away. Pin it here.
 	local base_url="${CATALYST_CLOUD_BASE_URL:-https://app.catalystcloud.dev/api/v1}"
 
+	# ⛔ EVERY LINE MUST BE `export` (Codex P1 on #3365). launch.sh SOURCES this file
+	# and then `exec`s bun. A bare `FOO=bar` in a sourced file is a SHELL-LOCAL
+	# variable — it is not in the child's environment, so bun would see no token,
+	# take its tokenless idle path, and `process.exit(0)`. Under the agent's
+	# `KeepAlive={SuccessfulExit:false}` a clean exit is PERMANENT: launchd never
+	# restarts it, and the only symptom is a replica that quietly stops advancing.
+	# (Verified against the three hosts already running: every existing
+	# cloud-sync.env uses `export`. This is the established form, not a new one.)
+	#
+	# CTL-1668: the token's env-var NAME is configurable, so honour the same
+	# precedence the writer resolves with — env override → Layer-2
+	# catalyst.cloud.tokenEnv → default. Writing a fixed name while the writer looks
+	# up a custom one produces the identical silent idle.
+	local token_var="${CATALYST_CLOUD_TOKEN_ENV:-}"
+	if [[ -z $token_var ]]; then
+		local l2_cfg="$HOME/.config/catalyst/config.json"
+		if [[ -r $l2_cfg ]] && command -v jq >/dev/null 2>&1; then
+			token_var="$(jq -r '.catalyst.cloud.tokenEnv // empty' "$l2_cfg" 2>/dev/null || true)"
+		fi
+	fi
+	[[ -n $token_var ]] || token_var="CATALYST_CLOUD_TOKEN"
+
 	# launchd does not read ~/.zshenv, so the writer's credentials have to live in
 	# this file. Written 0600 BEFORE the secret lands in it — never world-readable,
 	# not even momentarily.
@@ -1599,9 +1629,11 @@ setup_cloud_replica() {
 	{
 		echo "# Written by setup-catalyst.sh (CTL-1836). Consumed by"
 		echo "# plugins/dev/scripts/execution-core/cloud-sync/launch.sh under launchd."
-		echo "CATALYST_CLOUD_TOKEN=${token}"
-		echo "CATALYST_CLOUD_ACCOUNT=${account}"
-		echo "CATALYST_CLOUD_BASE_URL=${base_url}"
+		echo "# Every line is exported: launch.sh sources this then execs bun, and a"
+		echo "# non-exported assignment would leave the writer tokenless (silent idle exit)."
+		echo "export ${token_var}=${token}"
+		echo "export CATALYST_CLOUD_ACCOUNT=${account}"
+		echo "export CATALYST_CLOUD_BASE_URL=${base_url}"
 	} >"$tmp_env"
 	mv "$tmp_env" "$env_file"
 	chmod 600 "$env_file"

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -24,6 +24,10 @@ THOUGHTS_REPO=""
 WORKTREE_BASE=""
 USER_NAME=""
 NON_INTERACTIVE=0
+# CTL-1836: Catalyst Cloud replica provisioning. Empty → the cloud path is a
+# no-op and setup behaves exactly as it did before the flags existed.
+CLOUD_TOKEN=""
+CLOUD_ACCOUNT=""
 
 #
 # Utility functions
@@ -56,6 +60,24 @@ can_open_tty() {
 	(: </dev/tty) 2>/dev/null
 }
 
+print_usage() {
+	cat <<'USAGE'
+Usage: setup-catalyst.sh [--non-interactive|--defaults]
+                         [--cloud-token <token>] [--cloud-account <account>]
+
+  --non-interactive, --defaults   Answer every prompt with its default.
+
+  --cloud-token <token>     Provision the Catalyst Cloud read replica on this host.
+                            Env: CATALYST_CLOUD_TOKEN (or the name configured by
+                            CATALYST_CLOUD_TOKEN_ENV / Layer-2 catalyst.cloud.tokenEnv).
+  --cloud-account <account> REQUIRED whenever a cloud token is supplied. There is
+                            deliberately NO default here — see below.
+                            Env: CATALYST_CLOUD_ACCOUNT
+
+Omit the cloud flags and setup behaves exactly as it always has.
+USAGE
+}
+
 # Parse CLI flags. CATALYST_AUTONOMOUS is the project-wide headless signal
 # (same contract as plugins/dev/scripts/check-project-setup.sh).
 parse_args() {
@@ -68,13 +90,32 @@ parse_args() {
 			NON_INTERACTIVE=1
 			shift
 			;;
+		# CTL-1836: the Catalyst Cloud replica path. Absent → every behaviour below
+		# is byte-identical to before this flag existed, so existing installs are
+		# untouched. Env vars are the headless equivalent.
+		--cloud-token)
+			[[ $# -ge 2 ]] || {
+				print_error "--cloud-token requires a value"
+				exit 1
+			}
+			CLOUD_TOKEN="$2"
+			shift 2
+			;;
+		--cloud-account)
+			[[ $# -ge 2 ]] || {
+				print_error "--cloud-account requires a value"
+				exit 1
+			}
+			CLOUD_ACCOUNT="$2"
+			shift 2
+			;;
 		-h | --help)
-			echo "Usage: setup-catalyst.sh [--non-interactive|--defaults]"
+			print_usage
 			exit 0
 			;;
 		*)
 			print_error "Unknown option: $1"
-			echo "Usage: setup-catalyst.sh [--non-interactive|--defaults]"
+			print_usage
 			exit 1
 			;;
 		esac
@@ -1495,6 +1536,111 @@ EOF
 	echo ""
 }
 
+# ── CTL-1836: provision the Catalyst Cloud read replica ─────────────────────
+#
+# Before this, a brand-new user finished setup with a working local node, no
+# replica, and no indication one existed — every step below was a separate,
+# undocumented manual procedure. This closes the six blockers a new install hits,
+# in the order it hits them: no cloud path in the installer; hand-writing the
+# writer env; the tenant-0 account default; the legacy base URL; replica reads
+# defaulting off; and the project never being enrolled.
+#
+# ⛔ NO-DEFAULT RULE FOR THE ACCOUNT. cloud-sync.mjs:125 and cloud-sync/launch.sh:68
+# both default CATALYST_CLOUD_ACCOUNT to "tenant-0" — Ryan's workspace. For an
+# external user that default silently points their host at somebody else's tenant.
+# With a per-tenant key it fails CLOSED (the mirror forces the account to match the
+# key), but the result is an opaque 403 with no hint about why. So when a cloud
+# token is supplied here, the account is REQUIRED and we fail loudly instead.
+#
+# ⚠️ WHAT THIS DELIBERATELY DOES NOT DO: it does not change those runtime defaults.
+# Measured on the live fleet — both minis' ~/.config/catalyst/cloud-sync.env is a
+# single line containing only the token, pinning NEITHER the account NOR the base
+# URL. Changing either default would repoint or break both running replica writers
+# the moment they restarted. New installs get explicit values written here; the
+# defaults are a separate, evidence-gathering change.
+setup_cloud_replica() {
+	# Flags win over env. Absent → this whole function is a no-op and setup is
+	# byte-identical to before CTL-1836.
+	local token="${CLOUD_TOKEN:-${CATALYST_CLOUD_TOKEN:-}}"
+	local account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT:-}}"
+	[[ -n $token ]] || return 0
+
+	print_header "Provisioning Catalyst Cloud Replica"
+
+	if [[ -z $account ]]; then
+		print_error "A cloud token was supplied without an account."
+		echo ""
+		echo "  Pass --cloud-account <id> (or set CATALYST_CLOUD_ACCOUNT)."
+		echo ""
+		echo "  There is no default on purpose. The writer's built-in fallback is"
+		echo "  'tenant-0', which is the Catalyst maintainer's own tenant — defaulting"
+		echo "  to it would point THIS host at somebody else's workspace. Your key"
+		echo "  would be refused with an opaque 403 and no explanation."
+		return 1
+	fi
+
+	local config_dir="$HOME/.config/catalyst"
+	local env_file="${config_dir}/cloud-sync.env"
+
+	harden_secrets_dir "$config_dir"
+	ensure_secrets_gitignore "$config_dir"
+
+	# The canonical host. cloud-sync.mjs:124 still defaults to the LEGACY
+	# api.catalyst-cloud.coalescelabs.ai, which is being retired, so a new user who
+	# relies on the default is pointed at a host that is going away. Pin it here.
+	local base_url="${CATALYST_CLOUD_BASE_URL:-https://app.catalystcloud.dev/api/v1}"
+
+	# launchd does not read ~/.zshenv, so the writer's credentials have to live in
+	# this file. Written 0600 BEFORE the secret lands in it — never world-readable,
+	# not even momentarily.
+	local tmp_env
+	tmp_env=$(mktemp)
+	chmod 600 "$tmp_env"
+	{
+		echo "# Written by setup-catalyst.sh (CTL-1836). Consumed by"
+		echo "# plugins/dev/scripts/execution-core/cloud-sync/launch.sh under launchd."
+		echo "CATALYST_CLOUD_TOKEN=${token}"
+		echo "CATALYST_CLOUD_ACCOUNT=${account}"
+		echo "CATALYST_CLOUD_BASE_URL=${base_url}"
+	} >"$tmp_env"
+	mv "$tmp_env" "$env_file"
+	chmod 600 "$env_file"
+	print_success "Wrote $env_file (0600) — account and base URL pinned explicitly"
+
+	# Adopt the writer. Optional by design: a host without the stack installed still
+	# gets a correct env file, and adopting later picks it up.
+	local stack
+	stack=$(command -v catalyst-stack 2>/dev/null || true)
+	if [[ -n $stack ]]; then
+		if "$stack" adopt-cloud-sync >/dev/null 2>&1; then
+			print_success "cloud-sync writer adopted (launchd agent installed)"
+		else
+			print_warning "catalyst-stack adopt-cloud-sync failed — run it by hand once the stack is installed"
+		fi
+	else
+		print_warning "catalyst-stack not on PATH — run 'catalyst-stack adopt-cloud-sync' after installing the stack"
+	fi
+
+	# A populated replica that nothing reads is the failure this step exists to
+	# avoid: reads are opt-in (CATALYST_LINEAR_REPLICA=on) and off by default.
+	print_warning "Replica READS are opt-in. Add to your shell env and restart execution-core:"
+	echo "    export CATALYST_LINEAR_REPLICA=on"
+
+	# Without a registry entry the daemon dispatches nothing — a running stack that
+	# does literally nothing, which looks identical to a broken one.
+	if [[ -n ${TICKET_PREFIX:-} ]]; then
+		echo ""
+		echo "  Enroll this project so the daemon has work to find:"
+		echo "    catalyst-execution-core register --team ${TICKET_PREFIX}"
+	else
+		echo ""
+		echo "  Enroll this project so the daemon has work to find:"
+		echo "    catalyst-execution-core register --team <TEAM_KEY>"
+	fi
+
+	return 0
+}
+
 setup_catalyst_secrets() {
 	print_header "Setting Up Catalyst Secrets"
 
@@ -2594,6 +2740,10 @@ main() {
 	setup_project_config
 	setup_humanlayer_config
 	setup_catalyst_secrets
+	# CTL-1836: no-op unless a cloud token was supplied. Placed after secrets so it
+	# can reuse the hardened ~/.config/catalyst dir, and before the Linear/state
+	# steps so a failure here stops setup before it reports success.
+	setup_cloud_replica || exit 1
 	update_config_with_linear_states
 	setup_execution_core_states
 	init_session_database


### PR DESCRIPTION
Closes CTL-1836. Gives `setup-catalyst.sh` a Catalyst Cloud path so a new user installs in one step instead of finishing setup with a working local node, no replica, and no indication one exists.

## The gap, measured

`setup-catalyst.sh` is **2628 lines** and contained **zero** references to any cloud token, account, cloud-sync, replica flag, or registry enrollment:

| grep | count |
| --- | --- |
| `CATALYST_CLOUD_TOKEN` / `_ACCOUNT` / any `CATALYST_CLOUD` | **0** |
| `cloud-sync` | **0** |
| `CATALYST_LINEAR_REPLICA` | **0** |
| `registry.json` / `register --team` | **0** |
| *control:* `LINEAR_API_TOKEN` | 3 |
| *control:* `SENTRY_AUTH_TOKEN` | 2 |

The controls matter — they prove the greps read the file, so the zeros are real absence rather than a broken search. (Also confirmed: **0** references to `sops` / `age` / `catalyst-cluster`, so a fresh install genuinely is not blocked on org secrets. That part of the ticket's "good news" holds.)

## What lands

`--cloud-token <tok>` / `--cloud-account <id>` (env `CATALYST_CLOUD_TOKEN` / `CATALYST_CLOUD_ACCOUNT`), closing the six blockers in the order a new user hits them: no cloud path → hand-written writer env → the tenant-0 default → the legacy base URL → replica reads off → project never enrolled.

**Absent, setup is byte-identical to before** — the function returns before touching anything, and that is mutation-verified, not asserted.

## ⛔ The account has no default, on purpose

`cloud-sync.mjs:125` and `cloud-sync/launch.sh:68` both default `CATALYST_CLOUD_ACCOUNT` to **`tenant-0`** — the maintainer's own tenant. An external user who omits the account would silently point their host at somebody else's workspace. With a per-tenant key that fails *closed* (the mirror forces the account to match the key), but it surfaces as an opaque 403 with no hint about why.

So a token supplied without an account is a **loud refusal** that explains the footgun, never a silent default.

## ⚠️ What this deliberately does NOT change

It does not touch those runtime defaults. Measured on the live fleet first:

> both minis' `~/.config/catalyst/cloud-sync.env` is a **single 87-byte line containing only the token** — pinning **neither** the account **nor** the base URL.

The running replica writers depend on both defaults. Changing either would repoint or break them on their next restart. New installs get explicit values written here; changing the defaults is a separate change that needs its own evidence (specifically: whether the canonical host accepts the existing fleet tokens). Flagging it rather than doing it quietly.

## Verification

15/15 passing, every guard mutation-verified RED:

| mutation | result |
| --- | --- |
| drop the account-required guard | **RED** (10 pass / 2 fail) |
| drop the no-token no-op guard | **RED** (11 / 1) |
| pin the LEGACY base URL instead | **RED** (11 / 1) |
| stop writing the account | **RED** (11 / 1) |

**One of my own assertions was vacuous, and is fixed rather than kept.** "cloud-sync.env is 0600" passed with **every** `chmod` removed — `mktemp` creates 0600 and `mv` preserves it, so the mode was right for free and the check could not fail. Case 5 now starts from a hostile pre-existing **0644** env file (with an explicit precondition assertion proving the 0644 was really established) and verifies it is tightened to 0600. Replacing the tmp+mv write with a direct append goes **RED (13 / 2)**, catching a credential left readable by every local user. The weak assertion is kept, with a comment stating it is not sufficient on its own, so nobody re-trusts it later.

Registered in `execution-core-tests.yml` (hand-enumerated — an unregistered test never runs); YAML re-validated as parsing, and the test re-run from the registered `working-directory`.

## Notes

- The token env-var *name* is configurable per CTL-1668 (`CATALYST_CLOUD_TOKEN_ENV` / Layer-2 `catalyst.cloud.tokenEnv`); the help text says so rather than implying the name is fixed.
- `adopt-cloud-sync` is optional by design: a host without the stack installed still gets a correct env file, and adopting later picks it up.
- Out of scope, unchanged from the ticket: the user still needs their own `LINEAR_API_TOKEN` for `linearis` writes, so "install with ONLY a cloud key" is not achievable from this ticket alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
