### PR TITLE
feat(dev): CTL-1805 — durable once-per-edge advancement idempotency guard

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -854,6 +854,7 @@ jobs:
             phantom-worker-dir.test.mjs \
             worker-dir-gc.test.mjs \
             in-flight-supersede.test.mjs \
+            advance-idempotency.test.mjs \
             boot-resume-approval.test.mjs \
             boot-resume.test.mjs \
             claim.test.mjs \

--- a/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-agent-dispatch.test.sh
@@ -2506,6 +2506,66 @@ assert_eq "yes" "$(case "$STATUS74B" in claim-lost|running|dispatched|idempotent
 assert_eq "no" "$LAUNCHED74B" "74: the racing twin launched NO second worker (no double-spawn)"
 assert_eq "$CLAIMS_BEFORE74" "$CLAIMS_AFTER74" "74: the twin won no additional generation (claim count unchanged)"
 
+# ─── CTL-1805 (A3): a lost single-flight claim is AUDIBLE ────────────────────
+# Before CTL-1805 the dispatcher's bow-out (`status:"claim-lost"` on stdout,
+# exit 0) was completely silent — no stderr, no log, no event. Across the 13
+# CTL-56 collisions in the RCA there were ZERO claim-lost events. The fix emits
+# exactly one `phase.dispatch.claim-lost.<TICKET>` at the single point the
+# collision is confirmed, carrying ticket, phase, and the contested generation.
+# Fail-open: the emit must never change the exit-0 / stdout contract.
+
+echo ""
+echo "Test 100 (CTL-1805 A3): a lost claim emits exactly one phase.dispatch.claim-lost.<TICKET> event"
+fresh_env t100_claim_lost_event
+# Isolate the events dir so we assert only on THIS dispatch's emissions.
+CL_EVENTS_DIR="${TEST_DIR}/events"
+mkdir -p "$CL_EVENTS_DIR"
+export CATALYST_EVENTS_DIR="$CL_EVENTS_DIR"
+# Pre-seed a YOUNG (within-grace, fresh mtime) held claim at gen 1 with NO signal
+# file — the fixed-target claim-lost path (mirrors Test 43): a fresh dispatch
+# targets gen 1, collides with the tombstone, and — because the claim is young
+# (mtime ~now) — does NOT reap it, so it bows out as claim-lost.
+printf '{"generation":1,"claimedAt":"2026-05-30T00:00:00Z"}\n' >"${WORKER_DIR}/triage.claim.1"
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC100=$?
+assert_eq "0" "$RC100" "100: claim-lost still exits 0 (contract preserved)"
+assert_eq "claim-lost" "$(echo "$STDOUT" | jq -r '.status')" "100: stdout status = claim-lost (contract preserved)"
+assert_eq "no" "$([[ -s $CLAUDE_STUB_LOG ]] && echo yes || echo no)" "100: no worker spawned"
+# The event log for the current month — canonical_jsonl_append writes YYYY-MM.jsonl.
+CL_MONTH_FILE="$(ls "${CL_EVENTS_DIR}"/*.jsonl 2>/dev/null | head -1)"
+assert_eq "yes" "$([[ -n "$CL_MONTH_FILE" && -s "$CL_MONTH_FILE" ]] && echo yes || echo no)" \
+	"100: an event line was appended to the events dir"
+# Exactly one line whose event.name is the claim-lost name for this ticket.
+CL_COUNT=$(jq -c 'select(.attributes["event.name"] == "phase.dispatch.claim-lost.CTL-100")' "$CL_MONTH_FILE" 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "1" "$CL_COUNT" "100: exactly one phase.dispatch.claim-lost.CTL-100 event emitted"
+# The line carries ticket, phase, and the contested generation.
+CL_LINE=$(jq -c 'select(.attributes["event.name"] == "phase.dispatch.claim-lost.CTL-100")' "$CL_MONTH_FILE" 2>/dev/null | head -1)
+assert_eq "triage" "$(echo "$CL_LINE" | jq -r '.body.payload.phase // .attributes["catalyst.phase"] // empty')" \
+	"100: event carries phase=triage"
+assert_eq "1" "$(echo "$CL_LINE" | jq -r '.body.payload.generation // empty')" \
+	"100: event carries generation=1 (the contested target)"
+unset CATALYST_EVENTS_DIR
+
+echo ""
+echo "Test 100b (CTL-1805 A3, POSITIVE CONTROL): a fresh no-collision dispatch emits ZERO claim-lost events"
+fresh_env t100b_claim_lost_control
+CL_EVENTS_DIR2="${TEST_DIR}/events"
+mkdir -p "$CL_EVENTS_DIR2"
+export CATALYST_EVENTS_DIR="$CL_EVENTS_DIR2"
+# No pre-seeded claim → a clean fresh dispatch that WINS its generation and spawns.
+STDOUT=$("$DISPATCH" --phase triage --ticket CTL-100 --orch-dir "$ORCH_DIR" --orch-id orch-test 2>/dev/null)
+RC100B=$?
+assert_eq "0" "$RC100B" "100b: fresh dispatch exits 0"
+assert_eq "running" "$(echo "$STDOUT" | jq -r '.status')" "100b: fresh dispatch status = running (won its claim)"
+# Positive control: the events dir must contain NO claim-lost line for this ticket.
+CL_MONTH_FILE2="$(ls "${CL_EVENTS_DIR2}"/*.jsonl 2>/dev/null | head -1)"
+CL_COUNT2=0
+if [[ -n "$CL_MONTH_FILE2" ]]; then
+	CL_COUNT2=$(jq -c 'select(.attributes["event.name"] == "phase.dispatch.claim-lost.CTL-100")' "$CL_MONTH_FILE2" 2>/dev/null | wc -l | tr -d ' ')
+fi
+assert_eq "0" "$CL_COUNT2" "100b: ZERO claim-lost events on a successful dispatch (positive control)"
+unset CATALYST_EVENTS_DIR
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "phase-agent-dispatch: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -63,6 +63,8 @@ const INLINE_EVENT_NAMES = [
   "phase.triage.linear-transition.CTL-1", // triage-transition-event.mjs:53
   "phase.advance.held.CTL-1",         // CTL-755 recovery.mjs defaultAppendPhaseAdvanceHeldEvent
   "phase.advance.applied.CTL-1",      // CTL-1789 recovery.mjs defaultAppendPhaseAdvanceAppliedEvent
+  "phase.advance.suppressed-duplicate.CTL-1", // CTL-1805 recovery.mjs defaultAppendPhaseAdvanceSuppressedEvent (idempotency guard)
+  "phase.dispatch.claim-lost.CTL-1",  // CTL-1805 phase-agent-dispatch bow-out (audible lost single-flight claim)
   "linear.state.write.CTL-1",         // linear-state-write-event.mjs:77
   "agent.waiting_on_user",            // wait-event.mjs:buildWaitEnvelope
   "agent.resumed",                    // wait-event.mjs:buildWaitEnvelope
@@ -190,6 +192,31 @@ describe("recovery.mjs dynamic phase-slot producers", () => {
     // The slot itself is a documented exception (used by both actions).
     expect(isAllowedPhaseSlot("advance")).toBe(true);
     expect(KNOWN_PHASES.includes("advance")).toBe(false);
+  });
+
+  // CTL-1805: the idempotency-guard's two new audit events join the same
+  // allowed-but-non-routing posture. `suppressed-duplicate` rides the "advance"
+  // exception slot; `claim-lost` rides the pre-existing "dispatch" exception
+  // slot. Neither action ("suppressed-duplicate" / "claim-lost") is in
+  // PHASE_EVENT_PATTERN's terminal-status alternation, so phaseSlotOf returns
+  // null → tryPhaseLifecycleRoute returns [] → pure audit, no wake (identical to
+  // the CTL-1789 applied-advance property above). This is load-bearing: an
+  // 8-tick-per-window suppression storm must NEVER become a wake storm.
+  test("CTL-1805: suppressed-duplicate + claim-lost are allowed but create NO routing match", () => {
+    const suppressedName = "phase.advance.suppressed-duplicate.CTL-1";
+    const claimLostName = "phase.dispatch.claim-lost.CTL-1";
+    for (const name of [suppressedName, claimLostName]) {
+      expect(isBrokerProtectedName(name), `${name} must not be broker-protected`).toBe(false);
+      expect(PHASE_EVENT_PATTERN.test(name), `${name} must not match the routing pattern`).toBe(
+        false
+      );
+      expect(phaseSlotOf(name), `${name} must not resolve to a routable phase slot`).toBeNull();
+    }
+    // Both exception slots are documented and non-canonical.
+    expect(isAllowedPhaseSlot("advance")).toBe(true);
+    expect(isAllowedPhaseSlot("dispatch")).toBe(true);
+    expect(KNOWN_PHASES.includes("advance")).toBe(false);
+    expect(KNOWN_PHASES.includes("dispatch")).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/advance-guard.mjs
+++ b/plugins/dev/scripts/execution-core/advance-guard.mjs
@@ -1,0 +1,120 @@
+// advance-guard.mjs — CTL-1805. A durable once-per-edge idempotency guard for the
+// execution-core scheduler's advancement chokepoint.
+//
+// THE BUG THIS CLOSES. The advancement sweep is a PURE re-derivation on every
+// tick with NO durable record that an edge was ever applied. So an unchanging
+// predecessor signal map re-fires the SAME phase edge forever — on mini
+// 2026-08-12 the monitor-merge→monitor-deploy edge for CTL-56 applied 13× in 55s,
+// each tick re-reading the same stale phase-monitor-merge.json and fanning out a
+// 5-event dispatch/advance/linear-write/transition/reap burst per replay. The 13
+// fabricated advances were harmless ONLY because of an unrelated Linear guard
+// (skipped-terminal-no-backward); on a not-yet-terminal ticket all 13 would have
+// applied as backward state moves.
+//
+// THE FIX. Make an applied advance a FACT ON DISK, not a re-derivation. Before
+// dispatching the FSM-owed next phase, compute an edge key from the PREDECESSOR'S
+// IDENTITY — (ticket, from, to, predecessor_generation, predecessor_updatedAt) —
+// and suppress the whole fanout iff a marker already records a byte-identical key.
+// Keying on predecessor identity (not the bare edge) is load-bearing: a LEGITIMATE
+// re-advance (a CTL-1660 backward re-dispatch with a newer predecessor generation,
+// a CTL-653 verify⇄remediate re-entry at a new remediate generation) presents a
+// DIFFERENT key → not suppressed → marker overwritten. Only an unchanged-input
+// replay is suppressed.
+//
+// FAIL DIRECTION. Every read is fail-OPEN toward ALLOWING the advance: an
+// unreadable/absent/parse-broken marker returns "not yet applied", because a guard
+// that cannot read its own marker must never wedge the pipeline — the worst case
+// without any guard is the pre-CTL-1805 status quo (a replay), never a stall. The
+// write is best-effort: a failed marker write leaves the next duplicate merely
+// unsuppressed (status quo), never worse.
+//
+// ZERO-IMPORT LEAF (only node:fs / node:path), so scheduler.mjs and the CI-stable
+// advance-idempotency.test.mjs both import it without dragging in config.mjs's
+// bun:sqlite graph — same discipline as assertion-evidence.mjs / secret-contract.mjs.
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+// A field rendered explicitly so a missing value NEVER silently equals another.
+// `∅` (not the empty string) so a literal "" and an absent field stay distinct.
+const NULL_TOKEN = "∅";
+function renderField(v) {
+  if (v === undefined || v === null) return NULL_TOKEN;
+  const s = String(v);
+  return s.length === 0 ? NULL_TOKEN : s;
+}
+
+// computeAdvanceEdgeKey — a stable string from the edge PLUS the predecessor's
+// identity. `predRaw` is the predecessor phase's raw signal object (from
+// readPhaseSignalRaw, or the pre-reset remediateRaw for the remediate-detour
+// edge); null/undefined is tolerated (its generation/updatedAt render as ∅).
+export function computeAdvanceEdgeKey({ ticket, from, to, predRaw }) {
+  const generation = predRaw == null ? null : predRaw.generation;
+  const updatedAt = predRaw == null ? null : predRaw.updatedAt;
+  return [
+    renderField(ticket),
+    renderField(from),
+    renderField(to),
+    renderField(generation),
+    renderField(updatedAt),
+  ].join("|");
+}
+
+// advanceMarkerPath — one dotfile per (from,to) edge under the worker dir. The
+// name matches NONE of the tree's phase-*.json signal globs, so it is never read
+// as a phase signal (verified: no isPhaseSignalName / workerDirHasPhaseSignals
+// change needed).
+export function advanceMarkerPath(orchDir, ticket, from, to) {
+  return join(
+    orchDir,
+    "workers",
+    ticket,
+    `.advance-${renderField(from)}-to-${renderField(to)}.applied`
+  );
+}
+
+// isAdvanceAlreadyApplied — true IFF the marker exists AND its stored key is
+// byte-identical to `key`. Absent / unreadable / parse-broken / key-mismatch →
+// false (fail-open toward allowing the advance). A DIFFERING key (newer
+// predecessor generation/updatedAt, e.g. across a remediation cycle) is a
+// different edge instance → false → the advance proceeds and the marker is
+// overwritten by recordAdvanceApplied.
+export function isAdvanceAlreadyApplied(orchDir, ticket, from, to, key, deps = {}) {
+  const read = deps.readFileSync ?? readFileSync;
+  const path = advanceMarkerPath(orchDir, ticket, from, to);
+  let raw;
+  try {
+    raw = read(path, "utf8");
+  } catch {
+    return false; // absent or unreadable — allow (fail-open)
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return false; // corrupt marker — allow (fail-open)
+  }
+  return parsed != null && parsed.key === key;
+}
+
+// recordAdvanceApplied — atomic tmp+rename write of { key, from, to, appliedAt }.
+// rename OVERWRITES any stale-key marker (deliberately NOT O_EXCL — a differing
+// key must be replaced, e.g. across remediation cycles). Best-effort: on a write
+// failure it swallows and returns false (the next duplicate is at worst not
+// suppressed — status quo, never worse). Never throws.
+export function recordAdvanceApplied(orchDir, ticket, from, to, key, deps = {}) {
+  const write = deps.writeFileSync ?? writeFileSync;
+  const rename = deps.renameSync ?? renameSync;
+  const mkdir = deps.mkdirSync ?? mkdirSync;
+  const nowIso = deps.nowIso ?? (() => new Date().toISOString());
+  const path = advanceMarkerPath(orchDir, ticket, from, to);
+  try {
+    mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp.${process.pid}`;
+    write(tmp, JSON.stringify({ key, from: from ?? null, to: to ?? null, appliedAt: nowIso() }));
+    rename(tmp, path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/advance-idempotency.test.mjs
+++ b/plugins/dev/scripts/execution-core/advance-idempotency.test.mjs
@@ -1,0 +1,268 @@
+// advance-idempotency.test.mjs — CTL-1805.
+//
+// The CI-STABLE proof of the advancement idempotency guard (A1) plus a distilled
+// assertion of the A2 SDK-`done`-prelaunch no-op contract. The rich 13-tick CTL-56
+// reproduction that drives the real schedulerTick lives in scheduler.test.mjs (the
+// real-timer harness), which is deliberately EXCLUDED from CI for debounced-tick
+// flakiness — so the load-bearing invariants that MUST fail CI on a regression are
+// mirrored here as pure, deterministic helper + contract tests. Same discipline as
+// in-flight-supersede.test.mjs / phantom-worker-dir.test.mjs.
+//
+// CI-INCLUDED (registered in .github/workflows/execution-core-tests.yml).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test advance-idempotency.test.mjs
+
+import { afterAll, describe, test, expect } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  computeAdvanceEdgeKey,
+  advanceMarkerPath,
+  isAdvanceAlreadyApplied,
+  recordAdvanceApplied,
+} from "./advance-guard.mjs";
+import { verifyDispatchedSignal, NOOP_DONE_PRELAUNCH } from "./scheduler.mjs";
+
+const tmpDirs = [];
+function freshOrchDir() {
+  const d = mkdtempSync(join(tmpdir(), "ctl1805-advguard-"));
+  tmpDirs.push(d);
+  mkdirSync(join(d, "workers", "CTL-56"), { recursive: true });
+  return d;
+}
+afterAll(() => {
+  for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+});
+
+// ─── computeAdvanceEdgeKey — keyed on the PREDECESSOR'S IDENTITY, not the bare edge ───
+describe("computeAdvanceEdgeKey", () => {
+  const base = {
+    ticket: "CTL-56",
+    from: "monitor-merge",
+    to: "monitor-deploy",
+    predRaw: { generation: 1, updatedAt: "2026-08-12T05:18:36Z" },
+  };
+
+  test("is stable (byte-identical) for identical inputs — the replay case", () => {
+    expect(computeAdvanceEdgeKey(base)).toBe(computeAdvanceEdgeKey({ ...base }));
+  });
+
+  test("DIFFERS when the predecessor generation differs — a legitimate re-advance", () => {
+    const bumped = { ...base, predRaw: { ...base.predRaw, generation: 2 } };
+    expect(computeAdvanceEdgeKey(bumped)).not.toBe(computeAdvanceEdgeKey(base));
+  });
+
+  test("DIFFERS when the predecessor updatedAt differs", () => {
+    const restamped = { ...base, predRaw: { ...base.predRaw, updatedAt: "2026-08-12T05:19:00Z" } };
+    expect(computeAdvanceEdgeKey(restamped)).not.toBe(computeAdvanceEdgeKey(base));
+  });
+
+  test("DIFFERS on the edge itself (from/to), not only the predecessor", () => {
+    expect(computeAdvanceEdgeKey({ ...base, to: "teardown" })).not.toBe(
+      computeAdvanceEdgeKey(base)
+    );
+    expect(computeAdvanceEdgeKey({ ...base, from: "pr" })).not.toBe(computeAdvanceEdgeKey(base));
+  });
+
+  test('null/undefined/empty fields render DISTINCTLY — no null==undefined=="" collision', () => {
+    const nullGen = computeAdvanceEdgeKey({
+      ...base,
+      predRaw: { generation: null, updatedAt: "x" },
+    });
+    const undefGen = computeAdvanceEdgeKey({ ...base, predRaw: { updatedAt: "x" } });
+    const nullPred = computeAdvanceEdgeKey({ ...base, predRaw: null });
+    // null and undefined generation both render as the explicit ∅ token — the
+    // guard treats "no generation recorded" as one identity, not two.
+    expect(nullGen).toBe(undefGen);
+    // But an EMPTY-string field must never collapse into a populated one.
+    const emptyUpdatedAt = computeAdvanceEdgeKey({
+      ...base,
+      predRaw: { generation: 1, updatedAt: "" },
+    });
+    const realUpdatedAt = computeAdvanceEdgeKey({
+      ...base,
+      predRaw: { generation: 1, updatedAt: "2026-08-12T05:18:36Z" },
+    });
+    expect(emptyUpdatedAt).not.toBe(realUpdatedAt);
+    // A wholly-absent predecessor is distinct from an edge with a real one.
+    expect(nullPred).not.toBe(computeAdvanceEdgeKey(base));
+  });
+});
+
+// ─── isAdvanceAlreadyApplied / recordAdvanceApplied — the durable marker round-trip ───
+describe("advance marker round-trip", () => {
+  const T = "CTL-56";
+  const FROM = "monitor-merge";
+  const TO = "monitor-deploy";
+  const KEY = "CTL-56|monitor-merge|monitor-deploy|1|2026-08-12T05:18:36Z";
+
+  test("absent marker → false (fail-open toward allowing the advance)", () => {
+    const orchDir = freshOrchDir();
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY)).toBe(false);
+  });
+
+  test("after record → true for the SAME key", () => {
+    const orchDir = freshOrchDir();
+    expect(recordAdvanceApplied(orchDir, T, FROM, TO, KEY)).toBe(true);
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY)).toBe(true);
+  });
+
+  test("after record → false for a DIFFERENT key (stale marker does not suppress)", () => {
+    const orchDir = freshOrchDir();
+    recordAdvanceApplied(orchDir, T, FROM, TO, KEY);
+    const bumpedKey = "CTL-56|monitor-merge|monitor-deploy|2|2026-08-12T05:20:00Z";
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, bumpedKey)).toBe(false);
+  });
+
+  test("re-record OVERWRITES the marker to the new key (rename, not O_EXCL)", () => {
+    const orchDir = freshOrchDir();
+    recordAdvanceApplied(orchDir, T, FROM, TO, KEY);
+    const newKey = "CTL-56|monitor-merge|monitor-deploy|2|2026-08-12T05:20:00Z";
+    expect(recordAdvanceApplied(orchDir, T, FROM, TO, newKey)).toBe(true);
+    // old key no longer matches; new key does.
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY)).toBe(false);
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, newKey)).toBe(true);
+  });
+
+  test("marker payload carries key/from/to/appliedAt", () => {
+    const orchDir = freshOrchDir();
+    recordAdvanceApplied(orchDir, T, FROM, TO, KEY);
+    const parsed = JSON.parse(readFileSync(advanceMarkerPath(orchDir, T, FROM, TO), "utf8"));
+    expect(parsed.key).toBe(KEY);
+    expect(parsed.from).toBe(FROM);
+    expect(parsed.to).toBe(TO);
+    expect(typeof parsed.appliedAt).toBe("string");
+  });
+
+  test("corrupt (non-JSON) marker → false (fail-open)", () => {
+    const orchDir = freshOrchDir();
+    writeFileSync(advanceMarkerPath(orchDir, T, FROM, TO), "{not json");
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY)).toBe(false);
+  });
+
+  test("unreadable marker (read throws) → false (fail-open)", () => {
+    const orchDir = freshOrchDir();
+    const throwingRead = () => {
+      throw new Error("EIO");
+    };
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY, { readFileSync: throwingRead })).toBe(
+      false
+    );
+  });
+
+  test("record write failure → false, never throws (best-effort)", () => {
+    const orchDir = freshOrchDir();
+    const throwingWrite = () => {
+      throw new Error("ENOSPC");
+    };
+    expect(recordAdvanceApplied(orchDir, T, FROM, TO, KEY, { writeFileSync: throwingWrite })).toBe(
+      false
+    );
+    // and the guard still reports not-applied (no marker landed).
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, KEY)).toBe(false);
+  });
+});
+
+// ─── Helper-level suppression: the exact discriminator the sweep relies on ───
+describe("guard suppression discriminates a replay from a legitimate re-advance", () => {
+  const T = "CTL-56";
+  const FROM = "monitor-merge";
+  const TO = "monitor-deploy";
+  const predV1 = { generation: 1, updatedAt: "2026-08-12T05:18:36Z" };
+
+  test("an UNCHANGED predecessor re-firing the same edge is suppressed", () => {
+    const orchDir = freshOrchDir();
+    const key = computeAdvanceEdgeKey({ ticket: T, from: FROM, to: TO, predRaw: predV1 });
+    recordAdvanceApplied(orchDir, T, FROM, TO, key);
+    // second tick, same on-disk predecessor → same key → suppressed.
+    const key2 = computeAdvanceEdgeKey({ ticket: T, from: FROM, to: TO, predRaw: predV1 });
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, key2)).toBe(true);
+  });
+
+  test("a BUMPED predecessor generation is NOT suppressed (backward re-dispatch)", () => {
+    const orchDir = freshOrchDir();
+    const key = computeAdvanceEdgeKey({ ticket: T, from: FROM, to: TO, predRaw: predV1 });
+    recordAdvanceApplied(orchDir, T, FROM, TO, key);
+    const predV2 = { generation: 2, updatedAt: "2026-08-12T06:00:00Z" };
+    const key2 = computeAdvanceEdgeKey({ ticket: T, from: FROM, to: TO, predRaw: predV2 });
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, key2)).toBe(false);
+  });
+});
+
+// ─── Remediate-cycle disambiguation — proves NO REMEDIATE_CYCLE_FILES change needed ───
+describe("verify⇄remediate re-entry: each cycle re-earns its advance", () => {
+  test("two remediate→verify re-entries at generations 1 and 2 produce DIFFERENT keys", () => {
+    const orchDir = freshOrchDir();
+    const T = "CTL-56";
+    const FROM = "remediate";
+    const TO = "verify";
+    // cycle 1: remediate gen 1 done → verify re-dispatched, marker recorded.
+    const cycle1 = computeAdvanceEdgeKey({
+      ticket: T,
+      from: FROM,
+      to: TO,
+      predRaw: { generation: 1, updatedAt: "2026-08-12T05:00:00Z" },
+    });
+    recordAdvanceApplied(orchDir, T, FROM, TO, cycle1);
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, cycle1)).toBe(true);
+
+    // cycle 2: verify failed again, remediate gen 2 done → a DIFFERENT predecessor
+    // identity reusing the SAME .advance-remediate-to-verify.applied filename. It
+    // must NOT be suppressed — the guard keys on predecessor identity, not the
+    // edge alone, so no REMEDIATE_CYCLE_FILES entry is required.
+    const cycle2 = computeAdvanceEdgeKey({
+      ticket: T,
+      from: FROM,
+      to: TO,
+      predRaw: { generation: 2, updatedAt: "2026-08-12T05:30:00Z" },
+    });
+    expect(isAdvanceAlreadyApplied(orchDir, T, FROM, TO, cycle2)).toBe(false);
+  });
+});
+
+// ─── A2: SDK `done` prelaunch is a non-success NO-OP (distilled CI-stable mirror) ───
+// The rich version lives in scheduler.test.mjs's verifyDispatchedSignal block; this
+// is the assertion CI actually enforces, since scheduler.test.mjs is CI-excluded.
+describe("verifyDispatchedSignal — SDK `done` prelaunch is a no-op, not a launch (A2)", () => {
+  function writeSignal(orchDir, ticket, status) {
+    const dir = join(orchDir, "workers", ticket);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket, phase: "research", status, bg_job_id: null })
+    );
+  }
+
+  test("requireBgJob:false + `done` → { ok:false, reason:noop_done_prelaunch, noop:true }", () => {
+    const orchDir = freshOrchDir();
+    writeSignal(orchDir, "CTL-105", "done");
+    expect(verifyDispatchedSignal(orchDir, "CTL-105", "research", { requireBgJob: false })).toEqual(
+      {
+        ok: false,
+        reason: NOOP_DONE_PRELAUNCH,
+        noop: true,
+      }
+    );
+  });
+
+  test("requireBgJob:false + in-flight (dispatched/running) stays ok:true (no demotion)", () => {
+    const orchDir = freshOrchDir();
+    for (const status of ["dispatched", "running"]) {
+      const id = `CTL-105-${status}`;
+      writeSignal(orchDir, id, status);
+      const v = verifyDispatchedSignal(orchDir, id, "research", { requireBgJob: false });
+      expect(v).toEqual({ ok: true });
+      expect(v.noop).toBeUndefined();
+    }
+  });
+
+  test("requireBgJob:true + `done` stays status_not_runnable (bg path unchanged)", () => {
+    const orchDir = freshOrchDir();
+    writeSignal(orchDir, "CTL-105-bg", "done");
+    expect(verifyDispatchedSignal(orchDir, "CTL-105-bg", "research")).toEqual({
+      ok: false,
+      reason: "status_not_runnable",
+    });
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -1328,6 +1328,55 @@ export function defaultAppendPhaseAdvanceAppliedEvent({
   );
 }
 
+// CTL-1805: the SUPPRESSED-duplicate advance event —
+// phase.advance.suppressed-duplicate.<ticket>.
+//
+// The advancement sweep is a pure re-derivation on every tick with no durable
+// record that an edge was ever applied, so an unchanging predecessor signal
+// re-fires the same edge forever (on mini 2026-08-12 the monitor-merge→
+// monitor-deploy edge for CTL-56 applied 13× in 55s). The CTL-1805 idempotency
+// guard suppresses every replay after the first by keying on the predecessor's
+// identity (ticket|from|to|generation|updatedAt). This event is the CANARY the
+// RCA wanted: a bounded blast radius that is now VISIBLE instead of discovered
+// by accident from an 8-hour-retention log.
+//
+// WARN severity (deliberately, mirroring `held`): a suppressed duplicate is not
+// the system working — it is an input that stopped changing while the sweep kept
+// firing, worth an operator's attention. Emitted at most once per throttle window
+// per (ticket,from,to) edge so a wedged input can't flood the log.
+//
+// `from`/`to`/`edge_key` promoted to attributes because otel-forward strips
+// body.payload off-machine (from/to are bounded enums; edge_key is a bounded
+// per-ticket-lifetime string — no Loki cardinality risk at fleet scale). Same
+// "advance" phase slot as `held`/`applied`, so the namespace-parity source-scan
+// + hardcoded-slot snapshot ({advance,dispatch,scheduler}) stay unchanged, and
+// the action ("suppressed-duplicate") is outside PHASE_EVENT_PATTERN's
+// terminal-status alternation → pure audit, no wake.
+export function defaultAppendPhaseAdvanceSuppressedEvent({ orchId, ticket, from, to, edgeKey }) {
+  return appendEnvelopeBestEffort(
+    buildEventEnvelope({
+      phase: "advance",
+      ticket,
+      orchId,
+      action: "suppressed-duplicate",
+      severityText: "WARN",
+      severityNumber: 13,
+      reason: "duplicate-edge",
+      payloadExtras: {
+        from: from ?? null,
+        to: to ?? null,
+        edge_key: edgeKey ?? null,
+      },
+      attrExtras: {
+        "catalyst.advance.from": from ?? undefined,
+        "catalyst.advance.to": to ?? undefined,
+        "catalyst.advance.edge_key": edgeKey ?? undefined,
+      },
+    }),
+    "advance-suppressed-duplicate"
+  );
+}
+
 // CTL-713: cooldown GC event — phase.scheduler.cooldown-gc.<ticket>.
 // Emitted once per reaped cooldown marker so GC activity is queryable from the
 // unified event log.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -72,6 +72,11 @@ export { EMPTY_WORKER_DIR_GRACE_DEFAULT_MS };
 // the sweep and are injected, so the router itself is unit-testable.
 import { readVerifyVerdict } from "./work-done-probes.mjs";
 import { explainAdvanceEvidence } from "./assertion-evidence.mjs"; // CTL-1789: from-phase terminal attribution
+import {
+  computeAdvanceEdgeKey,
+  isAdvanceAlreadyApplied,
+  recordAdvanceApplied,
+} from "./advance-guard.mjs"; // CTL-1805: durable once-per-edge advancement idempotency guard
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
@@ -216,6 +221,7 @@ import {
   defaultAppendCooldownEscalatedEvent,
   defaultAppendPhaseAdvanceHeldEvent,
   defaultAppendPhaseAdvanceAppliedEvent, // CTL-1789: the positive half of the advancement gate
+  defaultAppendPhaseAdvanceSuppressedEvent, // CTL-1805: the idempotency-guard's suppressed-duplicate canary
   defaultAppendRunawayEvent,
   defaultAppendOrphanDetectedEvent,
 } from "./recovery.mjs";
@@ -3287,6 +3293,11 @@ export function readDispatchFailureReason(orchDir, ticket, phase) {
 // (the SDK path — see settleDispatchSync), leaving bg verification (the default,
 // requireBgJob:true) byte-identical. For the SDK path `done` is also a runnable
 // terminal state (an idempotent duplicate dispatch of an already-completed phase).
+// CTL-1805 (A2): the reason string for the idempotent SDK `done` prelaunch no-op.
+// Named (not a bare literal) so it stays greppable alongside the other
+// verifyDispatchedSignal reasons and is referenced identically at the call site.
+export const NOOP_DONE_PRELAUNCH = "noop_done_prelaunch";
+
 export function verifyDispatchedSignal(orchDir, ticket, phase, { requireBgJob = true } = {}) {
   const signalPath = join(orchDir, "workers", ticket, `phase-${phase}.json`);
   let raw;
@@ -3312,17 +3323,32 @@ export function verifyDispatchedSignal(orchDir, ticket, phase, { requireBgJob = 
     return { ok: false, reason: "signal_unparseable" };
   }
   const status = signal?.status;
+  // CTL-1805 (A2): an SDK (requireBgJob:false) dispatch of an already-`done`
+  // phase is NOT a launch — the worker never ran; the signal was already
+  // terminal. Before this fix `done` was folded into `runnable` on the SDK path
+  // and returned {ok:true}, which the call site read as a successful launch: it
+  // cleared the failure-only cooldown (re-arming the loop every tick) and emitted
+  // a phase.dispatch.launched with bg_job_id:null. Classify it as a distinct
+  // NON-success, NON-failure no-op so the caller neither clears nor writes the
+  // cooldown — this is the fuel the CTL-56 re-advance loop ran on.
+  if (requireBgJob === false && status === "done") {
+    return { ok: false, reason: NOOP_DONE_PRELAUNCH, noop: true };
+  }
   // CTL-1854: awaiting-work is runnable — a worker that dispatched and immediately
-  // declared a bounded wait has not failed to dispatch.
-  // CTL-1854: YIELDED_STATUS belongs on BOTH branches. Round 10 added it only to
-  // the bg branch, so an in-process (SDK/codex) retry against an already-yielded
-  // phase reported `status_not_runnable` and recorded a FALSE dispatch failure +
-  // cooldown — while dispatch.mjs's sdkSignalRunnable accepted the same signal.
-  // Two verifiers disagreeing about one lifecycle is how a phase gets punished for
-  // a state it correctly declared.
-  const runnable = requireBgJob
-    ? status === "dispatched" || status === "running" || status === YIELDED_STATUS
-    : status === "dispatched" || status === "running" || status === "done" || status === YIELDED_STATUS;
+  // declared a bounded wait has not failed to dispatch. YIELDED_STATUS belongs on
+  // BOTH paths: round 10 added it only to the bg branch, so an in-process
+  // (SDK/codex) retry against an already-yielded phase reported
+  // `status_not_runnable` and recorded a FALSE dispatch failure + cooldown — while
+  // dispatch.mjs's sdkSignalRunnable accepted the same signal. Two verifiers
+  // disagreeing about one lifecycle is how a phase gets punished for a state it
+  // correctly declared.
+  //
+  // Rebase note (CTL-1805 × CTL-1854): CTL-1854's SDK branch also listed `done` as
+  // runnable. The A2 guard above now returns before `done` can reach here on the
+  // SDK path, and `done` was never runnable on the bg path — so the two branches
+  // became identical and collapse to one expression. Both intents are preserved:
+  // SDK `done` is a no-op (A2), YIELDED_STATUS is runnable everywhere (CTL-1854).
+  const runnable = status === "dispatched" || status === "running" || status === YIELDED_STATUS;
   if (!runnable) {
     return { ok: false, reason: "status_not_runnable" };
   }
@@ -4532,6 +4558,10 @@ export function schedulerTick(
     // the advancement gate must not stay refusal-only on any host that forgets to
     // wire it. Tests inject a spy.
     appendPhaseAdvanceAppliedEvent = defaultAppendPhaseAdvanceAppliedEvent,
+    // CTL-1805: suppressed-duplicate audit emitter — phase.advance.suppressed-duplicate.<ticket>.
+    // Best-effort, at most once per throttle window per (ticket,from,to) edge. The
+    // idempotency guard's canary. Default-on; tests inject a spy.
+    appendPhaseAdvanceSuppressedEvent = defaultAppendPhaseAdvanceSuppressedEvent,
     // CTL-757: canonical linear.state.write audit emitter, injectable for tests.
     // Caller-emitted at the 4 scheduler write sites (scheduler-advance,
     // preemption-resume, terminal-sweep, reconcile-backstop) via the emitStateWrite
@@ -5067,6 +5097,18 @@ export function schedulerTick(
       // the SDK prelaunch signal has no bg_job_id, so the async path must not
       // require one.
       const v = verifyDispatched(orchDir, ticket, phase, { requireBgJob: !dispatchWasAsync });
+      // CTL-1805 (A2): an SDK dispatch of an already-`done` phase is an idempotent
+      // NO-OP, not a launch and not a failure. Short-circuit BEFORE the v.ok /
+      // failure ladder so we neither clear the cooldown (which re-armed the CTL-56
+      // re-advance loop every tick) nor emit a phase.dispatch.launched with
+      // bg_job_id:null nor record a dispatch failure (which would spuriously trip
+      // the circuit breaker / escalation ladder). The edge simply does not advance
+      // this tick — the loop's fuel is removed. The advancement sweep's caller
+      // treats a non-ok result as "did not advance" and (in its else branch) only
+      // reaps the predecessor, which is acceptable for a no-op.
+      if (v.noop === true) {
+        return { ok: false, noop: true, code: 0, reason: v.reason ?? NOOP_DONE_PRELAUNCH, signal: null };
+      }
       if (v.ok) {
         clearDispatchCooldown(orchDir, ticket, phase); // CTL-624: success clears any prior cool-down
         // CTL-660: record the VERIFIED launch. Re-read the signal for the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5107,7 +5107,13 @@ export function schedulerTick(
       // treats a non-ok result as "did not advance" and (in its else branch) only
       // reaps the predecessor, which is acceptable for a no-op.
       if (v.noop === true) {
-        return { ok: false, noop: true, code: 0, reason: v.reason ?? NOOP_DONE_PRELAUNCH, signal: null };
+        return {
+          ok: false,
+          noop: true,
+          code: 0,
+          reason: v.reason ?? NOOP_DONE_PRELAUNCH,
+          signal: null,
+        };
       }
       if (v.ok) {
         clearDispatchCooldown(orchDir, ticket, phase); // CTL-624: success clears any prior cool-down
@@ -7387,6 +7393,12 @@ export function schedulerTick(
   // CTL-705: preempted workers are skipped — their active status is not "done" so
   // deriveAdvancement returns null, but an early continue makes the intent explicit
   // and provides a regression anchor (test 9 in the plan).
+  //
+  // CTL-1805 (A1): the durable once-per-edge idempotency guard's on/off switch,
+  // read ONCE per tick so a test (and an operator) can flip process.env between
+  // schedulerTick calls. Default ON (enforce); "off" restores the exact pre-fix
+  // unbounded-replay behavior — the mechanism behind the positive control.
+  const advanceGuardEnabled = process.env.CATALYST_ADVANCE_GUARD !== "off";
   const advanced = [];
   for (const ticket of listInFlightTickets(orchDir)) {
     // Skip parked (preempted) tickets — they re-enter via the resume sweep (1.5).
@@ -7427,6 +7439,64 @@ export function schedulerTick(
       remediateCycleCount: cycleCount,
     });
     if (!next) continue;
+
+    // CTL-1805 (A1): resolve the PREDECESSOR IDENTITY and the edge key ONCE, here
+    // — hoisted out of the dv.ok branch below so BOTH the idempotency guard
+    // (check-before-dispatch, immediately after) and the CTL-1789 applied-event
+    // emit (reused verbatim on success) key off the SAME predecessor rather than
+    // computing it twice. The remediate-detour handling is the CTL-1789 round-1
+    // P1 fix, preserved: a remediation re-entry's `from` is `remediate`, resolved
+    // from the PRE-reset snapshot (maybeResetForRemediateCycle already deleted
+    // phase-remediate.json above) via the SAME resolveReapPredecessor the reap
+    // path uses, so the guard key, the applied-event `from`, and the reaped
+    // worker are always the same phase; every other edge is the FSM's own input
+    // via latestLivePhase.
+    const advanceDetour = resolveReapPredecessor(preResetSignals, next);
+    const fromPhase =
+      advanceDetour?.phase === REMEDIATE_PHASE ? REMEDIATE_PHASE : latestLivePhase(signals);
+    const fromRaw = fromPhase
+      ? fromPhase === REMEDIATE_PHASE
+        ? // the reset already deleted the file — remediateRaw is the pre-reset capture
+          (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, fromPhase))
+        : readPhaseSignalRaw(orchDir, ticket, fromPhase)
+      : null;
+    const advanceEdgeKey = computeAdvanceEdgeKey({
+      ticket,
+      from: fromPhase,
+      to: next,
+      predRaw: fromRaw,
+    });
+
+    // CTL-1805 (A1): durable once-per-edge idempotency guard. If this exact edge
+    // — the SAME predecessor identity (ticket|from|to|generation|updatedAt) —
+    // already applied, suppress the ENTIRE fanout (no dispatch, no
+    // linear.state.write, no worker.transition, no predecessor reap) and emit at
+    // most one throttled canary per (ticket,from,to) edge per window. A LEGITIMATE
+    // re-advance (a CTL-1660 backward re-dispatch at a newer predecessor
+    // generation, a CTL-653 verify⇄remediate re-entry at a new remediate
+    // generation) presents a DIFFERENT key → not suppressed → the marker is
+    // overwritten on success below. This is the check-before-dispatch half; the
+    // write-after-success half is recordAdvanceApplied in the dv.ok branch.
+    if (
+      advanceGuardEnabled &&
+      isAdvanceAlreadyApplied(orchDir, ticket, fromPhase, next, advanceEdgeKey)
+    ) {
+      const suppressKey = `${ticket}|${fromPhase}|${next}`;
+      const lastSuppressEmit = lastAdvanceSuppressEmit.get(suppressKey);
+      if (
+        lastSuppressEmit === undefined ||
+        now() - lastSuppressEmit >= ADVANCE_SUPPRESS_WINDOW_MS
+      ) {
+        lastAdvanceSuppressEmit.set(suppressKey, now());
+        safeEmit(
+          appendPhaseAdvanceSuppressedEvent,
+          { orchId: ticket, ticket, from: fromPhase, to: next, edgeKey: advanceEdgeKey },
+          { ticket, phase: "advance" }
+        );
+      }
+      continue;
+    }
+
     // (STEP B) CTL-755 admission gate — hold the triage→research promotion unless
     // STEP A admitted this ticket (deps terminal + won priority/capacity). Soft
     // hold: no dispatch → applyPhaseStatus(research)/applyEstimate never fire, the
@@ -7460,9 +7530,14 @@ export function schedulerTick(
       // true and verified — dispatchAndVerify has already confirmed a live
       // successor worker. Emit the positive half of the advancement gate.
       //
-      // `from` is re-derived with latestLivePhase from the SAME post-sanitize map
-      // deriveAdvancement consumed above, so the audit names the FSM's actual
-      // input rather than a second, independently-guessed predecessor.
+      // `from`/`fromRaw` were resolved ONCE above (hoisted for the CTL-1805
+      // idempotency guard) from the SAME post-sanitize map deriveAdvancement
+      // consumed — including the CTL-1789 round-1 P1 remediate-detour fix (a
+      // remediation re-entry's `from` is `remediate`, resolved from the pre-reset
+      // snapshot via resolveReapPredecessor rather than latestLivePhase, which
+      // scans PHASES and can never return the ANCILLARY `remediate`). So the
+      // audit names the FSM's actual input, and the applied-event `from`, the
+      // guard key, and the reaped worker are always the same phase.
       //
       // `evidence` classifies WHO wrote that from-phase's terminal: the agent's
       // own wrapper (declared) vs an infrastructure flip/reclaim (fabricated) vs
@@ -7474,29 +7549,6 @@ export function schedulerTick(
       // so the first pipeline pass after deploy reads `absent` /
       // evidence_reason="no-marker". Do not alarm on `absent` until a full ticket
       // has cycled through.
-      //
-      // REMEDIATE DETOUR (CTL-1789 round-1 P1, Codex): latestLivePhase scans
-      // PHASES, and `remediate` is an ANCILLARY phase (∉ PHASES) — so it can
-      // NEVER return `remediate`, whether or not the signal still exists. On
-      // top of that, maybeResetForRemediateCycle deleted phase-remediate.json
-      // above, before `signals` was even read. Left alone, every remediation
-      // re-entry therefore reported `from=implement` and classified its
-      // evidence off the long-finished implement signal — laundering a
-      // FABRICATED remediation terminal into a DECLARED one, corrupting the
-      // exact metric this event exists to produce. Resolve that one edge from
-      // the SAME pre-reset snapshot and the SAME resolver the predecessor-reap
-      // path uses (resolveReapPredecessor), so the audit's `from` and the
-      // reaped worker can never be two different phases for one advance. Every
-      // other edge stays on latestLivePhase — the FSM's own input.
-      const detour = resolveReapPredecessor(preResetSignals, next);
-      const fromPhase =
-        detour?.phase === REMEDIATE_PHASE ? REMEDIATE_PHASE : latestLivePhase(signals);
-      const fromRaw = fromPhase
-        ? fromPhase === REMEDIATE_PHASE
-          ? // the reset already deleted the file — remediateRaw is the pre-reset capture
-            (remediateRaw ?? readPhaseSignalRaw(orchDir, ticket, fromPhase))
-          : readPhaseSignalRaw(orchDir, ticket, fromPhase)
-        : null;
       const ev = explainAdvanceEvidence(fromRaw, { predecessorPhase: fromPhase });
       safeEmit(
         appendPhaseAdvanceAppliedEvent,
@@ -7512,6 +7564,16 @@ export function schedulerTick(
         },
         { ticket, phase: "advance" }
       );
+      // CTL-1805 (A1): record this edge as applied AFTER the successor is verified
+      // live (write-after-success, NOT before dispatch — a failed first dispatch
+      // must leave no marker so it is correctly retried next tick). The atomic
+      // tmp+rename OVERWRITES a stale-key marker (a remediation re-entry at a new
+      // generation), so a legitimate re-advance re-arms the guard for its own new
+      // predecessor identity. Best-effort: a failed write merely leaves the next
+      // duplicate unsuppressed (status quo), never wedges the pipeline.
+      if (advanceGuardEnabled) {
+        recordAdvanceApplied(orchDir, ticket, fromPhase, next, advanceEdgeKey);
+      }
       // CTL-755: a verified triage→research promotion consumed a slot this tick.
       // liveCount was read at the top of the tick (before this dispatch), so the
       // promotion has not yet incremented it — STEP C subtracts promotedCount
@@ -8813,6 +8875,14 @@ export const CIRCUIT_BREAKER_THRESHOLD =
 export const RUNAWAY_THRESHOLD = Number(process.env.SCHEDULER_RUNAWAY_THRESHOLD) || 50;
 export const RUNAWAY_WINDOW_MS = Number(process.env.SCHEDULER_RUNAWAY_WINDOW_MS) || 10 * 60 * 1000;
 
+// CTL-1805 (A1): the throttle window for the advancement idempotency guard's
+// suppressed-duplicate canary. At most one phase.advance.suppressed-duplicate.
+// <ticket> per (ticket,from,to) edge per window, so a wedged (unchanging) input
+// map cannot flood the event log with the same suppression. Mirrors
+// RUNAWAY_WINDOW_MS (10 min); env-overridable for tests.
+export const ADVANCE_SUPPRESS_WINDOW_MS =
+  Number(process.env.ADVANCE_SUPPRESS_WINDOW_MS) || 10 * 60 * 1000;
+
 // --- daemon module state ---
 let tickTimer = null;
 let debounceTimer = null;
@@ -8885,6 +8955,12 @@ let starvationStreak = 0;
 // only-on-change guard. Mirrors lastHeldEmitState but covers the full disposition set
 // (null = no label / cleared). Cleared on daemon restart (via __resetForTests).
 const lastDispositionEmit = new Map();
+
+// CTL-1805 (A1): in-process throttle for the advancement guard's suppressed-
+// duplicate canary — key `${ticket}|${from}|${to}` → last-emit ms (via the tick's
+// injected clock). Re-emits once after a daemon restart (cleared alongside
+// lastDispositionEmit in resetSchedulerModuleState) — acceptable for pure audit.
+const lastAdvanceSuppressEmit = new Map();
 
 // clearDispositionEmit — Codex #2970 round 3: the daemon runs the scheduler
 // in-process (daemon.mjs imports startScheduler from this module directly), so
@@ -10180,6 +10256,7 @@ export function __resetForTests() {
   lastHoldLogged.clear();
   starvationStreak = 0;
   lastDispositionEmit.clear(); // CTL-764 Phase 5: reset worker.transition only-on-change dedup
+  lastAdvanceSuppressEmit.clear(); // CTL-1805 (A1): reset advance-suppress canary throttle
   _unstuckLastRunMs = 0; // CTL-1064: reset Pass 0u throttle between tests
   _stallJanitorCensusLastRunMs = 0; // CTL-1324: reset Pass 0j census throttle between tests
   // rankedAboveSince is cleared by stopScheduler above (CTL-705)

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -14369,3 +14369,157 @@ describe("CTL-1789 phase.advance.applied", () => {
     });
   });
 });
+
+// ─── CTL-1805: the durable once-per-edge advancement idempotency guard ───────
+//
+// THE INCIDENT. On mini 2026-08-12 the advancement sweep applied the
+// monitor-merge→monitor-deploy edge for CTL-56 THIRTEEN times in 55 seconds, each
+// tick re-reading the SAME stale phase-monitor-merge.json (a teardown agent had
+// patched .pr into it, bumping its mtime past monitor-deploy's, so latestLivePhase
+// named monitor-merge and deriveAdvancement re-owed monitor-deploy every tick).
+// The sweep is a pure re-derivation with NO durable record that an edge was ever
+// applied, so an unchanging input map re-fired the same edge forever.
+//
+// This is the load-bearing PROOF (13-tick reproduction) + POSITIVE CONTROL
+// (CATALYST_ADVANCE_GUARD=off reproduces the unbounded replay, proving the guard
+// is load-bearing). scheduler.test.mjs is CI-EXCLUDED (debounced-tick flakiness);
+// the CI-enforced distillation lives in advance-idempotency.test.mjs.
+describe("CTL-1805 advancement idempotency guard (13-tick CTL-56 reproduction)", () => {
+  // Hermetic env: the ambient phase-agent dispatch env can set
+  // CATALYST_RECOVERY_PASS=enforce / CATALYST_BOARD_HEALTH, which make each full
+  // schedulerTick run slow, unrelated passes (~300ms recovery-pass) and would
+  // blow the 13-tick budget non-deterministically depending on the launching
+  // shell. This reproduction exercises the ADVANCEMENT sweep only, so neutralize
+  // those passes here (see the "Dispatch env leaks into hermetic tests" hazard).
+  let savedRecovery, savedBoardHealth;
+  beforeEach(() => {
+    savedRecovery = process.env.CATALYST_RECOVERY_PASS;
+    savedBoardHealth = process.env.CATALYST_BOARD_HEALTH;
+    delete process.env.CATALYST_RECOVERY_PASS;
+    delete process.env.CATALYST_BOARD_HEALTH;
+  });
+  afterEach(() => {
+    if (savedRecovery === undefined) delete process.env.CATALYST_RECOVERY_PASS;
+    else process.env.CATALYST_RECOVERY_PASS = savedRecovery;
+    if (savedBoardHealth === undefined) delete process.env.CATALYST_BOARD_HEALTH;
+    else process.env.CATALYST_BOARD_HEALTH = savedBoardHealth;
+  });
+
+  // Build the CTL-56 mid-burst worker dir. deriveAdvancement over this fixture
+  // returns monitor-deploy every tick (verified: latestLivePhase = monitor-merge
+  // because its mtime is newest; the successor-veto consulted a set the mtime rule
+  // emptied of the done monitor-deploy). fakeDispatch writes no signal, so the map
+  // is invariant across ticks → the edge re-derives identically.
+  function seedCtl56() {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignalRaw("CTL-56", "monitor-deploy", {
+      ticket: "CTL-56",
+      phase: "monitor-deploy",
+      status: "done",
+      generation: 1,
+      updatedAt: "2026-08-12T05:18:36Z",
+    });
+    writeSignalRaw("CTL-56", "teardown", {
+      ticket: "CTL-56",
+      phase: "teardown",
+      status: "dispatched",
+      generation: 2,
+      updatedAt: "2026-08-12T05:18:00Z",
+    });
+    writeSignalRaw("CTL-56", "monitor-merge", {
+      ticket: "CTL-56",
+      phase: "monitor-merge",
+      status: "done",
+      pr: { number: 56 },
+      updatedAt: "2026-08-12T05:12:31Z",
+    });
+    // mtime control (the :232-249 template): monitor-merge NEWEST (the teardown
+    // agent's .pr patch), monitor-deploy older, teardown oldest.
+    const dir = join(orchDir, "workers", "CTL-56");
+    const base = Date.now();
+    utimesSync(join(dir, "phase-teardown.json"), new Date(base - 120000), new Date(base - 120000));
+    utimesSync(
+      join(dir, "phase-monitor-deploy.json"),
+      new Date(base - 60000),
+      new Date(base - 60000)
+    );
+    utimesSync(join(dir, "phase-monitor-merge.json"), new Date(base), new Date(base));
+  }
+
+  const tick = (dispatch) =>
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+    });
+  const countByName = (name) =>
+    readEventLog().filter((e) => e?.attributes?.["event.name"] === name).length;
+  const appliedFor = (ticket) =>
+    readEventLog().filter(
+      (e) => e?.attributes?.["event.name"] === `phase.advance.applied.${ticket}`
+    );
+
+  test("guard ON: monitor-merge→monitor-deploy applies EXACTLY ONCE over 13 ticks", () => {
+    delete process.env.CATALYST_ADVANCE_GUARD; // unset = enforce (default)
+    seedCtl56();
+    const dispatch = fakeDispatch(); // shared across all 13 ticks
+    for (let i = 0; i < 13; i++) tick(dispatch);
+
+    const applied = appliedFor("CTL-56");
+    expect(applied).toHaveLength(1);
+    expect(applied[0].body.payload).toMatchObject({ from: "monitor-merge", to: "monitor-deploy" });
+    // Ticks 2–13 are fully suppressed — the edge is NOT re-dispatched …
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-56", phase: "monitor-deploy" }]);
+    // … and the throttled canary fires exactly once within the window.
+    expect(countByName("phase.advance.suppressed-duplicate.CTL-56")).toBe(1);
+  }, 30000);
+
+  test("POSITIVE CONTROL — guard OFF reproduces the unbounded replay (>1 applied)", () => {
+    process.env.CATALYST_ADVANCE_GUARD = "off";
+    try {
+      seedCtl56();
+      const dispatch = fakeDispatch();
+      for (let i = 0; i < 13; i++) tick(dispatch);
+      // The bug, unguarded: every tick re-applies the same edge and re-dispatches.
+      expect(appliedFor("CTL-56").length).toBeGreaterThan(1);
+      expect(dispatch.calls.length).toBeGreaterThan(1);
+      // With the guard off, no suppressed-duplicate canary is ever emitted.
+      expect(countByName("phase.advance.suppressed-duplicate.CTL-56")).toBe(0);
+    } finally {
+      delete process.env.CATALYST_ADVANCE_GUARD;
+    }
+  }, 30000);
+
+  test("a LEGITIMATE re-advance (newer predecessor identity) is NOT suppressed", () => {
+    delete process.env.CATALYST_ADVANCE_GUARD;
+    seedCtl56();
+    tick(fakeDispatch());
+    expect(appliedFor("CTL-56")).toHaveLength(1);
+
+    // The predecessor's identity CHANGES — monitor-merge re-runs at a NEWER
+    // updatedAt (a genuine backward re-dispatch). The marker's stored key no
+    // longer matches → the edge advances again and the marker is overwritten.
+    // Keying on predecessor identity (not the bare edge) is what keeps this legal.
+    writeSignalRaw("CTL-56", "monitor-merge", {
+      ticket: "CTL-56",
+      phase: "monitor-merge",
+      status: "done",
+      pr: { number: 56 },
+      updatedAt: "2026-08-12T09:00:00Z", // NEWER than the recorded marker's key
+    });
+    const dir = join(orchDir, "workers", "CTL-56");
+    const base = Date.now();
+    utimesSync(
+      join(dir, "phase-monitor-merge.json"),
+      new Date(base + 10_000),
+      new Date(base + 10_000)
+    );
+    tick(fakeDispatch());
+    // A second applied event: the guard did not swallow a real re-advance.
+    expect(appliedFor("CTL-56").length).toBe(2);
+    // …and no suppressed-duplicate was emitted (the key changed, so it never
+    // matched a marker).
+    expect(countByName("phase.advance.suppressed-duplicate.CTL-56")).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -6403,7 +6403,13 @@ describe("verifyDispatchedSignal (CTL-611)", () => {
     );
   });
 
-  test("requireBgJob:false also accepts a 'done' signal (idempotent duplicate sdk dispatch)", () => {
+  // CTL-1805 (A2): CONTRACT CHANGE (was {ok:true} under CTL-1367). An SDK
+  // (requireBgJob:false) dispatch of an already-`done` phase is NOT a launch —
+  // it is an idempotent no-op. It now returns a distinct NON-success,
+  // NON-failure outcome { ok:false, reason:"noop_done_prelaunch", noop:true } so
+  // the call site neither clears nor writes the failure-only cooldown (the
+  // cleared cooldown was the fuel the CTL-56 re-advance loop re-armed on).
+  test("CTL-1805: requireBgJob:false + 'done' is a non-success NO-OP, not a launch", () => {
     const dir = join(orchDir, "workers", "CTL-105");
     mkdirSync(dir, { recursive: true });
     writeFileSync(
@@ -6411,10 +6417,33 @@ describe("verifyDispatchedSignal (CTL-611)", () => {
       JSON.stringify({ ticket: "CTL-105", phase: "research", status: "done", bg_job_id: null })
     );
     expect(verifyDispatchedSignal(orchDir, "CTL-105", "research", { requireBgJob: false })).toEqual(
-      { ok: true }
+      { ok: false, reason: "noop_done_prelaunch", noop: true }
     );
     // bg verification rejects a `done` status as not-runnable (unchanged).
-    expect(verifyDispatchedSignal(orchDir, "CTL-105", "research").ok).toBe(false);
+    expect(verifyDispatchedSignal(orchDir, "CTL-105", "research")).toEqual({
+      ok: false,
+      reason: "status_not_runnable",
+    });
+  });
+
+  // CTL-1805 (A2): the noop demotion is SCOPED to `done`. An in-flight SDK
+  // prelaunch (dispatched / running) still verifies ok:true and is NOT a noop —
+  // a legitimate idempotent re-dispatch of a live phase must not be demoted.
+  test("CTL-1805: requireBgJob:false + 'dispatched'/'running' stay ok:true (no noop demotion)", () => {
+    for (const [id, status] of [
+      ["CTL-105a", "dispatched"],
+      ["CTL-105b", "running"],
+    ]) {
+      const dir = join(orchDir, "workers", id);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "phase-research.json"),
+        JSON.stringify({ ticket: id, phase: "research", status, bg_job_id: null })
+      );
+      const v = verifyDispatchedSignal(orchDir, id, "research", { requireBgJob: false });
+      expect(v).toEqual({ ok: true });
+      expect(v.noop).toBeUndefined();
+    }
   });
 
   test("requireBgJob:false STILL rejects a stalled/failed signal", () => {

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -831,6 +831,46 @@ if [[ $DRY_RUN -eq 0 ]]; then
 				fi
 			fi
 			if [[ $REAPED_ORPHAN -eq 0 ]]; then
+				# ─── CTL-1805 (A3): make the lost claim AUDIBLE ─────────────────────
+				# The bow-out below is stdout-only + exit 0 — completely silent to
+				# the event log. In the CTL-56 re-advance incident there were ZERO
+				# claim-lost events across 13 collisions, so the give-up path was
+				# invisible. Emit exactly one canonical event at this single point of
+				# confirmed collision (a live worker, a young claim, or a re-won
+				# generation), carrying ticket/phase/generation. Strictly fail-open:
+				# a build/write failure must NEVER change the stdout+exit-0 contract
+				# (that JSON line is the load-bearing idempotent-noop return,
+				# CTL-1367), so the whole emit is `|| true`. Reuses the same bash
+				# canonical seam (build_canonical_line + canonical_jsonl_append,
+				# sourced transitively via worktree-rebase.sh → rebase-telemetry.sh →
+				# canonical-event.sh) and the same events-dir chain every other bash
+				# producer uses (lib/rebase-telemetry.sh).
+				_emit_claim_lost() {
+					command -v build_canonical_line >/dev/null 2>&1 || return 0
+					command -v canonical_jsonl_append >/dev/null 2>&1 || return 0
+					local _cl_ts _cl_payload _cl_line
+					_cl_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+					_cl_payload="$(jq -nc \
+						--arg phase "$PHASE" \
+						--argjson generation "$TARGET_GENERATION" \
+						'{phase: $phase, generation: $generation, reason: "single-flight-lost"}')" || return 0
+					_cl_line="$(build_canonical_line \
+						--ts "$_cl_ts" \
+						--severity WARN \
+						--service "catalyst.phase-agent" \
+						--event-name "phase.dispatch.claim-lost.${TICKET}" \
+						--entity "phase" \
+						--action "claim-lost" \
+						--label "$TICKET" \
+						--orch "$ORCH_ID" \
+						--worker "$TICKET" \
+						--linear-ticket "$TICKET" \
+						--payload-json "$_cl_payload")" || return 0
+					canonical_jsonl_append \
+						"${EVENTS_DIR:-${CATALYST_EVENTS_DIR:-${CATALYST_DIR:-$HOME/catalyst}/events}}" \
+						"$_cl_line" || return 0
+				}
+				_emit_claim_lost || true
 				# A live/in-flight worker (signal present, or young claim), OR a
 				# concurrent dispatcher re-won the reaped generation → bow out.
 				jq -nc \


### PR DESCRIPTION
## CTL-1805 — the advancement chokepoint applies each phase edge at most once per predecessor state

Implements the RCA's Option A (make an applied advance a fact on disk) plus its two companions.

### A1 — durable once-per-edge advancement guard (core)
The advancement sweep was a pure re-derivation every tick with no durable record that an edge was ever applied, so an unchanging predecessor signal re-fired the same edge forever (mini 2026-08-12: `monitor-merge→monitor-deploy` for CTL-56 applied **13× in 55s**). The guard keys on the **predecessor's identity** (`ticket|from|to|generation|updatedAt`):
- **Check-before-dispatch** — a byte-identical replay suppresses the entire fanout (no dispatch / linear.state.write / worker.transition / predecessor reap) and emits ≤1 throttled `phase.advance.suppressed-duplicate.<ticket>` canary per window.
- **Write-after-success** — the marker is written only after `dv.ok`; a differing key (legitimate backward re-dispatch / verify⇄remediate re-entry) overwrites it and re-advances.
- `CATALYST_ADVANCE_GUARD=off` is the operator escape hatch + the positive control.

### A2 — SDK `done` prelaunch is a non-success no-op
`verifyDispatchedSignal(requireBgJob:false)` on an already-`done` phase now returns `{ok:false, reason:"noop_done_prelaunch", noop:true}` instead of `{ok:true}`, so the call site no longer clears the failure-only cooldown (the fuel the re-advance loop re-armed on). *(landed in the WIP commit; formatting tidied here)*

### A3 — a lost single-flight claim is audible
`phase.dispatch.claim-lost.<ticket>` is emitted at the dispatcher's bow-out. *(landed in an earlier commit)*

### Verification
- **New CI-stable** `advance-idempotency.test.mjs` (registered in `execution-core-tests.yml`): edge-key semantics, marker round-trip incl. fail-open, remediate-cycle disambiguation, A2 contract.
- `scheduler.test.mjs`: 13-tick CTL-56 reproduction (guard ON → **exactly 1** applied), `CATALYST_ADVANCE_GUARD=off` positive control (**>1** applied), legitimate-re-advance control.
- Green: advance-idempotency, namespace-parity (broker + orch-monitor), assertion-evidence-parity, beliefs/advance-rules. The 8 `scheduler.test.mjs` real-timer flakes are pre-existing and identical to the base commit.

Plan: `thoughts/shared/plans/2026-08-14-ctl-1805-advancement-idempotency-guard.md`

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1805

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-56