### PR TITLE
fix(dev): pin @catalyst-cloud/sdk 0.8.4, closing the migrator/writer schema skew

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "catalyst",
       "dependencies": {
-        "@catalyst-cloud/schema": "0.1.9",
+        "@catalyst-cloud/schema": "0.1.10",
         "@modelcontextprotocol/sdk": "1.29.0",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "^0.8.2",
+        "@catalyst-cloud/sdk": "0.8.4",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.3", "", { "dependencies": { "@catalyst-cloud/schema": "^0.1.3" } }, "sha512-7LyYJTG5fkjq9RA8OaCpCzP2b/gjPOYJJmCxRce++TPsIviQULpTiaffL7MuBfwGODf2dwGrO0ozeW7n8slTTQ=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.5", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.10" } }, "sha512-m7ZrRVMyItWKv19A+NhlxGohfjLxWDTWT6wmFyUwRlJd9OeeX11YNHJt7g7xq+FBYXKTkYUiyVNBs5Y9mjMvLA=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.9", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-eeRLP4gNXtfBoLPPoodHnsLICXsl5raeKMOBInUsIhfVtkUfJqolfcNTC0cevgOsE1TSEKq3iucAZhOHxCIqNQ=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.10", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-QEyiewCO+taYQ4seYOG3k5p5TBD4bpWbI6/045QcSBR6hILGNG51HnGbVPjrIIm85xRnMPOsgJBXWkrQIh04VQ=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.2", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "^0.1.3", "@catalyst-cloud/schema": "^0.1.3" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-QJZFWZAfDdLCr4jvfS05BfuZDR5jr6bN4n/DN2vgMQB9pRTTrZAtk+mbvcK8M3NwfxyuPD0ICVM4Qe+/8jtnEg=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.4", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.5", "@catalyst-cloud/schema": "0.1.10" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-UrFG6CP+FWe5/DQw0KuRdJmkxb1PvHQG8aZ+ISffUpmUla/IE2dDvdqgTSXLgkk19KVdnY19cMM9CvWlsGsBdw=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 
@@ -1543,10 +1543,6 @@
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@catalyst-cloud/replicate/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.5", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-00jtw6f9bUwwR3aeviECqNHfuMrlLK73cOym4wCLBdMJNLOBo0NYM7HlkH6ejWpqycq7EI2ECfys4wqzqnhT5g=="],
-
-    "@catalyst-cloud/sdk/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.5", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-00jtw6f9bUwwR3aeviECqNHfuMrlLK73cOym4wCLBdMJNLOBo0NYM7HlkH6ejWpqycq7EI2ECfys4wqzqnhT5g=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hono": "4.12.27"
   },
   "dependencies": {
-    "@catalyst-cloud/schema": "0.1.9",
+    "@catalyst-cloud/schema": "0.1.10",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/cloud-sync-schema-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-schema-identity.test.mjs
@@ -4,6 +4,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { createRequire } from "node:module";
+import { realpathSync } from "node:fs";
 import {
   appendSchemaIdentity,
   createSchemaReportingWsFactory,
@@ -50,15 +51,48 @@ describe("the reported identity is the bundle THE REPLICA APPLIES WITH", () => {
     // applying 16: three migrations behind, reported as CURRENT.
     const viaSdk = journalIdentity(sdkSchema);
     const viaBare = journalIdentity(bareSchema);
-    if (!viaSdk || !viaBare || viaSdk.tail === viaBare.tail) {
-      // Do NOT pass quietly: with one hoisted copy this cannot discriminate, and a
-      // green light here would mean "could not look", not "correct".
+    if (!viaSdk || !viaBare) {
+      // Do NOT pass quietly: a missing measurement is undiagnosable, and a green
+      // light here would mean "could not look", not "correct".
       throw new Error(
         `INCONCLUSIVE: this tree does not expose two distinct schema copies ` +
           `(sdk=${JSON.stringify(viaSdk)} bare=${JSON.stringify(viaBare)}); ` +
           `the regression cannot be observed here.`
       );
     }
+
+    if (viaSdk.tail === viaBare.tail) {
+      // ⭐ A UNIFIED tree — and that is a RESULT, not an absence of evidence.
+      // Once the SDK pin carries one exact schema through both `applyMigrations`
+      // and replicate's `applyDelta`, there is only one copy, so "reported the bare
+      // copy instead of the SDK's" is structurally unconstructible rather than
+      // merely unobserved. Treating that as INCONCLUSIVE turned the FIX into a red
+      // build (measured: this test failed CI on the 0.8.4 pin, whose whole purpose
+      // is to produce this state).
+      //
+      // ⛔ But identical journal tails are NOT proof of one copy — two distinct
+      // copies of the SAME version have identical tails, which is exactly the
+      // "could not look" case this test refuses to green-light. So PROVE it: the
+      // two resolutions must land on the same file on disk. If they don't, the
+      // discrimination really was possible and something else silenced it.
+      const realOf = (resolve) => {
+        try {
+          return realpathSync(resolve());
+        } catch {
+          return null;
+        }
+      };
+      const sdkPath = realOf(() => createRequire(req.resolve("@catalyst-cloud/sdk/node")).resolve("@catalyst-cloud/schema"));
+      const barePath = realOf(() => req.resolve("@catalyst-cloud/schema"));
+      expect(sdkPath).not.toBeNull();
+      expect(barePath).not.toBeNull();
+      expect(sdkPath).toBe(barePath);
+      // The invariant that still carries meaning in a unified tree: the reported
+      // identity is the one the replica applies with.
+      expect(replicaSchemaIdentity()).toEqual(viaSdk);
+      return;
+    }
+
     expect(replicaSchemaIdentity()).toEqual(viaSdk);
     expect(replicaSchemaIdentity().tail).not.toBe(viaBare.tail);
   });

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "^0.8.2",
+    "@catalyst-cloud/sdk": "0.8.4",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
## What

Pins `@catalyst-cloud/sdk` to an exact `0.8.4` (with lockfile), replacing the fleet's `^0.8.2`.

## Why

The replica's DDL and its row-binding come from **two different packages**, and the version instrument only ever saw the first. `catalyst-replica.js` imports `applyMigrations` from `@catalyst-cloud/schema` but `applyDelta` from `@catalyst-cloud/replicate`, which carries its **own** pinned schema. Under `^0.8.2` the migrator could run 0.1.10 while the writer's `KNOWN_COLUMNS` came from 0.1.5 — so every upsert filtered out columns that existed on disk, leaving permanently NULL columns under a green `loadedSchemaIdentity()`.

That filter is a **safety feature** (CTC-127) which assumes the bundled schema is the *older* one. When the migrator runs ahead of the writer, the same guard silently drops columns that really exist. A guard whose assumption reverses becomes the defect.

`0.8.4` closes it at the root: it pins `replicate@0.1.5`, and 0.1.5 pins `schema@0.1.10` **exactly**, where `0.1.3` had a loose `^0.1.3`.

## Verification

Resolved **off disk**, following symlinks, from the *importing* package rather than the workspace root — bun's isolated linker makes `node_modules/<pkg>` a link into `.bun/`, so walking up from the link finds the hoisted copy instead of the one that package loads, and `require.resolve` answers from a process-wide cache rather than the disk.

| tree | sdk | replicate via sdk | schema via replicate | verdict |
|---|---|---|---|---|
| fresh 0.8.4 | 0.8.4 | 0.1.5 | 0.1.10 | MIGRATED == WRITTEN |
| pre-upgrade | 0.8.3 | 0.1.3 | 0.1.5 | **skew detected** |

The second row is the positive control: the check demonstrably fails on the state it exists to catch.

## Canaried on mini-2 before this PR

No forced re-snapshot is needed — the replica deletes its own cursor when applied migrations change row shape (`\bADD\b` / `\bCREATE TABLE\b`), routing the client down the cold-seed path. Observed `snapshot seeded (117911 rows)`, after which `agent_sessions` (12 cols incl. `dismissed_at`/`archived_at`), `agent_activities`, and `fleet_activity` exist where all three previously read `no such table`; cursor kept advancing.

## Why exact, not a caret

`^0.8.2` is what let the running version drift from the declared one, and a range cannot express "these two bundles must agree."

**Policy: this pin stays exact. Bumping it is a deliberate PR, not a range that floats.** The whole defect class here is a declared version and a loaded version drifting apart; a caret re-opens it silently.

## Not fixed here (no client version can)

The mirror emits change frames for `pr_commits`, `pr_review_comments`, `pr_conversation_comments`, and `pr_events`; schema 0.1.10 defines none of them (checked all 30 `CREATE TABLE` statements in the published package), so every client drops those frames regardless of version. The chain, confirmed with backend:

- published schema **0.1.11** adds `pr_review_comments` (migration 0020)
- **#598** added `pr_commits` / `pr_conversation_comments` / `pr_events` (migration 0021) on main **without a version bump**, so they are in no published package at all
- SDK 0.8.4 pins schema **0.1.10**, which predates both

Backend is publishing schema 0.1.12 -> replicate 0.1.6 -> SDK 0.8.5. **This PR deliberately does not wait for it**: 0.8.4 fixes MIGRATED != WRITTEN and lands `agent_sessions` today, and 0.8.5 will be a one-line bump to this same exact pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)