### PR TITLE
fix(dev): CTL-1892 — the self-echo guard survives an app-actor rotation

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -314,13 +314,52 @@ export function readSelfEchoIdentities(layer1Path, layer2Path, ledgerPath, { onD
     const r = syncAndResolveSelfIdentities({ configIds, ledgerPath, source: "config" });
     // A degraded ledger is fail-open (config ids are still returned) but must never be
     // silent — "the rotation window is open again" has no other symptom.
-    if (r.ledgerStatus === "unreadable" && typeof onDegraded === "function") {
-      onDegraded({ status: r.ledgerStatus, reason: r.ledgerReason, path: ledgerPath });
+    //
+    // ⛔ A failed WRITE counts as degradation too. Reporting only `unreadable` misses
+    // the read-only-dir / full-disk case entirely: the re-read afterwards reports a
+    // healthy-looking `absent`, so durability is silently lost and nothing says so
+    // until the NEXT rotation, when the window is already open.
+    if (typeof onDegraded === "function") {
+      if (r.ledgerStatus === "unreadable") {
+        onDegraded({ kind: "ledger-unreadable", status: r.ledgerStatus, reason: r.ledgerReason, path: ledgerPath });
+      }
+      if (r.notDurable?.length) {
+        onDegraded({ kind: "ledger-not-durable", notDurable: r.notDurable, writeFailures: r.writeFailures, path: ledgerPath });
+      }
     }
     return r.ids;
   } catch {
     return configIds; // a ledger problem must never cost us the configured ids
   }
+}
+
+// refreshSelfEchoIdentitiesInto — re-resolve and merge INTO an existing Set (CTL-1892).
+//
+// The daemon resolves the identity set once and hands that Set to the monitor, the
+// scheduler, and both inbox writers, which capture it in closures. A rotation that
+// lands in Layer-2 while the daemon is running would therefore be invisible until a
+// restart — the boot-only failure the cluster-sync timer's own comment already warns
+// about for credentials ("a credential rotated at 03:00 on a daemon that booted at
+// 00:00 stays dead until a human restarts it"). The same argument applies here, and
+// the live-rotation moment is precisely the window this ticket exists to close.
+//
+// Merges in place and returns what it ADDED, so every existing closure observes the
+// new identity without re-plumbing. Deliberately MONOTONIC — never removes. A retired
+// id must stay recognised, and an id dropped from the set is one the fleet would begin
+// dispatching on: the exact defect, reintroduced by the refresh meant to fix it.
+export function refreshSelfEchoIdentitiesInto(target, layer1Path, layer2Path, ledgerPath, opts = {}) {
+  const added = [];
+  try {
+    for (const id of readSelfEchoIdentities(layer1Path, layer2Path, ledgerPath, opts)) {
+      if (!target.has(id)) {
+        target.add(id);
+        added.push(id);
+      }
+    }
+  } catch {
+    /* a refresh must never wedge the tick that carries it */
+  }
+  return added;
 }
 
 // readLinearBotWriteId — the SINGLE bot UUID the daemon writes as assignee on
@@ -1313,9 +1352,15 @@ export function startDaemon({
     // CTL-1892: rotation-durable — config ids UNION every identity this host has
     // written as, so an app-actor re-mint extends the self-echo set instead of
     // reopening a window where the fleet dispatches on its own echoes.
-    const linearBotUserIds = readSelfEchoIdentities(configPath, layer2Path, defaultIdentityLedgerPath(), {
-      onDegraded: (d) => log?.warn?.(d, "self-echo identity ledger unreadable — rotation window may be open"),
-    });
+    // A STABLE Set object, filled in place: the monitor, scheduler and both inbox
+    // writers capture this reference, so refreshing its CONTENTS on the cluster-sync
+    // tick is what makes a LIVE rotation visible without re-plumbing every closure.
+    const linearBotUserIds = new Set();
+    const refreshBotIdentities = () =>
+      refreshSelfEchoIdentitiesInto(linearBotUserIds, configPath, layer2Path, defaultIdentityLedgerPath(), {
+        onDegraded: (d) => log?.warn?.(d, "self-echo identity ledger degraded — rotation durability at risk"),
+      });
+    refreshBotIdentities();
     const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     // CTL-1654 (Codex P2 "gate the daemon before starting actuators"): resolve the
@@ -1650,6 +1695,19 @@ export function startDaemon({
           refreshClusterSecrets();
         } catch (err) {
           log.warn({ err: err?.message }, "cluster-sync timer: refresh threw (continuing)");
+        }
+        // CTL-1892: re-resolve the self-echo identity set on the SAME tick and for the
+        // SAME reason as the credential re-arm below — an app-actor rotated while this
+        // daemon is running is otherwise invisible until a restart, and that live
+        // window is exactly what this guard exists to close. Merges in place
+        // (monotonic), so the closures already holding the Set observe the new id.
+        try {
+          const addedIdentities = refreshBotIdentities();
+          if (addedIdentities.length) {
+            log.info({ added: addedIdentities }, "self-echo identity set extended (app-actor rotation)");
+          }
+        } catch (err) {
+          log.warn({ err: err?.message }, "cluster-sync timer: identity refresh threw (continuing)");
         }
         // CTL-1612: re-arm from disk on EVERY tick, unconditionally. Without this the
         // whole fix is boot-only: a credential rotated at 03:00 on a daemon that booted at

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -65,6 +65,7 @@ import {
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
 import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
+import { defaultIdentityLedgerPath, syncAndResolveSelfIdentities } from "./linear-bot-identity.mjs"; // CTL-1892
 import {
   clusterSync as realClusterSync,
   refreshClusterSecretsIfChanged as realRefreshClusterSecrets, // CTL-1393: change-detecting secret re-decrypt
@@ -286,6 +287,40 @@ export function readLinearBotUserIds(layer1Path, layer2Path) {
     if (typeof uid === "string" && uid.length > 0) s.add(uid);
   });
   return ids;
+}
+
+// readSelfEchoIdentities — the ROTATION-DURABLE self-echo set (CTL-1892).
+//
+// `readLinearBotUserIds` above is correct but POINT-IN-TIME: it names the currently
+// configured app-actors, so a rotation REPLACES the set instead of extending it. From
+// the moment a new app-actor starts writing until the config names it, the fleet's own
+// echoes read as third-party changes and it dispatches on its own writes. Nothing
+// errors — the symptom is indistinguishable from ordinary board activity. Measured on
+// this fleet: `f51bc697…` (handle `catalystorchestrator`, 2,241 writes through
+// 2026-08-10) was superseded same-day by `ba2989f1…` (`catalystorchestrator2`), and
+// only the second is named by any config.
+//
+// This unions the config set with a durable per-host ledger of every identity the
+// fleet has WRITTEN AS, and records the current ones on the way through — so the next
+// rotation extends the set rather than reopening the window.
+//
+// Left as a separate seam rather than folded into readLinearBotUserIds: that function
+// is pure and has an inlined twin in doctor.mjs, and giving it a default on-disk
+// ledger would make every existing unit test touch real state.
+export function readSelfEchoIdentities(layer1Path, layer2Path, ledgerPath, { onDegraded = null } = {}) {
+  const configIds = readLinearBotUserIds(layer1Path, layer2Path);
+  if (!ledgerPath) return configIds;
+  try {
+    const r = syncAndResolveSelfIdentities({ configIds, ledgerPath, source: "config" });
+    // A degraded ledger is fail-open (config ids are still returned) but must never be
+    // silent — "the rotation window is open again" has no other symptom.
+    if (r.ledgerStatus === "unreadable" && typeof onDegraded === "function") {
+      onDegraded({ status: r.ledgerStatus, reason: r.ledgerReason, path: ledgerPath });
+    }
+    return r.ids;
+  } catch {
+    return configIds; // a ledger problem must never cost us the configured ids
+  }
 }
 
 // readLinearBotWriteId — the SINGLE bot UUID the daemon writes as assignee on
@@ -1275,7 +1310,12 @@ export function startDaemon({
     // Layer-2 new global path) so inbox writers and the comment-wake guard
     // suppress self-echo from BOTH the worker app-actor AND the orchestrator
     // app-actor. Returns a Set<string> — empty = no filter (fail-open).
-    const linearBotUserIds = readLinearBotUserIds(configPath, layer2Path);
+    // CTL-1892: rotation-durable — config ids UNION every identity this host has
+    // written as, so an app-actor re-mint extends the self-echo set instead of
+    // reopening a window where the fleet dispatches on its own echoes.
+    const linearBotUserIds = readSelfEchoIdentities(configPath, layer2Path, defaultIdentityLedgerPath(), {
+      onDegraded: (d) => log?.warn?.(d, "self-echo identity ledger unreadable — rotation window may be open"),
+    });
     const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     // CTL-1654 (Codex P2 "gate the daemon before starting actuators"): resolve the

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
@@ -1,0 +1,172 @@
+// linear-bot-identity.mjs — CTL-1892.
+//
+// The self-echo guard's identity set, made ROTATION-DURABLE.
+//
+// ## The defect this exists to close
+//
+// `readLinearBotUserIds` builds its set from the CURRENTLY CONFIGURED app-actor ids.
+// That set is point-in-time, so a rotation REPLACES it rather than extending it, and
+// from the moment a new app-actor starts writing until every host's config names it,
+// the fleet's own echoes are not recognised as its own — it dispatches on its own
+// writes as if a third party had moved the board. Nothing errors; the symptom is
+// indistinguishable from ordinary activity.
+//
+// Measured on this fleet: two Linear actors both named "Catalyst Orchestrator" —
+// `f51bc697…` (handle `catalystorchestrator`, 2,241 writes, 2026-06-05 → 2026-08-10)
+// and `ba2989f1…` (handle `catalystorchestrator2`, from 2026-08-10). Linear's `2`
+// suffix on a taken handle plus the same-day handoff makes it a re-mint, not a stray
+// process. Only the second is named by any config, so every echo of the first read as
+// a third-party change.
+//
+// ## The mechanism
+//
+// A durable, append-only, per-host ledger of every identity THIS FLEET HAS WRITTEN AS.
+// The resolved set is `config ∪ ledger`, so a rotation EXTENDS rather than replaces.
+//
+// ⛔ ONLY ids the fleet writes as may enter the ledger — i.e. ids read from our own
+// config. An identity must never be admitted because it was OBSERVED writing, or a
+// third party could get itself suppressed by writing to the board, which inverts the
+// guard into a way to hide changes from the fleet. The recording seam takes ids from
+// config only, and that is the whole security argument for this file.
+//
+// ## What this does NOT close
+//
+// A cross-host propagation window. If host A rotates and writes as NEW while host B's
+// config still names OLD, B has never written as NEW and so cannot have it in its
+// ledger. Closing that requires the rotation to reach every host's config — which is
+// what the cluster config distribution already does. This makes each host's own view
+// MONOTONIC; it does not make one host learn another's brand-new identity.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export const LEDGER_VERSION = 1;
+
+/** Default ledger location: beside the rest of the host's durable Catalyst state. */
+export function defaultIdentityLedgerPath(catalystHome) {
+  return join(catalystHome || join(process.env.HOME || "", "catalyst"), "linear-bot-identities.json");
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A Linear user id we are willing to treat as an identity. Shape-checked so a
+ *  truncated/`null`/numeric value cannot enter the set and silently match nothing —
+ *  or worse, match an empty author id. */
+export function isPlausibleIdentityId(v) {
+  return typeof v === "string" && UUID_RE.test(v);
+}
+
+/**
+ * Read the ledger. THREE-VALUED — `absent` and `unreadable` are different verdicts.
+ *
+ * ⚠️ Collapsing them into "empty" is how a corrupt ledger silently degrades into
+ * today's point-in-time guard: the rotation window reopens and nothing says so. The
+ * caller decides what to do, but it is never allowed to be unable to tell.
+ */
+export function readIdentityLedger(path) {
+  if (!path) return { status: "absent", ids: new Set(), reason: "no-path" };
+  if (!existsSync(path)) return { status: "absent", ids: new Set(), reason: "no-file" };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (err) {
+    return { status: "unreadable", ids: new Set(), reason: `parse: ${err?.message ?? "unknown"}` };
+  }
+  // Shape is validated BEFORE any coercion. `[]`, `null`, and `{identities:"abc"}`
+  // all produce an empty set under a permissive read, which is indistinguishable
+  // from a healthy empty ledger — the exact false-clean this file refuses.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { status: "unreadable", ids: new Set(), reason: "not-an-object" };
+  }
+  if (!Array.isArray(parsed.identities)) {
+    return { status: "unreadable", ids: new Set(), reason: "identities-not-an-array" };
+  }
+  const ids = new Set();
+  let skipped = 0;
+  for (const entry of parsed.identities) {
+    const id = typeof entry === "string" ? entry : entry?.id;
+    if (isPlausibleIdentityId(id)) ids.add(id);
+    else skipped += 1;
+  }
+  return { status: "ok", ids, skipped, reason: null };
+}
+
+/**
+ * Record an identity the fleet writes as. Append-only and idempotent.
+ *
+ * Returns `{ recorded, alreadyKnown, status }`. NEVER throws — a ledger write must
+ * not be able to take down the daemon whose echoes it protects.
+ */
+export function recordIdentity(path, id, { source = "config", now = () => Date.now() } = {}) {
+  if (!path) return { recorded: false, alreadyKnown: false, status: "no-path" };
+  if (!isPlausibleIdentityId(id)) return { recorded: false, alreadyKnown: false, status: "implausible-id" };
+
+  const existing = readIdentityLedger(path);
+  // ⛔ Refuse to write over a ledger we could not READ. Rewriting an unreadable file
+  // would DESTROY the retired identities it still holds — turning a transient read
+  // problem into the permanent reopening of the rotation window.
+  if (existing.status === "unreadable") {
+    return { recorded: false, alreadyKnown: false, status: "refused-unreadable", reason: existing.reason };
+  }
+  if (existing.ids.has(id)) return { recorded: false, alreadyKnown: true, status: "ok" };
+
+  let prior = [];
+  if (existing.status === "ok") {
+    try {
+      const raw = JSON.parse(readFileSync(path, "utf8"));
+      if (Array.isArray(raw?.identities)) prior = raw.identities;
+    } catch {
+      return { recorded: false, alreadyKnown: false, status: "refused-unreadable", reason: "reread-failed" };
+    }
+  }
+
+  const next = {
+    version: LEDGER_VERSION,
+    identities: [...prior, { id, source, firstRecordedAt: now() }],
+  };
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp-${process.pid}`;
+    writeFileSync(tmp, `${JSON.stringify(next, null, 2)}\n`);
+    renameSync(tmp, path); // atomic: a concurrent reader sees old or new, never half
+  } catch (err) {
+    return { recorded: false, alreadyKnown: false, status: "write-failed", reason: err?.message };
+  }
+  return { recorded: true, alreadyKnown: false, status: "ok" };
+}
+
+/**
+ * The self-echo identity set: `configIds ∪ ledgerIds`.
+ *
+ * Fail-open on a bad ledger — the configured ids are still returned, because losing
+ * them would suppress NOTHING and turn every one of the fleet's own writes into a
+ * dispatch. But the degradation is REPORTED (`ledgerStatus`), never silent: the
+ * caller is expected to log it, since "the rotation window is open again" is exactly
+ * the condition that has no other symptom.
+ */
+export function resolveSelfIdentities({ configIds = new Set(), ledgerPath = null } = {}) {
+  const ledger = readIdentityLedger(ledgerPath);
+  const ids = new Set();
+  for (const id of configIds) if (isPlausibleIdentityId(id)) ids.add(id);
+  for (const id of ledger.ids) ids.add(id);
+  return {
+    ids,
+    ledgerStatus: ledger.status,
+    ledgerReason: ledger.reason ?? null,
+    fromLedgerOnly: [...ledger.ids].filter((id) => !configIds.has(id)),
+  };
+}
+
+/**
+ * Record every currently-configured identity, then return the unified set. This is
+ * the seam callers use: reading the config is also how the ledger LEARNS, so a
+ * rotation extends the set on the first tick after the new id lands in config.
+ */
+export function syncAndResolveSelfIdentities({ configIds = new Set(), ledgerPath = null, source = "config", now } = {}) {
+  const recorded = [];
+  for (const id of configIds) {
+    const r = recordIdentity(ledgerPath, id, { source, now });
+    if (r.recorded) recorded.push(id);
+  }
+  return { ...resolveSelfIdentities({ configIds, ledgerPath }), recorded };
+}

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
@@ -42,10 +42,47 @@ import { dirname, join } from "node:path";
 
 export const LEDGER_VERSION = 1;
 
-/** Default ledger location: beside the rest of the host's durable Catalyst state. */
+/**
+ * Default ledger location: beside the rest of the host's durable Catalyst state.
+ *
+ * ⚠️ Resolves CATALYST_DIR **per call**, exactly as `config.mjs` does. Hard-coding
+ * `$HOME/catalyst` would make two isolated installations sharing a home share retired
+ * identities — each suppressing the other's actors — and would lose persistence
+ * entirely on a host whose home is not writable but whose state root is. The env var
+ * is also how tests isolate, so a fixed path silently writes to real host state.
+ * Deliberately NOT imported from config.mjs: this module stays an import-light leaf
+ * (config.mjs pulls the bun:sqlite graph), so the one line is mirrored instead.
+ */
 export function defaultIdentityLedgerPath(catalystHome) {
-  return join(catalystHome || join(process.env.HOME || "", "catalyst"), "linear-bot-identities.json");
+  const home = catalystHome || process.env.CATALYST_DIR || join(process.env.HOME || "", "catalyst");
+  return join(home, "linear-bot-identities.json");
 }
+
+/**
+ * Identities this fleet has PROVABLY written as, established by evidence and committed
+ * so a host that first runs this code AFTER a rotation still recognises them.
+ *
+ * ⛔ Without this seed the ledger bootstraps empty while the config already names only
+ * the replacement, so a retired actor is never learned and its echoes stay third-party
+ * FOREVER — the rollout case, and the exact defect this module exists to close.
+ *
+ * The bar for adding an entry is the bar met below: same display name, a Linear
+ * handle-collision suffix, a same-day handoff with no overlap, and no other config
+ * anywhere naming it. "It wrote a lot" is NOT sufficient — an id admitted here can
+ * never be dispatched on again.
+ */
+export const KNOWN_RETIRED_IDENTITIES = Object.freeze([
+  {
+    id: "f51bc697-c64b-47b8-9fba-a2981fbfe652",
+    handle: "catalystorchestrator",
+    retiredOn: "2026-08-10",
+    supersededBy: "ba2989f1-f250-4273-943c-ca511c66e793", // handle catalystorchestrator2
+    evidence:
+      "2,241 writes 2026-06-05..2026-08-10 (1,404 state edges, 748 label writes); same display " +
+      "name 'Catalyst Orchestrator' as its successor, whose handle carries Linear's collision " +
+      "suffix '2'; same-day handoff with no overlap; named by no config, live or backup (CTL-1892)",
+  },
+]);
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -149,6 +186,10 @@ export function resolveSelfIdentities({ configIds = new Set(), ledgerPath = null
   const ids = new Set();
   for (const id of configIds) if (isPlausibleIdentityId(id)) ids.add(id);
   for (const id of ledger.ids) ids.add(id);
+  // Seeded regardless of ledger state: a host whose ledger is absent (first run) or
+  // unreadable must still recognise a known retired actor, or the rollout case leaves
+  // its echoes third-party forever.
+  for (const { id } of KNOWN_RETIRED_IDENTITIES) ids.add(id);
   return {
     ids,
     ledgerStatus: ledger.status,
@@ -164,9 +205,21 @@ export function resolveSelfIdentities({ configIds = new Set(), ledgerPath = null
  */
 export function syncAndResolveSelfIdentities({ configIds = new Set(), ledgerPath = null, source = "config", now } = {}) {
   const recorded = [];
+  const writeFailures = [];
   for (const id of configIds) {
     const r = recordIdentity(ledgerPath, id, { source, now });
     if (r.recorded) recorded.push(id);
+    // ⛔ A DISCARDED write failure is invisible: the re-read below reports a
+    // healthy-looking `absent` or `ok`, so a read-only dir or a full disk silently
+    // costs rotation durability with no symptom until the NEXT rotation — by which
+    // time the window is already open. Surface it as its own degradation.
+    else if (r.status === "write-failed" || r.status === "refused-unreadable") {
+      writeFailures.push({ id, status: r.status, reason: r.reason ?? null });
+    }
   }
-  return { ...resolveSelfIdentities({ configIds, ledgerPath }), recorded };
+  const resolved = resolveSelfIdentities({ configIds, ledgerPath });
+  // A configured id that is NOT durably on disk is the honest signal of lost
+  // durability — independent of why the write failed.
+  const notDurable = [...configIds].filter((id) => isPlausibleIdentityId(id) && !readIdentityLedger(ledgerPath).ids.has(id));
+  return { ...resolved, recorded, writeFailures, notDurable };
 }

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
@@ -10,6 +10,8 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  KNOWN_RETIRED_IDENTITIES,
+  defaultIdentityLedgerPath,
   isPlausibleIdentityId,
   readIdentityLedger,
   recordIdentity,
@@ -82,7 +84,12 @@ describe("Feature: the fleet recognises its own writes across rotations", () => 
     syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
     const { ids } = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
     expect(ids.has(HUMAN)).toBe(false);
-    expect([...ids].sort()).toEqual([NEW]);
+    // Tightened rather than loosened: every member must be justified — either
+    // configured, or an explicitly evidenced retired identity. Nothing else may
+    // appear, which is the real claim (an exact-equality on [NEW] would just be
+    // asserting the absence of the deliberate seed).
+    const retired = new Set(KNOWN_RETIRED_IDENTITIES.map((r) => r.id));
+    for (const id of ids) expect(id === NEW || retired.has(id)).toBe(true);
   });
 
   test("repeated rotations accumulate — three identities, all still self", () => {
@@ -201,7 +208,7 @@ describe("id shape", () => {
 });
 
 // ── the daemon-level seam ────────────────────────────────────────────────────
-import { readSelfEchoIdentities } from "./daemon.mjs";
+import { readSelfEchoIdentities, refreshSelfEchoIdentitiesInto } from "./daemon.mjs";
 
 describe("readSelfEchoIdentities — the seam the daemon actually calls", () => {
   const layer2 = (dirPath, ids) => {
@@ -237,13 +244,19 @@ describe("readSelfEchoIdentities — the seam the daemon actually calls", () => 
 
   test("an unreadable ledger is REPORTED and still fail-open", () => {
     writeFileSync(ledger, "{corrupt");
-    let reported = null;
+    // Collect EVERY report: a corrupt ledger degrades in two distinct ways (the read
+    // is unreadable AND the write is refused, so the id is not durable). Capturing
+    // only the last call would silently assert whichever fired second.
+    const reports = [];
     const ids = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), ledger, {
-      onDegraded: (d) => (reported = d),
+      onDegraded: (d) => reports.push(d),
     });
     expect(ids.has(NEW)).toBe(true); // fail-open: config ids survive
-    expect(reported).toMatchObject({ status: "unreadable" }); // but it is announced
-    expect(reported.reason).toBeTruthy();
+    const unreadable = reports.find((r) => r.kind === "ledger-unreadable");
+    expect(unreadable).toMatchObject({ status: "unreadable" }); // but it is announced
+    expect(unreadable.reason).toBeTruthy();
+    // and the lost durability is announced separately — different fault, different fix
+    expect(reports.find((r) => r.kind === "ledger-not-durable")?.notDurable).toContain(NEW);
   });
 
   test("both worker and orchestrator identities are learned", () => {
@@ -254,5 +267,146 @@ describe("readSelfEchoIdentities — the seam the daemon actually calls", () => 
     const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: HUMAN }), ledger);
     expect(after.has(NEW)).toBe(true);
     expect(after.has(OLD)).toBe(true);
+  });
+});
+
+// ── Codex round 1 ────────────────────────────────────────────────────────────
+
+describe("⭐ P1: the ROLLOUT case — a retired actor must be known on a fresh ledger", () => {
+  test("with an absent ledger and only the NEW id configured, the retired id is still self", () => {
+    // The deployment this change actually lands on: ledger absent, config already
+    // rotated. Without a committed seed the retired actor can never be learned, and
+    // its echoes stay third-party forever.
+    expect(readIdentityLedger(ledger).status).toBe("absent");
+    const { ids } = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(ids.has(OLD)).toBe(true);
+  });
+
+  test("the seed applies even when the ledger is UNREADABLE", () => {
+    writeFileSync(ledger, "{corrupt");
+    expect(resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger }).ids.has(OLD)).toBe(true);
+  });
+
+  test("the seed applies with no ledger path at all", () => {
+    expect(resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: null }).ids.has(OLD)).toBe(true);
+  });
+
+  test("⛔ each seeded entry carries the evidence that justified admitting it", () => {
+    // An id admitted here can never be dispatched on again, so provenance is not
+    // decoration — it is the record that lets a later reader re-check the claim.
+    for (const e of KNOWN_RETIRED_IDENTITIES) {
+      expect(isPlausibleIdentityId(e.id)).toBe(true);
+      expect(isPlausibleIdentityId(e.supersededBy)).toBe(true);
+      expect(e.evidence.length).toBeGreaterThan(40);
+      expect(e.retiredOn).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+});
+
+describe("⭐ P1: a ledger WRITE failure must not be silent", () => {
+  test("a read-only directory is reported as a write failure, not swallowed", () => {
+    const rd = join(dir, "ro2");
+    require("node:fs").mkdirSync(rd);
+    chmodSync(rd, 0o500);
+    const r = syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: join(rd, "l.json") });
+    expect(r.writeFailures.length).toBeGreaterThan(0);
+    expect(r.writeFailures[0]).toMatchObject({ id: NEW, status: "write-failed" });
+    // and the honest signal: the configured id is NOT durably on disk
+    expect(r.notDurable).toContain(NEW);
+    chmodSync(rd, 0o700);
+  });
+
+  test("a healthy write reports no failure and nothing non-durable", () => {
+    const r = syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(r.writeFailures).toEqual([]);
+    expect(r.notDurable).toEqual([]);
+  });
+
+  test("an unreadable ledger surfaces as a refusal, not a quiet no-op", () => {
+    writeFileSync(ledger, "{corrupt");
+    const r = syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(r.writeFailures[0]).toMatchObject({ status: "refused-unreadable" });
+    expect(r.notDurable).toContain(NEW);
+  });
+});
+
+describe("⭐ P2: the ledger honours CATALYST_DIR", () => {
+  test("CATALYST_DIR wins over $HOME, re-resolved per call", () => {
+    const prev = process.env.CATALYST_DIR;
+    try {
+      process.env.CATALYST_DIR = "/tmp/cat-dir-a";
+      expect(defaultIdentityLedgerPath()).toBe("/tmp/cat-dir-a/linear-bot-identities.json");
+      // per-call, not captured at import: two installations must not collide, and
+      // tests must be able to isolate.
+      process.env.CATALYST_DIR = "/tmp/cat-dir-b";
+      expect(defaultIdentityLedgerPath()).toBe("/tmp/cat-dir-b/linear-bot-identities.json");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prev;
+    }
+  });
+
+  test("an explicit home argument still wins over the env", () => {
+    const prev = process.env.CATALYST_DIR;
+    try {
+      process.env.CATALYST_DIR = "/tmp/cat-dir-a";
+      expect(defaultIdentityLedgerPath("/tmp/explicit")).toBe("/tmp/explicit/linear-bot-identities.json");
+    } finally {
+      if (prev === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prev;
+    }
+  });
+});
+
+describe("⭐ P1: a LIVE rotation is picked up without a daemon restart", () => {
+  const layer2At = (name, ids) => {
+    const p = join(dir, name);
+    writeFileSync(p, JSON.stringify({ catalyst: { linear: { bot: { orchestrator: { botUserId: ids } } } } }));
+    return p;
+  };
+
+  test("the refresh merges IN PLACE, so a captured closure sees the new identity", () => {
+    // This is the whole mechanism: monitor/scheduler/inbox writers capture the Set by
+    // reference at boot. Replacing the Set would leave every one of them on the old
+    // one — the boot-only failure this fixes.
+    const live = new Set();
+    const capturedByAClosure = live; // what the daemon hands to its actuators
+    refreshSelfEchoIdentitiesInto(live, null, layer2At("l2a.json", OLD), ledger);
+    expect(capturedByAClosure.has(OLD)).toBe(true);
+
+    // rotation lands in Layer-2 while the "daemon" keeps running
+    const added = refreshSelfEchoIdentitiesInto(live, null, layer2At("l2b.json", NEW), ledger);
+    expect(added).toContain(NEW);
+    expect(capturedByAClosure.has(NEW)).toBe(true); // ← same object, no re-plumbing
+    expect(capturedByAClosure).toBe(live);
+  });
+
+  test("⛔ the refresh is MONOTONIC — it never removes a known identity", () => {
+    // An id dropped from the set is one the fleet would start dispatching on: the
+    // exact defect, reintroduced by the refresh meant to fix it.
+    const live = new Set();
+    refreshSelfEchoIdentitiesInto(live, null, layer2At("m1.json", OLD), ledger);
+    refreshSelfEchoIdentitiesInto(live, null, layer2At("m2.json", NEW), ledger);
+    expect(live.has(OLD)).toBe(true);
+    expect(live.has(NEW)).toBe(true);
+  });
+
+  test("a repeat refresh with no rotation adds nothing (quiet steady state)", () => {
+    const live = new Set();
+    const l2 = layer2At("s.json", NEW);
+    refreshSelfEchoIdentitiesInto(live, null, l2, ledger);
+    expect(refreshSelfEchoIdentitiesInto(live, null, l2, ledger)).toEqual([]);
+  });
+
+  test("a throwing refresh never wedges the tick that carries it", () => {
+    const live = new Set([NEW]);
+    expect(() => refreshSelfEchoIdentitiesInto(live, null, "/nonexistent/l2.json", "\0bad")).not.toThrow();
+    expect(live.has(NEW)).toBe(true); // and does not damage what is already known
+  });
+
+  test("a third party is still never merged in", () => {
+    const live = new Set();
+    refreshSelfEchoIdentitiesInto(live, null, layer2At("t.json", NEW), ledger);
+    expect(live.has(HUMAN)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
@@ -1,0 +1,258 @@
+// linear-bot-identity.test.mjs — CTL-1892.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-bot-identity.test.mjs
+//
+// Real files in a temp dir: the whole claim under test is "what survives a rotation
+// on disk", which an in-memory fake cannot demonstrate.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isPlausibleIdentityId,
+  readIdentityLedger,
+  recordIdentity,
+  resolveSelfIdentities,
+  syncAndResolveSelfIdentities,
+} from "./linear-bot-identity.mjs";
+
+// The two real actors measured on this fleet. Same display name, different handle:
+// `catalystorchestrator` vs `catalystorchestrator2` — Linear's suffix on a taken
+// handle, which is what identifies this as a re-mint rather than a stray process.
+const OLD = "f51bc697-c64b-47b8-9fba-a2981fbfe652"; // retired 2026-08-10
+const NEW = "ba2989f1-f250-4273-943c-ca511c66e793"; // current, from 2026-08-10
+const HUMAN = "11111111-2222-3333-4444-555555555555"; // a genuine third party
+
+let dir;
+let ledger;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lbi-"));
+  ledger = join(dir, "linear-bot-identities.json");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Today's guard, reproduced exactly: the set IS the current config. */
+const todaysGuard = (configIds) => new Set(configIds);
+
+describe("⭐ POSITIVE CONTROL — the defect is real against today's guard", () => {
+  test("⛔ today's config-only guard treats a RETIRED identity as a third party", () => {
+    // This is the ticket's required failing control. It asserts the BUG, so it must
+    // pass here and would stop passing only if the point-in-time guard were fixed in
+    // place. It is the reason the rest of this file exists.
+    const afterRotation = todaysGuard([NEW]);
+    expect(afterRotation.has(OLD)).toBe(false); // ← the fleet dispatches on its own echo
+    expect(afterRotation.has(NEW)).toBe(true);
+  });
+
+  test("the ledger-backed set does NOT have that hole", () => {
+    recordIdentity(ledger, OLD, { source: "config:orchestrator" });
+    const { ids } = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(ids.has(OLD)).toBe(true);
+    expect(ids.has(NEW)).toBe(true);
+  });
+});
+
+describe("Feature: the fleet recognises its own writes across rotations", () => {
+  test("Scenario: the app actor is rotated — an OLD echo is still suppressed as self", () => {
+    // Given the orchestrator previously wrote as OLD (learned while OLD was configured)
+    let r = syncAndResolveSelfIdentities({ configIds: new Set([OLD]), ledgerPath: ledger });
+    expect(r.recorded).toEqual([OLD]);
+
+    // When it now writes as NEW (config rotated; OLD is gone from config entirely)
+    r = syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+
+    // Then BOTH are recognised as self — the rotation EXTENDED the set
+    expect(r.ids.has(OLD)).toBe(true);
+    expect(r.ids.has(NEW)).toBe(true);
+    expect(r.fromLedgerOnly).toContain(OLD);
+  });
+
+  test("Scenario: a genuine third party is still NOT suppressed", () => {
+    syncAndResolveSelfIdentities({ configIds: new Set([OLD, NEW]), ledgerPath: ledger });
+    const { ids } = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(ids.has(HUMAN)).toBe(false);
+  });
+
+  test("⛔ an OBSERVED writer never enters the ledger — only ids we write as", () => {
+    // The security argument for the whole file: if observation could admit an
+    // identity, a third party could suppress itself by writing to the board, and the
+    // guard becomes a way to HIDE changes from the fleet. There is deliberately no
+    // API that takes an observed author id.
+    syncAndResolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    const { ids } = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(ids.has(HUMAN)).toBe(false);
+    expect([...ids].sort()).toEqual([NEW]);
+  });
+
+  test("repeated rotations accumulate — three identities, all still self", () => {
+    const THIRD = "99999999-8888-7777-6666-555555555555";
+    for (const id of [OLD, NEW, THIRD]) {
+      syncAndResolveSelfIdentities({ configIds: new Set([id]), ledgerPath: ledger });
+    }
+    const { ids } = resolveSelfIdentities({ configIds: new Set([THIRD]), ledgerPath: ledger });
+    expect([...ids].sort()).toEqual([OLD, THIRD, NEW].sort());
+  });
+});
+
+describe("⛔ the ledger read is THREE-VALUED — absent and unreadable are different", () => {
+  test("absent is a clean empty, with a reason", () => {
+    const r = readIdentityLedger(ledger);
+    expect(r.status).toBe("absent");
+    expect(r.ids.size).toBe(0);
+  });
+
+  test("malformed JSON is UNREADABLE, never a healthy-looking empty", () => {
+    writeFileSync(ledger, "{not json");
+    expect(readIdentityLedger(ledger).status).toBe("unreadable");
+  });
+
+  test("shape is validated BEFORE coercion — the falsy-empty shapes are all unreadable", () => {
+    // Each of these yields an empty set under a permissive read, which is
+    // indistinguishable from a healthy empty ledger.
+    for (const bad of ["null", "[]", '{"identities":"abc"}', '{"identities":null}', '"str"']) {
+      writeFileSync(ledger, bad);
+      expect(readIdentityLedger(ledger).status).toBe("unreadable");
+    }
+  });
+
+  test("an entry with an implausible id is skipped and COUNTED, not silently dropped", () => {
+    writeFileSync(ledger, JSON.stringify({ version: 1, identities: [{ id: "nope" }, { id: NEW }, null, 42] }));
+    const r = readIdentityLedger(ledger);
+    expect(r.status).toBe("ok");
+    expect([...r.ids]).toEqual([NEW]);
+    expect(r.skipped).toBe(3);
+  });
+});
+
+describe("⛔ an unreadable ledger must never be overwritten", () => {
+  test("recordIdentity REFUSES rather than destroying retired identities", () => {
+    // Rewriting an unreadable file turns a transient read problem into the permanent
+    // reopening of the rotation window — the exact failure this ticket closes.
+    writeFileSync(ledger, "{corrupt");
+    const r = recordIdentity(ledger, NEW);
+    expect(r.recorded).toBe(false);
+    expect(r.status).toBe("refused-unreadable");
+    expect(readFileSync(ledger, "utf8")).toBe("{corrupt"); // untouched
+  });
+
+  test("resolve still returns the CONFIG ids when the ledger is unreadable (fail-open)", () => {
+    // Losing the configured ids would suppress nothing and turn every one of the
+    // fleet's own writes into a dispatch — strictly worse than the rotation window.
+    writeFileSync(ledger, "{corrupt");
+    const r = resolveSelfIdentities({ configIds: new Set([NEW]), ledgerPath: ledger });
+    expect(r.ids.has(NEW)).toBe(true);
+    expect(r.ledgerStatus).toBe("unreadable"); // ...but the degradation is REPORTED
+  });
+
+  test("the degradation is reportable, not silent", () => {
+    writeFileSync(ledger, "{corrupt");
+    expect(resolveSelfIdentities({ configIds: new Set(), ledgerPath: ledger }).ledgerReason).toBeTruthy();
+  });
+});
+
+describe("recording is append-only, idempotent, and never throws", () => {
+  test("recording the same id twice writes once", () => {
+    expect(recordIdentity(ledger, NEW).recorded).toBe(true);
+    const second = recordIdentity(ledger, NEW);
+    expect(second.recorded).toBe(false);
+    expect(second.alreadyKnown).toBe(true);
+    expect(JSON.parse(readFileSync(ledger, "utf8")).identities).toHaveLength(1);
+  });
+
+  test("a new id APPENDS rather than replacing", () => {
+    recordIdentity(ledger, OLD);
+    recordIdentity(ledger, NEW);
+    const ids = JSON.parse(readFileSync(ledger, "utf8")).identities.map((e) => e.id);
+    expect(ids).toEqual([OLD, NEW]);
+  });
+
+  test("an implausible id is refused — a truncated or empty value must not enter", () => {
+    for (const bad of ["", "abc", null, undefined, 42, `${NEW}x`]) {
+      expect(recordIdentity(ledger, bad).recorded).toBe(false);
+    }
+    expect(readIdentityLedger(ledger).status).toBe("absent"); // nothing was created
+  });
+
+  test("an unwritable path is reported, never thrown", () => {
+    const rd = join(dir, "ro");
+    require("node:fs").mkdirSync(rd);
+    chmodSync(rd, 0o500);
+    const r = recordIdentity(join(rd, "l.json"), NEW);
+    expect(r.recorded).toBe(false);
+    expect(r.status).toBe("write-failed");
+    chmodSync(rd, 0o700);
+  });
+
+  test("provenance is recorded, so a retired id can be explained later", () => {
+    recordIdentity(ledger, OLD, { source: "config:orchestrator", now: () => 1000 });
+    const [e] = JSON.parse(readFileSync(ledger, "utf8")).identities;
+    expect(e).toMatchObject({ id: OLD, source: "config:orchestrator", firstRecordedAt: 1000 });
+  });
+});
+
+describe("id shape", () => {
+  test("only a well-formed UUID is plausible", () => {
+    expect(isPlausibleIdentityId(NEW)).toBe(true);
+    for (const bad of ["", " ", "abc", null, undefined, 42, {}, `${NEW} `]) {
+      expect(isPlausibleIdentityId(bad)).toBe(false);
+    }
+  });
+});
+
+// ── the daemon-level seam ────────────────────────────────────────────────────
+import { readSelfEchoIdentities } from "./daemon.mjs";
+
+describe("readSelfEchoIdentities — the seam the daemon actually calls", () => {
+  const layer2 = (dirPath, ids) => {
+    const p = join(dirPath, "layer2.json");
+    writeFileSync(
+      p,
+      JSON.stringify({ catalyst: { linear: { bot: { orchestrator: { botUserId: ids.orchestrator }, worker: { botUserId: ids.worker } } } } }),
+    );
+    return p;
+  };
+
+  test("⭐ a rotation EXTENDS the set — the retired identity is still self", () => {
+    // Tick 1: OLD is configured, so the ledger learns it.
+    const before = readSelfEchoIdentities(null, layer2(dir, { orchestrator: OLD }), ledger);
+    expect(before.has(OLD)).toBe(true);
+
+    // Tick 2: the app is re-minted. Config names ONLY the new id.
+    const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), ledger);
+    expect(after.has(NEW)).toBe(true);
+    expect(after.has(OLD)).toBe(true); // ← the window that used to be open
+  });
+
+  test("⛔ a third party is still not suppressed after a rotation", () => {
+    readSelfEchoIdentities(null, layer2(dir, { orchestrator: OLD }), ledger);
+    const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), ledger);
+    expect(after.has(HUMAN)).toBe(false);
+  });
+
+  test("with NO ledger path it degrades to exactly today's behaviour", () => {
+    const ids = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), null);
+    expect([...ids]).toEqual([NEW]);
+  });
+
+  test("an unreadable ledger is REPORTED and still fail-open", () => {
+    writeFileSync(ledger, "{corrupt");
+    let reported = null;
+    const ids = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), ledger, {
+      onDegraded: (d) => (reported = d),
+    });
+    expect(ids.has(NEW)).toBe(true); // fail-open: config ids survive
+    expect(reported).toMatchObject({ status: "unreadable" }); // but it is announced
+    expect(reported.reason).toBeTruthy();
+  });
+
+  test("both worker and orchestrator identities are learned", () => {
+    const ids = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW, worker: OLD }), ledger);
+    expect(ids.has(NEW)).toBe(true);
+    expect(ids.has(OLD)).toBe(true);
+    // and both persist after the config drops them
+    const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: HUMAN }), ledger);
+    expect(after.has(NEW)).toBe(true);
+    expect(after.has(OLD)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes CTL-1892.

## The defect

The self-echo guard names the **currently configured** app-actor ids, so a rotation **replaces** the identity set instead of extending it. From the moment a new app-actor starts writing until the config names it, the fleet's own echoes are not recognised as its own — and it dispatches on its own writes as if a third party had moved the board.

Nothing errors. The symptom is indistinguishable from ordinary board activity, and the trigger is **scheduled**: re-minting the OAuth app is routine (CTL-1616's rotation classes).

## The stray actor, reconciled rather than allow-listed

Two Linear users share the display name "Catalyst Orchestrator" but differ by handle:

| actor | handle | writes | window |
|---|---|---|---|
| `f51bc697…` | `catalystorchestrator` | 2,241 (1,404 state edges, 748 label writes) | 2026-06-05 → **2026-08-10** |
| `ba2989f1…` | `catalystorchestrator2` | 118 | **2026-08-10** → current |

Linear's `2` suffix on a taken handle, plus a same-day handoff with no overlap, makes this a **re-mint of the same app** — not a stale process and not a third party. Only the second is named by any config.

Verified the retired id appears in **no** config, live or backup — **with a positive control on the current id**, because in this environment `grep -r` is a wrapper running `ugrep --ignore-files`, and `~/.config/catalyst/.gitignore` excludes `config*.json`. A recursive grep therefore skips every live Catalyst config and reports a clean zero. The control is what makes the negative mean anything.

## The fix

A durable per-host ledger of every identity this fleet has **written as**, unioned with the config set and recorded on the way through — so a rotation **extends** the set rather than reopening the window.

**⛔ Only ids read from our own config may enter the ledger.** There is deliberately no API that admits an *observed* author id: if observation could enrol an identity, a third party could suppress itself simply by writing to the board, inverting the guard into a way to hide changes from the fleet. That is the security argument for the module.

## Fail directions, each chosen and tested

- the ledger read is **three-valued** — `absent` and `unreadable` are different verdicts, and shape is validated **before** coercion, since `[]`, `null`, and `{identities:"abc"}` all yield an empty set under a permissive read and are indistinguishable from a healthy empty ledger
- an unreadable ledger is **never overwritten** — rewriting it would destroy the retired identities it still holds, turning a transient read problem into the *permanent* reopening of the rotation window
- resolution is **fail-open** on a bad ledger (configured ids survive, since losing them would suppress nothing and turn every one of the fleet's own writes into a dispatch) but the degradation is **reported**, never silent

## Scope boundary, stated rather than implied

This makes each host's own view **monotonic**. It does **not** close the cross-host window, where host A rotates and writes as NEW while host B's config still names OLD — B has never written as NEW, so it cannot have learned it. Closing that is the job of the existing cluster config distribution.

## Verification

24 tests, including the ticket's required **positive control** (today's config-only guard demonstrably treats the retired identity as a third party) and both Gherkin scenarios. Four guards mutation-verified — dropping the ledger union fails 5 tests, refuse-unreadable 2, shape validation 1, id-shape 3. `daemon.test.mjs`: 174 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)