### PR TITLE
docs(meta): a recursive grep can skip files without saying so — the fifth false-clean mechanism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ replica-read rule below is absolute).
   instrument against a case known to be present and saw it come back non-zero.** Before you report
   "zero", "absent", "unrelated", "clean", or "not owned", ask the question that separates *the thing
   is not there* from *I could not look* — and if you cannot separate them, say **inconclusive**. The
-  four mechanisms that have actually produced a false clean result here, all of them silent:
+  five mechanisms that have actually produced a false clean result here, all of them silent:
   (1) an unstructured match over structured data — a substring `grep` for an event name counted the
   name where it appeared inside a commit message, reporting events that did not exist; (2) a
   malformed call returning a falsy sentinel — an ownership helper invoked with its arguments
@@ -51,7 +51,17 @@ replica-read rule below is absolute).
   set feeding a loop, so the body never ran and the trailing all-clear line printed on the strength
   of zero iterations (`[].every(p)` is `true`); (4) the right question asked of the wrong surface —
   counting a bot's issue comments returned zero while an unresolved *review thread* was the thing
-  blocking the merge. Prefer the verified helpers in `plugins/dev/scripts/lib/verified-checks.mjs`
+  blocking the merge; (5) **the search tool skipping files it never says it skipped** — in the agent
+  shell `grep` is a wrapper around `ugrep --ignore-files`, which honours `.gitignore`, and
+  `~/.config/catalyst/.gitignore` excludes `config*.json`, so **a recursive grep never reads any live
+  Catalyst config** and answers "not configured anywhere" for a value sitting in `config.json`. It is
+  convincing because the `.bak-*` copies do NOT match that pattern, so you get plausible hits from
+  stale backups while the live file is skipped. A recursive-grep zero over config, secrets, or
+  build output is **inconclusive** until re-run with `/usr/bin/grep` or an explicit file list.
+  (Sibling traps in the same family: `find` does not follow symlinks, so it misses what
+  `cat`/`readFileSync` read straight through — e.g. bun's `.bun` store entries; and zsh kills an
+  unquoted `--include=*.mjs` with "no matches found", returning nothing, which also reads as a real
+  zero.) Prefer the verified helpers in `plugins/dev/scripts/lib/verified-checks.mjs`
   (count events by exact `event.name`, resolve ticket ownership under named rosters, enumerate every
   merge blocker) — each returns a verdict that can be explicitly **inconclusive** and throws on
   malformed input rather than degrading to a falsy answer. This rule governs the bullets below: a


### PR DESCRIPTION
## What

Adds a fifth entry to `AGENTS.md`'s list of mechanisms that have actually produced a **false clean result** in this repo.

## The mechanism

In the agent shell, `grep` is a wrapper around `ugrep --ignore-files`, which honours `.gitignore`. `~/.config/catalyst/.gitignore` contains `config*.json` — *"All Catalyst configs contain secrets - never commit"* — so **a recursive grep never reads any live Catalyst config** and answers "not configured anywhere" for a value sitting in `config.json`.

Measured 2026-08-16 while auditing which config names the orchestrator app-actor id:

```
grep -rl   "$ID" ~/.config/catalyst/          -> 2 files   (misses config.json)
grep -l    "$ID" ~/.config/catalyst/*         -> 3 files   (explicit args: finds it)
/usr/bin/grep -rl "$ID" ~/.config/catalyst/   -> 3 files
grep -c    "$ID" ~/.config/catalyst/config.json -> 1
```

`grep -rc "" <dir>` proved the file was never **traversed** (0), not merely unmatched.

## Why it's convincing rather than obviously broken

The `.bak-*` copies **do** match, because `config.json.bak-mcppos` doesn't end in `.json`. So you get plausible-looking hits from stale backups while the live file is skipped — the answer looks researched.

## Same family, same day, also returning clean zeros

- `find` does not follow symlinks: `find -maxdepth 4 -name package.json` returned nothing for a package whose `package.json` a `cat` read fine, because the isolated linker symlinks it into a store directory.
- zsh kills an unquoted `--include=*.mjs` with "no matches found", producing empty output that reads as a real zero.

## Checks

Vendor-neutral per the bridge lint (no tool names); `scripts/ci/check-agents-md-bridge.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)