### PR TITLE
fix(dev): pin @catalyst-cloud/sdk 0.8.5, ending the pr_* frame loss

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "catalyst",
       "dependencies": {
-        "@catalyst-cloud/schema": "0.1.10",
+        "@catalyst-cloud/schema": "0.1.12",
         "@modelcontextprotocol/sdk": "1.29.0",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.4",
+        "@catalyst-cloud/sdk": "0.8.5",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.5", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.10" } }, "sha512-m7ZrRVMyItWKv19A+NhlxGohfjLxWDTWT6wmFyUwRlJd9OeeX11YNHJt7g7xq+FBYXKTkYUiyVNBs5Y9mjMvLA=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.6", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.12" } }, "sha512-6+PPbIvd16wr9Sr7pVpdpzGOQoYC5aNIgYtnk6s+XJQC/+dmznsTFq8Y00z3D+DeYAdy9GRhYXjKFITuKDFiEg=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.10", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-QEyiewCO+taYQ4seYOG3k5p5TBD4bpWbI6/045QcSBR6hILGNG51HnGbVPjrIIm85xRnMPOsgJBXWkrQIh04VQ=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.12", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-O3G/96AJCrM8HB3XHa2A1yd6A/qB5kTAOEToiGdw1hUUejMkhb8ruVLaweZUMSuRTOWLoM62hJUD6s0Ly4rSVA=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.4", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.5", "@catalyst-cloud/schema": "0.1.10" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-UrFG6CP+FWe5/DQw0KuRdJmkxb1PvHQG8aZ+ISffUpmUla/IE2dDvdqgTSXLgkk19KVdnY19cMM9CvWlsGsBdw=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.5", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.6", "@catalyst-cloud/schema": "0.1.12" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-YIKP9yRsr5jH+kfu6rdQeadxqpp24b3VAYvDeC/v4qfRj4qjXo1jsLbFrpjLxbWGbaTuWPsphEHzFLH6NJGCMQ=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hono": "4.12.27"
   },
   "dependencies": {
-    "@catalyst-cloud/schema": "0.1.10",
+    "@catalyst-cloud/schema": "0.1.12",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.4",
+    "@catalyst-cloud/sdk": "0.8.5",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
## The data loss this ends

The mirror has been emitting change frames for four entities **no published schema defined** — `pr_commits`, `pr_review_comments`, `pr_conversation_comments`, `pr_events` — so every client dropped them regardless of version.

They are **dropped, not retried**: the cursor advances straight past a failed frame. That makes it *permanent per-entity data loss underneath a cursor that looks perfectly healthy* — the failure mode no existing instrument was watching.

Measured on the fleet, 20k-line log sample:

```
414  pr_commits
321  pr_review_comments
166  pr_conversation_comments
---
901  failed frames
```

**Positive control** in the same sample: 3,926 frames applied, and `issues` failures = **0**. So the zero above is evidence, not a broken query.

## The fix

`schema@0.1.12` defines all four — verified against the published tarball's `CREATE TABLE` statements, not the changelog. `0.8.5` pins `replicate@0.1.6` exactly, and `0.1.6` pins `schema@0.1.12` exactly, so both halves still name one schema and the CTL-1895 invariant holds across the bump.

## ⭐ Also bumps the ROOT schema pin, which the SDK bump does not move

The root `package.json` declared `@catalyst-cloud/schema: 0.1.10` **independently**, and `cloud-sync-schema-identity.mjs` imports that **bare** specifier while the replica applies with whatever the SDK resolves.

Bumping only the SDK would have left `bare = 0.1.10` against `sdk = 0.1.12` — precisely the **CTL-1869 split** (a host reporting a schema identity three migrations away from the one it applies), re-opened by the very upgrade meant to close a different version skew.

Caught by the one-copy gate on a fresh tree. It would **not** have appeared in any resolution check that starts from the SDK.

## Verification (off disk, following symlinks, from every importing position)

| resolution path | version |
|---|---|
| bare `@catalyst-cloud/schema` | 0.1.12 |
| schema **via sdk** | 0.1.12 |
| schema **via replicate** (the writer's `KNOWN_COLUMNS` source) | 0.1.12 |
| MIGRATED vs WRITTEN | **agree** |

The store retains an orphaned `schema@0.1.10` entry after the upgrade — bun's documented behaviour, and why a store-level copy count is only meaningful on a *truly fresh* tree. No resolution path reaches it; the authoritative check is what each importer resolves, and all three agree.

The CTL-1869 identity guard passes **17/17** here, exercising the unified-tree branch added in #3426 — a tree with one schema copy is a **result**, not an inconclusive test.

## Policy

Pin stays **exact**. A bump is a deliberate PR, never a range that floats — a caret is what let the running version drift from the declared one in the first place.

## Rollout

Same verified loop as #3426: merge → plugin-refresh delivers → restart mini-2 → mini → laptop, verifying LOADED per host and `pr_*` frames **applying** (0 failed) rather than trusting the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)