### PR TITLE
fix(dev): pin @catalyst-cloud/sdk 0.8.6 — PRAGMA-accurate columns close the skew class at the root

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.5",
+        "@catalyst-cloud/sdk": "0.8.6",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -214,7 +214,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.12", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-O3G/96AJCrM8HB3XHa2A1yd6A/qB5kTAOEToiGdw1hUUejMkhb8ruVLaweZUMSuRTOWLoM62hJUD6s0Ly4rSVA=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.5", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.6", "@catalyst-cloud/schema": "0.1.12" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-YIKP9yRsr5jH+kfu6rdQeadxqpp24b3VAYvDeC/v4qfRj4qjXo1jsLbFrpjLxbWGbaTuWPsphEHzFLH6NJGCMQ=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.6", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.6", "@catalyst-cloud/schema": "0.1.12" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-6POOST4PcGTJ7uBW7MjjtnZLMxjTtXzDfVPq3/m3FNIzFe22ptpHMdXFSC7q5cqzqhgatWalp8qq2vSAvv5Zzw=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.5",
+    "@catalyst-cloud/sdk": "0.8.6",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
## Why this differs from the last two bumps

`0.8.4` and `0.8.5` fixed two **instances** of the same defect by aligning versions. This fixes the **mechanism**, so a future misalignment cannot silently drop data again.

The original failure (CTL-1895): `applyDelta` filtered every upsert through `KNOWN_COLUMNS`, a constant baked from replicate's *own* bundled schema. That filter is a safety feature (CTC-127) which assumes the bundled schema is the **older** one — so when the migrator ran ahead, the same guard dropped columns that **did** exist on disk, leaving permanently NULL columns under a green `loadedSchemaIdentity()`.

Pinning versions makes the two agree *today*. It does nothing about the next time they don't.

CTC-603 replaces the bundled constant with a **PRAGMA-accurate column list read from the real table**, on both the node and browser paths. The column set now comes from the database being written to, so no skew between migrator and writer can filter a column out.

## Verified in the published bytes, with a control

| | `knownColumns` | `table_info` \| `PRAGMA` |
|---|---|---|
| 0.8.5 dist | **0** | 6 |
| 0.8.6 dist | **28** | 37 |

The **zero is the meaningful half**: it independently reproduces the CTL-1895 finding that the SDK never passed the `knownColumns` override at all — so the 28 is a real behaviour change rather than a renamed symbol. Checked against the tarball, not the changelog.

## The chain does not move

`0.8.6` pins `replicate@0.1.6` and `schema@0.1.12` exactly — identical to 0.8.5. Resolution verified off disk, following symlinks, from every importing position:

| path | version |
|---|---|
| bare `@catalyst-cloud/schema` | 0.1.12 |
| via sdk | 0.1.12 |
| via replicate (the writer's column source) | 0.1.12 |
| MIGRATED vs WRITTEN | **agree** |

CTL-1869 identity guard: **17 pass / 0 fail**.

## ⚠️ Rollout check differs from the last two

Because the schema does **not** change, `migrationsChangeRowShape` will not fire and there is **no one-time re-seed** — correctly, since nothing needs backfilling. So "new tables appeared" cannot be the verification this time.

Rollout verification is: **LOADED version per host** plus a still-healthy replica — cursor advancing, zero failed frames, row counts holding.

## Policy

Pin stays **exact**. A bump is a deliberate PR, never a range that floats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)