### PR TITLE
fix(dev): pin @catalyst-cloud/sdk 0.8.7 — the replica tenant fence

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.6",
+        "@catalyst-cloud/sdk": "0.8.7",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -214,7 +214,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.12", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-O3G/96AJCrM8HB3XHa2A1yd6A/qB5kTAOEToiGdw1hUUejMkhb8ruVLaweZUMSuRTOWLoM62hJUD6s0Ly4rSVA=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.6", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.6", "@catalyst-cloud/schema": "0.1.12" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-6POOST4PcGTJ7uBW7MjjtnZLMxjTtXzDfVPq3/m3FNIzFe22ptpHMdXFSC7q5cqzqhgatWalp8qq2vSAvv5Zzw=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.7", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.6", "@catalyst-cloud/schema": "0.1.12" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-gQ/7sBmI3oXhVGtCyEtbGp7CVShZDQwfmiJMSemgdXdAunDM8qu/E5wYV1wXp5dXidKQTHp50a+CuJwL5h0q0w=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/plugins/dev/scripts/execution-core/cloud-sync-account.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-account.mjs
@@ -31,10 +31,37 @@
  */
 export function resolveAccountProvenance(env = process.env, defaultAccount = "tenant-0") {
   const declared = env?.CATALYST_CLOUD_ACCOUNT || "";
+  // ⛔ THE LAUNCHER DEFAULTS THE ACCOUNT, so env-presence alone is NOT provenance.
+  // `cloud-sync/launch.sh` runs `CATALYST_CLOUD_ACCOUNT="${CATALYST_CLOUD_ACCOUNT:-tenant-0}"`,
+  // which makes the var always-set on the shipped launchd path. Deriving provenance from
+  // presence there returns "declared" for EVERY host, stamping every default replica as a
+  // declaration nobody made — the precise failure this contract exists to prevent, one
+  // layer further down. The launcher therefore captures the distinction BEFORE its own
+  // fallback and passes it here explicitly.
+  //
+  // ⚠️ Only the two known values are honoured, and anything else degrades to "default".
+  // An unrecognised marker must never be read as "declared": a declared stamp is permanent
+  // and refuses later transitions, while a default stamp stays recoverable. When the two
+  // directions cost different things, an unknown lands on the recoverable one.
+  const marker = env?.CATALYST_CLOUD_ACCOUNT_SOURCE;
+  const markerPresent = typeof marker === "string" && marker !== "";
+  // A PRESENT but unrecognised marker degrades to "default" — it does NOT fall through to
+  // presence-derivation. Falling through would re-open the whole bug on the launchd path,
+  // where the account is always set: a typo'd or truncated marker would derive "declared"
+  // for every host, which is exactly the state this marker exists to prevent. A marker that
+  // is present at all means something tried to tell us; if we cannot read it, the
+  // recoverable answer is the only safe one.
+  const accountSource = markerPresent
+    ? marker === "declared"
+      ? "declared"
+      : "default"
+    : declared
+      ? "declared"
+      : "default";
   return {
     account: declared || defaultAccount,
-    accountSource: declared ? "declared" : "default",
-    declared: Boolean(declared),
+    accountSource,
+    declared: accountSource === "declared",
   };
 }
 

--- a/plugins/dev/scripts/execution-core/cloud-sync-account.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-account.mjs
@@ -1,0 +1,101 @@
+// cloud-sync-account.mjs — CTL-1893 / sdk 0.8.7 replica tenant fence.
+//
+// Two pure pieces extracted from the script-shaped `cloud-sync.mjs` so they are
+// unit-testable without booting a writer — the same reason `depSkewEventEnvelope` lives
+// outside it.
+//
+// ## Why provenance is a separate fact from the account
+//
+// The SDK's tenant fence stamps `sync_meta.account` on first open and refuses a
+// mismatched one. Its refusal rule is:
+//
+//     refuse when   stored.source === "declared" || mySource !== "declared"
+//
+// so the truncate + cursor-drop + cold-reseed TRANSITION happens on exactly one edge:
+// a stored **default** meeting a configured **declared**. Everything else refuses,
+// deliberately — two disagreeing defaults give no basis to prefer either account, and
+// therefore none to DELETE either one's rows.
+//
+// ⛔ The consequence for us: if we pass only `account`, the SDK applies its
+// `accountSource: "default"` fallback, and an operator who explicitly sets
+// CATALYST_CLOUD_ACCOUNT is judged default-vs-default → REFUSED. The writer would fail to
+// start on the very reconfiguration the operator just performed. Passing provenance is
+// what makes that edge reachable.
+
+/**
+ * Resolve the account and whether it was DECLARED or DEFAULTED.
+ *
+ * ⚠️ An empty string is NOT a declaration. `CATALYST_CLOUD_ACCOUNT=""` is indistinguishable
+ * from unset in intent, and treating it as declared would stamp a permanent assertion off
+ * a value nobody chose — the precise failure this whole contract exists to avoid.
+ */
+export function resolveAccountProvenance(env = process.env, defaultAccount = "tenant-0") {
+  const declared = env?.CATALYST_CLOUD_ACCOUNT || "";
+  return {
+    account: declared || defaultAccount,
+    accountSource: declared ? "declared" : "default",
+    declared: Boolean(declared),
+  };
+}
+
+/**
+ * Is this error the SDK's permanent tenant-fence refusal?
+ *
+ * ⛔ Matched by `name`, never `instanceof`. The SDK can legitimately be present as more
+ * than one copy under bun's isolated linker, and a cross-copy `instanceof` is FALSE — which
+ * would silently route a permanent config fault back onto the retry-forever path. Name
+ * matching fails in the safe direction: the cost of a false positive is a writer that stays
+ * down loudly, the cost of a false negative is an infinite relaunch loop on a fault no
+ * restart can clear.
+ */
+export function isAccountMismatchError(err) {
+  return err?.name === "ReplicaAccountMismatchError";
+}
+
+/**
+ * The v2 envelope for a permanent, non-retryable refusal — same shape as the writer-idle
+ * event, ERROR severity because no restart clears it.
+ *
+ * The writer is about to stay DOWN, so this is the only structured record that will say so;
+ * it rides the unified event log rather than the replica this process just refused to open.
+ */
+export function accountMismatchEnvelope({
+  host,
+  dbPath,
+  storedAccount,
+  configuredAccount,
+  configuredSource,
+  ts,
+  id,
+  traceId,
+  spanId,
+  resource,
+}) {
+  return {
+    ts,
+    id,
+    observedTs: ts,
+    severityText: "ERROR",
+    severityNumber: 17,
+    traceId,
+    spanId,
+    resource,
+    attributes: {
+      "event.name": "catalyst.replica.account_mismatch",
+      "event.entity": "replica",
+      "event.action": "account_mismatch",
+      "event.label": host,
+      host,
+      db_path: dbPath,
+      stored_account: storedAccount ?? null,
+      configured_account: configuredAccount,
+      configured_source: configuredSource,
+    },
+    body: {
+      message:
+        `cloud-sync refusing to start: replica at ${dbPath} is stamped for ` +
+        `${storedAccount ?? "(unknown)"}, configured for ${configuredAccount} ` +
+        `(${configuredSource}). Permanent config fault — writer staying down.`,
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/cloud-sync-account.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-account.test.mjs
@@ -1,0 +1,116 @@
+// cloud-sync-account.test.mjs — CTL-1893 / sdk 0.8.7 replica tenant fence.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test cloud-sync-account.test.mjs
+
+import { describe, expect, test } from "bun:test";
+import {
+  accountMismatchEnvelope,
+  isAccountMismatchError,
+  resolveAccountProvenance,
+} from "./cloud-sync-account.mjs";
+
+describe("⭐ provenance: a DECLARED account is a different fact from a DEFAULTED one", () => {
+  test("an explicitly set env var is DECLARED", () => {
+    const r = resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-3" });
+    expect(r).toEqual({ account: "tenant-3", accountSource: "declared", declared: true });
+  });
+
+  test("unset falls back and is reported as DEFAULT", () => {
+    const r = resolveAccountProvenance({});
+    expect(r).toEqual({ account: "tenant-0", accountSource: "default", declared: false });
+  });
+
+  test("⛔ an EMPTY STRING is not a declaration", () => {
+    // `CATALYST_CLOUD_ACCOUNT=""` is indistinguishable from unset in intent. Treating it
+    // as declared would stamp a permanent assertion off a value nobody chose — the exact
+    // failure this contract exists to prevent.
+    const r = resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "" });
+    expect(r.accountSource).toBe("default");
+    expect(r.account).toBe("tenant-0");
+  });
+
+  test("the fallback account is injectable, not assumed", () => {
+    expect(resolveAccountProvenance({}, "tenant-9").account).toBe("tenant-9");
+  });
+
+  test("a missing env object does not throw", () => {
+    expect(resolveAccountProvenance(undefined, "t").account).toBe("t");
+    expect(resolveAccountProvenance(null, "t").accountSource).toBe("default");
+  });
+
+  test("⭐ THE EDGE THE SDK NEEDS: declared is what makes the transition reachable", () => {
+    // The SDK refuses when `mySource !== "declared"`. So a host reconfigured from the
+    // default tenant to an explicit one is REFUSED unless we report provenance —
+    // failing to start on the very reconfiguration the operator just performed.
+    const reconfigured = resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-3" });
+    expect(reconfigured.accountSource).toBe("declared"); // ← the transition edge
+    const untouched = resolveAccountProvenance({});
+    expect(untouched.accountSource).toBe("default"); // ← stays recoverable
+  });
+});
+
+describe("⛔ the permanent-refusal discriminator matches by NAME, not instanceof", () => {
+  test("the SDK's error is recognised", () => {
+    const e = new Error("nope");
+    e.name = "ReplicaAccountMismatchError";
+    expect(isAccountMismatchError(e)).toBe(true);
+  });
+
+  test("a cross-copy error object still matches — which instanceof would not", () => {
+    // The SDK can be present as more than one copy under the isolated linker; a
+    // cross-copy `instanceof` is FALSE and would silently route a permanent config fault
+    // back onto the retry-forever path. This is a plain object with the right name.
+    expect(isAccountMismatchError({ name: "ReplicaAccountMismatchError" })).toBe(true);
+  });
+
+  test("ordinary start failures are NOT treated as permanent", () => {
+    // These must keep exiting 1 so launchd retries: a second live writer, an unreachable
+    // host, a seed failure. Misclassifying one as permanent parks the writer forever.
+    for (const bad of [new Error("connect ECONNREFUSED"), { name: "TimeoutError" }, null, undefined, {}, "str"]) {
+      expect(isAccountMismatchError(bad)).toBe(false);
+    }
+  });
+});
+
+describe("the refusal envelope", () => {
+  const base = {
+    host: "mini-2",
+    dbPath: "/x/catalyst-replica.db",
+    storedAccount: "tenant-0",
+    configuredAccount: "tenant-3",
+    configuredSource: "declared",
+    ts: "2026-08-16T10:00:00Z",
+    id: "abc",
+    traceId: "t",
+    spanId: "s",
+    resource: { "service.name": "catalyst.cloud-sync" },
+  };
+
+  test("is ERROR severity — no restart clears this, so it is not a warning", () => {
+    const e = accountMismatchEnvelope(base);
+    expect(e.severityText).toBe("ERROR");
+    expect(e.severityNumber).toBe(17);
+  });
+
+  test("carries both accounts and the provenance in ATTRIBUTES", () => {
+    // otel-forward strips body.payload off-machine, so anything an alert must select on
+    // has to live in attributes.
+    const a = accountMismatchEnvelope(base).attributes;
+    expect(a["event.name"]).toBe("catalyst.replica.account_mismatch");
+    expect(a.stored_account).toBe("tenant-0");
+    expect(a.configured_account).toBe("tenant-3");
+    expect(a.configured_source).toBe("declared");
+    expect(a.db_path).toBe("/x/catalyst-replica.db");
+  });
+
+  test("an unknown stored account is null and named, never blank", () => {
+    const e = accountMismatchEnvelope({ ...base, storedAccount: undefined });
+    expect(e.attributes.stored_account).toBeNull();
+    expect(e.body.message).toContain("(unknown)");
+  });
+
+  test("the message states the consequence, not just the condition", () => {
+    // An operator reading this at 3am needs to know the writer is DOWN and will stay down.
+    expect(accountMismatchEnvelope(base).body.message).toContain("staying down");
+  });
+});

--- a/plugins/dev/scripts/execution-core/cloud-sync-account.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-account.test.mjs
@@ -114,3 +114,46 @@ describe("the refusal envelope", () => {
     expect(accountMismatchEnvelope(base).body.message).toContain("staying down");
   });
 });
+
+describe("⭐ Codex round 2 P1: the LAUNCHER defaults the account, erasing provenance", () => {
+  // cloud-sync/launch.sh runs CATALYST_CLOUD_ACCOUNT="${CATALYST_CLOUD_ACCOUNT:-tenant-0}",
+  // so on the shipped launchd path the var is ALWAYS set by the time the writer reads it.
+  // Env-presence alone therefore reports "declared" for every host, stamping every default
+  // replica with a declaration nobody made — permanently, since the stamp cannot be undone.
+  test("⛔ presence-only would say declared; the explicit marker says default", () => {
+    const launcherDefaulted = { CATALYST_CLOUD_ACCOUNT: "tenant-0", CATALYST_CLOUD_ACCOUNT_SOURCE: "default" };
+    expect(resolveAccountProvenance(launcherDefaulted).accountSource).toBe("default");
+    // and without the marker the old derivation is what would have gone wrong:
+    expect(resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-0" }).accountSource).toBe("declared");
+  });
+
+  test("a genuine operator declaration still reports declared through the launcher", () => {
+    const declared = { CATALYST_CLOUD_ACCOUNT: "tenant-3", CATALYST_CLOUD_ACCOUNT_SOURCE: "declared" };
+    const r = resolveAccountProvenance(declared);
+    expect(r).toEqual({ account: "tenant-3", accountSource: "declared", declared: true });
+  });
+
+  test("⛔ an UNRECOGNISED marker degrades to default, never to declared", () => {
+    // A declared stamp is permanent and refuses later transitions; a default stamp stays
+    // recoverable. An unknown value must land on the recoverable side.
+    // ⚠️ These run with the ACCOUNT SET, i.e. the launchd path — where falling through to
+    // presence-derivation would answer "declared" and re-open the bug. A present-but-
+    // unreadable marker must therefore NOT fall through.
+    for (const bad of ["DECLARED", "yes", "1", "true", "Default"]) {
+      const r = resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-3", CATALYST_CLOUD_ACCOUNT_SOURCE: bad });
+      expect(r.accountSource).toBe("default");
+      expect(r.declared).toBe(false);
+    }
+    // absent / empty / non-string = no marker at all → presence-derivation is correct,
+    // since a non-launcher caller may legitimately pass no marker.
+    for (const absent of ["", null, undefined, {}, 0]) {
+      const r = resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-3", CATALYST_CLOUD_ACCOUNT_SOURCE: absent });
+      expect(r.accountSource).toBe("declared");
+    }
+  });
+
+  test("with NO marker at all, presence-derivation still applies (non-launcher callers)", () => {
+    expect(resolveAccountProvenance({ CATALYST_CLOUD_ACCOUNT: "tenant-3" }).accountSource).toBe("declared");
+    expect(resolveAccountProvenance({}).accountSource).toBe("default");
+  });
+});

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -93,6 +93,7 @@ import {
 } from "./cloud-sync-deps.mjs";
 import { createRequire } from "node:module";
 import { appendFileSync, mkdirSync } from "node:fs";
+import { accountMismatchEnvelope, isAccountMismatchError, resolveAccountProvenance } from "./cloud-sync-account.mjs"; // CTL-1893
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
@@ -125,6 +126,33 @@ function hbLogger() {
 const DEFAULT_BASE_URL = "https://api.catalyst-cloud.coalescelabs.ai/api/v1";
 const DEFAULT_ACCOUNT = "tenant-0";
 export const WRITER_IDLE_EVENT = "catalyst.replica.writer_idle";
+
+// CTL-1893: a permanent, non-retryable refusal. Emitted on the SAME unified log and in the
+// SAME v2 envelope as emitWriterIdleEvent — the writer is about to stay DOWN, so this line
+// is the only thing that will say so. ERROR severity, since no restart can clear it.
+function emitAccountMismatchEvent({ host, db_path, stored_account, configured_account, configured_source }) {
+  try {
+    const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+    const envelope = accountMismatchEnvelope({
+      host,
+      dbPath: db_path,
+      storedAccount: stored_account,
+      configuredAccount: configured_account,
+      configuredSource: configured_source,
+      ts,
+      id: randomBytes(8).toString("hex"),
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.cloud-sync", host }),
+    });
+    const logPath = getEventLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
+    return true;
+  } catch {
+    return false; // emission must never mask the refusal it reports
+  }
+}
 
 function emitWriterIdleEvent({ host, tokenEnv, tokenSource, dbPath }) {
   try {
@@ -206,7 +234,19 @@ function scrub(s) {
 }
 
 const baseUrl = process.env.CATALYST_CLOUD_BASE_URL || DEFAULT_BASE_URL;
-const account = process.env.CATALYST_CLOUD_ACCOUNT || DEFAULT_ACCOUNT;
+// CTL-1893 / sdk 0.8.7: the account and its PROVENANCE are different facts, and the SDK's
+// tenant fence needs both. An operator setting CATALYST_CLOUD_ACCOUNT IS a declaration;
+// falling back to DEFAULT_ACCOUNT is not.
+//
+// ⛔ Passing only `account` makes the SDK apply its `accountSource: "default"` fallback, so
+// a host moving from the default tenant to an explicitly configured one is judged
+// default-vs-default — which the fence REFUSES (two disagreeing defaults give no basis to
+// prefer either, and therefore none to WIPE either) instead of taking the intended
+// truncate + cursor-drop + cold-reseed transition. The writer would then fail to start on
+// the very reconfiguration the operator just performed.
+//
+// An empty string is NOT a declaration: it falls back, and is reported as defaulted.
+const { account, accountSource } = resolveAccountProvenance(process.env, DEFAULT_ACCOUNT);
 // startTimeoutMs (sdk 0.2.1): reject start() if 'live' isn't reached within this — a
 // wedged cold /snapshot or unreachable host fails fast → exit 1 → launchd restarts, instead
 // of a supervised process hanging forever. A positive override wins; an explicit `0` DISABLES
@@ -246,6 +286,9 @@ const hlog = hbLogger();
 const replica = new CatalystReplica({
   baseUrl,
   account,
+  // sdk 0.8.7 tenant fence: provenance, not just the value. See the resolution above for
+  // why omitting this turns an operator's explicit reconfiguration into a refusal.
+  accountSource,
   auth: { kind: "token", token }, // the value flows ONLY here — never logged
   dbPath,
   startTimeoutMs,
@@ -307,6 +350,40 @@ try {
   // onStatus drives progress visibility meanwhile.
   await replica.start();
 } catch (err) {
+  // ⛔ A REPLICA ACCOUNT MISMATCH IS PERMANENT — it must not ride the retry path.
+  //
+  // sdk 0.8.7's tenant fence throws ReplicaAccountMismatchError when this database is
+  // stamped for a different account. That is a CONFIG fault: the same inputs fail
+  // identically forever. Exiting 1 hands it to `KeepAlive={SuccessfulExit:false}`, which
+  // relaunches — so the writer would spin on a misconfiguration indefinitely, which is
+  // exactly what the SDK exported a distinct error type to prevent. Exit 0 is the plist's
+  // "clean no-op, stay DOWN" contract, and staying down is the CORRECT response to a
+  // fault no restart can clear.
+  //
+  // Matched on `name`, not `instanceof`: the SDK can legitimately be present as more than
+  // one copy under the isolated linker, and a cross-copy `instanceof` is FALSE — which
+  // would silently drop this back onto the retry-forever path. Name-matching fails in the
+  // safe direction here.
+  //
+  // ⚠️ Staying down MUST be loud, or we trade a spin for a silent outage. The event goes to
+  // the unified log (broker/HUD/alerting read it) and the stderr line rides the
+  // Alloy-shipped .log — neither depends on the replica this process just refused to open.
+  if (isAccountMismatchError(err)) {
+    const detail = {
+      db_path: err?.dbPath ?? dbPath,
+      stored_account: err?.storedAccount ?? null,
+      configured_account: err?.configuredAccount ?? account,
+      configured_source: accountSource,
+    };
+    console.error(
+      `${TAG} REFUSING TO START — replica account mismatch: ${JSON.stringify(detail)}. ` +
+        `This database belongs to another account; nothing was written. This is a CONFIG ` +
+        `fault and will NOT be retried — fix CATALYST_CLOUD_ACCOUNT or the replica path, ` +
+        `then start the writer manually.`
+    );
+    emitAccountMismatchEvent({ host: getHostName(), ...detail });
+    process.exit(0); // stay DOWN under KeepAlive={SuccessfulExit:false}
+  }
   // A second live writer on this path, an unreachable host, or a seed failure lands
   // here. exit 1 → launchd restarts with backoff (and reclaims a stale self-lock).
   console.error(`${TAG} start failed: ${scrub(err?.message ?? String(err))}`);

--- a/plugins/dev/scripts/execution-core/cloud-sync/launch.sh
+++ b/plugins/dev/scripts/execution-core/cloud-sync/launch.sh
@@ -65,6 +65,14 @@ set -u
 
 # ─── Cloud feed coordinates (overridable; sane prod defaults) ────────────────
 export CATALYST_CLOUD_BASE_URL="${CATALYST_CLOUD_BASE_URL:-https://api.catalyst-cloud.coalescelabs.ai/api/v1}"
+# ⛔ CTL-1893: capture PROVENANCE BEFORE the fallback erases the distinction.
+# The fallback below makes CATALYST_CLOUD_ACCOUNT always-set by the time the writer reads
+# it, so the writer cannot tell "the operator declared tenant-0" from "nobody said
+# anything". Without this marker every default replica is stamped source=declared, and a
+# later REAL tenant declaration then hits the SDK's stored-declared refusal instead of the
+# intended truncate/cold-reseed transition — permanently, since the stamp cannot be undone.
+export CATALYST_CLOUD_ACCOUNT_SOURCE="${CATALYST_CLOUD_ACCOUNT:+declared}"
+export CATALYST_CLOUD_ACCOUNT_SOURCE="${CATALYST_CLOUD_ACCOUNT_SOURCE:-default}"
 export CATALYST_CLOUD_ACCOUNT="${CATALYST_CLOUD_ACCOUNT:-tenant-0}"
 
 # CATALYST_HOST_NAME may arrive pinned from the plist EnvironmentVariables; otherwise the

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.6",
+    "@catalyst-cloud/sdk": "0.8.7",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
Adds the SDK-side half of CTL-1893 (CTC-582): a `sync_meta.account` stamp with a per-account fence. On open, a stamp present and **different** refuses; **absent** adopts and stamps. Refusal throws the exported `ReplicaAccountMismatchError` carrying `dbPath`/`storedAccount`/`configuredAccount`, so a supervisor can distinguish *"pointed at the wrong tenant's database"* (config fault — page a human) from a transient open failure (retry). Without that, a supervisor retries a misconfiguration forever.

## ⚠️ This is a one-way door, and was treated as one

Once a host opens under 0.8.7 the stamp is **permanent absent a wipe**. So the published **tarball** was read before the pin moved — not the changelog, not a green workflow:

```
DEFAULT_ACCOUNT_SOURCE = "default"                        <- omission means DEFAULT
const mySource = this.opts.accountSource ?? DEFAULT_...   <- our callers pass nothing
stored.source === "declared" || mySource !== "declared"   <- the refuse condition
ReplicaAccountMismatchError exported from dist/node.js    <- and node.d.ts
```

**That first line is the entire safety of this bump.**

An earlier cut stamped the configured account *unconditionally*. `cloud-sync.mjs:209` resolves `process.env.CATALYST_CLOUD_ACCOUNT || DEFAULT_ACCOUNT` — **env-only, it never reads config** — and the env is unset on all three hosts. So **100% of this fleet would have stamped `tenant-0` as though someone had declared it**, and a host later becoming `tenant-3` would be refused from its *own* replica by an assertion nobody made. That version was merged but **never published**; the fix (provenance + wipe-on-transition) is what shipped.

Under 0.8.7 our hosts stamp `{account: "tenant-0", source: "default"}` — **recoverable**: a later declared account triggers truncate + cursor-drop + cold-seed, rather than a rename that would leave one account's rows under another's stamp.

## Why the transition is safe host-side

For one specific reason, now asserted upstream at our request: **it drops the cursor.**

`replica-read.mjs:253-260` already treats a present, non-empty cursor as the seed-completeness signal and refuses to serve without one — citing the SDK's own files by name. Preserving the cursor across a re-seed would hand every host reader a **seed-complete empty replica they would trust**, zeroing the board and stopping dispatch fleet-wide with nothing red. That is now an upstream invariant with its own firing test, not an implementation detail of the re-seed path.

## Chain does not move

`0.8.7` pins `replicate@0.1.6` and `schema@0.1.12` exactly — identical to 0.8.6. Verified off disk, following symlinks, from the importing package: via sdk 0.1.12, via replicate 0.1.12, **MIGRATED == WRITTEN**. CTL-1869 identity guard: **17 pass / 0 fail**.

## ⚠️ Rollout check (again different)

No schema change → no migration → **no re-seed**. So "new tables appeared" is not the check. The new observable is **the stamp itself**: `sync_meta` gains `account` = `tenant-0` and `account_source` = `default` on each host after restart.

## Known upstream gap, recorded rather than glossed

CTC reports `truncateReplica` has **no firing negative control** — removing it leaves their suite green, because dropping the cursor forces a cold seed that truncates anyway. It is kept as defence in depth for the window where the seed never runs. Their disclosure, not a discovery here, and it does not affect this fleet's defaulted path.

## Policy

Pin stays **exact**. A bump is a deliberate PR, never a range that floats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)