### PR TITLE
fix(dev): CTL-1892 — the fleet has TWO app identities and both rotated; only one was seeded

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.mjs
@@ -82,6 +82,21 @@ export const KNOWN_RETIRED_IDENTITIES = Object.freeze([
       "name 'Catalyst Orchestrator' as its successor, whose handle carries Linear's collision " +
       "suffix '2'; same-day handoff with no overlap; named by no config, live or backup (CTL-1892)",
   },
+  {
+    // ⚠️ The fleet runs TWO app identities, not one — an ORCHESTRATOR and a WORKER — and
+    // each has rotated. The first cut of this list seeded only the orchestrator pair, so
+    // the retired WORKER's 1,245 comments still read as third-party: the same defect this
+    // module exists to close, for the other identity. Found by enumerating every actor
+    // named Catalyst* in the replica rather than by reasoning from the one already known.
+    id: "72824b58-5a2f-4ff1-9565-d128fc355cda",
+    handle: "catalyst",
+    retiredOn: "2026-08-10",
+    supersededBy: "6dd38c1a-68d8-4cbf-8bae-40593481f324", // handle catalyst2
+    evidence:
+      "1,245 comments 2026-06-02..2026-08-10; same display name 'Catalyst' as its successor, " +
+      "whose handle carries Linear's collision suffix '2'; handoff with ZERO overlap " +
+      "(successor's first comment 2026-08-11); named by no config, live or backup (CTL-1892)",
+  },
 ]);
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
@@ -98,7 +98,12 @@ describe("Feature: the fleet recognises its own writes across rotations", () => 
       syncAndResolveSelfIdentities({ configIds: new Set([id]), ledgerPath: ledger });
     }
     const { ids } = resolveSelfIdentities({ configIds: new Set([THIRD]), ledgerPath: ledger });
-    expect([...ids].sort()).toEqual([OLD, THIRD, NEW].sort());
+    // Assert ACCUMULATION, not an exact set: the seeded retired identities are also
+    // members by design, and an exact-equality here would just be asserting their absence.
+    for (const id of [OLD, NEW, THIRD]) expect(ids.has(id)).toBe(true);
+    // and every member is still justified — learned, or explicitly seeded as retired
+    const seeded = new Set(KNOWN_RETIRED_IDENTITIES.map((r) => r.id));
+    for (const id of ids) expect([OLD, NEW, THIRD].includes(id) || seeded.has(id)).toBe(true);
   });
 });
 
@@ -408,5 +413,40 @@ describe("⭐ P1: a LIVE rotation is picked up without a daemon restart", () => 
     const live = new Set();
     refreshSelfEchoIdentitiesInto(live, null, layer2At("t.json", NEW), ledger);
     expect(live.has(HUMAN)).toBe(false);
+  });
+});
+
+describe("⭐ the fleet runs TWO app identities, and BOTH have rotated", () => {
+  // The first cut seeded only the orchestrator pair. The fleet also runs a WORKER
+  // app-actor, which rotated on the same day — so its predecessor's 1,245 comments still
+  // read as third-party: the same defect, for the other identity. Enumerating every
+  // Catalyst* actor in the replica found it; reasoning from the known one did not.
+  const RETIRED_WORKER = "72824b58-5a2f-4ff1-9565-d128fc355cda"; // handle `catalyst`
+  const CURRENT_WORKER = "6dd38c1a-68d8-4cbf-8bae-40593481f324"; // handle `catalyst2`
+
+  test("the retired WORKER identity is recognised as self", () => {
+    const { ids } = resolveSelfIdentities({ configIds: new Set([CURRENT_WORKER]), ledgerPath: ledger });
+    expect(ids.has(RETIRED_WORKER)).toBe(true);
+  });
+
+  test("both retired identities are seeded — orchestrator AND worker", () => {
+    const seeded = new Set(KNOWN_RETIRED_IDENTITIES.map((r) => r.id));
+    expect(seeded.has(OLD)).toBe(true); // catalystorchestrator
+    expect(seeded.has(RETIRED_WORKER)).toBe(true); // catalyst
+    expect(seeded.size).toBe(2);
+  });
+
+  test("each seeded entry names the successor it was superseded BY", () => {
+    // Without this the list is just an allowlist; with it, each entry is a checkable claim.
+    const bySucc = Object.fromEntries(KNOWN_RETIRED_IDENTITIES.map((r) => [r.id, r.supersededBy]));
+    expect(bySucc[RETIRED_WORKER]).toBe(CURRENT_WORKER);
+    expect(bySucc[OLD]).toBe(NEW);
+  });
+
+  test("⛔ a CURRENT identity is never seeded as retired", () => {
+    // Seeding a live identity would be indistinguishable from seeding a retired one, and
+    // an id admitted here can never be dispatched on again.
+    const seeded = new Set(KNOWN_RETIRED_IDENTITIES.map((r) => r.id));
+    for (const live of [NEW, CURRENT_WORKER]) expect(seeded.has(live)).toBe(false);
   });
 });


### PR DESCRIPTION
Shipped gap in #3428, found by **enumerating** every actor named `Catalyst*` in the replica rather than reasoning from the one identity already known.

## The miss

The fleet runs an **orchestrator** app-actor *and* a **worker** app-actor. Both have rotated, on the same day, in the same way — Linear appends a collision suffix when an app re-mints onto a taken handle:

| retired | → | current | seeded in #3428? |
|---|---|---|---|
| `catalystorchestrator` (`f51bc697`) | → | `catalystorchestrator2` (`ba2989f1`) | ✅ |
| `catalyst` (`72824b58`) | → | `catalyst2` (`6dd38c1a`) | ❌ **missed** |

So the retired **worker** — **1,245 comments** — still read as a third party. Its echoes would dispatch: exactly the defect CTL-1892 closed, for the other identity.

## It meets the admission bar more cleanly than the pair already seeded

| | comments | window | overlap |
|---|---|---|---|
| `catalyst` | 1,245 | 2026-06-02 → **2026-08-10** | — |
| `catalyst2` | 97 | **2026-08-11** → today | **zero** |

The orchestrator pair both touched 08-10; this one has a clean gap. Same display name, successor handle carries the `2` suffix, named by no config live or backup. Measured with a **positive control** — the same query shape on the known-good orchestrator pair reproduces its documented handoff.

## ⚠️ The generalisable miss

I seeded from the identity the investigation had surfaced, instead of enumerating the population. One rotation was visible because a stray actor had already been noticed; the other was equally present and simply had not been looked for.

**The fix for "we found A" is to ask what the SET is, not to record A.**

## Test changes

Assertions now check **accumulation** rather than an exact identity set — an exact-equality assertion here just asserts the absence of the deliberate seeds, and broke on this change for that reason. Added: each seeded entry must name the successor it was superseded by (making each a checkable claim rather than an allowlist entry), and no **current** identity may appear in the retired list.

42 tests. Mutation-verified: removing the worker seed fails 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)