### PR TITLE
fix(dev): CTL-1847 — restore DEFAULT_SETTLE_SEC; execute the parity CLI in tests

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-parity.mjs
@@ -245,6 +245,18 @@ export function explain(side, key, event, ctx = {}) {
   return hints.length ? hints.join(" | ") : null;
 }
 
+/**
+ * Default trailing-edge hold-back: replica write latency (~11 s measured) plus one
+ * producer tick (30 s default), with margin.
+ *
+ * ⛔ This constant was DELETED by an over-wide edit while rewriting explain(), and
+ * nothing caught it: every unit test passes `settleSec` explicitly so the default
+ * parameter below never evaluated, and the only importer is a CLI that no test
+ * EXECUTES — it was checked by grepping its source text. A source-level assertion
+ * cannot fail on a module that does not load.
+ */
+export const DEFAULT_SETTLE_SEC = 120;
+
 export function resolveWindow({
   nowMs,
   sinceMin = 60,

--- a/plugins/dev/scripts/execution-core/linear-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-parity.test.mjs
@@ -709,3 +709,45 @@ describe("⛔ unkeyable dispatch events make the run inconclusive", () => {
     expect(src).toContain("feed-unkeyable-events");
   });
 });
+
+// ── The CLI must LOAD and RUN, not merely contain the right strings ──────────
+describe("⛔ linear-feed-parity-run.mjs is executed, not grepped", () => {
+  // An over-wide edit deleted `DEFAULT_SETTLE_SEC`; the module then failed to
+  // load at all, and NOTHING caught it:
+  //   • every unit test passes `settleSec` explicitly, so resolveWindow's
+  //     default parameter — which references the deleted const — never evaluated;
+  //   • the CLI's own checks asserted on its SOURCE TEXT, and a source-level
+  //     assertion cannot fail on a module that does not load.
+  // It shipped to main and was found by running the harness on a host.
+  const CLI = new URL("./linear-feed-parity-run.mjs", import.meta.url).pathname;
+
+  test("the CLI loads and produces a verdict against empty inputs", async () => {
+    const proc = Bun.spawn(
+      ["bun", CLI, "--since-min", "5", "--events", "/nonexistent-events.jsonl", "--shadow", "/nonexistent-shadow.jsonl", "--lastseen", "/nonexistent.db"],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+    const [out, err] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    const code = await proc.exited;
+
+    // The specific failure this pins: a module-load error, which surfaces as a
+    // SyntaxError/ReferenceError on stderr rather than any verdict at all.
+    expect(err).not.toContain("SyntaxError");
+    expect(err).not.toContain("ReferenceError");
+    expect(err).not.toContain("not found in module");
+    // Empty inputs must be INCONCLUSIVE (exit 3), never a clean pass.
+    expect(out).toContain("[parity]");
+    expect(code).toBe(3);
+  }, 30_000);
+
+  test("every symbol the CLI imports actually exists in the module", async () => {
+    // Generic guard: parse the CLI's own import list rather than naming symbols,
+    // so a future deletion of ANY of them fails here.
+    const src = await Bun.file(CLI).text();
+    const m = src.match(/import \{([^}]*)\} from "\.\/linear-feed-parity\.mjs";/);
+    expect(m).not.toBeNull();
+    const mod = await import("./linear-feed-parity.mjs");
+    for (const name of m[1].split(",").map((x) => x.trim()).filter(Boolean)) {
+      expect(mod[name], `linear-feed-parity.mjs must export ${name}`).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
**The parity harness does not load on `main`.** Running it on mini-2:

```
SyntaxError: Export named 'DEFAULT_SETTLE_SEC' not found in module '.../linear-feed-parity.mjs'
```

An over-wide edit while rewriting `explain()` in #3439 round 6 deleted the const. Worse than a missing export: `resolveWindow`'s default parameter references it, so the function **throws whenever `settleSec` is omitted**.

## Why nothing caught it

This is the same defect class #3439 spent seven review rounds on, and I introduced it there myself:

- Every unit test passes `settleSec` **explicitly**, so the default parameter never evaluated.
- The only importer is a **CLI**, and its tests asserted on its **source text** (`expect(src).toContain("feedTailShort")`). **A source-level assertion cannot fail on a module that does not load.**

I wrote those greps two commits after arguing, in that same PR, that a check which cannot fail is not evidence.

## Fix + guard

The const is restored with a comment recording how it was lost, plus two tests that could not previously have passed:

1. **The CLI is spawned and run** against nonexistent inputs. stderr must contain no `SyntaxError` / `ReferenceError` / `"not found in module"`, and it must exit **3 (INCONCLUSIVE)** — not merely "not crash".
2. A **generic import guard** that parses the CLI's own import list and asserts every named symbol exists on the module, so a future deletion of *any* of them fails here without anyone remembering to name it.

Mutation-verified: deleting the const again reddens both. 75/0 on the suite.

## Impact

Harness-only. The daemon path is unaffected — `cloud-feed-gate.mjs`, `cloud-feed-timer.mjs` and `monitor.mjs` do not import this module, and shadow mode has been running correctly on both minis throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)