### PR TITLE
fix(dev): CTL-1904 — the feed sees label changes the updated_at cursor cannot reach

### DIFF
--- a/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
@@ -303,7 +303,12 @@ export function startCloudFeedTimer({
         r.sweep.mode !== "seeded" &&
         r.sweep.stoppedEarly !== true &&
         clean(r.sweep.edges) &&
-        clean(r.sweep.comments);
+        clean(r.sweep.comments) &&
+        // CTL-1904: the label sweep counts too. `labels` is absent on a seeding
+        // tick and from runSweep (the superseded history path), and absent is
+        // treated as clean — a sweep that never ran a label pass is not a label
+        // pass that failed. A PRESENT-and-dirty one disqualifies.
+        (r.sweep.labels === undefined || clean(r.sweep.labels));
 
       const wasReady = ready;
       ready = Array.isArray(reports) && reports.length > 0 && reports.every(swept);

--- a/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
@@ -307,6 +307,36 @@ describe("⛔ refuses to reseed when a durable cursor says we had a baseline", (
 });
 
 // ── CTL-1904: labels that land AFTER the cursor passed the issue ─────────────
+// `rows` are the file's SHAPED items ({issue, project, labels}); the label map
+// is consulted separately so it can move INDEPENDENTLY of the issue rows —
+// which is the entire race being reproduced.
+const raceSource = (rows, labelMap) => {
+  const withLabels = (r) => ({ ...r, labels: labelMap.get(r.issue.id) ?? [] });
+  return {
+    issuesSince(pos, lim = 100) {
+      const since = pos?.lastCreatedAt ?? 0;
+      return rows
+        .filter((r) => r.issue.updated_at > since || (r.issue.updated_at === since && r.issue.id > (pos?.lastId ?? "")))
+        .sort((a, b) => a.issue.updated_at - b.issue.updated_at || a.issue.id.localeCompare(b.issue.id))
+        .slice(0, lim)
+        .map(withLabels);
+    },
+    positionAfter(items) {
+      if (!items?.length) return null;
+      const last = items[items.length - 1];
+      return { lastCreatedAt: last.issue.updated_at, lastId: last.issue.id };
+    },
+    labelSets() {
+      const m = new Map();
+      for (const [k, v] of labelMap) if (v.length) m.set(k, [...v].sort());
+      return m;
+    },
+    issuesByIds(ids) {
+      return rows.filter((r) => ids.includes(r.issue.id)).map(withLabels);
+    },
+  };
+};
+
 describe("⛔ the label sweep catches what the updated_at cursor cannot", () => {
   // The live race, 2026-08-16: smee reported `linear.issue.updated
   // ['updatedAt','labelIds']` for CTL-1894 at 23:23:28Z; the feed emitted no
@@ -316,36 +346,6 @@ describe("⛔ the label sweep catches what the updated_at cursor cannot", () => 
   //
   // A source with labelSets()/issuesByIds(), where the label map can be changed
   // INDEPENDENTLY of the issue rows — which is the whole point.
-  // `rows` are the file's SHAPED items ({issue, project, labels}); the label map
-  // is consulted separately so it can move INDEPENDENTLY of the issue rows —
-  // which is the entire race being reproduced.
-  const raceSource = (rows, labelMap) => {
-    const withLabels = (r) => ({ ...r, labels: labelMap.get(r.issue.id) ?? [] });
-    return {
-      issuesSince(pos, lim = 100) {
-        const since = pos?.lastCreatedAt ?? 0;
-        return rows
-          .filter((r) => r.issue.updated_at > since || (r.issue.updated_at === since && r.issue.id > (pos?.lastId ?? "")))
-          .sort((a, b) => a.issue.updated_at - b.issue.updated_at || a.issue.id.localeCompare(b.issue.id))
-          .slice(0, lim)
-          .map(withLabels);
-      },
-      positionAfter(items) {
-        if (!items?.length) return null;
-        const last = items[items.length - 1];
-        return { lastCreatedAt: last.issue.updated_at, lastId: last.issue.id };
-      },
-      labelSets() {
-        const m = new Map();
-        for (const [k, v] of labelMap) if (v.length) m.set(k, [...v].sort());
-        return m;
-      },
-      issuesByIds(ids) {
-        return rows.filter((r) => ids.includes(r.issue.id)).map(withLabels);
-      },
-    };
-  };
-
   test("⭐ THE RACE: labels arrive after the cursor passed the issue — still emitted", () => {
     const rows = [issue("a", { updated_at: 1000 })];
     const labels = new Map([["a", []]]);
@@ -442,5 +442,73 @@ describe("⛔ the label sweep catches what the updated_at cursor cannot", () => 
     expect(r.labels).toBeDefined();
     expect(r.labels.failed).toBe(0);
     expect(Object.keys(r.labels.byReason)).toHaveLength(0);
+  });
+});
+
+// ── Codex P2 (#3446): the label sweep is bounded per tick ────────────────────
+describe("⛔ a bulk label change cannot stall the daemon event loop", () => {
+  const mkRows = (n) => Array.from({ length: n }, (_, i) => issue(`i${String(i).padStart(4, "0")}`));
+
+  test("a mass label change is processed in BUDGETED slices, not all at once", () => {
+    // A label rename or bulk edit changes many issues at once, and this pass sits
+    // outside the issue sweep's maxBatches bound. Measured at ~2.4 s for 2,843
+    // changed issues on the daemon event loop.
+    const rows = mkRows(50);
+    const labels = new Map(rows.map((r) => [r.issue.id, []]));
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+
+    for (const id of labels.keys()) labels.set(id, ["refactor"]); // all 50 at once
+
+    const emitted = [];
+    const r1 = runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: (e) => emitted.push(e), labelBudget: 10 });
+    expect(r1.labels.examined).toBe(50);
+    expect(emitted).toHaveLength(10); // budget respected
+    expect(r1.labels.deferred).toBe(40);
+  });
+
+  test("the deferred remainder is picked up on later ticks — bounded, not lost", () => {
+    const rows = mkRows(25);
+    const labels = new Map(rows.map((r) => [r.issue.id, []]));
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+    for (const id of labels.keys()) labels.set(id, ["refactor"]);
+
+    const emitted = [];
+    for (let i = 0; i < 5; i++) {
+      runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: (e) => emitted.push(e), labelBudget: 10 });
+    }
+    expect(emitted).toHaveLength(25); // every one eventually emitted
+    const last = runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {}, labelBudget: 10 });
+    expect(last.labels.deferred).toBe(0); // and it drains
+  });
+
+  test("⚠️ deferral does NOT land in byReason — a paced sweep must not un-arm enforce", () => {
+    // readiness treats any byReason entry as disqualifying. Deferral is healthy
+    // operation; only a failure should un-arm.
+    const rows = mkRows(30);
+    const labels = new Map(rows.map((r) => [r.issue.id, []]));
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+    for (const id of labels.keys()) labels.set(id, ["refactor"]);
+    const r = runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {}, labelBudget: 5 });
+    expect(r.labels.deferred).toBeGreaterThan(0);
+    expect(Object.keys(r.labels.byReason)).toHaveLength(0);
+    expect(r.labels.failed).toBe(0);
+  });
+
+  test("NEGATIVE CONTROL: a small change set is not deferred at all", () => {
+    const rows = mkRows(3);
+    const labels = new Map(rows.map((r) => [r.issue.id, []]));
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+    labels.set(rows[0].issue.id, ["refactor"]);
+    const r = runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {}, labelBudget: 200 });
+    expect(r.labels.deferred).toBe(0);
+    expect(r.labels.emitted).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
@@ -305,3 +305,142 @@ describe("⛔ refuses to reseed when a durable cursor says we had a baseline", (
     expect(Object.keys(r.edges.byReason).length).toBeGreaterThan(0);
   });
 });
+
+// ── CTL-1904: labels that land AFTER the cursor passed the issue ─────────────
+describe("⛔ the label sweep catches what the updated_at cursor cannot", () => {
+  // The live race, 2026-08-16: smee reported `linear.issue.updated
+  // ['updatedAt','labelIds']` for CTL-1894 at 23:23:28Z; the feed emitted no
+  // `labels` key for that ticket EVER, because the replica synced the issue row
+  // and its issue_labels rows at different times and `updated_at` (23:24:51Z)
+  // never advanced again.
+  //
+  // A source with labelSets()/issuesByIds(), where the label map can be changed
+  // INDEPENDENTLY of the issue rows — which is the whole point.
+  // `rows` are the file's SHAPED items ({issue, project, labels}); the label map
+  // is consulted separately so it can move INDEPENDENTLY of the issue rows —
+  // which is the entire race being reproduced.
+  const raceSource = (rows, labelMap) => {
+    const withLabels = (r) => ({ ...r, labels: labelMap.get(r.issue.id) ?? [] });
+    return {
+      issuesSince(pos, lim = 100) {
+        const since = pos?.lastCreatedAt ?? 0;
+        return rows
+          .filter((r) => r.issue.updated_at > since || (r.issue.updated_at === since && r.issue.id > (pos?.lastId ?? "")))
+          .sort((a, b) => a.issue.updated_at - b.issue.updated_at || a.issue.id.localeCompare(b.issue.id))
+          .slice(0, lim)
+          .map(withLabels);
+      },
+      positionAfter(items) {
+        if (!items?.length) return null;
+        const last = items[items.length - 1];
+        return { lastCreatedAt: last.issue.updated_at, lastId: last.issue.id };
+      },
+      labelSets() {
+        const m = new Map();
+        for (const [k, v] of labelMap) if (v.length) m.set(k, [...v].sort());
+        return m;
+      },
+      issuesByIds(ids) {
+        return rows.filter((r) => ids.includes(r.issue.id)).map(withLabels);
+      },
+    };
+  };
+
+  test("⭐ THE RACE: labels arrive after the cursor passed the issue — still emitted", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", []]]);
+    const emitted = [];
+    const emit = (e) => emitted.push(e?.body?.payload?.updatedFromKeys ?? []);
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit }); // seed
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit }); // steady, nothing
+    expect(emitted).toEqual([]);
+
+    // The label lands LATER, and the issue row's updated_at does NOT move — so the
+    // keyset cursor will never return this issue again.
+    labels.set("a", ["refactor"]);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain("labels");
+  });
+
+  test("⛔ CONTROL: without the label sweep this edge is lost forever", () => {
+    // Same fixture against a source with NO labelSets/issuesByIds — i.e. the
+    // pre-CTL-1904 capability set. Proves the fixture is not trivially passing.
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", []]]);
+    const emitted = [];
+    const emit = (e) => emitted.push(e);
+    const st = makeStore();
+    const full = raceSource(rows, labels);
+    const legacy = { issuesSince: (...a) => full.issuesSince(...a), positionAfter: (...a) => full.positionAfter(...a) };
+
+    runDiffSweep({ source: legacy, store: st, cursorPath, teams: TEAMS, emit });
+    runDiffSweep({ source: legacy, store: st, cursorPath, teams: TEAMS, emit });
+    labels.set("a", ["refactor"]);
+    runDiffSweep({ source: legacy, store: st, cursorPath, teams: TEAMS, emit });
+    runDiffSweep({ source: legacy, store: st, cursorPath, teams: TEAMS, emit });
+
+    expect(emitted).toEqual([]); // permanently invisible — the defect
+  });
+
+  test("a REMOVAL of the last label is detected (absence ≠ unknown)", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", ["refactor"]]]);
+    const emitted = [];
+    const emit = (e) => emitted.push(e?.body?.payload?.updatedFromKeys ?? []);
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit }); // seed w/ label
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit });
+    expect(emitted).toEqual([]);
+
+    labels.set("a", []); // last label removed — the issue vanishes from the map
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain("labels");
+  });
+
+  test("NEGATIVE CONTROL: an unchanged label set emits nothing, repeatedly", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", ["refactor"]]]);
+    const emitted = [];
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    for (let i = 0; i < 4; i++) {
+      runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: (e) => emitted.push(e) });
+    }
+    expect(emitted).toEqual([]);
+  });
+
+  test("no DOUBLE emit when the issue sweep already caught the label change", () => {
+    // updated_at moves AND labels change in the same tick: the issue sweep emits
+    // once and the label sweep must find no difference.
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", []]]);
+    const emitted = [];
+    const st = makeStore();
+    const src = raceSource(rows, labels);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+
+    rows[0] = issue("a", { updated_at: 2000, state: "Todo" });
+    labels.set("a", ["refactor"]);
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: (e) => emitted.push(e) });
+    expect(emitted).toHaveLength(1);
+  });
+
+  test("the label sweep reports its own counts, so a failure can un-arm enforce", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const src = raceSource(rows, new Map([["a", []]]));
+    const st = makeStore();
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+    const r = runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} });
+    expect(r.labels).toBeDefined();
+    expect(r.labels.failed).toBe(0);
+    expect(Object.keys(r.labels.byReason)).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-feed-lastseen.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-lastseen.mjs
@@ -116,6 +116,37 @@ export function createLastSeenStore({ path } = {}) {
       metaPut.run(SEEDED_KEY, String(at));
     },
 
+    /**
+     * idsWithLabels — issue ids whose stored snapshot carries at least one label.
+     *
+     * CTL-1904 needs this for the one case the label map cannot express: an issue
+     * whose LAST label was removed disappears from the map entirely, so absence
+     * has to be distinguishable from "never had any". Without it, removing every
+     * label from an issue would be undetectable.
+     */
+    idsWithLabels() {
+      const out = [];
+      try {
+        for (const r of db.prepare(
+          "SELECT issue_id FROM seen WHERE json_array_length(json_extract(snapshot, '$.labels')) > 0",
+        ).all()) out.push(r.issue_id);
+        return out;
+      } catch {
+        // JSON1 unavailable — fall back to parsing. Correctness over speed; this
+        // must not silently return [] , which would read as "no issue has labels"
+        // and quietly disable removal detection.
+        for (const r of db.prepare("SELECT issue_id, snapshot FROM seen").all()) {
+          try {
+            const snap = JSON.parse(r.snapshot);
+            if (Array.isArray(snap?.labels) && snap.labels.length > 0) out.push(r.issue_id);
+          } catch {
+            /* unparseable row: skip, the label sweep will re-snapshot it */
+          }
+        }
+        return out;
+      }
+    },
+
     size() {
       return db.prepare("SELECT COUNT(*) n FROM seen").get()?.n ?? 0;
     },

--- a/plugins/dev/scripts/execution-core/linear-feed-source.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-source.mjs
@@ -128,6 +128,50 @@ const COMMENT_SELECT = `
 // query — `issues.updated_at` is no more unique than `issue_history.created_at`, so
 // a timestamp-only watermark would skip same-millisecond siblings or re-read them
 // forever. Column names verified against the live replica, not inferred.
+// CTL-1904: the label map, keyed by issue id.
+//
+// ⛔ WHY THIS EXISTS AT ALL. The issue sweep keysets on `issues.updated_at`, and
+// the replica syncs an issue's row and its `issue_labels` rows at DIFFERENT
+// times. When the label rows land after the cursor has already passed that
+// issue's `updated_at`, the issue is never re-examined and the label change is
+// invisible PERMANENTLY — not late. Measured live on CTL-1894 (2026-08-16):
+// smee reported `linear.issue.updated ['updatedAt','labelIds']` at 23:23:28Z,
+// the feed emitted no `labels` key for that ticket ever, and `updated_at` sat
+// unchanged at 23:24:51Z across six checks over 2.5 minutes.
+//
+// `issue_labels` has no timestamp — only `(issue_id, label_id)` — so there is no
+// column to keyset on. Its rowid would catch INSERTS and silently miss REMOVALS,
+// which is the same shape of blind spot one level down. So the whole map is read
+// and diffed against the baseline each tick. Measured on the live replica:
+// 1.7 ms warm / 11.9 ms cold for 2,843 labelled issues, against 7 ms for the
+// existing issue query — cheap enough that correctness wins.
+const LABEL_MAP_SELECT = `
+  SELECT il.issue_id AS id,
+         group_concat(l.name, char(31)) AS labels__joined
+    FROM issue_labels il
+    JOIN labels l ON l.id = il.label_id
+   GROUP BY il.issue_id
+`;
+
+// Fetch specific issues by id — used for the (normally tiny) set whose labels
+// differ from the baseline, so the label sweep pays a full row read only for
+// what actually changed.
+const ISSUES_BY_ID_SELECT = (n) => `
+  SELECT
+    i.id AS id, i.identifier AS identifier, i.team_key AS team_key, i.state AS state,
+    i.assignee_id AS assignee_id, i.priority AS priority, i.estimate AS estimate,
+    i.project_id AS project_id, i.cycle_id AS cycle_id, i.parent_id AS parent_id,
+    i.team_id AS team_id, i.title AS title, i.due_date AS due_date,
+    i.delegate_id AS delegate_id, i.description AS description, i.updated_at AS updated_at,
+    p.name AS project__name,
+    (SELECT group_concat(l.name, char(31))
+       FROM issue_labels il JOIN labels l ON l.id = il.label_id
+      WHERE il.issue_id = i.id) AS labels__joined
+  FROM issues i
+  LEFT JOIN projects p ON p.id = i.project_id
+  WHERE i.id IN (${Array.from({ length: n }, () => "?").join(",")})
+`;
+
 const ISSUE_SELECT = `
   SELECT
     i.id           AS id,
@@ -268,6 +312,40 @@ export function createFeedSource({ dbPath = getReplicaDbPath(), limit = DEFAULT_
       return page(EDGE_SELECT, position, shapeEdgeRow, batchLimit);
     },
     /** Issue rows whose `updated_at` is strictly after `position`, oldest first. */
+    /**
+     * labelSets — every issue that currently has at least one label, as
+     * issueId -> sorted label names. Issues with NO labels are absent, which the
+     * caller must treat as "empty set", not "unknown" — that is how a removal of
+     * the last label is detected.
+     */
+    labelSets() {
+      const out = new Map();
+      for (const row of db.prepare(LABEL_MAP_SELECT).all()) {
+        const joined = row.labels__joined;
+        out.set(
+          row.id,
+          typeof joined === "string" && joined !== "" ? joined.split(LABEL_SEP).sort() : [],
+        );
+      }
+      return out;
+    },
+
+    /** issuesByIds — shaped rows for a specific, normally small, set of ids. */
+    issuesByIds(ids) {
+      const list = Array.isArray(ids) ? ids.filter((x) => typeof x === "string" && x !== "") : [];
+      if (list.length === 0) return [];
+      const out = [];
+      // Chunked so a large differing set cannot exceed SQLite's variable limit.
+      for (let i = 0; i < list.length; i += 400) {
+        const chunk = list.slice(i, i + 400);
+        for (const row of db.prepare(ISSUES_BY_ID_SELECT(chunk.length)).all(...chunk)) {
+          const shaped = shapeIssueRow(row);
+          if (shaped) out.push(shaped);
+        }
+      }
+      return out;
+    },
+
     issuesSince(position, batchLimit) {
       return page(ISSUE_SELECT, position, shapeIssueRow, batchLimit);
     },

--- a/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
@@ -36,7 +36,7 @@ import { CURSOR_OK, DEFAULT_RESET_LOOKBACK_MS, readCursor, resolveStartPosition,
 /** Bound the work one sweep may do, so a large backlog cannot monopolise a tick. */
 export const DEFAULT_MAX_BATCHES = 20;
 
-const emptyCounts = () => ({ emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {} });
+const emptyCounts = () => ({ emitted: 0, declined: 0, failed: 0, examined: 0, deferred: 0, byReason: {} });
 
 const note = (counts, reason) => {
   counts.byReason[reason] = (counts.byReason[reason] ?? 0) + 1;
@@ -211,6 +211,9 @@ export function runSweep({
 /** Bound one seeding pass so a cold start cannot monopolise a tick indefinitely. */
 export const SEED_MAX_BATCHES = 200;
 
+/** Max issues the label sweep will process in one tick (Codex P2, #3446). */
+export const DEFAULT_LABEL_BUDGET = 200;
+
 /**
  * Establish the baseline WITHOUT emitting anything.
  *
@@ -269,7 +272,7 @@ export function runDiffSweep({
   now = () => Date.now(),
   readCursorFn = readCursor,
   writeCursorFn = writeCursor,
-} = {}) {
+  labelBudget = DEFAULT_LABEL_BUDGET,} = {}) {
   const counts = emptyCounts();
 
   // ⛔ A MISSING BASELINE + A LIVE CURSOR IS A LOSS, NOT A FIRST RUN
@@ -469,8 +472,27 @@ export function runDiffSweep({
       }
 
       labelCounts.examined = changed.length;
-      if (changed.length > 0) {
-        for (const item of source.issuesByIds(changed)) {
+
+      // ⛔ PER-TICK BUDGET (Codex P2). A label RENAME or a bulk edit changes many
+      // issues at once, and this pass sits outside the issue sweep's `maxBatches`
+      // bound — so it would drain the whole set synchronously on the daemon event
+      // loop. Measured at ~2.4 s for 2,843 changed issues, which is a real stall
+      // for unrelated scheduler work (and compounds with CTL-1903's full-scan).
+      //
+      // The remainder needs no bookkeeping: the sweep recomputes the difference
+      // from the baseline every tick, so anything left over is simply picked up
+      // next tick. Deferral is bounded work, not lost work.
+      const budget = Number.isInteger(labelBudget) && labelBudget > 0 ? labelBudget : DEFAULT_LABEL_BUDGET;
+      const slice = changed.slice(0, budget);
+      // ⚠️ Reported in its own field, NOT in byReason — readiness treats any
+      // byReason entry as disqualifying, and a paced sweep is healthy operation,
+      // not a failure. A sweep that never drains shows up as `deferred` staying
+      // above zero every tick, which is observable without un-arming enforce on
+      // every bulk edit.
+      labelCounts.deferred = Math.max(0, changed.length - slice.length);
+
+      if (slice.length > 0) {
+        for (const item of source.issuesByIds(slice)) {
           const issueId = item?.issue?.id;
           if (!issueId) continue;
           const before = store.get(issueId);

--- a/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
@@ -437,5 +437,80 @@ export function runDiffSweep({
     }
   }
 
-  return { mode: start.mode, alarm: start.alarm, batches, stoppedEarly: stopped, position, edges: counts, comments: commentCounts };
+  // ── CTL-1904: the LABEL SWEEP ───────────────────────────────────────────────
+  // Runs AFTER the issue sweep, deliberately. Any issue whose labels changed AND
+  // whose `updated_at` advanced has already been handled above — its snapshot now
+  // holds the new labels, so it produces no difference here and cannot
+  // double-emit. What is left is exactly the case the cursor cannot reach: label
+  // rows that landed after the cursor passed the issue's timestamp.
+  //
+  // Compares the WHOLE label map against the baseline rather than keyseting,
+  // because `issue_labels` has no timestamp and its rowid would catch inserts
+  // while silently missing removals. Cost measured on the live replica: 1.7 ms
+  // warm / 11.9 ms cold for 2,843 labelled issues.
+  const labelCounts = emptyCounts();
+  if (!stopped && typeof source.labelSets === "function" && typeof source.issuesByIds === "function") {
+    try {
+      const current = source.labelSets();
+      const changed = [];
+
+      // (a) issues that HAVE labels now — differing from the baseline?
+      for (const [issueId, labels] of current) {
+        const before = store.get(issueId);
+        if (!before) continue; // not baselined yet; the issue sweep owns first sight
+        const prev = Array.isArray(before.labels) ? [...before.labels].sort() : [];
+        if (prev.join("\u001f") !== labels.join("\u001f")) changed.push(issueId);
+      }
+      // (b) issues whose LAST label was removed — absent from the map entirely,
+      // which is why absence must mean "empty set" and not "unknown". Without
+      // this branch, removing every label from an issue would be undetectable.
+      for (const issueId of store.idsWithLabels ? store.idsWithLabels() : []) {
+        if (!current.has(issueId)) changed.push(issueId);
+      }
+
+      labelCounts.examined = changed.length;
+      if (changed.length > 0) {
+        for (const item of source.issuesByIds(changed)) {
+          const issueId = item?.issue?.id;
+          if (!issueId) continue;
+          const before = store.get(issueId);
+          const after = snapshotOf(item.issue, item.labels);
+          const diff = diffSnapshots(before, after);
+          if (!diff) {
+            // The issue sweep already caught it in this same tick.
+            store.put(issueId, after, item.issue.updated_at ?? null);
+            continue;
+          }
+          const history = diffToHistoryRow(item.issue, diff, { now });
+          const verdict = classifyEdge({ history, issue: item.issue }, { teams, botUserIds });
+          if (!verdict.emit) {
+            note(labelCounts, verdict.reason);
+            labelCounts.declined += 1;
+            store.put(issueId, after, item.issue.updated_at ?? null);
+            continue;
+          }
+          try {
+            emit(buildIssueEvent({ history, issue: item.issue, labels: item.labels, project: item.project }));
+            labelCounts.emitted += 1;
+            // Snapshot only AFTER a successful emit — same last-contiguous-success
+            // discipline as the issue sweep, so a failed emit is retried next tick
+            // instead of being absorbed into the baseline.
+            store.put(issueId, after, item.issue.updated_at ?? null);
+          } catch (err) {
+            labelCounts.failed += 1;
+            note(labelCounts, `emit-failed:${err?.code ?? err?.message ?? "unknown"}`);
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      // Named, never swallowed: readiness treats any byReason entry as
+      // disqualifying, so a broken label sweep un-arms enforce rather than
+      // quietly reintroducing the blind spot it exists to close.
+      note(labelCounts, `label-sweep-failed:${err?.code ?? err?.message ?? "unknown"}`);
+      labelCounts.failed += 1;
+    }
+  }
+
+  return { mode: start.mode, alarm: start.alarm, batches, stoppedEarly: stopped, position, edges: counts, comments: commentCounts, labels: labelCounts };
 }


### PR DESCRIPTION
Closes **CTL-1904**, the largest of the five blockers on the enforce flip — and the one found by **running** the shadow window after seven rounds of review missed it.

## The race

`issuesSince` keysets on `issues.updated_at`. The replica syncs an issue's row and its `issue_labels` rows at **different times**. When the label rows land after the cursor has passed that issue's `updated_at`, the issue is never re-examined and the label change is invisible **permanently** — not late.

Measured live on CTL-1894:

| time | what |
|---|---|
| 23:23:28.727Z | **smee** `linear.issue.updated ['updatedAt','labelIds']` |
| 23:24:59Z | **feed** `['state','priority','estimate']` — no `labels` |
| ~23:36Z | the label finally appears in the replica's `issue_labels` |
| — | **feed label edges for that ticket: 0**, across the whole shadow file |

`issues.updated_at` then sat unchanged at 23:24:51 across six checks over 2.5 minutes while the label was present.

⚠️ Not "the feed cannot see labels" — the same window shows it correctly emitting `labels` edges for CTC-52, CTC-347, CTC-601, CTC-607, each **accompanied by another tracked change** that moved `updated_at` while the labels were already there. It is a race.

## Why it blocks enforce

`linear.issue.updated` is a dispatch class, and labels gate dispatch (`blocked`, `needs-human`, `worker-status`). Under enforce the gate suppresses smee's copy and the feed produces nothing, so a label-only change reaches **no handler**. Today it is delivered correctly — the cutover would *introduce* this.

## The fix, and why it is a full comparison rather than a keyset

A label sweep **after** the issue sweep, so anything the cursor already caught produces no difference here and cannot double-emit.

`issue_labels` has **no timestamp** — only `(issue_id, label_id)`. Its rowid would catch **inserts** and silently miss **removals**: the same blind spot one level down. So the whole map is diffed against the baseline. Measured on the live replica: **1.7 ms warm / 11.9 ms cold** for 2,843 labelled issues, against 7 ms for the existing issue query.

An issue whose **last** label is removed vanishes from the map, so absence must mean "empty set", not "unknown" — `store.idsWithLabels()` supplies that side, and its JSON1 fallback **parses** rather than returning `[]`, because a silent `[]` would read as "no issue has labels" and disable removal detection entirely.

Snapshots are written only **after** a successful emit (same last-contiguous-success rule as the issue sweep), and the sweep reports its own counts — which readiness now consumes, so a broken label sweep **un-arms enforce** rather than quietly restoring the blind spot it closes.

## Verified

**451/0** across the touched suites; all four node-resolution builds pass.

Mutation-tested three ways — disabling the sweep reddens **2**, dropping the removal branch reddens **1**, and making `idsWithLabels` return `[]` (the silent-disable mode) reddens **1**.

The race is a test: labels arrive after the cursor passed the issue and the edge is still emitted — with a **control** against a source exposing only the pre-CTL-1904 capabilities, where the same fixture stays permanently silent.

## After merge

plugin-refresh delivers it into shadow on both minis, and the overnight sampler (`~/catalyst/parity-overnight.log`) shows by morning whether label edges now appear on the feed side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)