### PR TITLE
fix(dev): CTL-1901 — a mid-sweep readiness drop strands an already-stamped edge

### DIFF
--- a/plugins/dev/scripts/execution-core/cloud-feed-gate.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-gate.mjs
@@ -163,8 +163,11 @@ export function ticketOf(event) {
  * @param {function} [opts.isEcho]  (ticket, field, value) => boolean — the CTL-1891 ring's probe.
  *                                  Omitted/absent ⇒ nothing is ever an echo.
  * @param {function|boolean} [opts.isReady]  () => boolean — has the producer seeded and
- *                                  begun emitting? Enforce degrades to shadow routing until
- *                                  this is true. Omitted/absent ⇒ NOT ready (safe half).
+ *                                  begun emitting? Consulted for the SMEE side only: while
+ *                                  false, smee keeps dispatching. It is deliberately NOT
+ *                                  consulted for feed events, whose authority is carried by
+ *                                  their own emission-time stamp (CTL-1901).
+ *                                  Omitted/absent ⇒ NOT ready (smee stays authoritative).
  * @returns {{suppress: boolean, reason: string, source: string, name: string}}
  *
  * `suppress: true` means "do not let this event reach monitor.mjs's handlers;
@@ -193,30 +196,6 @@ export function decideDispatch(event, { mode, isEcho = null, isReady = null } = 
   // over to an unproven dispatch source.
   let m = CLOUD_FEED_MODES.has(mode) ? mode : "off";
 
-  // ⛔ ENFORCE IS NOT ARMED UNTIL THE PRODUCER CAN ACTUALLY PRODUCE
-  // (Codex P1, #3439). On a host with a missing or cleared last-seen database,
-  // the gate would start suppressing smee immediately while `runDiffSweep`'s
-  // FIRST tick only seeds the baseline and emits nothing. Issue changes in that
-  // interval get absorbed into the baseline silently; comments are worse — the
-  // seeding tick never reads them and the next tick cold-starts the comment
-  // cursor at the current time, so comments in the gap reach no inbox EVER.
-  //
-  // So enforce degrades to shadow's routing (smee authoritative, feed
-  // suppressed) until the producer reports itself ready. Absent probe ⇒ NOT
-  // ready: a caller that forgets to wire readiness gets the safe half, never
-  // the suppressing one.
-  if (m === "enforce") {
-    let ready = false;
-    try {
-      ready = typeof isReady === "function" ? isReady() === true : isReady === true;
-    } catch {
-      ready = false; // a throwing probe is not a ready producer
-    }
-    if (!ready) {
-      return { suppress: source === SOURCE_CLOUD_FEED, reason: "enforce-not-armed", source, name };
-    }
-  }
-
   if (m !== "enforce") {
     // off / shadow: smee remains authoritative, exactly as today.
     if (source === SOURCE_CLOUD_FEED) {
@@ -229,48 +208,103 @@ export function decideDispatch(event, { mode, isEcho = null, isReady = null } = 
     return { suppress: false, reason: "webhook-authoritative", source, name };
   }
 
-  // enforce: the feed is the dispatch source; everything else is captured.
-  if (source !== SOURCE_CLOUD_FEED) {
-    return { suppress: true, reason: "smee-captured", source, name };
-  }
+  // ───────────────────────────── enforce ─────────────────────────────
+  //
+  // ⛔ THE TWO SIDES ARE DECIDED BY DIFFERENT THINGS, AND THAT ASYMMETRY IS THE
+  // WHOLE FIX (CTL-1901).
+  //
+  //   feed side → the event's OWN STAMP, and nothing else.
+  //   smee side → readiness AS OF NOW.
+  //
+  // Round 6 stamped `feedAuthority` at emission so a later readiness change
+  // could not retroactively GRANT authority to a line already on disk. But the
+  // armed check still ran FIRST, so the same later change could still REVOKE
+  // authority from a line that already had it — and the twin was already
+  // captured, and the sweep's cursor had already advanced past the edge, so
+  // there was no retry. The edge reached NEITHER path.
+  //
+  // ── why the stamp alone is not just safe but exactly right ──
+  // Let ticks be T₁,T₂,… and rₖ be readiness after tick k. An edge E occurring
+  // between Tₖ and Tₖ₊₁:
+  //   • its webhook twin is consumed at ≈E's time  → smee decided under rₖ
+  //   • its feed copy is emitted during Tₖ₊₁, stamped with the value carried
+  //     INTO that tick (cloud-feed-timer stamps before it recomputes) → also rₖ
+  // The two decisions therefore read the SAME rₖ, and deliveries = rₖ + ¬rₖ = 1.
+  // Exactly-once falls out of the stamp; it does NOT survive consulting a third,
+  // later reading of the flag. So this deletes a conjunct rather than adding a
+  // case — the class of change that has held on this feature.
+  //
+  // ── the residual, stated rather than asserted away ──
+  // The equality above holds while BOTH streams are current. It breaks under
+  // lag: if the producer is replaying a backlog, E's feed copy is emitted by
+  // Tₖ₊ₘ (m>1) and stamped rₖ₊ₘ₋₁ ≠ rₖ. Measured on mini-2 2026-08-17: 21
+  // readiness flaps in 3.1 h, EVERY un-arm exactly one tick long (29.8–30.5 s),
+  // 5.4% of wall clock unarmed — so this boundary is hit routinely, not rarely.
+  // ⚠️ cloud-feed-timer.mjs's claim that "flapping is harmless … no posture
+  // permits double-dispatch" was false in both directions and is corrected there.
+  if (source === SOURCE_CLOUD_FEED) {
+    // Checked BEFORE the echo probe on purpose: `isEcho` CONSUMES a ring token
+    // on a hit, and spending one on a line we are about to suppress anyway
+    // would let some other write's real echo through later.
+    //
+    // Absent stamp ⇒ NOT authoritative. Every feed event written by this code
+    // path carries one; a line without it predates the stamp or came from
+    // somewhere else, and neither is something to dispatch on.
+    if (event?.body?.payload?.feedAuthority !== true) {
+      return { suppress: true, reason: "feed-emitted-while-unarmed", source, name };
+    }
 
-  // CTL-1891: a host must not dispatch on its own proxied write coming back.
-  // ⚠️ Inert until the CTC-509 proxy caller (CTL-1889) records into the ring —
-  // with no recorder, every probe misses and this branch never fires. Wired now
-  // and proven by test so that landing the recorder is a one-line change rather
-  // than a second trip through the daemon's dispatch path.
-  if (typeof isEcho === "function") {
-    const ticket = ticketOf(event);
-    if (ticket) {
-      for (const probe of echoProbesFor(event)) {
-        let hit = false;
-        try {
-          hit = isEcho(ticket, probe.field, probe.value) === true;
-        } catch {
-          // A throwing ring must not wedge dispatch, and must not silently
-          // suppress either — fail OPEN (dispatch), which is what the fleet
-          // did before the ring existed.
-          hit = false;
-        }
-        if (hit) {
-          return { suppress: true, reason: "own-write-echo", source, name };
+    // CTL-1891: a host must not dispatch on its own proxied write coming back.
+    // ⚠️ Inert until the CTC-509 proxy caller (CTL-1889) records into the ring —
+    // with no recorder, every probe misses and this branch never fires. Wired now
+    // and proven by test so that landing the recorder is a one-line change rather
+    // than a second trip through the daemon's dispatch path.
+    if (typeof isEcho === "function") {
+      const ticket = ticketOf(event);
+      if (ticket) {
+        for (const probe of echoProbesFor(event)) {
+          let hit = false;
+          try {
+            hit = isEcho(ticket, probe.field, probe.value) === true;
+          } catch {
+            // A throwing ring must not wedge dispatch, and must not silently
+            // suppress either — fail OPEN (dispatch), which is what the fleet
+            // did before the ring existed.
+            hit = false;
+          }
+          if (hit) {
+            return { suppress: true, reason: "own-write-echo", source, name };
+          }
         }
       }
     }
+
+    return { suppress: false, reason: "feed-authoritative", source, name };
   }
 
-  // ⛔ THE EVENT'S OWN STAMP DECIDES, not a flag read now (Codex P1 round 6).
-  // `feedAuthority` is written by the sweep that emitted this line and is
-  // immutable thereafter, so a readiness transition between emission and
-  // consumption cannot retroactively grant authority to a line already on disk —
-  // which is exactly how the same edge got dispatched twice across an arming.
+  // ── smee (and any unknown producer) ──
   //
-  // Absent stamp ⇒ NOT authoritative. Every feed event written by this code path
-  // carries one; a line without it predates the stamp or came from somewhere
-  // else, and neither is something to dispatch on.
-  if (event?.body?.payload?.feedAuthority !== true) {
-    return { suppress: true, reason: "feed-emitted-while-unarmed", source, name };
+  // ⛔ ENFORCE DOES NOT SUPPRESS SMEE UNTIL THE PRODUCER CAN ACTUALLY PRODUCE
+  // (Codex P1, #3439). On a host with a missing or cleared last-seen database,
+  // the gate would start suppressing smee immediately while `runDiffSweep`'s
+  // FIRST tick only seeds the baseline and emits nothing. Issue changes in that
+  // interval get absorbed into the baseline silently; comments are worse — the
+  // seeding tick never reads them and the next tick cold-starts the comment
+  // cursor at the current time, so comments in the gap reach no inbox EVER.
+  //
+  // This is the ONE place current readiness is legitimately consulted, and it is
+  // the gate's own rule applied literally: suppression is only ever legitimate
+  // when a replacement exists. Absent probe ⇒ NOT ready, so a caller that forgets
+  // to wire readiness gets the non-suppressing half.
+  let ready = false;
+  try {
+    ready = typeof isReady === "function" ? isReady() === true : isReady === true;
+  } catch {
+    ready = false; // a throwing probe is not a ready producer
+  }
+  if (!ready) {
+    return { suppress: false, reason: "enforce-not-armed", source, name };
   }
 
-  return { suppress: false, reason: "feed-authoritative", source, name };
+  return { suppress: true, reason: "smee-captured", source, name };
 }

--- a/plugins/dev/scripts/execution-core/cloud-feed-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-gate.test.mjs
@@ -173,13 +173,30 @@ describe("decideDispatch — enforce is not armed until the producer is ready (C
     expect(v.reason).toBe("enforce-not-armed");
   });
 
-  test("NOT ready ⇒ the feed still cannot dispatch (no double-dispatch in the gap)", () => {
+  // ⛔ CTL-1901. This test previously asserted the DEFECT: a feed event already
+  // stamped authoritative by an armed sweep was expected to be suppressed once
+  // readiness went false. Its twin had already been captured under the older
+  // ready=true and the sweep's cursor had advanced past the edge, so the edge
+  // reached NEITHER path. The stamp is now sufficient on its own.
+  test("NOT ready ⇒ a STAMPED feed event still dispatches (the stamp is not revocable)", () => {
     const v = decideDispatch(feedEvent("linear.issue.state_changed"), {
       mode: "enforce",
       isReady: () => false,
     });
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("feed-authoritative");
+  });
+
+  test("NOT ready ⇒ an UNSTAMPED feed event still cannot dispatch", () => {
+    // The other half of the same boundary: readiness going false must not GRANT
+    // authority either. Without this, the test above would pass against a gate
+    // that simply stopped suppressing the feed.
+    const v = decideDispatch(unarmedFeedEvent("linear.issue.state_changed"), {
+      mode: "enforce",
+      isReady: () => false,
+    });
     expect(v.suppress).toBe(true);
-    expect(v.reason).toBe("enforce-not-armed");
+    expect(v.reason).toBe("feed-emitted-while-unarmed");
   });
 
   test("ready ⇒ enforce behaves as enforce", () => {
@@ -193,8 +210,11 @@ describe("decideDispatch — enforce is not armed until the producer is ready (C
     expect(noKey.reason).toBe("enforce-not-armed");
     expect(noKey.suppress).toBe(false);
     expect(decideDispatch(smeeEvent("linear.issue.state_changed"), { mode: "enforce", isReady: null }).suppress).toBe(false);
-    // ...and the feed correspondingly cannot dispatch on an unwired gate.
-    expect(decideDispatch(feedEvent("linear.issue.state_changed"), { mode: "enforce" }).suppress).toBe(true);
+    // ...and an UNSTAMPED feed event correspondingly cannot dispatch on an
+    // unwired gate. (A stamped one still can, and must: an unwired readiness
+    // probe is a caller mistake, and CTL-1901's rule is that it can only ever
+    // cost a duplicate — never a loss. See the exactly-once scenario below.)
+    expect(decideDispatch(unarmedFeedEvent("linear.issue.state_changed"), { mode: "enforce" }).suppress).toBe(true);
   });
 
   test("a THROWING probe is NOT ready", () => {
@@ -469,5 +489,113 @@ describe("⛔ the emission stamp decides, not a mutable flag", () => {
       expect(decideDispatch(feedEvent("linear.issue.updated"), { mode }).suppress).toBe(true);
       expect(decideDispatch(unarmedFeedEvent("linear.issue.updated"), { mode }).suppress).toBe(true);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTL-1901 — a mid-sweep readiness drop must not strand an already-stamped edge.
+//
+// Counted as DELIVERIES, not as per-event verdicts. Both earlier attempts at
+// this boundary passed their own per-event assertions while the edge as a whole
+// reached zero handlers; the only assertion that catches that is "how many times
+// did this ONE edge get delivered".
+// ─────────────────────────────────────────────────────────────────────────────
+describe("CTL-1901 — exactly-once delivery across a readiness transition", () => {
+  const armed = () => true;
+  const unarmed = () => false;
+
+  /** Deliveries for one edge = the copies the gate did NOT suppress. */
+  const deliveries = (copies) =>
+    copies.filter(({ event, isReady }) => !decideDispatch(event, { mode: "enforce", isReady }).suppress).length;
+
+  test("ACCEPTANCE: armed sweep emits A, the sweep then fails and un-arms — A still dispatches, its twin stays captured, exactly ONE delivery", () => {
+    // The exact sequence from the ticket:
+    //   1. an armed sweep stamps event A authoritative
+    //   2. A's webhook twin is consumed while readiness is still true → captured
+    //   3. a later row in that same sweep fails, readiness flips false
+    //   4. only THEN does the log tail reach A
+    // Before the fix the armed check ran first, so step 4 suppressed A — and
+    // step 2 had already captured the twin, and the sweep's successful prefix
+    // had advanced the cursor, so there was no retry. Zero deliveries.
+    const A = feedEvent("linear.issue.state_changed");
+    const twin = smeeEvent("linear.issue.state_changed");
+
+    expect(
+      deliveries([
+        { event: twin, isReady: armed }, // consumed while still armed → captured
+        { event: A, isReady: unarmed }, // consumed after the drop
+      ])
+    ).toBe(1);
+
+    // ...and it is specifically the FEED copy that delivered.
+    expect(decideDispatch(A, { mode: "enforce", isReady: unarmed }).reason).toBe("feed-authoritative");
+    expect(decideDispatch(twin, { mode: "enforce", isReady: armed }).reason).toBe("smee-captured");
+  });
+
+  test("NEGATIVE CONTROL: an UNSTAMPED event under the same sequence is still suppressed", () => {
+    // Without this, the acceptance test above would pass against a gate that had
+    // simply stopped suppressing the feed altogether.
+    const A = unarmedFeedEvent("linear.issue.state_changed");
+    const twin = smeeEvent("linear.issue.state_changed");
+
+    // The twin dispatched (it was consumed while unarmed), the feed copy did not.
+    expect(deliveries([{ event: twin, isReady: unarmed }, { event: A, isReady: unarmed }])).toBe(1);
+    expect(decideDispatch(A, { mode: "enforce", isReady: unarmed }).reason).toBe("feed-emitted-while-unarmed");
+  });
+
+  test("the steady states are still exactly-once in both postures", () => {
+    // Fully armed: feed delivers, smee captured.
+    expect(
+      deliveries([
+        { event: smeeEvent("linear.issue.state_changed"), isReady: armed },
+        { event: feedEvent("linear.issue.state_changed"), isReady: armed },
+      ])
+    ).toBe(1);
+
+    // Fully unarmed: smee delivers, the feed's copy is stamped false by the
+    // unarmed sweep that produced it.
+    expect(
+      deliveries([
+        { event: smeeEvent("linear.issue.state_changed"), isReady: unarmed },
+        { event: unarmedFeedEvent("linear.issue.state_changed"), isReady: unarmed },
+      ])
+    ).toBe(1);
+  });
+
+  test("across a RE-ARM the edge is delivered exactly once", () => {
+    // The mirror of the acceptance case. An edge occurring while unarmed: its
+    // twin dispatches (readiness false at consumption) and its feed copy is
+    // emitted by the recovering tick, which stamps with the value carried INTO
+    // that tick — still false. One delivery, via smee.
+    expect(
+      deliveries([
+        { event: smeeEvent("linear.comment.created"), isReady: unarmed },
+        { event: unarmedFeedEvent("linear.comment.created"), isReady: armed }, // consumed after the re-arm
+      ])
+    ).toBe(1);
+  });
+
+  test("readiness is consulted for the SMEE side only", () => {
+    // The asymmetry stated as a property: flipping readiness changes the smee
+    // verdict and never the feed verdict.
+    const A = feedEvent("linear.issue.updated");
+    expect(decideDispatch(A, { mode: "enforce", isReady: armed }).suppress).toBe(
+      decideDispatch(A, { mode: "enforce", isReady: unarmed }).suppress
+    );
+
+    const twin = smeeEvent("linear.issue.updated");
+    expect(decideDispatch(twin, { mode: "enforce", isReady: armed }).suppress).not.toBe(
+      decideDispatch(twin, { mode: "enforce", isReady: unarmed }).suppress
+    );
+  });
+
+  test("an unknown producer is still captured while armed, and never inherits the stamp", () => {
+    // `other` must not be able to buy authority by carrying a feedAuthority key.
+    const mystery = {
+      attributes: { "event.name": "linear.issue.state_changed", "linear.issue.identifier": "CTL-1" },
+      body: { payload: { ticket: "CTL-1", feedAuthority: true } },
+    };
+    expect(decideDispatch(mystery, { mode: "enforce", isReady: armed }).suppress).toBe(true);
+    expect(decideDispatch(mystery, { mode: "enforce", isReady: armed }).reason).toBe("smee-captured");
   });
 });

--- a/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
@@ -272,10 +272,26 @@ export function startCloudFeedTimer({
       // assume; it is one you would have to prove each tick, which is the same
       // thing as not latching.
       //
-      // Flapping is harmless here and that is what makes this safe: with ready
-      // false the gate makes smee authoritative AND still suppresses feed
-      // events, so no posture permits double-dispatch. The worst case is that
-      // dispatch alternates between two sources that both dispatch correctly.
+      // ⛔ "Flapping is harmless" — I wrote that here, and it was FALSE IN BOTH
+      // DIRECTIONS (CTL-1901). With ready false the gate also suppressed feed
+      // events that had ALREADY been stamped authoritative by an armed sweep,
+      // while their webhook twins had already been captured under the older
+      // ready=true — so the posture lost the edge outright rather than merely
+      // alternating sources. Measured on mini-2 2026-08-17: 21 flaps in 3.1 h,
+      // every un-arm exactly ONE tick long (29.8–30.5 s), 5.4% of wall clock
+      // unarmed — routinely hit, not a rare race.
+      //
+      // What makes flapping safe NOW is not this flag being steady; it is that
+      // cloud-feed-gate no longer consults it for feed events at all. The stamp
+      // written below is the feed's whole authority, and it is read from the
+      // value carried INTO this tick — the same value the webhook twin's own
+      // decision was made under — so the two agree and each edge is delivered
+      // exactly once. See the derivation in cloud-feed-gate.mjs's enforce block.
+      //
+      // ⚠️ THAT ORDERING IS LOAD-BEARING: `runOnceFn` (which emits, and whose
+      // sink reads `ready` to stamp) must run BEFORE `ready` is recomputed
+      // below. Sealed by cloud-feed-timer.test.mjs's "authority is sampled
+      // BEFORE readiness is recomputed" block, not by this comment.
       //
       // EVERY tenant must have swept cleanly — not `some`. A healthy tenant must
       // not mask a skipped or failing one, whose events would otherwise be

--- a/plugins/dev/scripts/execution-core/cloud-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-timer.test.mjs
@@ -624,3 +624,72 @@ describe("⛔ tenant scope is not cached at startup", () => {
     expect(calls).toBe(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTL-1901 — the stamp must carry the readiness the tick STARTED with.
+//
+// This is a WIRING test, not a value test. cloud-feed-gate's exactly-once
+// argument rests on an edge's webhook twin and its feed copy being decided under
+// the SAME readiness value: the twin under rₖ (readiness while the edge
+// happened), the feed copy under whatever this tick stamps with. That holds only
+// while `runOnce` is called BEFORE `ready` is recomputed. Recompute first and
+// every feed copy is stamped rₖ₊₁ instead — exactly-once breaks at every
+// transition and NOTHING reddens, because each individual value is still
+// "correct". Pinning the value without pinning the order is the shape that has
+// already shipped unverified on this feature three times.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("⛔ CTL-1901 — authority is sampled BEFORE readiness is recomputed", () => {
+  const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+  const DIRTY = { ...OKS, edges: { failed: 1, byReason: {} } };
+
+  const run = (sweeps) => {
+    const sampled = [];
+    let reports;
+    let handle;
+    const runOnceFn = () => {
+      // What the sink's `authorityNow()` would return for everything this sweep
+      // emits — read at the same point in the tick the real sink reads it.
+      sampled.push(handle.isReady());
+      return reports;
+    };
+    handle = startCloudFeedTimer({
+      mode: "enforce",
+      plans: [],
+      runOnceFn,
+      replicaFreshFn: () => true,
+      setIntervalFn: () => "H",
+    });
+    const after = [];
+    for (const s of sweeps) {
+      reports = [{ account: "t0", skipped: null, sweep: s }];
+      handle.tick();
+      after.push(handle.isReady());
+    }
+    return { sampled, after };
+  };
+
+  test("the UN-ARMING tick stamps TRUE — the value its edges' webhook twins were decided under", () => {
+    // The exact CTL-1901 sequence: armed, then a sweep goes dirty. Its edges
+    // must still be stamped authoritative, because their twins were captured
+    // under the readiness that was in force when they happened.
+    const { sampled, after } = run([OKS, DIRTY]);
+    expect(after).toEqual([true, false]); // it really did un-arm on tick 2
+    expect(sampled[1]).toBe(true); // ...and tick 2 still stamped TRUE
+  });
+
+  test("the RE-ARMING tick stamps FALSE — the mirror of the same rule", () => {
+    // Its edges happened while unarmed, so their twins already dispatched via
+    // smee. Stamping them true would deliver each of them a second time.
+    const { sampled, after } = run([DIRTY, OKS]);
+    expect(after).toEqual([false, true]);
+    expect(sampled[1]).toBe(false);
+  });
+
+  test("NEGATIVE CONTROL: in a steady state the sampled value tracks readiness", () => {
+    // Without this, the two above would pass against a stamp hardwired to the
+    // previous tick's value in a way that never converged.
+    const { sampled, after } = run([OKS, OKS, OKS]);
+    expect(after).toEqual([true, true, true]);
+    expect(sampled).toEqual([false, true, true]); // false only on the very first tick
+  });
+});


### PR DESCRIPTION
Closes CTL-1901. **Blocks the enforce flip.** Not reachable at `CATALYST_CLOUD_FEED=off`, which is how the fleet runs by default; both minis are in `shadow`.

## The defect

The enforce gate evaluated `armed` **before** the event's own authority stamp. So a readiness drop between emission and consumption *revoked* authority from a line that already had it — while its webhook twin had already been captured under the older `ready=true`, and the sweep's successful prefix had already advanced the cursor past the edge.

**The edge reached neither path, and there was no retry.**

Round 6 stamped `feedAuthority` at emission precisely so a later readiness change could not *grant* authority to an old line. This is the same boundary in the other direction.

## Why this is not a rare race — measured, not reasoned

On mini-2's exec-core daemon log, 3.1 h window since the 19:22 CDT restart:

| | |
|---|---|
| `producer armed` / `NO LONGER healthy` | 21 / 21 |
| un-arm duration (20 measured) | **all 29.83–30.53 s — exactly one tick** |
| unarmed share of wall clock | 600 s / 11,198 s = **5.4%** |

And the stamping order makes it worse than the ticket describes: `cloud-feed-timer` stamps during `runOnce`, which runs *before* `ready` is recomputed. So the tick that is about to un-arm stamps its events `feedAuthority: true` — and those freshly-stamped events were then suppressed on consumption. Under enforce that is roughly **6 lost dispatch-class edges per hour on this host**.

## The fix is subtractive

The stamp is sufficient on its own, checked before the armed gate. Exactly **one cell** of the enforce truth table changes:

| source | ready | stamp | before | after |
|---|---|---|---|---|
| feed | false | **true** | SUPPRESS ⛔ loss | **dispatch** |
| feed | false | false | SUPPRESS | SUPPRESS |
| feed | true | true | dispatch | dispatch |
| feed | true | false | SUPPRESS | SUPPRESS |
| smee | false | — | dispatch | dispatch |
| smee | true | — | SUPPRESS (captured) | SUPPRESS (captured) |

Readiness is still consulted — but only for the smee side, which is the gate's own stated rule applied literally: *suppression is only ever legitimate when a replacement exists*.

The stamp check also now runs **before** the echo probe, because `isEcho` consumes a ring token on a hit and spending one on a line we are about to suppress anyway would let some other write's real echo through later.

## Why the stamp alone is exactly right, not merely safer

For an edge E occurring between ticks Tk and Tk+1:

- its webhook twin is consumed at ≈E's time → decided under **rk**
- its feed copy is emitted during Tk+1, stamped with the value carried *into* that tick → also **rk**

Both decisions read the same rk, so deliveries = rk + ¬rk = **exactly 1**. The old code's bug was consulting a third, later reading of the flag.

Residual, stated in the code rather than asserted away: the equality holds while both streams are current, and breaks under producer/tail lag (a backlog replay stamps rk+m−1 ≠ rk).

## Also corrected

`cloud-feed-timer.mjs` claimed *"flapping is harmless … no posture permits double-dispatch."* That was false in both directions. Replaced with the measured numbers and the actual reason flapping is now safe.

## Verification

- **Mutation-tested.** Restoring the armed-first ordering reddens **5** tests including the acceptance case; the fix restores them.
- The stamping **order** the derivation rests on is load-bearing and was previously unsealed — a refactor could have broken exactly-once with nothing red. It now has its own wiring test, mutation-tested separately (arming before the sweep emits reddens 2).
- **Two pre-existing tests asserted the defect** and were rewritten, with the reason recorded inline.
- Suite: branch 9421 pass / 64 fail vs main baseline 9411 pass / 64 fail — **+10 tests, exactly the number added**. The single failure-set difference is in `scheduler.test.mjs`, which is flaky on *unmodified main* (668/7 then 669/6 across consecutive runs) and which this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)