### PR TITLE
fix(dev): CTL-1909 — readiness un-armed on the sweep's most common HEALTHY outcome

### DIFF
--- a/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-timer.mjs
@@ -91,22 +91,64 @@ export function defaultReplicaFresh(dbPath, { now = Date.now, staleMs = DEFAULT_
 
 /**
  * countsClean — a sweep counts block is clean only by DEMONSTRATING it worked:
- * no failure counter and NOTHING in byReason. Any reason, known or unknown,
- * disqualifies — so a future reason string needs no change here.
+ * no failure counter and NOTHING in `byFailure`. Any FAILURE reason, known or
+ * unknown, disqualifies — so a future failure reason needs no change here.
+ *
+ * ⛔ CTL-1909 — this read `byReason`, which is the DECLINE census, not the
+ * failure one. A decline is the sweep's most common HEALTHY outcome; its own
+ * module header says so ("on a multi-tenant replica ... most rows are
+ * declines"). So the gate un-armed on the producer working exactly correctly —
+ * measured live on both minis 2026-08-17 as
+ * `{"unready":[{"account":"tenant-0","reason":"edges:foreign-team"}]}`,
+ * triggered by ordinary CTC activity within two minutes of boot. The feed could
+ * only arm on a tick that examined ZERO foreign-team rows, so on a busy
+ * multi-team workspace `enforce` degraded to "smee, most of the time" and
+ * retiring the smee tunnel was structurally unreachable.
+ *
+ * The two maps are now split at the emitting site by MEANING, not by matching
+ * reason strings here (`linear-feed-sweep.mjs`: `decline()` → `byReason`,
+ * `fail()` → `byFailure`). Both of the old design's properties are kept: a new
+ * decline reason needs no change here, and a new failure reason needs none
+ * either.
+ *
+ * ⛔ `byFailure` MUST BE PRESENT. Defaulting it (`?? {}`) would score any counts
+ * block that predates the split — or any shape this gate does not recognise —
+ * as perfectly clean: a check whose "nothing wrong" and "could not look" are
+ * byte-identical, which is the exact defect class one level up. Absent ⇒ not
+ * clean ⇒ smee stays authoritative, which is the safe direction.
  */
 export function countsClean(counts) {
-  return counts != null && (counts.failed ?? 0) === 0 && Object.keys(counts.byReason ?? {}).length === 0;
+  if (counts == null) return false;
+  if ((counts.failed ?? 0) !== 0) return false;
+  if (!isFailureCensus(counts.byFailure)) return false;
+  return Object.keys(counts.byFailure).length === 0;
+}
+
+/**
+ * A failure census is a plain reason→count map. ⚠️ The array check is not
+ * pedantry: `typeof [] === "object"` and `Object.keys([]).length === 0`, so an
+ * array would sail through the obvious predicate and read as a perfect sweep.
+ */
+function isFailureCensus(v) {
+  return v != null && typeof v === "object" && !Array.isArray(v);
 }
 
 /**
  * countsDirtyWhy — why a counts block was NOT clean, as a short log string.
- * Reports the byReason KEYS rather than a count of them: the reason string is
- * the actionable part.
+ * Reports the byFailure KEYS rather than a count of them: the reason string is
+ * the actionable part. Declines are deliberately NOT reported here — they never
+ * make a block dirty, so naming them would be naming an innocent bystander.
  */
 export function countsDirtyWhy(counts) {
   if (counts == null) return "absent";
   const failed = counts.failed ?? 0;
-  const keys = Object.keys(counts.byReason ?? {});
+  // Distinguished from "no failure reasons": an absent map means this block came
+  // from a producer that does not report failures separately, so cleanliness was
+  // never demonstrated. Naming it keeps the un-arm actionable.
+  if (!isFailureCensus(counts.byFailure)) {
+    return failed > 0 ? `failed=${failed},no-failure-census` : "no-failure-census";
+  }
+  const keys = Object.keys(counts.byFailure);
   if (failed > 0 && keys.length > 0) return `failed=${failed},${keys.join("|")}`;
   if (failed > 0) return `failed=${failed}`;
   return keys.join("|") || "unknown";
@@ -386,8 +428,10 @@ export function startCloudFeedTimer({
       // not mask a skipped or failing one, whose events would otherwise be
       // suppressed with nothing to replace them.
       // A sweep counts as clean only by DEMONSTRATING it worked: no failure
-      // counters and NOTHING in byReason — any reason, known or unknown,
-      // disqualifies, so a future reason string needs no change here.
+      // counter and NOTHING in `byFailure` — any FAILURE reason, known or
+      // unknown, disqualifies, so a future one needs no change here. A DECLINE
+      // does not disqualify (CTL-1909); see `countsClean` for why that is not a
+      // loosening.
       // `countsClean` / `countsDirtyWhy` / `sweepUnreadyReason` are module-level
       // pure functions (above) so the readiness rule is unit-testable without a
       // replica, a clock, or a daemon.

--- a/plugins/dev/scripts/execution-core/cloud-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-feed-timer.test.mjs
@@ -293,7 +293,9 @@ describe("startCloudFeedTimer", () => {
 
   test("⛔ isReady() is FALSE until a real non-seeding sweep completes (Codex P1)", () => {
     const seeding = [{ account: "tenant-0", skipped: null, sweep: { mode: "seeded", seeded: 4000 } }];
-    const real = [{ account: "tenant-0", skipped: null, sweep: { mode: "resume", stoppedEarly: false, edges: { failed: 0 }, comments: { failed: 0 } } }];
+    const real = [
+      { account: "tenant-0", skipped: null, sweep: { mode: "resume", stoppedEarly: false, edges: { failed: 0, byFailure: {} }, comments: { failed: 0, byFailure: {} } } },
+    ];
     let reports = seeding;
     const handle = startCloudFeedTimer({
       feedHealthyFn: () => true,
@@ -339,7 +341,15 @@ describe("startCloudFeedTimer", () => {
       mode: "enforce",
       plans: [],
       runOnceFn: () => [
-        { account: "tenant-0", skipped: null, sweep: { mode: "resume", stoppedEarly: false, edges: { failed: 0 }, comments: { failed: 0 } } },
+        {
+          account: "tenant-0",
+          skipped: null,
+          // `byFailure: {}` is REQUIRED, not decoration — CTL-1909 made an absent
+          // failure census disqualifying, so this fixture without it would be
+          // asserting the opposite of what its name says. Sealed below by
+          // "a counts block with NO failure census does not arm".
+          sweep: { mode: "resume", stoppedEarly: false, edges: { failed: 0, byFailure: {} }, comments: { failed: 0, byFailure: {} } },
+        },
       ],
       setIntervalFn: () => "H",
     });
@@ -370,23 +380,23 @@ describe("startCloudFeedTimer", () => {
   // The bug was never one predicate — it was that each fix enumerated only the
   // failure shapes known at the time. This table is the place a fourth variant
   // gets added, so it cannot re-appear as a silent arming.
-  const OK = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+  const OK = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
   const FAILURE_SHAPES = [
     ["still seeding", { ...OK, mode: "seeded" }],
     ["stopped early", { ...OK, stoppedEarly: true }],
-    ["edge emit failures", { ...OK, edges: { failed: 2, byReason: {} } }],
-    ["comment emit failures", { ...OK, comments: { failed: 1, byReason: {} } }],
-    ["edge cursor unwritable", { ...OK, edges: { failed: 0, byReason: { "cursor-write-failed:EACCES": 1 } } }],
-    ["comment cursor unwritable", { ...OK, comments: { failed: 0, byReason: { "cursor-write-failed:ENOSPC": 1 } } }],
-    ["cursor failure with an unknown errno", { ...OK, edges: { failed: 0, byReason: { "cursor-write-failed:unknown": 1 } } }],
+    ["edge emit failures", { ...OK, edges: { failed: 2, byReason: {}, byFailure: {} } }],
+    ["comment emit failures", { ...OK, comments: { failed: 1, byReason: {}, byFailure: {} } }],
+    ["edge cursor unwritable", { ...OK, edges: { failed: 0, byReason: {}, byFailure: { "cursor-write-failed:EACCES": 1 } } }],
+    ["comment cursor unwritable", { ...OK, comments: { failed: 0, byReason: {}, byFailure: { "cursor-write-failed:ENOSPC": 1 } } }],
+    ["cursor failure with an unknown errno", { ...OK, edges: { failed: 0, byReason: {}, byFailure: { "cursor-write-failed:unknown": 1 } } }],
     // Round 4: a SECOND cursor reason my prefix match missed.
-    ["edge cursor init failed", { ...OK, edges: { failed: 0, byReason: { "cursor-init-failed:EACCES": 1 } } }],
-    ["comment cursor init failed", { ...OK, comments: { failed: 0, byReason: { "cursor-init-failed:EROFS": 1 } } }],
+    ["edge cursor init failed", { ...OK, edges: { failed: 0, byReason: {}, byFailure: { "cursor-init-failed:EACCES": 1 } } }],
+    ["comment cursor init failed", { ...OK, comments: { failed: 0, byReason: {}, byFailure: { "cursor-init-failed:EROFS": 1 } } }],
     // ⭐ The point of deriving readiness positively: a reason nobody has thought
     // of yet must disqualify WITHOUT a code change here. If this row ever needs
     // a new prefix added to make it pass, the enumeration bug is back.
-    ["a completely unknown future reason", { ...OK, edges: { failed: 0, byReason: { "some-reason-invented-in-2027": 1 } } }],
-    ["an unknown reason on the comment side", { ...OK, comments: { failed: 0, byReason: { "totally-new-thing": 4 } } }],
+    ["a completely unknown future reason", { ...OK, edges: { failed: 0, byReason: {}, byFailure: { "some-reason-invented-in-2027": 1 } } }],
+    ["an unknown reason on the comment side", { ...OK, comments: { failed: 0, byReason: {}, byFailure: { "totally-new-thing": 4 } } }],
   ];
 
   test.each(FAILURE_SHAPES)("readiness stays UNARMED: %s", (_label, sweep) => {
@@ -421,7 +431,7 @@ describe("startCloudFeedTimer", () => {
       mode: "enforce",
       plans: [],
       runOnceFn: () => [
-        { account: "tenant-0", skipped: null, sweep: { ...OK, comments: { failed: 0, byReason: { "cursor-write-failed:EROFS": 3 } } } },
+        { account: "tenant-0", skipped: null, sweep: { ...OK, comments: { failed: 0, byReason: {}, byFailure: { "cursor-write-failed:EROFS": 3 } } } },
       ],
       setIntervalFn: () => "H",
     });
@@ -434,7 +444,7 @@ describe("startCloudFeedTimer", () => {
     // is lost after arming, the next tick re-seeds, emits nothing, and absorbs
     // every intervening change — while a latched readiness keeps suppressing
     // smee. Those events would reach nobody.
-    const clean = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+    const clean = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
     let reports = [{ account: "tenant-0", skipped: null, sweep: clean }];
     const handle = startCloudFeedTimer({ feedHealthyFn: () => true, mode: "enforce", plans: [], runOnceFn: () => reports, setIntervalFn: () => "H" });
     handle.tick();
@@ -455,12 +465,12 @@ describe("startCloudFeedTimer", () => {
     // to open, runOnce reports an error, emits nothing, and a latched readiness
     // kept enforce suppressing every webhook copy indefinitely. Second time one
     // of my own tests has pinned behaviour that turned out to be the bug.
-    const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+    const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
     const unhealthy = [
       ["tenant error", [{ account: "t0", skipped: null, error: "replica gone" }]],
       ["tenant skipped", [{ account: "t0", skipped: "replica-absent" }]],
       ["re-seed", [{ account: "t0", skipped: null, sweep: { ...OKS, mode: "seeded" } }]],
-      ["emit failures", [{ account: "t0", skipped: null, sweep: { ...OKS, edges: { failed: 1, byReason: {} } } }]],
+      ["emit failures", [{ account: "t0", skipped: null, sweep: { ...OKS, edges: { failed: 1, byReason: {}, byFailure: {} } } }]],
       ["no tenants at all", []],
     ];
     for (const [label, bad] of unhealthy) {
@@ -479,7 +489,7 @@ describe("startCloudFeedTimer", () => {
   });
 
   test("EVERY tenant must be clean — a healthy one cannot mask a failing one", () => {
-    const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+    const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
     const handle = startCloudFeedTimer({
       feedHealthyFn: () => true,
       mode: "enforce",
@@ -512,7 +522,7 @@ describe("startCloudFeedTimer", () => {
 
 // ── CTL-1847 (Codex P1 round 6): a frozen replica must not stay armed ────────
 describe("⛔ CTL-1902 — FEED health (not writer liveness) is required for readiness", () => {
-  const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
+  const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
   const report = [{ account: "tenant-0", skipped: null, sweep: OKS }];
 
   test("an UNHEALTHY feed un-arms even though the sweep looks perfect", () => {
@@ -643,8 +653,8 @@ describe("⛔ tenant scope is not cached at startup", () => {
 // already shipped unverified on this feature three times.
 // ─────────────────────────────────────────────────────────────────────────────
 describe("⛔ CTL-1901 — authority is sampled BEFORE readiness is recomputed", () => {
-  const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {} }, comments: { failed: 0, byReason: {} } };
-  const DIRTY = { ...OKS, edges: { failed: 1, byReason: {} } };
+  const OKS = { mode: "resume", stoppedEarly: false, edges: { failed: 0, byReason: {}, byFailure: {} }, comments: { failed: 0, byReason: {}, byFailure: {} } };
+  const DIRTY = { ...OKS, edges: { failed: 1, byReason: {}, byFailure: {} } };
 
   const run = (sweeps) => {
     const sampled = [];
@@ -751,7 +761,7 @@ describe("⛔ CTL-1902 — defaultFeedHealthy reads published ingest evidence", 
 // "unhealthy" without saying why cannot be acted on.
 // ─────────────────────────────────────────────────────────────────────────────
 describe("⛔ CTL-1902 — sweepUnreadyReason names the failing conjunct", () => {
-  const OK = { failed: 0, byReason: {} };
+  const OK = { failed: 0, byReason: {}, byFailure: {} };
   const HEALTHY = { healthy: true };
   const good = { account: "t0", skipped: null, sweep: { mode: "resume", stoppedEarly: false, edges: OK, comments: OK } };
 
@@ -770,9 +780,9 @@ describe("⛔ CTL-1902 — sweepUnreadyReason names the failing conjunct", () =>
       [{ account: "t0" }, HEALTHY, "no-sweep"],
       [{ account: "t0", sweep: { ...good.sweep, mode: "seeded" } }, HEALTHY, "seeding"],
       [{ account: "t0", sweep: { ...good.sweep, stoppedEarly: true } }, HEALTHY, "stopped-early"],
-      [{ account: "t0", sweep: { ...good.sweep, edges: { failed: 3, byReason: {} } } }, HEALTHY, "edges:failed=3"],
-      [{ account: "t0", sweep: { ...good.sweep, comments: { failed: 0, byReason: { "rate-limited": 2 } } } }, HEALTHY, "comments:rate-limited"],
-      [{ account: "t0", sweep: { ...good.sweep, labels: { failed: 1, byReason: { deferred: 1 } } } }, HEALTHY, "labels:failed=1,deferred"],
+      [{ account: "t0", sweep: { ...good.sweep, edges: { failed: 3, byReason: {}, byFailure: {} } } }, HEALTHY, "edges:failed=3"],
+      [{ account: "t0", sweep: { ...good.sweep, comments: { failed: 0, byReason: {}, byFailure: { "rate-limited": 2 } } } }, HEALTHY, "comments:rate-limited"],
+      [{ account: "t0", sweep: { ...good.sweep, labels: { failed: 1, byReason: {}, byFailure: { "label-sweep-failed:EIO": 1 } } } }, HEALTHY, "labels:failed=1,label-sweep-failed:EIO"],
     ];
     const seen = new Set();
     for (const [report, health, expected] of cases) {
@@ -789,7 +799,7 @@ describe("⛔ CTL-1902 — sweepUnreadyReason names the failing conjunct", () =>
     // The seam stays authoritative: an unhealthy verdict disqualifies even a
     // perfect sweep, and a healthy one never rescues a dirty sweep.
     expect(sweepUnreadyReason(good, { healthy: false, reason: "absent" })).toBe("feed-unhealthy:absent");
-    expect(sweepUnreadyReason({ account: "t0", sweep: { ...good.sweep, edges: { failed: 1, byReason: {} } } }, HEALTHY)).toBe("edges:failed=1");
+    expect(sweepUnreadyReason({ account: "t0", sweep: { ...good.sweep, edges: { failed: 1, byReason: {}, byFailure: {} } } }, HEALTHY)).toBe("edges:failed=1");
   });
 
   test("an ABSENT health argument is not healthy (fail-closed default)", () => {
@@ -804,12 +814,130 @@ describe("⛔ CTL-1902 — sweepUnreadyReason names the failing conjunct", () =>
     expect(sweepUnreadyReason({ account: "t0", sweep: { ...good.sweep, labels: OK } }, HEALTHY)).toBe(null);
   });
 
-  test("countsClean / countsDirtyWhy: any byReason entry disqualifies, and its KEY is reported", () => {
-    expect(countsClean({ failed: 0, byReason: {} })).toBe(true);
+  test("countsClean / countsDirtyWhy: any byFailure entry disqualifies, and its KEY is reported", () => {
+    expect(countsClean({ failed: 0, byReason: {}, byFailure: {} })).toBe(true);
     expect(countsClean(null)).toBe(false);
-    expect(countsClean({ failed: 0, byReason: { "some-future-reason": 1 } })).toBe(false);
-    expect(countsDirtyWhy({ failed: 0, byReason: { "some-future-reason": 1 } })).toBe("some-future-reason");
-    expect(countsDirtyWhy({ failed: 2, byReason: { a: 1, b: 1 } })).toBe("failed=2,a|b");
+    expect(countsClean({ failed: 0, byReason: {}, byFailure: { "some-future-reason": 1 } })).toBe(false);
+    expect(countsDirtyWhy({ failed: 0, byReason: {}, byFailure: { "some-future-reason": 1 } })).toBe("some-future-reason");
+    expect(countsDirtyWhy({ failed: 2, byReason: {}, byFailure: { a: 1, b: 1 } })).toBe("failed=2,a|b");
     expect(countsDirtyWhy(null)).toBe("absent");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⛔ CTL-1909 — READINESS DISTINGUISHES A DECLINE FROM A FAILURE
+//
+// The gate read `byReason`, which is the DECLINE census. A decline is the
+// sweep's most common HEALTHY outcome, so the producer un-armed on working
+// correctly: measured live on BOTH minis 2026-08-17 as
+// `{"unready":[{"account":"tenant-0","reason":"edges:foreign-team"}]}` from
+// ordinary CTC activity, minutes after boot. Because the feed could only arm on
+// a tick that examined ZERO foreign-team rows, `enforce` degraded to "smee, most
+// of the time" and retiring the smee tunnel was unreachable.
+//
+// The controls this block owes (ticket AC): a foreign-team DECLINE must stay
+// ARMED, and a real FAILURE must UN-ARM — proven against the same fixture so
+// neither result can come from a predicate that is stuck.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("⛔ CTL-1909 — a decline is not a failure", () => {
+  const HEALTHY = { healthy: true };
+  const CLEAN = { failed: 0, byReason: {}, byFailure: {} };
+  const base = (edges) => ({
+    account: "t0",
+    skipped: null,
+    sweep: { mode: "resume", stoppedEarly: false, edges, comments: CLEAN },
+  });
+  const armed = (report) => {
+    const handle = startCloudFeedTimer({
+      feedHealthyFn: () => true,
+      mode: "enforce",
+      plans: [],
+      runOnceFn: () => [report],
+      setIntervalFn: () => "H",
+    });
+    handle.tick();
+    return handle.isReady();
+  };
+
+  // ⭐ THE TICKET'S FIRST CONTROL, at the live seam (not just the pure fn).
+  test("a sweep of ONLY declines is READY — the exact live shape that un-armed both minis", () => {
+    const declinesOnly = { emitted: 0, declined: 137, failed: 0, examined: 137, byReason: { "foreign-team": 137 }, byFailure: {} };
+    expect(countsClean(declinesOnly)).toBe(true);
+    expect(sweepUnreadyReason(base(declinesOnly), HEALTHY)).toBe(null);
+    expect(armed(base(declinesOnly))).toBe(true);
+  });
+
+  // ⭐ THE TICKET'S SECOND CONTROL, on the SAME fixture: one failure flips it.
+  // Same declines, same everything else — so a `true` above cannot be a
+  // predicate that always returns true.
+  test("the SAME sweep with one real failure is NOT ready", () => {
+    const withFailure = {
+      emitted: 0,
+      declined: 137,
+      failed: 1,
+      examined: 138,
+      byReason: { "foreign-team": 137 },
+      byFailure: { "build-failed:boom": 1 },
+    };
+    expect(countsClean(withFailure)).toBe(false);
+    expect(sweepUnreadyReason(base(withFailure), HEALTHY)).toBe("edges:failed=1,build-failed:boom");
+    expect(armed(base(withFailure))).toBe(false);
+  });
+
+  test("EVERY decline reason the classifier can produce keeps it armed", () => {
+    // Enumerated from linear-feed-event.mjs `classifyEdge` + the diff sweep's
+    // own `no-tracked-change`, minus the one FATAL verdict, which is asserted
+    // separately below. A future decline reason needs no change here — it is
+    // `decline()` at the emitting site that decides, not this list — but the
+    // list makes the CURRENT set's verdict explicit rather than assumed.
+    const DECLINE_REASONS = [
+      "foreign-team",
+      "bot-authored",
+      "no-tracked-change",
+      "unjoinable-issue",
+      "issue-has-no-team-key",
+      "issue-has-no-identifier",
+      "history-row-has-no-id",
+      "no-history-row",
+    ];
+    for (const reason of DECLINE_REASONS) {
+      const counts = { failed: 0, declined: 1, byReason: { [reason]: 1 }, byFailure: {} };
+      expect(countsClean(counts), reason).toBe(true);
+      expect(armed(base(counts)), reason).toBe(true);
+    }
+  });
+
+  test("a FAILURE reason invented in 2027 still un-arms, with no reader change", () => {
+    // The property the old design had and must not lose: failure disqualification
+    // is not an allow-list. It now comes from the emitting site choosing `fail`.
+    expect(countsClean({ failed: 0, byReason: {}, byFailure: { "something-nobody-has-written-yet": 1 } })).toBe(false);
+    expect(armed(base({ failed: 0, byReason: {}, byFailure: { "something-nobody-has-written-yet": 1 } }))).toBe(false);
+  });
+
+  // ⛔ FAIL-CLOSED ON SHAPE. A counts block from before the split has failure
+  // reasons sitting in `byReason` and no `byFailure` at all. Defaulting the map
+  // would read that as immaculate — "nothing wrong" and "could not look"
+  // byte-identical to the caller, which is the defect class this repo keeps
+  // paying for. Absent ⇒ not clean ⇒ smee stays authoritative.
+  test("a counts block with NO failure census does not arm, and says so", () => {
+    const preSplit = { failed: 0, byReason: { "cursor-write-failed:EACCES": 1 } };
+    expect(countsClean(preSplit)).toBe(false);
+    expect(countsDirtyWhy(preSplit)).toBe("no-failure-census");
+    expect(countsDirtyWhy({ failed: 2, byReason: {} })).toBe("failed=2,no-failure-census");
+    expect(armed(base(preSplit))).toBe(false);
+    // NEGATIVE CONTROL for the assertion above: the same block WITH the census
+    // present and empty does arm — so "not clean" came from the missing map, not
+    // from `byReason` still being consulted.
+    expect(armed(base({ failed: 0, byReason: { "cursor-write-failed:EACCES": 1 }, byFailure: {} }))).toBe(true);
+  });
+
+  test("a non-object failure census is not a census", () => {
+    for (const bogus of [[], "", 0, "none"]) {
+      expect(countsClean({ failed: 0, byReason: {}, byFailure: bogus }), JSON.stringify(bogus)).toBe(
+        // `[]` is an object with zero keys — it would pass a naive
+        // Object.keys().length check, which is why the type is asserted first.
+        false,
+      );
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-diffsweep.test.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 import { createLastSeenStore } from "./linear-feed-lastseen.mjs";
 import { runDiffSweep, seedBaseline } from "./linear-feed-sweep.mjs";
 import { CURSOR_ABSENT, CURSOR_OK, defaultCursorPath, readCursor } from "./linear-feed-cursor.mjs";
+// CTL-1909: the readiness predicate is IMPORTED, not restated here. A hand-built
+// copy of it in this file could agree with a fixture while disagreeing with the
+// gate the daemon actually runs.
+import { countsClean, sweepUnreadyReason } from "./cloud-feed-timer.mjs";
 
 let dir;
 let store;
@@ -277,7 +281,11 @@ describe("⛔ refuses to reseed when a durable cursor says we had a baseline", (
     expect(freshStore.isSeeded()).toBe(false); // did NOT silently reseed
     expect(r.alarm?.severity).toBe("error");
     expect(r.alarm?.reason).toBe("baseline-lost-with-live-cursor");
-    expect(Object.keys(r.edges.byReason)).toContain("baseline-lost-with-live-cursor");
+    // CTL-1909: a lost baseline is a FAILURE census entry, never a decline —
+    // it is the producer that cannot do its job, not a row it declined.
+    expect(Object.keys(r.edges.byFailure)).toContain("baseline-lost-with-live-cursor");
+    expect(r.edges.failed).toBe(1);
+    expect(r.edges.byReason).toEqual({});
   });
 
   test("NEGATIVE CONTROL: missing baseline + NO cursor is a legitimate first seed", () => {
@@ -298,11 +306,163 @@ describe("⛔ refuses to reseed when a durable cursor says we had a baseline", (
   });
 
   test("a baseline-lost sweep can never arm enforce (it is not a clean sweep)", () => {
-    // Belt and braces with the readiness predicate: mode !== "resume" and a
-    // byReason entry both disqualify it independently.
-    const r = { mode: "baseline-lost", stoppedEarly: true, edges: { failed: 0, byReason: { "baseline-lost-with-live-cursor": 1 } }, comments: { failed: 0, byReason: {} } };
+    // Belt and braces, asserted through the REAL predicate rather than by
+    // restating it: the hand-built shape this used to assert against could drift
+    // from what runDiffSweep actually returns and still pass.
+    const r = runDiffSweep({
+      source: fakeSource([]),
+      store: makeStore(),
+      cursorPath,
+      teams: TEAMS,
+      emit: () => {},
+      readCursorFn: () => ({ state: CURSOR_OK, position: { lastCreatedAt: 1, lastId: "x" } }),
+    });
     expect(r.mode).not.toBe("resume");
-    expect(Object.keys(r.edges.byReason).length).toBeGreaterThan(0);
+    expect(r.stoppedEarly).toBe(true);
+    expect(countsClean(r.edges)).toBe(false);
+    expect(sweepUnreadyReason({ account: "t0", skipped: null, sweep: r }, { healthy: true })).toBe("stopped-early");
+  });
+
+  // ── CTL-1909 ──────────────────────────────────────────────────────────────
+  // The whole point of the decline/failure split: a sweep that declines every
+  // row must ARM. These run the REAL sweep against the REAL readiness predicate
+  // (imported, not restated), so neither side can be satisfied by a fixture
+  // that only agrees with itself.
+  describe("⭐ CTL-1909 — the sweep's own output, judged by the real readiness gate", () => {
+    const ready = (sweep) => sweepUnreadyReason({ account: "t0", skipped: null, sweep }, { healthy: true });
+    const foreign = (id, over = {}) => issue(id, { identifier: `ZZZ-${id}`, team_key: "ZZZ", ...over });
+
+    test("a sweep of nothing but FOREIGN-TEAM rows arms enforce", () => {
+      const st = makeStore();
+      runDiffSweep({ source: fakeSource([foreign("f1"), foreign("f2")]), store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+      const emitted = [];
+      const r = runDiffSweep({
+        // same two issues, each with a real state change the sweep will diff
+        source: fakeSource([foreign("f1", { state: "Todo", updated_at: 2000 }), foreign("f2", { state: "Done", updated_at: 2001 })]),
+        store: st,
+        cursorPath,
+        teams: TEAMS,
+        emit: (e) => emitted.push(e),
+      });
+      expect(emitted).toEqual([]); // it emitted nothing...
+      expect(r.edges.declined).toBe(2);
+      expect(r.edges.byReason["foreign-team"]).toBe(2);
+      expect(r.edges.failed).toBe(0);
+      expect(r.edges.byFailure).toEqual({}); // ...and nothing went wrong
+      expect(countsClean(r.edges)).toBe(true);
+      expect(ready(r)).toBe(null); // ⭐ ARMED — this is the CTL-1909 fix
+    });
+
+    test("POSITIVE CONTROL on the same path: an emit failure does NOT arm", () => {
+      // Same sweep shape, only the emit throws. Without this, the assertion
+      // above could be satisfied by a gate that always says ready.
+      const st = makeStore();
+      runDiffSweep({ source: fakeSource([issue("m1")]), store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+      const r = runDiffSweep({
+        source: fakeSource([issue("m1", { state: "Done", updated_at: 2000 })]),
+        store: st,
+        cursorPath,
+        teams: TEAMS,
+        emit: () => {
+          throw new Error("boom");
+        },
+      });
+      expect(r.edges.failed).toBeGreaterThan(0);
+      expect(Object.keys(r.edges.byFailure)[0]).toContain("emit-failed");
+      expect(countsClean(r.edges)).toBe(false);
+      expect(ready(r)).not.toBe(null); // UN-ARMED
+    });
+
+    test("⛔ a producer with NO team scope refuses to sweep, and cannot arm", () => {
+      // The hole the split would otherwise open: with `teams` EMPTY, classifyEdge
+      // declines every row as `foreign-team` — a healthy decline under the new
+      // rule — so enforce would arm while the feed emitted nothing for anybody.
+      for (const teams of [undefined, new Set()]) {
+        const st = makeStore();
+        let wroteCursor = false;
+        const r = runDiffSweep({
+          source: fakeSource([issue("s1")]),
+          store: st,
+          cursorPath,
+          teams,
+          emit: () => {},
+          writeCursorFn: () => {
+            wroteCursor = true;
+          },
+        });
+        expect(r.edges.failed, String(teams)).toBe(1);
+        expect(countsClean(r.edges), String(teams)).toBe(false);
+        expect(ready(r), String(teams)).not.toBe(null);
+        // ...and it must not have consumed anything on the way out: no baseline,
+        // no cursor movement past rows it will never emit.
+        expect(st.isSeeded()).toBe(false);
+        expect(wroteCursor).toBe(false);
+      }
+    });
+
+    // ── the FATAL branch, at the altitude where it is WIRED ──────────────────
+    // `runDiffSweep` carries a `classifyFn` seam for exactly this: the fatal
+    // branch is unreachable through the real `classifyEdge` (teamScopeFailure
+    // pre-empts the only fatal verdict it can return), and an unreachable guard
+    // is one nothing can prove still works. These do not re-test the predicate —
+    // `linear-feed-sweep.test.mjs` owns that — they test that the sweep ACTS on
+    // it: no baseline absorbed, no cursor advanced, enforce un-armed.
+    const fatalVerdict = { emit: false, reason: "some-future-producer-fault", fatal: true };
+
+    test("⛔ a FATAL verdict mid-sweep does not advance the baseline, the cursor, or readiness", () => {
+      const st = makeStore();
+      runDiffSweep({ source: fakeSource([issue("k1")]), store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+      const seeded = st.get("k1");
+      expect(seeded.state).toBe("Backlog"); // the `before` the retry will need
+
+      let wroteCursor = false;
+      const emitted = [];
+      const r = runDiffSweep({
+        source: fakeSource([issue("k1", { state: "Done", updated_at: 2000 })]),
+        store: st,
+        cursorPath,
+        teams: TEAMS,
+        emit: (e) => emitted.push(e),
+        classifyFn: () => fatalVerdict,
+        writeCursorFn: () => {
+          wroteCursor = true;
+        },
+      });
+
+      expect(emitted).toEqual([]);
+      expect(r.edges.failed).toBe(1);
+      expect(r.edges.byFailure).toEqual({ "some-future-producer-fault": 1 });
+      expect(r.edges.byReason).toEqual({}); // NOT laundered into the decline census
+      expect(r.stoppedEarly).toBe(true);
+      // ⭐ the part a reason-string assertion cannot see: the edge is still
+      // re-derivable, because the baseline was not absorbed.
+      expect(st.get("k1").state).toBe("Backlog");
+      expect(wroteCursor).toBe(false);
+      expect(countsClean(r.edges)).toBe(false);
+      expect(ready(r)).not.toBe(null); // UN-ARMED — smee stays authoritative
+    });
+
+    test("NEGATIVE CONTROL: the same seam returning a NAMED decline arms, and settles the row", () => {
+      // Identical wiring, `fatal` removed. Proves the test above is driven by the
+      // fatal flag rather than by the injected seam declining at all.
+      const st = makeStore();
+      runDiffSweep({ source: fakeSource([issue("k2")]), store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+      const r = runDiffSweep({
+        source: fakeSource([issue("k2", { state: "Done", updated_at: 2000 })]),
+        store: st,
+        cursorPath,
+        teams: TEAMS,
+        emit: () => {},
+        classifyFn: () => ({ emit: false, reason: "some-future-producer-fault" }),
+      });
+      expect(r.edges.failed).toBe(0);
+      expect(r.edges.byReason).toEqual({ "some-future-producer-fault": 1 });
+      expect(r.edges.byFailure).toEqual({});
+      expect(r.stoppedEarly).toBe(false);
+      expect(st.get("k2").state).toBe("Done"); // examined and SETTLED
+      expect(countsClean(r.edges)).toBe(true);
+      expect(ready(r)).toBe(null); // ARMED
+    });
   });
 });
 
@@ -442,6 +602,68 @@ describe("⛔ the label sweep catches what the updated_at cursor cannot", () => 
     expect(r.labels).toBeDefined();
     expect(r.labels.failed).toBe(0);
     expect(Object.keys(r.labels.byReason)).toHaveLength(0);
+  });
+
+  // ── CTL-1909, third call site ────────────────────────────────────────────
+  // The label pass has its OWN `verdictIsFailure` branch and its own counts
+  // block, and `sweepUnreadyReason` gates on that block separately
+  // (`labels:` prefix). A split applied to two of three call sites would leave
+  // this one able to arm enforce on a producer-level fault.
+  test("⛔ CTL-1909: a FATAL verdict in the LABEL pass un-arms, and keeps the row re-derivable", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", []]]);
+    const src = raceSource(rows, labels);
+    const st = makeStore();
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+    labels.set("a", ["refactor"]); // a label-only change: only the label pass sees it
+
+    const emitted = [];
+    const r = runDiffSweep({
+      source: src,
+      store: st,
+      cursorPath,
+      teams: TEAMS,
+      emit: (e) => emitted.push(e),
+      classifyFn: () => ({ emit: false, reason: "some-future-producer-fault", fatal: true }),
+    });
+
+    expect(emitted).toEqual([]);
+    expect(r.labels.failed).toBe(1);
+    expect(r.labels.byFailure).toEqual({ "some-future-producer-fault": 1 });
+    expect(r.labels.byReason).toEqual({}); // not a decline
+    // the label change must survive in re-derivable form for the retry
+    expect(st.get("a").labels ?? []).toEqual([]);
+    expect(countsClean(r.labels)).toBe(false);
+    // `labels:` prefix ⇒ the LABEL block is what disqualified it, and the reason
+    // string names the fault so the un-arm is actionable.
+    expect(sweepUnreadyReason({ account: "t0", skipped: null, sweep: r }, { healthy: true })).toBe(
+      "labels:failed=1,some-future-producer-fault",
+    );
+  });
+
+  test("NEGATIVE CONTROL: a NAMED decline in the label pass arms, and settles the row", () => {
+    const rows = [issue("a", { updated_at: 1000 })];
+    const labels = new Map([["a", []]]);
+    const src = raceSource(rows, labels);
+    const st = makeStore();
+    runDiffSweep({ source: src, store: st, cursorPath, teams: TEAMS, emit: () => {} }); // seed
+    labels.set("a", ["refactor"]);
+
+    const r = runDiffSweep({
+      source: src,
+      store: st,
+      cursorPath,
+      teams: TEAMS,
+      emit: () => {},
+      classifyFn: () => ({ emit: false, reason: "foreign-team" }),
+    });
+
+    expect(r.labels.failed).toBe(0);
+    expect(r.labels.byReason).toEqual({ "foreign-team": 1 });
+    expect(r.labels.byFailure).toEqual({});
+    expect(st.get("a").labels ?? []).toEqual(["refactor"]); // examined and SETTLED
+    expect(countsClean(r.labels)).toBe(true);
+    expect(sweepUnreadyReason({ account: "t0", skipped: null, sweep: r }, { healthy: true })).toBe(null);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-event.mjs
@@ -201,7 +201,14 @@ export function classifyEdge({ history, issue } = {}, { teams, botUserIds } = {}
   // `teams` absent is NOT "allow everything" — an unconfigured producer must emit
   // nothing rather than every tenant's edges.
   if (!teams || typeof teams.has !== "function") {
-    return { emit: false, reason: "no-team-scope-configured" };
+    // ⛔ `fatal` (CTL-1909): this is the one non-emitting verdict whose cause is
+    // the PRODUCER, not the row. Every other verdict here declines one row and
+    // the next may still emit; this one declines all of them forever. Since the
+    // readiness split treats an ordinary decline as healthy, a scopeless
+    // producer would otherwise ARM enforce while emitting nothing at all —
+    // smee suppressed, feed silent. Marked at the point the distinction is
+    // known so the sweep needs no list of reason strings to tell them apart.
+    return { emit: false, reason: "no-team-scope-configured", fatal: true };
   }
   if (!teams.has(teamKey)) return { emit: false, reason: "foreign-team" };
 

--- a/plugins/dev/scripts/execution-core/linear-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-event.test.mjs
@@ -162,7 +162,29 @@ describe("team scoping comes from config, and an unconfigured producer emits NOT
       expect(classifyEdge({ history: historyRow(), issue: issueRow() }, { teams })).toEqual({
         emit: false,
         reason: "no-team-scope-configured",
+        // ⛔ CTL-1909: `fatal` is asserted, not tolerated. It is the flag that
+        // keeps this verdict disqualifying now that an ordinary decline is
+        // healthy — without it a scopeless producer would ARM enforce while
+        // emitting nothing at all.
+        fatal: true,
       });
+    }
+  });
+
+  test("⛔ CTL-1909: no OTHER verdict is fatal — `fatal` marks the producer, not a row", () => {
+    // If a per-row verdict picked up `fatal`, one malformed row would un-arm the
+    // feed forever, which is the pathology CTL-1909 exists to remove.
+    const cases = [
+      [{ history: null, issue: issueRow() }, { teams: TEAMS }],
+      [{ history: historyRow(), issue: null }, { teams: TEAMS }],
+      [{ history: historyRow(), issue: issueRow({ team_key: "ZZZ" }) }, { teams: TEAMS }],
+      [{ history: historyRow({ actor_id: "bot-1" }), issue: issueRow() }, { teams: TEAMS, botUserIds: new Set(["bot-1"]) }],
+    ];
+    for (const [item, opts] of cases) {
+      const v = classifyEdge(item, opts);
+      expect(v.emit, JSON.stringify(v)).toBe(false);
+      expect(typeof v.reason, JSON.stringify(v)).toBe("string"); // named, so the sweep can decline it
+      expect(v.fatal, JSON.stringify(v)).toBeUndefined();
     }
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
@@ -28,6 +28,40 @@
 // it forever. Conflating the two is how a producer wedges on the first row it was
 // never going to emit — and on a multi-tenant replica (CTL 4,993 · ADV 3,859 ·
 // CTC 851 · EVR 158 · OTL 114 state edges) most rows are declines.
+//
+// ── TWO COUNTERS, BECAUSE ONE OF THEM GATES ENFORCE (CTL-1909) ──────────────
+// That warning was stated here and then contradicted one module away. Declines and
+// failures both landed in a single `byReason` map, and `cloud-feed-timer`'s
+// readiness gate disqualified the producer on ANY entry in it — so the sweep's most
+// common HEALTHY outcome un-armed enforce. Measured live on both minis 2026-08-17:
+// `{"unready":[{"reason":"edges:foreign-team"}]}` within two minutes of boot, from
+// ordinary CTC activity. The feed could only be armed on a tick that examined zero
+// foreign-team rows, which on a busy multi-team workspace is a minority of ticks —
+// making "turn smee off" structurally unreachable.
+//
+// So the outcome maps are SPLIT, and the split is by MEANING at the call site, not
+// by matching reason strings at the reader:
+//
+//   decline(counts, reason) → counts.declined + counts.byReason
+//       The producer examined a row and deliberately produced nothing. Healthy,
+//       expected, unbounded in volume. Reported, never disqualifying.
+//   fail(counts, reason)    → counts.failed   + counts.byFailure
+//       The producer could not do its job. Always disqualifying, and a reason
+//       string invented in 2027 still disqualifies because the SITE chose `fail`.
+//
+// Adding a new decline reason therefore needs no reader change (the old design's
+// virtue) and adding a new failure reason needs no reader change either (the old
+// design's bug). The one judgement is which helper to call, made where the outcome
+// is actually known.
+//
+// ⛔ The line between them is NOT "is this row unusual". It is: **would un-arming
+// repair it?** A malformed row (`unjoinable-issue`, `issue-has-no-team-key`) is a
+// decline: the feed produces nothing for that row, but neither would smee's copy
+// survive the same downstream team scoping, and un-arming forever over one bad row
+// is the very pathology this ticket removes. A producer that cannot emit for ANY
+// row (`no-team-scope-configured`) is a failure — un-arming is exactly the right
+// response, because the alternative is enforce suppressing every webhook copy while
+// the feed emits nothing at all.
 
 import { buildCommentEvent, buildIssueEvent, classifyEdge } from "./linear-feed-event.mjs";
 import { diffSnapshots, diffToHistoryRow, snapshotOf } from "./linear-feed-diff.mjs";
@@ -36,11 +70,95 @@ import { CURSOR_OK, DEFAULT_RESET_LOOKBACK_MS, readCursor, resolveStartPosition,
 /** Bound the work one sweep may do, so a large backlog cannot monopolise a tick. */
 export const DEFAULT_MAX_BATCHES = 20;
 
-const emptyCounts = () => ({ emitted: 0, declined: 0, failed: 0, examined: 0, deferred: 0, byReason: {} });
+const emptyCounts = () => ({ emitted: 0, declined: 0, failed: 0, examined: 0, deferred: 0, byReason: {}, byFailure: {} });
 
-const note = (counts, reason) => {
-  counts.byReason[reason] = (counts.byReason[reason] ?? 0) + 1;
+const bump = (map, reason) => {
+  map[reason] = (map[reason] ?? 0) + 1;
 };
+
+/** Examined and deliberately not emitted. Counted, reported, NEVER disqualifying. */
+const decline = (counts, reason) => {
+  counts.declined += 1;
+  bump(counts.byReason, reason);
+};
+
+/**
+ * The producer could not do its job. ALWAYS disqualifying.
+ *
+ * ⚠️ This also folds the cursor failures into `counts.failed`, which they were not
+ * in before — they were noted in `byReason` alone and relied on the reader treating
+ * every entry as fatal. That reliance is what CTL-1909 removes, so a failure that
+ * does not increment `failed` would now be a failure the gate cannot see.
+ */
+const fail = (counts, reason) => {
+  counts.failed += 1;
+  bump(counts.byFailure, reason);
+};
+
+/**
+ * failureNameFor — `null` when a non-emitting verdict is a healthy DECLINE,
+ * otherwise the name to record it under as a FAILURE.
+ *
+ * A verdict is a healthy decline only when it NAMED a reason. `classify`
+ * returning `undefined`, `null`, or a reasonless object means the producer cannot
+ * say why it produced nothing — that is not a demonstrated decline, and the whole
+ * point of this gate is positive evidence. `fatal` marks a verdict whose cause is
+ * the producer rather than the row.
+ *
+ * ⛔ Deciding and NAMING are one function on purpose. They were briefly two — a
+ * `verdictIsFailure` predicate here plus `verdict?.reason || "unclassified"`
+ * repeated at each of the three call sites — and the two promptly disagreed: a
+ * non-string reason (`42`) was ruled unusable by the predicate and then used
+ * anyway as the census key, because `42 || "unclassified"` is `42`. That is the
+ * same shape as the bug this ticket fixes (two places holding one meaning, one of
+ * them wrong), one level down, so the naming lives where the decision is made and
+ * a caller cannot supply its own.
+ */
+const failureNameFor = (verdict) => {
+  if (verdict?.fatal === true) {
+    // A fatal verdict is trusted for its NAME only if it also named itself
+    // usably; the flag alone is what makes it a failure.
+    return typeof verdict.reason === "string" && verdict.reason.length > 0 ? verdict.reason : "unclassified";
+  }
+  if (typeof verdict?.reason !== "string" || verdict.reason.length === 0) return "unclassified";
+  return null; // named, non-fatal ⇒ a healthy decline
+};
+
+/**
+ * ⛔ A producer with no team scope declines EVERY row — with `teams` absent as
+ * `no-team-scope-configured`, and with `teams` merely EMPTY as `foreign-team`,
+ * which since the split above is a healthy decline. So an empty scope would arm
+ * enforce while emitting nothing for anybody: smee suppressed, feed silent.
+ *
+ * Production is already covered one layer up (`linear-feed-run.mjs` `planTenants`
+ * returns `skip: "no-registered-teams"`, and a skipped tenant never arms). This
+ * closes the same hole at the module boundary, where the split is made — a public
+ * export must not depend on a caller it cannot see for the invariant its own
+ * counters assert.
+ */
+function teamScopeFailure(teams) {
+  if (!teams || typeof teams.has !== "function") return "no-team-scope-configured";
+  if (typeof teams.size === "number" && teams.size === 0) return "empty-team-scope";
+  return null;
+}
+
+function noTeamScopeResult(reason) {
+  const counts = emptyCounts();
+  fail(counts, reason);
+  return {
+    mode: "no-team-scope",
+    alarm: {
+      severity: "error",
+      reason,
+      message:
+        "the producer has no team scope, so it would decline every row and emit nothing — refusing to sweep rather than advancing the cursor past edges it will never emit",
+    },
+    batches: 0,
+    stoppedEarly: true,
+    edges: counts,
+    comments: emptyCounts(),
+  };
+}
 
 /**
  * Process one page, in order, stopping at the first EMIT FAILURE.
@@ -54,8 +172,14 @@ export function processPage(items, { build, classify, emit, counts }) {
     counts.examined += 1;
     const verdict = classify(item);
     if (!verdict?.emit) {
-      counts.declined += 1;
-      note(counts, verdict?.reason ?? "unclassified");
+      const failureName = failureNameFor(verdict);
+      if (failureName) {
+        // Producer-level, or unexplained. Do NOT settle it: the cursor must not
+        // move past a row we never emitted and cannot account for.
+        fail(counts, failureName);
+        return { handled, stopped: true };
+      }
+      decline(counts, verdict.reason);
       handled.push(item); // examined and settled — the cursor MUST move past it
       continue;
     }
@@ -63,15 +187,13 @@ export function processPage(items, { build, classify, emit, counts }) {
     try {
       event = build(item);
     } catch (err) {
-      counts.failed += 1;
-      note(counts, `build-failed:${err?.message ?? "unknown"}`);
+      fail(counts, `build-failed:${err?.message ?? "unknown"}`);
       return { handled, stopped: true };
     }
     try {
       emit(event, item);
     } catch (err) {
-      counts.failed += 1;
-      note(counts, `emit-failed:${err?.message ?? "unknown"}`);
+      fail(counts, `emit-failed:${err?.message ?? "unknown"}`);
       return { handled, stopped: true }; // do NOT include this item
     }
     counts.emitted += 1;
@@ -99,6 +221,8 @@ export function runSweep({
   readCursorFn = readCursor,
   writeCursorFn = writeCursor,
 } = {}) {
+  const scopeFailure = teamScopeFailure(teams);
+  if (scopeFailure) return noTeamScopeResult(scopeFailure);
   const read = readCursorFn(cursorPath);
   const start = resolveStartPosition(read, { now, resetLookbackMs });
   const counts = emptyCounts();
@@ -122,7 +246,7 @@ export function runSweep({
     try {
       writeCursorFn(cursorPath, position);
     } catch (err) {
-      note(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
+      fail(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
     }
   }
 
@@ -138,7 +262,7 @@ export function runSweep({
       // A cursor we cannot persist means the next boot re-reads this window. That
       // is survivable (re-emission, bounded) and must not stop the sweep — but it
       // is NOT silent.
-      note(counts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
+      fail(counts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
     }
     return true;
   };
@@ -272,7 +396,18 @@ export function runDiffSweep({
   now = () => Date.now(),
   readCursorFn = readCursor,
   writeCursorFn = writeCursor,
+  // Injected so the FATAL-verdict branch below is reachable from a test. It is
+  // otherwise unreachable by construction — `teamScopeFailure` pre-empts the only
+  // fatal verdict `classifyEdge` can currently return — and an unreachable guard
+  // is one nothing can prove still works. The branch is kept because the next
+  // fatal verdict added to `classifyEdge` would otherwise be silently demoted to a
+  // healthy decline, which is CTL-1909 all over again.
+  classifyFn = classifyEdge,
   labelBudget = DEFAULT_LABEL_BUDGET,} = {}) {
+  // Checked BEFORE the store or the cursor is touched: a scopeless producer must
+  // not seed a baseline it will then decline every row against.
+  const scopeFailure = teamScopeFailure(teams);
+  if (scopeFailure) return noTeamScopeResult(scopeFailure);
   const counts = emptyCounts();
 
   // ⛔ A MISSING BASELINE + A LIVE CURSOR IS A LOSS, NOT A FIRST RUN
@@ -284,7 +419,7 @@ export function runDiffSweep({
   // this from "first seed" into a reportable failure.
   if (!store.isSeeded() && readCursorFn(cursorPath)?.state === CURSOR_OK) {
     const counts = emptyCounts();
-    note(counts, "baseline-lost-with-live-cursor");
+    fail(counts, "baseline-lost-with-live-cursor");
     return {
       mode: "baseline-lost",
       alarm: {
@@ -308,7 +443,7 @@ export function runDiffSweep({
       try {
         writeCursorFn(cursorPath, seed.position);
       } catch (err) {
-        note(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
+        fail(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
       }
     }
     return { mode: "seeded", alarm: null, seeded: seed.seeded, complete: seed.complete, batches: seed.batches, edges: counts };
@@ -330,7 +465,7 @@ export function runDiffSweep({
     try {
       writeCursorFn(cursorPath, position);
     } catch (err) {
-      note(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
+      fail(counts, `cursor-init-failed:${err?.code ?? err?.message ?? "unknown"}`);
     }
   }
 
@@ -350,18 +485,25 @@ export function runDiffSweep({
       if (!diff) {
         // The mirror rewrote the row without changing anything we track. Not an
         // event, and the baseline still advances so we don't re-examine it.
-        counts.declined += 1;
-        note(counts, "no-tracked-change");
+        decline(counts, "no-tracked-change");
         store.put(row.issue.id, after, row.issue.updated_at);
         handled.push(row);
         continue;
       }
       const history = diffToHistoryRow(row.issue, diff, { now });
       const item = { history, issue: row.issue, actor: null, assignee: null, project: row.project, labels: row.labels };
-      const verdict = classifyEdge(item, { teams, botUserIds });
+      const verdict = classifyFn(item, { teams, botUserIds });
       if (!verdict?.emit) {
-        counts.declined += 1;
-        note(counts, verdict?.reason ?? "unclassified");
+        const failureName = failureNameFor(verdict);
+        if (failureName) {
+          // Producer-level or unexplained: do NOT snapshot and do NOT settle.
+          // Absorbing the row into the baseline would destroy the `before` this
+          // edge must be re-derived from once the producer is repaired.
+          fail(counts, failureName);
+          stopped = true;
+          break;
+        }
+        decline(counts, verdict.reason);
         store.put(row.issue.id, after, row.issue.updated_at);
         handled.push(row);
         continue;
@@ -369,8 +511,7 @@ export function runDiffSweep({
       try {
         emit(buildIssueEvent(item), item);
       } catch (err) {
-        counts.failed += 1;
-        note(counts, `emit-failed:${err?.message ?? "unknown"}`);
+        fail(counts, `emit-failed:${err?.message ?? "unknown"}`);
         stopped = true;
         break; // baseline NOT updated — the `before` must survive for the retry
       }
@@ -385,7 +526,7 @@ export function runDiffSweep({
       try {
         writeCursorFn(cursorPath, position);
       } catch (err) {
-        note(counts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
+        fail(counts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
       }
     } else if (handled.length === 0) {
       break;
@@ -415,7 +556,7 @@ export function runDiffSweep({
         // write cannot land, every subsequent tick cold-starts at ITS current
         // time and permanently skips the comments created in between — and the
         // readiness gate, which reads these counts, saw nothing wrong.
-        note(commentCounts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
+        fail(commentCounts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
       }
     }
     const page = source.commentsSince(cPos);
@@ -434,7 +575,7 @@ export function runDiffSweep({
         try {
           writeCursorFn(commentCursorPath, next);
         } catch (err) {
-          note(commentCounts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
+          fail(commentCounts, `cursor-write-failed:${err?.code ?? err?.message ?? "unknown"}`);
         }
       }
     }
@@ -484,9 +625,11 @@ export function runDiffSweep({
       // next tick. Deferral is bounded work, not lost work.
       const budget = Number.isInteger(labelBudget) && labelBudget > 0 ? labelBudget : DEFAULT_LABEL_BUDGET;
       const slice = changed.slice(0, budget);
-      // ⚠️ Reported in its own field, NOT in byReason — readiness treats any
-      // byReason entry as disqualifying, and a paced sweep is healthy operation,
-      // not a failure. A sweep that never drains shows up as `deferred` staying
+      // ⚠️ Reported in its own field, NOT via `fail` — a paced sweep is healthy
+      // operation, not a failure. (Pre-CTL-1909 this said "not in byReason",
+      // because byReason was then the disqualifying map; the field is kept
+      // separate from the decline census too, since nothing was examined.)
+      // A sweep that never drains shows up as `deferred` staying
       // above zero every tick, which is observable without un-arming enforce on
       // every bulk edit.
       labelCounts.deferred = Math.max(0, changed.length - slice.length);
@@ -504,10 +647,14 @@ export function runDiffSweep({
             continue;
           }
           const history = diffToHistoryRow(item.issue, diff, { now });
-          const verdict = classifyEdge({ history, issue: item.issue }, { teams, botUserIds });
-          if (!verdict.emit) {
-            note(labelCounts, verdict.reason);
-            labelCounts.declined += 1;
+          const verdict = classifyFn({ history, issue: item.issue }, { teams, botUserIds });
+          if (!verdict?.emit) {
+            const failureName = failureNameFor(verdict);
+            if (failureName) {
+              fail(labelCounts, failureName);
+              break; // baseline NOT updated — same discipline as a failed emit
+            }
+            decline(labelCounts, verdict.reason);
             store.put(issueId, after, item.issue.updated_at ?? null);
             continue;
           }
@@ -519,18 +666,16 @@ export function runDiffSweep({
             // instead of being absorbed into the baseline.
             store.put(issueId, after, item.issue.updated_at ?? null);
           } catch (err) {
-            labelCounts.failed += 1;
-            note(labelCounts, `emit-failed:${err?.code ?? err?.message ?? "unknown"}`);
+            fail(labelCounts, `emit-failed:${err?.code ?? err?.message ?? "unknown"}`);
             break;
           }
         }
       }
     } catch (err) {
-      // Named, never swallowed: readiness treats any byReason entry as
-      // disqualifying, so a broken label sweep un-arms enforce rather than
-      // quietly reintroducing the blind spot it exists to close.
-      note(labelCounts, `label-sweep-failed:${err?.code ?? err?.message ?? "unknown"}`);
-      labelCounts.failed += 1;
+      // Named, never swallowed: a `byFailure` entry disqualifies readiness, so a
+      // broken label sweep un-arms enforce rather than quietly reintroducing the
+      // blind spot it exists to close.
+      fail(labelCounts, `label-sweep-failed:${err?.code ?? err?.message ?? "unknown"}`);
     }
   }
 

--- a/plugins/dev/scripts/execution-core/linear-feed-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-sweep.test.mjs
@@ -13,6 +13,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_MAX_BATCHES, processPage, runSweep } from "./linear-feed-sweep.mjs";
 import { defaultCursorPath, readCursor, writeCursor } from "./linear-feed-cursor.mjs";
+// CTL-1909: the readiness predicate is IMPORTED, not restated. A hand-written copy
+// of the gate could agree with these fixtures while disagreeing with the daemon.
+import { countsClean } from "./cloud-feed-timer.mjs";
 
 let dir;
 let cursorPath;
@@ -249,7 +252,11 @@ describe("bounds and failure posture", () => {
       },
     });
     expect(r.edges.emitted).toBe(2); // work still happened
-    expect(Object.keys(r.edges.byReason).some((k) => k.startsWith("cursor-write-failed"))).toBe(true);
+    expect(Object.keys(r.edges.byFailure).some((k) => k.startsWith("cursor-write-failed"))).toBe(true);
+    // CTL-1909: a cursor failure is a FAILURE, so it must also be counted as one
+    // — the readiness gate no longer infers that from the map alone.
+    expect(r.edges.failed).toBeGreaterThan(0);
+    expect(r.edges.byReason).toEqual({}); // ...and never as a decline
   });
 
   test("an empty replica is a clean no-op", () => {
@@ -257,11 +264,43 @@ describe("bounds and failure posture", () => {
     expect(r.edges).toMatchObject({ emitted: 0, declined: 0, failed: 0, examined: 0 });
     expect(r.stoppedEarly).toBe(false);
   });
+
+  // CTL-1909: `runSweep` carries the same team-scope guard as `runDiffSweep`, and
+  // it needs its own test — the diffsweep test cannot reach this function, so the
+  // guard here was live and unkillable. This path is the superseded history sweep,
+  // which is exactly why it would rot unnoticed.
+  test("⛔ CTL-1909: runSweep refuses to sweep with no team scope, and cannot arm", () => {
+    for (const teams of [undefined, new Set()]) {
+      let wroteCursor = false;
+      const r = runSweep({
+        source: fakeSource([edge("h1", 1)]),
+        cursorPath,
+        teams,
+        emit: () => {},
+        writeCursorFn: () => {
+          wroteCursor = true;
+        },
+      });
+      expect(r.mode, String(teams)).toBe("no-team-scope");
+      expect(r.edges.failed, String(teams)).toBe(1);
+      expect(r.edges.byReason, String(teams)).toEqual({}); // never a decline
+      expect(countsClean(r.edges), String(teams)).toBe(false);
+      expect(r.stoppedEarly, String(teams)).toBe(true);
+      expect(wroteCursor, String(teams)).toBe(false); // no cursor past rows it will never emit
+    }
+  });
+
+  test("NEGATIVE CONTROL: runSweep with a real team scope does sweep and can arm", () => {
+    const r = runSweep({ source: fakeSource([edge("h1", 1)]), cursorPath, teams: TEAMS, emit: () => {} });
+    expect(r.mode).not.toBe("no-team-scope");
+    expect(r.edges.failed).toBe(0);
+    expect(countsClean(r.edges)).toBe(true);
+  });
 });
 
 describe("processPage — the unit the loop is built on", () => {
   test("handled includes declines but stops before a failed emit", () => {
-    const counts = { emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {} };
+    const counts = { emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {}, byFailure: {} };
     const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
     const res = processPage(items, {
       classify: (i) => (i.id === "a" ? { emit: false, reason: "foreign-team" } : { emit: true, reason: "ok" }),
@@ -277,7 +316,7 @@ describe("processPage — the unit the loop is built on", () => {
   });
 
   test("a build failure stops the page too, and is named", () => {
-    const counts = { emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {} };
+    const counts = { emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {}, byFailure: {} };
     const res = processPage([{ id: "a" }], {
       classify: () => ({ emit: true, reason: "ok" }),
       build: () => {
@@ -288,7 +327,112 @@ describe("processPage — the unit the loop is built on", () => {
     });
     expect(res.stopped).toBe(true);
     expect(res.handled).toEqual([]);
-    expect(Object.keys(counts.byReason)[0]).toContain("build-failed");
+    expect(Object.keys(counts.byFailure)[0]).toContain("build-failed");
+    expect(counts.byReason).toEqual({});
+  });
+
+  // ── CTL-1909 ──────────────────────────────────────────────────────────────
+  // `verdictIsFailure` is the whole decline/failure split in one predicate, and
+  // each of its three clauses is the sole thing preventing a distinct way for a
+  // NON-decline to be scored as a healthy decline — i.e. to ARM enforce. Every
+  // clause therefore gets a case that fails if the clause is deleted, and a
+  // negative control on the same path so none of them can pass by the predicate
+  // simply always saying "failure".
+  describe("⭐ CTL-1909 — a non-decline must never be scored as a healthy decline", () => {
+    const freshCounts = () => ({ emitted: 0, declined: 0, failed: 0, examined: 0, byReason: {}, byFailure: {} });
+    const run = (verdict) => {
+      const counts = freshCounts();
+      const res = processPage([{ id: "a" }, { id: "b" }], {
+        classify: () => verdict,
+        build: (i) => i,
+        emit: () => {},
+        counts,
+      });
+      return { counts, res };
+    };
+
+    // Clause 1 — `verdict?.fatal === true`. A named reason, so clauses 2 and 3
+    // both pass; only the `fatal` clause can catch this. This is the verdict
+    // `classifyEdge` returns for `no-team-scope-configured`.
+    test("a FATAL verdict fails the sweep even though its reason is well-formed", () => {
+      const { counts, res } = run({ emit: false, reason: "no-team-scope-configured", fatal: true });
+      expect(counts.failed).toBe(1);
+      expect(counts.byFailure).toEqual({ "no-team-scope-configured": 1 });
+      expect(counts.byReason).toEqual({}); // NOT a decline
+      expect(counts.declined).toBe(0);
+      // ...and it stops the page: the cursor must not move past a row the
+      // producer was structurally unable to emit.
+      expect(res.stopped).toBe(true);
+      expect(res.handled).toEqual([]);
+      expect(counts.examined).toBe(1); // stopped at the first, did not grind on
+    });
+
+    // Clause 2 — `typeof verdict?.reason !== "string"`. A decline is only
+    // demonstrated when the producer SAYS why; an unexplained refusal is not
+    // evidence of health.
+    test.each([
+      ["reasonless object", { emit: false }],
+      ["null reason", { emit: false, reason: null }],
+      ["non-string reason", { emit: false, reason: 42 }],
+      ["undefined verdict", undefined],
+      ["null verdict", null],
+    ])("an unexplained refusal (%s) is a failure, named `unclassified`", (_label, verdict) => {
+      const { counts, res } = run(verdict);
+      expect(counts.failed).toBe(1);
+      expect(counts.byFailure).toEqual({ unclassified: 1 });
+      expect(counts.byReason).toEqual({});
+      expect(res.stopped).toBe(true);
+      expect(res.handled).toEqual([]);
+    });
+
+    // Clause 3 — `verdict.reason.length === 0`. `typeof "" === "string"`, so
+    // clause 2 passes an empty reason straight through; without this clause an
+    // empty string would be a perfectly healthy decline whose census entry is
+    // the empty key.
+    test('an EMPTY-string reason is a failure, not a decline keyed ""', () => {
+      const { counts, res } = run({ emit: false, reason: "" });
+      expect(counts.failed).toBe(1);
+      expect(counts.byFailure).toEqual({ unclassified: 1 });
+      expect(counts.byReason).toEqual({});
+      expect(res.stopped).toBe(true);
+    });
+
+    // The NAMING half, which is the same function on purpose. A fatal verdict is
+    // a failure on the strength of the flag alone, so its reason is untrusted for
+    // the census KEY — `verdict.reason || "unclassified"` would key this census on
+    // the number 42. (That was a real defect in this ticket's first cut: the
+    // predicate ruled the reason unusable and the call site used it anyway.)
+    test.each([
+      ["non-string", 42],
+      ["empty string", ""],
+      ["absent", undefined],
+    ])("a FATAL verdict with a %s reason is named `unclassified`, not keyed on the junk", (_label, reason) => {
+      const { counts } = run({ emit: false, reason, fatal: true });
+      expect(counts.failed).toBe(1);
+      expect(counts.byFailure).toEqual({ unclassified: 1 });
+      expect(counts.byReason).toEqual({});
+    });
+
+    test("NEGATIVE CONTROL: a fatal verdict that DID name itself keeps its own name", () => {
+      // Otherwise the assertions above would pass on a function that threw every
+      // fatal reason away, which would make the un-arm unactionable.
+      const { counts } = run({ emit: false, reason: "no-team-scope-configured", fatal: true });
+      expect(counts.byFailure).toEqual({ "no-team-scope-configured": 1 });
+    });
+
+    // NEGATIVE CONTROL on the identical path. Without this, every assertion
+    // above would still pass if `verdictIsFailure` were hard-wired to `true` —
+    // which would restore the CTL-1909 bug in its worst form (every decline
+    // un-arms enforce AND stops the sweep).
+    test("NEGATIVE CONTROL: an ordinary named decline is healthy, settled, and does not stop the page", () => {
+      const { counts, res } = run({ emit: false, reason: "foreign-team" });
+      expect(counts.failed).toBe(0);
+      expect(counts.byFailure).toEqual({});
+      expect(counts.declined).toBe(2);
+      expect(counts.byReason).toEqual({ "foreign-team": 2 });
+      expect(res.stopped).toBe(false);
+      expect(res.handled.map((i) => i.id)).toEqual(["a", "b"]); // cursor MUST advance
+    });
   });
 });
 


### PR DESCRIPTION
## The defect

The cloud-feed readiness gate (`cloud-feed-timer.mjs` `countsClean`) disqualified the producer on **any** entry in the sweep's `byReason` map, with the comment *"any reason, known or unknown, disqualifies, so a future reason string needs no change here."*

But `byReason` was the **decline** census, not the failure one — and a decline is the sweep's most common healthy outcome. `linear-feed-sweep.mjs`'s own header says so:

> ⚠️ A DECLINE IS NOT A FAILURE … on a multi-tenant replica (CTL 4,993 · ADV 3,859 · CTC 851 · EVR 158 · OTL 114 state edges) **most rows are declines**.

The two modules contradicted each other and the gate believed the wrong one.

**Confirmed live on BOTH minis**, 2026-08-17, minutes after the 15:15Z restart:

```
mini-2  15:17:42Z  {"unready":[{"account":"tenant-0","reason":"edges:foreign-team"}],
                    "msg":"cloud-feed: producer NO LONGER healthy — un-arming, smee is authoritative again"}
mini    15:17:26Z  same, same reason
```

The trigger was ordinary CTC activity — the producer behaving **exactly correctly**, declining rows for a team this host does not own.

Not a safety bug: un-armed ⇒ smee authoritative ⇒ no posture permits double-dispatch. It is a **coverage** bug. The feed could only arm on a tick that examined *zero* foreign-team rows, so `enforce` degraded to "smee, most of the time" and retiring the smee tunnel was structurally unreachable.

## The fix — split by MEANING at the emitting site, not by reason strings

```
decline(counts, reason) → counts.declined + counts.byReason
    examined and deliberately not emitted. Healthy, expected, unbounded in
    volume. Reported, never disqualifying.
fail(counts, reason)    → counts.failed   + counts.byFailure
    the producer could not do its job. Always disqualifying.
```

Both properties of the old design are preserved: a new **decline** reason needs no reader change (its virtue), and a new **failure** reason needs none either (its bug). The single judgement is which helper to call, made where the outcome is actually known — so the gate needs no allow-list, which is the ticket's explicit requirement.

The line between them is **not** "is this row unusual". It is: *would un-arming repair it?* A malformed row (`unjoinable-issue`, `issue-has-no-team-key`) is a decline — un-arming forever over one bad row is the pathology being removed. A producer that cannot emit for **any** row is a failure.

## Three holes the split would otherwise have opened

| hole | why it matters | closed by |
|---|---|---|
| A producer with an **empty** `teams` set declines every row as `foreign-team` — a healthy decline under the new rule — so it would **arm** enforce while emitting nothing for anybody: smee suppressed, feed silent. | this is the failure mode the split creates | `teamScopeFailure`, checked in **both** `runSweep` and `runDiffSweep` before the store or cursor is touched |
| `classifyEdge`'s `no-team-scope-configured` is the one verdict whose cause is the **producer**, not the row. | left unmarked it is indistinguishable from a row-level decline | `fatal: true`, set where the distinction is known |
| An **absent** `byFailure` (a counts block predating the split) would read as immaculate under `?? {}`. | "nothing wrong" and "could not look" byte-identical to the caller — the defect class this repo keeps paying for | absent ⇒ not clean ⇒ smee stays authoritative, reported as `no-failure-census` |

## Verification — 22-case mutation matrix, 22/22 killed

Every new decision point was mutated individually (literal string replacement; the harness reports `NOT-APPLIED` separately from `SURVIVED`, because a mutation that fails to apply otherwise self-certifies as killed).

**Two survived the first pass, and both were real gaps rather than test-writing misses:**

1. **`runSweep`'s copy of the scope guard had no test at all.** The diffsweep test cannot reach that function, so the guard was live and unkillable — on the superseded history path, which is exactly where it would rot unnoticed.
2. **Deciding and naming a failure were two things, and they disagreed.** A `verdictIsFailure` predicate plus `verdict?.reason || "unclassified"` repeated at three call sites: a non-string reason was ruled unusable by the predicate and then used anyway as the census key, because `42 || "unclassified"` is `42`. That is *this same bug one level down* — two places holding one meaning, one of them wrong. They are now one function (`failureNameFor`) and a caller cannot supply its own name.

Mutations covered: each clause of `failureNameFor` (fatal / non-string / empty-string / always / never / naming); `fail` not incrementing `failed`; `fail` writing into `byReason`; `decline` writing into `byFailure`; the gate reading `byReason`; the gate defaulting an absent census; the array-census hole (`Object.keys([]).length === 0`); the gate ignoring `failed`; both scope guards; the `fatal` flag at its source; and — separately from *counting* — whether the sweep **acts** on the verdict (advancing the cursor, absorbing the baseline in the issue pass, the same in the label pass).

## Ticket acceptance criteria

- [x] A sweep of only foreign-team / bot-authored rows is **ready** — asserted at the pure-predicate *and* live-timer altitudes.
- [x] A sweep with a genuine failure is **not ready**.
- [x] The distinction is on the counter's **meaning**, not an allow-list — an unknown *failure* reason still disqualifies with no reader change (test: `something-nobody-has-written-yet`); a new *decline* reason must not.
- [x] Positive control **on one fixture**: 137 `foreign-team` declines ⇒ ARMED; the same sweep plus one `build-failed:*` ⇒ UN-ARMED. Neither result can come from a stuck predicate.
- [ ] Re-measure the readiness duty cycle over ≥1 h — **after** this is merged and loaded on a mini. Recorded on the ticket, not here.

Tests **import** the real `countsClean` / `sweepUnreadyReason` rather than restating them: a hand-written copy of the gate could agree with a fixture while disagreeing with the daemon.

## Test posture

`bun test plugins/dev/scripts/execution-core/{linear-feed-*,cloud-feed-*}` — **278 pass, 0 fail** across the 9 feed-adjacent files (every importer of the three changed modules). No consumer of the sweep's `byReason` exists outside these modules (checked with `/usr/bin/grep`, since the agent-shell `grep` honours `.gitignore`).

Refs CTL-1909. Blocks the full smee cutover (CTL-1847).