### PR TITLE
fix(dev): CTL-1910 + CTL-1913 — the cloud installer pinned an NXDOMAIN host and never validated the token

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-cloud-base-url-resolves.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-base-url-resolves.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# CTL-1910 — THE BASE URL THE INSTALLER PINS MUST NAME A HOST THAT EXISTS.
+#
+# The defect this guards: `setup_cloud_replica` hard-pinned
+# `https://app.catalystcloud.dev/api/v1` into every new customer's 0600,
+# launchd-sourced `cloud-sync.env`. That host is NXDOMAIN. The writer could never
+# reach the hub, the replica was never created or seeded, and setup exited 0 with
+# two green checkmarks — a green install and a permanently empty replica, invisible
+# unless the operator went and read the file.
+#
+# Nothing in the suite could have caught it, because nothing ever asked the one
+# question that mattered: does this host exist?
+#
+# ── WHY THIS TEST HAS A CONTROL, AND REFUSES TO GUESS ────────────────────────
+# A DNS lookup failing proves nothing on its own — the runner may have no
+# resolver, no egress, or a captive DNS. So this asserts a NEGATIVE only after a
+# POSITIVE control on a host that must always resolve. Three distinct verdicts:
+#
+#   control resolves + pinned resolves  -> PASS
+#   control resolves + pinned NXDOMAIN  -> FAIL  (the real defect; the only failure)
+#   control does NOT resolve            -> SKIP  (this runner cannot look; say so)
+#
+# The third is the important one. Collapsing "could not look" into either PASS or
+# FAIL is the defect class that produced the bug in the first place.
+#
+# This is the same methodology the ticket used by hand: `web.dev` was resolved
+# first to prove the host could resolve `.dev` at all, so `app.catalystcloud.dev`
+# coming back empty was a real absence rather than a broken resolver.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/setup-catalyst.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+ok() {
+	PASS=$((PASS + 1))
+	echo "  ok   — $1"
+}
+bad() {
+	FAIL=$((FAIL + 1))
+	echo "  FAIL — $1"
+}
+skip() {
+	SKIP=$((SKIP + 1))
+	echo "  SKIP — $1"
+}
+
+echo "CTL-1910 — the pinned cloud base URL names a host that exists"
+
+[[ -f $SETUP ]] || {
+	bad "setup-catalyst.sh not found at $SETUP"
+	echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+	exit 1
+}
+
+# ── 1. Extract the pinned default FROM THE SHIPPED SCRIPT ────────────────────
+# Read out of the source rather than restated here: a copy in this file could
+# agree with itself while the installer shipped something else entirely.
+pinned="$(sed -n 's|.*CATALYST_CLOUD_BASE_URL:-\(https://[^}"]*\)}.*|\1|p' "$SETUP" | head -1)"
+if [[ -n $pinned ]]; then
+	ok "found the pinned default in setup-catalyst.sh: $pinned"
+else
+	bad "could not extract a pinned CATALYST_CLOUD_BASE_URL default from $SETUP — if the parameter-expansion default was reshaped, FIX THIS PARSE rather than deleting the test"
+	echo ""
+	echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+	exit 1
+fi
+
+host="${pinned#*://}"
+host="${host%%/*}"
+host="${host%%:*}"
+ok "host under test: $host"
+
+# ── 2. A resolver, or we cannot look ─────────────────────────────────────────
+resolve() {
+	# Two mechanisms, because a runner may ship either. Both print nothing on
+	# NXDOMAIN and something on success.
+	if command -v dig >/dev/null 2>&1; then
+		dig +short +timeout=5 +tries=2 "$1" 2>/dev/null | head -3
+	elif command -v host >/dev/null 2>&1; then
+		host -W 5 "$1" 2>/dev/null | grep -i 'has address' | head -3
+	elif command -v getent >/dev/null 2>&1; then
+		getent hosts "$1" 2>/dev/null | head -3
+	else
+		# No resolver tool at all — report the inability, never a clean answer.
+		return 2
+	fi
+}
+
+CONTROL_HOST="${CATALYST_DNS_CONTROL_HOST:-one.one.one.one}"
+control_out="$(resolve "$CONTROL_HOST")"
+control_rc=$?
+
+if [[ $control_rc -eq 2 ]]; then
+	skip "no DNS tool available (dig/host/getent all absent) — cannot look, so nothing is asserted"
+	echo ""
+	echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+	exit 0
+fi
+
+if [[ -z $control_out ]]; then
+	skip "control host $CONTROL_HOST did not resolve — this runner has no working DNS/egress, so a negative on $host would be meaningless"
+	echo ""
+	echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+	exit 0
+fi
+ok "POSITIVE CONTROL: $CONTROL_HOST resolves — this runner can resolve, so an empty answer below is a real absence"
+
+# ── 3. The assertion ─────────────────────────────────────────────────────────
+pinned_out="$(resolve "$host")"
+if [[ -n $pinned_out ]]; then
+	ok "the pinned host $host RESOLVES ($(echo "$pinned_out" | tr '\n' ' ' | sed 's/ *$//'))"
+else
+	bad "the pinned host $host does NOT RESOLVE (NXDOMAIN) while the control does — every new customer's cloud-sync.env would point the replica writer at a host that cannot be reached, and setup would still exit 0. This is CTL-1910 exactly."
+fi
+
+# ── 4. The specific dead host must never come back AS A VALUE ────────────────
+# Belt and braces, and it works with no DNS at all, so this fails even on an
+# offline runner where sections 2-3 skip.
+#
+# ⚠️ COMMENTS ARE STRIPPED FIRST, and that is not a loophole — it is the
+# difference between naming the dead host and USING it. The corrected comment in
+# setup_cloud_replica documents `app.catalystcloud.dev` as the NXDOMAIN host on
+# purpose: that record is why nobody re-pins it. A blunt whole-file grep flags
+# that documentation, which pressures the next person to delete the explanation
+# to get CI green — so the check is scoped to executable lines, where a re-pin
+# would actually have to live.
+# (Caught by this test failing against its own first draft.)
+code_hits="$(grep -vE '^[[:space:]]*#' "$SETUP" | grep -c 'app\.catalystcloud\.dev' || true)"
+if [[ ${code_hits:-0} -gt 0 ]]; then
+	bad "setup-catalyst.sh USES app.catalystcloud.dev on $code_hits executable line(s) — measured NXDOMAIN 2026-08-17 from two hosts, with a resolving .dev control"
+else
+	ok "app.catalystcloud.dev appears on no executable line (documented in comments only)"
+fi
+# ...and the mention must SURVIVE somewhere, or the reason it is forbidden is lost
+# and the next person re-pins it from the stale "canonical host" note in the docs.
+if grep -qE '^[[:space:]]*#.*app\.catalystcloud\.dev' "$SETUP"; then
+	ok "the NXDOMAIN finding is still recorded in a comment (the reason survives the fix)"
+else
+	bad "no comment records that app.catalystcloud.dev is NXDOMAIN — the finding was deleted along with the bug, so nothing stops it coming back"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[[ $FAIL -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -51,16 +51,61 @@ file_mode() {
 	printf '%s' "$m"
 }
 
+# ── TRANSPORT SEAL (CTL-1913) ────────────────────────────────────────────────
+# setup_cloud_replica now makes a real authenticated call before it writes
+# anything, so every case below needs the network sealed — otherwise this suite
+# either fails offline or, worse, sends fixture tokens to the live hub.
+#
+# ⛔ The seal is a `curl` STUB ON PATH, not an overridden shell function. A
+# function override only intercepts the one call site you thought of; a PATH stub
+# intercepts the transport, so a future call added anywhere in the sourced script
+# is caught too. `stub_calls` is what proves the seal actually held — a case that
+# asserts only on the outcome cannot tell "the stub answered 401" from "real curl
+# reached the internet and got 401".
+#
+# The stub speaks the ONE contract validate_cloud_token relies on: honour
+# `-w '%{http_code}'` by printing the code on stdout, and send the body to -o.
+make_curl_stub() {
+	local bindir="$1" code="$2"
+	mkdir -p "$bindir"
+	cat >"$bindir/curl" <<STUB
+#!/usr/bin/env bash
+# Records every invocation, then answers with a fixed HTTP code.
+echo "\$*" >>"$bindir/stub_calls"
+# validate_cloud_token feeds the auth header on stdin via --config -; drain it so
+# the writer never blocks on a full pipe, and prove the token never hit argv.
+if [[ " \$* " == *" --config - "* ]]; then cat >"$bindir/stub_stdin" 2>/dev/null || true; fi
+for a in "\$@"; do
+  if [[ \$a == "-o" ]]; then next=out; continue; fi
+  if [[ \${next:-} == out ]]; then : >"\$a" 2>/dev/null; next=; fi
+done
+printf '%s' "$code"
+exit 0
+STUB
+	chmod +x "$bindir/curl"
+}
+
 # Run setup_cloud_replica in a subshell with a fake HOME, sourcing the real script.
 # setup-catalyst.sh already guards main() behind a sourced-detection test;
 # CATALYST_SETUP_LIB_ONLY is its explicit belt-and-braces form.
+#
+# HTTP_CODE (4th arg, default 200) is what the sealed transport answers. Cases that
+# only care about the FILE the function writes leave it at 200; the CTL-1913 cases
+# drive it to 401/403/000.
 run_case() {
-	local home="$1" token="$2" account="$3"
+	local home="$1" token="$2" account="$3" code="${4:-200}"
+	local bindir="$home/.stub-bin"
+	make_curl_stub "$bindir" "$code"
 	(
 		export HOME="$home"
+		export PATH="$bindir:$PATH"
 		export CATALYST_SETUP_LIB_ONLY=1
 		export CATALYST_CLOUD_TOKEN="$token"
 		export CATALYST_CLOUD_ACCOUNT="$account"
+		# Deliberately NOT pinned by default: the base URL is left unset so the
+		# cases below exercise the REAL shipped default (CTL-1910's whole subject).
+		# Set CASE_BASE_URL to test the override path.
+		[[ -n ${CASE_BASE_URL:-} ]] && export CATALYST_CLOUD_BASE_URL="$CASE_BASE_URL"
 		# shellcheck disable=SC1090
 		source "$SETUP" >/dev/null 2>&1
 		# setup-catalyst.sh sets -e; re-disable AFTER sourcing so a deliberate
@@ -70,6 +115,9 @@ run_case() {
 		echo "$?"
 	)
 }
+
+# stub_was_called HOME -> 0 when the sealed transport handled the request.
+stub_was_called() { [[ -s "$1/.stub-bin/stub_calls" ]]; }
 
 echo "CTL-1836 — setup-catalyst.sh cloud replica provisioning"
 
@@ -118,16 +166,23 @@ if [[ -f "$ENV_FILE" ]]; then
 		bad "account not pinned explicitly in cloud-sync.env"
 	fi
 
-	# The legacy host is being retired; a new user must not be pointed at it.
 	if grep -q '^export CATALYST_CLOUD_BASE_URL=' "$ENV_FILE"; then
 		ok "base URL pinned explicitly"
 	else
-		bad "base URL not pinned — new install would inherit the LEGACY default"
+		bad "base URL not pinned — new install would inherit the code default"
 	fi
-	if grep -q 'api\.catalyst-cloud\.coalescelabs\.ai' "$ENV_FILE"; then
-		bad "cloud-sync.env pins the LEGACY base URL"
+	# ⛔ CTL-1910: the pinned default must be a host that EXISTS. This function used
+	# to write app.catalystcloud.dev, which is NXDOMAIN, into every customer's
+	# launchd-sourced config — a green install with a permanently empty replica.
+	if grep -q 'app\.catalystcloud\.dev' "$ENV_FILE"; then
+		bad "pins app.catalystcloud.dev — NXDOMAIN; the writer can never reach the hub (CTL-1910)"
 	else
-		ok "cloud-sync.env does not pin the legacy base URL"
+		ok "does not pin the NXDOMAIN host app.catalystcloud.dev"
+	fi
+	if grep -q '^export CATALYST_CLOUD_BASE_URL=https://staging\.catalystcloud\.dev/api/v1$' "$ENV_FILE"; then
+		ok "pins the ruled default staging.catalystcloud.dev (verified 200 with a live token)"
+	else
+		bad "expected the staging.catalystcloud.dev default, got: $(grep '^export CATALYST_CLOUD_BASE_URL=' "$ENV_FILE")"
 	fi
 
 	if grep -q '^export CATALYST_CLOUD_TOKEN=tok_test_abc$' "$ENV_FILE"; then
@@ -142,18 +197,19 @@ rm -rf "$H3"
 
 # ── Case 4: CATALYST_CLOUD_BASE_URL override is honoured ─────────────────────
 H4=$(mktemp -d)
-(
-	export HOME="$H4" CATALYST_SETUP_LIB_ONLY=1 CATALYST_CLOUD_TOKEN="t" CATALYST_CLOUD_ACCOUNT="a"
-	export CATALYST_CLOUD_BASE_URL="https://example.invalid/api/v1"
-	# shellcheck disable=SC1090
-	source "$SETUP" >/dev/null 2>&1
-	set +e
-	setup_cloud_replica >/dev/null 2>&1
-)
+CASE_BASE_URL="https://example.invalid/api/v1" rc=$(CASE_BASE_URL="https://example.invalid/api/v1" run_case "$H4" "t" "a")
 if grep -q '^export CATALYST_CLOUD_BASE_URL=https://example.invalid/api/v1$' "$H4/.config/catalyst/cloud-sync.env" 2>/dev/null; then
 	ok "explicit CATALYST_CLOUD_BASE_URL override is honoured"
 else
 	bad "base URL override ignored"
+fi
+# CTL-1913: the override must also be the host the token is VALIDATED against —
+# validating against the default while pinning an override would verify a hub the
+# writer never talks to.
+if grep -q 'example\.invalid' "$H4/.stub-bin/stub_calls" 2>/dev/null; then
+	ok "the token is validated against the OVERRIDE host, not the default"
+else
+	bad "validation call did not target the override host: $(cat "$H4/.stub-bin/stub_calls" 2>/dev/null)"
 fi
 rm -rf "$H4"
 
@@ -228,8 +284,10 @@ rm -rf "$H6"
 # Writing a fixed name while the writer resolves a custom one produces the same
 # silent idle as case 6.
 H7=$(mktemp -d)
+make_curl_stub "$H7/.stub-bin" 200
 (
 	export HOME="$H7" CATALYST_SETUP_LIB_ONLY=1
+	export PATH="$H7/.stub-bin:$PATH"
 	export CATALYST_CLOUD_TOKEN_ENV="MY_CUSTOM_CLOUD_TOKEN"
 	export MY_CUSTOM_CLOUD_TOKEN="tok_custom_name"
 	export CATALYST_CLOUD_ACCOUNT="tenant-4"
@@ -245,6 +303,120 @@ else
 	bad "configured token name ignored — writer would resolve a name the file never sets"
 fi
 rm -rf "$H7"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# CTL-1913 — AN UNUSABLE CLOUD TOKEN MUST FAIL THE INSTALL LOUDLY
+#
+# Before this, setup_cloud_replica made NO network call at all: it accepted a
+# token, wrote it to a 0600 launchd-sourced file, printed two green checkmarks and
+# exited 0. A correct token and `FAKE-TOKEN-NOT-REAL` were byte-identical to the
+# caller. The writer then exits 0 on a bad token, and under
+# KeepAlive={SuccessfulExit:false} that clean exit is PERMANENT — so the customer's
+# only symptom was a replica that never appeared.
+#
+# The load-bearing assertion in each case below is NOT just "rc != 0" — it is that
+# NOTHING WAS WRITTEN. A non-zero exit that still leaves a broken 0600 config on
+# disk (which launchd sources on every boot) is most of the original defect.
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "CTL-1913 — token validation"
+
+# The three rejection classes, measured live against the hub 2026-08-17:
+#   401 garbage/expired/revoked token
+#   403 valid token, but not scoped to the requested account (the tenant footgun)
+#   000 curl could not reach the host at all (the CTL-1910 NXDOMAIN shape)
+for spec in "401:a garbage or revoked token" "403:a token not scoped to this account" "000:an unreachable hub"; do
+	code="${spec%%:*}"
+	desc="${spec#*:}"
+	HB=$(mktemp -d)
+	rc=$(run_case "$HB" "FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code")
+	if [[ $rc != "0" ]]; then
+		ok "HTTP $code ($desc) → non-zero exit"
+	else
+		bad "HTTP $code ($desc) → returned 0; a green install with a dead writer"
+	fi
+	# ⭐ the one that matters most: no credential file, so launchd has nothing to
+	# source and no permanently-inert writer is left behind.
+	if [[ ! -e "$HB/.config/catalyst/cloud-sync.env" ]]; then
+		ok "HTTP $code → wrote NO cloud-sync.env (validated BEFORE persisting)"
+	else
+		bad "HTTP $code → wrote a config it had already proven cannot work"
+	fi
+	# Seal proof: this verdict came from the stub, not from the real internet.
+	if stub_was_called "$HB"; then
+		ok "HTTP $code → verdict came from the sealed transport (stub invoked)"
+	else
+		bad "HTTP $code → curl stub was never invoked; the seal did not hold, so this case proves nothing"
+	fi
+	rm -rf "$HB"
+done
+
+# ── POSITIVE CONTROL for all of the above ────────────────────────────────────
+# Identical fixture, only the HTTP code differs. Without this, every assertion
+# above would pass on a function that refused unconditionally — which would break
+# every real install rather than fix it.
+HOK=$(mktemp -d)
+rc=$(run_case "$HOK" "tok_good" "tenant-1" 200)
+if [[ $rc == "0" ]]; then
+	ok "POSITIVE CONTROL: HTTP 200 → returns 0 (the refusal is driven by the CODE, not unconditional)"
+else
+	bad "POSITIVE CONTROL: HTTP 200 → rc $rc; validation rejects even a good token"
+fi
+if [[ -f "$HOK/.config/catalyst/cloud-sync.env" ]]; then
+	ok "POSITIVE CONTROL: HTTP 200 → cloud-sync.env written"
+else
+	bad "POSITIVE CONTROL: HTTP 200 → no env file; a valid install is now blocked"
+fi
+
+# ── The validation must actually be AUTHENTICATED, and must not leak ─────────
+# A probe that omits the token would return 401 for a perfectly good token, and an
+# unauthenticated reachability ping would pass for a garbage one — the exact
+# "correct and garbage are indistinguishable" defect, reintroduced.
+if [[ -f "$HOK/.stub-bin/stub_stdin" ]] && grep -q 'Authorization: Bearer tok_good' "$HOK/.stub-bin/stub_stdin"; then
+	ok "the validation call carries the bearer token (authenticated, not a reachability ping)"
+else
+	bad "no Authorization header reached the transport — validation is unauthenticated"
+fi
+# ⛔ and the token must NOT be on argv: `ps` is world-readable, so a bearer token in
+# the command line is visible to every local user for the life of the call.
+if grep -q 'tok_good' "$HOK/.stub-bin/stub_calls" 2>/dev/null; then
+	bad "the token appears in curl's ARGV — readable by any local user via ps"
+else
+	ok "the token is never on curl's argv (passed via --config on stdin)"
+fi
+# It must query the account it is about to pin, or a 403 mismatch goes undetected.
+if grep -q 'account=tenant-1' "$HOK/.stub-bin/stub_calls" 2>/dev/null; then
+	ok "validation is scoped to the account being pinned"
+else
+	bad "validation did not pass the account: $(cat "$HOK/.stub-bin/stub_calls" 2>/dev/null)"
+fi
+rm -rf "$HOK"
+
+# ── The no-token no-op must remain network-free ──────────────────────────────
+# Case 1 proved it writes nothing. It must also not have PHONED HOME: a validation
+# call on the no-op path would make `setup-catalyst.sh` contact the hub on every
+# ordinary non-cloud install.
+HN=$(mktemp -d)
+rc=$(run_case "$HN" "" "")
+if ! stub_was_called "$HN"; then
+	ok "no token → no validation call at all (ordinary installs stay network-free)"
+else
+	bad "no token → still called out to the hub: $(cat "$HN/.stub-bin/stub_calls")"
+fi
+rm -rf "$HN"
+
+# ── The account refusal must also precede the network ────────────────────────
+# A token without an account is refused syntactically; spending a hub round-trip
+# first would be wasted work and would send the token somewhere before we had
+# decided the input was even usable.
+HA=$(mktemp -d)
+rc=$(run_case "$HA" "tok_test_abc" "" 200)
+if ! stub_was_called "$HA"; then
+	ok "token without account → refused BEFORE any network call"
+else
+	bad "token without account → sent the token to the hub before refusing"
+fi
+rm -rf "$HA"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -36,6 +36,13 @@ bad() {
 	echo "  FAIL — $1"
 }
 
+# ⚠️ Transient rm failures must not abort the suite. Observed once on macOS:
+# `rm: <tmpdir>: Directory not empty` on a directory that removed cleanly on retry
+# (a filesystem/indexer hiccup, not a test failure). Under `set -e` that aborted the
+# whole run mid-suite, which reads as a red suite for a reason unrelated to anything
+# under test — a cleanup step must never be able to fail the thing it cleans up after.
+scrub() { rm -rf "$@" 2>/dev/null || rm -rf "$@" 2>/dev/null || true; }
+
 # file_mode PATH -> the octal permission bits, portably.
 # ⛔ ORDER MATTERS AND BSD-FIRST IS WRONG. On Linux `stat -f` is --file-system, which
 # SUCCEEDS and prints filesystem info, so a `stat -f ... || stat -c ...` chain never
@@ -119,6 +126,44 @@ run_case() {
 # stub_was_called HOME -> 0 when the sealed transport handled the request.
 stub_was_called() { [[ -s "$1/.stub-bin/stub_calls" ]]; }
 
+# make_stack_stub BINDIR RC MESSAGE — a `catalyst-stack` on PATH that exits RC
+# after printing MESSAGE on stderr. Needed because `adopt-cloud-sync` is the other
+# thing CTL-1913 changed: its output used to go to /dev/null.
+make_stack_stub() {
+	local bindir="$1" rc="$2" msg="$3"
+	mkdir -p "$bindir"
+	cat >"$bindir/catalyst-stack" <<STACKSTUB
+#!/usr/bin/env bash
+echo "$msg" >&2
+exit $rc
+STACKSTUB
+	chmod +x "$bindir/catalyst-stack"
+}
+
+# run_case_capturing — like run_case, but returns the function's OUTPUT rather
+# than its rc, so assertions can be made about what the operator actually sees.
+#
+# ⚠️ CALL IT AS `out=$(run_case_capturing ... || true)`. An assignment takes the
+# exit status of its command substitution, so under `set -euo pipefail` a case that
+# deliberately drives a NON-ZERO return (every rejection case does) aborts the whole
+# suite mid-run instead of asserting. Cost one debugging round.
+run_case_capturing() {
+	local home="$1" token="$2" account="$3" code="${4:-200}"
+	local bindir="$home/.stub-bin"
+	make_curl_stub "$bindir" "$code"
+	(
+		export HOME="$home"
+		export PATH="$bindir:$PATH"
+		export CATALYST_SETUP_LIB_ONLY=1
+		export CATALYST_CLOUD_TOKEN="$token"
+		export CATALYST_CLOUD_ACCOUNT="$account"
+		# shellcheck disable=SC1090
+		source "$SETUP" >/dev/null 2>&1
+		set +e
+		setup_cloud_replica 2>&1
+	)
+}
+
 echo "CTL-1836 — setup-catalyst.sh cloud replica provisioning"
 
 # ── Case 1: no token → complete no-op (existing installs untouched) ──────────
@@ -130,7 +175,7 @@ if [[ ! -e "$H1/.config/catalyst/cloud-sync.env" ]]; then
 else
 	bad "no token → wrote cloud-sync.env, which would change existing-install behaviour"
 fi
-rm -rf "$H1"
+scrub "$H1"
 
 # ── Case 2: token WITHOUT account → loud refusal, nothing written ────────────
 # This is the tenant-0 footgun. It must fail, and it must not leave a half-written
@@ -143,7 +188,7 @@ if [[ ! -e "$H2/.config/catalyst/cloud-sync.env" ]]; then
 else
 	bad "token without account → wrote a credential file despite refusing"
 fi
-rm -rf "$H2"
+scrub "$H2"
 
 # ── Case 3: token + account → env file written, 0600, explicit values ────────
 H3=$(mktemp -d)
@@ -193,7 +238,7 @@ if [[ -f "$ENV_FILE" ]]; then
 else
 	bad "token + account → no cloud-sync.env written"
 fi
-rm -rf "$H3"
+scrub "$H3"
 
 # ── Case 4: CATALYST_CLOUD_BASE_URL override is honoured ─────────────────────
 H4=$(mktemp -d)
@@ -211,7 +256,7 @@ if grep -q 'example\.invalid' "$H4/.stub-bin/stub_calls" 2>/dev/null; then
 else
 	bad "validation call did not target the override host: $(cat "$H4/.stub-bin/stub_calls" 2>/dev/null)"
 fi
-rm -rf "$H4"
+scrub "$H4"
 
 # ── Case 5: a PRE-EXISTING world-readable env file must be tightened ─────────
 # This is the case that makes the permission behaviour real. A 0644 cloud-sync.env
@@ -243,7 +288,7 @@ if [[ $(grep -c '^export CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync
 else
 	bad "env file has $(grep -c '^export CATALYST_CLOUD_TOKEN=' "$H5/.config/catalyst/cloud-sync.env" 2>/dev/null) token lines — expected exactly 1"
 fi
-rm -rf "$H5"
+scrub "$H5"
 
 # ── Case 6: EVERY line must be exported (Codex P1 on #3365) ─────────────────
 # launch.sh SOURCES this file and then execs bun. A bare `FOO=bar` in a sourced
@@ -278,7 +323,7 @@ if [[ -f $E6 ]]; then
 else
 	bad "case 6: no env file written"
 fi
-rm -rf "$H6"
+scrub "$H6"
 
 # ── Case 7: the configured token NAME is honoured (CTL-1668, Codex P2) ──────
 # Writing a fixed name while the writer resolves a custom one produces the same
@@ -302,7 +347,7 @@ if grep -q '^export MY_CUSTOM_CLOUD_TOKEN=tok_custom_name$' "$E7" 2>/dev/null; t
 else
 	bad "configured token name ignored — writer would resolve a name the file never sets"
 fi
-rm -rf "$H7"
+scrub "$H7"
 
 # ═════════════════════════════════════════════════════════════════════════════
 # CTL-1913 — AN UNUSABLE CLOUD TOKEN MUST FAIL THE INSTALL LOUDLY
@@ -325,9 +370,29 @@ echo "CTL-1913 — token validation"
 #   401 garbage/expired/revoked token
 #   403 valid token, but not scoped to the requested account (the tenant footgun)
 #   000 curl could not reach the host at all (the CTL-1910 NXDOMAIN shape)
-for spec in "401:a garbage or revoked token" "403:a token not scoped to this account" "000:an unreachable hub"; do
+#
+# ⚠️ Each case also asserts the MESSAGE names its own cause. Refusing with the
+# wrong explanation is not equivalent to refusing with the right one: the three
+# classes need three different operator actions (get a new token / fix the
+# account / fix DNS-or-reachability), and the unreachable case is the one that
+# carries the CTL-1910 shape plus the exact curl to re-run. Found by mutation —
+# breaking the `000` branch so it fell through to the generic catch-all SURVIVED a
+# suite that asserted only "non-zero, nothing written".
+for spec in "401:a garbage or revoked token:REJECTED by the hub" \
+	"403:a token not scoped to this account:NOT scoped to account" \
+	"000:an unreachable hub:Could not reach the hub"; do
 	code="${spec%%:*}"
-	desc="${spec#*:}"
+	rest="${spec#*:}"
+	desc="${rest%%:*}"
+	expect_msg="${rest#*:}"
+	HB=$(mktemp -d)
+	out=$(run_case_capturing "$HB" "FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code" || true)
+	if grep -qF "$expect_msg" <<<"$out"; then
+		ok "HTTP $code → the message names its own cause (\"$expect_msg\")"
+	else
+		bad "HTTP $code → wrong or generic diagnostic; expected \"$expect_msg\", got: $(printf '%s' "$out" | tr '\n' '|' | head -c 200)"
+	fi
+	scrub "$HB"
 	HB=$(mktemp -d)
 	rc=$(run_case "$HB" "FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code")
 	if [[ $rc != "0" ]]; then
@@ -348,7 +413,7 @@ for spec in "401:a garbage or revoked token" "403:a token not scoped to this acc
 	else
 		bad "HTTP $code → curl stub was never invoked; the seal did not hold, so this case proves nothing"
 	fi
-	rm -rf "$HB"
+	scrub "$HB"
 done
 
 # ── POSITIVE CONTROL for all of the above ────────────────────────────────────
@@ -390,7 +455,64 @@ if grep -q 'account=tenant-1' "$HOK/.stub-bin/stub_calls" 2>/dev/null; then
 else
 	bad "validation did not pass the account: $(cat "$HOK/.stub-bin/stub_calls" 2>/dev/null)"
 fi
-rm -rf "$HOK"
+scrub "$HOK"
+
+# ── An UNLISTED status code must not be accepted ─────────────────────────────
+# Found by mutation: inserting `return 0` into the catch-all `*)` branch SURVIVED
+# the suite, because every case above drove a code the function names explicitly.
+# A 5xx, a 404 from a reshaped API, or a captive-portal 302 all land here — and
+# none of them is evidence the token works.
+for code in 500 502 404 302 418; do
+	HU=$(mktemp -d)
+	rc=$(run_case "$HU" "tok_unknown_code" "tenant-2" "$code")
+	if [[ $rc != "0" ]]; then
+		ok "HTTP $code (unlisted) → non-zero exit"
+	else
+		bad "HTTP $code (unlisted) → returned 0; an unrecognised response is treated as proof the token works"
+	fi
+	if [[ ! -e "$HU/.config/catalyst/cloud-sync.env" ]]; then
+		ok "HTTP $code (unlisted) → wrote NO cloud-sync.env"
+	else
+		bad "HTTP $code (unlisted) → wrote a config on an unverified token"
+	fi
+	scrub "$HU"
+done
+
+# ── adopt-cloud-sync's diagnostics must SURVIVE (CTL-1913 scenario 3) ────────
+# Also found by mutation: restoring `>/dev/null 2>&1` on the adopt call SURVIVED,
+# because nothing asserted on what the operator is shown. The whole point of that
+# change is that the reason for the failure is recoverable.
+HD=$(mktemp -d)
+mkdir -p "$HD/.stub-bin"
+make_stack_stub "$HD/.stub-bin" 3 "launchctl: Bootstrap failed: 5: Input/output error"
+out=$(run_case_capturing "$HD" "tok_adopt" "tenant-5" 200 || true)
+if grep -q 'Bootstrap failed: 5: Input/output error' <<<"$out"; then
+	ok "adopt-cloud-sync's stderr reaches the operator (not discarded to /dev/null)"
+else
+	bad "adopt-cloud-sync failed and its diagnostics were swallowed — the operator gets a generic warning for every possible cause"
+fi
+if grep -q 'rc=3' <<<"$out"; then
+	ok "the adopt exit code is reported"
+else
+	bad "the adopt exit code is not reported"
+fi
+# ...and a FAILED adopt must not be announced as a success.
+if grep -qi 'writer adopted' <<<"$out"; then
+	bad "printed the adopted success line despite a non-zero adopt"
+else
+	ok "no success line printed for a failed adopt"
+fi
+# NEGATIVE CONTROL: a SUCCEEDING adopt must not dump its output as if it failed.
+HS=$(mktemp -d)
+mkdir -p "$HS/.stub-bin"
+make_stack_stub "$HS/.stub-bin" 0 "some ordinary chatter on stderr"
+out=$(run_case_capturing "$HS" "tok_adopt" "tenant-6" 200 || true)
+if grep -qi 'writer adopted' <<<"$out" && ! grep -q 'ordinary chatter' <<<"$out"; then
+	ok "NEGATIVE CONTROL: a successful adopt prints the success line and stays quiet"
+else
+	bad "successful adopt output is wrong: $(printf '%s' "$out" | tr '\n' '|')"
+fi
+scrub "$HD" "$HS"
 
 # ── The no-token no-op must remain network-free ──────────────────────────────
 # Case 1 proved it writes nothing. It must also not have PHONED HOME: a validation
@@ -403,7 +525,7 @@ if ! stub_was_called "$HN"; then
 else
 	bad "no token → still called out to the hub: $(cat "$HN/.stub-bin/stub_calls")"
 fi
-rm -rf "$HN"
+scrub "$HN"
 
 # ── The account refusal must also precede the network ────────────────────────
 # A token without an account is refused syntactically; spending a hub round-trip
@@ -416,7 +538,7 @@ if ! stub_was_called "$HA"; then
 else
 	bad "token without account → sent the token to the hub before refusing"
 fi
-rm -rf "$HA"
+scrub "$HA"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -205,3 +205,101 @@ describe("checkCloudSync", () => {
               }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⛔ CTL-1913 — doctor must be ABLE to FAIL on a permanently-inert replica.
+//
+// Before this, every check on this path was WARN/INFO, so nothing in the install
+// path returned non-zero for a completely dead writer. The state that earns it:
+// the agent is ADOPTED and the replica db has never been created. That does not
+// heal — the writer exits 0 on an absent/misnamed/rejected token, and under
+// KeepAlive={SuccessfulExit:false} launchd never retries.
+//
+// ⚠️ The capability is OPT-IN (`strict`) and wired into no profile, because
+// doctor's exit code IS the catalyst-join activation gate and `do_doctor_gate`
+// runs BEFORE `install-services` — a default FAIL would block the join that
+// reinstalls the writer, i.e. block the self-heal for the condition it reports.
+// The suite above (which asserts NEVER-FAIL across an exhaustive matrix) is the
+// guard on that, and it still passes unchanged.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("CTL-1913 — the never-seeded FAIL capability", () => {
+  const LA = "/tmp/la";
+  const LABEL = "ai.coalesce.catalyst-cloud-sync";
+  // Adopted well past the grace, with no replica db: the terminal state.
+  const inert = (over = {}) =>
+    deps({
+      agentInstalled: () => true,
+      fileExists: () => false, // no replica db, no writer-lock
+      agentInstalledAt: () => NOW - 3_600_000, // adopted an hour ago
+      neverSeededGraceMs: 900_000,
+      ...over,
+    });
+
+  test("strict:true + adopted an hour ago + no replica → replica-fresh FAILs", () => {
+    const m = byName(checkCloudSync(inert({ strict: true })));
+    expect(m["replica-fresh"].status).toBe("fail");
+    expect(m["replica-fresh"].detail).toMatch(/never been created/i);
+    // The message must carry the ACTIONABLE cause, not just the symptom: the
+    // clean-exit/KeepAlive mechanism is why an operator cannot just wait.
+    expect(m["replica-fresh"].detail).toMatch(/never retries|does NOT self-heal/i);
+  });
+
+  test("⭐ DEFAULT (no strict) on the identical state → WARN, never FAIL", () => {
+    // The join-gate invariant. Same fixture, strict omitted.
+    const recs = checkCloudSync(inert());
+    expect(byName(recs)["replica-fresh"].status).toBe("warn");
+    expect(recs.every((r) => r.status !== "fail")).toBe(true);
+  });
+
+  test("strict:true but WITHIN the grace → WARN (a fresh adoption is not a fault)", () => {
+    // NEGATIVE CONTROL for the FAIL: without it, the assertion above could be
+    // satisfied by a check that FAILs on any missing db under strict, which would
+    // fire on every legitimate fresh install.
+    const m = byName(checkCloudSync(inert({ strict: true, agentInstalledAt: () => NOW - 60_000 })));
+    expect(m["replica-fresh"].status).toBe("warn");
+    expect(m["replica-fresh"].detail).toMatch(/first-seed window|has not seeded/i);
+  });
+
+  test("⛔ strict:true but the adoption time is UNREADABLE → WARN, not FAIL", () => {
+    // "Could not look" is not evidence of the terminal state. An unreadable plist
+    // mtime must not be escalated — and it must not be silently treated as 0
+    // either, which would compute an age of ~56 years and FAIL instantly.
+    for (const bad of [null, undefined, NaN, "nope"]) {
+      const m = byName(checkCloudSync(inert({ strict: true, agentInstalledAt: () => bad })));
+      expect(m["replica-fresh"].status, String(bad)).toBe("warn");
+      expect(m["replica-fresh"].detail, String(bad)).toMatch(/unreadable|not connected/i);
+    }
+  });
+
+  test("strict:true with NO agent adopted → WARN (nothing was provisioned to be broken)", () => {
+    const m = byName(checkCloudSync(inert({ strict: true, agentInstalled: () => false, mode: "on" })));
+    expect(m["replica-fresh"].status).toBe("warn");
+  });
+
+  test("strict:true with a HEALTHY replica → no FAIL anywhere", () => {
+    // Proves strict does not simply redden a working host.
+    const recs = checkCloudSync(deps({ strict: true }));
+    expect(recs.every((r) => r.status !== "fail")).toBe(true);
+    expect(byName(recs)["replica-fresh"].status).toBe("pass");
+  });
+
+  test("the real adoption-time probe reads the plist mtime, and returns null when absent", () => {
+    // The injected seam above is only honest if the DEFAULT it replaces actually
+    // works. Drive checkCloudSync with no agentInstalledAt override against a
+    // LaunchAgents dir that does not exist: the default probe must fail to a WARN
+    // (null) rather than throwing or fabricating a timestamp.
+    const recs = checkCloudSync(
+      deps({
+        strict: true,
+        agentInstalled: () => true,
+        fileExists: () => false,
+        laDir: "/tmp/definitely-not-a-launchagents-dir-ctl1913",
+        label: LABEL,
+      }),
+    );
+    const m = byName(recs);
+    expect(m["replica-fresh"].status).toBe("warn"); // null age ⇒ no escalation
+    expect(recs.every((r) => r.status !== "fail")).toBe(true);
+    expect(LA).toBe("/tmp/la"); // (fixture sanity; keeps the constant referenced)
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3122,6 +3122,34 @@ export function checkCloudSync(deps = {}) {
     sizeFloorBytes = 65_536,
     isSqliteFile = defaultIsSqliteFile, // CAT-35
     readDbTables = defaultReadDbTables, // CAT-35
+    // CTL-1913: when was the writer ADOPTED? The plist's mtime is the only local
+    // evidence of that, and it is what separates "provisioned minutes ago, still
+    // seeding" from "provisioned and has never once authenticated".
+    agentInstalledAt = defaultAgentInstalledAt,
+    // A writer that has not produced a replica within this window has not lost a
+    // race — it is inert. Generous on purpose: a cold seed of a large workspace is
+    // minutes, not seconds.
+    neverSeededGraceMs = Number(process.env.CATALYST_REPLICA_NEVER_SEEDED_GRACE_MS) || 900_000,
+    // ⛔ CTL-1913 — `strict` GOVERNS ONE BRANCH, AND IS DELIBERATELY UNWIRED.
+    //
+    // CTL-1913 asked for a doctor that CAN fail on a permanently-inert replica,
+    // because every check here was WARN/INFO and so nothing in the install path
+    // ever returned non-zero for one. The capability now exists — but it stays
+    // opt-in, for the reason this file already records twice (checkReaper,
+    // checkHealthResponder): **doctor's exit code IS the catalyst-join activation
+    // gate, and `do_doctor_gate` runs BEFORE `install-services`.** A FAIL here
+    // would block the join that reinstalls the writer — i.e. it would block the
+    // self-heal for the very condition it is reporting.
+    //
+    // Nor does the install profile want it: `installChecksForClass` deliberately
+    // omits the network/operational checks, since failing on a remote dependency
+    // would mis-attribute an operational gap to the install run.
+    //
+    // So this follows the precedent of `checkDeploymentModeConsistency`'s strict
+    // escalation — implemented and tested, wired into no profile yet. The
+    // install-time actuator is the one the ticket itself names:
+    // `catalyst-stack verify-cloud-sync --strict`.
+    strict = false,
   } = deps;
 
   const installed = agentInstalled(label, laDir);
@@ -3154,7 +3182,44 @@ export function checkCloudSync(deps = {}) {
   let size = 0;
   let statOk = false;
   if (!dbPresent) {
-    checks.push(mkCheck("replica-fresh", STATUS.WARN, "replica db not present — writer has not seeded yet (not connected)"));
+    // ⛔ CTL-1913 — THE ONE STATE IN THIS CHECK THAT EARNS A **FAIL**.
+    //
+    // Agent installed + replica never created is not a transient: the writer
+    // `process.exit(0)`s when its token is absent, misnamed, or rejected, and under
+    // `KeepAlive={SuccessfulExit:false}` a CLEAN EXIT IS PERMANENT — launchd never
+    // retries. So this state does not heal, and it is exactly what a green install
+    // with an unvalidated token produces. Every check on this path was WARN/INFO, so
+    // nothing in the install path ever returned non-zero for a completely inert
+    // replica; that is the gap this grade closes.
+    //
+    // Gated on the ADOPTION AGE rather than graded immediately, because a writer
+    // provisioned seconds ago legitimately has no db yet — escalating on that would
+    // be a false alarm on every fresh install. Three-valued, and it never escalates
+    // on an inability to measure: an unreadable plist mtime keeps the plain WARN and
+    // SAYS the grace could not be evaluated, rather than treating "could not look"
+    // as evidence of the terminal state.
+    const adoptedAt = installed ? agentInstalledAt(label, laDir) : null;
+    const measurable = typeof adoptedAt === "number" && Number.isFinite(adoptedAt);
+    if (installed && measurable && now - adoptedAt > neverSeededGraceMs) {
+      const mins = Math.round((now - adoptedAt) / 60_000);
+      checks.push(
+        mkCheck("replica-fresh", strict ? STATUS.FAIL : STATUS.WARN,
+          `writer agent adopted ${mins}m ago and the replica db has NEVER been created (${dbPath}) — ` +
+          `the writer has never authenticated. A token that is absent, misnamed, or rejected makes it exit 0, ` +
+          `and KeepAlive={SuccessfulExit:false} means launchd never retries, so this does NOT self-heal. ` +
+          `Check ~/catalyst/cloud-sync.log, confirm ${tokenEnv.envVar} is set in a 0600 file the launcher sources, ` +
+          `then: catalyst-stack verify-cloud-sync --strict`),
+      );
+    } else if (installed && !measurable) {
+      checks.push(
+        mkCheck("replica-fresh", STATUS.WARN,
+          "replica db not present, and the writer agent's adoption time is unreadable — cannot tell a fresh adoption from a writer that has never seeded (not connected)"),
+      );
+    } else {
+      // Unchanged wording for the ordinary not-yet-seeded case: a fresh adoption,
+      // or no agent at all.
+      checks.push(mkCheck("replica-fresh", STATUS.WARN, "replica db not present — writer has not seeded yet (not connected)"));
+    }
   } else {
     let dataNewest = 0; // newest of DB + non-empty -wal mtime = last mirrored change
     try { const s = statFile(dbPath); size = s.size; dataNewest = s.mtimeMs; statOk = true; } catch { /* unreadable → handled below */ }
@@ -4936,6 +5001,22 @@ function defaultLaunchAgentsDir() {
 // defaultAgentInstalled — is the launchd plist for <label> present? Deterministic file probe
 // (mirrors install-lifecycle.mjs defaultProbeWorkerAgents/defaultProbeUpdaterAgent). Honors
 // CATALYST_LAUNCHAGENTS_DIR for sandbox tests.
+// defaultAgentInstalledAt — the launchd plist's mtime in ms, or null. (CTL-1913)
+// This is the only local record of WHEN a writer was adopted, and it is what lets
+// checkCloudSync separate a fresh adoption still seeding from one that has never
+// authenticated. Returns null rather than a sentinel number on any failure: the
+// caller must be able to say "could not measure" instead of computing an age from
+// a fabricated timestamp — a `0` here would read as "adopted in 1970", i.e. an
+// instant FAIL on an unreadable plist.
+function defaultAgentInstalledAt(label, dir = defaultLaunchAgentsDir()) {
+  try {
+    const m = statSync(resolve(dir, `${label}.plist`)).mtimeMs;
+    return Number.isFinite(m) ? m : null;
+  } catch {
+    return null;
+  }
+}
+
 function defaultAgentInstalled(label, dir = defaultLaunchAgentsDir()) {
   try {
     return existsSync(resolve(dir, `${label}.plist`));

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1558,6 +1558,97 @@ EOF
 # URL. Changing either default would repoint or break both running replica writers
 # the moment they restarted. New installs get explicit values written here; the
 # defaults are a separate, evidence-gathering change.
+# validate_cloud_token TOKEN ACCOUNT BASE_URL — ONE authenticated call, and the
+# install refuses to continue unless it comes back 200. (CTL-1913)
+#
+# Endpoint choice is measured, not guessed. There is no /health, /me, /whoami or
+# /accounts on the hub (all 404), and `GET /issues?limit=1` discriminates BOTH
+# failure modes this function exists to catch — verified live 2026-08-17 against
+# staging.catalystcloud.dev:
+#
+#   valid token   + correct account -> 200
+#   garbage token + correct account -> 401 unauthorized
+#   valid token   + WRONG account   -> 403 forbidden
+#
+# That 403 is the tenant-0 footgun the account-required check above guards
+# syntactically; this catches the case where an account was supplied and is simply
+# not the one the key is scoped to — previously an opaque 403 the customer only met
+# hours later, in a log they had no reason to read.
+#
+# ⛔ EVERY NON-200 IS FATAL, INCLUDING "COULD NOT REACH". There is deliberately no
+# skip flag and no soft path. Provisioning a cloud replica REQUIRES reaching the
+# hub, so a host that cannot reach it at install time cannot succeed later either —
+# reporting success would recreate exactly the green-install-dead-writer state this
+# ticket removes. A distinct message per class keeps the failure actionable, and
+# `CATALYST_CLOUD_BASE_URL` remains the supported override for a different hub.
+#
+# The token is passed on stdin via a config file, never on the argv of a command
+# (`ps` is world-readable) and never interpolated into a URL.
+validate_cloud_token() {
+	local token="$1" account="$2" base_url="$3"
+
+	if ! command -v curl >/dev/null 2>&1; then
+		print_error "curl not found — cannot validate the cloud token."
+		echo ""
+		echo "  The install refuses to write a cloud config it could not verify."
+		echo "  Install curl and re-run."
+		return 1
+	fi
+
+	echo "  Validating the cloud token against ${base_url} ..."
+
+	# --max-time bounds a hung hub; -sS keeps the body quiet but lets curl's own
+	# error reach stderr. The header goes in a config file read from stdin so the
+	# bearer token never appears in this process's argv.
+	local code
+	code=$(
+		printf 'header = "Authorization: Bearer %s"\n' "$token" |
+			curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+				--config - \
+				"${base_url}/issues?account=${account}&limit=1" 2>/dev/null
+	) || code=""
+
+	case "$code" in
+	200)
+		print_success "cloud token validated against the hub (HTTP 200, account=${account})"
+		return 0
+		;;
+	401)
+		print_error "The cloud token was REJECTED by the hub (HTTP 401 unauthorized)."
+		echo ""
+		echo "  The token is wrong, expired, or revoked. Nothing has been written."
+		echo "  Re-run with a valid --cloud-token."
+		return 1
+		;;
+	403)
+		print_error "The token is valid but NOT scoped to account '${account}' (HTTP 403 forbidden)."
+		echo ""
+		echo "  The hub forces the account to match the key. Check --cloud-account"
+		echo "  against the tenant the token was issued for. Nothing has been written."
+		return 1
+		;;
+	000 | "")
+		print_error "Could not reach the hub at ${base_url} — the token was NOT validated."
+		echo ""
+		echo "  A cloud replica cannot be provisioned without reaching the hub, so this"
+		echo "  is fatal rather than a warning: reporting success here is what produced"
+		echo "  green installs with a permanently dead writer (CTL-1913)."
+		echo ""
+		echo "  Check the host resolves and is reachable, then re-run:"
+		echo "    curl -sS -o /dev/null -w '%{http_code}\\n' ${base_url}/issues"
+		echo "  (an unauthenticated 401 proves the host serves the API)"
+		return 1
+		;;
+	*)
+		print_error "The hub returned HTTP ${code} — the token was NOT validated."
+		echo ""
+		echo "  Nothing has been written. If the hub is having an outage, re-run once"
+		echo "  it recovers; a 5xx is not evidence the token is good OR bad."
+		return 1
+		;;
+	esac
+}
+
 setup_cloud_replica() {
 	# Flags win over env. Absent → this whole function is a no-op and setup is
 	# byte-identical to before CTL-1836.
@@ -1593,10 +1684,47 @@ setup_cloud_replica() {
 	harden_secrets_dir "$config_dir"
 	ensure_secrets_gitignore "$config_dir"
 
-	# The canonical host. cloud-sync.mjs:124 still defaults to the LEGACY
-	# api.catalyst-cloud.coalescelabs.ai, which is being retired, so a new user who
-	# relies on the default is pointed at a host that is going away. Pin it here.
-	local base_url="${CATALYST_CLOUD_BASE_URL:-https://app.catalystcloud.dev/api/v1}"
+	# ⛔ CTL-1910 — THIS COMMENT USED TO BE BACKWARDS, AND THE VALUE WITH IT.
+	# It called `app.catalystcloud.dev` "the canonical host" and
+	# `api.catalyst-cloud.coalescelabs.ai` "the LEGACY ... being retired". Measured
+	# 2026-08-17 from two hosts, with a control:
+	#
+	#   web.dev                             RESOLVES            <- control: .dev resolves here
+	#   app.catalystcloud.dev               NXDOMAIN (curl rc=6)   the pinned "canonical" host
+	#   catalystcloud.dev                   NXDOMAIN
+	#   staging.catalystcloud.dev           200 with a live token
+	#   api.catalyst-cloud.coalescelabs.ai  200 with a live token  the "retired" one
+	#
+	# The control matters: `web.dev` resolving proves the resolver handles `.dev`, so
+	# the NXDOMAIN is a real absence and not a broken lookup. So the host called
+	# canonical does not exist, and the one called retired is one of the two that
+	# actually answer. This function was writing the dead one into every new
+	# customer's 0600 launchd-sourced config: the writer could never reach the hub,
+	# the replica was never created, and setup exited 0 with two green checkmarks.
+	#
+	# Now pinned to `staging.catalystcloud.dev` (COORD's ruling — the live cloud).
+	# Verified equivalent, not assumed: authenticated `GET /api/v1/issues?limit=1`
+	# against staging and against the legacy host returned 200 with a
+	# BYTE-IDENTICAL first record, so they are the same backend serving the same
+	# tenant.
+	#
+	# ⚠️ `cloud-sync.mjs`'s own DEFAULT_BASE_URL is deliberately NOT changed here.
+	# The three hosts already running pin no base URL at all (measured: mini-2's
+	# cloud-sync.env has no CATALYST_CLOUD_BASE_URL line), so they resolve the code
+	# default — repointing it would repoint every live writer on its next restart.
+	# That is a fleet change, not an installer fix. New installs get an explicit
+	# value written below.
+	local base_url="${CATALYST_CLOUD_BASE_URL:-https://staging.catalystcloud.dev/api/v1}"
+
+	# ⛔ CTL-1913 — VALIDATE BEFORE WRITING ANYTHING.
+	# Ordered first on purpose: a config we have already proven cannot work must
+	# never reach disk. Previously nothing on this path made a single network call,
+	# so a correct token and `FAKE-TOKEN-NOT-REAL` produced byte-identical output —
+	# two green checkmarks and exit 0 — and the customer's only symptom was a
+	# replica that never appeared. (Why it stays silent: a tokenless/rejected writer
+	# `process.exit(0)`s, and under `KeepAlive={SuccessfulExit:false}` a clean exit
+	# is PERMANENT — launchd never retries.)
+	validate_cloud_token "$token" "$account" "$base_url" || return 1
 
 	# ⛔ EVERY LINE MUST BE `export` (Codex P1 on #3365). launch.sh SOURCES this file
 	# and then `exec`s bun. A bare `FOO=bar` in a sourced file is a SHELL-LOCAL
@@ -1644,10 +1772,21 @@ setup_cloud_replica() {
 	local stack
 	stack=$(command -v catalyst-stack 2>/dev/null || true)
 	if [[ -n $stack ]]; then
-		if "$stack" adopt-cloud-sync >/dev/null 2>&1; then
+		# ⛔ CTL-1913: the output is CAPTURED, not discarded. This was
+		# `>/dev/null 2>&1`, so whatever adopt-cloud-sync said about why it was
+		# unhappy was unrecoverable — the operator got one generic warning line for
+		# every possible cause. Kept out of the way on success, shown in full on
+		# failure, which is the only time anyone wants it.
+		local adopt_out adopt_rc=0
+		adopt_out=$("$stack" adopt-cloud-sync 2>&1) || adopt_rc=$?
+		if [[ $adopt_rc -eq 0 ]]; then
 			print_success "cloud-sync writer adopted (launchd agent installed)"
 		else
-			print_warning "catalyst-stack adopt-cloud-sync failed — run it by hand once the stack is installed"
+			print_warning "catalyst-stack adopt-cloud-sync failed (rc=${adopt_rc}) — its output follows"
+			# Indented so it reads as sub-output rather than as this script's own.
+			printf '%s\n' "$adopt_out" | sed 's/^/    /'
+			echo ""
+			echo "  Fix the cause above, then re-run: catalyst-stack adopt-cloud-sync"
 		fi
 	else
 		print_warning "catalyst-stack not on PATH — run 'catalyst-stack adopt-cloud-sync' after installing the stack"


### PR DESCRIPTION
Two gate-B P1s on the fresh-install path. Both produce the same customer experience: **green checkmarks, exit 0, and a replica that never appears.**

---

## CTL-1910 — the installer hard-pinned a host that does not exist

`setup_cloud_replica` wrote `https://app.catalystcloud.dev/api/v1` into every new customer's 0600, launchd-sourced `cloud-sync.env`. That host is NXDOMAIN. Measured from two hosts, **with a control**:

| host | result |
|---|---|
| `web.dev` | RESOLVES ← *control: this resolver handles `.dev`* |
| `app.catalystcloud.dev` | **NXDOMAIN** (curl rc=6) ← the pinned "canonical" host |
| `catalystcloud.dev` | NXDOMAIN |
| `staging.catalystcloud.dev` | **200** with a live token |
| `api.catalyst-cloud.coalescelabs.ai` | **200** with a live token ← the "retired" one |

The control is what makes the negative mean anything: `web.dev` resolving proves the empty answer is a real absence, not a broken lookup. The comment directly above the line called `app.` *"The canonical host"* and the one that actually answers *"the LEGACY … which is being retired"* — backwards in both directions, and worse than a bad doc link because it lands in a runtime config launchd sources on every boot.

Now pinned to `staging.catalystcloud.dev` (COORD's ruling). **Verified equivalent rather than taken on trust** — authenticated `GET /api/v1/issues?limit=1` against staging and against the legacy host both returned 200 with a **byte-identical first record**: same backend, same tenant.

⚠️ `cloud-sync.mjs`'s own `DEFAULT_BASE_URL` is deliberately **not** changed. The three hosts already running pin no base URL at all (measured — mini-2's `cloud-sync.env` has no such line), so they resolve the code default; repointing it would repoint every live writer on its next restart. That is a fleet change, not an installer fix.

## CTL-1913 — a correct token and a garbage token were byte-identical

The cloud path made **no network call**. It accepted a token, wrote it, printed two green checkmarks and exited 0. The writer then `process.exit(0)`s on an absent/misnamed/rejected token, and under `KeepAlive={SuccessfulExit:false}` a clean exit is **permanent** — launchd never retries. The customer's only symptom was a replica that never appeared.

- **One authenticated call, before anything is written.** Ordered first on purpose: a config already proven unusable must never reach disk. The endpoint was chosen by measurement — there is no `/health`, `/me`, `/whoami` or `/accounts` (all 404) — and `/issues?limit=1` discriminates **both** failure modes: `401` garbage token, `403` valid token not scoped to the requested account (the tenant footgun), `200` good.
- **Every non-200 is fatal, including "could not reach".** No skip flag: provisioning a cloud replica *requires* reaching the hub, so a host that cannot reach it at install time cannot succeed later either, and reporting success is precisely the defect. Each class gets its own message, because the three need three different operator actions.
- **The token never touches argv** (`ps` is world-readable) — the bearer header goes to curl via `--config -` on stdin.
- **`adopt-cloud-sync`'s output is captured, not discarded.** It was `>/dev/null 2>&1`, so the reason it was unhappy was unrecoverable; now shown in full on failure only.
- **`catalyst doctor` can now fail** on the terminal state: agent adopted, replica never created, past a 15-minute first-seed grace.

### ⚠️ Where I deliberately did not do what the ticket implied

"Make doctor FAIL" is wrong as stated, and this file already records the reason **twice** (`checkReaper`, `checkHealthResponder`):

> doctor's exit code IS the catalyst-join activation gate, and `do_doctor_gate` runs **before** `install-services`.

A default FAIL would block the join that reinstalls the writer — blocking the self-heal for the very condition it reports. `installChecksForClass` doesn't want it either; it deliberately omits network/operational checks so a remote dependency can't be mis-attributed to the install run.

So the capability is implemented and tested behind `strict`, wired into no profile — following the existing `checkDeploymentModeConsistency` precedent ("the strict install-profile escalation branch exists … but is not wired into any profile yet"). The install-time actuator stays the one the ticket itself names: `catalyst-stack verify-cloud-sync --strict`. **The pre-existing exhaustive never-FAIL matrix passes unchanged.**

---

## Verification — 19-case mutation matrix, 19/19 killed

`setup-cloud-replica.test.sh`: **20 → 53 assertions**. Plus a new `setup-cloud-base-url-resolves.test.sh` (6) and `doctor-replica.test.mjs` 21 → 28.

**The network is sealed with a `curl` stub on PATH, not an overridden shell function** — a function override only intercepts the call site you thought of; a PATH stub intercepts the transport, so a call added anywhere in the sourced script is caught too. Every case asserts the stub was actually invoked, so *"the stub answered 401"* is distinguishable from *"real curl reached the internet and got 401"*.

The load-bearing assertion in each rejection case is **not `rc != 0`** but that **nothing was written**: a non-zero exit that still leaves a broken 0600 config on disk is most of the original defect.

The new DNS test is **three-valued** and parses the pinned default *out of the shipped script* rather than restating it: control resolves + pinned resolves → PASS; control resolves + pinned NXDOMAIN → FAIL; **control does not resolve → SKIP**, because a DNS failure on the runner is "could not look", and collapsing that into PASS or FAIL is the defect class that produced the bug. It also fails offline if `app.catalystcloud.dev` returns as a *value* — while permitting it in comments, since deleting the record of *why* it is forbidden is how it comes back. (That distinction exists because the test failed against its own first draft.)

### Three real gaps the matrix found

| mutation | what survived |
|---|---|
| `return 0` in the catch-all `*)` | an **unlisted** code (5xx / 404 / 302) was accepted — nothing covered a code the function doesn't name |
| restore `>/dev/null 2>&1` on adopt | the adopt diagnostics were **unasserted** — the whole point of that change |
| break the `000` branch | refusing with the **wrong explanation** — verdict preserved, guidance lost |

### ⛔ And two defects in the harness itself

**A transient `rm` failure was reporting as a mutation KILL.** One case flipped `killed` → `SURVIVED` across two runs with no change to the code under test. Cause: cleanup ran `rm -rf` under `set -euo pipefail`, and a single macOS `rm: Directory not empty` (the same dir removed fine on retry) aborted the suite mid-run. An aborted suite exits non-zero, which is **byte-identical to a mutant being caught** — so the harness had been crediting itself for a mutant it never detected. Cleanup is now tolerant: a step that cleans up after the tests must never be able to fail them.

**`out=$(cmd)` takes the substitution's exit status,** so under `set -e` every deliberately-non-zero case aborted the suite instead of asserting.

**And a mutation that does not mutate:** `403)` → `403 | 999_never)` in a `case` changes nothing (403 still matches the first alternative), so it reported SURVIVED against a covered branch — the mirror image of the `NOT-APPLIED` verdict this harness reports separately, and the reason it reports it at all.

Both doctor directions are covered: losing the FAIL capability, **and** FAILing by default (which would block the join gate).

---

Not in scope, still open on CTL-1913: polling `verify-cloud-sync` after adoption until the replica reports seeded (the ticket's scenario 2).

Refs CTL-1910, CTL-1913.