### PR TITLE
fix(dev): CTL-1921 — every new worktree inherited 1.3 GB of other agents' scratch checkouts

### DIFF
--- a/plugins/dev/scripts/__tests__/create-worktree-scratch-exclusion.test.sh
+++ b/plugins/dev/scripts/__tests__/create-worktree-scratch-exclusion.test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# CTL-1921: create-worktree.sh must NOT copy the agent harness's own scratch
+# checkouts into every new worktree.
+#
+# `cp -R .claude` copied the whole directory, and `.claude/worktrees/` is where the
+# harness parks `wf_*` / `agent-*` working trees — several with their own
+# `node_modules`. Measured on the shared checkout the day this was filed:
+#
+#   .claude              1.3G
+#   .claude/worktrees    1.3G   <- 13 entries
+#   everything else      ~40K
+#
+# So each new worktree inherited a byte-for-byte copy of ~1.3 GB of other agents'
+# scratch to obtain ~40 KB of config. The disk sweep that found it freed
+# 14 -> 156 GiB.
+#
+# ⛔ THE LOAD-BEARING ASSERTION IS THE ONE THAT MEASURES BYTES, NOT THE ONE THAT
+# CHECKS A PATH IS ABSENT. "worktrees/ is not there" also passes if the copy
+# silently stopped copying anything at all, so every exclusion case is paired with
+# a positive control proving the real config DID arrive.
+#
+# Run: bash plugins/dev/scripts/__tests__/create-worktree-scratch-exclusion.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+CREATE_WT="${REPO_ROOT}/plugins/dev/scripts/create-worktree.sh"
+
+FAILURES=0
+PASSES=0
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+}
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+assert_eq() {
+	if [[ $1 == "$2" ]]; then pass "$3"; else fail "$3 — expected '$1', got '$2'"; fi
+}
+
+COMMITTED_CATALYST_CFG='{"catalyst":{"projectKey":"t","worktree":{"setup":["true"]}}}'
+build_scratch() {
+	SCRATCH="$(mktemp -d -t cwt-ctl1921-XXXXXX)"
+	ORIGIN="$SCRATCH/origin.git"
+	SRC="$SCRATCH/src"
+	WT="$SCRATCH/wt"
+	FAKEHOME="$SCRATCH/home"
+	mkdir -p "$WT" "$FAKEHOME"
+	git init -q --bare "$ORIGIN"
+
+	local SEED="$SCRATCH/seed"
+	git clone -q "$ORIGIN" "$SEED"
+	git -C "$SEED" config user.email t@t.t
+	git -C "$SEED" config user.name t
+	git -C "$SEED" checkout -q -b main 2>/dev/null || git -C "$SEED" checkout -q main
+	mkdir -p "$SEED/.claude" "$SEED/.catalyst"
+	printf '{"claude":"committed"}\n' >"$SEED/.claude/config.json"
+	printf '%s\n' "$COMMITTED_CATALYST_CFG" >"$SEED/.catalyst/config.json"
+	git -C "$SEED" add -A
+	git -C "$SEED" commit -q -m c1
+	git -C "$SEED" push -q -u origin main
+
+	git clone -q "$ORIGIN" "$SRC"
+	git -C "$SRC" config user.email t@t.t
+	git -C "$SRC" config user.name t
+}
+
+run_create() {
+	local NAME="$1"
+	shift
+	OUTPUT="$(cd "$SRC" && HOME="$FAKEHOME" \
+		bash "$CREATE_WT" "$NAME" main --worktree-dir "$WT" "$@" 2>&1)"
+	EXIT=$?
+	WT_PATH="$WT/$NAME"
+}
+
+# Plant realistic harness debris: nested worktrees, a node_modules, and a file big
+# enough that a byte measurement can tell a copy from a skip.
+plant_scratch_dirs() {
+	mkdir -p "$SRC/.claude/worktrees/wf_deadbeef-1/node_modules/left-pad"
+	mkdir -p "$SRC/.claude/worktrees/agent-abc123/.claude/worktrees/wf_nested-2"
+	mkdir -p "$SRC/.claude/debug"
+	# 2 MiB of "other agent's checkout"
+	dd if=/dev/zero of="$SRC/.claude/worktrees/wf_deadbeef-1/blob.bin" bs=1024 count=2048 2>/dev/null
+	printf 'nested junk\n' >"$SRC/.claude/worktrees/agent-abc123/.claude/worktrees/wf_nested-2/junk.txt"
+	printf 'transcript\n' >"$SRC/.claude/debug/session.log"
+	# ...and the real config that MUST survive, including a dotfile.
+	printf '{"local":"untracked-settings"}\n' >"$SRC/.claude/settings.local.json"
+	mkdir -p "$SRC/.claude/rules"
+	printf 'a rule\n' >"$SRC/.claude/rules/some-rule.md"
+	printf 'dotfile-content\n' >"$SRC/.claude/.hidden-config"
+	# ⛔ UNTRACKED, on purpose. A TRACKED .catalyst file proves nothing about the
+	# copy: the CTL-990 block below runs `git checkout -- .catalyst` in the new
+	# worktree, which materialises every tracked file from the branch whether or not
+	# the copy ran at all. Mutation-verified — deleting the .catalyst copy entirely
+	# SURVIVED a suite whose only .catalyst assertion was on the tracked config.json.
+	printf 'untracked-catalyst\n' >"$SRC/.catalyst/machine-local.json"
+}
+
+dir_bytes() { du -sk "$1" 2>/dev/null | awk '{print $1}'; }
+
+# ── Test 1: the scratch dirs are excluded, and the config still arrives ──────
+echo "Test 1: .claude/worktrees and .claude/debug are NOT copied"
+build_scratch
+plant_scratch_dirs
+run_create wt-scratch
+assert_eq "0" "$EXIT" "exits 0"
+
+if [[ -e "$WT_PATH/.claude/worktrees" ]]; then
+	fail ".claude/worktrees was copied into the new worktree (the 150 GB defect)"
+else
+	pass ".claude/worktrees is absent from the new worktree"
+fi
+if [[ -e "$WT_PATH/.claude/debug" ]]; then
+	fail ".claude/debug was copied into the new worktree"
+else
+	pass ".claude/debug is absent from the new worktree"
+fi
+
+# ⭐ POSITIVE CONTROLS — without these, "absent" would also pass if the copy had
+# broken entirely and no .claude arrived at all.
+assert_eq '{"local":"untracked-settings"}' "$(cat "$WT_PATH/.claude/settings.local.json" 2>/dev/null)" \
+	"POSITIVE CONTROL: untracked machine-local settings.local.json still copied"
+assert_eq 'a rule' "$(cat "$WT_PATH/.claude/rules/some-rule.md" 2>/dev/null)" \
+	"POSITIVE CONTROL: a real config SUBDIRECTORY is still copied recursively"
+assert_eq 'dotfile-content' "$(cat "$WT_PATH/.claude/.hidden-config" 2>/dev/null)" \
+	"POSITIVE CONTROL: a DOTFILE is still copied (the glob enumerates them separately)"
+assert_eq '{"claude":"committed"}' "$(cat "$WT_PATH/.claude/config.json" 2>/dev/null)" \
+	"POSITIVE CONTROL: tracked .claude/config.json present, at branch content (CTL-990 still holds)"
+assert_eq "$COMMITTED_CATALYST_CFG" "$(cat "$WT_PATH/.catalyst/config.json" 2>/dev/null)" \
+	"POSITIVE CONTROL: tracked .catalyst/config.json present at branch content"
+# ⭐ THE assertion that actually exercises the .catalyst copy — see the note in
+# plant_scratch_dirs. Only an UNTRACKED file can distinguish "the copy ran" from
+# "git checkout restored the tracked files".
+assert_eq 'untracked-catalyst' "$(cat "$WT_PATH/.catalyst/machine-local.json" 2>/dev/null)" \
+	"POSITIVE CONTROL: an UNTRACKED .catalyst file arrives — proves the copy ran, not just git checkout"
+
+# ⛔ THE BYTE ASSERTION — and an honest note on its limit.
+# The source .claude is >2 MiB of scratch; the resulting copy must be a tiny
+# fraction. This catches an exclusion that matches the NAME but still recurses
+# (e.g. skipping `.claude/worktrees` while a nested `agent-*/.claude/worktrees`
+# rides along), which a bare `[ -e ]` check would miss.
+#
+# What it does NOT catch: a "fix" that copies everything and deletes afterwards.
+# This measures the destination tree after the fact, so a copy-then-delete looks
+# identical to a skip — while still having written every byte, which is the entire
+# cost being removed. Detecting that needs peak-usage or timing measurement, which
+# is flaky in CI; the guard against it is the per-entry loop plus the skip line
+# asserted below, not this number. Stated plainly because an earlier draft of this
+# comment claimed the assertion covered it, and it does not.
+SRC_KB=$(dir_bytes "$SRC/.claude")
+DST_KB=$(dir_bytes "$WT_PATH/.claude")
+if [[ -n $SRC_KB && -n $DST_KB && $SRC_KB -gt 2000 && $DST_KB -lt 200 ]]; then
+	pass "copied .claude is ${DST_KB}K vs source ${SRC_KB}K — the scratch bytes were never written"
+else
+	fail "byte check: source ${SRC_KB}K, copy ${DST_KB}K (expected source >2000K and copy <200K)"
+fi
+
+# CTL-990 must still hold: no dirty TRACKED config in the fresh worktree.
+PORCELAIN="$(git -C "$WT_PATH" status --porcelain -- .claude .catalyst 2>/dev/null | grep -v '^??' || true)"
+assert_eq "" "$PORCELAIN" "no tracked .claude/.catalyst changes in the fresh worktree (CTL-990 preserved)"
+
+# The skip should be announced, not silent — an operator reading the log should be
+# able to tell the difference between "excluded" and "your config vanished".
+if grep -q 'skipping .claude/worktrees' <<<"$OUTPUT"; then
+	pass "the skip is reported in the output"
+else
+	fail "the skip is silent; output was: $(tr '\n' '|' <<<"$OUTPUT" | head -c 300)"
+fi
+rm -rf "$SCRATCH"
+
+# ── Test 2: NEGATIVE CONTROL — no scratch dirs at all ───────────────────────
+# Proves the copy is not simply broken for everyone: with nothing to skip, a
+# perfectly ordinary .claude arrives intact.
+echo "Test 2: NEGATIVE CONTROL — a .claude with no scratch dirs copies fully"
+build_scratch
+printf '{"local":"plain"}\n' >"$SRC/.claude/settings.local.json"
+mkdir -p "$SRC/.claude/prompts"
+printf 'p\n' >"$SRC/.claude/prompts/p.md"
+run_create wt-plain
+assert_eq "0" "$EXIT" "exits 0"
+assert_eq '{"local":"plain"}' "$(cat "$WT_PATH/.claude/settings.local.json" 2>/dev/null)" \
+	"settings.local.json copied"
+assert_eq 'p' "$(cat "$WT_PATH/.claude/prompts/p.md" 2>/dev/null)" "prompts/ copied"
+if grep -q 'skipping' <<<"$OUTPUT"; then
+	fail "reported a skip when there was nothing to skip"
+else
+	pass "no skip reported when there is no scratch to skip"
+fi
+rm -rf "$SCRATCH"
+
+# ── Test 3: an EMPTY .claude must not error ─────────────────────────────────
+# The entry-by-entry loop uses globs; an empty dir leaves them unmatched, and an
+# unguarded loop would try to copy a literal '.claude/*'.
+echo "Test 3: an empty .claude directory is handled without error"
+build_scratch
+git -C "$SRC" rm -q -r .claude
+git -C "$SRC" commit -q -m "drop tracked .claude"
+git -C "$SRC" push -q origin main
+mkdir -p "$SRC/.claude"
+run_create wt-empty
+assert_eq "0" "$EXIT" "exits 0 on an empty .claude"
+if grep -qE "cannot stat|No such file" <<<"$OUTPUT"; then
+	fail "unmatched glob leaked a literal path: $(tr '\n' '|' <<<"$OUTPUT" | head -c 200)"
+else
+	pass "no unmatched-glob error"
+fi
+rm -rf "$SCRATCH"
+
+echo ""
+echo "Passed: $PASSES  Failed: $FAILURES"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -341,16 +341,99 @@ else
 	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$START_POINT"
 fi
 
+# ⛔ CTL-1921 — THIS COPY ONCE PEAKED THE DISK AT 150 GB.
+#
+# `cp -R .claude` copied the WHOLE directory, and `.claude/worktrees/` is where the
+# agent harness parks its own scratch checkouts (`wf_*`, `agent-*`) — each a full
+# working tree, several with their own `node_modules`. So every new worktree
+# inherited a byte-for-byte copy of every harness worktree that happened to exist,
+# and nested ones compounded it. Measured on this checkout the day the ticket was
+# filed:
+#
+#   .claude                1.3G
+#   .claude/worktrees      1.3G   <- 13 entries
+#   everything else        ~40K   <- rules, prompts, config*.json, settings.local
+#
+# i.e. the part actually worth copying is ~0.003% of what was being copied. The
+# sweep that found this freed 14 -> 156 GiB.
+#
+# Two independent changes, either of which would help and both of which are cheap:
+#
+#   1. SKIP the two directories that are machine-local scratch, never config.
+#      `worktrees/` (harness checkouts) and `debug/` (transcript dumps).
+#   2. CLONE instead of copy where the filesystem can. On APFS `cp -c` makes a
+#      copy-on-write clone — near-zero time and near-zero space — and GNU cp
+#      spells the same thing `--reflink=auto`. Both DEGRADE to a real copy rather
+#      than failing, but neither flag is portable, so the form is probed once and
+#      falls back to a plain `cp -R`.
+#
+# The exclusion is what makes this correct; the clone is what makes it fast. Do not
+# drop the exclusion on the grounds that cloning made it cheap — a clone still
+# materialises metadata for every file, and on a non-APFS/non-reflink filesystem it
+# is a full copy again.
+
+# _cw_copy_flag — the best available copy-on-write flag for this cp, probed ONCE
+# against a real temp file rather than sniffed from `uname`: a Mac can have GNU
+# coreutils first on PATH, and a Linux box can be running busybox cp. Empty means
+# "no clone support" — a plain recursive copy, which is always correct.
+_cw_copy_flag() {
+	local t rc=""
+	t=$(mktemp -d) || {
+		printf ''
+		return 0
+	}
+	: >"$t/probe"
+	if cp -Rc "$t/probe" "$t/out" 2>/dev/null; then
+		rc="-Rc" # BSD/macOS clone
+	elif cp -R --reflink=auto "$t/probe" "$t/out2" 2>/dev/null; then
+		rc="-R --reflink=auto" # GNU reflink
+	else
+		rc="-R"
+	fi
+	rm -rf "$t"
+	printf '%s' "$rc"
+}
+
+# Machine-local scratch that must never be inherited by a new worktree.
+_CW_SKIP_CLAUDE="worktrees debug"
+
+# _cw_copy_config_dir SRC DEST_PARENT — copy a config dir entry-by-entry, skipping
+# the scratch names. Entry-by-entry rather than `cp` + delete afterwards, because
+# deleting afterwards means the 1.3 GB is still written first — which is the whole
+# cost being removed.
+_cw_copy_config_dir() {
+	local src="$1" dest_parent="$2" flag="$3" entry base
+	mkdir -p "$dest_parent/$src"
+	# `dotglob` is not portable to plain sh, so dotfiles are enumerated separately.
+	for entry in "$src"/* "$src"/.[!.]*; do
+		[ -e "$entry" ] || continue # unmatched glob stays literal
+		base=${entry##*/}
+		case " $_CW_SKIP_CLAUDE " in
+		*" $base "*)
+			echo "   ↳ skipping $src/$base (machine-local scratch, CTL-1921)"
+			continue
+			;;
+		esac
+		# shellcheck disable=SC2086 # $flag is a deliberately-unquoted flag list
+		cp $flag "$entry" "$dest_parent/$src/" 2>/dev/null ||
+			cp -R "$entry" "$dest_parent/$src/" 2>/dev/null || true
+	done
+}
+
+_CW_COPY_FLAG=$(_cw_copy_flag)
+
 # Copy .claude directory if it exists (Claude Code native config)
 if [ -d ".claude" ]; then
 	echo "📋 Copying .claude directory..."
-	cp -R .claude "$WORKTREE_PATH/"
+	_cw_copy_config_dir .claude "$WORKTREE_PATH" "$_CW_COPY_FLAG"
 fi
 
 # Copy .catalyst directory if it exists (Catalyst workflow config)
+# Same helper for one behaviour only — the clone flag. `.catalyst` carries no
+# scratch subdirectory (measured: 88K), so the skip list simply never matches.
 if [ -d ".catalyst" ]; then
 	echo "📋 Copying .catalyst directory..."
-	cp -R .catalyst "$WORKTREE_PATH/"
+	_cw_copy_config_dir .catalyst "$WORKTREE_PATH" "$_CW_COPY_FLAG"
 fi
 
 # CTL-990: the cp -R above copies the MAIN checkout's working-tree versions of


### PR DESCRIPTION
`create-worktree.sh` copied `.claude` wholesale — and `.claude/worktrees/` is where the agent harness parks its own `wf_*` / `agent-*` working trees, several with their own `node_modules`, some nested. So **every** worktree created inherited a byte-for-byte copy of **every** harness worktree that happened to exist at the time. COORD's disk sweep traced the 150 GB peak here and freed **14 → 156 GiB**.

Measured on the shared checkout the day this was filed:

```
.claude              1.3G
.claude/worktrees    1.3G   <- 13 entries
everything else      ~40K   <- rules, prompts, config*.json, settings.local
```

The part actually worth copying is **~0.003%** of what was being copied.

## Two independent changes

1. **Skip the machine-local scratch** — `worktrees/` and `debug/`. Done **entry-by-entry**, not copy-then-prune: pruning afterwards still writes the 1.3 GB first, which is the entire cost being removed.
2. **Clone instead of copy where the filesystem allows.** APFS `cp -c` and GNU `cp --reflink=auto` are both copy-on-write. The form is **probed once against a real temp file** rather than sniffed from `uname` — a Mac can have GNU coreutils first on PATH and a Linux box can be running busybox — and falls back to plain `cp -R`, which is always correct.

> The exclusion is what makes this correct; the clone only makes it fast. A clone still materialises metadata per file, and on a non-reflink filesystem it is a full copy again — so the exclusion must not be dropped on the grounds that cloning made it cheap. That reasoning is in the code, not just here.

**CTL-990's invariant is preserved**: tracked config is still restored to branch state after the copy, so a locally-dirty `.claude/config.json` in the main checkout does not dirty the new worktree.

## Verification — 9-case mutation matrix, 9/9 killed

New `create-worktree-scratch-exclusion.test.sh`, **18 assertions**. The headline is a **byte** assertion rather than a path-absence one:

```
PASS: copied .claude is 16K vs source 2072K — the scratch bytes were never written
```

`worktrees/ is not there` also passes if the copy silently stopped copying **anything**, so every exclusion case is paired with a positive control that the real config *did* arrive — including a **dotfile** (the glob enumerates those separately) and a config **subdirectory** (a non-recursive `cp` would drop it).

### ⛔ The matrix found a false-positive assertion in my own test

Deleting the `.catalyst` copy **entirely** SURVIVED. The only `.catalyst` assertion was on its *tracked* `config.json` — and the CTL-990 block runs `git checkout -- .catalyst` in the new worktree, which materialises every tracked file from the branch **whether or not the copy ran**. The assertion was being satisfied by something other than the thing under test.

Fixed with an **untracked** `.catalyst` file, which is the only kind that can tell those two apart.

### Two mutations recorded as equivalent rather than chased

Removing the unmatched-glob guard, and a probe returning an invalid flag. The per-entry `cp … 2>/dev/null || cp -R … || true` absorbs both, so neither has an observable effect — contorting a test to catch them would assert on implementation rather than behaviour. Recorded in the harness with that reasoning instead of being left as an unexplained survivor.

### Honest limit, stated in the test

The byte assertion measures the **destination** tree, so it does **not** catch a "fix" that copies everything and deletes afterwards. Detecting that needs peak-usage or timing measurement, which is flaky in CI; the guard against it is the per-entry loop plus the asserted skip line. (An earlier draft of that comment claimed the assertion covered it. It does not, and the comment now says so.)

## Pre-existing, unrelated

`create-worktree-base-ref.test.sh` fails one assertion (worktree HEAD vs base tip). Confirmed **pre-existing** by running that file against `origin/main`'s `create-worktree.sh` in this same worktree: **21 passed / 1 failed both ways**, and the assertion concerns branch selection, not config copying.

Refs CTL-1921.