### PR TITLE
chore(dev): pin the fleet to @catalyst-cloud/sdk 0.8.10 (schema 0.1.15, replicate 0.1.9)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "catalyst",
       "dependencies": {
-        "@catalyst-cloud/schema": "0.1.14",
+        "@catalyst-cloud/schema": "0.1.15",
         "@modelcontextprotocol/sdk": "1.29.0",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.9",
+        "@catalyst-cloud/sdk": "0.8.10",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.8", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.14" } }, "sha512-g3FK2FoN+0Xas8w/UCHHFB/T9ohbQlwLlPfcbwfLIvTQjYMrEzbCshqExuGhekdJbALgcOHzBk9w5he8e21h8A=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.9", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.15" } }, "sha512-Fp7pcHFgjAdlPD7xLuHhrqTSF2xPEiYnEufz3FRZIbvOfQntWTzCVaKgtLw1/YETs3KOw8E6OFMtK6dwrwA1Rw=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.14", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-ctURm67uXIHLj/h925ohig8UAyo7rox/AS32w2UucAQ+GpA7Kpam7dDxaSG84X9MjF0Cl+0NX2uF5oBhCnA3Mw=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.15", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-cEkcsisF7kqfVmm0dhTsTvj7BuPfFcKAgO0oZ83GZqQG6k3J/699d4A7X8cAI1LtfNAneKHylxuAjJgj93Zd+A=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.9", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.8", "@catalyst-cloud/schema": "0.1.14" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-1FyXoxlnudX4E9Qi6lC1bBRPHck0qul92mf1HbkV7UhR1nTBYL0mKt0qs4Si9bfld8pdkRUV0ZbkGeLCw36xdw=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.10", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.9", "@catalyst-cloud/schema": "0.1.15" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-/84cspI//N9b11omjFtWvUX8u3L0IRCZ+CZVmHaX7qtAc3FN8OXV0mroutY9D8EDEQIJbOeUc+7uLHWBh5OM+w=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hono": "4.12.27"
   },
   "dependencies": {
-    "@catalyst-cloud/schema": "0.1.14",
+    "@catalyst-cloud/schema": "0.1.15",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.9",
+    "@catalyst-cloud/sdk": "0.8.10",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
Backend published the CTC-628 chain: schema **0.1.15** adds
`team_workflow_mapping` (the tenant's phase->Linear-state choice, carrying
`workflow_rev`), reaching the fleet as **SDK 0.8.10**.

| | from | to |
|---|---|---|
| `plugins/dev/scripts/execution-core` -> `@catalyst-cloud/sdk` | 0.8.9 | **0.8.10** |
| root -> `@catalyst-cloud/schema` | 0.1.14 | **0.1.15** |
| (transitive) `@catalyst-cloud/replicate` | 0.1.8 | **0.1.9** |

Exact pins, not ranges — the fleet's dispatch path reads this replica, and a
floating range is how two hosts end up serving different schemas. SDK 0.8.10
*declares* replicate 0.1.9 + schema 0.1.15 exactly, so the lock chain is
coherent with the pin rather than merely compatible with it.

## Verified before pinning, not after

- All three versions exist on the registry.
- **One-copy gate**: exactly one resolved version of each `@catalyst-cloud`
  package in `bun.lock` (sdk 0.8.10, schema 0.1.15, replicate 0.1.9,
  read-model 0.1.1). Negative control: the same instrument reports `2` on a
  synthetic two-copy input, so the `1` is a measurement rather than a
  broken match.
- **Resolution probed off DISK from the IMPORTING package** — not from the
  workspace root, and not through `require.resolve` (CTL-1831: module
  resolution is cached process-wide and answers from cache, not disk). This
  run confirms why that matters:

```
workspace root                 sdk => NOT FOUND   replicate => NOT FOUND
execution-core (the importer)  sdk => 0.8.10
through the SDK's own dir      schema => 0.1.15   replicate => 0.1.9
through REPLICATE's own dir    schema => 0.1.15
```

  A top-level probe would have reported "absent" and told us nothing.
- **The LOADED criterion is actually in the installed package** — read from
  the copy execution-core resolves, not from the tarball and not from the
  lockfile: `CREATE TABLE workflow_states` and
  `CREATE TABLE team_workflow_mapping` are both present in
  `migrations.generated.ts`. Positive control `push_subscriptions` matched
  1; a fabricated table name matched 0.
  (First cut of this check read 0 for *every* table including the known
  present ones — broken backtick escaping. Zero on the positive control is
  what made it legible as "could not look" rather than "absent".)

## MIGRATED != WRITTEN

DDL present in the package only proves the table can be *created*. Both
tables are also bound in `mirror.ts` and exported from `index.ts`, but rows
arrive only when backend fires
`POST /admin/rebroadcast?entity=workflow_states` (+ `team_workflow_mapping`).
Row-level readback on a mini is verified separately, by content, after the
rebroadcast — not claimed here.

## Merging this does not relink a host

CTL-1831: `bun install` (frozen or not) prints `no changes` and exits 0 when
only a **transitive** resolution moved — so a successful install and a no-op
install are byte-identical to the caller. Each host is verified **by
content** after the refresh, and LOADED means a line written by a pid that
started after the refresh — never by the pin having merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>