### PR TITLE
feat(dev): CTL-1922 — `ask` skill: ask/decision-ticket SOP + threaded app-actor reply helper

### DIFF
--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// linear-reply.mjs — post a MACHINE reply on a Linear issue the way Ryan asked (2026-08-17):
+//   • threaded UNDER the human's comment (parentId = the ROOT of that thread; Linear threads are
+//     one level deep, so a reply-to-a-reply must target the root — measured, CTL-1891),
+//   • authored as the APP ACTOR ("Catalyst Cloud"), never as the personal token (a personal-identity
+//     comment reads as the human deciding and clears `needs-human` — CTL-1567 gate),
+//   • tagged with the agent's name via createAsUser (shows as botActor.userDisplayName).
+//
+// Usage:
+//   node linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown> [--parent <commentId>|--top]
+//   (body may also come from stdin: --body -)
+// Env: LINEAR_SYNC_CLIENT_ID / LINEAR_SYNC_CLIENT_SECRET (direnv catalyst-cloud profile).
+// Without --parent/--top: threads under the ROOT of the most recent comment authored by a HUMAN
+// (non-bot) user on the issue; if none exists, posts top-level.
+// Prints JSON {ok, commentId, parentId, url} on success; non-zero exit + message on failure.
+
+import { readFileSync } from "node:fs";
+
+const GQL = "https://api.linear.app/graphql";
+const OAUTH = "https://api.linear.app/oauth/token";
+const SCOPE = "read,write,comments:create,app:assignable,app:mentionable";
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 ? process.argv[i + 1] : dflt;
+}
+const issueKey = process.argv[2];
+const asAgent = arg("--as", "COORD");
+let body = arg("--body", "");
+const parentArg = arg("--parent", null);
+const top = process.argv.includes("--top");
+if (!issueKey || !body) {
+  console.error("usage: linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown|-> [--parent <id>|--top]");
+  process.exit(2);
+}
+if (body === "-") body = readFileSync(0, "utf8");
+
+const cid = process.env.LINEAR_SYNC_CLIENT_ID, csec = process.env.LINEAR_SYNC_CLIENT_SECRET;
+if (!cid || !csec) { console.error("LINEAR_SYNC_CLIENT_ID/SECRET missing (run under direnv)"); process.exit(2); }
+
+async function mint() {
+  const r = await fetch(OAUTH, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "client_credentials", client_id: cid, client_secret: csec, scope: SCOPE, actor: "app" }),
+  });
+  const j = await r.json();
+  if (!j.access_token) throw new Error("mint failed: " + JSON.stringify(j).slice(0, 200));
+  return j.access_token;
+}
+async function gql(token, query, variables) {
+  const r = await fetch(GQL, { method: "POST", headers: { "content-type": "application/json", authorization: token }, body: JSON.stringify({ query, variables }) });
+  const j = await r.json();
+  if (j.errors) throw new Error(JSON.stringify(j.errors).slice(0, 400));
+  return j.data;
+}
+
+const token = await mint();
+const d = await gql(token, `query($k:String!){ issue(id:$k){ id url comments(first:100, orderBy: createdAt){ nodes{ id createdAt parent{ id } user{ id name } botActor{ type userDisplayName } } } } }`, { k: issueKey });
+const issue = d.issue;
+if (!issue) { console.error("issue not found: " + issueKey); process.exit(1); }
+
+let parentId = null;
+if (parentArg) {
+  const c = issue.comments.nodes.find(n => n.id === parentArg);
+  parentId = c?.parent?.id ?? parentArg; // always the root
+} else if (!top) {
+  const humans = issue.comments.nodes.filter(n => n.user && !n.botActor);
+  const last = humans[humans.length - 1];
+  if (last) parentId = last.parent?.id ?? last.id;
+}
+const m = await gql(token, `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success comment{ id url } } }`, {
+  in: { issueId: issue.id, body, createAsUser: asAgent, ...(parentId ? { parentId } : {}) },
+});
+console.log(JSON.stringify({ ok: m.commentCreate.success, commentId: m.commentCreate.comment.id, parentId, url: m.commentCreate.comment.url }));

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -28,9 +28,23 @@ summary as "needs you" **must be an ask ticket** — never a status paragraph.
   cannot create labels, measured CTC-626). `catalyst-ask` is what the "Waiting on me" view and the push
   trigger key on; `ask/decision` is the human-readable class.
 - **Title:** starts with `ASK:` (or names the click/decision itself); one line a phone can show.
-- **Body, in this order:** WHY (one paragraph — what it unblocks) · **OPTIONS** (A/B/C, one line each) ·
-  **DEFAULT IF SILENT** (what happens if the human never answers — never an irreversible action; those
-  wait for an explicit go) · relations: `blocks → <work ticket(s)>`.
+- **Body — the EXACT shape the decision trigger parses** (`apps/mirror/src/do/ask-decision.ts`; a
+  body in any other shape gives the trigger ZERO options and every reply is rejected — CTC-653):
+  ```markdown
+  **Why:** <one paragraph — what it unblocks>
+
+  **Options:**
+  - <option A label>
+  - <option B label>
+  - <option C label>
+
+  **Default if silent:** <what happens if the human never answers>
+  ```
+  The letters are implicit by bullet order (first bullet = A). Exactly one blank line ends the list.
+  Never an irreversible default; those wait for an explicit go. Add relations: `blocks → <work ticket(s)>`.
+- **How the human answers so the trigger recognizes it (today's parser):** a reply that IS the letter
+  (`A`, `A.`, `option A`) or the option's exact text, or `DECIDED: <free text>`. `(A)` inside a sentence
+  is NOT recognized until CTC-653 lands. The trigger is deterministic — no LLM reads the reply (CTC-554).
 - Priority 1 if it blocks a live customer path, else 2.
 
 ```bash
@@ -38,7 +52,7 @@ linearis issues create "ASK: <one line>" --team CTL --priority 2 \
   --assignee c2a8cc92-cab6-4536-9500-0f24abdf702b \
   --labels "catalyst-ask,ask/decision" \
   --blocks CTL-NNNN \
-  --description "WHY: … OPTIONS: (A) … (B) … DEFAULT IF SILENT: …"
+  --description "$(printf '**Why:** …\n\n**Options:**\n- …\n- …\n\n**Default if silent:** …')"
 ```
 
 ## 3. Answering (the human)

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: ask
+description:
+  Ask/decision tickets ("what needs me") — the Catalyst-wide SOP for raising a human decision or action
+  as a Linear ticket, replying in-thread as the app actor, and closing it when the answer lands. Use
+  whenever an agent needs a human (Ryan) to decide or click something, whenever a human comments on an
+  ask ticket, and for any ticket labelled `catalyst-ask` / `ask/decision`.
+---
+
+# Ask / decision tickets — SOP (Catalyst-wide)
+
+> Source of the rules: Ryan, 2026-08-15 → 2026-08-17 (rule v3 + the 08-17 additions). Applies to every
+> Catalyst-managed Linear project (catalyst, catalyst-cloud, personal-os, …) and to every worker /
+> orchestrator / coordinator agent, Claude or Codex. Ticket for the full plugin verb: **CTL-1922**.
+
+## 1. What an ask ticket is
+
+A ticket that exists ONLY to obtain one human decision or one human action. It is **not** the work: the
+work lives on its own tickets, which the ask `blocks →`. Anything that reaches the human's board or
+summary as "needs you" **must be an ask ticket** — never a status paragraph.
+
+## 2. Creating one (the raising agent)
+
+- **Team:** the team the decision belongs to. **Assignee = the human** (Ryan:
+  `c2a8cc92-cab6-4536-9500-0f24abdf702b`); no delegate.
+- **Labels — both, exact names:** `catalyst-ask` + `ask/decision`. Linear labels are **team-scoped**:
+  if a team lacks them, create them once (`issueLabelCreate` with the personal token — the app actor
+  cannot create labels, measured CTC-626). `catalyst-ask` is what the "Waiting on me" view and the push
+  trigger key on; `ask/decision` is the human-readable class.
+- **Title:** starts with `ASK:` (or names the click/decision itself); one line a phone can show.
+- **Body, in this order:** WHY (one paragraph — what it unblocks) · **OPTIONS** (A/B/C, one line each) ·
+  **DEFAULT IF SILENT** (what happens if the human never answers — never an irreversible action; those
+  wait for an explicit go) · relations: `blocks → <work ticket(s)>`.
+- Priority 1 if it blocks a live customer path, else 2.
+
+```bash
+linearis issues create "ASK: <one line>" --team CTL --priority 2 \
+  --assignee c2a8cc92-cab6-4536-9500-0f24abdf702b \
+  --labels "catalyst-ask,ask/decision" \
+  --blocks CTL-NNNN \
+  --description "WHY: … OPTIONS: (A) … (B) … DEFAULT IF SILENT: …"
+```
+
+## 3. Answering (the human)
+
+A comment on the ticket — top-level or a threaded reply — reaches the monitor. One word is enough
+("A", "yes", "flip now"). Deciding by moving state without a comment is only seen on the next sweep.
+
+## 4. Replying (any agent) — the form
+
+- **Threaded under the human's comment.** Linear threads are **one level deep** (measured CTL-1891):
+  `parentId` must be the ROOT of the thread, so a reply-to-a-reply targets the root; new topic → the
+  human posts a new top-level comment.
+- **Authored as the app actor ("Catalyst Cloud"), tagged with the agent** (`createAsUser=<AGENT>`).
+  Never under the human's identity: `linearis issues discuss` with the personal token posts AS the
+  human, and a human-identity comment is what the fleet reads as "the human decided" (it clears
+  `needs-human`, CTL-1567).
+- **Helper (this plugin):**
+  ```bash
+  direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <AGENT> --body "<markdown>"
+  #   --body -          read the body from stdin
+  #   --parent <id>     thread under a specific comment (its root is used)
+  #   --top             start a new top-level comment
+  ```
+  Needs `LINEAR_SYNC_CLIENT_ID` / `LINEAR_SYNC_CLIENT_SECRET` (the app's client credentials — the
+  catalyst-cloud direnv profile has them); it mints the app-actor token itself.
+- Content: what was done in response · the outcome **as applied** (not proposed) · where the artifact
+  lives (PR / file / route).
+
+## 5. Closing (the raising agent)
+
+When the answer satisfies the ask: **verify** that it does (e.g. a token really carries the permission),
+reply threaded **"accepted — has what it needs"** (or state exactly what is still missing), and **move
+the ticket to Done yourself** (`linearis issues update <ID> --status Done`). Downstream work continues
+on the work tickets. If the human's action surfaces a defect (CTC-649 → CTC-652), file the defect,
+`blocks →` the ask, keep the ask open, say so in the thread.
+
+## 6. Where things live
+
+- Ask view: **My decisions — what needs me** — a decided item leaves it.
+- Board (summary, not the record): the "Catalyst on Linear — status board" Linear doc.
+- Skills: `linearis` (reads via the replica, writes via the CLI), `create-handoff`, `create-worktree`.
+- Measured Linear facts this SOP relies on: threads one level deep (CTL-1891); the app actor cannot
+  create states / labels / own views (CTC-626); `createAsUser` requires the app-actor token.
+
+## Gotchas
+
+- `linearis issues update --labels` fails with *"LabelIds for incorrect team"* when the label exists on
+  another team only — create it on this team first.
+- A `--relates-to` / `--blocks` list keeps only the LAST flag in some linearis versions — read the
+  ticket back after a multi-relation write.
+- File the ticket BEFORE citing its number anywhere; read the identifier back.


### PR DESCRIPTION
## What
Lands Ryan's ask/decision-ticket SOP as a checked-in **catalyst-dev skill** (`plugins/dev/skills/ask/SKILL.md`) so every worker/orchestrator agent — Claude or Codex, any Catalyst-managed Linear project — works from one product source instead of a local file, plus `plugins/dev/scripts/linear-reply.mjs`, the interim reply helper.

## The SOP (Ryan, 2026-08-17)
- Every ask = a ticket: assignee = the human, labels `catalyst-ask` + `ask/decision` (team-scoped — create once per team), `ASK:` title, WHY / OPTIONS / DEFAULT IF SILENT, `blocks →` the work. Nothing reaches "what needs me" as a status paragraph.
- Replies: **threaded** under the human's comment (Linear threads are one level deep → parentId = thread root), **authored as the app actor** tagged with the agent via `createAsUser` — never `linearis issues discuss` under the personal token (posts as the human; a human-identity comment clears `needs-human`).
- Close: the raising agent verifies the answer, replies "accepted — has what it needs", and moves the ticket to Done itself.

## Helper
`node scripts/linear-reply.mjs <ISSUE> --as <AGENT> --body "<md>" [--parent <id>|--top]` — mints the app-actor token from `LINEAR_SYNC_CLIENT_ID/SECRET`, threads under the root of the human's latest comment, posts with `createAsUser`. Used live today on CTC-607/601/649/648, CTL-1922.

## Scope
Increment 1 of CTL-1922 (docs + helper). The `ask create` / `ask accept` verbs (label create-if-missing, state → Done) follow in the next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sx9NuZKTM98pdeZKzRFVd