### PR TITLE
fix(dev): CTL-1920 — a writer re-seed is a torn read, not 400 changed tickets

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-sweep.mjs
@@ -66,6 +66,12 @@
 import { buildCommentEvent, buildIssueEvent, classifyEdge } from "./linear-feed-event.mjs";
 import { diffSnapshots, diffToHistoryRow, snapshotOf } from "./linear-feed-diff.mjs";
 import { CURSOR_OK, DEFAULT_RESET_LOOKBACK_MS, readCursor, resolveStartPosition, writeCursor } from "./linear-feed-cursor.mjs";
+import { classifyLabelMapTear, createTearTracker } from "./linear-feed-torn-read.mjs";
+
+// CTL-1920: process-wide by default so the consecutive-tear count survives across
+// ticks (one `runDiffSweep` call IS one tick). Keyed by cursorPath, so tenants can
+// never borrow each other's suspicion. Injectable per call for tests.
+const defaultTearTracker = createTearTracker();
 
 /** Bound the work one sweep may do, so a large backlog cannot monopolise a tick. */
 export const DEFAULT_MAX_BATCHES = 20;
@@ -403,7 +409,11 @@ export function runDiffSweep({
   // fatal verdict added to `classifyEdge` would otherwise be silently demoted to a
   // healthy decline, which is CTL-1909 all over again.
   classifyFn = classifyEdge,
-  labelBudget = DEFAULT_LABEL_BUDGET,} = {}) {
+  labelBudget = DEFAULT_LABEL_BUDGET,
+  // CTL-1920. Injected so a test can drive the multi-tick overrule deterministically
+  // without a module-global leaking between cases.
+  tornTracker = defaultTearTracker,
+  tornThresholds = null,} = {}) {
   // Checked BEFORE the store or the cursor is touched: a scopeless producer must
   // not seed a baseline it will then decline every row against.
   const scopeFailure = teamScopeFailure(teams);
@@ -608,9 +618,59 @@ export function runDiffSweep({
       // (b) issues whose LAST label was removed — absent from the map entirely,
       // which is why absence must mean "empty set" and not "unknown". Without
       // this branch, removing every label from an issue would be undetectable.
-      for (const issueId of store.idsWithLabels ? store.idsWithLabels() : []) {
-        if (!current.has(issueId)) changed.push(issueId);
+      //
+      // ⛔ CTL-1920: this branch is also exactly what a TORN REPLICA READ looks
+      // like. A writer re-seed truncates `issue_labels` and repopulates it in
+      // batches with no reader isolation, so a tick landing mid-re-seed finds every
+      // baselined issue "absent" and reads it as "all labels removed". Collected
+      // separately from (a) precisely so its magnitude can be judged — (a) cannot
+      // produce this shape, because an issue must still be IN the map to appear
+      // there at all.
+      const vanished = [];
+      const baselinedWithLabels = store.idsWithLabels ? [...store.idsWithLabels()] : [];
+      for (const issueId of baselinedWithLabels) {
+        if (!current.has(issueId)) vanished.push(issueId);
       }
+
+      const tearKey = cursorPath ?? "default";
+      const tear = classifyLabelMapTear({
+        vanished: vanished.length,
+        baselinedWithLabels: baselinedWithLabels.length,
+        consecutiveTorn: tornTracker.get(tearKey),
+        ...(tornThresholds ?? {}),
+      });
+      tornTracker.set(tearKey, tear.torn ? tear.nextConsecutive : 0);
+
+      if (tear.torn && !tear.accept) {
+        // Skip the ENTIRE pass — no emit, and critically no `store.put`, so the
+        // baseline keeps its pre-tear truth. Re-snapshotting here (the first-seed
+        // precedent) would bake the torn state IN and guarantee a second wave when
+        // the replica is restored — that is the other half of the measured 200+200.
+        //
+        // Routed through `fail` so readiness un-arms (a replica mid-rebuild is
+        // genuinely not dispatchable, and smee stays authoritative meanwhile) and so
+        // the reason is NAMED in the census rather than presenting as a
+        // suspiciously quiet clean sweep.
+        fail(labelCounts, tear.reason);
+        labelCounts.tornVanished = vanished.length;
+        return {
+          mode: start.mode,
+          alarm: start.alarm,
+          batches,
+          stoppedEarly: stopped,
+          position,
+          edges: counts,
+          comments: commentCounts,
+          labels: labelCounts,
+        };
+      }
+      // Held for `sustainedTicks` and then overruled as a genuine mass removal, which
+      // is emitted in full. Recorded rather than `fail`ed: a real change must not
+      // un-arm enforce.
+      if (tear.torn && tear.accept) labelCounts.tornOverruled = vanished.length;
+      // The fail-open degradation must not be readable as a clean tick.
+      if (tear.reason === "torn-check-uncomputable") fail(labelCounts, tear.reason);
+      changed.push(...vanished);
 
       labelCounts.examined = changed.length;
 

--- a/plugins/dev/scripts/execution-core/linear-feed-torn-read.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-torn-read.mjs
@@ -1,0 +1,182 @@
+/**
+ * CTL-1920 — telling a torn replica read apart from a real change set.
+ *
+ * ## The incident this exists for
+ *
+ * A `launchctl kickstart` of the cloud-sync writer on mini-2 (2026-08-17) produced
+ * **400 `linear.issue.updated` edges in one minute**, against an organic rate of 1–3.
+ * All 400 carried `feedAuthority: true`, so under `enforce` they were routed through
+ * the real dispatch handlers — measured, not inferred.
+ *
+ * The mechanism is a torn cross-table read, and every step of it is working as
+ * written:
+ *
+ *   1. A column-adding migration makes the SDK force ONE `/snapshot` re-seed.
+ *      `seedFromSnapshot` TRUNCATES every entity table in one transaction, then
+ *      repopulates in 1000-row batches — **one transaction per batch**. The SDK's own
+ *      comment says this preserves the writer's crash-safety "without holding one
+ *      giant transaction". That is writer recovery. It is **not reader isolation**.
+ *   2. The label sweep reads `issue_labels JOIN labels` and `issues` as two separate
+ *      queries at two separate instants, and it has no cursor to keyset on. A tick
+ *      landing after `issues` is restored but before the label rows are sees an
+ *      issue as **absent from the label map**.
+ *   3. Absence there legitimately means "every label removed" — that branch exists so
+ *      that clearing an issue's last label is detectable at all. So the sweep emits.
+ *   4. The baseline lives in a SEPARATE database the re-seed never touches. That
+ *      asymmetry — baseline survives, replica is wiped — is what makes the burst
+ *      constructible in the first place.
+ *
+ * ## Why this is a magnitude question and not a plumbing question
+ *
+ * The feed is **structurally blind** to a re-seed: `feed-progress.json` publishes
+ * eight fields and not one of them is a seed/generation marker (its `pid` has zero
+ * readers). So there is no flag to check. Measured across the whole feed path, there
+ * is also **no magnitude guard of any kind** — every numeric bound is a pagination
+ * budget or a staleness timer, and `counts.emitted` is incremented at three sites and
+ * read for comparison at none. Once seeded, a 4,000-row diff emits 4,000 edges with
+ * no objection.
+ *
+ * Guarding on magnitude rather than on a re-seed flag is the deliberate choice: it
+ * needs no cooperation from the writer, survives a version skew where the writer
+ * predates the feed, and catches **any** cause of mass divergence — a future truncate
+ * path, a restore, a corrupted replica — not just the one incident we happened to
+ * measure.
+ *
+ * ## ⚠️ The trap: a guard that cannot be overruled is a wedge
+ *
+ * A genuine mass label removal — deleting a label from the workspace — looks exactly
+ * like a torn read on the tick it happens. A guard that simply refused would refuse
+ * again next tick, and forever: the divergence never shrinks on its own, so the feed
+ * would go permanently silent on a real change. That is a worse failure than the
+ * burst.
+ *
+ * The discriminator is **persistence, not shape**. A torn read is transient by
+ * construction — the writer finishes its batches in seconds and the map comes back.
+ * A genuine removal persists. So a suspected tear is skipped for at most
+ * `sustainedTicks` consecutive ticks and then ACCEPTED as real. Same
+ * `sustainedTicks` discipline as CTL-1502's daemon watchdog and CTL-1659's dep-skew
+ * classifier, for the same reason: never let a detector take an irreversible action
+ * on one sample, and never let it hold an action forever.
+ *
+ * ## Why SKIP rather than re-snapshot
+ *
+ * The first-seed precedent (`seedBaseline`) re-snapshots silently, which is right
+ * when there is nothing to miss. Here there is: re-snapshotting from a torn replica
+ * would bake the torn state INTO the baseline — the exact corruption that doubles the
+ * burst today, since the emit path writes the empty label set back and the restore
+ * then diffs those same issues a second time. Skipping leaves the baseline untouched,
+ * so once the replica is whole the very next sweep diffs against real prior truth and
+ * emits precisely the genuine changes. **Skipping loses nothing; re-snapshotting
+ * would.**
+ */
+
+/** More than half the baselined-labelled corpus vanishing at once is not user activity. */
+export const DEFAULT_TORN_VANISH_RATIO = 0.5;
+
+/**
+ * An absolute floor, so a tenant with three labelled issues cannot trip the ratio by
+ * closing one. Below this the burst is not worth a false silence.
+ */
+export const DEFAULT_TORN_VANISH_FLOOR = 25;
+
+/**
+ * ~90 s at the default 30 s tick — comfortably longer than the observed re-seed, and
+ * a bounded delay (not a loss) for a genuine mass edit, which is emitted in full once
+ * the count is reached.
+ */
+export const DEFAULT_TORN_SUSTAINED_TICKS = 3;
+
+const isNonNegInt = (v) => Number.isInteger(v) && v >= 0;
+
+/**
+ * Classify one tick's label-map divergence.
+ *
+ * Pure: no clock, no I/O, no module state. The caller owns the consecutive counter so
+ * that the decision is reproducible from its inputs alone.
+ *
+ * @param {object} args
+ * @param {number} args.vanished              issues baselined WITH labels that are absent from the current map
+ * @param {number} args.baselinedWithLabels   size of the baselined-labelled corpus
+ * @param {number} args.consecutiveTorn       consecutive prior ticks already classified torn (0 on the first)
+ * @param {number} [args.ratio]
+ * @param {number} [args.floor]
+ * @param {number} [args.sustainedTicks]
+ * @returns {{torn: boolean, accept: boolean, reason: string|null, nextConsecutive: number}}
+ *   `torn`   — this tick's divergence has the shape of a torn read.
+ *   `accept` — proceed to emit anyway (either not torn, or torn for long enough to be real).
+ *   ⚠️ `torn && accept` is a REAL state, not a contradiction: it is the overrule.
+ */
+export function classifyLabelMapTear({
+  vanished,
+  baselinedWithLabels,
+  consecutiveTorn = 0,
+  ratio = DEFAULT_TORN_VANISH_RATIO,
+  floor = DEFAULT_TORN_VANISH_FLOOR,
+  sustainedTicks = DEFAULT_TORN_SUSTAINED_TICKS,
+} = {}) {
+  // ⚠️ Fail OPEN (accept, emit) on malformed input rather than closed. A guard that
+  // silences the feed on input it cannot parse would convert a counting bug into a
+  // dispatch outage — strictly worse than the burst it is here to prevent. The
+  // degradation is NAMED so it cannot be read as a clean tick.
+  if (!isNonNegInt(vanished) || !isNonNegInt(baselinedWithLabels)) {
+    return { torn: false, accept: true, reason: "torn-check-uncomputable", nextConsecutive: 0 };
+  }
+  if (!isNonNegInt(consecutiveTorn)) consecutiveTorn = 0;
+
+  const effFloor = isNonNegInt(floor) ? floor : DEFAULT_TORN_VANISH_FLOOR;
+  const effRatio = Number.isFinite(ratio) && ratio > 0 ? ratio : DEFAULT_TORN_VANISH_RATIO;
+  const effSustained =
+    Number.isInteger(sustainedTicks) && sustainedTicks > 0 ? sustainedTicks : DEFAULT_TORN_SUSTAINED_TICKS;
+
+  // Nothing vanished ⇒ nothing to suspect, whatever the corpus size.
+  if (vanished === 0) return { torn: false, accept: true, reason: null, nextConsecutive: 0 };
+
+  const overFloor = vanished >= effFloor;
+  const overRatio = baselinedWithLabels > 0 && vanished >= effRatio * baselinedWithLabels;
+  const torn = overFloor && overRatio;
+
+  if (!torn) return { torn: false, accept: true, reason: null, nextConsecutive: 0 };
+
+  const nextConsecutive = consecutiveTorn + 1;
+  // Held for `effSustained` ticks, then overruled. `>` (not `>=`) so that
+  // sustainedTicks=3 skips exactly 3 ticks and emits on the 4th.
+  if (nextConsecutive > effSustained) {
+    return {
+      torn: true,
+      accept: true,
+      reason: `torn-overruled-sustained:${nextConsecutive}`,
+      nextConsecutive,
+    };
+  }
+  return {
+    torn: true,
+    accept: false,
+    reason: `replica-torn-read:vanished=${vanished}/${baselinedWithLabels}:tick=${nextConsecutive}`,
+    nextConsecutive,
+  };
+}
+
+/**
+ * Per-tenant consecutive-tear counter.
+ *
+ * In-memory and per-process on purpose. A daemon restart resets it to 0, which can
+ * only ever ADD up to `sustainedTicks` of extra caution — it can never cause an
+ * emission that would otherwise have been held. Persisting it would buy nothing and
+ * would introduce a durable file whose own corruption the guard would then have to
+ * survive (CTL-1659's ledger lesson).
+ */
+export function createTearTracker() {
+  const byKey = new Map();
+  return {
+    get(key) {
+      return byKey.get(key) ?? 0;
+    },
+    set(key, value) {
+      if (isNonNegInt(value) && value > 0) byKey.set(key, value);
+      else byKey.delete(key);
+    },
+    size() {
+      return byKey.size;
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/linear-feed-torn-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-torn-read.test.mjs
@@ -1,0 +1,297 @@
+// linear-feed-torn-read.test.mjs — CTL-1920, telling a torn replica read from a
+// real change set.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-feed-torn-read.test.mjs
+//
+// Real SQLite baseline + real cursor file, same as the CTL-1847 sweep suite: the
+// central claim ("the baseline keeps its pre-tear truth") is a claim about what
+// survives on disk, so an in-memory double would not test it.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createLastSeenStore } from "./linear-feed-lastseen.mjs";
+import { runDiffSweep } from "./linear-feed-sweep.mjs";
+import { defaultCursorPath } from "./linear-feed-cursor.mjs";
+import {
+  DEFAULT_TORN_SUSTAINED_TICKS,
+  classifyLabelMapTear,
+  createTearTracker,
+} from "./linear-feed-torn-read.mjs";
+// ⚠️ IMPORTED, never restated (CTL-1909 discipline): a hand-built copy of the
+// readiness predicate could agree with this fixture while disagreeing with the gate
+// the daemon actually runs.
+import { countsClean, sweepUnreadyReason } from "./cloud-feed-timer.mjs";
+
+let dir;
+let cursorPath;
+let storeSeq = 0;
+const makeStore = () => createLastSeenStore({ path: join(dir, `s-${storeSeq++}.db`) });
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lftr-"));
+  cursorPath = defaultCursorPath(dir);
+});
+afterEach(() => {
+  // ⚠️ NEVER let cleanup fail the suite. A transient macOS `rm: Directory not empty`
+  // under `set -e` once aborted a whole mutation run, and an aborted suite exits
+  // non-zero — byte-identical to a mutant being caught. `force` + swallow.
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {}
+});
+
+const TEAMS = new Set(["CTL"]);
+const issue = (id, over = {}) => ({
+  issue: {
+    id, identifier: `CTL-${id}`, team_key: "CTL", state: "Backlog", assignee_id: null,
+    priority: null, estimate: null, project_id: null, cycle_id: null, parent_id: null,
+    team_id: "t1", title: "t", due_date: null, delegate_id: null, description: "d",
+    updated_at: 1000, ...over,
+  },
+  project: null,
+  labels: [],
+});
+
+/** Source whose label map can be mutated INDEPENDENTLY of the issue rows — which is
+ *  precisely the torn state a re-seed produces (issues back, labels not yet). */
+const raceSource = (rows, labelMap) => {
+  const withLabels = (r) => ({ ...r, labels: labelMap.get(r.issue.id) ?? [] });
+  return {
+    issuesSince(pos, lim = 100) {
+      const since = pos?.lastCreatedAt ?? 0;
+      return rows
+        .filter((r) => r.issue.updated_at > since || (r.issue.updated_at === since && r.issue.id > (pos?.lastId ?? "")))
+        .sort((a, b) => a.issue.updated_at - b.issue.updated_at || a.issue.id.localeCompare(b.issue.id))
+        .slice(0, lim)
+        .map(withLabels);
+    },
+    positionAfter(items) {
+      if (!items?.length) return null;
+      const last = items[items.length - 1];
+      return { lastCreatedAt: last.issue.updated_at, lastId: last.issue.id };
+    },
+    labelSets() {
+      const m = new Map();
+      for (const [k, v] of labelMap) if (v.length) m.set(k, [...v].sort());
+      return m;
+    },
+    issuesByIds(ids) {
+      return rows.filter((r) => ids.includes(r.issue.id)).map(withLabels);
+    },
+  };
+};
+
+/** N labelled issues — comfortably over DEFAULT_TORN_VANISH_FLOOR (25). */
+const corpus = (n) => {
+  const rows = [];
+  const labels = new Map();
+  for (let i = 0; i < n; i++) {
+    const id = `i${String(i).padStart(3, "0")}`;
+    rows.push(issue(id));
+    labels.set(id, ["refactor"]);
+  }
+  return { rows, labels };
+};
+
+describe("classifyLabelMapTear — the pure decision", () => {
+  test("nothing vanished ⇒ never torn, whatever the corpus", () => {
+    const r = classifyLabelMapTear({ vanished: 0, baselinedWithLabels: 5000 });
+    expect(r).toEqual({ torn: false, accept: true, reason: null, nextConsecutive: 0 });
+  });
+
+  test("⛔ under the ABSOLUTE FLOOR is never torn — a 3-issue tenant clearing 2 is not a re-seed", () => {
+    // 2/3 is 67% — way over the ratio — but 2 < floor(25).
+    const r = classifyLabelMapTear({ vanished: 2, baselinedWithLabels: 3 });
+    expect(r.torn).toBe(false);
+    expect(r.accept).toBe(true);
+  });
+
+  test("⛔ over the floor but under the RATIO is not torn — a big bulk edit is real work", () => {
+    // 100 vanished of 1000 baselined = 10%: over floor, well under 50%.
+    const r = classifyLabelMapTear({ vanished: 100, baselinedWithLabels: 1000 });
+    expect(r.torn).toBe(false);
+    expect(r.accept).toBe(true);
+  });
+
+  test("⭐ over BOTH ⇒ torn, and held (not accepted) on the first tick", () => {
+    const r = classifyLabelMapTear({ vanished: 2843, baselinedWithLabels: 2843, consecutiveTorn: 0 });
+    expect(r.torn).toBe(true);
+    expect(r.accept).toBe(false);
+    expect(r.nextConsecutive).toBe(1);
+    expect(r.reason).toContain("replica-torn-read");
+  });
+
+  test("⭐⭐ a SUSTAINED tear is OVERRULED — the guard can never wedge the feed forever", () => {
+    // The failure mode that matters: deleting a workspace label really does remove
+    // labels from the whole corpus, and it does NOT resolve on its own. A guard with
+    // no overrule would refuse it every tick, permanently.
+    let consecutive = 0;
+    const seen = [];
+    for (let tick = 1; tick <= DEFAULT_TORN_SUSTAINED_TICKS + 1; tick++) {
+      const r = classifyLabelMapTear({ vanished: 900, baselinedWithLabels: 1000, consecutiveTorn: consecutive });
+      consecutive = r.nextConsecutive;
+      seen.push(r.accept);
+    }
+    // Held for exactly sustainedTicks, then accepted.
+    expect(seen.slice(0, DEFAULT_TORN_SUSTAINED_TICKS)).toEqual(
+      Array(DEFAULT_TORN_SUSTAINED_TICKS).fill(false),
+    );
+    expect(seen[DEFAULT_TORN_SUSTAINED_TICKS]).toBe(true);
+  });
+
+  test("a tear that RESOLVES resets the counter — a later tear gets a full fresh hold", () => {
+    const t1 = classifyLabelMapTear({ vanished: 900, baselinedWithLabels: 1000, consecutiveTorn: 0 });
+    expect(t1.nextConsecutive).toBe(1);
+    const clear = classifyLabelMapTear({ vanished: 0, baselinedWithLabels: 1000, consecutiveTorn: t1.nextConsecutive });
+    expect(clear.nextConsecutive).toBe(0);
+    const t2 = classifyLabelMapTear({ vanished: 900, baselinedWithLabels: 1000, consecutiveTorn: clear.nextConsecutive });
+    expect(t2.accept).toBe(false); // full hold again, not one tick from overrule
+  });
+
+  test("⛔ malformed input FAILS OPEN, and says so — silence would be worse than the burst", () => {
+    for (const bad of [null, undefined, -1, 1.5, "12", NaN]) {
+      const r = classifyLabelMapTear({ vanished: bad, baselinedWithLabels: 100 });
+      expect(r.accept).toBe(true); // emits rather than silencing dispatch
+      expect(r.reason).toBe("torn-check-uncomputable"); // but never reads as clean
+    }
+  });
+});
+
+describe("createTearTracker", () => {
+  test("tenants cannot borrow each other's suspicion", () => {
+    const t = createTearTracker();
+    t.set("tenant-a", 2);
+    expect(t.get("tenant-a")).toBe(2);
+    expect(t.get("tenant-b")).toBe(0);
+  });
+  test("resetting to 0 releases the key rather than retaining a zero", () => {
+    const t = createTearTracker();
+    t.set("a", 3);
+    t.set("a", 0);
+    expect(t.size()).toBe(0);
+  });
+});
+
+describe("runDiffSweep — the incident, end to end", () => {
+  test("⭐⭐ THE INCIDENT: a mid-re-seed tick emits NOTHING and leaves the baseline intact", () => {
+    const { rows, labels } = corpus(60);
+    const emitted = [];
+    const emit = (e) => emitted.push(e);
+    const store = makeStore();
+    const src = raceSource(rows, labels);
+    const tornTracker = createTearTracker();
+    const opts = { source: src, store, cursorPath, teams: TEAMS, emit, tornTracker };
+
+    runDiffSweep(opts); // seed baseline (silent, by the first-seed precedent)
+    runDiffSweep(opts); // steady state
+    expect(emitted).toEqual([]);
+
+    // THE RE-SEED: `issue_labels` is truncated; `issues` is already restored.
+    labels.clear();
+    const torn = runDiffSweep(opts);
+
+    expect(emitted).toEqual([]); // ⭐ the 200 that used to fire
+    expect(torn.labels.tornVanished).toBe(60);
+    // The baseline still holds pre-tear truth — this is what prevents the SECOND wave.
+    expect(store.get("i000").labels).toEqual(["refactor"]);
+  });
+
+  test("⭐⭐ NO SECOND WAVE: when the replica comes back, only the GENUINE change emits", () => {
+    // The measured burst was 200 + 200: the first wave emitted, and writing the empty
+    // label set into the baseline manufactured the second. This is the regression test
+    // for that second half.
+    const { rows, labels } = corpus(60);
+    const restore = new Map([...labels]);
+    const emitted = [];
+    const emit = (e) => emitted.push(e?.body?.payload?.updatedFromKeys ?? []);
+    const store = makeStore();
+    const src = raceSource(rows, labels);
+    const tornTracker = createTearTracker();
+    const opts = { source: src, store, cursorPath, teams: TEAMS, emit, tornTracker };
+
+    runDiffSweep(opts);
+    runDiffSweep(opts);
+    labels.clear();
+    runDiffSweep(opts); // torn — held
+    expect(emitted).toEqual([]);
+
+    // Replica restored, and ONE issue genuinely changed while it was down.
+    for (const [k, v] of restore) labels.set(k, v);
+    labels.set("i007", ["refactor", "urgent"]);
+    runDiffSweep(opts);
+
+    expect(emitted).toHaveLength(1); // ⭐ 1, not 60
+    expect(emitted[0]).toContain("labels");
+  });
+
+  test("⭐ a SUSTAINED mass removal is eventually emitted — bounded delay, not lost work", () => {
+    const { rows, labels } = corpus(60);
+    const emitted = [];
+    const store = makeStore();
+    const src = raceSource(rows, labels);
+    const tornTracker = createTearTracker();
+    const opts = {
+      source: src, store, cursorPath, teams: TEAMS,
+      emit: (e) => emitted.push(e), tornTracker,
+      labelBudget: 1000,
+    };
+
+    runDiffSweep(opts);
+    runDiffSweep(opts);
+    labels.clear(); // a REAL workspace-label deletion: never resolves on its own
+    for (let i = 0; i < DEFAULT_TORN_SUSTAINED_TICKS; i++) {
+      runDiffSweep(opts);
+      expect(emitted).toEqual([]); // held...
+    }
+    const overruled = runDiffSweep(opts); // ...then overruled
+    expect(emitted.length).toBe(60);
+    expect(overruled.labels.tornOverruled).toBe(60);
+  });
+
+  test("⛔ NEGATIVE CONTROL: the guard does NOT break the branch it guards", () => {
+    // Removing the last label from ONE issue is exactly what branch (b) exists for.
+    // A guard that suppressed it would have silently deleted the CTL-1904 fix.
+    const { rows, labels } = corpus(60);
+    const emitted = [];
+    const store = makeStore();
+    const src = raceSource(rows, labels);
+    const opts = {
+      source: src, store, cursorPath, teams: TEAMS,
+      emit: (e) => emitted.push(e?.body?.payload?.updatedFromKeys ?? []),
+      tornTracker: createTearTracker(),
+    };
+
+    runDiffSweep(opts);
+    runDiffSweep(opts);
+    expect(emitted).toEqual([]);
+
+    labels.set("i003", []); // one issue loses its last label
+    runDiffSweep(opts);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain("labels");
+  });
+
+  test("⛔ readiness UN-ARMS on a torn tick, judged by the REAL predicate", () => {
+    const { rows, labels } = corpus(60);
+    const store = makeStore();
+    const src = raceSource(rows, labels);
+    const opts = { source: src, store, cursorPath, teams: TEAMS, emit: () => {}, tornTracker: createTearTracker() };
+
+    runDiffSweep(opts);
+    const healthy = runDiffSweep(opts);
+    expect(countsClean(healthy.labels)).toBe(true); // positive control
+
+    labels.clear();
+    const torn = runDiffSweep(opts);
+
+    expect(countsClean(torn.labels)).toBe(false);
+    const reason = sweepUnreadyReason(
+      { sweep: torn },
+      { healthy: true, reason: "ok" },
+    );
+    expect(reason).toContain("labels:");
+    expect(reason).toContain("replica-torn-read");
+  });
+});


### PR DESCRIPTION
`launchctl kickstart` of the cloud-sync writer on mini-2 produced **400
`linear.issue.updated` edges in one minute** against an organic 1-3. Re-measured
here with a STRUCTURED match (a branch named `…cloud-feed-producer` pollutes a
naive substring grep) and confirmed worse than the ticket claimed: **all 400
carried `feedAuthority: true`**, so under `enforce` they were routed through the
real dispatch handlers.

## The chain, every step working as written

1. A column-adding migration makes the SDK force one `/snapshot` re-seed.
   `seedFromSnapshot` TRUNCATES every entity table in one transaction, then
   repopulates in 1000-row batches — **one transaction per batch**. The SDK's own
   comment says this preserves the writer's crash-safety "without holding one
   giant transaction". That is writer recovery; it is **not reader isolation**.
2. The label sweep reads `issue_labels JOIN labels` and `issues` as two separate
   queries at two separate instants, with no cursor to keyset on. A tick landing
   after `issues` is restored but before the label rows are finds every baselined
   issue absent from the label map.
3. Absence there legitimately means "last label removed" — that branch is the
   CTL-1904 fix and must keep working.
4. The baseline lives in a SEPARATE database the re-seed never touches. Baseline
   survives, replica is wiped: that asymmetry is what makes the burst
   constructible.
5. The emit path then writes the empty label set back into the baseline, so the
   restore diffs the same rows a second time. **200 (budget) + 200 = the measured
   400** — arrived at from the code, not fitted to the number.

## Why a magnitude guard rather than a re-seed flag

The feed is **structurally blind** to a re-seed: `feed-progress.json` publishes
eight fields and none is a seed/generation marker (its `pid` has zero readers).
And there is **no magnitude guard anywhere in the feed path** — every numeric
bound is a pagination budget or a staleness timer, and `counts.emitted` is
incremented at three sites and read for comparison at none. Guarding on magnitude
needs no cooperation from the writer, survives a writer/feed version skew, and
catches any cause of mass divergence — a future truncate path, a restore, a
corrupted replica — not only the incident we happened to measure.

## The trap: a guard that cannot be overruled is a wedge

A genuine mass removal (deleting a workspace label) looks identical on the tick it
happens, and **does not resolve on its own** — a guard that simply refused would
refuse forever and silence the feed on a real change. The discriminator is
**persistence, not shape**: a tear is transient by construction. So a suspected
tear is held at most `sustainedTicks` (3, ~90 s) and then ACCEPTED and emitted in
full. Same discipline as CTL-1502's watchdog and CTL-1659's dep-skew classifier.

## SKIP, not re-snapshot

The first-seed precedent re-snapshots silently, which is right when there is
nothing to miss. Here there is: re-snapshotting from a torn replica bakes the torn
state INTO the baseline — the exact corruption that produces the second wave.
Skipping leaves the baseline untouched, so the next whole-replica sweep diffs
against real prior truth and emits precisely the genuine changes. **Skipping loses
nothing; re-snapshotting would.**

A held tick routes through `fail()`, so readiness un-arms — a replica mid-rebuild
is genuinely not dispatchable — and the reason is NAMED rather than presenting as
a suspiciously quiet clean sweep. Malformed input fails **open** (emit, but named
`torn-check-uncomputable`): silencing dispatch on an unparseable count would be
strictly worse than the burst.

## Verification

14 new tests. The ones that carry weight: the incident emits nothing and leaves
the baseline intact; the restore emits **1, not 60** (the second-wave regression
test); a sustained removal is emitted in full after the hold; and a **negative
control** proving the guard does not break single-issue last-label removal, i.e.
does not silently delete CTL-1904. Readiness is judged by the IMPORTED
`sweepUnreadyReason`/`countsClean`, never a restated copy.

**Mutation-tested the WIRING, not the value**, with three verdicts so a vacuous
mutation cannot masquerade as a pass — each mutation proven APPLIED by byte-diff,
and a suite that fails to COMPLETE scored INCONCLUSIVE rather than killed:

| mutation | verdict |
|---|---|
| delete the hold (`if (false)`) | KILLED (4) |
| always suppress (`if (true)`) | KILLED (4) |
| re-snapshot the baseline on a tear | KILLED (3) |

158 existing tests across the four neighbouring suites still pass.

⚠️ Known consequence: while smee is alive, a held tick makes the parity harness
score a smee-only asymmetry for those ticks instead of a feed-only burst. That is
the correct direction, but it should not be read as a parity regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>