### PR TITLE
chore(dev): pin the fleet to @catalyst-cloud/sdk 0.8.11 (the CTC-628 host echo)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.10",
+        "@catalyst-cloud/sdk": "0.8.11",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -214,7 +214,7 @@
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.15", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-cEkcsisF7kqfVmm0dhTsTvj7BuPfFcKAgO0oZ83GZqQG6k3J/699d4A7X8cAI1LtfNAneKHylxuAjJgj93Zd+A=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.10", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.9", "@catalyst-cloud/schema": "0.1.15" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-/84cspI//N9b11omjFtWvUX8u3L0IRCZ+CZVmHaX7qtAc3FN8OXV0mroutY9D8EDEQIJbOeUc+7uLHWBh5OM+w=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.11", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.9", "@catalyst-cloud/schema": "0.1.15" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-wuurRFd57j9ghxJjvxD/8kkiRSfQzD9n4AWVgJQKW1gtliGKTEykUO6l87Pm9dUkNpgTyNMc+Uqh6NxRa0b4HA=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.10",
+    "@catalyst-cloud/sdk": "0.8.11",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
Second leg of today's pin, per COORD-67/71. `@catalyst-cloud/sdk` 0.8.10 → **0.8.11**
— the CTC-628 host-sync echo (`&workflow_rev=<max rev from the replica>` on
`/connect`), with CTC-643's stale `EntityName` fix riding the same patch.

## ⭐ This bump is BURST-FREE by construction, unlike 0.8.10

`schema` and `replicate` are **unchanged** — 0.8.11 declares schema `0.1.15` and
replicate `0.1.9`, exactly as 0.8.10 did, and the `bun.lock` diff touches only the
`sdk` lines. That matters operationally rather than cosmetically:

- A forced `/snapshot` re-seed happens only when `migrationsChangeRowShape(appliedTags)`
  is true. No schema move ⇒ no row-shape migration ⇒ **no cold-seed** ⇒ none of the
  CTL-1920 torn-read burst that the 0.8.10 rollout had to be contained against.
- So this one needs no `shadow`-flip dance around the writer restart. The writer still
  wants a restart to LOAD the echo (it is the process that calls `/connect`), but that
  restart is the ordinary kind — the same one measured at 0 burst for execution-core.

## The LOADED criterion is the echo itself, not a version string

Read off the installed copy that `execution-core` actually resolves, with 0.8.10 as a
**negative control** — the criterion has to be able to come back absent:

```
0.8.11   workflow_rev              12   incl. `workflow_rev: String(rev) }`   <- the connect param
                                        and `MAX(workflow_rev) AS rev FROM team_workflow_mapping`
0.8.11   team_workflow_mapping      8
0.8.11   (a fabricated string)      0
0.8.10   workflow_rev               0   <- the echo is genuinely new here
```

## Verified before pinning, not after

- 0.8.11 exists on the registry; the chain is coherent (it *declares* the pinned
  schema/replicate rather than merely tolerating them).
- **One-copy gate**: exactly one resolved version of each `@catalyst-cloud` package.
- **Resolution probed off DISK from the IMPORTING package**, not the workspace root and
  not via `require.resolve` (CTL-1831 — resolution is cached process-wide):

```
workspace root                 sdk => NOT FOUND   replicate => NOT FOUND
execution-core (the importer)  sdk => 0.8.11
through the SDK's own dir      schema => 0.1.15   replicate => 0.1.9
```

⚠️ Merging does not relink a host. Each host is verified **by content** after the
refresh, and LOADED means a line written by a pid that started after it — never by the
pin having merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>