### PR TITLE
fix(dev): CTL-1928 — the join bundle stops re-creating the retired Linear smee path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,8 @@ Read these on demand:
 - **Decision records (ADRs)** — `docs/adrs.md`
 - **Specs & mockups** — `docs/specs/` (durable `draft → accepted` home for specs, requirements,
   and mockups; distinct from ADRs and `thoughts/` — see `docs/specs/README.md`)
+- **Linear smee retirement + rollback** — `docs/runbooks/cloud-feed-cutover.md` (CTL-1928: Linear
+  ingestion is the cloud feed; the GitHub smee half is deliberately still running)
 - **Release process** — `docs/releases.md`
 - **Observability signal catalog** — `catalyst-otel/docs/data-dictionary.md` (sister repo: every
   metric, log/event, trace, and alert; see the Observability section above)

--- a/docs/runbooks/cloud-feed-cutover.md
+++ b/docs/runbooks/cloud-feed-cutover.md
@@ -1,0 +1,188 @@
+# Runbook — the Linear smee retirement, and how to undo it
+
+**Status:** the Linear half of smee ingestion was retired on the live fleet
+**2026-08-17 ~16:50–17:02 CT** (CTL-1928). The GitHub half is deliberately still
+running. Read the scope section before touching anything — the two halves rode
+the *same* smee channel, so "turn smee back on" is not one switch.
+
+---
+
+## 1. What is true now
+
+Linear ingestion is the **cloud feed** (`execution-core/cloud-feed-timer.mjs`,
+gate `CATALYST_CLOUD_FEED=enforce`). The three dispatch-class events —
+`linear.issue.state_changed`, `linear.issue.updated`, `linear.comment.created` —
+are produced from the local replica and appended to `~/catalyst/events/YYYY-MM.jsonl`,
+where `monitor.mjs`'s existing tail dispatches them through the same three
+handlers as before. Nothing about dispatch *semantics* changed at the cutover;
+only the producer did.
+
+| Surface | State after CTL-1928 |
+| --- | --- |
+| Linear smee tunnel (orch-monitor, `→ /api/webhook/linear`) | **not started** on either mini |
+| 7 Linear webhook subscriptions (SLI/OTL/EVR/CTL/CTC/CRM/ADV) | **`enabled: false`**, not deleted |
+| `catalyst.monitor.linear.smeeChannel` + the 7 per-team copies | `""` on both minis |
+| Linear HMAC secret files, `webhookId` records, `/api/webhook/linear` route | **untouched** — rollback needs them |
+| GitHub smee tunnel + repo webhook `616654741` | **RUNNING — deliberately kept** |
+
+### ⛔ Why the GitHub half stayed
+
+The cloud feed replaces **Linear only**. `DISPATCH_CLASS_NAMES` in
+`cloud-feed-gate.mjs` is three `linear.*` names; there is no GitHub producer, and
+`catalyst-cloud` has no webhook ingestion route at all (verified by content, with
+a positive control — the string `webhook` *does* occur in that repo, in
+`packages/crypto` and `packages/read-model`, so the search works).
+
+Measured on mini-2, 6 h window: **1,616 `github.*` events** — `workflow_run` 924,
+`check_suite` 375, `push` 120, `pr` 111, `issue_comment` 70, `deployment_status` 16.
+Those drive `phase-monitor-merge`'s `wait-for`, the broker's PR-lifecycle routing,
+and CI waits. Deleting the GitHub webhook would blind the fleet to all of it.
+Retiring the GitHub half is **not** part of this cutover and needs a cloud
+GitHub-ingestion path to exist first.
+
+### ⚠️ One shared channel, not two
+
+Both tunnels subscribed to the **same** smee channel
+(`https://smee.io/WDgeZys5ST0uqtL`) and forwarded every payload to *both* local
+routes. That is why the pre-cutover logs showed mirror-image histograms — e.g.
+69× `200` on `/api/webhook` and 69× `401` on `/api/webhook/linear`, then 3× the
+reverse. **Those 401s were cross-delivery, not auth failure.** Anyone diagnosing
+a "Linear webhook 401 outage" from a one-sided count will reach the wrong
+conclusion; always read both routes' histograms together.
+
+---
+
+## 2. Rollback
+
+Two independent levers. **Lever A alone restores Linear dispatch via smee**;
+Lever B is the belt-and-braces flip if you also want the cloud feed to stop
+suppressing the webhook copies.
+
+### Lever A — put the smee path back (≈2 min)
+
+1. **Re-enable the subscriptions** (they were disabled, not deleted, precisely so
+   this is one call each — Linear **never re-issues a webhook secret**, so a
+   deleted webhook must be re-registered *and* have its local HMAC secret file
+   rewritten):
+
+   ```bash
+   # ids as of the cutover; re-read with `{ webhooks { nodes { id label enabled } } }`
+   for id in ea6a4382-a5ba-4e9c-b300-569a342dea1c \
+             1b8cef14-908e-42bd-bc6a-05d00ff79688 \
+             864790b7-7e8d-4d11-969c-3a463e17a72d \
+             0f9c3122-bdb7-411c-b403-77e895b8dfaa \
+             747cee41-a078-4d7f-9380-95695bddb2f1 \
+             da108fec-69a2-46f6-ae78-04adfee2e03e \
+             2f8f316a-a959-4387-a96d-a41981ff4648; do
+     curl -s -X POST https://api.linear.app/graphql \
+       -H "Authorization: $LINEAR_API_KEY" -H "Content-Type: application/json" \
+       -d "{\"query\":\"mutation{ webhookUpdate(id:\\\"$id\\\", input:{enabled:true}){ success } }\"}"
+   done
+   ```
+
+2. **Restore the channel in Layer-2 config on each host.** Every host kept a
+   pre-cutover backup at `~/.config/catalyst/config.json.bak-ctl1928-<ts>`; the
+   smallest correct restore is to put the channel back, not to overwrite the
+   whole file (it has moved on since):
+
+   ```bash
+   node -e '
+     const fs=require("fs"),os=require("os"),p=os.homedir()+"/.config/catalyst/config.json";
+     const c=JSON.parse(fs.readFileSync(p,"utf8"));
+     c.catalyst.monitor.linear.smeeChannel="https://smee.io/WDgeZys5ST0uqtL";
+     const t=p+".tmp"; fs.writeFileSync(t,JSON.stringify(c,null,2)+"\n",{mode:0o600});
+     JSON.parse(fs.readFileSync(t,"utf8"));          // fail closed: rejects concatenated docs
+     fs.renameSync(t,p);'
+   ~/.catalyst/bin/catalyst-monitor restart
+   ```
+
+   ⚠️ **The top-level key is enough to restore, but was NOT enough to retire.**
+   `readLinearSmeeChannel` (`orch-monitor/lib/webhook-config.ts`) falls back to
+   the **first per-team entry's** `smeeChannel`, so retiring required clearing
+   all 8 keys. Verified the hard way: clearing only the documented top-level key
+   and restarting still brought the tunnel up.
+
+3. **Verify by content** — `[linear-tunnel] … Forwarding …` must appear in
+   `~/catalyst/monitor.log` under the *new* pid, and
+   `grep -ac "linear-tunnel" ~/catalyst/monitor.log` must be non-zero. Use the
+   GitHub tunnel's own lines as the positive control that the log is live at all.
+
+### Lever B — stop the cloud feed driving dispatch
+
+```bash
+# per host: enforce -> shadow (smee copies stop being suppressed)
+sed -i "" "s/^export CATALYST_CLOUD_FEED=enforce$/export CATALYST_CLOUD_FEED=shadow/" \
+  ~/.config/catalyst/execution-core.env
+~/.catalyst/bin/catalyst-execution-core restart
+```
+
+⚠️ That env file holds a live `ghp_` PAT — `grep` the one line, never `cat` it.
+
+⛔ **Lever B is only a rollback when Lever A has already been done.** Before the
+cutover, flipping to `shadow` was safe because smee was still authoritative
+underneath. It no longer is: `shadow` with the Linear subscriptions disabled
+means **nothing** drives Linear dispatch. Order matters — A then B, never B alone.
+
+---
+
+## 3. What this removed that you may still be relying on
+
+- **The `shadow`-flip containment lever.** Cutting the writer over to `shadow`
+  around a `cloud-sync` restart used to be safe *because smee stayed
+  authoritative*. Post-retirement there is no second stream, so a re-seeding
+  writer restart is defended **only** by the CTL-1920 torn-read guard. That guard
+  is merged, loaded and mutation-tested, but as of the cutover it had **never
+  fired in production**. Treat the first re-seed after this date as the guard's
+  real first test and watch `catalyst.linear` event volume across it.
+- **The parity harness's comparison stream** (CTL-1916). It compared the feed
+  against smee out of one log; with smee's Linear side silent it now has one
+  input and can only ever report agreement. Retire or repurpose it deliberately —
+  an instrument that cannot disagree is not a check.
+- **CTL-1841's route-comparison alarm** (`webhook-route-health.ts`). It cannot
+  false-page — `raise` requires a *recent non-2xx* on the Linear route and that
+  route now receives nothing — but for the same reason it can never fire again.
+  Note its in-code comment ("GitHub and Linear use INDEPENDENT smee channels") was
+  already wrong on this fleet, and the shared channel had it **latched raised on
+  both minis** at cutover time, because GitHub cross-delivery kept making the
+  last Linear-route outcome a 401.
+
+---
+
+## 4. App authorizations — what drops, and what does not
+
+Short answer: **nothing drops from this cutover.**
+
+- The 7 Linear webhook subscriptions were **workspace webhooks created with a
+  personal API key** (`creator: Ryan Rozich`), not per-host app grants. Disabling
+  them changes no app authorization.
+- **CATALYST / CATALYST Orchestrator (Linear app-actors) stay.** They are how the
+  daemon *writes* — status transitions, labels, mirrored comments — and how
+  `catalyst-monitor` authenticates ("authenticated as Catalyst Orchestrator
+  app-actor, isolated 5000/hr bucket"). Reads still come from the replica, which
+  the cloud writer fills. These drop only when **CTL-1889** moves daemon writes
+  behind the cloud write proxy.
+- **GitHub app authorizations stay** — the GitHub webhook and `gh` operations are
+  untouched by this ticket.
+
+---
+
+## 5. New-host installs
+
+`join-bundle.mjs` no longer emits the Linear webhook block, and
+`catalyst-join.sh` strips it from any bundle that still carries one (a bundle is
+a file that outlives the code that wrote it). The whole block goes — both the
+top-level channel and the per-team `webhookId` map — because the per-team entry
+alone is enough to start a tunnel, and a `webhookId` arriving without its HMAC
+secret is what `catalyst doctor` grades as half-wired config residue.
+
+A **declared-`cloud`** node already created no smee wiring before this ticket
+(`catalyst-join.sh`'s gate settles on `decision=skip` for any recognized
+non-cluster mode); CTL-1928 additionally makes a **cluster** join stop re-creating
+the retired Linear path.
+
+`catalyst doctor` needs no change and got none for this: measured on both minis
+after the cutover it reports
+`[PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false, linear keys=7)`.
+Its declared-`cloud` WARN text was corrected, though — it used to say such a node
+had "no event ingestion at all", which is now wrong in the direction that sends an
+operator hunting a Linear outage that does not exist.

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -691,7 +691,8 @@ run "T2.8 multiHost roster + inferred mode FALLS BACK to heuristic and wires (CT
   jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$cfg\" >/dev/null &&
   echo \"\$out\" | grep -qF 'linear-stripped=yes' && \
   jq -e '(.catalyst.monitor | has(\"linear\")) | not' \"\$cfg\" >/dev/null &&
-  ! grep -qF 'smee.io/LIN' \"\$cfg\""
+  ! grep -qF 'smee.io/LIN' \"\$cfg\" &&
+  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null"
 
 # T2.8e (CTL-1928): a bundle whose monitorWebhooks carries ONLY the retired
 # Linear block has nothing left to write once the strip runs. The decision must
@@ -730,7 +731,33 @@ run "T2.8e bundle carrying ONLY the retired Linear block wires nothing (CTL-1928
   cfg=\"\$h/.config/catalyst/config.json\"
   echo \"\$out\" | grep -qF 'ONLY the retired Linear block' && \
   ! grep -qF 'smee.io/LIN' \"\$cfg\" && \
-  jq -e '((.catalyst.monitor // {}) | has(\"linear\")) | not' \"\$cfg\" >/dev/null"
+  jq -e '((.catalyst.monitor // {}) | has(\"linear\")) | not' \"\$cfg\" >/dev/null && \
+  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null"
+
+# T2.8f (CTL-1928, Codex #3485 P1): removing the Linear route must not leave a
+# node with NO Linear ingestion — the join provisions the cloud-feed
+# replacement, since readCloudFeedConfig defaults to "off" and doctor's
+# webhook-ingestion check is satisfied by the GitHub route alone (so the gap
+# would not even look broken). NON-CLOBBER: a node that already declares a mode
+# keeps its own.
+run "T2.8f an already-declared cloudFeed.mode is NOT clobbered by the join (CTL-1928)" bash -c "
+  h='${SCRATCH}/h28f'
+  mkdir -p \"\$h/.config/catalyst\"
+  printf '{\"catalyst\":{\"cloudFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/config.json\"
+  out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28f' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' 2>&1)
+  cfg=\"\$h/.config/catalyst/config.json\"
+  jq -e '.catalyst.cloudFeed.mode == \"shadow\"' \"\$cfg\" >/dev/null && \
+  echo \"\$out\" | grep -qF 'cloudFeed=shadow'"
 
 # T2.9 (fixture updated for CTL-1617 PR5 — see T2.8's note): same inferred-mode
 # fallback, but SINGLEHOST_WH_BUNDLE's roster=1 makes the heuristic (and hence

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -689,7 +689,48 @@ run "T2.8 multiHost roster + inferred mode FALLS BACK to heuristic and wires (CT
   echo \"\$out\" | grep -qF 'inferred=true' && \
   echo \"\$out\" | grep -qF 'heuristic_would=wire' && \
   jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$cfg\" >/dev/null &&
-  jq -e '.catalyst.monitor.linear.ctl.webhookId == \"wh-ctl\"' \"\$cfg\" >/dev/null"
+  echo \"\$out\" | grep -qF 'linear-stripped=yes' && \
+  jq -e '(.catalyst.monitor | has(\"linear\")) | not' \"\$cfg\" >/dev/null &&
+  ! grep -qF 'smee.io/LIN' \"\$cfg\""
+
+# T2.8e (CTL-1928): a bundle whose monitorWebhooks carries ONLY the retired
+# Linear block has nothing left to write once the strip runs. The decision must
+# report NOT wired and the config must gain no monitor block at all — the
+# failure this guards against is writing an empty/partial monitor block that
+# later reads as "ingestion configured".
+LINEAR_ONLY_WH_BUNDLE="${SCRATCH}/linear-only-wh.json"
+cat > "$LINEAR_ONLY_WH_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "thoughtsOrg": "CTL",
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini", "mini-2"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins",
+  "monitorWebhooks": {
+    "linear": {"smeeChannel": "https://smee.io/LIN", "ctl": {"webhookId": "wh-ctl"}}
+  }
+}
+BEOF
+
+run "T2.8e bundle carrying ONLY the retired Linear block wires nothing (CTL-1928)" bash -c "
+  h='${SCRATCH}/h28e'
+  out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28e' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$LINEAR_ONLY_WH_BUNDLE' 2>&1)
+  cfg=\"\$h/.config/catalyst/config.json\"
+  echo \"\$out\" | grep -qF 'ONLY the retired Linear block' && \
+  ! grep -qF 'smee.io/LIN' \"\$cfg\" && \
+  jq -e '((.catalyst.monitor // {}) | has(\"linear\")) | not' \"\$cfg\" >/dev/null"
 
 # T2.9 (fixture updated for CTL-1617 PR5 — see T2.8's note): same inferred-mode
 # fallback, but SINGLEHOST_WH_BUNDLE's roster=1 makes the heuristic (and hence

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -886,15 +886,39 @@ merge_shared_config() {
   info "webhook-wiring gate (CTL-1617 PR5): decision=${decision} rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} source=${CATALYST_DEPLOYMENT_MODE_SOURCE} inferred=${CATALYST_DEPLOYMENT_MODE_INFERRED} | heuristic_would=${heuristic_verdict} roster_len=${roster_len:-0} monitorWebhooks=${monitor_wh_state}${note_field}"
 
   if [[ "$decision" == "wire" ]]; then
+    # CTL-1928: strip the LINEAR webhook block before the merge. Linear
+    # ingestion is the cloud feed now, and the workspace's Linear webhook
+    # subscriptions were retired at the cutover — wiring them onto a joining
+    # host would re-create a path that no longer delivers. join-bundle.mjs no
+    # longer EMITS this block, but a bundle is a file that outlives the code
+    # that wrote it (a retained --bundle, or a seed on an older plugin-source),
+    # so the consumer strips it too rather than trusting the producer.
+    #
+    # Both halves must go. orch-monitor's readLinearSmeeChannel falls back to
+    # the first per-team entry's smeeChannel, so deleting only the top-level
+    # `.linear.smeeChannel` still leaves enough to start a tunnel; and a
+    # per-team `webhookId` arriving without its HMAC secret is what doctor
+    # grades as half-wired config residue (webhook-ingestion FAIL).
+    local monitor_wh_stripped stripped_linear="no"
+    monitor_wh_stripped="$(echo "$monitor_wh" | jq -c 'del(.linear)')" || {
+      fail "webhook-wiring: could not strip the retired Linear block from monitorWebhooks"
+      return 1
+    }
+    [[ "$(echo "$monitor_wh" | jq 'has("linear")')" == "true" ]] && stripped_linear="yes"
+    # Everything the bundle offered was Linear — nothing left to write.
+    if [[ "$(echo "$monitor_wh_stripped" | jq 'length')" -eq 0 ]]; then
+      info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928)"
+      return 0
+    fi
     local tmp2
     tmp2="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
     # Deep-merge ($wh * existing): existing node-local values WIN (non-clobber),
     # new keys from the bundle are added.
-    jq --argjson wh "$monitor_wh" '
+    jq --argjson wh "$monitor_wh_stripped" '
         .catalyst //= {}
         | .catalyst.monitor = ($wh * (.catalyst.monitor // {}))
       ' "$cfg" > "$tmp2" && mv "$tmp2" "$cfg" || { rm -f "$tmp2"; return 1; }
-    info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0})"
+    info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0} github-only=yes linear-stripped=${stripped_linear} CTL-1928)"
   else
     info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0})"
   fi

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -905,20 +905,52 @@ merge_shared_config() {
       return 1
     }
     [[ "$(echo "$monitor_wh" | jq 'has("linear")')" == "true" ]] && stripped_linear="yes"
-    # Everything the bundle offered was Linear — nothing left to write.
-    if [[ "$(echo "$monitor_wh_stripped" | jq 'length')" -eq 0 ]]; then
-      info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928)"
-      return 0
-    fi
+    # A bundle offering ONLY the retired Linear block leaves nothing to wire —
+    # but it must still fall through to the write below, because that write is
+    # what provisions the cloud-feed replacement. Merging an empty object into
+    # .catalyst.monitor is a no-op, so one code path serves both cases.
+    local github_wired="yes"
+    [[ "$(echo "$monitor_wh_stripped" | jq 'length')" -eq 0 ]] && github_wired="no"
     local tmp2
     tmp2="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
     # Deep-merge ($wh * existing): existing node-local values WIN (non-clobber),
     # new keys from the bundle are added.
+    #
+    # ⛔ CTL-1928 (Codex #3485 P1): provision the REPLACEMENT in the same write
+    # that removes the original. Stripping the Linear block above takes away
+    # this node's only Linear route, and `readCloudFeedConfig` defaults to
+    # "off" — so a fresh multi-host join would come up with NO Linear ingestion
+    # at all: no state-change, no issue-update, no comment events. It would not
+    # even look broken, because `webhook-ingestion` is satisfied by the GitHub
+    # route alone. Removing a path without enabling its successor is how a node
+    # ends up silently blind.
+    #
+    # `//=` so it is NON-CLOBBER: a node that already declares a mode (or an
+    # operator who has deliberately set "off"/"shadow") keeps its own value;
+    # only an ABSENT key is filled.
+    #
+    # "enforce" is the safe value to default to, not an aggressive one: the
+    # producer's own readiness gate fails CLOSED (defaultReplicaFresh — absent,
+    # unreadable, malformed or stale replica all read as NOT fresh), so the feed
+    # only becomes authoritative on a host whose replica writer is actually
+    # alive. The alternative default — "off" — cannot become authoritative
+    # under any condition, which on a post-cutover fleet means permanently no
+    # Linear dispatch. Note the live minis carry this as an ENV var in
+    # execution-core.env rather than in Layer-2, so this fills a genuinely
+    # empty key on a joining node rather than fighting an existing one.
     jq --argjson wh "$monitor_wh_stripped" '
         .catalyst //= {}
         | .catalyst.monitor = ($wh * (.catalyst.monitor // {}))
+        | .catalyst.cloudFeed //= {}
+        | .catalyst.cloudFeed.mode //= "enforce"
       ' "$cfg" > "$tmp2" && mv "$tmp2" "$cfg" || { rm -f "$tmp2"; return 1; }
-    info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0} github-only=yes linear-stripped=${stripped_linear} CTL-1928)"
+    local cf_mode
+    cf_mode="$(jq -r '.catalyst.cloudFeed.mode // "unset"' "$cfg" 2>/dev/null)"
+    if [[ "$github_wired" == "no" ]]; then
+      info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928); cloudFeed=${cf_mode}"
+    else
+      info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0} github-only=yes linear-stripped=${stripped_linear} cloudFeed=${cf_mode} CTL-1928)"
+    fi
   else
     info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0})"
   fi

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -1276,16 +1276,24 @@ export function checkWebhookIngestion(deps = {}) {
         ];
       }
       // (b) Declared CLOUD is a WARN, not a PASS: cloud suppresses the smee
-      //     tunnels but its replacement ingestion (the cloud SDK event
-      //     connection) does not exist yet — an otherwise-green doctor must
-      //     not certify a node with zero event ingestion. Flips to PASS only
-      //     when a real cloud ingestion check exists to stand in its place.
+      //     tunnels, and only ONE of the two routes has a replacement.
+      //     CTL-1928: Linear ingestion IS replaced — the cloud feed
+      //     (cloud-feed-timer.mjs, CATALYST_CLOUD_FEED) drives dispatch, and
+      //     the workspace's Linear webhook subscriptions were retired
+      //     fleet-wide. GitHub has NO cloud replacement: the cloud receives no
+      //     GitHub webhooks at all, so a declared-cloud node cannot see the
+      //     `github.*` events monitor-merge, CI waits, and the broker's
+      //     PR-lifecycle routing consume. That gap is what keeps this a WARN;
+      //     it flips to PASS when a real cloud GitHub-ingestion check exists.
+      //     (Saying "no event ingestion at all" here would now be wrong, and
+      //     wrong in the direction that sends an operator hunting a Linear
+      //     outage that isn't there.)
       if (declaredMode.mode === "cloud") {
         return [
           mkCheck(
             "webhook-ingestion",
             STATUS.WARN,
-            `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired, but cloud replacement ingestion is NOT yet implemented: this node currently has no event ingestion at all`,
+            `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired; Linear ingestion is replaced by the cloud feed (CTL-1928), but GitHub ingestion has NO cloud replacement yet: this node cannot see github.* events (monitor-merge, CI waits, PR-lifecycle routing)`,
           ),
           ...webhookShadow,
         ];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2938,11 +2938,19 @@ describe("checkWebhookIngestion — deployment-mode alignment (CTL-1617, #2913 C
     expect(primary.detail).toContain("intentionally not wired");
   });
 
-  it("declared cloud: WARN, not PASS — cloud replacement ingestion does not exist yet (#2918 follow-up)", () => {
+  // CTL-1928 narrowed WHY this is a WARN: Linear ingestion now HAS a cloud
+  // replacement (the cloud feed), GitHub still does not. The status is
+  // unchanged — the remaining GitHub gap is what keeps it off PASS.
+  it("declared cloud: WARN, not PASS — GitHub has no cloud replacement ingestion yet (#2918 follow-up, narrowed by CTL-1928)", () => {
     const checks = checkWebhookIngestion({ ...NO_ROUTE_DEPS, resolveDeploymentModeFn: () => mode("cloud") });
     const primary = checks.find((c) => c.name === "webhook-ingestion");
     expect(primary.status).toBe(STATUS.WARN);
-    expect(primary.detail).toContain("no event ingestion at all");
+    expect(primary.detail).toContain("GitHub ingestion has NO cloud replacement");
+    expect(primary.detail).toContain("cloud feed");
+    // The superseded claim must not come back: a cloud node is NOT blind to
+    // Linear, and telling an operator it has "no event ingestion at all"
+    // sends them hunting a Linear outage that does not exist.
+    expect(primary.detail).not.toContain("no event ingestion at all");
   });
 
   it("declared non-cluster with a DANGLING Linear key: half-wired FAIL fires before the aligned grant (#2918 follow-up ordering)", () => {

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -75,12 +75,33 @@ function resolvePluginSourceUrl(l2) {
 }
 
 // CTL-1284: extract the NON-SECRET webhook wiring a member needs to ingest
-// inbound GitHub/Linear events — smee channel URLs + the per-team webhookId map
-// that readAllLinearSecrets keys on. HMAC secrets are NEVER carried here; they
-// travel via the SOPS secret-files path (cluster-sync.mjs). Returns null when the
-// seed has no monitor block. The CONSUMER (merge_shared_config) gates writing
-// these onto a member by roster length > 1 — a single-host member must NOT
-// ingest webhooks (HRW no-op + claimDispatch skipped → double-dispatch).
+// inbound GitHub events — the smee channel URL. HMAC secrets are NEVER carried
+// here; they travel via the SOPS secret-files path (cluster-sync.mjs). Returns
+// null when the seed has no monitor block. The CONSUMER (merge_shared_config)
+// gates writing these onto a member by roster length > 1 — a single-host member
+// must NOT ingest webhooks (HRW no-op + claimDispatch skipped → double-dispatch).
+//
+// ⛔ CTL-1928: the LINEAR half is deliberately NOT carried any more. Linear
+// ingestion is the cloud feed (`cloud-feed-timer.mjs`, `CATALYST_CLOUD_FEED`),
+// and the workspace's 7 Linear webhook subscriptions were retired when the
+// fleet cut over. Propagating `linear.smeeChannel` would silently RE-CREATE the
+// retired path on every new join: `readLinearSmeeChannel` (orch-monitor's
+// webhook-config.ts) falls back to the FIRST per-team entry's `smeeChannel`, so
+// even a bundle carrying only the per-team map — no top-level channel — is
+// enough to start a Linear tunnel on the joining host. That is why the whole
+// `linear` block goes, rather than just the top-level key.
+//
+// Dropping the per-team `webhookId` map with it is deliberate too, and it is
+// what keeps `catalyst doctor` honest: its `webhook-ingestion` check FAILs a
+// member carrying a `webhookId` whose HMAC secret does not resolve ("half-wired
+// … config residue"). A joining host has no reason to hold identifiers for
+// subscriptions that no longer deliver, and carrying them would manufacture
+// exactly that dangling-key FAIL. The GitHub route stays: it is still smee-fed
+// (measured on the live fleet — ~1.6k `github.*` events per 6 h drive
+// monitor-merge, CI waits and the broker's PR-lifecycle routing), and the cloud
+// has no GitHub ingestion to replace it yet.
+//
+// The retirement + rollback procedure: docs/runbooks/cloud-feed-cutover.md.
 function extractMonitorWebhooks(l2) {
   const monitor = l2?.catalyst?.monitor;
   if (!monitor || typeof monitor !== "object") return null;
@@ -89,28 +110,6 @@ function extractMonitorWebhooks(l2) {
   const ghSmee = monitor.github?.smeeChannel;
   if (typeof ghSmee === "string" && ghSmee) {
     out.github = { smeeChannel: ghSmee };
-  }
-
-  const linear = monitor.linear;
-  if (linear && typeof linear === "object" && !Array.isArray(linear)) {
-    const lin = {};
-    if (typeof linear.smeeChannel === "string" && linear.smeeChannel) {
-      lin.smeeChannel = linear.smeeChannel;
-    }
-    // Per-team keyed entries: { ctl: {webhookId, smeeChannel, resourceTypes}, ... }.
-    // Keep only non-secret identifiers; drop registeredAt and anything else.
-    for (const key of Object.keys(linear)) {
-      const entry = linear[key];
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
-      if (typeof entry.webhookId !== "string" || !entry.webhookId) continue;
-      const e = { webhookId: entry.webhookId };
-      if (typeof entry.smeeChannel === "string" && entry.smeeChannel) {
-        e.smeeChannel = entry.smeeChannel;
-      }
-      if (Array.isArray(entry.resourceTypes)) e.resourceTypes = entry.resourceTypes;
-      lin[key] = e;
-    }
-    if (Object.keys(lin).length > 0) out.linear = lin;
   }
 
   return Object.keys(out).length > 0 ? out : null;

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -206,7 +206,10 @@ describe("assembleJoinBundle", () => {
     expect(assembleJoinBundle().monitorWebhooks).toBeNull();
   });
 
-  test("monitorWebhooks carries non-secret smee channels + per-team webhookId map", () => {
+  // CTL-1928: the GitHub channel still travels (GitHub ingestion is still
+  // smee-fed); the whole Linear block does NOT (retired — the cloud feed
+  // drives Linear dispatch, and the subscriptions no longer deliver).
+  test("monitorWebhooks carries the GitHub smee channel and NOT the retired Linear block", () => {
     writeLayer2({
       ...LAYER2_FIXTURE,
       catalyst: {
@@ -223,17 +226,37 @@ describe("assembleJoinBundle", () => {
     });
     const wh = assembleJoinBundle().monitorWebhooks;
     expect(wh.github).toEqual({ smeeChannel: "https://smee.io/GH" });
-    expect(wh.linear.smeeChannel).toBe("https://smee.io/LIN");
-    expect(wh.linear.ctl).toEqual({
-      webhookId: "wh-ctl",
-      smeeChannel: "https://smee.io/LIN",
-      resourceTypes: ["Issue"],
-    });
-    expect(wh.linear.adv).toEqual({ webhookId: "wh-adv" });
+    expect(wh.linear).toBeUndefined();
+    // Not just "no top-level channel": readLinearSmeeChannel falls back to the
+    // FIRST per-team entry, so a surviving per-team smeeChannel would still
+    // start a tunnel. Assert the URL is nowhere in the payload at all, and
+    // that no webhookId rides along to become a dangling-key doctor FAIL.
+    expect(JSON.stringify(wh)).not.toContain("smee.io/LIN");
+    expect(JSON.stringify(wh)).not.toContain("webhookId");
     // registeredAt is dropped; no secrets ever appear.
     expect(JSON.stringify(wh)).not.toContain("registeredAt");
     expect(JSON.stringify(wh)).not.toContain("Secret");
     expect(JSON.stringify(wh)).not.toContain("secret");
+  });
+
+  // A seed whose ONLY monitor wiring is the retired Linear block has nothing
+  // left to carry — the bundle key must be null, not an empty object (the
+  // consumer's `monitor_wh != "null"` conjunct is what gates the wire/skip
+  // decision, and `{}` would read as "present" and wire nothing).
+  test("monitorWebhooks is null when the seed carries ONLY the retired Linear block", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: {
+        ...LAYER2_FIXTURE.catalyst,
+        monitor: {
+          linear: {
+            smeeChannel: "https://smee.io/LIN",
+            ctl: { webhookId: "wh-ctl", smeeChannel: "https://smee.io/LIN" },
+          },
+        },
+      },
+    });
+    expect(assembleJoinBundle().monitorWebhooks).toBeNull();
   });
 
   // CTL-1231: allow-listed, secret-free ~/.claude/settings.json slice. The


### PR DESCRIPTION
## What

The fleet's Linear ingestion is the **cloud feed** now. As of 2026-08-17 ~16:50–17:02 CT both minis' Linear smee tunnels are gone and the workspace's 7 Linear webhook subscriptions are disabled (CTL-1928, executed on the live fleet — evidence on the ticket).

Nothing in the **install path** knew that. A new cluster join would read `monitorWebhooks.linear` straight out of the join bundle and start a tunnel for subscriptions that no longer deliver — silently re-creating the retired path on every new host.

- `join-bundle.mjs` stops emitting the Linear block.
- `catalyst-join.sh` strips it from any bundle that still carries one — a bundle is a file that outlives the code that wrote it (a retained `--bundle`, or a seed on an older plugin-source), so the consumer strips rather than trusting the producer.
- The GitHub block still travels.

## The whole block goes, not just the top-level channel

`readLinearSmeeChannel` (`orch-monitor/lib/webhook-config.ts`) falls back to the **first per-team entry's** `smeeChannel`. A bundle carrying only the per-team map is therefore enough to start a tunnel. Verified the hard way on mini-2: clearing just the documented top-level key and restarting brought the tunnel **back up**.

The per-team `webhookId`s go with it. A `webhookId` arriving without its HMAC secret is precisely what `catalyst doctor` grades as half-wired *"config residue"* — carrying them would manufacture a dangling-key FAIL on every join.

## GitHub is deliberately untouched

The cloud feed replaces **Linear only** — `DISPATCH_CLASS_NAMES` is three `linear.*` names, and `catalyst-cloud` has no webhook ingestion route at all (verified with a positive control: `webhook` *does* occur in that repo, in `packages/crypto` and `packages/read-model`).

Measured on mini-2, 6 h window: **1,616 `github.*` events** — `workflow_run` 924, `check_suite` 375, `push` 120, `pr` 111, `issue_comment` 70, `deployment_status` 16 — driving `phase-monitor-merge`'s `wait-for`, CI waits, and the broker's PR-lifecycle routing. Removing the GitHub webhook would blind the fleet to all of it.

## doctor

Needed no change to **accept** the new state — measured on both minis after the cutover:

```
[PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false, linear keys=7)
```

But its declared-`cloud` WARN said such a node has *"no event ingestion at all"*. That is now wrong, and wrong in the direction that sends an operator hunting a Linear outage that does not exist: Linear **is** replaced by the cloud feed; GitHub is the half still missing. Message narrowed; the WARN status is unchanged.

## Rollback

`docs/runbooks/cloud-feed-cutover.md` — the measured end state plus two levers, and the ordering constraint that `enforce → shadow` is **only** a rollback *after* the subscriptions are re-enabled (it used to be safe alone because smee was authoritative underneath; it no longer is).

The subscriptions were **disabled, not deleted**, on purpose: Linear never re-issues a webhook secret, so deletion turns a one-call rollback into 7 re-registrations that also rewrite local HMAC secret files.

## Tests

- `T2.8` inverted to assert the strip (it previously asserted the Linear block **was** written).
- New `T2.8e`: a bundle carrying *only* the retired block must wire nothing — not an empty monitor block that later reads as "ingestion configured".
- `catalyst-join.test.sh`: **53 passed / 1 failed** vs a clean `origin/main` worktree baseline of **52 passed / 1 failed** — the same pre-existing `T3.4` failure, zero regressions.
- `execution-core` doctor + join-bundle: **447 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)