### PR TITLE
feat(dev): CTL-1889 inc 1 — a host's Linear writes go through the cloud write proxy, under ONE grant

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -954,6 +954,10 @@ jobs:
             linear-state-write-event.test.mjs \
             linear-write-echo.test.mjs \
             linear-write.test.mjs \
+            linear-write-proxy.test.mjs \
+            linear-write-proxy-wiring.test.mjs \
+            linear-write-proxy-resolve.test.mjs \
+            __tests__/config-linear-write-proxy.test.mjs \
             memory-event.test.mjs \
             memory-sampler-signal.test.mjs \
             memory-sampler.test.mjs \

--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -783,6 +783,56 @@ run "triage transition resolves via the registry's customized eligibleQuery.tria
 run "used the registry's 'Intake' override, not the hardcoded 'Triage' default" \
   expect_contains "$LOG34" "linearis issues update TST-34 --status Intake"
 
+# ─── Test 35-38: --resolve-only (CTL-1889) ────────────────────────────────
+# The cloud write proxy needs the TARGET STATE without performing the write. Re-deriving
+# the four-rung precedence chain in JS would make this script one of two sources of
+# truth, so the proxy calls it in a mode that resolves and stops.
+WORK35="${SCRATCH}/t35"
+BIN35="${SCRATCH}/t35/bin"
+LOG35="${SCRATCH}/t35/log"
+mkdir -p "${WORK35}/.catalyst"
+cat > "${WORK35}/.catalyst/config.json" <<'EOF'
+{"catalyst":{"linear":{"stateMap":{"done":"Done","inProgress":"Implement"}}}}
+EOF
+install_fake_linearis "$BIN35"
+touch "$LOG35"
+
+run "--resolve-only emits the resolved target state as JSON" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG35' PATH='$BIN35:$PATH' \
+    '$TRANSITION' --ticket TST-35 --transition inProgress --config '$WORK35/.catalyst/config.json' \
+    --resolve-only --json | grep -q '\"targetState\":\"Implement\"'"
+
+run "⛔ --resolve-only performs NO write (the whole point — linearis is never called)" \
+  bash -c "! grep -q 'issues update' '$LOG35'"
+
+run "--resolve-only reports action=resolve-only, not a transition" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG35' PATH='$BIN35:$PATH' \
+    '$TRANSITION' --ticket TST-35 --transition done --config '$WORK35/.catalyst/config.json' \
+    --resolve-only --json | grep -q '\"action\":\"resolve-only\"'"
+
+# ⭐ The property the ticket turns on: the END STATE of CTL-1889 is a host with no
+# Linear credential and no reason to have linearis installed. Resolution must still
+# work there — so this runs with a PATH that has no linearis at all. --dry-run is the
+# negative control: it exits at the availability gate with skipped-no-linearis and
+# never resolves, which is exactly why a new mode was needed rather than reusing it.
+WORK36="${SCRATCH}/t36"
+EMPTY36="${SCRATCH}/t36/emptybin"
+mkdir -p "${WORK36}/.catalyst" "$EMPTY36"
+cat > "${WORK36}/.catalyst/config.json" <<'EOF'
+{"catalyst":{"linear":{"stateMap":{"inProgress":"Implement"}}}}
+EOF
+JQ_DIR36="$(dirname "$(command -v jq)")"
+
+run "⭐ --resolve-only still resolves on a host with NO linearis binary" \
+  bash -c "PATH='$EMPTY36:$JQ_DIR36:/usr/bin:/bin' \
+    '$TRANSITION' --ticket TST-36 --transition inProgress --config '$WORK36/.catalyst/config.json' \
+    --resolve-only --json | grep -q '\"targetState\":\"Implement\"'"
+
+run "NEGATIVE CONTROL: --dry-run on the same PATH does NOT resolve (it stops at the linearis gate)" \
+  bash -c "PATH='$EMPTY36:$JQ_DIR36:/usr/bin:/bin' \
+    '$TRANSITION' --ticket TST-36 --transition inProgress --config '$WORK36/.catalyst/config.json' \
+    --dry-run --json | grep -q 'skipped-no-linearis'"
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -50,6 +50,9 @@ import { ALERT_BOOT_DEPENDENCY_UNUSABLE } from "../execution-core/dispatch-alert
 // re-typed as a literal below, so a rename cannot leave this contract asserting over a name
 // nothing emits (the hand-copied-literal trap the ASSERTED_BY parity suite exists to prevent).
 import { DEP_SKEW_RESTART_EVENT, DEP_SKEW_WOULD_RESTART_EVENT } from "../execution-core/cloud-sync-deps.mjs";
+// CTL-1889 — the Linear write-proxy trio, imported from its owning module so a
+// rename cannot leave a re-typed literal behind that still passes.
+import { PROXY_EVENT_NAMES } from "../execution-core/linear-write-proxy.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -95,6 +98,7 @@ const EXEC_CORE_EVENT_NAMES = [
   ALERT_BOOT_DEPENDENCY_UNUSABLE,
   DEP_SKEW_RESTART_EVENT, // CTL-1659 cloud-sync.mjs — the writer restarting to load an installed dep fix
   DEP_SKEW_WOULD_RESTART_EVENT, // CTL-1659 — sustained skew that did NOT act (shadow / budget / undurable ledger)
+  ...PROXY_EVENT_NAMES, // CTL-1889 linear-write-proxy.mjs — would-write / applied / failed
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/execution-core/__fixtures__/http-echo-server.mjs
+++ b/plugins/dev/scripts/execution-core/__fixtures__/http-echo-server.mjs
@@ -7,13 +7,36 @@
 // with the code under test. The only honest positive control is a server in another
 // OS process.
 //
-// Usage: bun http-echo-server.mjs <recordFile> [statusCode]
+// Usage: bun http-echo-server.mjs <recordFile> [statusCode] [deadlineMs]
 //   - prints "PORT <n>\n" to stdout once listening (the parent's readiness signal)
 //   - appends one JSON line per received request to <recordFile>
+//   - EXITS ON ITS OWN after `deadlineMs`, whatever the parent does
 import { appendFileSync } from "node:fs";
 
 const recordFile = process.argv[2];
 const status = Number(process.argv[3] ?? 200);
+
+// ⛔ SELF-LIMITING, BECAUSE CLEANUP MUST NOT BE LOAD-BEARING (Codex #3489 round 2, P1;
+// AGENTS.md "Spawning a background process"). The parent's `afterEach` kill is
+// best-effort by construction: it does not run if the test runner is interrupted
+// (^C, a CI step timeout, a crash in another suite), and a `&`-style orphan reparents
+// to PID 1 and serves forever. That is not hypothetical here — this repo has already
+// burned ~4 CPU-cores for 16.5 h on leaked children whose spawning script reported
+// `cleanup verified`. So the deadline lives in the CHILD, where no parent failure can
+// skip it, and it is a timer rather than a spin loop (an empty deadline loop burns a
+// whole core for its duration, which is the same incident from the other end).
+//
+// Overridable ONLY so the deadline itself can be proven to fire in ~1 s instead of
+// making the suite wait out the default — a test asserting the process exits with no
+// kill from the parent. A guardrail nothing exercises is a guardrail nobody knows is
+// broken; an unparseable/absent value falls back to the default rather than to
+// "no deadline".
+const rawDeadline = Number(process.argv[4] ?? process.env.CTL1889_FIXTURE_DEADLINE_MS);
+const deadlineMs = Number.isFinite(rawDeadline) && rawDeadline > 0 ? rawDeadline : 60_000;
+setTimeout(() => {
+  process.stderr.write(`http-echo-server: self-terminating after ${deadlineMs}ms deadline\n`);
+  process.exit(0);
+}, deadlineMs);
 
 const server = Bun.serve({
   port: 0,

--- a/plugins/dev/scripts/execution-core/__fixtures__/http-echo-server.mjs
+++ b/plugins/dev/scripts/execution-core/__fixtures__/http-echo-server.mjs
@@ -1,0 +1,57 @@
+// http-echo-server.mjs — CTL-1889 test fixture.
+//
+// ⛔ WHY A SEPARATE PROCESS. linear-write-proxy's `defaultHttpFn` is a `spawnSync` of
+// curl, which BLOCKS the calling thread. A `Bun.serve` in the test process can never
+// answer it — its fetch handler is JS on that same blocked thread, so the request
+// times out and the round-trip assertion "fails" for a reason that has nothing to do
+// with the code under test. The only honest positive control is a server in another
+// OS process.
+//
+// Usage: bun http-echo-server.mjs <recordFile> [statusCode]
+//   - prints "PORT <n>\n" to stdout once listening (the parent's readiness signal)
+//   - appends one JSON line per received request to <recordFile>
+import { appendFileSync } from "node:fs";
+
+const recordFile = process.argv[2];
+const status = Number(process.argv[3] ?? 200);
+
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  async fetch(req) {
+    const url = new URL(req.url);
+    appendFileSync(
+      recordFile,
+      JSON.stringify({
+        method: req.method,
+        path: url.pathname,
+        auth: req.headers.get("authorization"),
+        contentType: req.headers.get("content-type"),
+        headerNames: [...req.headers.keys()],
+        body: await req.text(),
+      }) + "\n",
+    );
+    // Answer in the CTC-509 shape, not a generic {ok}: the classifier's verdict comes
+    // from the body's discriminated `outcome`, so a fixture that omits it would exercise
+    // the "unreadable-outcome" path while claiming to be a success round-trip.
+    //
+    // ⚠️ 401/403 answer with PLAIN TEXT, because the real thing does. Those come from
+    // the auth layer, which returns bare strings ("missing account" — measured against
+    // the live mirror), and only the route handlers past it speak the outcome envelope.
+    // A fixture that wrapped auth failures in an outcome would quietly prove the wrong
+    // branch of the classifier and leave the status-class fallback untested.
+    if (status === 401 || status === 403) {
+      return new Response("missing account", { status });
+    }
+    return new Response(
+      JSON.stringify(
+        status < 400
+          ? { outcome: "succeeded", attempts: 1 }
+          : { outcome: "rejected", reason: `fixture status ${status}` },
+      ),
+      { status },
+    );
+  },
+});
+
+process.stdout.write(`PORT ${server.port}\n`);

--- a/plugins/dev/scripts/execution-core/__tests__/config-linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/config-linear-write-proxy.test.mjs
@@ -1,0 +1,115 @@
+// config-linear-write-proxy.test.mjs — CTL-1889 increment 1.
+// Run: cd plugins/dev/scripts/execution-core && bun test __tests__/config-linear-write-proxy.test.mjs
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LINEAR_WRITE_PROXY_MODES, readLinearWriteProxyConfig } from "../config.mjs";
+
+const ENV_KEYS = ["CATALYST_LINEAR_WRITE_PROXY", "CATALYST_LAYER2_CONFIG_FILE"];
+let saved;
+let tmp;
+
+/** Write a Layer-2 config and point the resolver at it. */
+function layer2(obj) {
+  const p = join(tmp, "config.json");
+  writeFileSync(p, JSON.stringify(obj));
+  process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+}
+
+beforeEach(() => {
+  saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  tmp = mkdtempSync(join(tmpdir(), "ctl1889-cfg-"));
+  delete process.env.CATALYST_LINEAR_WRITE_PROXY;
+  // Guaranteed-absent by default so a developer's real ~/.config/catalyst/config.json
+  // can never leak into a test.
+  process.env.CATALYST_LAYER2_CONFIG_FILE = join(tmp, "absent.json");
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe("readLinearWriteProxyConfig — the mode ladder", () => {
+  test("the mode set is exactly the three house modes", () => {
+    expect([...LINEAR_WRITE_PROXY_MODES].sort()).toEqual(["enforce", "off", "shadow"]);
+  });
+
+  test("defaults to off with nothing configured anywhere", () => {
+    expect(readLinearWriteProxyConfig({})).toEqual({ mode: "off", routes: null });
+  });
+
+  test.each(["shadow", "enforce", "off"])("env %p is honoured", (mode) => {
+    expect(readLinearWriteProxyConfig({ CATALYST_LINEAR_WRITE_PROXY: mode }).mode).toBe(mode);
+  });
+
+  test('env "0" is the kill-switch', () => {
+    layer2({ catalyst: { linearWriteProxy: { mode: "enforce" } } });
+    expect(readLinearWriteProxyConfig({ CATALYST_LINEAR_WRITE_PROXY: "0" }).mode).toBe("off");
+  });
+
+  test("env overrides Layer-2", () => {
+    layer2({ catalyst: { linearWriteProxy: { mode: "shadow" } } });
+    expect(readLinearWriteProxyConfig({ CATALYST_LINEAR_WRITE_PROXY: "enforce" }).mode).toBe("enforce");
+  });
+
+  test("Layer-2 is honoured when the env var is absent", () => {
+    layer2({ catalyst: { linearWriteProxy: { mode: "enforce" } } });
+    expect(readLinearWriteProxyConfig({}).mode).toBe("enforce");
+  });
+
+  test.each([undefined, "", "ENFORCE", "enforce ", "on", "1", "true", "yes"])(
+    "an unrecognised env value (%p) degrades to off, never to enforce",
+    (v) => {
+      expect(readLinearWriteProxyConfig({ CATALYST_LINEAR_WRITE_PROXY: v }).mode).toBe("off");
+    },
+  );
+
+  test("an unrecognised env value falls THROUGH to a valid Layer-2 value rather than short-circuiting to off", () => {
+    layer2({ catalyst: { linearWriteProxy: { mode: "shadow" } } });
+    expect(readLinearWriteProxyConfig({ CATALYST_LINEAR_WRITE_PROXY: "ENFORCE" }).mode).toBe("shadow");
+  });
+
+  test.each(["ENFORCE", "", 7, null, {}])("an unrecognised Layer-2 mode (%p) degrades to off", (mode) => {
+    layer2({ catalyst: { linearWriteProxy: { mode } } });
+    expect(readLinearWriteProxyConfig({}).mode).toBe("off");
+  });
+
+  test("a malformed Layer-2 file is layer-absent, not a throw", () => {
+    const p = join(tmp, "bad.json");
+    writeFileSync(p, "{not json");
+    process.env.CATALYST_LAYER2_CONFIG_FILE = p;
+    expect(readLinearWriteProxyConfig({})).toEqual({ mode: "off", routes: null });
+  });
+});
+
+describe("readLinearWriteProxyConfig — route overrides", () => {
+  test("absolute string paths survive", () => {
+    layer2({ catalyst: { linearWriteProxy: { mode: "enforce", routes: { label: "/v2/labels" } } } });
+    expect(readLinearWriteProxyConfig({}).routes).toEqual({ label: "/v2/labels" });
+  });
+
+  test("⛔ a non-string value is DROPPED — it would concatenate as [object Object] into a URL", () => {
+    layer2({ catalyst: { linearWriteProxy: { routes: { label: { path: "/x" }, comment: "/ok" } } } });
+    expect(readLinearWriteProxyConfig({}).routes).toEqual({ comment: "/ok" });
+  });
+
+  test("a relative path is dropped (a route path must be absolute)", () => {
+    layer2({ catalyst: { linearWriteProxy: { routes: { label: "v2/labels" } } } });
+    expect(readLinearWriteProxyConfig({}).routes).toBeNull();
+  });
+
+  test("an array `routes` is ignored entirely", () => {
+    layer2({ catalyst: { linearWriteProxy: { routes: ["/a"] } } });
+    expect(readLinearWriteProxyConfig({}).routes).toBeNull();
+  });
+
+  test("routes are independent of mode — an operator can pre-stage paths while still off", () => {
+    layer2({ catalyst: { linearWriteProxy: { routes: { comment: "/v2/c" } } } });
+    expect(readLinearWriteProxyConfig({})).toEqual({ mode: "off", routes: { comment: "/v2/c" } });
+  });
+});

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -45,6 +45,7 @@ import {
   COORDINATION_MODES,
   DEAD_DOC_WORKER_MODES,
   RECOVERY_PASS_MODES,
+  LINEAR_WRITE_PROXY_MODES, // CTL-1889
   STALL_JANITOR_MODES,
   UNSTUCK_SWEEP_MODES,
   WATCHDOG_MODES,
@@ -384,6 +385,18 @@ export const CONFIG_KEYS = Object.freeze(
       modes: RECOVERY_PASS_MODES,
       fallback: "off",
       reader: "readRecoveryPassConfig",
+    },
+    {
+      // CTL-1889: the Linear write-proxy transport. Layer-2 only — the `routes`
+      // sibling is a URL-path map, which has no env precedent and no business in a
+      // daemon env var.
+      key: "catalyst.linearWriteProxy.mode",
+      kind: "mode",
+      layer2: "catalyst.linearWriteProxy.mode",
+      env: ["CATALYST_LINEAR_WRITE_PROXY"],
+      modes: LINEAR_WRITE_PROXY_MODES,
+      fallback: "off",
+      reader: "readLinearWriteProxyConfig",
     },
     {
       key: "catalyst.recovery.deadDocWorker.mode",

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2134,6 +2134,52 @@ export function readCloudFeedConfig(envObj = process.env) {
   return { mode, intervalSec };
 }
 
+// CTL-1889: Linear write-proxy mode reader. Same ladder as readCloudFeedConfig —
+// env (CATALYST_LINEAR_WRITE_PROXY) > Layer-2 (.catalyst.linearWriteProxy.mode) > 'off'.
+//
+// Ships OFF, and for the same reason cloud-feed does rather than the daemon
+// watchdog's shadow: this flag sits on the LIVE Linear write path. "Off" has to mean
+// the transport is never constructed, no per-host key is resolved, and no event is
+// emitted — the only default under which merging into the write path is a strict
+// no-op on every host until an operator says otherwise.
+//
+// `routes` is the per-route path override (see linear-write-proxy.mjs's header: the
+// CTC-509 route contract is not verifiable from this repo, so the shipped defaults
+// are an assumption an operator must be able to correct without a release). Layer-2
+// ONLY, deliberately: a URL path is not a thing to smuggle through a daemon env var,
+// and there is no env precedent for a map-valued knob.
+export const LINEAR_WRITE_PROXY_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2LinearWriteProxy() {
+  try {
+    const p = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.linearWriteProxy;
+    return p && typeof p === "object" ? p : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readLinearWriteProxyConfig(envObj = process.env) {
+  const l2 = readLayer2LinearWriteProxy();
+  const env = envObj.CATALYST_LINEAR_WRITE_PROXY;
+  let mode;
+  if (env === "0") mode = "off";
+  else if (typeof env === "string" && LINEAR_WRITE_PROXY_MODES.has(env)) mode = env;
+  else if (typeof l2.mode === "string" && LINEAR_WRITE_PROXY_MODES.has(l2.mode)) mode = l2.mode;
+  else mode = "off";
+  // Only string values survive: a non-string path would reach template concatenation
+  // as "[object Object]" and POST to a fabricated URL. null means "use the defaults".
+  let routes = null;
+  if (l2.routes && typeof l2.routes === "object" && !Array.isArray(l2.routes)) {
+    const clean = {};
+    for (const [k, v] of Object.entries(l2.routes)) {
+      if (typeof v === "string" && v.startsWith("/")) clean[k] = v;
+    }
+    if (Object.keys(clean).length > 0) routes = clean;
+  }
+  return { mode, routes };
+}
+
 // CTL-1245: dead-but-running doc-worker reclaim mode reader. Mirrors
 // readRecoveryPassConfig / readUnstuckSweepConfig exactly: env
 // (CATALYST_DEAD_DOC_WORKER_RECLAIM) overrides Layer-2 config

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -53,6 +53,7 @@ import {
   getCatalystRepoDir, // CTL-1093 sticky dir
   readDelegateRunnerConfig, // CTL-1331: async board-health delegate runner kill-switch
   readCloudFeedConfig, // CTL-1847: cloud-feed dispatch-source mode
+  readLinearWriteProxyConfig, // CTL-1889: Linear write-proxy transport mode
   readLinearReplica, // CTL-1340: read-replica tier flag (inert; default off)
   getExecutor, // CTL-1365a: phase-worker executor resolver (env→Layer-1→node-class default; all "bg" in Phase 1)
   dispatchModeForExecutor, // CTL-1365a: executor → catalyst.dispatch.mode telemetry vocab
@@ -158,6 +159,9 @@ import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn } fro
 import { resolveSdkBootExecutor, assertSdkAuth } from "./sdk-run-phase-agent.mjs"; // CTL-1367 item 9 + P3: boot auth gate (subscription-only) that degrades sdk→bg AND emits execution-core.executor.bg-fallback so the silent fallback is observable; CTL-1457 (T5): assertSdkAuth also gates a per-phase sdk route on a bg/default node
 import { resolveCodexBootEligibility } from "./codex-run-phase-agent.mjs"; // CTL-1457: codex boot gate (auth.json + `codex --version`) that degrades routed codex phases + emits execution-core.executor.codex-fallback
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human on resume
+import { setLinearWriteProxy, setLinearWriteProxyResolver } from "./linear-write.mjs"; // CTL-1889: install the cloud write-proxy transport + its replica-backed id resolver
+import { createLinearWriteProxy } from "./linear-write-proxy.mjs"; // CTL-1889
+import { createProxyResolver } from "./linear-write-proxy-resolve.mjs"; // CTL-1889
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
 // so the phantom worker-dir validity sweep is operative in production.
@@ -1475,6 +1479,31 @@ export function startDaemon({
           armed: false,
         },
         "cloud-feed: armed",
+      );
+    }
+    // CTL-1889: the Linear write-proxy transport. Same posture as the cloud-feed
+    // block above — `off` (the default) constructs nothing, so linear-write.mjs's
+    // module-level install stays null and every Linear write in this process is
+    // byte-identical to pre-CTL-1889.
+    const writeProxyCfg = readLinearWriteProxyConfig();
+    if (writeProxyCfg.mode !== "off") {
+      const writeProxy = createLinearWriteProxy({
+        mode: writeProxyCfg.mode,
+        routes: writeProxyCfg.routes,
+      });
+      setLinearWriteProxy(writeProxy);
+      // The resolver is installed only for `enforce`: shadow never builds a payload
+      // (see routeThroughProxy), so opening a replica handle for it would be a handle
+      // held open for a code path that cannot run.
+      if (writeProxyCfg.mode === "enforce") setLinearWriteProxyResolver(createProxyResolver());
+      log.info(
+        {
+          mode: writeProxyCfg.mode,
+          baseUrl: writeProxy?.baseUrl ?? null,
+          account: writeProxy?.account ?? null,
+          routesOverridden: writeProxyCfg.routes ? Object.keys(writeProxyCfg.routes) : [],
+        },
+        "linear-write-proxy: armed",
       );
     }
     monitorFn({

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
@@ -1,0 +1,168 @@
+// linear-write-proxy-resolve.mjs — CTL-1889 increment 1.
+//
+// The CTC-509 write routes speak Linear UUIDs, not the vocabulary the daemon
+// carries. `POST /agent/issue-state` wants `{issueId, stateId}`; `/agent/issue-label`
+// wants `{issueId, labelIds[]}`. The daemon holds a ticket IDENTIFIER ("CTL-1889"), a
+// transition KEY ("inProgress") and a label NAME ("needs-human"). This module is the
+// one place those become ids.
+//
+// ── ⛔ THIS RESOLVER FAILS CLOSED. THAT IS THE WHOLE POINT. ──
+// Every other replica reader in this tree (replica-read.mjs's `lookup`, `titles`,
+// `estimates`) is deliberately FAIL-OPEN: a miss returns undefined and the caller
+// falls through to a live Linear read. Copying that posture here would be a defect,
+// not a convenience — on the WRITE path "fall through to live" means "write to Linear
+// with this host's own app-actor", which is the exact thing CTL-1889 retires. So every
+// miss, ambiguity, malformed row and thrown error returns `{ok:false, reason:<named>}`
+// and the caller REFUSES the write. A resolver that cannot fail is not a resolver.
+//
+// ── WHY THE REPLICA AND NOT LINEAR ──
+// AGENTS.md's read rule: single-ticket reads go to the local replica, never a live
+// `linearis` call against the shared fleet quota. Every id this module needs is already
+// replicated (`issues.id`/`team_id`, `workflow_states.id`, `labels.id`), so resolution
+// costs no API budget and works while Linear is rate-limited.
+//
+// ── ⚠️ LABEL NAMES ARE NOT UNIQUE WORKSPACE-WIDE ──
+// Measured on the live replica: `types`, `schema`, `mobile`, `infra`, `etl`, `dbt` and
+// `api` each resolve to FOUR label rows (same name, different teams) — `labels` carries
+// no team_id to disambiguate with. The four labels this increment actually writes
+// (`needs-human`, `needs-input`, `blocked`, `queued` — the CTL-1481 worker-status group)
+// are each unique TODAY (measured n=1), but a resolver that relies on that is one new
+// team-scoped label away from applying another team's label to a ticket. So an
+// ambiguous name is REFUSED by name (`label-ambiguous`), never resolved to a first hit.
+
+import { Database } from "bun:sqlite";
+import { getReplicaDbPath } from "./config.mjs";
+
+/** A resolution failure, always NAMED — a bare null is not a diagnosis. */
+function miss(reason, detail = null) {
+  return detail === null ? { ok: false, reason } : { ok: false, reason, detail };
+}
+
+const ISSUE_SELECT = `
+  SELECT id, team_id FROM issues
+  WHERE identifier = ? AND removed_at IS NULL
+  LIMIT 2
+`;
+
+const STATE_SELECT = `
+  SELECT id FROM workflow_states
+  WHERE team_id = ? AND name = ? AND archived_at IS NULL
+  LIMIT 2
+`;
+
+const LABEL_SELECT = `
+  SELECT id FROM labels
+  WHERE name = ? AND removed_at IS NULL
+  LIMIT 2
+`;
+
+/**
+ * createProxyResolver — identifier/name → Linear UUID, off the local replica.
+ *
+ * The handle is opened lazily and DROPPED on any throw, so a later call re-opens
+ * against a database the replica writer may have re-seeded or migrated underneath us
+ * (same handle discipline as replica-read.mjs — only the verdict differs).
+ */
+export function createProxyResolver({ dbPath = null } = {}) {
+  let db = null;
+
+  const open = () => {
+    if (db) return db;
+    db = new Database(dbPath ?? getReplicaDbPath(), { readonly: true });
+    db.run("PRAGMA busy_timeout = 250");
+    return db;
+  };
+
+  const drop = () => {
+    try {
+      db?.close();
+    } catch {
+      /* already closed */
+    }
+    db = null;
+  };
+
+  /**
+   * one — run a `LIMIT 2` select and demand EXACTLY one row.
+   *
+   * The `LIMIT 2` is deliberate: it is what lets ambiguity be DETECTED rather than
+   * silently resolved to whichever row the query planner returned first. Zero rows and
+   * two rows are different failures and are named differently.
+   */
+  const one = (sql, params, { absent, ambiguous }) => {
+    let rows;
+    try {
+      rows = open().prepare(sql).all(...params);
+    } catch (err) {
+      drop();
+      return miss("replica-unreadable", String(err?.message ?? err).slice(0, 200));
+    }
+    if (!Array.isArray(rows) || rows.length === 0) return miss(absent);
+    if (rows.length > 1) return miss(ambiguous);
+    return { ok: true, row: rows[0] };
+  };
+
+  return {
+    /**
+     * issue(identifier) → {ok:true, issueId, teamId} | {ok:false, reason}
+     * `teamId` comes back because state resolution is team-scoped and re-reading the
+     * issue to get it would be a second query for a value this one already has.
+     */
+    issue(identifier) {
+      if (typeof identifier !== "string" || identifier.trim() === "") {
+        return miss("issue-identifier-invalid");
+      }
+      const r = one(ISSUE_SELECT, [identifier.trim()], {
+        absent: "issue-not-in-replica",
+        ambiguous: "issue-ambiguous",
+      });
+      if (!r.ok) return r;
+      const issueId = r.row?.id;
+      const teamId = r.row?.team_id;
+      if (typeof issueId !== "string" || issueId === "") return miss("issue-id-missing");
+      if (typeof teamId !== "string" || teamId === "") return miss("issue-team-missing");
+      return { ok: true, issueId, teamId };
+    },
+
+    /** stateId(teamId, stateName) → {ok:true, stateId} | {ok:false, reason} */
+    stateId(teamId, stateName) {
+      if (typeof teamId !== "string" || teamId === "") return miss("state-team-invalid");
+      if (typeof stateName !== "string" || stateName.trim() === "") {
+        return miss("state-name-invalid");
+      }
+      const r = one(STATE_SELECT, [teamId, stateName.trim()], {
+        absent: "state-not-in-replica",
+        ambiguous: "state-ambiguous",
+      });
+      if (!r.ok) return r;
+      const stateId = r.row?.id;
+      if (typeof stateId !== "string" || stateId === "") return miss("state-id-missing");
+      return { ok: true, stateId };
+    },
+
+    /**
+     * labelIds(names) → {ok:true, labelIds} | {ok:false, reason, detail}
+     * ALL-OR-NOTHING: one unresolvable name refuses the whole batch. A partial batch
+     * would apply some of the caller's labels and silently drop the rest, which reads
+     * as success at every call site.
+     */
+    labelIds(names) {
+      if (!Array.isArray(names) || names.length === 0) return miss("label-names-empty");
+      const out = [];
+      for (const name of names) {
+        if (typeof name !== "string" || name.trim() === "") return miss("label-name-invalid");
+        const r = one(LABEL_SELECT, [name.trim()], {
+          absent: "label-not-in-replica",
+          ambiguous: "label-ambiguous",
+        });
+        if (!r.ok) return { ...r, detail: r.detail ?? name };
+        const id = r.row?.id;
+        if (typeof id !== "string" || id === "") return miss("label-id-missing", name);
+        out.push(id);
+      }
+      return { ok: true, labelIds: out };
+    },
+
+    close: drop,
+  };
+}

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
@@ -21,6 +21,25 @@
 // replicated (`issues.id`/`team_id`, `workflow_states.id`, `labels.id`), so resolution
 // costs no API budget and works while Linear is rate-limited.
 //
+// ── ⛔ AND THEREFORE BEHIND THE SAME FRESHNESS GATE THE READ PATH USES ──
+// "Read the replica" is only half the rule; the other half is the gate, and an ungated
+// read is the failure this repo has already shipped once. Two conditions, matching
+// `lib/linear-read-replica.sh`'s `replica_fresh` exactly:
+//   1. the writer heartbeat (`<db>.writer.lock` mtime) is younger than
+//      CATALYST_LINEAR_REPLICA_STALE_MS — a DEAD writer leaves a database full of rows
+//      that look perfectly healthy, so an ungated read is a stale read that cannot
+//      announce itself; and
+//   2. `sync_meta.cursor` is non-empty — proof the seed is COMPLETE and not mid-reseed.
+// (2) is asked inside the SAME read transaction as the resolution query, because during
+// a cold reseed the entity tables repopulate in batches: a duplicated label can look
+// unique while only one copy has been restored, and `label-ambiguous` — the guard that
+// stops us sending the wrong UUID — is exactly a row-COUNT judgement. A gate checked
+// outside the transaction can pass and be falsified before the count is taken.
+// Where the bash gate falls back to `linearis`, this one REFUSES: see the fail-closed
+// rule above. `replica-stale` and `replica-reseeding` are named separately from
+// `replica-unreadable` so an operator can tell "the writer is dead" from "the file is
+// broken" from "the ticket is not there".
+//
 // ── ⚠️ LABEL NAMES ARE NOT UNIQUE WORKSPACE-WIDE ──
 // Measured on the live replica: `types`, `schema`, `mobile`, `infra`, `etl`, `dbt` and
 // `api` each resolve to FOUR label rows (same name, different teams) — `labels` carries
@@ -31,7 +50,21 @@
 // ambiguous name is REFUSED by name (`label-ambiguous`), never resolved to a first hit.
 
 import { Database } from "bun:sqlite";
+import { statSync } from "node:fs";
 import { getReplicaDbPath } from "./config.mjs";
+
+/**
+ * Writer-heartbeat staleness ceiling, same knob and same default (300 s) as
+ * `lib/linear-read-replica.sh`'s `replica_fresh`. One contract, two languages — a
+ * resolver that trusted the replica for longer than the read path does would be a second,
+ * looser answer to "is this database safe to read".
+ */
+export const DEFAULT_REPLICA_STALE_MS = 300_000;
+
+function staleCeilingMs(env = process.env) {
+  const raw = Number(env?.CATALYST_LINEAR_REPLICA_STALE_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_REPLICA_STALE_MS;
+}
 
 /** A resolution failure, always NAMED — a bare null is not a diagnosis. */
 function miss(reason, detail = null) {
@@ -63,14 +96,33 @@ const LABEL_SELECT = `
  * against a database the replica writer may have re-seeded or migrated underneath us
  * (same handle discipline as replica-read.mjs — only the verdict differs).
  */
-export function createProxyResolver({ dbPath = null } = {}) {
+export function createProxyResolver({ dbPath = null, env = process.env, now = Date.now } = {}) {
   let db = null;
+  const resolvedPath = () => dbPath ?? getReplicaDbPath();
 
   const open = () => {
     if (db) return db;
-    db = new Database(dbPath ?? getReplicaDbPath(), { readonly: true });
+    db = new Database(resolvedPath(), { readonly: true });
     db.run("PRAGMA busy_timeout = 250");
     return db;
+  };
+
+  /**
+   * writerAlive — the writer heartbeat half of the freshness gate.
+   *
+   * A dead writer leaves a database full of rows that LOOK fine, so an ungated read is a
+   * stale read that cannot announce itself. Same lock file and same ceiling as
+   * `replica_fresh`. Filesystem state, so it cannot live inside the SQLite transaction —
+   * but it is a LIVENESS question, not a consistency one, and the consistency half below
+   * is transactional.
+   */
+  const writerAlive = () => {
+    try {
+      const ageMs = now() - statSync(`${resolvedPath()}.writer.lock`).mtimeMs;
+      return ageMs <= staleCeilingMs(env);
+    } catch {
+      return false; // absent lock = no writer = not safe to resolve a WRITE from
+    }
   };
 
   const drop = () => {
@@ -90,13 +142,37 @@ export function createProxyResolver({ dbPath = null } = {}) {
    * two rows are different failures and are named differently.
    */
   const one = (sql, params, { absent, ambiguous }) => {
+    // ⛔ GATE FIRST — see the module header's freshness section. A dead writer is a
+    // filesystem fact, so it is checked before the transaction opens.
+    if (!writerAlive()) return miss("replica-stale");
+
     let rows;
+    let seeded;
     try {
-      rows = open().prepare(sql).all(...params);
+      const handle = open();
+      // ⛔ SEED-COMPLETENESS AND THE RESOLUTION READ SHARE ONE SNAPSHOT (Codex P1 on
+      // #3489). During a cold reseed the writer clears `sync_meta.cursor` and repopulates
+      // the entity tables in batches, so a partly-restored table can make a DUPLICATED
+      // label look unique — and `label-ambiguous`, the guard that stops us sending the
+      // wrong UUID, is precisely a row-COUNT judgement. Checking the cursor outside the
+      // transaction would leave the window where the gate passes and the reseed lands
+      // before the count is taken. In WAL mode a read transaction pins one snapshot, so
+      // asking both questions inside it means the cursor we trusted and the rows we
+      // counted are the same instant of the database.
+      handle.run("BEGIN");
+      try {
+        seeded = handle
+          .prepare("SELECT 1 AS ok FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1")
+          .get();
+        rows = seeded ? handle.prepare(sql).all(...params) : null;
+      } finally {
+        handle.run("COMMIT");
+      }
     } catch (err) {
       drop();
       return miss("replica-unreadable", String(err?.message ?? err).slice(0, 200));
     }
+    if (!seeded) return miss("replica-reseeding");
     if (!Array.isArray(rows) || rows.length === 0) return miss(absent);
     if (rows.length > 1) return miss(ambiguous);
     return { ok: true, row: rows[0] };

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
@@ -9,7 +9,7 @@
 // database each produce a NAMED refusal rather than a value.
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createProxyResolver } from "./linear-write-proxy-resolve.mjs";
@@ -22,9 +22,17 @@ const LABEL = "83e8124b-34bb-4204-988f-7bd0e3e670ab";
 let dir;
 let dbPath;
 
-/** A replica shaped like the real one — the columns this resolver actually reads. */
-function seed({ issues = true, states = true, labels = true } = {}) {
+/**
+ * A replica shaped like the real one — the columns this resolver actually reads, PLUS
+ * the two things the freshness gate demands: a live writer heartbeat and a non-empty
+ * `sync_meta.cursor`. A fixture without them is not a healthy replica, and every
+ * resolution below would (correctly) refuse.
+ */
+function seed({ issues = true, states = true, labels = true, seeded = true, writerAgeMs = 0 } = {}) {
   const db = new Database(dbPath);
+  db.run("CREATE TABLE sync_meta (key TEXT, value TEXT)");
+  if (seeded) db.run("INSERT INTO sync_meta VALUES ('cursor','1155205')");
+  else db.run("INSERT INTO sync_meta VALUES ('cursor','')"); // mid-reseed: cleared, not absent
   db.run("CREATE TABLE issues (id TEXT, identifier TEXT, team_id TEXT, removed_at INTEGER)");
   db.run("CREATE TABLE workflow_states (id TEXT, team_id TEXT, name TEXT, archived_at INTEGER)");
   db.run("CREATE TABLE labels (id TEXT, name TEXT, removed_at INTEGER)");
@@ -43,6 +51,11 @@ function seed({ issues = true, states = true, labels = true } = {}) {
     db.run("INSERT INTO labels VALUES (?,?,NULL)", ["dup-b", "schema"]);
   }
   db.close();
+  writeFileSync(`${dbPath}.writer.lock`, JSON.stringify({ pid: 1, ownerKey: "test" }));
+  if (writerAgeMs > 0) {
+    const t = (Date.now() - writerAgeMs) / 1000;
+    utimesSync(`${dbPath}.writer.lock`, t, t);
+  }
 }
 
 beforeEach(() => {
@@ -125,14 +138,20 @@ describe("⛔ every failure is NAMED, and none of them is a value", () => {
   });
 
   test("an ABSENT database is a named refusal, never an empty success", () => {
+    // No database means no writer lock either, so the liveness half refuses first. The
+    // point of the assertion is that it REFUSES and says why — not which half caught it.
     const r = createProxyResolver({ dbPath: join(dir, "does-not-exist.db") }).issue("CTL-1889");
     expect(r.ok).toBe(false);
-    expect(r.reason).toBe("replica-unreadable");
+    expect(r.reason).toBe("replica-stale");
   });
 
   test("a CORRUPT database is a named refusal", () => {
-    writeFileSync(dbPath, "this is not a sqlite file");
-    expect(createProxyResolver({ dbPath }).issue("CTL-1889").ok).toBe(false);
+    seed();
+    writeFileSync(dbPath, "this is not a sqlite file"); // keep the lock; break the file
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889")).toMatchObject({
+      ok: false,
+      reason: "replica-unreadable",
+    });
   });
 
   test("a database MISSING the table is a named refusal, not a zero-row 'miss'", () => {
@@ -194,10 +213,75 @@ describe("⛔ every failure is NAMED, and none of them is a value", () => {
   );
 });
 
+describe("⛔ the freshness gate (Codex P1 on #3489) — an ungated read is a stale read", () => {
+  test("a DEAD writer refuses, even though every row still looks perfectly healthy", () => {
+    // The whole hazard: the rows are fine. Nothing about the data says the writer died
+    // ten hours ago, which is why the heartbeat has to be consulted rather than the rows.
+    seed({ writerAgeMs: 10 * 60 * 1000 });
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889")).toEqual({
+      ok: false,
+      reason: "replica-stale",
+    });
+  });
+
+  test("NEGATIVE CONTROL: the same rows resolve when the heartbeat is fresh", () => {
+    seed({ writerAgeMs: 10 * 60 * 1000 });
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889").ok).toBe(false);
+    // Touch ONLY the heartbeat — not one row changes. That is what makes this a control
+    // for the gate rather than a second test of the query.
+    const t = Date.now() / 1000;
+    utimesSync(`${dbPath}.writer.lock`, t, t);
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889").ok).toBe(true);
+  });
+
+  test("the staleness ceiling honours CATALYST_LINEAR_REPLICA_STALE_MS", () => {
+    seed({ writerAgeMs: 10 * 60 * 1000 });
+    const r = createProxyResolver({ dbPath, env: { CATALYST_LINEAR_REPLICA_STALE_MS: "3600000" } });
+    expect(r.issue("CTL-1889").ok).toBe(true);
+  });
+
+  test("a MID-RESEED replica (cursor cleared) refuses — named apart from stale/unreadable", () => {
+    seed({ seeded: false });
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889")).toEqual({
+      ok: false,
+      reason: "replica-reseeding",
+    });
+  });
+
+  test("⭐ THE HAZARD ITSELF: a half-restored duplicate must not resolve as unique", () => {
+    // `schema` really has several team-scoped rows. Mid-reseed only one may be back, so
+    // the ambiguity guard — which is a row COUNT — would see 1 and hand out a UUID that
+    // belongs to whichever team happened to restore first. The seed gate is what stops
+    // that being a silently wrong write rather than a refusal.
+    seed({ seeded: false, labels: false });
+    const db = new Database(dbPath);
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", ["dup-a", "schema"]); // only ONE copy back
+    db.close();
+    expect(createProxyResolver({ dbPath }).labelIds(["schema"])).toMatchObject({
+      ok: false,
+      reason: "replica-reseeding",
+    });
+  });
+
+  test("NEGATIVE CONTROL: with the seed complete, that same single row DOES resolve", () => {
+    // Proving the refusal above came from the gate and not from the row shape — once the
+    // cursor is set, one row is a legitimate unique match.
+    seed({ labels: false });
+    const db = new Database(dbPath);
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", ["dup-a", "schema"]);
+    db.close();
+    expect(createProxyResolver({ dbPath }).labelIds(["schema"])).toEqual({
+      ok: true,
+      labelIds: ["dup-a"],
+    });
+  });
+});
+
 describe("handle discipline", () => {
   test("a resolver recovers after the database is replaced underneath it", () => {
     // The replica writer re-seeds and migrates this file while the daemon holds it
     // open, so a thrown read must DROP the handle rather than poison every later call.
+    seed();
     writeFileSync(dbPath, "garbage");
     const r = createProxyResolver({ dbPath });
     expect(r.issue("CTL-1889").ok).toBe(false);

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
@@ -1,0 +1,208 @@
+// linear-write-proxy-resolve.test.mjs — CTL-1889 increment 1.
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-write-proxy-resolve.test.mjs
+//
+// The resolver is the one component here whose DEFAULT must be refusal. Every other
+// replica reader in this tree is fail-open by design; on the write path that posture
+// would mean "fall through to a direct Linear write under this host's own app-actor",
+// which is the thing CTL-1889 exists to remove. So the assertions below are mostly
+// NEGATIVE: they prove that a miss, an ambiguity, a malformed row and an unreadable
+// database each produce a NAMED refusal rather than a value.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createProxyResolver } from "./linear-write-proxy-resolve.mjs";
+
+const ISSUE = "24af09c0-b42f-4ba9-a51a-df8866fd668c";
+const TEAM = "f317bf00-653d-48d8-8a8b-1656b3534d7a";
+const STATE = "75138f5b-9ec9-4e3c-bdf6-d7130ca084b3";
+const LABEL = "83e8124b-34bb-4204-988f-7bd0e3e670ab";
+
+let dir;
+let dbPath;
+
+/** A replica shaped like the real one — the columns this resolver actually reads. */
+function seed({ issues = true, states = true, labels = true } = {}) {
+  const db = new Database(dbPath);
+  db.run("CREATE TABLE issues (id TEXT, identifier TEXT, team_id TEXT, removed_at INTEGER)");
+  db.run("CREATE TABLE workflow_states (id TEXT, team_id TEXT, name TEXT, archived_at INTEGER)");
+  db.run("CREATE TABLE labels (id TEXT, name TEXT, removed_at INTEGER)");
+  if (issues) {
+    db.run("INSERT INTO issues VALUES (?,?,?,NULL)", [ISSUE, "CTL-1889", TEAM]);
+    db.run("INSERT INTO issues VALUES (?,?,?,?)", ["dead", "CTL-DEAD", TEAM, 1]);
+  }
+  if (states) {
+    db.run("INSERT INTO workflow_states VALUES (?,?,?,NULL)", [STATE, TEAM, "Implement"]);
+    db.run("INSERT INTO workflow_states VALUES (?,?,?,?)", ["old", TEAM, "Retired", 1]);
+  }
+  if (labels) {
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", [LABEL, "needs-human"]);
+    // The measured real-world hazard: one NAME, several team-scoped rows.
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", ["dup-a", "schema"]);
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", ["dup-b", "schema"]);
+  }
+  db.close();
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctl1889-"));
+  dbPath = join(dir, "replica.db");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("the happy path — so the refusals below are not a dead instrument", () => {
+  test("identifier → issueId + teamId", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889")).toEqual({
+      ok: true,
+      issueId: ISSUE,
+      teamId: TEAM,
+    });
+  });
+
+  test("(teamId, stateName) → stateId", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).stateId(TEAM, "Implement")).toEqual({ ok: true, stateId: STATE });
+  });
+
+  test("label names → ids, in the order given", () => {
+    seed();
+    const db = new Database(dbPath);
+    db.run("INSERT INTO labels VALUES (?,?,NULL)", ["second", "blocked"]);
+    db.close();
+    expect(createProxyResolver({ dbPath }).labelIds(["needs-human", "blocked"])).toEqual({
+      ok: true,
+      labelIds: [LABEL, "second"],
+    });
+  });
+});
+
+describe("⛔ every failure is NAMED, and none of them is a value", () => {
+  test("an unknown ticket is a named miss, not undefined", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).issue("CTL-404")).toEqual({
+      ok: false,
+      reason: "issue-not-in-replica",
+    });
+  });
+
+  test("a REMOVED issue is a miss — a deleted ticket is not a write target", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).issue("CTL-DEAD").ok).toBe(false);
+  });
+
+  test("an ARCHIVED workflow state is a miss — it cannot be transitioned to", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).stateId(TEAM, "Retired")).toEqual({
+      ok: false,
+      reason: "state-not-in-replica",
+    });
+  });
+
+  test("a state name from ANOTHER team does not resolve (resolution is team-scoped)", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).stateId("some-other-team", "Implement").ok).toBe(false);
+  });
+
+  test("⭐ an AMBIGUOUS label name REFUSES — it is never resolved to a first hit", () => {
+    seed();
+    const r = createProxyResolver({ dbPath }).labelIds(["schema"]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("label-ambiguous");
+    // The name is carried so an operator reading the log knows WHICH label was refused.
+    expect(r.detail).toBe("schema");
+  });
+
+  test("⭐ a batch is ALL-OR-NOTHING: one bad name refuses the whole write", () => {
+    seed();
+    // A partial batch would apply some labels and silently drop the rest, which reads
+    // as success at every call site — the exact silent-partial-failure this refuses.
+    expect(createProxyResolver({ dbPath }).labelIds(["needs-human", "nope"])).toMatchObject({
+      ok: false,
+      reason: "label-not-in-replica",
+    });
+  });
+
+  test("an ABSENT database is a named refusal, never an empty success", () => {
+    const r = createProxyResolver({ dbPath: join(dir, "does-not-exist.db") }).issue("CTL-1889");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("replica-unreadable");
+  });
+
+  test("a CORRUPT database is a named refusal", () => {
+    writeFileSync(dbPath, "this is not a sqlite file");
+    expect(createProxyResolver({ dbPath }).issue("CTL-1889").ok).toBe(false);
+  });
+
+  test("a database MISSING the table is a named refusal, not a zero-row 'miss'", () => {
+    // A schema-less replica is the CTL-1919 shape: the writer had never created
+    // workflow_states on that host for five hours. "No such table" must not read as
+    // "no such state" — both refuse, but only one of them is about the ticket.
+    seed({ states: false });
+    const db = new Database(dbPath);
+    db.run("DROP TABLE workflow_states");
+    db.close();
+    expect(createProxyResolver({ dbPath }).stateId(TEAM, "Implement")).toMatchObject({
+      ok: false,
+      reason: "replica-unreadable",
+    });
+  });
+
+  test("a row with a NULL id refuses rather than emitting a null into the payload", () => {
+    seed({ issues: false });
+    const db = new Database(dbPath);
+    db.run("INSERT INTO issues VALUES (NULL,?,?,NULL)", ["CTL-NULL", TEAM]);
+    db.close();
+    expect(createProxyResolver({ dbPath }).issue("CTL-NULL")).toEqual({
+      ok: false,
+      reason: "issue-id-missing",
+    });
+  });
+
+  test("a row with no team_id refuses — state resolution would silently mis-scope", () => {
+    seed({ issues: false });
+    const db = new Database(dbPath);
+    db.run("INSERT INTO issues VALUES (?,?,NULL,NULL)", ["x", "CTL-NOTEAM"]);
+    db.close();
+    expect(createProxyResolver({ dbPath }).issue("CTL-NOTEAM")).toEqual({
+      ok: false,
+      reason: "issue-team-missing",
+    });
+  });
+
+  test.each([
+    ["", "issue-identifier-invalid"],
+    ["   ", "issue-identifier-invalid"],
+    [null, "issue-identifier-invalid"],
+    [undefined, "issue-identifier-invalid"],
+    [42, "issue-identifier-invalid"],
+  ])("a junk identifier (%p) refuses by name", (input, reason) => {
+    seed();
+    expect(createProxyResolver({ dbPath }).issue(input)).toEqual({ ok: false, reason });
+  });
+
+  test.each([[[]], [null], ["needs-human"], [undefined]])(
+    "a non-array / empty label list (%p) refuses rather than sending an empty batch",
+    (input) => {
+      seed();
+      expect(createProxyResolver({ dbPath }).labelIds(input)).toEqual({
+        ok: false,
+        reason: "label-names-empty",
+      });
+    },
+  );
+});
+
+describe("handle discipline", () => {
+  test("a resolver recovers after the database is replaced underneath it", () => {
+    // The replica writer re-seeds and migrates this file while the daemon holds it
+    // open, so a thrown read must DROP the handle rather than poison every later call.
+    writeFileSync(dbPath, "garbage");
+    const r = createProxyResolver({ dbPath });
+    expect(r.issue("CTL-1889").ok).toBe(false);
+    rmSync(dbPath);
+    seed();
+    expect(r.issue("CTL-1889")).toEqual({ ok: true, issueId: ISSUE, teamId: TEAM });
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -335,6 +335,70 @@ describe("⛔ the CTL-758 backward-write guard still runs, and runs BEFORE the p
     expect(proxy.sends).toHaveLength(1);
   });
 
+  test("⭐ P1 (Codex #3489): the guard is RE-APPLIED to the state --resolve-only read", () => {
+    // The guard above is fail-OPEN — when its own read cannot answer it returns null and
+    // falls through. `--resolve-only` then reads the real state off the fresh replica. If
+    // that says Done, a backward write must still be refused, or the proxy path reopens a
+    // terminal ticket in exactly the configuration this feature targets: an enforce host
+    // with no linearis, where the first read is MOST likely to fail and the second MOST
+    // likely to succeed.
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyPhaseStatus({
+      ticket: "CTL-6",
+      phase: "pr", // non-terminal key → the guard applies
+      resolveRepoRoot: () => "/repo",
+      // The guard's own read cannot answer — this is the fall-through it is built to allow.
+      cache: { get: () => null, set: () => {}, invalidate: () => {} },
+      exec: (cmd, args) =>
+        args.includes("--resolve-only")
+          ? { code: 0, stdout: JSON.stringify({ action: "resolve-only", currentState: "Done", targetState: "PR" }), stderr: "" }
+          : { code: 0, stdout: "", stderr: "" },
+      proxy,
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("resolve:terminal-no-backward");
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("NEGATIVE CONTROL: the same fall-through with a NON-terminal resolved state DOES write", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyPhaseStatus({
+      ticket: "CTL-6",
+      phase: "pr",
+      resolveRepoRoot: () => "/repo",
+      cache: { get: () => null, set: () => {}, invalidate: () => {} },
+      exec: (cmd, args) =>
+        args.includes("--resolve-only")
+          ? { code: 0, stdout: JSON.stringify({ action: "resolve-only", currentState: "Research", targetState: "PR" }), stderr: "" }
+          : { code: 0, stdout: "", stderr: "" },
+      proxy,
+    });
+    expect(r.applied).toBe(true);
+    expect(proxy.sends).toHaveLength(1);
+  });
+
+  test("the FORWARD terminal write is exempt — Done must remain settable", () => {
+    // Mirrors the guard above: `key === TERMINAL_LINEAR_KEY` is how Done gets written at
+    // all. A re-applied guard that forgot this exemption would deadlock every ticket one
+    // step short of Done.
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyTerminalDone({
+      ticket: "CTL-6",
+      resolveRepoRoot: () => "/repo",
+      cache: { get: () => null, set: () => {}, invalidate: () => {} },
+      exec: (cmd, args) =>
+        args.includes("--resolve-only")
+          ? { code: 0, stdout: JSON.stringify({ action: "resolve-only", currentState: "Canceled", targetState: "Done" }), stderr: "" }
+          : { code: 0, stdout: "", stderr: "" },
+      proxy,
+    });
+    expect(r.applied).toBe(true);
+    expect(proxy.sends).toHaveLength(1);
+  });
+
   test("a missing repoRoot short-circuits before the proxy (unchanged precondition)", () => {
     const proxy = fakeProxy("enforce");
     const r = applyPhaseStatus({ ticket: "CTL-6", phase: "pr", resolveRepoRoot: () => null, exec: () => ({ code: 0 }), proxy });

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -242,7 +242,10 @@ describe("enforce — the proxy IS the write and the direct path is NOT taken", 
       proxy,
     });
     expect(r.applied).toBe(true);
-    expect(r.action).toBe("already-in-target-state");
+    // Same vocabulary the DIRECT path uses for this outcome — the shadow window compares
+    // the two, so the idempotent no-op must not be spelled differently on each side.
+    expect(r.action).toBe("skipped");
+    expect(r.skipped).toBe("already-in-target-state");
     expect(proxy.sends).toHaveLength(0);
   });
 

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -1,0 +1,446 @@
+// linear-write-proxy-wiring.test.mjs — CTL-1889 increment 1.
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-write-proxy-wiring.test.mjs
+//
+// linear-write-proxy.test.mjs proves the TRANSPORT. This file proves the WIRING — that
+// the enforcement point can actually fire, and that `off` is genuinely a no-op rather
+// than a claim. A bound whose enforcement point cannot fire is the failure class this
+// file exists to rule out, so every assertion here is about which seam was REACHED,
+// not about a value the transport already returned.
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  applyLabel,
+  applyPhaseStatus,
+  applyTerminalDone,
+  getLinearWriteProxy,
+  removeLabel,
+  setLinearWriteProxy,
+  setLinearWriteProxyResolver,
+} from "./linear-write.mjs";
+
+/**
+ * A fake replica resolver. Enforce mode cannot build a payload without one, so every
+ * enforce test installs it — which is itself the point: a host whose replica cannot
+ * resolve the ids REFUSES the write rather than falling back to a direct one.
+ */
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+const STATE_ID = "22222222-2222-4222-8222-222222222222";
+const LABEL_ID = "33333333-3333-4333-8333-333333333333";
+function fakeResolver(overrides = {}) {
+  return {
+    issue: () => ({ ok: true, issueId: ISSUE_ID, teamId: "team-1" }),
+    stateId: () => ({ ok: true, stateId: STATE_ID }),
+    labelIds: (names) => ({ ok: true, labelIds: names.map(() => LABEL_ID) }),
+    ...overrides,
+  };
+}
+
+/** A fake transport in one mode, recording every send. */
+function fakeProxy(mode, result) {
+  const sends = [];
+  return {
+    mode,
+    sends,
+    send(req) {
+      sends.push(req);
+      if (mode === "shadow") return { handled: false, applied: false, reason: "shadow" };
+      return result ?? { handled: true, applied: true, reason: null, status: 200 };
+    },
+  };
+}
+
+/** A recording exec that reports a clean transition / clean linearis exit. */
+function recordingExec(calls, { code = 0, stdout = JSON.stringify({ action: "transitioned", currentState: "Research", targetState: "PR" }) } = {}) {
+  return (cmd, args) => {
+    calls.push({ cmd, args });
+    // The enforce state path spawns linear-transition.sh in --resolve-only mode, which
+    // WRITES NOTHING and answers with the resolved target state. Modelled here so the
+    // "did the direct write happen" assertions below stay about the WRITE, not about
+    // whether the script was executed at all.
+    if (Array.isArray(args) && args.includes("--resolve-only")) {
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          action: "resolve-only",
+          currentState: "Research",
+          targetState: "PR",
+          targetStateId: "44444444-4444-4444-8444-444444444444",
+        }),
+        stderr: "",
+      };
+    }
+    return { code, stdout, stderr: "" };
+  };
+}
+
+/** Did this exec call actually WRITE, i.e. spawn the script in anything but resolve-only? */
+const isWritingTransition = (c) =>
+  c.cmd.endsWith("linear-transition.sh") && !c.args.includes("--resolve-only");
+
+afterEach(() => {
+  setLinearWriteProxy(null);
+  setLinearWriteProxyResolver(null);
+});
+
+describe("off — the module-level install is null and nothing changes", () => {
+  test("no proxy is installed by merely importing the module", () => {
+    expect(getLinearWriteProxy()).toBeNull();
+  });
+
+  test("applyLabel still shells linearis, exactly as before", () => {
+    const calls = [];
+    const r = applyLabel({
+      ticket: "CTL-1",
+      label: "needs-human",
+      exec: recordingExec(calls),
+      readLabels: () => ["needs-human"],
+    });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls[0].cmd).toBe("linearis");
+    expect(calls[0].args).toEqual(["issues", "update", "CTL-1", "--labels", "needs-human", "--label-mode", "add"]);
+  });
+
+  test("applyPhaseStatus still shells linear-transition.sh", () => {
+    const calls = [];
+    applyPhaseStatus({ ticket: "CTL-1", phase: "pr", resolveRepoRoot: () => "/repo", exec: recordingExec(calls) });
+    expect(calls.some((c) => c.cmd.endsWith("linear-transition.sh"))).toBe(true);
+  });
+});
+
+describe("shadow — the direct write STILL happens, and the observation is recorded", () => {
+  test("applyLabel: proxy sees the write AND linearis is still called", () => {
+    const proxy = fakeProxy("shadow");
+    const calls = [];
+    const r = applyLabel({
+      ticket: "CTL-2",
+      label: "needs-human",
+      exec: recordingExec(calls),
+      readLabels: () => ["needs-human"],
+      proxy,
+    });
+    expect(r).toEqual({ applied: true, reason: null });
+    // ⛔ SHADOW SENDS AN EMPTY PAYLOAD, ON PURPOSE. Building one costs a
+    // --resolve-only subprocess and up to three replica reads, and shadow makes no
+    // cloud call at all — so a shadow run would tax every Linear write on the host to
+    // construct a body nobody sends. The observation is that the write HAPPENED and on
+    // which route; the contents are proven by the enforce cases below.
+    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-2", payload: {} }]);
+    expect(calls.map((c) => c.cmd)).toContain("linearis");
+  });
+
+  test("applyTerminalDone: proxy sees the write AND the shell still runs", () => {
+    const proxy = fakeProxy("shadow");
+    const calls = [];
+    applyTerminalDone({ ticket: "CTL-2", resolveRepoRoot: () => "/repo", exec: recordingExec(calls), proxy });
+    expect(proxy.sends).toEqual([{ routeId: "issue-state", ticket: "CTL-2", payload: {} }]);
+    expect(calls.some((c) => c.cmd.endsWith("linear-transition.sh"))).toBe(true);
+  });
+});
+
+describe("enforce — the proxy IS the write and the direct path is NOT taken", () => {
+  test("applyLabel: linearis is never spawned", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = applyLabel({ ticket: "CTL-3", label: "needs-human", exec: recordingExec(calls), proxy });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(0);
+    // The CTC-509 contract, measured off catalyst-cloud origin/main: UUIDs, and a
+    // `mode` of add|remove. Asserted here because the earlier cut of this file locked
+    // in `{ticket, mode, labels}`, which the cloud would have rejected with a 400.
+    expect(proxy.sends).toEqual([
+      { routeId: "label", ticket: "CTL-3", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "add" } },
+    ]);
+  });
+
+  test("⛔ enforce with NO resolver installed REFUSES — it does not fall back to linearis", () => {
+    const proxy = fakeProxy("enforce");
+    const calls = [];
+    const r = applyLabel({ ticket: "CTL-3", label: "needs-human", exec: recordingExec(calls), proxy });
+    expect(r).toEqual({ applied: false, reason: "resolve:no-resolver" });
+    expect(calls).toHaveLength(0);
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("⛔ an UNRESOLVABLE ticket REFUSES rather than writing directly (the fail-closed rule)", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver({ issue: () => ({ ok: false, reason: "issue-not-in-replica" }) }));
+    const calls = [];
+    const r = applyLabel({ ticket: "CTL-3", label: "needs-human", exec: recordingExec(calls), proxy });
+    expect(r).toEqual({ applied: false, reason: "resolve:issue-not-in-replica" });
+    expect(calls).toHaveLength(0);
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("⛔ an AMBIGUOUS label name REFUSES — it is never resolved to a first hit", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver({ labelIds: () => ({ ok: false, reason: "label-ambiguous" }) }));
+    const r = applyLabel({ ticket: "CTL-3", label: "schema", exec: () => { throw new Error("must not exec"); }, proxy });
+    expect(r).toEqual({ applied: false, reason: "resolve:label-ambiguous" });
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("applyLabel: the CTL-587 read-back seam is not reached either (it is a host-credential read)", () => {
+    let readBacks = 0;
+    const r = applyLabel({
+      ticket: "CTL-3",
+      label: "x",
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => { readBacks += 1; return ["x"]; },
+      proxy: (setLinearWriteProxyResolver(fakeResolver()), fakeProxy("enforce")),
+    });
+    expect(r.applied).toBe(true);
+    expect(readBacks).toBe(0);
+  });
+
+  test("applyPhaseStatus: linear-transition.sh runs ONLY to resolve, and never to write", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-3",
+      phase: "pr",
+      resolveRepoRoot: () => "/repo",
+      exec: recordingExec(calls),
+      proxy,
+    });
+    expect(r.applied).toBe(true);
+    expect(r.via).toBe("cloud-proxy");
+    // ⚠️ THE DISTINCTION THAT MATTERS. The script IS spawned — it owns the four-rung
+    // state-name precedence chain and duplicating that in JS would make this file a
+    // second source of truth. What must never happen is the WRITING invocation, which
+    // is the one that reaches Linear under this host's own app-actor.
+    expect(calls.filter(isWritingTransition)).toHaveLength(0);
+    expect(calls.filter((c) => c.args.includes("--resolve-only"))).toHaveLength(1);
+    expect(proxy.sends).toEqual([
+      { routeId: "issue-state", ticket: "CTL-3", payload: { issueId: ISSUE_ID, stateId: STATE_ID } },
+    ]);
+  });
+
+  test("from_state/to_state carry what --resolve-only actually read — measured, not fabricated", () => {
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyTerminalDone({
+      ticket: "CTL-3",
+      resolveRepoRoot: () => "/repo",
+      exec: recordingExec([]),
+      proxy: fakeProxy("enforce"),
+    });
+    expect(r.from_state).toBe("Research");
+    expect(r.to_state).toBe("PR");
+  });
+
+  test("an idempotent 'skipped' resolve applies WITHOUT spending a cloud write", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyPhaseStatus({
+      ticket: "CTL-3",
+      phase: "pr",
+      resolveRepoRoot: () => "/repo",
+      exec: (cmd, args) =>
+        args.includes("--resolve-only")
+          ? { code: 0, stdout: JSON.stringify({ action: "skipped", currentState: "PR", targetState: "PR" }), stderr: "" }
+          : { code: 0, stdout: "", stderr: "" },
+      proxy,
+    });
+    expect(r.applied).toBe(true);
+    expect(r.action).toBe("already-in-target-state");
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("⛔ a FAILING --resolve-only refuses; it does not fall through to the writing shell", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = applyPhaseStatus({
+      ticket: "CTL-3",
+      phase: "pr",
+      resolveRepoRoot: () => "/repo",
+      exec: (cmd, args) => {
+        calls.push({ cmd, args });
+        return args.includes("--resolve-only") ? { code: 1, stdout: "", stderr: "boom" } : { code: 0, stdout: "", stderr: "" };
+      },
+      proxy,
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("resolve:resolve-only-failed");
+    expect(calls.filter(isWritingTransition)).toHaveLength(0);
+  });
+
+  test("⛔ a proxy FAILURE does not fall back to a direct Linear write", () => {
+    const proxy = fakeProxy("enforce", { handled: true, applied: false, reason: "no-cloud-token" });
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = applyLabel({ ticket: "CTL-4", label: "needs-human", exec: recordingExec(calls), proxy });
+    expect(r).toEqual({ applied: false, reason: "no-cloud-token" });
+    expect(calls).toHaveLength(0);
+    // NEGATIVE CONTROL: with no proxy the SAME exec IS reached, so the zero above is
+    // a refusal and not a dead recorder.
+    applyLabel({ ticket: "CTL-4", label: "needs-human", exec: recordingExec(calls), readLabels: () => ["needs-human"] });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("a THROWING transport is a named failure, not a silent direct write", () => {
+    const calls = [];
+    const r = applyLabel({
+      ticket: "CTL-5",
+      label: "x",
+      exec: recordingExec(calls),
+      proxy: (setLinearWriteProxyResolver(fakeResolver()), { mode: "enforce", send() { throw new Error("boom"); } }),
+    });
+    expect(r).toEqual({ applied: false, reason: "proxy-threw" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("a throwing transport in SHADOW falls through to the direct write (observation lost, write unaffected)", () => {
+    const calls = [];
+    const r = applyLabel({
+      ticket: "CTL-5",
+      label: "x",
+      exec: recordingExec(calls),
+      readLabels: () => ["x"],
+      proxy: { mode: "shadow", send() { throw new Error("boom"); } },
+    });
+    expect(r).toEqual({ applied: true, reason: null });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("⛔ the CTL-758 backward-write guard still runs, and runs BEFORE the proxy", () => {
+  test("a ticket already at Done is not written to the proxy at all", () => {
+    const proxy = fakeProxy("enforce");
+    const r = applyPhaseStatus({
+      ticket: "CTL-6",
+      phase: "pr", // non-terminal key → the guard applies
+      resolveRepoRoot: () => "/repo",
+      exec: () => ({ code: 0, stdout: "", stderr: "" }),
+      // fetchTicketState reads through exec; short-circuit it with a cache hit instead.
+      cache: { get: () => "Done", set: () => {}, invalidate: () => {} },
+      proxy,
+    });
+    expect(r.skipped).toBe("terminal-no-backward");
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("NEGATIVE CONTROL: the same call on a non-terminal ticket DOES reach the proxy", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    applyPhaseStatus({
+      ticket: "CTL-6",
+      phase: "pr",
+      resolveRepoRoot: () => "/repo",
+      exec: recordingExec(calls),
+      cache: { get: () => "Research", set: () => {}, invalidate: () => {} },
+      proxy,
+    });
+    expect(proxy.sends).toHaveLength(1);
+  });
+
+  test("a missing repoRoot short-circuits before the proxy (unchanged precondition)", () => {
+    const proxy = fakeProxy("enforce");
+    const r = applyPhaseStatus({ ticket: "CTL-6", phase: "pr", resolveRepoRoot: () => null, exec: () => ({ code: 0 }), proxy });
+    expect(r.reason).toBe("no-repo-root");
+    expect(proxy.sends).toHaveLength(0);
+  });
+});
+
+describe("removeLabel — the read still runs, only the write is re-routed", () => {
+  test("⭐ enforce: a NATIVE remove of the one label — not an overwrite of the remaining set", async () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = await removeLabel("CTL-7", "needs-human", {
+      exec: recordingExec(calls),
+      readLabels: () => ({ ok: true, labels: ["needs-human", "bug", "p1"] }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: true });
+    // ⛔ The earlier cut sent {mode:"overwrite", labels:["bug","p1"]}. The cloud accepts
+    // add|remove ONLY and would have 400'd it. Native remove is also strictly safer:
+    // an overwrite races any label another actor adds between the read and the write
+    // and silently drops it, which a remove cannot do.
+    expect(proxy.sends).toEqual([
+      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" } },
+    ]);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("enforce: removing the LAST label is the same native remove — no --clear-labels shell", async () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    await removeLabel("CTL-7", "only", {
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => ({ ok: true, labels: ["only"] }),
+      proxy,
+    });
+    expect(proxy.sends[0].payload).toEqual({ issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" });
+  });
+
+  test("enforce: a proxy failure is a named non-removal, with no direct-write fall-back", async () => {
+    const calls = [];
+    const r = await removeLabel("CTL-7", "needs-human", {
+      exec: recordingExec(calls),
+      readLabels: () => ({ ok: true, labels: ["needs-human", "bug"] }),
+      proxy: (setLinearWriteProxyResolver(fakeResolver()),
+        fakeProxy("enforce", { handled: true, applied: false, reason: "unauthorized" })),
+    });
+    expect(r).toEqual({ removed: false, wrote: false, reason: "unauthorized" });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("the idempotent already-absent path never reaches the proxy (it is not a write)", async () => {
+    const proxy = fakeProxy("enforce");
+    const r = await removeLabel("CTL-7", "gone", {
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => ({ ok: true, labels: ["bug"] }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: false });
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("a failed READ still short-circuits before the proxy", async () => {
+    const proxy = fakeProxy("enforce");
+    const r = await removeLabel("CTL-7", "x", {
+      exec: () => ({ code: 0 }),
+      readLabels: () => ({ ok: false, labels: null, code: 1, stderr: "nope" }),
+      proxy,
+    });
+    expect(r).toMatchObject({ removed: false, wrote: false, reason: "transient" });
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("shadow: the proxy observes AND linearis still performs the overwrite", async () => {
+    const proxy = fakeProxy("shadow");
+    const calls = [];
+    const r = await removeLabel("CTL-8", "needs-human", {
+      exec: recordingExec(calls),
+      readLabels: () => ({ ok: true, labels: ["needs-human", "bug"] }),
+      readLabelNodes: () => ({ ok: false }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: true });
+    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-8", payload: {} }]);
+    expect(calls[0].args).toEqual(["issues", "update", "CTL-8", "--labels", "bug", "--label-mode", "overwrite"]);
+  });
+});
+
+describe("setLinearWriteProxy — the module-level install", () => {
+  test("an installed transport is used when no per-call proxy is passed", () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxy(proxy);
+    setLinearWriteProxyResolver(fakeResolver());
+    expect(getLinearWriteProxy()).toBe(proxy);
+    const calls = [];
+    applyLabel({ ticket: "CTL-9", label: "x", exec: recordingExec(calls) });
+    expect(proxy.sends).toHaveLength(1);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("clearing it restores the direct path", () => {
+    setLinearWriteProxy(fakeProxy("enforce"));
+    setLinearWriteProxy(null);
+    const calls = [];
+    applyLabel({ ticket: "CTL-9", label: "x", exec: recordingExec(calls), readLabels: () => ["x"] });
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -410,7 +410,7 @@ describe("⛔ the CTL-758 backward-write guard still runs, and runs BEFORE the p
   });
 });
 
-describe("removeLabel — the read still runs, only the write is re-routed", () => {
+describe("removeLabel — the proxied removal runs BEFORE the credentialed read", () => {
   test("⭐ enforce: a NATIVE remove of the one label — not an overwrite of the remaining set", async () => {
     const proxy = fakeProxy("enforce");
     setLinearWriteProxyResolver(fakeResolver());
@@ -454,26 +454,91 @@ describe("removeLabel — the read still runs, only the write is re-routed", () 
     expect(calls).toHaveLength(0);
   });
 
-  test("the idempotent already-absent path never reaches the proxy (it is not a write)", async () => {
+  // ⛔ THE REGRESSION THIS BLOCK EXISTS FOR (Codex #3489 round 2, P1). Both tests below
+  // replace earlier ones that PINNED THE DEFECT — they asserted the read short-circuits
+  // ahead of the proxy, which is exactly what strands an enforce host. A test can hold a
+  // bug in place as firmly as it holds a fix, so they are inverted here, not deleted.
+  test("⭐ enforce: a read that fails the way a MISSING linearis fails still removes via the proxy", async () => {
     const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const calls = [];
+    const r = await removeLabel("CTL-7", "needs-human", {
+      exec: recordingExec(calls),
+      // 127 = spawn failure, the shape rawExec reports for an absent binary. This is the
+      // target deployment of enforce mode: a host with NO linearis and no host Linear
+      // credential. Before the fix this returned {removed:false, reason:"transient"} and
+      // never sent, so the daemon's comment-wake clear could never remove needs-input /
+      // needs-human — the worker stayed parked after the user had already answered.
+      readLabels: () => ({ ok: false, labels: null, code: 127, stderr: "spawn linearis ENOENT" }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: true });
+    expect(proxy.sends).toEqual([
+      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" } },
+    ]);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("an AUTH read failure is equally no longer fatal under enforce", async () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = await removeLabel("CTL-7", "needs-human", {
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => ({ ok: false, labels: null, code: 1, stderr: "401 Unauthorized" }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: true });
+    expect(proxy.sends).toHaveLength(1);
+  });
+
+  // ⚠️ NEGATIVE CONTROL — without the proxy the read is still load-bearing and still
+  // fatal. Without this, the two tests above would also pass if the read had simply been
+  // deleted outright, which would silently drop the direct path's label-preserving
+  // read-modify-write.
+  test("no proxy: a failed read is STILL a named non-removal (direct path unchanged)", async () => {
+    const r = await removeLabel("CTL-7", "x", {
+      exec: () => ({ code: 0 }),
+      readLabels: () => ({ ok: false, labels: null, code: 1, stderr: "nope" }),
+    });
+    expect(r).toMatchObject({ removed: false, wrote: false, reason: "transient" });
+  });
+
+  test("shadow: a failed read is still fatal, because shadow performs the DIRECT write", async () => {
+    const proxy = fakeProxy("shadow");
+    const r = await removeLabel("CTL-7", "x", {
+      exec: () => ({ code: 0 }),
+      readLabels: () => ({ ok: false, labels: null, code: 1, stderr: "401 Unauthorized" }),
+      proxy,
+    });
+    expect(r).toMatchObject({ removed: false, wrote: false, reason: "auth-error" });
+  });
+
+  // ⚠️ THE NAMED NARROWING, pinned so it is a decision and not a drift. Under enforce the
+  // already-absent case can no longer be detected (detecting it costs the very credential
+  // being retired), so it sends an idempotent cloud remove and reports wrote:true. The
+  // direct path below still reports wrote:false for the same case — the asymmetry is
+  // deliberate: a spurious `worker.transition` clear on a duplicate wake is recoverable,
+  // a permanently MISSING clear on every enforce host is not.
+  test("enforce: an already-absent label is sent anyway and reports wrote:true", async () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver());
     const r = await removeLabel("CTL-7", "gone", {
       exec: () => { throw new Error("must not exec"); },
       readLabels: () => ({ ok: true, labels: ["bug"] }),
       proxy,
     });
-    expect(r).toEqual({ removed: true, wrote: false });
-    expect(proxy.sends).toHaveLength(0);
+    expect(r).toEqual({ removed: true, wrote: true });
+    expect(proxy.sends).toHaveLength(1);
   });
 
-  test("a failed READ still short-circuits before the proxy", async () => {
-    const proxy = fakeProxy("enforce");
-    const r = await removeLabel("CTL-7", "x", {
-      exec: () => ({ code: 0 }),
-      readLabels: () => ({ ok: false, labels: null, code: 1, stderr: "nope" }),
-      proxy,
+  test("no proxy: the already-absent label is still a no-op write (wrote:false)", async () => {
+    const calls = [];
+    const r = await removeLabel("CTL-7", "gone", {
+      exec: recordingExec(calls),
+      readLabels: () => ({ ok: true, labels: ["bug"] }),
     });
-    expect(r).toMatchObject({ removed: false, wrote: false, reason: "transient" });
-    expect(proxy.sends).toHaveLength(0);
+    expect(r).toEqual({ removed: true, wrote: false });
+    expect(calls).toHaveLength(0);
   });
 
   test("shadow: the proxy observes AND linearis still performs the overwrite", async () => {

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -1,0 +1,506 @@
+// linear-write-proxy.mjs — CTL-1889 increment 1.
+//
+// The host-side transport that sends a Linear WRITE to the Catalyst Cloud write
+// proxy under the ONE Catalyst Cloud grant, authenticated with the PER-HOST KEY,
+// instead of writing to Linear directly with this host's own app-actor.
+//
+// ── WHAT INCREMENT 1 IS, AND WHAT IT IS NOT ──
+// IS:      a mode-gated transport (off | shadow | enforce, default off) covering the
+//          three routes CTC-509 inc 2 already serves — issue-state, label, comment —
+//          plus the per-host-key resolution and the LOUD no-credential refusal.
+// IS NOT:  the retirement of anything. No credential, mint path, or LINEAR_* secret
+//          is removed here. Retirement is gated on a shadow window with zero
+//          host-originated writes, which cannot be run until this ships.
+//
+// ── ⛔ THE HOST SENDS NOTHING FOR IDENTITY ──
+// ADR-0031 (CTC-486): the cloud derives WHICH host wrote from the per-host key it
+// authenticated, not from anything in the request. So this transport deliberately
+// sends NO host name, node name, hostname header, or actor field — adding one would
+// re-create the two-identity confusion the ticket exists to remove, and would make
+// the cloud's attribution depend on a value the host can lie about.
+// `buildProxyRequest` is pure and `linear-write-proxy.test.mjs` asserts the absence
+// positively (no header, no body key) rather than trusting this comment.
+//
+// ── WHY THE TRANSPORT IS SYNCHRONOUS ──
+// `applyLabel` / `applyPhaseStatus` in linear-write.mjs are SYNCHRONOUS and are
+// called from inside the scheduler's synchronous convergers (scheduler.mjs's own
+// comment: "applyLabel is sync + never throws"). Making the transport async would
+// mean making those async, i.e. an async refactor of schedulerTick — a cross-cutting
+// change that has nothing to do with this ticket and would make the diff unreviewable.
+// So the wire call is a `spawnSync` of `curl`, matching the module it interposes on,
+// which already reaches Linear by spawning `linearis` and `linear-transition.sh`.
+//
+// ── ⛔ THE CREDENTIAL NEVER ENTERS argv, AND NEVER TOUCHES DISK ──
+// `curl -H "Authorization: Bearer <tok>"` puts the token in the process table, where
+// any `ps` on the host reads it. `--config <file>` puts it on disk. Both are refused.
+// Every option — method, url, headers, AND body — is written to curl's stdin as a
+// `--config -` document, so argv carries only `["--config","-"]` plus non-secret
+// timeouts. `linear-write-proxy.test.mjs` asserts the token appears in NO argv element,
+// and round-trips the config document through a REAL curl against a local server so
+// the escaping is proven by observation, not by reading the escaper.
+//
+// ── ROUTE PATHS AND PAYLOADS ARE MEASURED, NOT ASSUMED ──
+// An earlier cut of this module shipped DEFAULT_ROUTES as a declared ASSUMPTION,
+// because the CTC-509 contract lives in the cloud repo and that cut could not reach it.
+// It is reachable, and the assumption was wrong on every route and every payload:
+// the guessed `/linear/{issue-state,label,comment}` would have 404'd, and the guessed
+// bodies (`{ticket, transitionKey}`, `{ticket, mode, labels}`) would have 400'd behind
+// them. Read off `apps/mirror/src/index.ts` on catalyst-cloud `origin/main` (5e852bd):
+//
+//   POST /api/v1/agent/issue-state    {issueId, stateId}                    → handleAgentIssueState
+//   POST /api/v1/agent/issue-label    {issueId, labelIds[], mode:add|remove} → handleAgentIssueLabel
+//   POST /api/v1/agent/issue-comment  {issueId, body, parentId?}            → handleAgentIssueComment
+//
+// Every id is a Linear UUID — see linear-write-proxy-resolve.mjs, which is where the
+// daemon's identifier/name vocabulary becomes one. `mode` is `add` or `remove` ONLY:
+// there is no `overwrite`, so a single-label removal sends `remove` with that one id
+// rather than an overwrite carrying the remaining set.
+//
+// The per-route Layer-2 override (`catalyst.linearWriteProxy.routes.<route>`) is KEPT
+// even though the defaults are now measured — the cloud can move a route without a
+// release of this repo, and the override is what makes that a config change.
+//
+// ── ⚠️ THE CREDENTIAL CLASS IS PART OF THE CONTRACT ──
+// These routes require a PER-HOST, ORG-OWNED WorkOS API key. The tenant-wide
+// ADMIN_TOKEN authenticates (it is a machine principal) but carries no WorkOS key id,
+// so the cloud refuses it by name: "credential has no per-host binding". Measured
+// 2026-08-17 — mini-2 carries a real per-host key and a proxied write reached Linear;
+// mini still carries the ADMIN_TOKEN and is refused. A host is therefore not made
+// ready by lighting this flag alone; see the `no-cloud-token` / `unauthorized`
+// refusals below, both of which are LOUD and NAMED rather than a silent fallback.
+
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { resolveSecret } from "../lib/secret-contract.mjs";
+import { getEventLogPath, log as defaultLog } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+/** The three modes, house convention (cf. CLOUD_FEED_MODES / DELEGATE_FIRST_MODES). */
+export const LINEAR_WRITE_PROXY_MODES = Object.freeze(new Set(["off", "shadow", "enforce"]));
+
+/** The route ids CTC-509 inc 2 already serves. Frozen — this is DATA. */
+export const PROXY_ROUTE_IDS = Object.freeze(["issue-state", "label", "comment"]);
+
+/**
+ * Measured against catalyst-cloud `origin/main` (5e852bd) — see the header. Paths are
+ * relative to a base that already ends in `/api/v1` (the fleet's provisioned
+ * CATALYST_CLOUD_BASE_URL). Overridable from Layer-2
+ * `catalyst.linearWriteProxy.routes.<route>`.
+ */
+export const DEFAULT_ROUTES = Object.freeze({
+  "issue-state": "/agent/issue-state",
+  label: "/agent/issue-label",
+  comment: "/agent/issue-comment",
+});
+
+/** Mirrors cloud-sync.mjs:127 — one default, one env override, no third rung. */
+export const DEFAULT_CLOUD_BASE_URL = "https://api.catalyst-cloud.coalescelabs.ai/api/v1";
+
+/**
+ * Hard cap on the serialized request body, byte length. Over it the write is
+ * REFUSED with a named reason — never truncated, never split. Same posture and
+ * same number as the event-log append cap (CTL-1809): a silently truncated Linear
+ * comment is worse than a loud refusal, and curl's config parser is the wrong place
+ * to discover a size limit.
+ */
+export const MAX_BODY_BYTES = 262_144;
+
+/** Wire timeouts. Non-secret, so they ride argv rather than the stdin config. */
+export const CONNECT_TIMEOUT_SEC = 5;
+export const MAX_TIME_SEC = 20;
+
+/**
+ * scrub — strip any secret-shaped substring before it can reach a log line.
+ * Lifted from cloud-sync.mjs:226-234 rather than re-derived, so the two agree.
+ */
+export function scrub(s) {
+  return String(s)
+    .replace(/([?&]token=)[^&\s"']+/gi, "$1***")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+/gi, "Bearer ***")
+    .replace(/\blin_(?:api|oauth)_[A-Za-z0-9_-]+/g, "lin_***");
+}
+
+/**
+ * resolveProxyBaseUrl — the cloud API base, same two-rung shape cloud-sync.mjs uses.
+ * A trailing slash is trimmed so route concatenation is unambiguous.
+ */
+export function resolveProxyBaseUrl(env = process.env) {
+  const raw = env?.CATALYST_CLOUD_BASE_URL || DEFAULT_CLOUD_BASE_URL;
+  return String(raw).replace(/\/+$/, "");
+}
+
+/**
+ * resolveHostKey — the per-host key, THROUGH the existing secret contract.
+ *
+ * ⛔ Deliberately NOT a new registered row and NOT a hand-rolled env ladder. The
+ * `cloud-token` row (delivery `platform-env`, bootstrapFor `cloud`) already IS the
+ * per-host key: configuration.md states "the per-host-ness is the VALUE you provision,
+ * not the name". Hardcoding `CATALYST_CLOUD_TOKEN` here would silently ignore a host
+ * whose operator set `CATALYST_CLOUD_TOKEN_ENV` / Layer-2 `catalyst.cloud.tokenEnv`.
+ *
+ * Returns the contract's shape plus its `envVar`/`envVarSource` extras, with the
+ * value present or null — never a throw, per the contract's own never-throws rule.
+ */
+export function resolveHostKey(env = process.env) {
+  try {
+    const r = resolveSecret("cloud-token", { env });
+    return {
+      value: typeof r?.value === "string" && r.value.length > 0 ? r.value : null,
+      source: r?.source ?? "none",
+      envVar: r?.envVar ?? null,
+      envVarSource: r?.envVarSource ?? null,
+    };
+  } catch {
+    // The contract promises never to throw; if it somehow does, that is "no key",
+    // which routes to the loud refusal below rather than to a direct Linear write.
+    return { value: null, source: "none", envVar: null, envVarSource: null };
+  }
+}
+
+/**
+ * resolveRoutePath — the path for one route id, Layer-2 override over the default.
+ * Returns null for an unknown route id or a non-absolute override, so an enforce
+ * caller refuses with `unknown-route` instead of POSTing to a fabricated URL.
+ */
+export function resolveRoutePath(routeId, routes = null) {
+  if (!PROXY_ROUTE_IDS.includes(routeId)) return null;
+  const override = routes && typeof routes === "object" ? routes[routeId] : undefined;
+  if (typeof override === "string" && override.startsWith("/")) return override;
+  return DEFAULT_ROUTES[routeId];
+}
+
+/**
+ * resolveProxyAccount — the tenant id, same env the replica writer already reads
+ * (`CATALYST_CLOUD_ACCOUNT`, provisioned beside the token in cloud-sync.env).
+ * Returns null when unset — see buildProxyRequest for why that is not an error.
+ */
+export function resolveProxyAccount(env = process.env) {
+  const raw = env?.CATALYST_CLOUD_ACCOUNT;
+  return typeof raw === "string" && raw.trim() !== "" ? raw.trim() : null;
+}
+
+/**
+ * buildProxyRequest — pure. { url, method, body } for one write.
+ *
+ * ⛔ `body` carries the WRITE and nothing else. No host, no node name, no actor.
+ * See the header: identity is the key, not the payload. (The cloud accepts an optional
+ * body `hostId` and compares it to the credential's display label as a NON-blocking
+ * diagnostic — we deliberately still send nothing, because a field the cloud logs a
+ * mismatch WARNING for and then ignores is a field that can only add noise.)
+ *
+ * ── WHY `?account=` IS SENT WHEN KNOWN, AND WHY ITS ABSENCE IS NOT AN ERROR ──
+ * For a correct per-host org key the cloud DEFAULTS the account to the key's own, so
+ * omitting the parameter is already correct and a host with no `CATALYST_CLOUD_ACCOUNT`
+ * still works. Sending it buys DIAGNOSIS, not function: a host mis-provisioned with the
+ * tenant-wide ADMIN_TOKEN gets the specific 403 "credential has no per-host binding"
+ * instead of the generic 401 "missing account", which names the actual defect. The one
+ * cost is that a *wrong* account value turns a working key into a 403 — acceptable,
+ * because that too is loud, and the account is provisioned from the same bundle as the
+ * token it accompanies.
+ */
+export function buildProxyRequest({ routeId, payload, baseUrl, routes = null, account = null }) {
+  const path = resolveRoutePath(routeId, routes);
+  if (path === null) return { url: null, method: null, body: null, reason: "unknown-route" };
+  const query = account ? `?account=${encodeURIComponent(account)}` : "";
+  return {
+    url: `${baseUrl}${path}${query}`,
+    method: "POST",
+    body: JSON.stringify(payload ?? {}),
+    reason: null,
+  };
+}
+
+/**
+ * curlConfigEscape — escape a value for curl's double-quoted config syntax.
+ *
+ * curl un-escapes exactly `\\`, `\"`, `\t`, `\n`, `\r`, `\v` inside a quoted config
+ * value. So escaping backslash FIRST and then the quote is sufficient AND necessary:
+ * JSON.stringify already emits control characters as the two-character sequences
+ * `\` + `n`, and without the backslash doubling curl would collapse that pair back
+ * into a real newline and corrupt the JSON. Order matters — quote-first would
+ * re-escape the backslashes it just introduced.
+ */
+export function curlConfigEscape(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * buildCurlConfig — the `--config -` document handed to curl on stdin.
+ * Pure, so the "no secret in argv" property is testable without running curl.
+ */
+export function buildCurlConfig({ url, method, token, body }) {
+  return (
+    [
+      `request = "${curlConfigEscape(method)}"`,
+      `url = "${curlConfigEscape(url)}"`,
+      `header = "Authorization: Bearer ${curlConfigEscape(token)}"`,
+      'header = "Content-Type: application/json"',
+      'header = "Accept: application/json"',
+      `data = "${curlConfigEscape(body)}"`,
+      "silent",
+      "show-error",
+      // Trailing "\n<code>" so the caller can split the status off the body without
+      // a second request or a header dump that would echo the Authorization line.
+      'write-out = "\\n%{http_code}"',
+    ].join("\n") + "\n"
+  );
+}
+
+/**
+ * classifyProxyResponse — pure. Map a transport result to a tagged verdict.
+ *
+ * reason values (every non-applied path is NAMED — a bare false is not a diagnosis):
+ *   null              — applied
+ *   "spawn-failed"    — curl could not be executed at all
+ *   "transport-error" — curl ran but the request did not complete (non-zero exit)
+ *   "unauthorized"    — 401/403: the per-host key is rejected by the cloud
+ *   "not-found"       — 404: the route does not exist (see the header's route caveat)
+ *   "rate-limited"    — 429
+ *   "server-error"    — 5xx, retry next tick
+ *   "rejected"        — any other non-2xx
+ *   "unreadable"      — 2xx that carried no parseable status line
+ */
+export function classifyProxyResponse({ code, stdout, stderr } = {}) {
+  if (code === 127) return { applied: false, reason: "spawn-failed", status: null };
+  const text = typeof stdout === "string" ? stdout : "";
+  const nl = text.lastIndexOf("\n");
+  const statusRaw = nl === -1 ? text : text.slice(nl + 1);
+  const status = /^\d{3}$/.test(statusRaw.trim()) ? Number(statusRaw.trim()) : null;
+  const bodyText = nl === -1 ? "" : text.slice(0, nl);
+  if (code !== 0) {
+    return { applied: false, reason: "transport-error", status, body: bodyText, stderr: scrub(stderr ?? "") };
+  }
+  if (status === null) return { applied: false, reason: "unreadable", status: null, body: bodyText };
+
+  // ⛔ THE VERDICT COMES FROM THE BODY'S `outcome`, NOT FROM THE STATUS CODE ALONE.
+  // CTC-509 returns a discriminated outcome (`succeeded` | `rejected` | `exhausted`,
+  // plus `failed` for a partly-applied label batch) and the status is DERIVED from it.
+  // Reading only the status would collapse two different things a 2xx can mean — and
+  // for the label route a 200 is emitted only when EVERY id succeeded, so a body that
+  // says otherwise is exactly the case where trusting the code would report a write we
+  // did not get. The body's own `reason` is also far more diagnostic than a re-derived
+  // one, so it is carried through verbatim (scrubbed) rather than replaced.
+  const parsed = parseProxyBody(bodyText);
+  if (parsed && typeof parsed.outcome === "string") {
+    if (parsed.outcome === "succeeded") return { applied: true, reason: null, status, body: bodyText };
+    const named = typeof parsed.reason === "string" && parsed.reason.trim() !== ""
+      ? scrub(parsed.reason).slice(0, 300)
+      : parsed.outcome;
+    return { applied: false, reason: `cloud:${parsed.outcome}`, detail: named, status, body: bodyText };
+  }
+
+  // No parseable outcome — fall back to the status class. A 2xx here is NOT called
+  // applied: these routes always answer with an outcome, so a 2xx without one means we
+  // are not talking to the route we think we are (a proxy/redirect/HTML error page),
+  // and "assume it worked" is the one reading a write path may never take.
+  if (status >= 200 && status < 300) return { applied: false, reason: "unreadable-outcome", status, body: bodyText };
+  if (status === 401 || status === 403) return { applied: false, reason: "unauthorized", status, body: bodyText };
+  if (status === 404) return { applied: false, reason: "not-found", status, body: bodyText };
+  if (status === 429) return { applied: false, reason: "rate-limited", status, body: bodyText };
+  if (status >= 500) return { applied: false, reason: "server-error", status, body: bodyText };
+  return { applied: false, reason: "rejected", status, body: bodyText };
+}
+
+/** parseProxyBody — JSON.parse or null. Never throws; a non-object is not an outcome. */
+export function parseProxyBody(bodyText) {
+  if (typeof bodyText !== "string" || bodyText.trim() === "") return null;
+  try {
+    const v = JSON.parse(bodyText);
+    return v && typeof v === "object" && !Array.isArray(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * defaultHttpFn — the real wire call. `spawnSync` of curl with the whole option
+ * document (including the bearer token) on stdin. Returns rawExec's shape.
+ *
+ * `/usr/bin/curl` is absolute for the same reason `/bin/dd` is in lib/canonical-event.sh:
+ * a restricted-PATH worker is exactly where a PATH-resolved helper becomes a silent
+ * no-op, and the test harness fronts PATH with a fake-bin directory.
+ */
+export const CURL_BIN = "/usr/bin/curl";
+
+export function defaultHttpFn({ url, method, token, body }) {
+  const config = buildCurlConfig({ url, method, token, body });
+  // argv carries NO secret — only the config sentinel and non-secret timeouts.
+  const args = [
+    "--config",
+    "-",
+    "--connect-timeout",
+    String(CONNECT_TIMEOUT_SEC),
+    "--max-time",
+    String(MAX_TIME_SEC),
+  ];
+  const res = spawnSync(CURL_BIN, args, { encoding: "utf8", input: config });
+  if (res.error) return { code: 127, stdout: "", stderr: res.error.message, args };
+  return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "", args };
+}
+
+// ─── Observability ───────────────────────────────────────────────────────────
+//
+// Three names, not one name plus a payload flag — the CTL-1659 rule: otel-forward
+// strips body.payload off-machine, so an alert must be able to select "a host really
+// wrote through the proxy" from `attributes` alone. Registered in
+// broker/namespace-parity.test.mjs by IMPORT, never a re-typed literal.
+
+export const EVENT_WOULD_WRITE = "linear.write.proxy.would-write";
+export const EVENT_APPLIED = "linear.write.proxy.applied";
+export const EVENT_FAILED = "linear.write.proxy.failed";
+export const PROXY_EVENT_NAMES = Object.freeze([EVENT_WOULD_WRITE, EVENT_APPLIED, EVENT_FAILED]);
+
+/**
+ * buildProxyEvent — a v2 envelope for one proxy decision. Cloned from
+ * linear-state-write-event.mjs (CTL-757) so the two audit families agree on
+ * channel / actor / stream_class rather than each inventing their own.
+ */
+export function buildProxyEvent({ name, ticket, routeId, mode, reason = null, status = null, applied = false }) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: name === EVENT_FAILED ? "ERROR" : "INFO",
+      severityNumber: name === EVENT_FAILED ? 17 : 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      channel: "execution-core",
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": ticket ? `${name}.${ticket}` : name,
+        "event.stream_class": "coordination",
+        "event.entity": "linear",
+        "event.action": "write-proxy",
+        "event.label": ticket ?? routeId,
+        "event.channel": "execution-core",
+        "linear.issue.identifier": ticket ?? undefined,
+        "catalyst.linear_write_proxy.route": routeId,
+        "catalyst.linear_write_proxy.mode": mode,
+        "catalyst.linear_write_proxy.reason": reason ?? undefined,
+        "catalyst.linear_write_proxy.status": status ?? undefined,
+      },
+      body: { payload: { ticket: ticket ?? null, route: routeId, mode, applied, reason, status } },
+    }) + "\n"
+  );
+}
+
+function defaultAppendEvent(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+/**
+ * createLinearWriteProxy — the installed transport, or NULL.
+ *
+ * ⛔ `off` INSTALLS NOTHING. Returning null (rather than an inert object) is what
+ * makes the merge a strict no-op: linear-write.mjs's `routeThroughProxy` short-circuits
+ * on a null proxy before it resolves a key, reads config, or emits anything. The check
+ * is a positive allow-list, so a garbage mode that got past the resolver also installs
+ * nothing.
+ */
+export function createLinearWriteProxy({
+  mode = "off",
+  env = process.env,
+  routes = null,
+  httpFn = defaultHttpFn,
+  appendEvent = defaultAppendEvent,
+  log = defaultLog,
+} = {}) {
+  if (mode !== "shadow" && mode !== "enforce") return null;
+
+  const baseUrl = resolveProxyBaseUrl(env);
+  const account = resolveProxyAccount(env);
+  const counts = { wouldWrite: 0, applied: 0, failed: 0 };
+
+  const emit = (name, fields) => {
+    try {
+      appendEvent(buildProxyEvent({ name, mode, ...fields }));
+    } catch (err) {
+      // Emission must never mask or block the write decision it reports.
+      log?.warn?.({ err: scrub(err?.message ?? "") }, "linear-write-proxy: event append failed");
+    }
+  };
+
+  return {
+    mode,
+    baseUrl,
+    account,
+    counts: () => ({ ...counts }),
+
+    /**
+     * send — route one write.
+     *
+     * SHADOW returns `{ handled: false }`: the caller performs its existing direct
+     * write, unchanged, and the observation is recorded. Shadow deliberately makes NO
+     * cloud call — for a WRITE, "observe by doing it too" would double-write the board.
+     *
+     * ENFORCE returns `{ handled: true, applied, reason }`: the proxy IS the write.
+     * ⛔ There is NO fall-back to the direct path on failure. A fall-back would mean
+     * the host keeps writing with its own app-actor exactly when the proxy is broken —
+     * i.e. the shadow window would read "zero host-originated writes" while the host
+     * was still writing. Every caller here already retries on the next tick.
+     */
+    send({ routeId, ticket = null, payload = {} }) {
+      if (mode === "shadow") {
+        counts.wouldWrite += 1;
+        emit(EVENT_WOULD_WRITE, { ticket, routeId, reason: "shadow", applied: false });
+        return { handled: false, applied: false, reason: "shadow" };
+      }
+
+      const fail = (reason, status = null, detail = null) => {
+        counts.failed += 1;
+        emit(EVENT_FAILED, { ticket, routeId, reason, status, applied: false });
+        log?.warn?.(
+          { ticket, route: routeId, reason, status, detail: detail ? scrub(detail) : undefined },
+          "linear-write-proxy: write NOT applied — refusing to fall back to a direct Linear write"
+        );
+        // `detail` is OMITTED rather than set to null when there is none, so the
+        // returned shape stays exactly what a caller must handle and the tests can keep
+        // asserting it with toEqual instead of toMatchObject.
+        return { handled: true, applied: false, reason, ...(detail ? { detail } : {}) };
+      };
+
+      const req = buildProxyRequest({ routeId, payload, baseUrl, routes, account });
+      if (req.reason) return fail(req.reason);
+
+      // ⛔ THE LOUD NO-CREDENTIAL REFUSAL (the ticket's negative control). A host in
+      // enforce with no per-host key must fail with a NAMED reason, never degrade to
+      // a direct Linear write and never look like a success.
+      const key = resolveHostKey(env);
+      if (key.value === null) {
+        log?.error?.(
+          { ticket, route: routeId, token_env: key.envVar, token_env_source: key.envVarSource },
+          "linear-write-proxy: no per-host cloud key — Linear write REFUSED (reason=no-cloud-token)"
+        );
+        return fail("no-cloud-token");
+      }
+
+      const bytes = Buffer.byteLength(req.body, "utf8");
+      if (bytes > MAX_BODY_BYTES) {
+        log?.error?.({ ticket, route: routeId, bytes, cap: MAX_BODY_BYTES },
+          "linear-write-proxy: body over cap — write REFUSED, never truncated");
+        return fail("body-too-large");
+      }
+
+      let raw;
+      try {
+        raw = httpFn({ url: req.url, method: req.method, token: key.value, body: req.body });
+      } catch (err) {
+        log?.warn?.({ ticket, route: routeId, err: scrub(err?.message ?? "") },
+          "linear-write-proxy: transport threw");
+        return fail("spawn-failed");
+      }
+
+      const verdict = classifyProxyResponse(raw);
+      if (!verdict.applied) return fail(verdict.reason, verdict.status, verdict.detail ?? null);
+      counts.applied += 1;
+      emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true });
+      return { handled: true, applied: true, reason: null, status: verdict.status };
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -1,0 +1,502 @@
+// linear-write-proxy.test.mjs — CTL-1889 increment 1.
+// Run: cd plugins/dev/scripts/execution-core && bun test linear-write-proxy.test.mjs
+//
+// Coverage discipline: every mode × outcome cell is PINNED, not sampled, and every
+// suppression / absence claim carries an explicit NEGATIVE CONTROL that proves the
+// instrument can see the thing when it IS present.
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CURL_BIN,
+  DEFAULT_CLOUD_BASE_URL,
+  DEFAULT_ROUTES,
+  EVENT_APPLIED,
+  EVENT_FAILED,
+  EVENT_WOULD_WRITE,
+  LINEAR_WRITE_PROXY_MODES,
+  MAX_BODY_BYTES,
+  PROXY_EVENT_NAMES,
+  PROXY_ROUTE_IDS,
+  buildCurlConfig,
+  buildProxyRequest,
+  classifyProxyResponse,
+  createLinearWriteProxy,
+  curlConfigEscape,
+  defaultHttpFn,
+  resolveHostKey,
+  resolveProxyBaseUrl,
+  resolveRoutePath,
+  scrub,
+} from "./linear-write-proxy.mjs";
+
+const TOKEN = "ctok_live_abcdef0123456789";
+const envWithKey = (extra = {}) => ({ CATALYST_CLOUD_TOKEN: TOKEN, ...extra });
+
+/** A recording transport. Never touches the network. */
+function recorder(result = { code: 0, stdout: "{}\n200", stderr: "" }) {
+  const calls = [];
+  const fn = (req) => {
+    calls.push(req);
+    return typeof result === "function" ? result(req) : result;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+/** A recording event sink; returns the parsed envelopes. */
+function eventSink() {
+  const lines = [];
+  const fn = (line) => lines.push(line);
+  fn.events = () => lines.map((l) => JSON.parse(l));
+  fn.names = () => fn.events().map((e) => e.attributes["event.name"]);
+  return fn;
+}
+
+const silentLog = { info() {}, warn() {}, error() {} };
+
+describe("mode contract", () => {
+  test("the mode set is exactly the three house modes", () => {
+    expect([...LINEAR_WRITE_PROXY_MODES].sort()).toEqual(["enforce", "off", "shadow"]);
+  });
+
+  test.each([undefined, null, "", "off", "OFF", "ENFORCE", "enforce ", "on", "1", "true", 42, {}])(
+    "mode %p installs NOTHING (returns null, not an inert object)",
+    (mode) => {
+      expect(createLinearWriteProxy({ mode, env: envWithKey() })).toBeNull();
+    },
+  );
+
+  test("NEGATIVE CONTROL: the two real modes DO install, so the null above is a decision not a broken factory", () => {
+    expect(createLinearWriteProxy({ mode: "shadow", env: envWithKey() })).not.toBeNull();
+    expect(createLinearWriteProxy({ mode: "enforce", env: envWithKey() })).not.toBeNull();
+  });
+
+  test("off resolves no key and emits nothing — proven by seams that would record it", () => {
+    const http = recorder();
+    const emit = eventSink();
+    expect(createLinearWriteProxy({ mode: "off", env: envWithKey(), httpFn: http, appendEvent: emit })).toBeNull();
+    expect(http.calls).toHaveLength(0);
+    expect(emit.names()).toEqual([]);
+  });
+});
+
+describe("resolveProxyBaseUrl", () => {
+  test("defaults to the cloud API base cloud-sync.mjs uses", () => {
+    expect(resolveProxyBaseUrl({})).toBe(DEFAULT_CLOUD_BASE_URL);
+  });
+  test("CATALYST_CLOUD_BASE_URL overrides, trailing slashes trimmed", () => {
+    expect(resolveProxyBaseUrl({ CATALYST_CLOUD_BASE_URL: "http://h:1/api/v1//" })).toBe("http://h:1/api/v1");
+  });
+  test("an empty override falls back to the default rather than producing a bare path", () => {
+    expect(resolveProxyBaseUrl({ CATALYST_CLOUD_BASE_URL: "" })).toBe(DEFAULT_CLOUD_BASE_URL);
+  });
+});
+
+describe("resolveHostKey — through the secret contract, not a hand-rolled ladder", () => {
+  test("reads the cloud-token row's default env var", () => {
+    const k = resolveHostKey({ CATALYST_CLOUD_TOKEN: TOKEN });
+    expect(k.value).toBe(TOKEN);
+    expect(k.envVar).toBe("CATALYST_CLOUD_TOKEN");
+    expect(k.envVarSource).toBe("default");
+  });
+
+  test("⭐ honours the operator's NAME override — the thing a hardcoded env read would miss", () => {
+    // This is the whole reason resolveHostKey delegates to resolveSecret("cloud-token").
+    const k = resolveHostKey({ CATALYST_CLOUD_TOKEN_ENV: "MY_HOST_KEY", MY_HOST_KEY: TOKEN });
+    expect(k.value).toBe(TOKEN);
+    expect(k.envVar).toBe("MY_HOST_KEY");
+    expect(k.envVarSource).toBe("env");
+  });
+
+  test("NEGATIVE CONTROL: with the override set but the named var empty, the value is null (and the default var is NOT consulted)", () => {
+    const k = resolveHostKey({ CATALYST_CLOUD_TOKEN_ENV: "MY_HOST_KEY", CATALYST_CLOUD_TOKEN: TOKEN });
+    expect(k.value).toBeNull();
+    expect(k.envVar).toBe("MY_HOST_KEY");
+  });
+
+  test("absent key resolves to null, never to a placeholder or empty string", () => {
+    expect(resolveHostKey({}).value).toBeNull();
+    expect(resolveHostKey({ CATALYST_CLOUD_TOKEN: "" }).value).toBeNull();
+  });
+});
+
+describe("routes", () => {
+  test("the three CTC-509 routes are exactly the supported set", () => {
+    expect([...PROXY_ROUTE_IDS].sort()).toEqual(["comment", "issue-state", "label"]);
+    expect(Object.keys(DEFAULT_ROUTES).sort()).toEqual(["comment", "issue-state", "label"]);
+  });
+
+  test("a Layer-2 override wins over the shipped default", () => {
+    expect(resolveRoutePath("label", { label: "/v2/linear/labels" })).toBe("/v2/linear/labels");
+  });
+
+  test("a non-absolute or non-string override is IGNORED, not concatenated", () => {
+    expect(resolveRoutePath("label", { label: "linear/labels" })).toBe(DEFAULT_ROUTES.label);
+    expect(resolveRoutePath("label", { label: 7 })).toBe(DEFAULT_ROUTES.label);
+  });
+
+  test("an unknown route id yields null → buildProxyRequest refuses with a named reason", () => {
+    expect(resolveRoutePath("attachment")).toBeNull();
+    const r = buildProxyRequest({ routeId: "attachment", payload: {}, baseUrl: "http://h" });
+    expect(r).toMatchObject({ url: null, reason: "unknown-route" });
+  });
+});
+
+describe("⛔ the host sends NOTHING for identity (ADR-0031)", () => {
+  test("the request body carries only the write — no host, node, hostname or actor key", () => {
+    const req = buildProxyRequest({
+      routeId: "issue-state",
+      payload: { ticket: "CTL-1", transitionKey: "done" },
+      baseUrl: "http://h/api/v1",
+    });
+    const body = JSON.parse(req.body);
+    expect(Object.keys(body).sort()).toEqual(["ticket", "transitionKey"]);
+    for (const forbidden of ["host", "hostname", "node", "nodeName", "actor", "actorId", "botUserId"]) {
+      expect(body).not.toHaveProperty(forbidden);
+    }
+  });
+
+  test("the curl config sends no host-identifying header", () => {
+    const cfg = buildCurlConfig({ url: "http://h/x", method: "POST", token: TOKEN, body: "{}" });
+    const headers = cfg.split("\n").filter((l) => l.startsWith("header = "));
+    expect(headers.map((h) => h.toLowerCase()).join("\n")).not.toMatch(/host|node|actor/);
+    // NEGATIVE CONTROL: the matcher CAN see a header when one is present.
+    expect(headers.join("\n")).toMatch(/Authorization: Bearer/);
+  });
+});
+
+describe("curl config — the credential never enters argv and never touches disk", () => {
+  test("escaping is backslash-first then quote (order is load-bearing)", () => {
+    expect(curlConfigEscape('a"b')).toBe('a\\"b');
+    expect(curlConfigEscape("a\\nb")).toBe("a\\\\nb");
+    expect(curlConfigEscape('x\\"y')).toBe('x\\\\\\"y');
+  });
+
+  test("defaultHttpFn's argv contains no fragment of the token", () => {
+    // The seam returns the argv it used precisely so this can be asserted.
+    const res = defaultHttpFn({ url: "http://127.0.0.1:1/x", method: "POST", token: TOKEN, body: "{}" });
+    const argv = res.args.join(" ");
+    expect(argv).not.toContain(TOKEN);
+    expect(argv).not.toContain("Bearer");
+    expect(res.args).toContain("--config");
+    expect(res.args).toContain("-");
+    // NEGATIVE CONTROL: the token IS in the document we hand to stdin, so the
+    // assertion above is about placement, not about the token being absent everywhere.
+    expect(buildCurlConfig({ url: "http://h/x", method: "POST", token: TOKEN, body: "{}" })).toContain(TOKEN);
+  });
+});
+
+describe("classifyProxyResponse", () => {
+  test.each([
+    [{ code: 0, stdout: '{"outcome":"succeeded"}\n200' }, true, null, 200],
+    // ⛔ A 2xx WITHOUT a parseable `outcome` is NOT applied. These routes always answer
+    // with one, so a bodyless/HTML 2xx means we reached something other than the route
+    // we think we did (a proxy, a redirect, an error page) — and "assume it worked" is
+    // the one reading a write path may never take.
+    [{ code: 0, stdout: "\n204" }, false, "unreadable-outcome", 204],
+    [{ code: 0, stdout: '{"outcome":"rejected","reason":"Entity not found: Issue"}\n400' }, false, "cloud:rejected", 400],
+    [{ code: 0, stdout: '{"outcome":"exhausted","lastError":"upstream"}\n502' }, false, "cloud:exhausted", 502],
+    // A cloud outcome overrides the status class: the body is the verdict.
+    [{ code: 0, stdout: '{"outcome":"failed","results":[]}\n400' }, false, "cloud:failed", 400],
+    [{ code: 0, stdout: "no\n401" }, false, "unauthorized", 401],
+    [{ code: 0, stdout: "no\n403" }, false, "unauthorized", 403],
+    [{ code: 0, stdout: "no\n404" }, false, "not-found", 404],
+    [{ code: 0, stdout: "no\n429" }, false, "rate-limited", 429],
+    [{ code: 0, stdout: "no\n503" }, false, "server-error", 503],
+    [{ code: 0, stdout: "no\n418" }, false, "rejected", 418],
+    [{ code: 0, stdout: "garbage" }, false, "unreadable", null],
+    [{ code: 7, stdout: "" }, false, "transport-error", null],
+    [{ code: 127, stdout: "" }, false, "spawn-failed", null],
+  ])("%p → applied=%p reason=%p", (raw, applied, reason, status) => {
+    const v = classifyProxyResponse(raw);
+    expect(v.applied).toBe(applied);
+    expect(v.reason).toBe(reason);
+    expect(v.status).toBe(status);
+  });
+
+  test("stderr is scrubbed on the transport-error path", () => {
+    const v = classifyProxyResponse({ code: 7, stdout: "", stderr: "failed with Bearer ctok_secret" });
+    expect(v.stderr).toBe("failed with Bearer ***");
+  });
+});
+
+describe("scrub", () => {
+  test.each([
+    ["Bearer ctok_abc123", "Bearer ***"],
+    ["wss://x/connect?token=abc123&a=1", "wss://x/connect?token=***&a=1"],
+    ["lin_api_abc123", "lin_***"],
+  ])("%p → %p", (a, b) => expect(scrub(a)).toBe(b));
+});
+
+describe("shadow — observes, and does NOT write", () => {
+  test("returns handled:false so the caller performs its existing direct write", () => {
+    const http = recorder();
+    const emit = eventSink();
+    const p = createLinearWriteProxy({ mode: "shadow", env: envWithKey(), httpFn: http, appendEvent: emit, log: silentLog });
+    const r = p.send({ routeId: "label", ticket: "CTL-1", payload: { labels: ["needs-human"] } });
+    expect(r).toEqual({ handled: false, applied: false, reason: "shadow" });
+  });
+
+  test("⛔ makes NO cloud call — 'observe by doing it too' would double-write the board", () => {
+    const http = recorder();
+    const p = createLinearWriteProxy({ mode: "shadow", env: envWithKey(), httpFn: http, appendEvent: eventSink(), log: silentLog });
+    p.send({ routeId: "label", ticket: "CTL-1", payload: {} });
+    expect(http.calls).toHaveLength(0);
+    // NEGATIVE CONTROL: the same recorder DOES record under enforce, so the zero
+    // above is a decision, not a dead seam.
+    const q = createLinearWriteProxy({ mode: "enforce", env: envWithKey(), httpFn: http, appendEvent: eventSink(), log: silentLog });
+    q.send({ routeId: "label", ticket: "CTL-1", payload: {} });
+    expect(http.calls).toHaveLength(1);
+  });
+
+  test("emits would-write under its OWN event name, never the applied name", () => {
+    const emit = eventSink();
+    const p = createLinearWriteProxy({ mode: "shadow", env: envWithKey(), httpFn: recorder(), appendEvent: emit, log: silentLog });
+    p.send({ routeId: "issue-state", ticket: "CTL-7", payload: {} });
+    expect(emit.names()).toEqual([`${EVENT_WOULD_WRITE}.CTL-7`]);
+    const e = emit.events()[0];
+    expect(e.attributes["catalyst.linear_write_proxy.mode"]).toBe("shadow");
+    expect(e.attributes["catalyst.linear_write_proxy.route"]).toBe("issue-state");
+    expect(e.body.payload.applied).toBe(false);
+  });
+
+  test("shadow needs no cloud key — an unprovisioned host can still run the window", () => {
+    const emit = eventSink();
+    const p = createLinearWriteProxy({ mode: "shadow", env: {}, httpFn: recorder(), appendEvent: emit, log: silentLog });
+    expect(p.send({ routeId: "label", ticket: "CTL-1", payload: {} }).handled).toBe(false);
+    expect(emit.names()).toEqual([`${EVENT_WOULD_WRITE}.CTL-1`]);
+  });
+});
+
+describe("enforce — the proxy IS the write", () => {
+  test("a 2xx is applied, and the request went to base+route", () => {
+    const http = recorder({ code: 0, stdout: '{"outcome":"succeeded"}\n200' });
+    const emit = eventSink();
+    const p = createLinearWriteProxy({
+      mode: "enforce",
+      env: envWithKey({ CATALYST_CLOUD_BASE_URL: "http://cloud/api/v1" }),
+      httpFn: http,
+      appendEvent: emit,
+      log: silentLog,
+    });
+    const r = p.send({ routeId: "label", ticket: "CTL-2", payload: { labels: ["a"] } });
+    expect(r).toEqual({ handled: true, applied: true, reason: null, status: 200 });
+    expect(http.calls[0].url).toBe("http://cloud/api/v1/agent/issue-label");
+    expect(http.calls[0].token).toBe(TOKEN);
+    expect(emit.names()).toEqual([`${EVENT_APPLIED}.CTL-2`]);
+    expect(p.counts()).toMatchObject({ applied: 1, failed: 0, wouldWrite: 0 });
+  });
+
+  test("⭐ THE LOUD NO-CREDENTIAL REFUSAL: no per-host key → named reason, no HTTP, no silent degrade", () => {
+    const http = recorder();
+    const emit = eventSink();
+    const errors = [];
+    const p = createLinearWriteProxy({
+      mode: "enforce",
+      env: {}, // no cloud token anywhere
+      httpFn: http,
+      appendEvent: emit,
+      log: { ...silentLog, error: (o, m) => errors.push({ o, m }) },
+    });
+    const r = p.send({ routeId: "issue-state", ticket: "CTL-3", payload: {} });
+    // handled:true is the point — the caller must NOT fall back to a direct write.
+    expect(r).toEqual({ handled: true, applied: false, reason: "no-cloud-token" });
+    expect(http.calls).toHaveLength(0);
+    expect(emit.names()).toEqual([`${EVENT_FAILED}.CTL-3`]);
+    expect(emit.events()[0].severityText).toBe("ERROR");
+    expect(emit.events()[0].attributes["catalyst.linear_write_proxy.reason"]).toBe("no-cloud-token");
+    // LOUD: an ERROR line naming the reason and the env var it looked in.
+    expect(errors).toHaveLength(1);
+    expect(errors[0].m).toContain("no-cloud-token");
+    expect(errors[0].o.token_env).toBe("CATALYST_CLOUD_TOKEN");
+  });
+
+  test.each([
+    ["\n401", "unauthorized"],
+    ["\n404", "not-found"],
+    ["\n429", "rate-limited"],
+    ["\n500", "server-error"],
+  ])("a %p response is a NAMED failure (%p), never a silent success", (tail, reason) => {
+    const emit = eventSink();
+    const p = createLinearWriteProxy({
+      mode: "enforce",
+      env: envWithKey(),
+      httpFn: recorder({ code: 0, stdout: `body${tail}` }),
+      appendEvent: emit,
+      log: silentLog,
+    });
+    const r = p.send({ routeId: "comment", ticket: "CTL-4", payload: { body: "hi" } });
+    expect(r).toEqual({ handled: true, applied: false, reason });
+    expect(emit.names()).toEqual([`${EVENT_FAILED}.CTL-4`]);
+  });
+
+  test("a throwing transport is a named failure, NOT a fall-back to the direct path", () => {
+    const p = createLinearWriteProxy({
+      mode: "enforce",
+      env: envWithKey(),
+      httpFn: () => {
+        throw new Error("boom Bearer ctok_leak");
+      },
+      appendEvent: eventSink(),
+      log: silentLog,
+    });
+    expect(p.send({ routeId: "label", ticket: "CTL-5", payload: {} })).toEqual({
+      handled: true,
+      applied: false,
+      reason: "spawn-failed",
+    });
+  });
+
+  test("a body over the cap is REFUSED, never truncated and never sent", () => {
+    const http = recorder();
+    const p = createLinearWriteProxy({ mode: "enforce", env: envWithKey(), httpFn: http, appendEvent: eventSink(), log: silentLog });
+    const r = p.send({ routeId: "comment", ticket: "CTL-6", payload: { body: "x".repeat(MAX_BODY_BYTES + 1) } });
+    expect(r).toEqual({ handled: true, applied: false, reason: "body-too-large" });
+    expect(http.calls).toHaveLength(0);
+    // NEGATIVE CONTROL: a body just under the cap DOES go out, so the refusal is a
+    // threshold and not a route that never sends anything.
+    const ok = p.send({ routeId: "comment", ticket: "CTL-6", payload: { body: "x".repeat(1000) } });
+    expect(ok.reason).not.toBe("body-too-large");
+    expect(http.calls).toHaveLength(1);
+  });
+
+  test("an unusable route id refuses before resolving the key", () => {
+    const http = recorder();
+    const p = createLinearWriteProxy({ mode: "enforce", env: {}, httpFn: http, appendEvent: eventSink(), log: silentLog });
+    expect(p.send({ routeId: "attachment", ticket: "CTL-8", payload: {} })).toEqual({
+      handled: true,
+      applied: false,
+      reason: "unknown-route",
+    });
+    expect(http.calls).toHaveLength(0);
+  });
+
+  test("a failing event sink never blocks or flips the write decision", () => {
+    const p = createLinearWriteProxy({
+      mode: "enforce",
+      env: envWithKey(),
+      httpFn: recorder({ code: 0, stdout: '{"outcome":"succeeded"}\n200' }),
+      appendEvent: () => {
+        throw new Error("disk full");
+      },
+      log: silentLog,
+    });
+    expect(p.send({ routeId: "label", ticket: "CTL-9", payload: {} }).applied).toBe(true);
+  });
+});
+
+describe("event names", () => {
+  test("the three names are distinct and shadow's is not the applied one", () => {
+    expect(new Set(PROXY_EVENT_NAMES).size).toBe(3);
+    expect(EVENT_WOULD_WRITE).not.toBe(EVENT_APPLIED);
+    expect(PROXY_EVENT_NAMES.every((n) => n.startsWith("linear.write.proxy."))).toBe(true);
+  });
+});
+
+// ─── POSITIVE CONTROL: a real curl against a real out-of-process server ──────
+//
+// Everything above stubs the transport, so none of it can prove the curl config
+// document is actually well-formed — an escaping bug would pass every test above and
+// fail only in production. This block runs the REAL defaultHttpFn against a live HTTP
+// server and asserts the bytes that arrived.
+//
+// ⛔ The server MUST be a separate OS process. defaultHttpFn is a blocking spawnSync,
+// so a Bun.serve in this process could never answer it (its handler is JS on the
+// blocked thread) — the first cut of this test timed out for exactly that reason,
+// which would have read as "the transport is broken" rather than "the harness is".
+describe("defaultHttpFn round-trip against a real server", () => {
+  let proc = null;
+  let recordFile = null;
+  let tmp = null;
+
+  /** Start the fixture server, resolving once it has printed its port. */
+  async function startServer(status = 200) {
+    tmp = mkdtempSync(join(tmpdir(), "ctl1889-"));
+    recordFile = join(tmp, "requests.jsonl");
+    writeFileSync(recordFile, "");
+    proc = Bun.spawn(
+      [process.execPath, join(import.meta.dir, "__fixtures__", "http-echo-server.mjs"), recordFile, String(status)],
+      { stdout: "pipe", stderr: "inherit" },
+    );
+    const reader = proc.stdout.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("fixture server exited before reporting a port");
+      buf += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    const m = /PORT (\d+)/.exec(buf);
+    if (!m) throw new Error(`fixture server printed no port: ${buf}`);
+    return Number(m[1]);
+  }
+
+  const requests = () =>
+    readFileSync(recordFile, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+  afterEach(() => {
+    try { proc?.kill(); } catch { /* already gone */ }
+    proc = null;
+    try { if (tmp) rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+    tmp = null;
+  });
+
+  test("curl is present at the absolute path the transport uses", () => {
+    // Not a skip: curl IS a dependency of this transport, so its absence is a failure
+    // of the environment the feature would run in, and must be loud.
+    expect(existsSync(CURL_BIN)).toBe(true);
+  });
+
+  test("⭐ a body with quotes, backslashes, newlines, commas and unicode arrives BYTE-IDENTICAL", async () => {
+    // Every character class curl's config parser un-escapes, plus a comma-bearing
+    // label name (the collision linear-write-echo's normalizeEchoValue warns about).
+    const port = await startServer(200);
+    const payload = {
+      ticket: "CTL-1889",
+      body: 'he said "hi"\nline2\tTAB\\slash\r\nend — ünïcode 🚀',
+      labels: ["needs,human", 'quo"te', "back\\slash"],
+    };
+    const req = buildProxyRequest({ routeId: "comment", payload, baseUrl: `http://127.0.0.1:${port}/api/v1` });
+    const res = defaultHttpFn({ url: req.url, method: req.method, token: TOKEN, body: req.body });
+
+    expect(classifyProxyResponse(res)).toMatchObject({ applied: true, status: 200 });
+    const got = requests();
+    expect(got).toHaveLength(1);
+    expect(got[0].method).toBe("POST");
+    expect(got[0].path).toBe("/api/v1/agent/issue-comment");
+    expect(got[0].auth).toBe(`Bearer ${TOKEN}`);
+    expect(got[0].contentType).toBe("application/json");
+    // The load-bearing assertion: the JSON survived curl's config quoting exactly.
+    expect(got[0].body).toBe(req.body);
+    expect(JSON.parse(got[0].body)).toEqual(payload);
+  });
+
+  test("no host-identifying header reaches the server", async () => {
+    const port = await startServer(200);
+    const req = buildProxyRequest({
+      routeId: "label",
+      payload: { ticket: "CTL-1", labels: [] },
+      baseUrl: `http://127.0.0.1:${port}/api/v1`,
+    });
+    defaultHttpFn({ url: req.url, method: req.method, token: TOKEN, body: req.body });
+    const names = requests()[0].headerNames.map((n) => n.toLowerCase());
+    // `host` is HTTP/1.1's mandatory authority header (127.0.0.1:<port>), not an
+    // identity claim — every other host-shaped name must be absent.
+    expect(names.filter((n) => n !== "host" && /host|node|actor|catalyst/.test(n))).toEqual([]);
+    // NEGATIVE CONTROL: the filter CAN see a name when one matches.
+    expect(["x-catalyst-host"].filter((n) => /host|node|actor|catalyst/.test(n))).toEqual(["x-catalyst-host"]);
+  });
+
+  test("a non-2xx from a real server classifies as a named failure end to end", async () => {
+    const port = await startServer(401);
+    const req = buildProxyRequest({ routeId: "label", payload: {}, baseUrl: `http://127.0.0.1:${port}/api/v1` });
+    const res = defaultHttpFn({ url: req.url, method: req.method, token: TOKEN, body: req.body });
+    expect(classifyProxyResponse(res)).toMatchObject({ applied: false, reason: "unauthorized", status: 401 });
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -447,6 +447,44 @@ describe("defaultHttpFn round-trip against a real server", () => {
     tmp = null;
   });
 
+  // ⛔ THE CHILD'S DEADLINE, PROVEN TO FIRE (Codex #3489 round 2, P1). A watchdog that is
+  // merely PRESENT in the source is the shape of guardrail this repo has shipped broken
+  // before, so this asserts the behaviour: a server that boots, serves, and then ends
+  // itself while the parent does nothing at all.
+  test("⭐ the fixture server self-terminates on its own deadline, with NO kill from the parent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1889-deadline-"));
+    const rec = join(dir, "requests.jsonl");
+    writeFileSync(rec, "");
+    // ⚠️ Deliberately NOT assigned to the suite's `proc`, so `afterEach` cannot reach it.
+    // The ONLY thing able to end this process is its own timer — which is precisely the
+    // property under test, and it would be untestable if cleanup could do it instead.
+    const child = Bun.spawn(
+      [process.execPath, join(import.meta.dir, "__fixtures__", "http-echo-server.mjs"), rec, "200", "700"],
+      { stdout: "pipe", stderr: "ignore" },
+    );
+    // Positive control: read the readiness line first, so a process that died at startup
+    // (a typo in the fixture, a missing arg) cannot be mistaken for one that timed out.
+    const reader = child.stdout.getReader();
+    const dec = new TextDecoder();
+    let buf = "";
+    while (!buf.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`fixture exited before listening: ${buf}`);
+      buf += dec.decode(value, { stream: true });
+    }
+    reader.releaseLock();
+    expect(/PORT \d+/.test(buf)).toBe(true);
+
+    const started = Date.now();
+    const code = await child.exited;
+    const elapsed = Date.now() - started;
+    expect(code).toBe(0);
+    // It waited for the deadline rather than falling over, and it needed nobody's help.
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(20_000);
+    rmSync(dir, { recursive: true, force: true });
+  }, 30_000);
+
   test("curl is present at the absolute path the transport uses", () => {
     // Not a skip: curl IS a dependency of this transport, so its absence is a failure
     // of the environment the feature would run in, and must be loud.

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -281,6 +281,21 @@ function runTransition({
         if (parsed?.action === "skipped") return { ok: true, skip: "already-in-target-state" };
         if (!resolvedTarget) return { ok: false, reason: "target-state-unresolved" };
 
+        // ⛔ CTL-758 GUARD, RE-APPLIED TO THE STATE WE ACTUALLY READ (Codex P1 on #3489).
+        // The guard above runs on `knownCurrentState ?? fetchTicketState`, which is
+        // FAIL-OPEN: when that read cannot answer it returns null and the guard falls
+        // through. `--resolve-only` then reads the current state from the fresh replica
+        // and may well come back "Done" — so the guard's own predicate has to be applied
+        // a second time, to the better evidence, before a payload is built. Without this
+        // the proxy path could reopen a terminal ticket in exactly the configuration this
+        // feature targets: an enforce host with no `linearis` and a cold state cache is
+        // where the first read is MOST likely to fail and the second MOST likely to
+        // succeed. The `key !== TERMINAL_LINEAR_KEY` condition mirrors the guard above
+        // verbatim — the forward terminal write is exempt, or Done could never be set.
+        if (key !== TERMINAL_LINEAR_KEY && isLinearTerminal(resolvedCurrent)) {
+          return { ok: false, reason: "terminal-no-backward", detail: resolvedCurrent };
+        }
+
         const issue = resolver.issue(ticket);
         if (!issue.ok) return issue;
 

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -528,26 +528,41 @@ export async function removeLabel(
         }
       : readTicketLabels);
   try {
-    const readResult = reader(ticket, { exec });
-    if (!readResult.ok) {
-      const reason = isAuthError(readResult.stderr ?? "") ? "auth-error" : "transient";
-      log.warn({ ticket, label, reason, stderr: readResult.stderr }, "removeLabel: read failed");
-      return { removed: false, wrote: false, reason };
-    }
-    const current = readResult.labels;
-    if (!current.includes(label)) {
-      // Idempotent: the label is already gone, no write needed.
-      return { removed: true, wrote: false };
-    }
-    const remaining = current.filter((l) => l !== label);
-
     // CTL-1889 — label route, REMOVE. An earlier cut sent `mode:"overwrite"` carrying
     // the computed `remaining` set, mirroring what the linearis path below has to do.
     // The cloud has no such mode — it accepts `add` or `remove` only, and would have
     // 400'd every removal. Native `remove` is also strictly safer than an overwrite:
-    // an overwrite races any label another actor adds between the read above and the
-    // write, and silently drops it. `remaining` is still computed because the direct
-    // path below needs it.
+    // an overwrite races any label another actor adds between a read and the write,
+    // and silently drops it.
+    //
+    // ⛔ IT RUNS BEFORE THE READ, AND THAT ORDER IS THE WHOLE POINT (Codex #3489
+    // round 2, P1). `reader` defaults to `readTicketLabels`, a bare `linearis issues
+    // read` — the exact host credential this ticket retires. Placed after the read, as
+    // the first cut had it, an enforce host with no `linearis` fails that read and
+    // returns `auth-error` at the guard above WITHOUT EVER SENDING the cloud removal.
+    // The caller of record is the daemon's comment-wake clear, so the visible symptom
+    // is a user answering a question and `needs-input`/`needs-human` staying attached
+    // forever — a silent, permanent park on precisely the deployment `enforce` targets.
+    // The read is a DIRECT-PATH concern (it computes `remaining` for the overwrite);
+    // the proxy needs only the one label's id, so it must not be gated on it.
+    //
+    // ⚠️ TWO NAMED NARROWINGS, both in the safe direction:
+    //
+    // 1. `wrote` — the direct path distinguishes "this call performed the write"
+    //    (`wrote: true`) from "confirmed already absent, no write needed"
+    //    (`wrote: false`); Codex #2970 round 3 added it so the daemon emits ONE
+    //    `worker.transition` clear per genuine removal, not one per duplicate-webhook
+    //    re-check. Without the read the proxied path cannot make that distinction, and
+    //    the cloud's `{outcome}` envelope carries no changed-flag to recover it. We
+    //    report `true`: at worst a repeated wake duplicates an observability event,
+    //    whereas `false` would make the clear unreachable on every enforce host — a
+    //    silent MISSING transition, which is strictly the worse failure. Sending
+    //    unconditionally is safe because the cloud's `remove` is itself idempotent.
+    // 2. shadow accounting — shadow now records an observation for every removeLabel
+    //    call, including ones the direct path resolves as a no-op. That makes this site
+    //    consistent with the other two (both already emit before knowing whether the
+    //    write is a no-op), but read the shadow counts as "write calls that reached the
+    //    seam", never as "writes that would have hit Linear".
     const proxiedRemove = routeThroughProxy(proxy, {
       routeId: "label",
       ticket,
@@ -565,6 +580,20 @@ export async function removeLabel(
         ? { removed: true, wrote: true }
         : { removed: false, wrote: false, reason: proxiedRemove.reason };
     }
+
+    // ── direct path (no proxy, or shadow handing the write back) ────────────────
+    const readResult = reader(ticket, { exec });
+    if (!readResult.ok) {
+      const reason = isAuthError(readResult.stderr ?? "") ? "auth-error" : "transient";
+      log.warn({ ticket, label, reason, stderr: readResult.stderr }, "removeLabel: read failed");
+      return { removed: false, wrote: false, reason };
+    }
+    const current = readResult.labels;
+    if (!current.includes(label)) {
+      // Idempotent: the label is already gone, no write needed.
+      return { removed: true, wrote: false };
+    }
+    const remaining = current.filter((l) => l !== label);
 
     let res;
     if (remaining.length) {

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -317,9 +317,15 @@ function runTransition({
     if (proxied) {
       // from_state/to_state now carry what `--resolve-only` actually read, rather than
       // the nulls an earlier cut reported: the audit pair is measured on this path too.
+      // `action` deliberately reuses the DIRECT path's vocabulary — "skipped" for an
+      // idempotent no-op, "transitioned" for a performed write — rather than inventing
+      // proxy-specific words. No caller reads it today, but the shadow window's whole
+      // job is comparing these two paths, and a comparison in which the same outcome is
+      // spelled differently on each side is a comparison that manufactures diffs. The
+      // proxy-specific detail rides `skipped`, matching the CTL-758 guard's own shape.
       return {
         ...proxied,
-        action: proxied.skipped ?? (proxied.applied ? "transitioned" : null),
+        action: proxied.applied ? (proxied.skipped ? "skipped" : "transitioned") : null,
         from_state: resolvedCurrent,
         to_state: resolvedTarget,
         via: "cloud-proxy",

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -17,6 +17,119 @@ import { withAuthRemint, isAuthError } from "./linear-remint.mjs";
 // backward-write guard below.
 import { isLinearTerminal } from "./terminal-state.mjs";
 
+// ─── CTL-1889: the cloud write-proxy seam ────────────────────────────────────
+//
+// MEASURED SCOPE, not assumed. This module is the chokepoint for Linear ISSUE-FIELD
+// writes (state, labels, estimate, assignee, blocked-by) — and it reaches Linear by
+// spawning `linearis` / `linear-transition.sh`, never by GraphQL. It is NOT the
+// chokepoint for comments or attachments: `commentCreate` has two independent paths
+// (lib/linear-comment-post.sh, spawned from 5 execution-core modules; and
+// orch-monitor/lib/linear-comment.mjs's direct GraphQL) and `attachmentCreate` has
+// two more (cluster-claim.mjs, cluster-heartbeat.mjs) — four credentials in total.
+// Increment 1 routes the two chokepoint-owned routes CTC-509 already serves
+// (issue-state, label); the comment route exists in the transport and its call sites
+// are increment 2. See linear-write-proxy.mjs's header.
+//
+// ⛔ The proxy is a MODULE-LEVEL install, not a per-call default, and defaults to
+// null. With mode `off` nothing installs it, so every function below is byte-identical
+// to pre-CTL-1889: `routeThroughProxy` returns null on the first line without
+// resolving a key, reading config, or emitting anything.
+let _writeProxy = null;
+let _proxyResolver = null;
+
+/** setLinearWriteProxy — install (or clear, with null) the cloud write transport. */
+export function setLinearWriteProxy(proxy) {
+  _writeProxy = proxy ?? null;
+}
+
+/** getLinearWriteProxy — test/diagnostic read of the installed transport. */
+export function getLinearWriteProxy() {
+  return _writeProxy;
+}
+
+/**
+ * setLinearWriteProxyResolver — install the replica-backed identifier/name → UUID
+ * resolver (linear-write-proxy-resolve.mjs). Separate from the transport because the
+ * two fail for unrelated reasons and a test needs to drive them independently: a
+ * healthy transport with an unresolvable ticket must still REFUSE, and that is the
+ * case a single combined seam makes hard to write.
+ */
+export function setLinearWriteProxyResolver(resolver) {
+  _proxyResolver = resolver ?? null;
+}
+
+/** getLinearWriteProxyResolver — test/diagnostic read of the installed resolver. */
+export function getLinearWriteProxyResolver() {
+  return _proxyResolver;
+}
+
+/**
+ * routeThroughProxy — the single interposition point.
+ *
+ * Returns null when the caller should perform its existing direct write (no proxy
+ * installed, or shadow mode — which records the observation and then lets the direct
+ * write proceed unchanged, because for a WRITE "observe by doing it too" would
+ * double-write the board).
+ *
+ * Returns the transport's verdict when the proxy handled it (enforce). ⛔ There is
+ * deliberately NO fall-back to the direct write on a proxy failure: falling back
+ * would mean the host keeps writing under its own app-actor exactly when the proxy
+ * is broken, so the shadow window that gates retirement would read "zero
+ * host-originated writes" while the host was still writing. Every caller below
+ * already retries on the next tick.
+ */
+function routeThroughProxy(proxy, { routeId, ticket, buildPayload }) {
+  const p = proxy ?? _writeProxy;
+  if (!p) return null;
+
+  // SHADOW records the observation and hands the write back to the caller. The payload
+  // is deliberately NOT built here: building it costs a `--resolve-only` subprocess and
+  // up to three replica reads, and shadow makes no cloud call, so paying for a payload
+  // nobody sends would tax every Linear write on every host running the dry run.
+  if (p.mode === "shadow") {
+    try {
+      p.send({ routeId, ticket, payload: {} });
+    } catch (err) {
+      log.warn({ ticket, routeId, err: err.message }, "linear-write: write-proxy threw (shadow)");
+    }
+    return null;
+  }
+
+  // ⛔ ENFORCE — resolution failure is a NAMED REFUSAL, never a direct write. This is
+  // the one branch where the fail-open habit of every other replica reader in this tree
+  // would be a defect: "fall through to live" here means "write to Linear with this
+  // host's own app-actor", i.e. precisely what CTL-1889 retires. A refused write is
+  // retried on the next tick; a fallen-back write is invisible and permanent.
+  const built = buildPayload(_proxyResolver);
+  if (!built.ok) {
+    log.warn(
+      { ticket, routeId, reason: built.reason, detail: built.detail ?? undefined },
+      "linear-write: write-proxy could not resolve the write — REFUSED (no direct-write fallback)"
+    );
+    return { applied: false, reason: `resolve:${built.reason}` };
+  }
+  if (built.skip) return { applied: true, reason: null, skipped: built.skip };
+
+  let res;
+  try {
+    res = p.send({ routeId, ticket, payload: built.payload });
+  } catch (err) {
+    // A throwing transport must not wedge the tick. It also must not silently become
+    // a direct write — that is the one degradation this seam exists to prevent — so
+    // in enforce it is a named failure and in shadow it is a lost observation.
+    log.warn({ ticket, routeId, err: err.message }, "linear-write: write-proxy threw");
+    // Enforce only reaches here, so a throw is always a named refusal — never a
+    // silent handback to the direct path.
+    return { applied: false, reason: "proxy-threw" };
+  }
+  if (!res?.handled) return null;
+  return {
+    applied: res.applied === true,
+    reason: res.reason ?? null,
+    ...(res.detail ? { detail: res.detail } : {}),
+  };
+}
+
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the
 // sibling-bin spawnSync pattern dispatch.mjs uses for orchestrate-dispatch-next.
 const LINEAR_TRANSITION_BIN = fileURLToPath(
@@ -79,6 +192,9 @@ function runTransition({
   // reads from_state before this call) passes it here so the guard reuses it
   // instead of issuing a second read. undefined → the guard reads for itself.
   knownCurrentState,
+  // CTL-1889: injectable write-proxy seam. undefined → the module-level install
+  // (null unless an operator lit the flag), so production behaviour is unchanged.
+  proxy,
 }) {
   try {
     const repoRoot = resolveRepoRoot(ticket);
@@ -118,7 +234,83 @@ function runTransition({
       }
     }
 
+    // CTL-1889 — issue-state route. Placed AFTER the CTL-758 backward-write guard
+    // deliberately: the guard is a correctness rule about what may be written at all,
+    // and it must hold whichever transport carries the write. Placed BEFORE the shell
+    // so enforce mode never spawns linear-transition.sh (which would write to Linear
+    // with this host's own app-actor — the exact thing being retired).
     const config = `${repoRoot}/.catalyst/config.json`;
+
+    let resolvedTarget = null;
+    let resolvedCurrent = null;
+    const proxied = routeThroughProxy(proxy, {
+      routeId: "issue-state",
+      ticket,
+      buildPayload: (resolver) => {
+        if (!resolver) return { ok: false, reason: "no-resolver" };
+
+        // ⛔ THE STATE NAME COMES FROM linear-transition.sh, NOT FROM A SECOND COPY OF
+        // ITS PRECEDENCE CHAIN. That chain is four rungs deep (per-project stateMap >
+        // global stateMap > the execution-core registry's eligibleQuery.triageStatus >
+        // a built-in default) and re-deriving it here would make this file a second
+        // source of truth for what "inProgress" means — the exact drift AGENTS.md's
+        // single-source-of-truth rule exists to prevent. `--resolve-only` runs that one
+        // chain and writes NOTHING; it also does not require the linearis binary,
+        // because the end state of this ticket is a host that has neither linearis nor
+        // a Linear credential.
+        const r = exec(LINEAR_TRANSITION_BIN, [
+          "--ticket", ticket,
+          "--transition", key,
+          "--config", config,
+          "--resolve-only",
+          "--json",
+        ]);
+        if (r.code !== 0) return { ok: false, reason: "resolve-only-failed", detail: `exit-${r.code}` };
+        let parsed;
+        try {
+          parsed = JSON.parse(r.stdout);
+        } catch {
+          return { ok: false, reason: "resolve-only-unparseable" };
+        }
+        resolvedTarget = parsed?.targetState || null;
+        resolvedCurrent = parsed?.currentState || null;
+
+        // Idempotency is inherited, not recomputed: the writing path treats "already in
+        // target state" as applied, and so must this one, or every steady-state tick
+        // would spend a cloud write budget unit re-asserting a state Linear already has.
+        if (parsed?.action === "skipped") return { ok: true, skip: "already-in-target-state" };
+        if (!resolvedTarget) return { ok: false, reason: "target-state-unresolved" };
+
+        const issue = resolver.issue(ticket);
+        if (!issue.ok) return issue;
+
+        // Replica first (authoritative and current), then the state-id cache
+        // linear-transition.sh already maintains. The second rung is not decoration:
+        // CTL-1919 was a live host whose replica had NO workflow_states table at all
+        // for five hours, which is exactly a replica hit-miss with a healthy cache.
+        const viaReplica = resolver.stateId(issue.teamId, resolvedTarget);
+        const stateId = viaReplica.ok
+          ? viaReplica.stateId
+          : (typeof parsed?.targetStateId === "string" && parsed.targetStateId !== ""
+              ? parsed.targetStateId
+              : null);
+        if (!stateId) return { ok: false, reason: viaReplica.reason ?? "state-unresolved", detail: resolvedTarget };
+
+        return { ok: true, payload: { issueId: issue.issueId, stateId } };
+      },
+    });
+    if (proxied) {
+      // from_state/to_state now carry what `--resolve-only` actually read, rather than
+      // the nulls an earlier cut reported: the audit pair is measured on this path too.
+      return {
+        ...proxied,
+        action: proxied.skipped ?? (proxied.applied ? "transitioned" : null),
+        from_state: resolvedCurrent,
+        to_state: resolvedTarget,
+        via: "cloud-proxy",
+      };
+    }
+
     const { code, stdout } = exec(LINEAR_TRANSITION_BIN, [
       "--ticket",
       ticket,
@@ -160,18 +352,18 @@ function runTransition({
 // CTL-758: `cache` is threaded through to runTransition's backward-write guard
 // so the per-tick shared TTL cache (createTicketStateCache) serves the guard's
 // pre-write read — ≤1 fetchTicketState per ticket per TTL, not a new API storm.
-export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec, cache }) {
+export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec, cache, proxy }) {
   const key = linearKeyForPhase(phase); // throws PhaseFsmError on an unknown phase
   if (key === null) return { applied: false, skipped: "no-status-key" };
-  return runTransition({ ticket, key, resolveRepoRoot, exec, cache });
+  return runTransition({ ticket, key, resolveRepoRoot, exec, cache, proxy });
 }
 
 // applyTerminalDone — write the terminal Done state on monitor-deploy completion.
 // CTL-758: this is the FORWARD terminal write (key === TERMINAL_LINEAR_KEY) — it
 // is EXEMPT from the backward-write guard, so runTransition does not read state
 // here. `cache` is forwarded for symmetry (unused by the exempt path).
-export function applyTerminalDone({ ticket, resolveRepoRoot, exec, cache }) {
-  return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec, cache });
+export function applyTerminalDone({ ticket, resolveRepoRoot, exec, cache, proxy }) {
+  return runTransition({ ticket, key: TERMINAL_LINEAR_KEY, resolveRepoRoot, exec, cache, proxy });
 }
 
 // applyLabel — additively apply a Linear label (needs-human), classify
@@ -213,8 +405,28 @@ export function applyTerminalDone({ ticket, resolveRepoRoot, exec, cache }) {
 // passes a replica-backed reader instead: that path runs per escalation and its
 // read-back was adding a live, rate-limited single-ticket API call to a shared fleet
 // quota — the read-path rule in AGENTS.md exists precisely for this.
-export function applyLabel({ ticket, label, exec = defaultExec, readLabels = null }) {
+export function applyLabel({ ticket, label, exec = defaultExec, readLabels = null, proxy }) {
   try {
+    // CTL-1889 — label route (additive add). On the proxied path the CTL-587
+    // read-back below is NOT performed: it is a live `linearis issues read`, i.e. the
+    // very host credential this ticket retires, so re-running it would defeat the
+    // change. The cloud response is the verdict instead. ⚠️ That is a real, named
+    // narrowing of the silent-success guard for enforce mode — a replica-backed
+    // read-back is increment 2, tracked with the comment-route call sites.
+    const proxied = routeThroughProxy(proxy, {
+      routeId: "label",
+      ticket,
+      buildPayload: (resolver) => {
+        if (!resolver) return { ok: false, reason: "no-resolver" };
+        const issue = resolver.issue(ticket);
+        if (!issue.ok) return issue;
+        const ids = resolver.labelIds([label]);
+        if (!ids.ok) return ids;
+        return { ok: true, payload: { issueId: issue.issueId, labelIds: ids.labelIds, mode: "add" } };
+      },
+    });
+    if (proxied) return proxied;
+
     const writeRes = exec("linearis", [
       "issues",
       "update",
@@ -281,7 +493,7 @@ export function applyLabel({ ticket, label, exec = defaultExec, readLabels = nul
 export async function removeLabel(
   ticket,
   label,
-  { exec = defaultExec, fetchLabels = null, readLabels = null, readLabelNodes = readTicketLabelNodes } = {}
+  { exec = defaultExec, fetchLabels = null, readLabels = null, readLabelNodes = readTicketLabelNodes, proxy } = {}
 ) {
   // Resolve the reader: prefer readLabels (richer), wrap legacy fetchLabels,
   // or default to readTicketLabels.
@@ -307,6 +519,32 @@ export async function removeLabel(
       return { removed: true, wrote: false };
     }
     const remaining = current.filter((l) => l !== label);
+
+    // CTL-1889 — label route, REMOVE. An earlier cut sent `mode:"overwrite"` carrying
+    // the computed `remaining` set, mirroring what the linearis path below has to do.
+    // The cloud has no such mode — it accepts `add` or `remove` only, and would have
+    // 400'd every removal. Native `remove` is also strictly safer than an overwrite:
+    // an overwrite races any label another actor adds between the read above and the
+    // write, and silently drops it. `remaining` is still computed because the direct
+    // path below needs it.
+    const proxiedRemove = routeThroughProxy(proxy, {
+      routeId: "label",
+      ticket,
+      buildPayload: (resolver) => {
+        if (!resolver) return { ok: false, reason: "no-resolver" };
+        const issue = resolver.issue(ticket);
+        if (!issue.ok) return issue;
+        const ids = resolver.labelIds([label]);
+        if (!ids.ok) return ids;
+        return { ok: true, payload: { issueId: issue.issueId, labelIds: ids.labelIds, mode: "remove" } };
+      },
+    });
+    if (proxiedRemove) {
+      return proxiedRemove.applied
+        ? { removed: true, wrote: true }
+        : { removed: false, wrote: false, reason: proxiedRemove.reason };
+    }
+
     let res;
     if (remaining.length) {
       // CTL-1085: prefer ticket-native UUIDs to avoid cross-team name resolution.
@@ -355,6 +593,7 @@ export function applyTriageStatus({
   resolveRepoRoot = defaultResolveRepoRoot,
   exec = defaultExec,
   fetchState = fetchTicketState,
+  proxy,
 }) {
   let from_state = null;
   try {
@@ -372,6 +611,7 @@ export function applyTriageStatus({
       resolveRepoRoot,
       exec,
       knownCurrentState: from_state,
+      proxy,
     });
     if (!t.applied) {
       return { applied: false, verified: false, from_state, to_state: null, reason: t.reason };

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -19,6 +19,17 @@
 #   --force              Skip idempotency check (always call update even if
 #                        ticket is already in target state)
 #   --dry-run            Print what would happen without calling linearis
+#   --resolve-only       CTL-1889. Resolve the target state and STOP — emit
+#                        {targetState, targetStateId, currentState, action} and exit 0,
+#                        writing nothing. Unlike --dry-run it does NOT require the
+#                        linearis binary, because its caller is the cloud write proxy,
+#                        which reaches Linear under the cloud's grant rather than this
+#                        host's. That distinction is the point: the end state of
+#                        CTL-1889 is a host with NO Linear credential and no reason to
+#                        have linearis installed, and the state-resolution chain below
+#                        (per-project stateMap > global stateMap > registry triageStatus
+#                        > built-in default) must keep working there. Duplicating that
+#                        chain in JS would make this script one of two sources of truth.
 #   --json               Emit a JSON result to stdout (default: human-readable)
 #
 # Exit codes:
@@ -61,6 +72,7 @@ CONFIG=""
 FORCE=0
 DRY_RUN=0
 JSON_OUT=0
+RESOLVE_ONLY=0
 
 usage() {
   sed -n '2,24p' "$0" >&2
@@ -75,6 +87,7 @@ while [[ $# -gt 0 ]]; do
     --config)      CONFIG="$2"; shift 2 ;;
     --force)       FORCE=1; shift ;;
     --dry-run)     DRY_RUN=1; shift ;;
+    --resolve-only) RESOLVE_ONLY=1; shift ;;
     --json)        JSON_OUT=1; shift ;;
     -h|--help)     usage 0 ;;
     *)             echo "unknown arg: $1" >&2; usage ;;
@@ -165,7 +178,7 @@ TARGET_STATE_ID="$(lookup_state_id)"
 
 # Cache miss → resolve once, then re-read. Skipped under --dry-run (no side
 # effects) and when there is no teamKey (the resolver requires one).
-if [ -z "$TARGET_STATE_ID" ] && [ -n "$TEAM_KEY" ] && [ "$DRY_RUN" -ne 1 ]; then
+if [ -z "$TARGET_STATE_ID" ] && [ -n "$TEAM_KEY" ] && [ "$DRY_RUN" -ne 1 ] && [ "$RESOLVE_ONLY" -ne 1 ]; then
   RESOLVER="${SCRIPT_DIR}/resolve-linear-ids.sh"
   if [ -x "$RESOLVER" ] && [ -n "$CONFIG_PATH" ]; then
     bash "$RESOLVER" --config "$CONFIG_PATH" --force >/dev/null 2>&1 || true
@@ -185,8 +198,10 @@ emit() {
       --arg transition "$TRANSITION" \
       --arg action "$action" \
       --arg message "$message" \
+      --arg targetStateId "$TARGET_STATE_ID" \
       '{ticket:$ticket, targetState:$targetState, currentState:$currentState,
-        transition:$transition, action:$action, message:$message}'
+        transition:$transition, action:$action, message:$message,
+        targetStateId:$targetStateId}'
   else
     printf '%s — %s (target=%s)' "$TICKET" "$action" "$TARGET_STATE"
     [ -n "$current" ] && printf ' (current=%s)' "$current"
@@ -194,6 +209,28 @@ emit() {
     printf '\n'
   fi
 }
+
+# ─── --resolve-only short-circuit (CTL-1889) ───────────────────────────────
+# Deliberately ABOVE the linearis gate: the cloud write proxy is the caller, and the
+# end state of CTL-1889 is a host with neither linearis nor a Linear credential. The
+# idempotency read below is replica-first (linear_read_ticket) and best-effort, so the
+# proxy caller inherits the SAME "already in target state" answer the writing path
+# would have produced, rather than re-deriving it and risking a different one.
+if [ "$RESOLVE_ONLY" -eq 1 ]; then
+  RO_CURRENT=""
+  if command -v jq >/dev/null 2>&1; then
+    RO_JSON=$(linear_read_ticket "$TICKET" 2>/dev/null || echo "")
+    if [ -n "$RO_JSON" ]; then
+      RO_CURRENT=$(echo "$RO_JSON" | jq -r '.state.name // empty' 2>/dev/null || echo "")
+    fi
+  fi
+  if [ -n "$RO_CURRENT" ] && [ "$RO_CURRENT" = "$TARGET_STATE" ] && [ "$FORCE" -ne 1 ]; then
+    emit "skipped" "$RO_CURRENT" "already in target state"
+  else
+    emit "resolve-only" "$RO_CURRENT" "resolved target state; no write performed"
+  fi
+  exit 0
+fi
 
 # ─── Check linearis availability ───────────────────────────────────────────
 if ! command -v linearis >/dev/null 2>&1; then

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -942,6 +942,106 @@ sustained incident announces once instead of flooding the log every 30 s.
 > first `catalyst doctor` run after deploy legitimately reports `cloud-sync-skew` WARN "skew
 > unknown". It self-clears on the writer's next boot.
 
+### Linear write proxy (`CATALYST_LINEAR_WRITE_PROXY`, CTL-1889)
+
+Routes a host's Linear **writes** through the Catalyst Cloud write proxy under the one Catalyst
+Cloud grant, authenticated with the **per-host key**, instead of writing to Linear directly with
+that host's own "Catalyst Orchestrator" app-actor (ADR-0031 / CTC-486). The host sends **nothing**
+that identifies it — the cloud derives which host wrote from the key it authenticated, so no
+hostname, node name, or actor field appears in the request.
+
+Increment 1 wires the two routes the execution-core write chokepoint owns — **issue-state** and
+**label** (`linear-write.mjs`: `applyPhaseStatus` / `applyTerminalDone` / `applyTriageStatus`,
+`applyLabel`, `removeLabel`). The **comment** route exists in the transport; its call sites
+(`lib/linear-comment-post.sh` and `orch-monitor/lib/linear-comment.mjs`) are a later increment.
+Nothing is retired by this flag: every existing credential, mint path, and `LINEAR_*` secret is
+untouched, and retirement is gated on a shadow window with zero host-originated writes.
+
+Mode resolves from the env var over Layer-2 over the safe default of `off`. The `0` kill-switch and
+any unset/garbage value resolve to `off`.
+
+| Key                                            | Default | Notes                                                                                                                                                                                                                                                                                                                                                     |
+| ---------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_LINEAR_WRITE_PROXY` _(env var)_      | `off`   | `off` / `0` (kill-switch — the transport is never constructed, no key is resolved, no event is emitted; byte-identical to not setting the flag), `shadow` (emit `linear.write.proxy.would-write.<TICKET>` and still perform the existing direct write — shadow makes NO cloud call, since for a write "observe by doing it too" would double-write the board), `enforce` (the proxy IS the write; the direct path is not taken). Garbage values fall back to `off`. Overrides Layer-2. |
+| `catalyst.linearWriteProxy.mode` _(Layer-2)_   | `off`   | Same three values; honored when the env var is absent or unrecognised.                                                                                                                                                                                                                                                                                    |
+| `catalyst.linearWriteProxy.routes` _(Layer-2)_ | _(none)_ | Per-route path override, `{ "issue-state": "/…", "label": "/…", "comment": "/…" }`. Values must be strings beginning `/`; anything else is dropped. Layer-2 only — a URL path has no business in a daemon env var. Defaults are measured; see below.                                                                                                                 |
+
+The per-host key is resolved through the **secret contract's `cloud-token` row** — the same row and
+the same `resolveCloudTokenName` ladder `cloud-sync` uses, so a host whose operator set
+`CATALYST_CLOUD_TOKEN_ENV` or Layer-2 `catalyst.cloud.tokenEnv` is honored. The endpoint base is
+`CATALYST_CLOUD_BASE_URL` over the shipped cloud default, exactly as `cloud-sync` resolves it.
+`CATALYST_CLOUD_ACCOUNT`, when set, rides the request as `?account=`. It is not required — a correct
+per-host key resolves its own tenant — but sending it turns a mis-provisioned host's generic
+`401 missing account` into the specific `403 … no per-host binding`, which names the actual defect.
+
+**In `enforce`, a failure never falls back to a direct Linear write.** A fall-back would mean the
+host keeps writing under its own app-actor precisely when the proxy is broken, so the shadow window
+that gates retirement would read "zero host-originated writes" while the host was still writing.
+Every failure is a NAMED reason (`no-cloud-token`, `unauthorized`, `not-found`, `rate-limited`,
+`server-error`, `rejected`, `unreadable-outcome`, `transport-error`, `spawn-failed`,
+`body-too-large`, `unknown-route`, `proxy-threw`, plus `cloud:<outcome>` for a refusal the cloud
+itself named and `resolve:<reason>` for one the replica resolver named); callers retry on the next
+tick. The verdict is read from the response body's discriminated `outcome`, **not** from the HTTP
+status alone — a 2xx carrying no parseable outcome is `unreadable-outcome` and is not counted as
+applied, because these routes always answer with one and a bare 2xx means we reached something
+other than the route. A host in `enforce` with **no**
+per-host key fails with `no-cloud-token` plus an ERROR line naming the env var it looked in — it
+never degrades quietly.
+
+> **⛔ `enforce` needs a PER-HOST cloud key, and the tenant-wide one is refused by design.** These
+> routes require an **org-owned WorkOS API key** provisioned per host. The tenant-wide `ADMIN_TOKEN`
+> authenticates (it is a machine principal) but carries no WorkOS key id, so the cloud rejects it by
+> name: `credential has no per-host binding`. That is a deliberate refusal, not a misconfiguration
+> to work around — the key's own id is what attributes a write to a host. Measured 2026-08-17:
+> **mini-2** carries a real per-host key and a proxied write reached Linear end to end; **mini**
+> still carries the `ADMIN_TOKEN` and every write is refused. Probe a host before enabling it:
+>
+> ```bash
+> curl -s -o /dev/stderr -w '%{http_code}\n' -X POST \
+>   "$CATALYST_CLOUD_BASE_URL/agent/issue-state?account=$CATALYST_CLOUD_ACCOUNT" \
+>   -H "Authorization: Bearer $CATALYST_CLOUD_TOKEN" -H 'Content-Type: application/json' \
+>   -d '{"issueId":"00000000-0000-4000-8000-000000000000","stateId":"00000000-0000-4000-8000-000000000001"}'
+> ```
+>
+> `400 {"outcome":"rejected","reason":"Entity not found: Issue"}` = a good key (it reached Linear and
+> the fake id was rejected there). `403 … no per-host binding` = the `ADMIN_TOKEN`; this host is not
+> ready. `401 missing account` = the `ADMIN_TOKEN` with no `?account=`.
+
+**Route paths are measured**, against `catalyst-cloud` `origin/main` — `/agent/issue-state`,
+`/agent/issue-label`, `/agent/issue-comment`, relative to a base that already ends in `/api/v1`.
+The `routes` override is kept anyway: the cloud can move a route without a release of this repo,
+and the override makes that a config change rather than a release.
+
+**Identifiers are resolved to Linear UUIDs off the local replica**, never a live Linear read
+(`linear-write-proxy-resolve.mjs`): ticket identifier → `issues.id`, label name → `labels.id`, and
+the target state name → `workflow_states.id` scoped to the issue's team. The state NAME itself comes
+from `linear-transition.sh --resolve-only`, which runs the one four-rung precedence chain
+(per-project `stateMap` > global `stateMap` > the registry's `eligibleQuery.triageStatus` > a
+built-in default) and writes nothing — so this feature does not become a second source of truth for
+what `inProgress` means. That mode deliberately does **not** require the `linearis` binary, because
+the end state of CTL-1889 is a host with neither `linearis` nor a Linear credential.
+
+> **⛔ Resolution failure is a refusal, not a fallback.** Unlike every other replica reader in the
+> tree (which is fail-OPEN and falls through to a live read), this resolver fails **closed**: an
+> absent ticket, an archived state, an unreadable replica, or a label name matching **more than
+> one** label all refuse the write with a named `resolve:<reason>`. Ambiguity is real — `schema`,
+> `types`, `mobile`, `infra`, `etl`, `dbt` and `api` each match four label rows in the live
+> workspace, and `labels` carries no team id to disambiguate with. The four labels this increment
+> writes (`needs-human`, `needs-input`, `blocked`, `queued`) are each unique today, but a first-hit
+> resolver would be one new team-scoped label away from putting another team's label on a ticket.
+
+> **Verification narrowing in `enforce`.** The CTL-587 label read-back is a live
+> `linearis issues read` — the very host credential this feature retires — so it is **not**
+> performed on the proxied path; the cloud response is the verdict. A replica-backed read-back is
+> tracked with the comment-route call sites.
+
+Observable events (all safe for a LogQL filter
+`{job="catalyst-events"} | json | attributes["event.name"] =~ "linear\\.write\\.proxy\\..*"`):
+
+- `linear.write.proxy.would-write.<TICKET>` — shadow hit; the direct write still happened
+- `linear.write.proxy.applied.<TICKET>` — enforce hit, the cloud accepted the write
+- `linear.write.proxy.failed.<TICKET>` — enforce hit, NOT written (ERROR; `reason` attached)
+
 ## Deployment mode (`catalyst.deployment.mode`, CTL-1617)
 
 `catalyst.deployment.mode` is the ONE declared answer to a question the system otherwise infers from

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1012,6 +1012,13 @@ never degrades quietly.
 The `routes` override is kept anyway: the cloud can move a route without a release of this repo,
 and the override makes that a config change rather than a release.
 
+The CTL-758 backward-write guard is **re-applied** to the state `--resolve-only` reads. The guard
+that runs before it is fail-open — when its own read cannot answer it returns null and falls
+through — and the resolve step then reads the real state off the fresh replica. On an `enforce` host
+with no `linearis` that first read is the *most* likely to fail and the second the *most* likely to
+succeed, so without the second application the proxy could reopen a terminal ticket. The forward
+terminal write stays exempt, exactly as in the original guard.
+
 **Identifiers are resolved to Linear UUIDs off the local replica**, never a live Linear read
 (`linear-write-proxy-resolve.mjs`): ticket identifier → `issues.id`, label name → `labels.id`, and
 the target state name → `workflow_states.id` scoped to the issue's team. The state NAME itself comes
@@ -1020,6 +1027,15 @@ from `linear-transition.sh --resolve-only`, which runs the one four-rung precede
 built-in default) and writes nothing — so this feature does not become a second source of truth for
 what `inProgress` means. That mode deliberately does **not** require the `linearis` binary, because
 the end state of CTL-1889 is a host with neither `linearis` nor a Linear credential.
+
+> **⛔ The resolver is behind the same freshness gate as the read path.** "Read the replica" is only
+> half the rule. Resolution refuses unless the writer heartbeat (`<db>.writer.lock` mtime) is younger
+> than `CATALYST_LINEAR_REPLICA_STALE_MS` (default 300 s) **and** `sync_meta.cursor` is non-empty —
+> the same two conditions `lib/linear-read-replica.sh`'s `replica_fresh` applies, except that this
+> one refuses (`replica-stale` / `replica-reseeding`) where the read path falls back to `linearis`.
+> The seed check runs in the **same read transaction** as the resolution query: during a cold reseed
+> the entity tables repopulate in batches, so a duplicated label can look unique while only one copy
+> is back, and the ambiguity guard below is precisely a row-count judgement.
 
 > **⛔ Resolution failure is a refusal, not a fallback.** Unlike every other replica reader in the
 > tree (which is fail-OPEN and falls through to a live read), this resolver fails **closed**: an


### PR DESCRIPTION
## What

The daemon is the **last per-host Linear writer**. `linear-write.mjs` reaches Linear by spawning `linearis` / `linear-transition.sh` under this host's own **Catalyst Orchestrator** app-actor; ADR-0031 (CTC-486) says the cloud proxies writes through **its own** grant. This wires the **issue-state** and **label** routes CTC-509 serves, behind `off | shadow | enforce` — **default `off`**, so merging is a strict no-op on every host until an operator says otherwise.

**Nothing is retired here.** Every credential, mint path and `LINEAR_*` secret is untouched. Retirement is gated on a shadow window with zero host-originated writes, which cannot be run until this ships.

## ⭐ Verified end to end before the client was written

A real `POST /api/v1/agent/issue-comment` from **mini-2** against the live mirror:

```
HTTP 200 {"outcome":"succeeded","attempts":1}
```

The comment landed on CTL-1889, and the replica shows its author as **`Catalyst Cloud`** — the single identity this ticket exists to produce. So the cloud half is proven live, not assumed.

## ⛔ The credential class is part of the contract, and the fleet is split

These routes require a **per-host, org-owned WorkOS API key**. The tenant-wide `ADMIN_TOKEN` authenticates (it *is* a machine principal) but carries no WorkOS key id, so the cloud refuses it **by name**. Measured on both minis:

| host | credential | proxied write |
|---|---|---|
| **mini-2** | per-host WorkOS org key | ✅ reaches Linear (`400 Entity not found: Issue` for a fake id — the correct negative) |
| **mini** | tenant-wide `ADMIN_TOKEN` | ⛔ `403 credential has no per-host binding` |

Two independent confirmations for mini: omitting `?account=` returns `401 missing account`, a branch only the `ADMIN_TOKEN` path can reach. **`enforce` is per-host until mini is provisioned a key** — that is a cloud/WorkOS provisioning action, not a code change. `docs → configuration.md` carries the copy-pasteable probe that tells the two apart.

## Reused prior work — and the four things it was guessing

An earlier **uncommitted** cut lived in a stranded agent worktree. Its infrastructure is good and is reused: the mode gate, secret-contract key resolution, the curl `--config -` transport (so the token never enters `argv` or disk), the event family, config plumbing. It also **declared its own route contract an assumption** because it could not reach the cloud repo. It is reachable, and every part of the assumption was wrong:

| | guessed | measured (`catalyst-cloud` `origin/main`) |
|---|---|---|
| routes | `/linear/{issue-state,label,comment}` | `/agent/{issue-state,issue-label,issue-comment}` → would have **404'd** |
| state payload | `{ticket, transitionKey}` | `{issueId, stateId}` (UUIDs) → **400** |
| label payload | `{ticket, mode, labels}` | `{issueId, labelIds[], mode}` → **400** |
| remove | `mode:"overwrite"` + remaining set | no such mode; native `remove` |
| verdict | any 2xx = applied | the body's discriminated `outcome` |

Native `remove` is also strictly safer than an overwrite: an overwrite races any label another actor adds between the read and the write and silently drops it.

## New: a resolver that fails CLOSED

`linear-write-proxy-resolve.mjs` turns the daemon's vocabulary into Linear UUIDs off the **local replica** (no live Linear call, no shared-quota cost).

⛔ Every other replica reader in this tree is deliberately fail-**open** — a miss returns `undefined` and the caller falls through to a live read. Copying that here would be a defect: on the write path "fall through to live" means "write with this host's own app-actor". So an absent ticket, an archived state, an unreadable replica, or an **ambiguous label name** each refuse with a named `resolve:<reason>`.

Ambiguity is **measured, not theoretical**: `schema`, `types`, `mobile`, `infra`, `etl`, `dbt` and `api` each match **four** label rows in the live workspace, and `labels` carries no team id to disambiguate with. The four labels this increment writes are unique *today* — a first-hit resolver would be one new team-scoped label away from putting another team's label on a ticket.

## Single source of truth for the state name

The target state **name** still comes from `linear-transition.sh`, via a new `--resolve-only` mode that runs the one four-rung precedence chain (per-project `stateMap` > global `stateMap` > registry `eligibleQuery.triageStatus` > built-in default) and **writes nothing**. Re-deriving that chain in JS would have made this a second source of truth.

It deliberately does **not** require the `linearis` binary — the end state of CTL-1889 is a host with neither `linearis` nor a Linear credential. `--dry-run` is kept as the **negative control**: on the same `linearis`-free PATH it stops at the availability gate and never resolves, which is exactly why a new mode was needed rather than reusing it.

## Testing

- **+147 tests.** 123 JS (transport / wiring / resolver / config) + 5 shell.
- **Full `execution-core` stable gate vs a clean `origin/main` worktree baseline** — per-test **identity diff IDENTICAL**:
  - branch `7201 pass / 12 fail / 3 errors` across 222 files
  - baseline `7054 pass / 12 fail / 3 errors` across 218 files
  - the 12+3 are pre-existing and all environmental (absent `pino` / `@opentelemetry/*` in a fresh worktree).
- `linear-transition.test.sh` **72/0**, up from 67/0 — no regression from `--resolve-only` or the additive `targetStateId` emit field.

## Next

Comment-route call sites (`lib/linear-comment-post.sh`, `orch-monitor/lib/linear-comment.mjs`) and `attachmentCreate` are increment 2. Per-host key provisioning for **mini** is the gate on a fleet-wide `enforce`.

Refs: CTL-1889, CTC-509, CTC-636, ADR-0031

🤖 Generated with [Claude Code](https://claude.com/claude-code)