### PR TITLE
fix(dev): CTL-1933 — the cloud's label remove is NOT idempotent; stop sending no-op removals

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.mjs
@@ -89,6 +89,15 @@ const LABEL_SELECT = `
   LIMIT 2
 `;
 
+// CTL-1933 — is this label currently ON this issue? The join table is keyed
+// (issue_id, label_id), so this is one indexed primary-key lookup against ids the
+// caller has ALREADY resolved on the same path — not a second resolution chain.
+const ISSUE_LABEL_SELECT = `
+  SELECT 1 AS present FROM issue_labels
+  WHERE issue_id = ? AND label_id = ?
+  LIMIT 1
+`;
+
 /**
  * createProxyResolver — identifier/name → Linear UUID, off the local replica.
  *
@@ -237,6 +246,45 @@ export function createProxyResolver({ dbPath = null, env = process.env, now = Da
         out.push(id);
       }
       return { ok: true, labelIds: out };
+    },
+
+    /**
+     * hasLabel(issueId, labelId) → {ok:true, present:boolean} | {ok:false, reason}
+     *
+     * CTL-1933. The cloud's label `remove` is NOT idempotent — measured against the live
+     * mirror on 2026-08-17 with the control firing first: `add` on an absent label 200s,
+     * `remove` on a PRESENT label 200s, and `remove` on an ABSENT label returns
+     * **400 `{"outcome":"failed"}`**. CTL-1889 inc 1 assumed the opposite in a code
+     * comment and shipped it, so every already-absent clear on an enforce host burned
+     * three cloud calls and then a CTL-1078 back-off, while reporting the label still
+     * attached when Linear said it was gone.
+     *
+     * ⛔ THE ANSWER IS THREE-VALUED AND ONLY ONE VALUE MAY SUPPRESS A WRITE. A caller
+     * may skip the removal on `{ok:true, present:false}` and on nothing else. Every
+     * inability to answer — dead writer, mid-reseed, unreadable database, a throwing
+     * query — comes back `{ok:false}` so the caller SENDS. Sending an unnecessary
+     * removal costs one 400; silently skipping a real one re-creates the permanent
+     * `needs-human` park that CTL-1889's own P1 existed to fix. The doubt has to fall
+     * on the side of doing the work.
+     *
+     * Runs through the same `one`-style gate as every resolver above, so the freshness
+     * check and the presence read share ONE snapshot: a mid-reseed `issue_labels` can be
+     * legitimately empty, which would read as "already absent" and suppress a real
+     * removal — the same class of trap the seed check was added for.
+     */
+    hasLabel(issueId, labelId) {
+      if (typeof issueId !== "string" || issueId === "") return miss("issue-id-invalid");
+      if (typeof labelId !== "string" || labelId === "") return miss("label-id-invalid");
+      const r = one(ISSUE_LABEL_SELECT, [issueId, labelId], {
+        // A zero-row answer here is a REAL answer, not a miss: the pair is simply not
+        // in the join table. `one` reports zero rows as `absent`, so that verdict is
+        // translated back into present:false rather than treated as a failure.
+        absent: "issue-label-absent",
+        ambiguous: "issue-label-ambiguous",
+      });
+      if (r.ok) return { ok: true, present: true };
+      if (r.reason === "issue-label-absent") return { ok: true, present: false };
+      return r;
     },
 
     close: drop,

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-resolve.test.mjs
@@ -36,6 +36,10 @@ function seed({ issues = true, states = true, labels = true, seeded = true, writ
   db.run("CREATE TABLE issues (id TEXT, identifier TEXT, team_id TEXT, removed_at INTEGER)");
   db.run("CREATE TABLE workflow_states (id TEXT, team_id TEXT, name TEXT, archived_at INTEGER)");
   db.run("CREATE TABLE labels (id TEXT, name TEXT, removed_at INTEGER)");
+  // CTL-1933: the join the presence check reads. Seeded EMPTY by default and filled
+  // per-test, so a test that forgets to attach the label gets "absent" — the verdict
+  // that suppresses a write — rather than silently inheriting one.
+  db.run("CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT)");
   if (issues) {
     db.run("INSERT INTO issues VALUES (?,?,?,NULL)", [ISSUE, "CTL-1889", TEAM]);
     db.run("INSERT INTO issues VALUES (?,?,?,?)", ["dead", "CTL-DEAD", TEAM, 1]);
@@ -288,5 +292,87 @@ describe("handle discipline", () => {
     rmSync(dbPath);
     seed();
     expect(r.issue("CTL-1889")).toEqual({ ok: true, issueId: ISSUE, teamId: TEAM });
+  });
+});
+
+
+// ─── CTL-1933: the presence check that stops a no-op removal becoming a 400 ──────────
+//
+// The cloud's label `remove` is NOT idempotent (measured against the live mirror:
+// add-on-absent 200, remove-on-present 200, remove-on-absent **400**). CTL-1889 inc 1
+// asserted the opposite in a comment and shipped it. This resolver answers the presence
+// question off the replica so no host credential is needed — and it is three-valued,
+// because only a CONFIDENT absent may suppress a write.
+describe("⛔ hasLabel — three-valued, and only one value may suppress a write", () => {
+  const attach = (issueId, labelId) => {
+    const db = new Database(dbPath);
+    db.run("INSERT INTO issue_labels VALUES (?,?)", [issueId, labelId]);
+    db.close();
+  };
+
+  test("the label IS on the issue → {ok:true, present:true}", () => {
+    seed();
+    attach(ISSUE, LABEL);
+    expect(createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL)).toEqual({ ok: true, present: true });
+  });
+
+  // ⭐ The row this ticket exists for: a real zero, reported as a VALUE, not a failure.
+  test("⭐ the label is NOT on the issue → {ok:true, present:false} (a real answer)", () => {
+    seed();
+    expect(createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL)).toEqual({ ok: true, present: false });
+  });
+
+  // ⛔ NEGATIVE CONTROL for the one above: same query, same empty-looking result, but the
+  // replica cannot be trusted. present:false here would suppress a REAL removal and
+  // re-create the permanent needs-human park. It must be ok:false instead — proving the
+  // instrument distinguishes "not attached" from "could not look".
+  test("⛔ a STALE writer is ok:false — never present:false", () => {
+    seed({ writerAgeMs: 10 * 60 * 1000 });
+    const r = createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL);
+    expect(r.ok).toBe(false);
+    expect(r.present).toBeUndefined();
+    expect(r.reason).toBe("replica-stale");
+  });
+
+  test("⛔ a MID-RESEED replica is ok:false — an emptied join table is not an absence", () => {
+    seed({ seeded: false });
+    const r = createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL);
+    expect(r.ok).toBe(false);
+    expect(r.present).toBeUndefined();
+    expect(r.reason).toBe("replica-reseeding");
+  });
+
+  test("⛔ an UNREADABLE replica is ok:false", () => {
+    seed();
+    const db = new Database(dbPath);
+    db.run("DROP TABLE issue_labels");
+    db.close();
+    const r = createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL);
+    expect(r.ok).toBe(false);
+    expect(r.present).toBeUndefined();
+  });
+
+  test("malformed ids are named refusals, not a false absence", () => {
+    seed();
+    const rv = createProxyResolver({ dbPath });
+    expect(rv.hasLabel("", LABEL)).toMatchObject({ ok: false, reason: "issue-id-invalid" });
+    expect(rv.hasLabel(ISSUE, null)).toMatchObject({ ok: false, reason: "label-id-invalid" });
+  });
+
+  // The presence check must not answer about a DIFFERENT issue's label — the join is
+  // keyed on both ids and a one-sided match would report a neighbour's label as ours.
+  test("a label attached to ANOTHER issue does not count as present", () => {
+    seed();
+    attach("dead", LABEL);
+    expect(createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL)).toEqual({ ok: true, present: false });
+  });
+
+  // Duplicate join rows are a replica artefact, not ambiguity: the answer to "is it
+  // attached" is yes either way. LIMIT 1 keeps it from becoming a spurious refusal.
+  test("a duplicated join row still reports present:true", () => {
+    seed();
+    attach(ISSUE, LABEL);
+    attach(ISSUE, LABEL);
+    expect(createProxyResolver({ dbPath }).hasLabel(ISSUE, LABEL)).toEqual({ ok: true, present: true });
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -30,6 +30,9 @@ function fakeResolver(overrides = {}) {
     issue: () => ({ ok: true, issueId: ISSUE_ID, teamId: "team-1" }),
     stateId: () => ({ ok: true, stateId: STATE_ID }),
     labelIds: (names) => ({ ok: true, labelIds: names.map(() => LABEL_ID) }),
+    // CTL-1933. Defaults to PRESENT so every pre-existing removal test still sends —
+    // the skip is opt-in per test, which keeps this change from silently muting them.
+    hasLabel: () => ({ ok: true, present: true }),
     ...overrides,
   };
 }
@@ -513,23 +516,60 @@ describe("removeLabel — the proxied removal runs BEFORE the credentialed read"
     expect(r).toMatchObject({ removed: false, wrote: false, reason: "auth-error" });
   });
 
-  // ⚠️ THE NAMED NARROWING, pinned so it is a decision and not a drift. Under enforce the
-  // already-absent case can no longer be detected (detecting it costs the very credential
-  // being retired), so it sends an idempotent cloud remove and reports wrote:true. The
-  // direct path below still reports wrote:false for the same case — the asymmetry is
-  // deliberate: a spurious `worker.transition` clear on a duplicate wake is recoverable,
-  // a permanently MISSING clear on every enforce host is not.
-  test("enforce: an already-absent label is sent anyway and reports wrote:true", async () => {
+  // ⛔ CTL-1933 — THE NARROWING IS GONE, and this test is the inverse of the one that
+  // pinned it. The first cut reported wrote:true here and SENT, on a code comment
+  // asserting the cloud's remove was idempotent. Measured against the live mirror it is
+  // not: remove-on-absent returns 400. The replica now answers the presence question, so
+  // the proxied path recovers both the no-op AND the wrote:false the direct path reports.
+  test("⭐ enforce: an already-absent label is NOT sent, and reports wrote:false", async () => {
     const proxy = fakeProxy("enforce");
-    setLinearWriteProxyResolver(fakeResolver());
+    setLinearWriteProxyResolver(fakeResolver({ hasLabel: () => ({ ok: true, present: false }) }));
     const r = await removeLabel("CTL-7", "gone", {
       exec: () => { throw new Error("must not exec"); },
-      readLabels: () => ({ ok: true, labels: ["bug"] }),
+      readLabels: () => { throw new Error("must not read — the credential is the thing being retired"); },
+      proxy,
+    });
+    expect(r).toEqual({ removed: true, wrote: false });
+    expect(proxy.sends).toHaveLength(0);
+  });
+
+  test("enforce: a PRESENT label is still sent and reports wrote:true", async () => {
+    const proxy = fakeProxy("enforce");
+    setLinearWriteProxyResolver(fakeResolver({ hasLabel: () => ({ ok: true, present: true }) }));
+    const r = await removeLabel("CTL-7", "needs-human", {
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => ({ ok: false, labels: null, code: 127, stderr: "spawn linearis ENOENT" }),
       proxy,
     });
     expect(r).toEqual({ removed: true, wrote: true });
-    expect(proxy.sends).toHaveLength(1);
+    expect(proxy.sends[0].payload).toEqual({ issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" });
   });
+
+  // ⛔ THE FAIL DIRECTION, asserted case by case. Doubt must never suppress a removal:
+  // an unnecessary remove costs one 400, a skipped real one is a permanent needs-human
+  // park. Each row is a DIFFERENT way of not knowing, because a single "unhappy" case
+  // would not prove the others are handled.
+  for (const [name, hasLabel] of [
+    ["a stale replica (gate refused)", () => ({ ok: false, reason: "replica-stale" })],
+    ["a mid-reseed replica", () => ({ ok: false, reason: "replica-reseeding" })],
+    ["an unreadable replica", () => ({ ok: false, reason: "replica-unreadable" })],
+    ["a resolver that throws", () => { throw new Error("boom"); }],
+    ["an OLDER resolver with no hasLabel at all", undefined],
+  ]) {
+    test(`enforce: ${name} → the removal IS sent (doubt never suppresses)`, async () => {
+      const proxy = fakeProxy("enforce");
+      const base = fakeResolver();
+      if (hasLabel === undefined) delete base.hasLabel; else base.hasLabel = hasLabel;
+      setLinearWriteProxyResolver(base);
+      const r = await removeLabel("CTL-7", "needs-human", {
+        exec: () => { throw new Error("must not exec"); },
+        readLabels: () => ({ ok: false, labels: null, code: 127, stderr: "spawn linearis ENOENT" }),
+        proxy,
+      });
+      expect(proxy.sends).toHaveLength(1);
+      expect(r.removed).toBe(true);
+    });
+  }
 
   test("no proxy: the already-absent label is still a no-op write (wrote:false)", async () => {
     const calls = [];

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -546,23 +546,31 @@ export async function removeLabel(
     // The read is a DIRECT-PATH concern (it computes `remaining` for the overwrite);
     // the proxy needs only the one label's id, so it must not be gated on it.
     //
-    // ⚠️ TWO NAMED NARROWINGS, both in the safe direction:
+    // ⛔ CTL-1933 — THE CLOUD'S `remove` IS NOT IDEMPOTENT, so the idempotency check
+    // cannot simply be dropped along with the credentialed read. Measured against the
+    // live mirror with the control firing first: `add` on an absent label 200s,
+    // `remove` on a PRESENT label 200s, `remove` on an ABSENT label returns
+    // **400 `{"outcome":"failed"}`**. The first cut of this block asserted the opposite
+    // in a comment ("the cloud's remove is itself idempotent, so sending unconditionally
+    // is safe") and shipped it unverified; on the first enforce host it turned every
+    // no-op clear into three failed cloud calls plus a CTL-1078 back-off, and reported
+    // the label still attached when Linear said it was gone.
     //
-    // 1. `wrote` — the direct path distinguishes "this call performed the write"
-    //    (`wrote: true`) from "confirmed already absent, no write needed"
-    //    (`wrote: false`); Codex #2970 round 3 added it so the daemon emits ONE
-    //    `worker.transition` clear per genuine removal, not one per duplicate-webhook
-    //    re-check. Without the read the proxied path cannot make that distinction, and
-    //    the cloud's `{outcome}` envelope carries no changed-flag to recover it. We
-    //    report `true`: at worst a repeated wake duplicates an observability event,
-    //    whereas `false` would make the clear unreachable on every enforce host — a
-    //    silent MISSING transition, which is strictly the worse failure. Sending
-    //    unconditionally is safe because the cloud's `remove` is itself idempotent.
-    // 2. shadow accounting — shadow now records an observation for every removeLabel
-    //    call, including ones the direct path resolves as a no-op. That makes this site
-    //    consistent with the other two (both already emit before knowing whether the
-    //    write is a no-op), but read the shadow counts as "write calls that reached the
-    //    seam", never as "writes that would have hit Linear".
+    // The presence question is therefore asked of the REPLICA, not of `linearis` — the
+    // resolver is already open on this path with both ids in hand, so it is one indexed
+    // lookup and it needs no host Linear credential, which is what lets the removal stay
+    // ahead of the read.
+    //
+    // ⚠️ ONLY A CONFIDENT "absent" MAY SUPPRESS THE WRITE. `hasLabel` is three-valued;
+    // any inability to answer (dead writer, mid-reseed, unreadable db) returns ok:false
+    // and we SEND. An unnecessary removal costs one 400; a silently skipped real removal
+    // re-creates the permanent needs-human park this whole path exists to fix.
+    //
+    // ⚠️ shadow accounting — shadow records an observation for every removeLabel call,
+    // including ones the direct path resolves as a no-op. That makes this site consistent
+    // with the other two (both already emit before knowing whether the write is a no-op),
+    // but read the shadow counts as "write calls that reached the seam", never as "writes
+    // that would have hit Linear".
     const proxiedRemove = routeThroughProxy(proxy, {
       routeId: "label",
       ticket,
@@ -572,10 +580,35 @@ export async function removeLabel(
         if (!issue.ok) return issue;
         const ids = resolver.labelIds([label]);
         if (!ids.ok) return ids;
+        // Skip ONLY on a positive absent. A resolver without `hasLabel`, one that
+        // cannot answer, or one that THROWS all fall through to the send by design.
+        // The try/catch is not defensive padding: this check is an OPTIMISATION, so its
+        // failure must cost a redundant cloud call, never the removal itself. Left
+        // unguarded it escapes to removeLabel's outer catch and returns
+        // `{removed:false, reason:"transient"}` — i.e. a broken presence probe would
+        // suppress the very write it exists to make cheaper. (`issue`/`labelIds` are
+        // deliberately NOT wrapped: without them there is no payload to send at all.)
+        let presence = null;
+        if (typeof resolver.hasLabel === "function") {
+          try {
+            presence = resolver.hasLabel(issue.issueId, ids.labelIds[0]);
+          } catch {
+            presence = null;
+          }
+        }
+        if (presence && presence.ok === true && presence.present === false) {
+          return { ok: true, skip: "label-already-absent" };
+        }
         return { ok: true, payload: { issueId: issue.issueId, labelIds: ids.labelIds, mode: "remove" } };
       },
     });
     if (proxiedRemove) {
+      // A skipped removal is a confirmed no-op, so it restores the `wrote: false` the
+      // direct path reports for the same case — which is what stops the daemon emitting a
+      // `worker.transition` clear for a duplicate-webhook re-check (Codex #2970 round 3).
+      if (proxiedRemove.skipped === "label-already-absent") {
+        return { removed: true, wrote: false };
+      }
       return proxiedRemove.applied
         ? { removed: true, wrote: true }
         : { removed: false, wrote: false, reason: proxiedRemove.reason };


### PR DESCRIPTION
Closes CTL-1933. A regression from **CTL-1889 inc 1 (#3489)**, found by watching mini-2 after enforcing it — then reproduced deliberately.

## What went wrong

#3489's round-2 P1 fix was right to move the proxied removal **ahead of** the credentialed read: on an enforce host with no `linearis`, the read fails and the cloud removal was never sent, so `needs-input`/`needs-human` stayed attached forever after a user replied.

But it then sent the removal **unconditionally**, on an in-code assumption:

> *"Sending unconditionally is safe because the cloud's `remove` is itself idempotent."*

⛔ **I wrote that, labelled it clearly, and never verified it.** It is false.

## Measured against the live mirror — control first

| step | mode | label state before | result |
|---|---|---|---|
| 1 | `add` | absent | **200 `applied`** ✅ control fired |
| 2 | `remove` | **present** | **200 `applied`** ✅ removals genuinely work |
| 3 | `remove` | **absent** | ⛔ **400 `cloud:failed`** |

Observed in production *before* it was reproduced:

```
linear.write.proxy.failed.CTL-1805  route=label status=400   ×3
clearStalledLabel: removal failed threshold times — entering back-off (CTL-1078)
```

CTL-1805 carried only `orchestrator` — the daemon was clearing a `needs-human` that was **already gone**.

⭐ **Row 2 is the load-bearing one: real removals succeed.** No ticket could be stranded parked by this. The cost was three wasted cloud calls per occurrence and a belief that a label was attached when Linear said it was not.

## The fix

The presence question now goes to the **replica**, through a new `hasLabel` on the proxy resolver — under the **same freshness gate** and the **same single read transaction** as every other resolver there. So it needs no host Linear credential, and the removal stays ahead of the read.

This is Codex's own round-2 alternative (*"or supply the freshness-gated replica reader for enforce mode"*), and it also **retires the `wrote` narrowing** #3489 had to accept: the proxied path can distinguish a real removal from a no-op again, so the daemon stops emitting a `worker.transition` clear for a duplicate-webhook re-check.

The skip reuses the **existing** `built.skip` path in `routeThroughProxy` (already used by the CTL-758 terminal guard) — no new control flow.

## ⛔ The asymmetry, which is the whole design

`hasLabel` is **three-valued**, and **only a confident `present:false` may suppress a write.** Stale writer, mid-reseed, unreadable db, a throwing probe, and an older resolver with no such method *all fall through to the send*.

An unnecessary removal costs one 400. A silently skipped real one re-creates the permanent `needs-human` park that #3489's P1 existed to fix.

⚠️ The throw case is guarded **locally** rather than left to `removeLabel`'s outer catch. Unguarded, a broken presence probe escaped and returned `{removed:false, reason:"transient"}` — i.e. it suppressed the very write it exists to make cheaper. **A test caught that; I had not foreseen it.**

## Tests

- The case that **pinned the narrowing** is inverted, not deleted.
- **Five distinct ways of not knowing** each assert the send still happens — one unhappy case would not prove the others are handled.
- Resolver suite gets a real-SQLite present/absent pair, whose **negative control** proves a stale replica reports `ok:false`, never `present:false` (same query, same empty-looking result, opposite verdict).
- A neighbour's label on another issue does not read as present; a duplicated join row still reads present.
- **Mutation-checked both directions:** disabling the skip (the shipped bug) reddens 1; skipping whenever unsure (the dangerous direction) reddens 5.

## Gate

`7425 pass / 2 fail`, failure set **diffed per-test** against a clean `origin/main` worktree (`7250 pass / 2 fail`) — **identical**; both are pre-existing and environment-dependent (hostname suffix; a local replica making a `mode off` fixture read `on`).

## Related

- CTL-1889 / #3489 — the increment that introduced it
- **CTL-1932** — permanent-vs-transient classification of proxy reasons (deferred P2 from #3489). `cloud:failed` here is transient-shaped and correctly retried; that ticket covers the genuinely permanent ones.
- CTL-1078 — the removal back-off that bounded this