### PR TITLE
feat(dev): CTL-1931 — the dep-skew detector can see a writer running the WRONG checkout

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -28,6 +28,7 @@ import {
   lockedVersionsFor,
   readDepsBreadcrumb,
   readRestartLedger,
+  SKEW_LINKS,
   recordRestartAttempt,
   sha256File,
   writeDepsBreadcrumb,
@@ -232,6 +233,10 @@ function evalDeps(files, over = {}) {
       return JSON.parse(files[p]);
     },
     processCommandForPid: (pid) => (pid === 4242 ? "bun /opt/plugin-source/plugins/dev/scripts/execution-core/cloud-sync.mjs" : null),
+    // CTL-1931: the healthy default — this node is configured to serve from the root the
+    // fixture writer actually loaded from. Tests for the OTHER links keep their meaning;
+    // the serving-root link gets its own block below, which overrides this.
+    expectedRoots: [ROOT],
     ...over,
   };
 }
@@ -894,5 +899,86 @@ describe("depSkewEventEnvelope (the unified event-log surface)", () => {
       expect(n.startsWith("filter.")).toBe(false);
       expect(n.startsWith("broker.daemon")).toBe(false);
     }
+  });
+});
+
+
+// ─── CTL-1931: link 3 — serving root ────────────────────────────────────────
+//
+// The other links are all SELF-REFERENTIAL: they compare the modules under whatever root
+// the process loaded from against THAT root's lockfile. A writer running out of a
+// different checkout entirely is internally consistent and grades clean on every one of
+// them. This block is the negative control the ticket demands.
+describe("evaluateDepSkew — link 3: serving root (CTL-1931)", () => {
+  test("the writer is serving a configured checkout → ok", () => {
+    expect(linkOf(evaluateDepSkew(evalDeps(fs())), "serving-root").status).toBe("ok");
+  });
+
+  // ⭐ THE NEGATIVE CONTROL THE TICKET REQUIRES: reconstruct CTL-1919. The laptop's writer
+  // ran from the dev checkout — three schema versions stale, so the replica had no
+  // `workflow_states` table and sat 5.5 h behind — and was found BY HAND while this
+  // detector reported nothing.
+  test("⭐ CTL-1919: a writer serving an UNCONFIGURED checkout → skew", () => {
+    const r = evaluateDepSkew(evalDeps(fs(), {
+      expectedRoots: ["/Users/ryan/catalyst/plugin-source"],
+    }));
+    const v = linkOf(r, "serving-root");
+    expect(v.status).toBe("skew");
+    expect(r.skew).toBe(true);
+    expect(v.detail).toContain(ROOT);                              // where it IS serving
+    expect(v.detail).toContain("/Users/ryan/catalyst/plugin-source"); // where it SHOULD
+  });
+
+  // ⛔ The point of the whole link, asserted directly: in that same CTL-1919 state every
+  // other link still reads ok. Without this, a reader could reasonably assume one of the
+  // existing links would have caught it eventually.
+  test("⛔ and in that state EVERY OTHER LINK still reads ok — which is why this link exists", () => {
+    const r = evaluateDepSkew(evalDeps(fs(), { expectedRoots: ["/somewhere/else"] }));
+    for (const link of SKEW_LINKS.filter((l) => l !== "serving-root")) {
+      expect(linkOf(r, link).status).toBe("ok");
+    }
+  });
+
+  test("no expectations configured → INCONCLUSIVE, never ok and never skew", () => {
+    for (const expectedRoots of [null, undefined, [], ["", "  "].slice(0, 1)]) {
+      const v = linkOf(evaluateDepSkew(evalDeps(fs(), { expectedRoots })), "serving-root");
+      expect(v.status).toBe("inconclusive");
+    }
+  });
+
+  // ⚠️ `[].includes(x)` is false, so the naive implementation reports SKEW here — a false
+  // alarm on every node with nothing configured. Inverting it to ok would be a check that
+  // passes because it never looked. Pinning the third value keeps both mistakes out.
+  test("⚠️ an empty expectation list is not a skew (the [].includes trap)", () => {
+    expect(evaluateDepSkew(evalDeps(fs(), { expectedRoots: [] })).skew).toBe(false);
+  });
+
+  test("a boot record with no root → INCONCLUSIVE", () => {
+    const args = evalDeps(fs());
+    const v = linkOf(evaluateDepSkew({ ...args, breadcrumb: { ...args.breadcrumb, root: null } }), "serving-root");
+    expect(v.status).toBe("inconclusive");
+  });
+
+  // Two spellings of one directory (a symlinked home, /System/Volumes/Data/...) must not
+  // manufacture a skew. The fixture paths do not exist on disk, so realpath is injected.
+  test("realpath-equal roots spelled differently are NOT a skew", () => {
+    const v = linkOf(evaluateDepSkew(evalDeps(fs(), {
+      expectedRoots: ["/System/Volumes/Data/opt/plugin-source"],
+      realpath: (x) => x.replace("/System/Volumes/Data", ""),
+    })), "serving-root");
+    expect(v.status).toBe("ok");
+  });
+
+  test("a trailing slash is not a skew", () => {
+    expect(linkOf(evaluateDepSkew(evalDeps(fs(), { expectedRoots: [`${ROOT}/`] })), "serving-root").status).toBe("ok");
+  });
+
+  // A throwing realpath must degrade to a literal comparison, not abort the evaluation —
+  // this is the path every unit test above actually takes (the fixture roots are fictional).
+  test("a throwing realpath falls back to the literal string", () => {
+    const v = linkOf(evaluateDepSkew(evalDeps(fs(), {
+      realpath: () => { throw new Error("ENOENT"); },
+    })), "serving-root");
+    expect(v.status).toBe("ok");
   });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
@@ -76,6 +76,10 @@ function deps(over = {}) {
       return JSON.parse(files[p]);
     },
     processCommandForPid: (pid) => (pid === 4242 ? "bun /opt/plugin-source/plugins/dev/scripts/execution-core/cloud-sync.mjs" : null),
+    // CTL-1931: injected, because the production default calls the REAL
+    // resolvePluginCheckoutRoots() — which on a developer machine returns that machine's
+    // own checkout and would make every fixture here read as a serving-root skew.
+    resolveExpectedRoots: () => [ROOT],
     ...over,
   };
 }
@@ -152,5 +156,44 @@ describe("checkCloudSyncSkew", () => {
   test("a throwing dependency degrades to WARN instead of crashing the whole doctor run", () => {
     const r = one(checkCloudSyncSkew(deps({ readBreadcrumb: () => { throw new Error("boom"); } })));
     expect(r.status).toBe("warn");
+  });
+});
+
+
+// ─── CTL-1931: the serving-root link, at the doctor boundary ────────────────
+describe("checkCloudSyncSkew — serving root (CTL-1931)", () => {
+  // ⭐ The CTL-1919 shape, end to end: a writer running out of a checkout this node is not
+  // configured to serve from. Everything else about the record is perfectly healthy, which
+  // is precisely why the other links never caught it.
+  test("⭐ a writer serving an UNCONFIGURED checkout → WARN naming DEPENDENCY SKEW", () => {
+    const r = one(checkCloudSyncSkew(deps({ resolveExpectedRoots: () => ["/Users/x/catalyst/plugin-source"] })));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("DEPENDENCY SKEW");
+    expect(r.detail).toContain("serving-root");
+    expect(noFail([r])).toBe(true); // advisory by construction — WARN, never FAIL
+  });
+
+  // ⚠️ The resolver runs on every doctor invocation, including on hosts where plugin dirs
+  // are unconfigured or the broker module is unhappy. A throw must not abort the run, and
+  // must not silently become a pass.
+  test("⚠️ a THROWING root resolver degrades to inconclusive, not to a pass", () => {
+    const r = one(checkCloudSyncSkew(deps({
+      resolveExpectedRoots: () => { throw new Error("pluginDirs unreadable"); },
+    })));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("UNKNOWN");
+    expect(r.detail).toContain("serving-root");
+  });
+
+  test("no configured roots → inconclusive, never a pass and never a skew", () => {
+    const r = one(checkCloudSyncSkew(deps({ resolveExpectedRoots: () => [] })));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("UNKNOWN");
+  });
+
+  // Positive control for the three above: the SAME harness still PASSes when the writer is
+  // where it belongs — so a WARN here is evidence about the root, not about the fixture.
+  test("POSITIVE CONTROL: the same harness passes when the serving root is configured", () => {
+    expect(one(checkCloudSyncSkew(deps())).status).toBe("pass");
   });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-cloud-sync-skew.test.mjs
@@ -9,7 +9,9 @@
 //   3. every deps is injected, so this suite touches no fs/ps/launchctl.
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor-cloud-sync-skew
 import { describe, test, expect } from "bun:test";
-import { checkCloudSyncSkew } from "../doctor.mjs";
+import { checkCloudSyncSkew, DOCTOR_REPO_CONFIG_PATH } from "../doctor.mjs";
+import { resolvePluginCheckoutRoots } from "../../broker/plugin-refresh.mjs";
+import { existsSync } from "node:fs";
 
 const ROOT = "/opt/plugin-source";
 const LOCK = `${ROOT}/bun.lock`;
@@ -195,5 +197,54 @@ describe("checkCloudSyncSkew — serving root (CTL-1931)", () => {
   // where it belongs — so a WARN here is evidence about the root, not about the fixture.
   test("POSITIVE CONTROL: the same harness passes when the serving root is configured", () => {
     expect(one(checkCloudSyncSkew(deps())).status).toBe("pass");
+  });
+});
+
+
+// ─── CTL-1931 / Codex #3493 P2: the PRODUCTION default, not the injected seam ───────
+//
+// Every test above injects `resolveExpectedRoots`, so none of them exercises what the
+// check actually does on a real node. That is precisely how the defect below survived
+// review the first time: `resolvePluginCheckoutRoots({})` leaves `repoConfigPath` null,
+// silently dropping the repo rung that the broker and updater pull paths both supply.
+describe("the production expected-root default (Codex #3493 P2)", () => {
+  test("DOCTOR_REPO_CONFIG_PATH points at THIS repo's .catalyst/config.json, and it exists", () => {
+    expect(DOCTOR_REPO_CONFIG_PATH.endsWith("/.catalyst/config.json")).toBe(true);
+    // Not a tautology: doctor.mjs sits four levels under the repo root, so a wrong number
+    // of `..` hops yields a path that does not exist. This asserts the derivation.
+    expect(existsSync(DOCTOR_REPO_CONFIG_PATH)).toBe(true);
+  });
+
+  // The contract the call site depends on: the repo rung OUTRANKS the machine rung. If a
+  // node's machine config carries a stale pluginDirs, passing null would compare against a
+  // root the node no longer maintains and report a false DEPENDENCY SKEW on a healthy host.
+  test("⛔ the repo config OUTRANKS the machine config — the rung passing null would skip", () => {
+    const files = {
+      "/repo/.catalyst/config.json": JSON.stringify({ catalyst: { orchestration: { pluginDirs: "/current" } } }),
+      "/machine/config.json": JSON.stringify({ catalyst: { orchestration: { pluginDirs: "/stale" } } }),
+    };
+    const args = {
+      env: {},
+      machineConfigPath: "/machine/config.json",
+      readFileFn: (p) => { if (!(p in files)) throw new Error(`ENOENT ${p}`); return files[p]; },
+      gitToplevelFn: (d) => d,
+    };
+    expect(resolvePluginCheckoutRoots({ ...args, repoConfigPath: "/repo/.catalyst/config.json" })).toEqual(["/current"]);
+    // POSITIVE CONTROL for the claim above: with repoConfigPath null — what the first cut
+    // of this check passed — the same inputs resolve the STALE root instead.
+    expect(resolvePluginCheckoutRoots({ ...args, repoConfigPath: null })).toEqual(["/stale"]);
+  });
+
+  // …and the Layer-1-only node Codex named: machine config absent entirely.
+  test("a node whose pluginDirs exists ONLY in the repo config still resolves a root", () => {
+    const files = { "/repo/.catalyst/config.json": JSON.stringify({ catalyst: { orchestration: { pluginDirs: "/only-here" } } }) };
+    const args = {
+      env: {},
+      machineConfigPath: "/machine/absent.json",
+      readFileFn: (p) => { if (!(p in files)) throw new Error(`ENOENT ${p}`); return files[p]; },
+      gitToplevelFn: (d) => d,
+    };
+    expect(resolvePluginCheckoutRoots({ ...args, repoConfigPath: "/repo/.catalyst/config.json" })).toEqual(["/only-here"]);
+    expect(resolvePluginCheckoutRoots({ ...args, repoConfigPath: null })).toEqual([]); // would sit inconclusive forever
   });
 });

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -35,7 +35,7 @@
 // doctor.mjs's other leaf imports honor.
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 // The packages whose loaded identity is recorded. A REGISTRY rather than an inline
@@ -324,7 +324,17 @@ export function lockedVersionForKey(lockText, key, id) {
 //                          catches what a restart does NOT fix (the partial install from
 //                          the 180s SIGKILL ceiling, and the CTL-1646 shadowed install).
 
-export const SKEW_LINKS = ["record-identity", "boot-record-complete", "loaded-vs-locked", "installed-vs-locked"];
+//   serving-root         — is the writer serving from a root this node is CONFIGURED to
+//                          serve from? CTL-1931: the three links above are all
+//                          SELF-REFERENTIAL to whatever root the process happens to have
+//                          loaded from — they compare that root's modules against THAT
+//                          root's lockfile. A writer running out of an entirely different
+//                          checkout is internally consistent and grades clean on every one
+//                          of them. That is not hypothetical: it is CTL-1919 exactly (the
+//                          laptop's writer served a dev checkout pinned three schema
+//                          versions back, so the replica had no `workflow_states` table and
+//                          sat 5.5 h stale) — found by hand, while this detector said ok.
+export const SKEW_LINKS = ["record-identity", "boot-record-complete", "serving-root", "loaded-vs-locked", "installed-vs-locked"];
 
 const ok = (link, detail) => ({ link, status: "ok", detail });
 const skew = (link, detail) => ({ link, status: "skew", detail });
@@ -344,6 +354,12 @@ export function evaluateDepSkew({
   readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
   processCommandForPid = () => null,
   writerPattern = "cloud-sync.mjs",
+  // CTL-1931. Injected, not imported: the resolver lives in broker/plugin-refresh.mjs and
+  // this module is loaded by the bare-Node doctor path as well as the bun writer. null (the
+  // default) means "the caller did not establish expectations", which reports INCONCLUSIVE
+  // — so an un-wired caller degrades loudly instead of silently passing the link.
+  expectedRoots = null,
+  realpath = realpathSync,
 } = {}) {
   if (!breadcrumb || typeof breadcrumb !== "object") {
     return summarize(SKEW_LINKS.map((l) => unknown(l, "no boot record — the writer has not booted since dep-skew capture shipped, or the write failed")));
@@ -381,6 +397,60 @@ export function evaluateDepSkew({
       ? unknown("boot-record-complete", `boot record is degraded: ${(breadcrumb.degradedReasons ?? []).join("; ") || "reason not recorded"}`)
       : ok("boot-record-complete", `${(breadcrumb.packages ?? []).length} package(s) recorded at boot`),
   );
+
+  // Link 3 — serving root (CTL-1931). The ONE question none of the others can ask.
+  //
+  // ⛔ WHY IT CANNOT BE DERIVED FROM THE RECORD. `captureLoadedDeps` anchors `root` on the
+  // first module it actually resolved, i.e. the root that served the bytes. Every other
+  // link then compares that root against ITS OWN lockfile, so a writer launched from the
+  // wrong checkout is perfectly self-consistent. The expected roots therefore have to come
+  // from OUTSIDE the record — injected by the caller (doctor passes
+  // `resolvePluginCheckoutRoots()`, the same resolver the real pull path and the
+  // plugin-source freshness check use, so this cannot drift from what the node actually
+  // maintains).
+  //
+  // ⚠️ Absent/empty expectations are INCONCLUSIVE, never ok. `[].includes(x)` is false, so
+  // a naive implementation would report *skew* on a node with nothing configured, and
+  // inverting that to `ok` would be a check that passes because it never looked. Both
+  // failure directions are wrong here, so the third value carries it.
+  const expected = Array.isArray(expectedRoots) ? expectedRoots.filter((r) => typeof r === "string" && r.length > 0) : null;
+  const servingRoot = typeof breadcrumb.root === "string" && breadcrumb.root.length > 0 ? breadcrumb.root : null;
+  if (servingRoot === null) {
+    verdicts.push(unknown("serving-root", "boot record names no serving root — cannot tell which checkout served the modules"));
+  } else if (expected === null || expected.length === 0) {
+    verdicts.push(
+      unknown(
+        "serving-root",
+        `no configured plugin-checkout root to compare against (writer is serving ${servingRoot}) — zero expectations is not a clean result`,
+      ),
+    );
+  } else {
+    // Compared through realpath so a symlinked home or /System/Volumes/Data prefix cannot
+    // manufacture a skew out of two spellings of one directory. realpath failures fall back
+    // to the literal string rather than throwing — an unresolvable path still compares, it
+    // just compares less generously.
+    const norm = (x) => {
+      const trimmed = x.endsWith("/") && x.length > 1 ? x.slice(0, -1) : x;
+      try {
+        return realpath(trimmed);
+      } catch {
+        return trimmed;
+      }
+    };
+    const got = norm(servingRoot);
+    const want = expected.map(norm);
+    if (want.includes(got)) {
+      verdicts.push(ok("serving-root", `writer is serving from a configured checkout (${servingRoot})`));
+    } else {
+      verdicts.push(
+        skew(
+          "serving-root",
+          `writer is serving from ${servingRoot}, which is NOT a configured plugin-checkout root (${expected.join(", ")}) — ` +
+            "every other link below compares that checkout against its OWN lockfile, so they can all read clean while the daemon runs entirely the wrong code (CTL-1919)",
+        ),
+      );
+    }
+  }
 
   const packages = Array.isArray(breadcrumb.packages) ? breadcrumb.packages : [];
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -96,6 +96,20 @@ import { assertSdkAuth } from "./sdk-run-phase-agent.mjs";
 // plugins/dev/scripts/lib/ (sibling of execution-core/).
 import { validateLayer1Config, RELOCATED_LAYER1_KEYS } from "../lib/validate-catalyst-config.mjs";
 import { resolvePluginCheckoutRoots } from "../broker/plugin-refresh.mjs"; // CTL-1421: same resolver the workers use
+
+// CTL-1931: doctor.mjs lives at <repo>/plugins/dev/scripts/execution-core/, so the repo's
+// `.catalyst/config.json` is four levels up — the same module-relative derivation
+// broker/router.mjs uses for its own `__REPO_CONFIG_PATH`. Exported so a test can assert
+// the production default actually supplies this rung rather than passing null.
+export const DOCTOR_REPO_CONFIG_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  ".catalyst",
+  "config.json"
+);
 import { shipsLogs, LABELS as MANIFEST_LABELS } from "./service-manifest.mjs"; // CTL-1473: per-class service manifest
 import { staleLockStatus, indexLockPath, STALE_LOCK_THRESHOLD_MS } from "../lib/stale-lock.mjs"; // CTL-1415
 import { listProjects } from "./registry.mjs";
@@ -3377,7 +3391,16 @@ export function checkCloudSyncSkew(deps = {}) {
     processCommandForPid = defaultProcessCommandForPid,
     // CTL-1931: the SAME resolver the real pull path and checkPluginSourceFreshness use, so
     // "the root this node maintains" cannot drift from "the root this check expects".
-    resolveExpectedRoots = () => resolvePluginCheckoutRoots({}),
+    //
+    // ⚠️ `repoConfigPath` is passed explicitly (Codex #3493 P2). The resolver's precedence is
+    // env > REPO `.catalyst/config.json` > machine config, and the parameter defaults to
+    // null — so `resolvePluginCheckoutRoots({})` silently skips the repo rung the broker and
+    // updater pull paths both supply. That matters here in a way it does not for a purely
+    // advisory reader: this check is GRADE-CHANGING, so on a node whose `pluginDirs` lives
+    // only in Layer 1 it would resolve no roots and sit inconclusive forever, and on a node
+    // whose machine config holds an OLDER value it would compare against a root the node no
+    // longer maintains and report a false DEPENDENCY SKEW on a healthy host.
+    resolveExpectedRoots = () => resolvePluginCheckoutRoots({ repoConfigPath: DOCTOR_REPO_CONFIG_PATH }),
   } = deps;
 
   // Wrapped whole: this check reads files and spawns `ps`, and a throw here would abort

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3375,6 +3375,9 @@ export function checkCloudSyncSkew(deps = {}) {
     readText = (p) => readFileSync(p, "utf8"),
     readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
     processCommandForPid = defaultProcessCommandForPid,
+    // CTL-1931: the SAME resolver the real pull path and checkPluginSourceFreshness use, so
+    // "the root this node maintains" cannot drift from "the root this check expects".
+    resolveExpectedRoots = () => resolvePluginCheckoutRoots({}),
   } = deps;
 
   // Wrapped whole: this check reads files and spawns `ps`, and a throw here would abort
@@ -3408,7 +3411,17 @@ export function checkCloudSyncSkew(deps = {}) {
       ];
     }
 
-    const result = evaluate({ breadcrumb: record, readText, readJson, processCommandForPid });
+    // The guard sits at the CALL SITE, not inside the default: an INJECTED resolver can
+    // throw too, and putting the try/catch in the default would let that escape to the
+    // outer catch and be reported as a generic check failure instead of the specific
+    // inconclusive serving-root verdict. null degrades to INCONCLUSIVE, never to a pass.
+    let expectedRoots = null;
+    try {
+      expectedRoots = resolveExpectedRoots();
+    } catch {
+      expectedRoots = null;
+    }
+    const result = evaluate({ breadcrumb: record, readText, readJson, processCommandForPid, expectedRoots });
     const bad = result.verdicts.filter((v) => v.status !== "ok");
     if (bad.length === 0) {
       return [mkCheck("cloud-sync-skew", STATUS.PASS, `loaded modules match the lockfile — ${result.verdicts.map((v) => v.link).join(", ")} all verified`)];


### PR DESCRIPTION
**Partial fix, deliberately.** This is the first of the **three** defects on CTL-1931 — and the only one that would have caught **CTL-1919**. The other two are named below and the ticket stays open.

## ⛔ The gap

All four existing links are **self-referential to whatever root the process happened to load from**: they compare that root's modules against *that root's* lockfile. A writer running out of an entirely different checkout is internally consistent and grades **clean on every one of them**.

That is CTL-1919 exactly — the laptop's `cloud-sync` served a dev checkout pinned three schema versions back, so the replica had no `workflow_states` table and sat 5.5 h stale. **Found by hand, while this detector said ok.**

The question nobody was asking is *"is this daemon serving from the root it is supposed to be?"*, and it **cannot be answered from the record alone** — the expectation has to come from outside it.

## The new `serving-root` link

Expectations are **injected, not imported**: doctor passes `resolvePluginCheckoutRoots()` — the same resolver the real pull path and `checkPluginSourceFreshness` use, so *"the root this node maintains"* cannot drift from *"the root this check expects"*. It also keeps `cloud-sync-deps.mjs` loadable from both the bun writer and the bare-Node doctor path without pulling in the broker graph.

**Three-valued, because both failure directions are wrong here.** `[].includes(x)` is `false`, so a naive version reports **skew** on a node with nothing configured — while inverting that to `ok` is a check that passes because it never looked. Absent record root, absent/empty expectations, and a throwing resolver are all **INCONCLUSIVE**.

Roots compare through `realpath`, so a symlinked home or a `/System/Volumes/Data` prefix cannot manufacture a skew out of two spellings of one directory; a `realpath` throw falls back to the literal string rather than aborting.

⚠️ The resolver guard sits at the **call site**, not in the default parameter — an *injected* resolver can throw too, and guarding only the default let that escape to the outer catch and surface as a generic check failure instead of the specific inconclusive verdict. **A test caught that.**

## Verified on the live fleet before shipping

A check that WARNs every host is worse than no check, so this was measured, not assumed:

- All three hosts' writers serve from a configured root (`expectedRoots` vs the writer's recorded root: `match: true` on laptop, mini, mini-2).
- A real run of the new link on this host prints **`OK serving-root: writer is serving from a configured checkout`** — printed **positively**, not inferred from "absent from the complaint list", because absence is also what a link that never ran looks like.
- `installed-vs-locked` still reads INCONCLUSIVE there, unchanged — see below.

## Tests

- ⭐ **The negative control the ticket demands:** the CTL-1919 case reconstructed and asserted to **skew**, naming both the root it is serving and the root it should.
- ⛔ **And in that same state, every *other* link is asserted to still read `ok`** — which is the entire argument for this link existing.
- The `[].includes` trap pinned explicitly (empty expectations ≠ skew).
- Symlink/trailing-slash/throwing-realpath cases.
- Doctor-boundary tests incl. a throwing resolver, with a **positive control** proving the same harness still PASSes when the root is configured.
- **Mutation-checked:** forcing the comparison true reddens the CTL-1919 test.

## ⚠️ Still open on CTL-1931 — unchanged by this PR

1. **`installed-vs-locked` remains INCONCLUSIVE fleet-wide.** bun's isolated linker resolves through a `.bun` store path, which is not an install *location*, so `lockKeyForPackageJsonPath` returns null. **This is the defect the ticket's own ACs describe, and it is not fixed here.**
2. **`CRITICAL_DEPS` holds only `@catalyst-cloud/sdk`**, while CTL-1919 was an `@catalyst-cloud/schema` skew — the package that caused the incident is not measured at all. Not a one-liner: `cloud-sync` reaches schema *through* the sdk, so a bare specifier is unresolvable from the writer's directory and would degrade every host's boot record into a permanent WARN. It needs per-dep resolution bases.

## Gate

`7438 pass / 2 fail`, failure set **diffed per-test** against a clean `origin/main` worktree — **identical**; both pre-existing and environment-dependent.

Refs CTL-1931, CTL-1919, CTL-1659.