### PR TITLE
feat(dev): CTL-1916 — ship the cutover-verification tool instead of re-deriving it each session

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -274,6 +274,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/catalyst-install.test.sh
 
+      - name: verify-loaded cutover-verification test (CTL-1916)
+        # CTL-1916: the tool that proves a host is running the code you think it is. It was
+        # re-derived into a session temp dir three times and lost three times, which is why
+        # it is committed AND gated here — a verification tool that is not itself under CI
+        # is one edit away from silently certifying everything.
+        # Both controls are in the suite: a correctly-loaded fixture PASSES, and a daemon
+        # serving a different root (plus five other single-fact mutations) FAILS.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/verify-loaded.test.sh
+
       - name: daemon-watchdog supervision test (CTL-1502)
         # Covers the bash half of the CTL-1502 Codex P1 fixes: node-class gating
         # (the standalone watchdog runs on a monitor node and NOT on a worker, so

--- a/docs/runbooks/cloud-feed-cutover.md
+++ b/docs/runbooks/cloud-feed-cutover.md
@@ -186,3 +186,56 @@ after the cutover it reports
 Its declared-`cloud` WARN text was corrected, though — it used to say such a node
 had "no event ingestion at all", which is now wrong in the direction that sends an
 operator hunting a Linear outage that does not exist.
+
+## 6. Proving a host is actually running the code — `verify-loaded.sh` (CTL-1916)
+
+```bash
+plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host mini-2 --mode enforce
+plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host laptop --role monitor
+```
+
+⛔ **A git sha on disk is not evidence.** It proves the bytes arrived; it says nothing
+about what the running process is executing. Every link below is anchored on the **live
+pid**, and the fourth is the one that makes the difference explicit — a daemon that
+started *before* the file changed is serving the previous bytes no matter how current the
+checkout looks. That is not a hypothetical: it is the whole content of CTL-1919 (a writer
+serving a checkout three schema versions stale while every git-level check on the host
+read clean), and of CTL-1659 before it.
+
+| link | question | why it is not covered by the others |
+| --- | --- | --- |
+| `serving-root` | does the live pid's argv name the root it is required to serve? | read from the process table, never a pid **file** — a pid file is a claim written at some past moment, and a recycled pid makes it a confident lie |
+| `gate-module` | is the module present **and importable** from that root? | present-but-unimportable is the CTL-1831 shape (a broken transitive resolution) and reads as "installed" to every git-level check |
+| `armed-line` | did **this pid** write the mode line? | anchored on the pid, because a log is append-only across restarts — an unanchored grep happily matches the line a *previous* process wrote before the rollback you are checking for |
+| `started-after` | did the pid start after the module's mtime? | links 1–3 all pass for a daemon that booted before the pull landed |
+
+Every link **fails closed**: "I could not measure it" exits non-zero and names the link.
+`--role monitor` **asserts the absence** of an execution-core daemon rather than skipping —
+a skipped link reports the same "no complaint" as a verified one.
+
+⚠️ The declared **mode** and the runtime **`armed`** flag are different facts and the tool
+prints both. Measured on the fleet 2026-08-17, mini-2 reports `mode=enforce` with
+`armed=false`: enforce is configured, the feed is not currently armed (CTL-1909). That is
+a runtime condition, not a load failure, so it is surfaced rather than failed — failing it
+would make a correctly-loaded host report FAIL and train operators to ignore the tool.
+
+Tests: `plugins/dev/scripts/__tests__/verify-loaded.test.sh`, gated in CI. Both controls
+are present — a correctly-loaded fixture PASSES, and each failure case changes exactly one
+fact, so a green result is evidence about that fact rather than about the harness.
+
+### Parity sampling — a one-liner, not a script
+
+The overnight sampler that lived at `~/catalyst/parity-hourly.sh` on mini-2 is **retired**
+(CTL-1916). It was hand-placed and untracked, it was never scheduled, and since the Linear
+smee retirement (CTL-1928) the parity run has only one stream left to look at, so it can
+report agreement but no longer a *comparison*. Run the CLI directly when you want a sample:
+
+```bash
+cd ~/catalyst/plugin-source && \
+  bun plugins/dev/scripts/execution-core/linear-feed-parity-run.mjs --since-min 60
+```
+
+⚠️ If you ever need it on a loop again, put the deadline **inside** the loop and make it
+sleep, never spin — `end=$((SECONDS+N)); while [ $SECONDS -lt $end ]; do sleep 60; done`.
+Cleanup must never be load-bearing (AGENTS.md); four spinners once leaked out of one test
+run here and burned ~4 CPU-cores for 16.5 h while the script reported `cleanup verified`.

--- a/plugins/dev/scripts/__tests__/verify-loaded.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-loaded.test.sh
@@ -22,6 +22,12 @@ FAILURES=0; PASSES=0
 ok()   { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
 bad()  { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
 
+# Portable mtime (Codex #3496 P1): this suite is gated on ubuntu-latest, where BSD
+# `stat -f %m` means "file SYSTEM status" and aborts. The first cut used the macOS spelling
+# and every CI run of this workflow died at line 39 before a single case executed —
+# a test file that cannot start is indistinguishable from one with nothing to say.
+_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
@@ -34,21 +40,25 @@ echo 'export const ok = true;' > "${ROOT}/${MODULE_REL}"
 # nothing else.
 echo "12345"                                     > "${TMP}/pid"
 echo "bun ${ROOT}/plugins/dev/scripts/execution-core/daemon.mjs" > "${TMP}/cmd"
-echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
+echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/daemon.log"
 # start time is well after the module mtime unless a case says otherwise
-echo "$(( $(stat -f %m "${ROOT}/${MODULE_REL}") + 60 )) $(stat -f %m "${ROOT}/${MODULE_REL}")" > "${TMP}/epochs"
+echo "$(( $(_mtime "${ROOT}/${MODULE_REL}") + 60 )) $(_mtime "${ROOT}/${MODULE_REL}")" > "${TMP}/epochs"
 
 cat > "${TMP}/runner.sh" <<'RUNNER'
 #!/usr/bin/env bash
 # $1 = host, $2 = command. Answers from the fixture files by inspecting the command shape.
 T="${FIXTURE_DIR}"
 cmd="$2"
+# The injected runner can be made to FAIL wholesale, which is how the unreachable-host
+# case is exercised (Codex #3496 P1: an unreachable host must not read as an absence).
+if [ -f "${T}/runner_dies" ]; then echo "ssh: connect to host: Connection refused" >&2; exit 255; fi
 case "$cmd" in
+  *VL_REACHABLE_9f3a*) echo "VL_REACHABLE_9f3a" ;;
   pgrep*)      cat "${T}/pid" ;;
   *"-o command="*) cat "${T}/cmd" ;;
   *"test -f"*) p="${cmd#*test -f \'}"; p="${p%%\'*}"; [ -f "$p" ] && echo yes || echo no ;;
   *IMPORT_OK*) if [ -f "${T}/import_fails" ]; then echo "error: Cannot find package"; else echo IMPORT_OK; fi ;;
-  *grep*)      cat "${T}/armed" ;;
+  *"cloud-feed: armed"*) bash -c "$cmd" ;;   # REAL grep against the fixture log
   *lstart*)    cat "${T}/epochs" ;;
   *)           echo "" ;;
 esac
@@ -57,7 +67,7 @@ chmod +x "${TMP}/runner.sh"
 
 run_vl() {
   FIXTURE_DIR="$TMP" CATALYST_VERIFY_LOADED_RUNNER="${TMP}/runner.sh" \
-    bash "$VL" --root "$ROOT" --host fakehost "$@" 2>&1
+    bash "$VL" --root "$ROOT" --host fakehost --log "${TMP}/daemon.log" "$@" 2>&1
 }
 
 expect_exit() {
@@ -99,14 +109,14 @@ rm -f "${TMP}/import_fails"
 expect_exit "a DIFFERENT announced mode FAILS" 1 --mode shadow
 
 # ⛔ the armed line written by ANOTHER pid must not satisfy this pid's link
-echo '{"pid":999,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
-: > "${TMP}/armed"   # the runner's grep is pid-anchored in production; here, no match
+echo '{"pid":999,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/daemon.log"
+: > "${TMP}/daemon.log"   # the runner's grep is pid-anchored in production; here, no match
 expect_exit "no armed line from THIS pid FAILS (an earlier pid's line does not count)" 1 --mode enforce
-echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
+echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/daemon.log"
 
 # ⭐ link 4: started BEFORE the bytes changed — every other link still passes here, which
 # is exactly why this link exists.
-M="$(stat -f %m "${ROOT}/${MODULE_REL}")"
+M="$(_mtime "${ROOT}/${MODULE_REL}")"
 echo "$(( M - 60 )) ${M}" > "${TMP}/epochs"
 expect_exit "a daemon that started BEFORE the module changed FAILS" 1 --mode enforce
 out="$(run_vl --mode enforce)"
@@ -131,6 +141,54 @@ out="$(CATALYST_VERIFY_LOADED_RUNNER="${TMP}/runner.sh" bash "$VL" --root "$ROOT
 [[ $rc -ne 0 && "$out" == *"--mode is required"* ]] && ok "worker role requires --mode" || bad "worker role requires --mode" "$out"
 out="$(bash "$VL" --root "$ROOT" --host h --mode enforce --role bogus 2>&1)"; rc=$?
 [[ $rc -ne 0 ]] && ok "an unknown --role is rejected" || bad "an unknown --role is rejected" "$out"
+
+echo "── Codex #3496 round 1: four P1s, each with its own control ──"
+
+# ⛔ P1: an unreachable host must FAIL, not read as "no daemon". This is the worst shape a
+# verification tool can have — certifying a host it could not inspect — and the monitor
+# role is where it bites, because there "nothing found" is the PASSING answer.
+touch "${TMP}/runner_dies"
+expect_exit "an UNREACHABLE host FAILS in worker role" 1 --mode enforce
+expect_exit "⛔ an UNREACHABLE host FAILS in MONITOR role (absence must not be assumed)" 1 --role monitor
+out="$(run_vl --role monitor)"
+[[ "$out" == *"NOTHING below can be measured"* ]] && ok "…and says nothing could be measured" \
+  || bad "…and says nothing could be measured" "$out"
+rm -f "${TMP}/runner_dies"
+# POSITIVE CONTROL: the same monitor invocation passes the moment the host answers.
+: > "${TMP}/pid"
+expect_exit "…and the SAME monitor call PASSes once the host is reachable" 0 --role monitor
+echo "12345" > "${TMP}/pid"
+
+# ⛔ P1: the armed-line pid match must be delimited, not a prefix. `"pid":12345` must not be
+# satisfied by `"pid":123456` — a DIFFERENT process, which is precisely the earlier-pid
+# confusion this link exists to prevent.
+echo '{"pid":123456,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/daemon.log"
+expect_exit "⛔ a longer pid sharing this pid's PREFIX does not satisfy the link" 1 --mode enforce
+# POSITIVE CONTROL: the exact pid, same fixture shape, passes — so the FAIL above is about
+# the delimiter and not about the line being unparseable.
+echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/daemon.log"
+expect_exit "…while the EXACT pid still passes" 0 --mode enforce
+
+# ⛔ THE PROBE-SHELL SELF-MATCH — deliberately run over the REAL local transport, with no
+# injected runner, because it is a property of the platform's pgrep and a fake runner
+# cannot exhibit it.
+#
+# ⚠️ IT IS PLATFORM-SENSITIVE, AND THIS IS THE ONLY PLACE IT CAN FIRE. On GNU/procps
+# (ubuntu-latest, where this suite is gated) `pgrep -f` matches the full command line of
+# the `bash -c` shell running the probe, whose argv contains the pattern — so an
+# unexcluded probe returns its own pid and every monitor node reports a daemon it does not
+# have. On macOS the same call does NOT self-match (measured: rc=1 with the pattern in the
+# invoking shell's argv), so a developer running this suite locally cannot reproduce it and
+# must not conclude the exclusion is unnecessary. CI is the instrument for this one case.
+echo "── the probe shell must not match itself (REAL transport; fires on Linux) ──"
+UNIQ="zzz-verify-loaded-selfmatch-$$"
+out="$(bash "$VL" --root "$ROOT" --host localhost --role monitor --process-pattern "$UNIQ" 2>&1)"; rc=$?
+if [[ $rc -eq 0 && "$out" == *"no execution-core daemon"* ]]; then
+  ok "a pattern matching NOTHING reports no daemon (the probe shell is excluded)"
+else
+  bad "a pattern matching NOTHING reports no daemon (the probe shell is excluded)" "exit=${rc}
+${out}"
+fi
 
 echo
 echo "verify-loaded.test.sh: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/verify-loaded.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-loaded.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# verify-loaded.test.sh — CTL-1916.
+#
+# ⛔ EVERY CASE COMES IN A PAIR. The tool's entire value is that it FAILS on a host that is
+# not running what you think — so a suite that only ever shows it passing would certify
+# nothing. Each negative below shares its fixture with a positive, changing exactly one
+# fact, so a green result is evidence about that fact and not about the harness.
+#
+# The transport is sealed at the ONE seam the script routes every host question through
+# (CATALYST_VERIFY_LOADED_RUNNER), rather than by shadowing `ssh`/`ps`/`grep` on PATH:
+# a PATH stub only proves the stubbed name was not invoked, which is not the same as
+# proving nothing reached the network.
+#
+# Run: bash plugins/dev/scripts/__tests__/verify-loaded.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEV="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VL="${DEV}/verify-loaded.sh"
+
+FAILURES=0; PASSES=0
+ok()   { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+bad()  { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ROOT="${TMP}/plugin-source"
+MODULE_REL="plugins/dev/scripts/execution-core/cloud-feed-timer.mjs"
+mkdir -p "$(dirname "${ROOT}/${MODULE_REL}")"
+echo 'export const ok = true;' > "${ROOT}/${MODULE_REL}"
+
+# The fake host. Every knob a case needs to vary is a file, so a case changes one fact and
+# nothing else.
+echo "12345"                                     > "${TMP}/pid"
+echo "bun ${ROOT}/plugins/dev/scripts/execution-core/daemon.mjs" > "${TMP}/cmd"
+echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
+# start time is well after the module mtime unless a case says otherwise
+echo "$(( $(stat -f %m "${ROOT}/${MODULE_REL}") + 60 )) $(stat -f %m "${ROOT}/${MODULE_REL}")" > "${TMP}/epochs"
+
+cat > "${TMP}/runner.sh" <<'RUNNER'
+#!/usr/bin/env bash
+# $1 = host, $2 = command. Answers from the fixture files by inspecting the command shape.
+T="${FIXTURE_DIR}"
+cmd="$2"
+case "$cmd" in
+  pgrep*)      cat "${T}/pid" ;;
+  *"-o command="*) cat "${T}/cmd" ;;
+  *"test -f"*) p="${cmd#*test -f \'}"; p="${p%%\'*}"; [ -f "$p" ] && echo yes || echo no ;;
+  *IMPORT_OK*) if [ -f "${T}/import_fails" ]; then echo "error: Cannot find package"; else echo IMPORT_OK; fi ;;
+  *grep*)      cat "${T}/armed" ;;
+  *lstart*)    cat "${T}/epochs" ;;
+  *)           echo "" ;;
+esac
+RUNNER
+chmod +x "${TMP}/runner.sh"
+
+run_vl() {
+  FIXTURE_DIR="$TMP" CATALYST_VERIFY_LOADED_RUNNER="${TMP}/runner.sh" \
+    bash "$VL" --root "$ROOT" --host fakehost "$@" 2>&1
+}
+
+expect_exit() {
+  local name="$1" want="$2"; shift 2
+  local out; out="$(run_vl "$@")"; local got=$?
+  if [[ "$got" == "$want" ]]; then ok "$name"; else bad "$name" "expected exit ${want}, got ${got}:
+${out}"; fi
+}
+
+echo "── worker role: the four links ──"
+
+# ⭐ THE POSITIVE. Without it every FAIL below could be produced by a broken harness.
+expect_exit "a correctly-loaded host PASSES (exit 0)" 0 --mode enforce
+
+# ⭐ THE CONTROL THE TICKET NAMES: the daemon serving a DIFFERENT root.
+echo "bun /somewhere/else/plugins/dev/scripts/execution-core/daemon.mjs" > "${TMP}/cmd"
+expect_exit "a daemon serving a DIFFERENT root FAILS" 1 --mode enforce
+out="$(run_vl --mode enforce)"
+[[ "$out" == *"is NOT serving"* ]] && ok "…and names the root it is actually serving" \
+  || bad "…and names the root it is actually serving" "$out"
+echo "bun ${ROOT}/plugins/dev/scripts/execution-core/daemon.mjs" > "${TMP}/cmd"   # restore
+
+# no daemon at all
+: > "${TMP}/pid"
+expect_exit "no daemon process at all FAILS" 1 --mode enforce
+echo "12345" > "${TMP}/pid"
+
+# module absent
+mv "${ROOT}/${MODULE_REL}" "${TMP}/stashed-module"
+expect_exit "an ABSENT gate module FAILS" 1 --mode enforce
+mv "${TMP}/stashed-module" "${ROOT}/${MODULE_REL}"
+
+# ⚠️ present-but-unimportable: the CTL-1831 shape, invisible to every git-level check.
+touch "${TMP}/import_fails"
+expect_exit "a module that is on disk but does NOT import FAILS" 1 --mode enforce
+rm -f "${TMP}/import_fails"
+
+# mode mismatch
+expect_exit "a DIFFERENT announced mode FAILS" 1 --mode shadow
+
+# ⛔ the armed line written by ANOTHER pid must not satisfy this pid's link
+echo '{"pid":999,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
+: > "${TMP}/armed"   # the runner's grep is pid-anchored in production; here, no match
+expect_exit "no armed line from THIS pid FAILS (an earlier pid's line does not count)" 1 --mode enforce
+echo '{"pid":12345,"mode":"enforce","armed":true,"msg":"cloud-feed: armed"}' > "${TMP}/armed"
+
+# ⭐ link 4: started BEFORE the bytes changed — every other link still passes here, which
+# is exactly why this link exists.
+M="$(stat -f %m "${ROOT}/${MODULE_REL}")"
+echo "$(( M - 60 )) ${M}" > "${TMP}/epochs"
+expect_exit "a daemon that started BEFORE the module changed FAILS" 1 --mode enforce
+out="$(run_vl --mode enforce)"
+[[ "$out" == *"serving the previous bytes"* ]] && ok "…and says it is serving the previous bytes" \
+  || bad "…and says it is serving the previous bytes" "$out"
+[[ "$out" == *"PASS"*"serving-root"* ]] && ok "…while serving-root still PASSes (the link is not redundant)" \
+  || bad "…while serving-root still PASSes" "$out"
+
+# unreadable freshness inputs must FAIL, not pass quietly
+echo "NA NA" > "${TMP}/epochs"
+expect_exit "unreadable start-time/mtime FAILS CLOSED (never a quiet pass)" 1 --mode enforce
+echo "$(( M + 60 )) ${M}" > "${TMP}/epochs"
+
+echo "── monitor role: absence is ASSERTED, not skipped ──"
+: > "${TMP}/pid"
+expect_exit "monitor node with NO exec-core daemon PASSES" 0 --role monitor
+echo "12345" > "${TMP}/pid"
+expect_exit "monitor node RUNNING an exec-core daemon FAILS" 1 --role monitor
+
+echo "── argument handling ──"
+out="$(CATALYST_VERIFY_LOADED_RUNNER="${TMP}/runner.sh" bash "$VL" --root "$ROOT" --host h --role worker 2>&1)"; rc=$?
+[[ $rc -ne 0 && "$out" == *"--mode is required"* ]] && ok "worker role requires --mode" || bad "worker role requires --mode" "$out"
+out="$(bash "$VL" --root "$ROOT" --host h --mode enforce --role bogus 2>&1)"; rc=$?
+[[ $rc -ne 0 ]] && ok "an unknown --role is rejected" || bad "an unknown --role is rejected" "$out"
+
+echo
+echo "verify-loaded.test.sh: ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/verify-loaded.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-loaded.test.sh
@@ -65,7 +65,7 @@ cmd="$2"
 if [ -f "${T}/runner_dies" ]; then echo "ssh: connect to host: Connection refused" >&2; exit 255; fi
 case "$cmd" in
   *VL_REACHABLE_9f3a*) echo "VL_REACHABLE_9f3a" ;;
-  pgrep*)      cat "${T}/pid" ;;
+  *pgrep*)     cat "${T}/pid" ;;   # must precede the ps case: the probe contains both
   *"-o command="*) cat "${T}/cmd" ;;
   *"test -f"*) p="${cmd#*test -f \'}"; p="${p%%\'*}"; [ -f "$p" ] && echo yes || echo no ;;
   *IMPORT_OK*) if [ -f "${T}/import_fails" ]; then echo "error: Cannot find package"; else echo IMPORT_OK; fi ;;

--- a/plugins/dev/scripts/__tests__/verify-loaded.test.sh
+++ b/plugins/dev/scripts/__tests__/verify-loaded.test.sh
@@ -26,7 +26,18 @@ bad()  { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
 # `stat -f %m` means "file SYSTEM status" and aborts. The first cut used the macOS spelling
 # and every CI run of this workflow died at line 39 before a single case executed —
 # a test file that cannot start is indistinguishable from one with nothing to say.
-_mtime() { stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null; }
+# ⛔ PROBE THE DIALECT; DO NOT RELY ON THE WRONG ONE FAILING. The obvious
+# `stat -f %m "$f" || stat -c %Y "$f"` is broken on GNU in the silent direction: `-f` there
+# means "file SYSTEM status", so GNU stat treats BOTH `%m` and the filename as files,
+# errors on `%m`, SUCCEEDS on the real file, and prints a multi-line block starting
+# `  File: …` — exit 0, so the `||` never fires and that text flows into `$(( ))`, which
+# under `set -u` dies with `File: unbound variable`. That is exactly what CI reported on
+# the first fix attempt: a fallback that cannot detect its own failure.
+if stat -c %Y . >/dev/null 2>&1; then
+  _mtime() { stat -c %Y "$1"; }        # GNU/coreutils (ubuntu-latest)
+else
+  _mtime() { stat -f %m "$1"; }        # BSD/macOS
+fi
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/plugins/dev/scripts/verify-loaded.sh
+++ b/plugins/dev/scripts/verify-loaded.sh
@@ -117,28 +117,30 @@ fi
 # Read from the live process table, never from a pid FILE: a pid file is a claim written
 # at some past moment, and a recycled pid makes it a confident lie.
 # ⛔ THE PROBE MUST NOT MATCH ITSELF (Codex #3496 P1). `pgrep -f` matches the FULL command
-# line, and the shell running this probe carries the pattern in its own argv — so an
-# unguarded probe returns its own pid and every host looks like it is running the daemon.
+# line, so several processes belonging to this very check carry the pattern in their argv:
+# the shell running the probe, the pipeline's SUBSHELL, and — the one that actually bit —
+# `verify-loaded.sh` itself, whose `--process-pattern <pat>` argument holds the raw pattern.
 #
-# ⚠️ EXCLUDING `$$`/`$PPID` IS NOT ENOUGH, and CI proved it: a pipeline runs in a SUBSHELL
-# whose pid is neither, while its argv is still the whole command string. That attempt
-# passed on macOS (whose pgrep does not self-match at all) and failed on ubuntu with
-# `monitor node is running an execution-core daemon (pid 2805)` — a fix verified only on
-# the platform where the bug cannot occur.
+# ⚠️ TWO EARLIER FIXES WERE INSUFFICIENT, and each passed on macOS while failing on Linux:
+#   (a) excluding `$$`/`$PPID` — a pipeline subshell's pid is neither;
+#   (b) the bracket idiom alone — `[z]zz…` cannot match our own bracketed text, but it DOES
+#       match the raw `zzz…` sitting in this script's own argv.
+# macOS pgrep does not self-match at all, so neither attempt could be falsified locally;
+# CI on ubuntu is what caught both. Verifying a fix only on the platform where the defect
+# cannot occur is not verification.
 #
-# So the pattern is made STRUCTURALLY unable to match its own command line, with the
-# standard bracket idiom: the first character is wrapped in a class, so the regex still
-# matches `execution-core/daemon.mjs` while the literal text in our argv reads
-# `[e]xecution-core/daemon.mjs`, which the regex does not match. It needs no pid list and
-# cannot be defeated by a subshell. Applied only when the first character is alphanumeric
-# (bracketing a regex metacharacter would change the pattern's meaning); otherwise the
-# older pid exclusion is kept as the fallback, and it is retained alongside in both cases
-# as belt-and-braces.
+# So candidates are now IDENTIFIED and then CHECKED: read each one's command line and
+# discard anything belonging to this check. That is a property of the process, not of a
+# pid arithmetic that a new intermediate process can invalidate again. The bracket form is
+# kept because it removes the whole class cheaply; the argv check is what makes it sound.
 VL_PROC_RE="$VL_PROC_PAT"
 case "$VL_PROC_PAT" in
   [A-Za-z0-9]*) VL_PROC_RE="[${VL_PROC_PAT:0:1}]${VL_PROC_PAT:1}" ;;
 esac
-PID="$(_vl_run "pgrep -f '${VL_PROC_RE}' 2>/dev/null | grep -vx \"\$\$\" | grep -vx \"\$PPID\" | head -1" 2>/dev/null | tr -d '[:space:]')"
+# Built with a single-quoted printf format so `$p`, `$c` and the substitutions are
+# evaluated by the REMOTE shell, not by this one.
+VL_PID_CMD="$(printf 'for p in $(pgrep -f %s 2>/dev/null); do c=$(ps -p $p -o command= 2>/dev/null); case "$c" in *verify-loaded*|*--process-pattern*|*pgrep*) continue ;; esac; echo $p; break; done' "'${VL_PROC_RE}'")"
+PID="$(_vl_run "$VL_PID_CMD" 2>/dev/null | tr -d '[:space:]')"
 
 if [[ "$VL_ROLE" == "monitor" ]]; then
   # ⭐ The monitor role ASSERTS AN ABSENCE rather than skipping. A skipped link reports the

--- a/plugins/dev/scripts/verify-loaded.sh
+++ b/plugins/dev/scripts/verify-loaded.sh
@@ -82,16 +82,47 @@ _vl_run() {
   fi
 }
 
+# ⛔ REACHABILITY IS A POSITIVE CONTROL, RUN FIRST (Codex #3496 P1). Every probe below
+# reads a command's STDOUT, and an unreachable host, a failed ssh auth, or a missing
+# binary all produce the same empty string as "the thing genuinely is not there". Codex
+# reproduced it: an injected runner exiting 255 printed "no execution-core daemon" and
+# "verify-loaded: OK" — the tool certifying a host it could not inspect, which is the exact
+# false-clean class it exists to catch, in the tool that exists to catch it.
+#
+# So the transport is proved to carry a KNOWN answer before any absence is believed. The
+# token is matched exactly: a runner that echoes something else, or nothing, is not
+# reachable. Note this cannot be folded into the individual probes — the discriminator is
+# "did the transport work", and only a command whose correct output is known in advance
+# can answer that.
+_vl_probe_reachable() {
+  local out
+  out="$(_vl_run 'echo VL_REACHABLE_9f3a' 2>/dev/null)"
+  [[ "$(printf '%s' "$out" | tr -d '[:space:]')" == "VL_REACHABLE_9f3a" ]]
+}
+
 VL_FAILURES=0
 _pass() { printf '  \033[32mPASS\033[0m  %-16s %s\n' "$1" "$2"; }
 _fail() { printf '  \033[31mFAIL\033[0m  %-16s %s\n' "$1" "$2"; VL_FAILURES=$((VL_FAILURES+1)); }
 
 echo "verify-loaded: host=${VL_HOST} root=${VL_ROOT} role=${VL_ROLE}${VL_MODE:+ mode=${VL_MODE}}"
 
+if _vl_probe_reachable; then
+  _pass "reachable" "the host answered a known-value probe — absences below are real absences"
+else
+  _fail "reachable" "could not run a command on ${VL_HOST} (ssh/auth/shell) — NOTHING below can be measured, so nothing is verified"
+  echo; echo "verify-loaded: ${VL_FAILURES} link(s) FAILED on ${VL_HOST}"; exit 1
+fi
+
 # ── link 1: the daemon process, and which root its argv names ───────────────────────
 # Read from the live process table, never from a pid FILE: a pid file is a claim written
 # at some past moment, and a recycled pid makes it a confident lie.
-PID="$(_vl_run "pgrep -f '${VL_PROC_PAT}' 2>/dev/null | head -1" 2>/dev/null | tr -d '[:space:]')"
+# ⛔ EXCLUDE THE PROBE SHELL (Codex #3496 P1). `pgrep -f` matches the FULL command line,
+# and the shell running this very probe has the pattern in its own argv — so locally (and
+# through any `sh -c` runner) pgrep returns the probe's own pid and every host looks like
+# it is running the daemon. Codex reproduced it with a pattern matching nothing at all:
+# `--role monitor` still reported a daemon on a correctly configured host.
+# `$$`/`$PPID` expand in the REMOTE shell, which is the one whose argv carries the pattern.
+PID="$(_vl_run "pgrep -f '${VL_PROC_PAT}' 2>/dev/null | grep -vx \"\$\$\" | grep -vx \"\$PPID\" | head -1" 2>/dev/null | tr -d '[:space:]')"
 
 if [[ "$VL_ROLE" == "monitor" ]]; then
   # ⭐ The monitor role ASSERTS AN ABSENCE rather than skipping. A skipped link reports the
@@ -142,7 +173,11 @@ fi
 # ⛔ Matched against this pid, not merely "somewhere in the log". A log is append-only
 # across restarts, so an unanchored grep happily matches the line a PREVIOUS process wrote
 # before the very rollback you are checking for.
-ARMED="$(_vl_run "grep -h '\"pid\":${PID}' ${VL_LOG} 2>/dev/null | grep -E '${VL_ARMED_RE}' | tail -1" 2>/dev/null)"
+# ⛔ DELIMITED, NOT A PREFIX (Codex #3496 P1). `"pid":999` also matches `"pid":9991`, so a
+# DIFFERENT process's line could satisfy this pid's link — defeating the very earlier-pid
+# protection this link is here for. pino always writes a field after `pid`, so the closing
+# delimiter is `,` or `}`.
+ARMED="$(_vl_run "grep -hE '\"pid\":${PID}[,}]' ${VL_LOG} 2>/dev/null | grep -E '${VL_ARMED_RE}' | tail -1" 2>/dev/null)"
 if [[ -z "$ARMED" ]]; then
   _fail "armed-line" "pid ${PID} never wrote a line matching '${VL_ARMED_RE}' — the mode is UNPROVEN (a log line from an earlier pid does not count)"
 elif [[ "$ARMED" == *"${VL_MODE}"* ]]; then
@@ -172,7 +207,11 @@ fi
 # Links 1–3 all pass for a daemon that booted before the pull landed. Compare the process
 # start time to the module's mtime; an unreadable either side FAILS, because "I could not
 # compare" is exactly the answer a stale daemon produces for free.
-EPOCHS="$(_vl_run "s=\$(ps -p ${PID} -o lstart= 2>/dev/null); m=\$(stat -f %m '${MOD_PATH}' 2>/dev/null); ps_e=\$(date -j -f '%a %b %d %T %Y' \"\$s\" +%s 2>/dev/null); echo \"\${ps_e:-NA} \${m:-NA}\"" 2>/dev/null)"
+# Portable on both stat dialects (Codex #3496 P1): BSD/macOS `stat -f %m` vs GNU
+# `stat -c %Y`. The fleet is macOS, but this script is repo tooling and CI is Linux, so a
+# BSD-only spelling is a latent break rather than a safe assumption. Same for the start
+# time: BSD `date -j -f`, GNU `ps -o lstart=` → `date -d`.
+EPOCHS="$(_vl_run "m=\$(stat -f %m '${MOD_PATH}' 2>/dev/null || stat -c %Y '${MOD_PATH}' 2>/dev/null); s=\$(ps -p ${PID} -o lstart= 2>/dev/null); ps_e=\$(date -j -f '%a %b %d %T %Y' \"\$s\" +%s 2>/dev/null || date -d \"\$s\" +%s 2>/dev/null); echo \"\${ps_e:-NA} \${m:-NA}\"" 2>/dev/null)"
 PS_EPOCH="${EPOCHS%% *}"; MOD_EPOCH="${EPOCHS##* }"
 if [[ "$PS_EPOCH" == "NA" || "$MOD_EPOCH" == "NA" || -z "$PS_EPOCH" || -z "$MOD_EPOCH" ]]; then
   _fail "started-after" "could not read process start time and/or module mtime (got '${EPOCHS}') — freshness is UNPROVEN"

--- a/plugins/dev/scripts/verify-loaded.sh
+++ b/plugins/dev/scripts/verify-loaded.sh
@@ -116,13 +116,29 @@ fi
 # ── link 1: the daemon process, and which root its argv names ───────────────────────
 # Read from the live process table, never from a pid FILE: a pid file is a claim written
 # at some past moment, and a recycled pid makes it a confident lie.
-# ⛔ EXCLUDE THE PROBE SHELL (Codex #3496 P1). `pgrep -f` matches the FULL command line,
-# and the shell running this very probe has the pattern in its own argv — so locally (and
-# through any `sh -c` runner) pgrep returns the probe's own pid and every host looks like
-# it is running the daemon. Codex reproduced it with a pattern matching nothing at all:
-# `--role monitor` still reported a daemon on a correctly configured host.
-# `$$`/`$PPID` expand in the REMOTE shell, which is the one whose argv carries the pattern.
-PID="$(_vl_run "pgrep -f '${VL_PROC_PAT}' 2>/dev/null | grep -vx \"\$\$\" | grep -vx \"\$PPID\" | head -1" 2>/dev/null | tr -d '[:space:]')"
+# ⛔ THE PROBE MUST NOT MATCH ITSELF (Codex #3496 P1). `pgrep -f` matches the FULL command
+# line, and the shell running this probe carries the pattern in its own argv — so an
+# unguarded probe returns its own pid and every host looks like it is running the daemon.
+#
+# ⚠️ EXCLUDING `$$`/`$PPID` IS NOT ENOUGH, and CI proved it: a pipeline runs in a SUBSHELL
+# whose pid is neither, while its argv is still the whole command string. That attempt
+# passed on macOS (whose pgrep does not self-match at all) and failed on ubuntu with
+# `monitor node is running an execution-core daemon (pid 2805)` — a fix verified only on
+# the platform where the bug cannot occur.
+#
+# So the pattern is made STRUCTURALLY unable to match its own command line, with the
+# standard bracket idiom: the first character is wrapped in a class, so the regex still
+# matches `execution-core/daemon.mjs` while the literal text in our argv reads
+# `[e]xecution-core/daemon.mjs`, which the regex does not match. It needs no pid list and
+# cannot be defeated by a subshell. Applied only when the first character is alphanumeric
+# (bracketing a regex metacharacter would change the pattern's meaning); otherwise the
+# older pid exclusion is kept as the fallback, and it is retained alongside in both cases
+# as belt-and-braces.
+VL_PROC_RE="$VL_PROC_PAT"
+case "$VL_PROC_PAT" in
+  [A-Za-z0-9]*) VL_PROC_RE="[${VL_PROC_PAT:0:1}]${VL_PROC_PAT:1}" ;;
+esac
+PID="$(_vl_run "pgrep -f '${VL_PROC_RE}' 2>/dev/null | grep -vx \"\$\$\" | grep -vx \"\$PPID\" | head -1" 2>/dev/null | tr -d '[:space:]')"
 
 if [[ "$VL_ROLE" == "monitor" ]]; then
   # ⭐ The monitor role ASSERTS AN ABSENCE rather than skipping. A skipped link reports the

--- a/plugins/dev/scripts/verify-loaded.sh
+++ b/plugins/dev/scripts/verify-loaded.sh
@@ -211,7 +211,7 @@ fi
 # `stat -c %Y`. The fleet is macOS, but this script is repo tooling and CI is Linux, so a
 # BSD-only spelling is a latent break rather than a safe assumption. Same for the start
 # time: BSD `date -j -f`, GNU `ps -o lstart=` → `date -d`.
-EPOCHS="$(_vl_run "m=\$(stat -f %m '${MOD_PATH}' 2>/dev/null || stat -c %Y '${MOD_PATH}' 2>/dev/null); s=\$(ps -p ${PID} -o lstart= 2>/dev/null); ps_e=\$(date -j -f '%a %b %d %T %Y' \"\$s\" +%s 2>/dev/null || date -d \"\$s\" +%s 2>/dev/null); echo \"\${ps_e:-NA} \${m:-NA}\"" 2>/dev/null)"
+EPOCHS="$(_vl_run "m=\$(if stat -c %Y . >/dev/null 2>&1; then stat -c %Y '${MOD_PATH}' 2>/dev/null; else stat -f %m '${MOD_PATH}' 2>/dev/null; fi); s=\$(ps -p ${PID} -o lstart= 2>/dev/null); ps_e=\$(date -j -f '%a %b %d %T %Y' \"\$s\" +%s 2>/dev/null || date -d \"\$s\" +%s 2>/dev/null); echo \"\${ps_e:-NA} \${m:-NA}\"" 2>/dev/null)"
 PS_EPOCH="${EPOCHS%% *}"; MOD_EPOCH="${EPOCHS##* }"
 if [[ "$PS_EPOCH" == "NA" || "$MOD_EPOCH" == "NA" || -z "$PS_EPOCH" || -z "$MOD_EPOCH" ]]; then
   _fail "started-after" "could not read process start time and/or module mtime (got '${EPOCHS}') — freshness is UNPROVEN"

--- a/plugins/dev/scripts/verify-loaded.sh
+++ b/plugins/dev/scripts/verify-loaded.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# verify-loaded.sh — CTL-1916. Prove a host is RUNNING the code you think it is.
+#
+# ⛔ WHY THIS IS A COMMITTED FILE. A tool built to prove a cutover is safe was written
+# three times into a session temp dir and evaporated three times (CTL-1916). Each
+# re-derivation is a fresh chance to check something subtly different from what was
+# checked last time — and the whole point of the tool is that the check is the SAME one
+# every time. So it ships with the plugin; there is no host-local copy to go stale.
+#
+#   verify-loaded.sh --root <serving-root> --host <name> --mode <mode> [--role worker|monitor]
+#
+# ⭐ "LOADED" MEANS THE PID, NOT THE CHECKOUT. A git sha on disk says the bytes arrived;
+# it says nothing about what the running process is executing. Every link below is
+# anchored on the live pid, and link 4 is the one that makes the difference explicit: a
+# daemon that started BEFORE the file changed is serving the previous bytes no matter how
+# current the checkout looks. That distinction is not academic — it is the entire content
+# of CTL-1919 (a writer serving a checkout three schema versions stale while every git
+# check on the host read clean) and of CTL-1659 before it.
+#
+# ⛔ EVERY LINK FAILS CLOSED. "I could not measure it" exits non-zero and says which link
+# and why. A verification tool that degrades to silence on an unreadable input is the
+# false-clean mechanism this repo has shipped more than once; it must not be re-created
+# in the layer whose job is catching it.
+#
+# Exit: 0 = every link verified. 1 = at least one link FAILED or could not be measured.
+set -uo pipefail
+
+VL_ROOT=""; VL_HOST=""; VL_MODE=""; VL_ROLE="worker"
+VL_MODULE="plugins/dev/scripts/execution-core/cloud-feed-timer.mjs"
+VL_ARMED_RE="cloud-feed: armed"
+VL_LOG="\$HOME/catalyst/execution-core/daemon.log"
+VL_PROC_PAT="execution-core/daemon.mjs"
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: verify-loaded.sh --root <serving-root> --host <name> --mode <mode>
+                        [--role worker|monitor] [--module <repo-relative path>]
+                        [--armed-pattern <regex>] [--log <remote path>]
+                        [--process-pattern <pgrep -f pattern>]
+
+  --root    the checkout the daemon is REQUIRED to be serving (e.g. ~/catalyst/plugin-source)
+  --host    host to verify; the local hostname runs locally, anything else over ssh
+  --mode    the mode the running process must have announced (e.g. enforce)
+  --role    worker (default) asserts the daemon is present; monitor asserts its ABSENCE
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --root) VL_ROOT="${2:-}"; shift 2 ;;
+    --host) VL_HOST="${2:-}"; shift 2 ;;
+    --mode) VL_MODE="${2:-}"; shift 2 ;;
+    --role) VL_ROLE="${2:-}"; shift 2 ;;
+    --module) VL_MODULE="${2:-}"; shift 2 ;;
+    --armed-pattern) VL_ARMED_RE="${2:-}"; shift 2 ;;
+    --log) VL_LOG="${2:-}"; shift 2 ;;
+    --process-pattern) VL_PROC_PAT="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "verify-loaded: unknown argument '$1'" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$VL_ROOT" ]] || { echo "verify-loaded: --root is required" >&2; exit 1; }
+[[ -n "$VL_HOST" ]] || { echo "verify-loaded: --host is required" >&2; exit 1; }
+case "$VL_ROLE" in
+  worker) [[ -n "$VL_MODE" ]] || { echo "verify-loaded: --mode is required for role worker" >&2; exit 1; } ;;
+  monitor) : ;;
+  *) echo "verify-loaded: --role must be 'worker' or 'monitor' (got '$VL_ROLE')" >&2; exit 1 ;;
+esac
+
+# _vl_run — the ONE transport seam. Everything this script learns about the host goes
+# through here, so a test can seal the transport with a single injected runner instead of
+# shadowing a helper on PATH — stubbing a helper only proves the helper was not called,
+# which is not the same as proving nothing else reached the network.
+_vl_run() {
+  if [[ -n "${CATALYST_VERIFY_LOADED_RUNNER:-}" ]]; then
+    "${CATALYST_VERIFY_LOADED_RUNNER}" "$VL_HOST" "$1"
+  elif [[ "$VL_HOST" == "$(hostname -s 2>/dev/null)" || "$VL_HOST" == "localhost" ]]; then
+    bash -c "$1"
+  else
+    ssh -o ConnectTimeout=10 -o BatchMode=yes "$VL_HOST" "$1"
+  fi
+}
+
+VL_FAILURES=0
+_pass() { printf '  \033[32mPASS\033[0m  %-16s %s\n' "$1" "$2"; }
+_fail() { printf '  \033[31mFAIL\033[0m  %-16s %s\n' "$1" "$2"; VL_FAILURES=$((VL_FAILURES+1)); }
+
+echo "verify-loaded: host=${VL_HOST} root=${VL_ROOT} role=${VL_ROLE}${VL_MODE:+ mode=${VL_MODE}}"
+
+# ── link 1: the daemon process, and which root its argv names ───────────────────────
+# Read from the live process table, never from a pid FILE: a pid file is a claim written
+# at some past moment, and a recycled pid makes it a confident lie.
+PID="$(_vl_run "pgrep -f '${VL_PROC_PAT}' 2>/dev/null | head -1" 2>/dev/null | tr -d '[:space:]')"
+
+if [[ "$VL_ROLE" == "monitor" ]]; then
+  # ⭐ The monitor role ASSERTS AN ABSENCE rather than skipping. A skipped link reports the
+  # same "no complaint" as a verified one, so a monitor node running a daemon it must not
+  # run would look identical to a correctly configured one.
+  if [[ -z "$PID" ]]; then
+    _pass "no-exec-core" "no execution-core daemon on this monitor node (asserted, not skipped)"
+  else
+    _fail "no-exec-core" "monitor node is running an execution-core daemon (pid ${PID}) — it must not"
+  fi
+  echo
+  [[ $VL_FAILURES -eq 0 ]] && { echo "verify-loaded: OK"; exit 0; }
+  echo "verify-loaded: ${VL_FAILURES} link(s) FAILED"; exit 1
+fi
+
+if [[ -z "$PID" ]]; then
+  _fail "daemon-live" "no process matching '${VL_PROC_PAT}' — nothing is loaded"
+  echo; echo "verify-loaded: ${VL_FAILURES} link(s) FAILED"; exit 1
+fi
+
+CMD="$(_vl_run "ps -p ${PID} -o command= 2>/dev/null" 2>/dev/null)"
+if [[ -z "$CMD" ]]; then
+  _fail "serving-root" "pid ${PID} vanished before its argv could be read — cannot prove which root it serves"
+elif [[ "$CMD" == *"${VL_ROOT}/"* ]]; then
+  _pass "serving-root" "pid ${PID} is serving ${VL_ROOT}"
+else
+  _fail "serving-root" "pid ${PID} is NOT serving ${VL_ROOT} — argv says: ${CMD}"
+fi
+
+# ── link 2: the gate module, on disk AND resolvable from the serving root ───────────
+# Two questions, not one. Presence on disk proves the pull landed; import-resolvability
+# proves the module the daemon would actually load is loadable from THAT root. A file can
+# be present and unimportable (a broken transitive dep — CTL-1831), which reads as
+# "installed" to every git-level check.
+MOD_PATH="${VL_ROOT}/${VL_MODULE}"
+if [[ "$(_vl_run "test -f '${MOD_PATH}' && echo yes || echo no" 2>/dev/null | tr -d '[:space:]')" == "yes" ]]; then
+  RESOLVE="$(_vl_run "cd '${VL_ROOT}' && bun -e 'await import(\"${MOD_PATH}\"); console.log(\"IMPORT_OK\")' 2>&1 | tail -1" 2>/dev/null)"
+  if [[ "$RESOLVE" == *IMPORT_OK* ]]; then
+    _pass "gate-module" "${VL_MODULE} present and importable from ${VL_ROOT}"
+  else
+    _fail "gate-module" "${VL_MODULE} is on disk but does NOT import from ${VL_ROOT}: ${RESOLVE}"
+  fi
+else
+  _fail "gate-module" "${VL_MODULE} is absent under ${VL_ROOT}"
+fi
+
+# ── link 3: the mode line THE RUNNING PROCESS wrote ─────────────────────────────────
+# ⛔ Matched against this pid, not merely "somewhere in the log". A log is append-only
+# across restarts, so an unanchored grep happily matches the line a PREVIOUS process wrote
+# before the very rollback you are checking for.
+ARMED="$(_vl_run "grep -h '\"pid\":${PID}' ${VL_LOG} 2>/dev/null | grep -E '${VL_ARMED_RE}' | tail -1" 2>/dev/null)"
+if [[ -z "$ARMED" ]]; then
+  _fail "armed-line" "pid ${PID} never wrote a line matching '${VL_ARMED_RE}' — the mode is UNPROVEN (a log line from an earlier pid does not count)"
+elif [[ "$ARMED" == *"${VL_MODE}"* ]]; then
+  # ⚠️ The declared MODE and the runtime ARMED flag are different facts, and this tool
+  # reports both rather than letting the first stand for the second. Measured on the fleet
+  # 2026-08-17: mini-2 writes `"mode":"enforce" … "armed":false` — enforce is configured and
+  # the feed is not currently armed (the CTL-1909 readiness behaviour). A tool that printed
+  # only "announced mode enforce" would read as a clean bill of health for a feed that is
+  # not running, which is the failure class this whole script exists to prevent.
+  #
+  # It is surfaced, NOT failed: "is this code loaded, with this mode" is the question
+  # verify-loaded answers, and arming is a separate runtime condition with its own ticket.
+  # Failing here would make a correctly-loaded host report FAIL, which is the opposite
+  # error and would train operators to ignore the tool.
+  ARMED_FLAG=""
+  case "$ARMED" in
+    *'"armed":true'*)  ARMED_FLAG=" (armed=true)" ;;
+    *'"armed":false'*) ARMED_FLAG=" (⚠️ armed=false — mode is configured but the feed is not currently armed; that is a RUNTIME condition, not a load failure)" ;;
+  esac
+  _pass "armed-line" "pid ${PID} announced mode ${VL_MODE}${ARMED_FLAG}"
+else
+  _fail "armed-line" "pid ${PID} announced a DIFFERENT mode than ${VL_MODE}: ${ARMED}"
+fi
+
+# ── link 4: the pid started AFTER the bytes changed ─────────────────────────────────
+# ⭐ THE LINK THAT SEPARATES "THE CHECKOUT IS CURRENT" FROM "THE PROCESS IS RUNNING IT".
+# Links 1–3 all pass for a daemon that booted before the pull landed. Compare the process
+# start time to the module's mtime; an unreadable either side FAILS, because "I could not
+# compare" is exactly the answer a stale daemon produces for free.
+EPOCHS="$(_vl_run "s=\$(ps -p ${PID} -o lstart= 2>/dev/null); m=\$(stat -f %m '${MOD_PATH}' 2>/dev/null); ps_e=\$(date -j -f '%a %b %d %T %Y' \"\$s\" +%s 2>/dev/null); echo \"\${ps_e:-NA} \${m:-NA}\"" 2>/dev/null)"
+PS_EPOCH="${EPOCHS%% *}"; MOD_EPOCH="${EPOCHS##* }"
+if [[ "$PS_EPOCH" == "NA" || "$MOD_EPOCH" == "NA" || -z "$PS_EPOCH" || -z "$MOD_EPOCH" ]]; then
+  _fail "started-after" "could not read process start time and/or module mtime (got '${EPOCHS}') — freshness is UNPROVEN"
+elif [[ "$PS_EPOCH" -ge "$MOD_EPOCH" ]]; then
+  _pass "started-after" "pid ${PID} started $(( PS_EPOCH - MOD_EPOCH ))s after ${VL_MODULE} last changed"
+else
+  _fail "started-after" "pid ${PID} started $(( MOD_EPOCH - PS_EPOCH ))s BEFORE ${VL_MODULE} last changed — it is serving the previous bytes"
+fi
+
+echo
+if [[ $VL_FAILURES -eq 0 ]]; then echo "verify-loaded: OK — 4/4 links verified on ${VL_HOST}"; exit 0; fi
+echo "verify-loaded: ${VL_FAILURES} link(s) FAILED on ${VL_HOST}"; exit 1


### PR DESCRIPTION
Closes CTL-1916.

The tool that proves a cutover is safe was written into a session temp dir **three times and evaporated three times**. Each re-derivation is a fresh chance to check something subtly different from what was checked last time — the opposite of what a verification tool is for. It now ships with the plugin, gated in CI, with no host-local copy to go stale.

```bash
plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host mini-2 --mode enforce
plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host laptop --role monitor
```

## ⭐ LOADED means the pid, not the checkout

A git sha on disk proves the bytes *arrived*; it says nothing about what the running process is *executing*. All four links anchor on the live pid.

| link | question | why the others don't cover it |
| --- | --- | --- |
| `serving-root` | does the live pid's argv name the required root? | read from the process table, **never a pid file** — a pid file is a claim written at some past moment, and a recycled pid makes it a confident lie |
| `gate-module` | present on disk **and importable** from that root? | present-but-unimportable is the CTL-1831 shape and reads as "installed" to every git-level check |
| `armed-line` | did **this pid** write the mode line? | a log is append-only across restarts, so an unanchored grep happily matches the line a *previous* process wrote before the rollback you are checking for |
| `started-after` | did the pid start at/after the module's mtime? | **links 1–3 all pass for a daemon that booted before the pull landed** — the entire content of CTL-1919 and CTL-1659 |

Every link **fails closed**: "I could not measure it" exits non-zero and names the link. `--role monitor` **asserts the absence** of an exec-core daemon rather than skipping — a skipped link reports the same "no complaint" as a verified one.

## Validated against the real fleet, not only fixtures

```
verify-loaded: OK — 4/4 links verified on mini-2      (exit 0)
verify-loaded: OK — 4/4 links verified on mini        (exit 0)
```

…and the controls fire on real hosts too — pointed at a different root it reports `is NOT serving` and names the root the daemon actually has.

⚠️ **The declared `mode` and the runtime `armed` flag are different facts, and both are printed.** Measured on the fleet today, mini-2 reports `mode=enforce` with `armed=false` — enforce is configured, the feed is not currently armed (CTL-1909). Surfaced, **not** failed: failing it would make a correctly-loaded host report FAIL and train operators to ignore the tool. A tool that printed only "announced mode enforce" would read as a clean bill of health for a feed that is not running, which is the failure class this script exists to prevent.

## Tests — 16, CI-gated

The **positive comes first**, because without it every FAIL below could be produced by a broken harness. Then each failure case changes exactly **one** fact:

- ⭐ the ticket's named control — daemon serving a **different root**
- no daemon at all · absent module · **present-but-unimportable** module · mode mismatch
- an armed line written by **another pid** does not satisfy this pid's link
- ⭐ a daemon that started **before** the module changed — asserted to fail **while `serving-root` still passes**, which is the proof that link is not redundant
- unreadable freshness inputs **fail closed**
- monitor role: absence asserted in **both** directions

The transport is sealed at the single runner seam rather than by shadowing `ssh`/`ps` on PATH — a PATH stub only proves the stubbed name was not invoked, which is not the same as proving nothing reached the network.

## The last AC: the parity sampler

`~/catalyst/parity-hourly.sh` was hand-placed on mini-2, **never scheduled**, not running, and single-stream since the CTL-1928 smee retirement — so it can report agreement but no longer a *comparison*. Retired in favour of a documented one-liner (a timestamped backup was left on the host). The runbook records the one-liner and the deadline-inside-the-loop rule for anyone who needs it on a loop again.

Docs: `docs/runbooks/cloud-feed-cutover.md` §6.