### PR TITLE
chore(dev): CTL-1929 — pin the fleet to @catalyst-cloud/sdk 0.8.12 / schema 0.1.16

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "catalyst",
       "dependencies": {
-        "@catalyst-cloud/schema": "0.1.15",
+        "@catalyst-cloud/schema": "0.1.16",
         "@modelcontextprotocol/sdk": "1.29.0",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.11",
+        "@catalyst-cloud/sdk": "0.8.12",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.9", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.15" } }, "sha512-Fp7pcHFgjAdlPD7xLuHhrqTSF2xPEiYnEufz3FRZIbvOfQntWTzCVaKgtLw1/YETs3KOw8E6OFMtK6dwrwA1Rw=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.10", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.16" } }, "sha512-R5MM3j+JdSSZYZzlVRQCXBINqp3bKor42mQikiX71zBF10us2XEoV9phyzyIzyhtzCqI0/u0AXW0zAIlVP+nHw=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.15", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-cEkcsisF7kqfVmm0dhTsTvj7BuPfFcKAgO0oZ83GZqQG6k3J/699d4A7X8cAI1LtfNAneKHylxuAjJgj93Zd+A=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.16", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-/v/jAVUpthFwKzwN3aUr0Q3hPjLNtH9aEUyljZLm6o9xRPggCAQDVp171jemOsAgM72Oi761n5OIeEVBE5yL3A=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.11", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.9", "@catalyst-cloud/schema": "0.1.15" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-wuurRFd57j9ghxJjvxD/8kkiRSfQzD9n4AWVgJQKW1gtliGKTEykUO6l87Pm9dUkNpgTyNMc+Uqh6NxRa0b4HA=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.12", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.10", "@catalyst-cloud/schema": "0.1.16" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-xUnFTPXOSsY3fWre0ceI6kFPNxhhMWXuWGFD0hEh8euGjUx8Zr+huYEVX/rbsAF/9bg8Ws0N3ueRITliOzXK5Q=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hono": "4.12.27"
   },
   "dependencies": {
-    "@catalyst-cloud/schema": "0.1.15",
+    "@catalyst-cloud/schema": "0.1.16",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.11",
+    "@catalyst-cloud/sdk": "0.8.12",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
## What

Pins the fleet to **`@catalyst-cloud/sdk` 0.8.12 / `@catalyst-cloud/schema` 0.1.16** (`replicate` follows 0.1.9 → 0.1.10 transitively via the sdk). All three published versions were verified against the registry before pinning.

## Why this is a blocker, not housekeeping

CTL-1929's GitHub feed producer reads its dispatch edges **from the local replica** — the Linear leg's design rule is zero API calls on the event path. So it cannot be built until the replica has the tables those edges live in.

The four tables CTC-667 added exist in schema 0.1.16 and exist on **neither host today** — measured, not inferred:

| table | mini | mini-2 |
|---|---|---|
| `pushes` | 0 | 0 |
| `deployments` | 0 | 0 |
| `deployment_statuses` | 0 | 0 |
| `pr_review_threads` | 0 | 0 |
| `team_workflow_mapping` | **1** | **1** |
| `check_runs` | 1 | 1 |

`team_workflow_mapping` present + `pushes` absent pins both hosts at 0.1.15 **by content**, not by a version string a process reports about itself.

## ⚠️ Merging this does not roll it out

Only the **cloud-sync writer** runs the replica schema migration, and `plugin-refresh` restarts `monitor` / `execution-core` / `otel-forward` — **never cloud-sync**. So no host's replica changes until an operator kickstarts the writer, and that restart is itself the CTL-1920 re-seed trigger. The pin bump and the burst containment are one task, not two.

**LOADED criterion for the rollout:** `pushes` (or any of the other three) *existing* on a host's replica. A table only the new schema creates is stronger evidence than any self-reported version.

## Verification

Gate: `bun test` in `plugins/dev/scripts/execution-core`, run on this branch **and** on a separately-installed clean `origin/main` worktree (both `bun install`-complete — a gate comparison across two worktrees is meaningless otherwise, per CTL-40).

- branch: **9699 pass / 53 fail / 9753 across 307 files**
- baseline `origin/main`: **9699 pass / 53 fail / 9753 across 307 files**

Failure sets diffed **per test**, ANSI stripped first (an unstripped grep returns empty, which reads as a false clean):

- 52 of 53 identical.
- The single difference is one 5000 ms **timeout** swapping for another (`CTL-1218 AUTOMATED-path worktree removal` on the branch; `CTL-539 AC5 crash recovery` on the baseline). 6 timeouts in each run.
- **All 47 non-timeout failures are identical** between branch and baseline.

⚠️ Both runs were executed concurrently on one laptop, which inflates exactly that timeout class — earlier sequential runs of the same two trees gave 51 and 52. Reported so the numbers are read for what they are: no regression attributable to this pin, and a `main` that is already red on 47 non-timeout tests independent of this change.

Refs CTL-1929.
