### PR TITLE
fix(dev): CTL-1931 — the dep-skew detector can reach a verdict on a bun isolated-linker host

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-dep-skew-wiring.test.mjs
@@ -31,7 +31,22 @@ describe("cloud-sync.mjs dep-skew wiring", () => {
     expect(SRC).toContain("writeDepsBreadcrumb");
     // Resolution goes through the real module resolver, so the record describes what was
     // ACTUALLY loaded rather than what the lockfile claims (the CTL-1646 trap).
-    expect(SRC).toMatch(/resolveModule:\s*\(specifier\)\s*=>\s*depsRequire\.resolve\(specifier\)/);
+    //
+    // ⚠️ Asserted as the PROPERTY, not as one spelling of it. This was pinned to the exact
+    // literal `(specifier) => depsRequire.resolve(specifier)` and went red on CTL-1931 —
+    // which added a second parameter while keeping the property completely intact. A test
+    // that fails on a signature it does not care about reports a regression that did not
+    // happen, and the next person's instinct is to loosen it rather than read it.
+    // The whole resolveModule expression, so the assertions below describe what it DOES
+    // rather than how it is spelled.
+    const resolver = /resolveModule:\s*\(([\s\S]*?)\n/.exec(SRC)?.[0] ?? "";
+    expect(resolver, "POSITIVE CONTROL — the extraction found the resolveModule expression at all").toContain("resolveModule:");
+    expect(resolver, "resolution must go through the module resolver, never a version read off a lockfile").toContain(".resolve(specifier)");
+    expect(resolver, "the daemon's own require is the DEFAULT base").toContain("depsRequire");
+    // CTL-1931: a `from` dep re-bases onto ANOTHER package's location, because under bun's
+    // isolated linker the copy the SDK loads and the copy the root links are independently
+    // determined — and the one that decides what the writer knows is the SDK's.
+    expect(resolver, "the from-rebase builds a require AT the base path rather than reusing the daemon's").toMatch(/createRequire\(\s*opts\??\.?fromPath\s*\)/);
   });
 
   test("the predicate is EVALUATED on the heartbeat tick, against a re-read lockfile digest", () => {

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -29,7 +29,7 @@ import {
   lockedVersionForKey,
   provenLockKey,
   splitBunStorePath,
-  workspaceDirsFromLock,
+  workspacesFromLock,
   lockedVersionsFor,
   readDepsBreadcrumb,
   readRestartLedger,
@@ -1051,18 +1051,25 @@ describe("CTL-1931 — decoding what bun encodes in a store directory name", () 
   });
 });
 
-describe("CTL-1931 — the lockfile's workspace directories", () => {
-  test("every workspace dir is listed, including the root's empty key", () => {
-    expect(workspaceDirsFromLock(LOCK_TEXT_ISOLATED)).toContain("plugins/dev/scripts/execution-core");
-    expect(workspaceDirsFromLock("{}"), "no workspaces block → no dirs, not a throw").toEqual([]);
-    expect(workspaceDirsFromLock(null)).toEqual([]);
+describe("CTL-1931 — the lockfile's workspaces", () => {
+  test("every workspace is listed with BOTH its directory and its package name", () => {
+    const ws = workspacesFromLock(LOCK_TEXT_ISOLATED);
+    expect(ws.map((w) => w.dir)).toContain("plugins/dev/scripts/execution-core");
+    // ⛔ The name is a DIFFERENT string from the directory basename, and bun keys chained lock
+    // entries by the NAME. Measured in this repo's own bun.lock: the workspace at
+    // `plugins/dev/scripts/orch-monitor/ui` is named `orch-monitor-ui` and its keys read
+    // `orch-monitor-ui/react` — never `ui/react`. Deriving the prefix from the basename probes
+    // a key that cannot exist and falls back to the unrelated bare resolution (Codex P2, #3499).
+    expect(ws.find((w) => w.dir === "plugins/dev/scripts/execution-core")?.name).toBe("catalyst-execution-core");
+    expect(workspacesFromLock("{}"), "no workspaces block → none, not a throw").toEqual([]);
+    expect(workspacesFromLock(null)).toEqual([]);
   });
 
   test("keys NESTED inside a workspace's own object are not mistaken for directories", () => {
     // "dependencies" / "@catalyst-cloud/sdk" sit one level deeper and must not be read as
     // workspace paths — the walk that produced them would send the importer search to
     // `<root>/dependencies/node_modules/...`, a directory that cannot exist.
-    const dirs = workspaceDirsFromLock(LOCK_TEXT_ISOLATED);
+    const dirs = workspacesFromLock(LOCK_TEXT_ISOLATED).map((w) => w.dir);
     expect(dirs).not.toContain("dependencies");
     expect(dirs).not.toContain("@catalyst-cloud/sdk");
     expect(dirs).not.toContain("name");
@@ -1240,5 +1247,65 @@ describe("CTL-1931 — CRITICAL_DEPS covers the package that CAUSED CTL-1919", (
     expect(record.degraded).toBe(true);
     expect(record.degradedReasons.join(" ")).toMatch(/base dependency @catalyst-cloud\/sdk\/node did not resolve/);
     expect(record.packages.some((p) => p.id === "@catalyst-cloud/schema"), "the dependent is SKIPPED, not recorded against the wrong base").toBe(false);
+  });
+});
+
+describe("CTL-1931 — the two review findings, pinned (#3499 round 1)", () => {
+  // A lockfile that resolves the SAME id at TWO locations with DIFFERENT versions: the root
+  // pins 0.1.15, the SDK's nested entry pins 0.1.12. This is the shape that makes a first-match
+  // importer search unsafe.
+  const LOCK_TWO_LOCATIONS = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst", "dependencies": { "@catalyst-cloud/schema": "0.1.15" } },
+    "plugins/dev/scripts/execution-core": { "name": "catalyst-execution-core", "dependencies": { "@catalyst-cloud/sdk": "0.8.11" } },
+  },
+  "packages": {
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.15", "", {}, "sha512-aaa=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.11", "", {}, "sha512-bbb=="],
+    "@catalyst-cloud/sdk/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.12", "", {}, "sha512-ccc=="],
+    "catalyst-execution-core/@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.11", "", {}, "sha512-ddd=="],
+  }
+}`;
+
+  test("⛔ P1 — two importers sharing ONE store dir is AMBIGUOUS, not the first match", () => {
+    // The root and the SDK both link the same copy, while the lockfile demands 0.1.15 at one
+    // location and 0.1.12 at the other. That disk state cannot satisfy both, so it IS a
+    // partial/shadowed install. Taking the root's bare key first would grade the shared copy
+    // against 0.1.15 and report `ok` — the exact miss this link exists to prevent.
+    const shared = SCHEMA_PKG_DIR("0.1.15");
+    const io = linkFs({
+      [`${ROOT}/node_modules/@catalyst-cloud/schema`]: shared,
+      [`${SDK_STORE}/node_modules/@catalyst-cloud/schema`]: shared,
+    });
+    expect(
+      provenLockKey({ root: ROOT, packageDir: shared, id: "@catalyst-cloud/schema", lockText: LOCK_TWO_LOCATIONS, ...io }),
+      "two proven importers disagreeing on the key must fail CLOSED",
+    ).toBeNull();
+  });
+
+  test("POSITIVE CONTROL — ONE importer against the SAME lockfile still resolves", () => {
+    // Without this, the null above would also be satisfied by a function that had simply
+    // started returning null for this lockfile.
+    const shared = SCHEMA_PKG_DIR("0.1.15");
+    const io = linkFs({ [`${ROOT}/node_modules/@catalyst-cloud/schema`]: shared });
+    expect(provenLockKey({ root: ROOT, packageDir: shared, id: "@catalyst-cloud/schema", lockText: LOCK_TWO_LOCATIONS, ...io })).toBe("@catalyst-cloud/schema");
+  });
+
+  test("⛔ P2 — a workspace's chained key uses its NAME, never its directory basename", () => {
+    // `plugins/dev/scripts/execution-core` is named `catalyst-execution-core`, so the key is
+    // `catalyst-execution-core/@catalyst-cloud/sdk`. Probing `execution-core/@catalyst-cloud/sdk`
+    // misses and silently falls back to the unrelated bare resolution.
+    const sdkDir = `${SDK_STORE}/node_modules/@catalyst-cloud/sdk`;
+    const io = linkFs({ [`${ROOT}/plugins/dev/scripts/execution-core/node_modules/@catalyst-cloud/sdk`]: sdkDir });
+    expect(provenLockKey({ root: ROOT, packageDir: sdkDir, id: "@catalyst-cloud/sdk", lockText: LOCK_TWO_LOCATIONS, ...io })).toBe("catalyst-execution-core/@catalyst-cloud/sdk");
+  });
+
+  test("a workspace with NO chained key in the lockfile still keys bare", () => {
+    // The common case: bun writes the bare key when a tree holds one version. The name-based
+    // probe must not turn a correct bare association into a miss.
+    const sdkDir = `${SDK_STORE}/node_modules/@catalyst-cloud/sdk`;
+    const io = linkFs({ [`${ROOT}/plugins/dev/scripts/execution-core/node_modules/@catalyst-cloud/sdk`]: sdkDir });
+    expect(provenLockKey({ root: ROOT, packageDir: sdkDir, id: "@catalyst-cloud/sdk", lockText: LOCK_TEXT_ISOLATED, ...io })).toBe("@catalyst-cloud/sdk");
   });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/cloud-sync-deps.test.mjs
@@ -23,8 +23,13 @@ import {
   depSkewFields,
   evaluateDepSkew,
   findLockRoot,
+  decodeBunStoreDir,
   lockKeyForPackageJsonPath,
+  lockLocationKeyFor,
   lockedVersionForKey,
+  provenLockKey,
+  splitBunStorePath,
+  workspaceDirsFromLock,
   lockedVersionsFor,
   readDepsBreadcrumb,
   readRestartLedger,
@@ -980,5 +985,260 @@ describe("evaluateDepSkew — link 3: serving root (CTL-1931)", () => {
       realpath: () => { throw new Error("ENOENT"); },
     })), "serving-root");
     expect(v.status).toBe("ok");
+  });
+});
+
+// ─── CTL-1931: bun's isolated linker ────────────────────────────────────────
+//
+// The defect these cover: `installed-vs-locked` answered "could not compare" on ALL THREE
+// hosts (laptop, mini, mini-2) from the day CTL-1659 shipped, because the writer resolves
+// through bun's isolated linker and `resolve()` hands back the store REALPATH — a content
+// address with no install location in it. So the one link that would have caught CTL-1919
+// (a writer serving schema 0.1.12 against a 0.1.15 pin) was inert on every host.
+//
+// Every case below is paired: a red is only evidence when the SAME instrument is shown
+// going green on the neighbouring input, and the association is proved by the symlink the
+// resolver actually traversed rather than read out of the store directory's own name —
+// which would be circular (the installed version IS the store name) and would grade every
+// host clean forever.
+const STORE = `${ROOT}/node_modules/.bun`;
+const SCHEMA_STORE = (v) => `${STORE}/@catalyst-cloud+schema@${v}+a0473b45aab9bf33`;
+const SCHEMA_PKG_DIR = (v) => `${SCHEMA_STORE(v)}/node_modules/@catalyst-cloud/schema`;
+const SDK_STORE = `${STORE}/@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33`;
+
+// A lockfile that pins schema 0.1.15 with NO chained key — the real shape measured in
+// plugin-source/bun.lock on 2026-08-17 (745 keys, 48 of them chained; schema is not one).
+const LOCK_TEXT_ISOLATED = `{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": { "name": "catalyst", "dependencies": { "@catalyst-cloud/schema": "0.1.15" } },
+    "plugins/dev/scripts/execution-core": { "name": "catalyst-execution-core", "dependencies": { "@catalyst-cloud/sdk": "0.8.11" } },
+  },
+  "packages": {
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.15", "", {}, "sha512-aaa=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.11", "", {}, "sha512-bbb=="],
+  }
+}`;
+
+// links — a symlink table as `realpath` sees it: the link path collapses to its target.
+// Anything absent resolves to itself, which is what the real realpathSync does for a plain
+// directory and what makes an unmatched candidate simply fail to equal the target.
+const linkFs = (links) => ({
+  realpath: (p) => links[p] ?? p,
+  listDir: (d) => (d === STORE ? [`@catalyst-cloud+schema@0.1.15+a0473b45aab9bf33`, `@catalyst-cloud+schema@0.1.12+a0473b45aab9bf33`, `@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33`] : []),
+});
+
+describe("CTL-1931 — decoding what bun encodes in a store directory name", () => {
+  test("the id is recovered; '+' in the name half is the scope separator", () => {
+    expect(decodeBunStoreDir("@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33")).toMatchObject({ id: "@catalyst-cloud/sdk", version: "0.8.11" });
+    expect(decodeBunStoreDir("pino@9.6.0")).toMatchObject({ id: "pino", version: "9.6.0" });
+    expect(decodeBunStoreDir("@catalyst-cloud+read-model@0.1.1")).toMatchObject({ id: "@catalyst-cloud/read-model", version: "0.1.1" });
+  });
+
+  test("a name with no version segment is null, not a half-decoded guess", () => {
+    expect(decodeBunStoreDir("@scope")).toBeNull();
+    expect(decodeBunStoreDir("")).toBeNull();
+    expect(decodeBunStoreDir(null)).toBeNull();
+    // POSITIVE CONTROL on the same instrument.
+    expect(decodeBunStoreDir("pino@9.6.0").id).toBe("pino");
+  });
+
+  test("splitBunStorePath rejects a path INSIDE the package, which would decode to a plausible id", () => {
+    expect(splitBunStorePath(ROOT, SCHEMA_PKG_DIR("0.1.15"))).toMatchObject({ id: "@catalyst-cloud/schema" });
+    expect(splitBunStorePath(ROOT, `${SCHEMA_PKG_DIR("0.1.15")}/dist`), "…/schema/dist is not the package directory").toBeNull();
+    expect(splitBunStorePath(ROOT, `${ROOT}/node_modules/@catalyst-cloud/schema`), "a hoisted path is not a store path").toBeNull();
+    expect(splitBunStorePath("/elsewhere", SCHEMA_PKG_DIR("0.1.15"))).toBeNull();
+  });
+});
+
+describe("CTL-1931 — the lockfile's workspace directories", () => {
+  test("every workspace dir is listed, including the root's empty key", () => {
+    expect(workspaceDirsFromLock(LOCK_TEXT_ISOLATED)).toContain("plugins/dev/scripts/execution-core");
+    expect(workspaceDirsFromLock("{}"), "no workspaces block → no dirs, not a throw").toEqual([]);
+    expect(workspaceDirsFromLock(null)).toEqual([]);
+  });
+
+  test("keys NESTED inside a workspace's own object are not mistaken for directories", () => {
+    // "dependencies" / "@catalyst-cloud/sdk" sit one level deeper and must not be read as
+    // workspace paths — the walk that produced them would send the importer search to
+    // `<root>/dependencies/node_modules/...`, a directory that cannot exist.
+    const dirs = workspaceDirsFromLock(LOCK_TEXT_ISOLATED);
+    expect(dirs).not.toContain("dependencies");
+    expect(dirs).not.toContain("@catalyst-cloud/sdk");
+    expect(dirs).not.toContain("name");
+  });
+});
+
+describe("CTL-1931 — the install location is recovered by PROOF, not by pattern", () => {
+  const args = (over = {}) => ({ root: ROOT, id: "@catalyst-cloud/schema", lockText: LOCK_TEXT_ISOLATED, ...over });
+
+  test("a package linked from the ROOT keys on the bare id", () => {
+    const io = linkFs({ [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.15") });
+    expect(provenLockKey(args({ packageDir: SCHEMA_PKG_DIR("0.1.15"), ...io }))).toBe("@catalyst-cloud/schema");
+  });
+
+  test("a package linked from a WORKSPACE is found — the case this fleet actually runs", () => {
+    // Measured 2026-08-17: @catalyst-cloud/sdk is absent from plugin-source's own
+    // node_modules and linked ONLY from plugins/dev/scripts/execution-core, so a search
+    // that checked the root alone would return null for the fleet's primary dependency.
+    const io = linkFs({ [`${ROOT}/plugins/dev/scripts/execution-core/node_modules/@catalyst-cloud/sdk`]: `${SDK_STORE}/node_modules/@catalyst-cloud/sdk` });
+    expect(provenLockKey(args({ id: "@catalyst-cloud/sdk", packageDir: `${SDK_STORE}/node_modules/@catalyst-cloud/sdk`, ...io }))).toBe("@catalyst-cloud/sdk");
+  });
+
+  test("⛔ THE CTL-1919 SHAPE — the SDK's OWN stale copy is caught while the root links a healthy one", () => {
+    // The root links the PINNED 0.1.15 and looks perfectly healthy. The SDK links 0.1.12,
+    // and the SDK's copy is the one that decides whether the writer knows about
+    // `workflow_states`. A search that stopped at the first healthy link would clear this.
+    const io = linkFs({
+      [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.15"),
+      [`${SDK_STORE}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.12"),
+    });
+    const key = provenLockKey(args({ packageDir: SCHEMA_PKG_DIR("0.1.12"), ...io }));
+    expect(key, "the STALE copy still resolves to the location the lockfile pins").toBe("@catalyst-cloud/schema");
+    expect(lockedVersionForKey(LOCK_TEXT_ISOLATED, key, "@catalyst-cloud/schema").version, "…and that location pins 0.1.15, so 0.1.12 is drift").toBe("0.1.15");
+  });
+
+  test("BRANCH CONTROL — with the store scan disabled the SAME input is null, so the scan is load-bearing", () => {
+    // Without this, the assertion above would also pass if the ROOT link had matched by
+    // accident: both spellings of the key are identical, so the key alone cannot tell the
+    // two branches apart.
+    const io = linkFs({
+      [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.15"),
+      [`${SDK_STORE}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.12"),
+    });
+    expect(provenLockKey(args({ packageDir: SCHEMA_PKG_DIR("0.1.12"), ...io, listDir: () => [] }))).toBeNull();
+  });
+
+  test("nothing links it → null → INCONCLUSIVE, never a version read off the store name", () => {
+    const io = linkFs({});
+    expect(provenLockKey(args({ packageDir: SCHEMA_PKG_DIR("0.1.12"), ...io }))).toBeNull();
+    // POSITIVE CONTROL: the same call with the link present does resolve, so the null above
+    // is a measurement rather than a function that only ever returns null.
+    const linked = linkFs({ [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.12") });
+    expect(provenLockKey(args({ packageDir: SCHEMA_PKG_DIR("0.1.12"), ...linked }))).toBe("@catalyst-cloud/schema");
+  });
+
+  test("lockLocationKeyFor prefers the structural ladder and falls back to the proof", () => {
+    // A classic hoisted layout still answers without touching the filesystem — proved by
+    // passing a realpath that would THROW if it were consulted.
+    const boom = () => {
+      throw new Error("realpath must not be consulted for a structural path");
+    };
+    expect(lockLocationKeyFor({ root: ROOT, packageJsonPath: SDK_PKG, id: "@catalyst-cloud/sdk", realpath: boom, listDir: boom })).toBe("@catalyst-cloud/sdk");
+    const io = linkFs({ [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR("0.1.15") });
+    expect(lockLocationKeyFor({ root: ROOT, packageJsonPath: `${SCHEMA_PKG_DIR("0.1.15")}/package.json`, id: "@catalyst-cloud/schema", lockText: LOCK_TEXT_ISOLATED, ...io })).toBe("@catalyst-cloud/schema");
+  });
+});
+
+describe("CTL-1931 — installed-vs-locked reaches a VERDICT on an isolated-linker host", () => {
+  // The full comparator, driven the way doctor drives it, on the layout every host runs.
+  const SCHEMA_ENTRY = (v) => `${SCHEMA_PKG_DIR(v)}/src/index.ts`;
+  const bootFor = (v) => ({
+    ts: NOW,
+    pid: 4242,
+    root: ROOT,
+    lockPath: LOCK,
+    lockHash: "sha256:deadbeef",
+    degraded: false,
+    degradedReasons: [],
+    packages: [{ id: "@catalyst-cloud/schema", specifier: "@catalyst-cloud/schema", resolvedPath: SCHEMA_ENTRY(v), packageJsonPath: `${SCHEMA_PKG_DIR(v)}/package.json`, version: v, entryHash: null }],
+  });
+  const gradeArgs = (v, over = {}) => {
+    const files = {
+      [LOCK]: LOCK_TEXT_ISOLATED,
+      [`${SCHEMA_PKG_DIR(v)}/package.json`]: JSON.stringify({ name: "@catalyst-cloud/schema", version: v }),
+    };
+    return {
+      breadcrumb: bootFor(v),
+      readText: (p) => {
+        if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+        return files[p];
+      },
+      readJson: (p) => {
+        if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT ${p}`);
+        return JSON.parse(files[p]);
+      },
+      processCommandForPid: (pid) => (pid === 4242 ? "bun /opt/plugin-source/plugins/dev/scripts/execution-core/cloud-sync.mjs" : null),
+      expectedRoots: [ROOT],
+      ...linkFs({ [`${ROOT}/node_modules/@catalyst-cloud/schema`]: SCHEMA_PKG_DIR(v) }),
+      ...over,
+    };
+  };
+
+  test("⭐ the pinned install grades ok — where it used to say 'could not compare'", () => {
+    expect(linkOf(evaluateDepSkew(gradeArgs("0.1.15")), "installed-vs-locked").status).toBe("ok");
+  });
+
+  test("⛔ NEGATIVE CONTROL — the CTL-1919 install (0.1.12 against a 0.1.15 pin) grades SKEW", () => {
+    const v = linkOf(evaluateDepSkew(gradeArgs("0.1.12")), "installed-vs-locked");
+    expect(v.status, "a genuinely stale install must still report MISMATCH").toBe("skew");
+    expect(v.detail).toContain("installed 0.1.12");
+    expect(v.detail).toContain("0.1.15");
+  });
+
+  test("the three-valued contract holds — an unprovable association is INCONCLUSIVE, never ok", () => {
+    // Same stale install, but nothing on disk links it: the comparator must not fall back
+    // to the permissive any-occurrence match that would find 0.1.12 elsewhere in the file.
+    const v = linkOf(evaluateDepSkew(gradeArgs("0.1.12", { realpath: (p) => p, listDir: () => [] })), "installed-vs-locked");
+    expect(v.status).toBe("inconclusive");
+    expect(v.detail).toMatch(/could not be associated/i);
+  });
+});
+
+describe("CTL-1931 — CRITICAL_DEPS covers the package that CAUSED CTL-1919", () => {
+  test("@catalyst-cloud/schema is recorded, resolved through the SDK that loads it", () => {
+    const schema = CRITICAL_DEPS.find((d) => d.id === "@catalyst-cloud/schema");
+    expect(schema, "the schema version is what decides whether the replica has workflow_states").toBeTruthy();
+    expect(schema.from, "the copy that matters is the SDK's, not a separate one the root may link").toBe("@catalyst-cloud/sdk/node");
+    // Ordering is load-bearing: `from` reads a resolution recorded EARLIER in the same pass.
+    expect(CRITICAL_DEPS.findIndex((d) => d.specifier === schema.from)).toBeLessThan(CRITICAL_DEPS.findIndex((d) => d.id === schema.id));
+  });
+
+  test("a `from` dep resolves from its base's location, not the daemon's", () => {
+    const SDK_DIR = `${SDK_STORE}/node_modules/@catalyst-cloud/sdk`;
+    const bases = [];
+    const record = captureLoadedDeps(
+      deps(
+        {
+          [LOCK]: LOCK_TEXT_ISOLATED,
+          [`${SDK_DIR}/dist/node.js`]: "// sdk\n",
+          [`${SDK_DIR}/package.json`]: JSON.stringify({ name: "@catalyst-cloud/sdk", version: "0.8.11" }),
+          [`${SCHEMA_PKG_DIR("0.1.12")}/src/index.ts`]: "// schema\n",
+          [`${SCHEMA_PKG_DIR("0.1.12")}/package.json`]: JSON.stringify({ name: "@catalyst-cloud/schema", version: "0.1.12" }),
+        },
+        {
+          deps: CRITICAL_DEPS,
+          resolveModule: (spec, opts) => {
+            bases.push(opts?.fromPath ?? null);
+            if (spec === "@catalyst-cloud/sdk/node") return `${SDK_DIR}/dist/node.js`;
+            if (spec === "@catalyst-cloud/schema") return `${SCHEMA_PKG_DIR("0.1.12")}/src/index.ts`;
+            throw new Error(`Cannot find module '${spec}'`);
+          },
+        },
+      ),
+    );
+    expect(bases[0], "the SDK itself resolves from the daemon").toBeNull();
+    expect(bases[1], "the schema resolves from the SDK's resolved path").toBe(`${SDK_DIR}/dist/node.js`);
+    expect(record.packages.map((p) => `${p.id}@${p.version}`)).toEqual(["@catalyst-cloud/sdk@0.8.11", "@catalyst-cloud/schema@0.1.12"]);
+  });
+
+  test("a `from` whose base did NOT resolve is degraded, never re-based onto the daemon", () => {
+    // Silently falling back to the daemon's own resolution would record a DIFFERENT copy
+    // than the writer runs — the substitution the field exists to prevent.
+    const record = captureLoadedDeps(
+      deps(
+        {},
+        {
+          deps: CRITICAL_DEPS,
+          resolveModule: (spec) => {
+            if (spec === "@catalyst-cloud/schema") return `${SCHEMA_PKG_DIR("0.1.12")}/src/index.ts`;
+            throw new Error(`Cannot find module '${spec}'`);
+          },
+        },
+      ),
+    );
+    expect(record.degraded).toBe(true);
+    expect(record.degradedReasons.join(" ")).toMatch(/base dependency @catalyst-cloud\/sdk\/node did not resolve/);
+    expect(record.packages.some((p) => p.id === "@catalyst-cloud/schema"), "the dependent is SKIPPED, not recorded against the wrong base").toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -377,18 +377,30 @@ export function splitBunStorePath(root, packageDir) {
   return { store, id: scoped ? `${tail[0]}/${tail[1]}` : tail[0] };
 }
 
-// workspaceDirsFromLock — the workspace directories bun records at the head of the lockfile.
-// Needed because a workspace is the THIRD place a package can be linked from, and it is the
+// workspacesFromLock — the workspaces bun records at the head of the lockfile, each as
+// `{ dir, name }`. A workspace is the THIRD place a package can be linked from, and it is the
 // one this fleet actually uses: `@catalyst-cloud/sdk` is a dependency of the
 // `plugins/dev/scripts/execution-core` workspace, not of the repo root, so its symlink lives
-// under that workspace and nowhere else. Scanned with a brace-depth walk rather than
-// JSON.parse because bun.lock is JSONC (trailing commas) and will not parse.
-export function workspaceDirsFromLock(lockText) {
+// under that workspace and nowhere else.
+//
+// ⛔ BOTH FIELDS ARE LOAD-BEARING, AND THEY ARE DIFFERENT STRINGS. The directory is where the
+// symlink lives; the NAME is what bun prefixes a chained lock key with. Measured in this
+// repository's own bun.lock: the workspace at `plugins/dev/scripts/orch-monitor/ui` is named
+// `orch-monitor-ui`, and its keys read `orch-monitor-ui/react`, NOT `ui/react`. Deriving the
+// prefix from the directory basename — as this did — probes a key that cannot exist, misses,
+// and silently falls back to the unrelated bare resolution. (Codex P2 on #3499; verified against
+// the lockfile before accepting it.) `plugins/dev/scripts/execution-core` is named
+// `catalyst-execution-core`, so this fleet's own primary dependency was affected.
+//
+// Scanned with a brace-depth walk rather than JSON.parse because bun.lock is JSONC (trailing
+// commas) and will not parse.
+export function workspacesFromLock(lockText) {
   if (typeof lockText !== "string") return [];
   const m = /"workspaces"\s*:\s*\{/.exec(lockText);
   if (!m) return [];
-  const dirs = [];
+  const out = [];
   let depth = 0;
+  let dir = null;
   let i = m.index + m[0].length - 1; // sit on the opening brace
   for (; i < lockText.length; i += 1) {
     const c = lockText[i];
@@ -399,19 +411,24 @@ export function workspaceDirsFromLock(lockText) {
     if (c === "}") {
       depth -= 1;
       if (depth === 0) break;
+      if (depth === 1) dir = null; // left a workspace's object
       continue;
     }
-    if (c === '"' && depth === 1) {
-      const end = lockText.indexOf('"', i + 1);
-      if (end === -1) break;
-      const key = lockText.slice(i + 1, end);
-      // Only a key — the next non-space character must be the ':' introducing its object.
-      const after = /^\s*:/.test(lockText.slice(end + 1));
-      i = end;
-      if (after && key.length > 0) dirs.push(key); // "" is the root workspace
+    if (c !== '"') continue;
+    const end = lockText.indexOf('"', i + 1);
+    if (end === -1) break;
+    const key = lockText.slice(i + 1, end);
+    const isKey = /^\s*:/.test(lockText.slice(end + 1));
+    if (depth === 1 && isKey) {
+      dir = key; // "" is the root workspace
+      out.push({ dir, name: null });
+    } else if (depth === 2 && isKey && key === "name" && out.length > 0 && dir !== null) {
+      const v = /^\s*:\s*"([^"]*)"/.exec(lockText.slice(end + 1));
+      if (v) out[out.length - 1].name = v[1];
     }
+    i = end;
   }
-  return dirs;
+  return out;
 }
 
 // provenLockKey — the lockfile install-location key for a package whose recorded path is a
@@ -445,14 +462,25 @@ export function provenLockKey({
     return resolved !== null && resolved === target;
   };
 
-  if (linksHere(root)) return id;
+  // ⛔ EVERY importer is collected before any key is chosen — the first match is NOT taken.
+  // Several importers can link the SAME store directory while the lockfile carries DISTINCT
+  // resolutions for them (a bare `<id>` and a nested `<parent>/<id>` at different versions).
+  // Returning on the first match would then grade the recorded package against whichever
+  // association happened to be tried first: if the shared copy satisfies the bare entry but not
+  // the nested one, that is a partial/shadowed install — precisely what this link exists to
+  // catch — reported as `ok`. (Codex P1 on #3499.) When the proven importers disagree about the
+  // key, the association is genuinely ambiguous and the answer is INCONCLUSIVE, never a pick.
+  const keys = new Set();
 
-  for (const ws of workspaceDirsFromLock(lockText)) {
-    if (ws.length === 0) continue; // the root workspace, already tried above
-    if (!linksHere(join(root, ws))) continue;
-    // A workspace dep is keyed bare unless bun had to disambiguate it.
-    const wsName = ws.split("/").pop();
-    return hasKey(`${wsName}/${id}`) ? `${wsName}/${id}` : id;
+  if (linksHere(root)) keys.add(id);
+
+  for (const ws of workspacesFromLock(lockText)) {
+    if (typeof ws.dir !== "string" || ws.dir.length === 0) continue; // root, tried above
+    if (!linksHere(join(root, ws.dir))) continue;
+    // A workspace dep is keyed bare unless bun had to disambiguate it — and when it does, the
+    // prefix is the workspace's NAME, not its directory basename.
+    const chained = ws.name ? `${ws.name}/${id}` : null;
+    keys.add(chained && hasKey(chained) ? chained : id);
   }
 
   const storeRoot = join(root, "node_modules", ".bun");
@@ -460,7 +488,7 @@ export function provenLockKey({
   try {
     entries = listDir(storeRoot);
   } catch {
-    return null; // no store to scan → unproven → INCONCLUSIVE
+    entries = []; // no store to scan; a root/workspace proof above may still stand
   }
   for (const entry of Array.isArray(entries) ? entries : []) {
     if (entry === parts.store.storeName) continue; // a package does not import itself
@@ -468,9 +496,12 @@ export function provenLockKey({
     if (!parent) continue;
     if (!linksHere(join(storeRoot, entry))) continue;
     const chained = `${parent.id}/${id}`;
-    return hasKey(chained) ? chained : id;
+    keys.add(hasKey(chained) ? chained : id);
   }
-  return null;
+
+  // Exactly one association → that is the location. Zero → unproven. More than one → the
+  // importers disagree and no evidence here can settle it; fail CLOSED.
+  return keys.size === 1 ? [...keys][0] : null;
 }
 
 // norm — realpath, falling back to the literal path. A path that cannot be resolved still

--- a/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync-deps.mjs
@@ -35,7 +35,7 @@
 // doctor.mjs's other leaf imports honor.
 
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 // The packages whose loaded identity is recorded. A REGISTRY rather than an inline
@@ -46,8 +46,18 @@ import { dirname, join } from "node:path";
 // `specifier` is what cloud-sync.mjs actually imports (`@catalyst-cloud/sdk/node`), so
 // the resolve below follows the SAME export map the running daemon followed; `id` is the
 // package name used to look the resolution up in the lockfile.
+//
+// ⛔ `from` — WHOSE COPY IS BEING RECORDED. Under bun's isolated linker every package gets
+// its OWN link for a transitive dependency, so "the schema the root links" and "the schema
+// the SDK loads" are independently determined and can differ. CTL-1919 is precisely that
+// divergence: the writer served schema 0.1.12 while the pin said 0.1.15, so its replica had
+// no `workflow_states` table. The copy that decides whether the writer knows about a table is
+// the one the SDK resolves — so `from` re-bases the resolution onto the named dep's location
+// instead of the daemon's, and the record describes the module the writer actually runs.
+// Resolution order follows this array, so a `from` must appear AFTER what it names.
 export const CRITICAL_DEPS = [
   { id: "@catalyst-cloud/sdk", specifier: "@catalyst-cloud/sdk/node" },
+  { id: "@catalyst-cloud/schema", specifier: "@catalyst-cloud/schema", from: "@catalyst-cloud/sdk/node" },
 ];
 
 // The discriminator stamped into the CTL-1508 self-heal breadcrumb when the writer exits
@@ -148,9 +158,22 @@ export function captureLoadedDeps({
   for (const dep of Array.isArray(deps) ? deps : []) {
     const id = dep?.id;
     const specifier = dep?.specifier ?? id;
+    // A `from` dep is resolved from ANOTHER recorded package's location, so a failure to
+    // resolve that base is recorded and the dependent is skipped — never silently re-based
+    // onto the daemon's own directory, which would record a different copy than the one the
+    // writer loads and is the exact substitution this field exists to prevent.
+    let fromPath;
+    if (dep?.from) {
+      const base = packages.find((q) => q.specifier === dep.from && q.resolvedPath);
+      if (!base) {
+        degradedReasons.push(`${id}: base dependency ${dep.from} did not resolve — cannot record the copy it loads`);
+        continue;
+      }
+      fromPath = base.resolvedPath;
+    }
     let resolvedPath = null;
     try {
-      resolvedPath = resolveModule(specifier);
+      resolvedPath = resolveModule(specifier, fromPath ? { fromPath } : undefined);
     } catch (err) {
       degradedReasons.push(`${id}: unresolvable (${err?.message ?? String(err)})`);
       continue;
@@ -290,6 +313,188 @@ export function lockKeyForPackageJsonPath(root, packageJsonPath) {
   return chain.length > 0 ? chain.join("/") : null;
 }
 
+
+// ─── bun isolated-linker store paths (CTL-1931) ─────────────────────────────
+//
+// THE DEFECT THIS CLOSES. `require.resolve()` returns a REALPATH, and under bun's isolated
+// linker a realpath is a CONTENT address rather than an install location:
+//
+//   <root>/node_modules/.bun/@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33/node_modules/@catalyst-cloud/sdk
+//
+// The ladder walk above needs repeated `node_modules/<pkg>` hops, and this path carries a
+// store directory in the middle, so it returns null for EVERY package the writer loads.
+// That is why `installed-vs-locked` has answered "could not compare" since CTL-1659
+// shipped — measured 2026-08-17 as the SAME message on laptop, mini and mini-2. A link
+// that can only ever say "I could not look" provides no coverage, which is the incident
+// CTL-1919 walked through untouched.
+//
+// ⛔ WHY THE STORE DIRECTORY'S OWN VERSION CANNOT BE THE ANSWER. The directory name encodes
+// `<id>@<version>+<peer-hash>`, so reading the version out of it and matching that against
+// the lockfile is the obvious fix and it is CIRCULAR: the installed version is *defined* by
+// the store name, so it would satisfy its own lock entry by construction and grade every
+// host clean forever. That converts a fail-CLOSED inconclusive into a fail-OPEN pass, which
+// the ticket names explicitly as worse than the current state.
+//
+// ⭐ SO THE LOCATION IS RECOVERED BY PROOF RATHER THAN BY PATTERN. The symlink the resolver
+// actually traversed is still on disk — only `realpath` erased it from the path. The search
+// below re-derives the association by testing the places bun can link a package FROM, and
+// accepts a candidate only when that candidate's realpath IS the recorded package
+// directory. It re-establishes the same edge the resolver walked; it does not guess one.
+// Nothing proven → null → INCONCLUSIVE, exactly as before.
+
+// decodeBunStoreDir — the identity bun encodes in a `.bun` store directory name.
+// `@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33` → { id: "@catalyst-cloud/sdk", version: "0.8.11" }.
+// A package name cannot contain `+`, so every `+` in the name half is unambiguously the
+// scope separator bun substituted for `/`. `version` is DIAGNOSTIC ONLY — see the circularity
+// note above; no comparator may grade on it.
+export function decodeBunStoreDir(name) {
+  if (typeof name !== "string" || name.length === 0) return null;
+  const at = name.lastIndexOf("@");
+  if (at <= 0) return null; // no version segment, or a bare scope with nothing after it
+  const rest = name.slice(at + 1);
+  if (rest.length === 0) return null;
+  const id = name.slice(0, at).replace(/\+/g, "/");
+  const plus = rest.indexOf("+");
+  return { id, version: plus === -1 ? rest : rest.slice(0, plus), storeName: name };
+}
+
+// splitBunStorePath — the (store, id) of a `.bun` store PACKAGE DIRECTORY, or null when the
+// directory is not one. Purely structural; touches no filesystem. The length check rejects a
+// path *inside* the package (`.../sdk/dist`), which would otherwise decode to a plausible id.
+export function splitBunStorePath(root, packageDir) {
+  if (typeof root !== "string" || root.length === 0) return null;
+  if (typeof packageDir !== "string" || packageDir.length === 0) return null;
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  if (!packageDir.startsWith(prefix)) return null;
+  const segs = packageDir.slice(prefix.length).split("/").filter((x) => x.length > 0);
+  if (segs.length < 5) return null;
+  if (segs[0] !== "node_modules" || segs[1] !== ".bun" || segs[3] !== "node_modules") return null;
+  const store = decodeBunStoreDir(segs[2]);
+  if (!store) return null;
+  const tail = segs.slice(4);
+  const scoped = tail[0].startsWith("@");
+  if (tail.length !== (scoped ? 2 : 1)) return null;
+  return { store, id: scoped ? `${tail[0]}/${tail[1]}` : tail[0] };
+}
+
+// workspaceDirsFromLock — the workspace directories bun records at the head of the lockfile.
+// Needed because a workspace is the THIRD place a package can be linked from, and it is the
+// one this fleet actually uses: `@catalyst-cloud/sdk` is a dependency of the
+// `plugins/dev/scripts/execution-core` workspace, not of the repo root, so its symlink lives
+// under that workspace and nowhere else. Scanned with a brace-depth walk rather than
+// JSON.parse because bun.lock is JSONC (trailing commas) and will not parse.
+export function workspaceDirsFromLock(lockText) {
+  if (typeof lockText !== "string") return [];
+  const m = /"workspaces"\s*:\s*\{/.exec(lockText);
+  if (!m) return [];
+  const dirs = [];
+  let depth = 0;
+  let i = m.index + m[0].length - 1; // sit on the opening brace
+  for (; i < lockText.length; i += 1) {
+    const c = lockText[i];
+    if (c === "{") {
+      depth += 1;
+      continue;
+    }
+    if (c === "}") {
+      depth -= 1;
+      if (depth === 0) break;
+      continue;
+    }
+    if (c === '"' && depth === 1) {
+      const end = lockText.indexOf('"', i + 1);
+      if (end === -1) break;
+      const key = lockText.slice(i + 1, end);
+      // Only a key — the next non-space character must be the ':' introducing its object.
+      const after = /^\s*:/.test(lockText.slice(end + 1));
+      i = end;
+      if (after && key.length > 0) dirs.push(key); // "" is the root workspace
+    }
+  }
+  return dirs;
+}
+
+// provenLockKey — the lockfile install-location key for a package whose recorded path is a
+// `.bun` store realpath, established by finding the symlink that points AT it.
+//
+// Candidates, in the order bun can create them:
+//   1. the root's own `node_modules/<id>`                    → key `<id>`
+//   2. a workspace's `node_modules/<id>`                     → key `<id>` (or `<ws>/<id>`)
+//   3. another store dir's `node_modules/<id>` (transitive)  → key `<parent>/<id>` (or `<id>`)
+//
+// ⚠️ The `lockText` argument chooses only the SPELLING of an already-proven location — bun
+// writes the bare `<id>` when a tree holds one version of it and the chained `<parent>/<id>`
+// when it does not (measured: 48 of this lockfile's 745 keys are chained). It never selects
+// *which* location to believe, so it cannot make a mismatch disappear: the version compared
+// is still the one recorded at the single proven site.
+export function provenLockKey({
+  root,
+  packageDir,
+  id,
+  lockText = "",
+  realpath = realpathSync,
+  listDir = readdirSync,
+  hasKey = (key) => new RegExp(`"${escapeRe(key)}"\\s*:\\s*\\[`).test(lockText),
+} = {}) {
+  const parts = splitBunStorePath(root, packageDir);
+  if (!parts || parts.id !== id) return null;
+  const target = norm(packageDir, realpath);
+  const linksHere = (dir) => {
+    const candidate = join(dir, "node_modules", id);
+    const resolved = norm(candidate, realpath);
+    return resolved !== null && resolved === target;
+  };
+
+  if (linksHere(root)) return id;
+
+  for (const ws of workspaceDirsFromLock(lockText)) {
+    if (ws.length === 0) continue; // the root workspace, already tried above
+    if (!linksHere(join(root, ws))) continue;
+    // A workspace dep is keyed bare unless bun had to disambiguate it.
+    const wsName = ws.split("/").pop();
+    return hasKey(`${wsName}/${id}`) ? `${wsName}/${id}` : id;
+  }
+
+  const storeRoot = join(root, "node_modules", ".bun");
+  let entries = [];
+  try {
+    entries = listDir(storeRoot);
+  } catch {
+    return null; // no store to scan → unproven → INCONCLUSIVE
+  }
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    if (entry === parts.store.storeName) continue; // a package does not import itself
+    const parent = decodeBunStoreDir(entry);
+    if (!parent) continue;
+    if (!linksHere(join(storeRoot, entry))) continue;
+    const chained = `${parent.id}/${id}`;
+    return hasKey(chained) ? chained : id;
+  }
+  return null;
+}
+
+// norm — realpath, falling back to the literal path. A path that cannot be resolved still
+// compares (it just compares less generously) and NEVER throws into a comparator.
+function norm(path, realpath) {
+  if (typeof path !== "string" || path.length === 0) return null;
+  try {
+    return realpath(path);
+  } catch {
+    return null;
+  }
+}
+
+// lockLocationKeyFor — the install-location key for a recorded package: the structural ladder
+// first (cheap, filesystem-free, correct for a hoisted/nested layout), then the isolated-linker
+// proof above. Null from BOTH remains INCONCLUSIVE — the permissive any-occurrence match is
+// still never a fallback.
+export function lockLocationKeyFor({ root, packageJsonPath, id, lockText = "", realpath = realpathSync, listDir = readdirSync } = {}) {
+  const structural = lockKeyForPackageJsonPath(root, packageJsonPath);
+  if (structural !== null) return structural;
+  if (typeof packageJsonPath !== "string" || packageJsonPath.length === 0) return null;
+  return provenLockKey({ root, packageDir: dirname(packageJsonPath), id, lockText, realpath, listDir });
+}
+
 // lockedVersionForKey — the ONE resolution bun records at a specific install location.
 // Anchored on the exact key AND the value's `name@` prefix (the same structured-match
 // discipline `lockedVersionsFor` uses, minus the `(?:[^"]*/)?` wildcard that made it accept
@@ -360,6 +565,10 @@ export function evaluateDepSkew({
   // — so an un-wired caller degrades loudly instead of silently passing the link.
   expectedRoots = null,
   realpath = realpathSync,
+  // CTL-1931. The `.bun` store scan that recovers an install LOCATION from a content-addressed
+  // realpath (see provenLockKey). Injected so a test can prove the association against a
+  // fixture instead of a 600-entry store on disk.
+  listDir = readdirSync,
 } = {}) {
   if (!breadcrumb || typeof breadcrumb !== "object") {
     return summarize(SKEW_LINKS.map((l) => unknown(l, "no boot record — the writer has not booted since dep-skew capture shipped, or the write failed")));
@@ -552,7 +761,7 @@ export function evaluateDepSkew({
       }
       // The installed package is matched to ITS OWN lock entry, keyed by the install
       // location, rather than to "any occurrence of this id anywhere in the lockfile".
-      const key = lockKeyForPackageJsonPath(root, p.packageJsonPath);
+      const key = lockLocationKeyFor({ root, packageJsonPath: p.packageJsonPath, id: p.id, lockText, realpath, listDir });
       const locked = lockedVersionForKey(lockText, key, p.id);
       if (!locked.conclusive) {
         // Deliberately NOT a fallback onto `lockedVersionsFor`'s any-occurrence match —

--- a/plugins/dev/scripts/execution-core/cloud-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cloud-sync.mjs
@@ -425,7 +425,10 @@ if (DEP_SKEW_MODE !== "off") {
   try {
     _bootDeps = captureLoadedDeps({
       startDir: dirname(fileURLToPath(import.meta.url)),
-      resolveModule: (specifier) => depsRequire.resolve(specifier),
+      // `fromPath` re-bases onto another package's location so a transitive dep is recorded
+      // as the copy THAT package loads (CTL-1931); without it, bun's isolated linker can hand
+      // back the root's separate copy and the record describes a module the writer never ran.
+      resolveModule: (specifier, opts) => (opts?.fromPath ? createRequire(opts.fromPath) : depsRequire).resolve(specifier),
     });
     writeDepsBreadcrumb(getCloudSyncDepsPath(), _bootDeps);
     hlog.info(


### PR DESCRIPTION
## The defect

`installed-vs-locked` has answered **"could not compare"** on **all three hosts** since CTL-1659 shipped. A link that can only ever say *"I could not look"* provides no coverage — and **CTL-1919 is the incident it exists to catch**: the laptop's writer served `@catalyst-cloud/schema` **0.1.12** against a **0.1.15** pin, so its replica had no `workflow_states` table and sat 5.5 h behind. It was found by hand.

## Root cause — measured, not inferred

`require.resolve()` returns a **realpath**, and under bun's isolated linker a realpath is a **content address**, not an install location:

```
<root>/node_modules/.bun/@catalyst-cloud+sdk@0.8.11+a0473b45aab9bf33/node_modules/@catalyst-cloud/sdk
```

`lockKeyForPackageJsonPath` walks `node_modules/<pkg>` hops; this path carries a store directory in the middle. So it returned `null` for **every** package the writer loads, on every host.

## ⛔ The obvious fix is circular, and is deliberately not taken

The store directory name encodes `<id>@<version>` — so reading the version out of it and matching that against the lockfile *looks* like a one-line fix. It **can never fail**: the installed version *is* the store name, so it satisfies its own lock entry by construction and would grade every host clean forever. That replaces a fail-**closed** inconclusive with a fail-**open** pass, which the ticket names explicitly as worse than the current state.

Instead the location is recovered **by proof**. The symlink the resolver traversed is still on disk — only `realpath` erased it from the path. `provenLockKey` tests the three places bun can link a package from (the root, a workspace, another store dir) and accepts a candidate **only when its realpath IS the recorded package directory**. Nothing proven → `null` → INCONCLUSIVE, unchanged. The lockfile chooses only the *spelling* of an already-proven location (bare vs chained — 48 of this lockfile's 745 keys are chained), never *which* location to believe.

## `CRITICAL_DEPS` now covers the package that caused CTL-1919

`@catalyst-cloud/schema` is added, resolved **through the SDK** via a new `from` field. Under the isolated linker, "the schema the root links" and "the schema the SDK loads" are independently determined — and the copy that decides whether the writer knows about a table is the SDK's. A `from` whose base did not resolve is recorded as **degraded**, never silently re-based onto the daemon.

## Controls — every one run

| control | result |
| -- | -- |
| **NEGATIVE** — the CTL-1919 install (0.1.12 vs a 0.1.15 pin) | **SKEW**, naming both versions |
| **CONTROL ON THE CONTROL** — the same input through `origin/main`'s code | **INCONCLUSIVE**, verbatim today's fleet message — so the red is attributable to this change |
| **DIVERGENT** — root links a healthy 0.1.15, the SDK links 0.1.12 | **SKEW** |
| **BRANCH CONTROL** — same input, store scan disabled | `null` — proving that branch is load-bearing (the key spells identically either way) |
| **POSITIVE** — the pinned install | **ok** — so the reds are not a comparator that simply reddened |
| **MUTATION** — revert `provenLockKey` to `null` | 7 of the new tests go red; diff-verified as applied before the red was trusted |
| **FLEET** — the LIVE boot record on laptop / mini / mini-2 | all three `before=INCONCLUSIVE → after=ok` |

## Gate

`bun test` in `execution-core`: **9717 pass / 52 fail**, against a **9700 / 52** baseline taken on `origin/main` with these changes reverted — the same 52 pre-existing failures, measured rather than assumed. `bun build cloud-sync.mjs --target=node` (the CI import-graph check) exits 0.

Closes CTL-1931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)