### PR TITLE
feat(dev): CTL-1914/1917/1918 — the documented install ends with a working node, not a list of hand-steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Catalyst integrates with your development tools through both **CLI-based** (toke
   [Linearis](https://www.npmjs.com/package/linearis))
   - `catalyst-dev`: Core research agents and workflow commands
   - `catalyst-pm`: Advanced PM workflows (PRDs, strategy, priorities)
-  - `catalyst-pm-ops`: Operational PM workflows (cycle analysis, milestone tracking, backlog grooming, cadence, comms)
+  - `catalyst-pm-ops`: Operational PM workflows (cycle analysis, milestone tracking, backlog
+    grooming, cadence, comms)
 
 ### Version Control & Code Hosting
 
@@ -140,9 +141,9 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
       --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
 ```
 
-> `-s --` is required for the piped form. Without it the flags are consumed by `bash`
-> itself rather than by the script, and the install silently runs interactive — which on
-> a host with no tty then falls back to defaults.
+> `-s --` is required for the piped form. Without it the flags are consumed by `bash` itself rather
+> than by the script, and the install silently runs interactive — which on a host with no tty then
+> falls back to defaults.
 
 Prefer to read the script first, or want the prompts?
 
@@ -155,15 +156,15 @@ chmod +x setup-catalyst.sh
 
 ### Have these ready
 
-| What | Where it goes | Format |
-| ---- | ------------- | ------ |
-| Catalyst Cloud token | `--cloud-token` / `CATALYST_CLOUD_TOKEN` | validated with one authenticated call before anything is written — a bad token fails the install loudly |
-| Catalyst Cloud account | `--cloud-account` / `CATALYST_CLOUD_ACCOUNT` | required whenever a token is supplied; there is deliberately no default |
-| Linear API token | `LINEAR_API_TOKEN`, or `~/.linear_api_token` | must be a **personal** key (`lin_api_…`). An OAuth token (`lin_oauth_…`) is rejected |
-| Sentry / PostHog / Exa | prompted, or their usual env vars | all optional |
+| What                   | Where it goes                                | Format                                                                                                  |
+| ---------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Catalyst Cloud token   | `--cloud-token` / `CATALYST_CLOUD_TOKEN`     | validated with one authenticated call before anything is written — a bad token fails the install loudly |
+| Catalyst Cloud account | `--cloud-account` / `CATALYST_CLOUD_ACCOUNT` | required whenever a token is supplied; there is deliberately no default                                 |
+| Linear API token       | `LINEAR_API_TOKEN`, or `~/.linear_api_token` | must be a **personal** key (`lin_api_…`). An OAuth token (`lin_oauth_…`) is rejected                    |
+| Sentry / PostHog / Exa | prompted, or their usual env vars            | all optional                                                                                            |
 
-Nothing above is required to get a working node — omit the cloud flags and setup behaves
-exactly as it always has.
+Nothing above is required to get a working node — omit the cloud flags and setup behaves exactly as
+it always has.
 
 This script will guide you through:
 
@@ -184,11 +185,11 @@ This script will guide you through:
 # Restart Claude Code
 ```
 
-**Install the CLI tools** — *setup now does this for you.* It puts `catalyst-stack` and the
-other `catalyst-*` commands in `$HOME/.catalyst/bin`, provisions `plugin-source`, turns on
-replica reads, and enrols the project. Anything it could not finish is printed at the end of
-the run as a **deferred step**, with the command that completes it and the command that
-verifies it — so if that list says "No steps were deferred", these are already done.
+**Install the CLI tools** — _setup now does this for you._ It puts `catalyst-stack` and the other
+`catalyst-*` commands in `$HOME/.catalyst/bin`, provisions `plugin-source`, turns on replica reads,
+and enrols the project. Anything it could not finish is printed at the end of the run as a
+**deferred step**, with the command that completes it and the command that verifies it — so if that
+list says "No steps were deferred", these are already done.
 
 To run it by hand anyway (or to complete a deferred step):
 

--- a/README.md
+++ b/README.md
@@ -132,17 +132,38 @@ and shared memory systems.
 
 Get started in 5 minutes with the unified setup script:
 
+**One command, one key** — works on a laptop, over SSH, or in CI:
+
 ```bash
-# Download the setup script
+curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
+  | bash -s -- --non-interactive \
+      --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
+```
+
+> `-s --` is required for the piped form. Without it the flags are consumed by `bash`
+> itself rather than by the script, and the install silently runs interactive — which on
+> a host with no tty then falls back to defaults.
+
+Prefer to read the script first, or want the prompts?
+
+```bash
 curl -O https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh
 chmod +x setup-catalyst.sh
-
-# Run it (interactive)
-./setup-catalyst.sh
-
-# ...or headless, for CI / SSH / any host with no tty:
-./setup-catalyst.sh --non-interactive
+./setup-catalyst.sh                    # interactive
+./setup-catalyst.sh --non-interactive  # same, no prompts
 ```
+
+### Have these ready
+
+| What | Where it goes | Format |
+| ---- | ------------- | ------ |
+| Catalyst Cloud token | `--cloud-token` / `CATALYST_CLOUD_TOKEN` | validated with one authenticated call before anything is written — a bad token fails the install loudly |
+| Catalyst Cloud account | `--cloud-account` / `CATALYST_CLOUD_ACCOUNT` | required whenever a token is supplied; there is deliberately no default |
+| Linear API token | `LINEAR_API_TOKEN`, or `~/.linear_api_token` | must be a **personal** key (`lin_api_…`). An OAuth token (`lin_oauth_…`) is rejected |
+| Sentry / PostHog / Exa | prompted, or their usual env vars | all optional |
+
+Nothing above is required to get a working node — omit the cloud flags and setup behaves
+exactly as it always has.
 
 This script will guide you through:
 
@@ -163,13 +184,17 @@ This script will guide you through:
 # Restart Claude Code
 ```
 
-**Install the CLI tools** (this is what puts `catalyst-stack` on your `PATH` — without it the
-next step fails with `command not found`):
+**Install the CLI tools** — *setup now does this for you.* It puts `catalyst-stack` and the
+other `catalyst-*` commands in `$HOME/.catalyst/bin`, provisions `plugin-source`, turns on
+replica reads, and enrols the project. Anything it could not finish is printed at the end of
+the run as a **deferred step**, with the command that completes it and the command that
+verifies it — so if that list says "No steps were deferred", these are already done.
+
+To run it by hand anyway (or to complete a deferred step):
 
 ```bash
-shopt -s nullglob
-_cli=( ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/install-cli.sh )
-[ ${#_cli[@]} -gt 0 ] && bash "${_cli[0]}" || echo "catalyst-dev plugin not installed — run the plugin step first"
+bash ~/catalyst/plugin-source/plugins/dev/scripts/install-cli.sh
+command -v catalyst-stack   # verify
 ```
 
 **Start the stack:**

--- a/plugins/dev/README.md
+++ b/plugins/dev/README.md
@@ -98,8 +98,12 @@ Reads `.catalyst/config.json` (safe to commit) and `~/.config/catalyst/config-{p
 Quick setup:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh | bash
+curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
+  | bash -s -- --non-interactive
 ```
+
+`-s --` is what passes the flags to the script rather than to `bash`. Omit it and the piped
+install runs interactive, which on a host with no tty degrades to defaults.
 
 ## Requirements
 

--- a/plugins/dev/README.md
+++ b/plugins/dev/README.md
@@ -1,19 +1,25 @@
 # Catalyst Dev Plugin
 
-Complete development workflow: research → plan → implement → validate → ship. 19 skills and 9 research agents covering the full Level 1 (single-skill) and Level 2 (guided-workflow) stack. Phase-agent / execution-core pipeline for Level 3 multi-ticket orchestration.
+Complete development workflow: research → plan → implement → validate → ship. 19 skills and 9
+research agents covering the full Level 1 (single-skill) and Level 2 (guided-workflow) stack.
+Phase-agent / execution-core pipeline for Level 3 multi-ticket orchestration.
 
 > **Plugin topology:**
+>
 > - The wave-orchestration skills `oneshot`, `orchestrate`, `god`, `setup-orchestrate` live in the
 >   **[catalyst-legacy](../legacy/README.md)** plugin — use `/catalyst-legacy:<skill>`. (The old
 >   redirect stubs that briefly lived here were removed.)
 > - The framework setup/maintenance skills `setup-catalyst`, `setup-warp`, and `research-curate`
 >   moved to the new **[catalyst-foundry](../foundry/README.md)** plugin — use
 >   `/catalyst-foundry:<skill>`.
-> - `briefing-followup` and `iterate-plan` are general workflow skills and live here in catalyst-dev.
+> - `briefing-followup` and `iterate-plan` are general workflow skills and live here in
+>   catalyst-dev.
 >
 > Both catalyst-legacy and catalyst-foundry depend on catalyst-dev for shared backing scripts.
 
-See the [Skills Reference](https://catalyst.coalescelabs.ai/reference/skills/) and [Agents Reference](https://catalyst.coalescelabs.ai/reference/agents/) for detailed per-skill documentation. The list below is the current inventory only.
+See the [Skills Reference](https://catalyst.coalescelabs.ai/reference/skills/) and
+[Agents Reference](https://catalyst.coalescelabs.ai/reference/agents/) for detailed per-skill
+documentation. The list below is the current inventory only.
 
 ## Skills (19)
 
@@ -75,7 +81,9 @@ See the [Skills Reference](https://catalyst.coalescelabs.ai/reference/skills/) a
 
 ## Automatic Workflow Context Tracking
 
-The plugin ships Claude Code hooks that keep `.catalyst/.workflow-context.json` up to date automatically. See [HOOKS.md](./HOOKS.md) and [WORKFLOW_CONTEXT.md](./WORKFLOW_CONTEXT.md) for the full mechanism.
+The plugin ships Claude Code hooks that keep `.catalyst/.workflow-context.json` up to date
+automatically. See [HOOKS.md](./HOOKS.md) and [WORKFLOW_CONTEXT.md](./WORKFLOW_CONTEXT.md) for the
+full mechanism.
 
 Summary:
 
@@ -93,7 +101,10 @@ Summary:
 
 ## Configuration
 
-Reads `.catalyst/config.json` (safe to commit) and `~/.config/catalyst/config-{projectKey}.json` (never committed — secrets). See the [Configuration Reference](https://catalyst.coalescelabs.ai/reference/configuration/) for the full schema.
+Reads `.catalyst/config.json` (safe to commit) and `~/.config/catalyst/config-{projectKey}.json`
+(never committed — secrets). See the
+[Configuration Reference](https://catalyst.coalescelabs.ai/reference/configuration/) for the full
+schema.
 
 Quick setup:
 
@@ -102,8 +113,8 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
   | bash -s -- --non-interactive
 ```
 
-`-s --` is what passes the flags to the script rather than to `bash`. Omit it and the piped
-install runs interactive, which on a host with no tty degrades to defaults.
+`-s --` is what passes the flags to the script rather than to `bash`. Omit it and the piped install
+runs interactive, which on a host with no tty degrades to defaults.
 
 ## Requirements
 
@@ -117,17 +128,26 @@ install runs interactive, which on a host with no tty degrades to defaults.
 Runtime utilities under `scripts/`:
 
 - `catalyst-db.sh` — SQLite session store CRUD and schema migrations (see ADR-008)
-- `catalyst-monitor.sh` — On-demand orch-monitor server management (`start`, `stop`, `status`, `open`, `url`)
-- `catalyst-session.sh` — Lifecycle CLI for agent sessions (`start`, `phase`, `metric`, `tool`, `pr`, `end`, `heartbeat`, `list`, `read`, `history`). Writes to SQLite via `catalyst-db.sh` and dual-writes JSONL events for backward compatibility
+- `catalyst-monitor.sh` — On-demand orch-monitor server management (`start`, `stop`, `status`,
+  `open`, `url`)
+- `catalyst-session.sh` — Lifecycle CLI for agent sessions (`start`, `phase`, `metric`, `tool`,
+  `pr`, `end`, `heartbeat`, `list`, `read`, `history`). Writes to SQLite via `catalyst-db.sh` and
+  dual-writes JSONL events for backward compatibility
 - `catalyst-state.sh` — Writes to `~/catalyst/state.json` and `~/catalyst/events/YYYY-MM.jsonl`
-- `check-config-drift.sh` — Detect keys present in `templates/config.template.json` but missing from `.catalyst/config.json` (CTL-489); supports `--json` enumeration and `--merge-into` for atomic deep-merge
+- `check-config-drift.sh` — Detect keys present in `templates/config.template.json` but missing from
+  `.catalyst/config.json` (CTL-489); supports `--json` enumeration and `--merge-into` for atomic
+  deep-merge
 - `check-project-setup.sh` — Validate workspace has thoughts system, config, etc.
 - `create-worktree.sh` — Worktree creation with setup hooks
 - `frontmatter-utils.sh` — Parse and update markdown frontmatter
-- `orch-monitor/` — React SPA + Bun server dashboard (default port 7400, configurable via `MONITOR_PORT`). Reads `~/catalyst/catalyst.db` (SQLite, WAL mode) and watches `~/catalyst/wt/`. Start with `cd plugins/dev/scripts/orch-monitor && bun run server.ts`, or use `catalyst-monitor.sh open`
+- `orch-monitor/` — React SPA + Bun server dashboard (default port 7400, configurable via
+  `MONITOR_PORT`). Reads `~/catalyst/catalyst.db` (SQLite, WAL mode) and watches `~/catalyst/wt/`.
+  Start with `cd plugins/dev/scripts/orch-monitor && bun run server.ts`, or use
+  `catalyst-monitor.sh open`
 - `orchestrate-fixup` — Fix issues found during orchestration verification
 - `orchestrate-followup` — Handle follow-up tasks after orchestration completes
-- `orchestrate-verify.sh` — Adversarial verification checks (test existence, reward-hacking patterns)
+- `orchestrate-verify.sh` — Adversarial verification checks (test existence, reward-hacking
+  patterns)
 - `pre-assign-migrations.sh` — Pre-assign database migration numbers to avoid conflicts
 - `resolve-ticket.sh` — Extract ticket IDs from various contexts
 - `workflow-context.sh` — Read/write `.catalyst/.workflow-context.json`
@@ -144,7 +164,8 @@ Hooks under `hooks/`:
 2. **Skills orchestrate** — Spawn parallel agents, manage processes
 3. **Context is precious** — Use thoughts system for persistence between sessions
 4. **Automation via hooks** — Track automatically, not manually
-5. **Worker-side work has a boundary** — Workers exit at PR creation; polling-until-merged is the orchestrator's job
+5. **Worker-side work has a boundary** — Workers exit at PR creation; polling-until-merged is the
+   orchestrator's job
 
 ## Documentation
 

--- a/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
@@ -25,27 +25,27 @@ WORK="$(mktemp -d)"
 # REHEARSAL_KEEP=1 preserves the sealed prefix so the transcripts outlive the run —
 # needed whenever the answer is "nothing fired", which is indistinguishable from
 # "the harness died early" until you can read the transcript.
-if [[ -z ${REHEARSAL_KEEP:-} ]]; then trap 'rm -rf "$WORK"' EXIT; fi
+if [[ -z ${REHEARSAL_KEEP-} ]]; then trap 'rm -rf "$WORK"' EXIT; fi
 
 # ── the sealed prefix ─────────────────────────────────────────────────────────
 # $1 = run label, $2 = path to the setup-catalyst.sh under test
 run_sealed() {
-  local label="$1" setup="$2"
-  local root="$WORK/$label"
-  rm -rf "$root"
-  mkdir -p "$root/home" "$root/dl" "$root/stubs" "$root/proj"
+	local label="$1" setup="$2"
+	local root="$WORK/$label"
+	rm -rf "$root"
+	mkdir -p "$root/home" "$root/dl" "$root/stubs" "$root/proj"
 
-  # The documented layout, exactly: ONE file in the directory you run from.
-  cp "$setup" "$root/dl/setup-catalyst.sh"
-  chmod +x "$root/dl/setup-catalyst.sh"
+	# The documented layout, exactly: ONE file in the directory you run from.
+	cp "$setup" "$root/dl/setup-catalyst.sh"
+	chmod +x "$root/dl/setup-catalyst.sh"
 
-  local log="$root/invocations.log"
-  : > "$log"
+	local log="$root/invocations.log"
+	: >"$log"
 
-  # Recording stubs. `git clone` copies this checkout instead of hitting the network,
-  # so the bootstrap-clone path is exercised for real and the helpers it lands are the
-  # real ones — then those helpers are themselves shadowed by stubs below.
-  cat > "$root/stubs/git" <<STUB
+	# Recording stubs. `git clone` copies this checkout instead of hitting the network,
+	# so the bootstrap-clone path is exercised for real and the helpers it lands are the
+	# real ones — then those helpers are themselves shadowed by stubs below.
+	cat >"$root/stubs/git" <<STUB
 #!/usr/bin/env bash
 echo "git \$*" >> "$log"
 if [[ "\$1" == "clone" ]]; then
@@ -71,11 +71,11 @@ esac
 exit 0
 STUB
 
-  # The four helper scripts whose invocation is the whole question. Shadowing them by
-  # NAME on PATH is not enough — setup calls them by absolute path — so they are
-  # planted over the cloned tree after the clone stub runs. Done via a wrapper on
-  # `bash` that records any invocation of a helper path and returns success.
-  cat > "$root/stubs/bash" <<STUB
+	# The four helper scripts whose invocation is the whole question. Shadowing them by
+	# NAME on PATH is not enough — setup calls them by absolute path — so they are
+	# planted over the cloned tree after the clone stub runs. Done via a wrapper on
+	# `bash` that records any invocation of a helper path and returns success.
+	cat >"$root/stubs/bash" <<STUB
 #!/bin/bash
 for a in "\$@"; do
   case "\$a" in
@@ -88,31 +88,31 @@ done
 exec /bin/bash "\$@"
 STUB
 
-  for c in launchctl humanlayer linearis claude curl gh sqlite3 bun node npm brew; do
-    cat > "$root/stubs/$c" <<STUB
+	for c in launchctl humanlayer linearis claude curl gh sqlite3 bun node npm brew; do
+		cat >"$root/stubs/$c" <<STUB
 #!/bin/bash
 echo "$c \$*" >> "$log"
 exit 0
 STUB
-  done
-  chmod +x "$root/stubs/"*
+	done
+	chmod +x "$root/stubs/"*
 
-  # `--no-clone-source` is deliberately NOT passed: cloning is the documented path's
-  # only route to the helpers, so suppressing it would rehearse a different install.
-  ( cd "$root/dl" && env -i \
-      HOME="$root/home" \
-      PATH="$root/stubs:/usr/bin:/bin:/usr/sbin:/sbin" \
-      TERM=dumb \
-      CATALYST_FORCE_OS=Darwin \
-      PROJECT_DIR="$root/proj" \
-      /bin/bash ./setup-catalyst.sh --non-interactive ) > "$root/transcript.txt" 2>&1
-  echo "$?" > "$root/rc"
-  echo "$root"
+	# `--no-clone-source` is deliberately NOT passed: cloning is the documented path's
+	# only route to the helpers, so suppressing it would rehearse a different install.
+	(cd "$root/dl" && env -i \
+		HOME="$root/home" \
+		PATH="$root/stubs:/usr/bin:/bin:/usr/sbin:/sbin" \
+		TERM=dumb \
+		CATALYST_FORCE_OS=Darwin \
+		PROJECT_DIR="$root/proj" \
+		/bin/bash ./setup-catalyst.sh --non-interactive) >"$root/transcript.txt" 2>&1
+	echo "$?" >"$root/rc"
+	echo "$root"
 }
 
 probe() { # label, human-readable question, grep pattern
-  local root="$1" q="$2" pat="$3"
-  if grep -qF -- "$pat" "$root/invocations.log" 2>/dev/null; then echo "  FIRED     $q"; else echo "  did-not   $q"; fi
+	local root="$1" q="$2" pat="$3"
+	if grep -qF -- "$pat" "$root/invocations.log" 2>/dev/null; then echo "  FIRED     $q"; else echo "  did-not   $q"; fi
 }
 
 echo "═══════════════════════════════════════════════════════════════"
@@ -121,21 +121,24 @@ echo " repo:     $REPO_ROOT"
 echo " baseline: $BASELINE_REF"
 echo "═══════════════════════════════════════════════════════════════"
 
-git -C "$REPO_ROOT" show "${BASELINE_REF}:setup-catalyst.sh" > "$WORK/baseline-setup.sh" 2>/dev/null || {
-  echo "cannot read ${BASELINE_REF}:setup-catalyst.sh — is the ref fetched?"; exit 2; }
+git -C "$REPO_ROOT" show "${BASELINE_REF}:setup-catalyst.sh" >"$WORK/baseline-setup.sh" 2>/dev/null || {
+	echo "cannot read ${BASELINE_REF}:setup-catalyst.sh — is the ref fetched?"
+	exit 2
+}
 
 BASE_ROOT="$(run_sealed baseline "$WORK/baseline-setup.sh")"
-HEAD_ROOT="$(run_sealed working  "$REPO_ROOT/setup-catalyst.sh")"
+HEAD_ROOT="$(run_sealed working "$REPO_ROOT/setup-catalyst.sh")"
 
 for pair in "BASELINE (${BASELINE_REF}):$BASE_ROOT" "WORKING TREE:$HEAD_ROOT"; do
-  label="${pair%%:*}"; root="${pair#*:}"
-  echo ""
-  echo "── $label ── exit rc=$(cat "$root/rc" 2>/dev/null)"
-  probe "$root" "orphan-sweep scheduler installed"        "HELPER install-orphan-sweep.sh"
-  probe "$root" "Linear state contract provisioned"       "HELPER setup-execution-core-states.sh"
-  probe "$root" "plugin-source provisioned"               "HELPER setup-plugin-source.sh"
-  probe "$root" "catalyst-* CLIs installed"               "HELPER install-cli.sh"
-  probe "$root" "a source tree was obtained (clone)"      "CLONE-PLANTED"
+	label="${pair%%:*}"
+	root="${pair#*:}"
+	echo ""
+	echo "── $label ── exit rc=$(cat "$root/rc" 2>/dev/null)"
+	probe "$root" "orphan-sweep scheduler installed" "HELPER install-orphan-sweep.sh"
+	probe "$root" "Linear state contract provisioned" "HELPER setup-execution-core-states.sh"
+	probe "$root" "plugin-source provisioned" "HELPER setup-plugin-source.sh"
+	probe "$root" "catalyst-* CLIs installed" "HELPER install-cli.sh"
+	probe "$root" "a source tree was obtained (clone)" "CLONE-PLANTED"
 done
 
 echo ""
@@ -144,9 +147,9 @@ echo "── deferred-step ledger, working tree ──"
 # the header — printing "1 step(s) were DEFERRED" and then nothing, which reads as a
 # tool that lost the answer. Take everything from the header to the end instead.
 if grep -q "No steps were deferred" "$HEAD_ROOT/transcript.txt"; then
-  grep "No steps were deferred" "$HEAD_ROOT/transcript.txt"
+	grep "No steps were deferred" "$HEAD_ROOT/transcript.txt"
 else
-  sed -n '/were DEFERRED/,$p' "$HEAD_ROOT/transcript.txt" | head -30
+	sed -n '/were DEFERRED/,$p' "$HEAD_ROOT/transcript.txt" | head -30
 fi
 echo ""
 echo "transcripts: $BASE_ROOT/transcript.txt  |  $HEAD_ROOT/transcript.txt"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
@@ -88,6 +88,22 @@ done
 exec /bin/bash "\$@"
 STUB
 
+	# ⛔ Codex #3500 P2: CATALYST_FORCE_OS is read by setup_sweep_config ONLY.
+	# check_prerequisites calls `uname -s` directly, so on a non-Darwin host it answered
+	# the unsupported-platform prompt with the non-interactive default and exited 0
+	# BEFORE any measured step — making both columns read all `did-not`, i.e. "the fix
+	# changes nothing", which is the same output a working baseline produces. Stub the
+	# platform so the documented path is actually walked.
+	cat >"$root/stubs/uname" <<STUB
+#!/bin/bash
+case "\$1" in
+  -s) echo "Darwin" ;;
+  -m) echo "arm64" ;;
+  -r) echo "26.6.2" ;;
+  *)  /usr/bin/uname "\$@" ;;
+esac
+STUB
+
 	for c in launchctl humanlayer linearis claude curl gh sqlite3 bun node npm brew; do
 		cat >"$root/stubs/$c" <<STUB
 #!/bin/bash
@@ -140,6 +156,25 @@ for pair in "BASELINE (${BASELINE_REF}):$BASE_ROOT" "WORKING TREE:$HEAD_ROOT"; d
 	probe "$root" "catalyst-* CLIs installed" "HELPER install-cli.sh"
 	probe "$root" "a source tree was obtained (clone)" "CLONE-PLANTED"
 done
+
+# ⛔ A rehearsal whose working column fires NOTHING is indistinguishable from a baseline,
+# and that is exactly what a run aborting before provisioning looks like. Treat it as
+# INCONCLUSIVE — "I could not look" is not "there is no difference".
+# ⚠️ `grep -c` prints "0" AND exits 1 when there are no matches, so the obvious
+# `$(grep -c … || echo 0)` captures BOTH zeros — "0\n0" — and the integer test below
+# then errors out and the guard never fires. Verified by mutation: with setup stubbed to
+# exit before provisioning, that form returned 0 instead of 2. `|| true` keeps grep's own
+# "0" and discards only its exit status.
+WORKING_FIRED=$(grep -c "^HELPER " "$HEAD_ROOT/invocations.log" 2>/dev/null || true)
+[ -n "$WORKING_FIRED" ] || WORKING_FIRED=0
+if [ "$WORKING_FIRED" -eq 0 ]; then
+	echo ""
+	echo "⛔ INCONCLUSIVE — the working-tree run fired ZERO provisioning probes."
+	echo "   That is what an abort BEFORE provisioning looks like, not a null result."
+	echo "   Transcript: $HEAD_ROOT/transcript.txt (re-run with REHEARSAL_KEEP=1 to keep it)"
+	sed -n '1,40p' "$HEAD_ROOT/transcript.txt" 2>/dev/null | sed 's/^/   | /'
+	exit 2
+fi
 
 echo ""
 echo "── deferred-step ledger, working tree ──"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# setup-catalyst-documented-path.rehearsal.sh — CTL-1914 / CTL-1917 / CTL-1918.
+#
+# Runs the DOCUMENTED install (a lone downloaded setup-catalyst.sh, --non-interactive)
+# inside a sealed prefix, and reports which provisioning steps actually fired.
+#
+# ⛔ It runs TWO scripts against the SAME sealed prefix and stub set: the working-tree
+# version and the one at a baseline ref (default origin/main). A single run cannot tell
+# "this step fires" from "my instrument records everything"; the pair can, because the
+# baseline is expected to come back EMPTY on exactly the lines the fix is about. That
+# baseline is the positive control, and it is why this is a rehearsal rather than a demo.
+#
+# Nothing here touches the real HOME, the network, or launchd: HOME is a scratch dir,
+# `git clone` is stubbed to a local copy of this checkout, and every helper the install
+# invokes is a recording stub.
+#
+# Usage: bash plugins/dev/scripts/__tests__/setup-catalyst-documented-path.rehearsal.sh [baseline-ref]
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../../../.." && pwd)"
+BASELINE_REF="${1:-origin/main}"
+WORK="$(mktemp -d)"
+# REHEARSAL_KEEP=1 preserves the sealed prefix so the transcripts outlive the run —
+# needed whenever the answer is "nothing fired", which is indistinguishable from
+# "the harness died early" until you can read the transcript.
+if [[ -z ${REHEARSAL_KEEP:-} ]]; then trap 'rm -rf "$WORK"' EXIT; fi
+
+# ── the sealed prefix ─────────────────────────────────────────────────────────
+# $1 = run label, $2 = path to the setup-catalyst.sh under test
+run_sealed() {
+  local label="$1" setup="$2"
+  local root="$WORK/$label"
+  rm -rf "$root"
+  mkdir -p "$root/home" "$root/dl" "$root/stubs" "$root/proj"
+
+  # The documented layout, exactly: ONE file in the directory you run from.
+  cp "$setup" "$root/dl/setup-catalyst.sh"
+  chmod +x "$root/dl/setup-catalyst.sh"
+
+  local log="$root/invocations.log"
+  : > "$log"
+
+  # Recording stubs. `git clone` copies this checkout instead of hitting the network,
+  # so the bootstrap-clone path is exercised for real and the helpers it lands are the
+  # real ones — then those helpers are themselves shadowed by stubs below.
+  cat > "$root/stubs/git" <<STUB
+#!/usr/bin/env bash
+echo "git \$*" >> "$log"
+if [[ "\$1" == "clone" ]]; then
+  dest="\${@: -1}"
+  mkdir -p "\$dest"
+  /bin/cp -R "$REPO_ROOT/plugins" "\$dest/" 2>/dev/null
+  /bin/cp "$REPO_ROOT/setup-catalyst.sh" "\$dest/" 2>/dev/null
+  echo "CLONE-PLANTED \$dest" >> "$log"
+  exit 0
+fi
+case "\$1" in
+  rev-parse)
+    # --git-dir and --show-toplevel both point at the sealed project dir
+    case "\$2" in --git-dir) echo "$root/proj/.git" ;; *) echo "$root/proj" ;; esac
+    exit 0 ;;
+  config)
+    # A plausible GitHub remote. Returning empty here stops setup at
+    # "Cannot detect GitHub org/repo" — i.e. the whole rehearsal reports
+    # "nothing fired" for a reason that has nothing to do with what it measures.
+    case "\$*" in *remote.origin.url*) echo "https://github.com/acme-widgets/widget.git" ;; *) echo "" ;; esac
+    exit 0 ;;
+esac
+exit 0
+STUB
+
+  # The four helper scripts whose invocation is the whole question. Shadowing them by
+  # NAME on PATH is not enough — setup calls them by absolute path — so they are
+  # planted over the cloned tree after the clone stub runs. Done via a wrapper on
+  # `bash` that records any invocation of a helper path and returns success.
+  cat > "$root/stubs/bash" <<STUB
+#!/bin/bash
+for a in "\$@"; do
+  case "\$a" in
+    */install-orphan-sweep.sh)          echo "HELPER install-orphan-sweep.sh" >> "$log"; exit 0 ;;
+    */setup-execution-core-states.sh)   echo "HELPER setup-execution-core-states.sh" >> "$log"; exit 0 ;;
+    */setup-plugin-source.sh)           echo "HELPER setup-plugin-source.sh" >> "$log"; exit 0 ;;
+    */install-cli.sh)                   echo "HELPER install-cli.sh" >> "$log"; exit 0 ;;
+  esac
+done
+exec /bin/bash "\$@"
+STUB
+
+  for c in launchctl humanlayer linearis claude curl gh sqlite3 bun node npm brew; do
+    cat > "$root/stubs/$c" <<STUB
+#!/bin/bash
+echo "$c \$*" >> "$log"
+exit 0
+STUB
+  done
+  chmod +x "$root/stubs/"*
+
+  # `--no-clone-source` is deliberately NOT passed: cloning is the documented path's
+  # only route to the helpers, so suppressing it would rehearse a different install.
+  ( cd "$root/dl" && env -i \
+      HOME="$root/home" \
+      PATH="$root/stubs:/usr/bin:/bin:/usr/sbin:/sbin" \
+      TERM=dumb \
+      CATALYST_FORCE_OS=Darwin \
+      PROJECT_DIR="$root/proj" \
+      /bin/bash ./setup-catalyst.sh --non-interactive ) > "$root/transcript.txt" 2>&1
+  echo "$?" > "$root/rc"
+  echo "$root"
+}
+
+probe() { # label, human-readable question, grep pattern
+  local root="$1" q="$2" pat="$3"
+  if grep -qF -- "$pat" "$root/invocations.log" 2>/dev/null; then echo "  FIRED     $q"; else echo "  did-not   $q"; fi
+}
+
+echo "═══════════════════════════════════════════════════════════════"
+echo " Documented-path rehearsal — sealed prefix, --non-interactive"
+echo " repo:     $REPO_ROOT"
+echo " baseline: $BASELINE_REF"
+echo "═══════════════════════════════════════════════════════════════"
+
+git -C "$REPO_ROOT" show "${BASELINE_REF}:setup-catalyst.sh" > "$WORK/baseline-setup.sh" 2>/dev/null || {
+  echo "cannot read ${BASELINE_REF}:setup-catalyst.sh — is the ref fetched?"; exit 2; }
+
+BASE_ROOT="$(run_sealed baseline "$WORK/baseline-setup.sh")"
+HEAD_ROOT="$(run_sealed working  "$REPO_ROOT/setup-catalyst.sh")"
+
+for pair in "BASELINE (${BASELINE_REF}):$BASE_ROOT" "WORKING TREE:$HEAD_ROOT"; do
+  label="${pair%%:*}"; root="${pair#*:}"
+  echo ""
+  echo "── $label ── exit rc=$(cat "$root/rc" 2>/dev/null)"
+  probe "$root" "orphan-sweep scheduler installed"        "HELPER install-orphan-sweep.sh"
+  probe "$root" "Linear state contract provisioned"       "HELPER setup-execution-core-states.sh"
+  probe "$root" "plugin-source provisioned"               "HELPER setup-plugin-source.sh"
+  probe "$root" "catalyst-* CLIs installed"               "HELPER install-cli.sh"
+  probe "$root" "a source tree was obtained (clone)"      "CLONE-PLANTED"
+done
+
+echo ""
+echo "── deferred-step ledger, working tree ──"
+# The ledger body contains blank lines, so a /^$/ range terminator truncates it to
+# the header — printing "1 step(s) were DEFERRED" and then nothing, which reads as a
+# tool that lost the answer. Take everything from the header to the end instead.
+if grep -q "No steps were deferred" "$HEAD_ROOT/transcript.txt"; then
+  grep "No steps were deferred" "$HEAD_ROOT/transcript.txt"
+else
+  sed -n '/were DEFERRED/,$p' "$HEAD_ROOT/transcript.txt" | head -30
+fi
+echo ""
+echo "transcripts: $BASE_ROOT/transcript.txt  |  $HEAD_ROOT/transcript.txt"
+echo "(the temp prefix is removed on exit — copy them now if you need them)"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # the single-quoted bodies handed to run_fn throughout this
+# file are shell source for a CHILD shell; their `$` deliberately does not expand here.
 # Tests for setup-catalyst.sh's Catalyst-source resolver and deferred-step ledger
 # (CTL-1914 + CTL-1918).
 #
@@ -25,69 +27,84 @@ PASSES=0
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
-pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
 fail() {
-  FAILURES=$((FAILURES + 1))
-  echo "  FAIL: $1"
-  shift
-  for line in "$@"; do echo "      $line"; done
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for line in "$@"; do echo "      $line"; done
 }
 
+# if/else rather than `A && pass || fail`: in the latter a non-zero exit from `pass`
+# itself runs the failure branch, so an assertion could report a failure it never had.
 assert_eq() {
-  local label="$1" actual="$2" expected="$3"
-  [[ "$actual" == "$expected" ]] && pass "$label" || fail "$label" "expected: $expected" "actual:   $actual"
+	local label="$1" actual="$2" expected="$3"
+	if [[ $actual == "$expected" ]]; then
+		pass "$label"
+	else
+		fail "$label" "expected: $expected" "actual:   $actual"
+	fi
 }
 assert_grep() {
-  local label="$1" output="$2" pattern="$3"
-  grep -qF -- "$pattern" <<<"$output" && pass "$label" \
-    || fail "$label" "expected substring: $pattern" "actual output:" "$(echo "$output" | head -25)"
+	local label="$1" output="$2" pattern="$3"
+	if grep -qF -- "$pattern" <<<"$output"; then
+		pass "$label"
+	else
+		fail "$label" "expected substring: $pattern" "actual output:" "$(echo "$output" | head -25)"
+	fi
 }
 assert_not_grep() {
-  local label="$1" output="$2" pattern="$3"
-  grep -qF -- "$pattern" <<<"$output" && fail "$label" "unexpected substring: $pattern" "$(echo "$output" | head -25)" \
-    || pass "$label"
-}
-assert_rc() {
-  local label="$1" actual="$2" expected="$3"
-  [[ "$actual" == "$expected" ]] && pass "$label" || fail "$label" "expected rc=$expected got rc=$actual"
+	local label="$1" output="$2" pattern="$3"
+	if grep -qF -- "$pattern" <<<"$output"; then
+		fail "$label" "unexpected substring: $pattern" "$(echo "$output" | head -25)"
+	else
+		pass "$label"
+	fi
 }
 
 # A sealed prefix: HOME, a documented-curl-layout download dir (setup script ONLY),
 # and a stub PATH. Nothing here can reach the real repo unless a test plants it.
 fresh_prefix() {
-  rm -rf "$SCRATCH/home" "$SCRATCH/dl" "$SCRATCH/stubs" "$SCRATCH/tree" "$SCRATCH/bin"
-  mkdir -p "$SCRATCH/home" "$SCRATCH/dl" "$SCRATCH/stubs"
-  cp "$SETUP" "$SCRATCH/dl/setup-catalyst.sh"
-  chmod +x "$SCRATCH/dl/setup-catalyst.sh"
+	rm -rf "${SCRATCH:?}/home" "${SCRATCH:?}/dl" "${SCRATCH:?}/stubs" "${SCRATCH:?}/tree" "${SCRATCH:?}/bin"
+	mkdir -p "$SCRATCH/home" "$SCRATCH/dl" "$SCRATCH/stubs"
+	cp "$SETUP" "$SCRATCH/dl/setup-catalyst.sh"
+	chmod +x "$SCRATCH/dl/setup-catalyst.sh"
 }
 
 # Materialise a *plausible* Catalyst source tree: the four helpers the installer needs,
 # each an executable stub that records that it ran.
 plant_tree() {
-  local root="$1" log="$2"
-  mkdir -p "$root/plugins/dev/scripts"
-  local s
-  for s in install-orphan-sweep.sh setup-execution-core-states.sh setup-plugin-source.sh install-cli.sh; do
-    cat > "$root/plugins/dev/scripts/$s" <<EOF
+	local root="$1" log="$2"
+	mkdir -p "$root/plugins/dev/scripts"
+	local s
+	for s in install-orphan-sweep.sh setup-execution-core-states.sh setup-plugin-source.sh install-cli.sh; do
+		cat >"$root/plugins/dev/scripts/$s" <<EOF
 #!/usr/bin/env bash
 echo "INVOKED $s args=\$*" >> "$log"
 exit 0
 EOF
-    chmod +x "$root/plugins/dev/scripts/$s"
-  done
+		chmod +x "$root/plugins/dev/scripts/$s"
+	done
 }
 
+# The single-quoted bodies passed to run_fn below are source text for a CHILD shell;
+# their `$` deliberately does not expand in this one.
+# shellcheck disable=SC2016
+#
 # Run a function from the sourced library inside the sealed prefix. CWD is the
 # download dir, which is what the documented curl install actually gives you.
 run_fn() {
-  local body="$1"
-  shift
-  env -i \
-    HOME="$SCRATCH/home" \
-    PATH="$SCRATCH/stubs:/usr/bin:/bin" \
-    CATALYST_SETUP_LIB_ONLY=1 \
-    "$@" \
-    /bin/bash -c "cd '$SCRATCH/dl' && source './setup-catalyst.sh' >/dev/null 2>&1; $body" 2>&1
+	local body="$1"
+	shift
+	env -i \
+		HOME="$SCRATCH/home" \
+		PATH="$SCRATCH/stubs:/usr/bin:/bin" \
+		CATALYST_SETUP_LIB_ONLY=1 \
+		"$@" \
+		/bin/bash -c "cd '$SCRATCH/dl' && source './setup-catalyst.sh' >/dev/null 2>&1; $body" 2>&1
 }
 
 echo ""
@@ -125,7 +142,7 @@ echo "=== resolve_catalyst_source: bootstrap clone materialises the tree ==="
 fresh_prefix
 # A git stub that "clones" by planting a tree at the destination — so the resolver's
 # post-clone validation is exercised for real rather than trusted.
-cat > "$SCRATCH/stubs/git" <<EOF
+cat >"$SCRATCH/stubs/git" <<EOF
 #!/usr/bin/env bash
 if [[ "\$1" == "clone" ]]; then
   dest="\${@: -1}"
@@ -148,7 +165,7 @@ assert_grep "resolved path is the plugin-source default" "$OUT" "$SCRATCH/home/c
 echo ""
 echo "=== ⛔ a clone that produces no usable tree is a NAMED failure, not a pass ==="
 fresh_prefix
-cat > "$SCRATCH/stubs/git" <<'EOF'
+cat >"$SCRATCH/stubs/git" <<'EOF'
 #!/usr/bin/env bash
 # exits 0 having created nothing — the "success that installed nothing" shape
 exit 0
@@ -164,17 +181,17 @@ fresh_prefix
 LOG="$SCRATCH/sweep.log"
 plant_tree "$SCRATCH/tree" "$LOG"
 mkdir -p "$SCRATCH/proj/.catalyst"
-echo '{"catalyst":{}}' > "$SCRATCH/proj/.catalyst/config.json"
+echo '{"catalyst":{}}' >"$SCRATCH/proj/.catalyst/config.json"
 OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj"'; setup_sweep_config' \
-  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_FORCE_OS=Darwin)
+	CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_FORCE_OS=Darwin)
 assert_grep "install-orphan-sweep.sh ran" "$(cat "$LOG" 2>/dev/null)" "INVOKED install-orphan-sweep.sh"
 
 echo "--- control: with NO tree and cloning disabled, it defers rather than silently skipping ---"
 fresh_prefix
 mkdir -p "$SCRATCH/proj2/.catalyst"
-echo '{"catalyst":{}}' > "$SCRATCH/proj2/.catalyst/config.json"
+echo '{"catalyst":{}}' >"$SCRATCH/proj2/.catalyst/config.json"
 OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj2"'; setup_sweep_config; print_deferred_steps' \
-  CATALYST_NO_CLONE_SOURCE=1 CATALYST_FORCE_OS=Darwin)
+	CATALYST_NO_CLONE_SOURCE=1 CATALYST_FORCE_OS=Darwin)
 assert_grep "the skip is announced, not silent" "$OUT" "orphan-sweep"
 assert_grep "the deferral carries a verify command" "$OUT" "verify:"
 
@@ -184,7 +201,7 @@ fresh_prefix
 LOG="$SCRATCH/states.log"
 plant_tree "$SCRATCH/tree" "$LOG"
 mkdir -p "$SCRATCH/proj3/.catalyst"
-echo '{"catalyst":{}}' > "$SCRATCH/proj3/.catalyst/config.json"
+echo '{"catalyst":{}}' >"$SCRATCH/proj3/.catalyst/config.json"
 OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj3"'; setup_execution_core_states' CATALYST_SOURCE_DIR="$SCRATCH/tree")
 assert_grep "setup-execution-core-states.sh ran" "$(cat "$LOG" 2>/dev/null)" "INVOKED setup-execution-core-states.sh"
 assert_not_grep "no longer prints the old silent-skip warning" "$OUT" "not found — skipping state contract"
@@ -210,33 +227,33 @@ plant_tree "$SCRATCH/tree" "$LOG"
 # later steps have something to call — exactly the state install-cli.sh leaves behind.
 mkdir -p "$SCRATCH/bin"
 for b in catalyst-stack catalyst-execution-core; do
-  cat > "$SCRATCH/bin/$b" <<EOF
+	cat >"$SCRATCH/bin/$b" <<EOF
 #!/usr/bin/env bash
 echo "INVOKED $b args=\$*" >> "$LOG"
 exit 0
 EOF
-  chmod +x "$SCRATCH/bin/$b"
+	chmod +x "$SCRATCH/bin/$b"
 done
 OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
-  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
+	CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
 FIN="$(cat "$LOG" 2>/dev/null)"
-assert_grep "install-cli.sh ran"              "$FIN" "INVOKED install-cli.sh"
-assert_grep "setup-plugin-source.sh ran"      "$FIN" "INVOKED setup-plugin-source.sh"
-assert_grep "replica reads were activated"    "$FIN" "INVOKED catalyst-stack args=activate-replica"
-assert_grep "the project was enrolled"        "$FIN" "INVOKED catalyst-execution-core args=register --team WIDGET"
-assert_grep "nothing was left deferred"       "$OUT" "No steps were deferred"
+assert_grep "install-cli.sh ran" "$FIN" "INVOKED install-cli.sh"
+assert_grep "setup-plugin-source.sh ran" "$FIN" "INVOKED setup-plugin-source.sh"
+assert_grep "replica reads were activated" "$FIN" "INVOKED catalyst-stack args=activate-replica"
+assert_grep "the project was enrolled" "$FIN" "INVOKED catalyst-execution-core args=register --team WIDGET"
+assert_grep "nothing was left deferred" "$OUT" "No steps were deferred"
 
 echo ""
 echo "--- control: the same call with NO source tree defers every step, loudly ---"
 fresh_prefix
 mkdir -p "$SCRATCH/bin"
 OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
-  CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
+	CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
 assert_not_grep "does NOT falsely claim a complete install" "$OUT" "No steps were deferred"
-assert_grep "CLI install deferred"       "$OUT" "Put the Catalyst CLIs on PATH"
-assert_grep "plugin-source deferred"     "$OUT" "Provision plugin-source"
-assert_grep "replica reads deferred"     "$OUT" "replica READS"
-assert_grep "enrolment deferred"         "$OUT" "Enrol this project"
+assert_grep "CLI install deferred" "$OUT" "Put the Catalyst CLIs on PATH"
+assert_grep "plugin-source deferred" "$OUT" "Provision plugin-source"
+assert_grep "replica reads deferred" "$OUT" "replica READS"
+assert_grep "enrolment deferred" "$OUT" "Enrol this project"
 assert_grep "every deferral is verifiable" "$OUT" "verify:"
 
 echo ""
@@ -248,8 +265,8 @@ echo "--- ⛔ regression: the deferral must carry the NAMED reason, not an empty
 fresh_prefix
 mkdir -p "$SCRATCH/bin"
 OUT=$(run_fn 'TICKET_PREFIX=WIDGET; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
-  CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
-assert_grep "the reason reaches the operator"   "$OUT" "no-source-tree"
+	CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
+assert_grep "the reason reaches the operator" "$OUT" "no-source-tree"
 assert_not_grep "no empty-parenthesis diagnosis" "$OUT" "PATH ()"
 
 echo ""
@@ -257,16 +274,16 @@ echo "--- a run with no team key names THAT, rather than emitting a placeholder 
 fresh_prefix
 plant_tree "$SCRATCH/tree" "$SCRATCH/noteam.log"
 OUT=$(run_fn 'CLOUD_TOKEN=""; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
-  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
+	CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
 assert_grep "missing team key is stated as the reason" "$OUT" "no Linear team key was discovered"
 
 echo ""
 echo "=== --help documents the headless contract (CTL-1917) ==="
 OUT=$(bash "$SETUP" --help 2>&1)
-assert_grep "--non-interactive documented"  "$OUT" "--non-interactive"
-assert_grep "--cloud-token documented"      "$OUT" "--cloud-token"
-assert_grep "--source-dir documented"       "$OUT" "--source-dir"
-assert_grep "piped form documents -s --"    "$OUT" "bash -s -- --non-interactive"
+assert_grep "--non-interactive documented" "$OUT" "--non-interactive"
+assert_grep "--cloud-token documented" "$OUT" "--cloud-token"
+assert_grep "--source-dir documented" "$OUT" "--source-dir"
+assert_grep "piped form documents -s --" "$OUT" "bash -s -- --non-interactive"
 
 echo ""
 echo "════════════════════════════════════════════"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Tests for setup-catalyst.sh's Catalyst-source resolver and deferred-step ledger
+# (CTL-1914 + CTL-1918).
+#
+# The defect these cover: FOUR separate lookups in setup-catalyst.sh resolved helper
+# scripts relative to the script's own directory (`dirname "${BASH_SOURCE[0]}"`), which
+# in the DOCUMENTED curl-download layout contains nothing but setup-catalyst.sh. Each
+# one degraded to a silent skip, so the documented install and a repo-clone install
+# produced materially different machines — and the more-broken one was the documented one.
+#
+# ⛔ Every "it now runs" assertion here is paired with a control that FIRES, because a
+# stub that is never invoked and a stub whose invocation is not recorded are the same
+# empty log. See CTL-1914's own evidence section for why that pairing is the point.
+#
+# Run: bash plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/setup-catalyst.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  shift
+  for line in "$@"; do echo "      $line"; done
+}
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  [[ "$actual" == "$expected" ]] && pass "$label" || fail "$label" "expected: $expected" "actual:   $actual"
+}
+assert_grep() {
+  local label="$1" output="$2" pattern="$3"
+  grep -qF -- "$pattern" <<<"$output" && pass "$label" \
+    || fail "$label" "expected substring: $pattern" "actual output:" "$(echo "$output" | head -25)"
+}
+assert_not_grep() {
+  local label="$1" output="$2" pattern="$3"
+  grep -qF -- "$pattern" <<<"$output" && fail "$label" "unexpected substring: $pattern" "$(echo "$output" | head -25)" \
+    || pass "$label"
+}
+assert_rc() {
+  local label="$1" actual="$2" expected="$3"
+  [[ "$actual" == "$expected" ]] && pass "$label" || fail "$label" "expected rc=$expected got rc=$actual"
+}
+
+# A sealed prefix: HOME, a documented-curl-layout download dir (setup script ONLY),
+# and a stub PATH. Nothing here can reach the real repo unless a test plants it.
+fresh_prefix() {
+  rm -rf "$SCRATCH/home" "$SCRATCH/dl" "$SCRATCH/stubs" "$SCRATCH/tree" "$SCRATCH/bin"
+  mkdir -p "$SCRATCH/home" "$SCRATCH/dl" "$SCRATCH/stubs"
+  cp "$SETUP" "$SCRATCH/dl/setup-catalyst.sh"
+  chmod +x "$SCRATCH/dl/setup-catalyst.sh"
+}
+
+# Materialise a *plausible* Catalyst source tree: the four helpers the installer needs,
+# each an executable stub that records that it ran.
+plant_tree() {
+  local root="$1" log="$2"
+  mkdir -p "$root/plugins/dev/scripts"
+  local s
+  for s in install-orphan-sweep.sh setup-execution-core-states.sh setup-plugin-source.sh install-cli.sh; do
+    cat > "$root/plugins/dev/scripts/$s" <<EOF
+#!/usr/bin/env bash
+echo "INVOKED $s args=\$*" >> "$log"
+exit 0
+EOF
+    chmod +x "$root/plugins/dev/scripts/$s"
+  done
+}
+
+# Run a function from the sourced library inside the sealed prefix. CWD is the
+# download dir, which is what the documented curl install actually gives you.
+run_fn() {
+  local body="$1"
+  shift
+  env -i \
+    HOME="$SCRATCH/home" \
+    PATH="$SCRATCH/stubs:/usr/bin:/bin" \
+    CATALYST_SETUP_LIB_ONLY=1 \
+    "$@" \
+    /bin/bash -c "cd '$SCRATCH/dl' && source './setup-catalyst.sh' >/dev/null 2>&1; $body" 2>&1
+}
+
+echo ""
+echo "=== resolve_catalyst_source: the function exists and is callable ==="
+fresh_prefix
+OUT=$(run_fn 'declare -F resolve_catalyst_source >/dev/null && echo DEFINED || echo MISSING')
+assert_grep "resolve_catalyst_source is defined" "$OUT" "DEFINED"
+
+echo ""
+echo "=== resolve_catalyst_source: finds a tree next to the script (repo-clone layout) ==="
+fresh_prefix
+plant_tree "$SCRATCH/dl" "$SCRATCH/planted.log"
+OUT=$(run_fn 'resolve_catalyst_source && echo "ORIGIN=$CATALYST_SOURCE_ORIGIN"')
+assert_grep "resolves the script-adjacent tree" "$OUT" "$SCRATCH/dl"
+assert_grep "names the origin as script-dir" "$OUT" "ORIGIN=script-dir"
+
+echo ""
+echo "=== resolve_catalyst_source: an explicit override wins ==="
+fresh_prefix
+plant_tree "$SCRATCH/dl" "$SCRATCH/planted.log"
+plant_tree "$SCRATCH/tree" "$SCRATCH/override.log"
+OUT=$(run_fn 'resolve_catalyst_source && echo "ORIGIN=$CATALYST_SOURCE_ORIGIN"' CATALYST_SOURCE_DIR="$SCRATCH/tree")
+assert_grep "override tree wins over script-adjacent" "$OUT" "$SCRATCH/tree"
+assert_grep "names the origin as env" "$OUT" "ORIGIN=env"
+
+echo ""
+echo "=== ⛔ documented curl layout + cloning disabled: NAMED failure, never a silent skip ==="
+fresh_prefix
+OUT=$(run_fn 'if resolve_catalyst_source; then rc=0; else rc=$?; fi; echo "RC=$rc"; echo "REASON=$CATALYST_SOURCE_REASON"' CATALYST_NO_CLONE_SOURCE=1)
+assert_grep "resolver fails rather than returning an empty success" "$OUT" "RC=1"
+assert_grep "the failure carries a named reason" "$OUT" "REASON=no-source-tree"
+
+echo ""
+echo "=== resolve_catalyst_source: bootstrap clone materialises the tree ==="
+fresh_prefix
+# A git stub that "clones" by planting a tree at the destination — so the resolver's
+# post-clone validation is exercised for real rather than trusted.
+cat > "$SCRATCH/stubs/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clone" ]]; then
+  dest="\${@: -1}"
+  mkdir -p "\$dest/plugins/dev/scripts"
+  for s in install-orphan-sweep.sh setup-execution-core-states.sh setup-plugin-source.sh install-cli.sh; do
+    printf '#!/usr/bin/env bash\necho "INVOKED %s args=\$*" >> "$SCRATCH/cloned.log"\n' "\$s" > "\$dest/plugins/dev/scripts/\$s"
+    chmod +x "\$dest/plugins/dev/scripts/\$s"
+  done
+  echo "GIT-CLONE-STUB dest=\$dest" >> "$SCRATCH/cloned.log"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$SCRATCH/stubs/git"
+OUT=$(run_fn 'resolve_catalyst_source && echo "ORIGIN=$CATALYST_SOURCE_ORIGIN"')
+assert_grep "clone origin is named" "$OUT" "ORIGIN=cloned"
+assert_grep "clone actually ran (control)" "$(cat "$SCRATCH/cloned.log" 2>/dev/null)" "GIT-CLONE-STUB"
+assert_grep "resolved path is the plugin-source default" "$OUT" "$SCRATCH/home/catalyst/plugin-source"
+
+echo ""
+echo "=== ⛔ a clone that produces no usable tree is a NAMED failure, not a pass ==="
+fresh_prefix
+cat > "$SCRATCH/stubs/git" <<'EOF'
+#!/usr/bin/env bash
+# exits 0 having created nothing — the "success that installed nothing" shape
+exit 0
+EOF
+chmod +x "$SCRATCH/stubs/git"
+OUT=$(run_fn 'if resolve_catalyst_source; then rc=0; else rc=$?; fi; echo "RC=$rc"; echo "REASON=$CATALYST_SOURCE_REASON"')
+assert_grep "an empty clone does not read as success" "$OUT" "RC=1"
+assert_grep "an empty clone is named" "$OUT" "REASON=clone-produced-no-tree"
+
+echo ""
+echo "=== setup_sweep_config: the documented layout now INVOKES the sweep installer ==="
+fresh_prefix
+LOG="$SCRATCH/sweep.log"
+plant_tree "$SCRATCH/tree" "$LOG"
+mkdir -p "$SCRATCH/proj/.catalyst"
+echo '{"catalyst":{}}' > "$SCRATCH/proj/.catalyst/config.json"
+OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj"'; setup_sweep_config' \
+  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_FORCE_OS=Darwin)
+assert_grep "install-orphan-sweep.sh ran" "$(cat "$LOG" 2>/dev/null)" "INVOKED install-orphan-sweep.sh"
+
+echo "--- control: with NO tree and cloning disabled, it defers rather than silently skipping ---"
+fresh_prefix
+mkdir -p "$SCRATCH/proj2/.catalyst"
+echo '{"catalyst":{}}' > "$SCRATCH/proj2/.catalyst/config.json"
+OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj2"'; setup_sweep_config; print_deferred_steps' \
+  CATALYST_NO_CLONE_SOURCE=1 CATALYST_FORCE_OS=Darwin)
+assert_grep "the skip is announced, not silent" "$OUT" "orphan-sweep"
+assert_grep "the deferral carries a verify command" "$OUT" "verify:"
+
+echo ""
+echo "=== setup_execution_core_states: the documented layout now finds the states script ==="
+fresh_prefix
+LOG="$SCRATCH/states.log"
+plant_tree "$SCRATCH/tree" "$LOG"
+mkdir -p "$SCRATCH/proj3/.catalyst"
+echo '{"catalyst":{}}' > "$SCRATCH/proj3/.catalyst/config.json"
+OUT=$(run_fn 'PROJECT_DIR='"$SCRATCH/proj3"'; setup_execution_core_states' CATALYST_SOURCE_DIR="$SCRATCH/tree")
+assert_grep "setup-execution-core-states.sh ran" "$(cat "$LOG" 2>/dev/null)" "INVOKED setup-execution-core-states.sh"
+assert_not_grep "no longer prints the old silent-skip warning" "$OUT" "not found — skipping state contract"
+
+echo ""
+echo "=== the deferred ledger ==="
+fresh_prefix
+OUT=$(run_fn 'catalyst_defer_step "Do the thing" "run-this --now" "verify-this --json"; print_deferred_steps')
+assert_grep "ledger prints the step title" "$OUT" "Do the thing"
+assert_grep "ledger prints the completing command" "$OUT" "run-this --now"
+assert_grep "ledger prints the verifying command" "$OUT" "verify-this --json"
+
+fresh_prefix
+OUT=$(run_fn 'print_deferred_steps')
+assert_grep "an empty ledger says so positively" "$OUT" "No steps were deferred"
+
+echo ""
+echo "=== finalize_install: performs the steps setup used to PRINT (CTL-1918) ==="
+fresh_prefix
+LOG="$SCRATCH/fin.log"
+plant_tree "$SCRATCH/tree" "$LOG"
+# The CLIs finalize_install is meant to install, pre-planted in the bin dir so the
+# later steps have something to call — exactly the state install-cli.sh leaves behind.
+mkdir -p "$SCRATCH/bin"
+for b in catalyst-stack catalyst-execution-core; do
+  cat > "$SCRATCH/bin/$b" <<EOF
+#!/usr/bin/env bash
+echo "INVOKED $b args=\$*" >> "$LOG"
+exit 0
+EOF
+  chmod +x "$SCRATCH/bin/$b"
+done
+OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
+FIN="$(cat "$LOG" 2>/dev/null)"
+assert_grep "install-cli.sh ran"              "$FIN" "INVOKED install-cli.sh"
+assert_grep "setup-plugin-source.sh ran"      "$FIN" "INVOKED setup-plugin-source.sh"
+assert_grep "replica reads were activated"    "$FIN" "INVOKED catalyst-stack args=activate-replica"
+assert_grep "the project was enrolled"        "$FIN" "INVOKED catalyst-execution-core args=register --team WIDGET"
+assert_grep "nothing was left deferred"       "$OUT" "No steps were deferred"
+
+echo ""
+echo "--- control: the same call with NO source tree defers every step, loudly ---"
+fresh_prefix
+mkdir -p "$SCRATCH/bin"
+OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+  CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
+assert_not_grep "does NOT falsely claim a complete install" "$OUT" "No steps were deferred"
+assert_grep "CLI install deferred"       "$OUT" "Put the Catalyst CLIs on PATH"
+assert_grep "plugin-source deferred"     "$OUT" "Provision plugin-source"
+assert_grep "replica reads deferred"     "$OUT" "replica READS"
+assert_grep "enrolment deferred"         "$OUT" "Enrol this project"
+assert_grep "every deferral is verifiable" "$OUT" "verify:"
+
+echo ""
+echo "--- ⛔ regression: the deferral must carry the NAMED reason, not an empty () ---"
+# The first cut of catalyst_helper_path called the resolver as `$(resolve_catalyst_source)`.
+# Command substitution is a subshell, so CATALYST_SOURCE_REASON — the entire point of
+# failing with a named reason — was discarded and the operator got "NOT installed ()".
+# The failure still *reported*; it just reported nothing usable.
+fresh_prefix
+mkdir -p "$SCRATCH/bin"
+OUT=$(run_fn 'TICKET_PREFIX=WIDGET; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+  CATALYST_NO_CLONE_SOURCE=1 CATALYST_BIN_DIR="$SCRATCH/bin")
+assert_grep "the reason reaches the operator"   "$OUT" "no-source-tree"
+assert_not_grep "no empty-parenthesis diagnosis" "$OUT" "PATH ()"
+
+echo ""
+echo "--- a run with no team key names THAT, rather than emitting a placeholder to decode ---"
+fresh_prefix
+plant_tree "$SCRATCH/tree" "$SCRATCH/noteam.log"
+OUT=$(run_fn 'CLOUD_TOKEN=""; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+  CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
+assert_grep "missing team key is stated as the reason" "$OUT" "no Linear team key was discovered"
+
+echo ""
+echo "=== --help documents the headless contract (CTL-1917) ==="
+OUT=$(bash "$SETUP" --help 2>&1)
+assert_grep "--non-interactive documented"  "$OUT" "--non-interactive"
+assert_grep "--cloud-token documented"      "$OUT" "--cloud-token"
+assert_grep "--source-dir documented"       "$OUT" "--source-dir"
+assert_grep "piped form documents -s --"    "$OUT" "bash -s -- --non-interactive"
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+echo "════════════════════════════════════════════"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-source-resolver.test.sh
@@ -234,7 +234,9 @@ exit 0
 EOF
 	chmod +x "$SCRATCH/bin/$b"
 done
-OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+# CLOUD_REPLICA_PROVISIONED=1 is what setup_cloud_replica sets at its success exit.
+# Activation keys on that OUTCOME, not on "a token was supplied" — see the case below.
+OUT=$(run_fn 'TICKET_PREFIX=WIDGET; CLOUD_TOKEN=tok; CLOUD_REPLICA_PROVISIONED=1; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
 	CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin")
 FIN="$(cat "$LOG" 2>/dev/null)"
 assert_grep "install-cli.sh ran" "$FIN" "INVOKED install-cli.sh"
@@ -242,6 +244,27 @@ assert_grep "setup-plugin-source.sh ran" "$FIN" "INVOKED setup-plugin-source.sh"
 assert_grep "replica reads were activated" "$FIN" "INVOKED catalyst-stack args=activate-replica"
 assert_grep "the project was enrolled" "$FIN" "INVOKED catalyst-execution-core args=register --team WIDGET"
 assert_grep "nothing was left deferred" "$OUT" "No steps were deferred"
+
+echo ""
+echo "--- ⛔ Codex #3500 P1: a token supplied but NOT provisioned must DEFER, not go quiet ---"
+# The token can arrive through the documented env var, where the global CLOUD_TOKEN stays
+# empty — so gating activation on that global skipped activate-replica AND recorded
+# nothing, letting setup report a fully provisioned node with replica reads off.
+fresh_prefix
+LOG="$SCRATCH/unprov.log"
+plant_tree "$SCRATCH/tree" "$LOG"
+mkdir -p "$SCRATCH/bin"
+for b in catalyst-stack catalyst-execution-core; do
+	printf '#!/usr/bin/env bash\necho "INVOKED %s args=$*" >> "%s"\nexit 0\n' "$b" "$LOG" >"$SCRATCH/bin/$b"
+	chmod +x "$SCRATCH/bin/$b"
+done
+# CLOUD_TOKEN empty, but the documented env var carries the token — the exact gap.
+OUT=$(run_fn 'TICKET_PREFIX=WIDGET; NON_INTERACTIVE=1; finalize_install; print_deferred_steps' \
+	CATALYST_SOURCE_DIR="$SCRATCH/tree" CATALYST_BIN_DIR="$SCRATCH/bin" CATALYST_CLOUD_TOKEN=tok-from-env)
+assert_grep "an env-supplied token is SEEN" "$OUT" "replica READS"
+assert_not_grep "and the run does not claim completeness" "$OUT" "No steps were deferred"
+assert_not_grep "activate-replica is NOT run against a replica that was never provisioned" \
+	"$(cat "$LOG" 2>/dev/null)" "activate-replica"
 
 echo ""
 echo "--- control: the same call with NO source tree defers every step, loudly ---"

--- a/plugins/dev/scripts/execution-core/doctor-status.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-status.mjs
@@ -1,0 +1,10 @@
+// doctor-status.mjs — the two primitives every doctor check is built from.
+//
+// Extracted so a check can live in its own module without importing doctor.mjs, which
+// would be circular (doctor.mjs imports the checks). Zero imports, by design: this is
+// the leaf both sides depend on. doctor.mjs re-exports both, so its public surface —
+// and every existing `import { STATUS, mkCheck } from "./doctor.mjs"` — is unchanged.
+
+export const STATUS = { PASS: "pass", WARN: "warn", FAIL: "fail", INFO: "info" };
+
+export const mkCheck = (name, status, detail) => ({ name, status, detail });

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3934,6 +3934,108 @@ export function checkDrainDisabled(deps = {}) {
   );
 }
 
+// checkInstallCompleteness — CTL-1918. Does this node carry the four things a
+// FINISHED install leaves behind, or only the things a STARTED one does?
+//
+// setup-catalyst.sh used to end by PRINTING instructions for steps it could perform,
+// so "setup completed successfully" and "this node works" were different states with
+// nothing measuring the gap. setup now performs them and records what it could not —
+// but that ledger is printed once, at the end of a run nobody re-reads. This is the
+// standing answer: the same four outcomes, checkable at any time.
+//
+// ⛔ ADVISORY — never FAIL. Install shape is an operator repair, and doctor's FAIL
+// count gates worker activation; a half-installed node must not be made unable to
+// work on the strength of a cosmetic gap. Same posture, and same reason, as
+// checkRegistryTeamIdentity.
+//
+// ⚠️ Every leg is three-valued. "I could not look" (unreadable config, absent
+// registry, a platform with no launchd) is reported as UNKNOWN and never folded into
+// "absent" — a check that reports a missing step for a file it failed to open is how
+// an operator gets sent to repair something that was never broken.
+export function checkInstallCompleteness(deps = {}) {
+  const {
+    env = process.env,
+    home = homedir(),
+    exists = (p) => existsSync(p),
+    readJson = (p) => {
+      try {
+        return { ok: true, value: JSON.parse(readFileSync(p, "utf8")) };
+      } catch {
+        return { ok: false, value: null };
+      }
+    },
+    layer2 = layer2Path(),
+    registryPath = join(home, "catalyst", "execution-core", "registry.json"),
+    platform = process.platform,
+  } = deps;
+
+  const legs = [];
+  const note = (name, state, detail) => legs.push({ name, state, detail });
+
+  // 1. the catalyst-* CLIs on PATH — what install-cli.sh leaves behind.
+  const binDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || join(home, ".catalyst", "bin");
+  note("cli", exists(join(binDir, "catalyst-stack")) ? "ok" : "missing", binDir);
+
+  // 2. pluginDirs registered — what setup-plugin-source.sh leaves behind. An
+  //    unreadable Layer-2 file is UNKNOWN: the key may well be there.
+  const cfg = readJson(layer2);
+  if (!cfg.ok) {
+    note("plugin-source", "unknown", `Layer-2 config unreadable (${layer2})`);
+  } else {
+    const pd = cfg.value?.catalyst?.orchestration?.pluginDirs;
+    const first = Array.isArray(pd) ? pd[0] : typeof pd === "string" ? pd : null;
+    note("plugin-source", first ? "ok" : "missing", first || "no pluginDirs key");
+  }
+
+  // 3. the orphan-sweep LaunchAgent — macOS only. On any other platform this is not
+  //    "missing", it is not applicable, and saying "missing" would be a false repair.
+  if (platform !== "darwin") {
+    note("orphan-sweep", "unknown", "not macOS — launchd scheduling is a follow-up (CTL-1030)");
+  } else {
+    const plist = join(home, "Library", "LaunchAgents", "ai.coalesce.catalyst-orphan-sweep.plist");
+    note("orphan-sweep", exists(plist) ? "ok" : "missing", plist);
+  }
+
+  // 4. at least one project enrolled — without a registry entry the daemon dispatches
+  //    nothing, which looks exactly like a broken one.
+  const reg = readJson(registryPath);
+  if (!exists(registryPath)) {
+    note("registry", "missing", `no registry at ${registryPath}`);
+  } else if (!reg.ok) {
+    note("registry", "unknown", `registry unreadable (${registryPath})`);
+  } else {
+    const projects = reg.value?.projects;
+    const n = Array.isArray(projects) ? projects.length : projects && typeof projects === "object" ? Object.keys(projects).length : 0;
+    note("registry", n > 0 ? "ok" : "missing", `${n} project(s) enrolled`);
+  }
+
+  const missing = legs.filter((l) => l.state === "missing");
+  const unknown = legs.filter((l) => l.state === "unknown");
+  const fmt = (ls) => ls.map((l) => `${l.name} (${l.detail})`).join("; ");
+
+  if (missing.length === 0 && unknown.length === 0) {
+    return mkCheck(
+      "install-completeness",
+      STATUS.PASS,
+      "install is complete — CLIs on PATH, plugin-source registered, orphan-sweep scheduled, project enrolled",
+    );
+  }
+  if (missing.length === 0) {
+    return mkCheck(
+      "install-completeness",
+      STATUS.INFO,
+      `install looks complete, but ${unknown.length} leg(s) could not be measured: ${fmt(unknown)}`,
+    );
+  }
+  return mkCheck(
+    "install-completeness",
+    STATUS.WARN,
+    `install is INCOMPLETE — ${missing.length} step(s) never landed: ${fmt(missing)}` +
+      (unknown.length ? ` | unmeasured: ${fmt(unknown)}` : "") +
+      " — re-run setup-catalyst.sh, or complete them from its deferred-step list (CTL-1918)",
+  );
+}
+
 // Advisory report for registry entries whose checkout declares a different
 // Linear team. This check is total and never FAILs: host registry state is an
 // operator repair, and doctor's FAIL count gates worker activation.
@@ -5798,6 +5900,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
     () => checkDrainDisabled(), // CTL-1678: surface the per-node drain override + the draining-but-ignored third state — advisory only (never FAIL)
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
+    () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
   ];
 }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -27,6 +27,11 @@
 import { readFileSync, statSync, existsSync, lstatSync, realpathSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
 import { resolve, dirname, isAbsolute, join } from "node:path";
 import { homedir } from "node:os";
+// CTL-1918: install-completeness lives in its own module. doctor.mjs is NOT
+// prettier-formatted on main (verified against a pristine checkout), so any edit here
+// drags a ~1,100-line reformat into the diff — extracting keeps this change reviewable.
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+import { checkInstallCompleteness } from "./install-completeness.mjs";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
 
@@ -153,9 +158,13 @@ function readLinearBotUserIds(l1Path, l2Path) {
 
 // ─── Check model ─────────────────────────────────────────────────────────────
 
-export const STATUS = { PASS: "pass", WARN: "warn", FAIL: "fail", INFO: "info" };
+// CTL-1918: STATUS/mkCheck moved to the zero-import leaf doctor-status.mjs so a check
+// can live in its own module without importing this one (which would be circular).
+// Re-exported here, so every existing `import { STATUS, mkCheck } from "./doctor.mjs"`
+// keeps working unchanged.
+export { STATUS, mkCheck } from "./doctor-status.mjs";
 
-export const mkCheck = (name, status, detail) => ({ name, status, detail });
+export { checkInstallCompleteness };
 
 // ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
 //
@@ -3931,108 +3940,6 @@ export function checkDrainDisabled(deps = {}) {
     "drain-disabled",
     STATUS.INFO,
     "not drain-disabled — this node honors the drain flag (CTL-1678)",
-  );
-}
-
-// checkInstallCompleteness — CTL-1918. Does this node carry the four things a
-// FINISHED install leaves behind, or only the things a STARTED one does?
-//
-// setup-catalyst.sh used to end by PRINTING instructions for steps it could perform,
-// so "setup completed successfully" and "this node works" were different states with
-// nothing measuring the gap. setup now performs them and records what it could not —
-// but that ledger is printed once, at the end of a run nobody re-reads. This is the
-// standing answer: the same four outcomes, checkable at any time.
-//
-// ⛔ ADVISORY — never FAIL. Install shape is an operator repair, and doctor's FAIL
-// count gates worker activation; a half-installed node must not be made unable to
-// work on the strength of a cosmetic gap. Same posture, and same reason, as
-// checkRegistryTeamIdentity.
-//
-// ⚠️ Every leg is three-valued. "I could not look" (unreadable config, absent
-// registry, a platform with no launchd) is reported as UNKNOWN and never folded into
-// "absent" — a check that reports a missing step for a file it failed to open is how
-// an operator gets sent to repair something that was never broken.
-export function checkInstallCompleteness(deps = {}) {
-  const {
-    env = process.env,
-    home = homedir(),
-    exists = (p) => existsSync(p),
-    readJson = (p) => {
-      try {
-        return { ok: true, value: JSON.parse(readFileSync(p, "utf8")) };
-      } catch {
-        return { ok: false, value: null };
-      }
-    },
-    layer2 = layer2Path(),
-    registryPath = join(home, "catalyst", "execution-core", "registry.json"),
-    platform = process.platform,
-  } = deps;
-
-  const legs = [];
-  const note = (name, state, detail) => legs.push({ name, state, detail });
-
-  // 1. the catalyst-* CLIs on PATH — what install-cli.sh leaves behind.
-  const binDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || join(home, ".catalyst", "bin");
-  note("cli", exists(join(binDir, "catalyst-stack")) ? "ok" : "missing", binDir);
-
-  // 2. pluginDirs registered — what setup-plugin-source.sh leaves behind. An
-  //    unreadable Layer-2 file is UNKNOWN: the key may well be there.
-  const cfg = readJson(layer2);
-  if (!cfg.ok) {
-    note("plugin-source", "unknown", `Layer-2 config unreadable (${layer2})`);
-  } else {
-    const pd = cfg.value?.catalyst?.orchestration?.pluginDirs;
-    const first = Array.isArray(pd) ? pd[0] : typeof pd === "string" ? pd : null;
-    note("plugin-source", first ? "ok" : "missing", first || "no pluginDirs key");
-  }
-
-  // 3. the orphan-sweep LaunchAgent — macOS only. On any other platform this is not
-  //    "missing", it is not applicable, and saying "missing" would be a false repair.
-  if (platform !== "darwin") {
-    note("orphan-sweep", "unknown", "not macOS — launchd scheduling is a follow-up (CTL-1030)");
-  } else {
-    const plist = join(home, "Library", "LaunchAgents", "ai.coalesce.catalyst-orphan-sweep.plist");
-    note("orphan-sweep", exists(plist) ? "ok" : "missing", plist);
-  }
-
-  // 4. at least one project enrolled — without a registry entry the daemon dispatches
-  //    nothing, which looks exactly like a broken one.
-  const reg = readJson(registryPath);
-  if (!exists(registryPath)) {
-    note("registry", "missing", `no registry at ${registryPath}`);
-  } else if (!reg.ok) {
-    note("registry", "unknown", `registry unreadable (${registryPath})`);
-  } else {
-    const projects = reg.value?.projects;
-    const n = Array.isArray(projects) ? projects.length : projects && typeof projects === "object" ? Object.keys(projects).length : 0;
-    note("registry", n > 0 ? "ok" : "missing", `${n} project(s) enrolled`);
-  }
-
-  const missing = legs.filter((l) => l.state === "missing");
-  const unknown = legs.filter((l) => l.state === "unknown");
-  const fmt = (ls) => ls.map((l) => `${l.name} (${l.detail})`).join("; ");
-
-  if (missing.length === 0 && unknown.length === 0) {
-    return mkCheck(
-      "install-completeness",
-      STATUS.PASS,
-      "install is complete — CLIs on PATH, plugin-source registered, orphan-sweep scheduled, project enrolled",
-    );
-  }
-  if (missing.length === 0) {
-    return mkCheck(
-      "install-completeness",
-      STATUS.INFO,
-      `install looks complete, but ${unknown.length} leg(s) could not be measured: ${fmt(unknown)}`,
-    );
-  }
-  return mkCheck(
-    "install-completeness",
-    STATUS.WARN,
-    `install is INCOMPLETE — ${missing.length} step(s) never landed: ${fmt(missing)}` +
-      (unknown.length ? ` | unmeasured: ${fmt(unknown)}` : "") +
-      " — re-run setup-catalyst.sh, or complete them from its deferred-step list (CTL-1918)",
   );
 }
 

--- a/plugins/dev/scripts/execution-core/install-completeness.mjs
+++ b/plugins/dev/scripts/execution-core/install-completeness.mjs
@@ -1,0 +1,113 @@
+// install-completeness.mjs — CTL-1918.
+//
+// checkInstallCompleteness — CTL-1918. Does this node carry the four things a
+// FINISHED install leaves behind, or only the things a STARTED one does?
+//
+// setup-catalyst.sh used to end by PRINTING instructions for steps it could perform,
+// so "setup completed successfully" and "this node works" were different states with
+// nothing measuring the gap. setup now performs them and records what it could not —
+// but that ledger is printed once, at the end of a run nobody re-reads. This is the
+// standing answer: the same four outcomes, checkable at any time.
+//
+// ⛔ ADVISORY — never FAIL. Install shape is an operator repair, and doctor's FAIL
+// count gates worker activation; a half-installed node must not be made unable to
+// work on the strength of a cosmetic gap. Same posture, and same reason, as
+// checkRegistryTeamIdentity.
+//
+// ⚠️ Every leg is three-valued. "I could not look" (unreadable config, absent
+// registry, a platform with no launchd) is reported as UNKNOWN and never folded into
+// "absent" — a check that reports a missing step for a file it failed to open is how
+// an operator gets sent to repair something that was never broken.
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+
+export function checkInstallCompleteness(deps = {}) {
+  const {
+    env = process.env,
+    home = homedir(),
+    exists = (p) => existsSync(p),
+    readJson = (p) => {
+      try {
+        return { ok: true, value: JSON.parse(readFileSync(p, "utf8")) };
+      } catch {
+        return { ok: false, value: null };
+      }
+    },
+    layer2 = layer2Path(),
+    registryPath = join(home, "catalyst", "execution-core", "registry.json"),
+    platform = process.platform,
+  } = deps;
+
+  const legs = [];
+  const note = (name, state, detail) => legs.push({ name, state, detail });
+
+  // 1. the catalyst-* CLIs on PATH — what install-cli.sh leaves behind.
+  const binDir = env.CATALYST_BIN_DIR || env.CATALYST_CLI_BIN_DIR || join(home, ".catalyst", "bin");
+  note("cli", exists(join(binDir, "catalyst-stack")) ? "ok" : "missing", binDir);
+
+  // 2. pluginDirs registered — what setup-plugin-source.sh leaves behind. An
+  //    unreadable Layer-2 file is UNKNOWN: the key may well be there.
+  const cfg = readJson(layer2);
+  if (!cfg.ok) {
+    note("plugin-source", "unknown", `Layer-2 config unreadable (${layer2})`);
+  } else {
+    const pd = cfg.value?.catalyst?.orchestration?.pluginDirs;
+    const first = Array.isArray(pd) ? pd[0] : typeof pd === "string" ? pd : null;
+    note("plugin-source", first ? "ok" : "missing", first || "no pluginDirs key");
+  }
+
+  // 3. the orphan-sweep LaunchAgent — macOS only. On any other platform this is not
+  //    "missing", it is not applicable, and saying "missing" would be a false repair.
+  if (platform !== "darwin") {
+    note("orphan-sweep", "unknown", "not macOS — launchd scheduling is a follow-up (CTL-1030)");
+  } else {
+    const plist = join(home, "Library", "LaunchAgents", "ai.coalesce.catalyst-orphan-sweep.plist");
+    note("orphan-sweep", exists(plist) ? "ok" : "missing", plist);
+  }
+
+  // 4. at least one project enrolled — without a registry entry the daemon dispatches
+  //    nothing, which looks exactly like a broken one.
+  const reg = readJson(registryPath);
+  if (!exists(registryPath)) {
+    note("registry", "missing", `no registry at ${registryPath}`);
+  } else if (!reg.ok) {
+    note("registry", "unknown", `registry unreadable (${registryPath})`);
+  } else {
+    const projects = reg.value?.projects;
+    const n = Array.isArray(projects)
+      ? projects.length
+      : projects && typeof projects === "object"
+        ? Object.keys(projects).length
+        : 0;
+    note("registry", n > 0 ? "ok" : "missing", `${n} project(s) enrolled`);
+  }
+
+  const missing = legs.filter((l) => l.state === "missing");
+  const unknown = legs.filter((l) => l.state === "unknown");
+  const fmt = (ls) => ls.map((l) => `${l.name} (${l.detail})`).join("; ");
+
+  if (missing.length === 0 && unknown.length === 0) {
+    return mkCheck(
+      "install-completeness",
+      STATUS.PASS,
+      "install is complete — CLIs on PATH, plugin-source registered, orphan-sweep scheduled, project enrolled"
+    );
+  }
+  if (missing.length === 0) {
+    return mkCheck(
+      "install-completeness",
+      STATUS.INFO,
+      `install looks complete, but ${unknown.length} leg(s) could not be measured: ${fmt(unknown)}`
+    );
+  }
+  return mkCheck(
+    "install-completeness",
+    STATUS.WARN,
+    `install is INCOMPLETE — ${missing.length} step(s) never landed: ${fmt(missing)}` +
+      (unknown.length ? ` | unmeasured: ${fmt(unknown)}` : "") +
+      " — re-run setup-catalyst.sh, or complete them from its deferred-step list (CTL-1918)"
+  );
+}

--- a/plugins/dev/scripts/execution-core/install-completeness.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-completeness.test.mjs
@@ -1,0 +1,147 @@
+// install-completeness.test.mjs — CTL-1918.
+//
+// checkInstallCompleteness answers "did the install FINISH", so its whole value is in
+// the difference between a step that did not happen and a step it could not measure.
+// These tests hold that distinction: every "missing" assertion is paired with an
+// "unknown" one over the same leg, because a check that reports a missing step for a
+// file it merely failed to open sends an operator to repair something that was never
+// broken — and reads identically in the report.
+
+import { describe, expect, test } from "bun:test";
+import { checkInstallCompleteness } from "./doctor.mjs";
+
+const HOME = "/seal/home";
+
+// A node where everything landed. Each test below removes exactly one thing from this,
+// so a failure names the leg rather than the fixture.
+function completeDeps(over = {}) {
+  const present = new Set([
+    "/seal/home/.catalyst/bin/catalyst-stack",
+    "/seal/home/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist",
+    "/seal/home/catalyst/execution-core/registry.json",
+  ]);
+  return {
+    env: {},
+    home: HOME,
+    platform: "darwin",
+    layer2: "/seal/layer2.json",
+    registryPath: "/seal/home/catalyst/execution-core/registry.json",
+    exists: (p) => present.has(p),
+    readJson: (p) =>
+      p === "/seal/layer2.json"
+        ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/seal/plugin-source/plugins/dev"] } } } }
+        : { ok: true, value: { projects: [{ team: "WIDGET" }] } },
+    _present: present,
+    ...over,
+  };
+}
+
+describe("checkInstallCompleteness", () => {
+  test("a finished install PASSes", () => {
+    const r = checkInstallCompleteness(completeDeps());
+    expect(r.status).toBe("pass");
+    expect(r.name).toBe("install-completeness");
+  });
+
+  test("⛔ never FAILs, whatever is missing — doctor's FAIL count gates worker activation", () => {
+    const r = checkInstallCompleteness(
+      completeDeps({
+        exists: () => false,
+        readJson: () => ({ ok: false, value: null }),
+      }),
+    );
+    expect(r.status).not.toBe("fail");
+  });
+
+  test("missing CLIs are named, not merely counted", () => {
+    const d = completeDeps();
+    d._present.delete("/seal/home/.catalyst/bin/catalyst-stack");
+    const r = checkInstallCompleteness(d);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("cli");
+    expect(r.detail).toContain("INCOMPLETE");
+  });
+
+  test("an absent pluginDirs key is missing", () => {
+    const r = checkInstallCompleteness(
+      completeDeps({
+        readJson: (p) =>
+          p === "/seal/layer2.json"
+            ? { ok: true, value: { catalyst: { orchestration: {} } } }
+            : { ok: true, value: { projects: [{ team: "W" }] } },
+      }),
+    );
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("plugin-source");
+  });
+
+  test("⛔ an UNREADABLE Layer-2 config is unknown, NOT missing", () => {
+    const r = checkInstallCompleteness(
+      completeDeps({
+        readJson: (p) =>
+          p === "/seal/layer2.json"
+            ? { ok: false, value: null }
+            : { ok: true, value: { projects: [{ team: "W" }] } },
+      }),
+    );
+    // Nothing is actually absent, so this must not accuse the operator of a missing step.
+    expect(r.status).toBe("info");
+    expect(r.detail).toContain("could not be measured");
+    expect(r.detail).not.toContain("INCOMPLETE");
+  });
+
+  test("⛔ a non-macOS host is unknown for orphan-sweep, not missing", () => {
+    const d = completeDeps({ platform: "linux" });
+    d._present.delete("/seal/home/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist");
+    const r = checkInstallCompleteness(d);
+    expect(r.status).toBe("info");
+    expect(r.detail).toContain("not macOS");
+  });
+
+  test("an empty registry is missing — a daemon with no work looks exactly like a broken one", () => {
+    const r = checkInstallCompleteness(
+      completeDeps({
+        readJson: (p) =>
+          p === "/seal/layer2.json"
+            ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/x"] } } } }
+            : { ok: true, value: { projects: [] } },
+      }),
+    );
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("registry");
+    expect(r.detail).toContain("0 project(s)");
+  });
+
+  test("⛔ an unreadable registry that EXISTS is unknown, not empty", () => {
+    const r = checkInstallCompleteness(
+      completeDeps({
+        readJson: (p) =>
+          p === "/seal/layer2.json"
+            ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/x"] } } } }
+            : { ok: false, value: null },
+      }),
+    );
+    expect(r.status).toBe("info");
+    expect(r.detail).toContain("unreadable");
+  });
+
+  test("an ABSENT registry file is missing (distinct from unreadable)", () => {
+    const d = completeDeps();
+    d._present.delete("/seal/home/catalyst/execution-core/registry.json");
+    const r = checkInstallCompleteness(d);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("no registry at");
+  });
+
+  test("CATALYST_BIN_DIR is honoured — a relocated install is not reported as missing", () => {
+    const present = new Set([
+      "/custom/bin/catalyst-stack",
+      "/seal/home/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist",
+      "/seal/home/catalyst/execution-core/registry.json",
+    ]);
+    const r = checkInstallCompleteness(
+      completeDeps({ env: { CATALYST_BIN_DIR: "/custom/bin" }, exists: (p) => present.has(p) }),
+    );
+    expect(r.status).toBe("pass");
+  });
+});

--- a/plugins/dev/scripts/execution-core/install-completeness.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-completeness.test.mjs
@@ -29,7 +29,12 @@ function completeDeps(over = {}) {
     exists: (p) => present.has(p),
     readJson: (p) =>
       p === "/seal/layer2.json"
-        ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/seal/plugin-source/plugins/dev"] } } } }
+        ? {
+            ok: true,
+            value: {
+              catalyst: { orchestration: { pluginDirs: ["/seal/plugin-source/plugins/dev"] } },
+            },
+          }
         : { ok: true, value: { projects: [{ team: "WIDGET" }] } },
     _present: present,
     ...over,
@@ -48,7 +53,7 @@ describe("checkInstallCompleteness", () => {
       completeDeps({
         exists: () => false,
         readJson: () => ({ ok: false, value: null }),
-      }),
+      })
     );
     expect(r.status).not.toBe("fail");
   });
@@ -69,7 +74,7 @@ describe("checkInstallCompleteness", () => {
           p === "/seal/layer2.json"
             ? { ok: true, value: { catalyst: { orchestration: {} } } }
             : { ok: true, value: { projects: [{ team: "W" }] } },
-      }),
+      })
     );
     expect(r.status).toBe("warn");
     expect(r.detail).toContain("plugin-source");
@@ -82,7 +87,7 @@ describe("checkInstallCompleteness", () => {
           p === "/seal/layer2.json"
             ? { ok: false, value: null }
             : { ok: true, value: { projects: [{ team: "W" }] } },
-      }),
+      })
     );
     // Nothing is actually absent, so this must not accuse the operator of a missing step.
     expect(r.status).toBe("info");
@@ -105,7 +110,7 @@ describe("checkInstallCompleteness", () => {
           p === "/seal/layer2.json"
             ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/x"] } } } }
             : { ok: true, value: { projects: [] } },
-      }),
+      })
     );
     expect(r.status).toBe("warn");
     expect(r.detail).toContain("registry");
@@ -119,7 +124,7 @@ describe("checkInstallCompleteness", () => {
           p === "/seal/layer2.json"
             ? { ok: true, value: { catalyst: { orchestration: { pluginDirs: ["/x"] } } } }
             : { ok: false, value: null },
-      }),
+      })
     );
     expect(r.status).toBe("info");
     expect(r.detail).toContain("unreadable");
@@ -140,7 +145,7 @@ describe("checkInstallCompleteness", () => {
       "/seal/home/catalyst/execution-core/registry.json",
     ]);
     const r = checkInstallCompleteness(
-      completeDeps({ env: { CATALYST_BIN_DIR: "/custom/bin" }, exists: (p) => present.has(p) }),
+      completeDeps({ env: { CATALYST_BIN_DIR: "/custom/bin" }, exists: (p) => present.has(p) })
     );
     expect(r.status).toBe("pass");
   });

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -86,15 +86,18 @@ can_open_tty() {
 # (`~/catalyst/plugin-source`), so the bootstrap clone IS the plugin-source checkout
 # and that script then reuses it rather than cloning a second copy.
 CATALYST_SOURCE_DIR_RESOLVED=""
-CATALYST_SOURCE_ORIGIN=""
-CATALYST_SOURCE_REASON=""
+# Which candidate won, and why a resolution failed. Both are read by callers and by
+# __tests__/setup-catalyst-source-resolver.test.sh; exported so the answer is visible
+# to a child process (and to shellcheck, which cannot see the test's use).
+export CATALYST_SOURCE_ORIGIN=""
+export CATALYST_SOURCE_REASON=""
 NO_CLONE_SOURCE=0
 
 # The marker for "this is a Catalyst source tree". Deliberately a directory rather
 # than any single helper: a tree that exists but is missing ONE script must report
 # that specific script as missing (`catalyst_helper_path`), not read as "no tree".
 catalyst_is_source_tree() {
-	[[ -n ${1:-} && -d "$1/plugins/dev/scripts" ]]
+	[[ -n ${1-} && -d "$1/plugins/dev/scripts" ]]
 }
 
 catalyst_source_clone_target() {
@@ -115,7 +118,7 @@ resolve_catalyst_source() {
 	CATALYST_SOURCE_REASON=""
 
 	local candidate script_dir
-	if [[ -n ${CATALYST_SOURCE_DIR:-} ]] && catalyst_is_source_tree "${CATALYST_SOURCE_DIR}"; then
+	if [[ -n ${CATALYST_SOURCE_DIR-} ]] && catalyst_is_source_tree "${CATALYST_SOURCE_DIR}"; then
 		CATALYST_SOURCE_DIR_RESOLVED="$(cd "${CATALYST_SOURCE_DIR}" && pwd)"
 		CATALYST_SOURCE_ORIGIN="env"
 		echo "$CATALYST_SOURCE_DIR_RESOLVED"
@@ -133,7 +136,7 @@ resolve_catalyst_source() {
 		return 0
 	fi
 
-	if catalyst_is_source_tree "${PROJECT_DIR:-}"; then
+	if catalyst_is_source_tree "${PROJECT_DIR-}"; then
 		CATALYST_SOURCE_DIR_RESOLVED="$(cd "${PROJECT_DIR}" && pwd)"
 		CATALYST_SOURCE_ORIGIN="project-dir"
 		echo "$CATALYST_SOURCE_DIR_RESOLVED"
@@ -148,7 +151,7 @@ resolve_catalyst_source() {
 		return 0
 	fi
 
-	if [[ $NO_CLONE_SOURCE -eq 1 || -n ${CATALYST_NO_CLONE_SOURCE:-} ]]; then
+	if [[ $NO_CLONE_SOURCE -eq 1 || -n ${CATALYST_NO_CLONE_SOURCE-} ]]; then
 		CATALYST_SOURCE_REASON="no-source-tree"
 		return 1
 	fi
@@ -281,7 +284,7 @@ USAGE
 # Parse CLI flags. CATALYST_AUTONOMOUS is the project-wide headless signal
 # (same contract as plugins/dev/scripts/check-project-setup.sh).
 parse_args() {
-	if [[ -n ${CATALYST_AUTONOMOUS:-} ]]; then
+	if [[ -n ${CATALYST_AUTONOMOUS-} ]]; then
 		NON_INTERACTIVE=1
 	fi
 	while [[ $# -gt 0 ]]; do
@@ -375,7 +378,7 @@ ask_yes_no() {
 # (or on EOF) echo the default without consuming stdin.
 prompt_value() {
 	local prompt="$1"
-	local default="${2:-}"
+	local default="${2-}"
 	local reply=""
 	if [[ ${NON_INTERACTIVE:-0} -eq 1 ]]; then
 		echo "$prompt [${default}] → ${default} (non-interactive)" >&2
@@ -409,7 +412,7 @@ merge_catalyst_section() {
 # harden_secrets_dir <dir> — mkdir -p then chmod 700. Idempotent.
 harden_secrets_dir() {
 	local dir="$1"
-	[[ -n "$dir" ]] || return 1
+	[[ -n $dir ]] || return 1
 	mkdir -p "$dir" || return 1
 	chmod 700 "$dir"
 }
@@ -419,9 +422,9 @@ ensure_secrets_gitignore() {
 	local dir="$1" gi line
 	gi="${dir}/.gitignore"
 	mkdir -p "$dir" || return 1
-	[[ -f "$gi" ]] || : > "$gi"
+	[[ -f $gi ]] || : >"$gi"
 	for line in 'config*.json' '*.env'; do
-		grep -qxF "$line" "$gi" 2>/dev/null || printf '%s\n' "$line" >> "$gi"
+		grep -qxF "$line" "$gi" 2>/dev/null || printf '%s\n' "$line" >>"$gi"
 	done
 }
 
@@ -429,7 +432,13 @@ ensure_secrets_gitignore() {
 write_secret_file() {
 	local content="$1" path="$2" tmp
 	tmp="$(mktemp)" || return 1
-	( umask 077; printf '%s' "$content" > "$tmp" ) || { rm -f "$tmp"; return 1; }
+	(
+		umask 077
+		printf '%s' "$content" >"$tmp"
+	) || {
+		rm -f "$tmp"
+		return 1
+	}
 	chmod 600 "$tmp"
 	mv "$tmp" "$path"
 }
@@ -729,7 +738,7 @@ setup_execution_core_states() {
 	# script. The Linear workflow-state contract and the `worker-status` label group
 	# were therefore never provisioned, behind a warning that read as informational.
 	local states_script=""
-	if [[ -n ${CLAUDE_PLUGIN_ROOT:-} && -f "${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh" ]]; then
+	if [[ -n ${CLAUDE_PLUGIN_ROOT-} && -f "${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh" ]]; then
 		states_script="${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh"
 	else
 		if catalyst_helper_path setup-execution-core-states.sh >/dev/null; then
@@ -856,7 +865,7 @@ detect_os() {
 # unknown → all three. Fresh Linux machines default to bash, so writing only
 # ~/.zshenv left installed tools invisible in new shells (CTL-844 remediate).
 path_rc_files() {
-	case "${SHELL:-}" in
+	case "${SHELL-}" in
 	*zsh) echo "$HOME/.zshenv" ;;
 	*bash) printf '%s\n' "$HOME/.bashrc" "$HOME/.profile" ;;
 	*) printf '%s\n' "$HOME/.zshenv" "$HOME/.bashrc" "$HOME/.profile" ;;
@@ -1049,7 +1058,7 @@ offer_install_node() {
 	arch=$([[ "$(detect_arch)" == "arm64" ]] && echo "arm64" || echo "x64")
 	version="${CATALYST_NODE_VERSION:-$(curl -fsSL https://nodejs.org/dist/index.json |
 		jq -r '[.[] | select(.lts != false)][0].version')}"
-	[[ -n "$version" && "$version" != "null" ]] || {
+	[[ -n $version && $version != "null" ]] || {
 		print_error "Could not resolve Node LTS version"
 		return 1
 	}
@@ -1138,12 +1147,18 @@ offer_install_gh_cli() {
 	local ver os arch ext dir tmp
 	ver=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest |
 		jq -r '.tag_name' | sed 's/^v//')
-	[[ -n "$ver" && "$ver" != "null" ]] || {
+	[[ -n $ver && $ver != "null" ]] || {
 		print_error "Could not resolve gh version. Manual: https://cli.github.com/"
 		return 1
 	}
-	if [[ "$(uname -s)" == "Darwin" ]]; then os="macOS"; ext="zip"; else os="linux"; ext="tar.gz"; fi
-	if [[ "$ext" == "zip" ]] && ! command -v unzip &>/dev/null; then
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		os="macOS"
+		ext="zip"
+	else
+		os="linux"
+		ext="tar.gz"
+	fi
+	if [[ $ext == "zip" ]] && ! command -v unzip &>/dev/null; then
 		print_error "unzip not found — cannot extract gh archive. Manual: https://cli.github.com/"
 		return 1
 	fi
@@ -1152,7 +1167,7 @@ offer_install_gh_cli() {
 	tmp=$(mktemp -d)
 	if curl -fsSL -o "$tmp/gh.$ext" \
 		"https://github.com/cli/cli/releases/download/v${ver}/${dir}.${ext}"; then
-		if [[ "$ext" == "zip" ]]; then
+		if [[ $ext == "zip" ]]; then
 			unzip -q "$tmp/gh.$ext" -d "$tmp"
 		else
 			tar -xzf "$tmp/gh.$ext" -C "$tmp"
@@ -1603,12 +1618,12 @@ setup_project_config() {
 	# "catalyst"; regenerating the config must not clobber it and fragment the
 	# node's thoughts subtree away from the fleet's.
 	local thoughts_directory="${REPO_NAME}" thoughts_profile="${ORG_NAME}"
-	if [[ -f "$config_file" ]]; then
+	if [[ -f $config_file ]]; then
 		local _existing_dir _existing_prof
 		_existing_dir=$(jq -r '.catalyst.thoughts.directory // empty' "$config_file" 2>/dev/null)
 		_existing_prof=$(jq -r '.catalyst.thoughts.profile // empty' "$config_file" 2>/dev/null)
-		[[ -n "$_existing_dir" ]] && thoughts_directory="$_existing_dir"
-		[[ -n "$_existing_prof" ]] && thoughts_profile="$_existing_prof"
+		[[ -n $_existing_dir ]] && thoughts_directory="$_existing_dir"
+		[[ -n $_existing_prof ]] && thoughts_profile="$_existing_prof"
 	fi
 
 	# Deployment mode (CTL-1622): default single-host, but PRESERVE an existing
@@ -1617,7 +1632,7 @@ setup_project_config() {
 	# single-host. Validation is deferred to the resolver + `catalyst doctor`
 	# (same as ticket prefix), so accept any value here.
 	local deployment_mode="single-host"
-	if [[ -f "$config_file" ]]; then
+	if [[ -f $config_file ]]; then
 		local _existing_mode
 		# Preserve the value whenever the key is PRESENT and NON-NULL — including an
 		# explicit `false`/number/garbage — rather than `// empty` (which jq treats
@@ -1629,7 +1644,7 @@ setup_project_config() {
 		# "null", an unrecognized value that flips doctor to FAIL after regeneration.
 		# Deferred validation (resolver + doctor) is what surfaces a genuinely bad value.
 		_existing_mode=$(jq -r 'if (.catalyst.deployment | objects | has("mode")) and (.catalyst.deployment.mode != null) then (.catalyst.deployment.mode | tostring) else empty end' "$config_file" 2>/dev/null)
-		[[ -n "$_existing_mode" ]] && deployment_mode="$_existing_mode"
+		[[ -n $_existing_mode ]] && deployment_mode="$_existing_mode"
 	fi
 
 	echo ""
@@ -1881,13 +1896,13 @@ setup_cloud_replica() {
 	# CTL-1668: also LOOK UP the token under the configured name, not just the
 	# default — otherwise a host using a custom name has its valid token treated as
 	# absent and provisioning is silently skipped (Codex P2 on #3365).
-	local _tv="${CATALYST_CLOUD_TOKEN_ENV:-}"
+	local _tv="${CATALYST_CLOUD_TOKEN_ENV-}"
 	if [[ -z $_tv ]] && [[ -r "$HOME/.config/catalyst/config.json" ]] && command -v jq >/dev/null 2>&1; then
 		_tv="$(jq -r '.catalyst.cloud.tokenEnv // empty' "$HOME/.config/catalyst/config.json" 2>/dev/null || true)"
 	fi
 	[[ -n $_tv ]] || _tv="CATALYST_CLOUD_TOKEN"
-	local token="${CLOUD_TOKEN:-${!_tv:-}}"
-	local account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT:-}}"
+	local token="${CLOUD_TOKEN:-${!_tv-}}"
+	local account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"
 	[[ -n $token ]] || return 0
 
 	print_header "Provisioning Catalyst Cloud Replica"
@@ -1965,7 +1980,7 @@ setup_cloud_replica() {
 	# precedence the writer resolves with — env override → Layer-2
 	# catalyst.cloud.tokenEnv → default. Writing a fixed name while the writer looks
 	# up a custom one produces the identical silent idle.
-	local token_var="${CATALYST_CLOUD_TOKEN_ENV:-}"
+	local token_var="${CATALYST_CLOUD_TOKEN_ENV-}"
 	if [[ -z $token_var ]]; then
 		local l2_cfg="$HOME/.config/catalyst/config.json"
 		if [[ -r $l2_cfg ]] && command -v jq >/dev/null 2>&1; then
@@ -3026,7 +3041,7 @@ init_session_database() {
 	local db_script=""
 	if [ -f "${PROJECT_DIR}/plugins/dev/scripts/catalyst-db.sh" ]; then
 		db_script="${PROJECT_DIR}/plugins/dev/scripts/catalyst-db.sh"
-	elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-db.sh" ]; then
+	elif [ -n "${CLAUDE_PLUGIN_ROOT-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-db.sh" ]; then
 		db_script="${CLAUDE_PLUGIN_ROOT}/scripts/catalyst-db.sh"
 	fi
 
@@ -3049,23 +3064,24 @@ setup_sweep_config() {
 	# Resolve REPO_ROOT and SCRIPT_DIR for this function. setup-catalyst.sh
 	# sits at the repo root; PROJECT_DIR is set by detect_git_repo() for
 	# interactive runs, but may be empty if sourced in lib-only mode.
+	# CTL-1914: the old script-relative SCRIPT_DIR is gone — helper resolution is
+	# catalyst_helper_path's job now, and keeping a second, private copy of that logic
+	# here is exactly how the silent skip survived four separate call sites.
 	local REPO_ROOT="${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "$PWD")}"
-	local SCRIPT_DIR
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "$PWD")/plugins/dev/scripts"
 	local config_file="${REPO_ROOT}/.catalyst/config.json"
-	[[ -f "$config_file" ]] || return 0
+	[[ -f $config_file ]] || return 0
 	local patch tmp
 	patch='{"idleHours":48,"intervalHours":1,"salvagePush":false,"maxRemovalsPerRun":10}'
 	tmp="${config_file}.tmp.$$"
 	# patch first so user overrides win
-	if jq --argjson p "$patch" '.catalyst.sweep = ($p + (.catalyst.sweep // {}))' "$config_file" > "$tmp" && mv "$tmp" "$config_file"; then
+	if jq --argjson p "$patch" '.catalyst.sweep = ($p + (.catalyst.sweep // {}))' "$config_file" >"$tmp" && mv "$tmp" "$config_file"; then
 		print_success "wrote catalyst.sweep defaults" 2>/dev/null || echo "setup: wrote catalyst.sweep defaults"
 	else
 		rm -f "$tmp"
 		echo "setup: warning: could not write catalyst.sweep defaults" >&2
 	fi
 	local _os="${CATALYST_FORCE_OS:-$(uname -s 2>/dev/null || echo unknown)}"
-	if [[ "$_os" == "Darwin" ]]; then
+	if [[ $_os == "Darwin" ]]; then
 		# CTL-1914: was `${SCRIPT_DIR}/install-orphan-sweep.sh` guarded by `[[ -x ]]`,
 		# which in the documented curl layout is a directory containing only
 		# setup-catalyst.sh — so the sweep scheduler was NEVER installed and nothing
@@ -3181,7 +3197,7 @@ finalize_install() {
 	# ── 4. enrol the project ──
 	# Without a registry entry the daemon dispatches nothing — a running stack that does
 	# literally nothing, which looks identical to a broken one.
-	if [[ -n ${TICKET_PREFIX:-} ]]; then
+	if [[ -n ${TICKET_PREFIX-} ]]; then
 		if [[ -n $core_bin && -x $core_bin ]]; then
 			if "$core_bin" register --team "${TICKET_PREFIX}" >/dev/null 2>&1; then
 				print_success "project enrolled in the execution-core registry (team ${TICKET_PREFIX})"
@@ -3278,7 +3294,7 @@ main() {
 #      function library without running setup even from contexts where the
 #      return-probe would succeed/fail unexpectedly (curl | bash runs from
 #      stdin where BASH_SOURCE is empty, so an env guard is the reliable signal).
-if (return 0 2>/dev/null) || [[ -n ${CATALYST_SETUP_LIB_ONLY:-} ]]; then
+if (return 0 2>/dev/null) || [[ -n ${CATALYST_SETUP_LIB_ONLY-} ]]; then
 	:
 else
 	main "$@"

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -60,6 +60,188 @@ can_open_tty() {
 	(: </dev/tty) 2>/dev/null
 }
 
+#
+# ── CTL-1914 / CTL-1918: ONE resolver for the Catalyst source tree ──
+#
+# Four separate steps below need a helper script that lives in `plugins/dev/scripts`
+# of a Catalyst checkout: the orphan-sweep launchd installer, the Linear state
+# contract, `setup-plugin-source.sh`, and `install-cli.sh`. Each used to resolve it
+# relative to THIS script's own directory — which, in the install path every
+# user-facing doc gives (`curl -O … && ./setup-catalyst.sh`), contains nothing but
+# setup-catalyst.sh. So each degraded to a silent skip, and the documented install
+# produced a materially more-broken machine than a repo clone.
+#
+# ⛔ The resolution is CENTRAL rather than per-call-site on purpose: four copies of a
+# lookup are four chances for the next one to skip silently, and the reason the
+# original defect survived is that each site failed in its own private way.
+#
+# Resolution order (first usable tree wins):
+#   1. $CATALYST_SOURCE_DIR / --source-dir   — an operator override
+#   2. next to this script                   — the repo-clone layout
+#   3. $PROJECT_DIR                          — setup was run inside a Catalyst checkout
+#   4. the plugin-source checkout            — what the daemons already run from
+#   5. clone one                             — the documented-curl bootstrap
+#
+# Step 5 clones to the SAME default path `setup-plugin-source.sh` uses
+# (`~/catalyst/plugin-source`), so the bootstrap clone IS the plugin-source checkout
+# and that script then reuses it rather than cloning a second copy.
+CATALYST_SOURCE_DIR_RESOLVED=""
+CATALYST_SOURCE_ORIGIN=""
+CATALYST_SOURCE_REASON=""
+NO_CLONE_SOURCE=0
+
+# The marker for "this is a Catalyst source tree". Deliberately a directory rather
+# than any single helper: a tree that exists but is missing ONE script must report
+# that specific script as missing (`catalyst_helper_path`), not read as "no tree".
+catalyst_is_source_tree() {
+	[[ -n ${1:-} && -d "$1/plugins/dev/scripts" ]]
+}
+
+catalyst_source_clone_target() {
+	echo "${CATALYST_PLUGIN_SOURCE:-${HOME}/catalyst/plugin-source}"
+}
+
+# resolve_catalyst_source — echo a usable source tree, or fail with a NAMED reason.
+#
+# ⛔ Never echoes a path it has not just validated, and never returns 0 without one.
+# "Could not look" and "there is nothing to find" are both failures here, but they are
+# DIFFERENT failures and the caller gets to see which: an empty clone that exits 0 is
+# the exact success-that-installed-nothing shape this whole ticket is about.
+resolve_catalyst_source() {
+	if [[ -n $CATALYST_SOURCE_DIR_RESOLVED ]]; then
+		echo "$CATALYST_SOURCE_DIR_RESOLVED"
+		return 0
+	fi
+	CATALYST_SOURCE_REASON=""
+
+	local candidate script_dir
+	if [[ -n ${CATALYST_SOURCE_DIR:-} ]] && catalyst_is_source_tree "${CATALYST_SOURCE_DIR}"; then
+		CATALYST_SOURCE_DIR_RESOLVED="$(cd "${CATALYST_SOURCE_DIR}" && pwd)"
+		CATALYST_SOURCE_ORIGIN="env"
+		echo "$CATALYST_SOURCE_DIR_RESOLVED"
+		return 0
+	fi
+
+	# `BASH_SOURCE[0]` is empty under `curl … | bash` (the script arrives on stdin), so
+	# this candidate simply does not apply there — which is correct, not a bug to work
+	# around: there is genuinely no adjacent tree in that layout.
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || script_dir=""
+	if catalyst_is_source_tree "$script_dir"; then
+		CATALYST_SOURCE_DIR_RESOLVED="$script_dir"
+		CATALYST_SOURCE_ORIGIN="script-dir"
+		echo "$CATALYST_SOURCE_DIR_RESOLVED"
+		return 0
+	fi
+
+	if catalyst_is_source_tree "${PROJECT_DIR:-}"; then
+		CATALYST_SOURCE_DIR_RESOLVED="$(cd "${PROJECT_DIR}" && pwd)"
+		CATALYST_SOURCE_ORIGIN="project-dir"
+		echo "$CATALYST_SOURCE_DIR_RESOLVED"
+		return 0
+	fi
+
+	candidate="$(catalyst_source_clone_target)"
+	if catalyst_is_source_tree "$candidate"; then
+		CATALYST_SOURCE_DIR_RESOLVED="$(cd "$candidate" && pwd)"
+		CATALYST_SOURCE_ORIGIN="plugin-source"
+		echo "$CATALYST_SOURCE_DIR_RESOLVED"
+		return 0
+	fi
+
+	if [[ $NO_CLONE_SOURCE -eq 1 || -n ${CATALYST_NO_CLONE_SOURCE:-} ]]; then
+		CATALYST_SOURCE_REASON="no-source-tree"
+		return 1
+	fi
+
+	# ── the bootstrap clone ──
+	# Same shape as setup-plugin-source.sh's own clone (main, single-branch) so the
+	# tree it later reuses is the tree it would have made. NOT --depth 1: the fleet's
+	# updater and `git merge-base --is-ancestor` checks need real history.
+	echo "" >&2
+	echo "📦 No Catalyst source tree found — cloning one to $(catalyst_source_clone_target)" >&2
+	mkdir -p "$(dirname "$(catalyst_source_clone_target)")" 2>/dev/null || true
+	if ! GIT_TERMINAL_PROMPT=0 git clone --branch main --single-branch \
+		"${CATALYST_SOURCE_REPO:-https://github.com/coalesce-labs/catalyst.git}" \
+		"$(catalyst_source_clone_target)" >/dev/null 2>&1; then
+		CATALYST_SOURCE_REASON="clone-failed"
+		return 1
+	fi
+	# ⛔ Validate the RESULT, not the exit code. A clone that exits 0 having produced
+	# nothing usable is precisely the failure mode this ticket exists to remove, and
+	# trusting rc=0 here would rebuild it one layer up.
+	candidate="$(catalyst_source_clone_target)"
+	if ! catalyst_is_source_tree "$candidate"; then
+		CATALYST_SOURCE_REASON="clone-produced-no-tree"
+		return 1
+	fi
+	CATALYST_SOURCE_DIR_RESOLVED="$(cd "$candidate" && pwd)"
+	CATALYST_SOURCE_ORIGIN="cloned"
+	echo "$CATALYST_SOURCE_DIR_RESOLVED"
+	return 0
+}
+
+# catalyst_helper_path <relative-path-under-plugins/dev/scripts>
+#
+# Echo the absolute path to a helper script, or fail. Sets CATALYST_SOURCE_REASON to
+# `missing-helper:<name>` when the tree resolved but this particular script is absent —
+# a different fact from "no tree", and one a caller must be able to report distinctly.
+#
+# ⛔ The resolver is invoked DIRECTLY, never as `$(resolve_catalyst_source)`. Command
+# substitution runs in a subshell, so every global the resolver sets — including
+# CATALYST_SOURCE_REASON, which is the entire point of failing with a NAMED reason —
+# is discarded when the subshell exits, and the caller's deferral prints an empty
+# "()" where the diagnosis should be. That is this ticket's own defect one level down:
+# a failure that still reports, but reports nothing usable. Callers read
+# CATALYST_HELPER_PATH rather than capturing stdout, for the same reason.
+CATALYST_HELPER_PATH=""
+catalyst_helper_path() {
+	local rel="$1"
+	CATALYST_HELPER_PATH=""
+	resolve_catalyst_source >/dev/null || return 1
+	if [[ ! -f "${CATALYST_SOURCE_DIR_RESOLVED}/plugins/dev/scripts/${rel}" ]]; then
+		CATALYST_SOURCE_REASON="missing-helper:${rel}"
+		return 1
+	fi
+	CATALYST_HELPER_PATH="${CATALYST_SOURCE_DIR_RESOLVED}/plugins/dev/scripts/${rel}"
+	echo "$CATALYST_HELPER_PATH"
+}
+
+#
+# ── CTL-1918: the deferred-step ledger ──
+#
+# Setup used to end by PRINTING instructions for steps it could have performed, so
+# "install finished" and "the system works" were different states with nothing
+# enforcing the gap was closed. Every step now either RUNS or is recorded here — and a
+# recorded step carries both the command that completes it AND the command that
+# verifies it later, so a deferral is checkable rather than advisory.
+CATALYST_DEFERRED_STEPS=()
+
+catalyst_defer_step() {
+	# title <TAB> complete-command <TAB> verify-command
+	CATALYST_DEFERRED_STEPS+=("${1}"$'\t'"${2}"$'\t'"${3}")
+}
+
+print_deferred_steps() {
+	local n=${#CATALYST_DEFERRED_STEPS[@]}
+	if [[ $n -eq 0 ]]; then
+		# Stated positively: an empty section and a section that was never reached read
+		# identically, and only one of them means the install is complete.
+		echo "✅ No steps were deferred — this node was fully provisioned."
+		return 0
+	fi
+	echo ""
+	echo "⚠️  ${n} step(s) were DEFERRED. This node is not fully provisioned until they are done:"
+	local entry title complete verify
+	for entry in "${CATALYST_DEFERRED_STEPS[@]}"; do
+		IFS=$'\t' read -r title complete verify <<<"$entry"
+		echo ""
+		echo "  • ${title}"
+		echo "      run:    ${complete}"
+		echo "      verify: ${verify}"
+	done
+	echo ""
+}
+
 print_usage() {
 	cat <<'USAGE'
 Usage: setup-catalyst.sh [--non-interactive|--defaults]
@@ -74,7 +256,25 @@ Usage: setup-catalyst.sh [--non-interactive|--defaults]
                             deliberately NO default here — see below.
                             Env: CATALYST_CLOUD_ACCOUNT
 
+  --source-dir <path>       Use an existing Catalyst checkout for the helper scripts
+                            setup needs (orphan-sweep installer, Linear state contract,
+                            plugin-source, CLI installer).
+                            Env: CATALYST_SOURCE_DIR
+  --no-clone-source         Never clone a Catalyst checkout. Any step that needs one is
+                            DEFERRED with the command to complete and verify it, rather
+                            than skipped.
+                            Env: CATALYST_NO_CLONE_SOURCE=1
+
 Omit the cloud flags and setup behaves exactly as it always has.
+
+Headless install (SSH-only / CI hosts), one command and one key:
+
+  curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
+    | bash -s -- --non-interactive \
+        --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
+
+  `-s --` is required for the piped form: without it the flags are consumed by bash
+  itself, not by this script, and the install silently runs interactive.
 USAGE
 }
 
@@ -108,6 +308,20 @@ parse_args() {
 			}
 			CLOUD_ACCOUNT="$2"
 			shift 2
+			;;
+		# CTL-1914: where setup finds the helper scripts it needs. Absent → the
+		# resolver's own ordered search, ending in a bootstrap clone.
+		--source-dir)
+			[[ $# -ge 2 ]] || {
+				print_error "--source-dir requires a value"
+				exit 1
+			}
+			CATALYST_SOURCE_DIR="$2"
+			shift 2
+			;;
+		--no-clone-source)
+			NO_CLONE_SOURCE=1
+			shift
 			;;
 		-h | --help)
 			print_usage
@@ -509,15 +723,27 @@ setup_execution_core_states() {
 	# states + registry entry. The stateMap write is idempotent (the states
 	# script preserves a template-default or user-customised map).
 
-	# Locate the standalone script — installed plugin root or the repo checkout.
+	# Locate the standalone script — installed plugin root, else the central resolver.
+	# CTL-1914: the second branch was the RELATIVE path `plugins/dev/scripts/…`, i.e.
+	# resolved against CWD, which for the documented curl install holds only the setup
+	# script. The Linear workflow-state contract and the `worker-status` label group
+	# were therefore never provisioned, behind a warning that read as informational.
 	local states_script=""
 	if [[ -n ${CLAUDE_PLUGIN_ROOT:-} && -f "${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh" ]]; then
 		states_script="${CLAUDE_PLUGIN_ROOT}/scripts/setup-execution-core-states.sh"
-	elif [[ -f "plugins/dev/scripts/setup-execution-core-states.sh" ]]; then
-		states_script="plugins/dev/scripts/setup-execution-core-states.sh"
+	else
+		if catalyst_helper_path setup-execution-core-states.sh >/dev/null; then
+			states_script="$CATALYST_HELPER_PATH"
+		else
+			states_script=""
+		fi
 	fi
 	if [[ -z $states_script ]]; then
-		print_warning "execution-core repo, but setup-execution-core-states.sh not found — skipping state contract"
+		print_warning "Linear state contract NOT provisioned (${CATALYST_SOURCE_REASON})"
+		catalyst_defer_step \
+			"Provision the Linear workflow-state contract and worker-status labels (${CATALYST_SOURCE_REASON})" \
+			"git clone https://github.com/coalesce-labs/catalyst.git ~/catalyst/plugin-source && bash ~/catalyst/plugin-source/plugins/dev/scripts/setup-execution-core-states.sh --config ${config_file}" \
+			"catalyst doctor"
 		return 0
 	fi
 
@@ -1792,22 +2018,11 @@ setup_cloud_replica() {
 		print_warning "catalyst-stack not on PATH — run 'catalyst-stack adopt-cloud-sync' after installing the stack"
 	fi
 
-	# A populated replica that nothing reads is the failure this step exists to
-	# avoid: reads are opt-in (CATALYST_LINEAR_REPLICA=on) and off by default.
-	print_warning "Replica READS are opt-in. Add to your shell env and restart execution-core:"
-	echo "    export CATALYST_LINEAR_REPLICA=on"
-
-	# Without a registry entry the daemon dispatches nothing — a running stack that
-	# does literally nothing, which looks identical to a broken one.
-	if [[ -n ${TICKET_PREFIX:-} ]]; then
-		echo ""
-		echo "  Enroll this project so the daemon has work to find:"
-		echo "    catalyst-execution-core register --team ${TICKET_PREFIX}"
-	else
-		echo ""
-		echo "  Enroll this project so the daemon has work to find:"
-		echo "    catalyst-execution-core register --team <TEAM_KEY>"
-	fi
+	# CTL-1918: replica READS and registry enrolment used to be PRINTED here as
+	# advisory text — a populated replica that nothing reads, and a daemon with no
+	# work to find, both looking identical to a healthy install. finalize_install now
+	# performs both (and defers them with a verify command if it cannot), so printing
+	# them here would tell an operator to redo work that is already done.
 
 	return 0
 }
@@ -2688,37 +2903,20 @@ print_summary() {
 	print_header "Next Steps"
 	echo ""
 
-	# Resolve setup-plugin-source.sh next to THIS script. Via the `curl … | bash`
-	# flow (or when run from a non-catalyst target repo) BASH_SOURCE is empty/stdin
-	# and no such script exists locally, so print a runnable clone+run command
-	# instead of a relative path that would fail.
-	local _pss_dir _pss_script
-	_pss_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)" || _pss_dir=""
-	_pss_script="${_pss_dir}/plugins/dev/scripts/setup-plugin-source.sh"
+	# CTL-1918: this used to be "1. Provision plugin-source …" — an instruction whose
+	# own fallback branch told the reader to clone the repo, which is exactly the work
+	# resolve_catalyst_source now does. finalize_install performs it; what remains is
+	# whatever genuinely could not be done, stated with its verify command.
+	print_deferred_steps
 
-	echo "1. Provision plugin-source (live plugin loading — NOT the marketplace cache,"
-	echo "   which lags releases and drifts per node):"
-	if [ -n "$_pss_dir" ] && [ -f "$_pss_script" ]; then
-		echo "   bash ${_pss_script}"
-	else
-		echo "   # Run from a catalyst checkout (this setup script was not run from one):"
-		echo "   git clone https://github.com/coalesce-labs/catalyst.git ~/catalyst-src \\"
-		echo "     && bash ~/catalyst-src/plugins/dev/scripts/setup-plugin-source.sh"
-	fi
-	echo "   → sets the pluginDirs machine-config key (workers load plugin-source via"
-	echo "     phase-agent-dispatch --plugin-dir) AND installs the interactive \`claude\`"
-	echo "     --plugin-dir wrapper in your shell rc (~/.zshrc or ~/.bashrc). Open a new"
-	echo "     shell to pick it up."
+	echo "1. Restart Claude Code to load configuration"
 	echo ""
 
-	echo "2. Restart Claude Code to load configuration"
-	echo ""
-
-	echo "3. Try your first workflow command:"
+	echo "2. Try your first workflow command:"
 	echo "   /research-codebase"
 	echo ""
 
-	echo "4. Create a worktree for parallel work:"
+	echo "3. Create a worktree for parallel work:"
 	echo "   /create-worktree PROJ-123 main"
 	echo ""
 
@@ -2868,12 +3066,142 @@ setup_sweep_config() {
 	fi
 	local _os="${CATALYST_FORCE_OS:-$(uname -s 2>/dev/null || echo unknown)}"
 	if [[ "$_os" == "Darwin" ]]; then
-		local installer="${SCRIPT_DIR}/install-orphan-sweep.sh"
-		if [[ -x "$installer" ]]; then
-			"$installer" >/dev/null 2>&1 || echo "setup: warning: launchd installer failed (non-fatal)" >&2
+		# CTL-1914: was `${SCRIPT_DIR}/install-orphan-sweep.sh` guarded by `[[ -x ]]`,
+		# which in the documented curl layout is a directory containing only
+		# setup-catalyst.sh — so the sweep scheduler was NEVER installed and nothing
+		# said so. Resolve centrally, and when it cannot be resolved, DEFER LOUDLY.
+		local installer
+		if catalyst_helper_path install-orphan-sweep.sh >/dev/null; then
+			installer="$CATALYST_HELPER_PATH"
+			if "$installer" >/dev/null 2>&1; then
+				print_success "orphan-sweep scheduler installed" 2>/dev/null || true
+			else
+				print_warning "orphan-sweep launchd installer failed" 2>/dev/null || true
+				catalyst_defer_step \
+					"Install the orphan-sweep scheduler (its installer ran but failed)" \
+					"bash ${installer}" \
+					"launchctl list | grep catalyst.orphan-sweep"
+			fi
+		else
+			print_warning "orphan-sweep scheduler NOT installed (${CATALYST_SOURCE_REASON})" 2>/dev/null || true
+			catalyst_defer_step \
+				"Install the orphan-sweep scheduler (no Catalyst source tree: ${CATALYST_SOURCE_REASON})" \
+				"git clone https://github.com/coalesce-labs/catalyst.git ~/catalyst/plugin-source && bash ~/catalyst/plugin-source/plugins/dev/scripts/install-orphan-sweep.sh" \
+				"launchctl list | grep catalyst.orphan-sweep"
 		fi
 	else
 		echo "setup: note: Linux scheduling is a follow-up (CTL-1030). Config written." >&2
+	fi
+}
+
+#
+# ── CTL-1918: finish the install instead of printing a list of hand-steps ──
+#
+# Setup used to end by printing three instructions it was perfectly able to perform,
+# so "setup completed successfully" and "this node works" were different states with
+# nothing enforcing the gap was closed. Each step below RUNS; a step that cannot run
+# is recorded in the deferred ledger with the command that completes it AND the
+# command that verifies it, so what is left is checkable rather than advisory.
+#
+# ⛔ Ordering is load-bearing: install-cli.sh is what puts `catalyst-stack` and
+# `catalyst-execution-core` on PATH, and the two steps after it are those binaries.
+# Running them first would produce two "command not found" deferrals on a node where
+# nothing was actually wrong.
+finalize_install() {
+	echo ""
+	print_header "Finishing the install"
+
+	local bin_dir="${CATALYST_BIN_DIR:-${HOME}/.catalyst/bin}"
+	local cli_script stack_bin core_bin pss
+
+	# ── 1. the CLIs on PATH ──
+	# README's "Quick Setup" never runs this, so a README-only reader reaches
+	# `command not found: catalyst-stack` at the last step of a "5 minute" install.
+	if catalyst_helper_path install-cli.sh >/dev/null; then
+		cli_script="$CATALYST_HELPER_PATH"
+		if bash "$cli_script" >/dev/null 2>&1; then
+			print_success "Catalyst CLIs installed to ${bin_dir}"
+		else
+			print_warning "install-cli.sh failed"
+			catalyst_defer_step "Put the Catalyst CLIs on PATH" \
+				"bash ${cli_script}" "command -v catalyst-stack"
+		fi
+	else
+		print_warning "Catalyst CLIs NOT installed (${CATALYST_SOURCE_REASON})"
+		catalyst_defer_step "Put the Catalyst CLIs on PATH (${CATALYST_SOURCE_REASON})" \
+			"bash <catalyst-checkout>/plugins/dev/scripts/install-cli.sh" "command -v catalyst-stack"
+	fi
+
+	# The freshly-installed symlinks are not on this process's PATH yet, and the steps
+	# below are those binaries. Resolve them by absolute path rather than hoping.
+	stack_bin="${bin_dir}/catalyst-stack"
+	core_bin="${bin_dir}/catalyst-execution-core"
+	[[ -x $stack_bin ]] || stack_bin="$(command -v catalyst-stack 2>/dev/null || echo "")"
+	[[ -x $core_bin ]] || core_bin="$(command -v catalyst-execution-core 2>/dev/null || echo "")"
+
+	# ── 2. plugin-source (live plugin loading) ──
+	# Was "Next Steps" item 1 — a printed instruction whose own fallback branch told the
+	# reader to clone the repo, i.e. the work the resolver above has already done.
+	if catalyst_helper_path setup-plugin-source.sh >/dev/null; then
+		pss="$CATALYST_HELPER_PATH"
+		local pss_args=()
+		[[ $NON_INTERACTIVE -eq 1 ]] && pss_args+=(--no-interactive-wrapper)
+		if bash "$pss" "${pss_args[@]+"${pss_args[@]}"}" >/dev/null 2>&1; then
+			print_success "plugin-source provisioned (pluginDirs registered)"
+		else
+			print_warning "setup-plugin-source.sh failed"
+			catalyst_defer_step "Provision plugin-source (live plugin loading)" \
+				"bash ${pss}" "catalyst doctor"
+		fi
+	else
+		catalyst_defer_step "Provision plugin-source (${CATALYST_SOURCE_REASON})" \
+			"bash <catalyst-checkout>/plugins/dev/scripts/setup-plugin-source.sh" "catalyst doctor"
+	fi
+
+	# ── 3. replica reads ──
+	# Only meaningful when a replica was actually provisioned; `activate-replica` gates
+	# itself on `verify-cloud-sync --json` reporting ok, so a broken replica is REFUSED
+	# here rather than switched on — which is the behaviour we want, and is why this
+	# calls the existing verb instead of writing the config key directly.
+	if [[ -n $CLOUD_TOKEN ]]; then
+		if [[ -n $stack_bin && -x $stack_bin ]]; then
+			if "$stack_bin" activate-replica >/dev/null 2>&1; then
+				print_success "replica reads activated (catalyst.linearReplica.mode = on)"
+			else
+				print_warning "activate-replica declined — the replica is not verifiably healthy yet"
+				catalyst_defer_step "Turn on replica READS once the replica verifies healthy" \
+					"catalyst-stack activate-replica" "catalyst-stack verify-cloud-sync --json"
+			fi
+		else
+			catalyst_defer_step "Turn on replica READS (catalyst-stack not on PATH)" \
+				"catalyst-stack activate-replica" "catalyst-stack verify-cloud-sync --json"
+		fi
+	fi
+
+	# ── 4. enrol the project ──
+	# Without a registry entry the daemon dispatches nothing — a running stack that does
+	# literally nothing, which looks identical to a broken one.
+	if [[ -n ${TICKET_PREFIX:-} ]]; then
+		if [[ -n $core_bin && -x $core_bin ]]; then
+			if "$core_bin" register --team "${TICKET_PREFIX}" >/dev/null 2>&1; then
+				print_success "project enrolled in the execution-core registry (team ${TICKET_PREFIX})"
+			else
+				print_warning "registry enrolment failed for team ${TICKET_PREFIX}"
+				catalyst_defer_step "Enrol this project so the daemon has work to find" \
+					"catalyst-execution-core register --team ${TICKET_PREFIX}" \
+					"catalyst-execution-core list-projects"
+			fi
+		else
+			catalyst_defer_step "Enrol this project so the daemon has work to find" \
+				"catalyst-execution-core register --team ${TICKET_PREFIX}" \
+				"catalyst-execution-core list-projects"
+		fi
+	else
+		# No team key discovered — the command cannot be spelled for the operator, so say
+		# exactly that rather than emitting a placeholder they must decode.
+		catalyst_defer_step "Enrol this project (no Linear team key was discovered during setup)" \
+			"catalyst-execution-core register --team <TEAM_KEY>" \
+			"catalyst-execution-core list-projects"
 	fi
 }
 
@@ -2921,6 +3249,9 @@ main() {
 	setup_sweep_config
 	init_humanlayer_thoughts
 	sync_thoughts
+	# CTL-1918: perform the steps setup used to print. Runs last so every input it
+	# needs (team key, cloud token, config) has been established.
+	finalize_install
 
 	# Validate
 	if validate_setup; then
@@ -2928,6 +3259,11 @@ main() {
 		exit 0
 	else
 		echo ""
+		# ⛔ The deferred ledger prints on BOTH paths. It lived only in print_summary,
+		# i.e. only on the success path — so an operator whose install FAILED, who is
+		# precisely the one who needs to know which provisioning steps did not happen,
+		# was the one person who never saw the list.
+		print_deferred_steps
 		print_error "Setup completed with errors. Please review and re-run if needed."
 		exit 1
 	fi

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -758,7 +758,21 @@ setup_execution_core_states() {
 
 	echo ""
 	echo "🔗 Ensuring execution-core Linear-state contract..."
-	bash "$states_script" --config "$config_file" || true
+	# ⛔ Codex #3500 P1: this was `|| true`, which swallowed a nonzero exit — Linear
+	# refusing to create a state, registry setup failing — with no deferral. The new
+	# ledger would then print its all-clear on a node whose state contract never landed,
+	# which is a worse failure than the silent skip this PR removed: it is a silent skip
+	# with a green receipt attached. The `|| true` stays (a failed contract must not
+	# abort setup), but the status is now CAPTURED and recorded.
+	local states_rc=0
+	bash "$states_script" --config "$config_file" || states_rc=$?
+	if [[ $states_rc -ne 0 ]]; then
+		print_warning "Linear state contract did NOT land (setup-execution-core-states.sh exited ${states_rc})"
+		catalyst_defer_step \
+			"Provision the Linear workflow-state contract (its installer ran and exited ${states_rc})" \
+			"bash ${states_script} --config ${config_file}" \
+			"catalyst doctor"
+	fi
 }
 
 # Discover existing Sentry auth token
@@ -1890,19 +1904,36 @@ validate_cloud_token() {
 	esac
 }
 
-setup_cloud_replica() {
-	# Flags win over env. Absent → this whole function is a no-op and setup is
-	# byte-identical to before CTL-1836.
-	# CTL-1668: also LOOK UP the token under the configured name, not just the
-	# default — otherwise a host using a custom name has its valid token treated as
-	# absent and provisioning is silently skipped (Codex P2 on #3365).
+# resolve_cloud_token — the ONE answer to "did this run get a cloud token".
+#
+# ⛔ Codex #3500 P1: this resolution used to live only inside setup_cloud_replica, as a
+# `local`. So a token supplied through the DOCUMENTED env var (or a custom name via
+# CATALYST_CLOUD_TOKEN_ENV) provisioned the writer while the global CLOUD_TOKEN stayed
+# empty — and finalize_install, which gated on that global, skipped `activate-replica`
+# AND recorded no deferral. Setup could report a fully provisioned node with replica
+# reads off: the exact "install finished ≠ system works" gap CTL-1918 exists to close,
+# reintroduced by the fix for it. Flags win over env; the configured name wins over the
+# default (CTL-1668).
+resolve_cloud_token() {
 	local _tv="${CATALYST_CLOUD_TOKEN_ENV-}"
 	if [[ -z $_tv ]] && [[ -r "$HOME/.config/catalyst/config.json" ]] && command -v jq >/dev/null 2>&1; then
 		_tv="$(jq -r '.catalyst.cloud.tokenEnv // empty' "$HOME/.config/catalyst/config.json" 2>/dev/null || true)"
 	fi
 	[[ -n $_tv ]] || _tv="CATALYST_CLOUD_TOKEN"
-	local token="${CLOUD_TOKEN:-${!_tv-}}"
-	local account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"
+	printf '%s' "${CLOUD_TOKEN:-${!_tv-}}"
+}
+
+# Set only when the replica was actually provisioned. finalize_install keys activation
+# on the OUTCOME, not on a re-derived precondition — activating reads against a replica
+# that was never provisioned is meaningless, and re-deriving is how the two drifted.
+CLOUD_REPLICA_PROVISIONED=0
+
+setup_cloud_replica() {
+	# Flags win over env. Absent → this whole function is a no-op and setup is
+	# byte-identical to before CTL-1836.
+	local token account
+	token="$(resolve_cloud_token)"
+	account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"
 	[[ -n $token ]] || return 0
 
 	print_header "Provisioning Catalyst Cloud Replica"
@@ -2039,6 +2070,11 @@ setup_cloud_replica() {
 	# performs both (and defers them with a verify command if it cannot), so printing
 	# them here would tell an operator to redo work that is already done.
 
+	# Reaching here means the writer env was written and the account was accepted, so
+	# there IS a replica for reads to be turned on against. Set at the single success
+	# exit rather than at the top: a function that announces provisioning before doing
+	# it hands finalize_install a precondition that was never met.
+	CLOUD_REPLICA_PROVISIONED=1
 	return 0
 }
 
@@ -3160,9 +3196,15 @@ finalize_install() {
 	# reader to clone the repo, i.e. the work the resolver above has already done.
 	if catalyst_helper_path setup-plugin-source.sh >/dev/null; then
 		pss="$CATALYST_HELPER_PATH"
-		local pss_args=()
-		[[ $NON_INTERACTIVE -eq 1 ]] && pss_args+=(--no-interactive-wrapper)
-		if bash "$pss" "${pss_args[@]+"${pss_args[@]}"}" >/dev/null 2>&1; then
+		# ⛔ Codex #3500 P1: this used to pass --no-interactive-wrapper whenever prompts
+		# were suppressed. That flag is NOT "the quiet variant" — its own header reserves
+		# it for the install-lifecycle acquire/pre-backup step, and it SKIPS the
+		# marketplace and shell-wrapper retirement. The result is skills links plus the
+		# two legacy load paths still live, which checkSkillsDirPlugins treats as
+		# precedence-blocking / double-loading, while setup reports plugin-source as
+		# provisioned. Prompt suppression is not a request for a partial workflow, so a
+		# headless install runs the SAME full cutover an interactive one does.
+		if bash "$pss" >/dev/null 2>&1; then
 			print_success "plugin-source provisioned (pluginDirs registered)"
 		else
 			print_warning "setup-plugin-source.sh failed"
@@ -3179,7 +3221,12 @@ finalize_install() {
 	# itself on `verify-cloud-sync --json` reporting ok, so a broken replica is REFUSED
 	# here rather than switched on — which is the behaviour we want, and is why this
 	# calls the existing verb instead of writing the config key directly.
-	if [[ -n $CLOUD_TOKEN ]]; then
+	if [[ -n "$(resolve_cloud_token)" ]] && [[ $CLOUD_REPLICA_PROVISIONED -eq 0 ]]; then
+		# A token was supplied but the replica never provisioned. Activating reads would
+		# be meaningless; saying nothing would let the all-clear stand.
+		catalyst_defer_step "Turn on replica READS (the replica was not provisioned this run)" \
+			"catalyst-stack activate-replica" "catalyst-stack verify-cloud-sync --json"
+	elif [[ $CLOUD_REPLICA_PROVISIONED -eq 1 ]]; then
 		if [[ -n $stack_bin && -x $stack_bin ]]; then
 			if "$stack_bin" activate-replica >/dev/null 2>&1; then
 				print_success "replica reads activated (catalyst.linearReplica.mode = on)"

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -13,7 +13,9 @@ Get Catalyst installed and running in about five minutes.
 - **Claude Code** — [install it](https://docs.anthropic.com/en/docs/claude-code) before you start.
 - **Git** — needed to detect your repo and run the thoughts system.
 
-The setup script installs the rest for you: `jq`, `sqlite3`, the HumanLayer CLI, and Bun (the runtime behind the dashboard and broker). It also offers to set up optional tools — the GitHub CLI (`gh`), the Linearis CLI, `agent-browser`, and `direnv`.
+The setup script installs the rest for you: `jq`, `sqlite3`, the HumanLayer CLI, and Bun (the
+runtime behind the dashboard and broker). It also offers to set up optional tools — the GitHub CLI
+(`gh`), the Linearis CLI, `agent-browser`, and `direnv`.
 
 ## 1. Run the setup script
 
@@ -23,7 +25,8 @@ chmod +x setup-catalyst.sh
 ./setup-catalyst.sh
 ```
 
-It checks your platform, installs the prerequisites, creates your project config, sets up a shared thoughts repository, and asks for any API tokens (like Linear).
+It checks your platform, installs the prerequisites, creates your project config, sets up a shared
+thoughts repository, and asks for any API tokens (like Linear).
 
 ### On a headless or SSH-only host
 
@@ -35,18 +38,18 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
       --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
 ```
 
-`-s --` is required: without it `bash` consumes the flags instead of passing them to the
-script, and the install runs interactive on a host with no terminal to be interactive with.
+`-s --` is required: without it `bash` consumes the flags instead of passing them to the script, and
+the install runs interactive on a host with no terminal to be interactive with.
 `CATALYST_AUTONOMOUS=1` is equivalent to `--non-interactive` if you prefer an env var.
 
 ### What to have ready
 
-| What | How to supply it | Notes |
-| ---- | ---------------- | ----- |
-| Catalyst Cloud token | `--cloud-token` or `CATALYST_CLOUD_TOKEN` | Validated with one authenticated call before anything is written. A bad token fails the install loudly rather than leaving green checkmarks over a broken system. |
-| Catalyst Cloud account | `--cloud-account` or `CATALYST_CLOUD_ACCOUNT` | Required whenever a token is supplied — there is deliberately no default. |
-| Linear API token | `LINEAR_API_TOKEN`, or a `~/.linear_api_token` file | Must be a **personal** API key, beginning `lin_api_`. An OAuth token (`lin_oauth_…`) is rejected. |
-| Sentry, PostHog, Exa | Prompted, or their usual env vars | All optional. |
+| What                   | How to supply it                                    | Notes                                                                                                                                                             |
+| ---------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Catalyst Cloud token   | `--cloud-token` or `CATALYST_CLOUD_TOKEN`           | Validated with one authenticated call before anything is written. A bad token fails the install loudly rather than leaving green checkmarks over a broken system. |
+| Catalyst Cloud account | `--cloud-account` or `CATALYST_CLOUD_ACCOUNT`       | Required whenever a token is supplied — there is deliberately no default.                                                                                         |
+| Linear API token       | `LINEAR_API_TOKEN`, or a `~/.linear_api_token` file | Must be a **personal** API key, beginning `lin_api_`. An OAuth token (`lin_oauth_…`) is rejected.                                                                 |
+| Sentry, PostHog, Exa   | Prompted, or their usual env vars                   | All optional.                                                                                                                                                     |
 
 Both cloud flags are optional. Omit them and setup behaves exactly as it did before they existed.
 
@@ -70,11 +73,12 @@ claude plugin install catalyst-dev@catalyst
 
 ## 3. Install the command-line tools
 
-Several Catalyst features call shell tools by name (`catalyst-monitor`, `catalyst-hud`, `catalyst-events`, and more — see the full [CLI command reference](/reference/catalyst-cli/)).
+Several Catalyst features call shell tools by name (`catalyst-monitor`, `catalyst-hud`,
+`catalyst-events`, and more — see the full [CLI command reference](/reference/catalyst-cli/)).
 
-**Setup already installed these.** Its last act is to put the `catalyst-*` commands on your
-PATH, provision `plugin-source`, turn on replica reads, and enrol the project. If the run
-ended with "No steps were deferred", skip to the check below.
+**Setup already installed these.** Its last act is to put the `catalyst-*` commands on your PATH,
+provision `plugin-source`, turn on replica reads, and enrol the project. If the run ended with "No
+steps were deferred", skip to the check below.
 
 If setup listed this as a deferred step, run it by hand:
 
@@ -82,7 +86,8 @@ If setup listed this as a deferred step, run it by hand:
 bash ~/catalyst/plugin-source/plugins/dev/scripts/install-cli.sh
 ```
 
-They install to `$HOME/.catalyst/bin`. If that folder isn't on your PATH, the installer adds it to your shell's startup file. Open a new terminal to pick up the change, then check it worked:
+They install to `$HOME/.catalyst/bin`. If that folder isn't on your PATH, the installer adds it to
+your shell's startup file. Open a new terminal to pick up the change, then check it worked:
 
 ```bash
 which catalyst-events
@@ -91,26 +96,31 @@ catalyst-events help
 
 ## 4. Start the stack
 
-Bring the three core Catalyst services up in dependency order (monitor → broker → execution-core), plus the opt-in mitmproxy capture service if you pass `--proxy`:
+Bring the three core Catalyst services up in dependency order (monitor → broker → execution-core),
+plus the opt-in mitmproxy capture service if you pass `--proxy`:
 
 ```bash
 catalyst-stack start
 ```
 
-Run this once after each reboot or after pulling new code. See [catalyst-stack reference](/reference/catalyst-stack/) for flags including `--hotpatch` (apply an update without reinstalling) and `--proxy` (opt-in Linear traffic capture via mitmproxy).
+Run this once after each reboot or after pulling new code. See
+[catalyst-stack reference](/reference/catalyst-stack/) for flags including `--hotpatch` (apply an
+update without reinstalling) and `--proxy` (opt-in Linear traffic capture via mitmproxy).
 
 The stack is three long-running services (plus an opt-in proxy):
 
 - **`catalyst-broker`** — the event bus every agent and the executor read and write through.
 - **`catalyst-monitor`** — watches your GitHub PRs and CI status and emits events.
-- **`catalyst-execution-core`** — the scheduler: it picks up Todo tickets and dispatches the phase-agent workers.
-- **`mitmproxy`** *(opt-in, `--proxy` only)* — logs Linear API traffic.
+- **`catalyst-execution-core`** — the scheduler: it picks up Todo tickets and dispatches the
+  phase-agent workers.
+- **`mitmproxy`** _(opt-in, `--proxy` only)_ — logs Linear API traffic.
 
 See the [catalyst-stack reference](/reference/catalyst-stack/) for the full command set.
 
 ## 5. Add Catalyst to your project
 
-Copy the Catalyst snippet into your project's `CLAUDE.md` so Claude Code knows the available workflows:
+Copy the Catalyst snippet into your project's `CLAUDE.md` so Claude Code knows the available
+workflows:
 
 ```bash
 cat ~/.claude/plugins/cache/catalyst/catalyst-dev/*/templates/CLAUDE_SNIPPET.md >> .claude/CLAUDE.md
@@ -124,7 +134,8 @@ Start a Claude Code session and run:
 /catalyst-dev:research-codebase
 ```
 
-Follow the prompts. Catalyst spawns helper agents, documents what your code does, and saves the findings to `thoughts/shared/research/`.
+Follow the prompts. Catalyst spawns helper agents, documents what your code does, and saves the
+findings to `thoughts/shared/research/`.
 
 ## Optional plugins
 
@@ -142,7 +153,8 @@ See [Plugins](/reference/plugins/) for what each one does.
 
 ## Keeping plugins up to date
 
-Claude Code checks for plugin updates when a session starts and pulls them automatically. Restart Claude Code to load a new version. To force an update now:
+Claude Code checks for plugin updates when a session starts and pulls them automatically. Restart
+Claude Code to load a new version. To force an update now:
 
 ```bash
 /plugins update
@@ -154,4 +166,5 @@ Check your installed versions any time with `/plugins`.
 
 - [How Catalyst works](/getting-started/how-catalyst-works/) — the autonomous loop, end to end
 - [Configuration](/reference/configuration/) — the settings Catalyst reads
-- [Remote and unattended hosts](/getting-started/remote-and-unattended-hosts/) — set up on a headless Mac reached over SSH
+- [Remote and unattended hosts](/getting-started/remote-and-unattended-hosts/) — set up on a
+  headless Mac reached over SSH

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -25,6 +25,31 @@ chmod +x setup-catalyst.sh
 
 It checks your platform, installs the prerequisites, creates your project config, sets up a shared thoughts repository, and asks for any API tokens (like Linear).
 
+### On a headless or SSH-only host
+
+There are no prompts to answer, so the whole install is one command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
+  | bash -s -- --non-interactive \
+      --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
+```
+
+`-s --` is required: without it `bash` consumes the flags instead of passing them to the
+script, and the install runs interactive on a host with no terminal to be interactive with.
+`CATALYST_AUTONOMOUS=1` is equivalent to `--non-interactive` if you prefer an env var.
+
+### What to have ready
+
+| What | How to supply it | Notes |
+| ---- | ---------------- | ----- |
+| Catalyst Cloud token | `--cloud-token` or `CATALYST_CLOUD_TOKEN` | Validated with one authenticated call before anything is written. A bad token fails the install loudly rather than leaving green checkmarks over a broken system. |
+| Catalyst Cloud account | `--cloud-account` or `CATALYST_CLOUD_ACCOUNT` | Required whenever a token is supplied — there is deliberately no default. |
+| Linear API token | `LINEAR_API_TOKEN`, or a `~/.linear_api_token` file | Must be a **personal** API key, beginning `lin_api_`. An OAuth token (`lin_oauth_…`) is rejected. |
+| Sentry, PostHog, Exa | Prompted, or their usual env vars | All optional. |
+
+Both cloud flags are optional. Omit them and setup behaves exactly as it did before they existed.
+
 ## 2. Install the plugin
 
 In Claude Code:
@@ -45,12 +70,16 @@ claude plugin install catalyst-dev@catalyst
 
 ## 3. Install the command-line tools
 
-Several Catalyst features call shell tools by name (`catalyst-monitor`, `catalyst-hud`, `catalyst-events`, and more — see the full [CLI command reference](/reference/catalyst-cli/)). Install them onto your PATH:
+Several Catalyst features call shell tools by name (`catalyst-monitor`, `catalyst-hud`, `catalyst-events`, and more — see the full [CLI command reference](/reference/catalyst-cli/)).
+
+**Setup already installed these.** Its last act is to put the `catalyst-*` commands on your
+PATH, provision `plugin-source`, turn on replica reads, and enrol the project. If the run
+ended with "No steps were deferred", skip to the check below.
+
+If setup listed this as a deferred step, run it by hand:
 
 ```bash
-shopt -s nullglob
-_cli=( ~/.claude/plugins/cache/catalyst/catalyst-dev/*/scripts/install-cli.sh )
-[ ${#_cli[@]} -gt 0 ] && bash "${_cli[0]}" || echo "catalyst-dev plugin not installed — run step 2 first"
+bash ~/catalyst/plugin-source/plugins/dev/scripts/install-cli.sh
 ```
 
 They install to `$HOME/.catalyst/bin`. If that folder isn't on your PATH, the installer adds it to your shell's startup file. Open a new terminal to pick up the change, then check it worked:

--- a/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
+++ b/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
@@ -10,6 +10,25 @@ common setup is a **headless Mac** (for example, a Mac mini) that you reach over
 leave running. This page covers the parts of setup that differ from the
 [interactive install](/getting-started/).
 
+## Install in one command
+
+The page you were sent here from presents step 1 as interactive. It does not have to be —
+`setup-catalyst.sh` has a full headless contract, so the entire install over SSH is:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
+  | bash -s -- --non-interactive \
+      --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
+```
+
+`-s --` is required — without it `bash` eats the flags and the script tries to open
+`/dev/tty` on a host that has none. `CATALYST_AUTONOMOUS=1` is an equivalent env-var form.
+
+Setup finishes the job rather than printing a list: it installs the `catalyst-*` CLIs,
+provisions `plugin-source`, turns on replica reads, and enrols the project. Anything it
+could not do is printed at the end as a deferred step with a `run:` and a `verify:` line.
+See [what to have ready](/getting-started/#what-to-have-ready) for the credentials.
+
 ## Install the plugin over SSH
 
 The in-app `/plugin` commands need an interactive Claude Code session. From a shell, use

--- a/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
+++ b/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
@@ -1,14 +1,15 @@
 ---
 title: Remote and unattended hosts
-description: Run Catalyst on a headless Mac you reach over SSH — plugin install, gh token migration, and bringing the stack up.
+description:
+  Run Catalyst on a headless Mac you reach over SSH — plugin install, gh token migration, and
+  bringing the stack up.
 sidebar:
   order: 6
 ---
 
-Catalyst is macOS-only, but the host does not have to be the Mac in front of you. A
-common setup is a **headless Mac** (for example, a Mac mini) that you reach over SSH and
-leave running. This page covers the parts of setup that differ from the
-[interactive install](/getting-started/).
+Catalyst is macOS-only, but the host does not have to be the Mac in front of you. A common setup is
+a **headless Mac** (for example, a Mac mini) that you reach over SSH and leave running. This page
+covers the parts of setup that differ from the [interactive install](/getting-started/).
 
 ## Install in one command
 
@@ -21,18 +22,18 @@ curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-c
       --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
 ```
 
-`-s --` is required — without it `bash` eats the flags and the script tries to open
-`/dev/tty` on a host that has none. `CATALYST_AUTONOMOUS=1` is an equivalent env-var form.
+`-s --` is required — without it `bash` eats the flags and the script tries to open `/dev/tty` on a
+host that has none. `CATALYST_AUTONOMOUS=1` is an equivalent env-var form.
 
-Setup finishes the job rather than printing a list: it installs the `catalyst-*` CLIs,
-provisions `plugin-source`, turns on replica reads, and enrols the project. Anything it
-could not do is printed at the end as a deferred step with a `run:` and a `verify:` line.
-See [what to have ready](/getting-started/#what-to-have-ready) for the credentials.
+Setup finishes the job rather than printing a list: it installs the `catalyst-*` CLIs, provisions
+`plugin-source`, turns on replica reads, and enrols the project. Anything it could not do is printed
+at the end as a deferred step with a `run:` and a `verify:` line. See
+[what to have ready](/getting-started/#what-to-have-ready) for the credentials.
 
 ## Install the plugin over SSH
 
-The in-app `/plugin` commands need an interactive Claude Code session. From a shell, use
-the CLI form instead:
+The in-app `/plugin` commands need an interactive Claude Code session. From a shell, use the CLI
+form instead:
 
 ```bash
 claude plugin marketplace add coalesce-labs/catalyst
@@ -45,15 +46,15 @@ Then install the CLI tools and start the stack exactly as in the
 ## Move your GitHub login to the remote host
 
 On macOS, `gh auth login` often stores the token in the **macOS keychain**, not in
-`~/.config/gh/hosts.yml`. Copying `hosts.yml` to another machine therefore silently
-fails — the token field is blank. Pipe the token across instead:
+`~/.config/gh/hosts.yml`. Copying `hosts.yml` to another machine therefore silently fails — the
+token field is blank. Pipe the token across instead:
 
 ```bash
 gh auth token | ssh your-host 'gh auth login --with-token'
 ```
 
-`gh auth token` reads from whichever store `gh` is using (keychain or `hosts.yml`), so
-this works regardless of how you logged in locally.
+`gh auth token` reads from whichever store `gh` is using (keychain or `hosts.yml`), so this works
+regardless of how you logged in locally.
 
 ## After a reboot
 
@@ -63,27 +64,26 @@ After the host reboots, reconnect and run:
 catalyst-stack start
 ```
 
-On a headless host you'll usually want this to happen automatically. Install the
-auto-start LaunchAgent once, then a reboot brings the whole stack back on its own:
+On a headless host you'll usually want this to happen automatically. Install the auto-start
+LaunchAgent once, then a reboot brings the whole stack back on its own:
 
 ```bash
 catalyst-stack install-services
 ```
 
-It runs `catalyst-stack start` at login plus a keep-alive that self-heals a crashed
-daemon. Because it's a per-user LaunchAgent, enable **automatic login** so it fires on
-boot without anyone signing in. See
-[Post-reboot and updates](/getting-started/reboot-and-updates/) for the day-to-day
-boot and update flow and the full `install-services` options.
+It runs `catalyst-stack start` at login plus a keep-alive that self-heals a crashed daemon. Because
+it's a per-user LaunchAgent, enable **automatic login** so it fires on boot without anyone signing
+in. See [Post-reboot and updates](/getting-started/reboot-and-updates/) for the day-to-day boot and
+update flow and the full `install-services` options.
 
 ## If the daemon dispatches nothing
 
-The execution-core daemon only dispatches work for **registered** projects. On a fresh or
-headless host the project registry (`~/catalyst/execution-core/registry.json`) may never have
-been written — the daemon then starts cleanly, logs normal ticks, and dispatches nothing.
+The execution-core daemon only dispatches work for **registered** projects. On a fresh or headless
+host the project registry (`~/catalyst/execution-core/registry.json`) may never have been written —
+the daemon then starts cleanly, logs normal ticks, and dispatches nothing.
 
-As of CTL-854 the daemon logs a one-time warning at startup when the registry is empty. To
-enroll a project, run from inside its repo:
+As of CTL-854 the daemon logs a one-time warning at startup when the registry is empty. To enroll a
+project, run from inside its repo:
 
 ```bash
 catalyst-execution-core register --team <TEAM> --repo-root "$(git rev-parse --show-toplevel)"
@@ -100,8 +100,8 @@ eligible-query format.
 
 ## Mirroring config to another node
 
-When adding a second host to a cluster, some config items must be copied verbatim from the seed
-node (SHARED) and others must be regenerated on the new host (PER-NODE). See
+When adding a second host to a cluster, some config items must be copied verbatim from the seed node
+(SHARED) and others must be regenerated on the new host (PER-NODE). See
 [Cluster config mirror contract](/reference/cluster-config-mirror/) for the full classification
-table, correct file locations for bot OAuth credentials, and the quota field-name schema consumed
-by monitoring and heartbeat code.
+table, correct file locations for bot OAuth credentials, and the quota field-name schema consumed by
+monitoring and heartbeat code.


### PR DESCRIPTION
Closes CTL-1914, CTL-1917, CTL-1918.

The install path every user-facing doc gives is a single downloaded `setup-catalyst.sh`.
**Four** steps resolved their helper scripts relative to the script's own directory —
which in that layout contains nothing but `setup-catalyst.sh`. Each degraded to a silent
skip, so the **documented** install produced a materially more-broken machine than a repo
clone. Three further steps were *printed as advice* rather than performed.

## What changed

**CTL-1914 — one resolver instead of four private lookups.**
`resolve_catalyst_source` / `catalyst_helper_path` resolve in order: `--source-dir` →
script-adjacent → `PROJECT_DIR` → plugin-source → **bootstrap clone**. The clone targets the
same default path `setup-plugin-source.sh` uses, so one checkout serves both. Centralising
is the point: four copies of a lookup are four chances for the next one to skip silently,
and the reason the original defect survived is that each site failed in its own private way.

Failure is **named** — `no-source-tree`, `clone-failed`, `clone-produced-no-tree`,
`missing-helper:<x>` — and a clone that exits 0 having produced nothing usable is a
failure, not a pass. The result is validated, never the exit code.

**CTL-1918 — `finalize_install` performs the printed hand-steps.**
`install-cli.sh`, plugin-source, replica reads, registry enrolment. Ordering is
load-bearing: `install-cli.sh` is what puts the binaries the next two steps *are* on PATH.
Replica reads go through the existing `catalyst-stack activate-replica`, which gates itself
on `verify-cloud-sync`, so a broken replica is **refused** rather than switched on.

Anything that cannot run goes to a **deferred-step ledger** carrying the command that
completes it *and* the command that verifies it. It prints on the **failure** path too — it
previously lived only in `print_summary`, so the operator whose install failed was the one
person who never saw what was skipped.

**CTL-1917 — the headless contract, documented where an operator reads it.**
README, getting-started, remote-and-unattended-hosts, `plugins/dev/README`. Including the
`bash -s --` the piped form requires (without it `bash` eats the flags and the install
silently runs interactive), plus a credentials-to-have-ready table naming each variable and
its required format.

**`catalyst doctor` gains `install-completeness`** — advisory, **never FAIL**: a
half-installed node must not be blocked from working over a cosmetic gap (same posture, and
same reason, as `checkRegistryTeamIdentity`). Every leg is three-valued — an unreadable
config or a non-macOS host reports **UNKNOWN**, never "missing", because a check that
reports a missing step for a file it merely failed to open sends an operator to repair
something that was never broken.

## Evidence

`__tests__/setup-catalyst-documented-path.rehearsal.sh` runs the documented install in a
sealed prefix (scratch `HOME`, no network, recording stubs) against **both** this tree and
`origin/main` with identical stubs — the baseline is the control:

```
── BASELINE (origin/main) ── exit rc=1        ── WORKING TREE ── exit rc=1
  did-not   orphan-sweep scheduler installed    FIRED     orphan-sweep scheduler installed
  did-not   Linear state contract provisioned   FIRED     Linear state contract provisioned
  did-not   plugin-source provisioned           FIRED     plugin-source provisioned
  did-not   catalyst-* CLIs installed           FIRED     catalyst-* CLIs installed
  did-not   a source tree was obtained (clone)  FIRED     a source tree was obtained (clone)
```

Both exit `rc=1` on the *same* stubbed-`humanlayer` artifact ("Thoughts not initialized"),
which is what makes the differential readable — the only thing that differs between the two
columns is the fix.

The working run's ledger, on the failure path:

```
⚠️  1 step(s) were DEFERRED. This node is not fully provisioned until they are done:
  • Enrol this project (no Linear team key was discovered during setup)
      run:    catalyst-execution-core register --team <TEAM_KEY>
      verify: catalyst-execution-core list-projects
```

— which is the honest answer for a sealed prefix with no Linear credential, rather than a
placeholder the operator has to decode.

## One defect worth naming, because it was mine

The first cut of `catalyst_helper_path` called the resolver as `$(resolve_catalyst_source)`.
Command substitution is a subshell, so `CATALYST_SOURCE_REASON` — the entire point of
failing with a *named* reason — was discarded, and the deferral printed
`Catalyst CLIs NOT installed ()`. The failure still reported; it just reported nothing
usable. That is this ticket's own defect one level down. Callers now read
`CATALYST_HELPER_PATH`, and a test pins it.

## Tests

- `__tests__/setup-catalyst-source-resolver.test.sh` — **39** assertions (resolver ordering,
  named failures, empty-clone, ledger, `finalize_install`'s four steps, the all-deferred
  control, `--help` contract).
- `execution-core/install-completeness.test.mjs` — **10** assertions; every "missing" case is
  paired with the "could not look" case over the same leg.
- The four pre-existing `setup-catalyst-*` test files pass unchanged.
- `trunk check`: **no new issues** (13 new issues on the first run, all fixed).
- `make check`: the first run aborted at `lint`; the full run was re-run after the lint fixes
  — result reported in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)