### PR TITLE
feat(dev): CTC-403 inc 1 — a host resolves Linear team and state ids from the replica, not from hand-written caches

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-identity.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-identity.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # the single-quoted bodies handed to run()/reason() below
+# are shell source for a CHILD shell; their `$` deliberately does not expand here.
+# Tests for lib/linear-identity.sh — CTC-403.
+#
+# The module's whole value is that a confident answer and "I could not look" are
+# different results. So every positive assertion below is paired with the degraded
+# case over the same call, and the two must NOT produce the same output. The failure
+# this guards against is on record: an empty-but-fresh replica read as healthy and
+# produced a fleet-wide admission freeze with every signal green (CTL-1420).
+#
+# Run: bash plugins/dev/scripts/__tests__/linear-identity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="${SCRIPT_DIR}/../lib/linear-identity.sh"
+
+FAILURES=0
+PASSES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+assert_eq() {
+	if [[ $2 == "$3" ]]; then pass "$1"; else fail "$1" "expected: $3" "actual:   $2"; fi
+}
+
+TEAM="f317bf00-0000-0000-0000-000000000001"
+
+# A fixture replica in the real schema's shape. `fresh=1` writes the writer-lock
+# heartbeat and the sync_meta cursor that `replica_fresh` gates on.
+make_db() {
+	local db="$1" fresh="${2:-1}" with_states="${3:-1}"
+	rm -f "$db" "$db.writer.lock"
+	sqlite3 "$db" "
+    CREATE TABLE sync_meta (key TEXT, value TEXT);
+    CREATE TABLE issues (id TEXT, team_key TEXT, team_id TEXT, removed_at INTEGER);
+    CREATE TABLE workflow_states (id TEXT, team_id TEXT, name TEXT, type TEXT, position REAL, archived_at INTEGER);
+    CREATE TABLE labels (id TEXT, name TEXT, removed_at INTEGER);
+    INSERT INTO sync_meta VALUES ('cursor','abc123');
+    INSERT INTO issues VALUES ('i1','CTL','${TEAM}',NULL);
+    INSERT INTO labels VALUES ('lab-uniq','needs-human',NULL);
+    INSERT INTO labels VALUES ('lab-dup-a','dupe',NULL);
+    INSERT INTO labels VALUES ('lab-dup-b','dupe',NULL);
+  " 2>/dev/null
+	if [[ $with_states == "1" ]]; then
+		sqlite3 "$db" "
+      INSERT INTO workflow_states VALUES ('st-done','${TEAM}','Done','completed',1.0,NULL);
+      INSERT INTO workflow_states VALUES ('st-todo','${TEAM}','Todo','unstarted',2.0,NULL);
+      INSERT INTO workflow_states VALUES ('st-old','${TEAM}','Retired','unstarted',3.0,1700000000000);
+    " 2>/dev/null
+	fi
+	if [[ $fresh == "1" ]]; then touch "$db.writer.lock"; else
+		touch "$db.writer.lock"
+		# 1 hour old — well past the 5-minute default staleness threshold
+		touch -t "$(date -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -d '1 hour ago' '+%Y%m%d%H%M')" "$db.writer.lock"
+	fi
+}
+
+# Each call runs in its own shell: the module caches its source-guard and exports a
+# reason global, and a leaked reason from a previous call would let a later assertion
+# pass on the wrong evidence.
+run() {
+	local db="$1" body="$2"
+	CATALYST_REPLICA_DB="$db" bash -c "set -uo pipefail; . '$LIB' >/dev/null 2>&1; $body" 2>/dev/null
+}
+reason() {
+	local db="$1" body="$2"
+	CATALYST_REPLICA_DB="$db" bash -c "set -uo pipefail; . '$LIB' >/dev/null 2>&1; $body >/dev/null 2>&1; printf '%s' \"\$LINEAR_IDENTITY_REASON\"" 2>/dev/null
+}
+
+DB="$SCRATCH/fresh.db"
+make_db "$DB" 1 1
+
+echo ""
+echo "=== a fresh, populated replica answers ==="
+assert_eq "team id resolves" "$(run "$DB" 'linear_identity_team_id CTL')" "$TEAM"
+assert_eq "state id resolves" "$(run "$DB" 'linear_identity_state_id CTL Done')" "st-done"
+assert_eq "success clears the reason" "$(reason "$DB" 'linear_identity_team_id CTL')" ""
+assert_eq "label id resolves" "$(run "$DB" 'linear_identity_label_id needs-human')" "lab-uniq"
+
+echo ""
+echo "=== archived states are excluded ==="
+# Resolving to an archived state produces a write Linear accepts and a board nobody sees.
+assert_eq "archived state is not found" "$(reason "$DB" 'linear_identity_state_id CTL Retired')" "state-not-found"
+assert_eq "states json omits the archived one" \
+	"$(run "$DB" 'linear_identity_states_json CTL | grep -c Retired || true')" "0"
+assert_eq "states json carries the live ones" \
+	"$(run "$DB" 'linear_identity_states_json CTL | grep -c st-done')" "1"
+
+echo ""
+echo "=== ⛔ degraded replicas fail NAMED, and never substitute a stale answer ==="
+STALE="$SCRATCH/stale.db"
+make_db "$STALE" 0 1
+assert_eq "a stale replica is refused" "$(reason "$STALE" 'linear_identity_team_id CTL')" "replica-stale"
+assert_eq "…and returns NOTHING, not a last-known-good id" "$(run "$STALE" 'linear_identity_team_id CTL')" ""
+
+ABSENT="$SCRATCH/nope.db"
+rm -f "$ABSENT"
+assert_eq "an absent replica is its own reason, not 'stale'" \
+	"$(reason "$ABSENT" 'linear_identity_team_id CTL')" "replica-absent"
+
+echo ""
+echo "=== ⛔ the CTL-1420 shape: empty BUT FRESH must not read as a confident answer ==="
+EMPTY="$SCRATCH/empty.db"
+make_db "$EMPTY" 1 0 # fresh gate open, zero workflow_states
+assert_eq "an empty state table is a failure, not '{}'" \
+	"$(reason "$EMPTY" 'linear_identity_states_json CTL')" "state-not-found"
+assert_eq "…and emits no object at all" "$(run "$EMPTY" 'linear_identity_states_json CTL')" ""
+# Positive control: the SAME call on the SAME fresh gate DOES answer when data exists,
+# so the failure above is the empty table and not a broken freshness gate.
+assert_eq "control — the gate itself is open on a populated db" \
+	"$(run "$DB" 'linear_identity_states_json CTL | grep -c st-todo')" "1"
+
+echo ""
+echo "=== a team with no issues is 'not resolvable', never 'no such team' ==="
+# The two are indistinguishable from this source; claiming the stronger one would send
+# an operator to re-create a team that already exists.
+assert_eq "unknown team key" "$(reason "$DB" 'linear_identity_team_id NOPE')" "team-not-resolvable"
+
+echo ""
+echo "=== an ambiguous label is refused rather than silently first-wins ==="
+# Picking one would apply a label to the wrong team's board and look like it worked.
+assert_eq "duplicate label name" "$(reason "$DB" 'linear_identity_label_id dupe')" "label-ambiguous"
+assert_eq "missing label name" "$(reason "$DB" 'linear_identity_label_id absent-label')" "label-not-found"
+
+echo ""
+echo "=== a quote in an argument cannot break out of the query ==="
+assert_eq "quoted team key is escaped, not injected" \
+	"$(reason "$DB" "linear_identity_team_id \"CTL' OR '1'='1\"")" "team-not-resolvable"
+
+echo ""
+echo "=== ⛔ regression: the reason survives, and the value is reachable without a subshell ==="
+# A caller that does `id=$(linear_identity_team_id X)` runs the function in a SUBSHELL,
+# so LINEAR_IDENTITY_REASON dies with it and the caller reports "unknown" — a failure
+# that reports, but reports nothing usable. LINEAR_IDENTITY_VALUE exists so a caller can
+# invoke directly and still get the answer. resolve-linear-ids.sh shipped the subshell
+# form first and printed "(unknown)" for an absent replica; this holds the fix.
+assert_eq "direct call exposes the value" \
+	"$(run "$DB" 'linear_identity_team_id CTL >/dev/null; printf "%s" "$LINEAR_IDENTITY_VALUE"')" "$TEAM"
+assert_eq "direct call preserves the NAMED reason on failure" \
+	"$(run "$ABSENT" 'linear_identity_team_id CTL >/dev/null 2>&1; printf "%s" "$LINEAR_IDENTITY_REASON"')" "replica-absent"
+assert_eq "a failed call leaves no stale value behind" \
+	"$(run "$ABSENT" 'linear_identity_team_id CTL >/dev/null 2>&1; printf "%s" "$LINEAR_IDENTITY_VALUE"')" ""
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+echo "════════════════════════════════════════════"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/linear-identity.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-identity.test.sh
@@ -154,6 +154,65 @@ assert_eq "a failed call leaves no stale value behind" \
 	"$(run "$ABSENT" 'linear_identity_team_id CTL >/dev/null 2>&1; printf "%s" "$LINEAR_IDENTITY_VALUE"')" ""
 
 echo ""
+echo "=== ⛔ Codex #3501 P1: the cursor gate and the read share ONE snapshot ==="
+# Two separate sqlite3 invocations let a cold reseed start between them, so the read
+# observes partially restored tables — a nonempty but INCOMPLETE state map, or a
+# duplicated label transiently looking unique. Both are confident WRONG answers, the one
+# outcome this module exists to prevent. Simulated here by the observable end state: a
+# fresh writer lock with the cursor gone (mid-reseed), which the in-snapshot gate must
+# catch even though replica_fresh's own cheap check already ran.
+RESEED="$SCRATCH/reseed.db"
+make_db "$RESEED" 1 1
+sqlite3 "$RESEED" "DELETE FROM sync_meta;" 2>/dev/null
+touch "$RESEED.writer.lock"
+assert_eq "a mid-reseed replica is named, not answered" \
+	"$(reason "$RESEED" 'linear_identity_team_id CTL')" "replica-reseeding"
+assert_eq "…and yields no id" "$(run "$RESEED" 'linear_identity_team_id CTL')" ""
+
+# ⚠️ The assertion above exercises the CHEAP early-out, not the race the P1 fix targets.
+# The race — a reseed starting AFTER the gate and BEFORE the read — cannot be reproduced
+# deterministically from a shell test. What CAN be tested is that the in-snapshot gate
+# stands on its own: stub replica_fresh to pass (i.e. pretend the early-out saw a healthy
+# replica) and confirm the read still refuses. Without this, the `_LID_NO_CURSOR` branch
+# would be a protection nobody has ever seen fire.
+assert_eq "the IN-SNAPSHOT gate refuses even when the early-out passes" \
+	"$(CATALYST_REPLICA_DB="$RESEED" bash -c "set -uo pipefail; . '$LIB' >/dev/null 2>&1
+	   replica_fresh() { return 0; }
+	   linear_identity_team_id CTL >/dev/null 2>&1; printf '%s' \"\$LINEAR_IDENTITY_REASON\"" 2>/dev/null)" \
+	"replica-reseeding"
+
+echo ""
+echo "=== ⛔ Codex #3501 P2: a SQLite failure is not an entity miss ==="
+# The recorded live condition: workflow_states absent on a replica whose gate is open.
+# The old helper sent sqlite's stderr to /dev/null, so the empty output was reinterpreted
+# as state-not-found — "could not query" became "the entity is not there".
+NOTABLE="$SCRATCH/notable.db"
+make_db "$NOTABLE" 1 1
+sqlite3 "$NOTABLE" "DROP TABLE workflow_states;" 2>/dev/null
+assert_eq "a missing table is 'unreadable', NOT 'state-not-found'" \
+	"$(reason "$NOTABLE" 'linear_identity_state_id CTL Done')" "replica-unreadable"
+assert_eq "…and the map helper agrees" \
+	"$(reason "$NOTABLE" 'linear_identity_states_json CTL')" "replica-unreadable"
+# Control on the same db: the team read, whose table still exists, still answers — so the
+# failure above is the dropped table and not a globally broken fixture.
+assert_eq "control — the surviving table still resolves" \
+	"$(run "$NOTABLE" 'linear_identity_team_id CTL')" "$TEAM"
+
+echo ""
+echo "=== ⛔ Codex #3501 P2: a NESTED failure keeps its reason ==="
+# state_id/states_json call team_id. Capturing that with $( ) ran it in a subshell and
+# discarded the reason, so a direct caller got rc=1 with an EMPTY reason — the module's
+# named-failure contract defeated at the two helpers most callers use.
+assert_eq "state_id surfaces the nested absent-replica reason" \
+	"$(reason "$ABSENT" 'linear_identity_state_id CTL Done')" "replica-absent"
+assert_eq "states_json surfaces it too" \
+	"$(reason "$ABSENT" 'linear_identity_states_json CTL')" "replica-absent"
+assert_eq "state_id surfaces a nested stale reason" \
+	"$(reason "$STALE" 'linear_identity_state_id CTL Done')" "replica-stale"
+assert_eq "state_id surfaces a nested unknown-team reason" \
+	"$(reason "$DB" 'linear_identity_state_id NOPE Done')" "team-not-resolvable"
+
+echo ""
 echo "════════════════════════════════════════════"
 echo "  PASSED: $PASSES   FAILED: $FAILURES"
 echo "════════════════════════════════════════════"

--- a/plugins/dev/scripts/__tests__/resolve-linear-ids.test.sh
+++ b/plugins/dev/scripts/__tests__/resolve-linear-ids.test.sh
@@ -303,6 +303,40 @@ REG13_AFTER=$(cat "$REG13")
 run "--dry-run does not modify the existing registry" \
   bash -c "[ '$REG13_BEFORE' = '$REG13_AFTER' ]"
 
+# ─── Test 14 (CTC-403): replica-first resolution, and the --json stream contract ──
+#
+# ⛔ Test 3 above runs the script with `> "$OUT3" 2>&1` — stderr MERGED into stdout,
+# then piped to jq. So in --json mode a bare stderr line is not "extra diagnostics": it
+# makes the whole document unparseable and every field unreadable. The replica-fallback
+# note shipped as a stderr echo first and broke exactly those three assertions. The
+# reason now rides the DOCUMENT instead; suppressing it in --json mode was the other
+# option and is worse, because the machine-readable path is precisely where a silent
+# degradation hides.
+WORK14="${SCRATCH}/t14"; HOME14="${WORK14}/home"; BIN14="${WORK14}/bin"
+OUT14="${WORK14}/stdout"
+build_config "$WORK14"
+build_secrets "$HOME14" "test-project"
+install_fake_curl "$BIN14"
+
+# No replica on this path → the API fallback, with the reason carried structurally.
+HOME="$HOME14" PATH="$BIN14:$PATH" CATALYST_REPLICA_DB="${WORK14}/absent-replica.db" \
+  "$RESOLVE" --config "$WORK14/.catalyst/config.json" --json > "$OUT14" 2>&1 || true
+
+run "--json stays parseable with stderr merged, even on the fallback path" \
+  bash -c "jq -e '.action == \"resolved\"' '$OUT14'"
+
+run "the fallback names its reason in the document" \
+  bash -c "jq -e '.replicaFallbackReason == \"replica-absent\"' '$OUT14'"
+
+run "the fallback reports which source actually answered" \
+  bash -c "jq -e '.source == \"api\"' '$OUT14'"
+
+# Human mode keeps the loud note — the diagnosis is not lost, it is routed.
+run "non-json mode still prints the note to stderr" \
+  bash -c "HOME='$HOME14' PATH='$BIN14:$PATH' CATALYST_REPLICA_DB='${WORK14}/absent-replica.db' \
+    '$RESOLVE' --config '$WORK14/.catalyst/config.json' --dry-run --force 2>&1 \
+    | grep -q 'replica identity unavailable (replica-absent)'"
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/lib/linear-identity.sh
+++ b/plugins/dev/scripts/lib/linear-identity.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# linear-identity.sh — CTC-403: resolve Linear TEAM, WORKFLOW-STATE and LABEL ids
+# from the Catalyst Cloud replica instead of from hand-written host caches.
+#
+# ── WHY ──
+# Identity was stored in four places, none authoritative: `.catalyst/config.json`
+# → `catalyst.linear.teamId` (21 files, 7 repoRoots × 3 hosts),
+# `~/.config/catalyst/linear-state-ids.json` (~248 workflow-state UUIDs, hosts
+# disagreeing), `filter-state.db`, and identifier-keyed marker dirs. A Linear-to-Linear
+# import preserves human identifiers and team keys but MINTS NEW INTERNAL UUIDs — and
+# Catalyst keys on the UUID while caching on the key. So after the cutover every cache
+# still MATCHED and every value beneath it was dead. That combination defeats staleness
+# detection by construction: there is no observation that distinguishes it from health.
+#
+# The cloud registry is already authoritative for (account → workspace → team) and the
+# replica already carries every workflow state on every issue, so this is mostly
+# SUBTRACTION — read the copy that is already replicated rather than keep a parallel
+# denormalized one with no invalidation path.
+#
+# ── ⛔ THE TRAP THIS DELIBERATELY DOES NOT WALK INTO ──
+# Making identity a replica read couples it to replica freshness, and this fleet has
+# that failure on record: an empty-but-fresh replica read as healthy and produced a
+# fleet-wide admission freeze with every signal green (CTL-1420). So:
+#   • freshness is GATED, via the SAME `replica_fresh` the ticket-read helper uses —
+#     writer-lock recency AND a non-empty sync_meta cursor (seed complete, not
+#     mid-reseed);
+#   • a confident answer and "I could not look" are DIFFERENT results, never merged;
+#   • there is NO fallback to a stale local cache. Substituting last-known-good is how
+#     the original drift was built, one layer down. Callers get a named failure and
+#     decide; this module never decides for them by guessing.
+#
+# Every function sets LINEAR_IDENTITY_REASON to "" on success, or to one of:
+#   no-sqlite3 · replica-absent · replica-stale · team-not-resolvable ·
+#   state-not-found · label-not-found · label-ambiguous
+#
+# Usage:
+#   source "${SCRIPT_DIR}/lib/linear-identity.sh"
+#   if team_id=$(linear_identity_team_id CTL); then … else echo "$LINEAR_IDENTITY_REASON"; fi
+#
+# Idempotent: sourcing twice is a no-op.
+
+[[ -n "${_CATALYST_LINEAR_IDENTITY_SH:-}" ]] && return 0
+_CATALYST_LINEAR_IDENTITY_SH=1
+
+# Reuse the ticket-read helper's replica path resolution and freshness gate rather than
+# re-deriving them. Two gates that must agree, maintained separately, is the same
+# drift-with-no-invalidation shape this module exists to remove.
+# shellcheck disable=SC2296
+__LID_SELF="${BASH_SOURCE[0]:-${(%):-%x}}"
+__LID_LIB_DIR="$(cd "$(dirname "$__LID_SELF")" && pwd)"
+# shellcheck disable=SC1091
+. "${__LID_LIB_DIR}/linear-read-replica.sh"
+
+# ⛔ THE RESULT IS ALSO A GLOBAL, AND THAT IS THE POINT.
+# Every function echoes its answer for convenience, but a caller that captures it with
+# `$(…)` runs the function in a SUBSHELL — so LINEAR_IDENTITY_REASON, the whole reason
+# a failure here is diagnosable, dies with that subshell and the caller reports
+# "unknown". Callers that need the reason must invoke the function directly and read
+# LINEAR_IDENTITY_VALUE instead:
+#
+#     if linear_identity_team_id CTL >/dev/null; then
+#       id="$LINEAR_IDENTITY_VALUE"
+#     else
+#       echo "$LINEAR_IDENTITY_REASON"    # replica-stale, not "unknown"
+#     fi
+#
+# This is not hypothetical tidiness — the first cut of resolve-linear-ids.sh's
+# replica branch captured with `$(…)` and printed `(unknown)` for an absent replica,
+# which is precisely the "the failure reports, but reports nothing usable" shape.
+export LINEAR_IDENTITY_REASON=""
+export LINEAR_IDENTITY_VALUE=""
+
+_lid_fail() {
+	LINEAR_IDENTITY_VALUE=""
+	LINEAR_IDENTITY_REASON="$1"
+	printf '[linear-identity] %s\n' "$1" >&2
+	return 1
+}
+
+# _lid_ready [db] — the shared precondition: sqlite3 present, file there, gate open.
+# ⛔ "absent" and "stale" are reported separately on purpose. They need different
+# repairs (provision the replica vs fix the writer), and collapsing them is what turns
+# an operator's first diagnostic step into a guess.
+_lid_ready() {
+	local db="${1:-$CATALYST_REPLICA_DB}"
+	command -v sqlite3 >/dev/null 2>&1 || {
+		_lid_fail "no-sqlite3"
+		return 1
+	}
+	[[ -f "$db" ]] || {
+		_lid_fail "replica-absent"
+		return 1
+	}
+	replica_fresh "$db" || {
+		_lid_fail "replica-stale"
+		return 1
+	}
+	LINEAR_IDENTITY_REASON=""
+}
+
+_lid_q() { sqlite3 "$1" "$2" 2>/dev/null; }
+
+# linear_identity_team_id <TEAM_KEY> [db] — echo the team UUID.
+#
+# ⚠️ Derived from the issues the replica carries for that key. A team with ZERO issues
+# is therefore not resolvable here, and that is reported as `team-not-resolvable`
+# rather than as "no such team": the two are indistinguishable from this source, and
+# claiming the stronger one would send an operator to re-create a team that exists.
+linear_identity_team_id() {
+	local key="$1" db="${2:-$CATALYST_REPLICA_DB}" id
+	_lid_ready "$db" || return 1
+	id=$(_lid_q "$db" "SELECT team_id FROM issues WHERE team_key='${key//\'/\'\'}' AND team_id IS NOT NULL AND removed_at IS NULL LIMIT 1;")
+	[[ -n "$id" ]] || {
+		_lid_fail "team-not-resolvable"
+		return 1
+	}
+	LINEAR_IDENTITY_VALUE="$id"
+	printf '%s' "$id"
+}
+
+# linear_identity_state_id <TEAM_KEY> <STATE_NAME> [db] — echo the workflow-state UUID.
+# Archived states are excluded: resolving to one produces a write Linear accepts and a
+# board nobody sees.
+linear_identity_state_id() {
+	local key="$1" name="$2" db="${3:-$CATALYST_REPLICA_DB}" team id
+	team=$(linear_identity_team_id "$key" "$db") || return 1
+	id=$(_lid_q "$db" "SELECT id FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND name='${name//\'/\'\'}' AND archived_at IS NULL LIMIT 1;")
+	[[ -n "$id" ]] || {
+		_lid_fail "state-not-found"
+		return 1
+	}
+	LINEAR_IDENTITY_VALUE="$id"
+	printf '%s' "$id"
+}
+
+# linear_identity_states_json <TEAM_KEY> [db] — echo {"<name>":"<uuid>", …} for the
+# team's live states. This is the shape linear-state-ids.json caches, so a caller can
+# compare the replica's answer to the cache without reshaping either.
+#
+# ⛔ An EMPTY object is a failure, not an empty answer: a fresh replica that carries no
+# workflow states for a team is exactly the empty-but-fresh case CTL-1420 turned into a
+# silent fleet-wide freeze. Returning `{}` here would hand a caller a confident nothing.
+linear_identity_states_json() {
+	local key="$1" db="${2:-$CATALYST_REPLICA_DB}" team json
+	team=$(linear_identity_team_id "$key" "$db") || return 1
+	json=$(_lid_q "$db" "SELECT COALESCE(json_group_object(name, id), '{}') FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND archived_at IS NULL;")
+	[[ -n "$json" && "$json" != "{}" ]] || {
+		_lid_fail "state-not-found"
+		return 1
+	}
+	LINEAR_IDENTITY_VALUE="$json"
+	printf '%s' "$json"
+}
+
+# linear_identity_label_id <NAME> [db] — echo the label UUID.
+#
+# Labels are workspace-scoped in the replica (no team column), so a duplicate NAME
+# across teams is genuinely ambiguous. That is reported as `label-ambiguous` rather
+# than silently taking the first row — picking one would apply a label to the wrong
+# team's board and look like it worked.
+linear_identity_label_id() {
+	local name="$1" db="${2:-$CATALYST_REPLICA_DB}" ids n
+	_lid_ready "$db" || return 1
+	ids=$(_lid_q "$db" "SELECT id FROM labels WHERE name='${name//\'/\'\'}' AND removed_at IS NULL;")
+	[[ -n "$ids" ]] || {
+		_lid_fail "label-not-found"
+		return 1
+	}
+	n=$(printf '%s\n' "$ids" | /usr/bin/grep -c .)
+	if [[ "$n" -gt 1 ]]; then
+		_lid_fail "label-ambiguous"
+		return 1
+	fi
+	LINEAR_IDENTITY_VALUE="$ids"
+	printf '%s' "$ids"
+}

--- a/plugins/dev/scripts/lib/linear-identity.sh
+++ b/plugins/dev/scripts/lib/linear-identity.sh
@@ -91,14 +91,69 @@ _lid_ready() {
 		_lid_fail "replica-absent"
 		return 1
 	}
+	# NOTE: replica_fresh also checks the sync_meta cursor. That check is KEPT here as a
+	# cheap early-out, but it is no longer the one that matters — the authoritative cursor
+	# gate now runs inside the same snapshot as the read (_lid_query_gated), because a
+	# gate that passes in one connection says nothing about what a later one observes.
 	replica_fresh "$db" || {
-		_lid_fail "replica-stale"
+		# replica_fresh folds two different conditions into one rc: a stale writer
+		# heartbeat, and an absent/empty seed cursor. They need different repairs — "the
+		# writer is behind" vs "the seed never finished / is mid-reseed" — so name them
+		# apart here rather than reporting both as stale.
+		if [[ -z "$(sqlite3 "$db" "SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'' LIMIT 1;" 2>/dev/null)" ]]; then
+			_lid_fail "replica-reseeding"
+		else
+			_lid_fail "replica-stale"
+		fi
 		return 1
 	}
 	LINEAR_IDENTITY_REASON=""
 }
 
-_lid_q() { sqlite3 "$1" "$2" 2>/dev/null; }
+# The sentinel a gated query returns when the seed cursor is absent. Deliberately not a
+# value any column can hold, so it can never be mistaken for a resolved id.
+_LID_NO_CURSOR="__LID_NO_CURSOR__"
+
+# _lid_query_gated <db> <scalar-select> — run the cursor gate and the read in ONE
+# statement, i.e. ONE snapshot.
+#
+# ⛔ Codex #3501 P1: these used to be two separate `sqlite3` invocations. A cold reseed
+# beginning after the cursor check but before the read lets the read observe partially
+# restored tables — a nonempty but INCOMPLETE state map, or a duplicated label
+# transiently looking unique. Both are confident wrong answers, which is the one outcome
+# this module exists to prevent. `linear-write-proxy-resolve.mjs` already resolves this
+# the same way (gate + resolution in one transaction); this now matches it.
+#
+# ⛔ Codex #3501 P2: the old helper sent sqlite's stderr to /dev/null, so an unreadable
+# or MISSING table — the recorded live condition where `workflow_states` was absent —
+# produced empty output that callers then read as `team-not-resolvable` /
+# `state-not-found` / `label-not-found`. "Could not query" became "the entity is not
+# there". The query status is now preserved and reported as its own named failure.
+_lid_query_gated() {
+	local db="$1" inner="$2" out rc=0
+	out=$(sqlite3 "$db" "SELECT CASE
+	      WHEN NOT EXISTS(SELECT 1 FROM sync_meta WHERE key='cursor' AND value<>'')
+	      THEN '${_LID_NO_CURSOR}'
+	      ELSE COALESCE((${inner}), '')
+	    END;" 2>/dev/null) || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		_lid_fail "replica-unreadable"
+		return 1
+	fi
+	if [[ "$out" == "$_LID_NO_CURSOR" ]]; then
+		# Seed incomplete / mid-reseed. Same class as stale, distinct name so an operator
+		# can tell "the writer is behind" from "the seed never finished".
+		_lid_fail "replica-reseeding"
+		return 1
+	fi
+	# ⛔ Result via a GLOBAL, not stdout. Every caller below would otherwise capture this
+	# with `$( )` — a subshell — and the reason set by the two _lid_fail calls above would
+	# be discarded, exactly as it was for the nested team lookup Codex flagged. That is
+	# the FOURTH time this defect appeared tonight, and the third inside a fix for it:
+	# in bash, "returns a value" and "returns a diagnosis" cannot both go through stdout.
+	_LID_QUERY_OUT="$out"
+}
+_LID_QUERY_OUT=""
 
 # linear_identity_team_id <TEAM_KEY> [db] — echo the team UUID.
 #
@@ -109,7 +164,8 @@ _lid_q() { sqlite3 "$1" "$2" 2>/dev/null; }
 linear_identity_team_id() {
 	local key="$1" db="${2:-$CATALYST_REPLICA_DB}" id
 	_lid_ready "$db" || return 1
-	id=$(_lid_q "$db" "SELECT team_id FROM issues WHERE team_key='${key//\'/\'\'}' AND team_id IS NOT NULL AND removed_at IS NULL LIMIT 1;")
+	_lid_query_gated "$db" "SELECT team_id FROM issues WHERE team_key='${key//\'/\'\'}' AND team_id IS NOT NULL AND removed_at IS NULL LIMIT 1" || return 1
+	id="$_LID_QUERY_OUT"
 	[[ -n "$id" ]] || {
 		_lid_fail "team-not-resolvable"
 		return 1
@@ -123,8 +179,18 @@ linear_identity_team_id() {
 # board nobody sees.
 linear_identity_state_id() {
 	local key="$1" name="$2" db="${3:-$CATALYST_REPLICA_DB}" team id
-	team=$(linear_identity_team_id "$key" "$db") || return 1
-	id=$(_lid_q "$db" "SELECT id FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND name='${name//\'/\'\'}' AND archived_at IS NULL LIMIT 1;")
+	# ⛔ Codex #3501 P2: this nested call used to be `team=$(linear_identity_team_id …)`.
+	# Command substitution is a SUBSHELL, so a replica-absent / replica-stale /
+	# team-not-resolvable reason set inside it was discarded, and a direct caller got
+	# rc=1 with an EMPTY reason — defeating this module's whole named-failure contract at
+	# the two helpers most callers actually use. Third occurrence of this defect in one
+	# night, the other two in setup-catalyst.sh and resolve-linear-ids.sh: in bash, a
+	# function returning a value on stdout cannot also return a diagnosis, so nested
+	# calls read LINEAR_IDENTITY_VALUE instead of capturing.
+	linear_identity_team_id "$key" "$db" >/dev/null || return 1
+	team="$LINEAR_IDENTITY_VALUE"
+	_lid_query_gated "$db" "SELECT id FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND name='${name//\'/\'\'}' AND archived_at IS NULL LIMIT 1" || return 1
+	id="$_LID_QUERY_OUT"
 	[[ -n "$id" ]] || {
 		_lid_fail "state-not-found"
 		return 1
@@ -142,8 +208,11 @@ linear_identity_state_id() {
 # silent fleet-wide freeze. Returning `{}` here would hand a caller a confident nothing.
 linear_identity_states_json() {
 	local key="$1" db="${2:-$CATALYST_REPLICA_DB}" team json
-	team=$(linear_identity_team_id "$key" "$db") || return 1
-	json=$(_lid_q "$db" "SELECT COALESCE(json_group_object(name, id), '{}') FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND archived_at IS NULL;")
+	# Same subshell trap as linear_identity_state_id above — read the global, do not capture.
+	linear_identity_team_id "$key" "$db" >/dev/null || return 1
+	team="$LINEAR_IDENTITY_VALUE"
+	_lid_query_gated "$db" "SELECT json_group_object(name, id) FROM workflow_states WHERE team_id='${team//\'/\'\'}' AND archived_at IS NULL" || return 1
+	json="$_LID_QUERY_OUT"
 	[[ -n "$json" && "$json" != "{}" ]] || {
 		_lid_fail "state-not-found"
 		return 1
@@ -161,12 +230,15 @@ linear_identity_states_json() {
 linear_identity_label_id() {
 	local name="$1" db="${2:-$CATALYST_REPLICA_DB}" ids n
 	_lid_ready "$db" || return 1
-	ids=$(_lid_q "$db" "SELECT id FROM labels WHERE name='${name//\'/\'\'}' AND removed_at IS NULL;")
+	# group_concat keeps this a SCALAR select so it fits the single-statement snapshot;
+	# the ambiguity count is derived from the separator, not from a second query.
+	_lid_query_gated "$db" "SELECT group_concat(id, ',') FROM labels WHERE name='${name//\'/\'\'}' AND removed_at IS NULL" || return 1
+	ids="$_LID_QUERY_OUT"
 	[[ -n "$ids" ]] || {
 		_lid_fail "label-not-found"
 		return 1
 	}
-	n=$(printf '%s\n' "$ids" | /usr/bin/grep -c .)
+	n=$(awk -F',' '{print NF}' <<<"$ids")
 	if [[ "$n" -gt 1 ]]; then
 		_lid_fail "label-ambiguous"
 		return 1

--- a/plugins/dev/scripts/resolve-linear-ids.sh
+++ b/plugins/dev/scripts/resolve-linear-ids.sh
@@ -93,6 +93,58 @@ if [ "$FORCE" -eq 0 ]; then
   fi
 fi
 
+# ── CTC-403: resolve from the REPLICA first ──────────────────────────────────
+#
+# The API path below needs `linear.apiToken` in the per-project secrets file and hard-
+# exits without it. On a host installed with a Catalyst Cloud token and nothing else —
+# the documented "one command, one key" install — that exit is the whole reason team
+# and state ids ended up hand-written on 21 config files.
+#
+# The replica already carries both: the account's issues give team key → team id, and
+# `workflow_states` gives every live state for that team. So ask it first. The API stays
+# as the fallback for a host with no replica yet, and the source is REPORTED either way —
+# an operator must be able to tell which answer they got.
+#
+# ⛔ No stale fallback. lib/linear-identity.sh gates freshness (writer-lock recency AND a
+# non-empty sync_meta cursor) and returns a NAMED failure — replica-absent, replica-stale,
+# team-not-resolvable, state-not-found — rather than a last-known-good id. An
+# empty-but-fresh replica is a failure there, not an empty answer: that exact shape once
+# produced a fleet-wide admission freeze with every signal green (CTL-1420).
+RESOLVE_SOURCE=""
+FALLBACK_REASON=""
+IDENTITY_LIB="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lib/linear-identity.sh"
+if [ "${CATALYST_RESOLVE_IDS_SOURCE:-auto}" != "api" ] && [ -r "$IDENTITY_LIB" ]; then
+  # shellcheck disable=SC1090
+  . "$IDENTITY_LIB"
+  # Direct calls + LINEAR_IDENTITY_VALUE, NOT `$(…)`: command substitution is a
+  # subshell, so the named reason would be discarded and the note below would print
+  # "(unknown)" for every failure — a diagnosis that diagnoses nothing.
+  if linear_identity_team_id "$TEAM_KEY" >/dev/null 2>&1; then
+    TEAM_ID="$LINEAR_IDENTITY_VALUE"
+  fi
+  if [ -n "${TEAM_ID:-}" ] && linear_identity_states_json "$TEAM_KEY" >/dev/null 2>&1; then
+    STATE_IDS="$LINEAR_IDENTITY_VALUE"
+    STATE_COUNT=$(echo "$STATE_IDS" | jq 'length')
+    RESOLVE_SOURCE="replica"
+  fi
+  if [ "$RESOLVE_SOURCE" = "replica" ]; then
+    :
+  fi
+  if [ -z "$RESOLVE_SOURCE" ]; then
+    # Loud, not silent: falling through to the API is a replica gap worth seeing. But
+    # `--json` callers merge stderr into stdout and pipe the result to jq, so a bare
+    # stderr line there is not "extra diagnostics" — it makes the document unparseable
+    # and every field unreadable. Carry the reason IN the document for those callers and
+    # print it for humans. Suppressing it in --json mode was the other option and is
+    # worse: the machine-readable path is exactly where a silent degradation hides.
+    FALLBACK_REASON="${LINEAR_IDENTITY_REASON:-unknown}"
+    if [ "$JSON_OUT" -eq 0 ]; then
+      echo "note: replica identity unavailable (${FALLBACK_REASON}) — falling back to the Linear API" >&2
+    fi
+  fi
+fi
+
+if [ -z "$RESOLVE_SOURCE" ]; then
 PROJECT_KEY=$(jq -r '.catalyst.projectKey // empty' "$CONFIG_PATH" 2>/dev/null)
 if [ -z "$PROJECT_KEY" ]; then
   echo "ERROR: catalyst.projectKey not set in $CONFIG_PATH — needed to locate secrets" >&2
@@ -137,11 +189,15 @@ fi
 TEAM_ID=$(echo "$TEAM_NODE" | jq -r '.id')
 STATE_IDS=$(echo "$TEAM_NODE" | jq '.states.nodes | map({(.name): .id}) | add')
 STATE_COUNT=$(echo "$TEAM_NODE" | jq '.states.nodes | length')
+  RESOLVE_SOURCE="api"
+fi
 
 if [ "$DRY_RUN" -eq 1 ]; then
   if [ "$JSON_OUT" -eq 1 ]; then
     jq -nc --arg tid "$TEAM_ID" --argjson sids "$STATE_IDS" --argjson count "$STATE_COUNT" \
-      '{action:"dry-run",teamId:$tid,stateIds:$sids,stateCount:$count}'
+      --arg src "$RESOLVE_SOURCE" --arg fb "${FALLBACK_REASON:-}" \
+      '{action:"dry-run",teamId:$tid,stateIds:$sids,stateCount:$count,source:$src}
+       + (if $fb == "" then {} else {replicaFallbackReason:$fb} end)'
   else
     echo "Would write teamId to $CONFIG_PATH:"
     echo "  teamId: $TEAM_ID"
@@ -176,10 +232,11 @@ fi
 
 if [ "$JSON_OUT" -eq 1 ]; then
   jq -nc --arg tid "$TEAM_ID" --argjson sids "$STATE_IDS" --argjson count "$STATE_COUNT" \
-    --arg reg "$REGISTRY_PATH" \
-    '{action:"resolved",teamId:$tid,stateIds:$sids,stateCount:$count,registry:$reg}'
+    --arg reg "$REGISTRY_PATH" --arg src "$RESOLVE_SOURCE" --arg fb "${FALLBACK_REASON:-}" \
+    '{action:"resolved",teamId:$tid,stateIds:$sids,stateCount:$count,registry:$reg,source:$src}
+     + (if $fb == "" then {} else {replicaFallbackReason:$fb} end)'
 else
-  echo "Resolved and cached $STATE_COUNT workflow states for team $TEAM_KEY"
+  echo "Resolved and cached $STATE_COUNT workflow states for team $TEAM_KEY (source: $RESOLVE_SOURCE)"
   echo "  teamId:   $TEAM_ID  ($CONFIG_PATH)"
   echo "  stateIds: $REGISTRY_PATH"
 fi


### PR DESCRIPTION
Part of CTC-403 (increment 1 — **additive**, no reader is cut over yet).

Identity is stored in **four** places, none authoritative. A Linear-to-Linear import
preserves team keys but **mints new internal UUIDs** — and Catalyst keys on the UUID while
caching on the key. So after a workspace cutover every cache still **matched** and every
value beneath it was dead. That is the worst combination: it defeats staleness detection
by construction.

The cloud registry is already authoritative for `(account → workspace → team)` and the
replica already carries every workflow state on every issue, so this is mostly
**subtraction** — read the copy that is already replicated.

## What's here

**`lib/linear-identity.sh`** — team id, state id, the full name→id map, and label id, read
from the replica behind the **same** `replica_fresh` gate the ticket-read helper uses
(writer-lock recency AND a non-empty `sync_meta` cursor). Reused rather than re-derived:
two gates that must agree, maintained separately, is exactly the drift this removes.

**`resolve-linear-ids.sh` asks the replica first.** Its API path needs `linear.apiToken`
in the per-project secrets file and **hard-exits without it**. On a host installed with a
Catalyst Cloud token and nothing else — the documented one-command install — that exit is
the whole reason team and state ids ended up hand-written across 21 config files. The API
stays as the fallback, and the source is **reported** either way.

## ⛔ The trap this deliberately does not walk into

Making identity a replica read couples it to replica freshness, and this fleet has that
failure on record. So every failure is **named** and there is **no stale fallback**:

| case | result | why not the obvious alternative |
| --- | --- | --- |
| empty **but fresh** replica | `state-not-found` | returning `{}` hands a caller a *confident nothing* — the CTL-1420 shape that froze admission fleet-wide with every signal green |
| replica absent vs stale | distinct reasons | they need different repairs; collapsing them turns the first diagnostic step into a guess |
| team with zero issues | `team-not-resolvable` | not "no such team" — indistinguishable from this source, and the stronger claim sends an operator to re-create a team that exists |
| duplicate label name | `label-ambiguous` | first-wins applies a label to the **wrong team's board** and looks like it worked |

## The `--json` stream contract

The fallback reason rides the **document** (`replicaFallbackReason`), not a bare stderr
line. `resolve-linear-ids.test.sh` runs the script with `> "$OUT" 2>&1` — stderr *merged*
into stdout, then piped to `jq` — so in `--json` mode a stderr note is not extra
diagnostics: it makes the whole document unparseable and every field unreadable. The first
cut shipped it as a stderr echo and broke three existing assertions.

Suppressing it under `--json` was the other option and is **worse**: the machine-readable
path is precisely where a silent degradation hides. Humans still get the stderr note.

```
$ resolve-linear-ids.sh --dry-run --json --force            # replica present
{"source":"replica","stateCount":12,"replicaFallbackReason":null}

$ CATALYST_REPLICA_DB=/nonexistent resolve-linear-ids.sh --dry-run --json --force
{"source":"api","replicaFallbackReason":"replica-absent"}
```

## One defect worth naming

The module exposes `LINEAR_IDENTITY_VALUE` because `$(fn)` is a **subshell** — the first
cut captured that way, so `LINEAR_IDENTITY_REASON` died with the subshell and the note
printed `(unknown)` for an absent replica. A failure that reports, but reports nothing
usable. This repo hit the identical defect in `setup-catalyst.sh` the same night (#3500);
both are pinned by tests now.

## Cross-validation

With the replica path and the forced-API path both run against the live workspace, the two
independently return the **same** `teamId` and the same 12 state UUIDs — so the replica's
answer is checked against Linear's own API, not just against itself.

## Tests

- `__tests__/linear-identity.test.sh` — **20** assertions over a fixture replica. Every
  positive is paired with its degraded case over the *same* call, and the empty-but-fresh
  case carries a positive control proving the freshness gate is open (so the failure is
  the empty table, not a broken gate). Includes SQL-quote escaping.
- `__tests__/resolve-linear-ids.test.sh` — **+4**, pinning the `--json` stream contract.
  **34 passed / 0 failed**, against a **measured `origin/main` baseline of 30/0** on the
  same harness (the 3 failures the first cut introduced were attributed by running that
  baseline, not assumed pre-existing).
- `linear-transition.test.sh`, `check-project-setup.test.sh` (the other
  `linear-state-ids.json` consumers): pass unchanged.
- `trunk check`: my files clean. `resolve-linear-ids.sh` and its test remain flagged as
  unformatted — **both are unformatted on `origin/main`** (verified against a pristine
  checkout), and reformatting them would bury this change under a whole-file sweep.

## Not in this increment

The 14 non-test callers of `getReplicaDbPath()`/`linear-state-ids.json` across JS **and**
bash. That cutover needs the one-registry / two-engines / parity-suite discipline of
`lib/secret-contract.mjs`, or a bash reader silently reads another tenant's replica — which
is worse than failing, because it returns plausible data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)