### PR TITLE
feat(dev): CTL-1936 — a host bounds its own cloud write spend, and stops re-issuing a write that already converged

### DIFF
--- a/plugins/dev/scripts/execution-core/clear-stall-nothing-to-clear.test.mjs
+++ b/plugins/dev/scripts/execution-core/clear-stall-nothing-to-clear.test.mjs
@@ -1,0 +1,81 @@
+// clear-stall-nothing-to-clear.test.mjs — CTL-1936.
+//
+// `defaultClearStall` used to issue a needs-human REMOVAL unconditionally, so a ticket
+// with no stalled signal and no needs-human sent one to Linear on every tick, forever.
+// That is the measured runaway: CTL-1805 — Done in Linear, carrying only `orchestrator`,
+// holding a worker directory untouched since Aug 15 — spent 302 of one host's 307 daily
+// cloud writes in ~13 minutes, and every unrelated ticket on that host lost its writes.
+//
+// The gate is a CONJUNCTION, and the two controls below are why: a previous clear can
+// delete the signal and then FAIL to remove the label, and that ticket must still retry
+// or the label is stranded forever.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defaultClearStall } from "./scheduler.mjs";
+
+let orchDir;
+let workerDir;
+let removals;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1936-clear-"));
+  workerDir = join(orchDir, "workers", "CTL-1805");
+  mkdirSync(workerDir, { recursive: true });
+  removals = [];
+});
+
+afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+const writeStatus = {
+  removeLabel: (...args) => {
+    removals.push(args);
+    return { removed: true };
+  },
+};
+
+const clear = () =>
+  defaultClearStall(orchDir, writeStatus)({ ticket: "CTL-1805", phase: "recovery-pass" });
+
+describe("nothing to clear is not a clear", () => {
+  test("⛔ no stalled signal and no label marker → no Linear write at all", () => {
+    // The exact CTL-1805 state: a worker dir whose phase signals are gone, on a ticket
+    // that carries no needs-human. Before the gate this issued a removal every tick.
+    writeFileSync(join(workerDir, ".some-unrelated-marker"), "");
+    expect(clear()).toBe(false);
+    expect(removals.length).toBe(0);
+  });
+
+  test("⛔ CONTROL: a stalled signal present → the clear proceeds and DOES write", () => {
+    // Proves the gate is not simply refusing everything — the same instrument,
+    // the same call, one differing precondition.
+    writeFileSync(
+      join(workerDir, "phase-recovery-pass.json"),
+      JSON.stringify({ status: "stalled" })
+    );
+    expect(clear()).toBe(true);
+    expect(removals.length).toBe(1);
+  });
+
+  test("⛔ CONTROL: signal gone but a label WAS applied → still retries the removal", () => {
+    // A previous clear deleted the signal and then failed to remove the label. Gating on
+    // the signal alone would strand that label on the ticket permanently.
+    writeFileSync(join(workerDir, ".linear-label-needs-human.applied"), "");
+    expect(clear()).toBe(true);
+    expect(removals.length).toBe(1);
+  });
+
+  test("⛔ CONTROL: a `.skipped` marker also counts as a reason to proceed", () => {
+    writeFileSync(join(workerDir, ".linear-label-needs-human.skipped"), "");
+    expect(clear()).toBe(true);
+    expect(removals.length).toBe(1);
+  });
+
+  test("an absent worker dir is nothing to clear, and does not throw", () => {
+    rmSync(workerDir, { recursive: true, force: true });
+    expect(clear()).toBe(false);
+    expect(removals.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -32,6 +32,8 @@ import { homedir } from "node:os";
 // drags a ~1,100-line reformat into the diff — extracting keeps this change reviewable.
 import { STATUS, mkCheck } from "./doctor-status.mjs";
 import { checkInstallCompleteness } from "./install-completeness.mjs";
+// CTL-1936 AC5: the standing answer to "is this host write-exhausted".
+import { checkLinearWriteBudget } from "./write-budget-health.mjs";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
 
@@ -165,6 +167,8 @@ function readLinearBotUserIds(l1Path, l2Path) {
 export { STATUS, mkCheck } from "./doctor-status.mjs";
 
 export { checkInstallCompleteness };
+
+export { checkLinearWriteBudget };
 
 // ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
 //
@@ -5904,6 +5908,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkDrainDisabled(), // CTL-1678: surface the per-node drain override + the draining-but-ignored third state — advisory only (never FAIL)
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
     () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
+    () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
   ];
 }

--- a/plugins/dev/scripts/execution-core/linear-write-budget.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-budget.mjs
@@ -1,0 +1,216 @@
+// linear-write-budget.mjs — CTL-1936.
+//
+// A host-side ledger and throttle for cloud write-proxy spend.
+//
+// ── WHAT HAPPENED ──
+// mini-2 spent its entire daily cloud write budget — 300/300 for UTC 2026-08-18 — in
+// about 13 minutes, on ONE ticket: 302 of 307 writes were `route=label` on CTL-1805,
+// a ticket that is Done in Linear and carries only `orchestrator`. Every Linear write
+// from that host was then refused (enforce has no direct-write fallback, by design),
+// and the same burst would recur at every UTC day boundary.
+//
+// ⛔ CTC-674 IS NOT THE DEFECT. Before it, removing an already-absent label returned
+// 400, so `clearStalledLabel`'s CTL-1078 back-off engaged and held the loop to ~6/hour.
+// CTC-674 correctly made that call return 200 `already-absent` — and the back-off, which
+// only counts FAILURES, stopped engaging. The loop went from ~6/hour to ~1,700/hour.
+// An error response had been doing a rate limiter's job and nobody knew. The idempotency
+// fix is right; what was missing is this file.
+//
+// ── WHY A PER-TICKET CAP AND NOT A HOST CAP ──
+// The failure is a non-converging caller, whose signature is volume concentrated on ONE
+// ticket — 302 vs 5 for everything else. A host-wide cap would fire on a host that is
+// legitimately busy across many tickets, which AC2's own negative control forbids: "a cap
+// that fires on healthy fan-out is a worse defect than the one it replaces." So the
+// throttle is per-ticket, and a refusal for one ticket never blocks another's writes.
+
+import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** The cloud-side daily cap this mirrors. Used for the exhaustion signal, not the throttle. */
+export const DEFAULT_DAILY_BUDGET = 300;
+
+/**
+ * One ticket's share of a day. 50 sits an order of magnitude above what a real ticket
+ * spends walking the 10-phase pipeline (state transitions + label add/remove + comments)
+ * and an order of magnitude below the 302 the runaway produced, so it separates the two
+ * populations rather than splitting either.
+ */
+export const DEFAULT_PER_TICKET_CAP = 50;
+
+export const REASONS = Object.freeze({
+  TICKET_CAP: "budget:ticket-cap",
+  DAY_EXHAUSTED: "budget:day-exhausted",
+  CONVERGED: "budget:already-converged",
+});
+
+/** The UTC day key. Deliberately UTC — the cloud budget resets on the UTC boundary. */
+export function utcDayOf(nowMs) {
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+export function emptyLedger(day) {
+  return { day, total: 0, byTicket: {}, converged: {}, exhaustedAnnounced: false };
+}
+
+/**
+ * readLedger — TRI-STATE, and the three states are not interchangeable.
+ *
+ *   { state: "fresh"   } — no ledger yet (ENOENT). A new day's worth of budget is correct.
+ *   { state: "loaded"  } — a usable ledger.
+ *   { state: "unusable"} — the file exists but cannot be read or parsed.
+ *
+ * ⛔ `unusable` is NOT folded into `fresh`. A corrupt ledger silently granting a full
+ * budget, and then being overwritten, is how a durable guard gets disarmed by the very
+ * corruption it exists to survive (the CTL-1659 shape). The caller is told, and says so.
+ */
+export function readLedger(path, { readFileFn = readFileSync } = {}) {
+  let raw;
+  try {
+    raw = readFileFn(path, "utf8");
+  } catch (err) {
+    if (err && (err.code === "ENOENT" || err.code === "ENOTDIR")) return { state: "fresh" };
+    return { state: "unusable", reason: `unreadable: ${err?.code ?? err?.message ?? "unknown"}` };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { state: "unusable", reason: "unparseable" };
+  }
+  // Field types are checked BEFORE any coercion: Number(null) and Number([]) are 0, which
+  // reads as "nothing spent yet" and hands a runaway a full fresh budget out of a file
+  // that is telling us it is broken.
+  if (!parsed || typeof parsed !== "object" || typeof parsed.day !== "string") {
+    return { state: "unusable", reason: "malformed" };
+  }
+  if (typeof parsed.total !== "number" || !Number.isFinite(parsed.total)) {
+    return { state: "unusable", reason: "malformed-total" };
+  }
+  if (!parsed.byTicket || typeof parsed.byTicket !== "object" || Array.isArray(parsed.byTicket)) {
+    return { state: "unusable", reason: "malformed-byTicket" };
+  }
+  return {
+    state: "loaded",
+    ledger: {
+      day: parsed.day,
+      total: parsed.total,
+      byTicket: parsed.byTicket,
+      converged:
+        parsed.converged && typeof parsed.converged === "object" && !Array.isArray(parsed.converged)
+          ? parsed.converged
+          : {},
+      exhaustedAnnounced: parsed.exhaustedAnnounced === true,
+    },
+  };
+}
+
+/**
+ * rollToDay — the reset is by DAY KEY, never by process start.
+ * A ledger whose day differs from today's is replaced, not merged: yesterday's spend has
+ * no claim on today's budget, and carrying it forward would throttle a healthy morning.
+ */
+export function rollToDay(ledger, day) {
+  if (!ledger || ledger.day !== day) return emptyLedger(day);
+  return ledger;
+}
+
+/**
+ * classifyWrite — pure. Decide whether this write may be issued.
+ *
+ * `convergenceKey` (optional) identifies a write whose desired state the cloud has already
+ * confirmed reached — see noteConvergence. Passing one is what makes AC3 work; omitting it
+ * simply means this write is never suppressed as converged.
+ */
+export function classifyWrite({
+  ledger,
+  ticket,
+  convergenceKey = null,
+  dailyBudget = DEFAULT_DAILY_BUDGET,
+  perTicketCap = DEFAULT_PER_TICKET_CAP,
+}) {
+  const spentForTicket = Number(ledger?.byTicket?.[ticket] ?? 0) || 0;
+  const total = Number(ledger?.total ?? 0) || 0;
+
+  if (convergenceKey && ledger?.converged?.[convergenceKey]) {
+    return { allow: false, reason: REASONS.CONVERGED, spentForTicket, total };
+  }
+  // ⛔ Per-ticket BEFORE host-wide: when a single runaway has eaten the day, the honest
+  // reason is that ticket's cap, not "the host is out" — and naming the host would send an
+  // operator looking for a fleet problem instead of the one stuck caller.
+  if (spentForTicket >= perTicketCap) {
+    return { allow: false, reason: REASONS.TICKET_CAP, spentForTicket, total, cap: perTicketCap };
+  }
+  if (total >= dailyBudget) {
+    return { allow: false, reason: REASONS.DAY_EXHAUSTED, spentForTicket, total, cap: dailyBudget };
+  }
+  return { allow: true, reason: null, spentForTicket, total };
+}
+
+/** recordWrite — pure. Count a write that was actually ISSUED (not one refused locally). */
+export function recordWrite(ledger, ticket) {
+  const key = ticket || "<no-ticket>";
+  const byTicket = { ...(ledger.byTicket ?? {}) };
+  byTicket[key] = (Number(byTicket[key] ?? 0) || 0) + 1;
+  return { ...ledger, total: (Number(ledger.total ?? 0) || 0) + 1, byTicket };
+}
+
+/**
+ * noteConvergence — pure. Record that the cloud confirmed the desired state is ALREADY
+ * reached, so an identical write need not be issued again.
+ *
+ * ⛔ This is NOT a failure. It must never feed the CTL-1078 removal-failure counter:
+ * folding it in would restore the old throttle by re-introducing a lie — the write
+ * succeeded. Convergence and failure are different states and stay different.
+ */
+export function noteConvergence(ledger, convergenceKey) {
+  if (!convergenceKey) return ledger;
+  return { ...ledger, converged: { ...(ledger.converged ?? {}), [convergenceKey]: true } };
+}
+
+/** clearConvergence — a genuinely-present label must still remove normally (AC3 control). */
+export function clearConvergence(ledger, convergenceKey) {
+  if (!convergenceKey || !ledger?.converged?.[convergenceKey]) return ledger;
+  const converged = { ...ledger.converged };
+  delete converged[convergenceKey];
+  return { ...ledger, converged };
+}
+
+/**
+ * convergenceKeyFor — identifies "this exact desired state, for this ticket".
+ * Route + ticket + a stable render of the payload's identity fields. A DIFFERENT label on
+ * the same ticket is a different key, so suppressing one never suppresses another.
+ */
+export function convergenceKeyFor({ routeId, ticket, payload }) {
+  if (!routeId || !ticket) return null;
+  const ids = Array.isArray(payload?.labelIds) ? [...payload.labelIds].sort().join(",") : "";
+  const mode = payload?.mode ?? "";
+  if (!ids || !mode) return null;
+  return `${routeId}:${ticket}:${mode}:${ids}`;
+}
+
+/**
+ * classifyExhaustion — edge-triggered (AC5): raise ONCE per episode, not once per refused
+ * write. A budget storm is exactly when a per-event alarm buries the one line that matters.
+ */
+export function classifyExhaustion(ledger, { dailyBudget = DEFAULT_DAILY_BUDGET } = {}) {
+  const total = Number(ledger?.total ?? 0) || 0;
+  const exhausted = total >= dailyBudget;
+  if (!exhausted) return { exhausted: false, announce: false };
+  return { exhausted: true, announce: ledger?.exhaustedAnnounced !== true };
+}
+
+export function markExhaustionAnnounced(ledger) {
+  return { ...ledger, exhaustedAnnounced: true };
+}
+
+/** writeLedger — atomic tmp+rename; never leaves a half-written ledger for the next read. */
+export function writeLedger(
+  path,
+  ledger,
+  { writeFileFn = writeFileSync, renameFn = renameSync, mkdirFn = mkdirSync } = {}
+) {
+  const tmp = `${path}.tmp.${process.pid}`;
+  mkdirFn(dirname(path), { recursive: true });
+  writeFileFn(tmp, `${JSON.stringify(ledger)}\n`, "utf8");
+  renameFn(tmp, path);
+}

--- a/plugins/dev/scripts/execution-core/linear-write-budget.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-budget.test.mjs
@@ -1,0 +1,229 @@
+// linear-write-budget.test.mjs — CTL-1936.
+//
+// The ticket's own negative control is the load-bearing one and it is asserted below:
+// a host legitimately doing a full day's writes across MANY tickets must not be
+// throttled. "A cap that fires on healthy fan-out is a worse defect than the one it
+// replaces." Every throttle assertion here is therefore paired with that fan-out case.
+
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_DAILY_BUDGET,
+  DEFAULT_PER_TICKET_CAP,
+  REASONS,
+  classifyExhaustion,
+  classifyWrite,
+  clearConvergence,
+  convergenceKeyFor,
+  emptyLedger,
+  markExhaustionAnnounced,
+  noteConvergence,
+  readLedger,
+  recordWrite,
+  rollToDay,
+  utcDayOf,
+} from "./linear-write-budget.mjs";
+
+const DAY = "2026-08-18";
+const spend = (ledger, ticket, n) => {
+  let l = ledger;
+  for (let i = 0; i < n; i++) l = recordWrite(l, ticket);
+  return l;
+};
+
+describe("AC1 — a host knows what it has spent", () => {
+  test("writes are counted per ticket and in total", () => {
+    let l = spend(emptyLedger(DAY), "CTL-1", 3);
+    l = spend(l, "CTL-2", 2);
+    expect(l.total).toBe(5);
+    expect(l.byTicket["CTL-1"]).toBe(3);
+    expect(l.byTicket["CTL-2"]).toBe(2);
+  });
+
+  test("the reset is by UTC DAY KEY, not by process start", () => {
+    const yesterday = spend(emptyLedger("2026-08-17"), "CTL-1", 299);
+    const rolled = rollToDay(yesterday, DAY);
+    expect(rolled.day).toBe(DAY);
+    expect(rolled.total).toBe(0);
+    // …and the same ledger on the SAME day is untouched — a restart must not reset it.
+    const same = rollToDay(spend(emptyLedger(DAY), "CTL-1", 7), DAY);
+    expect(same.total).toBe(7);
+  });
+
+  test("utcDayOf is UTC, not local — the cloud budget resets on the UTC boundary", () => {
+    // 2026-08-18T02:39Z is still Aug 17 in US Central; the ledger must say Aug 18.
+    expect(utcDayOf(Date.parse("2026-08-18T02:39:00Z"))).toBe("2026-08-18");
+  });
+});
+
+describe("readLedger is TRI-STATE and never grants a budget out of a broken file", () => {
+  const read = (payload) =>
+    readLedger("/x", {
+      readFileFn: () => {
+        if (payload instanceof Error) throw payload;
+        return payload;
+      },
+    });
+
+  test("absent → fresh", () => {
+    const e = new Error("nope");
+    e.code = "ENOENT";
+    expect(read(e).state).toBe("fresh");
+  });
+
+  test("⛔ unreadable is NOT fresh", () => {
+    const e = new Error("boom");
+    e.code = "EACCES";
+    expect(read(e).state).toBe("unusable");
+  });
+
+  test("⛔ unparseable is NOT fresh", () => {
+    expect(read("{not json").state).toBe("unusable");
+  });
+
+  test("⛔ a null/array total is malformed, not zero", () => {
+    // Number(null) and Number([]) are both 0, which reads as "nothing spent yet" and
+    // hands a runaway a full budget out of a file that is telling us it is broken.
+    expect(read(JSON.stringify({ day: DAY, total: null, byTicket: {} })).state).toBe("unusable");
+    expect(read(JSON.stringify({ day: DAY, total: [], byTicket: {} })).state).toBe("unusable");
+    expect(read(JSON.stringify({ day: DAY, total: 5, byTicket: [] })).state).toBe("unusable");
+  });
+
+  test("a well-formed ledger loads", () => {
+    const r = read(JSON.stringify({ day: DAY, total: 4, byTicket: { "CTL-1": 4 } }));
+    expect(r.state).toBe("loaded");
+    expect(r.ledger.total).toBe(4);
+  });
+});
+
+describe("AC2 — one ticket cannot spend the whole budget", () => {
+  test("a ticket at its cap is refused LOCALLY with a named reason", () => {
+    const l = spend(emptyLedger(DAY), "CTL-1805", DEFAULT_PER_TICKET_CAP);
+    const v = classifyWrite({ ledger: l, ticket: "CTL-1805" });
+    expect(v.allow).toBe(false);
+    expect(v.reason).toBe(REASONS.TICKET_CAP);
+  });
+
+  test("writes for OTHER tickets still go through", () => {
+    const l = spend(emptyLedger(DAY), "CTL-1805", DEFAULT_PER_TICKET_CAP + 20);
+    expect(classifyWrite({ ledger: l, ticket: "CTL-999" }).allow).toBe(true);
+  });
+
+  test("⛔ THE NEGATIVE CONTROL: a full day's writes spread over many tickets is NOT throttled", () => {
+    // 300 writes across 60 tickets — a legitimately busy host. A cap that fires here is
+    // a worse defect than the runaway it replaces.
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 60; i++) l = spend(l, `CTL-${i}`, 5);
+    expect(l.total).toBe(300);
+    for (let i = 0; i < 60; i++) {
+      expect(classifyWrite({ ledger: l, ticket: `CTL-${i}`, dailyBudget: 10_000 }).allow).toBe(
+        true
+      );
+    }
+  });
+
+  test("the runaway's real shape is caught: 302 on one ticket, 5 elsewhere", () => {
+    let l = spend(emptyLedger(DAY), "CTL-1805", 302);
+    l = spend(l, "CTL-OTHER", 5);
+    expect(classifyWrite({ ledger: l, ticket: "CTL-1805" }).reason).toBe(REASONS.TICKET_CAP);
+    // and the collateral the incident actually caused is prevented:
+    expect(classifyWrite({ ledger: l, ticket: "CTL-OTHER", dailyBudget: 10_000 }).allow).toBe(true);
+  });
+
+  test("the per-ticket reason wins over the host-wide one", () => {
+    // Naming the host would send an operator after a fleet problem instead of one caller.
+    const l = spend(emptyLedger(DAY), "CTL-1805", DEFAULT_DAILY_BUDGET);
+    expect(classifyWrite({ ledger: l, ticket: "CTL-1805" }).reason).toBe(REASONS.TICKET_CAP);
+  });
+
+  test("a host genuinely out of budget says so", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    expect(classifyWrite({ ledger: l, ticket: "T-NEW" }).reason).toBe(REASONS.DAY_EXHAUSTED);
+  });
+});
+
+describe("AC3 — a converged write is not re-issued", () => {
+  const key = convergenceKeyFor({
+    routeId: "label",
+    ticket: "CTL-1805",
+    payload: { labelIds: ["lab-1"], mode: "remove" },
+  });
+
+  test("a key is derived from route + ticket + mode + label ids", () => {
+    expect(key).toBe("label:CTL-1805:remove:lab-1");
+  });
+
+  test("after convergence the identical write is suppressed", () => {
+    const l = noteConvergence(emptyLedger(DAY), key);
+    const v = classifyWrite({ ledger: l, ticket: "CTL-1805", convergenceKey: key });
+    expect(v.allow).toBe(false);
+    expect(v.reason).toBe(REASONS.CONVERGED);
+  });
+
+  test("⛔ CONTROL: a DIFFERENT label on the same ticket still goes through", () => {
+    const l = noteConvergence(emptyLedger(DAY), key);
+    const other = convergenceKeyFor({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: { labelIds: ["lab-2"], mode: "remove" },
+    });
+    expect(classifyWrite({ ledger: l, ticket: "CTL-1805", convergenceKey: other }).allow).toBe(
+      true
+    );
+  });
+
+  test("⛔ CONTROL: an ADD of the same label is a different desired state", () => {
+    const l = noteConvergence(emptyLedger(DAY), key);
+    const add = convergenceKeyFor({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: { labelIds: ["lab-1"], mode: "add" },
+    });
+    expect(classifyWrite({ ledger: l, ticket: "CTL-1805", convergenceKey: add }).allow).toBe(true);
+  });
+
+  test("clearing convergence lets a genuinely-present label remove again", () => {
+    let l = noteConvergence(emptyLedger(DAY), key);
+    l = clearConvergence(l, key);
+    expect(classifyWrite({ ledger: l, ticket: "CTL-1805", convergenceKey: key }).allow).toBe(true);
+  });
+
+  test("⛔ convergence is NOT a failure — it touches no failure counter here", () => {
+    // Folding `already-absent` into the CTL-1078 removal-failure count would restore the
+    // old throttle by re-introducing a lie: the write succeeded.
+    const l = noteConvergence(emptyLedger(DAY), key);
+    expect(l.total).toBe(0);
+    expect(l.byTicket).toEqual({});
+  });
+});
+
+describe("AC5 — the exhausted state is loud, exactly once", () => {
+  test("no announcement below the budget", () => {
+    expect(classifyExhaustion(spend(emptyLedger(DAY), "T", 299)).announce).toBe(false);
+  });
+
+  test("announces on the first crossing", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    const v = classifyExhaustion(l);
+    expect(v.exhausted).toBe(true);
+    expect(v.announce).toBe(true);
+  });
+
+  test("⛔ and NOT again — a storm must not emit one alarm per refused write", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    l = markExhaustionAnnounced(l);
+    const v = classifyExhaustion(l);
+    expect(v.exhausted).toBe(true);
+    expect(v.announce).toBe(false);
+  });
+
+  test("the latch does not survive the day roll", () => {
+    let l = emptyLedger("2026-08-17");
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    const rolled = rollToDay(markExhaustionAnnounced(l), DAY);
+    expect(classifyExhaustion(rolled).exhausted).toBe(false);
+    expect(rolled.exhaustedAnnounced).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-budget.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-budget.test.mjs
@@ -1,0 +1,222 @@
+// linear-write-proxy-budget.test.mjs — CTL-1936, the wired behaviour.
+//
+// linear-write-budget.test.mjs covers the pure decisions. These cover the thing that
+// actually failed: whether the transport ASKS before it spends. Every refusal assertion
+// therefore also asserts that `httpFn` was NOT called — a refusal that still costs a
+// cloud call is not a fix, it is the incident with extra logging.
+
+import { describe, expect, test } from "bun:test";
+import { createLinearWriteProxy, EVENT_EXHAUSTED } from "./linear-write-proxy.mjs";
+import {
+  emptyLedger,
+  recordWrite,
+  utcDayOf,
+  DEFAULT_PER_TICKET_CAP,
+} from "./linear-write-budget.mjs";
+
+const DAY = utcDayOf(Date.parse("2026-08-18T04:00:00Z"));
+const NOW = () => Date.parse("2026-08-18T04:00:00Z");
+
+const okBody = (results) =>
+  `${JSON.stringify({ outcome: "succeeded", ...(results ? { results } : {}) })}\n200`;
+
+/** A proxy whose ledger lives in memory and whose HTTP is a counted stub. */
+function harness({ ledger = emptyLedger(DAY), stdout = okBody(null), env = {} } = {}) {
+  const calls = [];
+  const events = [];
+  let stored = ledger;
+  const proxy = createLinearWriteProxy({
+    mode: "enforce",
+    env: { CATALYST_CLOUD_TOKEN: "tok-abcdefghijklmnopqrstuvwxyz012345678901234567", ...env },
+    nowFn: NOW,
+    readLedgerFn: () =>
+      stored === null ? { state: "unusable", reason: "test" } : { state: "loaded", ledger: stored },
+    writeLedgerFn: (_p, l) => {
+      stored = l;
+    },
+    httpFn: (req) => {
+      calls.push(req);
+      return { code: 0, stdout, stderr: "" };
+    },
+    appendEvent: (line) => events.push(JSON.parse(line)),
+    log: { warn() {}, error() {}, info() {} },
+  });
+  return { proxy, calls, events, ledger: () => stored, unusable: () => (stored = null) };
+}
+
+const labelPayload = (ids, mode = "remove") => ({ issueId: "i-1", labelIds: ids, mode });
+
+describe("AC2 — a runaway ticket is refused locally, without a cloud call", () => {
+  test("at the per-ticket cap the write is refused and NOT sent", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < DEFAULT_PER_TICKET_CAP; i++) l = recordWrite(l, "CTL-1805");
+    const h = harness({ ledger: l });
+    const r = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("budget:ticket-cap");
+    // The whole point: a refusal at the cloud costs a budget unit; this one costs nothing.
+    expect(h.calls.length).toBe(0);
+  });
+
+  test("⛔ CONTROL: another ticket's write still goes through", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < DEFAULT_PER_TICKET_CAP + 20; i++) l = recordWrite(l, "CTL-1805");
+    const h = harness({ ledger: l });
+    const r = h.proxy.send({
+      routeId: "comment",
+      ticket: "CTL-999",
+      payload: { issueId: "i", body: "b" },
+    });
+    expect(r.applied).toBe(true);
+    expect(h.calls.length).toBe(1);
+  });
+
+  test("the refusal is an EVENT, not only a log line", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < DEFAULT_PER_TICKET_CAP; i++) l = recordWrite(l, "CTL-1805");
+    const h = harness({ ledger: l });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    const names = h.events.map((e) => e.attributes["event.name"]);
+    expect(names.some((n) => n.startsWith("linear.write.proxy.failed"))).toBe(true);
+    expect(h.events[0].attributes["catalyst.linear_write_proxy.reason"]).toBe("budget:ticket-cap");
+  });
+
+  test("a refused write does not count as spend — it never left the host", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < DEFAULT_PER_TICKET_CAP; i++) l = recordWrite(l, "CTL-1805");
+    const before = h_total(l);
+    const h = harness({ ledger: l });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    expect(h_total(h.ledger())).toBe(before);
+  });
+});
+
+const h_total = (l) => l.total;
+
+describe("AC1 — spend is recorded for writes that left the host", () => {
+  test("an applied write increments the ticket and the total", () => {
+    const h = harness();
+    h.proxy.send({ routeId: "comment", ticket: "CTL-7", payload: { issueId: "i", body: "b" } });
+    expect(h.ledger().total).toBe(1);
+    expect(h.ledger().byTicket["CTL-7"]).toBe(1);
+  });
+
+  test("⛔ a FAILED write still counts — it spent a budget unit", () => {
+    // Counting only successes is how the pre-CTC-674 loop spent a day invisibly: every
+    // one of those calls was a 400, and every one cost budget.
+    const h = harness({
+      stdout: `${JSON.stringify({ outcome: "rejected", reason: "nope" })}\n400`,
+    });
+    const r = h.proxy.send({ routeId: "label", ticket: "CTL-8", payload: labelPayload(["lab-1"]) });
+    expect(r.applied).toBe(false);
+    expect(h.ledger().total).toBe(1);
+  });
+});
+
+describe("AC3 — a converged removal is not re-issued", () => {
+  const allAbsent = okBody([{ labelId: "lab-1", outcome: "already-absent", attempts: 1 }]);
+
+  test("after an all-already-absent 200, the identical write is suppressed with no call", () => {
+    const h = harness({ stdout: allAbsent });
+    const first = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(first.applied).toBe(true);
+    expect(h.calls.length).toBe(1);
+
+    const second = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(second.applied).toBe(false);
+    expect(second.reason).toBe("budget:already-converged");
+    expect(h.calls.length).toBe(1); // still one — nothing was sent
+  });
+
+  test("⛔ CONTROL: a genuinely-present label removes normally and is NOT marked converged", () => {
+    const realRemoval = okBody([{ labelId: "lab-1", outcome: "succeeded", attempts: 1 }]);
+    const h = harness({ stdout: realRemoval });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    const second = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(second.applied).toBe(true);
+    expect(h.calls.length).toBe(2);
+  });
+
+  test("⛔ CONTROL: convergence on one label does not suppress a DIFFERENT label", () => {
+    const h = harness({ stdout: allAbsent });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    const other = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-2"]),
+    });
+    expect(other.applied).toBe(true);
+    expect(h.calls.length).toBe(2);
+  });
+});
+
+describe("AC4 — a write is attributable", () => {
+  test("caller and labels reach BOTH the attributes and the payload", () => {
+    // Attributes matter because otel-forward strips body.payload off-machine: a field
+    // only in the payload is invisible to the operator asking this from Loki.
+    const h = harness();
+    h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1", "lab-2"]),
+      caller: "clearStalledLabel",
+    });
+    const e = h.events.find((x) =>
+      x.attributes["event.name"].startsWith("linear.write.proxy.applied")
+    );
+    expect(e.attributes["catalyst.linear_write_proxy.caller"]).toBe("clearStalledLabel");
+    expect(e.attributes["catalyst.linear_write_proxy.labels"]).toBe("lab-1,lab-2");
+    expect(e.body.payload.caller).toBe("clearStalledLabel");
+    expect(e.body.payload.labels).toEqual(["lab-1", "lab-2"]);
+  });
+});
+
+describe("AC5 — exhaustion raises once", () => {
+  test("one event on the crossing, none on the writes after it", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 299; i++) l = recordWrite(l, `T-${i}`);
+    const h = harness({ ledger: l });
+    h.proxy.send({ routeId: "comment", ticket: "T-300", payload: { issueId: "i", body: "b" } });
+    const exhausted = () =>
+      h.events.filter((e) => e.attributes["event.name"].startsWith(EVENT_EXHAUSTED));
+    expect(exhausted().length).toBe(1);
+
+    // Subsequent traffic is refused by the gate and must NOT re-raise.
+    h.proxy.send({ routeId: "comment", ticket: "T-301", payload: { issueId: "i", body: "b" } });
+    h.proxy.send({ routeId: "comment", ticket: "T-302", payload: { issueId: "i", body: "b" } });
+    expect(exhausted().length).toBe(1);
+  });
+});
+
+describe("an unusable ledger fails OPEN, and never silently", () => {
+  test("the write still goes through when the ledger cannot be read", () => {
+    // Deliberate: failing closed here turns one corrupt file into a TOTAL Linear-write
+    // outage, which is worse than the runaway this bounds (the cloud's 429 still
+    // backstops that). What must not happen is failing open QUIETLY.
+    const h = harness();
+    h.unusable();
+    const r = h.proxy.send({
+      routeId: "comment",
+      ticket: "CTL-7",
+      payload: { issueId: "i", body: "b" },
+    });
+    expect(r.applied).toBe(true);
+    expect(h.calls.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-budget.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-budget.test.mjs
@@ -166,6 +166,93 @@ describe("AC3 — a converged removal is not re-issued", () => {
   });
 });
 
+describe("⛔ Codex #3505 P1 — convergence goes stale when the label is re-added", () => {
+  const allAbsent = okBody([{ labelId: "lab-1", outcome: "already-absent", attempts: 1 }]);
+
+  test("an ADD of the same label clears the stale remove-convergence, so the next removal is SENT", () => {
+    // Without this, `clearConvergence` had no production caller at all: a converged
+    // removal + a later re-add left the stale key in place, the next legitimate removal
+    // was refused locally as `budget:already-converged`, and the label stayed STRANDED on
+    // the ticket until the UTC day rolled — worse than the wasted call it saves.
+    const h = harness({ stdout: allAbsent });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    expect(h.calls.length).toBe(1);
+
+    // control: while converged, the removal really is suppressed
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    expect(h.calls.length).toBe(1);
+
+    // the label is re-added — the desired state recorded above is now FALSE
+    const added = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"], "add"),
+    });
+    expect(added.applied).toBe(true);
+
+    // …so the next removal must reach the cloud
+    const removal = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(removal.applied).toBe(true);
+    expect(h.calls.length).toBe(3);
+  });
+
+  test("⛔ CONTROL: adding a DIFFERENT label does not clear the convergence", () => {
+    const h = harness({ stdout: allAbsent });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-1"]) });
+    h.proxy.send({ routeId: "label", ticket: "CTL-1805", payload: labelPayload(["lab-2"], "add") });
+    const removal = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(removal.reason).toBe("budget:already-converged");
+  });
+});
+
+describe("⛔ Codex #3505 P2 — a nonsense cap is refused, not obeyed", () => {
+  test("a negative cap does NOT refuse every write", () => {
+    // `Number("-1") || DEFAULT` is -1, and `spent >= -1` is true before anything is
+    // spent — one character turning enforce mode into a total write outage.
+    const h = harness({ env: { CATALYST_LINEAR_WRITE_TICKET_CAP: "-1" } });
+    const r = h.proxy.send({
+      routeId: "comment",
+      ticket: "CTL-7",
+      payload: { issueId: "i", body: "b" },
+    });
+    expect(r.applied).toBe(true);
+  });
+
+  test("Infinity does not silently disable the bound", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < DEFAULT_PER_TICKET_CAP; i++) l = recordWrite(l, "CTL-1805");
+    const h = harness({ ledger: l, env: { CATALYST_LINEAR_WRITE_TICKET_CAP: "Infinity" } });
+    const r = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(r.reason).toBe("budget:ticket-cap");
+  });
+
+  test("⛔ CONTROL: a VALID override is still honoured", () => {
+    // Otherwise the two assertions above would pass against a resolver that ignores the
+    // env var entirely.
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 3; i++) l = recordWrite(l, "CTL-1805");
+    const h = harness({ ledger: l, env: { CATALYST_LINEAR_WRITE_TICKET_CAP: "3" } });
+    const r = h.proxy.send({
+      routeId: "label",
+      ticket: "CTL-1805",
+      payload: labelPayload(["lab-1"]),
+    });
+    expect(r.reason).toBe("budget:ticket-cap");
+  });
+});
+
 describe("AC4 — a write is attributable", () => {
   test("caller and labels reach BOTH the attributes and the payload", () => {
     // Attributes matter because otel-forward strips body.payload off-machine: a field

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -123,7 +123,7 @@ describe("shadow — the direct write STILL happens, and the observation is reco
     // cloud call at all — so a shadow run would tax every Linear write on the host to
     // construct a body nobody sends. The observation is that the write HAPPENED and on
     // which route; the contents are proven by the enforce cases below.
-    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-2", payload: {} }]);
+    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-2", payload: {}, caller: "applyLabel" }]);
     expect(calls.map((c) => c.cmd)).toContain("linearis");
   });
 
@@ -131,7 +131,7 @@ describe("shadow — the direct write STILL happens, and the observation is reco
     const proxy = fakeProxy("shadow");
     const calls = [];
     applyTerminalDone({ ticket: "CTL-2", resolveRepoRoot: () => "/repo", exec: recordingExec(calls), proxy });
-    expect(proxy.sends).toEqual([{ routeId: "issue-state", ticket: "CTL-2", payload: {} }]);
+    expect(proxy.sends).toEqual([{ routeId: "issue-state", ticket: "CTL-2", payload: {}, caller: "runTransition" }]);
     expect(calls.some((c) => c.cmd.endsWith("linear-transition.sh"))).toBe(true);
   });
 });
@@ -148,7 +148,7 @@ describe("enforce — the proxy IS the write and the direct path is NOT taken", 
     // `mode` of add|remove. Asserted here because the earlier cut of this file locked
     // in `{ticket, mode, labels}`, which the cloud would have rejected with a 400.
     expect(proxy.sends).toEqual([
-      { routeId: "label", ticket: "CTL-3", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "add" } },
+      { routeId: "label", ticket: "CTL-3", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "add" }, caller: "applyLabel" },
     ]);
   });
 
@@ -212,7 +212,7 @@ describe("enforce — the proxy IS the write and the direct path is NOT taken", 
     expect(calls.filter(isWritingTransition)).toHaveLength(0);
     expect(calls.filter((c) => c.args.includes("--resolve-only"))).toHaveLength(1);
     expect(proxy.sends).toEqual([
-      { routeId: "issue-state", ticket: "CTL-3", payload: { issueId: ISSUE_ID, stateId: STATE_ID } },
+      { routeId: "issue-state", ticket: "CTL-3", payload: { issueId: ISSUE_ID, stateId: STATE_ID }, caller: "runTransition" },
     ]);
   });
 
@@ -426,7 +426,7 @@ describe("removeLabel — the proxied removal runs BEFORE the credentialed read"
     // an overwrite races any label another actor adds between the read and the write
     // and silently drops it, which a remove cannot do.
     expect(proxy.sends).toEqual([
-      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" } },
+      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" }, caller: "removeLabel" },
     ]);
     expect(calls).toHaveLength(0);
   });
@@ -474,7 +474,7 @@ describe("removeLabel — the proxied removal runs BEFORE the credentialed read"
     });
     expect(r).toEqual({ removed: true, wrote: true });
     expect(proxy.sends).toEqual([
-      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" } },
+      { routeId: "label", ticket: "CTL-7", payload: { issueId: ISSUE_ID, labelIds: [LABEL_ID], mode: "remove" }, caller: "removeLabel" },
     ]);
     expect(calls).toHaveLength(0);
   });
@@ -551,7 +551,7 @@ describe("removeLabel — the proxied removal runs BEFORE the credentialed read"
       proxy,
     });
     expect(r).toEqual({ removed: true, wrote: true });
-    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-8", payload: {} }]);
+    expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-8", payload: {}, caller: "removeLabel" }]);
     expect(calls[0].args).toEqual(["issues", "update", "CTL-8", "--labels", "bug", "--label-mode", "overwrite"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -82,6 +82,7 @@ import {
   convergenceKeyFor,
   emptyLedger,
   markExhaustionAnnounced,
+  clearConvergence,
   noteConvergence,
   readLedger,
   recordWrite,
@@ -505,8 +506,28 @@ export function createLinearWriteProxy({
   // worst case is the cloud answering `already-absent` again, which is a wasted call, not
   // a wrong board state.
   const ledgerPath = budgetPath ?? defaultBudgetPath(env);
-  const dailyBudget = Number(env.CATALYST_LINEAR_WRITE_DAILY_BUDGET) || DEFAULT_DAILY_BUDGET;
-  const perTicketCap = Number(env.CATALYST_LINEAR_WRITE_TICKET_CAP) || DEFAULT_PER_TICKET_CAP;
+  // ⛔ Codex #3505 P2: `Number(x) || DEFAULT` accepts anything truthy and numeric. `-1`
+  // makes every `>= cap` test true before the host has spent anything, so enforce mode
+  // refuses EVERY Linear write — a one-character typo becomes a total write outage.
+  // `Infinity` silently disables the bound, which is the opposite failure and just as
+  // quiet. A limit is only accepted when it is a finite positive integer; anything else
+  // falls back to the default and SAYS so, because a silently-ignored limit is how an
+  // operator ends up believing a cap is in force that never was.
+  const resolveCap = (name, fallback) => {
+    const raw = env[name];
+    if (raw === undefined || raw === null || String(raw).trim() === "") return fallback;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n <= 0) {
+      log?.warn?.(
+        { env_var: name, value: String(raw), using: fallback },
+        "linear-write-proxy: write-budget limit must be a finite positive integer — IGNORING the configured value"
+      );
+      return fallback;
+    }
+    return n;
+  };
+  const dailyBudget = resolveCap("CATALYST_LINEAR_WRITE_DAILY_BUDGET", DEFAULT_DAILY_BUDGET);
+  const perTicketCap = resolveCap("CATALYST_LINEAR_WRITE_TICKET_CAP", DEFAULT_PER_TICKET_CAP);
 
   /**
    * loadLedger — read, then roll to today.
@@ -649,6 +670,22 @@ export function createLinearWriteProxy({
       // shape of the incident before CTC-674 changed the status code.
       let ledgerAfter = recordWrite(ledgerBefore, ticket);
       if (verdict.converged) ledgerAfter = noteConvergence(ledgerAfter, convergenceKey);
+      // ⛔ Codex #3505 P1: convergence records "the desired state is already reached", so a
+      // successful write in the OPPOSITE direction makes it FALSE. Without this, an
+      // `applyLabel` re-adding a label after a converged removal left the stale `remove`
+      // key in place, the next legitimate removal was refused locally as
+      // `budget:already-converged`, and the label stayed STRANDED on the ticket until the
+      // UTC day rolled — a worse outcome than the wasted call this suppression saves.
+      // `clearConvergence` existed and was referenced only by its own unit test; this is
+      // the production caller it was missing.
+      if (verdict.applied && routeId === "label") {
+        const opposite = convergenceKeyFor({
+          routeId,
+          ticket,
+          payload: { ...payload, mode: payload?.mode === "add" ? "remove" : "add" },
+        });
+        if (opposite) ledgerAfter = clearConvergence(ledgerAfter, opposite);
+      }
       const exhaustion = classifyExhaustion(ledgerAfter, { dailyBudget });
       if (exhaustion.announce) {
         ledgerAfter = markExhaustionAnnounced(ledgerAfter);

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -74,6 +74,21 @@ import { randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { resolveSecret } from "../lib/secret-contract.mjs";
+import {
+  DEFAULT_DAILY_BUDGET,
+  DEFAULT_PER_TICKET_CAP,
+  classifyExhaustion,
+  classifyWrite,
+  convergenceKeyFor,
+  emptyLedger,
+  markExhaustionAnnounced,
+  noteConvergence,
+  readLedger,
+  recordWrite,
+  rollToDay,
+  utcDayOf,
+  writeLedger,
+} from "./linear-write-budget.mjs";
 import { getEventLogPath, log as defaultLog } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
@@ -284,7 +299,18 @@ export function classifyProxyResponse({ code, stdout, stderr } = {}) {
   // one, so it is carried through verbatim (scrubbed) rather than replaced.
   const parsed = parseProxyBody(bodyText);
   if (parsed && typeof parsed.outcome === "string") {
-    if (parsed.outcome === "succeeded") return { applied: true, reason: null, status, body: bodyText };
+    if (parsed.outcome === "succeeded") {
+      // CTL-1936 / AC3: CTC-674 made an already-absent label removal answer 200
+      // `already-absent` instead of 400. That is correct — and it silently removed the
+      // only brake the host had, because the CTL-1078 back-off counts FAILURES and this
+      // is a success. Surface convergence as its own fact so the caller can stop
+      // re-issuing, WITHOUT calling it a failure: folding it into the failure counter
+      // would restore the throttle by re-introducing a lie.
+      const results = Array.isArray(parsed.results) ? parsed.results : null;
+      const converged =
+        results !== null && results.length > 0 && results.every((r) => r?.outcome === "already-absent");
+      return { applied: true, reason: null, status, body: bodyText, converged };
+    }
     const named = typeof parsed.reason === "string" && parsed.reason.trim() !== ""
       ? scrub(parsed.reason).slice(0, 300)
       : parsed.outcome;
@@ -350,14 +376,42 @@ export function defaultHttpFn({ url, method, token, body }) {
 export const EVENT_WOULD_WRITE = "linear.write.proxy.would-write";
 export const EVENT_APPLIED = "linear.write.proxy.applied";
 export const EVENT_FAILED = "linear.write.proxy.failed";
-export const PROXY_EVENT_NAMES = Object.freeze([EVENT_WOULD_WRITE, EVENT_APPLIED, EVENT_FAILED]);
+/** CTL-1936 / AC5 — raised ONCE per exhaustion episode, never once per refused write. */
+export const EVENT_EXHAUSTED = "linear.write.proxy.budget-exhausted";
+export const PROXY_EVENT_NAMES = Object.freeze([EVENT_WOULD_WRITE, EVENT_APPLIED, EVENT_FAILED, EVENT_EXHAUSTED]);
+
+/** Default ledger location. One file per host; the daemon and any CLI share it. */
+export function defaultBudgetPath(env = process.env) {
+  const home = env.HOME || "";
+  return `${env.CATALYST_DIR || `${home}/catalyst`}/linear-write-budget.json`;
+}
 
 /**
  * buildProxyEvent — a v2 envelope for one proxy decision. Cloned from
  * linear-state-write-event.mjs (CTL-757) so the two audit families agree on
  * channel / actor / stream_class rather than each inventing their own.
  */
-export function buildProxyEvent({ name, ticket, routeId, mode, reason = null, status = null, applied = false }) {
+/**
+ * CTL-1936 / AC4 — `caller` and `labels`.
+ *
+ * The incident could not be attributed from the event stream: the payload carried
+ * `{ticket, route, mode, applied}` and NOT the label name or the calling site, so 302
+ * writes on one ticket could not be traced to what issued them. `daemon.log` had rotated
+ * and retained one line. Both fields are also promoted to attributes, because
+ * otel-forward strips `body.payload` off-machine — a field only in the payload is
+ * invisible to exactly the operator asking this question from Loki.
+ */
+export function buildProxyEvent({
+  name,
+  ticket,
+  routeId,
+  mode,
+  reason = null,
+  status = null,
+  applied = false,
+  caller = null,
+  labels = null,
+}) {
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
   return (
     JSON.stringify({
@@ -382,8 +436,21 @@ export function buildProxyEvent({ name, ticket, routeId, mode, reason = null, st
         "catalyst.linear_write_proxy.mode": mode,
         "catalyst.linear_write_proxy.reason": reason ?? undefined,
         "catalyst.linear_write_proxy.status": status ?? undefined,
+        "catalyst.linear_write_proxy.caller": caller ?? undefined,
+        "catalyst.linear_write_proxy.labels": Array.isArray(labels) ? labels.join(",") : (labels ?? undefined),
       },
-      body: { payload: { ticket: ticket ?? null, route: routeId, mode, applied, reason, status } },
+      body: {
+        payload: {
+          ticket: ticket ?? null,
+          route: routeId,
+          mode,
+          applied,
+          reason,
+          status,
+          caller: caller ?? null,
+          labels: labels ?? null,
+        },
+      },
     }) + "\n"
   );
 }
@@ -410,12 +477,53 @@ export function createLinearWriteProxy({
   httpFn = defaultHttpFn,
   appendEvent = defaultAppendEvent,
   log = defaultLog,
+  // CTL-1936. Seams, so the throttle is testable without a filesystem.
+  budgetPath = null,
+  nowFn = () => Date.now(),
+  readLedgerFn = readLedger,
+  writeLedgerFn = writeLedger,
 } = {}) {
   if (mode !== "shadow" && mode !== "enforce") return null;
 
   const baseUrl = resolveProxyBaseUrl(env);
   const account = resolveProxyAccount(env);
-  const counts = { wouldWrite: 0, applied: 0, failed: 0 };
+  const counts = { wouldWrite: 0, applied: 0, failed: 0, refused: 0 };
+
+  // ── CTL-1936: the host's own spend ledger ──
+  const ledgerPath = budgetPath ?? defaultBudgetPath(env);
+  const dailyBudget = Number(env.CATALYST_LINEAR_WRITE_DAILY_BUDGET) || DEFAULT_DAILY_BUDGET;
+  const perTicketCap = Number(env.CATALYST_LINEAR_WRITE_TICKET_CAP) || DEFAULT_PER_TICKET_CAP;
+
+  /**
+   * loadLedger — read, then roll to today.
+   *
+   * ⛔ An UNUSABLE ledger (present but unreadable/corrupt) fails OPEN — the write is
+   * allowed — and says so loudly. That direction is deliberate and is the opposite of
+   * the restart-budget case: failing closed here would turn one corrupt file into a
+   * TOTAL Linear-write outage for the host, which is strictly worse than the runaway
+   * this guard exists to bound (the cloud's own 429 still backstops that). What must not
+   * happen is failing open SILENTLY, so the degradation is named every time.
+   */
+  const loadLedger = () => {
+    const day = utcDayOf(nowFn());
+    const r = readLedgerFn(ledgerPath);
+    if (r.state === "loaded") return { ledger: rollToDay(r.ledger, day), degraded: false };
+    if (r.state === "fresh") return { ledger: emptyLedger(day), degraded: false };
+    log?.warn?.(
+      { path: ledgerPath, reason: r.reason },
+      "linear-write-proxy: write-budget ledger unusable — allowing the write, but this host's spend is NOT being bounded"
+    );
+    return { ledger: emptyLedger(day), degraded: true };
+  };
+
+  const persist = (ledger) => {
+    try {
+      writeLedgerFn(ledgerPath, ledger);
+    } catch (err) {
+      // Never let bookkeeping fail a write that already happened.
+      log?.warn?.({ err: scrub(err?.message ?? "") }, "linear-write-proxy: budget ledger write failed");
+    }
+  };
 
   const emit = (name, fields) => {
     try {
@@ -445,16 +553,21 @@ export function createLinearWriteProxy({
      * i.e. the shadow window would read "zero host-originated writes" while the host
      * was still writing. Every caller here already retries on the next tick.
      */
-    send({ routeId, ticket = null, payload = {} }) {
+    send({ routeId, ticket = null, payload = {}, caller = null }) {
+      // CTL-1936 / AC4: what the operator needs to attribute a write. Derived here so
+      // every emit below carries it without each call site remembering to.
+      const labels = Array.isArray(payload?.labelIds) ? payload.labelIds : null;
+      const convergenceKey = convergenceKeyFor({ routeId, ticket, payload });
+
       if (mode === "shadow") {
         counts.wouldWrite += 1;
-        emit(EVENT_WOULD_WRITE, { ticket, routeId, reason: "shadow", applied: false });
+        emit(EVENT_WOULD_WRITE, { ticket, routeId, reason: "shadow", applied: false, caller, labels });
         return { handled: false, applied: false, reason: "shadow" };
       }
 
       const fail = (reason, status = null, detail = null) => {
         counts.failed += 1;
-        emit(EVENT_FAILED, { ticket, routeId, reason, status, applied: false });
+        emit(EVENT_FAILED, { ticket, routeId, reason, status, applied: false, caller, labels });
         log?.warn?.(
           { ticket, route: routeId, reason, status, detail: detail ? scrub(detail) : undefined },
           "linear-write-proxy: write NOT applied — refusing to fall back to a direct Linear write"
@@ -464,6 +577,25 @@ export function createLinearWriteProxy({
         // asserting it with toEqual instead of toMatchObject.
         return { handled: true, applied: false, reason, ...(detail ? { detail } : {}) };
       };
+
+      // ── CTL-1936 / AC2 + AC3: refuse LOCALLY, before any cloud call ──
+      // The runaway spent 302 of 307 writes on one ticket. A refusal here costs nothing,
+      // where a refusal at the cloud costs a budget unit — which is how the whole day's
+      // budget went in 13 minutes. `refused` is its own counter: it is not a failed
+      // write, and it is not an applied one.
+      const { ledger: ledgerBefore, degraded: ledgerDegraded } = loadLedger();
+      if (!ledgerDegraded) {
+        const gate = classifyWrite({ ledger: ledgerBefore, ticket, convergenceKey, dailyBudget, perTicketCap });
+        if (!gate.allow) {
+          counts.refused += 1;
+          emit(EVENT_FAILED, { ticket, routeId, reason: gate.reason, status: null, applied: false, caller, labels });
+          log?.warn?.(
+            { ticket, route: routeId, caller, labels, reason: gate.reason, spentForTicket: gate.spentForTicket, total: gate.total },
+            "linear-write-proxy: write refused by the HOST budget — not sent to the cloud"
+          );
+          return { handled: true, applied: false, reason: gate.reason };
+        }
+      }
 
       const req = buildProxyRequest({ routeId, payload, baseUrl, routes, account });
       if (req.reason) return fail(req.reason);
@@ -497,9 +629,26 @@ export function createLinearWriteProxy({
       }
 
       const verdict = classifyProxyResponse(raw);
+
+      // The write LEFT this host, so it spent budget — success or not. Counting only
+      // successes would let a failing loop spend the day invisibly, which is the exact
+      // shape of the incident before CTC-674 changed the status code.
+      let ledgerAfter = recordWrite(ledgerBefore, ticket);
+      if (verdict.converged) ledgerAfter = noteConvergence(ledgerAfter, convergenceKey);
+      const exhaustion = classifyExhaustion(ledgerAfter, { dailyBudget });
+      if (exhaustion.announce) {
+        ledgerAfter = markExhaustionAnnounced(ledgerAfter);
+        emit(EVENT_EXHAUSTED, { ticket, routeId, reason: "budget:day-exhausted", status: null, applied: false, caller, labels });
+        log?.error?.(
+          { total: ledgerAfter.total, dailyBudget, day: ledgerAfter.day },
+          "linear-write-proxy: host daily cloud write budget EXHAUSTED — every further Linear write is refused until the UTC day rolls"
+        );
+      }
+      if (!ledgerDegraded) persist(ledgerAfter);
+
       if (!verdict.applied) return fail(verdict.reason, verdict.status, verdict.detail ?? null);
       counts.applied += 1;
-      emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true });
+      emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true, caller, labels });
       return { handled: true, applied: true, reason: null, status: verdict.status };
     },
   };

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -490,6 +490,20 @@ export function createLinearWriteProxy({
   const counts = { wouldWrite: 0, applied: 0, failed: 0, refused: 0 };
 
   // ── CTL-1936: the host's own spend ledger ──
+  //
+  // ⚠️ SINGLE-WRITER BY CONSTRUCTION, and that is an assumption worth stating rather
+  // than a lock worth building. The ledger is a read-modify-write with no file lock, so
+  // two concurrent writers would lose counts. `createLinearWriteProxy` has exactly ONE
+  // non-test call site — daemon.mjs — and the daemon's scheduler tick is synchronous, so
+  // there is one writer per host today. If a second call site ever appears (a CLI, a
+  // second daemon), this needs a lock, and losing counts fails toward UNDER-counting,
+  // i.e. toward the pre-CTL-1936 behaviour rather than toward wrongly throttling a
+  // healthy host.
+  //
+  // ⚠️ A degraded (unusable) ledger also disables CONVERGENCE suppression, not just the
+  // cap — `classifyWrite` is skipped entirely. That is the same fail-open direction: the
+  // worst case is the cloud answering `already-absent` again, which is a wasted call, not
+  // a wrong board state.
   const ledgerPath = budgetPath ?? defaultBudgetPath(env);
   const dailyBudget = Number(env.CATALYST_LINEAR_WRITE_DAILY_BUDGET) || DEFAULT_DAILY_BUDGET;
   const perTicketCap = Number(env.CATALYST_LINEAR_WRITE_TICKET_CAP) || DEFAULT_PER_TICKET_CAP;

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -388,8 +388,13 @@ describe("enforce — the proxy IS the write", () => {
 });
 
 describe("event names", () => {
-  test("the three names are distinct and shadow's is not the applied one", () => {
-    expect(new Set(PROXY_EVENT_NAMES).size).toBe(3);
+  test("the names are distinct and shadow's is not the applied one", () => {
+    // CTL-1936 added a fourth: the budget-exhausted alarm. The assertion is on
+    // DISTINCTNESS and the shared prefix (which the broker's namespace contract keys
+    // on), not on a hard-coded count — a count makes every new event a test failure
+    // without saying anything about correctness.
+    expect(new Set(PROXY_EVENT_NAMES).size).toBe(PROXY_EVENT_NAMES.length);
+    expect(PROXY_EVENT_NAMES.length).toBeGreaterThanOrEqual(4);
     expect(EVENT_WOULD_WRITE).not.toBe(EVENT_APPLIED);
     expect(PROXY_EVENT_NAMES.every((n) => n.startsWith("linear.write.proxy."))).toBe(true);
   });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -78,7 +78,12 @@ export function getLinearWriteProxyResolver() {
  * host-originated writes" while the host was still writing. Every caller below
  * already retries on the next tick.
  */
-function routeThroughProxy(proxy, { routeId, ticket, buildPayload }) {
+// CTL-1936 / AC4: `caller` names the site that issued the write. The incident could not
+// be attributed from the event stream — 302 writes on one ticket with no record of what
+// produced them, and the daemon log had rotated. It is threaded from each call site
+// rather than derived here, because a stack-derived name changes with every refactor
+// while the semantic caller does not.
+function routeThroughProxy(proxy, { routeId, ticket, buildPayload, caller = null }) {
   const p = proxy ?? _writeProxy;
   if (!p) return null;
 
@@ -88,7 +93,7 @@ function routeThroughProxy(proxy, { routeId, ticket, buildPayload }) {
   // nobody sends would tax every Linear write on every host running the dry run.
   if (p.mode === "shadow") {
     try {
-      p.send({ routeId, ticket, payload: {} });
+      p.send({ routeId, ticket, payload: {}, caller });
     } catch (err) {
       log.warn({ ticket, routeId, err: err.message }, "linear-write: write-proxy threw (shadow)");
     }
@@ -112,7 +117,7 @@ function routeThroughProxy(proxy, { routeId, ticket, buildPayload }) {
 
   let res;
   try {
-    res = p.send({ routeId, ticket, payload: built.payload });
+    res = p.send({ routeId, ticket, payload: built.payload, caller });
   } catch (err) {
     // A throwing transport must not wedge the tick. It also must not silently become
     // a direct write — that is the one degradation this seam exists to prevent — so
@@ -246,6 +251,7 @@ function runTransition({
     const proxied = routeThroughProxy(proxy, {
       routeId: "issue-state",
       ticket,
+      caller: "runTransition",
       buildPayload: (resolver) => {
         if (!resolver) return { ok: false, reason: "no-resolver" };
 
@@ -437,6 +443,7 @@ export function applyLabel({ ticket, label, exec = defaultExec, readLabels = nul
     const proxied = routeThroughProxy(proxy, {
       routeId: "label",
       ticket,
+      caller: "applyLabel",
       buildPayload: (resolver) => {
         if (!resolver) return { ok: false, reason: "no-resolver" };
         const issue = resolver.issue(ticket);
@@ -566,6 +573,7 @@ export async function removeLabel(
     const proxiedRemove = routeThroughProxy(proxy, {
       routeId: "label",
       ticket,
+      caller: "removeLabel",
       buildPayload: (resolver) => {
         if (!resolver) return { ok: false, reason: "no-resolver" };
         const issue = resolver.issue(ticket);

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4139,6 +4139,33 @@ export function defaultClearStall(orchDir, writeStatus, { rmDir = rmSync } = {})
   return ({ ticket, phase }) => {
     if (!ticket || !phase) return false;
     const workerDir = join(orchDir, "workers", ticket);
+
+    // ── CTL-1936: NOTHING TO CLEAR IS NOT A CLEAR ──
+    // This used to run unconditionally, so a ticket with no stalled signal and no
+    // needs-human still issued a label REMOVAL to Linear on every tick, forever. That
+    // is the measured runaway: CTL-1805 — Done in Linear, carrying only `orchestrator`,
+    // holding a worker directory untouched since Aug 15 — spent 302 of one host's 307
+    // daily cloud writes in ~13 minutes, and every unrelated ticket on that host lost
+    // its writes as collateral.
+    //
+    // ⚠️ The gate is deliberately a CONJUNCTION, not just "is the stalled signal gone".
+    // A previous clear can delete the signal and then FAIL to remove the label; that
+    // ticket must still retry, or the label is stranded forever. So the skip requires
+    // BOTH to be absent: no stall to clear, and no local record that a label was ever
+    // applied. Either one present → proceed exactly as before.
+    const stalledSignal = join(workerDir, `phase-${phase}.json`);
+    const labelMarkerBase = join(workerDir, ".linear-label-needs-human");
+    const nothingToClear =
+      !existsSync(stalledSignal) &&
+      !existsSync(`${labelMarkerBase}.applied`) &&
+      !existsSync(`${labelMarkerBase}.skipped`);
+    if (nothingToClear) {
+      log.debug?.(
+        { ticket, phase },
+        "stall-janitor: no stalled signal and no needs-human marker — nothing to clear (CTL-1936)"
+      );
+      return false;
+    }
     // 1. delete the synthetic stalled signal (the actual unstick).
     try {
       rmSync(join(workerDir, `phase-${phase}.json`), { force: true });

--- a/plugins/dev/scripts/execution-core/write-budget-health.mjs
+++ b/plugins/dev/scripts/execution-core/write-budget-health.mjs
@@ -1,0 +1,96 @@
+// write-budget-health.mjs — CTL-1936 AC5, the `catalyst doctor` half.
+//
+// "Given a host has exhausted its daily cloud write budget … `catalyst doctor` reports the
+// host as write-exhausted rather than healthy."
+//
+// The event raised at the crossing is edge-triggered and therefore easy to miss — it fires
+// once, hours before anyone looks. This is the standing answer: the same fact, on demand.
+//
+// ⛔ ADVISORY — never FAIL. doctor's FAIL count gates worker activation, and a host whose
+// Linear write budget is spent can still do every other kind of work; taking it out of
+// service would turn a bounded degradation into an outage. Same posture, and same reason,
+// as checkRegistryTeamIdentity and install-completeness.
+
+import { existsSync } from "node:fs";
+
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+import {
+  DEFAULT_DAILY_BUDGET,
+  DEFAULT_PER_TICKET_CAP,
+  readLedger,
+  rollToDay,
+  utcDayOf,
+} from "./linear-write-budget.mjs";
+import { defaultBudgetPath } from "./linear-write-proxy.mjs";
+
+export function checkLinearWriteBudget(deps = {}) {
+  const {
+    env = process.env,
+    nowFn = () => Date.now(),
+    path = defaultBudgetPath(env),
+    readLedgerFn = readLedger,
+    exists = existsSync,
+    dailyBudget = Number(env.CATALYST_LINEAR_WRITE_DAILY_BUDGET) || DEFAULT_DAILY_BUDGET,
+    perTicketCap = Number(env.CATALYST_LINEAR_WRITE_TICKET_CAP) || DEFAULT_PER_TICKET_CAP,
+  } = deps;
+
+  if (!exists(path)) {
+    // No ledger is the normal state for a host with the proxy off, or one that has not
+    // written yet today. It is NOT evidence of health, and it is not a problem either.
+    return mkCheck(
+      "linear-write-budget",
+      STATUS.INFO,
+      `no write-budget ledger at ${path} — this host has not proxied a Linear write (proxy off, or none yet)`
+    );
+  }
+
+  const r = readLedgerFn(path);
+  if (r.state !== "loaded") {
+    // ⛔ Unusable is reported as unusable. Reading it as "nothing spent" would report a
+    // host as healthy on the strength of a file that is telling us it is broken — and
+    // that host's throttle is also disarmed, which is the thing an operator most needs
+    // to know here.
+    return mkCheck(
+      "linear-write-budget",
+      STATUS.WARN,
+      `write-budget ledger present but UNUSABLE (${r.reason ?? "unknown"}) at ${path} — ` +
+        "this host's cloud write spend is NOT being bounded (CTL-1936)"
+    );
+  }
+
+  // ⚠️ Roll to today BEFORE judging. Yesterday's exhausted ledger is not today's
+  // exhaustion — the budget resets on the UTC day boundary, so reading the stored totals
+  // without the roll would report a host as write-exhausted for a whole day after it
+  // recovered.
+  const today = utcDayOf(nowFn());
+  const ledger = rollToDay(r.ledger, today);
+  const total = Number(ledger.total ?? 0) || 0;
+  const byTicket = ledger.byTicket ?? {};
+  const worst = Object.entries(byTicket).sort((a, b) => (b[1] ?? 0) - (a[1] ?? 0))[0] ?? null;
+
+  if (total >= dailyBudget) {
+    return mkCheck(
+      "linear-write-budget",
+      STATUS.WARN,
+      `WRITE-EXHAUSTED — ${total}/${dailyBudget} cloud writes spent for UTC ${ledger.day}; ` +
+        `every further Linear write from this host is refused until the day rolls` +
+        (worst ? ` (largest single ticket: ${worst[0]} at ${worst[1]})` : "")
+    );
+  }
+  if (worst && (worst[1] ?? 0) >= perTicketCap) {
+    // A runaway in progress: the host is not out of budget, but one caller is capped —
+    // which is the shape that spent an entire day in 13 minutes before the cap existed.
+    return mkCheck(
+      "linear-write-budget",
+      STATUS.WARN,
+      `one ticket is at its per-ticket cap — ${worst[0]} at ${worst[1]}/${perTicketCap} ` +
+        `(host total ${total}/${dailyBudget}, UTC ${ledger.day}); its writes are refused locally while others proceed`
+    );
+  }
+  return mkCheck(
+    "linear-write-budget",
+    STATUS.PASS,
+    `cloud write spend ${total}/${dailyBudget} for UTC ${ledger.day}` +
+      (worst ? `; largest single ticket ${worst[0]} at ${worst[1]}/${perTicketCap}` : "")
+  );
+}

--- a/plugins/dev/scripts/execution-core/write-budget-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/write-budget-health.test.mjs
@@ -1,0 +1,76 @@
+// write-budget-health.test.mjs — CTL-1936 AC5 (the doctor half).
+
+import { describe, expect, test } from "bun:test";
+import { checkLinearWriteBudget } from "./write-budget-health.mjs";
+import { emptyLedger, recordWrite, utcDayOf } from "./linear-write-budget.mjs";
+
+const NOW = () => Date.parse("2026-08-18T04:00:00Z");
+const DAY = utcDayOf(NOW());
+const spend = (l, t, n) => {
+  let x = l;
+  for (let i = 0; i < n; i++) x = recordWrite(x, t);
+  return x;
+};
+const check = (ledger, over = {}) =>
+  checkLinearWriteBudget({
+    env: {},
+    nowFn: NOW,
+    path: "/seal/ledger.json",
+    exists: () => true,
+    readLedgerFn: () =>
+      ledger === null ? { state: "unusable", reason: "unparseable" } : { state: "loaded", ledger },
+    ...over,
+  });
+
+describe("checkLinearWriteBudget", () => {
+  test("a quiet host passes and states its spend", () => {
+    const r = check(spend(emptyLedger(DAY), "CTL-1", 4));
+    expect(r.status).toBe("pass");
+    expect(r.detail).toContain("4/300");
+  });
+
+  test("⛔ an exhausted host is NOT reported healthy", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    const r = check(l);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("WRITE-EXHAUSTED");
+  });
+
+  test("a capped single ticket is surfaced before the host runs out", () => {
+    // The runaway shape: the host is not out of budget, but one caller is capped.
+    const r = check(spend(emptyLedger(DAY), "CTL-1805", 60));
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("CTL-1805");
+    expect(r.detail).toContain("per-ticket cap");
+  });
+
+  test("⛔ YESTERDAY's exhausted ledger does not report TODAY as exhausted", () => {
+    // The budget resets on the UTC day boundary. Judging the stored totals without the
+    // roll would keep a recovered host reading exhausted for a whole day.
+    let l = emptyLedger("2026-08-17");
+    for (let i = 0; i < 300; i++) l = recordWrite(l, `T-${i}`);
+    const r = check(l);
+    expect(r.status).toBe("pass");
+    expect(r.detail).toContain("0/300");
+  });
+
+  test("⛔ an unusable ledger warns — it is not 'nothing spent'", () => {
+    const r = check(null);
+    expect(r.status).toBe("warn");
+    expect(r.detail).toContain("NOT being bounded");
+  });
+
+  test("an absent ledger is INFO, not a problem and not a clean bill of health", () => {
+    const r = check(emptyLedger(DAY), { exists: () => false });
+    expect(r.status).toBe("info");
+    expect(r.detail).toContain("has not proxied a Linear write");
+  });
+
+  test("⛔ never FAILs — doctor's FAIL count gates worker activation", () => {
+    let l = emptyLedger(DAY);
+    for (let i = 0; i < 500; i++) l = recordWrite(l, "CTL-1805");
+    expect(check(l).status).not.toBe("fail");
+    expect(check(null).status).not.toBe("fail");
+  });
+});


### PR DESCRIPTION
Closes CTL-1936 (P1).

mini-2 spent its **entire daily cloud write budget — 300/300 for UTC 2026-08-18 — in
about 13 minutes, on ONE ticket**: 302 of 307 writes were `route=label` on CTL-1805, a
ticket that is **Done** in Linear and carries only `orchestrator`. Every Linear write from
that host was then refused (`enforce` has no direct-write fallback, by design), and the
same burst would recur at every UTC day boundary.

## ⛔ CTC-674 is not the defect — it removed the brake, not the cause

| window (UTC) | status |
| --- | --- |
| 00:30 → 02:11 | `400 cloud:failed` ×15, ~6/hour — the CTL-1078 back-off holding it |
| 02:39 → 03:10 | `429 cloud:rejected`, every ~10 min |

Before CTC-674, removing an already-absent label returned **400**, so the back-off
engaged. CTC-674 correctly made that call return **200 `already-absent`** — and the
back-off, which counts only *failures*, stopped engaging. ~6/hour became ~1,700/hour.
**An error response had been doing a rate limiter's job and nobody knew.** The idempotency
fix is right; what was missing is this PR.

## ⭐ The ticket's open question is answered, not guessed

The ticket says *"what re-issues a `needs-human` removal on CTL-1805 every tick is not
answered, and I am not guessing at it."* It is: **`defaultClearStall` issued the removal
unconditionally**, and CTL-1805 held a worker directory **untouched since Aug 15 09:40** on
a ticket that is Done with no `needs-human`. Nothing to clear — cleared every tick,
forever. (Detaching that stale dir on mini-2 stopped the live drain: last `429` at
`03:10:16Z`, and five subsequent fire-windows silent.)

## What's here

**AC1 — durable per-UTC-day ledger** (`linear-write-budget.mjs`). Reset by **day key**, not
process start. `readLedger` is **tri-state** — absent → fresh, loaded, or **unusable** —
and never folds a corrupt file into "fresh". Field types are checked *before* coercion,
because `Number(null)` and `Number([])` are both `0`, which reads as "nothing spent yet"
and hands a runaway a full budget out of a file that is telling us it is broken.

**AC2 — per-ticket cap, refused locally.** Not host-wide: the failure's signature is volume
concentrated on **one** ticket (302 vs 5), and AC2's own control forbids a cap that fires
on healthy fan-out. The refusal happens **before any cloud call** — a refusal at the cloud
costs a budget unit, which is exactly how a day went in 13 minutes.

**AC3 — convergence.** An all-`already-absent` 200 is surfaced as its own fact and
suppresses the identical re-issue. ⛔ It is **not** fed to the failure counter: that would
restore the old throttle by re-introducing a lie, since the write *succeeded*.

**AC4 — attribution.** `caller` + `labels` on every proxy event, in **attributes and**
payload — otel-forward strips `body.payload` off-machine, so payload-only is invisible to
the operator asking this from Loki. Threaded from all three real call sites
(`runTransition`, `applyLabel`, `removeLabel`) rather than derived from a stack, which
changes with every refactor while the semantic caller does not.

**AC5 — exhaustion is edge-triggered.** One event per episode, never one per refused write:
a budget storm is exactly when a per-event alarm buries the one line that matters.

**`defaultClearStall` gains an `existsSync` gate**, and it is a **conjunction** on purpose:
a previous clear can delete the signal and then *fail* to remove the label, and that ticket
must still retry or the label is stranded forever. Skipping requires **no stalled signal
AND no `.linear-label-needs-human.{applied,skipped}`**.

## ⛔ One deliberate fail-open, stated

An **unusable ledger allows the write**, loudly. This is the opposite of the restart-budget
case and the reasoning is explicit: failing *closed* here turns one corrupt file into a
**total Linear-write outage** for the host, which is strictly worse than the runaway this
bounds (the cloud's own 429 still backstops that). What must not happen is failing open
*silently*, so the degradation is named on every write.

## Tests — 41 new

24 pure + 12 wired + 5 gate. **Every refusal assertion also asserts `httpFn` was NOT
called** — a refusal that still costs a cloud call is the incident with extra logging.
Controls carried:

- AC2's own negative control: **300 writes across 60 tickets, none throttled**.
- The runaway's real shape: 302 on one ticket + 5 elsewhere → the one is capped, the others still pass.
- AC3: a *genuinely present* label still removes normally; a **different** label is not suppressed; an `add` of the same label is a different desired state.
- A **failed** write still counts as spend — counting only successes is how the pre-CTC-674 loop spent a day invisibly.
- The gate's two controls: a stalled signal present → it *does* write; signal gone but a label marker present → it *still retries*.

⚠️ `scheduler.test.mjs` reports **8 failures — measured identical on `origin/main`** (same
eight names, diffed set-to-set), so they are pre-existing and untouched here. I ran that
baseline rather than assuming.

## Not in this PR

AC5's `catalyst doctor` half. It builds on the `doctor-status.mjs` leaf introduced by
#3500; it follows as soon as that lands, rather than duplicating the leaf or dragging a
~1,100-line reformat of `doctor.mjs` into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)