### PR TITLE
feat(dev): CTL-1908 — doctor reports when a login shell spends the FLEET's Claude budget

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3383,12 +3383,17 @@ function defaultProcessCommandForPid(pid) {
 export function checkFleetTokenExport(deps = {}) {
   const {
     home = homedir(),
-    rcFiles = [".zshenv", ".zprofile", ".zshrc", ".bash_profile", ".profile"],
+    // The same six candidates check-setup.sh's CTL-869 proxy-leak scan uses. ⛔ `.bashrc` was
+    // missing here: a bash operator sourcing the env file from it would inherit the fleet
+    // credential in every interactive shell while this check reported PASS off a clean
+    // `.profile` (Codex P2 on #3506).
+    rcFiles = [".zshenv", ".zprofile", ".zshrc", ".bash_profile", ".bashrc", ".profile"],
     fileExists = existsSync,
     readText = (p) => readFileSync(p, "utf8"),
   } = deps;
 
   const offenders = [];
+  const unreadable = [];
   let scanned = 0;
   for (const rc of rcFiles) {
     const path = resolve(home, rc);
@@ -3397,8 +3402,12 @@ export function checkFleetTokenExport(deps = {}) {
       if (!fileExists(path)) continue;
       text = readText(path);
     } catch {
-      continue; // unreadable rc: cannot judge it, and saying nothing is not the same as PASS —
-      // the `scanned` counter below is what keeps a zero honest.
+      // ⛔ NOT a `continue` that leaves `scanned > 0`. An unreadable rc may hold the very export
+      // being looked for, and an unreadable `.zshenv` beside a clean `.profile` used to report
+      // this host CLEAN — a fail-OPEN in a check whose only value is being trustworthy
+      // (Codex P2 on #3506). It now suppresses PASS below.
+      unreadable.push(rc);
+      continue;
     }
     scanned += 1;
     const lines = text.split("\n");
@@ -3408,14 +3417,32 @@ export function checkFleetTokenExport(deps = {}) {
       // and (since tonight) the minis carry the fix, so matching the bare text would report
       // every fixed host as broken.
       if (/^\s*#/.test(line)) continue;
-      if (/claude-accounts\.env/.test(line) || /\bCLAUDE_CODE_OAUTH_TOKEN\s*=/.test(line)) {
-        offenders.push(`${rc}:${i + 1}`);
-      }
+      // ⚠️ Only an ACTUAL source of the file counts. Merely naming it — `CLAUDE_ACCOUNTS_ENV=<path>`,
+      // or an alias that cats it — injects nothing, and telling an operator to comment those out is
+      // wrong advice from a check they are meant to trust (Codex P2 on #3506).
+      //
+      // ⛔ And `source`/`.` is NOT anchored to line start, because the form this fleet actually
+      // had is `[ -f "$HOME/…/claude-accounts.env" ] && . "$HOME/…/claude-accounts.env"` — the
+      // `.` sits after `&&`. check-setup.sh's analogous regex anchors at `^` and would miss the
+      // exact line that stalled the fleet for seven hours. Command position is start-of-line or
+      // after a shell separator.
+      const sourcesEnvFile = /(?:^|[;&|{(]|&&|\|\|)\s*(?:source|\.)\s+[^;&|]*claude-accounts\.env/.test(line);
+      const exportsToken = /\bCLAUDE_CODE_OAUTH_TOKEN\s*=/.test(line);
+      if (sourcesEnvFile || exportsToken) offenders.push(`${rc}:${i + 1}`);
     }
   }
 
   if (scanned === 0) {
-    return [mkCheck("fleet-token-export", STATUS.INFO, "no shell rc files found to inspect — nothing measured, which is not the same as clean")];
+    return [mkCheck("fleet-token-export", STATUS.INFO, `no readable shell rc files to inspect${unreadable.length ? ` (${unreadable.length} unreadable: ${unreadable.join(", ")})` : ""} — nothing measured, which is not the same as clean`)];
+  }
+  if (offenders.length === 0 && unreadable.length > 0) {
+    return [
+      mkCheck(
+        "fleet-token-export",
+        STATUS.INFO,
+        `${scanned} rc file(s) are clean, but ${unreadable.join(", ")} could not be read — the export may be in there, so this is UNKNOWN rather than clean`,
+      ),
+    ];
   }
   if (offenders.length > 0) {
     return [

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3353,6 +3353,73 @@ function defaultProcessCommandForPid(pid) {
   }
 }
 
+// checkFleetTokenExport — CTL-1908. Does a LOGIN SHELL hand the fleet's Claude subscription
+// token to every process this user starts?
+//
+// THE INCIDENT. 2026-08-17 ~02:00–08:57 CT the entire overnight fleet — three owner sessions
+// plus the coordinator's relaunches — stalled on "You've hit your weekly limit", while Ryan's
+// own account sat at 78%. `~/.zshenv` sourced `claude-accounts.env` in EVERY zsh, interactive
+// or not, exporting CLAUDE_CODE_OAUTH_TOKEN = the fleet's armed account. Claude Code prefers
+// the env token over the keychain login, so every shell-launched `claude` — coordinator,
+// owners, and Ryan's own terminal until he re-ran /login — silently spent the fleet's budget.
+// Seven hours of fleet time, and the symptom named the wrong account.
+//
+// ⭐ WHY THIS IS A CHECK AND NOT A FIX. The daemon does NOT need the login-shell export:
+// `catalyst-execution-core` sources `claude-accounts.env` into its own boot environment
+// unconditionally, and `claude --bg` children inherit it from there. So the export buys
+// nothing and costs the budget. But `~/.zshenv` is an unmanaged machine dotfile that nothing
+// in this repo writes, so the codified form of "keep it off" is a check that SAYS SO on every
+// host — measured 2026-08-17 23:2x CT, the laptop had been hand-fixed and BOTH minis had not,
+// which is exactly the drift an uncodified hand-fix produces.
+export function checkFleetTokenExport(deps = {}) {
+  const {
+    home = homedir(),
+    rcFiles = [".zshenv", ".zprofile", ".zshrc", ".bash_profile", ".profile"],
+    fileExists = existsSync,
+    readText = (p) => readFileSync(p, "utf8"),
+  } = deps;
+
+  const offenders = [];
+  let scanned = 0;
+  for (const rc of rcFiles) {
+    const path = resolve(home, rc);
+    let text;
+    try {
+      if (!fileExists(path)) continue;
+      text = readText(path);
+    } catch {
+      continue; // unreadable rc: cannot judge it, and saying nothing is not the same as PASS —
+      // the `scanned` counter below is what keeps a zero honest.
+    }
+    scanned += 1;
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      // A COMMENTED line is the fixed state, not a finding — that is precisely how the laptop
+      // and (since tonight) the minis carry the fix, so matching the bare text would report
+      // every fixed host as broken.
+      if (/^\s*#/.test(line)) continue;
+      if (/claude-accounts\.env/.test(line) || /\bCLAUDE_CODE_OAUTH_TOKEN\s*=/.test(line)) {
+        offenders.push(`${rc}:${i + 1}`);
+      }
+    }
+  }
+
+  if (scanned === 0) {
+    return [mkCheck("fleet-token-export", STATUS.INFO, "no shell rc files found to inspect — nothing measured, which is not the same as clean")];
+  }
+  if (offenders.length > 0) {
+    return [
+      mkCheck(
+        "fleet-token-export",
+        STATUS.WARN,
+        `a login shell exports the FLEET subscription token (${offenders.join(", ")}) — every shell-launched \`claude\` on this host spends the fleet's budget instead of its own login (CTL-1908). The daemon does not need it: catalyst-execution-core sources claude-accounts.env into its own boot env. Comment the line out.`,
+      ),
+    ];
+  }
+  return [mkCheck("fleet-token-export", STATUS.PASS, `no login-shell export of the fleet token in ${scanned} shell rc file(s)`)];
+}
+
 // checkCloudSyncSkew — CTL-1659. Is the RUNNING cloud-sync writer serving the modules the
 // current lockfile resolves? The measured incident (2026-08-04): a dependency fix landed
 // on main, the updater pulled it, the install succeeded, and the daemon kept serving the
@@ -5721,6 +5788,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkClusterSecretFreshness(), // CTL-1393: warn if running on stale rotated secrets (advisory)
       () => checkCloudSync(), // CTL-1394: developer nodes read Linear from the local replica too (advisory)
       () => checkCloudSyncSkew(), // CTL-1659: is the RUNNING writer serving the lockfile's modules? (advisory)
+      () => checkFleetTokenExport(), // CTL-1908: does a login shell spend the FLEET's Claude budget? (advisory)
       () => checkConfigScopeLeak(), // advisory
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
       () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
@@ -5790,6 +5858,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkClusterSecretFreshness(), // CTL-1393: warn if the node is running on stale rotated secrets (advisory)
     () => checkCloudSync(), // CTL-1394: supervised cloud-sync daemon + read tier on the worker hot path (advisory)
     () => checkCloudSyncSkew(), // CTL-1659: a merged dependency fix that never reached the running writer (advisory)
+    () => checkFleetTokenExport(), // CTL-1908: the login-shell export that stalled the fleet for 7h (advisory)
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)
     () => checkSdkDaemonEnv(), // CTL-1396 item A: under executor=sdk, the RUNNING daemon's process env must carry CLAUDE_CODE_OAUTH_TOKEN (not just the operator shell) + surface recent silent sdk→bg degrades
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -54,6 +54,7 @@ import {
   renderHuman,
   parseArgs,
   runDoctor,
+  checkFleetTokenExport,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -5728,4 +5729,53 @@ describe("checksForClass — checkConfigProvenance registration (CTL-1793)", () 
       expect(src({ recognized: true, class: cls })).toContain("checkConfigProvenance");
     });
   }
+});
+
+describe("checkFleetTokenExport — CTL-1908: a login shell must not spend the FLEET's budget", () => {
+  // The incident: 2026-08-17 02:00-08:57 CT the whole overnight fleet stalled on "You've hit your
+  // weekly limit" while Ryan's own account sat at 78%, because ~/.zshenv sourced
+  // claude-accounts.env in EVERY zsh and Claude Code prefers the env token over the keychain
+  // login. Seven hours, and the symptom named the wrong account.
+  const fs = (files) => ({
+    home: "/h",
+    rcFiles: [".zshenv", ".zprofile"],
+    fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+    readText: (p) => files[p],
+  });
+  const one = (files) => checkFleetTokenExport(fs(files))[0];
+
+  it("WARNs on an active source of claude-accounts.env, naming the file and line", () => {
+    const v = one({ "/h/.zshenv": '# unrelated\n[ -f "$HOME/.config/catalyst/claude-accounts.env" ] && . "$HOME/.config/catalyst/claude-accounts.env"\n' });
+    expect(v.status).toBe("warn");
+    expect(v.detail, "an operator must be told WHERE, not merely that something is wrong").toContain(".zshenv:2");
+  });
+
+  it("WARNs on a direct export of the token, not only on the file that carries it", () => {
+    expect(one({ "/h/.zprofile": 'export CLAUDE_CODE_OAUTH_TOKEN=sk-whatever\n' }).status).toBe("warn");
+  });
+
+  it("⭐ a COMMENTED line is the FIXED state, not a finding", () => {
+    // This is how the laptop and (since 2026-08-17 23:2x) both minis carry the fix. Matching the
+    // bare text would report every correctly-fixed host as broken, and the check would be
+    // uninstalled within a day.
+    const v = one({ "/h/.zshenv": '# CTL-1908: not exported to every shell\n# [ -f "$HOME/.config/catalyst/claude-accounts.env" ] && . "..."\n' });
+    expect(v.status).toBe("pass");
+  });
+
+  it("nothing to scan is INFO — a zero is not a clean result", () => {
+    // The vacuous-pass guard: with no rc file present there is no evidence either way, and
+    // "I could not look" must not render as "this host is fine".
+    expect(checkFleetTokenExport({ home: "/h", rcFiles: [".zshenv"], fileExists: () => false, readText: () => "" })[0].status).toBe("info");
+  });
+
+  it("POSITIVE CONTROL — the same instrument does return PASS on a genuinely clean rc", () => {
+    // Without this, the pass above would also be satisfied by a check that had stopped matching.
+    expect(one({ "/h/.zshenv": 'export EDITOR=vim\n' }).status).toBe("pass");
+  });
+
+  it("is wired into the doctor suites, not merely exported", () => {
+    // A check nobody runs is the failure mode this repo keeps meeting.
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    expect(src.split("checkFleetTokenExport()").length - 1, "registered in BOTH class suites").toBeGreaterThanOrEqual(2);
+  });
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -5738,9 +5738,13 @@ describe("checkFleetTokenExport — CTL-1908: a login shell must not spend the F
   // login. Seven hours, and the symptom named the wrong account.
   const fs = (files) => ({
     home: "/h",
-    rcFiles: [".zshenv", ".zprofile"],
+    rcFiles: [".zshenv", ".zprofile", ".bashrc", ".profile"],
     fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
-    readText: (p) => files[p],
+    // a `null` entry models a file that EXISTS but cannot be read
+    readText: (p) => {
+      if (files[p] === null) throw new Error("EACCES");
+      return files[p];
+    },
   });
   const one = (files) => checkFleetTokenExport(fs(files))[0];
 
@@ -5766,6 +5770,43 @@ describe("checkFleetTokenExport — CTL-1908: a login shell must not spend the F
     // The vacuous-pass guard: with no rc file present there is no evidence either way, and
     // "I could not look" must not render as "this host is fine".
     expect(checkFleetTokenExport({ home: "/h", rcFiles: [".zshenv"], fileExists: () => false, readText: () => "" })[0].status).toBe("info");
+  });
+
+  // ─── Codex round 1 on #3506 ────────────────────────────────────────────────
+  const REAL_LINE = '[ -f "$HOME/.config/catalyst/claude-accounts.env" ] && . "$HOME/.config/catalyst/claude-accounts.env"';
+
+  it("⛔ matches the form this fleet ACTUALLY had — `. ` after `&&`, not at line start", () => {
+    // check-setup.sh's analogous CTL-869 regex anchors source/. at `^`, which would MISS the
+    // exact line that was live on both minis and stalled the fleet for seven hours.
+    expect(one({ "/h/.zshenv": REAL_LINE }).status).toBe("warn");
+  });
+
+  it("scans .bashrc — a bash operator's interactive shell is the same leak", () => {
+    // ⛔ Deliberately does NOT pass `rcFiles`, so the PRODUCTION DEFAULT list is what is under
+    // test. The first version of this case supplied its own list including ".bashrc" and so
+    // asserted the fixture rather than the code — removing ".bashrc" from the default left it
+    // green. A test that cannot fail on the defect it names is worse than no test.
+    const files = { "/h/.bashrc": "source ~/.config/catalyst/claude-accounts.env" };
+    const v = checkFleetTokenExport({
+      home: "/h",
+      fileExists: (p) => Object.prototype.hasOwnProperty.call(files, p),
+      readText: (p) => files[p],
+    })[0];
+    expect(v.status).toBe("warn");
+    expect(v.detail).toContain(".bashrc:1");
+  });
+
+  it("⛔ an UNREADABLE rc beside a clean one is INCONCLUSIVE, never PASS", () => {
+    // The unreadable file may hold the very export being looked for. Reporting the host clean
+    // off its readable neighbour is a fail-OPEN in a check whose only value is being trusted.
+    expect(one({ "/h/.zshenv": null, "/h/.profile": "export EDITOR=vim" }).status).toBe("info");
+  });
+
+  it("merely NAMING the env file is not sourcing it — no false warning", () => {
+    // `CLAUDE_ACCOUNTS_ENV=<path>` and an alias that cats the file inject nothing. Telling an
+    // operator to comment those out is wrong advice from a check they are meant to trust.
+    expect(one({ "/h/.zshenv": "export CLAUDE_ACCOUNTS_ENV=$HOME/.config/catalyst/claude-accounts.env" }).status).toBe("pass");
+    expect(one({ "/h/.zshenv": 'alias showenv="cat ~/.config/catalyst/claude-accounts.env"' }).status).toBe("pass");
   });
 
   it("POSITIVE CONTROL — the same instrument does return PASS on a genuinely clean rc", () => {


### PR DESCRIPTION
## ⛔ The fix was applied to one host by hand, and the other two drifted

Measured **2026-08-17 23:2x CT**, nine hours after the incident:

| host | `~/.zshenv` | `CLAUDE_CODE_OAUTH_TOKEN` in a fresh login shell |
| -- | -- | -- |
| laptop | sourcing **commented out** | ✅ absent |
| **mini** | **active at line 19** | ⛔ **SET** |
| **mini-2** | **active at line 40** | ⛔ **SET** |

That is the exact condition of the **02:00–08:57 CT** stall — the whole overnight fleet on *"You've hit your weekly limit"* while Ryan's own account sat at 78% — still live on two of three hosts. It is what an uncodified hand-fix always produces.

## What I did to the minis, and what I checked first

Both fixed (commented out, reason inline, timestamped backup kept). ⭐ **Verified before touching them, not after:**

- `catalyst-execution-core` sources `claude-accounts.env` into its **own boot environment unconditionally**, so the login-shell export buys the daemon nothing and costs the budget;
- both minis carry a keychain entry **and** `~/.claude/.credentials.json`, so the AC's premise — an interactive `claude` falls back to its own login — actually holds there.

Verified after: the token is gone from a fresh login shell on each, **both exec-core daemons are alive**, and the daemon's own sourcing path still resolves the token.

## ⭐ Why this commit is a *check* rather than the fix

`~/.zshenv` is an unmanaged machine dotfile — **nothing in this repo writes one**, and inventing a dotfile manager is not what this ticket asked for. The codified form of *"keep it off"* is a check that says so on every host, every run. Without it, tonight's repair drifts again the first time a host is rebuilt — exactly as it just did.

## The check is narrow and three-valued

| state | verdict |
| -- | -- |
| an **active** line sourcing `claude-accounts.env` or exporting the token | **WARN**, naming `file:line` |
| a **commented** line | **PASS** — this is the *fixed* state |
| no rc file to read | **INFO** — a zero is not a clean result |

⭐ The comment-skip is load-bearing: matching the bare text would flag every correctly-fixed host and get the check uninstalled within a day. Registered in **both** class suites, with a test asserting that — a check nobody runs is the failure mode this repo keeps meeting.

**Six tests, one mutation control:** removing the comment-skip reddens *"a COMMENTED line is the FIXED state"* and only it, diff-verified as applied. `doctor.test.mjs`: **433 pass / 0 fail**.

## ⚠️ Not closed by this

Still open on CTL-1908: the **80%/95% page** on the armed account, the **100% failover-or-refuse-with-a-named-reason**, and `catalyst accounts arm <acct>` as one recorded command. This is the half that stops the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)