### PR TITLE
fix(dev): CTL-1937 — a mis-invoked CLI module cannot become a 7,592-process fork chain

### DIFF
--- a/plugins/dev/scripts/__tests__/exec-runtime-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/exec-runtime-guard.test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# exec-runtime-guard.test.sh — CTL-1937.
+#
+# Measured 2026-08-17 22:42–23:08 CT: a chain of 7,592 `bash` processes, each the parent of
+# the next, all running `bash …/cli/drain.mjs [--off] [--json]`. 87% of kern.maxprocperuid;
+# `fork()` failed for every agent on the machine for ~25 minutes.
+#
+# ⚠️ THE END-TO-END CASE BELOW DELIBERATELY SLEEPS AT EACH LEVEL. If the guard is broken
+# the recursion is unbounded AND fast, so a test that reproduced it at full speed would
+# re-run the incident on the machine running the test. With a sleep per level plus an
+# external watchdog, a broken guard produces a handful of processes instead of thousands —
+# still a clear failure, without taking the box down to prove it.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI="${SCRIPT_DIR}/../catalyst-execution-core"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+assert_grep() {
+	if grep -qF -- "$3" <<<"$2"; then pass "$1"; else fail "$1" "expected: $3" "got: $(head -c 400 <<<"$2")"; fi
+}
+
+echo ""
+echo "=== the depth guard refuses a re-entry ==="
+OUT=$(CATALYST_EXEC_RUNTIME_DEPTH=3 CATALYST_EXEC_RUNTIME_MAX_DEPTH=3 bash "$CLI" drain --status-read 2>&1)
+assert_grep "a re-entry at the cap is refused" "$OUT" "REFUSING"
+assert_grep "the refusal names the guard's ticket" "$OUT" "CTL-1937"
+assert_grep "it points at the actual cause to check" "$OUT" "shell is being used as the JS runtime"
+
+echo ""
+echo "--- ⛔ CONTROL: below the cap it does NOT refuse ---"
+# Without this the assertions above would pass against a wrapper that refuses everything.
+OUT=$(CATALYST_EXEC_RUNTIME_DEPTH=0 CATALYST_EXEC_RUNTIME_MAX_DEPTH=3 bash "$CLI" drain --status-read 2>&1)
+if grep -qF "REFUSING" <<<"$OUT"; then
+	fail "a normal invocation is not refused" "it printed REFUSING at depth 0"
+else
+	pass "a normal invocation is not refused"
+fi
+
+echo ""
+echo "=== a shell resolved as the JS runtime is refused by name ==="
+# The override is EXECUTION_CORE_RUNTIME (script line 37), not RUNTIME — the first cut of
+# this test used the wrong name and the case silently did not exercise the guard at all.
+OUT=$(EXECUTION_CORE_RUNTIME=bash bash "$CLI" drain --status-read 2>&1)
+assert_grep "a bash 'runtime' is refused" "$OUT" "resolved JS runtime is a shell"
+assert_grep "the reason is the doc-comment evaluation" "$OUT" "evaluates its own doc comment"
+
+echo ""
+echo "=== end-to-end: a genuine chain is BOUNDED (slowed, and watchdogged) ==="
+# A stub 'bun' that is really a shell — the exact mis-resolution — pointed at a module
+# whose first line re-invokes the CLI, i.e. the doc-comment bomb in miniature.
+mkdir -p "$SCRATCH/bin" "$SCRATCH/scripts/execution-core/cli"
+cp "$CLI" "$SCRATCH/scripts/catalyst-execution-core"
+COUNTER="$SCRATCH/levels"
+: >"$COUNTER"
+cat >"$SCRATCH/scripts/execution-core/cli/drain.mjs" <<EOF
+// drain.mjs — the bomb in miniature: a backticked command example on line 1.
+echo x >> "$COUNTER"
+sleep 0.2
+\`bash "$SCRATCH/scripts/catalyst-execution-core" drain --status-read\`
+EOF
+cat >"$SCRATCH/bin/bun" <<'EOF'
+#!/usr/bin/env bash
+exec /bin/bash "$@"
+EOF
+chmod +x "$SCRATCH/bin/bun"
+
+# The watchdog is the safety net, not the assertion: it must NOT be what stops the chain.
+(PATH="$SCRATCH/bin:/usr/bin:/bin" CATALYST_EXEC_RUNTIME_MAX_DEPTH=3 \
+	bash "$SCRATCH/scripts/catalyst-execution-core" drain --status-read >/dev/null 2>&1) &
+runner=$!
+(
+	sleep 8
+	kill -9 "$runner" 2>/dev/null
+) &
+watchdog=$!
+wait "$runner" 2>/dev/null
+kill "$watchdog" 2>/dev/null
+
+LEVELS=$(wc -l <"$COUNTER" | tr -d ' ')
+if [[ $LEVELS -ge 1 && $LEVELS -le 4 ]]; then
+	pass "the chain ran but STOPPED — ${LEVELS} level(s), cap 3"
+else
+	fail "the chain was not bounded by the guard" "levels reached: ${LEVELS} (expected 1..4)"
+fi
+# ⛔ The positive control for the whole case: if the module never ran at all, a bound of
+# zero would "pass" a guard that does nothing because nothing was ever invoked.
+if [[ $LEVELS -ge 1 ]]; then
+	pass "control — the module really was invoked (a zero here would prove nothing)"
+else
+	fail "control — the module never ran, so the bound above is meaningless"
+fi
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/exec-runtime-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/exec-runtime-guard.test.sh
@@ -68,9 +68,23 @@ mkdir -p "$SCRATCH/bin" "$SCRATCH/scripts/execution-core/cli"
 cp "$CLI" "$SCRATCH/scripts/catalyst-execution-core"
 COUNTER="$SCRATCH/levels"
 : >"$COUNTER"
+# ⛔ THE FIXTURE SELF-TERMINATES, and that is the point (Codex #3511 P1).
+#
+# My first cut relied on an external watchdog killing `$runner`. That is exactly the
+# antipattern AGENTS.md forbids: when the guard is broken — the case this test exists to
+# contain — every level has ALREADY spawned its child, so killing the first ancestor leaves
+# the descendants reparented and still recursing. Cleanup was load-bearing, in a test about
+# a fork bomb.
+#
+# The chain now carries its own deadline. The bound sits WELL ABOVE the guard's cap, so it
+# never decides the assertion: a working guard stops at 3 and the hard stop is never
+# reached; a broken guard stops at 10 instead of at the process table, and the level count
+# fails the test loudly.
+FIXTURE_HARD_STOP=10
 cat >"$SCRATCH/scripts/execution-core/cli/drain.mjs" <<EOF
 // drain.mjs — the bomb in miniature: a backticked command example on line 1.
 echo x >> "$COUNTER"
+if [ "\$(wc -l < "$COUNTER" | tr -d ' ')" -ge $FIXTURE_HARD_STOP ]; then exit 0; fi
 sleep 0.2
 \`bash "$SCRATCH/scripts/catalyst-execution-core" drain --status-read\`
 EOF
@@ -80,21 +94,39 @@ exec /bin/bash "$@"
 EOF
 chmod +x "$SCRATCH/bin/bun"
 
-# The watchdog is the safety net, not the assertion: it must NOT be what stops the chain.
+# The chain's own hard stop (above) is what bounds it. This watchdog is a THIRD line of
+# defence and it kills the whole PROCESS GROUP — killing `$runner` alone leaves reparented
+# descendants running, which is what made the first version of this test unsafe.
+set -m
 (PATH="$SCRATCH/bin:/usr/bin:/bin" CATALYST_EXEC_RUNTIME_MAX_DEPTH=3 \
 	bash "$SCRATCH/scripts/catalyst-execution-core" drain --status-read >/dev/null 2>&1) &
 runner=$!
 (
-	sleep 8
+	sleep 12
+	kill -9 -"$runner" 2>/dev/null
 	kill -9 "$runner" 2>/dev/null
 ) &
 watchdog=$!
 wait "$runner" 2>/dev/null
 kill "$watchdog" 2>/dev/null
+set +m
+
+# ⛔ Fail closed on residue: a passing level-count must not hide a leak.
+if pgrep -f "$SCRATCH/scripts/catalyst-execution-core" >/dev/null 2>&1; then
+	pkill -9 -f "$SCRATCH/scripts/catalyst-execution-core" 2>/dev/null
+	fail "the fixture left processes behind" "residue found and killed — the chain is not self-limiting"
+else
+	pass "no fixture processes survived the run"
+fi
 
 LEVELS=$(wc -l <"$COUNTER" | tr -d ' ')
 if [[ $LEVELS -ge 1 && $LEVELS -le 4 ]]; then
 	pass "the chain ran but STOPPED — ${LEVELS} level(s), cap 3"
+elif [[ $LEVELS -ge $FIXTURE_HARD_STOP ]]; then
+	# The fixture's own deadline stopped it, which means the GUARD did not. Telling these
+	# two apart is the whole reason the hard stop sits well above the cap.
+	fail "the GUARD did not bound the chain — the fixture's hard stop did" \
+		"levels reached: ${LEVELS} (hard stop ${FIXTURE_HARD_STOP}, guard cap 3)"
 else
 	fail "the chain was not bounded by the guard" "levels reached: ${LEVELS} (expected 1..4)"
 fi

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -479,6 +479,13 @@ _source_daemon_env_for_read() {
 	return 0 # fail-open: absent file is a no-op success, never a non-zero return
 }
 
+# CTL-1937: how many times this seam may be entered in one process ancestry before it
+# refuses. Legitimate use is depth 1 — the CLI shells out to exactly one module and
+# `exec`s, so no correct path ever re-enters. 3 leaves headroom for a future
+# module-calls-module case while still bounding a runaway at three processes instead of
+# 7,592.
+: "${CATALYST_EXEC_RUNTIME_MAX_DEPTH:=3}"
+
 exec_runtime_module() {
 	local module="$1"
 	shift
@@ -487,8 +494,53 @@ exec_runtime_module() {
 		echo "error: execution-core module not found: $module_path" >&2
 		return 1
 	fi
+
+	# ── CTL-1937: THE RECURSION GUARD ──
+	#
+	# Measured 2026-08-17 22:42–23:08 CT: a chain of **7,592 `bash` processes**, each the
+	# parent of the next, all running `bash …/cli/drain.mjs [--off] [--json]`. It reached
+	# 87% of `kern.maxprocperuid` (9,313 / 10,666) and `fork()` began failing for EVERY
+	# agent on the machine — including for the agent trying to report it.
+	#
+	# The mechanism: `cli/*.mjs` have no shebang, and the house style puts a backticked
+	# command example on the first line —
+	#     // cli/drain.mjs — CTL-1095. `catalyst-execution-core drain [--off] [--json]`
+	# Under bash `//` is not a comment and backticks are COMMAND SUBSTITUTION, so executing
+	# the file with a shell runs the wrapper, which runs the file again. The literal
+	# `[--off] [--json]` in every `ps` line was the doc comment's own words arriving as argv.
+	#
+	# ⛔ This guard is on DEPTH, not on identifying the runtime, and that is deliberate:
+	# `resolve_runtime` returns a NAME (`bun`) resolved through PATH, so a stub named `bun`
+	# that is really a shell script passes any is-it-a-JS-runtime test we could write here.
+	# Depth bounds the blast radius of EVERY cause, including ones nobody has thought of.
+	# The env var survives `exec` because it is exported, which is exactly what makes it
+	# able to see a chain the process table already forgot the shape of.
+	local depth="${CATALYST_EXEC_RUNTIME_DEPTH:-0}"
+	if [[ ! $depth =~ ^[0-9]+$ ]]; then depth=0; fi
+	if ((depth >= CATALYST_EXEC_RUNTIME_MAX_DEPTH)); then
+		echo "error: execution-core module re-entered ${depth} deep (module=${module}) — REFUSING." >&2
+		echo "  This is the CTL-1937 guard. A correct path never re-enters; a chain here once" >&2
+		echo "  reached 7,592 processes and took the machine's fork() down. Check whether a" >&2
+		echo "  shell is being used as the JS runtime (a PATH stub for bun/node, or" >&2
+		echo "  EXECUTION_CORE_RUNTIME set to one)." >&2
+		return 1
+	fi
+	export CATALYST_EXEC_RUNTIME_DEPTH=$((depth + 1))
+
 	local runtime
 	runtime="$(resolve_runtime)" || return 1
+
+	# Defence in depth, NOT the fix: refuse an obvious shell by name. It cannot catch a
+	# shell masquerading as `bun` on PATH — the depth guard above is what covers that —
+	# but it turns the common, honest misconfiguration into one clear line.
+	case "$(basename -- "$runtime")" in
+	sh | bash | zsh | dash | ksh | fish)
+		echo "error: resolved JS runtime is a shell (${runtime}) — refusing to execute ${module_path}." >&2
+		echo "  A cli/*.mjs run under a shell evaluates its own doc comment (CTL-1937)." >&2
+		return 1
+		;;
+	esac
+
 	exec "$runtime" "$module_path" "$@"
 }
 


### PR DESCRIPTION
Closes CTL-1937 (P1) — the guard half. The source-level half is called out below and left on the ticket.

## What happened

Measured on the dev laptop **2026-08-17 22:42–23:08 CT**: a chain of **7,592 `bash`
processes**, each the parent of the next, all running
`bash …/execution-core/cli/drain.mjs [--off] [--json]`.

| metric | value |
| --- | --- |
| processes owned by the user | **9,313** |
| `kern.maxprocperuid` | 10,666 (**87%**) |
| of those, `bash` | **7,592** |
| load average | **24** |

`fork()` failed for **every** agent on the machine for ~25 minutes — including for the one
trying to report it. Note the load average: the usual health signal looked survivable while
nothing could start.

## The mechanism

`cli/*.mjs` carry **no shebang**, and the house style puts a backticked command example on
line 1:

```js
// cli/drain.mjs — CTL-1095. `catalyst-execution-core drain [--off] [--json]`
```

Under bash, `//` is not a comment and backticks are **command substitution**. Executing the
file with a shell runs the wrapper, which runs the file again. The literal `[--off]
[--json]` in every `ps` line is the doc comment's own words arriving as argv.

## The guard, and why it is on depth

⛔ **Depth, not runtime identity.** `resolve_runtime` returns a *name* resolved through
PATH, so a stub called `bun` that is really a shell passes any is-it-a-JS-runtime test we
could write here. Depth bounds **every** cause, including ones nobody has thought of. The
counter is exported so it survives `exec` — which is precisely what lets it see a chain the
process table has already flattened into a line of identical entries.

A second, weaker layer refuses a runtime whose basename is a known shell. It cannot catch a
shell masquerading as `bun`; it turns the common honest misconfiguration into one clear line
instead of a bomb.

## ⚠️ This does not fix the population

A backticked first-line command example is the house style across **all 25 `cli/*.mjs`**, so
every one is the same bomb — `drain.mjs` is merely the one that fired, because `cmd_status`
shells out to it. Removing the hazard at source (a shebang, or no backticks in the header)
is the complementary change; it is left on the ticket rather than smuggled into this diff,
because it touches 25 files and deserves its own review.

## Tests — 8

- The depth refusal, **and its control**: below the cap it must *not* refuse. Without that,
  every assertion here passes against a wrapper that refuses everything.
- The shell-runtime refusal by name.
- **End-to-end**: a stub `bun` that really is a shell, pointed at a module whose first line
  re-invokes the CLI — the bomb in miniature. It stops at **3 levels against a cap of 3**,
  with a further control asserting the module really ran (a bound of *zero* would "pass" a
  guard that does nothing because nothing was ever invoked).

⚠️ **That end-to-end case sleeps at each level on purpose.** A broken guard makes the
recursion unbounded *and* fast, so reproducing it at full speed would re-run the incident on
the machine running the test. The sleep plus an external watchdog keeps a failure to a
handful of processes while still failing clearly. The watchdog is the safety net, not the
assertion — the assertion is the level count.

## Regression check

`status` and `drain --status-read` return **identical exit codes** to a pristine
`origin/main` worktree under identical conditions (the first comparison I ran used a copy in
`/tmp`, whose `SCRIPT_DIR` cannot find the modules — that baseline was meaningless and I
redid it in a real worktree).

## Credit

The mechanism was determined in **CTL-1938**, filed independently and since cancelled as a
duplicate; its analysis was better than mine and I folded it into CTL-1937 rather than let it
die with the ticket. My own filing had honestly recorded the mechanism as *undetermined*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)