### PR TITLE
feat(dev): CTL-1929 — the GitHub feed's read + event layers, with both blockers named rather than papered over

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -933,6 +933,8 @@ jobs:
             linear-feed-diff.test.mjs \
             linear-feed-diffsweep.test.mjs \
             linear-feed-parity.test.mjs \
+            github-feed-source.test.mjs \
+            github-feed-event.test.mjs \
             cloud-feed-gate.test.mjs \
             cloud-feed-capture.test.mjs \
             cloud-feed-timer.test.mjs \

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -1,0 +1,448 @@
+// github-feed-event.mjs — CTL-1929. Zero-I/O leaf: classify one replica row into an
+// emit/decline verdict, and build the v2 envelope for it.
+//
+// Twin of `linear-feed-event.mjs`. The envelope it produces must be readable by the
+// SAME consumer that reads the smee copy today (`broker/router.mjs`), so this file's
+// contract is not "a reasonable GitHub event" — it is **the exact fields that
+// consumer destructures**, reproduced from the replica.
+//
+// ── ⛔ THE THREE FIELDS THAT ARE JOIN KEYS, NOT DISPLAY TEXT ────────────────
+// Getting these wrong breaks a downstream chain while every event still routes:
+//   `attributes["vcs.revision"]` on `deployment.created`   -> filter_state.merge_commit_sha
+//   `body.payload.deploymentId`  on `deployment_status.*`  -> filter_state.deployment_id
+//   `attributes["vcs.ref.name"]` on `push`                 -> the base-branch match
+// The replica stores `deployments.id` / `deployment_statuses.deployment_id` as TEXT
+// and the webhook envelope carries a NUMBER (its parser's `getNum`), so both are
+// coerced here. A string 5936592703 does not match an integer 5936592703 in the
+// broker's `WHERE deployment_id = ?`, and nothing would report the miss.
+//
+// ── ⛔ TWO FIELDS DELIBERATELY NOT EMITTED, AND ONE DELIBERATELY WRONG ──────
+// 1. `github.pr.*` payloads carry NO `title` / `body` / `headRef`. The replica row
+//    has all three and including them is the natural thing to do — but
+//    `tryTicketLifecycleRoute` (`router.mjs:1856`) scrapes exactly those three for
+//    ticket ids, and that path is DORMANT: measured 1,208/1,208 live `github.pr.*`
+//    payloads contain none of them, so `prBodyTickets` is always `[]` and
+//    `_autoPrLifecycleFromTicket` never fires. Emitting them would SWITCH ON a
+//    dormant fleet-wide code path — a behavioural change wearing the costume of
+//    better parity. The webhook parser reads them and drops them; so do we.
+// 2. `pr_review_thread.resolved` emits `threadId: 0`, not the real id. Measured
+//    202/202 live events carry `0`, because GitHub's thread object has no numeric
+//    `id` and the parser's `getNum` returns its default. Our replica HAS a real
+//    thread id and emitting it would be strictly nicer — and would break the
+//    field-level parity that is the instrument this cutover is judged by. An
+//    instrument that changes shape at the moment of cutover cannot judge the
+//    cutover. The improvement is filed separately, to land after.
+//
+// ── ⚠️ THE ONE VALUE THAT NEEDS NORMALISING ────────────────────────────────
+// `reviews.state` is stored UPPERCASE (`COMMENTED`), the webhook emits GitHub's
+// REST lowercase (`commented`), and the consumer compares with `===` against
+// `"changes_requested"` / `"approved"` (`router.mjs:1539-1553`). Passing the stored
+// value through would match NEITHER branch and the review gate would go quiet.
+// ⚠️ BOUND, stated because it limits what this file can claim: **no `APPROVED` or
+// `CHANGES_REQUESTED` row has ever been observed on this fleet** — 6,630/6,630
+// replica rows and 3,093/3,093 live webhook events are `commented`. So the
+// lowercase mapping is verified by content for `commented` ONLY; the other two are
+// a documented convention, not a measurement, and the router branches they feed are
+// themselves untested in production here.
+//
+// ── PROVENANCE ─────────────────────────────────────────────────────────────
+// `body.payload.source = "cloud-feed"` is stamped POSITIVELY, and it is the whole
+// reason the gate can tell our copy from smee's. `cloud-feed-gate.sourceOf` reads
+// exactly that key; a producer that omits it classifies as SOURCE_OTHER and
+// inherits no authority — deliberate, so an unknown third producer cannot acquire
+// authority by default. `event.channel` is `"cloud-feed"` rather than `"webhook"`
+// for the same reason (and because `webhook.delivery.id`, which is how `sourceOf`
+// recognises smee NEGATIVELY, must NOT be stamped here).
+//
+// ⛔ `resource["service.name"]` stays `catalyst.github` — NOT `catalyst.execution-core`.
+// `router.mjs`'s `recordLastSeen` folds that value into the CTL-1122 ingestion-recency
+// map, whose `RECENCY_SOURCES` watches `catalyst.github`. Stamping our own service
+// name would leave the github ingestion-SILENCE detector believing github had gone
+// quiet at the exact moment we became its only producer.
+
+import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
+import { STREAM_BY_KEY } from "./github-feed-source.mjs";
+
+/** The service identity every `github.*` event must carry. See the header. */
+export const GITHUB_SERVICE_NAME = "catalyst.github";
+
+/** Positive provenance stamp, read by `cloud-feed-gate.sourceOf`. */
+export const SOURCE_CLOUD_FEED = "cloud-feed";
+
+/**
+ * The `github.*` names this producer can emit today.
+ *
+ * ⛔ `github.pr.merged` and `github.check_suite.completed` are consumed by the
+ * orchestrator and are NOT here, each for a measured reason:
+ *   `pr.merged`            — `pull_requests` has no `merge_commit_sha` (CTC-691).
+ *                            The sha is a join key for the whole deploy chain, so a
+ *                            twin without it routes and wakes while silently
+ *                            breaking `monitor-deploy`. A named gap beats that.
+ *   `check_suite.completed`— the mirror stores no suite row (CTC-667 item 4), and
+ *                            `check_runs` cannot stand in: one head sha carried 10
+ *                            distinct suite ids, several incomplete, so "every run
+ *                            I can see finished" fires early and GREEN on the merge
+ *                            gate.
+ * Exported so the parity ledger accounts for them as EXPECTED absences rather than
+ * as unexplained diffs, and so nothing can claim coverage this producer lacks.
+ */
+export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze([
+  "github.pr.opened",
+  "github.pr.closed",
+  "github.pr_review.submitted",
+  "github.pr_review_comment.created",
+  "github.pr_review_thread.resolved",
+  "github.deployment.created",
+  "github.deployment_status.success",
+  "github.deployment_status.failure",
+  "github.deployment_status.error",
+  "github.push",
+]);
+
+/** Names the orchestrator consumes that this producer cannot yet emit. */
+export const GITHUB_UNCOVERED_NAMES = Object.freeze([
+  "github.pr.merged",
+  "github.check_suite.completed",
+]);
+
+/**
+ * Streams the source can PAGE but this file cannot turn into a faithful event, keyed
+ * to the reason and the ticket that closes it. Declining by name keeps the gap
+ * counted rather than silent — see `classifyGithubRow`.
+ *
+ * `prMerged` is deliberately still a STREAM in `github-feed-source.mjs`: paging it
+ * costs nothing, proves the keyset works for it, and means CTC-691 lands as a one-
+ * line deletion here rather than as new read-layer code.
+ */
+export const UNCOVERED_STREAM_REASONS = Object.freeze({
+  prMerged: "uncovered:no-merge-commit-sha:CTC-691",
+});
+
+/**
+ * `User` | `Bot`, derived from the login itself rather than from a join.
+ *
+ * ⭐ The join was the tempting answer and it is measurably worse. `users` carries a
+ * GitHub `type` (`human`/`app`) but its coverage is INCOMPLETE: of 5 distinct review
+ * authors on mini-2, only 4 had a `users` row — and the missing one,
+ * `github:github-code-quality[bot]`, is a BOT. A left join would have yielded a null
+ * type for it, `isBot` would read false, and a bot review would be handled as a
+ * human's on the review gate.
+ *
+ * The `[bot]` suffix is GitHub's reserved marker for App accounts and it has 100%
+ * coverage here by construction. Positive control on the rule: over all 12 GitHub
+ * identities in `users`, `id LIKE '%[bot]'` agrees with `type = 'app'` **12/12, zero
+ * disagreements**.
+ *
+ * ⚠️ Bound: that is a convention validated on 12 identities, not a guarantee from
+ * GitHub's API. It is the best available signal from the data the replica carries.
+ */
+export function authorTypeOf(login) {
+  return typeof login === "string" && login.endsWith("[bot]") ? "Bot" : "User";
+}
+
+/**
+ * Replica actor ids are namespaced `github:<login>`; the envelope carries the bare
+ * login. Returns `""` for anything unusable, matching the webhook parser's `getStr`,
+ * which yields an empty string and never null.
+ */
+export function loginOf(actorId) {
+  if (typeof actorId !== "string" || actorId === "") return "";
+  return actorId.startsWith("github:") ? actorId.slice("github:".length) : actorId;
+}
+
+/** `{login, type}`, the shape `router.mjs` destructures for the bot check. */
+export function authorOf(actorId) {
+  const login = loginOf(actorId);
+  return { login, type: authorTypeOf(login) };
+}
+
+/**
+ * The stable identity of one edge.
+ *
+ * ⛔ This is load-bearing, not cosmetic. The producer re-reads the settle window
+ * every tick (see `github-feed-source.mjs`), and the broker dedups on the
+ * PER-EMISSION UUID `id` — so it will NOT suppress a re-emission for us. This id is
+ * what the producer's own seen-set keys on, and it must therefore be derived only
+ * from PRIMARY KEY columns plus the edge name: anything mutable would change between
+ * reads and defeat the very dedup it exists to serve.
+ */
+export function githubEdgeId(streamKey, row) {
+  const s = STREAM_BY_KEY[streamKey];
+  if (!s || !row) return null;
+  const id = row.__id;
+  if (id === undefined || id === null || id === "") return null;
+  return `gh:${streamKey}:${String(id)}`;
+}
+
+/**
+ * Decide whether a row is emittable, and say why when it is not.
+ *
+ * The decline/fail split follows the Linear leg's rule verbatim, because readiness
+ * is computed from it: **would un-arming the producer repair this?** A single
+ * malformed row is a DECLINE (un-arming fixes nothing and would hand dispatch back
+ * to a tunnel we are trying to retire). A condition that would make EVERY row
+ * unemittable is a FAILURE and is marked `fatal`.
+ */
+export function classifyGithubRow(streamKey, row) {
+  const s = STREAM_BY_KEY[streamKey];
+  if (!s) return { emit: false, reason: "unknown-stream", fatal: true };
+  // ⛔ A stream whose rows we can READ but whose EVENT we cannot build faithfully
+  // declines HERE, with a reason, rather than falling through to a `null` envelope.
+  // A silent null is the "success and failure are byte-identical to the caller"
+  // shape: the sweep would count neither an emit nor a decline and the gap would be
+  // invisible in the very counts readiness is computed from. Declining instead makes
+  // it appear in `byReason` every tick, named after the ticket that closes it.
+  const uncovered = UNCOVERED_STREAM_REASONS[streamKey];
+  if (uncovered) return { emit: false, reason: uncovered };
+  if (!row || typeof row !== "object") return { emit: false, reason: "row-not-an-object" };
+  if (typeof row.repo_id !== "string" || row.repo_id === "") {
+    return { emit: false, reason: "no-repo" };
+  }
+  if (!Number.isInteger(row.__ts)) return { emit: false, reason: "no-edge-timestamp" };
+  if (githubEdgeId(streamKey, row) === null) return { emit: false, reason: "no-edge-id" };
+
+  // PR-scoped streams are useless to the consumer without a PR number: every one of
+  // their router branches gates on `prList.includes(scope.pr)` first.
+  const prScoped = new Set([
+    "prOpened", "prClosed", "reviewSubmitted", "reviewCommentCreated", "threadResolved",
+  ]);
+  if (prScoped.has(streamKey)) {
+    const n = streamKey === "prOpened" || streamKey === "prClosed" ? row.number : row.pr_number;
+    if (!Number.isInteger(n) || n <= 0) return { emit: false, reason: "no-pr-number" };
+  }
+  if (streamKey === "deploymentStatus" && (typeof row.state !== "string" || row.state === "")) {
+    return { emit: false, reason: "no-deployment-state" };
+  }
+  if (streamKey === "push" && (typeof row.ref !== "string" || row.ref === "")) {
+    return { emit: false, reason: "no-ref" };
+  }
+  return { emit: true, reason: null };
+}
+
+/** The event name for a row (the one per-row name is `deployment_status.<state>`). */
+export function githubEventName(streamKey, row) {
+  const s = STREAM_BY_KEY[streamKey];
+  if (!s) return null;
+  if (s.event) return s.event;
+  if (streamKey === "deploymentStatus") return `github.deployment_status.${row?.state}`;
+  return null;
+}
+
+// `event.stream_class` is stamped by orch-monitor's builder, not execution-core's,
+// and every `github.*` name classifies the same way (the "github." prefix is in
+// COORDINATION_PREFIXES). Stated as a constant so the feed copy does not silently
+// lose a dimension the webhook copy carries into Loki.
+const STREAM_CLASS = "coordination";
+
+function envelope({ name, entity, action, label, attrs, payload, message, severityText = "INFO", severityNumber = 9 }, seams) {
+  const built = buildCanonicalEvent(
+    {
+      name,
+      serviceName: GITHUB_SERVICE_NAME,
+      severityText,
+      severityNumber,
+      attributes: {
+        ...attrs,
+        "event.entity": entity,
+        "event.action": action,
+        "event.channel": SOURCE_CLOUD_FEED,
+        ...(label !== undefined ? { "event.label": label } : {}),
+        "event.stream_class": STREAM_CLASS,
+      },
+      payload: { ...payload, source: SOURCE_CLOUD_FEED },
+    },
+    seams,
+  );
+  // `buildCanonicalEvent` forces `body.message = name`; the webhook copy carries a
+  // human sentence, and `summarizeEvent` puts `body.message.slice(0,200)` into every
+  // wake an agent reads. Restoring it keeps that surface unchanged. Assigning an
+  // existing key does not move it in JS insertion order, so the wire shape is intact.
+  built.body.message = message;
+  return built;
+}
+
+/**
+ * Build the v2 envelope for one row. Returns `null` when the row is not emittable —
+ * callers classify first and route the reason; this is the belt to that braces.
+ */
+export function buildGithubEvent(streamKey, row, seams) {
+  if (!classifyGithubRow(streamKey, row).emit) return null;
+  const repo = row.repo_id;
+  const name = githubEventName(streamKey, row);
+  if (!name) return null;
+
+  switch (streamKey) {
+    case "prOpened":
+    case "prClosed": {
+      const action = streamKey === "prOpened" ? "opened" : "closed";
+      return envelope({
+        name,
+        entity: "pr",
+        action,
+        label: `PR #${row.number}`,
+        attrs: { "vcs.repository.name": repo, "vcs.pr.number": row.number },
+        message: `${name} for ${repo} PR #${row.number}`,
+        payload: {
+          action,
+          // ⛔ `router.mjs:1525` tests `detail.merged === false` STRICTLY. A missing
+          // or truthy-coerced value silently fails to match and the closed-without-
+          // merging branch never fires.
+          merged: false,
+          mergedAt: null,
+          // Not carried by the replica (CTC-691). Null rather than absent, matching
+          // the webhook's `getOptStr`. Neither router branch for these two names
+          // reads it — only `pr.merged` does, which is why `pr.merged` is withheld.
+          mergeCommitSha: null,
+          draft: row.draft === 1 || row.draft === true,
+          mergeable: row.mergeable === null || row.mergeable === undefined
+            ? null
+            : row.mergeable === 1 || row.mergeable === true,
+        },
+      }, seams);
+    }
+
+    case "reviewSubmitted": {
+      const author = authorOf(row.user_id);
+      return envelope({
+        name,
+        entity: "pr_review",
+        action: "submitted",
+        label: `PR #${row.pr_number}`,
+        attrs: { "vcs.repository.name": repo, "vcs.pr.number": row.pr_number },
+        message: `${name} for ${repo} PR #${row.pr_number} by ${author.login}`,
+        payload: {
+          // See the header: stored UPPERCASE, compared lowercase by the consumer.
+          state: typeof row.state === "string" ? row.state.toLowerCase() : "",
+          // The webhook reads `reviewer` and `author.login` from the SAME source, so
+          // they are always equal; reproduced rather than "improved".
+          reviewer: author.login,
+          body: typeof row.body === "string" ? row.body : "",
+          author,
+        },
+      }, seams);
+    }
+
+    case "reviewCommentCreated": {
+      const author = authorOf(row.author_id);
+      const commentId = Number(row.id);
+      return envelope({
+        name,
+        entity: "pr_review_comment",
+        action: "created",
+        label: `PR #${row.pr_number}`,
+        attrs: { "vcs.repository.name": repo, "vcs.pr.number": row.pr_number },
+        // ⚠️ "on", not "for" — the webhook's template differs for this one name.
+        message: `${name} on ${repo} PR #${row.pr_number} by ${author.login}`,
+        payload: {
+          commentId: Number.isFinite(commentId) ? commentId : 0,
+          body: typeof row.body === "string" ? row.body : "",
+          // Not a stored column. Reconstructed from GitHub's stable permalink form
+          // — the consumer puts this straight into the wake reason an agent reads,
+          // so an empty string here degrades a human-facing surface.
+          htmlUrl: `https://github.com/${repo}/pull/${row.pr_number}#discussion_r${row.id}`,
+          author,
+        },
+      }, seams);
+    }
+
+    case "threadResolved": {
+      return envelope({
+        name,
+        entity: "pr_review_thread",
+        action: "resolved",
+        label: `PR #${row.pr_number}`,
+        attrs: { "vcs.repository.name": repo, "vcs.pr.number": row.pr_number },
+        message: `${name} for ${repo} PR #${row.pr_number}`,
+        // ⛔ Literal 0, deliberately — see the header. Not `row.id`.
+        payload: { threadId: 0 },
+      }, seams);
+    }
+
+    case "deploymentCreated": {
+      const deploymentId = Number(row.id);
+      const environment = typeof row.environment === "string" ? row.environment : "";
+      return envelope({
+        name,
+        entity: "deployment",
+        action: "created",
+        label: environment,
+        attrs: {
+          "vcs.repository.name": repo,
+          // ⛔ THE JOIN KEY against filter_state.merge_commit_sha.
+          "vcs.revision": typeof row.sha === "string" ? row.sha : "",
+          "vcs.ref.name": typeof row.ref === "string" ? row.ref : "",
+          "deployment.environment": environment,
+          "deployment.id": Number.isFinite(deploymentId) ? deploymentId : 0,
+        },
+        // ⚠️ "in", not "for".
+        message: `${name} in ${repo} env ${environment}`,
+        payload: {
+          deploymentId: Number.isFinite(deploymentId) ? deploymentId : 0,
+          // `deployment.payload_url` is not mirrored; the webhook's own value is
+          // null in practice and no consumer reads it.
+          payloadUrl: null,
+        },
+      }, seams);
+    }
+
+    case "deploymentStatus": {
+      const deploymentId = Number(row.deployment_id);
+      const environment = typeof row.environment === "string" ? row.environment : "";
+      const failed = row.state === "failure" || row.state === "error";
+      return envelope({
+        name,
+        entity: "deployment_status",
+        action: row.state,
+        label: environment,
+        attrs: {
+          "vcs.repository.name": repo,
+          "deployment.environment": environment,
+          "deployment.id": Number.isFinite(deploymentId) ? deploymentId : 0,
+        },
+        message: `${name} in ${repo} env ${environment}`,
+        severityText: failed ? "ERROR" : "INFO",
+        severityNumber: failed ? 17 : 9,
+        payload: {
+          // ⛔ THE JOIN KEY: filter-state matches `WHERE deployment_id = ?`. Coerced
+          // to a number because the replica stores it as TEXT and the webhook copy
+          // carries a number.
+          deploymentId: Number.isFinite(deploymentId) ? deploymentId : 0,
+          state: row.state,
+          targetUrl: typeof row.target_url === "string" && row.target_url !== "" ? row.target_url : null,
+          environmentUrl:
+            typeof row.environment_url === "string" && row.environment_url !== "" ? row.environment_url : null,
+        },
+      }, seams);
+    }
+
+    case "push": {
+      const headSha = typeof row.after === "string" ? row.after : "";
+      return envelope({
+        name,
+        entity: "push",
+        action: "pushed",
+        label: headSha.slice(0, 7),
+        attrs: {
+          "vcs.repository.name": repo,
+          // ⛔ The FULL ref (`refs/heads/x`), not a stripped branch — the consumer
+          // strips it itself and a pre-stripped value would fail its comparison.
+          "vcs.ref.name": row.ref,
+          "vcs.revision": headSha,
+        },
+        message: `${name} to ${repo} ${row.ref} (${headSha.slice(0, 7)})`,
+        payload: {
+          baseSha: typeof row.before === "string" ? row.before : "",
+          headSha,
+          // ⚠️ Always empty. The replica stores one row per ref and no commit list,
+          // so the commits array cannot be reconstructed. No consumer reads it
+          // (`router.mjs:1582` reads only `vcs.ref.name`), which is the measured
+          // reason this stream is shippable despite being lossy.
+          commits: [],
+        },
+      }, seams);
+    }
+
+    default:
+      return null;
+  }
+}

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -171,6 +171,19 @@ export function githubEdgeId(streamKey, row) {
   if (!s || !row) return null;
   const id = row.__id;
   if (id === undefined || id === null || id === "") return null;
+  // ⛔ A STREAM WHOSE ROW IS MUTATED IN PLACE HAS NO PER-EDGE PRIMARY KEY.
+  // `pushes` is keyed `(repo_id, ref)` and rewritten on every push, so `__id` is the
+  // same string for every push to a branch, forever. Keying the seen-set on it alone
+  // suppressed the second and all later pushes to a ref as re-reads — `github.push`
+  // dead after the first one, silently, taking rebase detection with it. Folding in
+  // the row's own coordinate plus the sha it landed on restores a per-edge identity:
+  // both change on a real push, and BOTH are stable across re-reads of the same push,
+  // which is what the settle-window re-read requires.
+  if (s.mutableRow) {
+    const ts = Number.isInteger(row.__ts) ? row.__ts : "?";
+    const at = typeof row.after === "string" && row.after !== "" ? row.after : "?";
+    return `gh:${streamKey}:${String(id)}:${ts}:${at}`;
+  }
   return `gh:${streamKey}:${String(id)}`;
 }
 
@@ -215,6 +228,14 @@ export function classifyGithubRow(streamKey, row) {
   }
   if (streamKey === "push" && (typeof row.ref !== "string" || row.ref === "")) {
     return { emit: false, reason: "no-ref" };
+  }
+  // ⛔ `vcs.revision` on this name is the JOIN KEY `setFilterStateDeploying` matches
+  // against `filter_state.merge_commit_sha`. Emitting `""` produces an event that is
+  // counted as emitted, routes to no interest, and leaves the deployment lifecycle
+  // parked forever — an unroutable event is worse than a declined row, because the
+  // decline is visible in `byReason` and the emission looks like success.
+  if (streamKey === "deploymentCreated" && (typeof row.sha !== "string" || row.sha === "")) {
+    return { emit: false, reason: "no-deployment-sha" };
   }
   return { emit: true, reason: null };
 }

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -226,6 +226,54 @@ describe("classification declines a row the consumer could not use", () => {
   });
 });
 
+describe("⛔ P1 (Codex #3513): a mutated row has no per-edge PK, so push folds in its coordinate", () => {
+  const push = (ts, after) => ({ __ts: ts, __id: "o/r@refs/heads/main", repo_id: "o/r", ref: "refs/heads/main", after });
+
+  test("two pushes to ONE ref get DIFFERENT identities", () => {
+    // The defect: `pushes` is keyed (repo_id, ref) and rewritten per push, so the
+    // bare PK is the same string forever. The seen-set then suppressed every push
+    // after the first as a re-read — github.push dead per ref, silently.
+    const a = githubEdgeId("push", push(1000, "sha-a"));
+    const b = githubEdgeId("push", push(2000, "sha-b"));
+    expect(a).not.toBe(b);
+  });
+
+  test("but the identity is STABLE across re-reads of the SAME push", () => {
+    // The settle window re-reads deliberately; suppression depends on the identity
+    // being byte-identical for an unchanged row.
+    expect(githubEdgeId("push", push(1000, "sha-a"))).toBe(githubEdgeId("push", push(1000, "sha-a")));
+  });
+
+  test("a same-millisecond force-push to a different sha is still distinct", () => {
+    expect(githubEdgeId("push", push(1000, "sha-a"))).not.toBe(githubEdgeId("push", push(1000, "sha-b")));
+  });
+
+  test("only push folds in the coordinate — insert-per-edge streams keep the bare PK", () => {
+    const row = { __ts: 5, __id: "r-1" };
+    expect(githubEdgeId("reviewSubmitted", row)).toBe(githubEdgeId("reviewSubmitted", { ...row, __ts: 9 }));
+  });
+});
+
+describe("⛔ P2 (Codex #3513): a row that would emit an unroutable event is declined", () => {
+  test("a deployment with no sha is declined, not emitted with an empty join key", () => {
+    // vcs.revision is what setFilterStateDeploying matches on. "" routes nowhere and
+    // parks the deployment lifecycle, while counting as a successful emit.
+    for (const sha of [undefined, null, "", 12345]) {
+      const v = classifyGithubRow("deploymentCreated", {
+        __ts: 1, __id: "d1", repo_id: "o/r", id: "d1", sha, environment: "production",
+      });
+      expect(v.emit).toBe(false);
+      expect(v.reason).toBe("no-deployment-sha");
+    }
+  });
+  test("a deployment WITH a sha still emits (the control — the rule can pass)", () => {
+    const v = classifyGithubRow("deploymentCreated", {
+      __ts: 1, __id: "d1", repo_id: "o/r", id: "d1", sha: "c671cd9c", environment: "production",
+    });
+    expect(v.emit).toBe(true);
+  });
+});
+
 describe("edge identity is stable and PK-derived", () => {
   test("the same row yields the same id across reads (the seen-set depends on it)", () => {
     const row = { __ts: 5, __id: "o/r#7", number: 7, repo_id: "o/r" };

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -1,0 +1,256 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-event.test.mjs
+//
+// These tests assert the fields `broker/router.mjs` DESTRUCTURES, not a shape that
+// merely looks like a GitHub event. Where a field is a join key or a strict `===`
+// comparison, the test says so — those are the ones whose failure is silent.
+
+import { describe, expect, test } from "bun:test";
+import {
+  GITHUB_DISPATCH_CLASS_NAMES,
+  GITHUB_SERVICE_NAME,
+  GITHUB_UNCOVERED_NAMES,
+  SOURCE_CLOUD_FEED,
+  UNCOVERED_STREAM_REASONS,
+  authorOf,
+  authorTypeOf,
+  buildGithubEvent,
+  classifyGithubRow,
+  githubEdgeId,
+  githubEventName,
+  loginOf,
+} from "./github-feed-event.mjs";
+
+// Deterministic seams so the envelope is byte-stable across runs.
+const SEAMS = {
+  now: () => new Date("2026-08-18T00:00:00.000Z"),
+  newId: () => "id0",
+  newTrace: () => "trace0",
+  newSpan: () => "span0",
+};
+const build = (k, row) => buildGithubEvent(k, { __ts: 1, __id: "k", ...row }, SEAMS);
+
+describe("envelope invariants shared by every name", () => {
+  const rows = {
+    prOpened: { repo_id: "o/r", number: 7, draft: 0, mergeable: 1 },
+    prClosed: { repo_id: "o/r", number: 7, draft: 0, mergeable: null },
+    reviewSubmitted: { repo_id: "o/r", pr_number: 7, user_id: "github:alice", state: "COMMENTED", body: "b" },
+    reviewCommentCreated: { repo_id: "o/r", pr_number: 7, id: "991", author_id: "github:alice", body: "b" },
+    threadResolved: { repo_id: "o/r", pr_number: 7, id: "PRRT_x" },
+    deploymentCreated: { repo_id: "o/r", id: "55", sha: "abc", ref: "main", environment: "production" },
+    deploymentStatus: { repo_id: "o/r", id: "9", deployment_id: "55", state: "success", environment: "production" },
+    push: { repo_id: "o/r", ref: "refs/heads/main", before: "b1", after: "a1" },
+  };
+
+  for (const [key, row] of Object.entries(rows)) {
+    test(`${key}: service.name stays catalyst.github`, () => {
+      // ⛔ router.mjs's recordLastSeen folds this into the CTL-1122 ingestion-recency
+      // map. A different value blinds the github ingestion-SILENCE detector at the
+      // exact moment this producer becomes github's only source.
+      expect(build(key, row).resource["service.name"]).toBe(GITHUB_SERVICE_NAME);
+      expect(GITHUB_SERVICE_NAME).toBe("catalyst.github");
+    });
+
+    test(`${key}: provenance is stamped positively as cloud-feed`, () => {
+      // cloud-feed-gate.sourceOf reads exactly this key; without it the event
+      // classifies as SOURCE_OTHER and inherits no authority.
+      const ev = build(key, row);
+      expect(ev.body.payload.source).toBe(SOURCE_CLOUD_FEED);
+      expect(ev.attributes["event.channel"]).toBe(SOURCE_CLOUD_FEED);
+    });
+
+    test(`${key}: does NOT stamp webhook.delivery.id`, () => {
+      // That attribute is how sourceOf recognises smee NEGATIVELY. Stamping it here
+      // would make our copy indistinguishable from the tunnel's.
+      expect(build(key, row).attributes["webhook.delivery.id"]).toBeUndefined();
+    });
+
+    test(`${key}: carries a non-empty human body.message and its event.name`, () => {
+      const ev = build(key, row);
+      expect(ev.body.message.length).toBeGreaterThan(0);
+      // summarizeEvent puts body.message into every wake an agent reads, so it must
+      // not collapse to the bare name the way the generic builder leaves it.
+      expect(ev.body.message).toContain("o/r");
+      expect(ev.attributes["event.name"]).toBe(ev.attributes["event.name"]);
+      expect(GITHUB_DISPATCH_CLASS_NAMES).toContain(ev.attributes["event.name"]);
+    });
+  }
+});
+
+describe("⛔ the two deliberate divergences from 'nicer'", () => {
+  test("pr payloads carry NO title / body / headRef — emitting them would wake a dormant path", () => {
+    // router.mjs:1856 scrapes exactly these three for ticket ids. Measured 1208/1208
+    // live payloads contain none of them, so _autoPrLifecycleFromTicket never fires.
+    // Including them would switch that on fleet-wide.
+    const ev = build("prOpened", {
+      repo_id: "o/r", number: 7, draft: 0, mergeable: 1,
+      title: "CTL-1 do a thing", body: "closes CTL-2", head_ref: "ryan/ctl-3-x",
+    });
+    expect(Object.keys(ev.body.payload).sort()).toEqual(
+      ["action", "draft", "mergeCommitSha", "mergeable", "merged", "mergedAt", "source"],
+    );
+    const wire = JSON.stringify(ev.body.payload);
+    expect(wire).not.toContain("CTL-1");
+    expect(wire).not.toContain("CTL-2");
+    expect(wire).not.toContain("CTL-3");
+  });
+
+  test("pr_review_thread.resolved emits threadId 0, not the real id", () => {
+    // Measured 202/202 live events carry 0 (GitHub's thread has no numeric id).
+    // Emitting the real id is nicer and breaks the parity instrument.
+    const ev = build("threadResolved", { repo_id: "o/r", pr_number: 7, id: "PRRT_realid" });
+    expect(ev.body.payload.threadId).toBe(0);
+    expect(JSON.stringify(ev.body.payload)).not.toContain("PRRT_realid");
+  });
+});
+
+describe("⛔ join keys — a wrong type here breaks a chain while everything still routes", () => {
+  test("deployment_status.deploymentId is a NUMBER (replica stores TEXT)", () => {
+    // filter-state.mjs:117 matches `WHERE deployment_id = ?`. "55" !== 55.
+    const ev = build("deploymentStatus", {
+      repo_id: "o/r", id: "9", deployment_id: "5936592703", state: "success", environment: "production",
+    });
+    expect(ev.body.payload.deploymentId).toBe(5936592703);
+    expect(typeof ev.body.payload.deploymentId).toBe("number");
+  });
+
+  test("deployment.created carries vcs.revision — the merge_commit_sha join key", () => {
+    const ev = build("deploymentCreated", {
+      repo_id: "o/r", id: "55", sha: "c671cd9c", ref: "main", environment: "production",
+    });
+    expect(ev.attributes["vcs.revision"]).toBe("c671cd9c");
+    expect(ev.attributes["deployment.environment"]).toBe("production");
+    expect(typeof ev.attributes["deployment.id"]).toBe("number");
+  });
+
+  test("push carries the FULL ref, not a stripped branch", () => {
+    // router.mjs:1583 strips `refs/heads/` itself; a pre-stripped value never matches.
+    const ev = build("push", { repo_id: "o/r", ref: "refs/heads/main", before: "b", after: "a1b2c3d4e5" });
+    expect(ev.attributes["vcs.ref.name"]).toBe("refs/heads/main");
+    expect(ev.attributes["event.label"]).toBe("a1b2c3d");
+  });
+
+  test("pr.closed sets merged === false STRICTLY (router.mjs:1525 uses ===)", () => {
+    const ev = build("prClosed", { repo_id: "o/r", number: 7, draft: 0, mergeable: null });
+    expect(ev.body.payload.merged).toBe(false);
+    expect(ev.body.payload.merged).not.toBeUndefined();
+  });
+});
+
+describe("review state normalisation", () => {
+  test("the stored UPPERCASE state is lowercased to what the consumer compares", () => {
+    // router.mjs:1539 compares === "changes_requested" / "approved". Passing
+    // "COMMENTED" through would match neither branch and the gate would go quiet.
+    const ev = build("reviewSubmitted", {
+      repo_id: "o/r", pr_number: 7, user_id: "github:alice", state: "COMMENTED", body: "b",
+    });
+    expect(ev.body.payload.state).toBe("commented");
+  });
+  test("CHANGES_REQUESTED and APPROVED map to the router's exact tokens", () => {
+    // ⚠️ Convention, not measurement: neither value has ever been observed on this
+    // fleet (6,630/6,630 replica rows and 3,093/3,093 live events are `commented`).
+    for (const [stored, want] of [["CHANGES_REQUESTED", "changes_requested"], ["APPROVED", "approved"]]) {
+      const ev = build("reviewSubmitted", { repo_id: "o/r", pr_number: 7, user_id: "github:a", state: stored, body: "" });
+      expect(ev.body.payload.state).toBe(want);
+    }
+  });
+});
+
+describe("author identity — derived from the login, not joined", () => {
+  test("the [bot] suffix rule classifies the author absent from the users table", () => {
+    // github:github-code-quality[bot] has no `users` row on mini-2; a left join would
+    // have yielded a null type and handled a bot review as a human's.
+    expect(authorTypeOf("github-code-quality[bot]")).toBe("Bot");
+    expect(authorTypeOf("chatgpt-codex-connector[bot]")).toBe("Bot");
+    expect(authorTypeOf("ryanrozich")).toBe("User");
+    expect(authorTypeOf(undefined)).toBe("User");
+  });
+  test("the github: namespace prefix is stripped", () => {
+    expect(loginOf("github:thagale")).toBe("thagale");
+    expect(loginOf("")).toBe("");
+    expect(authorOf("github:x[bot]")).toEqual({ login: "x[bot]", type: "Bot" });
+  });
+  test("review + review-comment payloads expose author.type for the bot gate", () => {
+    const r = build("reviewSubmitted", {
+      repo_id: "o/r", pr_number: 7, user_id: "github:chatgpt-codex-connector[bot]", state: "COMMENTED", body: "x",
+    });
+    expect(r.body.payload.author.type).toBe("Bot");
+    expect(r.body.payload.reviewer).toBe("chatgpt-codex-connector[bot]");
+    const c = build("reviewCommentCreated", {
+      repo_id: "o/r", pr_number: 7, id: "991", author_id: "github:ryanrozich", body: "x",
+    });
+    expect(c.body.payload.author).toEqual({ login: "ryanrozich", type: "User" });
+    expect(c.body.payload.htmlUrl).toBe("https://github.com/o/r/pull/7#discussion_r991");
+  });
+});
+
+describe("⛔ uncovered names decline with a reason — they never return a silent null", () => {
+  test("prMerged declines, naming the ticket that closes it", () => {
+    const v = classifyGithubRow("prMerged", { __ts: 1, __id: "k", repo_id: "o/r", number: 7 });
+    expect(v.emit).toBe(false);
+    expect(v.reason).toBe(UNCOVERED_STREAM_REASONS.prMerged);
+    expect(v.reason).toContain("CTC-691");
+    // A decline, NOT a failure: un-arming the producer would not repair it, and
+    // readiness must not un-arm on a gap we have already declared.
+    expect(v.fatal).toBeUndefined();
+  });
+  test("no uncovered name is reachable through the dispatch-class set", () => {
+    for (const n of GITHUB_UNCOVERED_NAMES) expect(GITHUB_DISPATCH_CLASS_NAMES).not.toContain(n);
+    expect(GITHUB_UNCOVERED_NAMES).toContain("github.pr.merged");
+    expect(GITHUB_UNCOVERED_NAMES).toContain("github.check_suite.completed");
+  });
+  test("buildGithubEvent refuses an uncovered stream", () => {
+    expect(build("prMerged", { repo_id: "o/r", number: 7 })).toBeNull();
+  });
+});
+
+describe("classification declines a row the consumer could not use", () => {
+  const cases = [
+    ["no repo", "prOpened", { __ts: 1, __id: "k", number: 7 }, "no-repo"],
+    ["no pr number", "prOpened", { __ts: 1, __id: "k", repo_id: "o/r" }, "no-pr-number"],
+    ["no edge timestamp", "prOpened", { __id: "k", repo_id: "o/r", number: 7 }, "no-edge-timestamp"],
+    ["no edge id", "prOpened", { __ts: 1, repo_id: "o/r", number: 7 }, "no-edge-id"],
+    ["no ref", "push", { __ts: 1, __id: "k", repo_id: "o/r" }, "no-ref"],
+    ["no deployment state", "deploymentStatus", { __ts: 1, __id: "k", repo_id: "o/r" }, "no-deployment-state"],
+  ];
+  for (const [label, key, row, reason] of cases) {
+    test(`${label} -> declined as ${reason}`, () => {
+      const v = classifyGithubRow(key, row);
+      expect(v.emit).toBe(false);
+      expect(v.reason).toBe(reason);
+    });
+  }
+  test("an unknown stream is FATAL — it would make every row unemittable", () => {
+    const v = classifyGithubRow("nope", {});
+    expect(v.emit).toBe(false);
+    expect(v.fatal).toBe(true);
+  });
+});
+
+describe("edge identity is stable and PK-derived", () => {
+  test("the same row yields the same id across reads (the seen-set depends on it)", () => {
+    const row = { __ts: 5, __id: "o/r#7", number: 7, repo_id: "o/r" };
+    expect(githubEdgeId("prOpened", row)).toBe(githubEdgeId("prOpened", { ...row, __ts: 9 }));
+  });
+  test("distinct streams over one row do not collide", () => {
+    const row = { __ts: 5, __id: "o/r#7" };
+    expect(githubEdgeId("prOpened", row)).not.toBe(githubEdgeId("prClosed", row));
+  });
+  test("a row with no id yields null rather than a colliding constant", () => {
+    expect(githubEdgeId("prOpened", { __ts: 1 })).toBeNull();
+  });
+});
+
+describe("deployment_status name and severity are per-row", () => {
+  const mk = (state) => build("deploymentStatus", {
+    repo_id: "o/r", id: "9", deployment_id: "55", state, environment: "production",
+  });
+  test("the name carries the state", () => {
+    expect(githubEventName("deploymentStatus", { state: "failure" })).toBe("github.deployment_status.failure");
+    expect(mk("success").attributes["event.name"]).toBe("github.deployment_status.success");
+  });
+  test("failure and error are ERROR severity; success is INFO", () => {
+    expect(mk("failure").severityText).toBe("ERROR");
+    expect(mk("error").severityNumber).toBe(17);
+    expect(mk("success").severityText).toBe("INFO");
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-source.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.mjs
@@ -1,0 +1,426 @@
+// github-feed-source.mjs — CTL-1929, the replica read layer for the GitHub leg of
+// the cloud-feed dispatch producer.
+//
+// The Linear leg's twin is `linear-feed-source.mjs`. This module is deliberately
+// NOT a copy of it, because the tables underneath are a different shape and the
+// difference decides the whole design.
+//
+// ── ⛔ THE STRUCTURAL DIFFERENCE FROM THE LINEAR LEG ────────────────────────
+// `linear-feed-source.mjs` reads `issue_history`: an APPEND-ONLY log with a
+// PRIMARY KEY, so a keyset over `(created_at, id)` replays the edge sequence
+// exactly. **Every GitHub table in the replica is a LAST-STATE PROJECTION**,
+// verified against the live schema on mini-2 (2026-08-17):
+//
+//   pull_requests       PRIMARY KEY (repo_id, number)     — one row per PR
+//   pushes              PRIMARY KEY (repo_id, ref)        — one row per ref
+//   check_runs          PRIMARY KEY (check_run_id)        — updated in place
+//   pr_review_threads   PRIMARY KEY (id)                  — `resolved` flips in place
+//   reviews / pr_review_comments / deployments / deployment_statuses — id PK
+//
+// A row is UPDATED IN PLACE, so `updated_at` is not a log position: a PR that is
+// opened and then merged carries one `updated_at`, and a producer keyed on it
+// that reads the row after the merge can no longer tell that an `opened` edge
+// was ever owed. Keying dispatch on `updated_at` would silently drop transitions.
+//
+// ── ⭐ WHAT MAKES A LAST-STATE TABLE REPLAYABLE ANYWAY ──────────────────────
+// Each edge we emit has its own timestamp column that is written EXACTLY ONCE,
+// at the moment that edge happens, and never moves afterwards:
+//
+//   github.pr.opened                 pull_requests.created_at
+//   github.pr.merged                 pull_requests.merged_at
+//   github.pr.closed                 pull_requests.closed_at   (merged = 0)
+//   github.pr_review.submitted       reviews.submitted_at
+//   github.pr_review_comment.created pr_review_comments.created_at
+//   github.pr_review_thread.resolved pr_review_threads.resolved_at
+//   github.deployment.created        deployments.created_at
+//   github.deployment_status.*       deployment_statuses.created_at
+//
+// Keyed on THOSE columns, each stream is append-only again — the table mutates,
+// but the coordinate we page over does not. Population was verified by content on
+// mini-2 before this design was built on it, because a NULL in one of these
+// columns is a silently skipped dispatch and nothing downstream would say so:
+//
+//   pull_requests    4230 rows · created_at 4230/4230 · closed_at 4143 · merged_at 3995
+//                    · merged=1 rows with a NULL merged_at: **0**
+//   reviews          6619 · submitted_at 6619/6619
+//   pr_review_comments 10155 · created_at 10155/10155
+//   pr_review_threads   32 · resolved=1 32 · resolved_at 32/32 · resolved-but-null: **0**
+//   deployments 2 · deployment_statuses 4 — both created_at complete
+//
+// `REQUIRED_COLUMNS` below is the CI-side half of that check; the live-schema
+// conformance test re-runs it against the host replica and reports INCONCLUSIVE
+// rather than passing when no replica is present.
+//
+// ── ⚠️ THE LATE-ARRIVAL HAZARD, AND WHY THE CURSOR IS NOT THE EMIT POSITION ──
+// The coordinate is EVENT time; rows appear at INGEST time, which is later and
+// out of order. A sweep that advanced its cursor to the newest event time it saw
+// would permanently skip any row that lands afterwards carrying an older stamp.
+//
+// Measured on mini-2, 6 h window, rows whose `updated_at` is inside the window so
+// historical backfill cannot flatter the number (n = 62, `synced_at - updated_at`):
+//
+//   <=5s 21 · <=15s 12 · <=60s 6 · <=120s 11 · <=300s 11 · >300s 1 · max 333s
+//
+// ⛔ **37% arrive more than 60 s after their own event time, and the tail reaches
+// 333 s.** So a settle window wide enough to be safe (>= ~600 s) would delay every
+// CI-wait edge by ten minutes — on the one path (`monitor-merge`) where latency is
+// the whole point. That trade is refused. Instead the two positions are SPLIT:
+//
+//   EMIT position   — every row past the cursor is emitted immediately, at replica
+//                     speed (median <= 5 s). Latency is not sacrificed.
+//   CURSOR position — advanced only to `min(lastKeySeen, now - settleMs)`, so the
+//                     window a late row can still land in stays BEHIND the cursor
+//                     and is re-read on the next tick rather than skipped.
+//
+// The cost of that split is re-emission of the rows inside the settle window, and
+// it is paid with a stable identity rather than absorbed: every edge id below is
+// derived from a PRIMARY KEY plus the edge name, so re-reading a row yields the
+// byte-identical id and the seen-set suppresses it. This is the same bargain the
+// Linear leg strikes with `issue_history.id` — dedup by primary key is what lets
+// an overlapping sweep be a no-op instead of a duplicate storm — reached here from
+// the other direction because our tables have no log to key on.
+//
+// ⚠️ `synced_at - updated_at` OVERSTATES ingestion lag whenever GitHub's
+// `updated_at` predates the webhook that carried the row. That is the conservative
+// direction for sizing a settle window, so the bound above is an upper bound and
+// is used as one. It is not a claim about the median path.
+//
+// ── ⛔ TWO DECLARED GAPS. NEITHER IS SILENT. ────────────────────────────────
+// 1. `github.push` is LOSSY BY SCHEMA. `pushes` is keyed `(repo_id, ref)`, so two
+//    pushes to one ref between ticks collapse to one row and the intermediate
+//    `before`/`after` pair is unrecoverable — no producer can reconstruct it.
+//    Measured: 36 rows in `pushes` against 111 `github.push` events in 3 h.
+//    It also has no once-set timestamp, so it is the one stream keyed on the
+//    mutable `updated_at`. The consumer is rebase detection (CTL-381), which asks
+//    "did this ref move", not "how many times" — so the collapse is survivable.
+//    It is declared here rather than discovered later, and `PUSH_IS_LOSSY` exists
+//    so a caller can assert on the fact rather than on a comment.
+// 2. `github.check_suite.completed` HAS NO STREAM AT ALL. The mirror accepts the
+//    `check_suite` payload and deliberately stores no row (`return []`), so there
+//    is nothing to page over. `check_runs` holds the constituent data (60,249 rows)
+//    but a suite is not reconstructable from it safely: one head sha carried **10
+//    distinct `check_suite_id`s** on mini-2, several with runs still incomplete, so
+//    "every run I can see has completed" fires early and green on a partial view —
+//    a false CI-pass on the merge gate. The derivation is CTC-667 item 4 and is
+//    theirs to declare; this module exports the gap as `UNBACKED_EVENT_NAMES`
+//    rather than inventing a second answer.
+
+import { Database } from "bun:sqlite";
+import { getReplicaDbPath } from "./config.mjs";
+
+/** Default rows per stream per sweep. Bounded so one call can never materialise a table. */
+export const DEFAULT_BATCH_LIMIT = 500;
+
+/**
+ * How far behind the newest key the durable cursor is held, so a row that arrives
+ * late carrying an older stamp is still ahead of it and gets re-read.
+ *
+ * 600 s = 1.8x the largest lag observed on the live fleet (333 s, see the header).
+ * It bounds RE-READ cost, never emission latency — emission does not wait for it.
+ */
+export const DEFAULT_SETTLE_MS = 600_000;
+
+/**
+ * Consumed `github.*` names with no replica stream behind them. Exported so a
+ * caller can refuse to claim coverage it does not have, and so the parity ledger
+ * can account for them as EXPECTED absences instead of as unexplained diffs.
+ */
+export const UNBACKED_EVENT_NAMES = Object.freeze(["github.check_suite.completed"]);
+
+/** `github.push` cannot be replayed faithfully. See gap (1) in the header. */
+export const PUSH_IS_LOSSY = true;
+
+/**
+ * The streams, in the order a sweep should read them.
+ *
+ * `tsCol` is the once-set edge timestamp (the keyset's major coordinate).
+ * `idExpr` is SQL yielding a value that is UNIQUE within the stream — it is both
+ * the keyset tie-break and the dedup identity, which is why it must come from a
+ * PRIMARY KEY and never from a mutable column.
+ *
+ * ⚠️ `repo_id || '#' || number` is a TEXT ordering over an integer, so `#10` sorts
+ * before `#9`. That is deliberate and harmless: the tie-break only has to be a
+ * TOTAL order over rows sharing one millisecond, not a meaningful one. What it
+ * must never be is non-unique, and `(repo_id, number)` is the table's PRIMARY KEY.
+ */
+export const STREAMS = Object.freeze([
+  {
+    key: "prOpened",
+    event: "github.pr.opened",
+    table: "pull_requests",
+    tsCol: "created_at",
+    idExpr: "repo_id || '#' || number",
+    where: null,
+  },
+  {
+    key: "prMerged",
+    event: "github.pr.merged",
+    table: "pull_requests",
+    tsCol: "merged_at",
+    idExpr: "repo_id || '#' || number",
+    // `merged_at IS NOT NULL` is implied by the keyset (NULL never compares > a
+    // number) but is stated so the index can be used and the intent is readable.
+    where: "merged_at IS NOT NULL",
+  },
+  {
+    key: "prClosed",
+    event: "github.pr.closed",
+    table: "pull_requests",
+    tsCol: "closed_at",
+    idExpr: "repo_id || '#' || number",
+    // ⛔ A MERGED PR IS NOT A CLOSED PR on this path. GitHub closes a PR when it
+    // merges, so `closed_at` is set on both; the webhook producer emits
+    // `github.pr.merged` for one and `github.pr.closed` for the other, never both.
+    // Live counts on mini-2 over 3 h agree (merged 22, closed 3) — without this
+    // predicate the feed would emit a spurious `closed` for every merge and the
+    // PR-lifecycle router would see a close it never sees today.
+    where: "closed_at IS NOT NULL AND (merged IS NULL OR merged = 0)",
+  },
+  {
+    key: "reviewSubmitted",
+    event: "github.pr_review.submitted",
+    table: "reviews",
+    tsCol: "submitted_at",
+    idExpr: "review_id",
+    where: null,
+  },
+  {
+    key: "reviewCommentCreated",
+    event: "github.pr_review_comment.created",
+    table: "pr_review_comments",
+    tsCol: "created_at",
+    idExpr: "id",
+    // A comment removed after the fact is not un-created; the edge still happened
+    // and its webhook twin was delivered. `removed_at` is carried in the row for
+    // the envelope, not used to filter the stream.
+    where: null,
+  },
+  {
+    key: "threadResolved",
+    event: "github.pr_review_thread.resolved",
+    table: "pr_review_threads",
+    tsCol: "resolved_at",
+    idExpr: "id",
+    where: "resolved = 1 AND resolved_at IS NOT NULL",
+  },
+  {
+    key: "deploymentCreated",
+    event: "github.deployment.created",
+    table: "deployments",
+    tsCol: "created_at",
+    idExpr: "id",
+    where: null,
+  },
+  {
+    key: "deploymentStatus",
+    // The action is per-row (`state`), so the name is resolved by the event
+    // builder rather than fixed here; this is the one stream whose event name is
+    // not a constant.
+    event: null,
+    table: "deployment_statuses",
+    tsCol: "created_at",
+    idExpr: "id",
+    where: null,
+  },
+  {
+    key: "push",
+    event: "github.push",
+    table: "pushes",
+    // ⛔ The one mutable coordinate in this table — see gap (1). `pushes` has no
+    // once-set column because the row IS the ref's current head.
+    tsCol: "updated_at",
+    idExpr: "repo_id || '@' || ref",
+    where: null,
+    lossy: true,
+  },
+]);
+
+/** Stream lookup by key, so callers name a stream instead of indexing an array. */
+export const STREAM_BY_KEY = Object.freeze(
+  Object.fromEntries(STREAMS.map((s) => [s.key, s])),
+);
+
+/**
+ * Columns this module reads, per table. Checked against the live replica by
+ * `github-feed-source.test.mjs`, which reports INCONCLUSIVE — never PASS — when
+ * no replica is present. A missing column here is a stream that silently returns
+ * nothing, which is the failure this list exists to make loud.
+ */
+export const REQUIRED_COLUMNS = Object.freeze({
+  pull_requests: [
+    "repo_id", "number", "state", "draft", "merged", "merged_at", "head_sha",
+    "base_ref", "head_ref", "title", "author_login", "created_at", "closed_at",
+    "updated_at", "linear_issue_identifier",
+  ],
+  reviews: ["repo_id", "pr_number", "review_id", "user_id", "state", "submitted_at", "body"],
+  pr_review_comments: [
+    "id", "repo_id", "pr_number", "review_id", "path", "line", "in_reply_to_id",
+    "author_id", "body", "created_at", "updated_at", "removed_at",
+  ],
+  pr_review_threads: [
+    "id", "repo_id", "pr_number", "resolved", "resolved_at", "resolver_id",
+    "first_comment_id", "comment_count", "updated_at",
+  ],
+  deployments: [
+    "id", "repo_id", "ref", "sha", "task", "environment", "production_environment",
+    "description", "creator_id", "created_at",
+  ],
+  deployment_statuses: [
+    "id", "repo_id", "deployment_id", "state", "environment", "target_url",
+    "environment_url", "description", "creator_id", "created_at",
+  ],
+  pushes: [
+    "repo_id", "ref", "before", "after", "forced", "created", "deleted",
+    "base_ref", "pusher_id", "head_commit_sha", "updated_at",
+  ],
+});
+
+/**
+ * Build one stream's keyset query.
+ *
+ * The comparison is the standard keyset form and the reasoning is the Linear leg's
+ * verbatim, because the hazard is a property of SQL and not of Linear:
+ *   `ts >  last`  skips every same-millisecond sibling not yet read when the batch
+ *                 was cut — a silently dropped dispatch edge;
+ *   `ts >= last`  re-reads the whole millisecond forever, and wedges permanently if
+ *                 one timestamp ever holds more rows than the batch limit.
+ */
+export function buildStreamQuery(stream) {
+  const s = typeof stream === "string" ? STREAM_BY_KEY[stream] : stream;
+  if (!s) throw new Error(`buildStreamQuery: unknown stream ${String(stream)}`);
+  const extra = s.where ? `(${s.where}) AND ` : "";
+  return `
+    SELECT *, ${s.tsCol} AS __ts, ${s.idExpr} AS __id
+    FROM ${s.table}
+    WHERE ${extra}(
+      (${s.tsCol} > $sinceMs)
+      OR (${s.tsCol} = $sinceMs AND ${s.idExpr} > $sinceId)
+    )
+    ORDER BY ${s.tsCol} ASC, ${s.idExpr} ASC
+    LIMIT $limit
+  `;
+}
+
+/**
+ * The position AFTER a page of rows: the keyset coordinate of its last row.
+ *
+ * ⛔ Returns `null` for an empty page. Advancing on an empty read is exactly how a
+ * producer skips a row that arrives a moment later carrying an equal timestamp.
+ */
+export function positionAfter(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const last = rows[rows.length - 1];
+  const ts = last?.__ts;
+  if (!Number.isInteger(ts)) return null;
+  return { lastCreatedAt: ts, lastId: typeof last.__id === "string" ? last.__id : String(last.__id ?? "") };
+}
+
+/**
+ * Compare two keyset positions. Total order, matching the SQL `ORDER BY ts, id`.
+ */
+function keyCmp(a, b) {
+  if (a.lastCreatedAt !== b.lastCreatedAt) return a.lastCreatedAt < b.lastCreatedAt ? -1 : 1;
+  const ai = typeof a.lastId === "string" ? a.lastId : "";
+  const bi = typeof b.lastId === "string" ? b.lastId : "";
+  return ai === bi ? 0 : ai < bi ? -1 : 1;
+}
+
+/**
+ * Hold the durable cursor behind the newest key the sweep may safely claim.
+ *
+ * ⭐ This is the emit/cursor split from the header, isolated as a pure function so it
+ * can be asserted on directly. `emitted` is where the sweep actually GOT to; the
+ * return value is all it is allowed to WRITE DOWN. Everything between the two is
+ * re-read next tick, and that gap is precisely what turns a late arrival into a
+ * duplicate (which the seen-set absorbs) instead of a permanent loss (which nothing
+ * would report).
+ *
+ * Two cases:
+ *   - the page ended at or before the horizon → claim it exactly; we have provably
+ *     seen everything up to there, and there is no reason to hold back further.
+ *   - the page ended PAST the horizon → we necessarily read every row at or before
+ *     the horizon, so claim the HORIZON ITSELF and leave the late-arrival window
+ *     open behind us. Claiming `emitted` here is the bug this function exists to
+ *     prevent; refusing to advance at all is the other one, and would wedge the
+ *     cursor permanently on a busy repo where every page ends inside the window.
+ *
+ * ⛔ The cursor NEVER moves backwards. A clock step, a shortened settle window, or a
+ * sparse page must not re-open a window already closed — the seen-set is bounded and
+ * may since have evicted those ids, so a backward step is a duplicate storm.
+ */
+export function settleCursor(emitted, { now, settleMs = DEFAULT_SETTLE_MS, previous = null } = {}) {
+  if (!Number.isInteger(now)) throw new Error("settleCursor: now must be an integer epoch-ms");
+  const bound = Number.isInteger(settleMs) && settleMs >= 0 ? settleMs : DEFAULT_SETTLE_MS;
+  const horizon = now - bound;
+  const prev = previous && Number.isInteger(previous.lastCreatedAt)
+    ? { lastCreatedAt: previous.lastCreatedAt, lastId: typeof previous.lastId === "string" ? previous.lastId : "" }
+    : null;
+
+  let claim;
+  if (!emitted || !Number.isInteger(emitted.lastCreatedAt)) {
+    // No usable page. The cursor may still advance to the horizon if we are already
+    // past it — but only when we HAVE a previous position, because a producer that
+    // has never read anything must not claim a window it never looked at.
+    claim = prev && prev.lastCreatedAt < horizon ? { lastCreatedAt: horizon, lastId: "" } : null;
+  } else if (emitted.lastCreatedAt <= horizon) {
+    claim = { lastCreatedAt: emitted.lastCreatedAt, lastId: typeof emitted.lastId === "string" ? emitted.lastId : "" };
+  } else {
+    claim = { lastCreatedAt: horizon, lastId: "" };
+  }
+
+  if (!claim) return prev;
+  if (!prev) return claim;
+  return keyCmp(claim, prev) > 0 ? claim : prev;
+}
+
+/**
+ * A read-only handle over the replica.
+ *
+ * Deliberately a separate handle from `createReplicaReader`'s: that one exposes
+ * domain methods, not a general query surface, and WAL exists precisely so
+ * concurrent readers do not contend.
+ */
+export function createGithubFeedSource({ dbPath = getReplicaDbPath(), limit = DEFAULT_BATCH_LIMIT } = {}) {
+  let db = null;
+  const open = () => {
+    if (db) return db;
+    db = new Database(dbPath, { readonly: true });
+    db.run("PRAGMA busy_timeout = 250");
+    return db;
+  };
+
+  /**
+   * Page one stream. Coerces defensively: a non-integer `lastCreatedAt` reads as 0
+   * and a non-string `lastId` as "" — and "" sorts before every id, so a cold start
+   * is inclusive of its own instant rather than one row short of it.
+   */
+  const page = (streamKey, position, batchLimit) => {
+    const sinceMs = Number.isInteger(position?.lastCreatedAt) ? position.lastCreatedAt : 0;
+    const sinceId = typeof position?.lastId === "string" ? position.lastId : "";
+    const lim = Number.isInteger(batchLimit) && batchLimit > 0 ? batchLimit : limit;
+    return open()
+      .prepare(buildStreamQuery(streamKey))
+      .all({ $sinceMs: sinceMs, $sinceId: sinceId, $limit: lim });
+  };
+
+  return {
+    /** Rows of a named stream strictly after `position`, oldest first. */
+    rowsSince: (streamKey, position, batchLimit) => page(streamKey, position, batchLimit),
+    /** Every stream key, in sweep order. */
+    streamKeys: () => STREAMS.map((s) => s.key),
+    positionAfter,
+    /**
+     * `PRAGMA table_info` for a table, so a caller can verify REQUIRED_COLUMNS
+     * against the schema actually on disk rather than against this file's belief.
+     */
+    columnsOf: (table) => open().prepare(`PRAGMA table_info(${table})`).all().map((r) => r.name),
+    close() {
+      try {
+        db?.close();
+      } catch {
+        /* already closed */
+      }
+      db = null;
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-source.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.mjs
@@ -232,6 +232,15 @@ export const STREAMS = Object.freeze([
     idExpr: "repo_id || '@' || ref",
     where: null,
     lossy: true,
+    // ⛔ THE ROW IS MUTATED PER PUSH, so this PK identifies the REF, not the edge.
+    // Every other stream inserts a row per edge, which makes its PK a complete edge
+    // identity. Here `repo_id@ref` is CONSTANT across every push to that branch — so
+    // an identity built from it alone is the same string forever, and the seen-set
+    // would suppress the second and every later push to a branch as a re-read. That
+    // is not "lossy": it is `github.push` DEAD after the first push per ref, taking
+    // base-branch rebase detection and plugin-refresh's auto-pull with it.
+    // `githubEdgeId` therefore folds the mutable coordinate in for this stream.
+    mutableRow: true,
   },
 ]);
 
@@ -358,9 +367,13 @@ export function settleCursor(emitted, { now, settleMs = DEFAULT_SETTLE_MS, previ
 
   let claim;
   if (!emitted || !Number.isInteger(emitted.lastCreatedAt)) {
-    // No usable page. The cursor may still advance to the horizon if we are already
-    // past it — but only when we HAVE a previous position, because a producer that
-    // has never read anything must not claim a window it never looked at.
+    // ⭐ No usable page — and on THIS coordinate an empty read is itself evidence.
+    // Nothing exists past the cursor right now, and the settle bound says anything
+    // stamped at or before the horizon has already arrived; so the horizon is safe to
+    // claim, and the suppression set drains at rest instead of holding a residue for
+    // the life of the process.
+    // ⛔ Only when we HAVE a previous position, though: a producer that has never read
+    // anything must not claim a window it never looked at.
     claim = prev && prev.lastCreatedAt < horizon ? { lastCreatedAt: horizon, lastId: "" } : null;
   } else if (emitted.lastCreatedAt <= horizon) {
     claim = { lastCreatedAt: emitted.lastCreatedAt, lastId: typeof emitted.lastId === "string" ? emitted.lastId : "" };

--- a/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
@@ -1,0 +1,298 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-source.test.mjs
+//
+// The keyset tests build a REAL SQLite database with the replica's actual DDL,
+// because the defect they exist to catch — same-millisecond siblings dropped by `>`
+// or re-read forever by `>=` — is a property of SQL comparison and ordering. A
+// mocked reader cannot exhibit it, so a mocked test would pass against a broken
+// query. Same reasoning as `linear-feed-source.test.mjs`.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_SETTLE_MS,
+  PUSH_IS_LOSSY,
+  REQUIRED_COLUMNS,
+  STREAMS,
+  STREAM_BY_KEY,
+  UNBACKED_EVENT_NAMES,
+  buildStreamQuery,
+  createGithubFeedSource,
+  positionAfter,
+  settleCursor,
+} from "./github-feed-source.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-feed-source-"));
+afterAll(() => {
+  // Cleanup must never fail the suite: an aborted suite exits non-zero, which is
+  // byte-identical to a caught mutant.
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+/** The replica's real DDL for the tables this module reads, verbatim from mini-2. */
+const DDL = `
+CREATE TABLE pull_requests (
+  repo_id text NOT NULL, number integer NOT NULL, node_id text, state text, draft integer,
+  merged integer, merged_at integer, head_sha text, base_ref text, mergeable integer,
+  mergeable_state text, auto_merge integer, updated_at integer, synced_at integer,
+  title text, body text, author_login text, author_avatar_url text, created_at integer,
+  closed_at integer, comment_count integer, milestone_title text, head_ref text,
+  linear_issue_identifier text, PRIMARY KEY(repo_id, number));
+CREATE TABLE reviews (
+  repo_id text NOT NULL, pr_number integer NOT NULL, review_id text PRIMARY KEY NOT NULL,
+  user_id text, state text, submitted_at integer, body text);
+CREATE TABLE pr_review_comments (
+  id text PRIMARY KEY NOT NULL, repo_id text NOT NULL, pr_number integer NOT NULL,
+  review_id text, commit_id text, path text, line integer, diff_hunk text,
+  in_reply_to_id text, author_id text, body text, created_at integer, updated_at integer,
+  removed_at integer);
+CREATE TABLE pr_review_threads (
+  id text PRIMARY KEY NOT NULL, repo_id text NOT NULL, pr_number integer NOT NULL,
+  resolved integer, resolved_at integer, resolver_id text, first_comment_id text,
+  comment_count integer, updated_at integer);
+CREATE TABLE deployments (
+  id text PRIMARY KEY NOT NULL, repo_id text NOT NULL, ref text, sha text, task text,
+  environment text, production_environment integer, transient_environment integer,
+  description text, creator_id text, created_at integer, updated_at integer);
+CREATE TABLE deployment_statuses (
+  id text PRIMARY KEY NOT NULL, repo_id text NOT NULL, deployment_id text NOT NULL,
+  state text, environment text, target_url text, environment_url text, description text,
+  creator_id text, created_at integer, updated_at integer);
+CREATE TABLE pushes (
+  repo_id text NOT NULL, ref text NOT NULL, before text, after text, forced integer,
+  created integer, deleted integer, base_ref text, pusher_id text, head_commit_sha text,
+  updated_at integer, PRIMARY KEY(repo_id, ref));
+`;
+
+let dbSeq = 0;
+function freshDb(seed = () => {}) {
+  const path = join(tmp, `replica-${dbSeq++}.db`);
+  const db = new Database(path);
+  db.exec(DDL);
+  seed(db);
+  db.close();
+  return path;
+}
+
+describe("keyset pagination over a real SQLite replica", () => {
+  // ⛔ THE CENTRAL PROPERTY. Four reviews share ONE millisecond. A `>` comparison on
+  // a bare timestamp drops the siblings that were not in the first page; a `>=` one
+  // never advances. Only the composite `(ts, id)` form pages them exactly once.
+  const path = freshDb((db) => {
+    const ins = db.prepare(
+      "INSERT INTO reviews (repo_id, pr_number, review_id, user_id, state, submitted_at, body) VALUES (?,?,?,?,?,?,?)",
+    );
+    for (const id of ["r-a", "r-b", "r-c", "r-d"]) ins.run("o/r", 1, id, "github:x", "COMMENTED", 1000, "");
+    ins.run("o/r", 1, "r-e", "github:x", "COMMENTED", 1001, "");
+  });
+
+  test("pages every same-millisecond sibling exactly once across a batch boundary", () => {
+    const src = createGithubFeedSource({ dbPath: path, limit: 2 });
+    const seen = [];
+    let pos = null;
+    for (let i = 0; i < 10; i++) {
+      const rows = src.rowsSince("reviewSubmitted", pos);
+      if (rows.length === 0) break;
+      seen.push(...rows.map((r) => r.review_id));
+      pos = positionAfter(rows);
+    }
+    src.close();
+    // Exactly once each, in key order — no drops (the `>` bug) and no repeats (`>=`).
+    expect(seen).toEqual(["r-a", "r-b", "r-c", "r-d", "r-e"]);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  test("a batch limit SMALLER than one millisecond's row count still advances", () => {
+    // The `>=` wedge: 4 rows share ts=1000 and the limit is 1. A producer that
+    // re-read the whole millisecond would return "r-a" forever.
+    const src = createGithubFeedSource({ dbPath: path, limit: 1 });
+    const seen = [];
+    let pos = null;
+    for (let i = 0; i < 12; i++) {
+      const rows = src.rowsSince("reviewSubmitted", pos);
+      if (rows.length === 0) break;
+      seen.push(...rows.map((r) => r.review_id));
+      pos = positionAfter(rows);
+    }
+    src.close();
+    expect(seen).toEqual(["r-a", "r-b", "r-c", "r-d", "r-e"]);
+  });
+
+  test("positionAfter returns null for an empty page, so a sweep cannot advance past nothing", () => {
+    expect(positionAfter([])).toBeNull();
+    expect(positionAfter(null)).toBeNull();
+  });
+});
+
+describe("stream predicates", () => {
+  test("prClosed excludes merged PRs; prMerged is the one that claims them", () => {
+    // ⛔ A merged PR also has closed_at set. Without the predicate the feed would
+    // emit a `closed` for every merge — an edge the webhook path never emits.
+    const path = freshDb((db) => {
+      const ins = db.prepare(
+        "INSERT INTO pull_requests (repo_id, number, merged, merged_at, closed_at, created_at) VALUES (?,?,?,?,?,?)",
+      );
+      ins.run("o/r", 1, 1, 500, 500, 100); // merged
+      ins.run("o/r", 2, 0, null, 600, 100); // closed unmerged
+    });
+    const src = createGithubFeedSource({ dbPath: path });
+    const closed = src.rowsSince("prClosed", null).map((r) => r.number);
+    const merged = src.rowsSince("prMerged", null).map((r) => r.number);
+    src.close();
+    expect(closed).toEqual([2]);
+    expect(merged).toEqual([1]);
+  });
+
+  test("threadResolved yields only resolved threads", () => {
+    const path = freshDb((db) => {
+      const ins = db.prepare(
+        "INSERT INTO pr_review_threads (id, repo_id, pr_number, resolved, resolved_at) VALUES (?,?,?,?,?)",
+      );
+      ins.run("t1", "o/r", 1, 1, 500);
+      ins.run("t2", "o/r", 1, 0, null);
+    });
+    const src = createGithubFeedSource({ dbPath: path });
+    const ids = src.rowsSince("threadResolved", null).map((r) => r.id);
+    src.close();
+    expect(ids).toEqual(["t1"]);
+  });
+
+  test("every stream's query is syntactically valid against the real DDL", () => {
+    // A stream whose SQL does not compile returns nothing at run time and looks
+    // exactly like a quiet stream. This makes that failure loud at CI instead.
+    const path = freshDb();
+    const src = createGithubFeedSource({ dbPath: path });
+    for (const s of STREAMS) {
+      expect(() => src.rowsSince(s.key, null)).not.toThrow();
+    }
+    src.close();
+  });
+});
+
+describe("settleCursor — the emit/cursor split", () => {
+  const NOW = 10_000_000;
+  const opts = (o = {}) => ({ now: NOW, settleMs: 1000, ...o });
+
+  test("claims a page that ended at or before the horizon exactly", () => {
+    const emitted = { lastCreatedAt: NOW - 5000, lastId: "z" };
+    expect(settleCursor(emitted, opts())).toEqual({ lastCreatedAt: NOW - 5000, lastId: "z" });
+  });
+
+  test("⛔ does NOT claim a page that ended past the horizon — it claims the horizon", () => {
+    // This is the whole point. Claiming `emitted` here is the silent-loss bug: a row
+    // arriving later with an older stamp would be behind the cursor forever.
+    const emitted = { lastCreatedAt: NOW - 10, lastId: "z" };
+    expect(settleCursor(emitted, opts())).toEqual({ lastCreatedAt: NOW - 1000, lastId: "" });
+  });
+
+  test("advances on a busy page rather than wedging", () => {
+    // The other failure: refusing to move at all when every page ends inside the
+    // window would freeze the cursor permanently on an active repo.
+    const prev = { lastCreatedAt: NOW - 9000, lastId: "a" };
+    const out = settleCursor({ lastCreatedAt: NOW - 10, lastId: "z" }, opts({ previous: prev }));
+    expect(out.lastCreatedAt).toBe(NOW - 1000);
+    expect(out.lastCreatedAt).toBeGreaterThan(prev.lastCreatedAt);
+  });
+
+  test("⛔ never moves backwards, even if the clock steps back or settleMs grows", () => {
+    const prev = { lastCreatedAt: NOW, lastId: "m" };
+    // A clock step back of an hour.
+    expect(settleCursor({ lastCreatedAt: NOW - 10, lastId: "z" }, opts({ now: NOW - 3_600_000, previous: prev })))
+      .toEqual(prev);
+    // A settle window widened to a day.
+    expect(settleCursor({ lastCreatedAt: NOW - 10, lastId: "z" }, opts({ settleMs: 86_400_000, previous: prev })))
+      .toEqual(prev);
+  });
+
+  test("a producer that has never read anything cannot claim a window it never looked at", () => {
+    expect(settleCursor(null, opts())).toBeNull();
+  });
+
+  test("throws on a non-integer clock rather than silently computing a garbage horizon", () => {
+    expect(() => settleCursor({ lastCreatedAt: 1 }, { now: undefined })).toThrow();
+  });
+
+  test("the default settle window exceeds the largest lag measured on the fleet (333s)", () => {
+    // Sizing evidence lives in the module header. If someone shrinks this below the
+    // measured tail, that is a decision that should have to edit a test.
+    expect(DEFAULT_SETTLE_MS).toBeGreaterThan(333_000);
+  });
+});
+
+describe("declared gaps are exported, not implied by a comment", () => {
+  test("check_suite.completed is named as unbacked", () => {
+    expect(UNBACKED_EVENT_NAMES).toContain("github.check_suite.completed");
+  });
+  test("no stream claims to produce an unbacked name", () => {
+    const produced = new Set(STREAMS.map((s) => s.event).filter(Boolean));
+    for (const n of UNBACKED_EVENT_NAMES) expect(produced.has(n)).toBe(false);
+  });
+  test("push is declared lossy, and is the only stream keyed on a mutable column", () => {
+    expect(PUSH_IS_LOSSY).toBe(true);
+    const mutable = STREAMS.filter((s) => s.tsCol === "updated_at").map((s) => s.key);
+    expect(mutable).toEqual(["push"]);
+  });
+});
+
+describe("live replica schema conformance", () => {
+  // Three-valued on purpose: with no replica present this reports INCONCLUSIVE and
+  // must be read as UNRUN, never as a pass. A column missing from the live schema is
+  // a stream that silently returns nothing.
+  // Resolved the way the daemon resolves it (`CATALYST_REPLICA_DB` > `CATALYST_DIR`
+  // > `$HOME`), so this can be pointed at a 0.1.16 snapshot on a host whose own
+  // replica is older — otherwise the check only ever reports INCONCLUSIVE and a
+  // verdict it has never returned is not evidence of anything.
+  const live =
+    process.env.CATALYST_REPLICA_DB ??
+    join(process.env.CATALYST_DIR ?? join(process.env.HOME ?? "", "catalyst"), "catalyst-replica.db");
+  test("every REQUIRED_COLUMN exists on the host replica", () => {
+    // ⛔ The guard must wrap the READ, not the construction. `createGithubFeedSource`
+    // opens lazily, so an unreadable replica throws here rather than there — and the
+    // first cut of this test put the try around the constructor, where it could never
+    // fire. A guard that cannot fire for the case it exists for is not a guard.
+    //
+    // "Unreadable" is a real and easily-hit state, not a theoretical one: a readonly
+    // open of a WAL-mode database with no `-shm` sidecar fails outright, because
+    // SQLite cannot create the sidecar without write access. A live host always has
+    // one (its writer maintains it); a copied snapshot does not.
+    const src = createGithubFeedSource({ dbPath: live });
+    try {
+      const missing = [];
+      for (const [table, cols] of Object.entries(REQUIRED_COLUMNS)) {
+        let have;
+        try {
+          have = new Set(src.columnsOf(table));
+        } catch (err) {
+          console.log(`INCONCLUSIVE: cannot read ${live} (${err?.message ?? err}) — treat this test as unrun, not as a pass.`);
+          return;
+        }
+        if (have.size === 0) {
+          console.log(`INCONCLUSIVE: table ${table} absent from ${live} — treat as unrun.`);
+          return;
+        }
+        for (const c of cols) if (!have.has(c)) missing.push(`${table}.${c}`);
+      }
+      expect(missing).toEqual([]);
+    } finally {
+      try { src.close(); } catch { /* never fail the suite in cleanup */ }
+    }
+  });
+});
+
+describe("buildStreamQuery", () => {
+  test("uses the composite keyset form, never a bare watermark", () => {
+    const sql = buildStreamQuery("reviewSubmitted");
+    // Both halves of the OR must be present; either alone is one of the two bugs.
+    expect(sql).toContain("submitted_at > $sinceMs");
+    expect(sql).toContain("submitted_at = $sinceMs AND review_id > $sinceId");
+    expect(sql).toContain("ORDER BY submitted_at ASC, review_id ASC");
+  });
+  test("refuses an unknown stream instead of returning a query that matches nothing", () => {
+    expect(() => buildStreamQuery("nope")).toThrow();
+  });
+  test("STREAM_BY_KEY covers every stream", () => {
+    expect(Object.keys(STREAM_BY_KEY).sort()).toEqual(STREAMS.map((s) => s.key).sort());
+  });
+});


### PR DESCRIPTION
Closes part of CTL-1929 (ask 2, the producer). **No daemon wiring in this PR** — the modules are not imported by anything that runs, so nothing on a live host changes. The sweep + gate + timer binding is the next PR; landing the pure layers first keeps that one small and reviewable.

Filed from this work: **CTC-691** (P1, a blocker on this ticket), **CTL-1941** (the containment-lever ticket).

## The measurement that shaped the design

`linear-feed-source.mjs` pages `issue_history` — an append-only log with a PK. **Every GitHub table in the replica is a last-state projection**, updated in place:

| table | PK |
| --- | --- |
| `pull_requests` | `(repo_id, number)` |
| `pushes` | `(repo_id, ref)` |
| `check_runs` | `check_run_id` |
| `pr_review_threads` / `reviews` / `pr_review_comments` / `deployments` / `deployment_statuses` | `id` |

So a producer keyed on `updated_at` reads a PR *after* its merge and can no longer tell an `opened` edge was ever owed — a silently dropped transition.

⭐ The way out: each edge has its own timestamp column written **exactly once** and never moved. Keyed on those, each stream is append-only again. Verified by content **before** building on it, because a NULL there is a skipped dispatch nothing reports:

```
pull_requests 4230 · created_at 4230/4230 · closed_at 4143 · merged_at 3995
              · merged=1 rows with a NULL merged_at:  0
reviews 6619 · submitted_at 6619/6619    pr_review_comments 10155 · created_at 10155/10155
pr_review_threads 32 · resolved=1 32 · resolved_at 32/32 · resolved-but-null:  0
```

## ⚠️ The late-arrival tail, and why emission and the cursor are split

The keyset coordinate is *event* time; rows land at *ingest* time, later and out of order. A cursor advanced to the newest event time seen would permanently skip late arrivals. Measured on mini-2 over 6 h, restricted to rows whose `updated_at` is inside the window so backfill cannot flatter it (n=62, `synced_at − updated_at`):

```
<=5s 21 · <=15s 12 · <=60s 6 · <=120s 11 · <=300s 11 · >300s 1 · max 333s
```

**37% arrive more than 60 s late; the tail reaches 333 s.** A settle window wide enough to be safe (≥ ~600 s) would delay every CI-wait edge by ten minutes — on the one path where latency is the point. So the two positions are split: rows **emit immediately**, the durable cursor advances only to `now − settleMs`. The re-read that costs is absorbed by PK-derived stable edge ids. ⛔ That seen-set is mandatory: the broker dedups on a **per-emission UUID**, so it will not suppress a re-emission for us.

(`synced_at − updated_at` overstates true lag whenever GitHub's `updated_at` predates the webhook that carried the row — the conservative direction for sizing a bound, and used as one.)

## ⛔ Two consumed names are NOT produced — and they decline with a reason

Not a silent `null`: a stream that classifies as emittable and then returns nothing is the *success-and-failure-are-byte-identical* shape, and the gap would be invisible in the very counts readiness is computed from. Both decline by name, so they appear in `byReason` every tick.

| name | why | ticket |
| --- | --- | --- |
| `github.pr.merged` | `pull_requests` has no `merge_commit_sha`. It is a **join key** — without it `setFilterStateMerged` never runs, `deployment.created` matches zero interests, and **`monitor-deploy` stops firing** while `pr.merged` still routes and wakes. | **CTC-691** |
| `github.check_suite.completed` | the mirror stores no suite row, and `check_runs` cannot stand in: one head sha carried **10 distinct suite ids**, several incomplete, so "every run I can see finished" fires early and GREEN on the merge gate. | **CTC-667 item 4** |

`prMerged` stays a *stream* in the read layer deliberately — paging it costs nothing, proves the keyset works for it, and makes CTC-691 land as a one-line deletion rather than new read-layer code.

## ⛔ Two deliberate divergences from "nicer"

Parity is the instrument this cutover is judged by, and an instrument that changes shape at the moment of cutover cannot judge the cutover.

- **`github.pr.*` payloads omit `title`/`body`/`headRef`** even though the row has all three. `tryTicketLifecycleRoute` (`router.mjs:1856`) scrapes exactly those three for ticket ids and is **dormant**: 1,208/1,208 live payloads contain none of them. Emitting them would switch on `_autoPrLifecycleFromTicket` fleet-wide — a behavioural change wearing the costume of better parity.
- **`pr_review_thread.resolved` emits `threadId: 0`**, matching 202/202 live events (GitHub's thread object has no numeric id), rather than the real id our replica holds. The improvement is filed to land *after* the cutover.

## Author identity: derived, not joined

`users` carries a GitHub `type`, and the join was the tempting answer. Its coverage is **incomplete** — 4 of 5 distinct review authors — and the missing one, `github-code-quality[bot]`, is a **bot** a left join would have handed to the review gate as a human. The `[bot]` suffix has 100% coverage by construction. Control: it agrees with `users.type` **12/12, zero disagreements**.

## Other things the consumer actually reads, now pinned

- `resource["service.name"]` stays **`catalyst.github`** — `recordLastSeen` folds it into the CTL-1122 ingestion-recency map, so our own service name would blind the github ingestion-*silence* detector at the moment we became github's only producer.
- `body.payload.source = "cloud-feed"` stamped **positively**; `webhook.delivery.id` deliberately **not** stamped (it is how `sourceOf` recognises smee negatively). An unstamped producer classifies `SOURCE_OTHER` and inherits no authority.
- `deploymentId` coerced to a **number** — the replica stores TEXT, `filter-state` matches `WHERE deployment_id = ?`.
- `reviews.state` lowercased — stored `COMMENTED`, compared `=== "approved"`. ⚠️ Bound: **no `APPROVED`/`CHANGES_REQUESTED` row has ever been seen on this fleet** (6,630/6,630 replica rows and 3,093/3,093 live events are `commented`), so the mapping is verified by content for `commented` only.
- `push` carries the **full** ref; `body.message` restored to the human sentence (`summarizeEvent` puts it into every wake an agent reads).

## Tests — 78 pass / 0 fail

Real SQLite with the replica's DDL, because same-millisecond drops are a property of SQL ordering that a mock cannot exhibit.

The live-schema conformance check is **three-valued**. It reported only INCONCLUSIVE against this laptop's pre-0.1.16 replica, so it was run against a **real 0.1.16 snapshot** for a genuine PASS — a verdict a check has never returned is not evidence. Both directions proven: an unreadable path prints INCONCLUSIVE and does **not** throw; the real replica passes with no INCONCLUSIVE line. ⚠️ Its first cut wrapped the *constructor*, which opens lazily — the guard could never fire. Fixed to wrap the read.

Both suites are added to `.github/workflows/execution-core-tests.yml`. That list is an **explicit allowlist, not a glob** — an unlisted suite silently never runs.

### 10 mutation controls, all killed

| # | mutation | result |
| --- | --- | --- |
| M1 | require a column that isn't there | 1 fail |
| M2 | `settleCursor` claims past the horizon | 2 fail |
| M3 | leak `title` into the pr payload | 1 fail |
| M4 | emit the real thread id | 1 fail |
| M5 | drop the review-state lowercase | 2 fail |
| M6 | leave `deploymentId` as TEXT | 1 fail |
| M7 | wrong `service.name` | 8 fail |
| M8 | bare `>` watermark (drops siblings) | 3 fail |
| M9 | `prClosed` without the merged exclusion | 1 fail |
| M10 | `prMerged` falls through silently | 1 fail |

Baseline and restored both **78 pass / 0 fail**.

⚠️ The first mutation run reported blanks for every mutant, which reads as "no failures" — the filter was grepping ANSI-coloured output. Re-run with the codes stripped; the table above is the corrected run.

## ⛔ What this does NOT do

- It does not retire the GitHub tunnel, and **that cannot happen until CTC-691 and CTC-667 item 4 land** — doing it now would blind the CI wait and the deploy chain.
- It is not wired into the daemon, so there is no shadow traffic yet and **no parity numbers yet**. That is the next PR.
- The full local shell suite was **not** run (COORD-113 — laptop load hit 141 tonight); targeted `bun test` only, CI carries the suite.