### PR TITLE
fix(dev): CTL-1918 — catalyst-doctor is CRASHING on every host (an extracted default referencing doctor's own scope)

### DIFF
--- a/plugins/dev/scripts/execution-core/install-completeness.mjs
+++ b/plugins/dev/scripts/execution-core/install-completeness.mjs
@@ -20,7 +20,21 @@
 // an operator gets sent to repair something that was never broken.
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+
+/**
+ * ⛔ DEFINED HERE, NOT IMPORTED FROM doctor.mjs — doctor.mjs imports THIS module, so an
+ * import back would be circular. When this check was extracted from doctor.mjs it kept
+ * calling doctor's `layer2Path()` as a default parameter, which crashed
+ * `catalyst-doctor` outright with `ReferenceError: layer2Path is not defined` on every
+ * host. Kept byte-identical to doctor.mjs's own resolver, including the env override.
+ */
+function layer2Path() {
+  return (
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json")
+  );
+}
 
 import { STATUS, mkCheck } from "./doctor-status.mjs";
 

--- a/plugins/dev/scripts/execution-core/install-completeness.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-completeness.test.mjs
@@ -41,6 +41,32 @@ function completeDeps(over = {}) {
   };
 }
 
+describe("⛔ THE DEFAULTS RUN — every test below this injects them, which is how the bug shipped", () => {
+  test("calling with NO deps at all does not throw", () => {
+    // `catalyst-doctor` calls this with no arguments. When the check was extracted from
+    // doctor.mjs it kept using doctor's `layer2Path()` as a DEFAULT PARAMETER, which is
+    // not in scope here — so the real entry point died with
+    // `ReferenceError: layer2Path is not defined` on every host, while every test in this
+    // file passed. They all injected `layer2`, so the default was never evaluated.
+    //
+    // This is the only assertion in the file that exercises the production call shape.
+    // Its value is not the returned status — it is that the function RUNS.
+    expect(() => checkInstallCompleteness()).not.toThrow();
+  });
+
+  test("the no-deps call returns a well-formed check", () => {
+    const r = checkInstallCompleteness();
+    expect(r.name).toBe("install-completeness");
+    expect(["pass", "warn", "info"]).toContain(r.status);
+    expect(typeof r.detail).toBe("string");
+  });
+
+  test("an env-only override still resolves every other default", () => {
+    // Half-injected is the shape most likely to hide a missing default.
+    expect(() => checkInstallCompleteness({ env: { CATALYST_BIN_DIR: "/nope" } })).not.toThrow();
+  });
+});
+
 describe("checkInstallCompleteness", () => {
   test("a finished install PASSes", () => {
     const r = checkInstallCompleteness(completeDeps());


### PR DESCRIPTION
**Live breakage from my own #3500. `catalyst-doctor` dies immediately on both minis:**

```
ReferenceError: layer2Path is not defined
  at checkInstallCompleteness (…/install-completeness.mjs:39:14)
```

## What happened

#3500 extracted `checkInstallCompleteness` out of `doctor.mjs` — deliberately, to keep
doctor.mjs's diff at 6 lines instead of dragging a ~1,100-line prettier sweep into a PR
about the installer. The extraction kept calling doctor's `layer2Path()` **as a default
parameter**. That function is not in the new module's scope, and a default parameter is
evaluated at **call** time — so the module imported fine, every test passed, CI was green,
and the real entry point died on its first invocation.

## ⛔ The defect is the test, not the missing import

**Every test in the file injected `layer2`**, so the default was never evaluated. The suite
was exercising a call shape no caller uses — `catalyst-doctor` calls this with **no
arguments**, and nothing tested that. A 10-assertion file, all green, against a function
that could not run.

Three new assertions exercise the production call shape: no deps at all, no-deps-returns-
well-formed, and half-injected (the shape most likely to hide a missing default).

**Mutation-tested**, because a regression test that does not catch the regression is
worthless: with the local `layer2Path` removed again, the no-deps test fails with the exact
`ReferenceError: layer2Path is not defined`; restored, 13/13 pass.

## The fix

`layer2Path` is defined **locally**, not imported from `doctor.mjs` — doctor.mjs imports
*this* module, so an import back would be circular. Byte-identical to doctor's own
resolver, `CATALYST_LAYER2_CONFIG_FILE` override included.

## The sibling was checked, not assumed

`checkLinearWriteBudget` (from #3505, extracted the same way for the same reason) resolves
all of its defaults correctly — verified by **calling it with no arguments**, not by reading
it. It returns a well-formed `info` check.

## How this was found

Not by CI. I was live-verifying #3500's "`doctor` proves it" claim on the minis, greped for
the check name, got nothing, and — rather than conclude the check was simply absent — asked
for the raw output. The crash was the first thing on stdout. A grep for an expected string
returning empty is *"I could not look"*, not *"it is not there"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)