### PR TITLE
fix(dev): CTL-1937 — a cli/*.mjs run by a SHELL refuses on its own, and CI keeps it that way

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -218,6 +218,22 @@ jobs:
         working-directory: .
         run: bun install --frozen-lockfile
 
+      - name: cli/*.mjs shell-guard lint (CTL-1937)
+        # THE CLASS GUARD. cli/*.mjs have no shebang and their line-1 doc comment carries a
+        # runnable command in BACKTICKS. Run by a shell instead of a JS runtime, that backtick
+        # executes and re-invokes the CLI: on 2026-08-17 that reached 7,592 nested bash
+        # processes and fork() failed machine-wide. This fails CI on any cli/*.mjs that does
+        # not open with the guard line, so a NEW module cannot reintroduce the class.
+        working-directory: .
+        run: bash plugins/dev/scripts/lint-cli-shell-guard.sh
+
+      - name: cli/*.mjs shell-guard regression test (CTL-1937)
+        # The lint proves the line is present; this proves the line WORKS — a real cli module
+        # run under bash/zsh/sh refuses by name, exits 97, and spawns nothing. Carries its own
+        # negative control (the same file with the guard stripped DOES fire the backtick), so
+        # a green result cannot come from a module that merely has nothing to detonate.
+        run: bash __tests__/cli-shell-guard.test.sh
+
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing
         # named export (the CTL-1093 outage: getCatalystRepoDir added to daemon.mjs

--- a/plugins/dev/scripts/execution-core/__tests__/cli-shell-guard.test.sh
+++ b/plugins/dev/scripts/execution-core/__tests__/cli-shell-guard.test.sh
@@ -120,5 +120,39 @@ else
 fi
 
 echo ""
+echo "=== ⛔ the lint does NOT descend into a nested checkout (Codex #3516 P2) ==="
+# The agent harness parks full scratch checkouts under .claude/worktrees/. A repo-wide `find`
+# walked into them, so the lint failed on another agent's branch and `--fix` would have edited
+# that agent's files. git ls-files cannot leave the current worktree.
+REPO_TOP="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+if [[ -n "$REPO_TOP" ]]; then
+	NESTED="$REPO_TOP/.claude/worktrees/fleet-scope-probe/cli"
+	mkdir -p "$NESTED"
+	# A nested REPOSITORY, exactly like a parked worktree — and an UNGUARDED module inside it.
+	git -C "$REPO_TOP/.claude/worktrees/fleet-scope-probe" init -q 2>/dev/null
+	printf '// cli/intruder.mjs — no guard on line 1\n' >"$NESTED/intruder.mjs"
+
+	# ⛔ Positive control FIRST: a plain `find` DOES see it, so the case is real and the check
+	# below is not passing because the fixture failed to create anything.
+	if find "$REPO_TOP" -type f -path '*/cli/*.mjs' 2>/dev/null | grep -q 'fleet-scope-probe'; then
+		pass "control — a repo-wide find DOES reach the nested checkout (the bug was real)"
+	else
+		fail "control — a repo-wide find reaches the nested checkout" \
+			"the fixture did not create a discoverable nested module; the scope check below proves nothing"
+	fi
+
+	if bash "$SCRIPT_DIR/../../lint-cli-shell-guard.sh" >/dev/null 2>&1; then
+		pass "the lint stays green — it did not descend into the nested checkout"
+	else
+		fail "the lint stays green with a nested checkout present" \
+			"it is still scanning outside the current worktree; --fix would edit another agent's files"
+	fi
+	rm -rf "$REPO_TOP/.claude/worktrees/fleet-scope-probe"
+	rmdir "$REPO_TOP/.claude/worktrees" 2>/dev/null || true
+else
+	echo "  SKIP: not inside a git worktree"
+fi
+
+echo ""
 echo "  PASSED: $PASSES   FAILED: $FAILURES"
 [[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/execution-core/__tests__/cli-shell-guard.test.sh
+++ b/plugins/dev/scripts/execution-core/__tests__/cli-shell-guard.test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# cli-shell-guard.test.sh — CTL-1937, the CLASS regression.
+#
+# CTL-1937's caller-side guard (exec_runtime_module) bounds re-entry for modules reached
+# through that one seam. This covers the class: a cli/*.mjs run by a shell by ANY route must
+# refuse on its own, name the reason, and spawn NOTHING.
+#
+# THE MECHANISM, reproduced before the guard was written:
+#   cli/*.mjs have no shebang, and their line-1 doc comment carries a runnable
+#   "catalyst-execution-core <verb> ..." example in BACKTICKS. `bash cli/drain.mjs` with a
+#   stub catalyst-execution-core on PATH executed "drain [--off] [--json]" straight out of
+#   that comment. In production the stub is the real CLI, which re-invokes the shell: on
+#   2026-08-17 that reached 7,592 nested bash processes and fork() failed machine-wide.
+#
+# ⚠️ SAFE BY CONSTRUCTION: the stub on PATH here RECORDS and EXITS. It cannot recurse, so
+# even a totally broken guard produces exactly one extra process, never a chain. This test
+# does not need a watchdog because there is nothing for a watchdog to contain.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLI_DIR="$SCRIPT_DIR/../cli"
+SUBJECT="$CLI_DIR/drain.mjs" # the module the real incident ran
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+
+# A stub named exactly like the backticked command. It appends to $MARKER and exits — so
+# "$MARKER is non-empty" means the doc-comment backtick EXECUTED.
+mkdir -p "$SCRATCH/bin"
+MARKER="$SCRATCH/marker"
+cat >"$SCRATCH/bin/catalyst-execution-core" <<EOF
+#!/bin/bash
+echo "FIRED: \$*" >>"$MARKER"
+exit 0
+EOF
+chmod +x "$SCRATCH/bin/catalyst-execution-core"
+
+# Run $1 (a .mjs) under shell $2, setting RUN_OUT and RUN_RC.
+# NOT a function that echoes its output: calling it as "$(run_under_shell ...)" puts the body
+# in a SUBSHELL, so the rc it recorded never reaches the caller (the first cut of this test
+# died on exactly that with "RUN_RC: unbound variable").
+RUN_OUT=""
+RUN_RC=0
+run_under_shell() {
+	local file="$1" shell="$2"
+	: >"$MARKER"
+	RUN_OUT="$(cd "$SCRATCH" && PATH="$SCRATCH/bin:/usr/bin:/bin" "$shell" "$file" 2>&1)"
+	RUN_RC=$?
+}
+
+echo ""
+echo "=== a cli/*.mjs run by a SHELL refuses, by name, in every shell ==="
+for shell in /bin/bash /bin/zsh /bin/sh; do
+	[[ -x "$shell" ]] || {
+		echo "  SKIP: $shell not present"
+		continue
+	}
+	run_under_shell "$SUBJECT" "$shell"
+	OUT="$RUN_OUT"
+	RC=$RUN_RC
+	if grep -qF "REFUSING" <<<"$OUT"; then pass "$shell — refuses"; else fail "$shell — refuses" "got: $(head -c 300 <<<"$OUT")"; fi
+	if grep -qF "CTL-1937" <<<"$OUT"; then pass "$shell — the refusal names the ticket"; else fail "$shell — the refusal names the ticket" "got: $(head -c 300 <<<"$OUT")"; fi
+	if [[ "$RC" -eq 97 ]]; then pass "$shell — exits 97"; else fail "$shell — exits 97" "rc=$RC"; fi
+	# THE POINT OF THE WHOLE TICKET: nothing was spawned.
+	if [[ -s "$MARKER" ]]; then
+		fail "$shell — ZERO children" "the doc-comment backtick EXECUTED: $(cat "$MARKER")"
+	else
+		pass "$shell — ZERO children (the backtick never ran)"
+	fi
+done
+
+echo ""
+echo "--- ⛔ NEGATIVE CONTROL: the same file WITHOUT the guard must fire the bomb ---"
+# Without this, every assertion above would also pass on a drain.mjs that simply has no
+# backtick to execute — i.e. against a guard that does nothing.
+UNGUARDED="$SCRATCH/unguarded.mjs"
+tail -n +2 "$SUBJECT" >"$UNGUARDED" # strip line 1, the guard
+run_under_shell "$UNGUARDED" /bin/bash
+if [[ -s "$MARKER" ]]; then
+	pass "control fired — unguarded, the backtick executed ($(head -1 "$MARKER"))"
+else
+	fail "control did NOT fire" \
+		"Stripping the guard left the bomb inert, so the checks above prove nothing about the guard." \
+		"Either line 1 of $SUBJECT is not the guard, or its line-1 doc comment no longer has a backtick."
+fi
+
+echo ""
+echo "--- ⛔ CONTROL: the guard must not break the real runtime ---"
+if command -v bun >/dev/null 2>&1; then
+	if bun build "$SUBJECT" --target=node --outfile /dev/null >/dev/null 2>&1; then
+		pass "bun still parses the guarded module"
+	else
+		fail "bun still parses the guarded module" "the guard broke the JS"
+	fi
+else
+	echo "  SKIP: bun not present"
+fi
+
+echo ""
+echo "=== EVERY cli/*.mjs carries the guard (the class, not one file) ==="
+if bash "$SCRIPT_DIR/../../lint-cli-shell-guard.sh" >/dev/null 2>&1; then
+	pass "lint-cli-shell-guard reports every cli/*.mjs guarded"
+else
+	fail "lint-cli-shell-guard reports every cli/*.mjs guarded" \
+		"run: bash plugins/dev/scripts/lint-cli-shell-guard.sh"
+fi
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/execution-core/cli/args.mjs
+++ b/plugins/dev/scripts/execution-core/cli/args.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/args.mjs — strict argv parser shared by the execution-core audit CLI
 // nouns (sessions / worktrees / branches / tidy).
 //

--- a/plugins/dev/scripts/execution-core/cli/args.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/args.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 import { describe, it, expect } from "bun:test";
 import { parseArgs, ArgError } from "./args.mjs";
 

--- a/plugins/dev/scripts/execution-core/cli/beliefs-shadow-status.mjs
+++ b/plugins/dev/scripts/execution-core/cli/beliefs-shadow-status.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/beliefs-shadow-status.mjs — CTL-935 Phase 6: flag-live verification helper.
 // Computes a shadow-collection health verdict from injected inputs (testable without
 // disk or process access).

--- a/plugins/dev/scripts/execution-core/cli/beliefs-shadow-status.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/beliefs-shadow-status.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/beliefs-shadow-status.test.mjs — CTL-935 Phase 6: flag-live verification.
 // Run: cd plugins/dev/scripts/execution-core && bun test cli/beliefs-shadow-status.test.mjs
 

--- a/plugins/dev/scripts/execution-core/cli/beliefs.mjs
+++ b/plugins/dev/scripts/execution-core/cli/beliefs.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/beliefs.mjs — CTL-935: beliefs CLI noun dispatcher.
 // Routes verbs: report -> beliefs/report.mjs main(); beliefs-status -> cli/beliefs-shadow-status.mjs main().
 import { main as reportMain } from "../beliefs/report.mjs";

--- a/plugins/dev/scripts/execution-core/cli/beliefs.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/beliefs.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/beliefs.test.mjs — CTL-935 remediate: cover the beliefs CLI noun
 // dispatcher (cli/beliefs.mjs). This file did not exist, which is exactly why
 // the high-severity async-dispatch crash shipped undetected: `beliefs-status`

--- a/plugins/dev/scripts/execution-core/cli/branches.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // branches.mjs — `catalyst-execution-core branches {list,prune}` (CTL-649
 // Phase 7).
 //

--- a/plugins/dev/scripts/execution-core/cli/branches.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/branches.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // branches.test.mjs — Phase 7 of CTL-649. `catalyst-execution-core branches
 // {list,prune}`. Bare git refs — no claude-session aspect — so prune deletes
 // directly (git branch -D / git push origin --delete), NOT through the reaper.

--- a/plugins/dev/scripts/execution-core/cli/cluster-ownership.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster-ownership.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cluster-ownership.test.mjs — CTL-1211. The HRW no-contention proof: every
 // ticket is owned by exactly one host, deterministically.
 import { describe, test, expect } from "bun:test";

--- a/plugins/dev/scripts/execution-core/cli/cluster.mjs
+++ b/plugins/dev/scripts/execution-core/cli/cluster.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/cluster.mjs — CTL-1188. `catalyst cluster <verb>` data verbs.
 // Pure functions (buildStatus, addHost, removeHost, renameHost, setAnchor, tune)
 // take injectable deps for unit testing; runX() wires real config/heartbeat/git;

--- a/plugins/dev/scripts/execution-core/cli/drain.mjs
+++ b/plugins/dev/scripts/execution-core/cli/drain.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/drain.mjs — CTL-1095. `catalyst-execution-core drain [--off] [--json]`
 //
 // Toggles the drain flag file, emits node.drain.changed, and prints drain

--- a/plugins/dev/scripts/execution-core/cli/drain.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/drain.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/drain.test.mjs — CTL-1095. Unit tests for setDrain / readDrainStatus.
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test cli/drain.test.mjs

--- a/plugins/dev/scripts/execution-core/cli/governance-env.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance-env.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/governance-env.mjs — CTL-1084. Emits `export CATALYST_*=...` lines for the
 // four beliefs-family flags resolved from the durable three-layer config, so the
 // launcher can inject the durable value into the daemon's env (no env-export

--- a/plugins/dev/scripts/execution-core/cli/governance-env.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance-env.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/governance-env.test.mjs — CTL-1084. buildGovernanceExports unit tests.
 // Run: cd plugins/dev/scripts/execution-core && bun test cli/governance-env.test.mjs
 

--- a/plugins/dev/scripts/execution-core/cli/governance.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/governance.mjs — CTL-1062. Operator-facing readout of which governance
 // modes the local daemon is actually running, sourced from the latest
 // node.heartbeat the daemon wrote (heartbeat carries the snapshot, CTL-1062 Phase 2).

--- a/plugins/dev/scripts/execution-core/cli/governance.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/governance.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/governance.test.mjs — CTL-1062. readLatestGovernance + renderGovernance.
 // Run: cd plugins/dev/scripts/execution-core && bun test cli/governance.test.mjs
 

--- a/plugins/dev/scripts/execution-core/cli/repo.mjs
+++ b/plugins/dev/scripts/execution-core/cli/repo.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // cli/repo.mjs — repo-root resolution + a throwing, stderr-capturing git runner
 // shared by the audit nouns (CTL-675).
 //

--- a/plugins/dev/scripts/execution-core/cli/repo.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/repo.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // repo.test.mjs — CTL-675. Hermetic coverage for the shared repo-root resolver
 // and the throwing, stderr-capturing git runner. Every external dependency
 // (git, fs, registry) is injected — no real git is invoked.

--- a/plugins/dev/scripts/execution-core/cli/sessions.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // sessions.mjs — `catalyst-execution-core sessions {list,show,prune}` (CTL-649
 // Phase 5). The first operator-facing audit surface.
 //

--- a/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/sessions.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // sessions.test.mjs — Phase 5 of CTL-649. Unit tests for the operator-facing
 // `catalyst-execution-core sessions {list,show,prune}` audit CLI.
 //

--- a/plugins/dev/scripts/execution-core/cli/tidy.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // tidy.mjs — `catalyst-execution-core tidy` (CTL-649 Phase 8).
 //
 // Composes the three resource prunes in the ONLY safe order and finishes with

--- a/plugins/dev/scripts/execution-core/cli/tidy.regression.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.regression.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // tidy.regression.test.mjs — CTL-675 end-to-end regression. Drives the REAL
 // tidy.mjs in a child process against a temp NON-repo dir with an empty
 // registry — the exact ticket scenario — and asserts the fixed behavior: exit

--- a/plugins/dev/scripts/execution-core/cli/tidy.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/tidy.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // tidy.test.mjs — Phase 8 of CTL-649. The `tidy` umbrella composes
 // sessions → worktrees → branches → `git worktree prune` in the ONLY safe
 // order: stopping sessions first means worktree removal never creates fresh

--- a/plugins/dev/scripts/execution-core/cli/worktrees.mjs
+++ b/plugins/dev/scripts/execution-core/cli/worktrees.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // worktrees.mjs — `catalyst-execution-core worktrees {list,prune}` (CTL-649
 // Phase 6).
 //

--- a/plugins/dev/scripts/execution-core/cli/worktrees.test.mjs
+++ b/plugins/dev/scripts/execution-core/cli/worktrees.test.mjs
@@ -1,3 +1,4 @@
+//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
 // worktrees.test.mjs — Phase 6 of CTL-649. `catalyst-execution-core worktrees
 // {list,prune}`. Classifier + prune-ordering are the tested surface; all I/O
 // (git, gh, sessions, fs) is injected.

--- a/plugins/dev/scripts/lint-cli-shell-guard.sh
+++ b/plugins/dev/scripts/lint-cli-shell-guard.sh
@@ -40,18 +40,26 @@ GUARD_LINE='//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is execut
 FIX=0
 [[ "${1:-}" == "--fix" ]] && FIX=1
 
+# ⛔ Codex #3516 P2: this used a repo-wide `find`, which descends into the full scratch checkouts
+# the agent harness parks under .claude/worktrees/ (create-worktree.sh:346-354). In a primary
+# checkout that means the lint FAILS because some other agent's branch lacks the guard, and
+# `--fix` EDITS FILES BELONGING TO ANOTHER AGENT. `git ls-files` is scoped to the current
+# worktree by construction and does not descend into nested checkouts; --others picks up a
+# brand-new module before it is committed, --exclude-standard keeps ignored files out.
+#
 # NOT `mapfile`: macOS ships /bin/bash 3.2, which does not have it. A lint that dies on the
 # operator's own shell is a lint nobody runs.
 FILES=()
 while IFS= read -r f; do
-	[ -n "$f" ] && FILES+=("$f")
-done < <(find "$REPO_ROOT" -type d -name node_modules -prune -o -type f -path '*/cli/*.mjs' -print | sort)
+	[ -n "$f" ] && FILES+=("$REPO_ROOT/$f")
+done < <(git -C "$REPO_ROOT" ls-files --cached --others --exclude-standard -- '*/cli/*.mjs' 'cli/*.mjs' 2>/dev/null | sort -u)
 
 # ⛔ A lint whose glob matches nothing reports a clean pass. Refuse instead: if the tree ever
 # moves, this must go red rather than quietly stop guarding anything.
 if [[ "${#FILES[@]}" -eq 0 ]]; then
 	echo "lint-cli-shell-guard: FAIL — matched ZERO cli/*.mjs files under $REPO_ROOT." >&2
-	echo "  Either the tree moved or the glob is wrong. A lint that checks nothing is not a pass." >&2
+	echo "  Either the tree moved, the glob is wrong, or this is not a git worktree." >&2
+	echo "  A lint that checks nothing is not a pass." >&2
 	exit 2
 fi
 

--- a/plugins/dev/scripts/lint-cli-shell-guard.sh
+++ b/plugins/dev/scripts/lint-cli-shell-guard.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# lint-cli-shell-guard.sh — CTL-1937. Every cli/*.mjs must carry the shell guard as line 1.
+#
+# THE CLASS THIS EXISTS FOR (measured 2026-08-17 22:42-23:08 CT)
+# --------------------------------------------------------------
+# cli/*.mjs have no shebang, and the house doc-comment style puts a runnable
+# "catalyst-execution-core <verb> ..." example in BACKTICKS on line 1. When a shell is
+# mis-resolved as the JS runtime, `bash cli/drain.mjs` command-substitutes that backtick
+# and re-invokes the CLI, which re-invokes the shell, which... On 2026-08-17 that reached
+# 7,592 nested bash processes (87% of kern.maxprocperuid) and fork() failed for every agent
+# on the machine for ~25 minutes.
+#
+# CTL-1937's caller-side guard (exec_runtime_module in catalyst-execution-core) bounds the
+# depth for modules reached THROUGH that seam. This lint covers the class: a cli/*.mjs run
+# by a shell by ANY route refuses on its own, before line 2 is ever parsed.
+#
+# Reproduced first-hand before this guard was written: `bash cli/drain.mjs` with a stub
+# `catalyst-execution-core` on PATH executed "catalyst-execution-core drain [--off] [--json]"
+# straight out of the line-1 doc comment. A copy of the same file with no backtick on line 1
+# executed nothing — so it is the backtick, not merely running the file.
+#
+# Usage: bash plugins/dev/scripts/lint-cli-shell-guard.sh [--fix]
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+# ── THE CANONICAL GUARD ─────────────────────────────────────────────────────────────────
+# One line, and it must be line 1. To a JS runtime it is a "//" line comment. To sh/bash/zsh
+# it is a command list that prints the refusal and exits 97 BEFORE the shell parses line 2 —
+# which is where the backtick lives. Verified in bash, zsh and sh (refusal + rc 97, zero
+# children) and under node and bun (module runs normally).
+#
+# "//bin/true" is not a real path on macOS ("//" is implementation-defined and does not
+# resolve), so it always fails — that is fine, it is only there because the line has to START
+# with "//" to be a JS comment. "2>/dev/null" suppresses the shell's diagnostic so the ONLY
+# thing an operator sees is the named refusal.
+GUARD_LINE='//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97'
+
+FIX=0
+[[ "${1:-}" == "--fix" ]] && FIX=1
+
+# NOT `mapfile`: macOS ships /bin/bash 3.2, which does not have it. A lint that dies on the
+# operator's own shell is a lint nobody runs.
+FILES=()
+while IFS= read -r f; do
+	[ -n "$f" ] && FILES+=("$f")
+done < <(find "$REPO_ROOT" -type d -name node_modules -prune -o -type f -path '*/cli/*.mjs' -print | sort)
+
+# ⛔ A lint whose glob matches nothing reports a clean pass. Refuse instead: if the tree ever
+# moves, this must go red rather than quietly stop guarding anything.
+if [[ "${#FILES[@]}" -eq 0 ]]; then
+	echo "lint-cli-shell-guard: FAIL — matched ZERO cli/*.mjs files under $REPO_ROOT." >&2
+	echo "  Either the tree moved or the glob is wrong. A lint that checks nothing is not a pass." >&2
+	exit 2
+fi
+
+MISSING=()
+for f in ${FILES[@]+"${FILES[@]}"}; do
+	if [[ "$(head -n 1 "$f")" != "$GUARD_LINE" ]]; then
+		MISSING+=("$f")
+	fi
+done
+
+if [[ "${#MISSING[@]}" -eq 0 ]]; then
+	echo "lint-cli-shell-guard: OK — all ${#FILES[@]} cli/*.mjs carry the CTL-1937 shell guard on line 1."
+	exit 0
+fi
+
+if [[ "$FIX" -eq 1 ]]; then
+	for f in ${MISSING[@]+"${MISSING[@]}"}; do
+		tmp="$f.guard.tmp"
+		{ printf '%s\n' "$GUARD_LINE"; cat "$f"; } >"$tmp" && mv "$tmp" "$f"
+		echo "  fixed: ${f#"$REPO_ROOT"/}"
+	done
+	echo "lint-cli-shell-guard: added the guard to ${#MISSING[@]} file(s); re-run without --fix to verify."
+	exit 0
+fi
+
+echo "lint-cli-shell-guard: FAIL — ${#MISSING[@]} of ${#FILES[@]} cli/*.mjs are MISSING the CTL-1937 shell guard:" >&2
+for f in ${MISSING[@]+"${MISSING[@]}"}; do echo "  ${f#"$REPO_ROOT"/}" >&2; done
+cat >&2 <<EOF
+
+Every cli/*.mjs must begin with EXACTLY this line:
+
+$GUARD_LINE
+
+Why: these modules have no shebang and their line-1 doc comment contains a backticked,
+runnable command. Run by a shell instead of a JS runtime, that backtick executes and
+re-invokes the CLI — CTL-1937's 7,592-process fork chain.
+
+Fix: bash plugins/dev/scripts/lint-cli-shell-guard.sh --fix
+EOF
+exit 1


### PR DESCRIPTION
Closes the **class** behind CTL-1937. #3511 (merged, `7ea8206b9`) guards the one seam — `exec_runtime_module`. This makes every `cli/*.mjs` refuse on its own, by **any** route, and adds a lint so a new module cannot reintroduce it.

## The mechanism, reproduced before writing the fix

I did not build to the incident write-up — I reproduced it. `cli/*.mjs` have no shebang, and the house doc-comment style puts a runnable command in **backticks** on line 1:

```js
// cli/drain.mjs — CTL-1095. `catalyst-execution-core drain [--off] [--json]`
```

`bash cli/drain.mjs`, with a stub `catalyst-execution-core` on `PATH`, executed `drain [--off] [--json]` **straight out of that comment**. The same file with no backtick on line 1 executed nothing — so it is the backtick, not merely running the file under a shell. Fires under **bash and sh**; **not** under zsh. In production the "stub" is the real CLI, which re-invokes the shell: on 2026-08-17 that reached **7,592 nested bash processes** (87% of `kern.maxprocperuid`) and `fork()` failed for every agent on the machine for ~25 minutes.

## The guard

One polyglot line, and it must be line 1:

```
//bin/true 2>/dev/null; exec 1>&2; echo "REFUSING: a SHELL is executing this JavaScript module — see CTL-1937."; exit 97
```

To node/bun it is a `//` line comment. To sh/bash/zsh it prints the named refusal and **exits 97 before the shell parses line 2**, which is where the backtick lives. `//bin/true` does not resolve on macOS (`//` is implementation-defined) — harmless; it is only there because the line must *start* with `//` to be a JS comment, and `2>/dev/null` keeps the shell's diagnostic out of the way so the refusal is the only output.

Applied to all **25** `cli/*.mjs`, `.test.mjs` included: the class is "a shebang-less `.mjs` a shell can be pointed at", which does not stop at the non-test files.

## Enforcement

| | |
|---|---|
| `plugins/dev/scripts/lint-cli-shell-guard.sh` | fails on any `cli/*.mjs` whose line 1 is not the guard — a **new** module cannot reintroduce the class. Also fails when its own glob matches **zero** files: a lint that checks nothing must not report a pass. Portable to macOS `/bin/bash` 3.2 (no `mapfile`). |
| `execution-core/__tests__/cli-shell-guard.test.sh` | proves the line **works**, not just that it is present: bash/zsh/sh each refuse by name, exit 97, and the stub on `PATH` is never invoked — **zero children**. |
| `execution-core-tests.yml` | both wired in; the workflow's existing `plugins/dev/scripts/**` path already covers them, so neither can be edited without running. |

## Controls that fired

- ⛔ **Negative control inside the test**: the same module with line 1 **stripped** *does* fire the backtick. Without it, every assertion would also pass against a module that simply has nothing to detonate.
- ⛔ **Mutation**: removing the guard from `drain.mjs` takes the test from **15 pass / 0 fail → 2 pass / 13 fail**; restoring it returns it to green.
- ⛔ **The lint's zero-files branch was exercised** against an empty tree. Its first cut used `${#FILES[@]:-0}` — a *bad substitution* — so the protection could not have fired at all. Caught by running it, not by reading it.
- `cli/` unit tests **241 pass / 0 fail** with the guard in place; #3511's own `exec-runtime-guard.test.sh` still **9 pass / 0 fail** on top of this change.
- Prettier leaves the guard line byte-identical (and already fails these files on `main`, so it is not enforced here).

## Safety of the test itself

The stub on `PATH` **records and exits** — it cannot recurse, so even a totally broken guard produces one extra process, never a chain. This test needs no watchdog because there is nothing for a watchdog to contain.

Refs CTL-1937, CTLI-5, COORD-119. Builds on #3511 rather than replacing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)