### PR TITLE
feat(dev): a remote owner on mini can post channel turns the laptop pulls (COORD-108/118/121)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -94,6 +94,9 @@ on:
       - "plugins/dev/scripts/__tests__/**"
       # CTL-1387: the CLI-reference generator + the page it drives are guarded by
       # cli-reference-drift.test.sh below; a change to either must run this suite.
+      # FLEET: the remote-owner channel transport ships its own bash test; without this
+      # path a PR touching only scripts/comms/ would skip the job that runs it.
+      - "scripts/comms/**"
       - "plugins/dev/scripts/gen-cli-reference.sh"
       - "website/src/content/docs/reference/catalyst-cli.md"
       # CTL-1530: the dual-harness migrator and its checkup §10 wiring — a change to
@@ -165,6 +168,9 @@ jobs:
               - "plugins/dev/scripts/orphan-sweep.sh"
               - "plugins/dev/scripts/install-orphan-sweep.sh"
               - "plugins/dev/scripts/__tests__/**"
+              # FLEET: the remote-owner channel transport ships its own bash test; without this
+              # path a PR touching only scripts/comms/ would skip the job that runs it.
+              - "scripts/comms/**"
               - "plugins/dev/scripts/gen-cli-reference.sh"
               - "website/src/content/docs/reference/catalyst-cli.md"
               - "plugins/dev/scripts/migrate-dual-harness.sh"
@@ -240,6 +246,14 @@ jobs:
         # that catches a case the others clear.
         working-directory: .
         run: bash plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
+
+      - name: remote-owner channel transport test (scripts/comms)
+        # post-turn.sh / drain-remote-turns.sh move channel turns from a remote owner host
+        # (mini) to the channel file on the laptop. Hermetic: the test injects a fake ssh via
+        # $CATALYST_SSH. Covers the atomic .part handoff, idempotence, and the deliberate
+        # at-least-once ordering (append first, ack second).
+        working-directory: .
+        run: bash scripts/comms/__tests__/remote-turns.test.sh
 
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing

--- a/scripts/comms/__tests__/remote-turns.test.sh
+++ b/scripts/comms/__tests__/remote-turns.test.sh
@@ -53,6 +53,14 @@ chmod +x "$SCRATCH/fake-ssh"
 
 queue() { HOME="$REMOTE_HOME" bash "$POST" --channel demo --owner "$1" >/dev/null 2>&1; }
 drain() { CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" bash "$DRAIN" --channel demo --hosts "${1:-mini}" 2>&1; }
+# ⛔ The mkdir-lock branch only runs when flock is ABSENT — the stock macOS shape. On a host that
+# has flock (this laptop does, via homebrew) the stale-lock cases would silently exercise the
+# flock branch and assert nothing; the live-holder control below is what caught that. A PATH of
+# /usr/bin:/bin covers everything the drainer uses (ls, sort, sed, cat, mkdir, grep, kill).
+drain_no_flock() {
+	PATH="/usr/bin:/bin" CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" \
+		bash "$DRAIN" --channel demo --hosts "${1:-mini}" 2>&1
+}
 
 echo ""
 echo "=== a queued turn is delivered to the channel ==="
@@ -152,6 +160,39 @@ if grep -qF "CONCURRENT TURN" "$CHANNEL_FILE"; then fail "the locked-out drain a
 # above would pass against a drain that is simply broken.
 OUT_AFTER="$(drain mini)"
 if grep -qF "CONCURRENT TURN" "$CHANNEL_FILE"; then pass "control — after the lock is released the turn is delivered"; else fail "control — the turn is delivered once unlocked" "$OUT_AFTER"; fi
+
+echo ""
+echo "--- ⛔ a STALE mkdir lock is taken over, not obeyed forever (Codex #3517 P2) ---"
+# A kill -9 / crash / reboot skips the EXIT trap. Before the fix every later drain read the
+# orphaned directory as a live owner and exited 0 — the transport wedged while reporting success.
+# Exercised directly (the mkdir branch is what runs on stock macOS, flock or not here).
+printf 'AFTER STALE LOCK\n' | queue FLEET
+mkdir -p "$CHANNEL_FILE.drain.lockdir"
+echo "999999" >"$CHANNEL_FILE.drain.lockdir/pid" # a pid that is not running
+OUT_STALE="$(drain_no_flock)"
+if command -v flock >/dev/null 2>&1 && PATH="/usr/bin:/bin" command -v flock >/dev/null 2>&1; then
+	fail "the fixture removed flock from PATH" "flock is still reachable; these cases would test the wrong branch"
+else
+	pass "control — flock is out of PATH, so the mkdir branch is the one under test"
+fi
+if grep -q "STALE lock" <<<"$OUT_STALE"; then pass "the stale lock is identified as stale"; else fail "the stale lock is identified" "$OUT_STALE"; fi
+if grep -qF "AFTER STALE LOCK" "$CHANNEL_FILE"; then pass "the turn was delivered despite the orphaned lock"; else fail "the turn was delivered despite the orphaned lock" "$OUT_STALE"; fi
+rm -rf "$CHANNEL_FILE.drain.lockdir"
+# ⛔ Positive control: a lock held by a LIVE process must still be obeyed, or the takeover above
+# would just be "the lock never works".
+printf 'MUST NOT DELIVER\n' | queue FLEET
+mkdir -p "$CHANNEL_FILE.drain.lockdir"
+sleep 30 &
+LIVE=$!
+echo "$LIVE" >"$CHANNEL_FILE.drain.lockdir/pid"
+OUT_LIVE="$(drain_no_flock)"
+kill "$LIVE" 2>/dev/null
+if grep -qF "MUST NOT DELIVER" "$CHANNEL_FILE"; then
+	fail "control — a LIVE lock is still obeyed" "the takeover ignores a running holder; the lock is useless"
+else
+	pass "control — a lock held by a LIVE pid is still obeyed"
+fi
+rm -rf "$CHANNEL_FILE.drain.lockdir"
 
 echo ""
 echo "--- ⛔ '..' as a channel slug is refused (Codex #3517 P2) ---"

--- a/scripts/comms/__tests__/remote-turns.test.sh
+++ b/scripts/comms/__tests__/remote-turns.test.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# remote-turns.test.sh — hermetic coverage for the remote-owner channel transport.
+#
+# The pair was first proven against the REAL mini (a turn queued there, drained onto the
+# laptop's channel, second drain a no-op). This test is the version CI can run: it injects a
+# fake `ssh` via $CATALYST_SSH that executes the command locally in a fake remote $HOME.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POST="$SCRIPT_DIR/../post-turn.sh"
+DRAIN="$SCRIPT_DIR/../drain-remote-turns.sh"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'chmod -R u+w "$SCRATCH" 2>/dev/null; rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+
+REMOTE_HOME="$SCRATCH/remote-home"
+CHANNELS="$SCRATCH/md-channels"
+mkdir -p "$REMOTE_HOME" "$CHANNELS"
+CHANNEL_FILE="$CHANNELS/demo.md"
+printf '# demo channel\n\nfirst line\n' >"$CHANNEL_FILE"
+
+# A stand-in for ssh: drop the -o flags and the host, run the rest in the fake remote HOME.
+# FAKE_SSH_FAIL_MV=1 makes only the ack step fail, which is how the at-least-once claim below
+# is exercised without needing a real broken host.
+cat >"$SCRATCH/fake-ssh" <<EOF
+#!/bin/bash
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -o) shift 2 ;;
+    *) break ;;
+  esac
+done
+host="\$1"; shift
+[ "\$host" = "unreachable" ] && exit 255
+if [ -n "\${FAKE_SSH_FAIL_MV:-}" ] && printf '%s' "\$*" | grep -q "mv --"; then exit 1; fi
+cd "$REMOTE_HOME" && HOME="$REMOTE_HOME" bash -c "\$*"
+EOF
+chmod +x "$SCRATCH/fake-ssh"
+
+queue() { HOME="$REMOTE_HOME" bash "$POST" --channel demo --owner "$1" >/dev/null 2>&1; }
+drain() { CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" bash "$DRAIN" --channel demo --hosts "${1:-mini}" 2>&1; }
+
+echo ""
+echo "=== a queued turn is delivered to the channel ==="
+printf '## Turn X — hello\nbody\n' | queue FLEET
+OUT="$(drain)"
+if grep -qF "## Turn X — hello" "$CHANNEL_FILE"; then pass "the turn body reached the channel"; else fail "the turn body reached the channel" "$OUT"; fi
+if grep -qF "first line" "$CHANNEL_FILE"; then pass "pre-existing channel content is preserved"; else fail "pre-existing channel content is preserved"; fi
+if [ -n "$(ls -A "$REMOTE_HOME/catalyst/comms/outbox/demo/sent" 2>/dev/null)" ]; then pass "the delivered turn moved to sent/"; else fail "the delivered turn moved to sent/" "$OUT"; fi
+
+echo ""
+echo "=== a second drain delivers NOTHING (no duplicate) ==="
+BEFORE="$(wc -l <"$CHANNEL_FILE")"
+drain >/dev/null
+AFTER="$(wc -l <"$CHANNEL_FILE")"
+if [ "$BEFORE" = "$AFTER" ]; then pass "channel unchanged at $AFTER lines"; else fail "channel unchanged" "$BEFORE -> $AFTER"; fi
+
+echo ""
+echo "=== ⛔ a half-written .part is NEVER delivered ==="
+printf 'HALF WRITTEN MUST NOT APPEAR\n' >"$REMOTE_HOME/catalyst/comms/outbox/demo/pending/99999999T999999Z-partial.part"
+drain >/dev/null
+if grep -qF "HALF WRITTEN MUST NOT APPEAR" "$CHANNEL_FILE"; then
+	fail "a .part was delivered" "the atomic rename is not protecting a partial write"
+else
+	pass "the .part was skipped"
+fi
+# ⛔ Positive control: the .part is skipped because of its EXTENSION, not because the drain is
+# broken and delivers nothing at all.
+printf 'CONTROL TURN DELIVERED\n' | queue FLEET
+drain >/dev/null
+if grep -qF "CONTROL TURN DELIVERED" "$CHANNEL_FILE"; then
+	pass "control — a real .md alongside the .part still delivers"
+else
+	fail "control — a real .md alongside the .part still delivers" \
+		"the .part check above proves nothing: this drain delivers nothing at all"
+fi
+
+echo ""
+echo "=== ⛔ AT-LEAST-ONCE: if the ack fails, the turn is NOT lost ==="
+printf 'ACK FAILURE TURN\n' | queue FLEET
+OUT="$(FAKE_SSH_FAIL_MV=1 CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" bash "$DRAIN" --channel demo --hosts mini 2>&1)"
+if grep -qF "ACK FAILURE TURN" "$CHANNEL_FILE"; then pass "the turn still reached the channel"; else fail "the turn still reached the channel" "$OUT"; fi
+if grep -q "could not mark it sent" <<<"$OUT"; then pass "the drain says LOUDLY that the next pass will duplicate"; else fail "the drain warns about the pending duplicate" "$OUT"; fi
+if ls "$REMOTE_HOME/catalyst/comms/outbox/demo/pending"/*.md >/dev/null 2>&1; then pass "the turn stayed queued (re-delivery, not loss)"; else fail "the turn stayed queued" "it was dropped despite the failed ack"; fi
+
+echo ""
+echo "=== refusals ==="
+printf '' | HOME="$REMOTE_HOME" bash "$POST" --channel demo --owner FLEET >/dev/null 2>&1
+[ $? -eq 3 ] && pass "an EMPTY turn is refused (rc 3)" || fail "an EMPTY turn is refused (rc 3)"
+printf 'x\n' | HOME="$REMOTE_HOME" bash "$POST" --channel ../../etc --owner FLEET >/dev/null 2>&1
+[ $? -eq 2 ] && pass "a traversing --channel is refused (rc 2)" || fail "a traversing --channel is refused (rc 2)"
+HOME="$REMOTE_HOME" bash "$POST" --owner FLEET </dev/null >/dev/null 2>&1
+[ $? -eq 2 ] && pass "a missing --channel is refused (rc 2)" || fail "a missing --channel is refused (rc 2)"
+
+echo ""
+echo "=== an unreachable host does not abort the other hosts' turns ==="
+printf 'AFTER UNREACHABLE\n' | queue FLEET
+OUT="$(drain "unreachable,mini")"
+if grep -qF "AFTER UNREACHABLE" "$CHANNEL_FILE"; then pass "mini's turn was delivered despite a dead host in the list"; else fail "mini's turn was delivered despite a dead host" "$OUT"; fi
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/scripts/comms/__tests__/remote-turns.test.sh
+++ b/scripts/comms/__tests__/remote-turns.test.sh
@@ -110,7 +110,62 @@ echo ""
 echo "=== an unreachable host does not abort the other hosts' turns ==="
 printf 'AFTER UNREACHABLE\n' | queue FLEET
 OUT="$(drain "unreachable,mini")"
+RC=$?
 if grep -qF "AFTER UNREACHABLE" "$CHANNEL_FILE"; then pass "mini's turn was delivered despite a dead host in the list"; else fail "mini's turn was delivered despite a dead host" "$OUT"; fi
+
+echo ""
+echo "--- ⛔ ...but an unreachable host must be REPORTED, not read as an empty queue (Codex #3517 P1) ---"
+# The first cut swallowed the listing rc with `|| true`, printed "nothing queued", and exited 0.
+if grep -q "COULD NOT LIST" <<<"$OUT"; then pass "the drain says it could not list the outbox"; else fail "the drain says it could not list the outbox" "$OUT"; fi
+if grep -q "NOT an empty queue" <<<"$OUT"; then pass "it distinguishes that from an empty queue"; else fail "it distinguishes that from an empty queue" "$OUT"; fi
+if [ "$RC" -ne 0 ]; then pass "the drain exits NON-ZERO when a host could not be inspected (rc=$RC)"; else fail "the drain exits non-zero on a failed listing" "rc=0 — a caller cannot tell anything went wrong"; fi
+# ⛔ Positive control: a REACHABLE host with a genuinely empty outbox must NOT be reported as a
+# failure, or the check above would pass against a drain that always complains.
+OUT_EMPTY="$(drain mini)"
+RC_EMPTY=$?
+if grep -q "reachable, nothing queued" <<<"$OUT_EMPTY" && [ "$RC_EMPTY" -eq 0 ]; then
+	pass "control — a reachable-but-empty host is NOT reported as a failure (rc=0)"
+else
+	fail "control — a reachable-but-empty host is not a failure" "rc=$RC_EMPTY: $OUT_EMPTY"
+fi
+
+echo ""
+echo "--- ⛔ a second concurrent drain must SKIP, not append alongside the first (Codex #3517 P1) ---"
+# Simulate the lock already being held. On a host with flock this is the flock branch; without
+# it (stock macOS) it is the mkdir branch — the bug was conflating the two.
+printf 'CONCURRENT TURN\n' | queue FLEET
+if command -v flock >/dev/null 2>&1; then
+	exec 8>"$CHANNEL_FILE.drain.lock"
+	flock -n 8
+	OUT_LOCK="$(drain mini)"
+	RC_LOCK=$?
+	exec 8>&-
+else
+	mkdir "$CHANNEL_FILE.drain.lockdir"
+	OUT_LOCK="$(drain mini)"
+	RC_LOCK=$?
+	rmdir "$CHANNEL_FILE.drain.lockdir"
+fi
+if grep -q "another drain holds" <<<"$OUT_LOCK"; then pass "the second drain skipped because the lock was held"; else fail "the second drain skipped" "$OUT_LOCK"; fi
+if grep -qF "CONCURRENT TURN" "$CHANNEL_FILE"; then fail "the locked-out drain appended anyway" "the single-appender guarantee does not hold"; else pass "it appended NOTHING while locked out"; fi
+# ⛔ Positive control: once the lock is released the same turn IS delivered — otherwise the check
+# above would pass against a drain that is simply broken.
+OUT_AFTER="$(drain mini)"
+if grep -qF "CONCURRENT TURN" "$CHANNEL_FILE"; then pass "control — after the lock is released the turn is delivered"; else fail "control — the turn is delivered once unlocked" "$OUT_AFTER"; fi
+
+echo ""
+echo "--- ⛔ '..' as a channel slug is refused (Codex #3517 P2) ---"
+# The original traversal case used ../../etc, which is rejected merely for containing a slash —
+# it never exercised the form that actually escapes.
+printf 'x\n' | HOME="$REMOTE_HOME" bash "$POST" --channel .. --owner FLEET >/dev/null 2>&1
+[ $? -eq 2 ] && pass "--channel .. is refused (rc 2)" || fail "--channel .. is refused (rc 2)"
+printf 'x\n' | HOME="$REMOTE_HOME" bash "$POST" --channel . --owner FLEET >/dev/null 2>&1
+[ $? -eq 2 ] && pass "--channel . is refused (rc 2)" || fail "--channel . is refused (rc 2)"
+if [ -n "$(find "$REMOTE_HOME/catalyst/comms/outbox" -name '*.md' -not -path '*/demo/*' 2>/dev/null)" ]; then
+	fail "no turn landed outside the channel directory" "$(find "$REMOTE_HOME/catalyst/comms/outbox" -name '*.md' -not -path '*/demo/*')"
+else
+	pass "no turn landed outside the channel directory"
+fi
 
 echo ""
 echo "  PASSED: $PASSES   FAILED: $FAILURES"

--- a/scripts/comms/__tests__/remote-turns.test.sh
+++ b/scripts/comms/__tests__/remote-turns.test.sh
@@ -57,8 +57,12 @@ drain() { CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" bash
 # has flock (this laptop does, via homebrew) the stale-lock cases would silently exercise the
 # flock branch and assert nothing; the live-holder control below is what caught that. A PATH of
 # /usr/bin:/bin covers everything the drainer uses (ls, sort, sed, cat, mkdir, grep, kill).
+# ⛔ PATH-stripping does NOT work here: every CI runner has /usr/bin/flock, so the first version
+# of this helper (PATH=/usr/bin:/bin) still found it and both stale-lock cases silently tested the
+# flock branch. CI caught it via the control below, exactly as intended. CATALYST_DRAIN_LOCK=mkdir
+# selects the stock-macOS branch explicitly, on any host.
 drain_no_flock() {
-	PATH="/usr/bin:/bin" CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" \
+	CATALYST_DRAIN_LOCK=mkdir CATALYST_SSH="$SCRATCH/fake-ssh" CATALYST_MD_CHANNELS="$CHANNELS" \
 		bash "$DRAIN" --channel demo --hosts "${1:-mini}" 2>&1
 }
 
@@ -170,10 +174,12 @@ printf 'AFTER STALE LOCK\n' | queue FLEET
 mkdir -p "$CHANNEL_FILE.drain.lockdir"
 echo "999999" >"$CHANNEL_FILE.drain.lockdir/pid" # a pid that is not running
 OUT_STALE="$(drain_no_flock)"
-if command -v flock >/dev/null 2>&1 && PATH="/usr/bin:/bin" command -v flock >/dev/null 2>&1; then
-	fail "the fixture removed flock from PATH" "flock is still reachable; these cases would test the wrong branch"
+# Control: the mkdir branch really is the one running. Its stale-lock message is unique to it,
+# so seeing it proves the selection took effect rather than assuming it did.
+if grep -qE "STALE lock|another drain \(pid" <<<"$OUT_STALE" || [ ! -d "$CHANNEL_FILE.drain.lockdir" ]; then
+	pass "control — CATALYST_DRAIN_LOCK=mkdir selected the portable branch"
 else
-	pass "control — flock is out of PATH, so the mkdir branch is the one under test"
+	fail "control — the mkdir branch is the one under test" "no mkdir-branch output; the flock branch probably ran"
 fi
 if grep -q "STALE lock" <<<"$OUT_STALE"; then pass "the stale lock is identified as stale"; else fail "the stale lock is identified" "$OUT_STALE"; fi
 if grep -qF "AFTER STALE LOCK" "$CHANNEL_FILE"; then pass "the turn was delivered despite the orphaned lock"; else fail "the turn was delivered despite the orphaned lock" "$OUT_STALE"; fi

--- a/scripts/comms/drain-remote-turns.sh
+++ b/scripts/comms/drain-remote-turns.sh
@@ -40,8 +40,26 @@ CHANNEL_FILE="$CHANNEL_DIR/$CHANNEL.md"
 # genuine contention silently took the OTHER lock and proceeded — two drains appending the same
 # turns, which is precisely the guarantee this lock exists to provide. Decide which mechanism is
 # available FIRST, then interpret its failure as contention and nothing else.
+# CATALYST_DRAIN_LOCK: auto (default) | flock | mkdir. The knob exists because the mkdir branch
+# is the STOCK-MACOS path — the hosts this actually runs on — and it is unreachable for testing on
+# any box that has flock, which includes every CI runner (/usr/bin/flock). Stripping PATH does not
+# work there. Without a way to select it, the portable branch would ship untested; the first
+# attempt to test it silently exercised the flock branch instead, and only a control caught that.
+LOCK_MODE="${CATALYST_DRAIN_LOCK:-auto}"
+case "$LOCK_MODE" in
+auto | flock | mkdir) ;;
+*)
+  echo "drain: CATALYST_DRAIN_LOCK must be auto, flock or mkdir (got '$LOCK_MODE')" >&2
+  exit 2
+  ;;
+esac
+if [[ "$LOCK_MODE" == "flock" ]] && ! command -v flock >/dev/null 2>&1; then
+  echo "drain: CATALYST_DRAIN_LOCK=flock but flock is not installed" >&2
+  exit 2
+fi
+
 LOCK="$CHANNEL_FILE.drain.lock"
-if command -v flock >/dev/null 2>&1; then
+if [[ "$LOCK_MODE" != "mkdir" ]] && command -v flock >/dev/null 2>&1; then
   exec 9>"$LOCK"
   if ! flock -n 9; then
     echo "drain: another drain holds $LOCK — skipping this pass" >&2

--- a/scripts/comms/drain-remote-turns.sh
+++ b/scripts/comms/drain-remote-turns.sh
@@ -35,13 +35,23 @@ CHANNEL_FILE="$CHANNEL_DIR/$CHANNEL.md"
 [[ -f "$CHANNEL_FILE" ]] || { echo "drain: no such channel file: $CHANNEL_FILE" >&2; exit 2; }
 
 # One appender at a time: two concurrent drains would interleave turns mid-line.
+# ⛔ Codex #3517 P1: the first cut ran `flock -n 9` and, on ANY nonzero exit, fell through to the
+# mkdir lock. But "flock is absent" and "flock says another drain holds it" both exit nonzero, so
+# genuine contention silently took the OTHER lock and proceeded — two drains appending the same
+# turns, which is precisely the guarantee this lock exists to provide. Decide which mechanism is
+# available FIRST, then interpret its failure as contention and nothing else.
 LOCK="$CHANNEL_FILE.drain.lock"
-exec 9>"$LOCK"
-if ! /usr/bin/env flock -n 9 2>/dev/null; then
-  # macOS has no flock(1) by default; fall back to an atomic mkdir lock.
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    echo "drain: another drain holds $LOCK — skipping this pass" >&2
+    exit 0
+  fi
+else
+  # macOS ships no flock(1); mkdir is atomic and is the portable stand-in.
   LOCKDIR="$CHANNEL_FILE.drain.lockdir"
   if ! mkdir "$LOCKDIR" 2>/dev/null; then
-    echo "drain: another drain holds the lock ($LOCKDIR) — skipping this pass" >&2
+    echo "drain: another drain holds $LOCKDIR — skipping this pass" >&2
     exit 0
   fi
   trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
@@ -54,10 +64,23 @@ for host in "${HOST_LIST[@]}"; do
   [[ -n "$host" ]] || continue
   remote_dir="$REMOTE_OUTBOX_ROOT/$CHANNEL/pending"
 
-  # `|| true`: an unreachable or outbox-less host must not abort the other hosts' turns.
-  files="$($SSH_CMD -o BatchMode=yes -o ConnectTimeout=10 "$host" \
-            "ls -1 '$remote_dir'/*.md 2>/dev/null | sort" 2>/dev/null || true)"
-  [[ -n "$files" ]] || { echo "drain: $host — nothing queued"; continue; }
+  # ⛔ Codex #3517 P1: the first cut swallowed the listing's exit status with `|| true`, so an
+  # unreachable host, an auth failure or an errored listing all produced empty output and printed
+  # "nothing queued" — with `failed` still 0 and the drain exiting 0. An owner's turns could sit
+  # undelivered indefinitely and every signal said fine. The remote command now ECHOES A SENTINEL
+  # on success, so "reachable with an empty outbox" is distinguishable from "could not look".
+  # A dead host still must not abort the other hosts, so this continues rather than exiting.
+  listing="$($SSH_CMD -o BatchMode=yes -o ConnectTimeout=10 "$host" \
+            "ls -1 '$remote_dir'/*.md 2>/dev/null | sort; echo '__DRAIN_LIST_OK__'" 2>/dev/null || true)"
+  if [[ "$listing" != *"__DRAIN_LIST_OK__"* ]]; then
+    echo "drain: $host — COULD NOT LIST the outbox (unreachable, auth, or a remote error)." >&2
+    echo "drain: $host — this is NOT an empty queue; turns may be waiting there." >&2
+    failed=$((failed + 1))
+    continue
+  fi
+  files="${listing%__DRAIN_LIST_OK__*}"
+  files="$(printf '%s' "$files" | sed '/^$/d')"
+  [[ -n "$files" ]] || { echo "drain: $host — reachable, nothing queued"; continue; }
 
   while IFS= read -r rf; do
     [[ -n "$rf" ]] || continue

--- a/scripts/comms/drain-remote-turns.sh
+++ b/scripts/comms/drain-remote-turns.sh
@@ -49,12 +49,28 @@ if command -v flock >/dev/null 2>&1; then
   fi
 else
   # macOS ships no flock(1); mkdir is atomic and is the portable stand-in.
+  #
+  # ⛔ Codex #3517 P2: a kill -9, a crash or a reboot skips the EXIT trap and leaves the lock
+  # directory on disk. Every later drain then read it as a live owner and exited 0 — the channel
+  # would quietly stop receiving remote turns forever, with a SUCCESSFUL exit status every pass.
+  # The holder's PID is recorded so a lock whose owner is gone can be identified as STALE and
+  # taken over, loudly, instead of wedging the transport.
   LOCKDIR="$CHANNEL_FILE.drain.lockdir"
   if ! mkdir "$LOCKDIR" 2>/dev/null; then
-    echo "drain: another drain holds $LOCKDIR — skipping this pass" >&2
-    exit 0
+    holder="$(cat "$LOCKDIR/pid" 2>/dev/null || true)"
+    if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+      echo "drain: another drain (pid $holder) holds $LOCKDIR — skipping this pass" >&2
+      exit 0
+    fi
+    echo "drain: STALE lock $LOCKDIR (holder '${holder:-unknown}' is not running) — taking it over" >&2
+    rm -rf "$LOCKDIR"
+    if ! mkdir "$LOCKDIR" 2>/dev/null; then
+      echo "drain: could not take over $LOCKDIR — skipping this pass" >&2
+      exit 0
+    fi
   fi
-  trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+  echo "$$" >"$LOCKDIR/pid"
+  trap 'rm -rf "$LOCKDIR" 2>/dev/null || true' EXIT
 fi
 
 drained=0 failed=0

--- a/scripts/comms/drain-remote-turns.sh
+++ b/scripts/comms/drain-remote-turns.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# drain-remote-turns.sh — run on the CHANNEL HOST (the laptop). Pulls queued turns from remote
+# owner hosts and appends them to the md-channel file.
+#
+# Direction is pull-only, and deliberately: the laptop does not accept ssh (measured 2026-08-18:
+# refused from both minis), and a pull keeps working while the laptop sleeps — remote turns queue
+# in the mini's outbox and land on the next drain.
+#
+# Delivery is AT-LEAST-ONCE, on purpose. The turn is appended to the channel FIRST and only marked
+# sent afterwards, so a crash in between re-delivers a turn (a visible duplicate) instead of
+# dropping one (a silent loss). Losing an owner's turn is the worse failure.
+#
+# Usage:
+#   scripts/comms/drain-remote-turns.sh --channel <name> [--hosts mini,mini-2] [--dry-run]
+
+set -euo pipefail
+
+CHANNEL_DIR="${CATALYST_MD_CHANNELS:-$HOME/catalyst/comms/md-channels}"
+REMOTE_OUTBOX_ROOT="${CATALYST_REMOTE_OUTBOX_ROOT:-catalyst/comms/outbox}"   # relative to remote $HOME
+CHANNEL="" HOSTS="mini,mini-2" DRY_RUN=0
+SSH_CMD="${CATALYST_SSH:-ssh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel) CHANNEL="${2:-}"; shift 2 ;;
+    --hosts)   HOSTS="${2:-}";   shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "drain: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$CHANNEL" ]] || { echo "drain: --channel is required" >&2; exit 2; }
+CHANNEL_FILE="$CHANNEL_DIR/$CHANNEL.md"
+[[ -f "$CHANNEL_FILE" ]] || { echo "drain: no such channel file: $CHANNEL_FILE" >&2; exit 2; }
+
+# One appender at a time: two concurrent drains would interleave turns mid-line.
+LOCK="$CHANNEL_FILE.drain.lock"
+exec 9>"$LOCK"
+if ! /usr/bin/env flock -n 9 2>/dev/null; then
+  # macOS has no flock(1) by default; fall back to an atomic mkdir lock.
+  LOCKDIR="$CHANNEL_FILE.drain.lockdir"
+  if ! mkdir "$LOCKDIR" 2>/dev/null; then
+    echo "drain: another drain holds the lock ($LOCKDIR) — skipping this pass" >&2
+    exit 0
+  fi
+  trap 'rmdir "$LOCKDIR" 2>/dev/null || true' EXIT
+fi
+
+drained=0 failed=0
+IFS=',' read -r -a HOST_LIST <<< "$HOSTS"
+
+for host in "${HOST_LIST[@]}"; do
+  [[ -n "$host" ]] || continue
+  remote_dir="$REMOTE_OUTBOX_ROOT/$CHANNEL/pending"
+
+  # `|| true`: an unreachable or outbox-less host must not abort the other hosts' turns.
+  files="$($SSH_CMD -o BatchMode=yes -o ConnectTimeout=10 "$host" \
+            "ls -1 '$remote_dir'/*.md 2>/dev/null | sort" 2>/dev/null || true)"
+  [[ -n "$files" ]] || { echo "drain: $host — nothing queued"; continue; }
+
+  while IFS= read -r rf; do
+    [[ -n "$rf" ]] || continue
+    body="$($SSH_CMD -o BatchMode=yes -o ConnectTimeout=10 "$host" "cat -- '$rf'" 2>/dev/null || true)"
+    if [[ -z "$body" ]]; then
+      echo "drain: $host — could not read '$rf' (or it is empty); LEAVING it queued" >&2
+      failed=$((failed + 1))
+      continue
+    fi
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      echo "drain: [dry-run] would append $host:$rf ($(printf '%s' "$body" | wc -c | tr -d ' ') bytes)"
+      drained=$((drained + 1))
+      continue
+    fi
+
+    # Append first, ack second — see the at-least-once note above.
+    { printf '\n'; printf '%s\n' "$body"; } >> "$CHANNEL_FILE"
+
+    if $SSH_CMD -o BatchMode=yes -o ConnectTimeout=10 "$host" \
+         "mkdir -p '$REMOTE_OUTBOX_ROOT/$CHANNEL/sent' && mv -- '$rf' '$REMOTE_OUTBOX_ROOT/$CHANNEL/sent'/" 2>/dev/null; then
+      echo "drain: $host — delivered $(basename "$rf")"
+    else
+      # Delivered but not acked: say so loudly, because the next pass WILL duplicate it.
+      echo "drain: $host — APPENDED '$rf' but could not mark it sent; the next drain will DUPLICATE it" >&2
+      failed=$((failed + 1))
+    fi
+    drained=$((drained + 1))
+  done <<< "$files"
+done
+
+echo "drain: $drained turn(s) delivered, $failed problem(s), channel=$CHANNEL_FILE"
+[[ "$failed" -eq 0 ]]

--- a/scripts/comms/post-turn.sh
+++ b/scripts/comms/post-turn.sh
@@ -32,8 +32,18 @@ done
 [[ -n "$CHANNEL" ]] || { echo "post-turn: --channel is required" >&2; exit 2; }
 [[ -n "$OWNER"   ]] || { echo "post-turn: --owner is required" >&2; exit 2; }
 # The channel name becomes a directory name; keep it a plain slug so it cannot escape the outbox.
-[[ "$CHANNEL" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "post-turn: --channel must match [A-Za-z0-9._-]+ (got '$CHANNEL')" >&2; exit 2; }
-[[ "$OWNER"   =~ ^[A-Za-z0-9._-]+$ ]] || { echo "post-turn: --owner must match [A-Za-z0-9._-]+ (got '$OWNER')" >&2; exit 2; }
+#
+# ⛔ Codex #3517 P2: the character class alone is NOT enough, and the test that "proved" it was
+# asserting the neighbour. `..` matches ^[A-Za-z0-9._-]+$ perfectly — no slash required — so
+# `--channel ..` resolved DEST_DIR to $OUTBOX_ROOT/../pending and reported success while putting
+# the turn where no drainer looks. The original test used `../../etc`, which is rejected for
+# containing a slash, so it never exercised the case that actually escapes.
+reject_slug() { echo "post-turn: --$1 must be a plain slug matching [A-Za-z0-9._-]+ and not '.' or '..' (got '$2')" >&2; exit 2; }
+for pair in "channel:$CHANNEL" "owner:$OWNER"; do
+  _name="${pair%%:*}"; _val="${pair#*:}"
+  [[ "$_val" =~ ^[A-Za-z0-9._-]+$ ]] || reject_slug "$_name" "$_val"
+  [[ "$_val" == "." || "$_val" == ".." ]] && reject_slug "$_name" "$_val"
+done
 
 DEST_DIR="$OUTBOX_ROOT/$CHANNEL/pending"
 mkdir -p "$DEST_DIR"

--- a/scripts/comms/post-turn.sh
+++ b/scripts/comms/post-turn.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# post-turn.sh — queue a channel turn from a REMOTE owner host (mini, mini-2).
+#
+# Why an outbox instead of writing the channel directly: the md-channel file lives ONLY on the
+# laptop, and the laptop does not accept ssh (measured 2026-08-18: `ssh laptop` is refused from
+# both minis; Remote Login is off and turning it on needs admin). So the remote owner cannot push.
+# It queues here, and the laptop PULLS with drain-remote-turns.sh. That direction is also the one
+# that survives the laptop sleeping: turns simply accumulate until it wakes.
+#
+# Handoff is atomic: the turn is written to <name>.part and only then renamed to <name>.md.
+# The drainer reads *.md exclusively, so it can never pick up a half-written turn.
+#
+# Usage:
+#   scripts/comms/post-turn.sh --channel <name> --owner <OWNER> [--file <path>]
+#   ... | scripts/comms/post-turn.sh --channel <name> --owner <OWNER>      # body on stdin
+
+set -euo pipefail
+
+OUTBOX_ROOT="${CATALYST_OUTBOX_ROOT:-$HOME/catalyst/comms/outbox}"
+CHANNEL="" OWNER="" BODY_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel) CHANNEL="${2:-}"; shift 2 ;;
+    --owner)   OWNER="${2:-}";   shift 2 ;;
+    --file)    BODY_FILE="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "post-turn: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$CHANNEL" ]] || { echo "post-turn: --channel is required" >&2; exit 2; }
+[[ -n "$OWNER"   ]] || { echo "post-turn: --owner is required" >&2; exit 2; }
+# The channel name becomes a directory name; keep it a plain slug so it cannot escape the outbox.
+[[ "$CHANNEL" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "post-turn: --channel must match [A-Za-z0-9._-]+ (got '$CHANNEL')" >&2; exit 2; }
+[[ "$OWNER"   =~ ^[A-Za-z0-9._-]+$ ]] || { echo "post-turn: --owner must match [A-Za-z0-9._-]+ (got '$OWNER')" >&2; exit 2; }
+
+DEST_DIR="$OUTBOX_ROOT/$CHANNEL/pending"
+mkdir -p "$DEST_DIR"
+
+# UTC so turns from different hosts sort correctly regardless of local zone; the host name keeps
+# two owners posting in the same second from colliding.
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BASE="${STAMP}-$(hostname -s)-${OWNER}-$$"
+PART="$DEST_DIR/$BASE.part"
+FINAL="$DEST_DIR/$BASE.md"
+
+if [[ -n "$BODY_FILE" ]]; then
+  [[ -r "$BODY_FILE" ]] || { echo "post-turn: cannot read --file '$BODY_FILE'" >&2; exit 2; }
+  cat -- "$BODY_FILE" > "$PART"
+else
+  cat > "$PART"
+fi
+
+# A turn with no body is a bug in the caller, not something to deliver silently.
+if [[ ! -s "$PART" ]]; then
+  rm -f "$PART"
+  echo "post-turn: refusing to queue an EMPTY turn (channel=$CHANNEL owner=$OWNER)" >&2
+  exit 3
+fi
+
+mv -- "$PART" "$FINAL"
+echo "post-turn: queued $FINAL ($(wc -c < "$FINAL" | tr -d ' ') bytes)"


### PR DESCRIPTION
Unblocks the **mini launch recipe** (COORD-108/118/121), which was gated on one unanswered question: how a remote owner posts to the md-channel file, which exists only on the laptop.

## The question had a wrong default answer

COORD offered *"rsync both ways / `ssh laptop 'cat >> …'` — pick what survives the laptop sleeping."* **Measured from both minis at 00:04 CT:**

```
mini   → ssh 192.168.1.205 : Connection refused
mini-2 → ssh 192.168.1.205 : Connection refused
```

The laptop does not accept ssh — Remote Login is off, and turning it on needs admin. So a remote owner **cannot push**. The direction that works is also the one that survives the laptop sleeping: **the mini queues, the laptop pulls.** Turns accumulate in the mini's outbox while the laptop is asleep and land on the next drain — no lost turn, no admin change, no rsync conflict on a file two hosts both append to.

| | |
|---|---|
| `post-turn.sh` | runs on the owner host. Writes `<name>.part`, then **renames** to `<name>.md`. The drainer reads `*.md` only, so it can never pick up a half-written turn. |
| `drain-remote-turns.sh` | runs on the laptop. Appends to the channel **first**, marks the turn sent **second**. |

Delivery is **at-least-once, deliberately**: a crash between append and ack re-delivers a visible duplicate rather than silently dropping an owner's turn. When the ack fails the drain says so loudly, naming the duplicate the next pass will produce. One appender at a time (lock) — two concurrent drains would interleave turns mid-line.

## Proven against the real mini, before the test was written

- a turn queued on mini → drained onto a scratch channel on the laptop → moved to `sent/`
- second drain: "nothing queued", channel line count **unchanged at 8**
- ⛔ a `.part` sitting in the same directory throughout was **never delivered**
- empty turn refused (`rc 3`); traversing `--channel` refused (`rc 2`); a normal turn **after** both refusals still queued — so the refusals are not a blanket failure

## Hermetic test (13 checks)

`scripts/comms/__tests__/remote-turns.test.sh` injects a fake `ssh` via `$CATALYST_SSH`. Covers delivery, idempotence, the `.part` skip **with a positive control beside it**, the at-least-once ack failure, the three refusals, and an unreachable host not aborting the other hosts' turns.

**Mutations run**, each producing exactly the targeted failure and no other:

| mutation | failure |
|---|---|
| drainer globs `*` instead of `*.md` | `FAIL: a .part was delivered` |
| ack moved **before** the append | `FAIL: the turn still reached the channel` |

Restoring each returns the suite to **13 pass / 0 fail**.

## Note for the merge train

This PR and #3516 both add steps to `execution-core-tests.yml`, in different regions. They are green independently; whichever lands second should be rebased before merge rather than trusted to auto-merge.

Refs COORD-108, COORD-118, COORD-121. The full recipe is posted on the channel and on CTL-1908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)