### PR TITLE
feat(dev): CTL-1929 — the sweep, the suppression set, and a parity ledger that can return INCONCLUSIVE

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -935,6 +935,8 @@ jobs:
             linear-feed-parity.test.mjs \
             github-feed-source.test.mjs \
             github-feed-event.test.mjs \
+            github-feed-sweep.test.mjs \
+            github-feed-parity.test.mjs \
             cloud-feed-gate.test.mjs \
             cloud-feed-capture.test.mjs \
             cloud-feed-timer.test.mjs \

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -33,6 +33,20 @@
 //    instrument that changes shape at the moment of cutover cannot judge the
 //    cutover. The improvement is filed separately, to land after.
 //
+// ── ⚠️ ONLY IMMUTABLE-AFTER-THE-EDGE FIELDS REPLAY FAITHFULLY ──────────────
+// The row's mutable columns hold the value NOW; the webhook held the value AT the
+// moment of the edge. Measured against 3 h of real traffic (151 events joined on a
+// stable key, 150 agreeing on every compared field), the single divergence was
+// exactly this: one `pr.opened` carried `draft: false` from the replica where smee
+// had said `draft: true` — a PR opened as a draft and later marked ready.
+//
+// `draft` and `mergeable` are therefore NOT faithfully replayable, and no field with
+// that property should be added here without the same note. They are kept rather
+// than dropped because removing them would itself be a payload-shape divergence, and
+// because nothing reads them: `router.mjs` has no `pr.opened` branch at all, and
+// `summarizeEvent`'s PAYLOAD_EXCERPT_KEYS are state/stateType/conclusion/title/
+// merged/action. Everything else this file emits is written once and never moves.
+//
 // ── ⚠️ THE ONE VALUE THAT NEEDS NORMALISING ────────────────────────────────
 // `reviews.state` is stored UPPERCASE (`COMMENTED`), the webhook emits GitHub's
 // REST lowercase (`commented`), and the consumer compares with `===` against

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -137,12 +137,25 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
   if (feed.length === 0) inconclusive.push("feed-side-empty");
   if (smee.length === 0) inconclusive.push("smee-side-empty");
 
+  // ⛔ MULTIPLICITY, NOT PRESENCE — a single-value map is a false-clean generator.
+  // Some join keys are deliberately COARSE (a review keys on repo/pr/reviewer/state
+  // because `review_id` is not on the webhook side), so repeats under one key are
+  // expected, not pathological. With a `Map<key, event>` a second webhook event
+  // OVERWRITES the first and every feed event under that key re-uses the one
+  // surviving twin — so 2 feed vs 1 smee, and 1 feed vs 2 smee, both report agreement.
+  // That is the ledger licensing a cutover across dropped or duplicated dispatches,
+  // which is the single worst thing this file could do. `linear-feed-parity.mjs`
+  // already compares by multiplicity for exactly this reason; that lesson is carried
+  // here rather than re-learned.
   const index = new Map();
   for (const e of smee) {
     const n = nameOf(e);
     const spec = COMPARE_SPEC[n];
     if (!spec) continue;
-    index.set(`${n}|${spec.key(e)}`, e);
+    const k = `${n}|${spec.key(e)}`;
+    const bucket = index.get(k);
+    if (bucket) bucket.push(e);
+    else index.set(k, [e]);
   }
 
   const byName = {};
@@ -155,11 +168,14 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
       continue;
     }
     const row = (byName[n] ??= { joined: 0, unjoined: 0, agree: 0, diffs: {}, observedOnly: {} });
-    const twin = index.get(`${n}|${spec.key(e)}`);
+    const bucket = index.get(`${n}|${spec.key(e)}`);
+    // CONSUMED, so one twin can serve exactly one feed event.
+    const twin = bucket && bucket.length > 0 ? bucket.shift() : null;
     if (!twin) {
-      // NOT a divergence: the two windows have different edges, so a feed event whose
-      // twin fell outside the sample is unjoinable, not disagreeing. Counted, never
-      // folded into `agree`.
+      // Ambiguous rather than disagreeing: it may be a window-skew artefact, or it may
+      // be a spurious dispatch. ⛔ It is NOT evidence of parity either way, so it
+      // forces INCONCLUSIVE below — never a silent pass. It is counted here and
+      // deliberately never folded into `agree`.
       row.unjoined += 1;
       continue;
     }
@@ -197,18 +213,32 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
     Object.entries(absent).filter(([n]) => !(n in KNOWN_ABSENT) && n in COMPARE_SPEC),
   );
 
+  // Twins nobody consumed: a webhook event the feed produced no counterpart for.
+  // Symmetric to `unjoined` and equally not-evidence — an unconsumed twin is either
+  // window skew or a MISSING dispatch, and a ledger that ignores it certifies a feed
+  // that silently drops events.
+  let smeeUnjoined = 0;
+  for (const bucket of index.values()) smeeUnjoined += bucket.length;
+
   const totals = Object.values(byName).reduce(
     (a, r) => ({ joined: a.joined + r.joined, agree: a.agree + r.agree, unjoined: a.unjoined + r.unjoined }),
     { joined: 0, agree: 0, unjoined: 0 },
   );
+  totals.smeeUnjoined = smeeUnjoined;
   if (totals.joined === 0) inconclusive.push("no-events-joined");
   if (unkeyable > 0) inconclusive.push(`feed-unkeyable-events:${unkeyable}`);
+  // ⛔ Both directions force INCONCLUSIVE. `[1,2]` vs `[1]` used to return clean:true
+  // because the predicate only looked at `joined - agree`; the extra event may be a
+  // duplicate or a spurious dispatch, and "I cannot tell" is not "they match".
+  if (totals.unjoined > 0) inconclusive.push(`feed-events-without-a-twin:${totals.unjoined}`);
+  if (smeeUnjoined > 0) inconclusive.push(`smee-events-without-a-twin:${smeeUnjoined}`);
 
   const diverged = totals.joined - totals.agree;
   return {
     totals,
     byName,
     unkeyable,
+    smeeUnjoined,
     expectedAbsent: Object.fromEntries(Object.entries(absent).filter(([n]) => n in KNOWN_ABSENT)),
     unexplainedAbsent,
     inconclusive,

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -1,0 +1,230 @@
+// github-feed-parity.mjs — CTL-1929 ask (3). The field-level ledger that decides
+// whether the GitHub feed may replace the smee tunnel.
+//
+// Twin of `linear-feed-parity.mjs`, and it exists as a SHIPPED MODULE rather than a
+// session scratch script for the reason CTL-1916 was filed: the verification tool
+// kept being re-derived, so no two cutover decisions were made on the same
+// instrument. The record this produced on 2026-08-18 (151 events joined, 150
+// agreeing on every compared field) is reproducible by running it again.
+//
+// ── ⛔ COUNTS ARE NOT PARITY ────────────────────────────────────────────────
+// Two streams can agree exactly on volume and disagree on every value. The join is
+// therefore on a STABLE PER-NAME KEY and the comparison is FIELD BY FIELD, over the
+// fields `broker/router.mjs` actually destructures — not over the whole envelope.
+// Comparing whole envelopes would report a permanent, meaningless diff: the feed
+// copy legitimately differs in `id`, `ts`, `traceId`, `event.channel`, and the
+// `body.payload.source` stamp that is the entire point of being distinguishable.
+// Those are listed in EXPECTED_DIVERGENCES so they are excluded BY NAME, and a field
+// that starts diverging cannot hide inside a blanket exclusion.
+//
+// ── ⚠️ AND EQUAL FIELDS ARE NOT NECESSARILY A FAITHFUL REPLAY ──────────────
+// The replica's mutable columns hold the value NOW, not the value at the edge, so a
+// field can agree today and diverge whenever the row is later updated. `draft` and
+// `mergeable` are exactly that; the ledger records them as OBSERVED-ONLY so a clean
+// run cannot be read as a guarantee about them.
+//
+// ── THE VERDICT IS THREE-VALUED ────────────────────────────────────────────
+// clean / diverged / INCONCLUSIVE. A window in which one side is empty, or in which
+// a name produced nothing on either side, is INCONCLUSIVE — never clean. `[].every()`
+// is `true`, and a ledger that reports agreement because it compared nothing is the
+// exact false-clean this repo keeps re-learning.
+
+/** Fields that MUST differ between the two producers. Excluded by name, never by prefix. */
+export const EXPECTED_DIVERGENCES = Object.freeze([
+  "id", "ts", "observedTs", "traceId", "spanId",
+  "attributes.event.channel",
+  "attributes.webhook.delivery.id",
+  "body.payload.source",
+  "body.payload.feedAuthority",
+]);
+
+/**
+ * Fields whose equality is OBSERVED but NOT GUARANTEED, because the replica stores
+ * current state rather than the value at the edge. Reported separately so a clean
+ * ledger cannot be read as a claim about them.
+ */
+export const OBSERVED_ONLY_FIELDS = Object.freeze([
+  "body.payload.draft",
+  "body.payload.mergeable",
+]);
+
+/**
+ * The join key per name, and the fields compared for it.
+ *
+ * A name absent from this table is not compared and is counted as `unkeyable` — it
+ * is never silently treated as agreeing.
+ */
+const COMPARE_SPEC_DRAFT = {
+  "github.pr.opened": {
+    key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class"],
+    payload: ["action", "merged", "mergedAt", "draft", "mergeable"],
+  },
+  "github.pr.closed": {
+    key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class"],
+    payload: ["action", "merged", "draft"],
+  },
+  "github.pr_review.submitted": {
+    // `reviews.review_id` is not on the webhook side, so the key is the tuple the
+    // consumer itself keys on plus the reviewer — coarser, and honest about it.
+    key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}|${e.body?.payload?.reviewer}|${e.body?.payload?.state}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action"],
+    payload: ["state", "reviewer", "author"],
+  },
+  "github.pr_review_comment.created": {
+    key: (e) => `c:${e.body?.payload?.commentId}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class"],
+    payload: ["commentId", "body", "htmlUrl", "author"],
+  },
+  "github.pr_review_thread.resolved": {
+    key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action"],
+    payload: ["threadId"],
+  },
+  "github.deployment.created": {
+    key: (e) => `d:${e.body?.payload?.deploymentId}`,
+    attrs: ["vcs.repository.name", "vcs.revision", "vcs.ref.name", "deployment.environment", "deployment.id", "event.label"],
+    payload: ["deploymentId"],
+  },
+  "github.push": {
+    key: (e) => `p:${e.attributes?.["vcs.repository.name"]}|${e.attributes?.["vcs.ref.name"]}|${e.body?.payload?.headSha}`,
+    attrs: ["vcs.repository.name", "vcs.ref.name", "vcs.revision", "event.entity", "event.action", "event.label"],
+    payload: ["baseSha", "headSha"],
+  },
+};
+
+// `deployment_status` is one name per state, so the rows are generated rather than
+// typed out — and the object is frozen only AFTER they are added. Freezing the
+// literal first would silently drop them in a sloppy runtime and throw in a strict
+// one; both are worse than never comparing the name at all, which is what a missing
+// spec quietly does.
+for (const state of ["success", "failure", "error", "in_progress", "pending", "queued", "inactive"]) {
+  COMPARE_SPEC_DRAFT[`github.deployment_status.${state}`] = {
+    key: (e) => `ds:${e.body?.payload?.deploymentId}|${e.body?.payload?.state}`,
+    attrs: ["vcs.repository.name", "deployment.environment", "deployment.id", "event.entity", "event.action"],
+    payload: ["deploymentId", "state", "targetUrl", "environmentUrl"],
+  };
+}
+
+/** The join key per name, and the fields compared for it. Frozen once complete. */
+export const COMPARE_SPEC = Object.freeze(COMPARE_SPEC_DRAFT);
+
+/**
+ * Names the orchestrator consumes that the producer cannot emit yet. Their absence
+ * from the feed side is EXPECTED and is reported as such — not as a divergence, and
+ * not silently ignored either.
+ */
+export const KNOWN_ABSENT = Object.freeze({
+  "github.pr.merged": "CTC-691: pull_requests has no merge_commit_sha",
+  "github.check_suite.completed": "CTC-667 item 4: the mirror stores no suite row",
+});
+
+const nameOf = (e) => e?.attributes?.["event.name"];
+const eq = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+
+/**
+ * Compare a feed stream against a webhook stream.
+ *
+ * Both arrays are the events already filtered to one window by the caller — the
+ * windowing is deliberately not done here so the comparator stays pure and testable.
+ */
+export function compareGithubStreams(feedEvents, smeeEvents) {
+  const feed = Array.isArray(feedEvents) ? feedEvents : [];
+  const smee = Array.isArray(smeeEvents) ? smeeEvents : [];
+
+  const inconclusive = [];
+  if (feed.length === 0) inconclusive.push("feed-side-empty");
+  if (smee.length === 0) inconclusive.push("smee-side-empty");
+
+  const index = new Map();
+  for (const e of smee) {
+    const n = nameOf(e);
+    const spec = COMPARE_SPEC[n];
+    if (!spec) continue;
+    index.set(`${n}|${spec.key(e)}`, e);
+  }
+
+  const byName = {};
+  let unkeyable = 0;
+  for (const e of feed) {
+    const n = nameOf(e);
+    const spec = COMPARE_SPEC[n];
+    if (!spec) {
+      unkeyable += 1;
+      continue;
+    }
+    const row = (byName[n] ??= { joined: 0, unjoined: 0, agree: 0, diffs: {}, observedOnly: {} });
+    const twin = index.get(`${n}|${spec.key(e)}`);
+    if (!twin) {
+      // NOT a divergence: the two windows have different edges, so a feed event whose
+      // twin fell outside the sample is unjoinable, not disagreeing. Counted, never
+      // folded into `agree`.
+      row.unjoined += 1;
+      continue;
+    }
+    row.joined += 1;
+    let ok = true;
+    for (const f of spec.attrs) {
+      if (eq(e.attributes?.[f], twin.attributes?.[f])) continue;
+      ok = false;
+      (row.diffs[`attributes.${f}`] ??= []).push({ feed: e.attributes?.[f], smee: twin.attributes?.[f] });
+    }
+    for (const f of spec.payload) {
+      if (eq(e.body?.payload?.[f], twin.body?.payload?.[f])) continue;
+      const path = `body.payload.${f}`;
+      if (OBSERVED_ONLY_FIELDS.includes(path)) {
+        // Divergence here is EXPECTED whenever the row was mutated after its edge.
+        // Recorded, and deliberately not counted against cleanliness.
+        (row.observedOnly[path] ??= []).push({ feed: e.body?.payload?.[f], smee: twin.body?.payload?.[f] });
+        continue;
+      }
+      ok = false;
+      (row.diffs[path] ??= []).push({ feed: e.body?.payload?.[f], smee: twin.body?.payload?.[f] });
+    }
+    if (ok) row.agree += 1;
+  }
+
+  // A name present on the smee side and wholly absent from the feed side is either a
+  // declared gap or a real hole — and the two must never look alike.
+  const absent = {};
+  for (const e of smee) {
+    const n = nameOf(e);
+    if (byName[n]) continue;
+    absent[n] = (absent[n] ?? 0) + 1;
+  }
+  const unexplainedAbsent = Object.fromEntries(
+    Object.entries(absent).filter(([n]) => !(n in KNOWN_ABSENT) && n in COMPARE_SPEC),
+  );
+
+  const totals = Object.values(byName).reduce(
+    (a, r) => ({ joined: a.joined + r.joined, agree: a.agree + r.agree, unjoined: a.unjoined + r.unjoined }),
+    { joined: 0, agree: 0, unjoined: 0 },
+  );
+  if (totals.joined === 0) inconclusive.push("no-events-joined");
+  if (unkeyable > 0) inconclusive.push(`feed-unkeyable-events:${unkeyable}`);
+
+  const diverged = totals.joined - totals.agree;
+  return {
+    totals,
+    byName,
+    unkeyable,
+    expectedAbsent: Object.fromEntries(Object.entries(absent).filter(([n]) => n in KNOWN_ABSENT)),
+    unexplainedAbsent,
+    inconclusive,
+    // ⛔ Clean requires POSITIVE evidence: something was actually joined, nothing was
+    // inconclusive, nothing diverged, and no consumed name went silently missing.
+    clean:
+      inconclusive.length === 0 &&
+      totals.joined > 0 &&
+      diverged === 0 &&
+      Object.keys(unexplainedAbsent).length === 0,
+  };
+}
+
+/** 0 clean · 2 diverged · 3 inconclusive. Same contract as the Linear leg's runner. */
+export function parityExitCode(report) {
+  if (!report) return 3;
+  if (report.inconclusive.length > 0) return 3;
+  return report.clean ? 0 : 2;
+}

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -28,7 +28,7 @@ const comment = (id, over = {}) =>
 describe("a clean ledger has to be earned", () => {
   test("identical streams are clean", () => {
     const r = compareGithubStreams([comment(1), comment(2)], [comment(1), comment(2)]);
-    expect(r.totals).toEqual({ joined: 2, agree: 2, unjoined: 0 });
+    expect(r.totals).toEqual({ joined: 2, agree: 2, unjoined: 0, smeeUnjoined: 0 });
     expect(r.clean).toBe(true);
     expect(parityExitCode(r)).toBe(0);
   });
@@ -62,6 +62,59 @@ describe("a clean ledger has to be earned", () => {
     const r = compareGithubStreams([comment(1), comment(2)], [comment(1)]);
     expect(r.byName["github.pr_review_comment.created"].unjoined).toBe(1);
     expect(r.totals.agree).toBe(1);
+  });
+});
+
+describe("⛔ P1 (Codex #3520): the ledger must compare MULTIPLICITY, not presence", () => {
+  // Codex built exactly these two controls and both returned clean:true before the
+  // fix — the ledger certifying parity across a dropped or duplicated dispatch.
+  test("2 feed vs 1 smee under one key is NOT clean", () => {
+    const r = compareGithubStreams([comment(1), comment(1)], [comment(1)]);
+    expect(r.clean).toBe(false);
+    expect(r.totals.unjoined).toBe(1);
+    expect(parityExitCode(r)).toBe(3);
+  });
+
+  test("1 feed vs 2 smee under one key is NOT clean", () => {
+    const r = compareGithubStreams([comment(1)], [comment(1), comment(1)]);
+    expect(r.clean).toBe(false);
+    expect(r.smeeUnjoined).toBe(1);
+    expect(r.inconclusive).toContain("smee-events-without-a-twin:1");
+  });
+
+  test("a twin is CONSUMED — it cannot serve two feed events", () => {
+    const r = compareGithubStreams([comment(1), comment(1), comment(1)], [comment(1), comment(1)]);
+    expect(r.totals.joined).toBe(2);
+    expect(r.totals.unjoined).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("balanced repeats under one key ARE clean — the fix must not forbid legitimate duplicates", () => {
+    // The positive control. Coarse keys (review keys on repo/pr/reviewer/state) make
+    // repeats expected, so a rule that called all repetition dirty would be useless.
+    const r = compareGithubStreams([comment(1), comment(1)], [comment(1), comment(1)]);
+    expect(r.totals).toEqual({ joined: 2, agree: 2, unjoined: 0, smeeUnjoined: 0 });
+    expect(r.clean).toBe(true);
+  });
+});
+
+describe("⛔ P1 (Codex #3520): an unmatched event cannot certify parity", () => {
+  test("feed [1,2] vs smee [1] is INCONCLUSIVE, not clean", () => {
+    // Before the fix this returned clean:true — one pair joined and agreed, and the
+    // predicate only looked at `joined - agree`. The extra event may be a duplicate
+    // or a spurious dispatch; either way it is not evidence of parity.
+    const r = compareGithubStreams([comment(1), comment(2)], [comment(1)]);
+    expect(r.totals.joined).toBe(1);
+    expect(r.totals.agree).toBe(1);
+    expect(r.clean).toBe(false);
+    expect(r.inconclusive).toContain("feed-events-without-a-twin:1");
+    expect(parityExitCode(r)).toBe(3);
+  });
+
+  test("smee [1,2] vs feed [1] is INCONCLUSIVE too — the rule is symmetric", () => {
+    const r = compareGithubStreams([comment(1)], [comment(1), comment(2)]);
+    expect(r.clean).toBe(false);
+    expect(r.inconclusive).toContain("smee-events-without-a-twin:1");
   });
 });
 
@@ -135,7 +188,12 @@ describe("⛔ a consumed name that vanishes must not read as agreement", () => {
     const r = compareGithubStreams([comment(1)], [comment(1), push]);
     expect(r.unexplainedAbsent["github.push"]).toBe(1);
     expect(r.clean).toBe(false);
-    expect(parityExitCode(r)).toBe(2);
+    // ⚠️ INCONCLUSIVE (3), not diverged (2). The push has no twin on the feed side,
+    // and from the ledger alone a missing name is indistinguishable from window skew.
+    // Both are non-clean and both refuse a cutover; "I cannot tell" is the honest
+    // label, and `unexplainedAbsent` still names the specific hole to investigate.
+    expect(parityExitCode(r)).toBe(3);
+    expect(r.inconclusive).toContain("smee-events-without-a-twin:1");
   });
 
   test("both declared gaps name the ticket that closes them", () => {

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -1,0 +1,167 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-parity.test.mjs
+//
+// Most of these test the ways a ledger LIES — an empty side, nothing joined, a name
+// that vanished. A parity harness that can only report agreement is the instrument
+// failure this repo has shipped before, so every "clean" here has to be earned.
+
+import { describe, expect, test } from "bun:test";
+import {
+  COMPARE_SPEC,
+  KNOWN_ABSENT,
+  OBSERVED_ONLY_FIELDS,
+  compareGithubStreams,
+  parityExitCode,
+} from "./github-feed-parity.mjs";
+
+const ev = (name, attrs, payload, extra = {}) => ({
+  ts: "2026-08-18T00:00:00Z", id: "x", attributes: { "event.name": name, ...attrs },
+  body: { message: name, payload }, ...extra,
+});
+
+const comment = (id, over = {}) =>
+  ev("github.pr_review_comment.created",
+    { "vcs.repository.name": "o/r", "vcs.pr.number": 7, "event.entity": "pr_review_comment",
+      "event.action": "created", "event.label": "PR #7", "event.stream_class": "coordination" },
+    { commentId: id, body: "b", htmlUrl: `https://github.com/o/r/pull/7#discussion_r${id}`,
+      author: { login: "alice", type: "User" }, ...over });
+
+describe("a clean ledger has to be earned", () => {
+  test("identical streams are clean", () => {
+    const r = compareGithubStreams([comment(1), comment(2)], [comment(1), comment(2)]);
+    expect(r.totals).toEqual({ joined: 2, agree: 2, unjoined: 0 });
+    expect(r.clean).toBe(true);
+    expect(parityExitCode(r)).toBe(0);
+  });
+
+  test("⛔ an empty feed side is INCONCLUSIVE, never clean", () => {
+    // [].every() is true. A ledger that reports agreement because it compared
+    // nothing is the exact false-clean this module exists to refuse.
+    const r = compareGithubStreams([], [comment(1)]);
+    expect(r.clean).toBe(false);
+    expect(r.inconclusive).toContain("feed-side-empty");
+    expect(parityExitCode(r)).toBe(3);
+  });
+
+  test("⛔ an empty smee side is INCONCLUSIVE, never clean", () => {
+    const r = compareGithubStreams([comment(1)], []);
+    expect(r.clean).toBe(false);
+    expect(r.inconclusive).toContain("smee-side-empty");
+    expect(parityExitCode(r)).toBe(3);
+  });
+
+  test("⛔ two non-empty streams that share no key are INCONCLUSIVE, not clean", () => {
+    // Nothing was actually compared. Reporting 0 divergences here would be a lie.
+    const r = compareGithubStreams([comment(1)], [comment(999)]);
+    expect(r.totals.joined).toBe(0);
+    expect(r.inconclusive).toContain("no-events-joined");
+    expect(r.clean).toBe(false);
+    expect(parityExitCode(r)).toBe(3);
+  });
+
+  test("an unjoined feed event is counted, never folded into agreement", () => {
+    const r = compareGithubStreams([comment(1), comment(2)], [comment(1)]);
+    expect(r.byName["github.pr_review_comment.created"].unjoined).toBe(1);
+    expect(r.totals.agree).toBe(1);
+  });
+});
+
+describe("field-level divergence", () => {
+  test("a payload diff is caught and NAMED with both values", () => {
+    const r = compareGithubStreams([comment(1, { body: "changed" })], [comment(1)]);
+    expect(r.clean).toBe(false);
+    const d = r.byName["github.pr_review_comment.created"].diffs["body.payload.body"];
+    expect(d[0]).toEqual({ feed: "changed", smee: "b" });
+    expect(parityExitCode(r)).toBe(2);
+  });
+
+  test("an attribute diff is caught", () => {
+    const bad = comment(1); bad.attributes["vcs.pr.number"] = 9;
+    const r = compareGithubStreams([bad], [comment(1)]);
+    expect(r.clean).toBe(false);
+    expect(r.byName["github.pr_review_comment.created"].diffs["attributes.vcs.pr.number"]).toBeDefined();
+  });
+
+  test("⭐ the fields that MUST differ do not count as divergence", () => {
+    // Otherwise the ledger reports a permanent diff on every run and stops meaning
+    // anything — the two producers legitimately differ in id/ts/channel/source.
+    const f = comment(1); f.id = "feed-id"; f.ts = "2026-08-18T09:99:99Z";
+    f.attributes["event.channel"] = "cloud-feed"; f.body.payload.source = "cloud-feed";
+    const s = comment(1); s.id = "smee-id"; s.attributes["event.channel"] = "webhook";
+    s.attributes["webhook.delivery.id"] = "abc";
+    expect(compareGithubStreams([f], [s]).clean).toBe(true);
+  });
+});
+
+describe("⚠️ observed-only fields: equal today, not guaranteed", () => {
+  const pr = (draft) => ev("github.pr.opened",
+    { "vcs.repository.name": "o/r", "vcs.pr.number": 7, "event.entity": "pr", "event.action": "opened",
+      "event.label": "PR #7", "event.stream_class": "coordination" },
+    { action: "opened", merged: false, mergedAt: null, draft, mergeable: null });
+
+  test("a draft divergence is REPORTED but does not break clean", () => {
+    // The replica holds current state; the webhook held the value at the edge. This
+    // is the one real diff the live 3h ledger found, and it is inherent.
+    const r = compareGithubStreams([pr(false)], [pr(true)]);
+    expect(r.clean).toBe(true);
+    expect(r.byName["github.pr.opened"].observedOnly["body.payload.draft"][0])
+      .toEqual({ feed: false, smee: true });
+  });
+
+  test("the observed-only list is explicit, so nothing hides inside a prefix rule", () => {
+    expect(OBSERVED_ONLY_FIELDS).toEqual(["body.payload.draft", "body.payload.mergeable"]);
+  });
+});
+
+describe("⛔ a consumed name that vanishes must not read as agreement", () => {
+  const merged = ev("github.pr.merged",
+    { "vcs.repository.name": "o/r", "vcs.pr.number": 7 },
+    { action: "closed", merged: true, mergeCommitSha: "abc" });
+  const suite = ev("github.check_suite.completed",
+    { "vcs.repository.name": "o/r", "vcs.revision": "abc" },
+    { conclusion: "success", status: "completed", prNumbers: [7] });
+
+  test("a DECLARED gap is reported as expected and stays clean", () => {
+    const r = compareGithubStreams([comment(1)], [comment(1), merged, suite]);
+    expect(r.expectedAbsent["github.pr.merged"]).toBe(1);
+    expect(r.unexplainedAbsent).toEqual({});
+    expect(r.clean).toBe(true);
+  });
+
+  test("an UNDECLARED absence breaks clean", () => {
+    // A name smee delivers, that we claim to produce, and produced none of.
+    const push = ev("github.push",
+      { "vcs.repository.name": "o/r", "vcs.ref.name": "refs/heads/main", "vcs.revision": "a1" },
+      { baseSha: "b", headSha: "a1", commits: [] });
+    const r = compareGithubStreams([comment(1)], [comment(1), push]);
+    expect(r.unexplainedAbsent["github.push"]).toBe(1);
+    expect(r.clean).toBe(false);
+    expect(parityExitCode(r)).toBe(2);
+  });
+
+  test("both declared gaps name the ticket that closes them", () => {
+    expect(KNOWN_ABSENT["github.pr.merged"]).toContain("CTC-691");
+    expect(KNOWN_ABSENT["github.check_suite.completed"]).toContain("CTC-667");
+  });
+});
+
+describe("coverage of the spec itself", () => {
+  test("every name the producer emits has a compare spec", async () => {
+    // A name with no spec is counted `unkeyable` and would otherwise quietly never
+    // be compared at all.
+    const { GITHUB_DISPATCH_CLASS_NAMES } = await import("./github-feed-event.mjs");
+    const missing = GITHUB_DISPATCH_CLASS_NAMES.filter((n) => !(n in COMPARE_SPEC));
+    expect(missing).toEqual([]);
+  });
+
+  test("an unspecced name is counted unkeyable and forces INCONCLUSIVE", () => {
+    const weird = ev("github.workflow_run.completed", { "vcs.repository.name": "o/r" }, {});
+    const r = compareGithubStreams([comment(1), weird], [comment(1)]);
+    expect(r.unkeyable).toBe(1);
+    expect(r.inconclusive).toContain("feed-unkeyable-events:1");
+    expect(r.clean).toBe(false);
+  });
+
+  test("a null report is inconclusive, not clean", () => {
+    expect(parityExitCode(null)).toBe(3);
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-seen.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-seen.mjs
@@ -1,0 +1,132 @@
+// github-feed-seen.mjs — CTL-1929. The durable suppression set that makes the
+// emit/cursor split safe.
+//
+// ── WHY THIS EXISTS AT ALL ─────────────────────────────────────────────────
+// `github-feed-source.mjs` emits every row past the cursor immediately but only
+// ADVANCES the cursor to `now - settleMs`, so a row arriving late with an older
+// stamp is still ahead of the cursor and gets re-read. That is what makes a late
+// arrival a duplicate instead of a permanent loss — 37% of rows arrive more than
+// 60 s after their own event time on this fleet, tail 333 s.
+//
+// ⛔ The broker will NOT absorb those duplicates for us. It dedups on the envelope's
+// `id`, which is a fresh UUID per emission (`canonical-event.mjs`), so two emissions
+// of one edge are two different ids and BOTH route and BOTH wake. The Linear leg
+// never needed this: it keys emission on `issue_history.id`, a PRIMARY KEY of an
+// append-only log, so an overlapping sweep is a no-op by construction. Our tables
+// have no log to key on, so the same guarantee has to be stored.
+//
+// ── ⭐ WHY IT IS BOUNDED BY CONSTRUCTION, NOT BY A POLICY ───────────────────
+// A suppression set that grows forever is a liability, and one trimmed by an
+// arbitrary "keep the last N" is worse — it evicts on volume, so a busy hour
+// silently re-opens the duplicates it exists to stop.
+//
+// This one has an exact, provable retention bound: **a row is re-readable only
+// while it is at or after the cursor.** Once the cursor passes a key, the source's
+// keyset can never return that row again, so its entry can never be consulted.
+// Pruning at the cursor's own position is therefore lossless BY DEFINITION, and the
+// set's size is bounded by the number of edges inside one settle window rather than
+// by uptime or traffic. `pruneBefore(cursorTs)` is the whole retention policy.
+//
+// ⚠️ Prune AFTER the cursor is durably written, never before. Pruning first and then
+// failing to persist the cursor would leave a window that is both re-readable and
+// unsuppressed — the one ordering that produces the duplicate storm this module is
+// here to prevent.
+
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export function defaultSeenPath(orchDir, account = "tenant-0") {
+  return join(orchDir, `github-feed-seen-${account}.db`);
+}
+
+/**
+ * Open (creating if needed) the suppression set.
+ *
+ * Unlike the read source this handle is READ-WRITE, and it is a separate database
+ * from the replica on purpose: the replica is owned by the cloud-sync writer and
+ * this producer must never hold a write handle on it.
+ */
+export function createSeenStore({ path } = {}) {
+  if (typeof path !== "string" || path === "") {
+    throw new Error("createSeenStore: path is required");
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const db = new Database(path);
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA busy_timeout = 250");
+  db.run("CREATE TABLE IF NOT EXISTS seen (edge_id TEXT PRIMARY KEY, ts INTEGER NOT NULL)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_seen_ts ON seen (ts)");
+  // `meta` carries the durable "this producer has run before" flag. It is deliberately
+  // independent of the cursor file, so losing the cursor cannot ALSO lose the knowledge
+  // that we had one — that distinction is what stops a lost cursor from cold-starting
+  // at `now` and silently skipping everything since the last good position.
+  db.run("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+
+  const qHas = db.query("SELECT 1 FROM seen WHERE edge_id = $id LIMIT 1");
+  const qAdd = db.query("INSERT OR IGNORE INTO seen (edge_id, ts) VALUES ($id, $ts)");
+  const qPrune = db.query("DELETE FROM seen WHERE ts < $before");
+  const qCount = db.query("SELECT count(*) AS n FROM seen");
+  const qGetMeta = db.query("SELECT value FROM meta WHERE key = $k");
+  const qSetMeta = db.query("INSERT INTO meta (key, value) VALUES ($k, $v) ON CONFLICT(key) DO UPDATE SET value = $v");
+
+  return {
+    /** Has this edge already been emitted? */
+    has: (edgeId) => typeof edgeId === "string" && edgeId !== "" && qHas.get({ $id: edgeId }) !== null,
+
+    /**
+     * Record an emitted edge. `INSERT OR IGNORE` so a re-record is a no-op and the
+     * ORIGINAL emission timestamp is kept — refreshing it on every re-read would
+     * push the entry forward and defeat the cursor-based prune.
+     */
+    add(edgeId, ts) {
+      if (typeof edgeId !== "string" || edgeId === "") return false;
+      qAdd.run({ $id: edgeId, $ts: Number.isInteger(ts) ? ts : 0 });
+      return true;
+    },
+
+    /**
+     * Drop entries the source can no longer return. Pass the DURABLE cursor position,
+     * after it has been written — see the header for why the order matters.
+     *
+     * ⚠️ Strictly `<`, never `<=`. A row sharing the cursor's exact millisecond but
+     * carrying a HIGHER id is still re-readable — the keyset's tie-break is
+     * `ts = since AND id > sinceId` — and a timestamp-only prune cannot distinguish
+     * it from one already passed. Keeping both is the conservative direction; the
+     * alternative silently drops the suppression entry for a row that can still come
+     * back, which is a duplicate. The residue is bounded by one millisecond's worth
+     * of edges, so the retention argument in the header is unaffected.
+     */
+    pruneBefore(cursorTs) {
+      if (!Number.isInteger(cursorTs)) return 0;
+      return qPrune.run({ $before: cursorTs }).changes ?? 0;
+    },
+
+    size: () => qCount.get().n,
+
+    /**
+     * Durable "this STREAM has emitted before", for `resolveStartPosition`.
+     *
+     * ⛔ Per stream, not per producer, because the cursors are per stream. A single
+     * global flag is wrong in a way that hides the thing it exists to detect: the
+     * first stream to emit would set it, and then every OTHER stream's absent cursor
+     * — on the very same first run — reads as "we HAD a position and lost it" rather
+     * than "first run". Measured on a real replica replay before this was fixed: 8
+     * spurious `cursor-vanished-after-first-run` declines in one cold start. Each one
+     * takes the bounded-lookback reset path and raises a WARN, so a genuine cursor
+     * loss becomes indistinguishable from ordinary startup noise.
+     */
+    everRan: (streamKey) => qGetMeta.get({ $k: `everRan:${streamKey}` })?.value === "1",
+    markRan(streamKey) {
+      qSetMeta.run({ $k: `everRan:${streamKey}`, $v: "1" });
+    },
+
+    close() {
+      try {
+        db.close();
+      } catch {
+        /* already closed */
+      }
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-seen.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-seen.mjs
@@ -55,8 +55,18 @@ export function createSeenStore({ path } = {}) {
   const db = new Database(path);
   db.run("PRAGMA journal_mode = WAL");
   db.run("PRAGMA busy_timeout = 250");
-  db.run("CREATE TABLE IF NOT EXISTS seen (edge_id TEXT PRIMARY KEY, ts INTEGER NOT NULL)");
-  db.run("CREATE INDEX IF NOT EXISTS idx_seen_ts ON seen (ts)");
+  // ⛔ `stream` IS NOT DECORATION — IT SCOPES THE PRUNE.
+  // The table is shared by every stream, but each stream has its OWN durable cursor
+  // and they advance independently (a repo can be quiet on deployments for days
+  // while reviews stream). An unscoped `DELETE WHERE ts < ?` therefore lets a stream
+  // with a NEWER cursor delete the suppression entries of a stream with an OLDER one
+  // — entries that stream can still re-read, so its next sweep re-emits them with
+  // fresh envelope ids and the broker (which dedups on that id) wakes twice.
+  // The trigger does not need anything exotic: one stream's cursor write failing
+  // while the others succeed is enough, and the per-stream catch is designed to let
+  // exactly that happen.
+  db.run("CREATE TABLE IF NOT EXISTS seen (edge_id TEXT PRIMARY KEY, stream TEXT NOT NULL, ts INTEGER NOT NULL)");
+  db.run("CREATE INDEX IF NOT EXISTS idx_seen_stream_ts ON seen (stream, ts)");
   // `meta` carries the durable "this producer has run before" flag. It is deliberately
   // independent of the cursor file, so losing the cursor cannot ALSO lose the knowledge
   // that we had one — that distinction is what stops a lost cursor from cold-starting
@@ -64,8 +74,8 @@ export function createSeenStore({ path } = {}) {
   db.run("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
 
   const qHas = db.query("SELECT 1 FROM seen WHERE edge_id = $id LIMIT 1");
-  const qAdd = db.query("INSERT OR IGNORE INTO seen (edge_id, ts) VALUES ($id, $ts)");
-  const qPrune = db.query("DELETE FROM seen WHERE ts < $before");
+  const qAdd = db.query("INSERT OR IGNORE INTO seen (edge_id, stream, ts) VALUES ($id, $stream, $ts)");
+  const qPrune = db.query("DELETE FROM seen WHERE stream = $stream AND ts < $before");
   const qCount = db.query("SELECT count(*) AS n FROM seen");
   const qGetMeta = db.query("SELECT value FROM meta WHERE key = $k");
   const qSetMeta = db.query("INSERT INTO meta (key, value) VALUES ($k, $v) ON CONFLICT(key) DO UPDATE SET value = $v");
@@ -79,15 +89,21 @@ export function createSeenStore({ path } = {}) {
      * ORIGINAL emission timestamp is kept — refreshing it on every re-read would
      * push the entry forward and defeat the cursor-based prune.
      */
-    add(edgeId, ts) {
+    add(edgeId, ts, streamKey) {
       if (typeof edgeId !== "string" || edgeId === "") return false;
-      qAdd.run({ $id: edgeId, $ts: Number.isInteger(ts) ? ts : 0 });
+      if (typeof streamKey !== "string" || streamKey === "") {
+        // Fail closed: an unscoped row could never be pruned by its own stream and
+        // would be silently eligible for another stream's prune. Refusing is louder.
+        throw new Error("seen.add: streamKey is required (the prune is scoped by it)");
+      }
+      qAdd.run({ $id: edgeId, $stream: streamKey, $ts: Number.isInteger(ts) ? ts : 0 });
       return true;
     },
 
     /**
-     * Drop entries the source can no longer return. Pass the DURABLE cursor position,
-     * after it has been written — see the header for why the order matters.
+     * Drop entries THIS STREAM can no longer return. Pass the stream's own DURABLE
+     * cursor position, after it has been written — see the header for why the order
+     * matters, and the table comment for why the scope does.
      *
      * ⚠️ Strictly `<`, never `<=`. A row sharing the cursor's exact millisecond but
      * carrying a HIGHER id is still re-readable — the keyset's tie-break is
@@ -97,12 +113,18 @@ export function createSeenStore({ path } = {}) {
      * back, which is a duplicate. The residue is bounded by one millisecond's worth
      * of edges, so the retention argument in the header is unaffected.
      */
-    pruneBefore(cursorTs) {
+    pruneBefore(cursorTs, streamKey) {
       if (!Number.isInteger(cursorTs)) return 0;
-      return qPrune.run({ $before: cursorTs }).changes ?? 0;
+      if (typeof streamKey !== "string" || streamKey === "") {
+        throw new Error("seen.pruneBefore: streamKey is required — an unscoped prune deletes other streams' entries");
+      }
+      return qPrune.run({ $stream: streamKey, $before: cursorTs }).changes ?? 0;
     },
 
-    size: () => qCount.get().n,
+    size: (streamKey) =>
+      streamKey === undefined
+        ? qCount.get().n
+        : db.query("SELECT count(*) AS n FROM seen WHERE stream = $s").get({ $s: streamKey }).n,
 
     /**
      * Durable "this STREAM has emitted before", for `resolveStartPosition`.

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
@@ -1,0 +1,278 @@
+// github-feed-sweep.mjs — CTL-1929. One tick of the GitHub feed producer:
+// resume → page → classify → suppress → emit → advance → prune, per stream.
+//
+// ── ⛔ THE GITHUB LEG HAS ITS OWN MODE FLAG. THIS IS A SAFETY PROPERTY. ─────
+// Both minis run `CATALYST_CLOUD_FEED=enforce` today. If this producer were gated
+// on that same value, then merely MERGING its wiring would put the GitHub leg into
+// enforce on every host at once — and enforce means the gate SUPPRESSES smee's copy.
+// The GitHub tunnel is still the only real source for `pr.merged` and
+// `check_suite.completed` (CTC-691 / CTC-667 item 4), so that merge would blind the
+// CI wait and the deploy chain fleet-wide, with no operator action and no rollout.
+//
+// `CATALYST_GITHUB_FEED` is therefore a SEPARATE knob defaulting to `off`, and the
+// two legs are never read from one value. Ship-inert is the requirement, not a
+// preference: a cutover an operator did not choose is not a cutover.
+//
+// ── COUNTS: THE DECLINE / FAILURE SPLIT, AND WHY IT DECIDES READINESS ──────
+// Inherited verbatim from `linear-feed-sweep.mjs`, because readiness is computed
+// from these counts and `cloud-feed-timer.countsClean` reads `failed` + `byFailure`
+// (NOT `byReason`). The rule for choosing between them is one question:
+//
+//     WOULD UN-ARMING THE PRODUCER REPAIR THIS?
+//
+// A malformed row, or an edge we have declared we cannot build (`pr.merged` until
+// CTC-691), is a DECLINE — un-arming repairs nothing and would hand dispatch back to
+// a tunnel we are trying to retire. A condition that makes EVERY row unemittable —
+// an unreadable replica, an unknown stream — is a FAILURE, and readiness un-arms.
+//
+// ⛔ That distinction is exactly what CTL-1909 was filed for: readiness once read
+// `byReason`, so ordinary healthy declines un-armed enforce within two minutes of
+// boot. Declines must not reach `byFailure`.
+//
+// ── ORDERING WITHIN A STREAM ───────────────────────────────────────────────
+// emit → mark seen → write cursor → prune. Each step is safe to repeat and none may
+// be reordered:
+//   * marking seen BEFORE emitting would suppress an edge that never reached the log;
+//   * pruning BEFORE the cursor is durable would leave a window both re-readable and
+//     unsuppressed, which is the duplicate storm the seen-set exists to prevent.
+// A throw anywhere leaves the cursor where it was, so the next tick re-reads and the
+// seen-set makes that re-read a no-op. Losing forward progress is recoverable;
+// advancing past an unemitted row is not.
+
+import {
+  CURSOR_ABSENT,
+  readCursor,
+  resolveStartPosition,
+  writeCursor,
+} from "./linear-feed-cursor.mjs";
+import {
+  DEFAULT_BATCH_LIMIT,
+  DEFAULT_SETTLE_MS,
+  STREAMS,
+  settleCursor,
+} from "./github-feed-source.mjs";
+import { buildGithubEvent, classifyGithubRow, githubEdgeId } from "./github-feed-event.mjs";
+import { countsClean, countsDirtyWhy } from "./cloud-feed-timer.mjs";
+
+/** Pages per stream per tick. Bounds one tick's work; the remainder rides the next. */
+export const DEFAULT_MAX_BATCHES = 20;
+
+/** A zeroed counts record. `byFailure` is PRESENT and empty — see the note below. */
+export function emptyCounts() {
+  return {
+    emitted: 0,
+    suppressed: 0,
+    declined: 0,
+    failed: 0,
+    byReason: {},
+    // ⛔ Must exist even when empty. `cloud-feed-timer.countsClean` treats an ABSENT
+    // `byFailure` as not-clean on purpose: "nothing went wrong" and "I could not
+    // look" must not be byte-identical to the reader.
+    byFailure: {},
+    byStream: {},
+  };
+}
+
+const bump = (m, k) => {
+  m[k] = (m[k] ?? 0) + 1;
+};
+
+/** A row was examined and deliberately not emitted. Healthy; readiness unaffected. */
+export function decline(counts, reason) {
+  counts.declined += 1;
+  bump(counts.byReason, reason || "unclassified");
+}
+
+/** Something happened that un-arming would repair. Readiness un-arms on this. */
+export function fail(counts, reason) {
+  counts.failed += 1;
+  bump(counts.byFailure, reason || "unclassified");
+}
+
+/** Per-stream cursor file. One file per stream, deliberately — see `runGithubSweep`. */
+export function streamCursorPath(orchDir, streamKey, account = "tenant-0") {
+  return `${orchDir}/github-feed-cursor-${account}-${streamKey}.json`;
+}
+
+/**
+ * Sweep ONE stream. Extracted so a stream's failure is contained: a throw here is
+ * caught by the caller and counted against that stream alone, leaving the other
+ * eight to make progress. A single shared try-block would let one malformed table
+ * stall every name.
+ */
+export function sweepStream({
+  source,
+  seen,
+  sink,
+  streamKey,
+  cursorPath,
+  now,
+  settleMs = DEFAULT_SETTLE_MS,
+  batchLimit = DEFAULT_BATCH_LIMIT,
+  maxBatches = DEFAULT_MAX_BATCHES,
+  counts,
+  seams,
+  readCursorFn = readCursor,
+  writeCursorFn = writeCursor,
+}) {
+  const read = readCursorFn(cursorPath);
+  const start = resolveStartPosition(read, { now: () => now, everRan: seen.everRan(streamKey) });
+  if (start.alarm) {
+    // A silently-reset producer is indistinguishable from a working one, so the
+    // reset is counted. It is a DECLINE, not a failure: the position is already
+    // bounded by a stated lookback and un-arming would not restore it.
+    decline(counts, `cursor-reset:${start.alarm.reason}`);
+  }
+
+  // ⛔ A COLD START OR RESET BEGINS ONE SETTLE WINDOW BACK, NOT AT `now`.
+  // `resolveStartPosition` hands back `now` for a first run, which is right for the
+  // Linear leg: its coordinate is an append-only log's `created_at`, and a row is on
+  // disk by the time it exists. Ours is EVENT time on a row that arrives later —
+  // measured up to 333 s later. Starting at `now` would therefore bake a guaranteed
+  // blind spot into every first run and every cursor reset: everything already in
+  // flight carries a stamp before `now` and would land permanently behind the cursor.
+  // The offset is the same bound the cursor is held back by, for the same reason, and
+  // it stays a STATED bound rather than a bare clock read.
+  const startSince = start.mode === "resume" ? start.since : start.since - settleMs;
+  let position =
+    read.state === CURSOR_ABSENT || start.mode !== "resume"
+      ? { lastCreatedAt: startSince, lastId: "" }
+      : read.position;
+
+  const streamCounts = { emitted: 0, suppressed: 0, declined: 0, batches: 0 };
+  let emittedPosition = null;
+
+  for (let b = 0; b < maxBatches; b++) {
+    const rows = source.rowsSince(streamKey, position, batchLimit);
+    if (rows.length === 0) break;
+    streamCounts.batches += 1;
+
+    for (const row of rows) {
+      const verdict = classifyGithubRow(streamKey, row);
+      if (!verdict.emit) {
+        if (verdict.fatal) fail(counts, verdict.reason);
+        else decline(counts, verdict.reason);
+        streamCounts.declined += 1;
+        continue;
+      }
+      const edgeId = githubEdgeId(streamKey, row);
+      // The settle window guarantees we re-read; this is where that becomes free.
+      if (seen.has(edgeId)) {
+        counts.suppressed += 1;
+        streamCounts.suppressed += 1;
+        continue;
+      }
+      const event = buildGithubEvent(streamKey, row, seams);
+      if (!event) {
+        // Classified emittable but unbuildable — never expected, so it is a FAILURE:
+        // it means classification and construction disagree, which un-arming (and a
+        // human) really should look at.
+        fail(counts, `unbuildable:${streamKey}`);
+        streamCounts.declined += 1;
+        continue;
+      }
+      sink(event);
+      // Marked only AFTER the sink returns. Marking first would suppress an edge
+      // that never reached the log.
+      seen.add(edgeId, row.__ts);
+      counts.emitted += 1;
+      streamCounts.emitted += 1;
+    }
+
+    emittedPosition = source.positionAfter(rows);
+    if (!emittedPosition) break;
+    position = emittedPosition;
+    if (rows.length < batchLimit) break;
+  }
+
+  // The durable position is NOT where we got to — it is held behind by the settle
+  // window so late arrivals stay ahead of it. See github-feed-source.mjs.
+  const previous = read.state === "ok" ? read.position : null;
+  const durable = settleCursor(emittedPosition, { now, settleMs, previous });
+  if (durable && (!previous || durable.lastCreatedAt !== previous.lastCreatedAt || durable.lastId !== previous.lastId)) {
+    writeCursorFn(cursorPath, durable);
+    // Only now, with the cursor durable, can the suppression set forget anything.
+    seen.pruneBefore(durable.lastCreatedAt);
+  }
+  if (streamCounts.emitted > 0) seen.markRan(streamKey);
+
+  counts.byStream[streamKey] = streamCounts;
+  return streamCounts;
+}
+
+/**
+ * One full tick across every stream.
+ *
+ * ⭐ Cursors are PER STREAM, in separate files. A single combined file would make one
+ * corrupt write cost all nine positions, and the streams have genuinely independent
+ * positions (a repo can be quiet on deployments for days while reviews stream). It
+ * also means the reusable single-position cursor module is called unchanged rather
+ * than forked into a multi-position variant.
+ */
+export function runGithubSweep({
+  source,
+  seen,
+  sink,
+  orchDir,
+  account = "tenant-0",
+  now = Date.now(),
+  settleMs = DEFAULT_SETTLE_MS,
+  batchLimit = DEFAULT_BATCH_LIMIT,
+  maxBatches = DEFAULT_MAX_BATCHES,
+  streams = STREAMS.map((s) => s.key),
+  seams,
+  cursorPathFn = streamCursorPath,
+  readCursorFn = readCursor,
+  writeCursorFn = writeCursor,
+}) {
+  const counts = emptyCounts();
+  for (const streamKey of streams) {
+    try {
+      sweepStream({
+        source,
+        seen,
+        sink,
+        streamKey,
+        cursorPath: cursorPathFn(orchDir, streamKey, account),
+        now,
+        settleMs,
+        batchLimit,
+        maxBatches,
+        counts,
+        seams,
+        readCursorFn,
+        writeCursorFn,
+      });
+    } catch (err) {
+      // Contained per stream: the other eight still make progress. A FAILURE, since
+      // an unreadable table is exactly the condition un-arming should respond to.
+      fail(counts, `stream-threw:${streamKey}:${err?.code ?? err?.name ?? "unknown"}`);
+    }
+  }
+  return counts;
+}
+
+/**
+ * Why this tick does not arm the GitHub producer, or `null` when it does.
+ *
+ * A twin of `cloud-feed-timer.sweepUnreadyReason` rather than a call to it: that
+ * one's conjuncts are named for the Linear leg's streams (`edges`, `comments`,
+ * `labels`) and a GitHub report has none of them. What IS shared — and is imported
+ * rather than restated — is `countsClean` / `countsDirtyWhy`, the part that actually
+ * decides. A hand-built copy of that predicate could agree with a fixture while
+ * disagreeing with the gate the daemon runs.
+ *
+ * Fail-closed at every rung: an absent report, an absent counts record, or an absent
+ * `byFailure` all read as NOT ready. "Nothing went wrong" and "I could not look" must
+ * never be byte-identical to the caller.
+ */
+export function githubSweepUnreadyReason(report, feedHealth = { healthy: false, reason: "unknown" }) {
+  if (!report) return "no-report";
+  if (report.skipped) return `skipped:${report.skipped}`;
+  if (report.error) return `error:${report.error}`;
+  if (feedHealth?.healthy !== true) return `feed-unhealthy:${feedHealth?.reason ?? "unknown"}`;
+  if (!report.counts) return "no-sweep";
+  if (report.stoppedEarly === true) return "stopped-early";
+  if (!countsClean(report.counts)) return `streams:${countsDirtyWhy(report.counts)}`;
+  return null;
+}

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
@@ -174,7 +174,7 @@ export function sweepStream({
       sink(event);
       // Marked only AFTER the sink returns. Marking first would suppress an edge
       // that never reached the log.
-      seen.add(edgeId, row.__ts);
+      seen.add(edgeId, row.__ts, streamKey);
       counts.emitted += 1;
       streamCounts.emitted += 1;
     }
@@ -191,10 +191,19 @@ export function sweepStream({
   const durable = settleCursor(emittedPosition, { now, settleMs, previous });
   if (durable && (!previous || durable.lastCreatedAt !== previous.lastCreatedAt || durable.lastId !== previous.lastId)) {
     writeCursorFn(cursorPath, durable);
-    // Only now, with the cursor durable, can the suppression set forget anything.
-    seen.pruneBefore(durable.lastCreatedAt);
+    // Only now, with the cursor durable, can the suppression set forget anything —
+    // and only THIS stream's entries. The table is shared; the cursors are not, and
+    // an unscoped prune lets a stream with a newer cursor delete a slower stream's
+    // still-re-readable entries (`github-feed-seen.mjs`).
+    seen.pruneBefore(durable.lastCreatedAt, streamKey);
+    // ⛔ MARK ON A DURABLE CURSOR, NOT ON AN EMISSION. A stream whose rows all
+    // DECLINE still advances its cursor, and that advance is itself proof the stream
+    // has run. Keying `everRan` on `emitted > 0` left such a stream flagged as
+    // first-run, so a later cursor loss cold-starts it at `now - settleMs` instead of
+    // replaying the stated lookback — permanently skipping anything that happened
+    // during the downtime outside the settle window but inside that lookback.
+    seen.markRan(streamKey);
   }
-  if (streamCounts.emitted > 0) seen.markRan(streamKey);
 
   counts.byStream[streamKey] = streamCounts;
   return streamCounts;

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
@@ -302,6 +302,100 @@ describe("⛔ first-run detection is PER STREAM, not per producer", () => {
   });
 });
 
+describe("⛔ P1 (Codex #3520): the prune is scoped to its own stream", () => {
+  test("a stream with a NEWER cursor does not delete a slower stream's entries", () => {
+    // The seen table is shared; the cursors are not. An unscoped prune let the
+    // faster stream delete entries the slower one can still re-read, so its next
+    // sweep re-emitted them with fresh envelope ids — and the broker dedups on that
+    // id, so it wakes twice.
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      addReview(db, "old", NOW - 900);
+      db.prepare("INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)")
+        .run("o/r", "refs/heads/main", "b1", "a1", NOW - 100);
+    });
+    try {
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+        settleMs: 1000, seams: SEAMS };
+      // BOTH streams sweep at NOW so each lands an entry AND a durable cursor. The
+      // push stream must actually acquire one here — without it, its later sweep
+      // reads nothing, writes no cursor and prunes nothing, and this test passes
+      // whether or not the prune is scoped. (That is exactly how the first cut of
+      // this test failed to catch the bug it was written for.)
+      runGithubSweep({ ...opts, now: NOW, streams: ["reviewSubmitted", "push"] });
+      expect(w.seen.size("reviewSubmitted")).toBe(1);
+      expect(w.seen.size("push")).toBe(1);
+
+      // Push alone now sweeps far in the future. It reads nothing new, so its cursor
+      // advances to the horizon — way past the review entry at NOW-900 — and it
+      // prunes. An UNSCOPED prune deletes the review entry here.
+      runGithubSweep({ ...opts, now: NOW + 1_000_000, streams: ["push"] });
+
+      // ⛔ The review entry must survive: reviews' own cursor has not passed it, so
+      // that row is still re-readable and re-emitting it would double-wake.
+      expect(w.seen.size("reviewSubmitted")).toBe(1);
+
+      // ⭐ CONTROL — the precondition for the bug must actually hold, or this test
+      // proves nothing. Push's durable cursor has to be PAST the review entry's
+      // timestamp, because that is exactly what makes an unscoped
+      // `DELETE ... WHERE ts < cursor` delete it. Assert that rather than assuming it:
+      // the first cut of this test let push read nothing, so it wrote no cursor,
+      // pruned nothing, and passed under the mutant.
+      const pushCursor = JSON.parse(readFileSync(streamCursorPath(w.dir, "push"), "utf8"));
+      expect(pushCursor.lastCreatedAt).toBeGreaterThan(NOW - 900);
+    } finally { w.close(); }
+  });
+
+  test("a stream still prunes its OWN entries — the scoping must not disable pruning", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => { addReview(db, "a", NOW - 900); addReview(db, "b", NOW - 500); });
+    try {
+      sweep(w, NOW);
+      expect(w.seen.size("reviewSubmitted")).toBe(2);
+      sweep(w, NOW + 1_000_000);
+      expect(w.seen.size("reviewSubmitted")).toBe(1);
+    } finally { w.close(); }
+  });
+
+  test("an unscoped add or prune is REFUSED rather than silently mis-scoped", () => {
+    const w = world();
+    try {
+      expect(() => w.seen.add("gh:x:1", 1)).toThrow();
+      expect(() => w.seen.pruneBefore(1)).toThrow();
+    } finally { w.close(); }
+  });
+});
+
+describe("⛔ P2 (Codex #3520): a stream that only DECLINES has still run", () => {
+  test("everRan is set from the durable cursor, not from an emission", () => {
+    // A decline-only stream advances its cursor, and that advance IS proof it ran.
+    // Keyed on `emitted > 0` it stayed flagged first-run, so a later cursor loss
+    // cold-started it and permanently skipped the reset lookback window.
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      db.prepare("INSERT INTO pull_requests (repo_id,number,merged,merged_at,created_at) VALUES (?,?,?,?,?)")
+        .run("o/r", 7, 1, NOW - 500, NOW - 900);
+    });
+    try {
+      const c = sweep(w, NOW, { streams: ["prMerged"] });
+      expect(c.emitted).toBe(0);
+      expect(c.declined).toBe(1);
+      expect(w.seen.everRan("prMerged")).toBe(true);
+    } finally { w.close(); }
+  });
+
+  test("a stream that read nothing at all is still first-run", () => {
+    // The control: the flag must not become "always true", or a genuine first run
+    // takes the bounded-lookback reset path forever.
+    const NOW = 10_000_000;
+    const w = world();
+    try {
+      sweep(w, NOW, { streams: ["prMerged"] });
+      expect(w.seen.everRan("prMerged")).toBe(false);
+    } finally { w.close(); }
+  });
+});
+
 describe("cursor ordering and durability", () => {
   test("the durable cursor is held BEHIND the emitted position", () => {
     const NOW = 10_000_000;

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
@@ -1,0 +1,371 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-sweep.test.mjs
+//
+// Real SQLite for both the replica and the suppression set, and real cursor files.
+// The properties under test are about what survives a SECOND tick, which a mocked
+// store cannot exhibit.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createGithubFeedSource } from "./github-feed-source.mjs";
+import { createSeenStore } from "./github-feed-seen.mjs";
+import { emptyCounts, runGithubSweep, streamCursorPath } from "./github-feed-sweep.mjs";
+import { countsClean } from "./cloud-feed-timer.mjs";
+import { githubSweepUnreadyReason } from "./github-feed-sweep.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-feed-sweep-"));
+afterAll(() => {
+  try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ }
+});
+
+const DDL = `
+CREATE TABLE pull_requests (
+  repo_id text NOT NULL, number integer NOT NULL, state text, draft integer, merged integer,
+  merged_at integer, head_sha text, base_ref text, mergeable integer, updated_at integer,
+  synced_at integer, title text, body text, author_login text, created_at integer,
+  closed_at integer, head_ref text, linear_issue_identifier text,
+  PRIMARY KEY(repo_id, number));
+CREATE TABLE reviews (repo_id text NOT NULL, pr_number integer NOT NULL,
+  review_id text PRIMARY KEY NOT NULL, user_id text, state text, submitted_at integer, body text);
+CREATE TABLE pr_review_comments (id text PRIMARY KEY NOT NULL, repo_id text NOT NULL,
+  pr_number integer NOT NULL, review_id text, commit_id text, path text, line integer,
+  diff_hunk text, in_reply_to_id text, author_id text, body text, created_at integer,
+  updated_at integer, removed_at integer);
+CREATE TABLE pr_review_threads (id text PRIMARY KEY NOT NULL, repo_id text NOT NULL,
+  pr_number integer NOT NULL, resolved integer, resolved_at integer, resolver_id text,
+  first_comment_id text, comment_count integer, updated_at integer);
+CREATE TABLE deployments (id text PRIMARY KEY NOT NULL, repo_id text NOT NULL, ref text,
+  sha text, task text, environment text, production_environment integer,
+  transient_environment integer, description text, creator_id text, created_at integer,
+  updated_at integer);
+CREATE TABLE deployment_statuses (id text PRIMARY KEY NOT NULL, repo_id text NOT NULL,
+  deployment_id text NOT NULL, state text, environment text, target_url text,
+  environment_url text, description text, creator_id text, created_at integer, updated_at integer);
+CREATE TABLE pushes (repo_id text NOT NULL, ref text NOT NULL, before text, after text,
+  forced integer, created integer, deleted integer, base_ref text, pusher_id text,
+  head_commit_sha text, updated_at integer, PRIMARY KEY(repo_id, ref));
+`;
+
+const SEAMS = {
+  now: () => new Date("2026-08-18T00:00:00.000Z"),
+  newId: () => "id0", newTrace: () => "t0", newSpan: () => "s0",
+};
+
+let seq = 0;
+/** A fresh, isolated world: replica + suppression set + orchDir for cursor files. */
+function world(seed = () => {}) {
+  const dir = join(tmp, `w${seq++}`);
+  mkdirSync(dir, { recursive: true });
+  const dbPath = join(dir, "replica.db");
+  const db = new Database(dbPath, { create: true });
+  db.exec(DDL);
+  seed(db);
+  db.close();
+  const source = createGithubFeedSource({ dbPath });
+  const seen = createSeenStore({ path: join(dir, "seen.db") });
+  const emitted = [];
+  const sink = (ev) => emitted.push(ev);
+  return { dir, dbPath, source, seen, sink, emitted, close: () => { source.close(); seen.close(); } };
+}
+
+const addReview = (db, id, ts) =>
+  db.prepare("INSERT INTO reviews (repo_id,pr_number,review_id,user_id,state,submitted_at,body) VALUES (?,?,?,?,?,?,?)")
+    .run("o/r", 7, id, "github:alice", "COMMENTED", ts, "b");
+
+const sweep = (w, now, extra = {}) =>
+  runGithubSweep({
+    source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+    now, settleMs: 1000, streams: ["reviewSubmitted"], seams: SEAMS, ...extra,
+  });
+
+describe("⭐ the property the whole design exists for: a late arrival is not lost", () => {
+  test("a row inserted AFTER the tick that passed its timestamp is still emitted", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "r-early", NOW - 100));
+    try {
+      // Tick 1 emits r-early. Its timestamp is INSIDE the settle window, so the
+      // durable cursor is held at the horizon rather than at the row.
+      const c1 = sweep(w, NOW);
+      expect(c1.emitted).toBe(1);
+
+      // Now a row arrives carrying an OLDER stamp than one already emitted — the
+      // exact out-of-order ingestion measured at 37% >60s on the live fleet.
+      const db = new Database(w.dbPath);
+      addReview(db, "r-late", NOW - 500);
+      db.close();
+
+      // ⛔ A producer that had advanced its cursor to `r-early` would never see it.
+      const c2 = sweep(w, NOW + 1);
+      expect(c2.emitted).toBe(1);
+      expect(w.emitted.map((e) => e.attributes["vcs.pr.number"])).toEqual([7, 7]);
+      expect(c2.suppressed).toBe(1); // r-early re-read and correctly suppressed
+    } finally { w.close(); }
+  });
+
+  test("re-reading the settle window emits nothing twice", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => { addReview(db, "a", NOW - 100); addReview(db, "b", NOW - 90); });
+    try {
+      expect(sweep(w, NOW).emitted).toBe(2);
+      for (let i = 1; i <= 4; i++) {
+        const c = sweep(w, NOW + i);
+        expect(c.emitted).toBe(0);
+        expect(c.suppressed).toBe(2);
+      }
+      expect(w.emitted.length).toBe(2);
+    } finally { w.close(); }
+  });
+
+  test("entries strictly older than the cursor are pruned — the set is bounded by the window, not by uptime", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => { addReview(db, "a", NOW - 900); addReview(db, "b", NOW - 500); });
+    try {
+      sweep(w, NOW);
+      expect(w.seen.size()).toBe(2);
+      // A much later tick: the cursor advances to the newest row, so everything
+      // strictly older than it can never be re-read and is dropped.
+      sweep(w, NOW + 1_000_000);
+      expect(w.seen.size()).toBe(1);
+
+      // ⚠️ The one entry left sits exactly ON the cursor's timestamp. Pruning is
+      // `ts < cursor`, never `<=`: a row sharing that millisecond with a HIGHER id is
+      // still re-readable (the tie-break is `ts = since AND id > sinceId`), and a
+      // timestamp-only prune cannot tell it apart from one already passed. Keeping it
+      // is the conservative direction.
+      //
+      // ⭐ And it does not linger: an IDLE tick reads nothing, which is itself proof
+      // that everything at or before the horizon has arrived, so the cursor advances
+      // to the horizon and the set drains completely. The retention bound is
+      // therefore one settle window in the worst case and zero at rest — bounded by
+      // the window, never by uptime.
+      sweep(w, NOW + 2_000_000);
+      expect(w.seen.size()).toBe(0);
+    } finally { w.close(); }
+  });
+});
+
+describe("⛔ P1 regression (Codex #3513): consecutive pushes to one ref both reach the log", () => {
+  test("a second push to the SAME ref is emitted, not suppressed as a re-read", () => {
+    // This is the test that would have caught it. `pushes` is keyed (repo_id, ref)
+    // and REWRITTEN per push, so the row's PK is constant — the seen-set suppressed
+    // every push after the first, per ref, for as long as the entry lived. The unit
+    // test on identity is necessary but not sufficient: only driving two sweeps over
+    // a MUTATED row shows the suppression actually happening.
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      db.prepare("INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)")
+        .run("o/r", "refs/heads/main", "sha0", "sha1", NOW - 500);
+    });
+    try {
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+        settleMs: 1000, streams: ["push"], seams: SEAMS };
+      expect(runGithubSweep({ ...opts, now: NOW }).emitted).toBe(1);
+
+      // The SAME row is now rewritten in place by a second push — exactly what the
+      // mirror does, and why the PK is not an edge identity here.
+      const db2 = new Database(w.dbPath);
+      db2.prepare("UPDATE pushes SET before=?, after=?, updated_at=? WHERE repo_id=? AND ref=?")
+        .run("sha1", "sha2", NOW - 400, "o/r", "refs/heads/main");
+      db2.close();
+
+      const c2 = runGithubSweep({ ...opts, now: NOW + 1 });
+      expect(c2.emitted).toBe(1);
+      expect(c2.suppressed).toBe(0);
+      expect(w.emitted.map((e) => e.body.payload.headSha)).toEqual(["sha1", "sha2"]);
+    } finally { w.close(); }
+  });
+
+  test("an UNCHANGED push row is still suppressed on re-read", () => {
+    // The other direction — the fix must not defeat suppression entirely, or every
+    // settle-window re-read becomes a duplicate wake.
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      db.prepare("INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)")
+        .run("o/r", "refs/heads/main", "sha0", "sha1", NOW - 500);
+    });
+    try {
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+        settleMs: 1000, streams: ["push"], seams: SEAMS };
+      expect(runGithubSweep({ ...opts, now: NOW }).emitted).toBe(1);
+      const c2 = runGithubSweep({ ...opts, now: NOW + 1 });
+      expect(c2.emitted).toBe(0);
+      expect(c2.suppressed).toBe(1);
+    } finally { w.close(); }
+  });
+});
+
+describe("⛔ declines never reach byFailure — this is the CTL-1909 property", () => {
+  test("an uncovered stream declines and readiness stays armed", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      db.prepare("INSERT INTO pull_requests (repo_id,number,merged,merged_at,created_at) VALUES (?,?,?,?,?)")
+        .run("o/r", 7, 1, NOW - 500, NOW - 900);
+    });
+    try {
+      const c = sweep(w, NOW, { streams: ["prMerged"] });
+      expect(c.declined).toBe(1);
+      expect(c.failed).toBe(0);
+      expect(Object.keys(c.byReason)[0]).toContain("CTC-691");
+      // The gate the daemon actually runs, imported rather than restated — a
+      // hand-built copy could agree with this fixture and disagree with production.
+      expect(countsClean(c)).toBe(true);
+    } finally { w.close(); }
+  });
+
+  test("a malformed row declines; readiness is unaffected", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "ok", NOW - 100));
+    try {
+      const db2 = new Database(w.dbPath);
+      // No pr_number -> the consumer could not use it -> decline, not failure.
+      db2.prepare("INSERT INTO reviews (repo_id,pr_number,review_id,user_id,state,submitted_at) VALUES (?,?,?,?,?,?)")
+        .run("o/r", 0, "bad", "github:a", "COMMENTED", NOW - 99);
+      db2.close();
+      const c = sweep(w, NOW);
+      expect(c.emitted).toBe(1);
+      expect(c.declined).toBe(1);
+      expect(c.failed).toBe(0);
+      expect(countsClean(c)).toBe(true);
+    } finally { w.close(); }
+  });
+
+  test("a stream that throws is a FAILURE, is contained, and un-arms readiness", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "a", NOW - 100));
+    try {
+      const exploding = {
+        rowsSince: (k, ...rest) => {
+          if (k === "push") throw Object.assign(new Error("boom"), { code: "SQLITE_CORRUPT" });
+          return w.source.rowsSince(k, ...rest);
+        },
+        positionAfter: w.source.positionAfter,
+      };
+      const c = runGithubSweep({
+        source: exploding, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        settleMs: 1000, streams: ["push", "reviewSubmitted"], seams: SEAMS,
+      });
+      expect(c.failed).toBe(1);
+      expect(Object.keys(c.byFailure)[0]).toContain("push");
+      // Contained: the other stream still made progress.
+      expect(c.emitted).toBe(1);
+      expect(countsClean(c)).toBe(false);
+    } finally { w.close(); }
+  });
+
+  test("emptyCounts carries byFailure PRESENT and empty", () => {
+    // An absent byFailure reads as not-clean on purpose: "nothing wrong" and "could
+    // not look" must not be byte-identical.
+    const c = emptyCounts();
+    expect(c.byFailure).toEqual({});
+    expect(countsClean(c)).toBe(true);
+    const stripped = { ...c }; delete stripped.byFailure;
+    expect(countsClean(stripped)).toBe(false);
+  });
+});
+
+describe("⛔ first-run detection is PER STREAM, not per producer", () => {
+  test("a cold start across many streams raises no cursor-reset declines", () => {
+    // A single global everRan flag meant the first stream to emit set it, and every
+    // other stream on the SAME first run then read its absent cursor as a LOST one.
+    // Measured on a real replica replay: 8 spurious cursor-vanished declines in one
+    // cold start — which is exactly how a genuine cursor loss gets lost in the noise.
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      addReview(db, "a", NOW - 500);
+      db.prepare("INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)")
+        .run("o/r", "refs/heads/main", "b1", "a1", NOW - 500);
+      db.prepare("INSERT INTO pr_review_comments (id,repo_id,pr_number,author_id,body,created_at) VALUES (?,?,?,?,?,?)")
+        .run("c1", "o/r", 7, "github:alice", "x", NOW - 500);
+    });
+    try {
+      const c = runGithubSweep({
+        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        settleMs: 1000, streams: ["reviewSubmitted", "push", "reviewCommentCreated"], seams: SEAMS,
+      });
+      expect(c.emitted).toBe(3);
+      const resets = Object.keys(c.byReason).filter((r) => r.startsWith("cursor-reset"));
+      expect(resets).toEqual([]);
+    } finally { w.close(); }
+  });
+
+  test("and a stream that HAS run keeps its own flag", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "a", NOW - 500));
+    try {
+      sweep(w, NOW);
+      expect(w.seen.everRan("reviewSubmitted")).toBe(true);
+      // A stream that never emitted must NOT inherit it — that inheritance is the bug.
+      expect(w.seen.everRan("push")).toBe(false);
+    } finally { w.close(); }
+  });
+});
+
+describe("cursor ordering and durability", () => {
+  test("the durable cursor is held BEHIND the emitted position", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "a", NOW - 100));
+    try {
+      sweep(w, NOW);
+      const p = streamCursorPath(w.dir, "reviewSubmitted");
+      expect(existsSync(p)).toBe(true);
+      const cur = JSON.parse(readFileSync(p, "utf8"));
+      // Held at the horizon (NOW-1000), NOT at the emitted row (NOW-100).
+      expect(cur.lastCreatedAt).toBe(NOW - 1000);
+      expect(cur.lastCreatedAt).toBeLessThan(NOW - 100);
+    } finally { w.close(); }
+  });
+
+  test("a failed sink leaves the cursor unmoved, so the next tick re-reads", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "a", NOW - 500));
+    try {
+      expect(() => runGithubSweep({
+        source: w.source, seen: w.seen,
+        sink: () => { throw new Error("log unavailable"); },
+        orchDir: w.dir, now: NOW, settleMs: 1000, streams: ["reviewSubmitted"], seams: SEAMS,
+      })).not.toThrow();
+      // No cursor was written, and nothing was marked seen — so a healthy next tick
+      // re-emits. Losing progress is recoverable; advancing past an unemitted row is not.
+      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted"))).toBe(false);
+      expect(w.seen.size()).toBe(0);
+      expect(sweep(w, NOW).emitted).toBe(1);
+    } finally { w.close(); }
+  });
+
+  test("cursors are per stream — one stream's position does not move another's", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => {
+      addReview(db, "a", NOW - 500);
+      db.prepare("INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)")
+        .run("o/r", "refs/heads/main", "b1", "a1", NOW - 500);
+    });
+    try {
+      runGithubSweep({
+        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        settleMs: 1000, streams: ["reviewSubmitted", "push"], seams: SEAMS,
+      });
+      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted"))).toBe(true);
+      expect(existsSync(streamCursorPath(w.dir, "push"))).toBe(true);
+      expect(streamCursorPath(w.dir, "push")).not.toBe(streamCursorPath(w.dir, "reviewSubmitted"));
+    } finally { w.close(); }
+  });
+});
+
+describe("readiness reads these counts the way the daemon does", () => {
+  test("a clean sweep yields no unready reason", () => {
+    const NOW = 10_000_000;
+    const w = world((db) => addReview(db, "a", NOW - 500));
+    try {
+      const counts = sweep(w, NOW);
+      // sweepUnreadyReason is imported from the module the daemon runs, not restated.
+      expect(githubSweepUnreadyReason({ counts, stoppedEarly: false }, { healthy: true })).toBeNull();
+      // Fail-closed rungs: absent report / absent counts / unhealthy feed all un-arm.
+      expect(githubSweepUnreadyReason(null, { healthy: true })).toBe("no-report");
+      expect(githubSweepUnreadyReason({}, { healthy: true })).toBe("no-sweep");
+      expect(githubSweepUnreadyReason({ counts }, { healthy: false, reason: "stall" }))
+        .toBe("feed-unhealthy:stall");
+    } finally { w.close(); }
+  });
+});


### PR DESCRIPTION
Stacked on **#3513** (retargets to `main` automatically when that merges). CTL-1929 ask (2) completion + ask (3) tooling. **Still no daemon wiring**, so nothing on a live host changes.

## What this adds

| module | role |
| --- | --- |
| `github-feed-sweep.mjs` | the tick: resume → page → classify → suppress → emit → advance → prune, per stream |
| `github-feed-seen.mjs` | the durable suppression set the emit/cursor split depends on |
| `github-feed-parity.mjs` | the field-level ledger that decides whether the feed may replace the tunnel |

## Why the suppression set exists at all

Rows emit immediately; the cursor is held at `now − settleMs` so a late arrival stays *ahead* of it and is re-read. ⛔ **The broker will not absorb those re-reads for us** — it dedups on a per-emission UUID, so two emissions of one edge are two ids and both route and both wake. The Linear leg never needed this: it keys on `issue_history.id`, a PK of an append-only log, so an overlapping sweep is a no-op by construction. Our tables have no log to key on, so the guarantee has to be stored.

⭐ **Retention is bounded by construction, not by policy.** Once the cursor passes a key the source can never return that row, so pruning at the cursor is lossless *by definition* — and an idle tick advances to the horizon, so the set drains to **zero at rest**. No "keep the last N", which would evict on volume and silently re-open duplicates during exactly the busy hour you care about.

## ⛔ Two bugs that only running against real data found

A 115-test suite at 0 fail did not catch either. Replaying the producer over a real 0.1.16 replica snapshot did.

1. **`everRan` was one global flag while the cursors are per stream.** The first stream to emit set it, so every *other* stream's absent cursor — on the same first run — read as "we HAD a position and lost it". **8 spurious `cursor-vanished-after-first-run` declines in one cold start**, each raising a WARN. Benign in effect (the lookback is bounded), corrosive in signal: it makes a genuine cursor loss indistinguishable from ordinary startup noise. Now per stream; the replay re-ran with **zero**.
2. **A cold start began at `now`.** That bakes a guaranteed blind spot into every first run and every reset: everything already in flight carries a stamp *before* `now` and lands permanently behind the cursor. It now begins one settle window back — the same stated bound, for the same reason.

## The decline/failure split

Inherited verbatim from `linear-feed-sweep.mjs` because readiness is computed from these counts, and **CTL-1909 exists because that distinction was once wrong** — readiness read `byReason`, so ordinary healthy declines un-armed enforce within two minutes of boot. The rule is one question: *would un-arming the producer repair this?* A malformed row or a declared gap is a **decline**; an unreadable table is a **failure**. `byFailure` is present-and-empty rather than absent, so "nothing went wrong" and "I could not look" are not byte-identical to the reader.

## The parity ledger

Ships as a module rather than a session script — that is what **CTL-1916** was filed for.

- ⛔ **Counts are not parity.** The join is on a stable per-name key; the comparison is field by field over what `router.mjs` destructures.
- Fields that **must** differ (`id`, `ts`, `event.channel`, `body.payload.source`, …) are excluded **BY NAME**, never by a prefix rule — so a field that starts diverging cannot hide inside a blanket exclusion.
- ⚠️ `draft` / `mergeable` are **observed-only**: a last-state table holds the value NOW, not the value at the edge, so they can agree today and diverge the moment the row is updated. A clean run is explicitly not a claim about them.
- The verdict is **three-valued**: an empty side, nothing joined, or an unspecced name is **INCONCLUSIVE**, never clean. `[].every()` is `true`, and a ledger reporting agreement because it compared nothing is the exact false-clean this repo keeps re-learning.

### ⛔ CORRECTION — measured against 3 h of real fleet traffic, the verdict is INCONCLUSIVE

This PR originally reported `clean = true, exit 0`. **That was the ledger's own false-clean, and Codex's round-1 P1s are what exposed it.** With multiplicity preserved and unmatched events forced inconclusive, the same replay now reads:

```
253 joined / 253 agree · 0 field diffs · 0 unkeyable
unjoined:  feed 1 · smee 138          <-- 101 of the 138 are github.push
inconclusive: feed-events-without-a-twin:1, smee-events-without-a-twin:138
clean = false, exit 3 (INCONCLUSIVE)
expectedAbsent: check_suite.completed 612, pr.merged 25   (both declared gaps)
observedOnly:   draft 1, mergeable 2
```

⭐ **Every field that was compared still agrees — 253/253, including `htmlUrl` (not a stored column, reconstructed, matching smee byte-for-byte 81/81).** What the old predicate hid is that the feed produced **no counterpart at all for 101 push events**, which is the `pushes` PK collapse I had already documented in prose *in the same write-up that quoted the clean verdict*. The fact and the instrument disagreed and I read past it.

So the honest state is: **field-level fidelity looks strong; coverage on `github.push` does not, and the ledger now says so instead of certifying it.**

## ⚠️ What this record is NOT

It is **replay** parity, not **live shadow** parity, and the difference matters:

- a replay reads each row's *final* state, so it **understates `github.push`** (38 vs 108 events — one row per ref). The live loss is only pushes to one ref *within a single tick*, which is unknowable until it runs on a host;
- it measures **no latency at all**;
- `pr.merged` and `check_suite.completed` remain unproducible (**CTC-691**, **CTC-667 item 4**), so this cannot license retiring the tunnel.

## Tests

115 pass / 0 fail across the four suites; all four in the CI allowlist (an explicit list, not a glob). The sweep tests drive **two ticks over a mutated row**, because the properties under test — late arrival not lost, unchanged row still suppressed, cursor held behind, set drains at rest — are about what survives a *second* tick and a mocked store cannot exhibit them.
