### PR TITLE
fix(dev): CTC-633 — back-fill the thoughts/ ignore onto worktrees that already exist

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -97,6 +97,11 @@ on:
       # FLEET: the remote-owner channel transport ships its own bash test; without this
       # path a PR touching only scripts/comms/ would skip the job that runs it.
       - "scripts/comms/**"
+
+      # CTC-633: the worktree thoughts/ back-fill ships its own bash test; without this path a
+      # PR touching only scripts/ would skip the job that runs it.
+      - "scripts/__tests__/**"
+      - "scripts/worktree-thoughts-exclude-backfill.sh"
       - "plugins/dev/scripts/gen-cli-reference.sh"
       - "website/src/content/docs/reference/catalyst-cli.md"
       # CTL-1530: the dual-harness migrator and its checkup §10 wiring — a change to
@@ -171,6 +176,11 @@ jobs:
               # FLEET: the remote-owner channel transport ships its own bash test; without this
               # path a PR touching only scripts/comms/ would skip the job that runs it.
               - "scripts/comms/**"
+
+              # CTC-633: the worktree thoughts/ back-fill ships its own bash test; without this path a
+              # PR touching only scripts/ would skip the job that runs it.
+              - "scripts/__tests__/**"
+              - "scripts/worktree-thoughts-exclude-backfill.sh"
               - "plugins/dev/scripts/gen-cli-reference.sh"
               - "website/src/content/docs/reference/catalyst-cli.md"
               - "plugins/dev/scripts/migrate-dual-harness.sh"
@@ -254,6 +264,14 @@ jobs:
         # at-least-once ordering (append first, ack second).
         working-directory: .
         run: bash scripts/comms/__tests__/remote-turns.test.sh
+
+      - name: worktree thoughts/ back-fill test (CTC-633)
+        # info/exclude only silences UNTRACKED paths, so this test pins BOTH halves: the
+        # untracked case being fixed, and the tracked-modified case being reported rather than
+        # counted as fixed. Includes a negative control (a repo without the defect is not
+        # touched) and a zero-discovery case that must exit 2, not report a clean pass.
+        working-directory: .
+        run: bash scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
 
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing

--- a/scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
+++ b/scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# worktree-thoughts-exclude-backfill.test.sh — CTC-633's reclaim, applied to EXISTING worktrees.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../worktree-thoughts-exclude-backfill.sh"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+
+git_q() { git -C "$1" -c user.email=t@t -c user.name=T "${@:2}" >/dev/null 2>&1; }
+
+# repo A: has a worktree with an UNTRACKED thoughts/ — the case the backfill fixes.
+# repo B: identical shape but NO thoughts/ at all — the negative control; it must be left alone.
+for r in A B; do
+	R="$SCRATCH/repo$r"
+	mkdir -p "$R"
+	git_q "$R" init -b main
+	echo hi >"$R/f.txt"
+	git_q "$R" add -A
+	git_q "$R" commit -m init
+	git_q "$R" worktree add "$SCRATCH/wt/repo$r/w1" -b w1
+done
+mkdir -p "$SCRATCH/wt/repoA/w1/thoughts/shared"
+echo note >"$SCRATCH/wt/repoA/w1/thoughts/shared/n.md"
+
+# repo C: thoughts/ is TRACKED, then modified — no ignore rule can silence it.
+R="$SCRATCH/repoC"
+mkdir -p "$R/thoughts"
+git_q "$R" init -b main
+echo v1 >"$R/thoughts/tracked.md"
+git_q "$R" add -A
+git_q "$R" commit -m init
+git_q "$R" worktree add "$SCRATCH/wt/repoC/w1" -b w1
+echo v2 >"$SCRATCH/wt/repoC/w1/thoughts/tracked.md"
+
+run_backfill() { CATALYST_WT_ROOT="$SCRATCH/wt" bash "$SUBJECT" "$@" 2>&1; }
+
+echo ""
+echo "=== before: repoA's worktree is dirty because of thoughts/ ==="
+if git -C "$SCRATCH/wt/repoA/w1" status --porcelain | grep -q '^?? *thoughts/'; then
+	pass "repoA/w1 shows an untracked thoughts/ (the defect exists to be fixed)"
+else
+	fail "repoA/w1 shows an untracked thoughts/" "the fixture is wrong; nothing below means anything"
+fi
+
+echo ""
+echo "=== --dry-run changes NOTHING on disk ==="
+OUT="$(run_backfill --dry-run)"
+if grep -qxF "thoughts/" "$SCRATCH/repoA/.git/info/exclude" 2>/dev/null; then
+	fail "--dry-run left the exclude untouched" "it wrote to repoA anyway"
+else
+	pass "--dry-run left the exclude untouched"
+fi
+grep -q "dry-run" <<<"$OUT" && pass "--dry-run says so" || fail "--dry-run says so" "$OUT"
+
+echo ""
+echo "=== the real run fixes repoA ==="
+OUT="$(run_backfill)"
+RC=$?
+if grep -qxF "thoughts/" "$SCRATCH/repoA/.git/info/exclude" 2>/dev/null; then pass "repoA got the exclude"; else fail "repoA got the exclude" "$OUT"; fi
+if git -C "$SCRATCH/wt/repoA/w1" status --porcelain | grep -q 'thoughts/'; then
+	fail "repoA/w1 is no longer dirty from thoughts/" "$(git -C "$SCRATCH/wt/repoA/w1" status --porcelain)"
+else
+	pass "repoA/w1 is no longer dirty from thoughts/"
+fi
+[ "$RC" -eq 0 ] && pass "exit 0 when every untracked case was fixed" || fail "exit 0" "rc=$RC"
+
+echo ""
+echo "--- ⛔ NEGATIVE CONTROL: a repo without the defect is NOT touched ---"
+if [ -f "$SCRATCH/repoB/.git/info/exclude" ] && grep -qxF "thoughts/" "$SCRATCH/repoB/.git/info/exclude"; then
+	fail "repoB was left alone" "the script writes to every repo it discovers, not just affected ones"
+else
+	pass "repoB was left alone"
+fi
+
+echo ""
+echo "--- ⛔ a TRACKED-MODIFIED thoughts/ is REPORTED, not silently counted as fixed ---"
+if grep -q "TRACKED-MODIFIED" <<<"$OUT"; then pass "the tracked case is reported"; else fail "the tracked case is reported" "$OUT"; fi
+if git -C "$SCRATCH/wt/repoC/w1" status --porcelain | grep -q 'thoughts/tracked.md'; then
+	pass "control — the tracked path is genuinely still dirty (so the report is true)"
+else
+	fail "control — the tracked path is still dirty" "the fixture stopped exercising the tracked case"
+fi
+
+echo ""
+echo "=== idempotence: a second run is a no-op ==="
+BEFORE="$(md5 -q "$SCRATCH/repoA/.git/info/exclude" 2>/dev/null || md5sum "$SCRATCH/repoA/.git/info/exclude" | cut -d' ' -f1)"
+OUT2="$(run_backfill)"
+AFTER="$(md5 -q "$SCRATCH/repoA/.git/info/exclude" 2>/dev/null || md5sum "$SCRATCH/repoA/.git/info/exclude" | cut -d' ' -f1)"
+[ "$BEFORE" = "$AFTER" ] && pass "the exclude file is byte-identical after a re-run" || fail "re-run is a no-op" "the file changed"
+grep -q "already ignored" <<<"$OUT2" && pass "the re-run says 'already ignored'" || fail "the re-run says 'already ignored'" "$OUT2"
+
+echo ""
+echo "--- ⛔ discovering ZERO repos must FAIL, not report success ---"
+OUT3="$(CATALYST_WT_ROOT="$SCRATCH/nonexistent" bash "$SUBJECT" 2>&1)"
+RC3=$?
+[ "$RC3" -eq 2 ] && pass "zero-discovery exits 2" || fail "zero-discovery exits 2" "rc=$RC3: $OUT3"
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
+++ b/scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
@@ -106,6 +106,98 @@ AFTER="$(md5 -q "$SCRATCH/repoA/.git/info/exclude" 2>/dev/null || md5sum "$SCRAT
 grep -q "already ignored" <<<"$OUT2" && pass "the re-run says 'already ignored'" || fail "the re-run says 'already ignored'" "$OUT2"
 
 echo ""
+echo "--- ⛔ a worktree path containing a SPACE is not truncated (Codex #3521 P2) ---"
+# `awk '/^worktree /{print $2}'` returned only the first component, so a spaced path became a
+# nonexistent one, was skipped, and the run reported still-untracked=0 and exited 0.
+R="$SCRATCH/repoD"
+mkdir -p "$R"
+git_q "$R" init -b main
+echo hi >"$R/f.txt"
+git_q "$R" add -A
+git_q "$R" commit -m init
+git_q "$R" worktree add "$SCRATCH/wt/repoD/with space" -b w1
+mkdir -p "$SCRATCH/wt/repoD/with space/thoughts"
+echo n >"$SCRATCH/wt/repoD/with space/thoughts/n.md"
+# ⛔ Positive control: the defect really is there before the run.
+if git -C "$SCRATCH/wt/repoD/with space" status --porcelain | grep -q '^?? *thoughts/'; then
+	pass "control — the spaced-path worktree really has the defect"
+else
+	fail "control — the spaced-path worktree has the defect" "fixture wrong; the check below proves nothing"
+fi
+OUT_SP="$(run_backfill)"
+if grep -qxF "thoughts/" "$R/.git/info/exclude" 2>/dev/null; then
+	pass "the spaced-path worktree's repo was found and fixed"
+else
+	fail "the spaced-path worktree's repo was found and fixed" "$OUT_SP"
+fi
+
+echo ""
+echo "--- ⛔ an UNREADABLE worktree is not counted as clean (Codex #3521 P2) ---"
+# git status failing was discarded and the empty output read as a clean tree — a false zero.
+R="$SCRATCH/repoE"
+mkdir -p "$R"
+git_q "$R" init -b main
+echo hi >"$R/f.txt"
+git_q "$R" add -A
+git_q "$R" commit -m init
+git_q "$R" worktree add "$SCRATCH/wt/repoE/w1" -b w1
+git_q "$R" worktree add "$SCRATCH/wt/repoE/healthy" -b healthy
+mkdir -p "$SCRATCH/wt/repoE/healthy/thoughts"
+echo n >"$SCRATCH/wt/repoE/healthy/thoughts/n.md"
+# Break ONLY w1's metadata. The healthy sibling keeps the repo discoverable — Codex's exact
+# scenario, and without it the broken worktree is simply never discovered and the case is moot.
+echo "gitdir: /nonexistent/definitely/not/here" >"$SCRATCH/wt/repoE/w1/.git"
+if git -C "$SCRATCH/wt/repoE/w1" status --porcelain >/dev/null 2>&1; then
+	fail "control — w1's status really is unreadable" "the fixture did not break it"
+else
+	pass "control — w1's status really is unreadable"
+fi
+OUT_UR="$(run_backfill)"
+RC_UR=$?
+if grep -q "UNREADABLE" <<<"$OUT_UR"; then pass "the unreadable worktree is reported"; else fail "the unreadable worktree is reported" "$OUT_UR"; fi
+if [ "$RC_UR" -ne 0 ]; then pass "the run exits NON-ZERO on an unreadable worktree (rc=$RC_UR)"; else fail "the run exits non-zero on an unreadable worktree" "rc=0 — an unknown was reported as a pass"; fi
+rm -rf "$SCRATCH/wt/repoE"
+
+echo ""
+echo "--- ⛔ detection survives a status stream larger than the pipe buffer (Codex #3521 P2) ---"
+# `git status --porcelain | grep -q` let grep exit on first match, git took SIGPIPE, and under
+# `set -o pipefail` the pipeline returned nonzero — so a repo that DID have the defect was
+# counted as skipped. Needs enough output to fill the ~64 KiB pipe buffer.
+R="$SCRATCH/repoF"
+mkdir -p "$R"
+git_q "$R" init -b main
+echo hi >"$R/f.txt"
+git_q "$R" add -A
+git_q "$R" commit -m init
+git_q "$R" worktree add "$SCRATCH/wt/repoF/w1" -b w1
+mkdir -p "$SCRATCH/wt/repoF/w1/thoughts"
+echo n >"$SCRATCH/wt/repoF/w1/thoughts/n.md"
+# ⛔ TWO fixture mistakes had to be fixed before this case tested anything, and both were caught
+# by running a mutation rather than by reading:
+#  1. Files in a subdirectory collapse to one "?? pad/" line in porcelain — 6000 of them produced
+#     21 bytes of status. Hence top-level files. (The byte-count control caught this.)
+#  2. They must sort AFTER "thoughts/", or grep matches on the LAST line, git has already written
+#     everything, and there is no SIGPIPE at all — the mutation below passed happily. Hence the
+#     zzz_ prefix: thoughts/ matches early, git still has ~145 KB to write, and the pipe breaks.
+i=0
+while [ "$i" -lt 6000 ]; do
+	: >"$SCRATCH/wt/repoF/w1/zzz_padding_$i.txt"
+	i=$((i + 1))
+done
+BYTES="$(git -C "$SCRATCH/wt/repoF/w1" status --porcelain | wc -c | tr -d ' ')"
+if [ "$BYTES" -gt 65536 ]; then
+	pass "control — the status stream is ${BYTES} bytes, past the 64 KiB pipe buffer"
+else
+	fail "control — the status stream exceeds the pipe buffer" "only ${BYTES} bytes; the case is not exercised"
+fi
+OUT_BIG="$(run_backfill)"
+if grep -qxF "thoughts/" "$R/.git/info/exclude" 2>/dev/null; then
+	pass "the large-status repo was still detected and fixed"
+else
+	fail "the large-status repo was still detected and fixed" "$(tail -5 <<<"$OUT_BIG")"
+fi
+
+echo ""
 echo "--- ⛔ discovering ZERO repos must FAIL, not report success ---"
 OUT3="$(CATALYST_WT_ROOT="$SCRATCH/nonexistent" bash "$SUBJECT" 2>&1)"
 RC3=$?

--- a/scripts/worktree-thoughts-exclude-backfill.sh
+++ b/scripts/worktree-thoughts-exclude-backfill.sh
@@ -92,12 +92,44 @@ printf '%s' "$COMMON_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u >"$LIST"
 # ignore into all of them would be scope creep on someone's machine — one of the discovered
 # repos is literally named "thoughts", where ignoring thoughts/ would be actively wrong.
 # The predicate is: at least one worktree of this repo shows an UNTRACKED thoughts/ entry.
+# ── Reading a worktree's status, the three ways it silently lied (Codex #3521) ──
+#
+# P2a: `awk '/^worktree /{print $2}'` returns only the FIRST whitespace-delimited component, so a
+#      checkout path containing a space was truncated to a nonexistent path and skipped — the
+#      script then reported still-untracked=0 and exited 0 with the defect untouched.
+# P2b: a worktree with temporarily unreadable git metadata made `git status` fail; the error was
+#      discarded and the empty output read as a CLEAN tree. Same false zero.
+# P2c: `git status --porcelain | grep -q` lets grep exit on first match, git takes SIGPIPE, and
+#      under `set -o pipefail` the pipeline returns nonzero — so a repo that DID have the defect
+#      was counted as skipped. Reproducible with thoughts/ plus ~20k untracked files.
+#
+# All three collapse into: read the status ONCE into a variable, check the exit status, and never
+# pipe git into an early-exiting consumer.
+list_worktrees() {
+	# Everything after the "worktree " prefix, spaces included.
+	git --git-dir="$1" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p'
+}
+
+WT_STATUS=""
+read_worktree_status() {
+	WT_STATUS="$(git -C "$1" status --porcelain 2>/dev/null)"
+	return $?
+}
+
 repo_has_untracked_thoughts() {
 	local gcd="$1" wt
 	while IFS= read -r wt; do
 		[ -d "$wt" ] || continue
-		if git -C "$wt" status --porcelain 2>/dev/null | grep -q '^?? *thoughts/'; then return 0; fi
-	done < <(git --git-dir="$gcd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+		if ! read_worktree_status "$wt"; then
+			echo "  ⛔ could not read git status in $wt — NOT treating that as clean" >&2
+			UNREADABLE=$((UNREADABLE + 1))
+			continue
+		fi
+		case "$WT_STATUS" in
+		*'?? thoughts/'*) return 0 ;;
+		esac
+		printf '%s\n' "$WT_STATUS" | grep -q '^?? *thoughts/' && return 0
+	done < <(list_worktrees "$gcd")
 	return 1
 }
 
@@ -105,6 +137,7 @@ echo "== 1. repos with an UNTRACKED thoughts/ in at least one worktree"
 CHANGED=0
 ALREADY=0
 SKIPPED=0
+UNREADABLE=0
 while IFS= read -r gcd; do
 	name="$(basename "$(dirname "$gcd")")"
 	excl="$gcd/info/exclude"
@@ -147,7 +180,12 @@ TRACKED=0
 while IFS= read -r gcd; do
 	while IFS= read -r wt; do
 		[ -d "$wt" ] || continue
-		st="$(git -C "$wt" status --porcelain 2>/dev/null | grep 'thoughts/')"
+		if ! read_worktree_status "$wt"; then
+			echo "  ⛔ UNREADABLE: $wt — git status failed; this is NOT a clean worktree"
+			UNREADABLE=$((UNREADABLE + 1))
+			continue
+		fi
+		st="$(printf '%s\n' "$WT_STATUS" | grep 'thoughts/')"
 		[ -z "$st" ] && continue
 		u="$(printf '%s\n' "$st" | grep -c '^?? *thoughts/')"
 		t="$(printf '%s\n' "$st" | grep -cE '^ ?[MADRU].*thoughts/')"
@@ -159,11 +197,11 @@ while IFS= read -r gcd; do
 			echo "  ⚠️  TRACKED-MODIFIED ($t): $wt"
 			TRACKED=$((TRACKED + 1))
 		fi
-	done < <(git --git-dir="$gcd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+	done < <(list_worktrees "$gcd")
 done <"$LIST"
 
 echo ""
-echo "backfill: repos changed=$CHANGED already=$ALREADY | worktrees still-untracked=$STILL tracked-modified=$TRACKED (dry-run=$DRY_RUN)"
+echo "backfill: repos changed=$CHANGED already=$ALREADY | worktrees still-untracked=$STILL tracked-modified=$TRACKED unreadable=$UNREADABLE (dry-run=$DRY_RUN)"
 if [ "$TRACKED" -gt 0 ]; then
 	echo ""
 	echo "⚠️  $TRACKED worktree(s) show TRACKED-MODIFIED thoughts/ paths. No ignore rule of any kind"
@@ -171,5 +209,6 @@ if [ "$TRACKED" -gt 0 ]; then
 	echo "    They need 'git update-index --skip-worktree' or a sweeper-side rule."
 fi
 # A non-dry run that left untracked cases behind did not do its job.
-if [ "$DRY_RUN" -eq 0 ] && [ "$STILL" -gt 0 ]; then exit 1; fi
+# An unreadable worktree is an UNKNOWN, not a pass: exiting 0 there is the false zero Codex named.
+if [ "$DRY_RUN" -eq 0 ] && { [ "$STILL" -gt 0 ] || [ "$UNREADABLE" -gt 0 ]; }; then exit 1; fi
 exit 0

--- a/scripts/worktree-thoughts-exclude-backfill.sh
+++ b/scripts/worktree-thoughts-exclude-backfill.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# worktree-thoughts-exclude-backfill.sh — CTC-633's reclaim, applied to worktrees that ALREADY
+# EXIST. One-shot and idempotent; safe to re-run.
+#
+# WHY THIS IS NEEDED AT ALL
+# -------------------------
+# CTC-633 ignores `thoughts/` so the orphan sweeper stops reading it as SALVAGE_DIRTY and can
+# reclaim a stale worktree. That fix arrived as a `.gitignore` commit, which only helps a
+# worktree whose branch CONTAINS that commit — every worktree cut before the merge still shows
+# `?? thoughts/` and stays unreclaimable. `.git/info/exclude` is the per-checkout equivalent and
+# is shared by every worktree of a repo (it lives in $GIT_COMMON_DIR), so one write per repo
+# covers all of them at once.
+#
+# ⛔ WHAT THIS CANNOT FIX, MEASURED — read before believing a clean run means "all fixed".
+# `info/exclude`, like `.gitignore`, applies ONLY TO UNTRACKED FILES. A worktree whose
+# `thoughts/global`, `thoughts/ryan`, `thoughts/shared` are TRACKED symlinks shows them as
+# ` M thoughts/...` (modified), and no ignore rule of any kind will silence that. Measured on the
+# dev laptop 2026-08-18 00:27 CT: of 9 polluted worktrees, 4 were untracked (this script fixes
+# them) and 5 were tracked-modified (it cannot, and it says so per worktree rather than
+# reporting a clean sweep). Those need `git update-index --skip-worktree` or a sweeper-side
+# rule — a different ticket, not a silent gap in this one.
+#
+# Usage:
+#   bash scripts/worktree-thoughts-exclude-backfill.sh [--dry-run] [REPO ...]
+# With no REPO arguments it backfills the repos owning worktrees under $CATALYST_WT_ROOT
+# (default ~/catalyst/wt, scanned two levels deep), plus any repo given on the command line.
+
+set -uo pipefail
+
+WT_ROOT="${CATALYST_WT_ROOT:-$HOME/catalyst/wt}"
+MARKER="thoughts/"
+DRY_RUN=0
+REPOS=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dry-run)
+		DRY_RUN=1
+		shift
+		;;
+	-h | --help)
+		sed -n '2,30p' "$0"
+		exit 0
+		;;
+	*)
+		REPOS+=("$1")
+		shift
+		;;
+	esac
+done
+
+# Discover the distinct git common dirs owning the worktrees under $WT_ROOT. A repo reached by
+# several worktrees must be written once, not once per worktree.
+COMMON_DIRS=""
+add_common_dir() {
+	local d="$1" cd_out
+	cd_out="$(git -C "$d" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 0
+	[ -n "$cd_out" ] || return 0
+	case "$COMMON_DIRS" in
+	*"|$cd_out|"*) return 0 ;;
+	esac
+	COMMON_DIRS="$COMMON_DIRS|$cd_out|"
+}
+
+for r in ${REPOS[@]+"${REPOS[@]}"}; do add_common_dir "$r"; done
+
+# Scope: repos the Catalyst fleet manages, i.e. those owning a worktree under $WT_ROOT. TWO
+# levels, and the second one is the whole point — ~/catalyst/wt/catalyst-cloud is a DIRECTORY
+# CONTAINING worktrees, not a worktree itself, so a one-level glob discovered catalyst, Adva and
+# slides and missed catalyst-cloud, the only repo with the defect. (Widening instead to every
+# checkout on the machine was the other wrong answer: it pulled in unrelated repos including one
+# literally named "thoughts", where ignoring thoughts/ would be actively wrong.)
+if [ -d "$WT_ROOT" ]; then
+	for d in "$WT_ROOT"/*/ "$WT_ROOT"/*/*/; do
+		[ -d "$d" ] && add_common_dir "$d"
+	done
+fi
+
+# ⛔ Discovering nothing must not read as "everything is already fine".
+if [ -z "$COMMON_DIRS" ]; then
+	echo "backfill: FAIL — found ZERO git repositories to back-fill (WT_ROOT=$WT_ROOT)." >&2
+	echo "  A run that touched no repository is not a successful run." >&2
+	exit 2
+fi
+
+LIST="$(mktemp)"
+trap 'rm -f "$LIST"' EXIT
+printf '%s' "$COMMON_DIRS" | tr '|' '\n' | grep -v '^$' | sort -u >"$LIST"
+
+# ⛔ Only repos that ACTUALLY HAVE THE DEFECT are touched. Discovery deliberately over-collects
+# (every checkout under $REPO_ROOT) because the affected repo was not under $WT_ROOT; writing an
+# ignore into all of them would be scope creep on someone's machine — one of the discovered
+# repos is literally named "thoughts", where ignoring thoughts/ would be actively wrong.
+# The predicate is: at least one worktree of this repo shows an UNTRACKED thoughts/ entry.
+repo_has_untracked_thoughts() {
+	local gcd="$1" wt
+	while IFS= read -r wt; do
+		[ -d "$wt" ] || continue
+		if git -C "$wt" status --porcelain 2>/dev/null | grep -q '^?? *thoughts/'; then return 0; fi
+	done < <(git --git-dir="$gcd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+	return 1
+}
+
+echo "== 1. repos with an UNTRACKED thoughts/ in at least one worktree"
+CHANGED=0
+ALREADY=0
+SKIPPED=0
+while IFS= read -r gcd; do
+	name="$(basename "$(dirname "$gcd")")"
+	excl="$gcd/info/exclude"
+	# ⛔ Report a repo we ALREADY fixed as "already ignored", not as "nothing to do". Once the
+	# exclude works the repo stops matching repo_has_untracked_thoughts, so keying only on that
+	# made a re-run print "changed=0 already=0" — a zero an operator cannot tell apart from "did
+	# not look". Caught by the idempotence case in the test, not by reading the code.
+	if [ -f "$excl" ] && grep -qxF "$MARKER" "$excl" 2>/dev/null; then
+		echo "  already ignored: $name"
+		ALREADY=$((ALREADY + 1))
+		continue
+	fi
+	if ! repo_has_untracked_thoughts "$gcd"; then
+		SKIPPED=$((SKIPPED + 1))
+		continue
+	fi
+	if [ "$DRY_RUN" -eq 1 ]; then
+		echo "  [dry-run] would add '$MARKER' to $excl"
+		CHANGED=$((CHANGED + 1))
+		continue
+	fi
+	mkdir -p "$gcd/info"
+	{
+		echo ""
+		echo "# CTC-633: the thoughts/ farm is symlinked in per worktree and must never make a"
+		echo "# tree read as dirty — an unreclaimable worktree is how the host runs out of disk."
+		echo "# Added by scripts/worktree-thoughts-exclude-backfill.sh for worktrees on branches"
+		echo "# cut before the .gitignore commit. Shared by every worktree of this repo."
+		echo "$MARKER"
+	} >>"$excl"
+	echo "  ADDED: $name ($excl)"
+	CHANGED=$((CHANGED + 1))
+done <"$LIST"
+echo "  ($SKIPPED repo(s) had no untracked thoughts/ and were left alone)"
+
+echo ""
+echo "== 2. per-worktree result (the measurement, not the intent)"
+STILL=0
+TRACKED=0
+while IFS= read -r gcd; do
+	while IFS= read -r wt; do
+		[ -d "$wt" ] || continue
+		st="$(git -C "$wt" status --porcelain 2>/dev/null | grep 'thoughts/')"
+		[ -z "$st" ] && continue
+		u="$(printf '%s\n' "$st" | grep -c '^?? *thoughts/')"
+		t="$(printf '%s\n' "$st" | grep -cE '^ ?[MADRU].*thoughts/')"
+		if [ "$u" -gt 0 ]; then
+			echo "  ⛔ STILL UNTRACKED ($u): $wt"
+			STILL=$((STILL + 1))
+		fi
+		if [ "$t" -gt 0 ]; then
+			echo "  ⚠️  TRACKED-MODIFIED ($t): $wt"
+			TRACKED=$((TRACKED + 1))
+		fi
+	done < <(git --git-dir="$gcd" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+done <"$LIST"
+
+echo ""
+echo "backfill: repos changed=$CHANGED already=$ALREADY | worktrees still-untracked=$STILL tracked-modified=$TRACKED (dry-run=$DRY_RUN)"
+if [ "$TRACKED" -gt 0 ]; then
+	echo ""
+	echo "⚠️  $TRACKED worktree(s) show TRACKED-MODIFIED thoughts/ paths. No ignore rule of any kind"
+	echo "    silences a tracked path, so this backfill cannot fix them and does not pretend to."
+	echo "    They need 'git update-index --skip-worktree' or a sweeper-side rule."
+fi
+# A non-dry run that left untracked cases behind did not do its job.
+if [ "$DRY_RUN" -eq 0 ] && [ "$STILL" -gt 0 ]; then exit 1; fi
+exit 0


### PR DESCRIPTION
CTC-633's reclaim shipped as a `.gitignore` commit, which only helps a worktree whose branch **contains** it. Every worktree cut before the merge still shows `?? thoughts/`, the sweeper still grades it `SALVAGE_DIRTY`, and the disk is still not reclaimed. `.git/info/exclude` is the per-checkout equivalent and lives in `$GIT_COMMON_DIR`, so **one write per repo covers all of that repo's worktrees**.

This is COORD's decision 1 — codify it as a script, merge, then run on all three hosts — rather than the `echo 'thoughts/' >> .git/info/exclude` hand-edit that FLEET-6 deliberately did not do.

## Measured, before and after (dev laptop, 00:27–00:41 CT)

| | |
|---|---|
| **before** | **9** worktrees had `thoughts/` in `git status` — **4 untracked** (catalyst-cloud) + **5 tracked-modified** (catalyst-workspace) |
| **after** | **0 untracked remain**, verified by an *independent* count rather than the script's own summary. 1 repo changed. |

⚠️ Note this also corrects the framing in FLEET-6: *"0 of 29 worktrees carry the ignore"* was true but read as 29 broken trees. Only **9** were actually polluted, and only **4** of those are fixable by an ignore rule.

## ⛔ What it cannot fix, printed rather than glossed

`info/exclude`, like `.gitignore`, applies **only to untracked files**. A worktree whose `thoughts/{global,ryan,shared}` are **tracked** symlinks shows ` M thoughts/…`, and no ignore rule of any kind silences that. Those 5 need `git update-index --skip-worktree` or a sweeper-side rule. The script names them per worktree; reporting a clean sweep would have been the easy and wrong answer.

## ⛔ Three scoping mistakes caught by running it, not by reading it

1. A **one-level** `$WT_ROOT` glob discovered catalyst, Adva and slides and **missed catalyst-cloud — the only repo with the defect**. `~/catalyst/wt/catalyst-cloud` is a *directory containing* worktrees, not a worktree. Now two levels deep.
2. Widening instead to every checkout under `~/code-repos/github/*/*` was the other wrong answer: it pulled in unrelated repos (media-tool, humanlayer) including one literally **named `thoughts`**, where ignoring `thoughts/` would be actively wrong. Scope is now "repos owning a worktree under `$WT_ROOT`", and within those only repos that actually *have* an untracked `thoughts/`.
3. A re-run reported `changed=0 already=0`, because a fixed repo no longer matches the affected predicate — **a zero indistinguishable from "did not look"**. Repos already carrying the marker now report `already ignored`.

## Tests — 12 checks

`scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh`: the fix, the `--dry-run` no-op, idempotence (exclude **byte-identical** on re-run), the tracked-modified report *with a control proving the path really is still dirty*, and zero-discovery exiting **2** rather than reporting a clean pass.

- ⛔ **Negative control**: a repo *without* the defect must not be touched.
- ⛔ **Mutation**: dropping the affected-only predicate fails **exactly** that check and no other.

Wired into `execution-core-tests.yml` with its paths — an unwired test is a test nobody runs.

## Note for the merge train

This PR, #3516 and #3517 each add a step to `execution-core-tests.yml` in different regions. They are green independently; whichever lands last should be rebased rather than trusted to auto-merge.

Refs CTC-633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)