### PR TITLE
feat(dev): CTL-1929 — run the GitHub producer in shadow, behind its OWN knob, with enforce refused by name

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -954,6 +954,7 @@ jobs:
             github-feed-event.test.mjs \
             github-feed-sweep.test.mjs \
             github-feed-parity.test.mjs \
+            github-feed-timer.test.mjs \
             cloud-feed-gate.test.mjs \
             cloud-feed-capture.test.mjs \
             cloud-feed-timer.test.mjs \

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2134,6 +2134,45 @@ export function readCloudFeedConfig(envObj = process.env) {
   return { mode, intervalSec };
 }
 
+// CTL-1929: GitHub-feed dispatch-source mode reader. Same ladder as
+// readCloudFeedConfig — env (CATALYST_GITHUB_FEED) > Layer-2
+// (.catalyst.githubFeed.mode) > 'off'.
+//
+// ⛔ A SEPARATE KNOB FROM `CATALYST_CLOUD_FEED`, AND THAT IS A SAFETY PROPERTY,
+// NOT TIDINESS. Every worker in this fleet already runs the Linear leg at
+// `enforce`. If the GitHub leg read the same value, then merely MERGING its wiring
+// would put it into enforce on every host at once — with no operator action, no
+// rollout, and no per-leg rollback. The GitHub tunnel is still the ONLY source of
+// `github.pr.merged` and `github.check_suite.completed` (CTC-691 / CTC-667 item 4),
+// so that merge would blind the CI wait and the deploy chain fleet-wide. The two
+// legs cut over independently or they cut over recklessly.
+const GITHUB_FEED_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2GithubFeed() {
+  try {
+    const gf = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.githubFeed;
+    return gf && typeof gf === "object" ? gf : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readGithubFeedConfig(envObj = process.env) {
+  const l2 = readLayer2GithubFeed();
+  const env = envObj.CATALYST_GITHUB_FEED;
+  let mode;
+  if (env === "0") mode = "off";
+  else if (typeof env === "string" && GITHUB_FEED_MODES.has(env)) mode = env;
+  else if (typeof l2.mode === "string" && GITHUB_FEED_MODES.has(l2.mode)) mode = l2.mode;
+  else mode = "off";
+  const rawInterval = envObj.CATALYST_GITHUB_FEED_INTERVAL_SEC ?? l2.intervalSeconds;
+  const parsed = Number(rawInterval);
+  // Number("") and Number(null) are both 0, which would read as a valid "0 seconds"
+  // and busy-spin the tick. Require a finite value >= 5.
+  const intervalSec = Number.isFinite(parsed) && parsed >= 5 ? Math.floor(parsed) : 30;
+  return { mode, intervalSec };
+}
+
 // CTL-1889: Linear write-proxy mode reader. Same ladder as readCloudFeedConfig —
 // env (CATALYST_LINEAR_WRITE_PROXY) > Layer-2 (.catalyst.linearWriteProxy.mode) > 'off'.
 //

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -35,6 +35,7 @@ import {
   writeDaemonRuntimeEnv, // CTL-1678: boot-time env snapshot for read-only surfaces
   getRegistryPath,
   getEventLogPath,
+  getReplicaDbPath, // CTL-1929: the github-feed producer reads the replica
   getJobsRoot, // CTL-1165 D3: job-dir GC root
   log,
   EVENT_DEBOUNCE_MS,
@@ -53,6 +54,7 @@ import {
   getCatalystRepoDir, // CTL-1093 sticky dir
   readDelegateRunnerConfig, // CTL-1331: async board-health delegate runner kill-switch
   readCloudFeedConfig, // CTL-1847: cloud-feed dispatch-source mode
+  readGithubFeedConfig, // CTL-1929: github-feed dispatch-source mode (SEPARATE knob)
   readLinearWriteProxyConfig, // CTL-1889: Linear write-proxy transport mode
   readLinearReplica, // CTL-1340: read-replica tier flag (inert; default off)
   getExecutor, // CTL-1365a: phase-worker executor resolver (env→Layer-1→node-class default; all "bg" in Phase 1)
@@ -109,6 +111,7 @@ import { sweepWtCleanupQueue } from "./wt-cleanup-drain.mjs"; // CTL-1218: wt-cl
 import { ProcReaper } from "./proc-reaper.mjs"; // CTL-1165 D2: orphan child-process reaper (default shadow)
 import { startWorktreeRefreshTimer, readWorktreeRefreshConfig } from "./worktree-refresh-timer.mjs";
 import { startCloudFeedTimer } from "./cloud-feed-timer.mjs"; // CTL-1847
+import { startGithubFeedTimer } from "./github-feed-timer.mjs"; // CTL-1929
 import { createCaptureSink, defaultCapturePath } from "./cloud-feed-capture.mjs"; // CTL-1847
 // CTL-1331: the async board-health delegate runner timer (kicks the DETACHED
 // drainer that does the heavy worktree-provision + `claude --bg` off the daemon
@@ -232,6 +235,7 @@ let _stalledPrTimer = null;
 // CAT-40: periodic GitHub core REST quota snapshot sampler.
 let _githubQuotaTimer = null;
 let _cloudFeedTimer = null; // CTL-1847: cloud-feed producer tick
+let _githubFeedTimer = null; // CTL-1929: github-feed producer tick
 // CTL-650: the push-based session wait-state watcher handle.
 let _waitWatcher = null;
 // CTL-685: per-worker memory sampler handle.
@@ -1481,6 +1485,44 @@ export function startDaemon({
         "cloud-feed: armed",
       );
     }
+    // CTL-1929: the GitHub leg's producer tick.
+    //
+    // ⛔ READ FROM ITS OWN KNOB, AND NO GATE IS INSTALLED. Both of those are the
+    // safety argument, not style:
+    //   * `CATALYST_GITHUB_FEED` is separate from `CATALYST_CLOUD_FEED`, which every
+    //     worker already runs at `enforce` — sharing the value would have enforced
+    //     the GitHub leg on every host the moment this merged.
+    //   * There is deliberately NO `setGithubFeedGate` call. A gate is what
+    //     suppresses smee's copy, and suppressing it for `github.pr.merged` /
+    //     `github.check_suite.completed` — which this producer cannot emit until
+    //     CTC-691 and CTC-667 item 4 land — would take out the CI wait and the
+    //     deploy chain with nothing behind them. `enforce` therefore degrades to
+    //     shadow inside the timer and says so.
+    // So on every host until an operator sets the flag, this block constructs
+    // nothing and routing is byte-identical to pre-CTL-1929.
+    const githubFeedCfg = readGithubFeedConfig();
+    if (githubFeedCfg.mode !== "off") {
+      _githubFeedTimer = startGithubFeedTimer({
+        mode: githubFeedCfg.mode,
+        intervalSec: githubFeedCfg.intervalSec,
+        orchDir,
+        dbPath: getReplicaDbPath(),
+        eventLogPath: getEventLogPath(),
+        appendFn: (path, line) => appendFileSync(path, line),
+        logger: log,
+      });
+      log.info(
+        {
+          requested: _githubFeedTimer?.mode?.requested ?? githubFeedCfg.mode,
+          effective: _githubFeedTimer?.mode?.effective ?? null,
+          degraded: _githubFeedTimer?.mode?.degraded ?? false,
+          intervalSec: githubFeedCfg.intervalSec,
+          gate: "none — the github leg suppresses nothing (CTC-691 / CTC-667 item 4)",
+        },
+        "github-feed: armed (shadow only)",
+      );
+    }
+
     // CTL-1889: the Linear write-proxy transport. Same posture as the cloud-feed
     // block above — `off` (the default) constructs nothing, so linear-write.mjs's
     // module-level install stays null and every Linear write in this process is
@@ -2417,6 +2459,14 @@ export function stopDaemon() {
   // not just the timer: a live gate with a dead producer would keep suppressing
   // smee in enforce mode while nothing replaced it — a silent total dispatch
   // outage, which is strictly worse than either half alone.
+  if (_githubFeedTimer) {
+    try {
+      _githubFeedTimer.stop();
+    } catch {
+      /* best effort */
+    }
+    _githubFeedTimer = null;
+  }
   if (_cloudFeedTimer) {
     try {
       _cloudFeedTimer.stop();

--- a/plugins/dev/scripts/execution-core/github-feed-seen.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-seen.mjs
@@ -36,7 +36,15 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-export function defaultSeenPath(orchDir, account = "tenant-0") {
+/**
+ * ⚠️ No account default here on purpose — the caller resolves it once
+ * (`github-feed-timer.resolveAccount`) and threads it, so there is exactly one
+ * answer per process to which tenant this host is.
+ */
+export function defaultSeenPath(orchDir, account) {
+  if (typeof account !== "string" || account === "") {
+    throw new Error("defaultSeenPath: account is required — an unlabelled store files evidence under the wrong tenant");
+  }
   return join(orchDir, `github-feed-seen-${account}.db`);
 }
 

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
@@ -90,7 +90,10 @@ export function fail(counts, reason) {
 }
 
 /** Per-stream cursor file. One file per stream, deliberately — see `runGithubSweep`. */
-export function streamCursorPath(orchDir, streamKey, account = "tenant-0") {
+export function streamCursorPath(orchDir, streamKey, account) {
+  if (typeof account !== "string" || account === "") {
+    throw new Error("streamCursorPath: account is required — an unlabelled cursor files producer state under the wrong tenant");
+  }
   return `${orchDir}/github-feed-cursor-${account}-${streamKey}.json`;
 }
 
@@ -223,7 +226,11 @@ export function runGithubSweep({
   seen,
   sink,
   orchDir,
-  account = "tenant-0",
+  // ⛔ No default. The account NAMES every per-tenant artifact (cursor files, the
+  // suppression store, the marker attribute); defaulting it means a host configured
+  // for another account silently files its state under `tenant-0` and still looks
+  // complete. `github-feed-timer.resolveAccount` is the one resolver.
+  account,
   now = Date.now(),
   settleMs = DEFAULT_SETTLE_MS,
   batchLimit = DEFAULT_BATCH_LIMIT,

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
@@ -15,6 +15,7 @@ import { emptyCounts, runGithubSweep, streamCursorPath } from "./github-feed-swe
 import { countsClean } from "./cloud-feed-timer.mjs";
 import { githubSweepUnreadyReason } from "./github-feed-sweep.mjs";
 
+const ACCT = "tenant-0";
 const tmp = mkdtempSync(join(tmpdir(), "gh-feed-sweep-"));
 afterAll(() => {
   try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ }
@@ -76,7 +77,7 @@ const addReview = (db, id, ts) =>
 
 const sweep = (w, now, extra = {}) =>
   runGithubSweep({
-    source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+    source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT,
     now, settleMs: 1000, streams: ["reviewSubmitted"], seams: SEAMS, ...extra,
   });
 
@@ -159,7 +160,7 @@ describe("⛔ P1 regression (Codex #3513): consecutive pushes to one ref both re
         .run("o/r", "refs/heads/main", "sha0", "sha1", NOW - 500);
     });
     try {
-      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT,
         settleMs: 1000, streams: ["push"], seams: SEAMS };
       expect(runGithubSweep({ ...opts, now: NOW }).emitted).toBe(1);
 
@@ -186,7 +187,7 @@ describe("⛔ P1 regression (Codex #3513): consecutive pushes to one ref both re
         .run("o/r", "refs/heads/main", "sha0", "sha1", NOW - 500);
     });
     try {
-      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT,
         settleMs: 1000, streams: ["push"], seams: SEAMS };
       expect(runGithubSweep({ ...opts, now: NOW }).emitted).toBe(1);
       const c2 = runGithubSweep({ ...opts, now: NOW + 1 });
@@ -243,7 +244,7 @@ describe("⛔ declines never reach byFailure — this is the CTL-1909 property",
         positionAfter: w.source.positionAfter,
       };
       const c = runGithubSweep({
-        source: exploding, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        source: exploding, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT, now: NOW,
         settleMs: 1000, streams: ["push", "reviewSubmitted"], seams: SEAMS,
       });
       expect(c.failed).toBe(1);
@@ -281,7 +282,7 @@ describe("⛔ first-run detection is PER STREAM, not per producer", () => {
     });
     try {
       const c = runGithubSweep({
-        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT, now: NOW,
         settleMs: 1000, streams: ["reviewSubmitted", "push", "reviewCommentCreated"], seams: SEAMS,
       });
       expect(c.emitted).toBe(3);
@@ -315,7 +316,7 @@ describe("⛔ P1 (Codex #3520): the prune is scoped to its own stream", () => {
         .run("o/r", "refs/heads/main", "b1", "a1", NOW - 100);
     });
     try {
-      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir,
+      const opts = { source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT,
         settleMs: 1000, seams: SEAMS };
       // BOTH streams sweep at NOW so each lands an entry AND a durable cursor. The
       // push stream must actually acquire one here — without it, its later sweep
@@ -341,7 +342,7 @@ describe("⛔ P1 (Codex #3520): the prune is scoped to its own stream", () => {
       // `DELETE ... WHERE ts < cursor` delete it. Assert that rather than assuming it:
       // the first cut of this test let push read nothing, so it wrote no cursor,
       // pruned nothing, and passed under the mutant.
-      const pushCursor = JSON.parse(readFileSync(streamCursorPath(w.dir, "push"), "utf8"));
+      const pushCursor = JSON.parse(readFileSync(streamCursorPath(w.dir, "push", ACCT), "utf8"));
       expect(pushCursor.lastCreatedAt).toBeGreaterThan(NOW - 900);
     } finally { w.close(); }
   });
@@ -402,7 +403,7 @@ describe("cursor ordering and durability", () => {
     const w = world((db) => addReview(db, "a", NOW - 100));
     try {
       sweep(w, NOW);
-      const p = streamCursorPath(w.dir, "reviewSubmitted");
+      const p = streamCursorPath(w.dir, "reviewSubmitted", ACCT);
       expect(existsSync(p)).toBe(true);
       const cur = JSON.parse(readFileSync(p, "utf8"));
       // Held at the horizon (NOW-1000), NOT at the emitted row (NOW-100).
@@ -418,11 +419,11 @@ describe("cursor ordering and durability", () => {
       expect(() => runGithubSweep({
         source: w.source, seen: w.seen,
         sink: () => { throw new Error("log unavailable"); },
-        orchDir: w.dir, now: NOW, settleMs: 1000, streams: ["reviewSubmitted"], seams: SEAMS,
+        orchDir: w.dir, account: ACCT, now: NOW, settleMs: 1000, streams: ["reviewSubmitted"], seams: SEAMS,
       })).not.toThrow();
       // No cursor was written, and nothing was marked seen — so a healthy next tick
       // re-emits. Losing progress is recoverable; advancing past an unemitted row is not.
-      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted"))).toBe(false);
+      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted", ACCT))).toBe(false);
       expect(w.seen.size()).toBe(0);
       expect(sweep(w, NOW).emitted).toBe(1);
     } finally { w.close(); }
@@ -437,12 +438,12 @@ describe("cursor ordering and durability", () => {
     });
     try {
       runGithubSweep({
-        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, now: NOW,
+        source: w.source, seen: w.seen, sink: w.sink, orchDir: w.dir, account: ACCT, now: NOW,
         settleMs: 1000, streams: ["reviewSubmitted", "push"], seams: SEAMS,
       });
-      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted"))).toBe(true);
-      expect(existsSync(streamCursorPath(w.dir, "push"))).toBe(true);
-      expect(streamCursorPath(w.dir, "push")).not.toBe(streamCursorPath(w.dir, "reviewSubmitted"));
+      expect(existsSync(streamCursorPath(w.dir, "reviewSubmitted", ACCT))).toBe(true);
+      expect(existsSync(streamCursorPath(w.dir, "push", ACCT))).toBe(true);
+      expect(streamCursorPath(w.dir, "push", ACCT)).not.toBe(streamCursorPath(w.dir, "reviewSubmitted", ACCT));
     } finally { w.close(); }
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.mjs
@@ -36,11 +36,29 @@ import { createGithubFeedSource } from "./github-feed-source.mjs";
 import { createSeenStore, defaultSeenPath } from "./github-feed-seen.mjs";
 import { githubSweepUnreadyReason, runGithubSweep } from "./github-feed-sweep.mjs";
 import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
+import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
+
+/**
+ * Which account this host is.
+ *
+ * ⛔ Imported from the Linear leg rather than re-typed, and resolved from the same
+ * env var, because every per-account artifact this timer writes — the shadow file,
+ * the suppression DB, nine cursor files, and the `catalyst.account` attribute on
+ * every would-dispatch marker — is NAMED by it. A hard-coded `tenant-0` on a host
+ * configured for another account does not fail: it silently files that host's parity
+ * evidence and producer state under the wrong tenant, which is worse than an error
+ * because the artifacts still look complete. `linear-feed-run.mjs`'s own comment
+ * gives the rule: this must match `cloud-sync.mjs`'s resolution "so the two cannot
+ * disagree about which account this host is".
+ */
+export function resolveAccount(envObj = process.env) {
+  return envObj.CATALYST_CLOUD_ACCOUNT || DEFAULT_ACCOUNT;
+}
 
 /** The shadow-only marker name. Deliberately NOT a `github.*` name — see the header. */
 export const EVENT_WOULD_DISPATCH = "github-feed.would-dispatch";
 
-export function defaultShadowPath(orchDir, account = "tenant-0") {
+export function defaultShadowPath(orchDir, account = resolveAccount()) {
   return join(orchDir, "shadow", `github-feed-${account}.jsonl`);
 }
 
@@ -82,7 +100,7 @@ export function resolveEffectiveMode(requested) {
 }
 
 /** One would-dispatch marker for an event the producer would have emitted. */
-export function buildWouldDispatchEvent(event, { account = "tenant-0" } = {}, seams) {
+export function buildWouldDispatchEvent(event, { account = resolveAccount() } = {}, seams) {
   return buildCanonicalEvent(
     {
       name: EVENT_WOULD_DISPATCH,
@@ -113,7 +131,7 @@ export function buildWouldDispatchEvent(event, { account = "tenant-0" } = {}, se
 export function runGithubFeedTick({
   mode,
   orchDir,
-  account = "tenant-0",
+  account = resolveAccount(),
   dbPath,
   now = Date.now(),
   appendEventFn,
@@ -191,7 +209,7 @@ export function startGithubFeedTimer({
   mode,
   intervalSec = 30,
   orchDir,
-  account = "tenant-0",
+  account = resolveAccount(),
   dbPath,
   eventLogPath,
   shadowPath,

--- a/plugins/dev/scripts/execution-core/github-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.mjs
@@ -1,0 +1,247 @@
+// github-feed-timer.mjs — CTL-1929. The daemon-hosted tick for the GitHub leg.
+//
+// ── ⛔ `enforce` IS NOT REACHABLE YET, BY DESIGN ────────────────────────────
+// On the Linear leg, `enforce` means two things at once: the producer emits the
+// real event AND `cloud-feed-gate` suppresses smee's copy. Those halves are not
+// separable — emitting real `github.*` events while the tunnel is still delivering
+// its own would put BOTH on the log, and every consumer would route twice: two
+// `monitor-merge` wakes, two CI-wait resolutions, two `filter_state` transitions.
+//
+// The gate is not wired for `github.*` (`DISPATCH_CLASS_NAMES` is three `linear.*`
+// names), and it MUST NOT be until `github.pr.merged` and
+// `github.check_suite.completed` exist — CTC-691 and CTC-667 item 4 — because
+// suppressing smee for names this producer cannot emit is a total loss of the CI
+// wait and the deploy chain.
+//
+// So `enforce` here DEGRADES TO SHADOW and says so, loudly, once per process. It
+// does not silently do nothing (an operator would read the flag as active), and it
+// does not half-activate (which is the double-dispatch above). A mode that cannot
+// be honoured is refused by name.
+//
+// ── WHAT SHADOW EMITS, AND WHY IT IS A DIFFERENT NAME ──────────────────────
+// `github-feed.would-dispatch`, never the real `github.*` name. Re-emitting
+// `github.pr.merged` with a shadow flag would fire every `wait-for` subscriber, the
+// broker's PR-lifecycle router, and `plugin-refresh`'s merge auto-pull — a shadow
+// that actuates is not a shadow. Same reasoning, and the same shape, as
+// `cloud-feed-timer.mjs`'s `cloud-feed.would-dispatch`.
+//
+// ⚠️ The full event is ALSO written to a shadow FILE, and that file — not the
+// would-dispatch line — is what the parity ledger reads. The ledger must compare
+// the exact envelope the producer would have emitted, and an instrument that
+// changes shape at the moment of cutover cannot judge the cutover.
+
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createGithubFeedSource } from "./github-feed-source.mjs";
+import { createSeenStore, defaultSeenPath } from "./github-feed-seen.mjs";
+import { githubSweepUnreadyReason, runGithubSweep } from "./github-feed-sweep.mjs";
+import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
+
+/** The shadow-only marker name. Deliberately NOT a `github.*` name — see the header. */
+export const EVENT_WOULD_DISPATCH = "github-feed.would-dispatch";
+
+export function defaultShadowPath(orchDir, account = "tenant-0") {
+  return join(orchDir, "shadow", `github-feed-${account}.jsonl`);
+}
+
+/**
+ * ⛔ Refuse any path that looks like the unified event log.
+ *
+ * The shadow sink appends raw producer output. If that path were ever the event
+ * log, every shadow event would become a REAL one and the whole containment
+ * argument would silently invert — while every counter still read "shadow".
+ */
+export function assertNotEventLog(path) {
+  const p = String(path ?? "");
+  if (/[\\/]events[\\/]\d{4}-\d{2}\.jsonl$/.test(p) || p.endsWith("/events")) {
+    throw new Error(`github-feed shadow sink refuses an event-log path: ${p}`);
+  }
+  return p;
+}
+
+/**
+ * Resolve the mode actually in force, separately from the mode requested.
+ *
+ * Returns `{ effective, requested, degraded, reason }`. Keeping the two apart is
+ * the point: a caller must be able to log what the operator asked for AND what is
+ * running, or a degraded node is indistinguishable from a configured one.
+ */
+export function resolveEffectiveMode(requested) {
+  if (requested === "enforce") {
+    return {
+      requested,
+      effective: "shadow",
+      degraded: true,
+      reason:
+        "enforce requires the dispatch gate to suppress the smee copy; the gate carries no github.* names " +
+        "(and must not until CTC-691 and CTC-667 item 4 land, or the CI wait and deploy chain lose their only source). " +
+        "Running as shadow.",
+    };
+  }
+  return { requested, effective: requested, degraded: false, reason: null };
+}
+
+/** One would-dispatch marker for an event the producer would have emitted. */
+export function buildWouldDispatchEvent(event, { account = "tenant-0" } = {}, seams) {
+  return buildCanonicalEvent(
+    {
+      name: EVENT_WOULD_DISPATCH,
+      serviceName: "catalyst.execution-core",
+      attributes: {
+        "catalyst.github_feed.event_name": event?.attributes?.["event.name"] ?? "unknown",
+        "vcs.repository.name": event?.attributes?.["vcs.repository.name"],
+        "catalyst.account": account,
+      },
+      payload: {
+        account,
+        eventName: event?.attributes?.["event.name"] ?? "unknown",
+        // The scoping the ledger and a human both need, without duplicating the
+        // whole envelope onto the event log (the shadow FILE carries that).
+        pr: event?.attributes?.["vcs.pr.number"] ?? null,
+        ref: event?.attributes?.["vcs.ref.name"] ?? null,
+        sha: event?.attributes?.["vcs.revision"] ?? null,
+      },
+    },
+    seams,
+  );
+}
+
+/**
+ * Run one tick. Pure-ish: every side effect is an injected seam so the whole tick
+ * is testable without a daemon, a replica, or a clock.
+ */
+export function runGithubFeedTick({
+  mode,
+  orchDir,
+  account = "tenant-0",
+  dbPath,
+  now = Date.now(),
+  appendEventFn,
+  appendShadowFn,
+  sourceFactory = createGithubFeedSource,
+  seenFactory = createSeenStore,
+  sweepFn = runGithubSweep,
+  feedHealth = { healthy: true },
+  seams,
+  logger = null,
+}) {
+  const resolved = resolveEffectiveMode(mode);
+  if (resolved.effective === "off") {
+    return { skipped: "mode-off", mode: resolved, counts: null, ready: false };
+  }
+
+  let source = null;
+  let seen = null;
+  try {
+    source = sourceFactory({ dbPath });
+    seen = seenFactory({ path: defaultSeenPath(orchDir, account) });
+  } catch (err) {
+    // A producer that cannot open its inputs is a FAILURE, not a quiet no-op: it is
+    // exactly the state readiness exists to refuse to arm on.
+    try { source?.close?.(); } catch { /* best effort */ }
+    return {
+      skipped: null,
+      mode: resolved,
+      error: `open-failed:${err?.code ?? err?.name ?? "unknown"}`,
+      counts: null,
+      ready: false,
+    };
+  }
+
+  try {
+    const emitted = [];
+    const counts = sweepFn({
+      source,
+      seen,
+      sink: (event) => {
+        emitted.push(event);
+        // The FULL envelope goes to the shadow file — that is the ledger's input.
+        appendShadowFn?.(event);
+        // A marker, under its own name, goes to the event log so the tick is
+        // observable without the ledger.
+        if (appendEventFn) appendEventFn(buildWouldDispatchEvent(event, { account }, seams));
+      },
+      orchDir,
+      account,
+      now,
+      seams,
+    });
+
+    const report = { counts, stoppedEarly: false };
+    const unready = githubSweepUnreadyReason(report, feedHealth);
+    if (resolved.degraded && logger?.warn) {
+      // Once per tick is deliberate here rather than latched: this state is a
+      // deliberate operator-visible refusal, not a flapping alarm, and it ends the
+      // moment someone sets the flag to something honourable.
+      logger.warn({ requested: resolved.requested, effective: resolved.effective, reason: resolved.reason },
+        "github-feed: enforce requested but not honourable — running as shadow");
+    }
+    return { skipped: null, mode: resolved, counts, emitted: emitted.length, ready: unready === null, unready };
+  } finally {
+    try { source.close(); } catch { /* best effort */ }
+    try { seen.close(); } catch { /* best effort */ }
+  }
+}
+
+/**
+ * Start the recurring tick. Returns `null` when the mode is `off`, so a caller can
+ * assert on "no timer was created at all" rather than on a timer that does nothing.
+ */
+export function startGithubFeedTimer({
+  mode,
+  intervalSec = 30,
+  orchDir,
+  account = "tenant-0",
+  dbPath,
+  eventLogPath,
+  shadowPath,
+  appendFn,
+  logger = null,
+  clock = { setInterval, clearInterval },
+} = {}) {
+  const resolved = resolveEffectiveMode(mode);
+  if (resolved.effective === "off") return null;
+
+  const shadow = assertNotEventLog(shadowPath ?? defaultShadowPath(orchDir, account));
+  mkdirSync(dirname(shadow), { recursive: true });
+
+  const appendShadowFn = (event) => {
+    try {
+      appendFn(shadow, `${JSON.stringify(event)}\n`);
+    } catch (err) {
+      // Fail-open: the shadow file is EVIDENCE, and evidence must never be
+      // load-bearing for the thing it observes.
+      logger?.warn?.({ err: err?.message }, "github-feed: shadow append failed");
+    }
+  };
+  const appendEventFn = (event) => {
+    try {
+      appendFn(eventLogPath, `${JSON.stringify(event)}\n`);
+    } catch (err) {
+      logger?.warn?.({ err: err?.message }, "github-feed: would-dispatch append failed");
+    }
+  };
+
+  let last = null;
+  const tick = () => {
+    try {
+      last = runGithubFeedTick({ mode, orchDir, account, dbPath, appendEventFn, appendShadowFn, logger });
+    } catch (err) {
+      // A guardrail that can wedge the daemon tick is not a guardrail.
+      logger?.error?.({ err: err?.message }, "github-feed: tick threw");
+      last = { error: `tick-threw:${err?.name ?? "unknown"}`, ready: false };
+    }
+  };
+
+  const handle = clock.setInterval(tick, Math.max(5, intervalSec) * 1000);
+  handle?.unref?.();
+  return {
+    stop: () => clock.clearInterval(handle),
+    tickNow: tick,
+    lastReport: () => last,
+    // Always false today — `enforce` degrades to shadow, so nothing this producer
+    // emits is ever authoritative. Exposed so a future gate reads one answer.
+    isReady: () => false,
+    mode: resolved,
+  };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
@@ -8,10 +8,15 @@ import {
   EVENT_WOULD_DISPATCH,
   assertNotEventLog,
   buildWouldDispatchEvent,
+  defaultShadowPath,
+  resolveAccount,
   resolveEffectiveMode,
   runGithubFeedTick,
   startGithubFeedTimer,
 } from "./github-feed-timer.mjs";
+import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
+import { defaultSeenPath } from "./github-feed-seen.mjs";
+import { streamCursorPath } from "./github-feed-sweep.mjs";
 import { readGithubFeedConfig } from "./config.mjs";
 
 const tmp = mkdtempSync(join(tmpdir(), "gh-feed-timer-"));
@@ -39,6 +44,31 @@ describe("⛔ the knob is SEPARATE from the Linear leg's — a merge must not fl
       expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED_INTERVAL_SEC: v, HOME: tmp }).intervalSec).toBe(30);
     }
     expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED_INTERVAL_SEC: "60", HOME: tmp }).intervalSec).toBe(60);
+  });
+});
+
+describe("⛔ P2 (Codex #3524): the account is resolved, never hard-coded", () => {
+  test("a host on another tenant labels its artifacts with THAT tenant", () => {
+    // A hard-coded default does not fail here — it silently files this host's parity
+    // evidence, suppression store and nine cursor files under `tenant-0` while the
+    // artifacts still look complete. That is worse than an error.
+    expect(resolveAccount({ CATALYST_CLOUD_ACCOUNT: "tenant-7" })).toBe("tenant-7");
+    expect(defaultShadowPath("/o", resolveAccount({ CATALYST_CLOUD_ACCOUNT: "tenant-7" })))
+      .toContain("github-feed-tenant-7.jsonl");
+    expect(buildWouldDispatchEvent({ attributes: {} }, { account: "tenant-7" }).body.payload.account)
+      .toBe("tenant-7");
+  });
+
+  test("it falls back to the SAME default the Linear leg uses, imported not re-typed", () => {
+    expect(resolveAccount({})).toBe(DEFAULT_ACCOUNT);
+    expect(DEFAULT_ACCOUNT).toBe("tenant-0");
+  });
+
+  test("⛔ per-tenant artifact builders REFUSE an absent account", () => {
+    // Fail closed rather than defaulting: an unlabelled artifact is indistinguishable
+    // from a correctly-labelled one after the fact.
+    expect(() => defaultSeenPath("/o")).toThrow();
+    expect(() => streamCursorPath("/o", "push")).toThrow();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
@@ -1,0 +1,174 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-timer.test.mjs
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  EVENT_WOULD_DISPATCH,
+  assertNotEventLog,
+  buildWouldDispatchEvent,
+  resolveEffectiveMode,
+  runGithubFeedTick,
+  startGithubFeedTimer,
+} from "./github-feed-timer.mjs";
+import { readGithubFeedConfig } from "./config.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-feed-timer-"));
+afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
+
+describe("⛔ the knob is SEPARATE from the Linear leg's — a merge must not flip GitHub to enforce", () => {
+  test("CATALYST_CLOUD_FEED=enforce leaves the GitHub leg OFF", () => {
+    // Every worker already runs the Linear leg at enforce. If this read the same
+    // value, merging the wiring would enforce the GitHub leg fleet-wide with no
+    // operator action — while pr.merged and check_suite.completed are unproducible.
+    const cfg = readGithubFeedConfig({ CATALYST_CLOUD_FEED: "enforce", HOME: tmp });
+    expect(cfg.mode).toBe("off");
+  });
+
+  test("it ships OFF, and only its own env var moves it", () => {
+    expect(readGithubFeedConfig({ HOME: tmp }).mode).toBe("off");
+    expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED: "shadow", HOME: tmp }).mode).toBe("shadow");
+    expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED: "0", HOME: tmp }).mode).toBe("off");
+    expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED: "nonsense", HOME: tmp }).mode).toBe("off");
+  });
+
+  test("a zero or empty interval cannot busy-spin the tick", () => {
+    // Number("") and Number(null) are both 0 — a valid-looking "0 seconds".
+    for (const v of ["", "0", "1", "abc"]) {
+      expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED_INTERVAL_SEC: v, HOME: tmp }).intervalSec).toBe(30);
+    }
+    expect(readGithubFeedConfig({ CATALYST_GITHUB_FEED_INTERVAL_SEC: "60", HOME: tmp }).intervalSec).toBe(60);
+  });
+});
+
+describe("⛔ enforce is refused BY NAME, not silently", () => {
+  test("enforce degrades to shadow and carries a reason", () => {
+    const r = resolveEffectiveMode("enforce");
+    expect(r.effective).toBe("shadow");
+    expect(r.degraded).toBe(true);
+    expect(r.reason).toContain("CTC-691");
+    // requested and effective stay distinct — a degraded node must not be
+    // indistinguishable from a configured one.
+    expect(r.requested).toBe("enforce");
+  });
+
+  test("shadow and off are not degraded", () => {
+    expect(resolveEffectiveMode("shadow")).toEqual({ requested: "shadow", effective: "shadow", degraded: false, reason: null });
+    expect(resolveEffectiveMode("off").effective).toBe("off");
+  });
+
+  test("nothing this producer emits is ever authoritative today", () => {
+    const t = startGithubFeedTimer({
+      mode: "enforce", orchDir: join(tmp, "auth"), dbPath: ":memory:",
+      eventLogPath: join(tmp, "auth", "ev.jsonl"), appendFn: () => {},
+      clock: { setInterval: () => ({ unref() {} }), clearInterval: () => {} },
+    });
+    expect(t.isReady()).toBe(false);
+    t.stop();
+  });
+});
+
+describe("⛔ the shadow sink refuses the unified event log", () => {
+  test("an events/YYYY-MM.jsonl path is refused", () => {
+    // If the shadow file were ever the event log, every shadow event would become a
+    // REAL one while every counter still read "shadow".
+    expect(() => assertNotEventLog("/home/x/catalyst/events/2026-08.jsonl")).toThrow();
+    expect(() => assertNotEventLog("/home/x/catalyst/events")).toThrow();
+  });
+  test("an ordinary shadow path is accepted", () => {
+    expect(assertNotEventLog("/home/x/catalyst/shadow/github-feed-tenant-0.jsonl"))
+      .toContain("github-feed");
+  });
+});
+
+describe("the would-dispatch marker", () => {
+  const src = {
+    attributes: { "event.name": "github.pr.merged", "vcs.repository.name": "o/r", "vcs.pr.number": 7, "vcs.revision": "abc" },
+    body: { message: "m", payload: { merged: true } },
+  };
+  test("⛔ it does NOT reuse the real github.* name", () => {
+    // Re-emitting the real name with a shadow flag would fire every wait-for
+    // subscriber, the PR-lifecycle router, and plugin-refresh's auto-pull. A shadow
+    // that actuates is not a shadow.
+    const m = buildWouldDispatchEvent(src, {});
+    expect(m.attributes["event.name"]).toBe(EVENT_WOULD_DISPATCH);
+    expect(m.attributes["event.name"].startsWith("github.")).toBe(false);
+  });
+  test("it carries the scoping a reader needs", () => {
+    const m = buildWouldDispatchEvent(src, { account: "tenant-0" });
+    expect(m.body.payload).toMatchObject({ eventName: "github.pr.merged", pr: 7, sha: "abc", account: "tenant-0" });
+  });
+});
+
+describe("the tick", () => {
+  const fakeSource = { close() {} };
+  const fakeSeen = { close() {} };
+  const okCounts = { emitted: 1, suppressed: 0, declined: 0, failed: 0, byReason: {}, byFailure: {}, byStream: {} };
+
+  test("mode off creates no timer at all", () => {
+    expect(startGithubFeedTimer({ mode: "off", orchDir: tmp, appendFn: () => {} })).toBeNull();
+  });
+
+  test("shadow writes the FULL envelope to the shadow file and a MARKER to the event log", () => {
+    // The ledger reads the shadow file, so it must carry the exact envelope the
+    // producer would have emitted — not the marker.
+    const shadow = []; const events = [];
+    const ev = { attributes: { "event.name": "github.push", "vcs.ref.name": "refs/heads/main" }, body: { payload: {} } };
+    const r = runGithubFeedTick({
+      mode: "shadow", orchDir: tmp, dbPath: ":memory:",
+      appendShadowFn: (e) => shadow.push(e), appendEventFn: (e) => events.push(e),
+      sourceFactory: () => fakeSource, seenFactory: () => fakeSeen,
+      sweepFn: ({ sink }) => { sink(ev); return okCounts; },
+    });
+    expect(r.emitted).toBe(1);
+    expect(shadow[0].attributes["event.name"]).toBe("github.push");
+    expect(events[0].attributes["event.name"]).toBe(EVENT_WOULD_DISPATCH);
+  });
+
+  test("an unopenable input is an ERROR, never a quiet no-op", () => {
+    const r = runGithubFeedTick({
+      mode: "shadow", orchDir: tmp, dbPath: "/nope/nope.db",
+      sourceFactory: () => { throw Object.assign(new Error("x"), { code: "SQLITE_CANTOPEN" }); },
+      seenFactory: () => fakeSeen,
+    });
+    expect(r.error).toContain("SQLITE_CANTOPEN");
+    expect(r.ready).toBe(false);
+    expect(r.counts).toBeNull();
+  });
+
+  test("a failed sweep un-arms readiness", () => {
+    const dirty = { ...okCounts, failed: 1, byFailure: { "stream-threw:push": 1 } };
+    const r = runGithubFeedTick({
+      mode: "shadow", orchDir: tmp, dbPath: ":memory:",
+      appendShadowFn: () => {}, appendEventFn: () => {},
+      sourceFactory: () => fakeSource, seenFactory: () => fakeSeen, sweepFn: () => dirty,
+    });
+    expect(r.ready).toBe(false);
+    expect(r.unready).toContain("streams:");
+  });
+
+  test("an unhealthy feed un-arms readiness even on clean counts", () => {
+    const r = runGithubFeedTick({
+      mode: "shadow", orchDir: tmp, dbPath: ":memory:",
+      appendShadowFn: () => {}, appendEventFn: () => {},
+      sourceFactory: () => fakeSource, seenFactory: () => fakeSeen, sweepFn: () => okCounts,
+      feedHealth: { healthy: false, reason: "record-stale" },
+    });
+    expect(r.ready).toBe(false);
+    expect(r.unready).toBe("feed-unhealthy:record-stale");
+  });
+
+  test("⛔ a throwing tick cannot wedge the daemon", () => {
+    let handle = null;
+    const t = startGithubFeedTimer({
+      mode: "shadow", orchDir: join(tmp, "wedge"), dbPath: "/nope/nope.db",
+      eventLogPath: join(tmp, "wedge", "ev.jsonl"),
+      appendFn: () => { throw new Error("disk full"); },
+      clock: { setInterval: (fn) => { handle = fn; return { unref() {} }; }, clearInterval: () => {} },
+    });
+    expect(() => handle()).not.toThrow();
+    expect(t.lastReport()).not.toBeNull();
+    t.stop();
+  });
+});


### PR DESCRIPTION
Third and last PR of CTL-1929 ask (2). Wires the producer (#3513, #3520) into the daemon tick.

**Ship-inert.** `CATALYST_GITHUB_FEED` defaults to `off`, so on every host until an operator sets it this block constructs nothing and routing is byte-identical to pre-CTL-1929.

## ⛔ Two refusals, and both are the safety argument

### 1. The knob is SEPARATE from `CATALYST_CLOUD_FEED`

Every worker in this fleet already runs the Linear leg at **`enforce`**. Had the GitHub leg read the same value, then **merely merging this PR** would have put it into enforce on every host at once — no operator action, no rollout, no per-leg rollback — while `github.pr.merged` and `github.check_suite.completed` remain unproducible (**CTC-691**, **CTC-667 item 4**).

That merge would have blinded the CI wait and the deploy chain fleet-wide. The two legs cut over independently or they cut over recklessly.

### 2. `enforce` is REFUSED BY NAME, not honoured

On the Linear leg, `enforce` means two inseparable things: the producer emits the real event **and** the gate suppresses smee's copy.

- There is deliberately **no `setGithubFeedGate` call**. Suppressing smee for names this producer cannot emit is a *total* loss of those consumers.
- Emitting real `github.*` events **without** suppressing smee is the other half of the trap: both copies land and every consumer routes twice — two `monitor-merge` wakes, two CI-wait resolutions, two `filter_state` transitions.

So `enforce` **degrades to shadow** and says so, keeping `requested` and `effective` distinct — a degraded node must not be indistinguishable from a configured one. `isReady()` is hard `false`: nothing this producer emits is authoritative today.

## What shadow actually does

| sink | content | why |
| --- | --- | --- |
| shadow **file** | the **full** envelope | the parity ledger reads this; an instrument that changes shape at the moment of cutover cannot judge the cutover |
| event log | a marker named **`github-feed.would-dispatch`** | so the tick is observable without the ledger |

⛔ The marker never reuses the real `github.*` name. Re-emitting `github.pr.merged` with a shadow flag would fire every `wait-for` subscriber, the broker's PR-lifecycle router, and `plugin-refresh`'s merge auto-pull. **A shadow that actuates is not a shadow.** The sink also structurally refuses any event-log-shaped path — if that file were ever the event log, every shadow event would become a real one while every counter still read "shadow".

## ⚠️ A bug `node --check` cannot see

`getReplicaDbPath` was used in the daemon before it was imported. That is a `ReferenceError` fired **only by setting the flag** — i.e. precisely when someone was relying on it, and never before. Caught by checking every named import from `config.mjs` against its actual exports (**35 checked, 0 missing**), which is the general form of the class rather than a one-off fix.

## Tests

142 pass across the five `github-feed-*` suites; `config` suites **298 / 0** (this touches `config.mjs`). New suite added to the CI allowlist — it is an explicit list, not a glob.

### 7 mutation controls, all killed

| mutation | result |
| --- | --- |
| ⛔ share the Linear knob (the merge-flips-enforce bug) | 1 fail |
| default to `shadow` instead of `off` | 2 fail |
| accept a 0-second interval (busy-spin) | 1 fail |
| ⛔ honour `enforce` (double-dispatch) | 1 fail |
| shadow reuses the real `github.*` name | 2 fail |
| shadow sink accepts an event-log path | 1 fail |
| `isReady()` claims authority | 1 fail |

Baseline and restored both 16/0 on the timer suite.

## ⛔ What still blocks the actual cutover

Nothing in this PR moves the fleet. Ask (4) parity-in-shadow and ask (5) tunnel retirement remain blocked on:

- **CTC-691** — `pull_requests` has no `merge_commit_sha`, so `github.pr.merged` cannot be emitted without silently breaking the merge→deploy join;
- **CTC-667 item 4** — no `check_suite` row, so the CI wait's highest-volume signal has no stream;
- and now measured rather than assumed: **`github.push` coverage is not yet demonstrable** — the corrected parity ledger reads INCONCLUSIVE on 138 unmatched smee events, 101 of them pushes. The live rate is only knowable from a shadow run on a host, which is what this PR makes possible.