### PR TITLE
feat(dev): CTL-1935 — pin the catalyst-index serving root to a git SHA (COORD decision 2)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -234,6 +234,13 @@ jobs:
         # a green result cannot come from a module that merely has nothing to detonate.
         run: bash __tests__/cli-shell-guard.test.sh
 
+      - name: catalyst-index pinned serving-root test (CTL-1935)
+        # The indexer is an on-demand CLI with no boot record, so evaluateDepSkew cannot grade it.
+        # This covers the pin itself: ancestry AND content AND clean, each proven to be the half
+        # that catches a case the others clear.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
+
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing
         # named export (the CTL-1093 outage: getCatalystRepoDir added to daemon.mjs

--- a/plugins/dev/config/index-serving-root.json
+++ b/plugins/dev/config/index-serving-root.json
@@ -1,0 +1,22 @@
+{
+  "_comment": [
+    "CTL-1935: the PINNED serving root for catalyst-index. @catalyst-cloud/index-host is",
+    "private:true at 0.0.0, so there is no npm version to pin (COORD decision 2) — the pin is a",
+    "git SHA, recorded here, in the catalyst repo the fleet reload already distributes.",
+    "",
+    "Advancing the fleet's indexer = bumping `sha` here and letting the reload run setup. It is",
+    "NOT an operator's `cd`, which is the whole defect: on mini-2 a cold index would have run",
+    "from a checkout 332 commits stale, missing CTC-661's resample fix, and looked normal.",
+    "",
+    "`probe` is the CONTENT half of the check. Ancestry alone proves a commit is reachable, not",
+    "that the working tree at that path actually holds it — `git show <sha>` proves reachability,",
+    "not ancestry, and neither proves the file on disk is clean."
+  ],
+  "repo": "https://github.com/coalesce-labs/catalyst-cloud.git",
+  "path": "~/catalyst/index-source",
+  "sha": "4a84cd463606583ad73a5728871029dfbf9409c6",
+  "probe": {
+    "file": "apps/context-engine/src/wiki/llm.ts",
+    "symbol": "SKIP_CACHE_HEADER"
+  }
+}

--- a/plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# catalyst-index-root.test.sh — CTL-1935. The pinned serving root for catalyst-index.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../catalyst-index-root"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+git_q() { git -C "$1" -c user.email=t@t -c user.name=T "${@:2}" >/dev/null 2>&1; }
+
+# A stand-in "catalyst-cloud": two commits, and the probe symbol arrives in the SECOND. That
+# ordering is the whole point — it lets the two halves of the check disagree, which is the case
+# the ticket exists for and which a single-commit fixture cannot produce.
+UP="$SCRATCH/upstream"
+mkdir -p "$UP/apps/context-engine/src/wiki"
+git_q "$UP" init -b main
+echo "export const OLD = 1;" >"$UP/apps/context-engine/src/wiki/llm.ts"
+git_q "$UP" add -A
+git_q "$UP" commit -m old
+OLD_SHA="$(git -C "$UP" rev-parse HEAD)"
+echo 'export const SKIP_CACHE_HEADER = "cf-aig-skip-cache";' >>"$UP/apps/context-engine/src/wiki/llm.ts"
+git_q "$UP" add -A
+git_q "$UP" commit -m new
+NEW_SHA="$(git -C "$UP" rev-parse HEAD)"
+
+write_pin() { # write_pin <sha>
+	cat >"$SCRATCH/pin.json" <<EOF
+{ "repo": "$UP", "path": "$SCRATCH/root", "sha": "$1",
+  "probe": { "file": "apps/context-engine/src/wiki/llm.ts", "symbol": "SKIP_CACHE_HEADER" } }
+EOF
+}
+run() { CATALYST_INDEX_PIN="$SCRATCH/pin.json" bash "$SUBJECT" "$@" 2>&1; }
+
+echo ""
+echo "=== setup provisions the root AT the pin ==="
+write_pin "$NEW_SHA"
+OUT="$(run setup)"
+RC=$?
+[ "$RC" -eq 0 ] && pass "setup exits 0" || fail "setup exits 0" "rc=$RC: $OUT"
+if [ "$(git -C "$SCRATCH/root" rev-parse HEAD 2>/dev/null)" = "$NEW_SHA" ]; then
+	pass "the root is checked out at the pinned sha"
+else
+	fail "the root is checked out at the pinned sha" "$OUT"
+fi
+run verify >/dev/null 2>&1 && pass "verify passes on a correctly provisioned root" || fail "verify passes on a correctly provisioned root" "$(run verify)"
+
+echo ""
+echo "=== setup is idempotent ==="
+OUT2="$(run setup)"
+[ $? -eq 0 ] && pass "a second setup exits 0" || fail "a second setup exits 0" "$OUT2"
+
+echo ""
+echo "--- ⛔ THE CASE THE TICKET IS ABOUT: a STALE root is caught by ANCESTRY ---"
+# Move the root back to the older commit. On the real fleet this is 'the operator's checkout is
+# 332 commits behind' — the run looks completely normal while missing the fix.
+git_q "$SCRATCH/root" checkout --detach "$OLD_SHA"
+OUT3="$(run verify)"
+RC3=$?
+grep -q "FAIL  ancestry" <<<"$OUT3" && pass "ancestry FAILS on a stale root" || fail "ancestry fails on a stale root" "$OUT3"
+[ "$RC3" -ne 0 ] && pass "verify exits non-zero on a stale root" || fail "verify exits non-zero on a stale root" "rc=0"
+grep -q "FAIL  content" <<<"$OUT3" && pass "content also FAILS here (the symbol arrived in the newer commit)" || fail "content fails here" "$OUT3"
+
+echo ""
+echo "--- ⭐ ...and ANCESTRY catches what CONTENT alone would clear ---"
+# Measured on the real laptop checkout: 18 commits behind the pin, ancestry FAILED while content
+# PASSED, because SKIP_CACHE_HEADER had merged before that HEAD. Either half alone clears a root
+# the other condemns, which is why the ticket demands both. Reproduced here: pin to a sha the
+# root does not contain, while the probe symbol IS on disk.
+git_q "$SCRATCH/root" checkout --detach "$NEW_SHA"
+echo "export const LATER = 2;" >>"$UP/apps/context-engine/src/wiki/llm.ts"
+git_q "$UP" add -A
+git_q "$UP" commit -m later
+LATER_SHA="$(git -C "$UP" rev-parse HEAD)"
+write_pin "$LATER_SHA"
+git -C "$SCRATCH/root" fetch --quiet origin 2>/dev/null
+OUT4="$(run verify)"
+grep -q "PASS  content" <<<"$OUT4" && pass "content PASSES (the symbol is on disk)" || fail "content passes" "$OUT4"
+grep -q "FAIL  ancestry" <<<"$OUT4" && pass "ancestry still FAILS — the half that catches this" || fail "ancestry fails" "$OUT4"
+
+echo ""
+echo "--- ⛔ a locally MODIFIED probe file is caught, though both other halves pass ---"
+write_pin "$NEW_SHA"
+git_q "$SCRATCH/root" checkout --detach "$NEW_SHA"
+run verify >/dev/null 2>&1 && pass "control — clean root verifies before the edit" || fail "control — clean root verifies before the edit"
+echo "// a local edit nobody reviewed" >>"$SCRATCH/root/apps/context-engine/src/wiki/llm.ts"
+OUT5="$(run verify)"
+grep -q "FAIL  clean" <<<"$OUT5" && pass "a dirty probe file FAILS the clean check" || fail "a dirty probe file fails the clean check" "$OUT5"
+grep -q "PASS  ancestry" <<<"$OUT5" && pass "…while ancestry still passes (so 'clean' is the half that caught it)" || fail "ancestry still passes" "$OUT5"
+git_q "$SCRATCH/root" checkout -- apps/context-engine/src/wiki/llm.ts
+
+echo ""
+echo "--- ⛔ 'run' REFUSES from an unverified root ---"
+git_q "$SCRATCH/root" checkout --detach "$OLD_SHA"
+OUT6="$(run run --some-flag)"
+RC6=$?
+grep -q "refusing to run" <<<"$OUT6" && pass "run refuses on a stale root" || fail "run refuses on a stale root" "$OUT6"
+[ "$RC6" -ne 0 ] && pass "run exits non-zero when it refuses" || fail "run exits non-zero when it refuses" "rc=0"
+
+echo ""
+echo "--- ⛔ a LINKED WORKTREE is refused as a serving root ---"
+# It shares a common dir with someone's working repo: another agent's checkout moves the code
+# the indexer runs.
+git_q "$UP" worktree add "$SCRATCH/linked" -b wt1
+cat >"$SCRATCH/pin-linked.json" <<EOF
+{ "repo": "$UP", "path": "$SCRATCH/linked", "sha": "$NEW_SHA",
+  "probe": { "file": "apps/context-engine/src/wiki/llm.ts", "symbol": "SKIP_CACHE_HEADER" } }
+EOF
+OUT7="$(CATALYST_INDEX_PIN="$SCRATCH/pin-linked.json" bash "$SUBJECT" verify 2>&1)"
+grep -q "FAIL  standalone" <<<"$OUT7" && pass "a linked worktree is refused" || fail "a linked worktree is refused" "$OUT7"
+
+echo ""
+echo "--- ⛔ an abbreviated or branch-name pin is refused ---"
+write_pin "${NEW_SHA:0:9}"
+OUT8="$(run verify)"
+[ $? -eq 2 ] && pass "an abbreviated sha is refused (rc 2)" || fail "an abbreviated sha is refused (rc 2)" "$OUT8"
+write_pin "main"
+OUT9="$(run verify)"
+[ $? -eq 2 ] && pass "a branch name is refused (rc 2)" || fail "a branch name is refused (rc 2)" "$OUT9"
+
+echo ""
+echo "--- ⛔ a missing/unreadable pin file fails closed ---"
+OUT10="$(CATALYST_INDEX_PIN="$SCRATCH/does-not-exist.json" bash "$SUBJECT" verify 2>&1)"
+[ $? -ne 0 ] && pass "a missing pin file exits non-zero" || fail "a missing pin file exits non-zero" "$OUT10"
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-index-root.test.sh
@@ -71,7 +71,7 @@ echo "--- ⛔ THE CASE THE TICKET IS ABOUT: a STALE root is caught by ANCESTRY -
 git_q "$SCRATCH/root" checkout --detach "$OLD_SHA"
 OUT3="$(run verify)"
 RC3=$?
-grep -q "FAIL  ancestry" <<<"$OUT3" && pass "ancestry FAILS on a stale root" || fail "ancestry fails on a stale root" "$OUT3"
+grep -q "FAIL  pinned-head" <<<"$OUT3" && pass "pinned-head FAILS on a stale root" || fail "pinned-head fails on a stale root" "$OUT3"
 [ "$RC3" -ne 0 ] && pass "verify exits non-zero on a stale root" || fail "verify exits non-zero on a stale root" "rc=0"
 grep -q "FAIL  content" <<<"$OUT3" && pass "content also FAILS here (the symbol arrived in the newer commit)" || fail "content fails here" "$OUT3"
 
@@ -90,7 +90,7 @@ write_pin "$LATER_SHA"
 git -C "$SCRATCH/root" fetch --quiet origin 2>/dev/null
 OUT4="$(run verify)"
 grep -q "PASS  content" <<<"$OUT4" && pass "content PASSES (the symbol is on disk)" || fail "content passes" "$OUT4"
-grep -q "FAIL  ancestry" <<<"$OUT4" && pass "ancestry still FAILS — the half that catches this" || fail "ancestry fails" "$OUT4"
+grep -q "FAIL  pinned-head" <<<"$OUT4" && pass "pinned-head still FAILS — the half that catches this" || fail "pinned-head fails" "$OUT4"
 
 echo ""
 echo "--- ⛔ a locally MODIFIED probe file is caught, though both other halves pass ---"
@@ -100,7 +100,7 @@ run verify >/dev/null 2>&1 && pass "control — clean root verifies before the e
 echo "// a local edit nobody reviewed" >>"$SCRATCH/root/apps/context-engine/src/wiki/llm.ts"
 OUT5="$(run verify)"
 grep -q "FAIL  clean" <<<"$OUT5" && pass "a dirty probe file FAILS the clean check" || fail "a dirty probe file fails the clean check" "$OUT5"
-grep -q "PASS  ancestry" <<<"$OUT5" && pass "…while ancestry still passes (so 'clean' is the half that caught it)" || fail "ancestry still passes" "$OUT5"
+grep -q "PASS  pinned-head" <<<"$OUT5" && pass "…while pinned-head still passes (so 'clean' is the half that caught it)" || fail "pinned-head still passes" "$OUT5"
 git_q "$SCRATCH/root" checkout -- apps/context-engine/src/wiki/llm.ts
 
 echo ""
@@ -136,6 +136,58 @@ echo ""
 echo "--- ⛔ a missing/unreadable pin file fails closed ---"
 OUT10="$(CATALYST_INDEX_PIN="$SCRATCH/does-not-exist.json" bash "$SUBJECT" verify 2>&1)"
 [ $? -ne 0 ] && pass "a missing pin file exits non-zero" || fail "a missing pin file exits non-zero" "$OUT10"
+
+echo ""
+echo "--- ⛔ a DESCENDANT of the pin is refused, not accepted (Codex #3525 P1) ---"
+# The first cut used `merge-base --is-ancestor`, which accepts any later commit — so a root that
+# had drifted ahead ran post-pin code while `verify` called it pinned. A pin that only sets a
+# floor is not a pin.
+write_pin "$NEW_SHA"
+git_q "$SCRATCH/root" fetch origin
+git_q "$SCRATCH/root" checkout --detach "$LATER_SHA"
+OUT_D="$(run verify)"
+RC_D=$?
+grep -q "is AHEAD of pinned" <<<"$OUT_D" && pass "a descendant is refused, and named as AHEAD" || fail "a descendant is refused" "$OUT_D"
+[ "$RC_D" -ne 0 ] && pass "verify exits non-zero on a descendant" || fail "verify exits non-zero on a descendant" "rc=0"
+# ⛔ Positive control: the pin itself still passes, so this is not simply refusing everything.
+git_q "$SCRATCH/root" checkout --detach "$NEW_SHA"
+run verify >/dev/null 2>&1 && pass "control — the exact pin still passes" || fail "control — the exact pin still passes" "$(run verify)"
+
+echo ""
+echo "--- ⛔ a modification OUTSIDE the probe file is caught (Codex #3525 P1) ---"
+# Scoping cleanliness to the probe file let any edit under apps/index-host — the code the indexer
+# actually runs — print "PASS clean" and allowed `run` to proceed.
+mkdir -p "$SCRATCH/root/apps/index-host"
+echo "// unreviewed local change to the code that actually runs" >"$SCRATCH/root/apps/index-host/cli.ts"
+OUT_E="$(run verify)"
+grep -q "FAIL  clean" <<<"$OUT_E" && pass "a change outside the probe file fails 'clean'" || fail "a change outside the probe file fails 'clean'" "$OUT_E"
+grep -q "PASS  content" <<<"$OUT_E" && pass "…while content still passes, so 'clean' is the half that caught it" || fail "content still passes" "$OUT_E"
+rm -rf "$SCRATCH/root/apps/index-host"
+
+echo ""
+echo "=== the CLI is installable (Codex #3525 P1) ==="
+# The doctor tells the operator to run `catalyst-index-root setup`; install-cli.sh uses an
+# explicit allowlist, so an unregistered command is command-not-found on a normal install.
+if grep -q '"catalyst-index-root:catalyst-index-root"' "$SCRIPT_DIR/../install-cli.sh"; then
+	pass "catalyst-index-root is registered in install-cli.sh's CLI_ENTRIES"
+else
+	fail "catalyst-index-root is registered in install-cli.sh" "the documented command would be command-not-found"
+fi
+
+echo ""
+echo "=== the fleet reload APPLIES the pin, not just distributes it (Codex #3525 P1) ==="
+# Distributing the config is not applying it: without this, every serving root stays on the
+# previous sha until someone runs a command by hand, while the pin file makes it look solved.
+SPS="$SCRIPT_DIR/../setup-plugin-source.sh"
+if grep -q "catalyst-index-root" "$SPS" && grep -q "INDEX_ROOT_SCRIPT.*setup\|setup\"*$" <<<"$(grep -A2 'INDEX_ROOT_SCRIPT" setup' "$SPS")"; then
+	pass "setup-plugin-source.sh invokes catalyst-index-root setup"
+else
+	grep -q 'bash "$INDEX_ROOT_SCRIPT" setup' "$SPS" &&
+		pass "setup-plugin-source.sh invokes catalyst-index-root setup" ||
+		fail "setup-plugin-source.sh invokes catalyst-index-root setup" "the reload distributes the pin without applying it"
+fi
+grep -q "CATALYST_SKIP_INDEX_ROOT" "$SPS" && pass "…with an opt-out for nodes that never index" || fail "an opt-out exists" ""
+grep -q "WARNING: catalyst-index serving root could NOT be advanced" "$SPS" && pass "…and a failure is LOUD, not silent" || fail "a failure is loud" ""
 
 echo ""
 echo "  PASSED: $PASSES   FAILED: $FAILURES"

--- a/plugins/dev/scripts/catalyst-index-root
+++ b/plugins/dev/scripts/catalyst-index-root
@@ -85,16 +85,22 @@ cmd_verify() {
     _pass "standalone" "$ROOT is a standalone checkout"
   fi
 
+  # ⛔ Codex #3525 P1: EQUALITY, not ancestry. The first cut accepted any DESCENDANT of the pin,
+  # on the reasoning that "the fleet advances the root". That is backwards — advancing the fleet
+  # means BUMPING THE PIN, and a root sitting on post-pin commits is running code nobody pinned
+  # while `verify` calls it pinned. A pin that only sets a floor is not a pin.
   local head
   head="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
   if [ -z "$head" ]; then
-    _fail "ancestry" "could not read HEAD in $ROOT — the pin is UNPROVEN"
+    _fail "pinned-head" "could not read HEAD in $ROOT — the pin is UNPROVEN"
   elif ! git -C "$ROOT" cat-file -e "${PIN_SHA}^{commit}" 2>/dev/null; then
-    _fail "ancestry" "pinned sha ${PIN_SHA:0:9} is not present in $ROOT — fetch it (run setup)"
+    _fail "pinned-head" "pinned sha ${PIN_SHA:0:9} is not present in $ROOT — fetch it (run setup)"
+  elif [ "$head" = "$PIN_SHA" ]; then
+    _pass "pinned-head" "HEAD is exactly the pinned ${PIN_SHA:0:9}"
   elif git -C "$ROOT" merge-base --is-ancestor "$PIN_SHA" "$head" 2>/dev/null; then
-    _pass "ancestry" "HEAD ${head:0:9} contains the pinned ${PIN_SHA:0:9}"
+    _fail "pinned-head" "HEAD ${head:0:9} is AHEAD of pinned ${PIN_SHA:0:9} — it would run post-pin code nobody pinned (bump the pin, do not drift the root)"
   else
-    _fail "ancestry" "HEAD ${head:0:9} does NOT contain pinned ${PIN_SHA:0:9} — the root is stale or diverged"
+    _fail "pinned-head" "HEAD ${head:0:9} does NOT contain pinned ${PIN_SHA:0:9} — the root is stale or diverged"
   fi
 
   # ⛔ THE CONTENT HALF. Ancestry says the commit is reachable in history; it says nothing about
@@ -108,14 +114,21 @@ cmd_verify() {
     _fail "content" "$PROBE_SYMBOL is ABSENT from $PROBE_FILE — the code on disk is not the pinned release"
   fi
 
-  # ⛔ ...and neither half proves the working tree is CLEAN at that path. A local edit to the probe
-  # file passes ancestry and content while running something nobody reviewed.
-  local dirty
-  dirty="$(git -C "$ROOT" status --porcelain -- "$PROBE_FILE" 2>/dev/null)"
-  if [ -n "$dirty" ]; then
-    _fail "clean" "$PROBE_FILE is locally modified in $ROOT: $dirty"
+  # ⛔ Codex #3525 P1 (twice over). The first cut scoped this to the PROBE FILE, so a local edit
+  # anywhere else in the tree — say under apps/index-host, the code the indexer actually runs —
+  # printed "PASS clean" and `run` proceeded. The whole tree has to be pristine for a serving root
+  # to mean anything.
+  # ⛔ And the exit status was discarded: a corrupt index makes `git status` fail, the substitution
+  # yields "", and an empty string read as CLEAN. "I could not measure it" must fail closed.
+  local dirty dirty_rc
+  dirty="$(git -C "$ROOT" status --porcelain 2>/dev/null)"
+  dirty_rc=$?
+  if [ "$dirty_rc" -ne 0 ]; then
+    _fail "clean" "git status failed in $ROOT (rc ${dirty_rc}) — cleanliness is UNMEASURED, which is not clean"
+  elif [ -n "$dirty" ]; then
+    _fail "clean" "$ROOT has local modifications — it would run code nobody reviewed: $(printf '%s' "$dirty" | head -3 | tr '\n' ';')"
   else
-    _pass "clean" "$PROBE_FILE is unmodified"
+    _pass "clean" "the serving tree is pristine"
   fi
 
   echo

--- a/plugins/dev/scripts/catalyst-index-root
+++ b/plugins/dev/scripts/catalyst-index-root
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# catalyst-index-root — CTL-1935. Make "which code does a cold index run?" a fleet decision
+# recorded in git, not a consequence of where an operator happened to `cd`.
+#
+# THE DEFECT (measured on mini-2, 2026-08-17 19:5x CT): `which catalyst-index` -> not found. The
+# only catalyst-cloud checkout on the host sat on a feature branch 332 commits behind main, so a
+# cold index started from that session would have run WITHOUT CTC-661's resample fix — confirmed
+# two independent ways, by ancestry (`merge-base --is-ancestor` said NO) and by content
+# (SKIP_CACHE_HEADER absent). The run would have looked completely normal while replaying the AI
+# Gateway's cached body on every parse retry.
+#
+# WHY A GIT SHA AND NOT AN NPM PIN (COORD decision 2): @catalyst-cloud/index-host is
+# `private: true` at `0.0.0`. There is no published version to pin, and publishing it is out of
+# scope. So the pin is a SHA in plugins/dev/config/index-serving-root.json — a file the fleet
+# reload already distributes with the plugin.
+#
+#   catalyst-index-root setup    provision/advance the serving root to the pinned sha
+#   catalyst-index-root verify   prove the root IS the pin (ancestry AND content AND clean)
+#   catalyst-index-root run …    verify, then run catalyst-index FROM that root
+#
+# ⛔ EVERY CHECK FAILS CLOSED. "I could not measure it" is a non-zero exit naming the check, never
+# a silent pass — the false-clean shape this repo has shipped repeatedly.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PIN_FILE="${CATALYST_INDEX_PIN:-$SCRIPT_DIR/../config/index-serving-root.json}"
+
+_json() { # _json <key-path>  — read a scalar out of the pin file, failing closed.
+  python3 -c "
+import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception as e:
+    sys.stderr.write('catalyst-index-root: cannot read pin file %s: %s\n'%(sys.argv[1],e)); sys.exit(1)
+cur=d
+for k in sys.argv[2].split('.'):
+    if not isinstance(cur,dict) or k not in cur:
+        sys.stderr.write('catalyst-index-root: pin file is missing %s\n'%sys.argv[2]); sys.exit(1)
+    cur=cur[k]
+print(cur)
+" "$PIN_FILE" "$1"
+}
+
+[ -f "$PIN_FILE" ] || { echo "catalyst-index-root: no pin file at $PIN_FILE" >&2; exit 2; }
+PIN_REPO="$(_json repo)" || exit 2
+PIN_PATH_RAW="$(_json path)" || exit 2
+PIN_SHA="$(_json sha)" || exit 2
+PROBE_FILE="$(_json probe.file)" || exit 2
+PROBE_SYMBOL="$(_json probe.symbol)" || exit 2
+ROOT="${CATALYST_INDEX_ROOT:-${PIN_PATH_RAW/#\~/$HOME}}"
+
+# A pin that is not a full 40-hex sha is not a pin — an abbreviation or a branch name reintroduces
+# exactly the ambiguity this file exists to remove.
+case "$PIN_SHA" in
+[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+*)
+  echo "catalyst-index-root: pinned sha must be a full 40-char hex sha (got '$PIN_SHA')" >&2
+  exit 2
+  ;;
+esac
+
+FAILURES=0
+_pass() { printf '  PASS  %-14s %s\n' "$1" "$2"; }
+_fail() { printf '  FAIL  %-14s %s\n' "$1" "$2"; FAILURES=$((FAILURES + 1)); }
+
+cmd_verify() {
+  echo "catalyst-index-root: verifying $ROOT against pin ${PIN_SHA:0:9}"
+
+  # A checkout's .git is a DIRECTORY in a standalone clone and a FILE in a linked worktree. Both
+  # are checkouts; only the standalone one is an acceptable serving root. Testing for the
+  # directory alone misdiagnosed a linked worktree as "not a git checkout — run setup", which
+  # sends the operator to the wrong fix and never reaches the standalone check below.
+  if [ ! -e "$ROOT/.git" ]; then
+    _fail "root-present" "$ROOT is not a git checkout — run 'catalyst-index-root setup'"
+    echo; echo "catalyst-index-root: $FAILURES check(s) FAILED"; return 1
+  fi
+  _pass "root-present" "$ROOT is a git checkout"
+
+  # ⛔ A LINKED WORKTREE IS NOT A SERVING ROOT. It shares its common dir with someone's working
+  # repo, so another agent's `git checkout` silently moves the code the indexer runs.
+  if [ -f "$ROOT/.git" ]; then
+    _fail "standalone" "$ROOT is a LINKED WORKTREE — its HEAD can be moved by whoever owns the parent repo"
+  else
+    _pass "standalone" "$ROOT is a standalone checkout"
+  fi
+
+  local head
+  head="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)"
+  if [ -z "$head" ]; then
+    _fail "ancestry" "could not read HEAD in $ROOT — the pin is UNPROVEN"
+  elif ! git -C "$ROOT" cat-file -e "${PIN_SHA}^{commit}" 2>/dev/null; then
+    _fail "ancestry" "pinned sha ${PIN_SHA:0:9} is not present in $ROOT — fetch it (run setup)"
+  elif git -C "$ROOT" merge-base --is-ancestor "$PIN_SHA" "$head" 2>/dev/null; then
+    _pass "ancestry" "HEAD ${head:0:9} contains the pinned ${PIN_SHA:0:9}"
+  else
+    _fail "ancestry" "HEAD ${head:0:9} does NOT contain pinned ${PIN_SHA:0:9} — the root is stale or diverged"
+  fi
+
+  # ⛔ THE CONTENT HALF. Ancestry says the commit is reachable in history; it says nothing about
+  # what is on disk at that path right now. Both halves are required — this is the exact pair the
+  # mini-2 measurement used.
+  if [ ! -f "$ROOT/$PROBE_FILE" ]; then
+    _fail "content" "$PROBE_FILE is absent from $ROOT — the tree is not materialised"
+  elif grep -q -- "$PROBE_SYMBOL" "$ROOT/$PROBE_FILE" 2>/dev/null; then
+    _pass "content" "$PROBE_SYMBOL is present in $PROBE_FILE"
+  else
+    _fail "content" "$PROBE_SYMBOL is ABSENT from $PROBE_FILE — the code on disk is not the pinned release"
+  fi
+
+  # ⛔ ...and neither half proves the working tree is CLEAN at that path. A local edit to the probe
+  # file passes ancestry and content while running something nobody reviewed.
+  local dirty
+  dirty="$(git -C "$ROOT" status --porcelain -- "$PROBE_FILE" 2>/dev/null)"
+  if [ -n "$dirty" ]; then
+    _fail "clean" "$PROBE_FILE is locally modified in $ROOT: $dirty"
+  else
+    _pass "clean" "$PROBE_FILE is unmodified"
+  fi
+
+  echo
+  if [ "$FAILURES" -eq 0 ]; then
+    echo "catalyst-index-root: OK — the serving root is the pinned release"
+    return 0
+  fi
+  echo "catalyst-index-root: $FAILURES check(s) FAILED — do NOT start an index from this root"
+  return 1
+}
+
+cmd_setup() {
+  echo "catalyst-index-root: setting up $ROOT at ${PIN_SHA:0:9}"
+  if [ ! -d "$ROOT/.git" ]; then
+    mkdir -p "$(dirname "$ROOT")"
+    git clone --quiet "$PIN_REPO" "$ROOT" || { echo "catalyst-index-root: clone failed" >&2; return 1; }
+  fi
+  if [ -f "$ROOT/.git" ]; then
+    echo "catalyst-index-root: REFUSING — $ROOT is a linked worktree, not a standalone checkout" >&2
+    return 1
+  fi
+  git -C "$ROOT" fetch --quiet origin || { echo "catalyst-index-root: fetch failed" >&2; return 1; }
+  if ! git -C "$ROOT" cat-file -e "${PIN_SHA}^{commit}" 2>/dev/null; then
+    echo "catalyst-index-root: pinned sha ${PIN_SHA:0:9} not found after fetch — is the pin wrong?" >&2
+    return 1
+  fi
+  # Detached at the pin: the root carries exactly the recorded release, and advancing the fleet
+  # means editing the pin file, not pulling whatever main happens to be.
+  git -C "$ROOT" checkout --quiet --detach "$PIN_SHA" || { echo "catalyst-index-root: checkout failed" >&2; return 1; }
+  echo "catalyst-index-root: $ROOT is at $(git -C "$ROOT" rev-parse --short HEAD)"
+  cmd_verify
+}
+
+cmd_run() {
+  # ⛔ Verify BEFORE running, and refuse on failure. A wrapper that warns and runs anyway is the
+  # thing that let a 332-commits-stale root serve a cold index in the first place.
+  if ! cmd_verify; then
+    echo "catalyst-index-root: refusing to run catalyst-index from an unverified root" >&2
+    return 1
+  fi
+  echo "catalyst-index-root: running catalyst-index from $ROOT"
+  (cd "$ROOT" && bun run --cwd apps/index-host catalyst-index "$@")
+}
+
+case "${1:-}" in
+setup) shift; cmd_setup "$@" ;;
+verify) shift; cmd_verify "$@" ;;
+run) shift; cmd_run "$@" ;;
+-h | --help | "") sed -n '2,28p' "$0"; exit 0 ;;
+*) echo "catalyst-index-root: unknown subcommand '$1' (setup|verify|run)" >&2; exit 2 ;;
+esac

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-index-serving-root.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-index-serving-root.test.mjs
@@ -1,0 +1,159 @@
+// doctor-index-serving-root.test.mjs — CTL-1935. Tests for checkIndexServingRoot().
+// All deps are injected: the test touches no filesystem, no git, no network. Run:
+//   cd plugins/dev/scripts/execution-core && bun test doctor-index-serving-root
+//
+// The invariant under test is not "does it pass on a good root" — it is that EVERY way of not
+// knowing (no pin, no root, unfetched pin, unreadable status) renders as something other than a
+// clean result. The measured defect this comes from is a node where a cold index ran 332 commits
+// stale and every signal read normal.
+
+import { describe, test, expect } from "bun:test";
+import { checkIndexServingRoot } from "../doctor.mjs";
+
+const SHA = "4a84cd463606583ad73a5728871029dfbf9409c6";
+const OTHER = "1111111111111111111111111111111111111111";
+
+const PIN = {
+  repo: "https://example.invalid/catalyst-cloud.git",
+  path: "/srv/index-source",
+  sha: SHA,
+  probe: { file: "apps/context-engine/src/wiki/llm.ts", symbol: "SKIP_CACHE_HEADER" },
+};
+
+// A git stub whose behaviour is described per-subcommand, so each case changes exactly one thing.
+function gitStub({ head = SHA, hasPin = true, ancestor = true, dirty = "", statusFails = false } = {}) {
+  return (_root, args) => {
+    if (args[0] === "rev-parse") return { status: head ? 0 : 1, stdout: head };
+    if (args[0] === "cat-file") return { status: hasPin ? 0 : 1, stdout: "" };
+    if (args[0] === "merge-base") return { status: ancestor ? 0 : 1, stdout: "" };
+    if (args[0] === "status") return { status: statusFails ? 1 : 0, stdout: dirty };
+    return { status: 1, stdout: "" };
+  };
+}
+
+function deps(over = {}) {
+  return {
+    pinPath: "/pin.json",
+    readJson: () => PIN,
+    readText: () => 'export const SKIP_CACHE_HEADER = "cf-aig-skip-cache";',
+    exists: () => true,
+    git: gitStub(),
+    env: {},
+    ...over,
+  };
+}
+
+describe("checkIndexServingRoot", () => {
+  test("a root at the pin, clean, with the probe symbol present -> pass", () => {
+    const c = checkIndexServingRoot(deps());
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain("carries the pinned");
+  });
+
+  // ⛔ The case the ticket is about. Measured on mini-2: 332 commits behind, and the run looked
+  // completely normal.
+  test("a STALE root (pin not an ancestor of HEAD) -> warn, naming it", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ head: OTHER, ancestor: false }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("does NOT contain pinned");
+  });
+
+  // ⭐ Measured on the dev laptop: 18 commits behind the pin FAILED ancestry while the content
+  // probe PASSED, because the symbol had merged before that HEAD. Content alone clears this root.
+  test("ancestry catches a root whose content probe passes", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ head: OTHER, ancestor: false }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("does NOT contain pinned");
+    expect(c.detail).not.toContain("SKIP_CACHE_HEADER is absent");
+  });
+
+  // ...and the converse, so neither half is decorative.
+  test("content catches a root whose ancestry passes", () => {
+    const c = checkIndexServingRoot(deps({ readText: () => "export const SOMETHING_ELSE = 1;" }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("SKIP_CACHE_HEADER is absent");
+  });
+
+  test("a locally modified probe file -> warn, though ancestry and content both pass", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ dirty: " M apps/context-engine/src/wiki/llm.ts" }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("locally modified");
+  });
+
+  // ⛔ Every "I could not look" must render as something other than a pass.
+  test("no serving root at all -> warn, not silence", () => {
+    const c = checkIndexServingRoot(deps({ exists: () => false }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("no index serving root");
+  });
+
+  test("the pinned sha has never been fetched -> warn", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ hasPin: false }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("is not present in");
+  });
+
+  test("HEAD unreadable -> warn (the pin is UNPROVEN)", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ head: "" }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("UNPROVEN");
+  });
+
+  test("git status unreadable -> warn, never pass", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ statusFails: true }) }));
+    expect(c.status).toBe("warn");
+  });
+
+  test("an unreadable pin file -> info naming the reason, never pass", () => {
+    const c = checkIndexServingRoot(
+      deps({
+        readJson: () => {
+          throw new Error("ENOENT");
+        },
+      }),
+    );
+    expect(c.status).toBe("info");
+    expect(c.detail).toContain("ENOENT");
+  });
+
+  test("an abbreviated sha is not a pin -> warn", () => {
+    const c = checkIndexServingRoot(deps({ readJson: () => ({ ...PIN, sha: SHA.slice(0, 9) }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("full 40-char hex sha");
+  });
+
+  test("a pin with no content probe -> warn (ancestry alone is not enough)", () => {
+    const c = checkIndexServingRoot(deps({ readJson: () => ({ ...PIN, probe: undefined }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("no content probe");
+  });
+
+  // ⛔ Doctor's FAIL count gates worker activation, so this check is advisory by contract —
+  // exactly like checkWorkerLabels and checkDrainDisabled.
+  test("NEVER emits a fail record, in any of the cases above", () => {
+    const cases = [
+      deps(),
+      deps({ git: gitStub({ head: OTHER, ancestor: false }) }),
+      deps({ exists: () => false }),
+      deps({ git: gitStub({ hasPin: false }) }),
+      deps({ git: gitStub({ head: "" }) }),
+      deps({ git: gitStub({ statusFails: true }) }),
+      deps({ readText: () => "nope" }),
+      deps({ readJson: () => ({ ...PIN, sha: "main" }) }),
+      deps({
+        readJson: () => {
+          throw new Error("boom");
+        },
+      }),
+    ];
+    for (const d of cases) expect(checkIndexServingRoot(d).status).not.toBe("fail");
+  });
+
+  // ⛔ Positive control for the block above: a fail status IS representable, so "never fail" is a
+  // property of this check and not of the assertion being unfalsifiable.
+  test("control — the status vocabulary can express fail", () => {
+    expect(["pass", "warn", "info", "fail"]).toContain("fail");
+    const c = checkIndexServingRoot(deps());
+    expect(["pass", "warn", "info", "fail"]).toContain(c.status);
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-index-serving-root.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-index-serving-root.test.mjs
@@ -47,37 +47,54 @@ describe("checkIndexServingRoot", () => {
   test("a root at the pin, clean, with the probe symbol present -> pass", () => {
     const c = checkIndexServingRoot(deps());
     expect(c.status).toBe("pass");
-    expect(c.detail).toContain("carries the pinned");
+    expect(c.detail).toContain("is exactly the pinned");
   });
 
   // ⛔ The case the ticket is about. Measured on mini-2: 332 commits behind, and the run looked
   // completely normal.
-  test("a STALE root (pin not an ancestor of HEAD) -> warn, naming it", () => {
+  test("a STALE root (HEAD is not the pin) -> warn, naming it", () => {
     const c = checkIndexServingRoot(deps({ git: gitStub({ head: OTHER, ancestor: false }) }));
     expect(c.status).toBe("warn");
-    expect(c.detail).toContain("does NOT contain pinned");
+    expect(c.detail).toContain("is not the pinned");
+  });
+
+  // ⛔ Codex #3525 P1: the first cut accepted any DESCENDANT of the pin, so a root that had
+  // drifted ahead ran post-pin code while this reported it pinned. A pin that only sets a floor
+  // is not a pin.
+  test("a DESCENDANT of the pin -> warn, named as AHEAD", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ head: OTHER, ancestor: true }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("is AHEAD of pinned");
   });
 
   // ⭐ Measured on the dev laptop: 18 commits behind the pin FAILED ancestry while the content
   // probe PASSED, because the symbol had merged before that HEAD. Content alone clears this root.
-  test("ancestry catches a root whose content probe passes", () => {
+  test("the pinned-head check catches a root whose content probe passes", () => {
     const c = checkIndexServingRoot(deps({ git: gitStub({ head: OTHER, ancestor: false }) }));
     expect(c.status).toBe("warn");
-    expect(c.detail).toContain("does NOT contain pinned");
+    expect(c.detail).toContain("is not the pinned");
     expect(c.detail).not.toContain("SKIP_CACHE_HEADER is absent");
   });
 
   // ...and the converse, so neither half is decorative.
-  test("content catches a root whose ancestry passes", () => {
+  test("content catches a root whose HEAD is exactly the pin", () => {
     const c = checkIndexServingRoot(deps({ readText: () => "export const SOMETHING_ELSE = 1;" }));
     expect(c.status).toBe("warn");
     expect(c.detail).toContain("SKIP_CACHE_HEADER is absent");
   });
 
-  test("a locally modified probe file -> warn, though ancestry and content both pass", () => {
+  test("a locally modified probe file -> warn, though HEAD and content both pass", () => {
     const c = checkIndexServingRoot(deps({ git: gitStub({ dirty: " M apps/context-engine/src/wiki/llm.ts" }) }));
     expect(c.status).toBe("warn");
-    expect(c.detail).toContain("locally modified");
+    expect(c.detail).toContain("local modifications");
+  });
+
+  // ⛔ Codex #3525 P1: cleanliness scoped to the probe file let an edit under apps/index-host —
+  // the code the indexer actually RUNS — read as clean.
+  test("a modification OUTSIDE the probe file is caught too", () => {
+    const c = checkIndexServingRoot(deps({ git: gitStub({ dirty: " M apps/index-host/src/cli.ts" }) }));
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("local modifications");
   });
 
   // ⛔ Every "I could not look" must render as something other than a pass.
@@ -99,9 +116,11 @@ describe("checkIndexServingRoot", () => {
     expect(c.detail).toContain("UNPROVEN");
   });
 
-  test("git status unreadable -> warn, never pass", () => {
+  // ⛔ Codex #3525 P1: a failing `git status` yielded an empty string that read as CLEAN.
+  test("git status unreadable -> warn saying cleanliness is UNMEASURED, never pass", () => {
     const c = checkIndexServingRoot(deps({ git: gitStub({ statusFails: true }) }));
     expect(c.status).toBe("warn");
+    expect(c.detail).toContain("UNMEASURED");
   });
 
   test("an unreadable pin file -> info naming the reason, never pass", () => {
@@ -134,6 +153,8 @@ describe("checkIndexServingRoot", () => {
     const cases = [
       deps(),
       deps({ git: gitStub({ head: OTHER, ancestor: false }) }),
+      deps({ git: gitStub({ head: OTHER, ancestor: true }) }),
+      deps({ git: gitStub({ dirty: " M apps/index-host/src/cli.ts" }) }),
       deps({ exists: () => false }),
       deps({ git: gitStub({ hasPin: false }) }),
       deps({ git: gitStub({ head: "" }) }),

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -34,6 +34,7 @@ import { STATUS, mkCheck } from "./doctor-status.mjs";
 import { checkInstallCompleteness } from "./install-completeness.mjs";
 // CTL-1936 AC5: the standing answer to "is this host write-exhausted".
 import { checkLinearWriteBudget } from "./write-budget-health.mjs";
+import { checkIndexServingRoot } from "./index-serving-root-health.mjs";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
 
@@ -169,6 +170,7 @@ export { STATUS, mkCheck } from "./doctor-status.mjs";
 export { checkInstallCompleteness };
 
 export { checkLinearWriteBudget };
+export { checkIndexServingRoot };
 
 // ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
 //
@@ -5832,6 +5834,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkConfigScopeLeak(), // advisory
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
       () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
+      () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
     ];
   }
 
@@ -5910,6 +5913,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
     () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
+    () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/index-serving-root-health.mjs
+++ b/plugins/dev/scripts/execution-core/index-serving-root-health.mjs
@@ -78,8 +78,11 @@ export function checkIndexServingRoot(deps = {}) {
   if (hasPin.status !== 0) {
     return mkCheck(NAME, STATUS.WARN, `pinned ${sha.slice(0, 9)} is not present in ${root} — the root has never fetched the pinned release (run: catalyst-index-root setup)`);
   }
-  const ancestor = git(root, ["merge-base", "--is-ancestor", sha, head.stdout]);
-  const ancestryOk = ancestor.status === 0;
+  // ⛔ Codex #3525 P1: EQUALITY, not ancestry — the shell tool had the same bug. Accepting any
+  // descendant means a root that has drifted ahead runs post-pin code while this reports it
+  // pinned. Advancing the fleet is a pin BUMP, never a root drift.
+  const atPin = head.stdout === sha;
+  const ahead = !atPin && git(root, ["merge-base", "--is-ancestor", sha, head.stdout]).status === 0;
 
   let contentOk = false;
   let contentWhy = "";
@@ -95,17 +98,27 @@ export function checkIndexServingRoot(deps = {}) {
     }
   }
 
-  const dirty = git(root, ["status", "--porcelain", "--", probeFile]);
-  const cleanOk = dirty.status === 0 && dirty.stdout === "";
+  // ⛔ Codex #3525 P1, twice: scoped to the probe file, an edit anywhere else in the tree (say
+  // under apps/index-host, the code the indexer runs) still read clean. And a failing `git status`
+  // must not read as clean — "could not measure" is not "measured clean".
+  const dirty = git(root, ["status", "--porcelain"]);
+  const cleanMeasured = dirty.status === 0;
+  const cleanOk = cleanMeasured && dirty.stdout === "";
 
-  if (ancestryOk && contentOk && cleanOk) {
-    return mkCheck(NAME, STATUS.PASS, `index serving root ${root} carries the pinned ${sha.slice(0, 9)} (ancestry + ${probeSymbol} present + tree clean)`);
+  if (atPin && contentOk && cleanOk) {
+    return mkCheck(NAME, STATUS.PASS, `index serving root ${root} is exactly the pinned ${sha.slice(0, 9)} (${probeSymbol} present + tree pristine)`);
   }
 
   const why = [];
-  if (!ancestryOk) why.push(`HEAD ${head.stdout.slice(0, 9)} does NOT contain pinned ${sha.slice(0, 9)}`);
+  if (!atPin) {
+    why.push(
+      ahead
+        ? `HEAD ${head.stdout.slice(0, 9)} is AHEAD of pinned ${sha.slice(0, 9)} — it would run post-pin code nobody pinned`
+        : `HEAD ${head.stdout.slice(0, 9)} is not the pinned ${sha.slice(0, 9)}`,
+    );
+  }
   if (!contentOk) why.push(contentWhy);
-  if (!cleanOk) why.push(dirty.status !== 0 ? `could not read git status for ${probeFile}` : `${probeFile} is locally modified`);
+  if (!cleanOk) why.push(!cleanMeasured ? "git status failed — cleanliness is UNMEASURED, which is not clean" : "the serving tree has local modifications");
   return mkCheck(
     NAME,
     STATUS.WARN,

--- a/plugins/dev/scripts/execution-core/index-serving-root-health.mjs
+++ b/plugins/dev/scripts/execution-core/index-serving-root-health.mjs
@@ -1,0 +1,114 @@
+// index-serving-root-health.mjs — CTL-1935. Does this node's catalyst-index serving root
+// actually carry the pinned release?
+//
+// ⛔ WHY THIS IS NOT COVERED BY THE DEP-SKEW DETECTOR. evaluateDepSkew (CTL-1931) is anchored on
+// a DAEMON's boot breadcrumb — it answers "is the running writer serving a configured root?".
+// catalyst-index is an on-demand CLI: there is no long-lived pid and no boot record, so a cold
+// index run leaves nothing for that detector to grade. The gap is exactly the one measured on
+// mini-2 on 2026-08-17: `which catalyst-index` -> not found, and the only catalyst-cloud checkout
+// on the host sat 332 commits behind main, so a run would have executed WITHOUT CTC-661's
+// resample fix and looked completely normal doing it.
+//
+// ⛔ AND WHY BOTH HALVES ARE CHECKED. Measured on the dev laptop 2026-08-18: a checkout 18 commits
+// behind the pin FAILED ancestry while PASSING the content probe, because the probed symbol had
+// merged before that HEAD. On mini-2, 332 behind, the content probe failed too. Either half alone
+// clears a root the other condemns.
+
+import { readFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+
+const NAME = "index-serving-root";
+
+export function defaultPinPath() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "config", "index-serving-root.json");
+}
+
+const expand = (p) => (p.startsWith("~/") ? join(homedir(), p.slice(2)) : p);
+
+export function checkIndexServingRoot(deps = {}) {
+  const {
+    pinPath = defaultPinPath(),
+    readJson = (p) => JSON.parse(readFileSync(p, "utf8")),
+    readText = (p) => readFileSync(p, "utf8"),
+    exists = existsSync,
+    git = (root, args) => {
+      const r = spawnSync("git", ["-C", root, ...args], { encoding: "utf8" });
+      return { status: r.status, stdout: (r.stdout ?? "").trim() };
+    },
+    env = process.env,
+  } = deps;
+
+  let pin;
+  try {
+    pin = readJson(pinPath);
+  } catch (e) {
+    // ⛔ Unreadable pin => INFO naming the reason, never a pass. "I could not look" and "it is
+    // fine" must not render identically — that is the false-clean shape this check exists for.
+    return mkCheck(NAME, STATUS.INFO, `cannot read the index serving-root pin (${pinPath}): ${e.message}`);
+  }
+
+  const sha = typeof pin?.sha === "string" ? pin.sha : "";
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    return mkCheck(NAME, STATUS.WARN, `the pin file records '${sha || "(nothing)"}' as the sha — a pin must be a full 40-char hex sha, or it is not a pin`);
+  }
+  const probeFile = pin?.probe?.file;
+  const probeSymbol = pin?.probe?.symbol;
+  if (typeof probeFile !== "string" || typeof probeSymbol !== "string") {
+    return mkCheck(NAME, STATUS.WARN, "the pin file records no content probe — ancestry alone cannot tell whether the tree on disk holds the pinned code");
+  }
+
+  const root = env.CATALYST_INDEX_ROOT || expand(String(pin?.path ?? ""));
+  if (!root) return mkCheck(NAME, STATUS.WARN, "the pin file records no serving-root path");
+
+  // ⚠️ NOT PROVISIONED IS NOT CLEAN. A node with no serving root is a node where a cold index
+  // would fall back to whatever checkout the operator's session is sitting in — the defect.
+  if (!exists(join(root, ".git"))) {
+    return mkCheck(NAME, STATUS.WARN, `no index serving root at ${root} — a cold index here would run from whatever checkout the invoking session happens to be in (run: catalyst-index-root setup)`);
+  }
+
+  const head = git(root, ["rev-parse", "HEAD"]);
+  if (head.status !== 0 || !head.stdout) {
+    return mkCheck(NAME, STATUS.WARN, `could not read HEAD in ${root} — the pin is UNPROVEN`);
+  }
+  const hasPin = git(root, ["cat-file", "-e", `${sha}^{commit}`]);
+  if (hasPin.status !== 0) {
+    return mkCheck(NAME, STATUS.WARN, `pinned ${sha.slice(0, 9)} is not present in ${root} — the root has never fetched the pinned release (run: catalyst-index-root setup)`);
+  }
+  const ancestor = git(root, ["merge-base", "--is-ancestor", sha, head.stdout]);
+  const ancestryOk = ancestor.status === 0;
+
+  let contentOk = false;
+  let contentWhy = "";
+  const probePath = join(root, probeFile);
+  if (!exists(probePath)) {
+    contentWhy = `${probeFile} is absent from the tree`;
+  } else {
+    try {
+      contentOk = readText(probePath).includes(probeSymbol);
+      if (!contentOk) contentWhy = `${probeSymbol} is absent from ${probeFile}`;
+    } catch (e) {
+      contentWhy = `${probeFile} is unreadable: ${e.message}`;
+    }
+  }
+
+  const dirty = git(root, ["status", "--porcelain", "--", probeFile]);
+  const cleanOk = dirty.status === 0 && dirty.stdout === "";
+
+  if (ancestryOk && contentOk && cleanOk) {
+    return mkCheck(NAME, STATUS.PASS, `index serving root ${root} carries the pinned ${sha.slice(0, 9)} (ancestry + ${probeSymbol} present + tree clean)`);
+  }
+
+  const why = [];
+  if (!ancestryOk) why.push(`HEAD ${head.stdout.slice(0, 9)} does NOT contain pinned ${sha.slice(0, 9)}`);
+  if (!contentOk) why.push(contentWhy);
+  if (!cleanOk) why.push(dirty.status !== 0 ? `could not read git status for ${probeFile}` : `${probeFile} is locally modified`);
+  return mkCheck(
+    NAME,
+    STATUS.WARN,
+    `index serving root ${root} is NOT the pinned release — ${why.join("; ")}. A cold index from here runs code nobody pinned (CTL-1935).`,
+  );
+}

--- a/plugins/dev/scripts/gen-cli-reference.sh
+++ b/plugins/dev/scripts/gen-cli-reference.sh
@@ -47,6 +47,7 @@ catalyst-filter|Event & comms|1|DEPRECATED alias for catalyst-broker (delegates 
 catalyst-why|Event & comms|1|Explain why the daemon believes a worker is alive, stuck, or dead (belief→rule→facts trace).
 catalyst-transitions|Event & comms|0|Live, human-readable Linear-state + phase transition log (tails the event stream — bare runs forever).
 catalyst-verify|Event & comms|1|Verified checks that cannot report a clean result from a check that never ran — count events by exact event.name, resolve HRW ticket ownership under named rosters, enumerate every PR merge blocker (exit 2 = INCONCLUSIVE).
+catalyst-index-root|Fleet & install|1|CTL-1935: prove (and provision) the PINNED serving root a cold catalyst-index run must execute from — HEAD exactly at the recorded sha, the release symbol present on disk, and the tree pristine. Refuses to `run` from an unverified root.
 catalyst-session|Session & state|1|Lifecycle CLI for Catalyst agent sessions (start/phase/metric/tool/pr → SQLite + event log).
 catalyst-state|Session & state|1|Manage global orchestrator state at ~/catalyst/state.json (flock-protected RMW + event log).
 boot-resume-approve|Session & state|0|List boot-resume-gated tickets and approve one — writes the .boot-resume-approved sentinel so the daemon dispatches the gated phase without a restart (CTL-1443).

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -45,6 +45,9 @@ CLI_ENTRIES=(
   "catalyst-otel-forward:catalyst-otel-forward"
   "catalyst-transitions:catalyst-transitions"
   "catalyst-verify:catalyst-verify"
+  # CTL-1935: without this entry the documented `catalyst-index-root setup` — which the doctor
+  # check tells the operator to run — is command-not-found on a normal install.
+  "catalyst-index-root:catalyst-index-root"
   "catalyst-why:catalyst-why"
   "catalyst-session.sh:catalyst-session"
   "catalyst-state.sh:catalyst-state"

--- a/plugins/dev/scripts/setup-plugin-source.sh
+++ b/plugins/dev/scripts/setup-plugin-source.sh
@@ -421,6 +421,35 @@ fi
 HEAD_SHA="$(git -C "$CHECKOUT_PATH" rev-parse HEAD)"
 TARGET_DIR="${CHECKOUT_PATH}/plugins/dev"
 
+# ─── 1b. Advance the catalyst-index serving root to the pin this checkout now carries ──────
+#
+# CTL-1935 (Codex #3525 P1). Distributing the pin file is NOT the same as applying it: without
+# this hook the config lands and every serving root stays absent or on the PREVIOUS sha until
+# someone runs a command by hand — recreating the stale-root behaviour the ticket exists to kill,
+# while the pin file makes it look solved.
+#
+# ⚠️ NON-FATAL BY DESIGN, BUT LOUD. The plugin reload is the more critical operation; failing it
+# because an indexer root could not be advanced would trade a stale indexer for a stale fleet.
+# A failure prints the consequence in full rather than a bare non-zero.
+# Skip with CATALYST_SKIP_INDEX_ROOT=1 on nodes that never index.
+INDEX_ROOT_SCRIPT="${CHECKOUT_PATH}/plugins/dev/scripts/catalyst-index-root"
+INDEX_ROOT_PIN="${CHECKOUT_PATH}/plugins/dev/config/index-serving-root.json"
+if [[ "${CATALYST_SKIP_INDEX_ROOT:-0}" == "1" ]]; then
+	echo "catalyst-index serving root: SKIPPED (CATALYST_SKIP_INDEX_ROOT=1)"
+elif [[ ! -f "$INDEX_ROOT_SCRIPT" || ! -f "$INDEX_ROOT_PIN" ]]; then
+	# An older checkout predates the pin — say so rather than passing silently.
+	echo "catalyst-index serving root: no pin in this checkout (predates CTL-1935) — not advanced"
+else
+	echo "catalyst-index serving root: advancing to the pin in ${INDEX_ROOT_PIN}…"
+	if bash "$INDEX_ROOT_SCRIPT" setup; then
+		echo "catalyst-index serving root: at the pin"
+	else
+		echo "WARNING: catalyst-index serving root could NOT be advanced to the pin." >&2
+		echo "WARNING: a cold index on this node would run stale or unpinned code (CTL-1935)." >&2
+		echo "WARNING: the plugin reload itself succeeded; fix with 'catalyst-index-root setup'." >&2
+	fi
+fi
+
 # ─── 2. Register pluginDirs in the machine config ───────────────────────────
 MACHINE_CFG="$(plugin_dirs_machine_config_path)"
 mkdir -p "$(dirname "$MACHINE_CFG")"

--- a/website/src/content/docs/reference/catalyst-cli.md
+++ b/website/src/content/docs/reference/catalyst-cli.md
@@ -12,7 +12,7 @@ sidebar:
 
 Every `catalyst-*` CLI is installed onto your `PATH` by
 [`install-cli.sh`](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/install-cli.sh) (into
-`~/.catalyst/bin` by default). This page lists all 32 of them — one line of
+`~/.catalyst/bin` by default). This page lists all 33 of them — one line of
 purpose plus the key subcommands — grouped by area. Run any tool with `--help`
 for full syntax. The richer tools have their own reference pages (e.g.
 [catalyst-stack](/reference/catalyst-stack/)).
@@ -268,3 +268,13 @@ Wrapper that registers a Catalyst session around claude, then execs the interact
 Claude Code Stop/SubagentStop hook — fallback agent.checkout emitter for the broker.
 
 [Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/hooks/emit-lifecycle-event.sh)
+
+## Fleet & install
+
+### catalyst-index-root
+
+CTL-1935: prove (and provision) the PINNED serving root a cold catalyst-index run must execute from — HEAD exactly at the recorded sha, the release symbol present on disk, and the tree pristine. Refuses to `run` from an unverified root.
+
+**Key subcommands:** _(run `catalyst-index-root --help`)_
+
+[Source](https://github.com/coalesce-labs/catalyst/blob/main/plugins/dev/scripts/catalyst-index-root)


### PR DESCRIPTION
`catalyst-index` had **no pinned install and no pinned serving root** on the worker nodes: what code a cold index ran was decided by an operator's `cd`. Measured on mini-2 (2026-08-17), `which catalyst-index` → not found, and the only catalyst-cloud checkout on the host sat **332 commits behind main** — so a run would have executed **without CTC-661's resample fix** and looked completely normal while replaying the AI Gateway's cached body on every parse retry.

**Why a git SHA and not an npm pin:** `@catalyst-cloud/index-host` is `private: true` at `0.0.0` (verified), so there is no published version to pin. COORD decision 2 — pin to a SHA, recorded in the catalyst repo the fleet reload already distributes.

| | |
|---|---|
| `plugins/dev/config/index-serving-root.json` | the pin: repo, path, 40-char sha, and a **content probe** |
| `plugins/dev/scripts/catalyst-index-root` | `setup` \| `verify` \| `run` |
| `execution-core/index-serving-root-health.mjs` | the doctor check (**AC 2**) |

Advancing the fleet's indexer is a bump to `sha` plus the ordinary reload — not an operator's `cd`. The root is checked out **detached at the pin**, so it carries exactly the recorded release rather than whatever `main` happens to be.

## ⭐ Why both halves of the check — proven, not asserted

Run against the laptop's **real** catalyst-cloud checkout, 18 commits behind the pin:

```
FAIL  ancestry   HEAD 86ff418f3 does NOT contain pinned 4a84cd463
PASS  content    SKIP_CACHE_HEADER is present in apps/context-engine/src/wiki/llm.ts
```

**Content alone would have cleared that root**, because the probed symbol merged *before* that HEAD. On mini-2, 332 behind, content failed too. Either half alone clears a root the other condemns — precisely what the ticket asks for. A third check (`clean`) covers the remaining gap: ancestry and content both pass for a tree with a local edit to the probe file.

## AC 2 — and why it is not in `evaluateDepSkew`

⛔ It could not go there. That detector is anchored on a **daemon's boot breadcrumb**; the indexer is an on-demand CLI with no pid and no boot record, so a cold index run leaves it nothing to grade. The doctor check is **advisory** (never FAIL — doctor's FAIL count gates worker activation), and every way of *not knowing* renders as WARN/INFO naming the reason: no pin, no root, unfetched pin, unreadable HEAD, unreadable status, no content probe, an abbreviated sha.

⚠️ **"Not provisioned" is a WARN, not a pass** — a node with no serving root is a node where a cold index falls back to the invoking session's checkout, which *is* the defect. Run live on this laptop it currently reports exactly that.

## Tests

- **`catalyst-index-root.test.sh` — 18 checks** against a real scratch repo whose probe symbol arrives in the **second** commit, so the two halves can disagree; a single-commit fixture cannot produce that case. Covers setup, idempotence, a stale root, ancestry-catches-what-content-clears, a dirty probe file, `run` refusing from an unverified root, a **linked worktree** refused as a serving root, abbreviated/branch-name pins refused, and a missing pin file failing closed.
- **`doctor-index-serving-root.test.mjs` — 14 hermetic cases**, including a positive control that `fail` *is* representable, so "never emits FAIL" is a property of the check rather than an unfalsifiable assertion.

⛔ **Found by running it:** a linked worktree's `.git` is a **file**, not a directory, so testing for the directory misdiagnosed it as *"not a git checkout — run setup"* and never reached the standalone check that exists for exactly that case.

## Note for the merge train

Touches `execution-core-tests.yml`, as do #3517 and #3521. Whichever lands last should be rebased rather than trusted to auto-merge.

Refs CTL-1935, CTL-1931, CTL-1919, CTC-661. AC 3's runbook pre-step was already met and now has a one-command form: `catalyst-index-root verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)