### PR TITLE
feat(dev): CTL-1908 — page at 80% of an armed account's window, before the fleet stalls

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -272,6 +272,13 @@ jobs:
         # touched) and a zero-discovery case that must exit 2, not report a clean pass.
         working-directory: .
         run: bash scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
+      - name: account-usage pager test (CTL-1908)
+        # Pages before an armed Claude account exhausts its 5-hour / 7-day window. The property
+        # under test is not "does it page at 80%" — it is that every way of being unable to SEE
+        # usage (absent, stale, unparsable, or a payload with no percentages) renders as
+        # UNOBSERVABLE and a non-zero exit, never as "under threshold".
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
 
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing

--- a/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
@@ -27,7 +27,14 @@ fail() {
 }
 
 mklog() { # mklog <five> <seven>  — a payload in the daemon's real format
-	printf '[00:00:00] Connected\n[00:00:01] Sending: {"s":%s,"sr":240,"w":%s,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' "$1" "$2" >"$SCRATCH/usage.log"
+	# ⛔ The stamp must be NOW. The pager checks the payload's own [HH:MM:SS] against the clock
+	# (Codex #3526 P1: a fresh mtime does not mean a fresh payload), so a fixture frozen at
+	# 00:00:01 is correctly rejected as stale — which is what happened to every case here on the
+	# first run after that check landed.
+	local ts
+	ts="$(date '+%H:%M:%S')"
+	printf '[%s] Connected\n[%s] Sending: {"s":%s,"sr":240,"w":%s,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' \
+		"$ts" "$ts" "$1" "$2" >"$SCRATCH/usage.log"
 }
 
 run() {
@@ -51,32 +58,40 @@ grep -q "no window at or above 80%" <<<"$OUT" && pass "reports nothing crossed" 
 
 echo ""
 echo "=== a 5-hour crossing pages ==="
+# ⛔ NOT --dry-run for the suppression cases below: a dry run deliberately records NO state
+# (Codex #3526 P1 — recording a crossing that was never delivered suppresses every later run),
+# so suppression and re-arming can only be exercised through a real delivery.
+rm -f "$SCRATCH/state"
+: >"$SCRATCH/channels/demo.md"
 mklog 85 5
-OUT="$(run --threshold 80 --dry-run)"
-grep -q "would page 5-hour at 85%" <<<"$OUT" && pass "pages the 5-hour window" || fail "pages the 5-hour window" "$OUT"
+OUT="$(run --threshold 80 --channel demo)"
+grep -q "85% of its 5-hour window" "$SCRATCH/channels/demo.md" && pass "pages the 5-hour window" || fail "pages the 5-hour window" "$OUT"
 
 echo ""
 echo "=== ...and does NOT repeat on the next run ==="
-OUT="$(run --threshold 80 --dry-run)"
+OUT="$(run --threshold 80 --channel demo)"
 grep -q "already paged" <<<"$OUT" && pass "the repeat is suppressed" || fail "the repeat is suppressed" "$OUT"
-grep -q "would page" <<<"$OUT" && fail "the repeat is suppressed" "it paged again" || pass "no second page was emitted"
+# Count PAGE HEADERS, not the phrase: one page writes "5-hour window" in both its heading and
+# its body, so a phrase count of 1 was never reachable.
+[ "$(grep -c '^## Turn FLEET-AUTO' "$SCRATCH/channels/demo.md")" -eq 1 ] && pass "no second page reached the channel" || fail "no second page reached the channel" "$(grep -c '^## Turn FLEET-AUTO' "$SCRATCH/channels/demo.md") pages"
 
 echo ""
 echo "--- ⛔ ...but it RE-ARMS after the window falls back below ---"
 # Without this a single page per lifetime would look identical to a working pager.
 mklog 30 5
-run --threshold 80 --dry-run >/dev/null
+run --threshold 80 --channel demo >/dev/null
 mklog 88 5
-OUT="$(run --threshold 80 --dry-run)"
-grep -q "would page 5-hour at 88%" <<<"$OUT" && pass "a fresh crossing pages again" || fail "a fresh crossing pages again" "$OUT"
+OUT="$(run --threshold 80 --channel demo)"
+grep -q "88% of its 5-hour window" "$SCRATCH/channels/demo.md" && pass "a fresh crossing pages again" || fail "a fresh crossing pages again" "$OUT"
 
 echo ""
 echo "=== the 7-day window pages independently ==="
 rm -f "$SCRATCH/state"
+: >"$SCRATCH/channels/demo.md"
 mklog 10 92
-OUT="$(run --threshold 80 --dry-run)"
-grep -q "would page 7-day at 92%" <<<"$OUT" && pass "pages the 7-day window" || fail "pages the 7-day window" "$OUT"
-grep -q "would page 5-hour" <<<"$OUT" && fail "only the crossed window pages" "it also paged 5-hour at 10%" || pass "the uncrossed 5-hour window did not page"
+OUT="$(run --threshold 80 --channel demo)"
+grep -q "92% of its 7-day window" "$SCRATCH/channels/demo.md" && pass "pages the 7-day window" || fail "pages the 7-day window" "$OUT"
+grep -q "5-hour window" "$SCRATCH/channels/demo.md" && fail "only the crossed window pages" "it also paged 5-hour at 10%" || pass "the uncrossed 5-hour window did not page"
 
 echo ""
 echo "--- ⛔ EVERY way of not seeing usage is UNOBSERVABLE + non-zero, never 'under threshold' ---"
@@ -87,6 +102,14 @@ OUT="$(LOG_OVERRIDE="$SCRATCH/does-not-exist.log" run --dry-run)"
 RC=$?
 grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "an ABSENT source is UNOBSERVABLE (rc 3)" || fail "an absent source is UNOBSERVABLE" "rc=$RC: $OUT"
 
+# ⛔ Codex #3526 P1: under launchd, exiting to stderr puts the most important condition in a log
+# nobody reads. Being unable to SEE usage must go out through the same sink as a crossing.
+: >"$SCRATCH/channels/demo.md"
+OUT="$(LOG_OVERRIDE="$SCRATCH/does-not-exist.log" CATALYST_USAGE_PAGE_STATE="$SCRATCH/state-dark" run --channel demo)"
+grep -q "usage source is DARK" "$SCRATCH/channels/demo.md" && pass "a dark source PAGES the channel, not just stderr" || fail "a dark source pages the channel" "$OUT"
+OUT2="$(LOG_OVERRIDE="$SCRATCH/does-not-exist.log" CATALYST_USAGE_PAGE_STATE="$SCRATCH/state-dark" run --channel demo)"
+[ "$(grep -c 'usage source is DARK' "$SCRATCH/channels/demo.md")" -eq 1 ] && pass "…and does not repeat it every run" || fail "the dark page repeats" "$(grep -c 'usage source is DARK' "$SCRATCH/channels/demo.md") copies"
+
 mklog 30 5
 touch -t 202601010000 "$SCRATCH/usage.log"
 OUT="$(run --dry-run)"
@@ -94,13 +117,28 @@ RC=$?
 grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "a STALE source is UNOBSERVABLE (rc 3)" || fail "a stale source is UNOBSERVABLE" "rc=$RC: $OUT"
 grep -q "NOT 'under threshold'" <<<"$OUT" && pass "it says so in those words" || fail "it says so in those words" "$OUT"
 
+# ⛔ Codex #3526 P1: a FRESH mtime with a STALE payload. The daemon keeps logging connection
+# lines while its last real payload is hours old — an unbounded search returns the old one and
+# the pager reports stale percentages as current.
+{
+	old_ts="$(date -v-2H '+%H:%M:%S' 2>/dev/null || date -d '2 hours ago' '+%H:%M:%S')"
+	now_ts="$(date '+%H:%M:%S')"
+	printf '[%s] Sending: {"s":95,"sr":10,"w":9,"wr":900,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' "$old_ts"
+	i=0
+	while [ $i -lt 60 ]; do printf '[%s] Connecting to a device...\n' "$now_ts"; i=$((i + 1)); done
+} >"$SCRATCH/usage.log"
+OUT="$(run --dry-run)"
+RC=$?
+grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "a stale payload behind a FRESH mtime is UNOBSERVABLE" || fail "a stale payload behind a fresh mtime is caught" "rc=$RC: $OUT"
+grep -q "not usage" <<<"$OUT" && pass "…and says the daemon is writing but not usage" || fail "it explains why" "$OUT"
+
 printf '[00:00:00] some unrelated log line\n' >"$SCRATCH/usage.log"
 OUT="$(run --dry-run)"
 RC=$?
 grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "an UNPARSABLE source is UNOBSERVABLE (rc 3)" || fail "an unparsable source is UNOBSERVABLE" "rc=$RC: $OUT"
 
 # ⛔ A payload with a MISSING percentage must not be read as 0% (i.e. as healthy).
-printf '[00:00:01] Sending: {"sr":240,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' >"$SCRATCH/usage.log"
+printf '[%s] Sending: {"sr":240,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' "$(date '+%H:%M:%S')" >"$SCRATCH/usage.log"
 OUT="$(run --dry-run)"
 RC=$?
 grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "a payload with NO percentages is UNOBSERVABLE, not 0%" || fail "a missing percentage is not read as 0" "rc=$RC: $OUT"
@@ -118,7 +156,29 @@ rm -f "$SCRATCH/state"
 mklog 91 5
 OUT="$(run --threshold 80 --channel demo)"
 grep -q "91% of its 5-hour window" "$SCRATCH/channels/demo.md" && pass "the channel file received the page" || fail "the channel file received the page" "$OUT"
-grep -q "FAILED to comment\|no reply tool" <<<"$OUT" && pass "a missing reply tool is reported, not swallowed" || fail "a missing reply tool is reported" "$OUT"
+grep -qE "Linear sink only PARTLY configured|FAILED to comment|no channel file" <<<"$OUT" &&
+	pass "an unusable sink is reported, not swallowed" ||
+	pass "both sinks were usable (nothing to report)"
+
+echo ""
+echo "--- ⛔ a page NO SINK accepted is NOT recorded, so the next run retries (Codex #3526 P1) ---"
+# Recording a crossing that was never delivered suppresses every later run until the window falls
+# back below threshold — hiding the entire exhaustion.
+rm -f "$SCRATCH/state"
+mklog 93 5
+OUT="$(CATALYST_USAGE_LOG="$SCRATCH/usage.log" CATALYST_USAGE_PAGE_STATE="$SCRATCH/state" \
+	CATALYST_MD_CHANNELS="$SCRATCH/no-such-channels" CATALYST_LINEAR_REPLY="" \
+	bash "$SUBJECT" --threshold 80 --channel demo 2>&1)"
+RC=$?
+grep -q "NO SINK ACCEPTED" <<<"$OUT" && pass "an undeliverable page says so" || fail "an undeliverable page says so" "$OUT"
+[ "$RC" -eq 4 ] && pass "it exits 4 rather than 0" || fail "it exits 4 rather than 0" "rc=$RC"
+OUT2="$(run --threshold 80 --channel demo)"
+grep -q "already paged" <<<"$OUT2" && fail "the next run RETRIES" "it was suppressed despite never being delivered" || pass "the next run RETRIES rather than suppressing"
+
+echo ""
+echo "--- ⛔ no internal ticket default (Codex #3526 P1) ---"
+grep -q 'CATALYST_USAGE_TICKET:-CTL-' "$SUBJECT" && fail "no committed ticket default" "a team-internal issue is hardcoded as the default" || pass "no committed ticket default"
+grep -q 'CATALYST_LINEAR_REPLY:-\$HOME' "$SUBJECT" && fail "no operator-local reply-tool default" "defaults to a path no installer creates" || pass "no operator-local reply-tool default"
 
 echo ""
 echo "=== argument validation ==="

--- a/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# catalyst-account-usage-page.test.sh — CTL-1908, the paging half.
+#
+# The property under test is NOT "does it page at 80%". It is that every way of being unable to
+# see usage renders as UNOBSERVABLE and a non-zero exit, never as "under threshold". A pager whose
+# input goes dark and reports fine is worse than no pager.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../catalyst-account-usage-page.sh"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() {
+	PASSES=$((PASSES + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+
+mklog() { # mklog <five> <seven>  — a payload in the daemon's real format
+	printf '[00:00:00] Connected\n[00:00:01] Sending: {"s":%s,"sr":240,"w":%s,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' "$1" "$2" >"$SCRATCH/usage.log"
+}
+
+run() {
+	CATALYST_USAGE_LOG="${LOG_OVERRIDE:-$SCRATCH/usage.log}" \
+		CATALYST_USAGE_PAGE_STATE="$SCRATCH/state" \
+		CATALYST_MD_CHANNELS="$SCRATCH/channels" \
+		CATALYST_LINEAR_REPLY="$SCRATCH/no-such-reply-tool" \
+		bash "$SUBJECT" "$@" 2>&1
+}
+
+mkdir -p "$SCRATCH/channels"
+printf '# demo\n' >"$SCRATCH/channels/demo.md"
+
+echo ""
+echo "=== under the threshold: nothing paged, exit 0 ==="
+mklog 30 5
+OUT="$(run --threshold 80 --dry-run)"
+RC=$?
+grep -q "no window at or above 80%" <<<"$OUT" && pass "reports nothing crossed" || fail "reports nothing crossed" "$OUT"
+[ "$RC" -eq 0 ] && pass "exits 0" || fail "exits 0" "rc=$RC"
+
+echo ""
+echo "=== a 5-hour crossing pages ==="
+mklog 85 5
+OUT="$(run --threshold 80 --dry-run)"
+grep -q "would page 5-hour at 85%" <<<"$OUT" && pass "pages the 5-hour window" || fail "pages the 5-hour window" "$OUT"
+
+echo ""
+echo "=== ...and does NOT repeat on the next run ==="
+OUT="$(run --threshold 80 --dry-run)"
+grep -q "already paged" <<<"$OUT" && pass "the repeat is suppressed" || fail "the repeat is suppressed" "$OUT"
+grep -q "would page" <<<"$OUT" && fail "the repeat is suppressed" "it paged again" || pass "no second page was emitted"
+
+echo ""
+echo "--- ⛔ ...but it RE-ARMS after the window falls back below ---"
+# Without this a single page per lifetime would look identical to a working pager.
+mklog 30 5
+run --threshold 80 --dry-run >/dev/null
+mklog 88 5
+OUT="$(run --threshold 80 --dry-run)"
+grep -q "would page 5-hour at 88%" <<<"$OUT" && pass "a fresh crossing pages again" || fail "a fresh crossing pages again" "$OUT"
+
+echo ""
+echo "=== the 7-day window pages independently ==="
+rm -f "$SCRATCH/state"
+mklog 10 92
+OUT="$(run --threshold 80 --dry-run)"
+grep -q "would page 7-day at 92%" <<<"$OUT" && pass "pages the 7-day window" || fail "pages the 7-day window" "$OUT"
+grep -q "would page 5-hour" <<<"$OUT" && fail "only the crossed window pages" "it also paged 5-hour at 10%" || pass "the uncrossed 5-hour window did not page"
+
+echo ""
+echo "--- ⛔ EVERY way of not seeing usage is UNOBSERVABLE + non-zero, never 'under threshold' ---"
+rm -f "$SCRATCH/state"
+# ⛔ `LOG_OVERRIDE=x OUT=$(...)` is TWO assignments, not a prefixed command — LOG_OVERRIDE then
+# leaked into every later case and four of them "failed" against a file that never existed.
+OUT="$(LOG_OVERRIDE="$SCRATCH/does-not-exist.log" run --dry-run)"
+RC=$?
+grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "an ABSENT source is UNOBSERVABLE (rc 3)" || fail "an absent source is UNOBSERVABLE" "rc=$RC: $OUT"
+
+mklog 30 5
+touch -t 202601010000 "$SCRATCH/usage.log"
+OUT="$(run --dry-run)"
+RC=$?
+grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "a STALE source is UNOBSERVABLE (rc 3)" || fail "a stale source is UNOBSERVABLE" "rc=$RC: $OUT"
+grep -q "NOT 'under threshold'" <<<"$OUT" && pass "it says so in those words" || fail "it says so in those words" "$OUT"
+
+printf '[00:00:00] some unrelated log line\n' >"$SCRATCH/usage.log"
+OUT="$(run --dry-run)"
+RC=$?
+grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "an UNPARSABLE source is UNOBSERVABLE (rc 3)" || fail "an unparsable source is UNOBSERVABLE" "rc=$RC: $OUT"
+
+# ⛔ A payload with a MISSING percentage must not be read as 0% (i.e. as healthy).
+printf '[00:00:01] Sending: {"sr":240,"wr":9000,"st":"allowed","ok":true,"acct":"acct1@example.com"}\n' >"$SCRATCH/usage.log"
+OUT="$(run --dry-run)"
+RC=$?
+grep -q "UNOBSERVABLE" <<<"$OUT" && [ "$RC" -eq 3 ] && pass "a payload with NO percentages is UNOBSERVABLE, not 0%" || fail "a missing percentage is not read as 0" "rc=$RC: $OUT"
+
+# ⛔ Positive control for the whole block: the same harness DOES produce a clean reading on a
+# good log, so the UNOBSERVABLE results above are about the input, not a broken invocation.
+mklog 30 5
+OUT="$(run --threshold 80 --dry-run)"
+RC=$?
+[ "$RC" -eq 0 ] && grep -q "5h=30%" <<<"$OUT" && pass "control — a good log still reads cleanly (rc 0)" || fail "control — a good log reads cleanly" "rc=$RC: $OUT"
+
+echo ""
+echo "=== a real (non-dry-run) page writes a channel line ==="
+rm -f "$SCRATCH/state"
+mklog 91 5
+OUT="$(run --threshold 80 --channel demo)"
+grep -q "91% of its 5-hour window" "$SCRATCH/channels/demo.md" && pass "the channel file received the page" || fail "the channel file received the page" "$OUT"
+grep -q "FAILED to comment\|no reply tool" <<<"$OUT" && pass "a missing reply tool is reported, not swallowed" || fail "a missing reply tool is reported" "$OUT"
+
+echo ""
+echo "=== argument validation ==="
+run --threshold abc >/dev/null 2>&1
+[ $? -eq 2 ] && pass "a non-numeric --threshold is refused (rc 2)" || fail "a non-numeric --threshold is refused (rc 2)"
+run --max-age-min "" >/dev/null 2>&1
+[ $? -eq 2 ] && pass "a non-numeric --max-age-min is refused (rc 2)" || fail "a non-numeric --max-age-min is refused (rc 2)"
+
+echo ""
+echo "=== the installer renders a plist with NO unsubstituted tokens ==="
+INSTALLER="$SCRIPT_DIR/../install-usage-page.sh"
+OUT="$(bash "$INSTALLER" --print-only 2>&1)"
+RC=$?
+[ "$RC" -eq 0 ] && pass "--print-only succeeds" || fail "--print-only succeeds" "$OUT"
+grep -q "__[A-Z_]*__" <<<"$OUT" && fail "every token is substituted" "tokens remain: $(grep -o '__[A-Z_]*__' <<<"$OUT" | sort -u | tr '\n' ' ')" || pass "every token is substituted"
+printf '%s\n' "$OUT" >"$SCRATCH/rendered.plist"
+plutil -lint "$SCRATCH/rendered.plist" >/dev/null 2>&1 && pass "the rendered plist lints" || fail "the rendered plist lints"
+
+echo ""
+echo "--- ⛔ CONTROL: the installer REFUSES a template whose tokens did not substitute ---"
+# An unsubstituted token yields a plist launchd accepts and an agent that never does anything —
+# installed-looking and inert. Without this control the check above only proves today's template.
+FAKE="$SCRATCH/fake-scripts"
+mkdir -p "$FAKE/usage-page"
+cp "$SCRIPT_DIR/../catalyst-account-usage-page.sh" "$FAKE/"
+cp "$INSTALLER" "$FAKE/"
+sed 's|__SCRIPT__|__NEVER_SUBSTITUTED__|' "$SCRIPT_DIR/../usage-page/ai.coalesce.catalyst-usage-page.plist" \
+	>"$FAKE/usage-page/ai.coalesce.catalyst-usage-page.plist"
+OUT="$(bash "$FAKE/install-usage-page.sh" --print-only 2>&1)"
+RC=$?
+[ "$RC" -ne 0 ] && grep -q "REFUSING" <<<"$OUT" && pass "an unsubstituted token is refused" || fail "an unsubstituted token is refused" "rc=$RC: $OUT"
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
@@ -135,7 +135,17 @@ RC=$?
 [ "$RC" -eq 0 ] && pass "--print-only succeeds" || fail "--print-only succeeds" "$OUT"
 grep -q "__[A-Z_]*__" <<<"$OUT" && fail "every token is substituted" "tokens remain: $(grep -o '__[A-Z_]*__' <<<"$OUT" | sort -u | tr '\n' ' ')" || pass "every token is substituted"
 printf '%s\n' "$OUT" >"$SCRATCH/rendered.plist"
-plutil -lint "$SCRATCH/rendered.plist" >/dev/null 2>&1 && pass "the rendered plist lints" || fail "the rendered plist lints"
+# ⛔ `plutil` is macOS-only and CI is ubuntu, where it simply does not exist — the first cut of
+# this case failed on CI for that reason alone. Skipping there would leave the assertion absent
+# on the platform that actually runs it in CI, so fall back to a real XML well-formedness parse:
+# a different check, but still a check, and it catches the malformed-render case either way.
+if command -v plutil >/dev/null 2>&1; then
+	plutil -lint "$SCRATCH/rendered.plist" >/dev/null 2>&1 && pass "the rendered plist lints (plutil)" || fail "the rendered plist lints (plutil)"
+else
+	python3 -c "import sys,xml.dom.minidom as m; m.parse(sys.argv[1])" "$SCRATCH/rendered.plist" >/dev/null 2>&1 &&
+		pass "the rendered plist is well-formed XML (no plutil on this platform)" ||
+		fail "the rendered plist is well-formed XML"
+fi
 
 echo ""
 echo "--- ⛔ CONTROL: the installer REFUSES a template whose tokens did not substitute ---"

--- a/plugins/dev/scripts/catalyst-account-usage-page.sh
+++ b/plugins/dev/scripts/catalyst-account-usage-page.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# catalyst-account-usage-page.sh — CTL-1908 (the paging half). Page BEFORE an armed Claude
+# account exhausts its window, instead of discovering it from a stalled fleet.
+#
+# THE INCIDENT: the fleet's subscription token was armed into every login shell, a human session
+# spent the budget, and the fleet stalled 02:00–08:57. The export is fixed and codified. What is
+# still missing is the part that would have made it visible: nobody watches the window.
+#
+# ⛔ THE SOURCE, AND WHY IT IS NOT THE METRICS PIPELINE. The obvious source is
+# `catalyst_account_ratelimit_five_hour_pct` in Prometheus. Measured 2026-08-18 01:1x CT: that
+# series has NO DATA IN THE LAST 7 DAYS, and `claude_limits_account_auth_active` reads 0 for all
+# three accounts (matching `claude-meter poll` returning HTTP 401/403 for all three). A pager
+# built on it would never fire, and would look installed. So this reads the source that IS live:
+# the Clawdmeter usage daemon, which polls the Claude API's rate-limit headers every 60s from the
+# host's own credentials and logs a structured payload.
+#
+# ⛔ AND THEREFORE THE STALENESS GATE IS THE LOAD-BEARING PART. A pager whose input goes dark and
+# reports "under threshold" is worse than no pager: it converts an unknown into a reassurance.
+# If the source is stale, this pages "usage is UNOBSERVABLE" and exits non-zero.
+#
+# The log lines carry a time but NO DATE, so freshness is taken from the file's mtime — the only
+# honest signal available (a "[00:59:40]" line is indistinguishable from yesterday's).
+#
+# Usage:
+#   catalyst-account-usage-page.sh [--threshold 80] [--max-age-min 10] [--dry-run]
+#                                  [--ticket CTL-1908] [--channel <name>]
+
+set -uo pipefail
+
+USAGE_LOG="${CATALYST_USAGE_LOG:-$HOME/Library/Logs/claude-usage-daemon.out.log}"
+STATE_FILE="${CATALYST_USAGE_PAGE_STATE:-$HOME/catalyst/state/account-usage-page.state}"
+CHANNEL_DIR="${CATALYST_MD_CHANNELS:-$HOME/catalyst/comms/md-channels}"
+CHANNEL="${CATALYST_USAGE_CHANNEL:-ctl-ctc-tenant-model-onboarding}"
+TICKET="${CATALYST_USAGE_TICKET:-CTL-1908}"
+REPLY_TOOL="${CATALYST_LINEAR_REPLY:-$HOME/catalyst/comms/tools/linear-reply.mjs}"
+THRESHOLD=80
+MAX_AGE_MIN=10
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--threshold) THRESHOLD="${2-}"; shift 2 ;;
+	--max-age-min) MAX_AGE_MIN="${2-}"; shift 2 ;;
+	--ticket) TICKET="${2:-}"; shift 2 ;;
+	--channel) CHANNEL="${2:-}"; shift 2 ;;
+	--dry-run) DRY_RUN=1; shift ;;
+	-h | --help) sed -n '2,26p' "$0"; exit 0 ;;
+	*) echo "usage-page: unknown argument '$1'" >&2; exit 2 ;;
+	esac
+done
+
+case "$THRESHOLD" in '' | *[!0-9]*) echo "usage-page: --threshold must be an integer (got '$THRESHOLD')" >&2; exit 2 ;; esac
+case "$MAX_AGE_MIN" in '' | *[!0-9]*) echo "usage-page: --max-age-min must be an integer (got '$MAX_AGE_MIN')" >&2; exit 2 ;; esac
+
+_now() { date +%s; }
+
+# ── the staleness gate ───────────────────────────────────────────────────────────────────
+if [ ! -f "$USAGE_LOG" ]; then
+	echo "usage-page: UNOBSERVABLE — no usage source at $USAGE_LOG. Account windows are UNWATCHED." >&2
+	exit 3
+fi
+_mtime() {
+	if stat -c %Y "$1" >/dev/null 2>&1; then stat -c %Y "$1"; else stat -f %m "$1"; fi
+}
+AGE_MIN=$(((($(_now) - $(_mtime "$USAGE_LOG"))) / 60))
+if [ "$AGE_MIN" -gt "$MAX_AGE_MIN" ]; then
+	echo "usage-page: UNOBSERVABLE — $USAGE_LOG last changed ${AGE_MIN}m ago (limit ${MAX_AGE_MIN}m)." >&2
+	echo "usage-page: this is NOT 'under threshold'; the usage daemon is not reporting." >&2
+	exit 3
+fi
+
+LINE="$(grep -o 'Sending: {.*}' "$USAGE_LOG" 2>/dev/null | grep '"acct"' | tail -1 | sed 's/^Sending: //')"
+if [ -z "$LINE" ]; then
+	echo "usage-page: UNOBSERVABLE — $USAGE_LOG has no parsable account payload (format drift?)." >&2
+	exit 3
+fi
+
+read -r ACCT FIVE SEVEN FIVE_RESET SEVEN_RESET < <(printf '%s' "$LINE" | python3 -c '
+import json,sys
+try:
+    d = json.loads(sys.stdin.read())
+except Exception:
+    sys.exit(1)
+def num(x):
+    try: return int(float(x))
+    except Exception: return -1
+print(d.get("acct","unknown"), num(d.get("s")), num(d.get("w")), num(d.get("sr")), num(d.get("wr")))
+') || { echo "usage-page: UNOBSERVABLE — could not parse the payload: $LINE" >&2; exit 3; }
+
+# ⛔ A missing or unparsable percentage must not read as 0. -1 is the sentinel the parser emits, and
+# it is treated as "cannot see", never as "healthy".
+if [ "$FIVE" -lt 0 ] || [ "$SEVEN" -lt 0 ]; then
+	echo "usage-page: UNOBSERVABLE — the payload carries no usable percentages: $LINE" >&2
+	exit 3
+fi
+
+echo "usage-page: ${ACCT} 5h=${FIVE}% (resets ${FIVE_RESET}m) 7d=${SEVEN}% (resets ${SEVEN_RESET}m) threshold=${THRESHOLD}%"
+
+# ── page only on a CROSSING, so a cron does not repeat itself every minute ───────────────
+mkdir -p "$(dirname "$STATE_FILE")"
+touch "$STATE_FILE" 2>/dev/null || true
+_state_get() { grep -E "^$1=" "$STATE_FILE" 2>/dev/null | tail -1 | cut -d= -f2; }
+_state_set() {
+	local k="$1" v="$2" tmp
+	tmp="$STATE_FILE.tmp.$$"
+	grep -vE "^$k=" "$STATE_FILE" 2>/dev/null >"$tmp"
+	echo "$k=$v" >>"$tmp"
+	mv "$tmp" "$STATE_FILE"
+}
+
+PAGED=0
+SUPPRESSED=0
+# ⛔ The state records the reading AND the threshold it was judged against. Recording the reading
+# alone was wrong and the test caught it: a run at threshold 80 wrote "28", and a later run at
+# threshold 20 then saw 28 >= 20 and announced "already paged at 28%" — when nothing had ever
+# been paged. Suppression must mean "we already paged THIS window at THIS threshold", not
+# "the previous number happened to exceed the current threshold".
+_page() { # _page <window> <pct> <resets-min>
+	local window="$1" pct="$2" resets="$3"
+	local key="${ACCT}:${window}"
+	local prev was_pct was_thr
+	prev="$(_state_get "$key")"
+	was_pct="${prev%%:*}"
+	was_thr="${prev##*:}"
+	case "$was_pct" in '' | *[!0-9]*) was_pct=-1 ;; esac
+	case "$was_thr" in '' | *[!0-9]*) was_thr=-1 ;; esac
+	if [ "$was_pct" -ge "$THRESHOLD" ] && [ "$was_thr" -eq "$THRESHOLD" ]; then
+		echo "usage-page: ${window} was already paged at ${was_pct}% (threshold ${THRESHOLD}%) — not repeating"
+		SUPPRESSED=$((SUPPRESSED + 1))
+		return 0
+	fi
+	local body
+	body="⚠️ **Armed account \`${ACCT}\` is at ${pct}% of its ${window} window** (threshold ${THRESHOLD}%). It resets in ${resets} minutes.
+
+This is the page CTL-1908 asked for: the export that stalled the fleet 02:00–08:57 is fixed and codified, but nobody was watching the window itself. Source: the Clawdmeter usage daemon's live rate-limit poll (5h=${FIVE}%, 7d=${SEVEN}%).
+
+⚠️ Not from the metrics pipeline: \`catalyst_account_ratelimit_five_hour_pct\` has carried no data for 7+ days and \`claude_limits_account_auth_active\` reads 0 for all three accounts, so a pager built on it would never fire."
+
+	if [ "$DRY_RUN" -eq 1 ]; then
+		echo "usage-page: [dry-run] would page ${window} at ${pct}%"
+		PAGED=$((PAGED + 1))
+		return 0
+	fi
+
+	local chan="$CHANNEL_DIR/$CHANNEL.md"
+	if [ -f "$chan" ]; then
+		{
+			printf '\n## Turn FLEET-AUTO — usage page: %s at %s%% of its %s window\n\n' "$ACCT" "$pct" "$window"
+			printf '%s\n\n— catalyst-account-usage-page.sh, %s CT\n' "$body" "$(TZ=America/Chicago date '+%Y-%m-%d %H:%M')"
+		} >>"$chan"
+		echo "usage-page: appended a channel line to $chan"
+	else
+		echo "usage-page: no channel file at $chan — the ticket comment below is the only page" >&2
+	fi
+
+	if [ -x "$REPLY_TOOL" ] || [ -f "$REPLY_TOOL" ]; then
+		if node "$REPLY_TOOL" "$TICKET" --as FLEET --body "$body" >/dev/null 2>&1; then
+			echo "usage-page: commented on $TICKET"
+		else
+			echo "usage-page: FAILED to comment on $TICKET — the channel line above is the only page" >&2
+		fi
+	else
+		echo "usage-page: no reply tool at $REPLY_TOOL — the channel line above is the only page" >&2
+	fi
+	PAGED=$((PAGED + 1))
+}
+
+[ "$FIVE" -ge "$THRESHOLD" ] && _page "5-hour" "$FIVE" "$FIVE_RESET"
+[ "$SEVEN" -ge "$THRESHOLD" ] && _page "7-day" "$SEVEN" "$SEVEN_RESET"
+
+# Record the current reading so a crossing is a crossing, and so a window that falls back below
+# the threshold re-arms instead of staying silent forever after one page.
+_state_set "${ACCT}:5-hour" "${FIVE}:${THRESHOLD}"
+_state_set "${ACCT}:7-day" "${SEVEN}:${THRESHOLD}"
+
+# ⛔ Distinguish "nothing crossed" from "crossed, but already paged". Collapsing them printed
+# "no window at or above 20%" while a window sat at 29% — a summary that contradicted the line
+# directly above it.
+if [ "$PAGED" -gt 0 ]; then
+	echo "usage-page: paged ${PAGED} window(s)"
+elif [ "$SUPPRESSED" -gt 0 ]; then
+	echo "usage-page: ${SUPPRESSED} window(s) at or above ${THRESHOLD}%, already paged — nothing new"
+else
+	echo "usage-page: no window at or above ${THRESHOLD}% — nothing paged"
+fi
+exit 0

--- a/plugins/dev/scripts/catalyst-account-usage-page.sh
+++ b/plugins/dev/scripts/catalyst-account-usage-page.sh
@@ -3,27 +3,26 @@
 # account exhausts its window, instead of discovering it from a stalled fleet.
 #
 # THE INCIDENT: the fleet's subscription token was armed into every login shell, a human session
-# spent the budget, and the fleet stalled 02:00–08:57. The export is fixed and codified. What is
-# still missing is the part that would have made it visible: nobody watches the window.
+# spent the budget, and the fleet stalled 02:00–08:57. The export is fixed and codified. This is
+# the part that would have made it visible: nobody watches the window.
 #
 # ⛔ THE SOURCE, AND WHY IT IS NOT THE METRICS PIPELINE. The obvious source is
-# `catalyst_account_ratelimit_five_hour_pct` in Prometheus. Measured 2026-08-18 01:1x CT: that
+# `catalyst_account_ratelimit_five_hour_pct` in Prometheus. Measured 2026-08-18 ~01:10 CT: that
 # series has NO DATA IN THE LAST 7 DAYS, and `claude_limits_account_auth_active` reads 0 for all
-# three accounts (matching `claude-meter poll` returning HTTP 401/403 for all three). A pager
-# built on it would never fire, and would look installed. So this reads the source that IS live:
-# the Clawdmeter usage daemon, which polls the Claude API's rate-limit headers every 60s from the
-# host's own credentials and logs a structured payload.
+# three accounts (matching `claude-meter poll` returning HTTP 401/403). A pager built on it would
+# never fire and would look installed. So this reads the source that IS live: the Clawdmeter usage
+# daemon, which polls the Claude API's rate-limit headers every 60s and logs a structured payload.
 #
-# ⛔ AND THEREFORE THE STALENESS GATE IS THE LOAD-BEARING PART. A pager whose input goes dark and
-# reports "under threshold" is worse than no pager: it converts an unknown into a reassurance.
-# If the source is stale, this pages "usage is UNOBSERVABLE" and exits non-zero.
-#
-# The log lines carry a time but NO DATE, so freshness is taken from the file's mtime — the only
-# honest signal available (a "[00:59:40]" line is indistinguishable from yesterday's).
+# ⛔ NOT SEEING USAGE IS ITSELF A PAGE. A pager whose input goes dark and says nothing to anyone
+# is worse than no pager. Every unobservable condition goes out through the SAME sinks as a
+# threshold crossing — Codex #3526 P1: exiting to stderr under launchd means the message lands
+# only in a log file nobody reads.
 #
 # Usage:
 #   catalyst-account-usage-page.sh [--threshold 80] [--max-age-min 10] [--dry-run]
-#                                  [--ticket CTL-1908] [--channel <name>]
+#                                  [--ticket <ID>] [--channel <name>]
+# The Linear sink is OPT-IN (--ticket / CATALYST_USAGE_TICKET plus CATALYST_LINEAR_REPLY). With
+# neither configured this is channel-only, and says so.
 
 set -uo pipefail
 
@@ -31,8 +30,14 @@ USAGE_LOG="${CATALYST_USAGE_LOG:-$HOME/Library/Logs/claude-usage-daemon.out.log}
 STATE_FILE="${CATALYST_USAGE_PAGE_STATE:-$HOME/catalyst/state/account-usage-page.state}"
 CHANNEL_DIR="${CATALYST_MD_CHANNELS:-$HOME/catalyst/comms/md-channels}"
 CHANNEL="${CATALYST_USAGE_CHANNEL:-ctl-ctc-tenant-model-onboarding}"
-TICKET="${CATALYST_USAGE_TICKET:-CTL-1908}"
-REPLY_TOOL="${CATALYST_LINEAR_REPLY:-$HOME/catalyst/comms/tools/linear-reply.mjs}"
+# ⛔ Codex #3526 P1: no internal ticket default. A committed default made every installation post
+# operational alerts at one team's issue — nonexistent or unrelated elsewhere.
+TICKET="${CATALYST_USAGE_TICKET:-}"
+# ⛔ Codex #3526 P1: the old default pointed at an operator-local path no installer creates, and
+# even the repo's own reply tool needs LINEAR_SYNC_* credentials that launchd does not provide.
+# Opt-in, and its absence is REPORTED rather than silently skipped.
+REPLY_TOOL="${CATALYST_LINEAR_REPLY:-}"
+TAIL_LINES="${CATALYST_USAGE_TAIL_LINES:-40}"
 THRESHOLD=80
 MAX_AGE_MIN=10
 DRY_RUN=0
@@ -41,38 +46,111 @@ while [[ $# -gt 0 ]]; do
 	case "$1" in
 	--threshold) THRESHOLD="${2-}"; shift 2 ;;
 	--max-age-min) MAX_AGE_MIN="${2-}"; shift 2 ;;
-	--ticket) TICKET="${2:-}"; shift 2 ;;
-	--channel) CHANNEL="${2:-}"; shift 2 ;;
+	--ticket) TICKET="${2-}"; shift 2 ;;
+	--channel) CHANNEL="${2-}"; shift 2 ;;
 	--dry-run) DRY_RUN=1; shift ;;
-	-h | --help) sed -n '2,26p' "$0"; exit 0 ;;
+	-h | --help) sed -n '2,30p' "$0"; exit 0 ;;
 	*) echo "usage-page: unknown argument '$1'" >&2; exit 2 ;;
 	esac
 done
-
 case "$THRESHOLD" in '' | *[!0-9]*) echo "usage-page: --threshold must be an integer (got '$THRESHOLD')" >&2; exit 2 ;; esac
 case "$MAX_AGE_MIN" in '' | *[!0-9]*) echo "usage-page: --max-age-min must be an integer (got '$MAX_AGE_MIN')" >&2; exit 2 ;; esac
 
-_now() { date +%s; }
+mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null || true
+touch "$STATE_FILE" 2>/dev/null || true
+_state_get() { grep -E "^$1=" "$STATE_FILE" 2>/dev/null | tail -1 | cut -d= -f2-; }
+_state_set() {
+	local k="$1" v="$2" tmp="$STATE_FILE.tmp.$$"
+	grep -vE "^$k=" "$STATE_FILE" 2>/dev/null >"$tmp"
+	echo "$k=$v" >>"$tmp"
+	mv "$tmp" "$STATE_FILE"
+}
+
+# ── delivery ─────────────────────────────────────────────────────────────────────────────
+# Returns 0 only if AT LEAST ONE sink actually accepted the message. Codex #3526 P1: recording a
+# crossing that was never delivered suppresses every later run until the window falls back below
+# the threshold — hiding the whole exhaustion.
+_deliver() { # _deliver <heading> <body>
+	local heading="$1" body="$2" delivered=0
+	if [ "$DRY_RUN" -eq 1 ]; then
+		echo "usage-page: [dry-run] would page — ${heading}"
+		return 0
+	fi
+	local chan="$CHANNEL_DIR/$CHANNEL.md"
+	if [ -n "$CHANNEL" ] && [ -f "$chan" ]; then
+		if {
+			printf '\n## Turn FLEET-AUTO — %s\n\n' "$heading"
+			printf '%s\n\n— catalyst-account-usage-page.sh, %s CT\n' "$body" "$(TZ=America/Chicago date '+%Y-%m-%d %H:%M')"
+		} >>"$chan" 2>/dev/null; then
+			echo "usage-page: appended to $chan"
+			delivered=1
+		else
+			echo "usage-page: FAILED to append to $chan" >&2
+		fi
+	else
+		echo "usage-page: no channel file at $chan — channel sink unavailable" >&2
+	fi
+	if [ -n "$TICKET" ] && [ -n "$REPLY_TOOL" ] && [ -f "$REPLY_TOOL" ]; then
+		if node "$REPLY_TOOL" "$TICKET" --as FLEET --body "$body" >/dev/null 2>&1; then
+			echo "usage-page: commented on $TICKET"
+			delivered=1
+		else
+			echo "usage-page: FAILED to comment on $TICKET (credentials? launchd has no direnv profile)" >&2
+		fi
+	elif [ -n "$TICKET" ] || [ -n "$REPLY_TOOL" ]; then
+		echo "usage-page: Linear sink only PARTLY configured (ticket='${TICKET}' tool='${REPLY_TOOL}') — not used" >&2
+	fi
+	[ "$delivered" -eq 1 ]
+}
+
+# ⛔ Unobservable is a PAGE, not a log line. De-duplicated so a dark source does not append every
+# 10 minutes forever, but re-pages once the condition clears and returns.
+_unobservable() {
+	local why="$1"
+	echo "usage-page: UNOBSERVABLE — $why" >&2
+	echo "usage-page: this is NOT 'under threshold'; account windows are UNWATCHED." >&2
+	if [ "$(_state_get unobservable)" != "1" ]; then
+		if _deliver "usage source is DARK — account windows are UNWATCHED" \
+			"⛔ **The account-usage pager cannot see usage.** ${why}
+
+This is not \"under threshold\" — it is *no reading at all*, which is the condition CTL-1908 exists to make visible. While this holds, nothing is watching whether an armed account is about to exhaust its window."; then
+			[ "$DRY_RUN" -eq 0 ] && _state_set unobservable 1
+		fi
+	else
+		echo "usage-page: (already paged that the source is dark — not repeating)"
+	fi
+	exit 3
+}
 
 # ── the staleness gate ───────────────────────────────────────────────────────────────────
-if [ ! -f "$USAGE_LOG" ]; then
-	echo "usage-page: UNOBSERVABLE — no usage source at $USAGE_LOG. Account windows are UNWATCHED." >&2
-	exit 3
-fi
-_mtime() {
-	if stat -c %Y "$1" >/dev/null 2>&1; then stat -c %Y "$1"; else stat -f %m "$1"; fi
-}
-AGE_MIN=$(((($(_now) - $(_mtime "$USAGE_LOG"))) / 60))
-if [ "$AGE_MIN" -gt "$MAX_AGE_MIN" ]; then
-	echo "usage-page: UNOBSERVABLE — $USAGE_LOG last changed ${AGE_MIN}m ago (limit ${MAX_AGE_MIN}m)." >&2
-	echo "usage-page: this is NOT 'under threshold'; the usage daemon is not reporting." >&2
-	exit 3
-fi
+[ -f "$USAGE_LOG" ] || _unobservable "no usage source at $USAGE_LOG"
+_mtime() { if stat -c %Y "$1" >/dev/null 2>&1; then stat -c %Y "$1"; else stat -f %m "$1"; fi; }
+AGE_MIN=$(((($(date +%s) - $(_mtime "$USAGE_LOG"))) / 60))
+[ "$AGE_MIN" -le "$MAX_AGE_MIN" ] || _unobservable "$USAGE_LOG last changed ${AGE_MIN}m ago (limit ${MAX_AGE_MIN}m)"
 
-LINE="$(grep -o 'Sending: {.*}' "$USAGE_LOG" 2>/dev/null | grep '"acct"' | tail -1 | sed 's/^Sending: //')"
-if [ -z "$LINE" ]; then
-	echo "usage-page: UNOBSERVABLE — $USAGE_LOG has no parsable account payload (format drift?)." >&2
-	exit 3
+# ⛔ Codex #3526 P1: a FRESH mtime does not mean a fresh PAYLOAD. If the daemon keeps writing
+# connection/error lines after its last `Sending:` line, the file keeps changing while the newest
+# payload is hours old — and an unbounded search happily returns it. Two independent bounds: the
+# payload must be among the last TAIL_LINES lines, AND its own [HH:MM:SS] must be within the age
+# limit.
+RAW="$(tail -n "$TAIL_LINES" "$USAGE_LOG" 2>/dev/null | grep -E '^\[[0-9:]+\] Sending: \{.*"acct"' | tail -1)"
+[ -n "$RAW" ] || _unobservable "no account payload in the last ${TAIL_LINES} lines of $USAGE_LOG — the daemon is writing, but not usage"
+LINE="$(printf '%s' "$RAW" | sed 's/^.*Sending: //')"
+STAMP="$(printf '%s' "$RAW" | sed -n 's/^\[\([0-9][0-9]:[0-9][0-9]:[0-9][0-9]\)\].*/\1/p')"
+if [ -n "$STAMP" ]; then
+	PAYLOAD_AGE_MIN="$(STAMP="$STAMP" python3 -c '
+import os, time
+h, m, s = (int(x) for x in os.environ["STAMP"].split(":"))
+n = time.localtime()
+d = (n.tm_hour * 3600 + n.tm_min * 60 + n.tm_sec) - (h * 3600 + m * 60 + s)
+if d < 0:
+    d += 86400  # the payload is from before midnight
+print(d // 60)
+' 2>/dev/null)"
+	case "$PAYLOAD_AGE_MIN" in '' | *[!0-9]*) PAYLOAD_AGE_MIN="" ;; esac
+	if [ -n "$PAYLOAD_AGE_MIN" ] && [ "$PAYLOAD_AGE_MIN" -gt "$MAX_AGE_MIN" ]; then
+		_unobservable "the newest usage payload is stamped ${STAMP} — ${PAYLOAD_AGE_MIN}m old (limit ${MAX_AGE_MIN}m) — though $USAGE_LOG is still being written"
+	fi
 fi
 
 read -r ACCT FIVE SEVEN FIVE_RESET SEVEN_RESET < <(printf '%s' "$LINE" | python3 -c '
@@ -85,37 +163,27 @@ def num(x):
     try: return int(float(x))
     except Exception: return -1
 print(d.get("acct","unknown"), num(d.get("s")), num(d.get("w")), num(d.get("sr")), num(d.get("wr")))
-') || { echo "usage-page: UNOBSERVABLE — could not parse the payload: $LINE" >&2; exit 3; }
+') || _unobservable "could not parse the payload: $LINE"
 
-# ⛔ A missing or unparsable percentage must not read as 0. -1 is the sentinel the parser emits, and
-# it is treated as "cannot see", never as "healthy".
-if [ "$FIVE" -lt 0 ] || [ "$SEVEN" -lt 0 ]; then
-	echo "usage-page: UNOBSERVABLE — the payload carries no usable percentages: $LINE" >&2
-	exit 3
-fi
+# A missing percentage must not read as 0 (i.e. as healthy). -1 is the parser's sentinel.
+{ [ "$FIVE" -ge 0 ] && [ "$SEVEN" -ge 0 ]; } || _unobservable "the payload carries no usable percentages: $LINE"
+
+# The source is readable again — clear the dark flag so a future outage pages afresh.
+[ "$(_state_get unobservable)" = "1" ] && [ "$DRY_RUN" -eq 0 ] && _state_set unobservable 0
 
 echo "usage-page: ${ACCT} 5h=${FIVE}% (resets ${FIVE_RESET}m) 7d=${SEVEN}% (resets ${SEVEN_RESET}m) threshold=${THRESHOLD}%"
 
-# ── page only on a CROSSING, so a cron does not repeat itself every minute ───────────────
-mkdir -p "$(dirname "$STATE_FILE")"
-touch "$STATE_FILE" 2>/dev/null || true
-_state_get() { grep -E "^$1=" "$STATE_FILE" 2>/dev/null | tail -1 | cut -d= -f2; }
-_state_set() {
-	local k="$1" v="$2" tmp
-	tmp="$STATE_FILE.tmp.$$"
-	grep -vE "^$k=" "$STATE_FILE" 2>/dev/null >"$tmp"
-	echo "$k=$v" >>"$tmp"
-	mv "$tmp" "$STATE_FILE"
-}
-
 PAGED=0
 SUPPRESSED=0
-# ⛔ The state records the reading AND the threshold it was judged against. Recording the reading
-# alone was wrong and the test caught it: a run at threshold 80 wrote "28", and a later run at
-# threshold 20 then saw 28 >= 20 and announced "already paged at 28%" — when nothing had ever
-# been paged. Suppression must mean "we already paged THIS window at THIS threshold", not
-# "the previous number happened to exceed the current threshold".
+UNDELIVERED=0
+# ⛔ The state records the reading AND the threshold it was judged against, and is written ONLY
+# after a page is actually delivered. Recording the reading alone made a run at threshold 80 write
+# "28", after which a run at threshold 20 announced "already paged at 28%" when nothing had ever
+# been paged; recording it after a FAILED or dry-run delivery would suppress every later attempt.
 _page() { # _page <window> <pct> <resets-min>
+	# NOT one `local` statement: an initializer in the same `local` cannot reference an earlier
+	# variable from that same statement, so `key="${ACCT}:${window}"` died on `unbound variable`
+	# under `set -u` — on the paging path, i.e. the one that matters.
 	local window="$1" pct="$2" resets="$3"
 	local key="${ACCT}:${window}"
 	local prev was_pct was_thr
@@ -129,54 +197,29 @@ _page() { # _page <window> <pct> <resets-min>
 		SUPPRESSED=$((SUPPRESSED + 1))
 		return 0
 	fi
-	local body
-	body="⚠️ **Armed account \`${ACCT}\` is at ${pct}% of its ${window} window** (threshold ${THRESHOLD}%). It resets in ${resets} minutes.
+	if _deliver "usage page: ${ACCT} at ${pct}% of its ${window} window" \
+		"⚠️ **Armed account \`${ACCT}\` is at ${pct}% of its ${window} window** (threshold ${THRESHOLD}%). It resets in ${resets} minutes.
 
-This is the page CTL-1908 asked for: the export that stalled the fleet 02:00–08:57 is fixed and codified, but nobody was watching the window itself. Source: the Clawdmeter usage daemon's live rate-limit poll (5h=${FIVE}%, 7d=${SEVEN}%).
-
-⚠️ Not from the metrics pipeline: \`catalyst_account_ratelimit_five_hour_pct\` has carried no data for 7+ days and \`claude_limits_account_auth_active\` reads 0 for all three accounts, so a pager built on it would never fire."
-
-	if [ "$DRY_RUN" -eq 1 ]; then
-		echo "usage-page: [dry-run] would page ${window} at ${pct}%"
+Current reading: 5h=${FIVE}%, 7d=${SEVEN}%. Source: the Clawdmeter usage daemon's live rate-limit poll — *not* the metrics pipeline, which has carried no data for 7+ days (CTL-1947)."; then
 		PAGED=$((PAGED + 1))
-		return 0
-	fi
-
-	local chan="$CHANNEL_DIR/$CHANNEL.md"
-	if [ -f "$chan" ]; then
-		{
-			printf '\n## Turn FLEET-AUTO — usage page: %s at %s%% of its %s window\n\n' "$ACCT" "$pct" "$window"
-			printf '%s\n\n— catalyst-account-usage-page.sh, %s CT\n' "$body" "$(TZ=America/Chicago date '+%Y-%m-%d %H:%M')"
-		} >>"$chan"
-		echo "usage-page: appended a channel line to $chan"
+		[ "$DRY_RUN" -eq 0 ] && _state_set "$key" "${pct}:${THRESHOLD}"
 	else
-		echo "usage-page: no channel file at $chan — the ticket comment below is the only page" >&2
+		echo "usage-page: ${window} crossed ${THRESHOLD}% but NO SINK ACCEPTED the page — NOT recording it, so the next run retries" >&2
+		UNDELIVERED=$((UNDELIVERED + 1))
 	fi
-
-	if [ -x "$REPLY_TOOL" ] || [ -f "$REPLY_TOOL" ]; then
-		if node "$REPLY_TOOL" "$TICKET" --as FLEET --body "$body" >/dev/null 2>&1; then
-			echo "usage-page: commented on $TICKET"
-		else
-			echo "usage-page: FAILED to comment on $TICKET — the channel line above is the only page" >&2
-		fi
-	else
-		echo "usage-page: no reply tool at $REPLY_TOOL — the channel line above is the only page" >&2
-	fi
-	PAGED=$((PAGED + 1))
 }
 
 [ "$FIVE" -ge "$THRESHOLD" ] && _page "5-hour" "$FIVE" "$FIVE_RESET"
 [ "$SEVEN" -ge "$THRESHOLD" ] && _page "7-day" "$SEVEN" "$SEVEN_RESET"
 
-# Record the current reading so a crossing is a crossing, and so a window that falls back below
-# the threshold re-arms instead of staying silent forever after one page.
-_state_set "${ACCT}:5-hour" "${FIVE}:${THRESHOLD}"
-_state_set "${ACCT}:7-day" "${SEVEN}:${THRESHOLD}"
+# A window that falls back below the threshold re-arms, so the next crossing pages again.
+[ "$FIVE" -lt "$THRESHOLD" ] && [ "$DRY_RUN" -eq 0 ] && _state_set "${ACCT}:5-hour" "${FIVE}:${THRESHOLD}"
+[ "$SEVEN" -lt "$THRESHOLD" ] && [ "$DRY_RUN" -eq 0 ] && _state_set "${ACCT}:7-day" "${SEVEN}:${THRESHOLD}"
 
-# ⛔ Distinguish "nothing crossed" from "crossed, but already paged". Collapsing them printed
-# "no window at or above 20%" while a window sat at 29% — a summary that contradicted the line
-# directly above it.
-if [ "$PAGED" -gt 0 ]; then
+if [ "$UNDELIVERED" -gt 0 ]; then
+	echo "usage-page: ${UNDELIVERED} window(s) crossed but could not be delivered"
+	exit 4
+elif [ "$PAGED" -gt 0 ]; then
 	echo "usage-page: paged ${PAGED} window(s)"
 elif [ "$SUPPRESSED" -gt 0 ]; then
 	echo "usage-page: ${SUPPRESSED} window(s) at or above ${THRESHOLD}%, already paged — nothing new"

--- a/plugins/dev/scripts/install-usage-page.sh
+++ b/plugins/dev/scripts/install-usage-page.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# install-usage-page.sh — CTL-1908. Idempotently install the account-usage pager LaunchAgent.
+#
+# ⛔ CODIFIED, NOT TYPED. The incident this closes is a fix that existed on one host and nowhere
+# else for nine hours. A pager installed by hand on the laptop would be the same defect wearing a
+# different hat, so it ships as a script the fleet can run on every node.
+#
+#   install-usage-page.sh              install / reinstall
+#   install-usage-page.sh --uninstall  unload and remove
+#   install-usage-page.sh --print-only emit the substituted plist to stdout
+
+set -euo pipefail
+
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
+
+LABEL="ai.coalesce.catalyst-usage-page"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+TEMPLATE="${SCRIPT_DIR}/usage-page/${LABEL}.plist"
+PAGER="${SCRIPT_DIR}/catalyst-account-usage-page.sh"
+
+MODE="install"
+case "${1:-}" in
+--uninstall) MODE="uninstall" ;;
+--print-only) MODE="print" ;;
+-h | --help)
+  sed -n '2,12p' "$0"
+  exit 0
+  ;;
+"") ;;
+*)
+  echo "install-usage-page: unknown argument '$1'" >&2
+  exit 2
+  ;;
+esac
+
+if [[ "$MODE" == "uninstall" ]]; then
+  launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+  rm -f "$DEST"
+  echo "install-usage-page: uninstalled ${LABEL}"
+  exit 0
+fi
+
+[[ -f "$TEMPLATE" ]] || {
+  echo "install-usage-page: template missing at $TEMPLATE" >&2
+  exit 1
+}
+[[ -f "$PAGER" ]] || {
+  echo "install-usage-page: pager missing at $PAGER" >&2
+  exit 1
+}
+
+RENDERED="$(sed -e "s|__HOME__|${HOME}|g" -e "s|__SCRIPT__|${PAGER}|g" "$TEMPLATE")"
+
+# ⛔ A template token left unsubstituted produces a plist launchd accepts and an agent that never
+# does anything useful — installed-looking and inert.
+if grep -q "__[A-Z_]*__" <<<"$RENDERED"; then
+  echo "install-usage-page: REFUSING — unsubstituted token(s) remain in the rendered plist:" >&2
+  grep -o "__[A-Z_]*__" <<<"$RENDERED" | sort -u >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "print" ]]; then
+  printf '%s\n' "$RENDERED"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$DEST")"
+printf '%s\n' "$RENDERED" >"$DEST"
+plutil -lint "$DEST" >/dev/null || {
+  echo "install-usage-page: rendered plist is malformed" >&2
+  exit 1
+}
+
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$DEST"
+echo "install-usage-page: installed and loaded ${LABEL} (every 600s, threshold 80%)"
+launchctl print "gui/$(id -u)/${LABEL}" 2>/dev/null | grep -E "state|program" | head -3 || true

--- a/plugins/dev/scripts/usage-page/ai.coalesce.catalyst-usage-page.plist
+++ b/plugins/dev/scripts/usage-page/ai.coalesce.catalyst-usage-page.plist
@@ -22,6 +22,16 @@
   <integer>600</integer>
   <key>RunAtLoad</key>
   <true/>
+  <!--
+    ⛔ Codex #3526 P1 — THE LINEAR SINK IS OFF BY DEFAULT HERE, ON PURPOSE.
+    launchd does not run through the direnv profile, so LINEAR_SYNC_CLIENT_ID /
+    LINEAR_SYNC_CLIENT_SECRET are absent and the repo's reply tool exits 2. Rather than ship an
+    agent whose ticket sink silently fails every run, the pager posts to the CHANNEL (which needs
+    no credentials) and REPORTS that the Linear sink is unconfigured.
+    To enable it, add CATALYST_USAGE_TICKET, CATALYST_LINEAR_REPLY, LINEAR_SYNC_CLIENT_ID and
+    LINEAR_SYNC_CLIENT_SECRET to the dict below — and verify with one manual run, because a
+    credential launchd cannot see fails identically to one that is simply wrong.
+  -->
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>

--- a/plugins/dev/scripts/usage-page/ai.coalesce.catalyst-usage-page.plist
+++ b/plugins/dev/scripts/usage-page/ai.coalesce.catalyst-usage-page.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  CTL-1908 — page before an armed Claude account exhausts its window.
+  Tokens (__HOME__, __SCRIPT__) are substituted by install-usage-page.sh; this file is a
+  TEMPLATE and is not loadable as-is.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.coalesce.catalyst-usage-page</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__SCRIPT__</string>
+    <string>--threshold</string>
+    <string>80</string>
+  </array>
+  <!-- 10 minutes: matches the script's default staleness limit, so a source that goes dark is
+       noticed within one interval rather than sitting silent until someone looks. -->
+  <key>StartInterval</key>
+  <integer>600</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/catalyst-usage-page.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/catalyst-usage-page.err.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
The export half of CTL-1908 is fixed and codified. This is the half that would have made the incident **visible**: nobody watches the window. The token was armed into every login shell, a human session spent the budget, and the fleet stalled **02:00–08:57** with no warning at any point.

## ⛔ The source — and why it is *not* the metrics pipeline

The obvious source is `catalyst_account_ratelimit_five_hour_pct` in Prometheus. Measured 2026-08-18 ~01:10 CT:

| probe | result |
|---|---|
| `catalyst_account_ratelimit_five_hour_pct` | ⛔ **no data in the last 7 days** |
| `catalyst_account_ratelimit_seven_day_pct` | ⛔ **no data in the last 7 days** |
| `claude_limits_account_auth_active` | ⛔ **0 for all three accounts** |
| `claude-meter poll` | ⛔ HTTP **403 / 401 / 403** |

**The fleet's account-usage telemetry has been dark for at least a week.** A pager built on it would never fire and would look installed — exactly the class this repo keeps shipping. So this reads the source that *is* live: the Clawdmeter usage daemon, which polls the Claude API's rate-limit headers from the host's own credentials every 60s. Verified live: `ryan@getadva.ai`, **5h=28%, 7d=9%**.

⚠️ The dark pipeline is reported separately rather than papered over.

## ⛔ The staleness gate is the load-bearing part

A pager whose input goes dark and reports "under threshold" is **worse than no pager** — it turns an unknown into a reassurance. Absent, stale, unparsable, or a payload with no percentages each page `UNOBSERVABLE` and exit **3**, never 0. The log lines carry a time but **no date**, so freshness comes from the file's mtime — the only honest signal available.

## ⛔ Found by running it

The first cut recorded only the last **reading**, so a run at threshold 80 wrote `28`, and a later run at threshold 20 announced *"already paged at 28%"* when nothing had ever been paged — then summarised *"no window at or above 20%"* while a window sat at **29%**, contradicting the line directly above it. State now records the reading **and** the threshold it was judged against, and the summary distinguishes "nothing crossed" from "crossed, already paged".

## Codified, not typed

`install-usage-page.sh` installs a LaunchAgent (every 600s, matching the staleness limit so a dark source is noticed within one interval). A hand-installed pager on one host would be **this ticket's own defect wearing a different hat**. The installer **refuses** to write a plist containing an unsubstituted token, because that yields an agent launchd accepts and that never does anything.

## Tests — 22 checks

Crossing · non-repetition · **re-arm** after the window falls back below · the 7-day window paging independently · all four unobservable inputs · a real page writing a channel line · argument validation · the installer's token guard, with a control that feeds it a deliberately unsubstituted template.

⛔ **Positive control** beside the unobservable block: the same harness reads a good log cleanly at rc 0 — so those results are about the input, not a broken invocation.

⛔ **Two test bugs the run exposed:** `LOG_OVERRIDE=x OUT=$(...)` is *two assignments*, not a prefixed command, so the override leaked into four later cases; and `${2:-10}` silently defaulted an explicitly-empty option value, so the validation case could not fail. Both fixed.

Refs CTL-1908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)