### PR TITLE
feat(dev): CTL-1943 — a dispatched phase narrates itself as a Linear agent session, without blocking the tick

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -869,6 +869,7 @@ jobs:
             assertion-evidence.test.mjs \
             assertion-evidence-parity.test.mjs \
             cli-header-backtick-guard.test.mjs \
+            agent-session-narrator.test.mjs \
             autotune-decision.test.mjs \
             autotune-lifecycle.test.mjs \
             autotune-writeback.test.mjs \

--- a/plugins/dev/scripts/execution-core/agent-session-narrator.mjs
+++ b/plugins/dev/scripts/execution-core/agent-session-narrator.mjs
@@ -1,0 +1,176 @@
+// agent-session-narrator.mjs — CTL-1943 (COORD-107 decision 1, under COORD-122's contract).
+//
+// Makes a ticket being worked VISIBLE where the work is tracked: as a Linear agent
+// session whose plan is the pipeline and whose activities are the phase transitions.
+// The cloud half is CTC-682 (catalyst-cloud#780, POST /api/v1/agent/session).
+//
+// ── ⛔ THE ONE CONSTRAINT THAT SHAPES EVERYTHING HERE ──
+// The single shared dispatch seam, `dispatchTicket`, is called from INSIDE the
+// synchronous `schedulerTick`. The write-proxy's normal transport is a `spawnSync` of
+// curl with a 20 s ceiling. So narrating from this seam on the synchronous path would
+// add up to 20 s PER DISPATCH to a tick that CTL-1524 already records as blocking the
+// daemon's event loop — a fleet-wide stall traded for a status line.
+//
+// COORD-122 decided the asymmetry: this route, and ONLY this route, is non-blocking.
+// The mechanism lives in linear-write-proxy.mjs (`sendAsync` / NON_BLOCKING_ROUTE_IDS);
+// this module is the caller. `narrate` therefore:
+//   • never returns a promise the tick could be tempted to await,
+//   • never throws — a narration defect must not fail a dispatch,
+//   • reports every refusal with the TICKET and the PHASE, because "narration failed"
+//     without them is an alert nobody can act on.
+//
+// ⚠️ WHAT A MISSING NARRATION LOOKS LIKE, so nobody reads it as a dead agent: CTC-682's
+// own author flagged that a session which stops emitting goes `stale` at 30 min and then
+// reads as "the agent didn't start". A refused or failed narration here is exactly that
+// shape, which is why every refusal is named and logged rather than counted.
+//
+// ── THE PAYLOAD CONTRACT (read off the merged route, not guessed) ──
+//   { issueId, plan: [{content, status}], activity: {...} }
+//   `plan` is a BARE ARRAY and its entries use `content` — Linear rejects `title` with
+//   "Unrecognized key". An EMPTY plan is refused by the cloud on purpose ("an empty plan
+//   would erase a visible one"), so `buildSessionPayload` never emits one. An
+//   unrecognized `activity.type` is refused by name rather than defaulted.
+
+import { PHASES } from "../lib/workflow-descriptor.mjs";
+
+/** The Linear plan-entry statuses. Frozen — this is the cloud's vocabulary, not ours. */
+export const PLAN_STATUS = Object.freeze({
+  PENDING: "pending",
+  IN_PROGRESS: "inProgress",
+  COMPLETED: "completed",
+  CANCELED: "canceled",
+});
+
+/** The route id in linear-write-proxy's registry. */
+export const SESSION_ROUTE_ID = "session";
+
+/** Names this call site in every proxy event (CTL-1936 / AC4 attribution). */
+export const NARRATOR_CALLER = "agent-session-narrator";
+
+/**
+ * planFor — the pipeline as a Linear plan, with the current phase in progress.
+ *
+ * Every phase BEFORE the current one reads `completed`. That is a statement about
+ * pipeline POSITION, not about outcome: the pipeline is strictly ordered, so reaching
+ * phase N means N-1 terminated. It deliberately does not try to reconstruct per-phase
+ * success from signal files — that would be a second source of truth for "what happened",
+ * which is the cost option 1 in the ticket was rejected for.
+ *
+ * An unknown phase (an ancillary step like `remediate`, or a typo) yields a plan with
+ * nothing in progress rather than throwing — the caller's dispatch must not depend on
+ * this function's opinion of a phase name.
+ */
+export function planFor(phase, { phases = PHASES, closed = false } = {}) {
+  const idx = phases.indexOf(phase);
+  return phases.map((p, i) => {
+    if (closed) return { content: p, status: PLAN_STATUS.COMPLETED };
+    if (idx < 0) return { content: p, status: PLAN_STATUS.PENDING };
+    if (i < idx) return { content: p, status: PLAN_STATUS.COMPLETED };
+    if (i === idx) return { content: p, status: PLAN_STATUS.IN_PROGRESS };
+    return { content: p, status: PLAN_STATUS.PENDING };
+  });
+}
+
+/**
+ * isClosingPhase — is this dispatch the pipeline's last?
+ *
+ * `teardown` is the terminal step, so dispatching it is the only moment this seam sees
+ * that can honestly be called "close". Derived from the descriptor's last element rather
+ * than a literal, so a descriptor change cannot leave a hardcoded name behind.
+ */
+export function isClosingPhase(phase, { phases = PHASES } = {}) {
+  return phases.length > 0 && phase === phases[phases.length - 1];
+}
+
+/**
+ * buildSessionPayload — pure. The whole request body for one narration.
+ *
+ * The closing dispatch sends a `response` activity, which is the route's terminal type;
+ * every other dispatch sends an `action` naming the phase. `action` is used rather than
+ * `thought` because a phase dispatch is something the agent DID, and the route models
+ * that distinction.
+ */
+export function buildSessionPayload({ issueId, phase, phases = PHASES, host = null }) {
+  const closed = isClosingPhase(phase, { phases });
+  const activity = closed
+    ? {
+        type: "response",
+        body: `Pipeline complete — \`${phase}\` dispatched, all ${phases.length} phases done.`,
+      }
+    : {
+        type: "action",
+        action: `Dispatch \`${phase}\``,
+        parameter: phase,
+      };
+  return {
+    issueId,
+    plan: planFor(phase, { phases, closed }),
+    activity,
+    ...(host ? { hostId: host } : {}),
+  };
+}
+
+/**
+ * createAgentSessionNarrator — bind the transport and the id resolver.
+ *
+ * Returns `{ narrate }`, or null when there is nothing to narrate through. A null
+ * narrator is the DEFAULT state of the daemon (the proxy is `off` unless configured), so
+ * the no-narrator path is the one that must stay free — `dispatchTicket` treats a null
+ * narrator as a no-op.
+ */
+export function createAgentSessionNarrator({ proxy, resolver = null, log = null, phases = PHASES } = {}) {
+  if (!proxy || typeof proxy.sendAsync !== "function") return null;
+
+  return {
+    /**
+     * narrate — one call per dispatched phase. SYNCHRONOUS AND TOTAL.
+     *
+     * ⛔ Returns a plain verdict object and NEVER a promise: the tick must not be able to
+     * await this even by accident. It also never throws — every failure path below ends
+     * in a named, logged verdict, because a narration defect that fails a dispatch would
+     * be strictly worse than no narration at all.
+     */
+    narrate(ticket, phase, { host = null } = {}) {
+      try {
+        if (typeof ticket !== "string" || ticket.trim() === "") {
+          return { narrated: false, reason: "no-ticket" };
+        }
+        if (typeof phase !== "string" || phase.trim() === "") {
+          return { narrated: false, reason: "no-phase" };
+        }
+
+        // ⛔ The issue UUID comes from the freshness-gated replica resolver, exactly like
+        // every other proxied write. There is no live-Linear fallback ON PURPOSE: this
+        // route is worth zero dispatch risk and zero shared-quota API calls, so an
+        // unresolvable ticket is a named skip, not a reason to reach for the API.
+        if (!resolver || typeof resolver.issue !== "function") {
+          return { narrated: false, reason: "no-resolver" };
+        }
+        const r = resolver.issue(ticket);
+        if (!r?.ok) {
+          const reason = `resolve:${r?.reason ?? "unknown"}`;
+          log?.warn?.({ ticket, phase, reason }, "agent-session: cannot resolve issue id — narration skipped");
+          return { narrated: false, reason };
+        }
+
+        const payload = buildSessionPayload({ issueId: r.issueId, phase, phases, host });
+        const res = proxy.sendAsync({
+          routeId: SESSION_ROUTE_ID,
+          ticket,
+          phase,
+          payload,
+          caller: NARRATOR_CALLER,
+        });
+        return { narrated: res?.dispatched === true, reason: res?.reason ?? null };
+      } catch (err) {
+        // The catch-all exists so this function's own defects can never reach the
+        // scheduler. It is not a place to hide one — it logs with ticket and phase.
+        log?.warn?.(
+          { ticket, phase, err: String(err?.message ?? err).slice(0, 200) },
+          "agent-session: narration threw — dispatch unaffected"
+        );
+        return { narrated: false, reason: "narrator-threw" };
+      }
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
+++ b/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
@@ -13,6 +13,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
 import {
   NARRATOR_CALLER,
   PLAN_STATUS,
@@ -23,7 +24,7 @@ import {
   planFor,
 } from "./agent-session-narrator.mjs";
 import { dispatchTicket, getAgentSessionNarrator, setAgentSessionNarrator } from "./dispatch.mjs";
-import { NON_BLOCKING_ROUTE_IDS, createLinearWriteProxy } from "./linear-write-proxy.mjs";
+import { ASYNC_MAX_ATTEMPTS, NON_BLOCKING_ROUTE_IDS, createLinearWriteProxy, defaultAsyncHttpFn } from "./linear-write-proxy.mjs";
 import { PHASES } from "../lib/workflow-descriptor.mjs";
 
 /** The route the ticket says is hung: it accepts the send and never answers. */
@@ -253,5 +254,134 @@ describe("CTL-1943 — the transport asymmetry is enforced, not just documented"
   test("a proxy without sendAsync yields no narrator at all", () => {
     expect(createAgentSessionNarrator({ proxy: null })).toBe(null);
     expect(createAgentSessionNarrator({ proxy: { send() {} } })).toBe(null);
+  });
+});
+
+
+// ── Codex #3529 round 1 ────────────────────────────────────────────────────────────────
+
+/** A curl stand-in whose stdin fails ASYNCHRONOUSLY, the way a closed pipe really does. */
+function fakeCurl({ stdinError = null, closeCode = 0 } = {}) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  const stdin = new EventEmitter();
+  stdin.end = () => {
+    if (stdinError) stdin.emit("error", new Error(stdinError));
+    else queueMicrotask(() => child.emit("close", closeCode));
+  };
+  child.stdin = stdin;
+  child.kill = () => child.emit("close", closeCode);
+  child.unref = () => {};
+  return child;
+}
+
+describe("round-1 P1 — an EPIPE on curl's stdin must not kill the daemon", () => {
+  test("⛔ INSTRUMENT CONTROL: emit('error') with no listener really does throw", () => {
+    // This is why the defect was fatal: Node re-throws an unhandled 'error' event as an
+    // uncaught exception. If this control ever stops throwing, the test below is vacuous.
+    const bare = new EventEmitter();
+    expect(() => bare.emit("error", new Error("EPIPE"))).toThrow();
+  });
+
+  test("a stdin EPIPE is absorbed — the transport does not throw", () => {
+    expect(() =>
+      defaultAsyncHttpFn({
+        url: "https://example.invalid/x",
+        method: "POST",
+        token: "t",
+        body: "{}",
+        spawnFn: () => fakeCurl({ stdinError: "EPIPE: broken pipe" }),
+      })
+    ).not.toThrow();
+  });
+
+  test("a stdin EPIPE does not settle early and discard curl's real verdict", () => {
+    // `settle` is once-only, so settling on a broken stdin would throw away the answer
+    // curl was about to give. The child's own close is the verdict.
+    const seen = [];
+    defaultAsyncHttpFn({
+      url: "https://example.invalid/x", method: "POST", token: "t", body: "{}",
+      onDone: (r) => seen.push(r.code),
+      spawnFn: () => fakeCurl({ stdinError: "EPIPE: broken pipe", closeCode: 28 }),
+    });
+    expect(seen).toEqual([28]);
+  });
+
+  test("a synchronously-throwing spawn is reported, not swallowed", () => {
+    const seen = [];
+    const out = defaultAsyncHttpFn({
+      url: "u", method: "POST", token: "t", body: "{}",
+      onDone: (r) => seen.push(r.code),
+      spawnFn: () => { throw new Error("ENOENT"); },
+    });
+    expect(out).toEqual({ dispatched: false });
+    expect(seen).toEqual([127]);
+  });
+});
+
+describe("round-1 P2 — a failed dispatch must not be narrated as work in progress", () => {
+  test("a nonzero dispatch result narrates NOTHING", () => {
+    // The defect: a plan marking the phase inProgress with no worker to correct it, so
+    // Linear shows active work until the 30-minute staleness timeout — the "the agent
+    // didn't start" misreading, manufactured by the feature meant to prevent it.
+    const calls = [];
+    setAgentSessionNarrator({ narrate: (t, p) => calls.push([t, p]) });
+    dispatchTicket("/tmp/o", "CTL-8", "implement", { dispatch: () => ({ code: 1 }) });
+    expect(calls).toEqual([]);
+  });
+
+  test("a successful dispatch DOES narrate — the control that keeps the above honest", () => {
+    const calls = [];
+    setAgentSessionNarrator({ narrate: (t, p) => calls.push([t, p]) });
+    dispatchTicket("/tmp/o", "CTL-8", "implement", { dispatch: () => ({ code: 0 }) });
+    expect(calls).toEqual([["CTL-8", "implement"]]);
+  });
+
+  test("the SDK path narrates: a thenable means the prelaunch signal is already written", () => {
+    const calls = [];
+    setAgentSessionNarrator({ narrate: (t, p) => calls.push([t, p]) });
+    const pending = Promise.resolve({ code: 0 });
+    dispatchTicket("/tmp/o", "CTL-8", "research", { dispatch: () => pending });
+    expect(calls).toEqual([["CTL-8", "research"]]);
+    return pending;
+  });
+
+  test("the dispatch result is returned UNCHANGED — narration is not in the value path", () => {
+    setAgentSessionNarrator({ narrate: () => {} });
+    const token = { code: 0, marker: Symbol("x") };
+    expect(dispatchTicket("/tmp/o", "CTL-8", "verify", { dispatch: () => token })).toBe(token);
+  });
+});
+
+describe("round-1 P2 — the budget must not be under-charged by a retry", () => {
+  test("⛔ exactly ONE attempt: the retry is deleted, not accounted for", async () => {
+    // Charging a retry would mean writing the ledger from the async callback, which
+    // breaks the single-writer invariant the synchronous charge exists to hold. And
+    // POST /agent/session APPENDS — a timeout after the cloud accepted would have
+    // appended the same activity twice.
+    expect(ASYNC_MAX_ATTEMPTS).toBe(1);
+    let spawns = 0;
+    const seen = [];
+    defaultAsyncHttpFn({
+      url: "u", method: "POST", token: "t", body: "{}",
+      onDone: (r) => seen.push(r.attempts),
+      spawnFn: () => { spawns += 1; return fakeCurl({ closeCode: 28 }); },
+    });
+    // The fake settles on a microtask, exactly as a real child's `close` does — so the
+    // assertion has to reach the next turn or it would measure nothing.
+    await Promise.resolve();
+    expect(spawns).toBe(1);
+    expect(seen).toEqual([1]);
+  });
+
+  test("one ledger charge per send, and the transport is invoked once", () => {
+    const order = [];
+    const proxy = proxyWith({
+      writeLedgerFn: () => order.push("ledger"),
+      asyncHttpFn: ({ onDone }) => { order.push("spawn"); onDone({ code: 28, stdout: "", stderr: "timeout" }); return { dispatched: true }; },
+    });
+    proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-6", phase: "plan", payload: { issueId: "x" } });
+    expect(order).toEqual(["ledger", "spawn"]);
   });
 });

--- a/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
+++ b/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
@@ -1,0 +1,257 @@
+// agent-session-narrator.test.mjs — CTL-1943.
+//
+// The load-bearing property is a TIMING one: narrating a phase must not delay the
+// dispatch, because `dispatchTicket` runs inside the synchronous `schedulerTick`.
+//
+// ⛔ A timing test that only asserts "fast" is the classic check that cannot fail — it
+// passes for a narrator that never ran, for a narrator that was never installed, and for
+// a `dispatchTicket` that ignores narrators entirely. So every timing assertion here is
+// paired with a NEGATIVE CONTROL on the same instrument: a deliberately BLOCKING
+// narrator, measured by the same clock through the same call, which must be caught. If
+// the control ever stops failing, the instrument is broken and the positive result means
+// nothing.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  NARRATOR_CALLER,
+  PLAN_STATUS,
+  SESSION_ROUTE_ID,
+  buildSessionPayload,
+  createAgentSessionNarrator,
+  isClosingPhase,
+  planFor,
+} from "./agent-session-narrator.mjs";
+import { dispatchTicket, getAgentSessionNarrator, setAgentSessionNarrator } from "./dispatch.mjs";
+import { NON_BLOCKING_ROUTE_IDS, createLinearWriteProxy } from "./linear-write-proxy.mjs";
+import { PHASES } from "../lib/workflow-descriptor.mjs";
+
+/** The route the ticket says is hung: it accepts the send and never answers. */
+const hungAsyncHttpFn = () => ({ dispatched: true });
+
+const okResolver = { issue: () => ({ ok: true, issueId: "11111111-2222-3333-4444-555555555555", teamId: "t" }) };
+
+function proxyWith(overrides = {}) {
+  return createLinearWriteProxy({
+    mode: "enforce",
+    env: { CATALYST_CLOUD_TOKEN: "test-token", CATALYST_CLOUD_BASE_URL: "https://example.invalid/api/v1" },
+    appendEvent: () => {},
+    log: { warn() {}, error() {}, info() {} },
+    budgetPath: "/dev/null",
+    readLedgerFn: () => ({ state: "fresh" }),
+    writeLedgerFn: () => {},
+    asyncHttpFn: hungAsyncHttpFn,
+    ...overrides,
+  });
+}
+
+afterEach(() => setAgentSessionNarrator(null));
+
+describe("CTL-1943 — the narration cannot delay the dispatch", () => {
+  test("a hung session route does not delay dispatchTicket", () => {
+    setAgentSessionNarrator(createAgentSessionNarrator({ proxy: proxyWith(), resolver: okResolver }));
+    let dispatched = false;
+    const t0 = performance.now();
+    dispatchTicket("/tmp/orch", "CTL-1", "implement", { dispatch: () => { dispatched = true; return { code: 0 }; } });
+    const elapsed = performance.now() - t0;
+    expect(dispatched).toBe(true);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test("⛔ NEGATIVE CONTROL: the same clock DOES catch a blocking narrator", () => {
+    // Exactly the shape the ticket refused — a synchronous wire call in the dispatch
+    // seam. Measured with `/bin/sleep`, which is what the blocking transport really does
+    // (spawnSync). If this does not exceed the bound, the assertion above is vacuous.
+    setAgentSessionNarrator({ narrate: () => { spawnSync("/bin/sleep", ["0.6"]); return { narrated: true }; } });
+    const t0 = performance.now();
+    dispatchTicket("/tmp/orch", "CTL-1", "implement", { dispatch: () => ({ code: 0 }) });
+    const elapsed = performance.now() - t0;
+    expect(elapsed).toBeGreaterThan(500);
+  });
+
+  test("narrate returns a plain verdict, never a promise the tick could await", () => {
+    const n = createAgentSessionNarrator({ proxy: proxyWith(), resolver: okResolver });
+    const res = n.narrate("CTL-1", "implement");
+    expect(typeof res?.then).not.toBe("function");
+    expect(res.narrated).toBe(true);
+  });
+
+  test("a narrator that throws never fails the dispatch", () => {
+    setAgentSessionNarrator({ narrate: () => { throw new Error("boom"); } });
+    // dispatchTicket does not wrap the call, so this asserts the CONTRACT that narrate
+    // is total — and documents that a narrator violating it is the caller's bug.
+    expect(() => dispatchTicket("/tmp/o", "CTL-1", "implement", { dispatch: () => ({ code: 0 }) })).toThrow();
+    // The real narrator honours the contract: an exploding resolver is swallowed.
+    const real = createAgentSessionNarrator({
+      proxy: proxyWith(),
+      resolver: { issue: () => { throw new Error("replica gone"); } },
+    });
+    setAgentSessionNarrator(real);
+    let dispatched = false;
+    dispatchTicket("/tmp/o", "CTL-1", "implement", { dispatch: () => { dispatched = true; return { code: 0 }; } });
+    expect(dispatched).toBe(true);
+    expect(real.narrate("CTL-1", "implement")).toEqual({ narrated: false, reason: "narrator-threw" });
+  });
+});
+
+describe("CTL-1943 — the default (no narrator) path stays free", () => {
+  // ⛔ Every OTHER test in this tree injects or installs something. This one asserts the
+  // shape the whole fleet actually runs: nothing installed. A default that no test
+  // exercises is a default that ships broken (CTL-1918 shipped exactly that).
+  test("with nothing installed, dispatchTicket forwards its args unchanged", () => {
+    expect(getAgentSessionNarrator()).toBe(null);
+    let seen = null;
+    const out = dispatchTicket("/tmp/o", "CTL-9", "verify", { dispatch: (a) => { seen = a; return { code: 0 }; } });
+    expect(seen).toEqual({ orchDir: "/tmp/o", ticket: "CTL-9", phase: "verify" });
+    expect(out).toEqual({ code: 0 });
+  });
+
+  test("an explicit null narrator overrides an installed one", () => {
+    let called = false;
+    setAgentSessionNarrator({ narrate: () => { called = true; } });
+    dispatchTicket("/tmp/o", "CTL-9", "verify", { dispatch: () => ({ code: 0 }), narrator: null });
+    expect(called).toBe(false);
+  });
+});
+
+describe("CTL-1943 — the payload matches the route contract", () => {
+  test("plan is a BARE array whose entries use `content`, never `title`", () => {
+    const p = buildSessionPayload({ issueId: "id", phase: "implement" });
+    expect(Array.isArray(p.plan)).toBe(true);
+    expect(p.plan.every((e) => typeof e.content === "string")).toBe(true);
+    expect(p.plan.some((e) => "title" in e)).toBe(false);
+    expect(JSON.stringify(p.plan)).not.toContain("entries");
+  });
+
+  test("the plan is never empty — the cloud refuses an empty plan on purpose", () => {
+    for (const phase of [...PHASES, "remediate", "not-a-phase"]) {
+      expect(buildSessionPayload({ issueId: "id", phase }).plan.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("the current phase is inProgress and earlier phases are completed", () => {
+    const p = planFor("verify");
+    const idx = PHASES.indexOf("verify");
+    expect(p[idx].status).toBe(PLAN_STATUS.IN_PROGRESS);
+    expect(p.slice(0, idx).every((e) => e.status === PLAN_STATUS.COMPLETED)).toBe(true);
+    expect(p.slice(idx + 1).every((e) => e.status === PLAN_STATUS.PENDING)).toBe(true);
+  });
+
+  test("an unknown phase yields a plan with nothing in progress, and does not throw", () => {
+    const p = planFor("remediate");
+    expect(p.every((e) => e.status === PLAN_STATUS.PENDING)).toBe(true);
+  });
+
+  test("the closing phase sends a terminal `response` and completes every entry", () => {
+    expect(isClosingPhase(PHASES[PHASES.length - 1])).toBe(true);
+    expect(isClosingPhase("implement")).toBe(false);
+    const p = buildSessionPayload({ issueId: "id", phase: PHASES[PHASES.length - 1] });
+    expect(p.activity.type).toBe("response");
+    expect(typeof p.activity.body).toBe("string");
+    expect(p.plan.every((e) => e.status === PLAN_STATUS.COMPLETED)).toBe(true);
+  });
+
+  test("a non-closing phase sends an `action`, one of the route's accepted types", () => {
+    const p = buildSessionPayload({ issueId: "id", phase: "implement" });
+    expect(p.activity.type).toBe("action");
+    expect(p.activity.action).toContain("implement");
+    // The route refuses an unrecognized type by name rather than defaulting it.
+    expect(["thought", "response", "error", "action"]).toContain(p.activity.type);
+  });
+
+  test("hostId is omitted unless supplied — identity is the key, not the payload", () => {
+    expect("hostId" in buildSessionPayload({ issueId: "id", phase: "plan" })).toBe(false);
+    expect(buildSessionPayload({ issueId: "id", phase: "plan", host: "mini" }).hostId).toBe("mini");
+  });
+});
+
+describe("CTL-1943 — the transport asymmetry is enforced, not just documented", () => {
+  test("only `session` is declared non-blocking", () => {
+    expect([...NON_BLOCKING_ROUTE_IDS]).toEqual([SESSION_ROUTE_ID]);
+    for (const id of ["issue-state", "label", "comment"]) {
+      expect(NON_BLOCKING_ROUTE_IDS.has(id)).toBe(false);
+    }
+  });
+
+  test("sendAsync REFUSES a dispatch-critical route by name", () => {
+    // The regression that matters: a future caller reaching for the fast path to speed
+    // up a write whose result something depends on.
+    const errors = [];
+    const proxy = proxyWith({ log: { warn() {}, error: (o, m) => errors.push([o, m]), info() {} } });
+    for (const id of ["issue-state", "label", "comment"]) {
+      const res = proxy.sendAsync({ routeId: id, ticket: "CTL-1", payload: {} });
+      expect(res).toEqual({ handled: true, dispatched: false, reason: "route-not-async-eligible" });
+    }
+    expect(errors.length).toBe(3);
+  });
+
+  test("a narration failure is logged with BOTH the ticket and the phase", () => {
+    // "narration failed" with neither is an alert nobody can act on.
+    const warns = [];
+    const proxy = proxyWith({
+      log: { warn: (o, m) => warns.push([o, m]), error: (o, m) => warns.push([o, m]), info() {} },
+      asyncHttpFn: ({ onDone }) => { onDone({ code: 22, stdout: "", stderr: "HTTP 500" }); return { dispatched: true }; },
+    });
+    proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-77", phase: "implement", payload: { issueId: "x" }, caller: NARRATOR_CALLER });
+    const hit = warns.find(([o]) => o.ticket === "CTL-77" && o.phase === "implement");
+    expect(hit).toBeDefined();
+  });
+
+  test("the send spends budget SYNCHRONOUSLY, before the child is spawned", () => {
+    // The ledger is an unlocked read-modify-write and is only safe because it has one
+    // writer. If sendAsync recorded from its async callback, two RMW cycles could
+    // interleave with `send`'s. Asserted by ordering, not by reading the code.
+    const order = [];
+    const proxy = proxyWith({
+      readLedgerFn: () => ({ state: "fresh" }),
+      writeLedgerFn: () => order.push("ledger"),
+      asyncHttpFn: () => { order.push("spawn"); return { dispatched: true }; },
+    });
+    proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-5", phase: "plan", payload: { issueId: "x" } });
+    expect(order).toEqual(["ledger", "spawn"]);
+  });
+
+  test("⛔ repeated narrations of one ticket are NOT convergence-suppressed", () => {
+    // CTL-1936 suppresses a repeated write whose desired state is already reached. That
+    // is right for a label and WRONG for a narration: every phase must emit, and a
+    // session that stops emitting goes `stale` at 30 min and then reads as "the agent
+    // didn't start" — the exact failure this feature exists to prevent. The suppression
+    // key is null for a session payload (it needs labelIds + mode), so this holds by
+    // construction; asserted because "by construction" is how it would silently change.
+    const sent = [];
+    const proxy = proxyWith({ asyncHttpFn: () => { sent.push(1); return { dispatched: true }; } });
+    for (const phase of ["research", "plan", "implement", "implement"]) {
+      const r = proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-3", phase, payload: { issueId: "x", plan: [], activity: {} } });
+      expect(r.dispatched).toBe(true);
+    }
+    expect(sent.length).toBe(4);
+  });
+
+  test("an unresolvable ticket is a NAMED skip, never a live-Linear fallback", () => {
+    const n = createAgentSessionNarrator({
+      proxy: proxyWith(),
+      resolver: { issue: () => ({ ok: false, reason: "replica-stale" }) },
+    });
+    expect(n.narrate("CTL-1", "implement")).toEqual({ narrated: false, reason: "resolve:replica-stale" });
+  });
+
+  test("⛔ a host with NO per-host key REFUSES loudly and narrates nothing", () => {
+    // The negative control that caught an error in this very test file: the first cut
+    // passed the wrong env var name, and the transport refused every send by name rather
+    // than sending without a credential. That refusal is the behaviour, so it is asserted.
+    const errors = [];
+    const proxy = proxyWith({
+      env: { CATALYST_CLOUD_BASE_URL: "https://example.invalid/api/v1" }, // no token
+      log: { warn() {}, error: (o, m) => errors.push([o, m]), info() {} },
+    });
+    const res = proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-2", phase: "plan", payload: { issueId: "x" } });
+    expect(res.dispatched).toBe(false);
+    expect(res.reason).toBe("no-cloud-token");
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  test("a proxy without sendAsync yields no narrator at all", () => {
+    expect(createAgentSessionNarrator({ proxy: null })).toBe(null);
+    expect(createAgentSessionNarrator({ proxy: { send() {} } })).toBe(null);
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -155,12 +155,13 @@ import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dep
 import { getReconcileHealth } from "./reconcile-health.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
-import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
+import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn, setAgentSessionNarrator } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
 import { resolveSdkBootExecutor, assertSdkAuth } from "./sdk-run-phase-agent.mjs"; // CTL-1367 item 9 + P3: boot auth gate (subscription-only) that degrades sdk→bg AND emits execution-core.executor.bg-fallback so the silent fallback is observable; CTL-1457 (T5): assertSdkAuth also gates a per-phase sdk route on a bg/default node
 import { resolveCodexBootEligibility } from "./codex-run-phase-agent.mjs"; // CTL-1457: codex boot gate (auth.json + `codex --version`) that degrades routed codex phases + emits execution-core.executor.codex-fallback
 import { removeLabel as defaultRemoveLabel } from "./linear-write.mjs"; // CTL-549: clear needs-human on resume
 import { setLinearWriteProxy, setLinearWriteProxyResolver } from "./linear-write.mjs"; // CTL-1889: install the cloud write-proxy transport + its replica-backed id resolver
 import { createLinearWriteProxy } from "./linear-write-proxy.mjs"; // CTL-1889
+import { createAgentSessionNarrator } from "./agent-session-narrator.mjs"; // CTL-1943
 import { createProxyResolver } from "./linear-write-proxy-resolve.mjs"; // CTL-1889
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
@@ -1496,6 +1497,27 @@ export function startDaemon({
       // (see routeThroughProxy), so opening a replica handle for it would be a handle
       // held open for a code path that cannot run.
       if (writeProxyCfg.mode === "enforce") setLinearWriteProxyResolver(createProxyResolver());
+
+      // ── CTL-1943: narrate each dispatched phase as a Linear agent session ──
+      //
+      // Only in ENFORCE, and for the same reason the resolver above is: the narrator
+      // needs a resolved issue UUID, and shadow deliberately builds no payload and makes
+      // no cloud call. Installing it in shadow would open a replica handle for a path
+      // that cannot run.
+      //
+      // ⚠️ It gets its OWN resolver handle rather than sharing the write path's. They are
+      // read-only SQLite handles onto the same replica, and `createProxyResolver` closes
+      // over one lazily-opened connection; sharing would couple this route's lifetime to
+      // the write path's `close()`.
+      if (writeProxyCfg.mode === "enforce") {
+        setAgentSessionNarrator(
+          createAgentSessionNarrator({
+            proxy: writeProxy,
+            resolver: createProxyResolver(),
+            log,
+          }),
+        );
+      }
       log.info(
         {
           mode: writeProxyCfg.mode,

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -471,14 +471,23 @@ export function dispatchTicket(
   // 20 s ceiling. A blocking narration here would add up to 20 s per dispatch to a tick
   // CTL-1524 already records as blocking the event loop.
   //
-  // Placed BEFORE `dispatch(args)` so the session exists by the time the worker starts
-  // emitting, and so a narration that somehow costs time is visible in the tick timing
-  // rather than hidden behind the launch. It cannot delay the dispatch: no await, no
-  // promise, and `narrate` swallows its own failures by contract.
+  // ⛔ Placed AFTER `dispatch(args)`, and only on a CONFIRMED launch (Codex #3529
+  // round-1 P2). An earlier cut narrated first, so a dispatch that FAILED — a missing
+  // registry entry, failed worktree provisioning, a nonzero phase-agent launch — still
+  // posted a plan marking the phase `inProgress` with no worker in existence to correct
+  // it. Linear then showed active work until a later retry or the 30-minute staleness
+  // timeout, which is exactly the "the agent didn't start" misreading this feature exists
+  // to prevent, manufactured by the feature itself.
+  //
+  // "Confirmed" follows this module's own rule: a THENABLE means the SDK path, whose
+  // synchronous prelaunch has already written the status:"dispatched" signal before the
+  // promise is returned (see settleDispatchSync) — the launch happened. A plain result is
+  // confirmed by `code === 0`, the same field every dispatch consumer reads.
   const n = narrator !== undefined ? narrator : _sessionNarrator;
-  if (n) n.narrate(ticket, phase);
+  const result = dispatch(args);
+  if (n && (isThenable(result) || result?.code === 0)) n.narrate(ticket, phase);
 
-  return dispatch(args);
+  return result;
 }
 
 // ── CTL-1367 P1: async-dispatch settlement seam ─────────────────────────────

--- a/plugins/dev/scripts/execution-core/dispatch.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch.mjs
@@ -420,6 +420,27 @@ export function makeCommentWakeDispatch(dispatch, { emitBackstop } = {}) {
     );
 }
 
+// ─── CTL-1943: the agent-session narrator, installed once by the daemon ──────
+//
+// A module-level singleton in the shape of setLinearWriteProxy — the daemon installs it
+// at boot, every other consumer of dispatchTicket gets it for free, and a test (or a
+// daemon with the write proxy off) leaves it null.
+//
+// ⛔ NULL IS THE DEFAULT AND THE DEFAULT MUST STAY FREE. Every dispatch in this tree,
+// including every existing test that never heard of this ticket, goes through the
+// `if (!_sessionNarrator)` branch below. That branch must remain a plain no-op.
+let _sessionNarrator = null;
+
+/** setAgentSessionNarrator — install (or clear, with null) the phase narrator. */
+export function setAgentSessionNarrator(narrator) {
+  _sessionNarrator = narrator ?? null;
+}
+
+/** getAgentSessionNarrator — test/diagnostic read of the installed narrator. */
+export function getAgentSessionNarrator() {
+  return _sessionNarrator;
+}
+
 // dispatchTicket — thin seam over the injectable dispatch function.
 // CTL-705: forwards optional resumeSession so the resume re-dispatch path can
 // pass a resume UUID. Omitted when absent — the legacy toEqual assertions stay
@@ -428,13 +449,35 @@ export function dispatchTicket(
   orchDir,
   ticket,
   phase,
-  { dispatch = defaultDispatch, resumeSession, handoffPath, attempt, clusterGeneration } = {}
+  { dispatch = defaultDispatch, resumeSession, handoffPath, attempt, clusterGeneration, narrator } = {}
 ) {
   const args = { orchDir, ticket, phase };
   if (resumeSession) args.resumeSession = resumeSession;
   if (handoffPath) args.handoffPath = handoffPath;
   if (attempt != null) args.attempt = attempt; // CTL-761
   if (clusterGeneration != null) args.clusterGeneration = clusterGeneration; // CTL-864
+
+  // ── CTL-1943 — narrate the phase as a Linear agent session ──
+  //
+  // ⛔ THE ASYMMETRY, AT THE CALL SITE, SO NOBODY GENERALISES IT (COORD-122).
+  // This is the ONLY network write this function performs, and it is NON-BLOCKING:
+  // `narrate` is synchronous and total, and the request it issues is a `spawn` (not
+  // `spawnSync`) whose response is collected on a later event-loop turn. The other
+  // three proxied routes — issue-state, label, comment — stay SYNCHRONOUS, because a
+  // dispatch decision depends on each of them.
+  //
+  // The reason is `dispatchTicket`'s position, not a preference: it is called from
+  // inside the synchronous `schedulerTick`, and the proxy's blocking transport has a
+  // 20 s ceiling. A blocking narration here would add up to 20 s per dispatch to a tick
+  // CTL-1524 already records as blocking the event loop.
+  //
+  // Placed BEFORE `dispatch(args)` so the session exists by the time the worker starts
+  // emitting, and so a narration that somehow costs time is visible in the tick timing
+  // rather than hidden behind the launch. It cannot delay the dispatch: no await, no
+  // promise, and `narrate` swallows its own failures by contract.
+  const n = narrator !== undefined ? narrator : _sessionNarrator;
+  if (n) n.narrate(ticket, phase);
+
   return dispatch(args);
 }
 

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -418,8 +418,24 @@ export function defaultHttpFn({ url, method, token, body }) {
  */
 export const ASYNC_MAX_TIME_SEC = 10;
 
-/** One retry, and only for a transport-level failure — never for a 4xx the cloud meant. */
-export const ASYNC_MAX_ATTEMPTS = 2;
+/**
+ * ⛔ EXACTLY ONE ATTEMPT. Codex #3529 round-1 P2 — an earlier cut retried once on a
+ * transport failure, and the retry was wrong in two independent ways:
+ *
+ *  1. `sendAsync` charges the ledger ONCE, synchronously, before the transport is
+ *     invoked (that is what keeps the ledger single-writer). A retry therefore made a
+ *     second cloud call the budget never saw, so repeated timeouts could spend close to
+ *     twice the configured daily and per-ticket limits while reporting the configured
+ *     number. Charging the retry instead would mean writing the ledger from the async
+ *     callback — which breaks the very invariant the synchronous charge exists to hold.
+ *  2. `POST /agent/session` APPENDS an activity; it is not idempotent. A timeout AFTER
+ *     the cloud accepted the first request would append the same activity twice.
+ *
+ * A narration is worth neither. It is emitted once per phase, and a lost one self-heals
+ * on the next dispatch — which is the same property that made this route eligible for the
+ * non-blocking path at all. So the retry is deleted rather than accounted for.
+ */
+export const ASYNC_MAX_ATTEMPTS = 1;
 
 export function defaultAsyncHttpFn({ url, method, token, body, onDone = null, spawnFn = spawn }) {
   const config = buildCurlConfig({ url, method, token, body });
@@ -432,46 +448,57 @@ export function defaultAsyncHttpFn({ url, method, token, body, onDone = null, sp
     String(ASYNC_MAX_TIME_SEC),
   ];
 
-  const attempt = (n) => {
-    let child;
-    try {
-      child = spawnFn(CURL_BIN, args, { stdio: ["pipe", "pipe", "pipe"] });
-    } catch (err) {
-      // A spawn that throws synchronously never produces a `close`, so report here or
-      // the outcome is lost.
-      onDone?.({ code: 127, stdout: "", stderr: String(err?.message ?? err), args, attempts: n });
-      return;
-    }
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
-    child.stdout?.on("data", (d) => { stdout += d; });
-    child.stderr?.on("data", (d) => { stderr += d; });
-    // A child that fails to spawn ASYNCHRONOUSLY emits `error` and may emit no `close`.
-    // Both paths funnel through `settle` so exactly one outcome is reported.
-    const settle = (code) => {
-      if (settled) return;
-      settled = true;
-      // Retry ONLY a transport failure (curl could not complete the exchange). A cloud
-      // that answered — even with a 4xx — has said something, and repeating the call
-      // would spend another unit of the host's daily write budget to be told the same
-      // thing.
-      if (code !== 0 && n < ASYNC_MAX_ATTEMPTS) return attempt(n + 1);
-      onDone?.({ code, stdout, stderr, args, attempts: n });
-    };
-    child.on("error", (err) => { stderr += String(err?.message ?? err); settle(127); });
-    child.on("close", (code) => settle(code ?? 0));
-    try {
-      child.stdin?.end(config);
-    } catch (err) {
-      stderr += String(err?.message ?? err);
-      settle(127);
-      return;
-    }
-    child.unref?.();
+  let child;
+  try {
+    child = spawnFn(CURL_BIN, args, { stdio: ["pipe", "pipe", "pipe"] });
+  } catch (err) {
+    // A spawn that throws synchronously never produces a `close`, so report here or the
+    // outcome is lost.
+    onDone?.({ code: 127, stdout: "", stderr: String(err?.message ?? err), args, attempts: 1 });
+    return { dispatched: false };
+  }
+
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+  const settle = (code) => {
+    if (settled) return;
+    settled = true;
+    onDone?.({ code, stdout, stderr, args, attempts: 1 });
   };
 
-  attempt(1);
+  child.stdout?.on("data", (d) => { stdout += d; });
+  child.stderr?.on("data", (d) => { stderr += d; });
+  child.stdout?.on("error", () => {});
+  child.stderr?.on("error", () => {});
+  child.on("error", (err) => { stderr += String(err?.message ?? err); settle(127); });
+  child.on("close", (code) => settle(code ?? 0));
+
+  // ⛔ Codex #3529 round-1 P1. `end()` writes ASYNCHRONOUSLY. If curl has already exited
+  // — a connect timeout, a killed child, a closed pipe — the write fails with an
+  // ASYNCHRONOUS `EPIPE` on the stdin stream. A `try/catch` catches only the synchronous
+  // throw, and an 'error' event with NO listener is re-thrown by Node as an uncaught
+  // exception, which terminates the whole execution-core daemon. That would let an
+  // OPTIONAL narration transport kill all dispatching — the precise outcome this route
+  // was made non-blocking to avoid. The listener is attached BEFORE `end()` is called,
+  // because the failure can be delivered on the very next turn.
+  child.stdin?.on("error", (err) => {
+    stderr += String(err?.message ?? err);
+    // Do NOT settle here: curl may still be alive and about to answer, and `settle` is
+    // once-only, so settling on a broken stdin would discard the real verdict. The
+    // child's own `close`/`error` remains the verdict; if it never arrives, `--max-time`
+    // bounds the wait.
+    child.kill?.();
+  });
+  try {
+    child.stdin?.end(config);
+  } catch (err) {
+    stderr += String(err?.message ?? err);
+    settle(127);
+    return { dispatched: false };
+  }
+  child.unref?.();
+
   // The synchronous return value: the request has LEFT, its verdict is not yet known.
   return { dispatched: true };
 }

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -69,7 +69,7 @@
 // ready by lighting this flag alone; see the `no-cloud-token` / `unauthorized`
 // refusals below, both of which are LOUD and NAMED rather than a silent fallback.
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
@@ -96,8 +96,37 @@ import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 /** The three modes, house convention (cf. CLOUD_FEED_MODES / DELEGATE_FIRST_MODES). */
 export const LINEAR_WRITE_PROXY_MODES = Object.freeze(new Set(["off", "shadow", "enforce"]));
 
-/** The route ids CTC-509 inc 2 already serves. Frozen — this is DATA. */
-export const PROXY_ROUTE_IDS = Object.freeze(["issue-state", "label", "comment"]);
+/**
+ * The route ids the cloud serves. Frozen — this is DATA.
+ *
+ * `session` (CTL-1943) is the CTC-682 agent-session route. It is listed here so it
+ * shares this module's credential handling, budget ledger, and event names — but it is
+ * the ONE route sent through `sendAsync` rather than `send`; see NON_BLOCKING_ROUTE_IDS.
+ */
+export const PROXY_ROUTE_IDS = Object.freeze(["issue-state", "label", "comment", "session"]);
+
+/**
+ * ⛔ THE ASYMMETRY, AS DATA — read this before adding an id.
+ *
+ * Every route in this set is sent WITHOUT waiting for the response. That is safe for
+ * exactly one reason, and it is a property of the route, not a preference: a failed
+ * `session` write degrades OBSERVABILITY and nothing else. Nothing downstream reads its
+ * result, no dispatch decision depends on it, and a lost narration self-heals on the
+ * next phase.
+ *
+ * The other three are dispatch-critical and MUST stay synchronous. `issue-state` decides
+ * whether a ticket advances; `label` carries the worker-disposition contract the
+ * scheduler reads back; `comment` is the durable record a human replies to. For those,
+ * "sent and forgotten" would mean the daemon believing a board state it never achieved.
+ *
+ * The reason this set exists at all: `dispatchTicket` is called from inside the
+ * synchronous `schedulerTick`, and this module's transport is a `spawnSync` of curl with
+ * a 20 s ceiling. Narrating from that seam on the synchronous path would add up to 20 s
+ * per dispatch to a tick that CTL-1524 already records as blocking the event loop — a
+ * fleet-wide stall traded for a status line. So do NOT add an id here to make something
+ * faster. Add one only when its failure costs nothing but a missing observation.
+ */
+export const NON_BLOCKING_ROUTE_IDS = Object.freeze(new Set(["session"]));
 
 /**
  * Measured against catalyst-cloud `origin/main` (5e852bd) — see the header. Paths are
@@ -109,6 +138,9 @@ export const DEFAULT_ROUTES = Object.freeze({
   "issue-state": "/agent/issue-state",
   label: "/agent/issue-label",
   comment: "/agent/issue-comment",
+  // CTL-1943 / CTC-682, read off the merged handler rather than guessed — the earlier
+  // cut of this module shipped guessed paths and was wrong on every one of them.
+  session: "/agent/session",
 });
 
 /** Mirrors cloud-sync.mjs:127 — one default, one env override, no third rung. */
@@ -367,6 +399,83 @@ export function defaultHttpFn({ url, method, token, body }) {
   return { code: res.status ?? 0, stdout: res.stdout ?? "", stderr: res.stderr ?? "", args };
 }
 
+/**
+ * ── THE NON-BLOCKING TRANSPORT (CTL-1943) ──
+ *
+ * Same curl, same stdin `--config -` document, same credential discipline — the token
+ * still never enters argv and never touches disk. The ONE difference is `spawn` instead
+ * of `spawnSync`: this returns the moment the child is launched, so the caller's
+ * synchronous frame (and therefore `schedulerTick`) is never held by a network write.
+ *
+ * ⚠️ It is non-blocking, NOT fire-and-forget. The child's outcome is still collected and
+ * still reported through `onDone` — dropping it would make a permanently-broken
+ * narration route indistinguishable from a working one, which is the "check that cannot
+ * fail" this repo keeps rediscovering. What is given up is only the ABILITY TO ACT on
+ * the result, which is exactly what makes the route eligible for this path.
+ *
+ * `unref()` so a pending narration can never hold the process open at shutdown; the
+ * daemon is long-lived, so `close` still fires in every normal case.
+ */
+export const ASYNC_MAX_TIME_SEC = 10;
+
+/** One retry, and only for a transport-level failure — never for a 4xx the cloud meant. */
+export const ASYNC_MAX_ATTEMPTS = 2;
+
+export function defaultAsyncHttpFn({ url, method, token, body, onDone = null, spawnFn = spawn }) {
+  const config = buildCurlConfig({ url, method, token, body });
+  const args = [
+    "--config",
+    "-",
+    "--connect-timeout",
+    String(CONNECT_TIMEOUT_SEC),
+    "--max-time",
+    String(ASYNC_MAX_TIME_SEC),
+  ];
+
+  const attempt = (n) => {
+    let child;
+    try {
+      child = spawnFn(CURL_BIN, args, { stdio: ["pipe", "pipe", "pipe"] });
+    } catch (err) {
+      // A spawn that throws synchronously never produces a `close`, so report here or
+      // the outcome is lost.
+      onDone?.({ code: 127, stdout: "", stderr: String(err?.message ?? err), args, attempts: n });
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    child.stdout?.on("data", (d) => { stdout += d; });
+    child.stderr?.on("data", (d) => { stderr += d; });
+    // A child that fails to spawn ASYNCHRONOUSLY emits `error` and may emit no `close`.
+    // Both paths funnel through `settle` so exactly one outcome is reported.
+    const settle = (code) => {
+      if (settled) return;
+      settled = true;
+      // Retry ONLY a transport failure (curl could not complete the exchange). A cloud
+      // that answered — even with a 4xx — has said something, and repeating the call
+      // would spend another unit of the host's daily write budget to be told the same
+      // thing.
+      if (code !== 0 && n < ASYNC_MAX_ATTEMPTS) return attempt(n + 1);
+      onDone?.({ code, stdout, stderr, args, attempts: n });
+    };
+    child.on("error", (err) => { stderr += String(err?.message ?? err); settle(127); });
+    child.on("close", (code) => settle(code ?? 0));
+    try {
+      child.stdin?.end(config);
+    } catch (err) {
+      stderr += String(err?.message ?? err);
+      settle(127);
+      return;
+    }
+    child.unref?.();
+  };
+
+  attempt(1);
+  // The synchronous return value: the request has LEFT, its verdict is not yet known.
+  return { dispatched: true };
+}
+
 // ─── Observability ───────────────────────────────────────────────────────────
 //
 // Three names, not one name plus a payload flag — the CTL-1659 rule: otel-forward
@@ -476,6 +585,7 @@ export function createLinearWriteProxy({
   env = process.env,
   routes = null,
   httpFn = defaultHttpFn,
+  asyncHttpFn = defaultAsyncHttpFn, // CTL-1943 — the non-blocking peer, see NON_BLOCKING_ROUTE_IDS
   appendEvent = defaultAppendEvent,
   log = defaultLog,
   // CTL-1936. Seams, so the throttle is testable without a filesystem.
@@ -701,6 +811,127 @@ export function createLinearWriteProxy({
       counts.applied += 1;
       emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true, caller, labels });
       return { handled: true, applied: true, reason: null, status: verdict.status };
+    },
+
+    /**
+     * sendAsync — route one write WITHOUT waiting for its response. CTL-1943.
+     *
+     * ⛔ Only for a route in NON_BLOCKING_ROUTE_IDS. Read that comment before calling
+     * this: the eligibility is a property of the route (its failure costs nothing but an
+     * observation), not a way to make a slow write feel faster. An ineligible route is
+     * refused BY NAME rather than quietly downgraded, so a future caller that reaches for
+     * this to speed up `issue-state` gets an error instead of a daemon that believes
+     * board states it never achieved.
+     *
+     * ── WHY THIS IS A PEER OF `send` AND NOT A FLAG ON IT ──
+     * `send` is on the dispatch-critical path for three routes. Threading a mode through
+     * its body would put a branch inside the function whose synchronous verdict the
+     * scheduler's convergers depend on. As a peer, `send` is byte-identical to before
+     * this ticket and the two share only the closure — one ledger, one emitter, one set
+     * of counters.
+     *
+     * ── WHY THE LEDGER IS STILL SINGLE-WRITER ──
+     * The module header warns that the ledger is an unlocked read-modify-write and is
+     * safe only because there is one writer. That still holds: every ledger read and
+     * write below happens SYNCHRONOUSLY, before the child is spawned, on the same
+     * single-threaded daemon loop as `send`. The asynchronous half only EMITS — it never
+     * touches the ledger — so no two RMW cycles can interleave.
+     */
+    sendAsync({ routeId, ticket = null, payload = {}, caller = null, phase = null }) {
+      const labels = Array.isArray(payload?.labelIds) ? payload.labelIds : null;
+      const convergenceKey = convergenceKeyFor({ routeId, ticket, payload });
+      const ctx = { ticket, route: routeId, phase, caller };
+
+      if (!NON_BLOCKING_ROUTE_IDS.has(routeId)) {
+        log?.error?.(ctx, "linear-write-proxy: sendAsync REFUSED — route is not declared non-blocking");
+        return { handled: true, dispatched: false, reason: "route-not-async-eligible" };
+      }
+
+      if (mode === "shadow") {
+        counts.wouldWrite += 1;
+        emit(EVENT_WOULD_WRITE, { ticket, routeId, reason: "shadow", applied: false, caller, labels });
+        return { handled: false, dispatched: false, reason: "shadow" };
+      }
+
+      const refuse = (reason, status = null) => {
+        counts.failed += 1;
+        emit(EVENT_FAILED, { ticket, routeId, reason, status, applied: false, caller, labels });
+        log?.warn?.({ ...ctx, reason, status }, "linear-write-proxy: narration NOT sent");
+        return { handled: true, dispatched: false, reason };
+      };
+
+      // Same local budget gate as `send`, and for the same reason: a refusal here costs
+      // nothing, where a refusal at the cloud costs a budget unit.
+      const { ledger: ledgerBefore, degraded: ledgerDegraded } = loadLedger();
+      if (!ledgerDegraded) {
+        const gate = classifyWrite({ ledger: ledgerBefore, ticket, convergenceKey, dailyBudget, perTicketCap });
+        if (!gate.allow) {
+          counts.refused += 1;
+          emit(EVENT_FAILED, { ticket, routeId, reason: gate.reason, status: null, applied: false, caller, labels });
+          log?.warn?.({ ...ctx, reason: gate.reason, total: gate.total },
+            "linear-write-proxy: narration refused by the HOST budget — not sent to the cloud");
+          return { handled: true, dispatched: false, reason: gate.reason };
+        }
+      }
+
+      const req = buildProxyRequest({ routeId, payload, baseUrl, routes, account });
+      if (req.reason) return refuse(req.reason);
+
+      const key = resolveHostKey(env);
+      if (key.value === null) {
+        log?.error?.({ ...ctx, token_env: key.envVar },
+          "linear-write-proxy: no per-host cloud key — narration REFUSED (reason=no-cloud-token)");
+        return refuse("no-cloud-token");
+      }
+
+      const bytes = Buffer.byteLength(req.body, "utf8");
+      if (bytes > MAX_BODY_BYTES) return refuse("body-too-large");
+
+      // The write is leaving the host, so it spends budget — recorded NOW, synchronously,
+      // because that is what keeps this a single-writer ledger. Counting it only on
+      // success would let a failing narration loop spend the day invisibly.
+      if (!ledgerDegraded) {
+        let after = recordWrite(ledgerBefore, ticket);
+        const exhaustion = classifyExhaustion(after, { dailyBudget });
+        if (exhaustion.announce) {
+          after = markExhaustionAnnounced(after);
+          emit(EVENT_EXHAUSTED, { ticket, routeId, reason: "budget:day-exhausted", status: null, applied: false, caller, labels });
+          log?.error?.({ total: after.total, dailyBudget, day: after.day },
+            "linear-write-proxy: host daily cloud write budget EXHAUSTED — every further Linear write is refused until the UTC day rolls");
+        }
+        persist(after);
+      }
+
+      const onDone = (raw) => {
+        // ⛔ Runs on a LATER event-loop turn. It must never throw into the daemon loop,
+        // and it must never touch the ledger (see the single-writer note above).
+        try {
+          const verdict = classifyProxyResponse(raw);
+          if (verdict.applied) {
+            counts.applied += 1;
+            emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true, caller, labels });
+            return;
+          }
+          counts.failed += 1;
+          emit(EVENT_FAILED, { ticket, routeId, reason: verdict.reason, status: verdict.status, applied: false, caller, labels });
+          // The ticket AND the phase, because "narration failed" with neither is an
+          // alert nobody can act on.
+          log?.warn?.(
+            { ...ctx, reason: verdict.reason, status: verdict.status, attempts: raw?.attempts ?? null },
+            "linear-write-proxy: narration failed (non-blocking route — the dispatch was NOT affected)"
+          );
+        } catch (err) {
+          log?.warn?.({ ...ctx, err: scrub(err?.message ?? "") }, "linear-write-proxy: narration settle threw");
+        }
+      };
+
+      try {
+        asyncHttpFn({ url: req.url, method: req.method, token: key.value, body: req.body, onDone });
+      } catch (err) {
+        log?.warn?.({ ...ctx, err: scrub(err?.message ?? "") }, "linear-write-proxy: async transport threw");
+        return refuse("spawn-failed");
+      }
+      return { handled: true, dispatched: true, reason: null };
     },
   };
 }

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -18,6 +18,7 @@ import {
   LINEAR_WRITE_PROXY_MODES,
   MAX_BODY_BYTES,
   PROXY_EVENT_NAMES,
+  NON_BLOCKING_ROUTE_IDS,
   PROXY_ROUTE_IDS,
   buildCurlConfig,
   buildProxyRequest,
@@ -123,9 +124,24 @@ describe("resolveHostKey — through the secret contract, not a hand-rolled ladd
 });
 
 describe("routes", () => {
-  test("the three CTC-509 routes are exactly the supported set", () => {
-    expect([...PROXY_ROUTE_IDS].sort()).toEqual(["comment", "issue-state", "label"]);
-    expect(Object.keys(DEFAULT_ROUTES).sort()).toEqual(["comment", "issue-state", "label"]);
+  test("the supported routes are exactly the set below — fails in both directions", () => {
+    // CTL-1943 added `session` (CTC-682). The exact-equality shape is deliberate: a new
+    // route must be argued for HERE, because every id in this set is a path the daemon
+    // will send a Linear write to.
+    const expected = ["comment", "issue-state", "label", "session"];
+    expect([...PROXY_ROUTE_IDS].sort()).toEqual(expected);
+    expect(Object.keys(DEFAULT_ROUTES).sort()).toEqual(expected);
+  });
+
+  test("⛔ exactly ONE route is non-blocking, and it is not a dispatch-critical one", () => {
+    // The asymmetry COORD-122 decided. Asserted as an exact set so a future id cannot be
+    // added to the fast path without this failing — the three routes below each carry a
+    // decision the daemon reads back, so "sent and forgotten" would mean believing a
+    // board state that was never achieved.
+    expect([...NON_BLOCKING_ROUTE_IDS]).toEqual(["session"]);
+    for (const id of ["issue-state", "label", "comment"]) {
+      expect(NON_BLOCKING_ROUTE_IDS.has(id)).toBe(false);
+    }
   });
 
   test("a Layer-2 override wins over the shipped default", () => {


### PR DESCRIPTION
## What

`dispatchTicket` now narrates each dispatched phase as a **Linear agent session** via the cloud's `POST /api/v1/agent/session` route (CTC-682, catalyst-cloud#780) — the plan is the pipeline, an activity marks each transition, and the closing phase sends a terminal `response`.

Closes **CTL-1943**. Implements COORD-107 decision 1 under **COORD-122's** contract.

## ⛔ The asymmetry, and why it is deliberate

`dispatchTicket` is the right seam — all five non-test dispatch call sites route through it, so one hook is genuinely "once per phase". But it runs **inside the synchronous `schedulerTick`**, and the write-proxy's transport is a `spawnSync` of curl with a **20 s ceiling**. A blocking narration there would add up to 20 s *per dispatch* to a tick CTL-1524 already records as blocking the daemon's event loop — a fleet-wide stall traded for a status line.

So `session` is the **one** route sent without waiting, because its failure degrades *observability and nothing else*: nothing downstream reads the result and no dispatch decision depends on it.

| route | transport | why |
|---|---|---|
| `issue-state` | **synchronous** | decides whether a ticket advances |
| `label` | **synchronous** | the worker-disposition contract the scheduler reads back |
| `comment` | **synchronous** | the durable record a human replies to |
| `session` | **non-blocking** | narration only — a loss self-heals next phase |

Written in three places that cannot drift from the code: `NON_BLOCKING_ROUTE_IDS` (data), the `dispatchTicket` call site, and a test asserting the set is exactly `["session"]`. `sendAsync` **refuses a dispatch-critical route by name** rather than quietly downgrading it.

## Non-blocking, NOT fire-and-forget

`sendAsync` is a **peer** of `send`, not a flag on it — `send` is byte-identical, because three dispatch-critical routes depend on its synchronous verdict. They share only the closure.

The child's outcome is still collected and reported (`linear.write.proxy.applied|failed`, carrying **the ticket and the phase**). Dropping it would make a permanently-broken narration route indistinguishable from a working one. What is given up is only the ability to *act* on the result.

The budget ledger stays **single-writer**: every read-modify-write happens synchronously before the child spawns, on the same single-threaded loop as `send`. The async half only emits.

## Verification

- **The load-bearing property is timing, and a "fast" assertion passes for a narrator that never ran.** Every timing assertion is paired with a **negative control** on the same clock through the same call — a deliberately blocking narrator (`spawnSync /bin/sleep 0.6`) that must be caught.
- **The no-narrator default** — what the fleet actually runs — has its own test. CTL-1918 shipped a default that ten passing tests never exercised.
- **A repeated narration must not be convergence-suppressed** (right for a label, wrong here: a session that stops emitting goes `stale` at 30 min and reads as "the agent didn't start").
- The first cut of the suite passed the **wrong credential env var**, and the transport refused every send *by name*. That refusal is now its own test.
- **Registered in the required `execution-core-unit-tests` list**, verified by parsing the workflow YAML rather than grepping the file — #3519's round-1 P1 was exactly this omission.

21 new tests; `linear-write-proxy` / `dispatch` / `linear-write` suites green (308 pass, 0 fail).

## Rollout

Installed only under `linearWriteProxy.mode = enforce` (where the id resolver exists). `off` and `shadow` construct nothing, so the no-narration path is byte-identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
