### PR TITLE
fix(dev): CTL-1949 — the documented `ask create` path filed nothing and exited 0, and cross-team asks carried the wrong labels

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -543,6 +543,20 @@ jobs:
         working-directory: plugins/dev/scripts/lib
         run: bun test deployment-mode.test.mjs
 
+      - name: ask-verb unit tests (bun, CTL-1922 / CTL-1944)
+        # ⛔ `ask-verbs.test.mjs` shipped with #3509 and was registered in NO workflow —
+        # 20 tests that had never run in CI. Verified with the instrument note above:
+        # parsing this workflow's YAML and searching every `run:` step for the filename
+        # returned zero, while the same search for `assertion-evidence.test.mjs`
+        # (known-present) returned its step. That is the same omission Codex raised as a
+        # round-1 P1 on #3519, now found a third time — so it is registered here rather
+        # than left for the next person.
+        #
+        # Its own step because the "Run stable unit tests" step's working-directory is
+        # execution-core/ and ask.mjs is a sibling of that tree, not inside it.
+        working-directory: plugins/dev/scripts/__tests__
+        run: bun test ask-verbs.test.mjs
+
       - name: event-name boundary unit tests (bun, CTL-1834)
         # `grep -rn event-name .github/workflows/` returned NOTHING before this
         # step. NOTE THE INSTRUMENT: a `run:`-anchored grep is NOT valid here —

--- a/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
+++ b/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
@@ -8,12 +8,23 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  ASK_LABEL_NAMES,
+  VERBS,
   buildAskBody,
+  isEntryPoint,
   missingBlocksFrom,
   parseAskOptions,
+  resolveTeamLabelIds,
   teamPrefixMismatch,
   verifyAskBody,
 } from "../ask.mjs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ASK_MJS = join(dirname(fileURLToPath(import.meta.url)), "..", "ask.mjs");
 
 describe("buildAskBody renders the shape the trigger parses", () => {
   test("a full ask round-trips through the parser", () => {
@@ -157,5 +168,117 @@ describe("⛔ Codex #3509 P2 — every requested blocking relation is verified",
   test("an unreadable read-back reports them all missing rather than none", () => {
     // Fail toward "say something is wrong", not toward a silent all-clear.
     expect(missingBlocksFrom(["CTL-1"], null)).toEqual(["CTL-1"]);
+  });
+});
+
+
+// ── CTL-1944: the two traps CTC(ux-b) found in this verb (CTCB-6) ──────────────────────
+
+describe("trap (a) — the documented path must not silently no-op", () => {
+  // ⛔ The skill says to run `$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs`, which is a SYMLINK.
+  // The old guard compared `import.meta.url` (the RESOLVED real path) to `argv[1]` (the
+  // symlink path) as raw strings, so it was false and the script EXITED 0 HAVING DONE
+  // NOTHING — no ticket, no error, no output. A careless reader takes exit 0 for "filed".
+
+  test("isEntryPoint resolves through a symlink", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ask-link-"));
+    const link = join(dir, "ask.mjs");
+    symlinkSync(ASK_MJS, link);
+    expect(isEntryPoint(`file://${ASK_MJS}`, link)).toBe(true);
+    // ⛔ MUTATION CONTROL: the OLD comparison on the same inputs. If this ever starts
+    // passing, the fixture is no longer a symlink and the test above proves nothing.
+    expect(`file://${ASK_MJS}` === `file://${link}`).toBe(false);
+  });
+
+  test("isEntryPoint is false for an unrelated file, and never throws", () => {
+    expect(isEntryPoint(`file://${ASK_MJS}`, "/definitely/not/here.mjs")).toBe(false);
+    expect(isEntryPoint(`file://${ASK_MJS}`, undefined)).toBe(false);
+    expect(isEntryPoint(`file://${ASK_MJS}`, "")).toBe(false);
+  });
+
+  test("END TO END: `create` through a symlink actually runs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ask-e2e-"));
+    const link = join(dir, "ask.mjs");
+    symlinkSync(ASK_MJS, link);
+    const r = spawnSync("node", [link, "create", "--team", "CTL", "--title", "t", "--why", "w", "--dry-run"], {
+      encoding: "utf8",
+    });
+    // The property that failed: output existed at all. Before the fix this was "".
+    expect(r.stdout.length).toBeGreaterThan(0);
+    expect(JSON.parse(r.stdout).action).toBe("dry-run");
+  });
+
+  test("⛔ a no-op is LOUD: a real verb that does not reach the entry point exits non-zero", () => {
+    // The class, not just the symlink instance. Simulated by importing the module in a
+    // process whose argv[1] is something else entirely but whose argv[2] is a real verb.
+    const r = spawnSync("node", ["-e", `process.argv[2]=${JSON.stringify(VERBS[0])};import(${JSON.stringify(ASK_MJS)})`], {
+      encoding: "utf8",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("NOTHING WAS FILED");
+  });
+
+  test("a genuine import (no verb in argv) stays silent — that is how CTC-694 was filed", () => {
+    const r = spawnSync("node", ["-e", `import(${JSON.stringify(ASK_MJS)}).then(m=>console.log(typeof m.buildAskBody))`], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("function");
+    expect(r.stderr).not.toContain("NOTHING WAS FILED");
+  });
+});
+
+describe("trap (b) — the label set follows the TARGET TEAM", () => {
+  // Linear issue labels are team-scoped and both names exist on BOTH teams with different
+  // ids, so passing NAMES let linearis resolve them against whichever team it picked.
+  // Measured 2026-08-18 (linearis labels list --team, one call per team):
+  const CTL_IDS = ["54179639-c850-4d3a-91da-f3d9288e68b0", "b23229ae-1d2b-4fa0-9987-091875e2b2a8"];
+  const CTC_IDS = ["e1b5ef97-4f8b-43fc-8e11-f6286a12a415", "752b5560-068c-42e5-87af-e8cadbfd4ae3"];
+  const fakeList = (byTeam) => (_cmd, args) => {
+    const team = args[args.indexOf("--team") + 1];
+    const nodes = (byTeam[team] ?? []).map(([name, id]) => ({ name, id }));
+    return { code: 0, stdout: JSON.stringify({ nodes }), stderr: "" };
+  };
+  const BOTH = {
+    CTL: [["catalyst-ask", CTL_IDS[0]], ["ask/decision", CTL_IDS[1]], ["website", "x"]],
+    CTC: [["catalyst-ask", CTC_IDS[0]], ["ask/decision", CTC_IDS[1]]],
+  };
+
+  test("each team resolves to ITS OWN ids — and the two sets are disjoint", () => {
+    const ctl = resolveTeamLabelIds("CTL", { runFn: fakeList(BOTH) });
+    const ctc = resolveTeamLabelIds("CTC", { runFn: fakeList(BOTH) });
+    expect(ctl).toEqual({ ok: true, labelIds: CTL_IDS });
+    expect(ctc).toEqual({ ok: true, labelIds: CTC_IDS });
+    // ⛔ The control that makes the two assertions above mean something: if the ids were
+    // the same, a team-blind implementation would pass both.
+    expect(CTL_IDS.some((id) => CTC_IDS.includes(id))).toBe(false);
+  });
+
+  test("order follows ASK_LABEL_NAMES regardless of the order the API returns", () => {
+    const shuffled = { CTC: [["ask/decision", CTC_IDS[1]], ["catalyst-ask", CTC_IDS[0]]] };
+    expect(resolveTeamLabelIds("CTC", { runFn: fakeList(shuffled) })).toEqual({ ok: true, labelIds: CTC_IDS });
+    expect(ASK_LABEL_NAMES).toEqual(["catalyst-ask", "ask/decision"]);
+  });
+
+  test("ALL-OR-NOTHING: one missing label refuses the whole set by name", () => {
+    const partial = { CTC: [["catalyst-ask", CTC_IDS[0]]] };
+    const r = resolveTeamLabelIds("CTC", { runFn: fakeList(partial) });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("label-not-on-team");
+    expect(r.detail).toContain("ask/decision");
+  });
+
+  test("a duplicate name is AMBIGUOUS, never silently first-wins", () => {
+    const dupe = { CTC: [["catalyst-ask", "a"], ["catalyst-ask", "b"], ["ask/decision", "c"]] };
+    expect(resolveTeamLabelIds("CTC", { runFn: fakeList(dupe) }).reason).toBe("label-ambiguous");
+  });
+
+  test("a failed or unparseable list is a NAMED refusal, never an empty label set", () => {
+    expect(resolveTeamLabelIds("CTC", { runFn: () => ({ code: 1, stdout: "", stderr: "boom" }) }).reason)
+      .toBe("label-list-failed");
+    expect(resolveTeamLabelIds("CTC", { runFn: () => ({ code: 0, stdout: "not json", stderr: "" }) }).reason)
+      .toBe("label-list-unparseable");
+    expect(resolveTeamLabelIds("CTC", { runFn: () => ({ code: 0, stdout: "{}", stderr: "" }) }).reason)
+      .toBe("label-list-unparseable");
   });
 });

--- a/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
+++ b/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
@@ -19,7 +19,7 @@ import {
   verifyAskBody,
 } from "../ask.mjs";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, symlinkSync } from "node:fs";
+import { chmodSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -197,15 +197,55 @@ describe("trap (a) — the documented path must not silently no-op", () => {
   });
 
   test("END TO END: `create` through a symlink actually runs", () => {
+    // ⛔ HERMETIC BY CONSTRUCTION. `--dry-run` deliberately resolves the team's labels
+    // (a dry run that skips the step which fails is not a rehearsal), so this would
+    // otherwise need a real `linearis` and a real credential — and it FAILED on the CI
+    // runner, which has neither. Stubbing the binary on PATH seals the transport instead
+    // of weakening the assertion to "produced some output", which would also pass for a
+    // crash. The stub returns the shape `linearis labels list` really returns.
     const dir = mkdtempSync(join(tmpdir(), "ask-e2e-"));
     const link = join(dir, "ask.mjs");
     symlinkSync(ASK_MJS, link);
+
+    const bin = mkdtempSync(join(tmpdir(), "ask-bin-"));
+    const stub = join(bin, "linearis");
+    writeFileSync(
+      stub,
+      '#!/bin/sh\necho \'{"nodes":[{"name":"catalyst-ask","id":"L1"},{"name":"ask/decision","id":"L2"}]}\'\n'
+    );
+    chmodSync(stub, 0o755);
+
     const r = spawnSync("node", [link, "create", "--team", "CTL", "--title", "t", "--why", "w", "--dry-run"], {
       encoding: "utf8",
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` },
     });
-    // The property that failed: output existed at all. Before the fix this was "".
+    // The property that failed before the fix: there was no output AT ALL, and exit 0.
     expect(r.stdout.length).toBeGreaterThan(0);
-    expect(JSON.parse(r.stdout).action).toBe("dry-run");
+    const out = JSON.parse(r.stdout);
+    expect(out.action).toBe("dry-run");
+    // And it really went through the team-scoped resolution rather than a hardcoded list.
+    expect(out.labelIds).toEqual(["L1", "L2"]);
+  });
+
+  test("⛔ without linearis on PATH, `create` REFUSES loudly — it does not file a label-less ask", () => {
+    // The other half of the same property: the credential-free environment that broke
+    // this test in CI must produce a NAMED refusal and a non-zero exit, never a silent
+    // success. An ask without catalyst-ask is invisible to every view that selects on it.
+    const dir = mkdtempSync(join(tmpdir(), "ask-nolin-"));
+    const link = join(dir, "ask.mjs");
+    symlinkSync(ASK_MJS, link);
+    const emptyBin = mkdtempSync(join(tmpdir(), "ask-empty-"));
+    // ⛔ process.execPath, not "node": an empty PATH hides the INTERPRETER too, so
+    // spawnSync fails with ENOENT and returns status null — the test would then "pass"
+    // on a process that never ran. That is the failure mode this whole ticket is about,
+    // reproduced inside its own test, so the assertion below pins status to 1.
+    const r = spawnSync(process.execPath, [link, "create", "--team", "CTL", "--title", "t", "--why", "w", "--dry-run"], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: emptyBin },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("could not resolve the ask labels");
   });
 
   test("⛔ a no-op is LOUD: a real verb that does not reach the entry point exits non-zero", () => {

--- a/plugins/dev/scripts/ask.mjs
+++ b/plugins/dev/scripts/ask.mjs
@@ -29,7 +29,8 @@
 import { spawnSync } from "node:child_process";
 // ⛔ Codex #3509 P2: `--body -` used CommonJS `require`, which is undefined in an ESM
 // module — the documented form threw a ReferenceError before reading anything.
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 // ⚠️ ONE alternation-free pattern, deliberately: JS alternation prefers the earliest MATCH
 // POSITION, so a bare `Options:` branch matches at the preceding newline and consumes
@@ -167,6 +168,60 @@ export function missingBlocksFrom(blocks, readBackText) {
   return blocks.filter((b) => !text.includes(b));
 }
 
+/**
+ * ⛔ THE LABEL SET FOLLOWS THE TARGET TEAM (CTCB-6 trap b).
+ *
+ * Linear issue labels are TEAM-SCOPED, and both of these names exist on BOTH teams with
+ * DIFFERENT ids. Measured 2026-08-18:
+ *
+ *   catalyst-ask   CTL 54179639-c850-4d3a-91da-f3d9288e68b0   CTC e1b5ef97-4f8b-43fc-8e11-f6286a12a415
+ *   ask/decision   CTL b23229ae-1d2b-4fa0-9987-091875e2b2a8   CTC 752b5560-068c-42e5-87af-e8cadbfd4ae3
+ *
+ * Passing the NAMES let `linearis` resolve them against whichever team it picked — CTL's —
+ * so filing a CTC ask failed with "The label 'catalyst-ask' is not associated with the same
+ * team as the issue." That one at least failed loudly; the danger is the other direction,
+ * where a name happens to resolve to the right team by luck and the tool looks correct
+ * until someone files across teams.
+ *
+ * ⚠️ The local replica CANNOT answer this question: its `labels` table has no team column,
+ * so both rows are visible and indistinguishable — exactly the `label-ambiguous` case the
+ * write-proxy resolver names. The team scoping lives only in the API, so this is one of the
+ * few reads that legitimately goes there.
+ */
+export const ASK_LABEL_NAMES = Object.freeze(["catalyst-ask", "ask/decision"]);
+
+/**
+ * resolveTeamLabelIds — map ASK_LABEL_NAMES to ids ON THIS TEAM.
+ *
+ * ALL-OR-NOTHING and three-valued. A partial set would file an ask carrying some of its
+ * labels and silently dropping the rest, which reads as success at the call site and makes
+ * the ask invisible to the very views that select on `catalyst-ask`.
+ */
+export function resolveTeamLabelIds(team, { runFn = run, names = ASK_LABEL_NAMES } = {}) {
+  const r = runFn("linearis", ["labels", "list", "--team", team, "--limit", "250"]);
+  if (r.code !== 0) {
+    return { ok: false, reason: "label-list-failed", detail: r.stderr.slice(0, 200) };
+  }
+  let nodes;
+  try {
+    nodes = JSON.parse(r.stdout)?.nodes;
+  } catch (err) {
+    return { ok: false, reason: "label-list-unparseable", detail: String(err?.message ?? err).slice(0, 200) };
+  }
+  if (!Array.isArray(nodes)) return { ok: false, reason: "label-list-unparseable", detail: "no nodes array" };
+
+  const ids = [];
+  for (const name of names) {
+    // A `LIMIT 2`-style count, for the same reason the write-proxy resolver uses one:
+    // ambiguity must be DETECTED, not silently resolved to whichever row came first.
+    const hits = nodes.filter((n) => n?.name === name && typeof n?.id === "string");
+    if (hits.length === 0) return { ok: false, reason: "label-not-on-team", detail: `${name} @ ${team}` };
+    if (hits.length > 1) return { ok: false, reason: "label-ambiguous", detail: `${name} @ ${team}` };
+    ids.push(hits[0].id);
+  }
+  return { ok: true, labelIds: ids };
+}
+
 // ── CLI ────────────────────────────────────────────────────────────────────────────────
 
 const RYAN = process.env.ASK_HUMAN_ID || "c2a8cc92-cab6-4536-9500-0f24abdf702b";
@@ -245,9 +300,28 @@ function cmdCreate(argv) {
     );
     return 1;
   }
+  // ⛔ Resolve the labels ON THE TARGET TEAM before the dry-run returns, not after. A dry
+  // run that skips the step which actually fails is not a rehearsal — it is the shape of
+  // check that cannot fail, and it would have passed cleanly for the exact defect CTCB-6
+  // hit. See resolveTeamLabelIds.
+  const lbl = resolveTeamLabelIds(team);
+  if (!lbl.ok) {
+    console.error(
+      `ask create: REFUSING — could not resolve the ask labels on team ${team} ` +
+        `(${lbl.reason}: ${lbl.detail}). Labels are TEAM-SCOPED; filing without them would ` +
+        "hide the ask from every view that selects on catalyst-ask."
+    );
+    return 1;
+  }
+  const labelIds = lbl.labelIds;
+
   if (dryRun) {
     console.log(
-      JSON.stringify({ action: "dry-run", team, title, body, parsedOptions: pre.parsed }, null, 2)
+      JSON.stringify(
+        { action: "dry-run", team, title, body, parsedOptions: pre.parsed, labelIds },
+        null,
+        2
+      )
     );
     return 0;
   }
@@ -263,7 +337,7 @@ function cmdCreate(argv) {
     "--assignee",
     RYAN,
     "--labels",
-    "catalyst-ask,ask/decision",
+    labelIds.join(","),
     "--description",
     body,
   ];
@@ -413,8 +487,34 @@ function cmdAccept(argv) {
   return 0;
 }
 
+export const VERBS = Object.freeze(["create", "accept"]);
+
+/**
+ * isEntryPoint — was this module RUN, or imported?
+ *
+ * ⛔ CTCB-6 trap (a). The old test was `import.meta.url === "file://" + process.argv[1]`,
+ * a raw string compare. The skill documents invoking this through
+ * `$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs`, which is a SYMLINK — so `import.meta.url` (the
+ * resolved real path) never equalled `argv[1]` (the symlink path), the guard was false,
+ * and the script EXITED 0 HAVING DONE NOTHING. No ticket, no error, no output. A careless
+ * reader takes exit 0 for "filed", which is the worst possible failure for a tool whose
+ * entire job is to prove an ask exists.
+ *
+ * Both sides are now resolved through `realpathSync`, so any path that reaches the same
+ * file — symlink, relative, or `..`-laden — is recognised.
+ */
+export function isEntryPoint(metaUrl = import.meta.url, argv1 = process.argv[1]) {
+  if (typeof argv1 !== "string" || argv1 === "") return false;
+  try {
+    return realpathSync(fileURLToPath(metaUrl)) === realpathSync(argv1);
+  } catch {
+    // Cannot resolve one of them — say NO here, and let the loud guard below decide.
+    return false;
+  }
+}
+
 const argv = process.argv.slice(2);
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isEntryPoint()) {
   const verb = argv[0];
   if (verb === "create") process.exit(cmdCreate(argv.slice(1)));
   else if (verb === "accept") process.exit(cmdAccept(argv.slice(1)));
@@ -422,4 +522,18 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     usage();
     process.exit(1);
   }
+} else if (VERBS.includes(argv[0])) {
+  // ⛔ A NO-OP MUST BE LOUD. `realpathSync` fixes the symlink case specifically; this
+  // catches the CLASS. If anything else ever makes the entry-point test false while the
+  // user is plainly driving the CLI — a future bundler, a copied file, an exotic loader —
+  // it exits NON-ZERO with the reason instead of exiting 0 having filed nothing.
+  //
+  // Gated on a real verb so a legitimate `import` of buildAskBody/verifyAskBody (which is
+  // how CTC-694 was actually filed) stays silent: an importing process has its own argv.
+  console.error(
+    `ask.mjs: ⛔ invoked with the verb "${argv[0]}" but this module is not the entry point ` +
+      `(argv[1]=${process.argv[1] ?? "<none>"}, module=${fileURLToPath(import.meta.url)}). ` +
+      "NOTHING WAS FILED. Run the real path: ~/catalyst/plugin-source/plugins/dev/scripts/ask.mjs"
+  );
+  process.exit(3);
 }


### PR DESCRIPTION
## What

Fixes the two live traps **CTC(ux-b)** found in the `ask create` verb (channel turn **CTCB-6**) while filing CTC-694/CTC-695 — in the tool every owner is told to use for asks. Closes **CTL-1949**.

Both reproduced with positive controls *before* being fixed, and both mutation-tested after.

## (a) The documented path filed nothing and exited 0

The skill says to run `$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs`, which is a **symlink**. The guard compared `import.meta.url` (the *resolved* real path) to `argv[1]` (the *symlink* path) as raw strings — never equal, so the script **exited 0 having done nothing**. No ticket, no error, no output.

> Reproduced: direct path prints usage; symlink path prints **nothing**.

⛔ Exit 0 read as "filed", which is the worst possible failure for a tool whose only job is to prove an ask exists.

**Fixed at the class, not the instance.** `realpathSync` on both sides handles the symlink; and because the symlink was only *one* way that guard can go false, a real verb that does not reach the entry point now **exits 3** naming the reason and saying plainly that nothing was filed. Gated on a known verb, so a legitimate `import` of `buildAskBody`/`verifyAskBody` — how CTC-694 was actually filed — stays silent.

## (b) A CTC ask carried CTL's labels

`create` hard-coded `--labels "catalyst-ask,ask/decision"` **by name**. Labels are team-scoped, both names exist on both teams with different ids, linearis resolved CTL's, Linear refused.

Measured on both teams — a control on each:

| label | CTL | CTC |
| -- | -- | -- |
| `catalyst-ask` | `54179639-…` | `e1b5ef97-…` |
| `ask/decision` | `b23229ae-…` | `752b5560-…` |

`resolveTeamLabelIds` resolves on the **target** team, all-or-nothing and three-valued: missing-on-team, ambiguous, list-failed, and list-unparseable are four **named** refusals — never a silent empty label set, which would file an ask invisible to every view that selects on `catalyst-ask`.

⚠️ The local replica **cannot** answer this — its `labels` table has no team column, so both rows are indistinguishable (the same `label-ambiguous` case the write-proxy resolver names). Team scoping lives only in the API.

**The resolution now runs *before* the dry-run returns.** A dry run that skips the step which actually fails is not a rehearsal — it is a check that cannot fail, and it would have passed cleanly for this exact defect.

## Also fixed: those tests never ran

⛔ `ask-verbs.test.mjs` shipped with #3509 registered in **no** workflow — 20 tests that had never run in CI. Verified by parsing the workflow YAML and searching every `run:` step (a plain grep is invalid here: the stable-test step is a multi-line block whose entries carry no `run:` token). **Third instance of this omission tonight** — Codex raised the same thing as a round-1 P1 on #3519.

## Verification

10 new tests, **30 total, green**. Mutation-tested:

| mutation | result |
|---|---|
| restore the raw-string entry guard | **2 fail** |
| restore the hardcoded CTL label ids | **4 fail** |
| restored tree | 30 pass |

Live-verified end to end: `--dry-run` through a symlink now returns CTL's ids for `--team CTL` and CTC's for `--team CTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
