### PR TITLE
feat(dev): a LaunchAgent that actually drains remote owners' turns (COORD-108/118/121)

### DIFF
--- a/scripts/comms/__tests__/remote-turns.test.sh
+++ b/scripts/comms/__tests__/remote-turns.test.sh
@@ -215,5 +215,43 @@ else
 fi
 
 echo ""
+echo "=== the drain LaunchAgent installer renders cleanly ==="
+# ⛔ Without a periodic drain the transport is only half a delivery path: a mini queues turns
+# correctly and nothing ever pulls them, so it LOOKS installed and delivers nothing.
+INSTALLER="$SCRIPT_DIR/../install-comms-drain.sh"
+OUT="$(bash "$INSTALLER" --print-only 2>&1)"
+RC=$?
+[ "$RC" -eq 0 ] && pass "--print-only succeeds" || fail "--print-only succeeds" "$OUT"
+grep -q "__[A-Z_]*__" <<<"$OUT" && fail "every token is substituted" "tokens remain" || pass "every token is substituted"
+grep -q "drain-remote-turns.sh" <<<"$OUT" && pass "it points at the drain script" || fail "it points at the drain script" "$OUT"
+printf '%s\n' "$OUT" >"$SCRATCH/drain.plist"
+if command -v plutil >/dev/null 2>&1; then
+	plutil -lint "$SCRATCH/drain.plist" >/dev/null 2>&1 && pass "the rendered plist lints (plutil)" || fail "the rendered plist lints"
+else
+	python3 -c "import sys,xml.dom.minidom as m; m.parse(sys.argv[1])" "$SCRATCH/drain.plist" >/dev/null 2>&1 &&
+		pass "the rendered plist is well-formed XML (no plutil here)" || fail "the rendered plist is well-formed XML"
+fi
+# The channel/hosts actually reach the agent's argv — a plist that lints but drains the wrong
+# channel is the same inert-install failure in a politer form.
+grep -q "custom-chan" <<<"$(bash "$INSTALLER" --print-only --channel custom-chan --hosts only-mini 2>&1)" &&
+	pass "--channel reaches the rendered argv" || fail "--channel reaches the rendered argv"
+grep -q "only-mini" <<<"$(bash "$INSTALLER" --print-only --channel custom-chan --hosts only-mini 2>&1)" &&
+	pass "--hosts reaches the rendered argv" || fail "--hosts reaches the rendered argv"
+bash "$INSTALLER" --print-only --channel "" >/dev/null 2>&1
+[ $? -eq 2 ] && pass "an empty --channel is refused (rc 2)" || fail "an empty --channel is refused (rc 2)"
+
+echo ""
+echo "--- ⛔ CONTROL: the installer refuses an unsubstituted template ---"
+FAKE2="$SCRATCH/fake-drain"
+mkdir -p "$FAKE2/agent"
+cp "$INSTALLER" "$FAKE2/"
+cp "$SCRIPT_DIR/../drain-remote-turns.sh" "$FAKE2/"
+sed 's|__CHANNEL__|__NEVER_SUBSTITUTED__|' "$SCRIPT_DIR/../agent/ai.coalesce.catalyst-comms-drain.plist" \
+	>"$FAKE2/agent/ai.coalesce.catalyst-comms-drain.plist"
+OUT="$(bash "$FAKE2/install-comms-drain.sh" --print-only 2>&1)"
+RC=$?
+[ "$RC" -ne 0 ] && grep -q "REFUSING" <<<"$OUT" && pass "an unsubstituted token is refused" || fail "an unsubstituted token is refused" "rc=$RC: $OUT"
+
+echo ""
 echo "  PASSED: $PASSES   FAILED: $FAILURES"
 [[ $FAILURES -eq 0 ]]

--- a/scripts/comms/agent/ai.coalesce.catalyst-comms-drain.plist
+++ b/scripts/comms/agent/ai.coalesce.catalyst-comms-drain.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  COORD-108/118/121 — drain remote owners' queued channel turns onto the channel host.
+  Tokens (__HOME__, __SCRIPT__, __CHANNEL__, __HOSTS__) are substituted by install-comms-drain.sh;
+  this file is a TEMPLATE and is not loadable as-is.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.coalesce.catalyst-comms-drain</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__SCRIPT__</string>
+    <string>--channel</string>
+    <string>__CHANNEL__</string>
+    <string>--hosts</string>
+    <string>__HOSTS__</string>
+  </array>
+  <!--
+    120s. A remote owner's turn is a coordination signal — the whole point is that COORD reads it
+    on the next pass, not eventually. The drain is cheap (one ssh listing per host) and is a no-op
+    when nothing is queued.
+  -->
+  <key>StartInterval</key>
+  <integer>120</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <!-- ssh must resolve; launchd's default PATH does not include homebrew. -->
+    <key>PATH</key>
+    <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>__HOME__/Library/Logs/catalyst-comms-drain.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__HOME__/Library/Logs/catalyst-comms-drain.err.log</string>
+</dict>
+</plist>

--- a/scripts/comms/install-comms-drain.sh
+++ b/scripts/comms/install-comms-drain.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# install-comms-drain.sh — COORD-108/118/121. Install the LaunchAgent that pulls remote owners'
+# queued channel turns onto the channel host.
+#
+# ⛔ WHY THIS EXISTS. The transport (post-turn.sh / drain-remote-turns.sh) is only half a delivery
+# path: a mini can queue a turn, but nothing on the laptop was pulling. A relaunched remote owner
+# would post correctly and its turns would sit in the outbox unread — the transport would LOOK
+# installed and deliver nothing, which is the class this whole night was about.
+#
+# Runs on the CHANNEL HOST (the laptop), not on the owners. The laptop does not accept ssh
+# (measured 2026-08-18: refused from both minis), so pull is the only direction available — and it
+# is the one that survives the laptop sleeping, since turns simply queue until it wakes.
+#
+#   install-comms-drain.sh [--channel <name>] [--hosts a,b]
+#   install-comms-drain.sh --uninstall
+#   install-comms-drain.sh --print-only
+
+set -euo pipefail
+
+_SRC="${BASH_SOURCE[0]}"
+while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
+SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+unset _SRC
+
+LABEL="ai.coalesce.catalyst-comms-drain"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+TEMPLATE="${SCRIPT_DIR}/agent/${LABEL}.plist"
+DRAIN="${SCRIPT_DIR}/drain-remote-turns.sh"
+CHANNEL="${CATALYST_USAGE_CHANNEL:-ctl-ctc-tenant-model-onboarding}"
+HOSTS="mini,mini-2"
+MODE="install"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --channel) CHANNEL="${2-}"; shift 2 ;;
+  --hosts) HOSTS="${2-}"; shift 2 ;;
+  --uninstall) MODE="uninstall"; shift ;;
+  --print-only) MODE="print"; shift ;;
+  -h | --help) sed -n '2,18p' "$0"; exit 0 ;;
+  *) echo "install-comms-drain: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [[ "$MODE" == "uninstall" ]]; then
+  launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+  rm -f "$DEST"
+  echo "install-comms-drain: uninstalled ${LABEL}"
+  exit 0
+fi
+
+[[ -n "$CHANNEL" ]] || { echo "install-comms-drain: --channel must not be empty" >&2; exit 2; }
+[[ -n "$HOSTS" ]] || { echo "install-comms-drain: --hosts must not be empty" >&2; exit 2; }
+[[ -f "$TEMPLATE" ]] || { echo "install-comms-drain: template missing at $TEMPLATE" >&2; exit 1; }
+[[ -f "$DRAIN" ]] || { echo "install-comms-drain: drain script missing at $DRAIN" >&2; exit 1; }
+
+RENDERED="$(sed -e "s|__HOME__|${HOME}|g" -e "s|__SCRIPT__|${DRAIN}|g" \
+  -e "s|__CHANNEL__|${CHANNEL}|g" -e "s|__HOSTS__|${HOSTS}|g" "$TEMPLATE")"
+
+# ⛔ An unsubstituted token yields a plist launchd accepts and an agent that drains nothing —
+# installed-looking and inert.
+if grep -q "__[A-Z_]*__" <<<"$RENDERED"; then
+  echo "install-comms-drain: REFUSING — unsubstituted token(s) remain:" >&2
+  grep -o "__[A-Z_]*__" <<<"$RENDERED" | sort -u >&2
+  exit 1
+fi
+
+if [[ "$MODE" == "print" ]]; then printf '%s\n' "$RENDERED"; exit 0; fi
+
+mkdir -p "$(dirname "$DEST")"
+printf '%s\n' "$RENDERED" >"$DEST"
+if command -v plutil >/dev/null 2>&1; then
+  plutil -lint "$DEST" >/dev/null || { echo "install-comms-drain: rendered plist is malformed" >&2; exit 1; }
+fi
+
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$DEST"
+echo "install-comms-drain: installed ${LABEL} — channel=${CHANNEL} hosts=${HOSTS}, every 120s"


### PR DESCRIPTION
The transport merged in #3517 is only **half** a delivery path. A mini can queue a turn and **nothing on the laptop was pulling** — a relaunched remote owner would post correctly and its turns would sit in the outbox unread. The transport would look installed and deliver nothing: the exact class this whole night was about, in a deliverable I own.

`install-comms-drain.sh` installs the agent on the **channel host**, every 120 s. The drain is cheap (one ssh listing per host) and a no-op when nothing is queued. 120 s because a remote owner's turn is a coordination signal — the point is that COORD reads it on the *next pass*, not eventually.

Pull remains the only available direction: the laptop does not accept ssh (measured 2026-08-18, refused from both minis), and pull is also what survives the laptop sleeping, since turns queue until it wakes.

The installer **refuses** to write a plist containing an unsubstituted token — that yields an agent launchd accepts and that drains nothing. Its `PATH` includes homebrew, or `ssh` would not resolve under launchd's default.

## Tests — 35 in `remote-turns.test.sh`

The render · no leftover tokens · it points at the drain script · plist lint (with an XML-parse fallback where `plutil` is absent, since CI is ubuntu) · that `--channel` and `--hosts` actually reach the **rendered argv** — a plist that lints but drains the wrong channel is the same inert install in a politer form · an empty `--channel` refused · and a control feeding the installer a deliberately unsubstituted template.

Completes step 4 of the mini launch recipe (FLEET-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)