### PR TITLE
feat(dev): CTL-1929 — the GitHub leg's enforce flip, suppressing smee PER NAME

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1002,6 +1002,10 @@ jobs:
             github-feed-sweep.test.mjs \
             github-feed-parity.test.mjs \
             github-feed-timer.test.mjs \
+            github-feed-gate.test.mjs \
+            github-feed-ready.test.mjs \
+            github-feed-gate-install.test.mjs \
+            github-feed-gate-wiring.test.mjs \
             cloud-feed-gate.test.mjs \
             cloud-feed-capture.test.mjs \
             cloud-feed-timer.test.mjs \

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -83,7 +83,7 @@ import {
   clearDebounceTimers,
   seedLastSeenByService,
 } from "./router.mjs";
-import { seedTailer, startTailing, stopTailing, loadExistingRegistrations } from "./tailer.mjs";
+import { seedTailer, startTailing, stopTailing, loadExistingRegistrations, initGithubFeedGate } from "./tailer.mjs";
 import { startCacheReconcileTimer } from "./cache-reconcile.mjs";
 import { gcStaleInterests } from "./gc-startup.mjs";
 import { getExecutionCoreDir, getRunsRoot } from "../execution-core/config.mjs";
@@ -531,6 +531,13 @@ function main() {
     },
   });
 
+  // CTL-1929: install the `github.*` dispatch gate BEFORE the tail starts.
+  //
+  // ⛔ ORDER IS LOAD-BEARING, same as the Linear gate's placement before monitorFn
+  // (daemon.mjs:1448). Arming it after `startTailing()` leaves a window in which
+  // enforce-mode smee events route normally — exactly the double-dispatch the gate
+  // exists to prevent, for however many events land in that window.
+  initGithubFeedGate();
   startTailing();
   const watchdogId = startWatchdog();
   const driftCheckId = startDriftCheckWatcher();

--- a/plugins/dev/scripts/broker/tailer.mjs
+++ b/plugins/dev/scripts/broker/tailer.mjs
@@ -25,6 +25,11 @@ import {
   isOrchestratorStatusFresh,
 } from "./router.mjs";
 import { getInterests } from "./state.mjs";
+// CTL-1929: the `github.*` dispatch gate. Imported from execution-core for the same
+// reason event-tail.mjs is — the two processes share this feature's modules, and the
+// gate must be the SAME decision function the producer's tests drive.
+import { decideDispatch as decideGithubDispatch } from "../execution-core/github-feed-gate.mjs";
+import { createGithubFeedGate } from "../execution-core/github-feed-gate-install.mjs";
 
 // Identity-stable alias — loadExistingRegistrations reports interests.size.
 const interests = getInterests();
@@ -33,6 +38,23 @@ const interests = getInterests();
 // (daemon env is set at launch); ON unless CATALYST_TICK_TIMING=off.
 const BROKER_ROUTE_TIMING = process.env.CATALYST_TICK_TIMING !== "off";
 const BROKER_SLOW_ROUTE_MS = Number(process.env.CATALYST_BROKER_SLOW_ROUTE_MS) || 100;
+
+// CTL-1929: which producer's `github.*` events may drive routing on this host.
+//
+// ⛔ NULL UNLESS AN OPERATOR OPTS IN. `createGithubFeedGate` returns null for
+// `CATALYST_GITHUB_FEED=off`, which is the default on every host, so the block in
+// readNewEvents below is skipped entirely and routing is byte-identical to
+// pre-CTL-1929. Resolved once at module load, matching BROKER_ROUTE_TIMING above:
+// the daemon's env is fixed at launch, and a per-event config read on the tail that
+// sees every event in the fleet is not something to add casually.
+let _githubGate = null;
+export function initGithubFeedGate(gate = undefined) {
+  _githubGate = gate === undefined ? createGithubFeedGate({ orchDir: CATALYST_DIR, logger: log }) : gate;
+  return _githubGate;
+}
+export function getGithubFeedGate() {
+  return _githubGate;
+}
 
 // --- Reactive event log tailing ---
 let lastByteOffset = 0;
@@ -130,6 +152,28 @@ export function readNewEvents() {
       // life blind. Same process counter, same non-gating contract: the event is
       // ROUTED regardless, so this can never change what the broker delivers.
       checkEnvelope(event);
+      // CTL-1929: WHICH producer's `github.*` events may drive routing. Both the
+      // smee→webhook receiver and the GitHub feed write the same names into this one
+      // log; the gate picks one per event and the loser is CAPTURED, not dropped, so
+      // "did the feed miss this edge?" stays answerable after the fact.
+      //
+      // ⛔ SUPPRESSION IS PER NAME. Nine of the twelve names the router consumes have
+      // a faithful feed replacement; `github.pr.merged` (CTC-691),
+      // `github.check_suite.completed` (CTC-667 item 4) and `github.push` (CTC-704)
+      // do not, and for those the gate never suppresses smee no matter how healthy
+      // the producer is. See github-feed-gate.mjs.
+      //
+      // ⚠️ Placed BEFORE processEvent and before the timing block, so a suppressed
+      // event is neither routed nor counted as a route — a suppressed event that
+      // still showed up in the slow-route histogram would make the two instruments
+      // disagree about what the broker did.
+      if (_githubGate) {
+        const verdict = decideGithubDispatch(event, _githubGate);
+        if (verdict.suppress) {
+          _githubGate.capture?.append(event, verdict);
+          continue;
+        }
+      }
       // CTL-1330 Tier 1: time each route; surface ONLY slow routes (default
       // >100ms) so we catch a broker-side hot-loop stall without flooding Loki —
       // the broker routes every appended event. ON by default (CATALYST_TICK_TIMING).

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1488,17 +1488,20 @@ export function startDaemon({
     }
     // CTL-1929: the GitHub leg's producer tick.
     //
-    // ⛔ READ FROM ITS OWN KNOB, AND NO GATE IS INSTALLED. Both of those are the
-    // safety argument, not style:
-    //   * `CATALYST_GITHUB_FEED` is separate from `CATALYST_CLOUD_FEED`, which every
-    //     worker already runs at `enforce` — sharing the value would have enforced
-    //     the GitHub leg on every host the moment this merged.
-    //   * There is deliberately NO `setGithubFeedGate` call. A gate is what
-    //     suppresses smee's copy, and suppressing it for `github.pr.merged` /
-    //     `github.check_suite.completed` — which this producer cannot emit until
-    //     CTC-691 and CTC-667 item 4 land — would take out the CI wait and the
-    //     deploy chain with nothing behind them. `enforce` therefore degrades to
-    //     shadow inside the timer and says so.
+    // ⛔ READS FROM ITS OWN KNOB. `CATALYST_GITHUB_FEED` is separate from
+    // `CATALYST_CLOUD_FEED`, which every worker already runs at `enforce` — sharing
+    // the value would have enforced the GitHub leg on every host the moment this
+    // merged. The two legs cut over independently or they cut over recklessly.
+    //
+    // ⚠️ AND THERE IS STILL NO `setGithubFeedGate` CALL HERE, WHICH IS NOT AN
+    // OVERSIGHT. The Linear gate lives in this process because `monitor.mjs` — its
+    // consumer — is in this process. The `github.*` consumer is `broker/tailer.mjs`
+    // → `broker/router.mjs`, a SEPARATE process, so the GitHub gate is installed
+    // there (`broker/index.mjs`, via `github-feed-gate-install.mjs`) and readiness
+    // reaches it through the file `github-feed-ready.mjs` defines rather than through
+    // a closure. Installing a second gate here would be a second authority path the
+    // real consumer does not share.
+    //
     // So on every host until an operator sets the flag, this block constructs
     // nothing and routing is byte-identical to pre-CTL-1929.
     const githubFeedCfg = readGithubFeedConfig();
@@ -1518,9 +1521,11 @@ export function startDaemon({
           effective: _githubFeedTimer?.mode?.effective ?? null,
           degraded: _githubFeedTimer?.mode?.degraded ?? false,
           intervalSec: githubFeedCfg.intervalSec,
-          gate: "none — the github leg suppresses nothing (CTC-691 / CTC-667 item 4)",
+          gate: "installed in the BROKER process (github-feed-gate-install.mjs), not here",
+          readyPath: _githubFeedTimer?.readyPath ?? null,
+          residual: _githubFeedTimer?.mode?.reason ?? null,
         },
-        "github-feed: armed (shadow only)",
+        "github-feed: armed",
       );
     }
 

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
@@ -1,0 +1,82 @@
+// github-feed-gate-install.mjs — CTL-1929. Builds the `github.*` dispatch gate for
+// the BROKER process, which is where the consumer lives.
+//
+// ⛔ SEPARATE FROM THE DAEMON'S WIRING BECAUSE THE PROCESSES ARE SEPARATE. The
+// Linear leg installs its gate inside `daemon.mjs`, next to the producer, and passes
+// `isReady` as a closure over the producer's timer handle. That is not available
+// here: `github-feed-timer` runs in the daemon and `broker/tailer.mjs` →
+// `broker/router.mjs` runs in its own process, so readiness arrives through the file
+// `github-feed-ready.mjs` defines and nothing else.
+//
+// ⚠️ AND THE HOT PATH IS NOT THE SAME EITHER. `monitor.mjs`'s tail sees `linear.*`
+// events; the broker's tail sees EVERY event this fleet appends — 687 per 5 min
+// measured on mini-2, into a log that has reached 883 MB (CTL-1529). A readFileSync
+// per routed event is not acceptable at that rate, so the readiness verdict is cached
+// for a short window. The cache is bounded far below the staleness window it feeds,
+// so it can delay an un-arm by at most `READY_CACHE_MS` — not defeat it.
+
+import { readGithubFeedConfig } from "./config.mjs";
+import { createCaptureSink } from "./cloud-feed-capture.mjs";
+import { defaultReadyPath, readReadyState } from "./github-feed-ready.mjs";
+import { resolveAccount } from "./github-feed-timer.mjs";
+import { join } from "node:path";
+
+/**
+ * How long a readiness verdict is reused.
+ *
+ * 1 s against a 90 s staleness window: three orders of magnitude of read reduction
+ * on a tail that routes every event in the fleet, for at most 1 s of extra latency on
+ * an un-arm. ⛔ It must stay far below `staleWindowMs`, or the cache becomes a second,
+ * longer latch on top of the one the staleness bound exists to break.
+ */
+export const READY_CACHE_MS = 1000;
+
+export function defaultGithubCapturePath(orchDir, account = "tenant-0") {
+  return join(orchDir, "capture", `github-suppressed-${account}.jsonl`);
+}
+
+/**
+ * createGithubFeedGate — the object `decideDispatch` takes as its second argument.
+ *
+ * Returns `null` when the mode is `off`, so the caller can skip the gate entirely
+ * and keep routing byte-identical to pre-CTL-1929 rather than running a gate that
+ * decides nothing on every event.
+ */
+export function createGithubFeedGate({
+  orchDir,
+  account = resolveAccount(),
+  config = readGithubFeedConfig(),
+  readyPath,
+  capturePath,
+  now = () => Date.now(),
+  readState = readReadyState,
+  captureFactory = createCaptureSink,
+  logger = null,
+} = {}) {
+  if (config.mode === "off") return null;
+
+  const readyFile = readyPath ?? defaultReadyPath(orchDir, account);
+  const capture = captureFactory({ path: capturePath ?? defaultGithubCapturePath(orchDir, account) });
+
+  let cachedAt = -Infinity;
+  let cached = { ready: false, reason: "ready-never-read" };
+
+  const isReady = () => {
+    const t = now();
+    if (t - cachedAt < READY_CACHE_MS) return cached;
+    // ⛔ The cache is refreshed even when the read FAILS. Keeping the last good
+    // verdict on an error would make an unreadable file behave like a fresh one,
+    // which is the latch again — readReadyState already returns a not-ready verdict
+    // for every failure mode, so simply taking its answer is the safe path.
+    cached = readState(readyFile, { now: t, intervalSec: config.intervalSec });
+    cachedAt = t;
+    return cached;
+  };
+
+  logger?.info?.(
+    { mode: config.mode, readyFile, capture: capture.path, cacheMs: READY_CACHE_MS },
+    "github-feed gate: armed",
+  );
+
+  return { mode: config.mode, isReady, capture, readyPath: readyFile };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
@@ -1,0 +1,158 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-gate-install.test.mjs
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { READY_CACHE_MS, createGithubFeedGate, defaultGithubCapturePath } from "./github-feed-gate-install.mjs";
+import { staleWindowMs } from "./github-feed-ready.mjs";
+import { decideDispatch } from "./github-feed-gate.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-gate-install-"));
+afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
+
+const stubCapture = () => ({ path: "/dev/null", append() {}, stats: () => ({}) });
+
+describe("⛔ off constructs NOTHING — routing stays byte-identical to pre-CTL-1929", () => {
+  test("mode off returns null", () => {
+    expect(createGithubFeedGate({ orchDir: tmp, config: { mode: "off", intervalSec: 30 }, captureFactory: stubCapture })).toBeNull();
+  });
+
+  test("shadow and enforce construct a gate", () => {
+    for (const mode of ["shadow", "enforce"]) {
+      const g = createGithubFeedGate({ orchDir: tmp, config: { mode, intervalSec: 30 }, captureFactory: stubCapture });
+      expect(g?.mode).toBe(mode);
+    }
+  });
+});
+
+describe("⚠️ the readiness cache spares the broker's hot path without becoming a second latch", () => {
+  const mkGate = (states, { clock }) => {
+    let i = 0;
+    const reads = [];
+    const g = createGithubFeedGate({
+      orchDir: tmp,
+      config: { mode: "enforce", intervalSec: 30 },
+      captureFactory: stubCapture,
+      now: () => clock.t,
+      readState: () => { reads.push(clock.t); return states[Math.min(i++, states.length - 1)]; },
+    });
+    return { g, reads };
+  };
+
+  test("repeated probes inside the window read the file ONCE", () => {
+    // The broker routes every event this fleet appends (687 per 5 min on mini-2,
+    // into an 883 MB log). A readFileSync per event is the thing this exists to stop.
+    const clock = { t: 1000 };
+    const { g, reads } = mkGate([{ ready: true, reason: "producer-ready" }], { clock });
+    for (let n = 0; n < 500; n += 1) g.isReady();
+    expect(reads).toHaveLength(1);
+  });
+
+  test("⛔ the cache expires, so an un-arm is delayed by at most READY_CACHE_MS", () => {
+    const clock = { t: 1000 };
+    const { g, reads } = mkGate(
+      [{ ready: true, reason: "producer-ready" }, { ready: false, reason: "ready-file-stale:95s" }],
+      { clock },
+    );
+    expect(g.isReady().ready).toBe(true);
+    clock.t += READY_CACHE_MS - 1;
+    expect(g.isReady().ready).toBe(true); // still cached
+    clock.t += 2;
+    expect(g.isReady().ready).toBe(false); // re-read
+    expect(reads).toHaveLength(2);
+  });
+
+  test("⛔ the cache window stays FAR below the staleness window it feeds", () => {
+    // If the cache ever grew past the staleness bound it would become a second,
+    // longer latch on top of the one that bound exists to break. Asserted as a
+    // relation rather than as two constants, so tuning either cannot invert it.
+    expect(READY_CACHE_MS).toBeLessThan(staleWindowMs(30) / 10);
+    expect(READY_CACHE_MS).toBeLessThan(staleWindowMs(5) / 10);
+  });
+
+  test("⚠️ a failing read REPLACES the cached verdict rather than preserving the last good one", () => {
+    // Keeping the last good verdict on error would make an unreadable file behave
+    // like a fresh one — the latch again, arriving through the error path.
+    const clock = { t: 1000 };
+    const { g } = mkGate(
+      [{ ready: true, reason: "producer-ready" }, { ready: false, reason: "ready-file-absent" }],
+      { clock },
+    );
+    expect(g.isReady().ready).toBe(true);
+    clock.t += READY_CACHE_MS + 1;
+    expect(g.isReady()).toMatchObject({ ready: false, reason: "ready-file-absent" });
+  });
+
+  test("⛔ the FIRST probe reads the file — it never answers from a construction-time default", () => {
+    // ⚠️ I first wrote this as "before any read, the gate is NOT ready" and the
+    //    mutation (seeding the cache `ready: true`) PASSED — because the first
+    //    isReady() always re-reads, the seed value is unreachable and asserting on it
+    //    asserts nothing. The real property is that no event can be decided before a
+    //    read has happened, which is what makes the seed unreachable in the first place.
+    const clock = { t: 0 };
+    let reads = 0;
+    const g = createGithubFeedGate({
+      orchDir: tmp,
+      config: { mode: "enforce", intervalSec: 30 },
+      captureFactory: stubCapture,
+      now: () => clock.t,
+      readState: () => { reads += 1; return { ready: false, reason: "ready-file-absent" }; },
+    });
+    expect(reads).toBe(0); // construction does not probe
+    expect(g.isReady()).toMatchObject({ ready: false, reason: "ready-file-absent" });
+    expect(reads).toBe(1); // ...the first probe does
+  });
+});
+
+describe("the installed gate composes with decideDispatch as one decision", () => {
+  const smee = (name) => ({
+    attributes: { "event.name": name, "webhook.delivery.id": "d1" },
+    body: { payload: {} },
+  });
+
+  const gateWith = (ready) =>
+    createGithubFeedGate({
+      orchDir: tmp,
+      config: { mode: "enforce", intervalSec: 30 },
+      captureFactory: stubCapture,
+      readState: () => ready,
+    });
+
+  test("ready producer → a covered name is suppressed", () => {
+    expect(decideDispatch(smee("github.pr.opened"), gateWith({ ready: true, reason: "producer-ready" })).suppress).toBe(true);
+  });
+
+  test("⛔ stale ready file → smee keeps authority, and the capture record says why", () => {
+    const v = decideDispatch(smee("github.pr.opened"), gateWith({ ready: false, reason: "ready-file-stale:95s" }));
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("enforce-not-armed:ready-file-stale:95s");
+  });
+
+  test("⛔ ready producer still does NOT suppress an uncovered name", () => {
+    // The whole-system statement of the per-name rule: a healthy producer cannot
+    // earn the right to suppress the merge→deploy join key.
+    const v = decideDispatch(smee("github.pr.merged"), gateWith({ ready: true, reason: "producer-ready" }));
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toContain("CTC-691");
+  });
+});
+
+describe("the capture path is per account and is not the event log", () => {
+  test("account appears in the path", () => {
+    expect(defaultGithubCapturePath("/orch", "tenant-0")).toContain("tenant-0");
+    expect(defaultGithubCapturePath("/orch", "tenant-0")).toContain("github-suppressed");
+  });
+
+  test("⛔ construction refuses an event-log-shaped capture path", () => {
+    // Inherited from createCaptureSink's structural refusal: if the capture file were
+    // the event log, every suppressed event would be re-appended as a real one.
+    expect(() =>
+      createGithubFeedGate({
+        orchDir: tmp,
+        config: { mode: "enforce", intervalSec: 30 },
+        capturePath: join(tmp, "events", "2026-08.jsonl"),
+      }),
+    ).toThrow();
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-gate-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-wiring.test.mjs
@@ -1,0 +1,76 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-gate-wiring.test.mjs
+//
+// ⚠️ SOURCE-LEVEL, AND THAT IS A COMPROMISE WORTH NAMING. The two properties below
+// are ORDERING invariants in the broker process, and both files' comments call them
+// load-bearing. Importing `broker/tailer.mjs` here to assert them behaviourally
+// pulls in `broker/config.mjs`, whose pino import is unresolvable in this checkout
+// (execution-core/config.mjs carries a console shim; the broker's does not), so
+// `bun test` cannot load it at all — a gap that predates this change and fails
+// identically on an unmodified main.
+//
+// A structural assertion is weaker than a behavioural one: it proves the call sites
+// are ordered as written, not that the ordering has the effect claimed. It is here
+// because the alternative was asserting nothing about the wiring, and an ordering
+// bug in either file is silent — a gate armed after the tail routes real events
+// through the window it was supposed to close.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const brokerDir = join(import.meta.dir, "..", "broker");
+
+/**
+ * ⛔ COMMENTS ARE STRIPPED BEFORE MATCHING, and this is not tidiness.
+ *
+ * My first version searched the raw source and the ordering assertion FAILED on
+ * correctly-ordered code: `index.mjs:432` mentions "startTailing() below" inside a
+ * comment 100 lines above the real call, so `indexOf` found the prose. A structural
+ * test that reads comments is measuring the documentation, not the program — the
+ * same class of false reading as counting event names with `grep` over payloads that
+ * quote them (CTL-50).
+ *
+ * Block comments are stripped too, since both files use them heavily.
+ */
+const read = (f) =>
+  readFileSync(join(brokerDir, f), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .map((l) => l.replace(/\/\/.*$/, ""))
+    .join("\n");
+
+describe("⛔ the gate decides BEFORE the router runs", () => {
+  const tailer = read("tailer.mjs");
+
+  test("the suppression block precedes every processEvent call", () => {
+    const gate = tailer.indexOf("decideGithubDispatch(event");
+    expect(gate).toBeGreaterThan(-1);
+    const firstRoute = tailer.indexOf("processEvent(event)");
+    expect(firstRoute).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(firstRoute);
+  });
+
+  test("⚠️ and before the route-timing block, so the two instruments agree", () => {
+    // A suppressed event that still appeared in the slow-route histogram would make
+    // the timing counter and the capture file disagree about what the broker did.
+    expect(tailer.indexOf("decideGithubDispatch(event")).toBeLessThan(tailer.indexOf("BROKER_ROUTE_TIMING) {"));
+  });
+
+  test("a suppressed event is CAPTURED, never dropped", () => {
+    const block = tailer.slice(tailer.indexOf("decideGithubDispatch(event"));
+    const head = block.slice(0, block.indexOf("continue;"));
+    expect(head).toContain("capture?.append(event, verdict)");
+  });
+});
+
+describe("⛔ the gate is installed BEFORE the tail starts", () => {
+  const index = read("index.mjs");
+
+  test("initGithubFeedGate precedes startTailing", () => {
+    const init = index.indexOf("initGithubFeedGate()");
+    const start = index.indexOf("startTailing()");
+    expect(init).toBeGreaterThan(-1);
+    expect(start).toBeGreaterThan(-1);
+    expect(init).toBeLessThan(start);
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-gate.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.mjs
@@ -1,0 +1,293 @@
+// github-feed-gate.mjs — CTL-1929, the one place that decides WHICH producer's
+// `github.*` events are allowed to drive dispatch.
+//
+// The peer of `cloud-feed-gate.mjs`, and it inherits that file's whole argument:
+// both producers keep writing into the same unified log, the gate picks a winner
+// per event, and the loser is CAPTURED rather than dropped so parity stays
+// answerable during the cutover itself. Rollback is a flag flip.
+//
+// ⛔ IT IS NOT A COPY, AND THE TWO DIFFERENCES ARE BOTH SAFETY PROPERTIES.
+//
+// ── DIFFERENCE 1: SUPPRESSION IS PER NAME, NOT PER STREAM ──────────────────
+// The Linear gate may suppress its whole dispatch class, because the Linear
+// producer covers all three names. This producer covers 10 of 12 consumed names
+// and CANNOT emit the other two (`github.pr.merged` — no `merge_commit_sha`,
+// CTC-691; `github.check_suite.completed` — the mirror stores no suite row,
+// CTC-667 item 4). Suppressing smee for a name with no replacement is not a
+// degraded cutover, it is a total loss of that signal: the CI wait and the whole
+// merge→deploy chain, fleet-wide, with no second copy because enforce suppressed it.
+//
+// So `enforce` here suppresses smee ONLY for names this producer can faithfully
+// replace, and the exclusion set is derived from the producer's OWN declarations
+// (`GITHUB_UNCOVERED_NAMES`, `PUSH_IS_LOSSY`) rather than re-typed here. A gate
+// with a second, hand-maintained coverage list is a gate that goes stale silently
+// the first time coverage changes — and the change that closes these gaps is a
+// schema bump landing in another repo, which is exactly the kind of change nobody
+// remembers to mirror into a constant.
+//
+// ⭐ This is the Linear gate's own rule applied one level finer. That file already
+// says it twice — `INTERNAL_SOURCES` ("suppression is only ever legitimate when a
+// replacement exists") and `enforce-not-armed`. Both apply it to the STREAM. Here
+// the replacement exists for some names and not others, so the rule has to bind to
+// the NAME or it does not bind at all.
+//
+// ── DIFFERENCE 2: READINESS CROSSES A PROCESS BOUNDARY ─────────────────────
+// The Linear gate's `isReady` is a closure over the producer's timer, valid because
+// producer and consumer share `daemon.mjs`. The `github.*` consumer is
+// `broker/tailer.mjs` → `broker/router.mjs`, a SEPARATE PROCESS. See
+// `github-feed-ready.mjs` for why a naive port fails silently in the direction that
+// looks fine.
+//
+// Pure: no I/O, no clock, no env. Every dependency is an argument.
+
+import { getEventName } from "../lib/event-name.mjs";
+import {
+  GITHUB_DISPATCH_CLASS_NAMES,
+  GITHUB_UNCOVERED_NAMES,
+  SOURCE_CLOUD_FEED,
+} from "./github-feed-event.mjs";
+import { PUSH_IS_LOSSY } from "./github-feed-source.mjs";
+
+/** The three modes, house convention. */
+export const GITHUB_FEED_MODES = Object.freeze(new Set(["off", "shadow", "enforce"]));
+
+/**
+ * ⛔ `github.push` EMITS BUT MUST NOT SUPPRESS — and the reason corrects a claim
+ * this feature shipped in two of its own files.
+ *
+ * `github-feed-source.mjs`'s header says the `(repo_id, ref)` collapse is
+ * "survivable" because "the consumer is rebase detection (CTL-381), which asks 'did
+ * this ref move', not 'how many times'". `packages/schema/src/mirror.ts`'s comment
+ * on `pushes` makes the same argument. Measured against the consumer, both are wrong:
+ *
+ *   * `broker/router.mjs:1582` reads `scope.ref` and NOTHING else on `github.push`.
+ *     It never reads `before`/`after` and never compares against a stored head, so
+ *     it is not asking "did the ref move" — it has no memory to ask that with.
+ *   * It sets no `wakeStateKey` (only `check_run`/`check_suite` do, `router.mjs:1510`),
+ *     so `suppress_identical_wakes` (`router.mjs:2857`) never applies to push. Every
+ *     ARRIVING push edge is a distinct wake, deliberately.
+ *
+ * So what the consumer consumes is the ARRIVAL, not the column's value, and a
+ * last-state projection cannot carry an arrival. Under shadow that is a parity gap
+ * (101 of 138 unmatched smee events, CTL-48). Under enforce with smee suppressed it
+ * is a wake that never happens and no second copy to recover it from — a worker
+ * waiting on a base-branch move parks until its timeout.
+ *
+ * CTC-704 keys `pushes` per delivery. When it lands, `PUSH_IS_LOSSY` goes false in
+ * the source and this set empties itself — no edit here.
+ */
+export function githubLossyNames(pushIsLossy = PUSH_IS_LOSSY) {
+  return Object.freeze(pushIsLossy ? ["github.push"] : []);
+}
+
+export const GITHUB_LOSSY_NAMES = githubLossyNames();
+
+/**
+ * Names `enforce` may suppress smee for: the dispatch class, minus everything this
+ * producer cannot faithfully replace.
+ *
+ * ⭐ COMPUTED, NEVER LITERAL. Every input is the producer's own export, so coverage
+ * and suppression cannot drift apart — the failure mode a hand-written list has is
+ * that it keeps suppressing a name after that name stops being covered, and nothing
+ * reads differently until the signal is already gone.
+ */
+/**
+ * computeSuppressible — the derivation, as a pure function of its three inputs.
+ *
+ * ⚠️ EXTRACTED SO THE DERIVATION IS OBSERVABLE. Applied to today's real constants
+ * it returns the same list a hand-written literal would, so a test that only
+ * compares the exported constant against `["github.push"]` passes whether the set
+ * is derived or typed — it asserts a tautology and would keep passing after CTC-704
+ * lands and the set is supposed to EMPTY itself. Taking the inputs as arguments is
+ * what lets a test drive the post-CTC-704 world today.
+ */
+export function computeSuppressible({ consumed, uncovered, lossy }) {
+  const excluded = new Set([...uncovered, ...lossy]);
+  return Object.freeze(consumed.filter((n) => !excluded.has(n)));
+}
+
+/**
+ * ⛔ THE GATE'S UNIVERSE IS WHAT THE ROUTER CONSUMES, NOT WHAT THE PRODUCER EMITS.
+ *
+ * `GITHUB_DISPATCH_CLASS_NAMES` is the producer's export and means "names I emit"
+ * — it deliberately excludes `github.pr.merged` and `github.check_suite.completed`,
+ * which is why they live in `GITHUB_UNCOVERED_NAMES`. But the ROUTER acts on both:
+ * `router.mjs:1497` (check_suite → the CI wait), `:1513` (pr.merged →
+ * `setFilterStateMerged`, the merge→deploy join key), plus `:1856`, `:1871`, `:1941`.
+ *
+ * ⚠️ Taking the producer's list as the universe made this gate answer
+ * `not-dispatch-class` for `github.pr.merged` — "the gate has no opinion" about the
+ * single most dangerous name in this feature. That happens to be SAFE today, since
+ * both readings end in `suppress: false`. It is safe by accident, and an accident
+ * is not a property: the capture record would have said the gate never looked,
+ * rather than that it looked and refused, and the difference is the whole audit
+ * trail during a cutover. Caught by running the decision table, not by reading it.
+ */
+export const GITHUB_CONSUMED_NAMES = Object.freeze([
+  ...GITHUB_DISPATCH_CLASS_NAMES,
+  ...GITHUB_UNCOVERED_NAMES,
+]);
+
+export const GITHUB_SUPPRESSIBLE_NAMES = computeSuppressible({
+  consumed: GITHUB_CONSUMED_NAMES,
+  uncovered: GITHUB_UNCOVERED_NAMES,
+  lossy: GITHUB_LOSSY_NAMES,
+});
+
+const DISPATCH_CLASS_SET = new Set(GITHUB_CONSUMED_NAMES);
+const SUPPRESSIBLE_SET = new Set(GITHUB_SUPPRESSIBLE_NAMES);
+
+/**
+ * Why a dispatch-class name is excluded, for the capture record.
+ *
+ * An excluded name is the normal, expected state today, so the capture file must be
+ * able to say WHICH gap kept smee authoritative — otherwise "enforce is on and smee
+ * still dispatched" is indistinguishable from a broken gate.
+ */
+export const EXCLUSION_REASONS = Object.freeze({
+  "github.pr.merged": "no-replacement:no-merge-commit-sha:CTC-691",
+  "github.check_suite.completed": "no-replacement:no-suite-row:CTC-667-item-4",
+  "github.push": "lossy-replacement:pushes-keyed-per-ref:CTC-704",
+});
+
+export const SOURCE_WEBHOOK = "webhook";
+export const SOURCE_OTHER = "other";
+
+/** Does this event reach one of the broker router's `github.*` branches? */
+export function isGithubDispatchClass(event) {
+  return DISPATCH_CLASS_SET.has(getEventName(event));
+}
+
+/**
+ * sourceOf — which producer wrote this event.
+ *
+ * Same asymmetry as the Linear gate, for the same reason: the feed's answer is
+ * POSITIVE (`body.payload.source === "cloud-feed"`, stamped by
+ * `github-feed-event.mjs`), everything else is identified by elimination and lands
+ * in `webhook`/`other`, both of which the enforce branch treats as smee. A third
+ * producer nobody has thought of must not inherit the feed's authority by default.
+ *
+ * ⚠️ There is no `INTERNAL_SOURCES` peer here, and that is a measured absence
+ * rather than an omission: the Linear leg needs one because `buildResumeEvent`
+ * synthesises a `linear.comment.created` that Linear never sees. Nothing on the
+ * GitHub side synthesises a `github.*` name — every one of them originates at a
+ * real GitHub delivery. If that ever stops being true, this is where it goes, and
+ * it goes ABOVE the mode branches.
+ */
+export function sourceOf(event) {
+  const src = event?.body?.payload?.source;
+  if (typeof src === "string" && src === SOURCE_CLOUD_FEED) return SOURCE_CLOUD_FEED;
+  const delivery = event?.attributes?.["webhook.delivery.id"];
+  if (typeof delivery === "string" && delivery !== "") return SOURCE_WEBHOOK;
+  return SOURCE_OTHER;
+}
+
+/**
+ * decideDispatch — the whole gate, as one pure function.
+ *
+ * @param {object} event  a parsed event-log line
+ * @param {object} opts
+ * @param {string} opts.mode  "off" | "shadow" | "enforce" (anything else degrades to "off")
+ * @param {function|boolean} [opts.isReady]  () => boolean — is the producer currently
+ *        arming? Consulted for the SMEE side ONLY; a feed event's authority is carried
+ *        by its own emission-time stamp (CTL-1901's asymmetry, inherited verbatim).
+ *        Omitted/absent ⇒ NOT ready, so a wiring mistake keeps smee authoritative.
+ * @returns {{suppress: boolean, reason: string, source: string, name: string}}
+ *
+ * `suppress: true` means "do not route this event; write it to the capture sink
+ * instead". It never means "discard".
+ */
+export function decideDispatch(event, { mode, isReady = null } = {}) {
+  const name = getEventName(event);
+  const source = sourceOf(event);
+
+  if (!DISPATCH_CLASS_SET.has(name)) {
+    return { suppress: false, reason: "not-dispatch-class", source, name };
+  }
+
+  // An unrecognised mode degrades to today's behaviour, not the new one — a typo in
+  // a daemon env var must not cut a host over to an unproven dispatch source.
+  const m = GITHUB_FEED_MODES.has(mode) ? mode : "off";
+
+  if (m !== "enforce") {
+    if (source === SOURCE_CLOUD_FEED) {
+      // Defence in depth: in shadow the producer writes only to its own sink and to
+      // `github-feed.would-dispatch`, so a real `github.*` feed event reaching this
+      // log means a stale enforce-mode producer survived a rollback. It must not
+      // dispatch — that is the precise shape of a rollback that does not roll back.
+      return { suppress: true, reason: "feed-not-authoritative", source, name };
+    }
+    return { suppress: false, reason: "webhook-authoritative", source, name };
+  }
+
+  // ───────────────────────────── enforce ─────────────────────────────
+
+  if (source === SOURCE_CLOUD_FEED) {
+    // ⛔ A feed event for an EXCLUDED name must not dispatch either. The producer
+    // should never emit one — but if a future coverage change lets a name through
+    // here while this gate still excludes it, the result would be BOTH copies
+    // dispatching (smee is unsuppressed for excluded names by the branch below).
+    // Refusing on both sides makes the two halves of the exclusion agree by
+    // construction rather than by everyone remembering to change them together.
+    if (!SUPPRESSIBLE_SET.has(name)) {
+      return {
+        suppress: true,
+        reason: `feed-excluded:${EXCLUSION_REASONS[name] ?? "unknown"}`,
+        source,
+        name,
+      };
+    }
+    // Absent stamp ⇒ NOT authoritative. Every feed event written by this code path
+    // carries one; a line without it predates the stamp or came from somewhere
+    // else, and neither is something to dispatch on.
+    if (event?.body?.payload?.feedAuthority !== true) {
+      return { suppress: true, reason: "feed-emitted-while-unarmed", source, name };
+    }
+    return { suppress: false, reason: "feed-authoritative", source, name };
+  }
+
+  // ── smee (and any unknown producer) ──
+
+  // ⛔ CHECKED BEFORE READINESS, and the order matters. A name with no replacement
+  // is unsuppressible no matter how healthy the producer is, so asking "is the
+  // producer ready" first would imply that a ready producer could earn the right to
+  // suppress `github.pr.merged` — which is the single worst outcome this feature
+  // has (the merge→deploy chain, fleet-wide, with no second copy).
+  if (!SUPPRESSIBLE_SET.has(name)) {
+    return {
+      suppress: false,
+      reason: EXCLUSION_REASONS[name] ?? "no-replacement:unknown",
+      source,
+      name,
+    };
+  }
+
+  // The readiness lever, inherited from the Linear gate: enforce does not suppress
+  // smee until the producer can actually produce. Absent probe ⇒ not ready.
+  let ready = false;
+  let reason = "enforce-not-armed";
+  try {
+    if (typeof isReady === "function") {
+      const verdict = isReady();
+      // Accepts a bare boolean or a `{ ready, reason }` verdict — the cross-process
+      // reader returns the latter so a capture record can say WHY smee kept authority.
+      if (typeof verdict === "boolean") ready = verdict;
+      else if (verdict && typeof verdict === "object") {
+        ready = verdict.ready === true;
+        if (typeof verdict.reason === "string" && verdict.reason !== "") {
+          reason = `enforce-not-armed:${verdict.reason}`;
+        }
+      }
+    } else if (isReady === true) {
+      ready = true;
+    }
+  } catch {
+    ready = false; // a throwing probe is not a ready producer
+    reason = "enforce-not-armed:probe-threw";
+  }
+  if (!ready) {
+    return { suppress: false, reason, source, name };
+  }
+
+  return { suppress: true, reason: "smee-captured", source, name };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
@@ -1,0 +1,256 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-gate.test.mjs
+
+import { describe, expect, test } from "bun:test";
+import {
+  EXCLUSION_REASONS,
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_LOSSY_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+  computeSuppressible,
+  decideDispatch,
+  githubLossyNames,
+  isGithubDispatchClass,
+  sourceOf,
+} from "./github-feed-gate.mjs";
+import {
+  GITHUB_DISPATCH_CLASS_NAMES,
+  GITHUB_UNCOVERED_NAMES,
+  SOURCE_CLOUD_FEED,
+} from "./github-feed-event.mjs";
+import { PUSH_IS_LOSSY } from "./github-feed-source.mjs";
+
+const ev = (name, { attrs = {}, payload = {} } = {}) => ({
+  attributes: { "event.name": name, ...attrs },
+  body: { payload },
+});
+const smee = (name) => ev(name, { attrs: { "webhook.delivery.id": "delivery-1" } });
+const feed = (name, { authority = true } = {}) =>
+  ev(name, { payload: { source: SOURCE_CLOUD_FEED, ...(authority ? { feedAuthority: true } : {}) } });
+
+describe("⛔ the gate's universe is what the ROUTER consumes, not what the producer emits", () => {
+  test("both uncovered names are IN the universe — they are the two most dangerous names here", () => {
+    // router.mjs:1497 (check_suite → CI wait) and :1513 (pr.merged →
+    // setFilterStateMerged, the merge→deploy join key) both act on these.
+    // Taking the producer's emit-list as the universe answered "not-dispatch-class"
+    // for pr.merged — safe by accident, and it would have recorded that the gate
+    // never looked rather than that it looked and refused.
+    for (const name of GITHUB_UNCOVERED_NAMES) {
+      expect(GITHUB_CONSUMED_NAMES).toContain(name);
+      expect(isGithubDispatchClass(smee(name))).toBe(true);
+    }
+  });
+
+  test("a github.* name the router does NOT consume gets no opinion", () => {
+    const v = decideDispatch(smee("github.issues.opened"), { mode: "enforce", isReady: () => true });
+    expect(v.reason).toBe("not-dispatch-class");
+    expect(v.suppress).toBe(false);
+  });
+});
+
+describe("⛔ suppression is per NAME, and the excluded set is COMPUTED from the producer's own declarations", () => {
+  test("the suppressible set is exactly the consumed names minus uncovered minus lossy", () => {
+    const excluded = new Set([...GITHUB_UNCOVERED_NAMES, ...GITHUB_LOSSY_NAMES]);
+    expect(GITHUB_SUPPRESSIBLE_NAMES).toEqual(GITHUB_CONSUMED_NAMES.filter((n) => !excluded.has(n)));
+    // The property that matters, stated independently of the arithmetic above:
+    // nothing the producer declared uncovered is suppressible.
+    for (const n of GITHUB_UNCOVERED_NAMES) expect(GITHUB_SUPPRESSIBLE_NAMES).not.toContain(n);
+  });
+
+  test("⚠️ the lossy set TRACKS PUSH_IS_LOSSY — driven in BOTH states, not asserted as a tautology", () => {
+    // ⛔ The obvious version of this test —
+    //      expect(GITHUB_LOSSY_NAMES).toEqual(PUSH_IS_LOSSY ? ["github.push"] : [])
+    //    — passes whether the set is derived or typed, because PUSH_IS_LOSSY is true
+    //    today and both branches evaluate to the same literal. It asserts nothing and
+    //    would still pass after CTC-704 lands, when the set is supposed to be empty.
+    expect(githubLossyNames(true)).toEqual(["github.push"]);
+    expect(githubLossyNames(false)).toEqual([]);
+    expect(GITHUB_LOSSY_NAMES).toEqual(githubLossyNames(PUSH_IS_LOSSY));
+  });
+
+  test("⭐ the post-CTC-704 world: when pushes is keyed per delivery, push becomes suppressible", () => {
+    // Drives the change that closes the gap, today, so landing CTC-704 is a flag
+    // flip in one file rather than a second trip through this gate's design.
+    const after = computeSuppressible({
+      consumed: GITHUB_CONSUMED_NAMES,
+      uncovered: GITHUB_UNCOVERED_NAMES,
+      lossy: githubLossyNames(false),
+    });
+    expect(after).toContain("github.push");
+    // and the two genuinely-uncovered names are STILL excluded — closing one gap
+    // must not silently open the other two.
+    for (const n of GITHUB_UNCOVERED_NAMES) expect(after).not.toContain(n);
+  });
+
+  test("⭐ the post-CTC-691 world: emptying the uncovered list makes those names suppressible", () => {
+    const after = computeSuppressible({
+      consumed: GITHUB_CONSUMED_NAMES,
+      uncovered: [],
+      lossy: GITHUB_LOSSY_NAMES,
+    });
+    expect(after).toContain("github.pr.merged");
+    expect(after).toContain("github.check_suite.completed");
+    expect(after).not.toContain("github.push"); // still lossy until CTC-704
+  });
+
+  test("every excluded name carries a reason naming the ticket that closes it", () => {
+    for (const n of [...GITHUB_UNCOVERED_NAMES, ...GITHUB_LOSSY_NAMES]) {
+      expect(EXCLUSION_REASONS[n]).toMatch(/CTC-\d+/);
+    }
+  });
+});
+
+describe("⛔ enforce must NOT suppress smee for a name with no faithful replacement", () => {
+  // Precondition asserted before the outcome: a fully-armed, ready producer is the
+  // ONLY state in which this rule can be observed to bind. Asserting the outcome
+  // under a not-ready producer would pass with the rule deleted.
+  const armed = { mode: "enforce", isReady: () => true };
+
+  test("a suppressible name IS suppressed when armed — the control that proves the rest is not vacuous", () => {
+    const v = decideDispatch(smee("github.pr.opened"), armed);
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("smee-captured");
+  });
+
+  test("github.pr.merged survives — no merge_commit_sha (CTC-691)", () => {
+    const v = decideDispatch(smee("github.pr.merged"), armed);
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("no-replacement:no-merge-commit-sha:CTC-691");
+  });
+
+  test("github.check_suite.completed survives — no suite row (CTC-667 item 4)", () => {
+    const v = decideDispatch(smee("github.check_suite.completed"), armed);
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("no-replacement:no-suite-row:CTC-667-item-4");
+  });
+
+  test("⛔ github.push survives — the collapse loses an ARRIVAL, not a value (CTC-704)", () => {
+    // router.mjs:1582 reads scope.ref and nothing else, and sets no wakeStateKey, so
+    // every arriving push is its own wake. Suppressing smee here under enforce is a
+    // wake that never happens with no second copy to recover it from.
+    const v = decideDispatch(smee("github.push"), armed);
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("lossy-replacement:pushes-keyed-per-ref:CTC-704");
+  });
+
+  test("⚠️ an excluded name reports ITS OWN reason even while the producer is un-armed", () => {
+    // ⛔ WHAT THIS OWNS, precisely — and my first version of it asserted the wrong
+    //    thing. I wrote it as an order control ("readiness first would let a ready
+    //    producer suppress pr.merged") and the mutation DID NOT FIRE: moving the
+    //    no-replacement block below the readiness check still returns suppress:false
+    //    for pr.merged, because the block simply runs later and catches it anyway.
+    //    The suppress bit is invariant under that reordering. The test passed with
+    //    the rule it was named for deleted.
+    //
+    //    The order buys DIAGNOSIS, not safety, and that is worth a control of its
+    //    own: an operator reading the capture file mid-cutover has to tell
+    //    "smee kept authority because the producer is stalled" (transient, chase it)
+    //    from "because this name has no replacement" (permanent until CTC-691 lands).
+    //    Under the wrong order every excluded name reports `enforce-not-armed`
+    //    whenever the producer happens to be un-armed, and the two collapse.
+    const v = decideDispatch(smee("github.pr.merged"), { mode: "enforce", isReady: () => false });
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("no-replacement:no-merge-commit-sha:CTC-691");
+    expect(v.reason).not.toMatch(/^enforce-not-armed/);
+  });
+});
+
+describe("the readiness lever — enforce hands authority back to smee whenever the producer cannot produce", () => {
+  const cases = [
+    ["absent probe", undefined, "enforce-not-armed"],
+    ["null probe", null, "enforce-not-armed"],
+    ["boolean false", false, "enforce-not-armed"],
+    ["probe returns false", () => false, "enforce-not-armed"],
+    ["probe throws", () => { throw new Error("boom"); }, "enforce-not-armed:probe-threw"],
+    [
+      "verdict object carries WHY into the capture record",
+      () => ({ ready: false, reason: "ready-file-stale:95s" }),
+      "enforce-not-armed:ready-file-stale:95s",
+    ],
+  ];
+  for (const [label, isReady, reason] of cases) {
+    test(`smee stays authoritative — ${label}`, () => {
+      const v = decideDispatch(smee("github.pr.opened"), { mode: "enforce", isReady });
+      expect(v.suppress).toBe(false);
+      expect(v.reason).toBe(reason);
+    });
+  }
+
+  test("a verdict object with ready:true arms", () => {
+    const v = decideDispatch(smee("github.pr.opened"), { mode: "enforce", isReady: () => ({ ready: true }) });
+    expect(v.suppress).toBe(true);
+  });
+});
+
+describe("the feed side is decided by its OWN stamp (CTL-1901's asymmetry), never by readiness", () => {
+  test("a stamped feed event dispatches even while the probe says NOT ready", () => {
+    // The whole point of the asymmetry: a later readiness change must not retroactively
+    // revoke authority from a line already on disk, or the edge reaches neither path.
+    const v = decideDispatch(feed("github.pr.opened"), { mode: "enforce", isReady: () => false });
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toBe("feed-authoritative");
+  });
+
+  test("an UNSTAMPED feed event does not dispatch", () => {
+    const v = decideDispatch(feed("github.pr.opened", { authority: false }), { mode: "enforce", isReady: () => true });
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("feed-emitted-while-unarmed");
+  });
+
+  test("⛔ a feed event for an EXCLUDED name is refused on the feed side too", () => {
+    // Both halves of the exclusion must agree by construction. If the feed side
+    // allowed it while the smee side (correctly) declines to suppress, BOTH copies
+    // dispatch — the double-dispatch the gate exists to prevent.
+    const v = decideDispatch(feed("github.pr.merged"), { mode: "enforce", isReady: () => true });
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("feed-excluded:no-replacement:no-merge-commit-sha:CTC-691");
+  });
+});
+
+describe("modes below enforce leave routing byte-identical to pre-CTL-1929", () => {
+  for (const mode of ["off", "shadow", undefined, "ENFORCE", "enfroce"]) {
+    test(`mode ${JSON.stringify(mode)}: smee dispatches every consumed name`, () => {
+      for (const name of GITHUB_CONSUMED_NAMES) {
+        const v = decideDispatch(smee(name), { mode, isReady: () => true });
+        expect(v.suppress).toBe(false);
+        expect(v.reason).toBe("webhook-authoritative");
+      }
+    });
+  }
+
+  test("⚠️ a real github.* feed event in shadow is refused — a rollback that does not roll back", () => {
+    // In shadow the producer emits only `github-feed.would-dispatch`. A real name
+    // reaching this log means a stale enforce-mode producer survived the flip back.
+    const v = decideDispatch(feed("github.pr.opened"), { mode: "shadow", isReady: () => true });
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("feed-not-authoritative");
+  });
+});
+
+describe("sourceOf identifies the feed POSITIVELY and everything else by elimination", () => {
+  test("the feed's stamp wins", () => {
+    expect(sourceOf(feed("github.pr.opened"))).toBe(SOURCE_CLOUD_FEED);
+  });
+  test("a webhook delivery id reads as webhook", () => {
+    expect(sourceOf(smee("github.pr.opened"))).toBe("webhook");
+  });
+  test("⛔ an unknown producer lands in `other` and is treated as smee, never as the feed", () => {
+    const mystery = ev("github.pr.opened", { payload: { source: "some-new-thing" } });
+    expect(sourceOf(mystery)).toBe("other");
+    // and it must not inherit the feed's authority
+    const v = decideDispatch(mystery, { mode: "enforce", isReady: () => true });
+    expect(v.reason).toBe("smee-captured");
+  });
+  test("an empty-string delivery id is not a webhook", () => {
+    expect(sourceOf(ev("github.pr.opened", { attrs: { "webhook.delivery.id": "" } }))).toBe("other");
+  });
+});
+
+describe("the producer's own emit-list stays the source of truth for coverage", () => {
+  test("every name the producer emits is either suppressible or explicitly lossy", () => {
+    for (const n of GITHUB_DISPATCH_CLASS_NAMES) {
+      const suppressible = GITHUB_SUPPRESSIBLE_NAMES.includes(n);
+      const lossy = GITHUB_LOSSY_NAMES.includes(n);
+      expect(suppressible || lossy).toBe(true);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-ready.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-ready.mjs
@@ -1,0 +1,131 @@
+// github-feed-ready.mjs — CTL-1929. A readiness signal that crosses a PROCESS
+// BOUNDARY, because the GitHub leg's producer and its consumer are not in the
+// same process and the Linear leg's readiness mechanism therefore does not port.
+//
+// ── ⛔ WHY THIS FILE EXISTS AT ALL ──────────────────────────────────────────
+// On the Linear leg, `setCloudFeedGate` receives `isReady` as a CLOSURE over the
+// producer's timer handle (`daemon.mjs:1470`) — legitimate there, because the
+// producer (`cloud-feed-timer`) and the consumer (`monitor.mjs`'s tail) both run
+// inside `execution-core/daemon.mjs`. One process, one heap, one live answer.
+//
+// The GitHub leg is NOT shaped like that. Its producer runs in the daemon, but the
+// consumer that acts on `github.*` is `broker/tailer.mjs` → `broker/router.mjs`,
+// which is a SEPARATE PROCESS (`broker/index.mjs` is its own entry point). A closure
+// cannot span it.
+//
+// ⚠️ AND THE NAIVE MIRROR FAILS SILENTLY IN THE DIRECTION THAT LOOKS FINE. Copying
+// the Linear wiring gives the broker `isReady: null`, and `decideDispatch`'s
+// "absent probe ⇒ NOT ready" rule then makes smee authoritative for every event,
+// forever. No double-dispatch, no error, no alarm — the host logs `mode: enforce`
+// and behaves exactly like shadow. The flip would be a LIE, and the way anyone
+// would discover it is by eventually retiring the tunnel and losing dispatch.
+// A safe fail direction is not the same as a correct one.
+//
+// ── THE SHAPE ──────────────────────────────────────────────────────────────
+// The producer WRITES a small file after each tick with the tick's own verdict;
+// the consumer READS it and applies a staleness bound. Readiness is therefore
+// "the producer said it was ready, recently enough that the statement is still
+// about now" — which is the honest cross-process version of the same question.
+//
+// ⛔ STALENESS IS NOT OPTIONAL AND IS NOT A DETAIL. A file is a LATCH: if the
+// daemon dies mid-enforce, the last thing it wrote was `ready: true`, and without a
+// bound the broker would keep suppressing smee on the authority of a process that
+// no longer exists — the exact failure the readiness lever is for, made permanent
+// by the mechanism meant to prevent it. The bound converts the latch back into a
+// heartbeat.
+//
+// The window is derived from the tick interval rather than fixed: a host running a
+// 30 s tick and a host running a 120 s tick do not share a sensible constant, and a
+// hard-coded one would either flap on the slow host or latch on the fast one.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * How many missed ticks it takes to call the producer stale.
+ *
+ * 3, not 1: a single late tick is ordinary (the sweep shares the daemon's event
+ * loop, and CTL-1524 is the precedent for a tick that blocks it), and un-arming on
+ * one of those would hand dispatch back to smee for a host that is working fine —
+ * which is safe but flappy, and flapping across an authority boundary is what
+ * CTL-1901 had to correct on the Linear leg. 3 is long enough that a real stall is
+ * still caught inside two minutes at the default interval.
+ */
+export const STALE_TICKS = 3;
+
+/** Absolute floor on the window, for a pathologically small configured interval. */
+export const MIN_STALE_MS = 30_000;
+
+export function defaultReadyPath(orchDir, account) {
+  return join(orchDir, "shadow", `github-feed-ready-${account}.json`);
+}
+
+/**
+ * The staleness window for a given tick interval.
+ *
+ * Exported so the producer and the consumer cannot disagree about it — the one
+ * genuinely dangerous bug in a heartbeat is a writer and a reader with different
+ * ideas of "recent", which yields either permanent staleness or a latch.
+ */
+export function staleWindowMs(intervalSec) {
+  const sec = Number(intervalSec);
+  const base = Number.isFinite(sec) && sec >= 5 ? sec : 30;
+  return Math.max(MIN_STALE_MS, base * 1000 * STALE_TICKS);
+}
+
+/**
+ * writeReadyState — called by the producer once per tick.
+ *
+ * Fail-open on write errors, deliberately: this file is EVIDENCE about the
+ * producer, and evidence must never be load-bearing for the thing it observes. A
+ * failed write simply ages out, which un-arms enforce — the safe direction.
+ */
+export function writeReadyState(path, state, { writeFn = writeFileSync, logger = null } = {}) {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFn(path, `${JSON.stringify(state)}\n`);
+    return true;
+  } catch (err) {
+    logger?.warn?.({ err: err?.message }, "github-feed: ready-state write failed");
+    return false;
+  }
+}
+
+/**
+ * readReadyState — the consumer side. Returns a VERDICT, never a bare boolean, so
+ * a suppressed event's capture record can say WHY smee kept authority.
+ *
+ * Every failure mode resolves to `ready: false` with a distinct reason: absent
+ * file (producer never ran / different account), unparseable, missing stamp,
+ * stale, or the producer's own `ready: false`.
+ */
+export function readReadyState(path, { now = Date.now(), intervalSec = 30, readFn = readFileSync } = {}) {
+  let raw;
+  try {
+    raw = readFn(path, "utf8");
+  } catch {
+    return { ready: false, reason: "ready-file-absent", state: null };
+  }
+  let state;
+  try {
+    state = JSON.parse(raw);
+  } catch {
+    return { ready: false, reason: "ready-file-unparseable", state: null };
+  }
+  const at = Number(state?.at);
+  if (!Number.isFinite(at)) {
+    return { ready: false, reason: "ready-file-unstamped", state };
+  }
+  const age = now - at;
+  const window = staleWindowMs(intervalSec);
+  // ⚠️ A stamp from the FUTURE is treated as stale, not as fresh. Clock skew or a
+  // hand-edited file must not be able to grant indefinite authority — the one
+  // direction where "trust the stamp" has no safe reading.
+  if (age > window || age < -window) {
+    return { ready: false, reason: `ready-file-stale:${Math.round(age / 1000)}s`, state };
+  }
+  if (state?.ready !== true) {
+    return { ready: false, reason: `producer-unready:${state?.unready ?? "unknown"}`, state };
+  }
+  return { ready: true, reason: "producer-ready", state };
+}

--- a/plugins/dev/scripts/execution-core/github-feed-ready.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-ready.test.mjs
@@ -1,0 +1,135 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-ready.test.mjs
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MIN_STALE_MS,
+  STALE_TICKS,
+  defaultReadyPath,
+  readReadyState,
+  staleWindowMs,
+  writeReadyState,
+} from "./github-feed-ready.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-feed-ready-"));
+afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
+
+const NOW = 1_700_000_000_000;
+const p = (name) => join(tmp, name);
+
+describe("⛔ the staleness bound is what stops a FILE from becoming a latch", () => {
+  test("a fresh ready stamp arms", () => {
+    const f = p("fresh.json");
+    writeReadyState(f, { ready: true, at: NOW });
+    expect(readReadyState(f, { now: NOW + 1000, intervalSec: 30 })).toMatchObject({ ready: true, reason: "producer-ready" });
+  });
+
+  test("⛔ a stamp older than the window does NOT arm — the daemon-died case", () => {
+    // Without this, the last thing a dying daemon wrote was `ready: true`, and the
+    // broker would keep suppressing smee on the authority of a process that no
+    // longer exists: the exact failure the readiness lever exists to prevent, made
+    // permanent by the mechanism meant to prevent it.
+    const f = p("stale.json");
+    writeReadyState(f, { ready: true, at: NOW });
+    const v = readReadyState(f, { now: NOW + staleWindowMs(30) + 1, intervalSec: 30 });
+    expect(v.ready).toBe(false);
+    expect(v.reason).toMatch(/^ready-file-stale:/);
+  });
+
+  test("⚠️ a stamp from the FUTURE is stale, not fresh — clock skew must not grant authority", () => {
+    const f = p("future.json");
+    writeReadyState(f, { ready: true, at: NOW + staleWindowMs(30) + 60_000 });
+    const v = readReadyState(f, { now: NOW, intervalSec: 30 });
+    expect(v.ready).toBe(false);
+    expect(v.reason).toMatch(/^ready-file-stale:/);
+  });
+
+  test("the window scales with the configured interval, and never below the floor", () => {
+    expect(staleWindowMs(30)).toBe(30 * 1000 * STALE_TICKS);
+    expect(staleWindowMs(120)).toBe(120 * 1000 * STALE_TICKS);
+    // An interval below 5 is not a slow host, it is an invalid config — the same
+    // reading config.mjs's own knob takes (`>= 5 ? parsed : 30`). It falls back to
+    // the default rather than to the floor, so the two readers cannot disagree.
+    expect(staleWindowMs(1)).toBe(30 * 1000 * STALE_TICKS);
+    expect(staleWindowMs(undefined)).toBe(30 * 1000 * STALE_TICKS);
+    expect(staleWindowMs("nonsense")).toBe(30 * 1000 * STALE_TICKS);
+    // The floor binds at the smallest VALID interval, where 3 ticks would otherwise
+    // be 15 s — short enough that one blocked tick (CTL-1524) reads as a dead producer.
+    expect(staleWindowMs(5)).toBe(MIN_STALE_MS);
+  });
+
+  test("⚠️ a host on a SLOW interval is not permanently stale — the writer/reader agree by construction", () => {
+    // The one genuinely dangerous bug in a heartbeat is a writer and a reader with
+    // different ideas of "recent". Both sides call staleWindowMs, so this drives the
+    // slow-host case that a hard-coded constant would break.
+    const f = p("slow.json");
+    writeReadyState(f, { ready: true, at: NOW });
+    expect(readReadyState(f, { now: NOW + 200_000, intervalSec: 120 }).ready).toBe(true);
+    // and the same age against the DEFAULT interval is stale
+    expect(readReadyState(f, { now: NOW + 200_000, intervalSec: 30 }).ready).toBe(false);
+  });
+});
+
+describe("every failure mode resolves to not-ready, with a reason the capture record can use", () => {
+  test("absent file", () => {
+    expect(readReadyState(p("nope.json"), { now: NOW })).toMatchObject({ ready: false, reason: "ready-file-absent" });
+  });
+
+  test("unparseable file", () => {
+    const f = p("bad.json");
+    writeFileSync(f, "{not json");
+    expect(readReadyState(f, { now: NOW })).toMatchObject({ ready: false, reason: "ready-file-unparseable" });
+  });
+
+  test("missing stamp", () => {
+    const f = p("unstamped.json");
+    writeFileSync(f, JSON.stringify({ ready: true }));
+    expect(readReadyState(f, { now: NOW })).toMatchObject({ ready: false, reason: "ready-file-unstamped" });
+  });
+
+  test("the producer's own not-ready verdict carries its reason through", () => {
+    const f = p("unready.json");
+    writeReadyState(f, { ready: false, at: NOW, unready: "feed-unhealthy" });
+    const v = readReadyState(f, { now: NOW + 1000, intervalSec: 30 });
+    expect(v.ready).toBe(false);
+    expect(v.reason).toBe("producer-unready:feed-unhealthy");
+  });
+
+  test("⛔ `ready` must be exactly true — a truthy value is not a verdict", () => {
+    const f = p("truthy.json");
+    writeFileSync(f, JSON.stringify({ ready: "yes", at: NOW }));
+    expect(readReadyState(f, { now: NOW + 1000, intervalSec: 30 }).ready).toBe(false);
+  });
+});
+
+describe("the writer fails OPEN — evidence must never be load-bearing for what it observes", () => {
+  test("a throwing write returns false rather than propagating", () => {
+    const thrower = () => { throw new Error("EROFS"); };
+    let warned = null;
+    const ok = writeReadyState(p("x.json"), { ready: true, at: NOW }, {
+      writeFn: thrower,
+      logger: { warn: (o) => { warned = o; } },
+    });
+    expect(ok).toBe(false);
+    expect(warned).not.toBeNull();
+  });
+
+  test("⚠️ and a failed write AGES OUT rather than latching — the safe direction", () => {
+    // The consequence of failing open on the write side: the previous stamp simply
+    // gets old, and the staleness bound un-arms enforce. This asserts the two
+    // behaviours COMPOSE, which neither test above does on its own.
+    const f = p("ages-out.json");
+    writeReadyState(f, { ready: true, at: NOW });
+    writeReadyState(f, { ready: true, at: NOW + 30_000 }, { writeFn: () => { throw new Error("EROFS"); } });
+    expect(readReadyState(f, { now: NOW + staleWindowMs(30) + 1, intervalSec: 30 }).ready).toBe(false);
+  });
+});
+
+describe("the path is per account, so two accounts cannot read each other's readiness", () => {
+  test("defaultReadyPath includes the account", () => {
+    expect(defaultReadyPath("/orch", "tenant-0")).toContain("tenant-0");
+    expect(defaultReadyPath("/orch", "tenant-0")).not.toBe(defaultReadyPath("/orch", "tenant-9"));
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.mjs
@@ -1,22 +1,27 @@
 // github-feed-timer.mjs — CTL-1929. The daemon-hosted tick for the GitHub leg.
 //
-// ── ⛔ `enforce` IS NOT REACHABLE YET, BY DESIGN ────────────────────────────
-// On the Linear leg, `enforce` means two things at once: the producer emits the
-// real event AND `cloud-feed-gate` suppresses smee's copy. Those halves are not
-// separable — emitting real `github.*` events while the tunnel is still delivering
-// its own would put BOTH on the log, and every consumer would route twice: two
-// `monitor-merge` wakes, two CI-wait resolutions, two `filter_state` transitions.
+// ── `enforce` IS REACHABLE, AND IT IS REACHABLE PER NAME ───────────────────
+// It was not, until `github-feed-gate.mjs` landed. The blocker was never the
+// producer: `enforce` means the producer emits the real event AND the gate
+// suppresses smee's copy, and those halves are not separable — emitting real
+// `github.*` names while the tunnel still delivers its own puts BOTH on the log and
+// every consumer routes twice.
 //
-// The gate is not wired for `github.*` (`DISPATCH_CLASS_NAMES` is three `linear.*`
-// names), and it MUST NOT be until `github.pr.merged` and
-// `github.check_suite.completed` exist — CTC-691 and CTC-667 item 4 — because
-// suppressing smee for names this producer cannot emit is a total loss of the CI
-// wait and the deploy chain.
+// ⛔ WHAT CHANGED IS THE GRANULARITY, NOT THE RULE. The earlier refusal was
+// all-or-nothing: because this producer cannot emit `github.pr.merged` (CTC-691) or
+// `github.check_suite.completed` (CTC-667 item 4), enforce was refused ENTIRELY, so
+// nine fully-covered names sat behind two uncovered ones. The gate now suppresses
+// smee per NAME, so the two gaps hold back only themselves.
 //
-// So `enforce` here DEGRADES TO SHADOW and says so, loudly, once per process. It
-// does not silently do nothing (an operator would read the flag as active), and it
-// does not half-activate (which is the double-dispatch above). A mode that cannot
-// be honoured is refused by name.
+// ⚠️ THIS FILE MUST THEREFORE EMIT REAL NAMES ONLY FOR WHAT THE GATE CAN SUPPRESS.
+// The two sides are the same invariant read from opposite ends — the producer
+// decides what to emit, the gate decides what to suppress, and if they disagree the
+// result is either a double dispatch (feed emits, gate does not suppress smee) or a
+// dropped edge (gate suppresses smee, feed declined to emit). Both sides read
+// `GITHUB_SUPPRESSIBLE_NAMES`, so they cannot disagree.
+//
+// An excluded name still goes out as a `would-dispatch` marker under enforce, so
+// the parity ledger keeps observing it and the gap stays measurable while it lasts.
 //
 // ── WHAT SHADOW EMITS, AND WHY IT IS A DIFFERENT NAME ──────────────────────
 // `github-feed.would-dispatch`, never the real `github.*` name. Re-emitting
@@ -37,6 +42,11 @@ import { createSeenStore, defaultSeenPath } from "./github-feed-seen.mjs";
 import { githubSweepUnreadyReason, runGithubSweep } from "./github-feed-sweep.mjs";
 import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
 import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+} from "./github-feed-gate.mjs";
+import { defaultReadyPath, writeReadyState } from "./github-feed-ready.mjs";
 
 /**
  * Which account this host is.
@@ -57,6 +67,12 @@ export function resolveAccount(envObj = process.env) {
 
 /** The shadow-only marker name. Deliberately NOT a `github.*` name — see the header. */
 export const EVENT_WOULD_DISPATCH = "github-feed.would-dispatch";
+
+/**
+ * The names this producer may emit under their REAL name. Derived from the gate's
+ * export, never re-typed — see the header's "same invariant from opposite ends".
+ */
+const SUPPRESSIBLE_SET = new Set(GITHUB_SUPPRESSIBLE_NAMES);
 
 export function defaultShadowPath(orchDir, account = resolveAccount()) {
   return join(orchDir, "shadow", `github-feed-${account}.jsonl`);
@@ -84,16 +100,28 @@ export function assertNotEventLog(path) {
  * the point: a caller must be able to log what the operator asked for AND what is
  * running, or a degraded node is indistinguishable from a configured one.
  */
-export function resolveEffectiveMode(requested) {
+export function resolveEffectiveMode(
+  requested,
+  // ⚠️ INJECTABLE SO THE DERIVATION IS OBSERVABLE. With the real constants baked
+  // in, a hand-written "9 of 12" in the reason string is indistinguishable from the
+  // computed one — the test that claims to own that mutation passes with it applied,
+  // and would keep passing after a gap closes and the true number becomes 10. That
+  // sentence is what an operator reads to decide the tunnel can retire.
+  { suppressible = GITHUB_SUPPRESSIBLE_NAMES, consumed = GITHUB_CONSUMED_NAMES } = {},
+) {
   if (requested === "enforce") {
+    // ⚠️ NOT degraded, but not unqualified either — the reason is retained and now
+    // states the residual, because an operator who reads `mode: enforce` and infers
+    // "the tunnel can go" would be wrong until all three gaps close. A mode that is
+    // partially honoured has to say which part.
     return {
       requested,
-      effective: "shadow",
-      degraded: true,
+      effective: "enforce",
+      degraded: false,
       reason:
-        "enforce requires the dispatch gate to suppress the smee copy; the gate carries no github.* names " +
-        "(and must not until CTC-691 and CTC-667 item 4 land, or the CI wait and deploy chain lose their only source). " +
-        "Running as shadow.",
+        `enforce is authoritative for ${suppressible.length} of ${consumed.length} consumed names; ` +
+        `smee stays authoritative for ${consumed.length - suppressible.length} ` +
+        `(CTC-691, CTC-667 item 4, CTC-704) and the tunnel cannot retire until they close.`,
     };
   }
   return { requested, effective: requested, degraded: false, reason: null };
@@ -134,6 +162,10 @@ export function runGithubFeedTick({
   account = resolveAccount(),
   dbPath,
   now = Date.now(),
+  // Readiness as of the END of the PREVIOUS tick. Defaults false so a caller that
+  // forgets to thread it emits unstamped events, which the gate refuses — the
+  // non-dispatching half, same direction as every other absent probe here.
+  authorityAtEntry = false,
   appendEventFn,
   appendShadowFn,
   sourceFactory = createGithubFeedSource,
@@ -147,6 +179,12 @@ export function runGithubFeedTick({
   if (resolved.effective === "off") {
     return { skipped: "mode-off", mode: resolved, counts: null, ready: false };
   }
+
+  // Readiness AS THIS TICK BEGAN. Captured before the sweep runs, so every event
+  // this sweep emits is stamped with one value that cannot change underneath it —
+  // see the stamp comment in the sink. `authorityAtEntry` is recomputed at the end
+  // of the tick for the NEXT one; that is the value written to the ready file.
+  const authorityNow = () => authorityAtEntry;
 
   let source = null;
   let seen = null;
@@ -173,11 +211,45 @@ export function runGithubFeedTick({
       seen,
       sink: (event) => {
         emitted.push(event);
-        // The FULL envelope goes to the shadow file — that is the ledger's input.
+        // The FULL envelope goes to the shadow file — that is the ledger's input,
+        // in EVERY mode. An instrument that changes shape at the moment of cutover
+        // cannot judge the cutover.
         appendShadowFn?.(event);
-        // A marker, under its own name, goes to the event log so the tick is
-        // observable without the ledger.
-        if (appendEventFn) appendEventFn(buildWouldDispatchEvent(event, { account }, seams));
+        if (!appendEventFn) return;
+
+        const name = event?.attributes?.["event.name"];
+        // ⛔ REAL NAME ONLY FOR WHAT THE GATE CAN SUPPRESS. Read from the gate's own
+        // export so the producer and the gate cannot drift: emitting a real name the
+        // gate will not suppress double-dispatches that name, and declining a name
+        // the gate DOES suppress drops the edge entirely.
+        if (resolved.effective === "enforce" && SUPPRESSIBLE_SET.has(name)) {
+          // ⛔ AUTHORITY IS STAMPED AT EMISSION, not read at consumption (CTL-1901).
+          // A later readiness change must not retroactively grant OR revoke authority
+          // for a line already on disk — the sweep's cursor has advanced past the
+          // edge, so a revoked line reaches neither path.
+          //
+          // ⚠️ And here the stamp is doing MORE work than on the Linear leg, because
+          // the consumer is a different process: the broker cannot see this timer's
+          // state at all, so the stamp is the only authority signal that crosses.
+          const stamped = {
+            ...event,
+            body: {
+              ...event.body,
+              payload: { ...(event.body?.payload ?? {}), feedAuthority: authorityNow() === true },
+            },
+          };
+          // ⛔ NO try/catch. In enforce this append IS the dispatch: swallowing a
+          // failure would let the sweep settle the emission and advance its cursor
+          // past the edge while the gate suppresses smee's copy — the edge would
+          // reach nothing, permanently, with a counter as the only trace. Letting it
+          // throw engages the sweep's last-contiguous-success rule so the next tick
+          // re-emits. Opposite posture to the shadow sink above, which is evidence.
+          appendEventFn(stamped);
+          return;
+        }
+        // Shadow, or an excluded name under enforce: a marker under its OWN name, so
+        // nothing actuates and the ledger keeps observing the gap while it lasts.
+        appendEventFn(buildWouldDispatchEvent(event, { account }, seams));
       },
       orchDir,
       account,
@@ -213,6 +285,7 @@ export function startGithubFeedTimer({
   dbPath,
   eventLogPath,
   shadowPath,
+  readyPath,
   appendFn,
   logger = null,
   clock = { setInterval, clearInterval },
@@ -240,14 +313,46 @@ export function startGithubFeedTimer({
     }
   };
 
+  const readyFile = readyPath ?? defaultReadyPath(orchDir, account);
+
   let last = null;
+  // Readiness carried BETWEEN ticks. The sweep stamps every event it emits with the
+  // value that was true when the tick began (see runGithubFeedTick), so a flip
+  // during a tick cannot split that tick's output across two authority regimes.
+  let authority = false;
+
+  const publishReady = (state) => {
+    // ⛔ WRITTEN EVERY TICK, INCLUDING THE UNREADY ONES. A heartbeat that is only
+    // written while healthy is indistinguishable from a dead process — which is the
+    // same failure the staleness bound exists for, arriving one step earlier. The
+    // un-ready ticks are the ones whose REASON an operator most needs.
+    writeReadyState(readyFile, { ...state, at: Date.now(), intervalSec }, { logger });
+  };
+
   const tick = () => {
     try {
-      last = runGithubFeedTick({ mode, orchDir, account, dbPath, appendEventFn, appendShadowFn, logger });
+      last = runGithubFeedTick({
+        mode,
+        orchDir,
+        account,
+        dbPath,
+        appendEventFn,
+        appendShadowFn,
+        logger,
+        authorityAtEntry: authority,
+      });
+      authority = last?.ready === true;
+      publishReady({ ready: authority, unready: last?.unready ?? null, mode: last?.mode?.effective ?? null });
     } catch (err) {
       // A guardrail that can wedge the daemon tick is not a guardrail.
       logger?.error?.({ err: err?.message }, "github-feed: tick threw");
       last = { error: `tick-threw:${err?.name ?? "unknown"}`, ready: false };
+      // ⛔ A THROWN TICK MUST UN-ARM, and must say so rather than simply stop
+      // writing. If it only stopped writing, the previous `ready: true` would sit
+      // there until the staleness window expired and the gate would keep suppressing
+      // smee for up to 90 s on the authority of a tick that crashed.
+      authority = false;
+      publishReady({ ready: false, unready: `tick-threw:${err?.name ?? "unknown"}`, mode: null });
     }
   };
 
@@ -257,9 +362,14 @@ export function startGithubFeedTimer({
     stop: () => clock.clearInterval(handle),
     tickNow: tick,
     lastReport: () => last,
-    // Always false today — `enforce` degrades to shadow, so nothing this producer
-    // emits is ever authoritative. Exposed so a future gate reads one answer.
-    isReady: () => false,
+    // ⚠️ THE IN-PROCESS ANSWER, AND IT IS NOT THE ONE THE GATE USES. The `github.*`
+    // consumer is the broker, a separate process, which reads the ready FILE instead
+    // (github-feed-ready.mjs). This is exposed for the daemon's own logging and for
+    // tests; wiring it into a gate that lives in this process would work and would
+    // also be a second, in-memory authority path that the real consumer does not
+    // share — two answers to one question.
+    isReady: () => last?.ready === true,
+    readyPath: readyFile,
     mode: resolved,
   };
 }

--- a/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
@@ -18,6 +18,7 @@ import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
 import { defaultSeenPath } from "./github-feed-seen.mjs";
 import { streamCursorPath } from "./github-feed-sweep.mjs";
 import { readGithubFeedConfig } from "./config.mjs";
+import { GITHUB_CONSUMED_NAMES, GITHUB_SUPPRESSIBLE_NAMES } from "./github-feed-gate.mjs";
 
 const tmp = mkdtempSync(join(tmpdir(), "gh-feed-timer-"));
 afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
@@ -72,15 +73,42 @@ describe("⛔ P2 (Codex #3524): the account is resolved, never hard-coded", () =
   });
 });
 
-describe("⛔ enforce is refused BY NAME, not silently", () => {
-  test("enforce degrades to shadow and carries a reason", () => {
+describe("enforce is honoured PER NAME, and says which part it cannot honour", () => {
+  // ⚠️ THIS REPLACES "enforce degrades to shadow". That refusal was all-or-nothing:
+  // nine fully-covered names sat behind two uncovered ones. github-feed-gate.mjs
+  // suppresses per NAME, so the gaps now hold back only themselves. The property
+  // being asserted is no longer "enforce is refused" but "enforce is qualified".
+  test("enforce is effective, undegraded, and names the residual", () => {
     const r = resolveEffectiveMode("enforce");
-    expect(r.effective).toBe("shadow");
-    expect(r.degraded).toBe(true);
-    expect(r.reason).toContain("CTC-691");
-    // requested and effective stay distinct — a degraded node must not be
-    // indistinguishable from a configured one.
+    expect(r.effective).toBe("enforce");
+    expect(r.degraded).toBe(false);
     expect(r.requested).toBe("enforce");
+    // ⛔ The reason must still name every open gap. An operator who reads
+    // `mode: enforce` and infers "the tunnel can go" is wrong until all three close,
+    // so a partially-honoured mode has to say which part.
+    for (const ticket of ["CTC-691", "CTC-667", "CTC-704"]) {
+      expect(r.reason).toContain(ticket);
+    }
+  });
+
+  test("⛔ the counts in the reason are DERIVED — driven with a DIFFERENT name set", () => {
+    // ⚠️ My first version compared the reason against the real constants, and the
+    // mutation (hand-writing "9 of 12") PASSED — the literal and the computed value
+    // are the same string today. It asserted a tautology. The only way to observe a
+    // derivation is to change its inputs, so this drives the post-CTC-704 world:
+    // one more name covered, one fewer excluded.
+    const r = resolveEffectiveMode("enforce", {
+      suppressible: [...GITHUB_SUPPRESSIBLE_NAMES, "github.push"],
+      consumed: GITHUB_CONSUMED_NAMES,
+    });
+    expect(r.reason).toContain(`${GITHUB_SUPPRESSIBLE_NAMES.length + 1} of ${GITHUB_CONSUMED_NAMES.length}`);
+    expect(r.reason).toContain(
+      `smee stays authoritative for ${GITHUB_CONSUMED_NAMES.length - GITHUB_SUPPRESSIBLE_NAMES.length - 1}`,
+    );
+    // and the shipped default still reports today's real partition
+    expect(resolveEffectiveMode("enforce").reason).toContain(
+      `${GITHUB_SUPPRESSIBLE_NAMES.length} of ${GITHUB_CONSUMED_NAMES.length}`,
+    );
   });
 
   test("shadow and off are not degraded", () => {
@@ -88,12 +116,14 @@ describe("⛔ enforce is refused BY NAME, not silently", () => {
     expect(resolveEffectiveMode("off").effective).toBe("off");
   });
 
-  test("nothing this producer emits is ever authoritative today", () => {
+  test("a producer that has not completed a sweep is NOT ready", () => {
     const t = startGithubFeedTimer({
       mode: "enforce", orchDir: join(tmp, "auth"), dbPath: ":memory:",
       eventLogPath: join(tmp, "auth", "ev.jsonl"), appendFn: () => {},
       clock: { setInterval: () => ({ unref() {} }), clearInterval: () => {} },
     });
+    // setInterval is stubbed, so no tick has run — readiness must be false rather
+    // than defaulting to "armed because the mode says enforce".
     expect(t.isReady()).toBe(false);
     t.stop();
   });
@@ -200,5 +230,119 @@ describe("the tick", () => {
     expect(() => handle()).not.toThrow();
     expect(t.lastReport()).not.toBeNull();
     t.stop();
+  });
+});
+
+describe("⛔ under enforce the producer emits a REAL name only for what the gate can suppress", () => {
+  // The producer and the gate are the same invariant read from opposite ends. If
+  // they disagree the result is a double dispatch (feed emits, gate does not
+  // suppress smee) or a dropped edge (gate suppresses smee, feed declined). These
+  // drive the sink directly through the injected sweep seam — no replica needed.
+  const ghEvent = (name) => ({
+    attributes: { "event.name": name, "vcs.repository.name": "r" },
+    body: { payload: { source: "cloud-feed" } },
+  });
+
+  const drive = (mode, names, { authorityAtEntry = true } = {}) => {
+    const log = [];
+    runGithubFeedTick({
+      mode,
+      orchDir: join(tmp, "emit"),
+      dbPath: ":memory:",
+      authorityAtEntry,
+      appendEventFn: (e) => log.push(e),
+      appendShadowFn: () => {},
+      sourceFactory: () => ({ close() {} }),
+      seenFactory: () => ({ close() {} }),
+      sweepFn: ({ sink }) => {
+        for (const n of names) sink(ghEvent(n));
+        return { emitted: names.length, suppressed: 0, declined: 0, failures: 0, byReason: {} };
+      },
+    });
+    return log.map((e) => e?.attributes?.["event.name"]);
+  };
+
+  test("a suppressible name goes out under its REAL name", () => {
+    expect(drive("enforce", ["github.pr.opened"])).toEqual(["github.pr.opened"]);
+  });
+
+  test("⛔ an EXCLUDED name stays a would-dispatch marker even under enforce", () => {
+    // pr.merged / check_suite have no replacement (CTC-691, CTC-667 item 4) and push
+    // has a lossy one (CTC-704). Emitting these for real would put two copies on the
+    // log, because the gate correctly refuses to suppress smee for them.
+    for (const n of ["github.pr.merged", "github.check_suite.completed", "github.push"]) {
+      expect(drive("enforce", [n])).toEqual([EVENT_WOULD_DISPATCH]);
+    }
+  });
+
+  test("shadow emits would-dispatch for EVERYTHING, including suppressible names", () => {
+    expect(drive("shadow", ["github.pr.opened", "github.pr.merged"]))
+      .toEqual([EVENT_WOULD_DISPATCH, EVENT_WOULD_DISPATCH]);
+  });
+
+  test("⭐ the real-name set is exactly the gate's suppressible set — asserted over ALL consumed names", () => {
+    // The control that makes the two tests above non-anecdotal: drive every name the
+    // router consumes through one tick and compare the partition to the gate's.
+    const emitted = drive("enforce", GITHUB_CONSUMED_NAMES);
+    const real = emitted.filter((n) => n !== EVENT_WOULD_DISPATCH);
+    expect(real.sort()).toEqual([...GITHUB_SUPPRESSIBLE_NAMES].sort());
+    expect(emitted.filter((n) => n === EVENT_WOULD_DISPATCH)).toHaveLength(
+      GITHUB_CONSUMED_NAMES.length - GITHUB_SUPPRESSIBLE_NAMES.length,
+    );
+  });
+});
+
+describe("⛔ the emission-time authority stamp is what crosses the process boundary", () => {
+  const ghEvent = (name) => ({
+    attributes: { "event.name": name },
+    body: { payload: { source: "cloud-feed" } },
+  });
+  const stampFor = (authorityAtEntry) => {
+    const log = [];
+    runGithubFeedTick({
+      mode: "enforce",
+      orchDir: join(tmp, "stamp"),
+      dbPath: ":memory:",
+      authorityAtEntry,
+      appendEventFn: (e) => log.push(e),
+      appendShadowFn: () => {},
+      sourceFactory: () => ({ close() {} }),
+      seenFactory: () => ({ close() {} }),
+      sweepFn: ({ sink }) => {
+        sink(ghEvent("github.pr.opened"));
+        return { emitted: 1, suppressed: 0, declined: 0, failures: 0, byReason: {} };
+      },
+    });
+    return log[0]?.body?.payload?.feedAuthority;
+  };
+
+  test("an armed tick stamps true", () => {
+    expect(stampFor(true)).toBe(true);
+  });
+
+  test("⛔ an UN-armed tick stamps false, and the gate then refuses the line", () => {
+    // The broker cannot see this timer's state, so the stamp is the only authority
+    // signal that crosses. An unstamped/false line must not dispatch.
+    expect(stampFor(false)).toBe(false);
+  });
+
+  test("⚠️ the stamp defaults to FALSE when a caller forgets to thread readiness", () => {
+    // Same direction as every other absent probe in this feature: the non-dispatching
+    // half. A default of `true` would make a wiring mistake authoritative.
+    const log = [];
+    runGithubFeedTick({
+      mode: "enforce",
+      orchDir: join(tmp, "stamp2"),
+      dbPath: ":memory:",
+      appendEventFn: (e) => log.push(e),
+      appendShadowFn: () => {},
+      sourceFactory: () => ({ close() {} }),
+      seenFactory: () => ({ close() {} }),
+      sweepFn: ({ sink }) => {
+        sink(ghEvent("github.pr.opened"));
+        return { emitted: 1, suppressed: 0, declined: 0, failures: 0, byReason: {} };
+      },
+    });
+    expect(log[0]?.body?.payload?.feedAuthority).toBe(false);
   });
 });


### PR DESCRIPTION
## What this is

`enforce` on the GitHub leg was refused **entirely**, and the refusal was correct but too coarse. This producer cannot emit `github.pr.merged` (**CTC-691**, no `merge_commit_sha`) or `github.check_suite.completed` (**CTC-667 item 4**, the mirror stores no suite row), and suppressing smee for a name with no replacement takes out the CI wait and the whole merge→deploy chain fleet-wide with nothing behind them. So `enforce` degraded to shadow and **nine fully-covered names sat behind two uncovered ones**.

This makes enforce reachable at the granularity the problem actually has: **the gate suppresses smee per NAME.** 9 of the 12 names the router consumes cut over; the 3 gaps hold back only themselves and each names its own ticket in the capture record.

⛔ **No host changes.** `CATALYST_GITHUB_FEED` is `off` everywhere except mini-2 (`shadow`). Merging this flips nothing — `createGithubFeedGate` returns `null` for `off`, so the broker's tail skips the block entirely and routing is byte-identical to pre-CTL-1929.

## ⛔ The finding: `github.push` is excluded, and that corrects a claim this feature shipped

`github-feed-source.mjs`'s header and `packages/schema/src/mirror.ts`'s comment on `pushes` both justify the `(repo_id, ref)` collapse the same way:

> *"Rebase detection asks 'has this ref moved since I last looked', which a per-ref head answers exactly."*

**That describes a polling consumer. We do not have one.** Measured against the code:

- `broker/router.mjs:1582` — on `github.push` the router reads **`scope.ref` and nothing else**, matches it against the interest's `base_branches`, and wakes the worker. It never reads `before`/`after` and never compares against a stored head.
- It sets **no `wakeStateKey`** (only `check_run`/`check_suite` do, `:1510`), so `suppress_identical_wakes` (`:2857`) **never applies to push**. Every arriving push edge is a distinct wake, deliberately.

So what the consumer consumes is the **arrival**, not the column's value, and a last-state projection cannot carry an arrival. Under shadow that is a parity gap (101 of 138 unmatched smee events, CTL-48). **Under enforce with smee suppressed it is a wake that never happens, with no second copy to recover it from.** Hence the exclusion, until **CTC-704** keys `pushes` per delivery — at which point `PUSH_IS_LOSSY` goes false in the source and the set empties itself with no edit here.

## ⚠️ Readiness crosses a PROCESS boundary, and the naive port fails silently in the direction that looks fine

The Linear gate's `isReady` is a closure over the producer's timer (`daemon.mjs:1470`) — legitimate there, because `cloud-feed-timer` and `monitor.mjs` are both in the daemon. **The `github.*` consumer is `broker/tailer.mjs` → `broker/router.mjs`, a separate process.**

Copying the Linear wiring gives the broker `isReady: null`, and `decideDispatch`'s "absent probe ⇒ NOT ready" then makes smee authoritative **forever**. No double-dispatch, no error, no alarm — the host logs `mode: enforce` and behaves exactly like shadow. **The flip would be a lie**, and the way anyone would find out is by retiring the tunnel and losing dispatch. A safe fail direction is not a correct one.

`github-feed-ready.mjs` carries the verdict through a file, with a **staleness bound derived from the tick interval** — because a file without one is a latch: a daemon that dies mid-enforce leaves `ready: true` behind it, and the broker would keep suppressing smee on the authority of a process that no longer exists.

## Files

| file | |
| --- | --- |
| `github-feed-gate.mjs` | the decision, pure — per-name suppression, refused on **both** sides |
| `github-feed-ready.mjs` | the cross-process readiness signal + staleness bound |
| `github-feed-gate-install.mjs` | the broker-side gate; 1 s readiness cache (the broker routes **every** event in the fleet, 687/5 min into an 883 MB log — a read per event is not acceptable) |
| `github-feed-timer.mjs` | enforce emits **real names only for what the gate can suppress**, stamped with emission-time authority (CTL-1901); ready file written every tick, including un-ready ones |
| `broker/{tailer,index}.mjs` | gate decides before the router; armed before the tail starts |

The producer and the gate both read `GITHUB_SUPPRESSIBLE_NAMES`, so they cannot disagree — a disagreement is either a double dispatch or a dropped edge.

## Tests — 11 mutations run, and **3 of them passed**

New: 33 gate + 13 readiness + 12 installer + 4 wiring. Full `github-feed`/`cloud-feed` subset: **365 pass, 0 fail**.

⛔ **Three of my own tests were vacuous and are called out at their site**, because the mutation was run rather than reasoned about:

1. **The order control** asserted "readiness first would let a ready producer suppress `pr.merged`" — false. The suppress bit is invariant under that reordering; the block just runs later and catches it. Rewritten to assert what the order actually buys: **diagnosis**. An operator mid-cutover must distinguish "smee kept authority because the producer stalled" (transient) from "because this name has no replacement" (permanent until CTC-691).
2. **`PUSH_IS_LOSSY` tracking** compared the constant against `PUSH_IS_LOSSY ? [...] : []` — a tautology, since both sides are the same literal today. It would still pass after CTC-704, when the set is supposed to be **empty**. The derivation is now an injectable pure function driven in both states.
3. **"the gate is not ready before any read"** — the seeded cache value is unreachable, since the first probe always re-reads. Replaced with the property that makes it unreachable: construction does not probe, and the first probe does.

The same trap bit the `resolveEffectiveMode` counts ("9 of 12" hand-written passes against the derived value) — now driven with a different name set.

⭐ And the **smoke test caught a real defect before any test did**: taking the producer's emit-list as the gate's universe made `decideDispatch` answer `not-dispatch-class` for `github.pr.merged` — "the gate has no opinion" about the most dangerous name here. Safe today by accident; it would have recorded that the gate never looked rather than that it looked and refused. The universe is now what the **router** consumes (`GITHUB_CONSUMED_NAMES`).

## ⚠️ Gate run — not clean, and here is the accounting

Full `execution-core` suite on this branch: **9869 pass / 65 fail / 3 errors**. Baseline on `origin/main` (`6a413b301`), same machine, same run shape: **9803 pass / 61 fail / 3 errors**.

Diffed by test name, the delta is **4 tests, all in `__tests__/cloud-sync-idle-event.test.mjs`**:

- they **pass 5/5 in isolation** on this branch;
- they failed with `exitCode: null` — the spawned subprocess was **killed**, not an assertion mismatch;
- the file spawns `cloud-sync.mjs` with `CATALYST_REPLICA_START_TIMEOUT_MS=1` under a 9,935-test parallel run, with backend's schema cascade also running on this box;
- **`cloud-sync.mjs` imports nothing in this diff** — verified: not `github-feed-*`, not `daemon.mjs`.

That is the EAGAIN/resource-contention class, not a regression. Stating it rather than reporting a clean gate. **CI is authoritative here.**

## Rollout

Merged ≠ flipped. The flip is a separate, deliberate step: mini-2 first as canary under the tunnel-retirement runbook (CTL-1929), then mini, and **only after** schema 0.1.17 lands and the parity ledger returns CLEAN. Webhook `616654741` stays.

Refs CTL-1929, CTC-691, CTC-667, CTC-704, CTL-48, CTL-1901