### PR TITLE
chore(deps): pin @catalyst-cloud/sdk 0.8.13 / schema 0.1.17 — CTC-691 + CTC-667 item 4 + CTC-704

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "catalyst",
       "dependencies": {
-        "@catalyst-cloud/schema": "0.1.16",
+        "@catalyst-cloud/schema": "0.1.17",
         "@modelcontextprotocol/sdk": "1.29.0",
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.12",
+        "@catalyst-cloud/sdk": "0.8.13",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.10", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.16" } }, "sha512-R5MM3j+JdSSZYZzlVRQCXBINqp3bKor42mQikiX71zBF10us2XEoV9phyzyIzyhtzCqI0/u0AXW0zAIlVP+nHw=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.11", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.17" } }, "sha512-QtVxTng3XfP3QdUuAOv2NiSLOlZSc/JSUwyM5KPSpRC8MnKUAxXo62ClnBnjv0m8TU/ntuJgPOO2dWWfT4qBXA=="],
 
-    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.16", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-/v/jAVUpthFwKzwN3aUr0Q3hPjLNtH9aEUyljZLm6o9xRPggCAQDVp171jemOsAgM72Oi761n5OIeEVBE5yL3A=="],
+    "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.17", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-/e23/wXxZ4Ko7wttMpDQCWOYFfqMZtDjCSUz1BjHi2pvJo546PX/J2Qq75vGf0es1UKVNxrkVyegubIVUm56AQ=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.12", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.10", "@catalyst-cloud/schema": "0.1.16" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-xUnFTPXOSsY3fWre0ceI6kFPNxhhMWXuWGFD0hEh8euGjUx8Zr+huYEVX/rbsAF/9bg8Ws0N3ueRITliOzXK5Q=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.13", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.11", "@catalyst-cloud/schema": "0.1.17" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-IMn4WS60pEtoO2ubXgx2Jw9Xh6lzxaT9pDzci+AqVXoxACvJce8lph4abl8inZISorkHoIQ2nU7Sd71QFE6ebA=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hono": "4.12.27"
   },
   "dependencies": {
-    "@catalyst-cloud/schema": "0.1.16",
+    "@catalyst-cloud/schema": "0.1.17",
     "@modelcontextprotocol/sdk": "1.29.0"
   }
 }

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.12",
+    "@catalyst-cloud/sdk": "0.8.13",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
**This is what actually rolls the schema cascade onto the fleet.** Merging catalyst-cloud rolls out nothing: the hosts' replica schema comes from these pins, and only the cloud-sync writer runs the replica migration (CTL-44 — `plugin-refresh` restarts monitor / execution-core / otel-forward, never cloud-sync, so each host still needs an explicit `launchctl kickstart`).

Same shape as #3498, which did this for 0.1.16.

| pin | from | to |
| --- | --- | --- |
| `@catalyst-cloud/schema` (root) | 0.1.16 | **0.1.17** |
| `@catalyst-cloud/sdk` (execution-core) | 0.8.12 | **0.8.13** |

## What the fleet gets

Three facts the orchestrator's dispatch needs and the mirror did not carry — **the two remaining blockers on CTL's list plus the one CTL-48 uncovered**:

- **`pull_requests.merge_commit_sha`** (CTC-691, P1) — without it `pr.merged` silently breaks the merge→deploy join once the GitHub feed replaces smee.
- **`check_suites`** (CTC-667 item 4) — GitHub's own CI rollup, the highest-volume signal in the census and what every phase agent's CI wait blocks on.
- **`push_events`** (CTC-704) — one row per push **delivery**. A producer emits one edge per row, so the per-ref `pushes` row caps the feed at one edge per ref per tick; CTL-48 measured **101 of 138** unmatched smee events as pushes, which made GitHub parity structurally INCONCLUSIVE.

## Why this is safe to canary

Migration `0027` is **fully additive** — two `CREATE TABLE`s and one `ADD COLUMN`, no table rebuild. A host that does not restart its cloud-sync writer is **unchanged, not broken**, which is the property COORD-128's canary plan relies on: mini-2 first, and a bad canary leaves mini on the old pin with nothing regressed.

## Verified by content, not by range

`node_modules` resolves **schema 0.1.17** and **sdk 0.8.13**, read out of the `.bun` store path rather than trusted from the declared range — per CTL-1931, a version bump does not necessarily re-lock, and the isolated linker's store dir is exactly where that check goes wrong.

Source: coalesce-labs/catalyst-cloud#825 · SDK: coalesce-labs/catalyst-cloud-sdk#26 (merged).