### PR TITLE
fix(dev): CTL-1952 — a fully successful narration was recorded as a failure; the session route answers per part

### DIFF
--- a/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
+++ b/plugins/dev/scripts/execution-core/agent-session-narrator.test.mjs
@@ -24,7 +24,14 @@ import {
   planFor,
 } from "./agent-session-narrator.mjs";
 import { dispatchTicket, getAgentSessionNarrator, setAgentSessionNarrator } from "./dispatch.mjs";
-import { ASYNC_MAX_ATTEMPTS, NON_BLOCKING_ROUTE_IDS, createLinearWriteProxy, defaultAsyncHttpFn } from "./linear-write-proxy.mjs";
+import {
+  ASYNC_MAX_ATTEMPTS,
+  NON_BLOCKING_ROUTE_IDS,
+  SESSION_PART_SUCCESS,
+  classifySessionResponse,
+  createLinearWriteProxy,
+  defaultAsyncHttpFn,
+} from "./linear-write-proxy.mjs";
 import { PHASES } from "../lib/workflow-descriptor.mjs";
 
 /** The route the ticket says is hung: it accepts the send and never answers. */
@@ -383,5 +390,77 @@ describe("round-1 P2 — the budget must not be under-charged by a retry", () =>
     });
     proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-6", phase: "plan", payload: { issueId: "x" } });
     expect(order).toEqual(["ledger", "spawn"]);
+  });
+});
+
+
+// ── CTL-1951: the session route's verdict, measured on the live cloud ──────────────────
+
+describe("the session route's per-part outcome is read correctly", () => {
+  // ⛔ THE FIXTURE IS THE REAL RESPONSE, captured from production on mini-2 2026-08-18 at
+  // HTTP 200 — not an invented one. The generic classifier read it as `unreadable-outcome`,
+  // so a narration that FULLY SUCCEEDED was counted and logged as a FAILURE: the
+  // instrument reporting the opposite of what happened.
+  const LIVE_BODY =
+    '{"session":{"outcome":"reused","sessionId":"8fd311c5-9394-4eff-811a-ae3f121c239c","attempts":1},' +
+    '"plan":{"outcome":"succeeded","attempts":1},"activity":{"outcome":"succeeded","attempts":1}}';
+  const resp = (body, status = 200, code = 0) => ({ code, stdout: `${body}\n${status}`, stderr: "" });
+
+  test("⛔ the REAL production body is applied, not `unreadable-outcome`", () => {
+    const v = classifySessionResponse(resp(LIVE_BODY));
+    expect(v.applied).toBe(true);
+    expect(v.reason).toBeNull();
+    expect(v.status).toBe(200);
+  });
+
+  test("a failing part is named with its part AND its literal value", () => {
+    const v = classifySessionResponse(
+      resp('{"session":{"outcome":"reused"},"plan":{"outcome":"rejected"},"activity":{"outcome":"succeeded"}}')
+    );
+    expect(v.applied).toBe(false);
+    expect(v.reason).toBe("cloud:session-part-failed");
+    expect(v.detail).toBe("plan:rejected");
+  });
+
+  test("⛔ an UNRECOGNISED outcome is not assumed benign", () => {
+    // The vocabulary was measured, not documented. A future "deferred"/"partial" must not
+    // read as applied just because it is not a word we know means failure.
+    const v = classifySessionResponse(resp('{"activity":{"outcome":"deferred"}}'));
+    expect(v.applied).toBe(false);
+    expect(v.detail).toBe("activity:deferred");
+    expect(SESSION_PART_SUCCESS.has("deferred")).toBe(false);
+  });
+
+  test("a body with no recognised part stays `unreadable-outcome`", () => {
+    // Not talking to the route we think we are — a proxy or an HTML error page. "Assume
+    // it worked" is the one reading a write path may never take.
+    expect(classifySessionResponse(resp("<html>gateway</html>")).reason).toBe("unreadable-outcome");
+    expect(classifySessionResponse(resp('{"hello":"world"}')).reason).toBe("unreadable-outcome");
+  });
+
+  test("transport and status verdicts are unchanged — only the BODY reading differs", () => {
+    expect(classifySessionResponse({ code: 127 }).reason).toBe("spawn-failed");
+    expect(classifySessionResponse(resp("{}", 401)).reason).toBe("unauthorized");
+    expect(classifySessionResponse(resp("{}", 429)).reason).toBe("rate-limited");
+    expect(classifySessionResponse(resp("{}", 503)).reason).toBe("server-error");
+    expect(classifySessionResponse({ code: 28, stdout: "", stderr: "timeout" }).reason).toBe("transport-error");
+  });
+
+  test("END TO END: a live-shaped 200 counts as APPLIED, not FAILED, through sendAsync", () => {
+    const proxy = proxyWith({
+      asyncHttpFn: ({ onDone }) => { onDone({ code: 0, stdout: `${LIVE_BODY}\n200`, stderr: "" }); return { dispatched: true }; },
+    });
+    proxy.sendAsync({ routeId: SESSION_ROUTE_ID, ticket: "CTL-1943", phase: "implement", payload: { issueId: "x" } });
+    expect(proxy.counts()).toMatchObject({ applied: 1, failed: 0 });
+  });
+
+  test("⛔ CONTROL: the three CTC-509 routes still use the generic classifier", () => {
+    // They answer with a TOP-LEVEL outcome, and routing them through the session reader
+    // would be the same defect in the other direction.
+    const proxy = proxyWith({
+      httpFn: () => ({ code: 0, stdout: '{"outcome":"succeeded"}\n200', stderr: "" }),
+    });
+    proxy.send({ routeId: "comment", ticket: "CTL-1", payload: { issueId: "x", body: "b" } });
+    expect(proxy.counts()).toMatchObject({ applied: 1, failed: 0 });
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -363,6 +363,60 @@ export function classifyProxyResponse({ code, stdout, stderr } = {}) {
 }
 
 /** parseProxyBody — JSON.parse or null. Never throws; a non-object is not an outcome. */
+/**
+ * ⛔ THE SESSION ROUTE ANSWERS IN A DIFFERENT SHAPE, MEASURED ON THE LIVE CLOUD.
+ *
+ * `classifyProxyResponse` reads a TOP-LEVEL `outcome`, which is the CTC-509 contract the
+ * three dispatch-critical routes use. CTC-682's `/agent/session` does not have one — it
+ * reports PER PART, because one request can create a session, replace a plan, and append
+ * an activity independently. Measured against production from mini-2 on 2026-08-18, HTTP
+ * 200:
+ *
+ *   {"session":{"outcome":"reused","sessionId":"8fd311c5-…","attempts":1},
+ *    "plan":{"outcome":"succeeded","attempts":1},
+ *    "activity":{"outcome":"succeeded","attempts":1}}
+ *
+ * Run through the generic classifier that reads as `unreadable-outcome` — so every
+ * narration that FULLY SUCCEEDED was counted and logged as a FAILURE. That is the worst
+ * class of defect for an observability feature: the instrument reporting the opposite of
+ * what happened, which would have had an operator chasing a broken narration route that
+ * was working perfectly.
+ *
+ * ── THE FAIL DIRECTION IS DELIBERATE ──
+ * Only outcomes KNOWN to mean success count as success. The vocabulary was measured, not
+ * documented, so an unrecognised value must be reported with its part and its literal
+ * value rather than assumed benign — the reverse would let a future `"deferred"` or
+ * `"partial"` read as applied. A body with no recognised parts at all stays
+ * `unreadable-outcome`, unchanged.
+ */
+export const SESSION_PART_SUCCESS = Object.freeze(new Set(["succeeded", "created", "reused", "unchanged"]));
+
+/** The parts one /agent/session response can report on. Absent parts are not judged. */
+export const SESSION_PARTS = Object.freeze(["session", "plan", "activity"]);
+
+export function classifySessionResponse(raw) {
+  // Transport-level questions are identical for every route, so reuse that judgement
+  // rather than re-deriving it — only the BODY reading differs.
+  const base = classifyProxyResponse(raw);
+  if (base.reason !== "unreadable-outcome") return base; // spawn/transport/status verdicts stand
+
+  const parsed = parseProxyBody(base.body ?? "");
+  if (!parsed || typeof parsed !== "object") return base;
+
+  const present = SESSION_PARTS.filter((k) => parsed[k] && typeof parsed[k].outcome === "string");
+  // No recognised part means we are not talking to the route we think we are — the same
+  // reading the generic classifier takes, and for the same reason.
+  if (present.length === 0) return base;
+
+  const bad = present
+    .filter((k) => !SESSION_PART_SUCCESS.has(parsed[k].outcome))
+    .map((k) => `${k}:${parsed[k].outcome}`);
+  if (bad.length > 0) {
+    return { applied: false, reason: "cloud:session-part-failed", detail: bad.join(","), status: base.status, body: base.body };
+  }
+  return { applied: true, reason: null, status: base.status, body: base.body, converged: false };
+}
+
 export function parseProxyBody(bodyText) {
   if (typeof bodyText !== "string" || bodyText.trim() === "") return null;
   try {
@@ -933,7 +987,11 @@ export function createLinearWriteProxy({
         // ⛔ Runs on a LATER event-loop turn. It must never throw into the daemon loop,
         // and it must never touch the ledger (see the single-writer note above).
         try {
-          const verdict = classifyProxyResponse(raw);
+          // Route-aware: the session route reports per part and has no top-level
+          // `outcome`. See classifySessionResponse — a generic read called every
+          // successful narration a failure.
+          const verdict =
+            routeId === "session" ? classifySessionResponse(raw) : classifyProxyResponse(raw);
           if (verdict.applied) {
             counts.applied += 1;
             emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true, caller, labels });


### PR DESCRIPTION
## Found by live verification, not by a test

Minutes after **#3529** (CTL-1943) merged and both minis loaded it, I drove a real narration on **mini-2** against a real ticket with the real per-host key. It **worked** — HTTP 200, session created/reused (`sessionId 8fd311c5-…`), plan and activity both `succeeded`.

⛔ **And the host recorded it as a failure:**

```
WARN linear-write-proxy: narration failed (non-blocking route — the dispatch was NOT affected)
  {"ticket":"CTL-1943","route":"session","phase":"implement","reason":"unreadable-outcome","status":200}
counts: {"wouldWrite":0,"applied":0,"failed":1,"refused":0}
```

Closes **CTL-1952**.

## Why

`classifyProxyResponse` reads a **top-level** `outcome` — the CTC-509 contract the three dispatch-critical routes use. CTC-682's `/agent/session` has none; it reports **per part**, because one request can create a session, replace a plan, and append an activity independently:

```json
{"session":{"outcome":"reused","sessionId":"8fd311c5-…","attempts":1},
 "plan":{"outcome":"succeeded","attempts":1},
 "activity":{"outcome":"succeeded","attempts":1}}
```

No `outcome` key → the deliberately-strict `unreadable-outcome` branch. Correct for the routes it was written for; wrong for this one.

## Why it is worse than a wrong counter

This is the worst class of defect for an **observability** feature: **the instrument reporting the opposite of what happened.** Every successful narration would land in `failed` and log a warning, so an operator would chase a broken narration route *that was working perfectly* — while a genuinely broken one would be indistinguishable from it. It also hid budget being spent: the writes were landing the whole time while the counters said none had applied.

## The fix, and its fail direction

`classifySessionResponse` reuses the generic **transport/status** judgement — only the *body* reading differs — and requires every **present** part to carry a known-success outcome.

⚠️ The success vocabulary was **measured, not documented** (`succeeded`, `reused` observed; `created`, `unchanged` accepted as obvious siblings). So an unrecognised value is reported **with its part and its literal value** rather than assumed benign — a future `deferred`/`partial` must not read as applied. A body with no recognised part stays `unreadable-outcome`: *assume it worked* is the one reading a write path may never take.

**@CTC(ux-b)** — asked on the ticket for CTC-682's full outcome vocabulary so the accept-set can stop being an inference. If a success value is missing it fails **loudly** (a named `cloud:session-part-failed`), which is the intended direction, but it would be a false alarm.

## Verification

The fixture is the **real production body** captured from mini-2, not an invented one. 38 pass, 0 fail. Mutation-tested:

| mutation | result |
|---|---|
| route the session response through the generic classifier (the bug) | **1 fail** |
| accept any outcome as success | **2 fail** |
| restored | 38 pass |

Plus a control that the three CTC-509 routes still use the generic classifier — the same defect in the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
