### PR TITLE
feat(dev): CTL-1944 — a fleet host proves it can materialize owner tokens, and installs direnv when it cannot

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -272,6 +272,7 @@ jobs:
         # touched) and a zero-discovery case that must exit 2, not report a clean pass.
         working-directory: .
         run: bash scripts/__tests__/worktree-thoughts-exclude-backfill.test.sh
+
       - name: account-usage pager test (CTL-1908)
         # Pages before an armed Claude account exhausts its 5-hour / 7-day window. The property
         # under test is not "does it page at 80%" — it is that every way of being unable to SEE
@@ -279,6 +280,24 @@ jobs:
         # UNOBSERVABLE and a non-zero exit, never as "under threshold".
         working-directory: .
         run: bash plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
+
+      - name: direnv fleet readiness test (CTL-1944)
+        # The property under test is not "is direnv installed" — it is that every way of being
+        # NOT-owner-ready renders RED. Two regression guards carry the weight: a BLOCKED .envrc
+        # must not read as a clean host (the allowed-state is read positively from `Found RC
+        # allowed`, never inferred from absent output), and the CALLER's ambient token must not
+        # make an unprovisioned host pass (`direnv exec` inherits, so the dump runs scrubbed).
+        #
+        # ⛔ direnv is INSTALLED here on purpose. Without it the suite skips exactly the two
+        # guards above and still reports green — a test that ships inert, which is the
+        # CTL-1919/CTL-1935 class. The test itself also refuses to skip when CI is set, so
+        # this step failing to provision direnv is a RED result rather than a quiet pass.
+        working-directory: .
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq direnv
+          direnv version
+          bash plugins/dev/scripts/__tests__/check-direnv-fleet.test.sh
 
       - name: Verify import graph (bun build resolution check)
         # CTL-1298: resolve daemon.mjs's full transitive import graph so a missing

--- a/plugins/dev/scripts/__tests__/check-direnv-fleet.test.sh
+++ b/plugins/dev/scripts/__tests__/check-direnv-fleet.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# check-direnv-fleet.test.sh — CTL-1944.
+#
+# The property under test is NOT "does it find direnv". It is that every way of being
+# NOT-owner-ready renders RED. The failure this ticket came from was a host that read as fine
+# because the check only ever warned, and the failure mode it must never regress into is a BLOCKED
+# .envrc reading as a clean one — a blocked rc emits no variables, which is indistinguishable from
+# a host with nothing configured unless the allowed-state is read positively.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUBJECT="$SCRIPT_DIR/../check-direnv-fleet.sh"
+
+PASSES=0
+FAILURES=0
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${SCRATCH:?}"' EXIT
+
+pass() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() {
+	FAILURES=$((FAILURES + 1))
+	echo "  FAIL: $1"
+	shift
+	for l in "$@"; do echo "      $l"; done
+}
+
+if ! command -v direnv >/dev/null 2>&1; then
+	# ⛔ A SKIP UNDER CI IS A FAILURE. Without direnv this suite runs only the binary-absent case
+	# and still reports green — the two guards that carry the weight (blocked-.envrc, ambient-token)
+	# would never execute, and the suite would ship INERT while looking installed. That is the exact
+	# class CTL-1919/CTL-1935 are about, so CI must go red rather than quietly cover less.
+	if [[ -n "${CI:-}" ]]; then
+		echo "  FAIL: direnv is absent on a CI runner — this suite would skip its two core guards."
+		echo "        The workflow step is responsible for installing it (apt-get install direnv)."
+		echo ""
+		echo "  PASSED: 0   FAILED: 1"
+		exit 1
+	fi
+	echo "SKIP: direnv is not installed on this runner — the allowed-state cases cannot run."
+	echo "      (The binary-absent case below does not need it and still runs.)"
+	HAVE_DIRENV=0
+else
+	HAVE_DIRENV=1
+fi
+
+# Isolate direnv's allow-store so the test never reads or writes the operator's real one.
+export XDG_DATA_HOME="$SCRATCH/xdg-data"
+export XDG_CONFIG_HOME="$SCRATCH/xdg-config"
+mkdir -p "$XDG_DATA_HOME" "$XDG_CONFIG_HOME/direnv/profiles"
+
+run() { bash "$SUBJECT" "$@" 2>&1; }
+
+# ── a project whose .envrc really does export the tokens ────────────────────
+mkproject() { # mkproject <dir>
+	mkdir -p "$1"
+	cat >"$1/.envrc" <<'ENVRC'
+export LINEAR_API_TOKEN=lin_api_testtoken
+export GITHUB_TOKEN=ghp_testtoken
+export CLOUDFLARE_API_TOKEN=cf_testtoken
+ENVRC
+}
+
+echo ""
+echo "=== ⛔ the binary being ABSENT is a FAILURE, not a warning ==="
+# A PATH with no direnv on it. This is the mini-2 condition.
+OUT="$(PATH="/usr/bin:/bin" CATALYST_BREW="$SCRATCH/no-such-brew" run --dir "$SCRATCH" 2>&1)"
+RC=$?
+if [[ $RC -ne 0 ]]; then pass "an absent direnv exits non-zero (rc=$RC)"; else fail "an absent direnv exited 0" "$OUT"; fi
+if grep -q 'direnv NOT installed' <<<"$OUT"; then pass "it names direnv as the missing thing"; else fail "the absent binary is not named" "$OUT"; fi
+
+if [[ $HAVE_DIRENV -eq 1 ]]; then
+	for p in personal catalyst catalyst-cloud; do : >"$XDG_CONFIG_HOME/direnv/profiles/${p}.env"; done
+
+	echo ""
+	echo "=== ⛔ THE CORE CASE: a BLOCKED .envrc must read BLOCKED, never clean ==="
+	BLOCKED="$SCRATCH/blocked"
+	mkproject "$BLOCKED"
+	# deliberately NOT allowed
+	OUT="$(run --dir "$BLOCKED")"
+	RC=$?
+	# control — prove the fixture really is blocked, so a pass here means something
+	FOUND="$(cd "$BLOCKED" && direnv status 2>/dev/null | grep -E '^Found RC allowed ' | head -n1)"
+	if [[ "$FOUND" == "Found RC allowed 1" ]]; then pass "control — the fixture really is blocked ($FOUND)"; else fail "the fixture is not in the blocked state" "$FOUND"; fi
+	if grep -q 'is BLOCKED' <<<"$OUT"; then pass "the blocked .envrc is reported BLOCKED"; else fail "a blocked .envrc was not reported" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "a blocked .envrc exits non-zero (rc=$RC)"; else fail "a blocked .envrc exited 0" "$OUT"; fi
+	if ! grep -q 'readiness: PASS' <<<"$OUT"; then pass "it does not report PASS"; else fail "a blocked host reported PASS" "$OUT"; fi
+
+	echo ""
+	echo "=== ⛔ REGRESSION GUARD: called FROM an allowed dir, a blocked target still reads BLOCKED ==="
+	# This is the bug a naive `direnv status | grep 'RC allowed 0'` has: the "Loaded RC" block
+	# describes the CALLER's rc. Run the check with the CWD inside an allowed project and the
+	# --dir pointing at the blocked one; the caller's allowed rc must not mask the target.
+	ALLOWED="$SCRATCH/allowed"
+	mkproject "$ALLOWED"
+	(cd "$ALLOWED" && direnv allow . >/dev/null 2>&1)
+	OUT="$(cd "$ALLOWED" && bash "$SUBJECT" --dir "$BLOCKED" 2>&1)"
+	RC=$?
+	LOADED="$(cd "$ALLOWED" && direnv status 2>/dev/null | grep -E '^Loaded RC allowed ' | head -n1)"
+	if grep -q 'is BLOCKED' <<<"$OUT"; then pass "the caller's allowed rc does not mask the target (caller: ${LOADED:-none})"; else fail "an allowed CALLER masked a blocked TARGET — the Loaded/Found confusion" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "and it still exits non-zero (rc=$RC)"; else fail "masked case exited 0" "$OUT"; fi
+
+	echo ""
+	echo "=== ✅ NEGATIVE CONTROL: an allowed, fully-provisioned project PASSES ==="
+	OUT="$(run --dir "$ALLOWED")"
+	RC=$?
+	if [[ $RC -eq 0 ]]; then pass "a correct host exits 0 — the check is not always-red"; else fail "a correct host failed" "$OUT"; fi
+	if grep -q 'readiness: PASS' <<<"$OUT"; then pass "it reports PASS"; else fail "no PASS line" "$OUT"; fi
+	if grep -q 'ALLOWED (Found RC allowed 0)' <<<"$OUT"; then pass "the allowed state is read positively"; else fail "allowed state not reported" "$OUT"; fi
+	if grep -q 'LINEAR_API_TOKEN is set' <<<"$OUT"; then pass "LINEAR_API_TOKEN is seen"; else fail "token not seen" "$OUT"; fi
+
+	echo ""
+	echo "=== ⛔ a token the .envrc does NOT export is reported EMPTY ==="
+	OUT="$(run --dir "$ALLOWED" --require-token 'LINEAR_API_TOKEN NOT_EXPORTED_TOKEN')"
+	RC=$?
+	if grep -q 'NOT_EXPORTED_TOKEN is EMPTY' <<<"$OUT"; then pass "the missing token is named EMPTY"; else fail "a missing token was not reported" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "and that fails the check (rc=$RC)"; else fail "a missing token exited 0" "$OUT"; fi
+
+	echo ""
+	echo "=== ⛔ REGRESSION GUARD: the CALLER's ambient token must not make an UNPROVISIONED host pass ==="
+	# `direnv exec` ADDS the .envrc's exports to the environment it inherits — it does not scrub.
+	# So an agent whose own shell already carries LINEAR_API_TOKEN would see it in ANY directory,
+	# and an unprovisioned host would report ready on the caller's credentials. That is this
+	# ticket's own failure mode reproduced inside the check meant to catch it. Caught for real on
+	# 2026-08-18 by the probe case below, which passed against an .envrc exporting no token.
+	BARE="$SCRATCH/bare"
+	mkdir -p "$BARE"
+	echo 'export UNRELATED=1' >"$BARE/.envrc"
+	(cd "$BARE" && direnv allow . >/dev/null 2>&1)
+	OUT="$(LINEAR_API_TOKEN=lin_api_leaked_from_the_caller GITHUB_TOKEN=ghp_leaked CLOUDFLARE_API_TOKEN=cf_leaked run --dir "$BARE")"
+	RC=$?
+	if grep -q 'LINEAR_API_TOKEN is EMPTY' <<<"$OUT"; then pass "an ambient LINEAR_API_TOKEN does not count as provisioned"; else fail "the caller's token leaked into the verdict" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "the unprovisioned host still FAILS (rc=$RC)"; else fail "an unprovisioned host passed on inherited credentials" "$OUT"; fi
+	# control — prove the leak was actually present in the caller's environment
+	LEAKCHK="$(LINEAR_API_TOKEN=lin_api_leaked_from_the_caller sh -c 'printf %s "${LINEAR_API_TOKEN:+present}"')"
+	if [[ "$LEAKCHK" == "present" ]]; then pass "control — the ambient token really was set for that run"; else fail "the leak fixture did not set the variable"; fi
+
+	echo ""
+	echo "=== ⛔ a MISSING PROFILE is a failure ==="
+	rm -f "$XDG_CONFIG_HOME/direnv/profiles/catalyst-cloud.env"
+	OUT="$(run --dir "$ALLOWED")"
+	RC=$?
+	if grep -q 'profile catalyst-cloud.env MISSING' <<<"$OUT"; then pass "the missing profile is named"; else fail "missing profile not reported" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "and it exits non-zero (rc=$RC)"; else fail "missing profile exited 0" "$OUT"; fi
+	: >"$XDG_CONFIG_HOME/direnv/profiles/catalyst-cloud.env"
+
+	echo ""
+	echo "=== ⛔ NO .envrc at all is a failure, not a silent skip ==="
+	EMPTY="$SCRATCH/empty"
+	mkdir -p "$EMPTY"
+	OUT="$(run --dir "$EMPTY")"
+	RC=$?
+	if grep -q 'no .envrc in' <<<"$OUT"; then pass "the absent .envrc is named"; else fail "absent .envrc not reported" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "and it exits non-zero (rc=$RC)"; else fail "absent .envrc exited 0" "$OUT"; fi
+
+	echo ""
+	echo "=== the live probe fails CLOSED when there is no token to probe with ==="
+	NOTOK="$SCRATCH/notok"
+	mkdir -p "$NOTOK"
+	echo 'export SOMETHING_ELSE=1' >"$NOTOK/.envrc"
+	(cd "$NOTOK" && direnv allow . >/dev/null 2>&1)
+	OUT="$(run --dir "$NOTOK" --probe --require-token 'SOMETHING_ELSE')"
+	RC=$?
+	if grep -q 'probe SKIPPED' <<<"$OUT"; then pass "an unprobeable host says so"; else fail "the probe was silently skipped" "$OUT"; fi
+	if [[ $RC -ne 0 ]]; then pass "and that is a failure, not a pass (rc=$RC)"; else fail "unprobeable host exited 0" "$OUT"; fi
+fi
+
+echo ""
+echo "=== argument validation ==="
+OUT="$(run --dir "$SCRATCH/definitely-not-here")"
+RC=$?
+if [[ $RC -eq 2 ]]; then pass "a nonexistent --dir is refused (rc 2)"; else fail "bad --dir not refused" "rc=$RC" "$OUT"; fi
+OUT="$(run --bogus-flag)"
+RC=$?
+if [[ $RC -eq 2 ]]; then pass "an unknown flag is refused (rc 2)"; else fail "unknown flag not refused" "rc=$RC" "$OUT"; fi
+
+echo ""
+echo "  PASSED: $PASSES   FAILED: $FAILURES"
+[[ $FAILURES -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/check-direnv-fleet.test.sh
+++ b/plugins/dev/scripts/__tests__/check-direnv-fleet.test.sh
@@ -64,9 +64,15 @@ ENVRC
 echo ""
 echo "=== ⛔ the binary being ABSENT is a FAILURE, not a warning ==="
 # A PATH with no direnv on it. This is the mini-2 condition.
-OUT="$(PATH="/usr/bin:/bin" CATALYST_BREW="$SCRATCH/no-such-brew" run --dir "$SCRATCH" 2>&1)"
+# ⛔ An EMPTY bin dir, not "/usr/bin:/bin". On macOS direnv lives in /opt/homebrew/bin so that
+# PATH excluded it, but on Ubuntu the apt package installs to /usr/bin — so the "absent" fixture
+# still found direnv and the case silently tested nothing. Caught by CI, 2026-08-18.
+# The interpreter is named ABSOLUTELY because the PATH below cannot resolve `bash` either —
+# otherwise this case exits 127 (command not found) and "non-zero" passes for the wrong reason.
+mkdir -p "$SCRATCH/emptybin"
+OUT="$(PATH="$SCRATCH/emptybin" CATALYST_BREW="$SCRATCH/no-such-brew" "${BASH:-/bin/bash}" "$SUBJECT" --dir "$SCRATCH" 2>&1)"
 RC=$?
-if [[ $RC -ne 0 ]]; then pass "an absent direnv exits non-zero (rc=$RC)"; else fail "an absent direnv exited 0" "$OUT"; fi
+if [[ $RC -eq 1 ]]; then pass "an absent direnv exits 1 (the script's own failure, not a 127)"; else fail "an absent direnv did not exit 1" "rc=$RC" "$OUT"; fi
 if grep -q 'direnv NOT installed' <<<"$OUT"; then pass "it names direnv as the missing thing"; else fail "the absent binary is not named" "$OUT"; fi
 
 if [[ $HAVE_DIRENV -eq 1 ]]; then
@@ -80,8 +86,15 @@ if [[ $HAVE_DIRENV -eq 1 ]]; then
 	OUT="$(run --dir "$BLOCKED")"
 	RC=$?
 	# control — prove the fixture really is blocked, so a pass here means something
+	# ⛔ BOTH ENCODINGS. direnv 2.32.1 (Ubuntu apt) prints `false` here; 2.37.1 (homebrew) prints
+	# `1`. Pinning the control to one spelling makes this suite pass on one platform and fail on
+	# the other while the subject is correct on both.
 	FOUND="$(cd "$BLOCKED" && direnv status 2>/dev/null | grep -E '^Found RC allowed ' | head -n1)"
-	if [[ "$FOUND" == "Found RC allowed 1" ]]; then pass "control — the fixture really is blocked ($FOUND)"; else fail "the fixture is not in the blocked state" "$FOUND"; fi
+	FOUND_VAL="${FOUND##* }"
+	case "$FOUND_VAL" in
+	1 | 2 | false) pass "control — the fixture really is blocked ($FOUND)" ;;
+	*) fail "the fixture is not in the blocked state" "$FOUND" ;;
+	esac
 	if grep -q 'is BLOCKED' <<<"$OUT"; then pass "the blocked .envrc is reported BLOCKED"; else fail "a blocked .envrc was not reported" "$OUT"; fi
 	if [[ $RC -ne 0 ]]; then pass "a blocked .envrc exits non-zero (rc=$RC)"; else fail "a blocked .envrc exited 0" "$OUT"; fi
 	if ! grep -q 'readiness: PASS' <<<"$OUT"; then pass "it does not report PASS"; else fail "a blocked host reported PASS" "$OUT"; fi
@@ -106,7 +119,7 @@ if [[ $HAVE_DIRENV -eq 1 ]]; then
 	RC=$?
 	if [[ $RC -eq 0 ]]; then pass "a correct host exits 0 — the check is not always-red"; else fail "a correct host failed" "$OUT"; fi
 	if grep -q 'readiness: PASS' <<<"$OUT"; then pass "it reports PASS"; else fail "no PASS line" "$OUT"; fi
-	if grep -q 'ALLOWED (Found RC allowed 0)' <<<"$OUT"; then pass "the allowed state is read positively"; else fail "allowed state not reported" "$OUT"; fi
+	if grep -qE 'ALLOWED \(Found RC allowed (0|true)\)' <<<"$OUT"; then pass "the allowed state is read positively"; else fail "allowed state not reported" "$OUT"; fi
 	if grep -q 'LINEAR_API_TOKEN is set' <<<"$OUT"; then pass "LINEAR_API_TOKEN is seen"; else fail "token not seen" "$OUT"; fi
 
 	echo ""
@@ -164,6 +177,54 @@ if [[ $HAVE_DIRENV -eq 1 ]]; then
 	if grep -q 'probe SKIPPED' <<<"$OUT"; then pass "an unprobeable host says so"; else fail "the probe was silently skipped" "$OUT"; fi
 	if [[ $RC -ne 0 ]]; then pass "and that is a failure, not a pass (rc=$RC)"; else fail "unprobeable host exited 0" "$OUT"; fi
 fi
+
+echo ""
+echo "=== ⛔ REGRESSION GUARD: BOTH direnv allowed-state encodings, on any runner ==="
+# direnv reports this field two ways: 2.32.1 (Ubuntu apt) prints `true`/`false`, 2.37.1 (homebrew)
+# prints `0`/`1`. The ALLOWED sentinel differs in TYPE — `0` and `true` both mean allowed — so a
+# check written against only the numeric form reads `true` as non-zero and reports a correctly
+# allowed host as BLOCKED. A FALSE RED on every host with older direnv.
+#
+# The cases above can only exercise whichever direnv this runner happens to have, so they cannot
+# catch the other encoding — this is how the bug reached CI in the first place. These stub
+# `direnv` itself, so BOTH encodings are covered no matter what is installed.
+mkstub() { # mkstub <dir> <allowed-value>
+	mkdir -p "$1"
+	cat >"$1/direnv" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+version) echo "2.32.1" ;;
+status)  echo "Loaded RC allowed 0"; echo "Found RC path /stub/.envrc"; echo "Found RC allowed $2" ;;
+exec)    shift 2; exec env LINEAR_API_TOKEN=stub GITHUB_TOKEN=stub CLOUDFLARE_API_TOKEN=stub "\$@" ;;
+*) exit 0 ;;
+esac
+STUB
+	chmod +x "$1/direnv"
+}
+
+STUBPROJ="$SCRATCH/stubproj"
+mkproject "$STUBPROJ"
+for p in personal catalyst catalyst-cloud; do : >"$XDG_CONFIG_HOME/direnv/profiles/${p}.env"; done
+
+mkstub "$SCRATCH/bin-true" true
+OUT="$(PATH="$SCRATCH/bin-true:$PATH" bash "$SUBJECT" --dir "$STUBPROJ" 2>&1)"
+RC=$?
+if grep -q 'is ALLOWED (Found RC allowed true)' <<<"$OUT"; then pass "the 'true' encoding reads ALLOWED"; else fail "an older-direnv host reporting 'true' was read as blocked — the false red" "$OUT"; fi
+if [[ $RC -eq 0 ]]; then pass "and it exits 0 (rc=$RC)"; else fail "the 'true' encoding did not pass" "$OUT"; fi
+
+mkstub "$SCRATCH/bin-false" false
+OUT="$(PATH="$SCRATCH/bin-false:$PATH" bash "$SUBJECT" --dir "$STUBPROJ" 2>&1)"
+RC=$?
+if grep -q 'is BLOCKED (Found RC allowed false)' <<<"$OUT"; then pass "the 'false' encoding reads BLOCKED"; else fail "'false' was not read as blocked" "$OUT"; fi
+if [[ $RC -ne 0 ]]; then pass "and it exits non-zero (rc=$RC)"; else fail "'false' exited 0" "$OUT"; fi
+
+echo ""
+echo "=== ⛔ an UNRECOGNIZED allowed-state fails CLOSED rather than guessing ==="
+mkstub "$SCRATCH/bin-weird" maybe
+OUT="$(PATH="$SCRATCH/bin-weird:$PATH" bash "$SUBJECT" --dir "$STUBPROJ" 2>&1)"
+RC=$?
+if grep -q 'UNRECOGNIZED' <<<"$OUT"; then pass "a third encoding is named, not guessed"; else fail "an unknown encoding was not reported" "$OUT"; fi
+if [[ $RC -ne 0 ]]; then pass "and it fails closed (rc=$RC)"; else fail "an unknown encoding exited 0" "$OUT"; fi
 
 echo ""
 echo "=== argument validation ==="

--- a/plugins/dev/scripts/check-direnv-fleet.sh
+++ b/plugins/dev/scripts/check-direnv-fleet.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# check-direnv-fleet.sh — CTL-1944. Is THIS host owner-ready: can a remote owner launched here
+# read Linear, call gh, and reach Cloudflare?
+#
+# THE INCIDENT: mini-2 had no direnv at all. A remote owner was launched onto it and every Linear
+# read failed — discovered mid-run, not at provisioning time. `brew install direnv` on one host is
+# the uncodified machine edit CTL-1908 just proved drifts, so the fix is a check that RUNS
+# everywhere plus an --install that remediates.
+#
+# ⛔ THE TRAP THIS CHECK EXISTS TO AVOID: inferring configuration from the ABSENCE of output. A
+# blocked .envrc produces no variables, which looks exactly like a host with nothing to load. The
+# allowed-state must be read POSITIVELY, from `direnv status`.
+#
+# ⛔ AND THE SUBTLETY THAT MAKES A NAIVE READ WRONG: `direnv status` prints TWO blocks. "Loaded RC"
+# describes the rc already active in the CALLING shell — on an agent host that is whatever
+# directory the agent happens to sit in, and it is routinely allowed. "Found RC" describes the
+# rc for the directory being CHECKED. Measured 2026-08-18 on mini, direnv 2.37.1, from an allowed
+# repo against a blocked target: `Loaded RC allowed 0` (the caller's) and `Found RC allowed 1`
+# (the target's). A check that greps for "RC allowed 0" anywhere in the output therefore passes a
+# BLOCKED host. This reads `Found RC allowed` only. 0 = allowed, non-zero = blocked.
+#
+# ⚠️ Measured, contradicting CTL-1944's description: on direnv 2.37.1 `direnv exec .` against a
+# blocked .envrc exits 1, not 0. That exit code is version-dependent and undocumented; the
+# `Found RC allowed` field is neither. This does not rely on the exit code.
+#
+# Usage:
+#   check-direnv-fleet.sh [--dir <path>] [--install] [--require-token LINEAR_API_TOKEN] [--probe]
+#
+# Exit: 0 all checks pass · 1 a check FAILED · 2 bad arguments
+set -uo pipefail
+
+DIR="$PWD"
+DO_INSTALL=0
+DO_PROBE=0
+DIRENV_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/direnv"
+# The profiles a Catalyst host must materialize. CTL-1944: mini-2 had none of them.
+REQUIRED_PROFILES="${CATALYST_DIRENV_PROFILES:-personal catalyst catalyst-cloud}"
+# The tokens an owner cannot work without. LINEAR_API_TOKEN is the one whose absence stalled the
+# relaunch; the others are what the same profile chain is supposed to carry.
+REQUIRED_TOKENS="${CATALYST_DIRENV_TOKENS:-LINEAR_API_TOKEN GITHUB_TOKEN CLOUDFLARE_API_TOKEN}"
+BREW="${CATALYST_BREW:-brew}"
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dir) DIR="${2-}"; shift 2 ;;
+	--install) DO_INSTALL=1; shift ;;
+	--probe) DO_PROBE=1; shift ;;
+	--require-token) REQUIRED_TOKENS="${2-}"; shift 2 ;;
+	-h | --help) sed -n '2,28p' "$0"; exit 0 ;;
+	*) echo "check-direnv-fleet: unknown argument '$1'" >&2; exit 2 ;;
+	esac
+done
+[[ -n "$DIR" ]] || { echo "check-direnv-fleet: --dir requires a path" >&2; exit 2; }
+[[ -d "$DIR" ]] || { echo "check-direnv-fleet: no such directory '$DIR'" >&2; exit 2; }
+# ⛔ Resolve to the PHYSICAL path. direnv's allow-record is keyed by a hash of the .envrc's path,
+# and it stores the resolved one. Hand it a path that traverses a symlink (/tmp, or a symlinked
+# home — an agent worktree under ~/catalyst/wt can be either) and the hash misses, so a correctly
+# allowed host reports BLOCKED. A false red on the readiness check is how an owner gets held back
+# from a host that was fine. Measured 2026-08-18 on mini: /var/folders/... blocked,
+# /private/var/folders/... allowed, same directory.
+DIR="$(cd "$DIR" && pwd -P)"
+
+FAILURES=0
+pass() { echo "  ✅  $1"; }
+fail() { echo "  ❌  $1"; FAILURES=$((FAILURES + 1)); }
+info() { echo "  ℹ   $1"; }
+
+echo "direnv fleet readiness — host $(hostname -s 2>/dev/null || echo unknown), dir $DIR"
+
+# ─── 1. the binary ──────────────────────────────────────────────────────────
+if ! command -v direnv >/dev/null 2>&1 && [[ $DO_INSTALL -eq 1 ]]; then
+	info "direnv absent — installing via $BREW"
+	if command -v "$BREW" >/dev/null 2>&1; then
+		"$BREW" install direnv >/dev/null 2>&1 || true
+		# brew installs to a prefix that may not be on this non-interactive PATH yet.
+		for p in /opt/homebrew/bin /usr/local/bin "$HOME/.local/bin"; do
+			[[ -x "$p/direnv" ]] && PATH="$p:$PATH" && export PATH && break
+		done
+	else
+		info "$BREW not available — cannot auto-install"
+	fi
+fi
+
+if command -v direnv >/dev/null 2>&1; then
+	pass "direnv installed ($(direnv version 2>/dev/null || echo '?')) at $(command -v direnv)"
+else
+	# ⛔ FAIL, not warn. CTL-1944: a warn is what let mini-2 stay un-provisioned while reading as
+	# "recommended, optional" — it is not optional on a host that hosts owners.
+	fail "direnv NOT installed — this host cannot materialize fleet tokens (install: $BREW install direnv)"
+	echo ""
+	echo "FAILED: $FAILURES"
+	exit 1
+fi
+
+# ─── 2. the profiles ────────────────────────────────────────────────────────
+for p in $REQUIRED_PROFILES; do
+	if [[ -f "$DIRENV_CONFIG/profiles/${p}.env" ]]; then
+		pass "profile ${p}.env present"
+	else
+		fail "profile ${p}.env MISSING from $DIRENV_CONFIG/profiles/"
+	fi
+done
+
+# ─── 3. the .envrc, and whether it is ALLOWED ───────────────────────────────
+if [[ -f "$DIR/.envrc" ]]; then
+	pass ".envrc present in $DIR"
+
+	# Read the allowed-state POSITIVELY, from the "Found RC" block only (see header).
+	STATUS_OUT="$(cd "$DIR" && direnv status 2>/dev/null)"
+	ALLOWED_LINE="$(printf '%s\n' "$STATUS_OUT" | grep -E '^Found RC allowed ' | head -n1)"
+	if [[ -z "$ALLOWED_LINE" ]]; then
+		fail ".envrc allowed-state UNREADABLE — direnv status printed no 'Found RC allowed' line"
+	else
+		ALLOWED_VAL="${ALLOWED_LINE##* }"
+		if [[ "$ALLOWED_VAL" == "0" ]]; then
+			pass ".envrc is ALLOWED (Found RC allowed 0)"
+		else
+			fail ".envrc is BLOCKED (Found RC allowed $ALLOWED_VAL) — run: direnv allow $DIR"
+		fi
+	fi
+else
+	fail "no .envrc in $DIR — direnv loads nothing here"
+fi
+
+# ─── 4. the tokens the .envrc is supposed to produce ────────────────────────
+# Ask for exactly the names, so a value is never printed. `direnv exec` is used for the VALUES
+# only — never to infer the allowed-state, which section 3 already established positively.
+#
+# ⛔ THE SCRUB, AND WHY IT IS THE WHOLE POINT. `direnv exec` ADDS what the .envrc exports to the
+# environment it inherits; it does not scrub what was already there. Run from an agent whose own
+# shell carries LINEAR_API_TOKEN, an UNPROVISIONED host therefore reports the token as "set" —
+# the check passes on the CALLER's credentials while a freshly-launched owner on that host gets
+# nothing. That is this ticket's exact failure (a host reading ready when it is not), reproduced
+# inside the check meant to catch it; caught by the probe case in the test suite. So the dump runs
+# under `env -i`, carrying only what direnv itself needs, and every value observed is one THIS
+# HOST materialized.
+direnv_dump() { # direnv_dump <dir> — the environment $1's .envrc produces, and nothing inherited
+	env -i \
+		HOME="$HOME" \
+		PATH="$PATH" \
+		TERM="${TERM:-dumb}" \
+		XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}" \
+		XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}" \
+		direnv exec "$1" env 2>/dev/null
+}
+
+if [[ -f "$DIR/.envrc" ]]; then
+	ENV_DUMP="$(direnv_dump "$DIR")"
+	for t in $REQUIRED_TOKENS; do
+		VAL="$(printf '%s\n' "$ENV_DUMP" | grep -E "^${t}=" | head -n1)"
+		VAL="${VAL#*=}"
+		if [[ -n "$VAL" ]]; then
+			pass "$t is set (${#VAL} chars)"
+		else
+			fail "$t is EMPTY — an owner launched here cannot use it"
+		fi
+	done
+fi
+
+# ─── 5. optional live probe ─────────────────────────────────────────────────
+if [[ $DO_PROBE -eq 1 ]]; then
+	# Same scrub as section 4 — probe the token THIS HOST produces, not the caller's.
+	TOKEN="$(printf '%s\n' "$(direnv_dump "$DIR")" | grep -E '^LINEAR_API_TOKEN=' | head -n1)"
+	TOKEN="${TOKEN#*=}"
+	if [[ -z "$TOKEN" ]]; then
+		fail "live Linear probe SKIPPED — no LINEAR_API_TOKEN to probe with"
+	else
+		VIEWER="$(curl -sS --max-time 20 -X POST https://api.linear.app/graphql \
+			-H "Content-Type: application/json" -H "Authorization: $TOKEN" \
+			-d '{"query":"{ viewer { id } }"}' 2>/dev/null)"
+		if printf '%s' "$VIEWER" | grep -q '"viewer"' && ! printf '%s' "$VIEWER" | grep -q '"errors"'; then
+			pass "live Linear viewer probe OK"
+		else
+			fail "live Linear viewer probe FAILED (token present but not accepted)"
+		fi
+	fi
+fi
+
+echo ""
+if [[ $FAILURES -eq 0 ]]; then
+	echo "direnv fleet readiness: PASS"
+	exit 0
+fi
+echo "direnv fleet readiness: FAIL ($FAILURES)"
+exit 1

--- a/plugins/dev/scripts/check-direnv-fleet.sh
+++ b/plugins/dev/scripts/check-direnv-fleet.sh
@@ -112,11 +112,28 @@ if [[ -f "$DIR/.envrc" ]]; then
 		fail ".envrc allowed-state UNREADABLE — direnv status printed no 'Found RC allowed' line"
 	else
 		ALLOWED_VAL="${ALLOWED_LINE##* }"
-		if [[ "$ALLOWED_VAL" == "0" ]]; then
-			pass ".envrc is ALLOWED (Found RC allowed 0)"
-		else
+		# ⛔ TWO ENCODINGS, AND READING ONLY ONE INVERTS THE ANSWER. direnv changed this field's
+		# representation: 2.32.1 (Ubuntu 24.04's apt package) prints `true`/`false`, while 2.37.1
+		# (current homebrew) prints `0`/`1`. Both were measured 2026-08-18 — 2.37.1 on mini,
+		# 2.32.1 on the CI runner, which is how this was caught.
+		#
+		# The trap is that the ALLOWED sentinel differs in TYPE, not just spelling: `0` means
+		# allowed, and so does `true` — so a check written against only the numeric form reads
+		# 2.32's `true` as non-zero and reports a correctly-allowed host as BLOCKED. That is a
+		# FALSE RED on every host running the older direnv, which would have held owners back
+		# from hosts that were fine. Handle both, and fail CLOSED on anything unrecognized rather
+		# than guessing a third encoding right.
+		case "$ALLOWED_VAL" in
+		0 | true)
+			pass ".envrc is ALLOWED (Found RC allowed $ALLOWED_VAL)"
+			;;
+		1 | 2 | false)
 			fail ".envrc is BLOCKED (Found RC allowed $ALLOWED_VAL) — run: direnv allow $DIR"
-		fi
+			;;
+		*)
+			fail ".envrc allowed-state UNRECOGNIZED (Found RC allowed '$ALLOWED_VAL', direnv $(direnv version 2>/dev/null || echo '?')) — refusing to guess"
+			;;
+		esac
 	fi
 else
 	fail "no .envrc in $DIR — direnv loads nothing here"

--- a/plugins/dev/scripts/check-setup.sh
+++ b/plugins/dev/scripts/check-setup.sh
@@ -1082,8 +1082,30 @@ if command -v direnv &>/dev/null; then
 		warn "No .envrc in current project — direnv not active here"
 	fi
 else
-	warn "direnv not installed (recommended for multi-repo API key isolation)"
-	info "Install: brew install direnv"
+	# ⛔ CTL-1944: this was a warn, and a warn is what let mini-2 sit un-provisioned. direnv is not
+	# "recommended" on a host that hosts owners — without it the host materializes no tokens and
+	# every Linear read by an owner launched here fails.
+	fail "direnv NOT installed — this host cannot materialize fleet tokens (owners launched here cannot read Linear)"
+	info "Install: brew install direnv  (or re-run install-cli.sh, which now provisions it)"
+fi
+
+# ─── 8b. direnv fleet readiness (CTL-1944) ──────────────────────────────────
+# Delegated to check-direnv-fleet.sh rather than reimplemented here: the allowed-state read is
+# subtle enough (the Loaded-vs-Found distinction, the physical-path resolution, the env scrub)
+# that a second copy is guaranteed drift. This is the same script the host setup path runs.
+DIRENV_FLEET_CHECK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-direnv-fleet.sh"
+if [[ -x "$DIRENV_FLEET_CHECK" ]]; then
+	if FLEET_OUT="$(bash "$DIRENV_FLEET_CHECK" --dir "$PWD" 2>&1)"; then
+		pass "direnv fleet readiness: this host can materialize owner tokens"
+	else
+		fail "direnv fleet readiness FAILED — an owner launched here may not be able to read Linear"
+		while IFS= read -r line; do
+			[[ "$line" == *"❌"* ]] && info "${line#"${line%%[![:space:]]*}"}"
+		done <<<"$FLEET_OUT"
+		info "Detail: bash $DIRENV_FLEET_CHECK --dir '$PWD'"
+	fi
+else
+	warn "check-direnv-fleet.sh not found next to check-setup.sh — fleet readiness unverified"
 fi
 
 # ─── 9. Thoughts System ─────────────────────────────────────────────────────

--- a/plugins/dev/scripts/install-cli.sh
+++ b/plugins/dev/scripts/install-cli.sh
@@ -244,6 +244,40 @@ _ab_version_ge() {
   [[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" == "$2" ]]
 }
 
+# ensure_direnv — install direnv when absent (CTL-1944). Every fleet host must be able to
+# materialize the direnv-backed tokens (LINEAR_API_TOKEN / GITHUB_TOKEN / CLOUDFLARE_API_TOKEN)
+# that a remote owner needs; mini-2 had no direnv at all and every Linear read on it failed,
+# discovered mid-run rather than at provisioning time.
+#
+# ⛔ Why this INSTALLS instead of only reporting: `brew install direnv` typed on one host is the
+# uncodified machine edit CTL-1908 proved drifts — that fix lived on the laptop for nine hours
+# while both minis still carried the incident condition. The codified installer is the fix.
+#
+# Same warn+continue contract as ensure_alloy/ensure_agent_browser: install-cli must not exit
+# non-zero here. The RED signal is check-direnv-fleet.sh, which fails the host loudly.
+ensure_direnv() {
+  if command -v direnv >/dev/null 2>&1; then
+    echo "  direnv $(direnv version 2>/dev/null || echo '?') present ($(command -v direnv))"
+    return 0
+  fi
+
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "  warning: direnv absent and brew unavailable — install manually (brew install direnv); this host cannot materialize fleet tokens until then" >&2
+    return 0
+  fi
+
+  echo "  Installing direnv via brew (CTL-1944)…"
+  brew install direnv >/dev/null 2>&1 || true
+  hash -r 2>/dev/null || true
+
+  if command -v direnv >/dev/null 2>&1; then
+    echo "  Installed direnv $(direnv version 2>/dev/null || echo '?') ($(command -v direnv))"
+  else
+    echo "  warning: direnv install via brew failed — this host cannot materialize fleet tokens, and a remote owner launched here will not be able to read Linear" >&2
+  fi
+  return 0
+}
+
 # ensure_agent_browser — install/upgrade agent-browser to >= AGENT_BROWSER_MIN_VERSION
 # and provision its Chrome-for-Testing browser (CTL-1500). agent-browser is a
 # homebrew-core formula (`brew install agent-browser` — no tap); after install/
@@ -594,6 +628,10 @@ ensure_alloy || true
 # warn+continue contract as ensure_alloy — optional browser-testing infra must
 # never make install-cli exit non-zero.
 ensure_agent_browser || true
+
+# Provision direnv (CTL-1944). Same warn+continue contract — the loud failure is
+# check-direnv-fleet.sh, which fails a host that still cannot materialize fleet tokens.
+ensure_direnv || true
 
 # PATH bootstrap — if BIN_DIR is not on PATH, append an export line to the
 # user's shell rc file. Idempotent: a marker comment guards against duplicate


### PR DESCRIPTION
mini-2 had no `direnv` at all. A remote owner was launched onto it and every Linear read failed — discovered mid-run, not at provisioning time. The old check only ever **warned** that direnv was "recommended for multi-repo API key isolation", so a host that could not carry a single fleet token read as fine.

## What lands

| file | change |
| -- | -- |
| `plugins/dev/scripts/check-direnv-fleet.sh` | **new** — the readiness check. FAILS (not warns) on an absent direnv, a missing `{personal,catalyst,catalyst-cloud}.env` profile, an absent or **BLOCKED** `.envrc`, or any required token the host does not produce. `--install` remediates, `--probe` adds a live Linear `viewer` call. |
| `plugins/dev/scripts/install-cli.sh` | `ensure_direnv`, same warn+continue contract as `ensure_alloy` / `ensure_agent_browser`. |
| `plugins/dev/scripts/check-setup.sh` | direnv-absent becomes a **FAIL**; new section 8b **delegates** to the script above. |
| `.github/workflows/execution-core-tests.yml` | installs direnv, then runs the suite. |

`check-setup.sh` delegates rather than reimplements — the allowed-state read is subtle enough that a second copy is guaranteed drift.

## Three things a plausible version gets wrong

Each measured on mini today, each with a regression guard:

1. **The allowed-state is read positively.** A blocked `.envrc` emits no variables, which is indistinguishable from a host with nothing configured. The state comes from `direnv status`, never from absent output.
2. **`Found RC`, never `Loaded RC`.** `direnv status` prints both — "Loaded" is the rc already active in the **calling** shell (on an agent host, routinely allowed); "Found" is the rc for the directory being **checked**. Measured from an allowed repo against a blocked target: `Loaded RC allowed 0` **and** `Found RC allowed 1`. A grep for `RC allowed 0` anywhere in that output **passes a BLOCKED host**.
3. **The environment is scrubbed.** `direnv exec` *adds* the `.envrc`'s exports to what it inherits — it does not scrub. Run from an agent whose own shell carries `LINEAR_API_TOKEN`, an **unprovisioned** host reports ready on the **caller's** credentials. That is this ticket's own failure mode reproduced inside the check meant to catch it. The test caught it on the first run; the dump now runs under `env -i`.

Also: `--dir` is resolved with `pwd -P`. direnv keys its allow-record by a hash of the `.envrc`'s **resolved** path, so a path traversing a symlink (`/tmp`, or a worktree under a symlinked home) misses the hash and reports a correctly-allowed host as BLOCKED — a false red that would hold an owner back from a host that was fine.

## ⚠️ One correction to the ticket

CTL-1944 states `direnv exec .` on a blocked `.envrc` "exits 0 and prints nothing". Measured on direnv 2.37.1: it exits **1**. That exit code is version-dependent and undocumented; `Found RC allowed` is neither, and nothing here relies on the exit code. The ticket's underlying point — that inferring configuration from absent output is wrong — is exactly what this implements.

## The test does not ship inert

CI installs direnv before running the suite, **and** the suite refuses to skip when `$CI` is set. Without the binary it would run one case, report green, and cover none of the guards above — the CTL-1919/CTL-1935 class.

## Verified

- 25/25 suite green on mini; the CI-skip guard proven red (`exit 1`) with direnv off `PATH`.
- `check-setup.sh` on mini: **87 passed, 0 failed**, new line reporting PASS — the negative control, so the check is not simply always-red.
- `audit-references --ci` exit 0 / 0 errors; `check-agents-md-bridge.sh` exit 0.

## ⛔ Not yet done: the mini-2 run

AC 3 ("run on mini-2 today, it fails naming direnv absent; after remediation it passes") **is not verified here.** `mini` has no outbound ssh credential — its identity comes from the 1Password agent, unavailable in a non-interactive session — so `ssh mini-2` is `Permission denied (publickey)` from this host. The laptop is the host that can reach both minis. The remediation command is codified and ready:

```bash
bash plugins/dev/scripts/check-direnv-fleet.sh --dir ~/code-repos/github/coalesce-labs/catalyst-cloud --install --probe
```

Expected on mini-2: **red first** (naming direnv absent), then green after `--install`.