### PR TITLE
feat(dev): CTL-1929 — the installer stops opening the GitHub smee tunnel once the feed is authoritative

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1041,6 +1041,7 @@ jobs:
             github-feed-ready.test.mjs \
             github-feed-gate-install.test.mjs \
             github-feed-gate-wiring.test.mjs \
+            github-feed-mode-leaf.test.mjs \
             cloud-feed-gate.test.mjs \
             cloud-feed-capture.test.mjs \
             cloud-feed-timer.test.mjs \

--- a/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-pino-fallback.test.mjs
@@ -58,6 +58,11 @@ function stageScratch() {
   // module graph resolves identically to production (same rationale as deployment-mode.mjs
   // above).
   cpSync(resolve(__dirname, "../lib/secret-contract.mjs"), join(libDir, "secret-contract.mjs"));
+  // CTL-1929: readGithubFeedConfig now delegates to the zero-import github-feed-mode
+  // leaf, so it is part of config.mjs's relative-import graph too. ⭐ This test caught
+  // the omission on the first full run rather than letting a host discover it — which
+  // is exactly the contract the comment above states, working.
+  cpSync(resolve(__dirname, "../lib/github-feed-mode.mjs"), join(libDir, "github-feed-mode.mjs"));
   // type:module + no deps -> pino unresolvable from this directory tree.
   writeFileSync(
     join(scratch, "package.json"),

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -85,6 +85,10 @@ export {
   resolveDeploymentMode,
   getDeploymentMode,
 } from "../lib/deployment-mode.mjs";
+// CTL-1929: the canonical github-feed resolver. Zero-import leaf for the same reason
+// deployment-mode.mjs above is one — doctor.mjs runs under bare Node and cannot load
+// this file (its chain reaches bun:sqlite via linear-query.mjs).
+import { resolveGithubFeedMode } from "../lib/github-feed-mode.mjs";
 
 // --- Paths ---
 // Re-resolved per call so tests can redirect by setting CATALYST_DIR;
@@ -2146,30 +2150,25 @@ export function readCloudFeedConfig(envObj = process.env) {
 // `github.pr.merged` and `github.check_suite.completed` (CTC-691 / CTC-667 item 4),
 // so that merge would blind the CI wait and the deploy chain fleet-wide. The two
 // legs cut over independently or they cut over recklessly.
-const GITHUB_FEED_MODES = new Set(["off", "shadow", "enforce"]);
-
-function readLayer2GithubFeed() {
-  try {
-    const gf = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.githubFeed;
-    return gf && typeof gf === "object" ? gf : {};
-  } catch {
-    return {};
-  }
-}
-
+// ⛔ THIS READER NOW DELEGATES TO `lib/github-feed-mode.mjs` AND KEEPS NO COPY.
+//
+// Four readers in three processes ask this question — the producer (daemon), the
+// dispatch gate (broker), the smee-tunnel gate (orch-monitor) and doctor — and
+// doctor runs under bare Node, which cannot load this file at all (the import chain
+// reaches `bun:sqlite` via linear-query.mjs). So the resolution had to move to a
+// zero-import leaf regardless; leaving a second copy here is what would turn a
+// config question into a dispatch bug. A producer that read `enforce` while the
+// tunnel gate read something else is a double dispatch on every covered name, and
+// it would present as a parity failure rather than as the config drift it is.
+//
+// ⚠️ Delegating also CHANGES ONE BEHAVIOUR, deliberately: a set-but-invalid env
+// value now falls back to `off` **and overrides Layer-2**, per CAT-57's contract
+// (see `config.test.mjs`'s "a SET-but-invalid env value ... overrides Layer-2
+// enforce"). The version this replaces fell through to Layer-2 on a typo, which is
+// the wrong direction for a containment knob — an operator reaching for the env var
+// to REDUCE actuation would have silently left a Layer-2 `enforce` live.
 export function readGithubFeedConfig(envObj = process.env) {
-  const l2 = readLayer2GithubFeed();
-  const env = envObj.CATALYST_GITHUB_FEED;
-  let mode;
-  if (env === "0") mode = "off";
-  else if (typeof env === "string" && GITHUB_FEED_MODES.has(env)) mode = env;
-  else if (typeof l2.mode === "string" && GITHUB_FEED_MODES.has(l2.mode)) mode = l2.mode;
-  else mode = "off";
-  const rawInterval = envObj.CATALYST_GITHUB_FEED_INTERVAL_SEC ?? l2.intervalSeconds;
-  const parsed = Number(rawInterval);
-  // Number("") and Number(null) are both 0, which would read as a valid "0 seconds"
-  // and busy-spin the tick. Require a finite value >= 5.
-  const intervalSec = Number.isFinite(parsed) && parsed >= 5 ? Math.floor(parsed) : 30;
+  const { mode, intervalSec } = resolveGithubFeedMode({ env: envObj });
   return { mode, intervalSec };
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -38,6 +38,14 @@ import { checkIndexServingRoot } from "./index-serving-root-health.mjs";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
 
+// CTL-1929: the GitHub-feed mode + the consumed/suppressible name lists, from two
+// zero-import leaves. ⛔ `github-feed-gate.mjs` — where the name lists used to live
+// — reaches `bun:sqlite` and this file runs under BARE NODE, so importing it here
+// fails at load (measured: config.mjs LOADS under bare node, github-feed-gate.mjs
+// REJECTS). The alternative was a hand-maintained copy here, which would keep
+// reporting three uncovered names after CTC-691/CTC-667/CTC-704 close.
+import { resolveGithubFeedMode } from "../lib/github-feed-mode.mjs";
+import { GITHUB_CONSUMED_NAMES, GITHUB_SUPPRESSIBLE_NAMES } from "../lib/github-feed-names.mjs";
 import {
   getHostName,
   getClusterHosts,
@@ -1188,6 +1196,11 @@ export function checkWebhookIngestion(deps = {}) {
     // undefined = the pre-alignment FAIL behavior (grading must fail closed,
     // unlike the INFO-only shadow's throw handling).
     resolveDeploymentModeFn = resolveDeploymentMode,
+    // CTL-1929: the GitHub-feed mode, injectable for the same reason
+    // resolveDeploymentModeFn is — the declared-cloud branch's grade now depends on
+    // it, and driving it through the real env would make these tests mutate a
+    // process-wide flag that four readers in three processes consult.
+    resolveGithubFeedModeFn = resolveGithubFeedMode,
   } = deps;
 
   const roster = resolveRoster();
@@ -1318,11 +1331,59 @@ export function checkWebhookIngestion(deps = {}) {
       //     wrong in the direction that sends an operator hunting a Linear
       //     outage that isn't there.)
       if (declaredMode.mode === "cloud") {
+        // CTL-1929: the GitHub half of this WARN is no longer unconditional.
+        //
+        // ⛔ AND IT IS STILL NOT AN UNCONDITIONAL PASS. The GitHub feed at
+        // `enforce` replaces smee for the names it COVERS — 9 of the 12 the broker
+        // router consumes. `github.pr.merged` (CTC-691),
+        // `github.check_suite.completed` (CTC-667 item 4) and `github.push`
+        // (CTC-704) have no faithful replacement, so on a declared-cloud node —
+        // which has no tunnel at all — those three are genuinely unseen. Reporting
+        // PASS here would tell an operator the route is whole at exactly the moment
+        // the merge→deploy join, the CI wait, and rebase detection are the parts
+        // that are missing.
+        //
+        // ⚠️ The residual is read from the gate rather than restated, so this line
+        // stops warning by itself when the gaps close instead of needing an edit
+        // that nobody will remember to make.
+        // ⛔ A THROWING RESOLVER GRADES AS "no cloud replacement", not as a pass.
+        // Same fail-closed direction the deployment-mode resolver above takes: an
+        // unreadable config must never be the reason doctor tells an operator the
+        // GitHub route is whole.
+        let ghFeed;
+        try {
+          ghFeed = resolveGithubFeedModeFn();
+        } catch {
+          ghFeed = { mode: "off", source: "resolver-threw" };
+        }
+        if (ghFeed.mode === "enforce") {
+          const uncovered = GITHUB_CONSUMED_NAMES.filter(
+            (n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n),
+          );
+          if (uncovered.length === 0) {
+            return [
+              mkCheck(
+                "webhook-ingestion",
+                STATUS.PASS,
+                `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired; Linear ingestion is replaced by the cloud feed (CTL-1928) and GitHub ingestion by the GitHub feed at enforce (CTL-1929), covering all ${GITHUB_CONSUMED_NAMES.length} consumed github.* names`,
+              ),
+              ...webhookShadow,
+            ];
+          }
+          return [
+            mkCheck(
+              "webhook-ingestion",
+              STATUS.WARN,
+              `declared deployment mode "cloud" (source=${declaredMode.source}) — GitHub feed at enforce (source=${ghFeed.source}) covers ${GITHUB_SUPPRESSIBLE_NAMES.length}/${GITHUB_CONSUMED_NAMES.length} consumed github.* names, but ${uncovered.length} have NO source on this node: ${uncovered.join(", ")} — the merge→deploy join, the CI wait and rebase detection degrade`,
+            ),
+            ...webhookShadow,
+          ];
+        }
         return [
           mkCheck(
             "webhook-ingestion",
             STATUS.WARN,
-            `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired; Linear ingestion is replaced by the cloud feed (CTL-1928), but GitHub ingestion has NO cloud replacement yet: this node cannot see github.* events (monitor-merge, CI waits, PR-lifecycle routing)`,
+            `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired; Linear ingestion is replaced by the cloud feed (CTL-1928), but GitHub ingestion has NO cloud replacement active (CATALYST_GITHUB_FEED=${ghFeed.mode}, source=${ghFeed.source}): this node cannot see github.* events (monitor-merge, CI waits, PR-lifecycle routing)`,
           ),
           ...webhookShadow,
         ];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -7,6 +7,9 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
+// CTL-1929: the consumed/suppressible name lists, from the zero-import leaf that
+// doctor.mjs itself reads — so this test cannot drift from the grade it asserts on.
+import { GITHUB_CONSUMED_NAMES, GITHUB_SUPPRESSIBLE_NAMES } from "../lib/github-feed-names.mjs";
 import {
   STATUS,
   mkCheck,
@@ -728,6 +731,85 @@ describe("checkWebhookIngestion", () => {
     expect(checks[0].name).toBe("webhook-ingestion");
     expect(checks[0].status).toBe(STATUS.PASS);
     expect(checks[0].detail).toContain("single-host");
+  });
+
+  // ─── CTL-1929: the declared-cloud grade now depends on the GitHub feed ──────
+  describe("declared cloud + the GitHub feed (CTL-1929)", () => {
+    const cloud = () => ({ mode: "cloud", source: "layer2", inferred: false, recognized: true });
+    const run = (ghFeed) =>
+      checkWebhookIngestion({
+        resolveDeploymentModeFn: cloud,
+        resolveRoster: multiHost,
+        monitor: { github: { smeeChannel: "" }, linear: {} },
+        secretFileNonEmpty: noSecrets,
+        resolveSecretContract: agreeingSecretContract(false),
+        resolveGithubFeedModeFn: () => ghFeed,
+      })[0];
+
+    it("feed OFF → WARN naming the mode, because github.* has no source at all", () => {
+      const c = run({ mode: "off", source: "default" });
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("NO cloud replacement active");
+      expect(c.detail).toContain("CATALYST_GITHUB_FEED=off");
+    });
+
+    it("⚠️ feed SHADOW is still a WARN — shadow replaces nothing", () => {
+      // The trap: shadow looks healthy (a producer is running, events are being
+      // observed) and grades identically to off, because nothing it emits is
+      // authoritative and the dispatch gate suppresses nothing.
+      const c = run({ mode: "shadow", source: "env" });
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("NO cloud replacement active");
+    });
+
+    it("⛔ feed ENFORCE with gaps open is a WARN that NAMES the uncovered names", () => {
+      // Not a PASS. On a declared-cloud node there is no tunnel, so the three
+      // uncovered names are genuinely unseen — reporting the route whole here would
+      // say "fine" at exactly the moment the merge→deploy join, the CI wait and
+      // rebase detection are the parts that are missing.
+      const c = run({ mode: "enforce", source: "env" });
+      expect(c.status).toBe(STATUS.WARN);
+      for (const n of GITHUB_CONSUMED_NAMES.filter((x) => !GITHUB_SUPPRESSIBLE_NAMES.includes(x))) {
+        expect(c.detail).toContain(n);
+      }
+      expect(c.detail).toContain(`${GITHUB_SUPPRESSIBLE_NAMES.length}/${GITHUB_CONSUMED_NAMES.length}`);
+    });
+
+    it("⭐ the counts and names are DERIVED — the WARN stops warning by itself when the gaps close", () => {
+      // Drives the post-CTC-691/667/704 world through the same code path. A
+      // hand-written detail string passes every test above and keeps reporting three
+      // uncovered names forever.
+      const uncovered = GITHUB_CONSUMED_NAMES.filter((x) => !GITHUB_SUPPRESSIBLE_NAMES.includes(x));
+      expect(uncovered.length).toBeGreaterThan(0); // precondition: gaps are open today
+      expect(GITHUB_SUPPRESSIBLE_NAMES.length).toBeLessThan(GITHUB_CONSUMED_NAMES.length);
+      const c = run({ mode: "enforce", source: "env" });
+      expect(c.detail).toContain(`${uncovered.length} have NO source`);
+    });
+
+    it("⛔ a THROWING feed resolver grades as NO REPLACEMENT, not as a degraded enforce", () => {
+      // ⚠️ My first version of this asserted only `status === WARN` plus the string
+      // "resolver-threw", and the mutation (fail OPEN to enforce) PASSED — because
+      // while the three gaps are open BOTH branches grade WARN and both print the
+      // source. The assertion could not tell the two apart, and would have started
+      // being wrong precisely when the gaps closed and fail-open became a PASS.
+      //
+      // The distinguishing fact is WHICH branch answered, so assert on that: an
+      // unreadable config must land in the same place as `mode: off`.
+      const c = checkWebhookIngestion({
+        resolveDeploymentModeFn: cloud,
+        resolveRoster: multiHost,
+        monitor: { github: { smeeChannel: "" }, linear: {} },
+        secretFileNonEmpty: noSecrets,
+        resolveSecretContract: agreeingSecretContract(false),
+        resolveGithubFeedModeFn: () => { throw new Error("unreadable config"); },
+      })[0];
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("NO cloud replacement active");
+      expect(c.detail).toContain("resolver-threw");
+      // ⛔ and NOT the enforce branch's language, which would claim partial coverage
+      // this node has no basis to claim.
+      expect(c.detail).not.toContain("covers");
+    });
   });
 
   it("FAILs a multiHost node with no webhook route enabled", () => {

--- a/plugins/dev/scripts/execution-core/github-feed-gate.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.mjs
@@ -41,12 +41,19 @@
 // Pure: no I/O, no clock, no env. Every dependency is an argument.
 
 import { getEventName } from "../lib/event-name.mjs";
-import {
-  GITHUB_DISPATCH_CLASS_NAMES,
-  GITHUB_UNCOVERED_NAMES,
-  SOURCE_CLOUD_FEED,
-} from "./github-feed-event.mjs";
+import { SOURCE_CLOUD_FEED } from "./github-feed-event.mjs";
 import { PUSH_IS_LOSSY } from "./github-feed-source.mjs";
+// ⛔ THE NAME LISTS MOVED TO A ZERO-IMPORT LEAF and this file no longer owns them.
+// `catalyst doctor` is now a consumer — it must report WHICH names a declared-cloud
+// node cannot see — and doctor runs under bare Node, which cannot load this file at
+// all (it reaches `bun:sqlite` via github-feed-source.mjs). A second copy in doctor
+// would keep reporting three uncovered names after CTC-691/667/704 close.
+import {
+  EXCLUSION_REASONS as LEAF_EXCLUSION_REASONS,
+  GITHUB_CONSUMED_NAMES as LEAF_CONSUMED_NAMES,
+  GITHUB_UNCOVERED_NAMES as LEAF_UNCOVERED_NAMES,
+  computeSuppressible as leafComputeSuppressible,
+} from "../lib/github-feed-names.mjs";
 
 /** The three modes, house convention. */
 export const GITHUB_FEED_MODES = Object.freeze(new Set(["off", "shadow", "enforce"]));
@@ -82,51 +89,11 @@ export function githubLossyNames(pushIsLossy = PUSH_IS_LOSSY) {
 
 export const GITHUB_LOSSY_NAMES = githubLossyNames();
 
-/**
- * Names `enforce` may suppress smee for: the dispatch class, minus everything this
- * producer cannot faithfully replace.
- *
- * ⭐ COMPUTED, NEVER LITERAL. Every input is the producer's own export, so coverage
- * and suppression cannot drift apart — the failure mode a hand-written list has is
- * that it keeps suppressing a name after that name stops being covered, and nothing
- * reads differently until the signal is already gone.
- */
-/**
- * computeSuppressible — the derivation, as a pure function of its three inputs.
- *
- * ⚠️ EXTRACTED SO THE DERIVATION IS OBSERVABLE. Applied to today's real constants
- * it returns the same list a hand-written literal would, so a test that only
- * compares the exported constant against `["github.push"]` passes whether the set
- * is derived or typed — it asserts a tautology and would keep passing after CTC-704
- * lands and the set is supposed to EMPTY itself. Taking the inputs as arguments is
- * what lets a test drive the post-CTC-704 world today.
- */
-export function computeSuppressible({ consumed, uncovered, lossy }) {
-  const excluded = new Set([...uncovered, ...lossy]);
-  return Object.freeze(consumed.filter((n) => !excluded.has(n)));
-}
-
-/**
- * ⛔ THE GATE'S UNIVERSE IS WHAT THE ROUTER CONSUMES, NOT WHAT THE PRODUCER EMITS.
- *
- * `GITHUB_DISPATCH_CLASS_NAMES` is the producer's export and means "names I emit"
- * — it deliberately excludes `github.pr.merged` and `github.check_suite.completed`,
- * which is why they live in `GITHUB_UNCOVERED_NAMES`. But the ROUTER acts on both:
- * `router.mjs:1497` (check_suite → the CI wait), `:1513` (pr.merged →
- * `setFilterStateMerged`, the merge→deploy join key), plus `:1856`, `:1871`, `:1941`.
- *
- * ⚠️ Taking the producer's list as the universe made this gate answer
- * `not-dispatch-class` for `github.pr.merged` — "the gate has no opinion" about the
- * single most dangerous name in this feature. That happens to be SAFE today, since
- * both readings end in `suppress: false`. It is safe by accident, and an accident
- * is not a property: the capture record would have said the gate never looked,
- * rather than that it looked and refused, and the difference is the whole audit
- * trail during a cutover. Caught by running the decision table, not by reading it.
- */
-export const GITHUB_CONSUMED_NAMES = Object.freeze([
-  ...GITHUB_DISPATCH_CLASS_NAMES,
-  ...GITHUB_UNCOVERED_NAMES,
-]);
+/** Re-exported from the leaf so producer, gate and doctor read ONE source. */
+export const GITHUB_CONSUMED_NAMES = LEAF_CONSUMED_NAMES;
+export const GITHUB_UNCOVERED_NAMES = LEAF_UNCOVERED_NAMES;
+export const computeSuppressible = leafComputeSuppressible;
+export const EXCLUSION_REASONS = LEAF_EXCLUSION_REASONS;
 
 export const GITHUB_SUPPRESSIBLE_NAMES = computeSuppressible({
   consumed: GITHUB_CONSUMED_NAMES,
@@ -136,19 +103,6 @@ export const GITHUB_SUPPRESSIBLE_NAMES = computeSuppressible({
 
 const DISPATCH_CLASS_SET = new Set(GITHUB_CONSUMED_NAMES);
 const SUPPRESSIBLE_SET = new Set(GITHUB_SUPPRESSIBLE_NAMES);
-
-/**
- * Why a dispatch-class name is excluded, for the capture record.
- *
- * An excluded name is the normal, expected state today, so the capture file must be
- * able to say WHICH gap kept smee authoritative — otherwise "enforce is on and smee
- * still dispatched" is indistinguishable from a broken gate.
- */
-export const EXCLUSION_REASONS = Object.freeze({
-  "github.pr.merged": "no-replacement:no-merge-commit-sha:CTC-691",
-  "github.check_suite.completed": "no-replacement:no-suite-row:CTC-667-item-4",
-  "github.push": "lossy-replacement:pushes-keyed-per-ref:CTC-704",
-});
 
 export const SOURCE_WEBHOOK = "webhook";
 export const SOURCE_OTHER = "other";

--- a/plugins/dev/scripts/execution-core/github-feed-mode-leaf.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-mode-leaf.test.mjs
@@ -1,0 +1,176 @@
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-mode-leaf.test.mjs
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  DEFAULT_GITHUB_FEED_MODE,
+  GITHUB_FEED_MODES,
+  githubFeedIsAuthoritative,
+  resolveGithubFeedMode,
+} from "../lib/github-feed-mode.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_LOSSY_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+  GITHUB_UNCOVERED_NAMES,
+  computeSuppressible,
+} from "../lib/github-feed-names.mjs";
+import { readGithubFeedConfig } from "./config.mjs";
+
+const tmp = mkdtempSync(join(tmpdir(), "gh-feed-mode-"));
+afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
+
+const l2 = (obj) => {
+  const p = join(tmp, `l2-${Math.abs(JSON.stringify(obj).length)}-${Object.keys(obj).length}.json`);
+  writeFileSync(p, JSON.stringify(obj));
+  return p;
+};
+const r = (env, path) => resolveGithubFeedMode({ env, layer2ConfigPath: path ?? join(tmp, "absent.json") });
+
+describe("the ladder: env → Layer-2 → off", () => {
+  test("unset resolves to the default, and says the source was the default", () => {
+    expect(r({})).toEqual({ mode: DEFAULT_GITHUB_FEED_MODE, intervalSec: 30, source: "default" });
+  });
+
+  test("every valid env value is honoured", () => {
+    for (const mode of GITHUB_FEED_MODES) {
+      expect(r({ CATALYST_GITHUB_FEED: mode })).toMatchObject({ mode, source: "env" });
+    }
+  });
+
+  test("`0` means off, explicitly from env", () => {
+    expect(r({ CATALYST_GITHUB_FEED: "0" })).toMatchObject({ mode: "off", source: "env" });
+  });
+
+  test("Layer-2 is read when env is unset", () => {
+    const p = l2({ catalyst: { githubFeed: { mode: "enforce", intervalSeconds: 45 } } });
+    expect(r({}, p)).toEqual({ mode: "enforce", intervalSec: 45, source: "layer2" });
+  });
+
+  test("env beats Layer-2", () => {
+    const p = l2({ catalyst: { githubFeed: { mode: "enforce" } } });
+    expect(r({ CATALYST_GITHUB_FEED: "shadow" }, p)).toMatchObject({ mode: "shadow", source: "env" });
+  });
+});
+
+describe("⛔ CAT-57's rule: a SET-but-invalid env value falls back to off AND overrides Layer-2", () => {
+  const p = () => l2({ catalyst: { githubFeed: { mode: "enforce" } } });
+
+  test("baseline — with no env var, Layer-2 enforce is honoured", () => {
+    expect(r({}, p())).toMatchObject({ mode: "enforce", source: "layer2" });
+  });
+
+  test("a typo does NOT fall through to Layer-2 enforce", () => {
+    // ⛔ The failure direction that matters: an operator reaching for the env var to
+    // REDUCE actuation must not silently leave a Layer-2 enforce live. This is the
+    // behaviour execution-core/config.mjs's own readGithubFeedConfig did NOT have
+    // before it delegated here.
+    for (const typo of ["enfroce", "shadwo", "ENFORCE", "enforce ", "1", "true"]) {
+      const v = r({ CATALYST_GITHUB_FEED: typo }, p());
+      expect(v.mode).toBe("off");
+      expect(v.source).toBe("env-invalid");
+    }
+  });
+
+  test("⚠️ but an EMPTY or whitespace var still defers to Layer-2 — unset, not invalid", () => {
+    // `export CATALYST_GITHUB_FEED=` is the same operator intent as not setting it.
+    // Treating it as a typo would let an empty var silently disable a Layer-2 rollout.
+    for (const empty of ["", "   ", "\t"]) {
+      expect(r({ CATALYST_GITHUB_FEED: empty }, p())).toMatchObject({ mode: "enforce", source: "layer2" });
+    }
+  });
+});
+
+describe("the interval", () => {
+  test("below the floor, absent, or unparseable → the default", () => {
+    for (const v of ["", "0", "1", "4", "nonsense", null, undefined]) {
+      expect(r({ CATALYST_GITHUB_FEED_INTERVAL_SEC: v }).intervalSec).toBe(30);
+    }
+  });
+  test("a valid value is honoured and floored to an integer", () => {
+    expect(r({ CATALYST_GITHUB_FEED_INTERVAL_SEC: "60" }).intervalSec).toBe(60);
+    expect(r({ CATALYST_GITHUB_FEED_INTERVAL_SEC: "45.9" }).intervalSec).toBe(45);
+  });
+});
+
+describe("⛔ githubFeedIsAuthoritative is named for the RULE, not the comparison", () => {
+  test("only enforce is authoritative", () => {
+    expect(githubFeedIsAuthoritative({ env: { CATALYST_GITHUB_FEED: "enforce" } })).toBe(true);
+    // ⚠️ shadow especially: in shadow nothing the producer emits is authoritative and
+    // the dispatch gate suppresses nothing, so a caller that widened this to
+    // `!== "off"` would close the smee tunnel on a host that only meant to observe —
+    // taking GitHub ingestion to zero.
+    expect(githubFeedIsAuthoritative({ env: { CATALYST_GITHUB_FEED: "shadow" } })).toBe(false);
+    expect(githubFeedIsAuthoritative({ env: { CATALYST_GITHUB_FEED: "off" } })).toBe(false);
+    expect(githubFeedIsAuthoritative({ env: {} })).toBe(false);
+  });
+});
+
+describe("⛔ config.mjs DELEGATES — the two readers cannot disagree", () => {
+  test("readGithubFeedConfig agrees with the leaf across the whole ladder", () => {
+    // The property that matters: not that either is right in isolation, but that a
+    // producer reading one and a tunnel gate reading the other get the same answer.
+    for (const env of [
+      {}, { CATALYST_GITHUB_FEED: "shadow" }, { CATALYST_GITHUB_FEED: "enforce" },
+      { CATALYST_GITHUB_FEED: "0" }, { CATALYST_GITHUB_FEED: "enfroce" },
+      { CATALYST_GITHUB_FEED_INTERVAL_SEC: "90" },
+    ]) {
+      const withHome = { ...env, HOME: tmp };
+      const viaConfig = readGithubFeedConfig(withHome);
+      const viaLeaf = resolveGithubFeedMode({ env: withHome });
+      expect(viaConfig.mode).toBe(viaLeaf.mode);
+      expect(viaConfig.intervalSec).toBe(viaLeaf.intervalSec);
+    }
+  });
+});
+
+describe("⛔ both leaves load under BARE NODE — the constraint doctor.mjs actually has", () => {
+  const node = process.execPath.includes("bun") ? "node" : process.execPath;
+  const leafDir = join(import.meta.dir, "..", "lib");
+
+  for (const leaf of ["github-feed-mode.mjs", "github-feed-names.mjs"]) {
+    test(`${leaf} imports cleanly under bare node`, () => {
+      // Spawned, not imported: this test file runs under bun, where bun:sqlite
+      // resolves fine, so an in-process import would pass for a module doctor
+      // cannot actually load. The whole point is the OTHER runtime.
+      const out = execFileSync(node, ["-e", `import(${JSON.stringify(join(leafDir, leaf))}).then(()=>console.log("OK"))`], {
+        encoding: "utf8",
+      });
+      expect(out).toContain("OK");
+    });
+  }
+
+  test("⚠️ control: github-feed-gate.mjs REJECTS under bare node", () => {
+    // The negative control that makes the two above meaningful — if bare node
+    // loaded everything, moving the name lists to a leaf bought nothing.
+    let threw = false;
+    try {
+      execFileSync(node, ["-e", `import(${JSON.stringify(join(import.meta.dir, "github-feed-gate.mjs"))})`], {
+        encoding: "utf8", stdio: "pipe",
+      });
+    } catch { threw = true; }
+    expect(threw).toBe(true);
+  });
+});
+
+describe("the name lists are ONE source, shared by producer, gate and doctor", () => {
+  test("the gate re-exports the leaf's lists rather than keeping its own", async () => {
+    const gate = await import("./github-feed-gate.mjs");
+    expect(gate.GITHUB_CONSUMED_NAMES).toBe(GITHUB_CONSUMED_NAMES);
+    expect(gate.GITHUB_UNCOVERED_NAMES).toBe(GITHUB_UNCOVERED_NAMES);
+    expect(gate.GITHUB_SUPPRESSIBLE_NAMES).toEqual(GITHUB_SUPPRESSIBLE_NAMES);
+  });
+
+  test("⭐ the derivation still derives — driven with different inputs", () => {
+    const afterAllGapsClose = computeSuppressible({
+      consumed: GITHUB_CONSUMED_NAMES, uncovered: [], lossy: [],
+    });
+    expect(afterAllGapsClose).toEqual(GITHUB_CONSUMED_NAMES);
+    expect(GITHUB_SUPPRESSIBLE_NAMES.length).toBe(
+      GITHUB_CONSUMED_NAMES.length - GITHUB_UNCOVERED_NAMES.length - GITHUB_LOSSY_NAMES.length,
+    );
+  });
+});

--- a/plugins/dev/scripts/lib/github-feed-mode.d.mts
+++ b/plugins/dev/scripts/lib/github-feed-mode.d.mts
@@ -1,0 +1,39 @@
+// Types for github-feed-mode.mjs (CTL-1929) — the runtime stays .mjs so the
+// broker/execution-core .mjs daemons and doctor's bare-Node runtime import it
+// unchanged; this gives the TS consumer (orch-monitor/server.ts, the smee-tunnel
+// gate) proper types. Mirrors the deployment-mode.d.mts convention it sits beside:
+// hand-written companion, no build step.
+
+export type GithubFeedMode = "off" | "shadow" | "enforce";
+/** `env-invalid` is a SET but unrecognised env value — it overrides Layer-2 (CAT-57). */
+export type GithubFeedModeSource = "env" | "env-invalid" | "layer2" | "default";
+
+export const GITHUB_FEED_MODES: readonly GithubFeedMode[];
+export const DEFAULT_GITHUB_FEED_MODE: GithubFeedMode;
+export const MIN_INTERVAL_SEC: number;
+export const DEFAULT_INTERVAL_SEC: number;
+
+export interface GithubFeedModeResolution {
+  mode: GithubFeedMode;
+  /** producer tick interval; never below MIN_INTERVAL_SEC */
+  intervalSec: number;
+  source: GithubFeedModeSource;
+}
+
+export interface ResolveGithubFeedModeOptions {
+  /** resolution env (default process.env) */
+  env?: Record<string, string | undefined>;
+  /** explicit Layer-2 (~/.config/catalyst/config.json) path override */
+  layer2ConfigPath?: string;
+}
+
+export function resolveGithubFeedMode(
+  opts?: ResolveGithubFeedModeOptions,
+): GithubFeedModeResolution;
+
+/**
+ * True only for `enforce`. ⛔ Named for the RULE, not the comparison: a caller that
+ * widens this to `!== "off"` closes the smee tunnel in `shadow`, where the producer
+ * emits nothing authoritative — taking GitHub ingestion to zero.
+ */
+export function githubFeedIsAuthoritative(opts?: ResolveGithubFeedModeOptions): boolean;

--- a/plugins/dev/scripts/lib/github-feed-mode.mjs
+++ b/plugins/dev/scripts/lib/github-feed-mode.mjs
@@ -1,0 +1,156 @@
+// github-feed-mode.mjs — CTL-1929: the canonical `CATALYST_GITHUB_FEED` resolver.
+//
+// ── WHY THIS FILE EXISTS ───────────────────────────────────────────────────
+// Three processes need to know whether the GitHub cloud feed is authoritative on
+// this host, and they do not share a runtime:
+//   * `execution-core/daemon.mjs` (bun) — decides whether to run the producer
+//   * `broker/tailer.mjs`         (bun) — decides whether to suppress smee
+//   * `orch-monitor/server.ts`    (bun) — decides whether to OPEN the smee tunnel
+//   * `execution-core/doctor.mjs` (bare Node) — grades the ingestion route
+//
+// ⚠️ THE STATED REASON FOR A LEAF HERE IS NOT THE ONE I FIRST WROTE, AND THE
+// DIFFERENCE IS WORTH RECORDING. `lib/deployment-mode.mjs`'s header says
+// `execution-core/config.mjs`'s import chain reaches `bun:sqlite` via
+// `linear-query.mjs` and that doctor's bare-Node runtime therefore rejects it. I
+// repeated that and then measured it: **config.mjs LOADS under bare Node today**
+// (`node -e "import('.../config.mjs')"` succeeds; pino degrades to its console
+// shim). That comment is stale — the sqlite reach became lazy at some point.
+// `github-feed-gate.mjs` and `github-feed-source.mjs` genuinely DO reject, so the
+// sibling `lib/github-feed-names.mjs` leaf is load-bearing for that reason; this
+// one is not.
+//
+// ⛔ IT IS STILL A LEAF, FOR A REASON THAT DOES HOLD: four readers in three
+// processes must resolve one flag identically, and `config.mjs` is a bun-oriented
+// module that orch-monitor's own header already argues against importing for a
+// value it can get from a leaf. Zero-import (node:fs / node:os / node:path only),
+// the same shape `lib/deployment-mode.mjs` uses.
+//
+// The general form, since it cost me a wrong comment: a comment asserting another
+// module's load behaviour is a measurement with no test behind it. Re-measure
+// before repeating one.
+//
+// ⛔ AND `config.mjs` DELEGATES TO THIS FILE RATHER THAN KEEPING ITS OWN COPY.
+// Two independent readers of one flag is the failure this feature can least afford:
+// the producer emitting real events because it read `enforce` while the tunnel gate
+// read something else and kept smee open is a double dispatch on every covered
+// name, and it would look like a parity bug rather than a config bug.
+//
+// ── ENV-VS-FILE ASYMMETRY — the same caveat deployment-mode.mjs states ──────
+// Layer-2 FILE edits are picked up live (every call re-reads from disk). The ENV
+// var is captured into a long-lived process exactly once, at launch. A running
+// daemon keeps resolving its OLD value until restarted.
+//
+// ⚠️ That caveat is sharper here than for deployment mode, because this flag has
+// FOUR readers in THREE processes. Flipping it and restarting only execution-core
+// leaves the producer emitting real `github.*` names while the broker's gate and
+// the tunnel gate are still on the old value — the producer is authoritative and
+// nothing suppresses smee. Flip this flag and restart execution-core AND the
+// broker AND orch-monitor, or flip it in Layer-2 where every reader picks it up.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+/** The closed enum. Frozen: callers must never mutate this in place. */
+export const GITHUB_FEED_MODES = Object.freeze(["off", "shadow", "enforce"]);
+
+/**
+ * The degradation target for every soft-failure case.
+ *
+ * `off`, not `shadow` — and the asymmetry with a watchdog's shadow is deliberate,
+ * inherited verbatim from `readCloudFeedConfig`: a watchdog's shadow observes a
+ * daemon it does not touch, while this feature's shadow starts a producer that
+ * reads the replica on a timer inside the daemon process. "Off" therefore has to
+ * mean "no new work in the tick at all".
+ */
+export const DEFAULT_GITHUB_FEED_MODE = "off";
+
+/** Minimum tick interval. Number("") and Number(null) are both 0, which would busy-spin. */
+export const MIN_INTERVAL_SEC = 5;
+export const DEFAULT_INTERVAL_SEC = 30;
+
+// Mirrors deployment-mode.mjs's resolveLayer2Path, including its parity decision:
+// resolve `~` from the INJECTED env, so a caller passing { env: { HOME: fixture } }
+// is genuinely sandboxed rather than silently reading the real user's config.
+function resolveLayer2Path(env, layer2ConfigPath) {
+  if (typeof layer2ConfigPath === "string" && layer2ConfigPath.length > 0) {
+    return layer2ConfigPath;
+  }
+  const override = env?.CATALYST_LAYER2_CONFIG_FILE;
+  if (typeof override === "string" && override.length > 0) return override;
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  return resolve(home, ".config", "catalyst", "config.json");
+}
+
+function readLayer2GithubFeed(env, layer2ConfigPath) {
+  try {
+    const parsed = JSON.parse(readFileSync(resolveLayer2Path(env, layer2ConfigPath), "utf8"));
+    const gf = parsed?.catalyst?.githubFeed;
+    return gf && typeof gf === "object" ? gf : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * resolveGithubFeedMode — env (`CATALYST_GITHUB_FEED`) → Layer-2
+ * (`catalyst.githubFeed.mode`) → `off`.
+ *
+ * Returns `{ mode, intervalSec, source }`. `source` is reported so an operator can
+ * tell a deliberately-configured host from one that fell through to the default —
+ * a distinction that matters most during a cutover, when "why is this host still
+ * on smee?" has two very different answers.
+ *
+ * ⚠️ An UNRECOGNISED value degrades to `off`, not to the next rung. A typo in a
+ * daemon env var must not silently cut a host over to an unproven dispatch source,
+ * and must not silently inherit a Layer-2 value the operator was trying to override.
+ */
+export function resolveGithubFeedMode({ env = process.env, layer2ConfigPath } = {}) {
+  const l2 = readLayer2GithubFeed(env, layer2ConfigPath);
+  const raw = env?.CATALYST_GITHUB_FEED;
+  // ⚠️ EMPTY-OR-WHITESPACE IS "UNSET", NOT "INVALID". CAT-57's contract is explicit
+  // that an empty var still defers to Layer-2 rather than overriding it — an unset
+  // var and a var set to "" are the same operator intent, and treating "" as a typo
+  // would make `export CATALYST_GITHUB_FEED=` silently disable a Layer-2 rollout.
+  const set = typeof raw === "string" && raw.trim().length > 0;
+
+  let mode = DEFAULT_GITHUB_FEED_MODE;
+  let source = "default";
+  if (raw === "0") {
+    mode = "off";
+    source = "env";
+  } else if (set && GITHUB_FEED_MODES.includes(raw)) {
+    mode = raw;
+    source = "env";
+  } else if (set) {
+    // ⛔ SET-BUT-INVALID FALLS BACK TO `off` **AND OVERRIDES LAYER-2** — CAT-57's
+    // rule, which `execution-core/config.mjs`'s readGithubFeedConfig does NOT
+    // currently follow (it falls through to Layer-2 on a typo). That is the wrong
+    // direction for a knob whose whole purpose is containment: an operator reaching
+    // for the env var to REDUCE actuation would silently leave Layer-2 `enforce`
+    // live. Corrected here, and config.mjs now delegates, so the two cannot differ.
+    mode = "off";
+    source = "env-invalid";
+  } else if (typeof l2.mode === "string" && GITHUB_FEED_MODES.includes(l2.mode)) {
+    mode = l2.mode;
+    source = "layer2";
+  }
+
+  const parsed = Number(env?.CATALYST_GITHUB_FEED_INTERVAL_SEC ?? l2.intervalSeconds);
+  const intervalSec =
+    Number.isFinite(parsed) && parsed >= MIN_INTERVAL_SEC ? Math.floor(parsed) : DEFAULT_INTERVAL_SEC;
+
+  return { mode, intervalSec, source };
+}
+
+/**
+ * githubFeedIsAuthoritative — the one question the tunnel gate and doctor ask.
+ *
+ * ⛔ Named for what it MEANS, not for the value it compares against. A call site
+ * reading `mode === "enforce"` invites the next person to add `|| mode === "shadow"`
+ * when shadow starts looking healthy — and shadow is precisely the mode in which
+ * smee must keep running, because nothing the producer emits is authoritative.
+ */
+export function githubFeedIsAuthoritative(opts = {}) {
+  return resolveGithubFeedMode(opts).mode === "enforce";
+}

--- a/plugins/dev/scripts/lib/github-feed-names.mjs
+++ b/plugins/dev/scripts/lib/github-feed-names.mjs
@@ -1,0 +1,114 @@
+// github-feed-names.mjs — CTL-1929: WHICH `github.*` names the orchestrator
+// consumes, which of them this producer can faithfully replace, and the derivation
+// between the two.
+//
+// ── WHY IT IS A LEAF, AND WHY THE DATA MOVED HERE ──────────────────────────
+// These lists were born in `execution-core/github-feed-event.mjs` and
+// `github-feed-source.mjs`, next to the code that uses them, which was right while
+// the only consumers were the producer and the gate. `catalyst doctor` is now a
+// consumer too — it grades the GitHub ingestion route and must say WHICH names a
+// declared-cloud node cannot see — and doctor runs under **bare Node**, which
+// cannot load either of those files: both reach `bun:sqlite` through
+// `github-feed-source.mjs`'s Database import.
+//
+// ⭐ MEASURED, NOT ASSUMED (because the neighbouring claim about config.mjs turned
+// out to be stale — see lib/github-feed-mode.mjs's header):
+//   node -e "import('.../execution-core/config.mjs')"            → LOADS
+//   node -e "import('.../execution-core/github-feed-gate.mjs')"   → REJECTS
+//   node -e "import('.../execution-core/github-feed-source.mjs')" → REJECTS
+// So this leaf is load-bearing and its sibling is a consistency choice.
+//
+// ⛔ THE ALTERNATIVE WAS A SECOND, HAND-MAINTAINED COPY IN DOCTOR, AND THAT IS THE
+// FAILURE THIS WHOLE FEATURE KEEPS DESIGNING AGAINST. A doctor that carried its own
+// list would keep reporting three uncovered names after CTC-691/CTC-667/CTC-704
+// close — telling an operator the route is broken when it is whole, or (worse, on
+// the other edge) whole when it is broken. The producer, the dispatch gate and
+// doctor now read ONE source.
+//
+// Zero-import leaf (no imports at all — this is pure data plus one pure function),
+// the same constraint `lib/deployment-mode.mjs` and `lib/github-feed-mode.mjs`
+// document for the same bare-Node reason.
+
+/**
+ * The `github.*` names the BROKER ROUTER acts on — the gate's universe.
+ *
+ * ⛔ NOT "the names the producer emits". `github.pr.merged` and
+ * `github.check_suite.completed` are consumed here (`broker/router.mjs:1497`,
+ * `:1513`, `:1856`, `:1871`, `:1941`) and cannot yet be emitted, which is exactly
+ * why they must be IN this list: a gate whose universe is the producer's emit-list
+ * answers "not-dispatch-class" for the most dangerous name in the feature.
+ */
+export const GITHUB_CONSUMED_NAMES = Object.freeze([
+  "github.pr.opened",
+  "github.pr.closed",
+  "github.pr.merged",
+  "github.pr_review.submitted",
+  "github.pr_review_comment.created",
+  "github.pr_review_thread.resolved",
+  "github.check_suite.completed",
+  "github.deployment.created",
+  "github.deployment_status.success",
+  "github.deployment_status.failure",
+  "github.deployment_status.error",
+  "github.push",
+]);
+
+/**
+ * Consumed names with NO replica stream behind them at all.
+ *
+ * `github.pr.merged` — `pull_requests` has no `merge_commit_sha` column, and
+ * `body.payload.mergeCommitSha` is a JOIN KEY: `router.mjs:1513` writes it via
+ * `setFilterStateMerged` and `github.deployment.created` later matches
+ * `WHERE merge_commit_sha = ?`. A twin without it routes and wakes `monitor-merge`
+ * normally while `monitor-deploy` stops firing fleet-wide. → CTC-691
+ *
+ * `github.check_suite.completed` — the mirror stores no suite row. `check_runs`
+ * cannot stand in: one head sha carried 10 distinct `check_suite_id`s on mini-2,
+ * several incomplete, so "every run I can see finished" fires EARLY and GREEN on
+ * the merge gate. → CTC-667 item 4
+ */
+export const GITHUB_UNCOVERED_NAMES = Object.freeze([
+  "github.pr.merged",
+  "github.check_suite.completed",
+]);
+
+/**
+ * Consumed names that CAN be emitted but not faithfully, so smee must keep carrying
+ * them even at `enforce`.
+ *
+ * `github.push` — `pushes` is keyed `(repo_id, ref)`, so pushes to one ref between
+ * ticks collapse to one row. ⛔ The collapse loses an ARRIVAL, not a value:
+ * `router.mjs:1582` reads `scope.ref` and nothing else and sets no `wakeStateKey`,
+ * so `suppress_identical_wakes` never applies and every arriving push is its own
+ * wake. Under enforce with smee suppressed, a collapsed edge is a wake that never
+ * happens. Measured: 101 of 138 unmatched smee events (CTL-48). → CTC-704
+ */
+export const GITHUB_LOSSY_NAMES = Object.freeze(["github.push"]);
+
+/**
+ * computeSuppressible — the derivation, as a pure function of its three inputs.
+ *
+ * ⚠️ TAKES ITS INPUTS AS ARGUMENTS SO THE DERIVATION IS OBSERVABLE. Applied to
+ * today's real constants it returns exactly what a hand-written literal would, so a
+ * test comparing only the exported constant asserts a tautology and would keep
+ * passing after a gap closes and the list is supposed to GROW. Driving it with
+ * different inputs is the only way to test that it derives rather than restates.
+ */
+export function computeSuppressible({ consumed, uncovered, lossy }) {
+  const excluded = new Set([...uncovered, ...lossy]);
+  return Object.freeze(consumed.filter((n) => !excluded.has(n)));
+}
+
+/** The names `enforce` may suppress smee for today: consumed − uncovered − lossy. */
+export const GITHUB_SUPPRESSIBLE_NAMES = computeSuppressible({
+  consumed: GITHUB_CONSUMED_NAMES,
+  uncovered: GITHUB_UNCOVERED_NAMES,
+  lossy: GITHUB_LOSSY_NAMES,
+});
+
+/** Why an excluded name is excluded — for capture records and doctor output. */
+export const EXCLUSION_REASONS = Object.freeze({
+  "github.pr.merged": "no-replacement:no-merge-commit-sha:CTC-691",
+  "github.check_suite.completed": "no-replacement:no-suite-row:CTC-667-item-4",
+  "github.push": "lossy-replacement:pushes-keyed-per-ref:CTC-704",
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/github-feed-tunnel-gate.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/github-feed-tunnel-gate.test.ts
@@ -1,0 +1,132 @@
+// github-feed-tunnel-gate.test.ts — CTL-1929.
+//
+// The GitHub smee tunnel must not open on a host whose cloud feed is AUTHORITATIVE
+// (`CATALYST_GITHUB_FEED=enforce`) — the feed drives `github.*` dispatch and the
+// broker's gate suppresses the smee copy for the names it covers, so a live tunnel
+// there is a second delivery of events already being delivered.
+//
+// ⛔ THE INVERSION GUARD IS THE POINT, exactly as CTL-1617's sibling gate documents
+// (design §10 risk 7): a consumer that reads a mode to SKIP something must
+// independently prove it never skips for the other values. `shadow` is the
+// dangerous one — it looks healthy and suppresses nothing, so closing the tunnel
+// there would take GitHub ingestion to ZERO on a host that only meant to observe.
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { createServer } from "../server";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length > 0) {
+    const fn = cleanups.pop();
+    try { fn?.(); } catch { /* ignore */ }
+  }
+});
+
+function makeWtDir(prefix: string): string {
+  const tmp = mkdtempSync(join(tmpdir(), prefix));
+  const wtDir = join(tmp, "wt");
+  mkdirSync(wtDir, { recursive: true });
+  cleanups.push(() => rmSync(tmp, { recursive: true, force: true }));
+  return wtDir;
+}
+
+const settle = (ms = 30) => new Promise((r) => setTimeout(r, ms));
+
+function makeFakeFactory(): {
+  factory: () => { start: () => Promise<unknown>; stop: () => Promise<void> };
+  constructorCalls: () => number;
+} {
+  let calls = 0;
+  return {
+    factory: () => {
+      calls++;
+      return { start: () => Promise.resolve({}), stop: () => Promise.resolve() };
+    },
+    constructorCalls: () => calls,
+  };
+}
+
+async function startGithub(prefix: string, authoritative: boolean | null) {
+  const wtDir = makeWtDir(prefix);
+  const { factory, constructorCalls } = makeFakeFactory();
+  const srv = createServer({
+    port: 0,
+    wtDir,
+    startWatcher: false,
+    webhookConfig: {
+      smeeChannel: "https://smee.io/gh-feed-gate-test",
+      secret: "s3cr3t",
+      tunnelFactory: factory,
+    },
+    // Pin deployment mode away from "cloud" so THIS gate is the only thing that
+    // could suppress the tunnel — otherwise a pass would prove nothing about it.
+    deploymentModeReader: () => "single-host",
+    githubFeedAuthoritativeReader: authoritative === null ? null : () => authoritative,
+  });
+  cleanups.push(() => void srv.stop(true));
+  await settle();
+  return { srv, constructorCalls };
+}
+
+describe("⛔ the GitHub tunnel does not open when the cloud feed is authoritative", () => {
+  it("feed AUTHORITATIVE (enforce) → no tunnel is constructed", async () => {
+    const { constructorCalls } = await startGithub("gh-feed-gate-on-", true);
+    expect(constructorCalls()).toBe(0);
+  });
+});
+
+describe("⛔ inversion guard — it never skips for anything else", () => {
+  it("⚠️ feed NOT authoritative (shadow/off) → the tunnel DOES open", async () => {
+    // The failure this guards: widening the gate to `mode !== "off"` would close the
+    // tunnel in shadow, where the producer emits nothing authoritative and the
+    // dispatch gate suppresses nothing — GitHub ingestion would drop to zero on a
+    // host that only meant to observe, and the parity ledger would then be comparing
+    // the feed against an empty smee stream and reporting agreement.
+    const { constructorCalls } = await startGithub("gh-feed-gate-off-", false);
+    expect(constructorCalls()).toBe(1);
+  });
+
+  it("no reader injected (production wiring, feed unset) → the tunnel DOES open", async () => {
+    // Exercises `githubFeedAuthoritativeReaderOpt ?? githubFeedIsAuthoritative`
+    // against the REAL resolver rather than a stub. With CATALYST_GITHUB_FEED unset
+    // in the test process the real answer is `off`, so this asserts the production
+    // default is non-suppressing — the byte-for-byte no-op every host gets today.
+    const saved = process.env.CATALYST_GITHUB_FEED;
+    delete process.env.CATALYST_GITHUB_FEED;
+    try {
+      const { constructorCalls } = await startGithub("gh-feed-gate-real-", null);
+      expect(constructorCalls()).toBe(1);
+    } finally {
+      if (saved === undefined) delete process.env.CATALYST_GITHUB_FEED;
+      else process.env.CATALYST_GITHUB_FEED = saved;
+    }
+  });
+});
+
+describe("⛔ it gates the GITHUB tunnel ONLY — the Linear leg retired on its own terms", () => {
+  it("an authoritative GitHub feed does not touch the Linear tunnel", async () => {
+    // The two legs have separate knobs and separate rollouts by design; CTL-1928
+    // retired Linear's tunnel already. A gate that closed both would couple two
+    // cutovers that were deliberately decoupled — and would silently undo whatever
+    // state the Linear leg is in on a host being cut over for GitHub.
+    const wtDir = makeWtDir("gh-feed-gate-linear-");
+    const { factory, constructorCalls } = makeFakeFactory();
+    const srv = createServer({
+      port: 0,
+      wtDir,
+      startWatcher: false,
+      linearWebhookConfig: {
+        linearSecrets: [{ key: "test", secret: "linear-test-secret" }],
+        smeeChannel: "https://smee.io/linear-test",
+        tunnelFactory: factory,
+      },
+      deploymentModeReader: () => "single-host",
+      githubFeedAuthoritativeReader: () => true,
+    });
+    cleanups.push(() => void srv.stop(true));
+    await settle();
+    expect(constructorCalls()).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -71,6 +71,10 @@ import { buildFsmDescriptor } from "../lib/fsm-descriptor.mjs";
 // exact direct cross-directory `.mjs` import shape: the fsm-descriptor.mjs
 // import immediately above, and ui/src/board/process-surface.test.ts:5.
 import { getDeploymentMode } from "../lib/deployment-mode.mjs";
+// CTL-1929: whether the GitHub cloud feed is authoritative on this host. Same
+// zero-import-leaf shape and the same direct cross-directory import as the line
+// above, for the same reason (execution-core/config.mjs reaches bun:sqlite).
+import { githubFeedIsAuthoritative } from "../lib/github-feed-mode.mjs";
 // CTL-1100: belief store query functions (pure, db-injected). belief-store-queries.mjs
 // has no static bun:sqlite import — plain static import is safe for Vite/esbuild graph.
 import {
@@ -614,6 +618,16 @@ export interface CreateServerOptions {
    */
   deploymentModeReader?: (() => string) | null;
   /**
+   * CTL-1929: override for the GitHub-feed authority reader that gates the GITHUB
+   * smee tunnel (a host whose cloud feed is at `enforce` must not open it — the
+   * feed drives `github.*` dispatch and the broker's gate suppresses the smee
+   * copy). Production defaults to `githubFeedIsAuthoritative` (env → Layer-2 →
+   * `off`). Injected by tests for the same reason `deploymentModeReader` is:
+   * exercising the gate through the real env would mutate a process-wide flag that
+   * four readers in three processes consult.
+   */
+  githubFeedAuthoritativeReader?: (() => boolean) | null;
+  /**
    * CTL-1653: override for the child-process Claude-account probe runner.
    * Production spawns claude-accounts-usage.mjs in a token-scoped subshell
    * (defaultAccountsProbeExec); tests inject a scripted fake; null disables
@@ -962,6 +976,7 @@ export function createServer(opts: CreateServerOptions): BunServer {
     pushSubscriptionsDbPath,
     vapidKeysPath,
     deploymentModeReader: deploymentModeReaderOpt,
+    githubFeedAuthoritativeReader: githubFeedAuthoritativeReaderOpt, // CTL-1929
     accountsProbeExec: accountsProbeExecOpt,
     accountsTtlMs = 5 * 60 * 1000,
     accountsRefreshFloorMs = 30 * 1000,
@@ -5689,8 +5704,34 @@ export function createServer(opts: CreateServerOptions): BunServer {
   const deploymentModeForTunnelGate = resolveDeploymentModeForTunnelGate();
   const cloudModeSuppressesTunnels = deploymentModeForTunnelGate === "cloud";
 
+  // CTL-1929: a SECOND, independent reason to leave the GitHub tunnel closed — the
+  // GitHub cloud feed is authoritative on this host.
+  //
+  // ⛔ IT GATES THE GITHUB TUNNEL ONLY, unlike the deployment-mode gate above which
+  // suppresses both. The two legs have separate knobs and separate rollouts by
+  // design (see execution-core/config.mjs's note on CATALYST_GITHUB_FEED), and the
+  // Linear tunnel's retirement is CTL-1928's, already done on its own terms. A gate
+  // that closed both would couple two cutovers that were deliberately decoupled.
+  //
+  // ⚠️ `enforce` ONLY — never `shadow`. In shadow the producer emits nothing
+  // authoritative and the dispatch gate suppresses nothing, so closing the tunnel
+  // there would take GitHub ingestion to zero on a host that only meant to observe.
+  // That is why this reads `githubFeedIsAuthoritative()` rather than comparing the
+  // mode string here: the next person to look at this line should not be able to
+  // widen it to `!== "off"` without going to the function that names the rule.
+  const resolveGithubFeedAuthority =
+    githubFeedAuthoritativeReaderOpt ?? githubFeedIsAuthoritative;
+  const githubFeedSuppressesTunnel = resolveGithubFeedAuthority() === true;
+
   if (webhookConfig && webhookHandler) {
-    if (cloudModeSuppressesTunnels) {
+    if (githubFeedSuppressesTunnel && !cloudModeSuppressesTunnels) {
+      // Loud, for the same reason the cloud branch below is: a channel IS
+      // configured, so the old gate alone would have started the tunnel, and a
+      // silently-absent tunnel is undiagnosable.
+      console.info(
+        `[server] suppressing GitHub webhook smee tunnel start: CATALYST_GITHUB_FEED is "enforce" — the cloud feed drives github.* dispatch (CTL-1929), and the broker's gate suppresses the smee copy for the names it covers`,
+      );
+    } else if (cloudModeSuppressesTunnels) {
       // Loud on purpose: a declared-cloud node silently not opening the
       // GitHub webhook tunnel would be undiagnosable otherwise (a channel is
       // configured, so the OLD gate at `webhookConfig && webhookHandler`


### PR DESCRIPTION
⚠️ **Stacked on #3535** (`ctl-1929-github-enforce-flip`) — it introduces the coverage lists doctor reads here. Base will retarget to `main` when #3535 merges.

## What this is

Step 3 of the tunnel-retirement runbook (posted on CTL-1929): **new** hosts stop creating the GitHub smee tunnel when `CATALYST_GITHUB_FEED=enforce`, and `catalyst doctor` stops reporting a declared-cloud node as having no GitHub replacement when it has one.

⛔ **Running tunnels are untouched.** That is what makes this landable before any flip, and it is why it is step 3 and not step 4 — step 4 (stopping the running client) is a separate, reversible action on each host.

## ⛔ `enforce` only — never `shadow`

In shadow the producer emits nothing authoritative and the dispatch gate suppresses nothing. Closing the tunnel there takes GitHub ingestion to **zero** on a host that only meant to observe — and the parity ledger would then be comparing the feed against an empty smee stream and **reporting agreement**. A silent, self-confirming failure.

So the call site reads `githubFeedIsAuthoritative()` rather than comparing a mode string inline: the next person to look at it should not be able to widen it to `!== "off"` without going to the function that names the rule. It ships with an explicit inversion guard, the same one CTL-1617's sibling gate documents (design §10 risk 7).

⛔ **It gates the GitHub tunnel only.** The two legs have separate knobs and separate rollouts by design; Linear's retired on its own terms (CTL-1928). A gate that closed both would couple two cutovers that were deliberately decoupled — covered by its own test.

## Doctor: a PASS only when nothing is left uncovered

`doctor.mjs:1325`'s declared-cloud WARN — *"GitHub ingestion has NO cloud replacement yet"* — is no longer unconditional:

| feed | grade |
| --- | --- |
| `off` | WARN — no source for `github.*` at all |
| `shadow` | WARN — **shadow replaces nothing** |
| `enforce`, gaps open | WARN, **naming the uncovered names** and the coverage ratio |
| `enforce`, all covered | PASS |
| resolver throws | WARN, fails closed to the `off` wording |

⛔ **Enforce is deliberately not an unconditional PASS.** A declared-cloud node has no tunnel at all, so `github.pr.merged` (CTC-691), `github.check_suite.completed` (CTC-667 item 4) and `github.push` (CTC-704) are genuinely unseen there. Reporting the route whole would say "fine" at exactly the moment the merge→deploy join, the CI wait and rebase detection are the parts that are missing. The counts and names are **derived**, so the WARN stops warning by itself when the gaps close.

## Two zero-import leaves — and a stale comment I repeated before measuring

**`lib/github-feed-names.mjs`** — the consumed/suppressible name lists, moved out of `github-feed-gate.mjs`. Doctor is now a consumer and runs under **bare Node**, which cannot load the gate (it reaches `bun:sqlite` via `github-feed-source.mjs`). The alternative was a hand-maintained copy in doctor that would keep reporting three uncovered names after the tickets close — the exact drift this feature keeps designing against.

**`lib/github-feed-mode.mjs`** — the canonical `CATALYST_GITHUB_FEED` resolver, with `config.mjs` **delegating** so four readers in three processes cannot disagree. A producer that read `enforce` while the tunnel gate read something else is a double dispatch on every covered name, and it would present as a parity failure rather than as the config drift it is.

⚠️ **I justified that second leaf with `deployment-mode.mjs`'s claim** that `config.mjs` is unloadable under bare Node — then measured it:

```
node -e "import('.../execution-core/config.mjs')"            → LOADS
node -e "import('.../execution-core/github-feed-gate.mjs')"   → REJECTS
node -e "import('.../execution-core/github-feed-source.mjs')" → REJECTS
```

**That comment is stale** — the sqlite reach became lazy at some point. The names leaf is load-bearing; the mode leaf is a consistency choice, and both headers now say so. A comment asserting another module's load behaviour is a measurement with no test behind it.

⚠️ Delegating also **corrects one behaviour**: a set-but-invalid env value now falls back to `off` **and overrides Layer-2**, per CAT-57's documented contract (`config.test.mjs`: *"a SET-but-invalid env value ... overrides Layer-2 enforce"*), which `readGithubFeedConfig` did not follow. Empty/whitespace still defers to Layer-2 — unset and `""` are the same operator intent, and treating `""` as a typo would let `export CATALYST_GITHUB_FEED=` silently disable a Layer-2 rollout.

## Tests

New: **17** leaf + **5** doctor + **4** tunnel-gate. Affected suites together: **922 pass, 0 fail**.

**11 mutations run.** Two of my own tests were vacuous and are rewritten with the reason recorded at their site:

1. **The fail-closed assertion on a throwing resolver passed with the mutation applied** — while the three gaps are open, *both* branches grade WARN and both print the source, so `status === WARN` could not distinguish fail-open from fail-closed. It would have started being wrong precisely when the gaps closed and fail-open became a PASS. Now asserts *which branch answered*.
2. The doctor coverage detail, same class as the ones called out in #3535.

⭐ **And `config-pino-fallback.test.mjs` caught a real integration gap on the first full-gate run**: its fixture stages every relative import `config.mjs` has, and my new leaf was not staged, so the module failed to load under the no-deps fixture. Its own comment states that contract — the test worked exactly as designed, and the fix is one `cpSync`.

## ⚠️ Gate accounting

Full execution-core suite: **9893 pass / 63 fail** before the pino fix. Diffed by name against an untouched `origin/main` worktree (58 failures) and against #3535's branch, the **only** delta introduced by this commit was those 2 pino-fallback tests — now fixed and green. The rest are the same pre-existing local-environment failures documented on #3535 (hostname, replica, scheduler, and the `cloud-sync-idle-event` EAGAIN class).

Separately, 4 pre-existing failures in `deployment-mode-tunnel-gate.test.ts` are ~6 s `fetch` timeouts local to this machine — **identical 4 pass / 4 fail on untouched main**. My tunnel tests assert on the tunnel constructor rather than through HTTP for that reason.

**CI is authoritative.**

Refs CTL-1929, CTC-691, CTC-667, CTC-704, CTL-1928, CAT-57, CTL-1617