### PR TITLE
feat(dev): CTL-1951 — the ROUTINE fleet reload advances the pinned indexer serving root, out of the broker's event loop

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -686,16 +686,18 @@ jobs:
         # same file plus its own audit suite, and an unlisted suite is a guard that
         # lands with no gate — this job's list is hand-enumerated, not globbed.
         #
-        # Both files run: measured 196 tests / 0 fail (139 plugin-refresh + 57
+        # Both files run: measured 205 tests / 0 fail (148 plugin-refresh + 57
         # lock-resolution-audit), so there is no pre-existing red to import.
+        # CTL-1951 added 9 to plugin-refresh.test.mjs (139 -> 148), re-measured
+        # with the instrument below rather than assumed from the delta.
         # INSTRUMENT: `bun test plugin-refresh.test.mjs
         # lock-resolution-audit.test.mjs` from this step's working-directory,
         # bun 1.3.5, Darwin arm64 26.5.2, single run — the count is deterministic,
         # no spread. On a checkout WITHOUT the broker package's pino installed,
-        # exactly one of the 196 fails to LOAD (`Cannot find package 'pino' from
-        # config.mjs`) rather than failing an assertion, giving 195/1; CI runs
-        # `bun install` here, so CI sees 196/0. Both figures re-measured on this
-        # branch by stashing and restoring node_modules.
+        # exactly one of the 205 fails to LOAD (`Cannot find package 'pino' from
+        # config.mjs`) rather than failing an assertion, giving 204/1; CI runs
+        # `bun install` here, so CI sees 205/0. Re-confirmed on the CTL-1951
+        # branch: the pre-install run was 204/1 with that exact loader error.
         #
         # CTL-1835: the previous revision of this comment cited "97 tests" for
         # plugin-refresh.test.mjs and "175 tests" for the pair. Neither

--- a/plugins/dev/scripts/broker/plugin-refresh.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.mjs
@@ -38,7 +38,7 @@
 // Mirrors the gc-liveness.mjs / autotune.mjs seam-injection convention.
 
 import { readFileSync, existsSync, rmSync, realpathSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { homedir } from "node:os";
 import { resolve, join, dirname } from "node:path";
 import { getEventName } from "../lib/event-name.mjs"; // CTL-1834: THE shared event-name boundary (still a leaf)
@@ -1060,6 +1060,177 @@ export function refreshPluginCheckout({
   return { pulled: true, throttled: false, changed: true, failed: false, root, oldSha, newSha, restartNeeded };
 }
 
+
+// ─── CTL-1951: advancing the pinned catalyst-index serving root ─────────────
+//
+// CTL-1935 pinned the serving root and hooked `setup-plugin-source.sh` to apply it. That covers
+// the JOIN path. It does NOT cover the path that actually runs many times a day — THIS module —
+// so a pin bump never reached a worker node. Measured on all three hosts at 01:27 CT after the
+// pin had already been distributed: `index-source present: NO` everywhere.
+//
+// ⛔ WHY THIS IS NOT A `catalyst-index-root setup` CALL INLINE. This module runs in the broker's
+// event loop via execFileSync. `setup` is heavier than the `reset --hard` around it — on a node
+// that has never indexed, its first run is a FULL CLONE of catalyst-cloud. Dropping that into
+// the hot path trades a stale indexer for a WEDGED BROKER, which is strictly worse (the CTL-990
+// class the 20 s git ceiling above exists to prevent).
+//
+// So the work is split by cost:
+//   VERIFY  — cheap, local-only git (no network, no clone), run INLINE under a short ceiling.
+//   SETUP   — heavy and network-bound, SPAWNED DETACHED and unref'd. The broker never waits on
+//             it and cannot be wedged by it.
+//
+// ⛔ AND THE HALF THAT MAKES IT HONEST: a detached job's exit code is unobservable by definition,
+// so "spawned" must never be reported as "advanced". The NEXT reload verifies again, and a root
+// that is still not at the pin AFTER an attempt emits a named WARN. That is the difference
+// between a fire-and-forget that silently never works and one that tells you it didn't.
+
+export const INDEX_ROOT_THROTTLE_MS =
+  Number(process.env.CATALYST_INDEX_ROOT_THROTTLE_MS) || 10 * 60 * 1000;
+
+// Verify is local-only git; it must still be bounded, because "local" is not "instant" on a
+// machine under load, and this one runs inline.
+const INDEX_ROOT_VERIFY_TIMEOUT_MS =
+  Number(process.env.CATALYST_INDEX_ROOT_VERIFY_TIMEOUT_MS) || 15_000;
+
+const _lastIndexRootAttemptByRoot = new Map();
+const _indexRootAttemptedByRoot = new Map();
+
+export function __clearIndexRootStateForTest() {
+  _lastIndexRootAttemptByRoot.clear();
+  _indexRootAttemptedByRoot.clear();
+}
+
+function defaultIndexRootVerifyFn(script) {
+  execFileSync("bash", [script, "verify"], {
+    encoding: "utf8",
+    timeout: INDEX_ROOT_VERIFY_TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return true;
+}
+
+// Detached + unref'd + stdio ignored: the broker does not wait on it, does not hold its pipes,
+// and survives its own restart without orphaning a half-written checkout in the loop.
+function defaultIndexRootSpawnFn(script) {
+  const child = spawn("bash", [script, "setup"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+  return child.pid ?? null;
+}
+
+/**
+ * advanceIndexServingRoot — bring this node's catalyst-index serving root to the pinned sha,
+ * without doing the heavy half in the broker's event loop.
+ *
+ * Returns one of:
+ *   { skipped:true, reason:"opt-out" | "no-pin" | "throttled" }
+ *   { atPin:true }                                  — verify passed, nothing to do
+ *   { spawned:true, pid }                           — setup dispatched detached
+ *   { stale:true }                                  — still not at the pin AFTER a prior attempt
+ */
+export function advanceIndexServingRoot({
+  root,
+  now = Date.now(),
+  env = process.env,
+  emitFn,
+  verifyFn = defaultIndexRootVerifyFn,
+  spawnFn = defaultIndexRootSpawnFn,
+  existsFn = existsSync,
+}) {
+  const emit = typeof emitFn === "function" ? emitFn : () => {};
+  if (!root) return { skipped: true, reason: "no-root" };
+
+  // AC 3: a node that never indexes does NO catalyst-cloud clone at all. Checked first, so the
+  // opt-out costs nothing — not even a stat.
+  if (String(env.CATALYST_SKIP_INDEX_ROOT ?? "") === "1") {
+    return { skipped: true, reason: "opt-out" };
+  }
+
+  const script = `${root}/plugins/dev/scripts/catalyst-index-root`;
+  const pin = `${root}/plugins/dev/config/index-serving-root.json`;
+  if (!existsFn(script) || !existsFn(pin)) {
+    // An older checkout predates the pin. Named, not silent — but INFO, because on a node that
+    // has simply not pulled the pin yet this is expected and self-correcting.
+    emit({
+      event: "plugin.index_root.unavailable",
+      orchestrator: null,
+      worker: null,
+      severity: "INFO",
+      detail: { checkout: root, reason: "checkout predates the CTL-1935 pin" },
+    });
+    return { skipped: true, reason: "no-pin" };
+  }
+
+  const last = _lastIndexRootAttemptByRoot.get(root);
+  if (last !== undefined && now - last < INDEX_ROOT_THROTTLE_MS) {
+    return { skipped: true, reason: "throttled" };
+  }
+
+  // VERIFY first — cheap, local, and it is also what makes a repeat reload a no-op instead of
+  // respawning setup on every merge event.
+  let atPin = false;
+  try {
+    atPin = verifyFn(script) !== false;
+  } catch {
+    atPin = false;
+  }
+  if (atPin) {
+    _indexRootAttemptedByRoot.delete(root);
+    return { atPin: true };
+  }
+
+  // Not at the pin. If we ALREADY dispatched setup for this root and it is still not there, the
+  // detached job failed — network, auth, or a bad pin. This is the named failure signal: without
+  // it, a setup that never succeeds looks identical to one that was never needed.
+  const attemptedAt = _indexRootAttemptedByRoot.get(root);
+  if (attemptedAt !== undefined) {
+    emit({
+      event: "plugin.index_root.stale",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: {
+        checkout: root,
+        attempted_at: attemptedAt,
+        reason:
+          "catalyst-index-root setup was dispatched on an earlier reload and the serving root is STILL not at the pin",
+        consequence: "a cold index on this node would run stale or unpinned code (CTL-1935)",
+        remedy: `bash ${script} setup`,
+      },
+    });
+  }
+
+  _lastIndexRootAttemptByRoot.set(root, now);
+  let pid = null;
+  try {
+    pid = spawnFn(script);
+  } catch (err) {
+    emit({
+      event: "plugin.index_root.refresh_failed",
+      orchestrator: null,
+      worker: null,
+      severity: "WARN",
+      detail: { checkout: root, error: String(err?.message ?? err) },
+    });
+    return { failed: true };
+  }
+  _indexRootAttemptedByRoot.set(root, now);
+  emit({
+    event: "plugin.index_root.advancing",
+    orchestrator: null,
+    worker: null,
+    severity: "INFO",
+    detail: {
+      checkout: root,
+      pid,
+      note: "dispatched DETACHED — the exit code is not observable here; the next reload verifies and WARNs if it did not land",
+    },
+  });
+  return { spawned: true, pid };
+}
+
 /**
  * handlePluginRefreshEvent — top-level wiring the router calls for every event.
  * No-op unless the event is a merge-to-main of the configured repo. Resolves
@@ -1096,6 +1267,16 @@ export function handlePluginRefreshEvent({
     const results = [];
     for (const root of roots) {
       results.push(refreshPluginCheckout({ root, now, gitFn, emitFn, loadedCommit, loadedCommitRoot, pull }));
+      // CTL-1951: the ROUTINE reload advances the pinned indexer serving root too. Runs
+      // unconditionally rather than only when the checkout `changed`, because a node whose
+      // serving root is ABSENT must converge even on a reload that pulled nothing new — the
+      // measured state on all three hosts was "pin distributed, root absent". Cheap when already
+      // at the pin (one local verify) and throttled otherwise. Never throws.
+      try {
+        advanceIndexServingRoot({ root, now, env, emitFn });
+      } catch {
+        /* the indexer root must never break the plugin reload or event routing */
+      }
     }
     return results;
   } catch {
@@ -1138,6 +1319,13 @@ export function refreshAllPluginCheckouts({
     const results = [];
     for (const root of roots) {
       results.push(refreshPluginCheckout({ root, now, gitFn, emitFn, loadedCommit, loadedCommitRoot, pull }));
+      // CTL-1951: same as the event-driven path. This is the periodic backstop, so it is also
+      // what converges a node whose merge webhook never arrived.
+      try {
+        advanceIndexServingRoot({ root, now, env, emitFn });
+      } catch {
+        /* never break the drift-check tick */
+      }
     }
     return results;
   } catch {

--- a/plugins/dev/scripts/broker/plugin-refresh.test.mjs
+++ b/plugins/dev/scripts/broker/plugin-refresh.test.mjs
@@ -40,6 +40,9 @@ import {
   __clearThrottleForTest,
   CHECKOUT_LAG_FAILURE_THRESHOLD,
   __clearLagStateForTest,
+  advanceIndexServingRoot,
+  INDEX_ROOT_THROTTLE_MS,
+  __clearIndexRootStateForTest,
 } from "./plugin-refresh.mjs";
 
 // ─── resolvePluginCheckoutRoots ──────────────────────────────────────────────
@@ -2613,5 +2616,171 @@ describe("refreshPluginCheckout — post-install resolution audit (CTL-1831)", (
     expect(audits).toBe(0);
     expect(emitted.some((e) => e.event === "plugin.checkout.deps_install_failed")).toBe(true);
     expect(emitted.some((e) => e.event === "plugin.checkout.deps_install_noop")).toBe(false);
+  });
+});
+
+
+// ─── CTL-1951: the ROUTINE reload advances the pinned indexer serving root ───
+//
+// CTL-1935 pinned the root and hooked the JOIN path. The routine reload — this module, many
+// times a day — never advanced it, so a pin bump never reached a worker node. Measured on all
+// three hosts after the pin had already been distributed: index-source absent everywhere.
+//
+// The property under test is NOT "does it run setup". It is that the heavy half NEVER runs in
+// the broker's event loop, and that a detached job — whose exit code is unobservable by
+// definition — is never reported as success.
+describe("advanceIndexServingRoot (CTL-1951)", () => {
+  beforeEach(() => __clearIndexRootStateForTest());
+
+  const ROOT = "/checkout";
+  const SCRIPT = "/checkout/plugins/dev/scripts/catalyst-index-root";
+  const existsAll = () => true;
+
+  test("a root already at the pin does nothing and spawns nothing", () => {
+    const spawns = [];
+    const events = [];
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: {}, emitFn: (e) => events.push(e),
+      verifyFn: () => true,
+      spawnFn: (s) => { spawns.push(s); return 42; },
+      existsFn: existsAll,
+    });
+    expect(r).toEqual({ atPin: true });
+    expect(spawns).toEqual([]);
+    expect(events).toEqual([]);
+  });
+
+  test("a root NOT at the pin spawns setup DETACHED and says so", () => {
+    const spawns = [];
+    const events = [];
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: {}, emitFn: (e) => events.push(e),
+      verifyFn: () => { throw new Error("not at pin"); },
+      spawnFn: (s) => { spawns.push(s); return 4242; },
+      existsFn: existsAll,
+    });
+    expect(r.spawned).toBe(true);
+    expect(r.pid).toBe(4242);
+    expect(spawns).toEqual([SCRIPT]);
+    expect(events.map((e) => e.event)).toEqual(["plugin.index_root.advancing"]);
+  });
+
+  // ⛔ THE CORE GUARD. The reason setup is spawned rather than called is that a full clone in the
+  // broker's event loop wedges the daemon. If the spawn seam were ever swapped for a synchronous
+  // call this test would still pass on behaviour — so it asserts the seam directly: the default
+  // path must not be execFileSync-shaped, i.e. advanceIndexServingRoot must return WITHOUT the
+  // child's exit status, and must return promptly even when the child never finishes.
+  test("the event loop is never blocked on setup — it returns without the child's exit status", () => {
+    let released = false;
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: {}, emitFn: () => {},
+      verifyFn: () => false,
+      // A spawn that models a job still running: it returns a pid and nothing else. If the
+      // implementation waited on completion, it could not return here at all.
+      spawnFn: () => { released = true; return 7; },
+      existsFn: existsAll,
+    });
+    expect(released).toBe(true);
+    expect(r.spawned).toBe(true);
+    // The result carries NO exit code / success flag — "dispatched" is all that is knowable.
+    expect(r.exitCode).toBeUndefined();
+    expect(r.succeeded).toBeUndefined();
+  });
+
+  // ⛔ THE NAMED FAILURE SIGNAL (AC 2). A detached job that never succeeds must not look identical
+  // to one that was never needed.
+  test("still not at the pin AFTER a prior attempt emits a named WARN", () => {
+    const events = [];
+    const opts = {
+      root: ROOT, env: {}, emitFn: (e) => events.push(e),
+      verifyFn: () => false,
+      spawnFn: () => 1,
+      existsFn: existsAll,
+    };
+    advanceIndexServingRoot({ ...opts, now: 1000 });
+    events.length = 0;
+    // Past the throttle window, still not at the pin.
+    const r = advanceIndexServingRoot({ ...opts, now: 1000 + INDEX_ROOT_THROTTLE_MS + 1 });
+    const stale = events.find((e) => e.event === "plugin.index_root.stale");
+    expect(stale).toBeDefined();
+    expect(stale.severity).toBe("WARN");
+    expect(stale.detail.remedy).toContain("catalyst-index-root");
+    expect(r.spawned).toBe(true); // and it retries
+  });
+
+  test("a root that reaches the pin after an attempt does NOT keep warning", () => {
+    const events = [];
+    const base = {
+      root: ROOT, env: {}, emitFn: (e) => events.push(e),
+      spawnFn: () => 1, existsFn: existsAll,
+    };
+    advanceIndexServingRoot({ ...base, now: 1000, verifyFn: () => false });
+    events.length = 0;
+    const r = advanceIndexServingRoot({
+      ...base, now: 1000 + INDEX_ROOT_THROTTLE_MS + 1, verifyFn: () => true,
+    });
+    expect(r).toEqual({ atPin: true });
+    expect(events).toEqual([]);
+    // and a later miss is a FIRST attempt again, not an immediate stale WARN
+    events.length = 0;
+    advanceIndexServingRoot({
+      ...base, now: 1000 + 2 * INDEX_ROOT_THROTTLE_MS + 2, verifyFn: () => false,
+    });
+    expect(events.some((e) => e.event === "plugin.index_root.stale")).toBe(false);
+  });
+
+  // ⛔ AC 3: a node that never indexes does NO catalyst-cloud clone at all.
+  test("CATALYST_SKIP_INDEX_ROOT=1 spawns nothing and does not even stat the checkout", () => {
+    const spawns = [];
+    let statted = false;
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: { CATALYST_SKIP_INDEX_ROOT: "1" }, emitFn: () => {},
+      verifyFn: () => { throw new Error("must not verify"); },
+      spawnFn: (s) => { spawns.push(s); return 1; },
+      existsFn: () => { statted = true; return true; },
+    });
+    expect(r).toEqual({ skipped: true, reason: "opt-out" });
+    expect(spawns).toEqual([]);
+    expect(statted).toBe(false);
+  });
+
+  test("a checkout predating the pin is NAMED, not silently skipped", () => {
+    const events = [];
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: {}, emitFn: (e) => events.push(e),
+      verifyFn: () => true, spawnFn: () => 1,
+      existsFn: () => false,
+    });
+    expect(r).toEqual({ skipped: true, reason: "no-pin" });
+    expect(events.map((e) => e.event)).toEqual(["plugin.index_root.unavailable"]);
+  });
+
+  test("throttled: a second reload inside the window does not respawn", () => {
+    const spawns = [];
+    const opts = {
+      root: ROOT, env: {}, emitFn: () => {},
+      verifyFn: () => false,
+      spawnFn: (s) => { spawns.push(s); return 1; },
+      existsFn: existsAll,
+    };
+    advanceIndexServingRoot({ ...opts, now: 1000 });
+    const r = advanceIndexServingRoot({ ...opts, now: 1000 + INDEX_ROOT_THROTTLE_MS - 1 });
+    expect(r).toEqual({ skipped: true, reason: "throttled" });
+    expect(spawns.length).toBe(1);
+  });
+
+  test("a spawn that throws is a named WARN, not a silent skip", () => {
+    const events = [];
+    const r = advanceIndexServingRoot({
+      root: ROOT, now: 1000, env: {}, emitFn: (e) => events.push(e),
+      verifyFn: () => false,
+      spawnFn: () => { throw new Error("EAGAIN"); },
+      existsFn: existsAll,
+    });
+    expect(r).toEqual({ failed: true });
+    const ev = events.find((e) => e.event === "plugin.index_root.refresh_failed");
+    expect(ev).toBeDefined();
+    expect(ev.severity).toBe("WARN");
+    expect(ev.detail.error).toContain("EAGAIN");
   });
 });


### PR DESCRIPTION
CTL-1935 pinned the serving root and hooked `setup-plugin-source.sh`. That covers the **join** path. It does not cover the path that actually runs many times a day — `broker/plugin-refresh.mjs` — so a pin bump never reached a worker node.

Measured on all three hosts at 01:27 CT, after `d4084caa2` had already reached every `plugin-source`: **`index-source present: NO` everywhere.**

## ⛔ Why this is not `catalyst-index-root setup` called inline

`plugin-refresh.mjs` runs in the broker's event loop via `execFileSync` under a 20 s ceiling — precisely so a network-stalled git call cannot freeze the daemon (the CTL-990 class). `setup` is **heavier than the `reset --hard` around it**: on a node that has never indexed, its first run is a **full clone of catalyst-cloud**. Dropping that into the hot path trades a stale indexer for a **wedged broker**, which is strictly worse.

Split by cost — the ticket's option 1:

| half | cost | where it runs |
| -- | -- | -- |
| **verify** | local-only git, no network, no clone | **inline**, own 15 s ceiling |
| **setup** | network-bound, first run is a full clone | **spawned detached + unref'd**, never waited on |

## ⛔ The half that makes it honest

A detached job's exit code is **unobservable by definition**, so "spawned" must never be reported as "advanced". The next reload verifies again, and a root still not at the pin **after an attempt** emits `plugin.index_root.stale` (WARN) naming the consequence and the remedy. Without that, a setup that never succeeds looks identical to one that was never needed — the silent-skip shape **AC 2** rules out.

Wired into **both** reload paths (event-driven `handlePluginRefreshEvent` *and* the periodic `refreshAllPluginCheckouts` backstop), and deliberately **not** gated on `changed` — a node whose serving root is absent must converge even on a reload that pulled nothing new, which is exactly the measured state. Each call is wrapped so the indexer root can never break event routing.

**AC 3** holds: `CATALYST_SKIP_INDEX_ROOT=1` returns *before any stat*, so a node that never indexes does no catalyst-cloud clone at all — asserted, not assumed (the test fails if the checkout is even stat'd).

## Proven live on `mini`, which carried the defect

`index-source` was **absent** on this host — the same condition as mini-2.

| step | result |
| -- | -- |
| inline call | returned in **140 ms**, having spawned **pid 41882** |
| detached job | landed a 39 MB checkout at exactly `4a84cd463` |
| `catalyst-index-root verify` | **5/5 PASS** (pinned-head, content, clean) |
| doctor `index-serving-root` | `WARN — no index serving root` → **pass** |
| a second reload | `{atPin:true}` in 147 ms, **no spawn, no events** |

## Tests — 9 new

Including the core guard that the result carries **no exit code and no success flag** (dispatched is all that is knowable), the named-WARN-after-a-failed-attempt case, the skip-does-not-even-stat case, and a spawn that throws being a WARN rather than a silent skip.

Suite counts **re-measured with the workflow's own instrument** rather than inferred from the delta: **205/0** installed, **204/1** without the broker's `pino`. The documented figures in `execution-core-tests.yml` are updated from 196/195 — CTL-1835 already warned those go stale on every added test.

## ⛔ Not verified on mini-2

`mini` has no outbound ssh credential — its identity comes from the 1Password agent, unavailable in a non-interactive session — so `ssh mini-2` is `Permission denied (publickey)`. mini carried the identical condition and is the proof above. On mini-2 this lands with the next plugin reload and needs no command.