### PR TITLE
feat(dev): CTL-1929 — wire pr.merged and per-push into the producer on schema 0.1.17

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -76,6 +76,10 @@
 
 import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
 import { STREAM_BY_KEY } from "./github-feed-source.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_UNCOVERED_NAMES as LEAF_UNCOVERED_NAMES,
+} from "../lib/github-feed-names.mjs";
 
 /** The service identity every `github.*` event must carry. See the header. */
 export const GITHUB_SERVICE_NAME = "catalyst.github";
@@ -100,37 +104,26 @@ export const SOURCE_CLOUD_FEED = "cloud-feed";
  * Exported so the parity ledger accounts for them as EXPECTED absences rather than
  * as unexplained diffs, and so nothing can claim coverage this producer lacks.
  */
-export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze([
-  "github.pr.opened",
-  "github.pr.closed",
-  // ⭐ CTC-691 landed in schema 0.1.17 — `merge_commit_sha` is a real column now.
-  "github.pr.merged",
-  "github.pr_review.submitted",
-  "github.pr_review_comment.created",
-  "github.pr_review_thread.resolved",
-  "github.deployment.created",
-  "github.deployment_status.success",
-  "github.deployment_status.failure",
-  "github.deployment_status.error",
-  "github.push",
-]);
+export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze(
+  GITHUB_CONSUMED_NAMES.filter((n) => !LEAF_UNCOVERED_NAMES.includes(n)),
+);
 
-/** Names the orchestrator consumes that this producer cannot yet emit. */
-export const GITHUB_UNCOVERED_NAMES = Object.freeze([
-  // ⛔ STILL UNCOVERED ON 0.1.17, AND NOT FOR THE REASON THE TABLE SUGGESTS.
-  // `check_suites` exists now, but the association the CONSUMER keys on does not:
-  // `router.mjs:1497` reaches an interest only through `detail.prNumbers`, which the
-  // webhook fills from `check_suite.pull_requests[].number` — a field the mirror does
-  // not store, and `check_runs` cannot supply (it is PR-less too).
-  //
-  // The only derivation is `check_suites.head_sha` → `pull_requests.head_sha`, and
-  // that is a LAST-STATE join: measured on mini-2, 93 of 202 suites (46%) resolve,
-  // and the misses are dominated by ACTIVE PR BRANCHES whose head moved after the
-  // suite ran — `ctc-pin-sdk-0.8.13` appears 10 times in the hits and 10 in the
-  // misses. Emitting on a 46% join would hang the CI wait silently, with no smee copy
-  // under `enforce`. → CTC-712
-  "github.check_suite.completed",
-]);
+/**
+ * ⛔ RE-EXPORTED FROM `lib/github-feed-names.mjs`, NOT DECLARED HERE.
+ *
+ * These lists used to live in this file, which was right while the producer and the
+ * gate were the only readers. `catalyst doctor` became a third reader (it must name
+ * which github.* events a declared-cloud node cannot see) and runs under bare Node,
+ * which cannot load this module at all — so the lists moved to a zero-import leaf.
+ *
+ * ⚠️ CI CAUGHT THE HALF-DONE VERSION OF EXACTLY THIS. The move (#3540) pointed the
+ * GATE at the leaf but left this file's own copies in place, and the next change
+ * (#3544, removing `pr.merged` on CTC-691) edited the copy the gate no longer reads.
+ * Locally both passed, because that branch predated the move; on main the two lists
+ * disagreed and the gate kept excluding a name the producer had started emitting.
+ * One source or it drifts — this file now derives.
+ */
+export const GITHUB_UNCOVERED_NAMES = LEAF_UNCOVERED_NAMES;
 
 /**
  * Streams the source can PAGE but this file cannot turn into a faithful event, keyed

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -103,6 +103,8 @@ export const SOURCE_CLOUD_FEED = "cloud-feed";
 export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze([
   "github.pr.opened",
   "github.pr.closed",
+  // ⭐ CTC-691 landed in schema 0.1.17 — `merge_commit_sha` is a real column now.
+  "github.pr.merged",
   "github.pr_review.submitted",
   "github.pr_review_comment.created",
   "github.pr_review_thread.resolved",
@@ -115,7 +117,18 @@ export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze([
 
 /** Names the orchestrator consumes that this producer cannot yet emit. */
 export const GITHUB_UNCOVERED_NAMES = Object.freeze([
-  "github.pr.merged",
+  // ⛔ STILL UNCOVERED ON 0.1.17, AND NOT FOR THE REASON THE TABLE SUGGESTS.
+  // `check_suites` exists now, but the association the CONSUMER keys on does not:
+  // `router.mjs:1497` reaches an interest only through `detail.prNumbers`, which the
+  // webhook fills from `check_suite.pull_requests[].number` — a field the mirror does
+  // not store, and `check_runs` cannot supply (it is PR-less too).
+  //
+  // The only derivation is `check_suites.head_sha` → `pull_requests.head_sha`, and
+  // that is a LAST-STATE join: measured on mini-2, 93 of 202 suites (46%) resolve,
+  // and the misses are dominated by ACTIVE PR BRANCHES whose head moved after the
+  // suite ran — `ctc-pin-sdk-0.8.13` appears 10 times in the hits and 10 in the
+  // misses. Emitting on a 46% join would hang the CI wait silently, with no smee copy
+  // under `enforce`. → CTC-712
   "github.check_suite.completed",
 ]);
 
@@ -129,7 +142,14 @@ export const GITHUB_UNCOVERED_NAMES = Object.freeze([
  * line deletion here rather than as new read-layer code.
  */
 export const UNCOVERED_STREAM_REASONS = Object.freeze({
-  prMerged: "uncovered:no-merge-commit-sha:CTC-691",
+  // ⭐ EMPTY SINCE CTC-691 LANDED (schema 0.1.17). `pull_requests.merge_commit_sha`
+  // exists and is populated, so `prMerged` emits — the stream was deliberately kept
+  // paging all along so this would be a deletion here rather than new read-layer code,
+  // and it was.
+  //
+  // ⛔ A row whose `merge_commit_sha` is NULL still declines, but per ROW rather than
+  // per STREAM — see `classifyGithubRow`. Pre-0.1.17 merges were never backfilled, so
+  // those rows exist and must not emit a twin without the join key.
 });
 
 /**
@@ -231,11 +251,30 @@ export function classifyGithubRow(streamKey, row) {
   // PR-scoped streams are useless to the consumer without a PR number: every one of
   // their router branches gates on `prList.includes(scope.pr)` first.
   const prScoped = new Set([
-    "prOpened", "prClosed", "reviewSubmitted", "reviewCommentCreated", "threadResolved",
+    "prOpened", "prClosed", "prMerged", "reviewSubmitted", "reviewCommentCreated", "threadResolved",
   ]);
   if (prScoped.has(streamKey)) {
-    const n = streamKey === "prOpened" || streamKey === "prClosed" ? row.number : row.pr_number;
+    const n = streamKey === "prOpened" || streamKey === "prClosed" || streamKey === "prMerged"
+      ? row.number
+      : row.pr_number;
     if (!Number.isInteger(n) || n <= 0) return { emit: false, reason: "no-pr-number" };
+  }
+  // ⛔ `mergeCommitSha` IS THE JOIN KEY, and a merged twin without it is worse than no
+  // twin at all. `router.mjs:1513` writes it via `setFilterStateMerged` and
+  // `github.deployment.created` later matches `WHERE merge_commit_sha = ?`. An event
+  // missing it still routes and still wakes `monitor-merge` normally, so it LOOKS
+  // like success — while `monitor-deploy` stops firing for that PR, permanently,
+  // with no smee copy under `enforce`.
+  //
+  // ⚠️ These rows are real, not hypothetical: CTC-691 added the column without a
+  // backfill (COORD-124 names the 4,230 pre-existing PR rows), so every merge that
+  // predates the 0.1.17 pin has it NULL. They decline, visibly, in `byReason` —
+  // exactly the posture `deploymentCreated` takes for its own sha below.
+  if (streamKey === "prMerged" && (typeof row.merge_commit_sha !== "string" || row.merge_commit_sha === "")) {
+    return { emit: false, reason: "no-merge-commit-sha:not-backfilled" };
+  }
+  if (streamKey === "pushEvent" && (typeof row.ref !== "string" || row.ref === "")) {
+    return { emit: false, reason: "no-ref" };
   }
   if (streamKey === "deploymentStatus" && (typeof row.state !== "string" || row.state === "")) {
     return { emit: false, reason: "no-deployment-state" };
@@ -450,6 +489,11 @@ export function buildGithubEvent(streamKey, row, seams) {
       }, seams);
     }
 
+    // ⭐ CTC-704: identical envelope to `push`, from a per-DELIVERY row. Sharing the
+    // case is deliberate — the two streams differ in WHICH ROWS they yield, never in
+    // what an event looks like, and a second copy of this builder is how the feed
+    // copy and its own replacement would drift apart on a field the consumer reads.
+    case "pushEvent":
     case "push": {
       const headSha = typeof row.after === "string" ? row.after : "";
       return envelope({
@@ -468,11 +512,47 @@ export function buildGithubEvent(streamKey, row, seams) {
         payload: {
           baseSha: typeof row.before === "string" ? row.before : "",
           headSha,
-          // ⚠️ Always empty. The replica stores one row per ref and no commit list,
-          // so the commits array cannot be reconstructed. No consumer reads it
-          // (`router.mjs:1582` reads only `vcs.ref.name`), which is the measured
-          // reason this stream is shippable despite being lossy.
+          // ⚠️ Always empty, on BOTH streams. Neither `pushes` nor `push_events`
+          // stores a commit list, so the array cannot be reconstructed. No consumer
+          // reads it (`router.mjs:1582` reads only `vcs.ref.name`) — which is what
+          // makes the absence survivable, and is measured rather than assumed.
           commits: [],
+        },
+      }, seams);
+    }
+
+    case "prMerged": {
+      // ⭐ Unblocked by CTC-691 (schema 0.1.17). Deliberately NOT folded into the
+      // prOpened/prClosed case: those two hard-code `merged: false` and
+      // `mergeCommitSha: null` because `router.mjs:1525` tests `detail.merged === false`
+      // STRICTLY, and this name is the exact inverse on both fields.
+      return envelope({
+        name,
+        entity: "pr",
+        action: "merged",
+        label: `PR #${row.number}`,
+        attrs: {
+          "vcs.repository.name": repo,
+          "vcs.pr.number": row.number,
+          // The merge commit, on the attribute the deploy chain scopes by.
+          "vcs.revision": row.merge_commit_sha,
+        },
+        message: `${name} for ${repo} PR #${row.number}`,
+        payload: {
+          action: "closed",
+          // ⛔ GitHub sends `action: "closed"` with `merged: true` for a merge — the
+          // action is NOT "merged". `tryPrLifecycleRoute` and the webhook builder both
+          // read the pair, so inventing an action nobody emits would leave the
+          // lifecycle branch unmatched while every count still read "emitted".
+          merged: true,
+          mergedAt: typeof row.merged_at === "number" ? new Date(row.merged_at).toISOString() : null,
+          // The join key. `classifyGithubRow` has already refused the row if it is
+          // absent, so this is never null here — the guard is there, not here.
+          mergeCommitSha: row.merge_commit_sha,
+          draft: row.draft === 1 || row.draft === true,
+          mergeable: row.mergeable === null || row.mergeable === undefined
+            ? null
+            : row.mergeable === 1 || row.mergeable === true,
         },
       }, seams);
     }

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -184,18 +184,47 @@ describe("author identity — derived from the login, not joined", () => {
 });
 
 describe("⛔ uncovered names decline with a reason — they never return a silent null", () => {
-  test("prMerged declines, naming the ticket that closes it", () => {
-    const v = classifyGithubRow("prMerged", { __ts: 1, __id: "k", repo_id: "o/r", number: 7 });
-    expect(v.emit).toBe(false);
-    expect(v.reason).toBe(UNCOVERED_STREAM_REASONS.prMerged);
-    expect(v.reason).toContain("CTC-691");
-    // A decline, NOT a failure: un-arming the producer would not repair it, and
-    // readiness must not un-arm on a gap we have already declared.
-    expect(v.fatal).toBeUndefined();
+  test("⭐ prMerged EMITS now that CTC-691 landed — the stream-level decline is gone", () => {
+    // This test asserted the opposite until schema 0.1.17. `merge_commit_sha` is a
+    // real column, so the whole-stream refusal is deleted and the guard moved to the
+    // ROW (see the next test) — which is the finer, and only correct, granularity.
+    const v = classifyGithubRow("prMerged", {
+      __ts: 1, __id: "k", repo_id: "o/r", number: 7, merge_commit_sha: "abc123",
+    });
+    expect(v.emit).toBe(true);
+    expect(UNCOVERED_STREAM_REASONS.prMerged).toBeUndefined();
+  });
+
+  test("⛔ a prMerged row with NO merge_commit_sha declines — the un-backfilled rows", () => {
+    // ⚠️ Not hypothetical: CTC-691 added the column without backfilling the ~4,230
+    // pre-existing PR rows (COORD-124), so every merge predating the pin has it NULL.
+    // A twin without the join key routes and wakes monitor-merge normally while
+    // monitor-deploy stops firing — it LOOKS like success, which is why it declines.
+    for (const sha of [undefined, null, "", 12345]) {
+      const v = classifyGithubRow("prMerged", {
+        __ts: 1, __id: "k", repo_id: "o/r", number: 7, merge_commit_sha: sha,
+      });
+      expect(v.emit).toBe(false);
+      expect(v.reason).toBe("no-merge-commit-sha:not-backfilled");
+      // A decline, NOT a failure: un-arming the producer would not repair a row that
+      // predates the column, and readiness must not drop on a declared gap.
+      expect(v.fatal).toBeUndefined();
+    }
+    // ⭐ Control: the SAME row with a sha emits. Without this the test above passes
+    // if classify refuses every prMerged row for some unrelated reason.
+    const ok = classifyGithubRow("prMerged", {
+      __ts: 1, __id: "k", repo_id: "o/r", number: 7, merge_commit_sha: "abc123",
+    });
+    expect(ok.emit).toBe(true);
   });
   test("no uncovered name is reachable through the dispatch-class set", () => {
     for (const n of GITHUB_UNCOVERED_NAMES) expect(GITHUB_DISPATCH_CLASS_NAMES).not.toContain(n);
-    expect(GITHUB_UNCOVERED_NAMES).toContain("github.pr.merged");
+    // ⭐ pr.merged moved OUT of uncovered (CTC-691, schema 0.1.17) and INTO the
+    // emit-list. check_suite.completed did not — the table landed but the PR
+    // association the consumer keys on did not (CTC-712).
+    expect(GITHUB_DISPATCH_CLASS_NAMES).toContain("github.pr.merged");
+    expect(GITHUB_UNCOVERED_NAMES).not.toContain("github.pr.merged");
+    expect(GITHUB_UNCOVERED_NAMES).toContain("github.check_suite.completed");
     expect(GITHUB_UNCOVERED_NAMES).toContain("github.check_suite.completed");
   });
   test("buildGithubEvent refuses an uncovered stream", () => {
@@ -300,5 +329,84 @@ describe("deployment_status name and severity are per-row", () => {
     expect(mk("failure").severityText).toBe("ERROR");
     expect(mk("error").severityNumber).toBe(17);
     expect(mk("success").severityText).toBe("INFO");
+  });
+});
+
+describe("⭐ github.pr.merged — the envelope the deploy chain joins on (CTC-691)", () => {
+  const row = {
+    __ts: 1, __id: "o/r#7", repo_id: "o/r", number: 7,
+    merge_commit_sha: "deadbeefcafe", merged_at: 1_700_000_000_000,
+    draft: 0, mergeable: 1,
+  };
+  const ev = () => buildGithubEvent("prMerged", row);
+
+  test("⛔ mergeCommitSha is carried on BOTH the payload and vcs.revision", () => {
+    // `router.mjs:1513` reads `detail.mergeCommitSha` and writes it via
+    // setFilterStateMerged; `github.deployment.created` later matches
+    // `WHERE merge_commit_sha = ?`. This is the join key, not a description.
+    const e = ev();
+    expect(e.body.payload.mergeCommitSha).toBe("deadbeefcafe");
+    expect(e.attributes["vcs.revision"]).toBe("deadbeefcafe");
+  });
+
+  test("⛔ action is `closed` with merged:true — GitHub never sends action `merged`", () => {
+    // Inventing an action nobody emits leaves tryPrLifecycleRoute unmatched while
+    // every count still reads "emitted".
+    const e = ev();
+    expect(e.body.payload.action).toBe("closed");
+    expect(e.body.payload.merged).toBe(true);
+    expect(e.attributes["event.action"]).toBe("merged"); // the OTel action, not the payload's
+  });
+
+  test("⚠️ it does NOT carry title/body/headRef — the dormant lifecycle scraper", () => {
+    // `tryTicketLifecycleRoute` (router.mjs:1856) scrapes exactly those three for
+    // ticket ids and is dormant on this fleet (1,208/1,208 live payloads lack them).
+    // Including them switches `_autoPrLifecycleFromTicket` on fleet-wide.
+    const p = ev().body.payload;
+    for (const k of ["title", "body", "headRef"]) expect(p[k]).toBeUndefined();
+  });
+
+  test("mergedAt renders ISO-8601 UTC from the stored epoch-ms", () => {
+    expect(ev().body.payload.mergedAt).toBe(new Date(1_700_000_000_000).toISOString());
+    // A row with no merged_at yields null rather than "Invalid Date".
+    const e = buildGithubEvent("prMerged", { ...row, merged_at: null });
+    expect(e.body.payload.mergedAt).toBeNull();
+  });
+
+  test("the envelope keeps this feature's three invariants", () => {
+    const e = ev();
+    expect(e.resource["service.name"]).toBe("catalyst.github"); // CTL-1122 recency map
+    expect(e.attributes["event.channel"]).toBe("cloud-feed");
+    expect(e.body.payload.source).toBe("cloud-feed");
+  });
+
+  test("⛔ a row with no sha builds NOTHING — the guard is upstream of the builder", () => {
+    expect(buildGithubEvent("prMerged", { ...row, merge_commit_sha: null })).toBeNull();
+  });
+});
+
+describe("⭐ github.push from push_events is byte-identical to the pushes copy (CTC-704)", () => {
+  // The two streams differ in WHICH ROWS they yield, never in what an event looks
+  // like. A second builder is how the feed copy and its own replacement drift apart
+  // on a field the consumer reads.
+  const shared = { __ts: 5, repo_id: "o/r", ref: "refs/heads/main", before: "aaa", after: "bbb" };
+
+  test("both streams produce the same envelope for the same row", () => {
+    const fromPushes = buildGithubEvent("push", { ...shared, __id: "o/r@refs/heads/main" });
+    const fromEvents = buildGithubEvent("pushEvent", { ...shared, __id: "d1", delivery_id: "d1" });
+    // ids/timestamps are per-emission; compare everything the consumer reads.
+    expect(fromEvents.attributes).toEqual(fromPushes.attributes);
+    expect(fromEvents.body.payload).toEqual(fromPushes.body.payload);
+    expect(fromEvents.body.message).toBe(fromPushes.body.message);
+  });
+
+  test("⛔ the FULL ref is carried, not a stripped branch", () => {
+    // router.mjs:1582 strips `refs/heads/` itself; a pre-stripped value fails its match.
+    expect(buildGithubEvent("pushEvent", { ...shared, __id: "d1" }).attributes["vcs.ref.name"])
+      .toBe("refs/heads/main");
+  });
+
+  test("a row with no ref declines", () => {
+    expect(classifyGithubRow("pushEvent", { __ts: 5, __id: "d1", repo_id: "o/r", ref: "" }).emit).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
@@ -130,11 +130,13 @@ describe("the installed gate composes with decideDispatch as one decision", () =
   });
 
   test("⛔ ready producer still does NOT suppress an uncovered name", () => {
-    // The whole-system statement of the per-name rule: a healthy producer cannot
-    // earn the right to suppress the merge→deploy join key.
-    const v = decideDispatch(smee("github.pr.merged"), gateWith({ ready: true, reason: "producer-ready" }));
+    // The whole-system statement of the per-name rule: a healthy producer cannot earn
+    // the right to suppress a name whose consumer it cannot reach. ⚠️ The example
+    // moved from pr.merged to check_suite when CTC-691 landed — pr.merged is covered
+    // now; check_suite's TABLE landed but the PR association did not (CTC-712).
+    const v = decideDispatch(smee("github.check_suite.completed"), gateWith({ ready: true, reason: "producer-ready" }));
     expect(v.suppress).toBe(false);
-    expect(v.reason).toContain("CTC-691");
+    expect(v.reason).toContain("CTC-667");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
@@ -255,3 +255,28 @@ describe("the producer's own emit-list stays the source of truth for coverage", 
     }
   });
 });
+
+describe("⛔ ONE source of truth for the name lists — CI caught the half-done move", () => {
+  test("the gate, the producer and doctor all read the same lists", async () => {
+    // ⚠️ THE BUG THIS OWNS, and it shipped: #3540 moved the lists to
+    // `lib/github-feed-names.mjs` and pointed the GATE at the leaf, but left
+    // `github-feed-event.mjs`'s own copies in place. #3544 then removed `pr.merged`
+    // (CTC-691) from the copy the gate no longer read. Both branches passed locally —
+    // each predated the other's change — and on main the two lists disagreed: the
+    // gate kept excluding a name the producer had started emitting under its real
+    // name, which is a dropped edge under enforce. Identity, not deep-equality: a
+    // second array with equal contents is exactly the drift this asserts against.
+    const leaf = await import("../lib/github-feed-names.mjs");
+    const event = await import("./github-feed-event.mjs");
+    const gate = await import("./github-feed-gate.mjs");
+    expect(event.GITHUB_UNCOVERED_NAMES).toBe(leaf.GITHUB_UNCOVERED_NAMES);
+    expect(gate.GITHUB_UNCOVERED_NAMES).toBe(leaf.GITHUB_UNCOVERED_NAMES);
+    expect(gate.GITHUB_CONSUMED_NAMES).toBe(leaf.GITHUB_CONSUMED_NAMES);
+  });
+
+  test("⭐ every uncovered name is excluded from suppression, and pr.merged is not one", () => {
+    const excluded = GITHUB_CONSUMED_NAMES.filter((n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n));
+    for (const n of GITHUB_UNCOVERED_NAMES) expect(excluded).toContain(n);
+    expect(GITHUB_UNCOVERED_NAMES).not.toContain("github.pr.merged");
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
@@ -81,13 +81,12 @@ describe("⛔ suppression is per NAME, and the excluded set is COMPUTED from the
     for (const n of GITHUB_UNCOVERED_NAMES) expect(after).not.toContain(n);
   });
 
-  test("⭐ the post-CTC-691 world: emptying the uncovered list makes those names suppressible", () => {
+  test("⭐ the post-CTC-712 world: emptying the uncovered list makes those names suppressible", () => {
     const after = computeSuppressible({
       consumed: GITHUB_CONSUMED_NAMES,
       uncovered: [],
       lossy: GITHUB_LOSSY_NAMES,
     });
-    expect(after).toContain("github.pr.merged");
     expect(after).toContain("github.check_suite.completed");
     expect(after).not.toContain("github.push"); // still lossy until CTC-704
   });
@@ -111,10 +110,12 @@ describe("⛔ enforce must NOT suppress smee for a name with no faithful replace
     expect(v.reason).toBe("smee-captured");
   });
 
-  test("github.pr.merged survives — no merge_commit_sha (CTC-691)", () => {
+  test("⭐ github.pr.merged is now SUPPRESSIBLE — CTC-691 landed in schema 0.1.17", () => {
+    // This asserted the opposite until the pin. `merge_commit_sha` is a real column,
+    // the producer emits the name, and the gate may therefore suppress smee's copy.
     const v = decideDispatch(smee("github.pr.merged"), armed);
-    expect(v.suppress).toBe(false);
-    expect(v.reason).toBe("no-replacement:no-merge-commit-sha:CTC-691");
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("smee-captured");
   });
 
   test("github.check_suite.completed survives — no suite row (CTC-667 item 4)", () => {
@@ -147,9 +148,9 @@ describe("⛔ enforce must NOT suppress smee for a name with no faithful replace
     //    from "because this name has no replacement" (permanent until CTC-691 lands).
     //    Under the wrong order every excluded name reports `enforce-not-armed`
     //    whenever the producer happens to be un-armed, and the two collapse.
-    const v = decideDispatch(smee("github.pr.merged"), { mode: "enforce", isReady: () => false });
+    const v = decideDispatch(smee("github.check_suite.completed"), { mode: "enforce", isReady: () => false });
     expect(v.suppress).toBe(false);
-    expect(v.reason).toBe("no-replacement:no-merge-commit-sha:CTC-691");
+    expect(v.reason).toBe("no-replacement:no-suite-row:CTC-667-item-4");
     expect(v.reason).not.toMatch(/^enforce-not-armed/);
   });
 });
@@ -200,9 +201,9 @@ describe("the feed side is decided by its OWN stamp (CTL-1901's asymmetry), neve
     // Both halves of the exclusion must agree by construction. If the feed side
     // allowed it while the smee side (correctly) declines to suppress, BOTH copies
     // dispatch — the double-dispatch the gate exists to prevent.
-    const v = decideDispatch(feed("github.pr.merged"), { mode: "enforce", isReady: () => true });
+    const v = decideDispatch(feed("github.check_suite.completed"), { mode: "enforce", isReady: () => true });
     expect(v.suppress).toBe(true);
-    expect(v.reason).toBe("feed-excluded:no-replacement:no-merge-commit-sha:CTC-691");
+    expect(v.reason).toBe("feed-excluded:no-replacement:no-suite-row:CTC-667-item-4");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -65,6 +65,22 @@ const COMPARE_SPEC_DRAFT = {
     attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class"],
     payload: ["action", "merged", "draft"],
   },
+  // ⭐ Comparable since CTC-691 (schema 0.1.17). ⛔ `mergeCommitSha` is compared and
+  // must never move to OBSERVED_ONLY: it is the JOIN KEY the deploy chain matches on
+  // (`setFilterStateMerged` → `github.deployment.created`'s
+  // `WHERE merge_commit_sha = ?`). A ledger that read `clean` while the two producers
+  // disagreed on it would be certifying the exact failure this name exists to prevent.
+  //
+  // ⚠️ `mergedAt` IS compared, and it is the field most likely to diverge first: the
+  // feed reads `pull_requests.merged_at` and renders ISO-8601, while the webhook
+  // copies GitHub's own string. Both are UTC ISO — asserted rather than assumed, and
+  // if it ever diverges the ledger should say so loudly rather than have it excluded
+  // here in advance.
+  "github.pr.merged": {
+    key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}`,
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class", "vcs.revision"],
+    payload: ["action", "merged", "mergedAt", "mergeCommitSha", "draft", "mergeable"],
+  },
   "github.pr_review.submitted": {
     // `reviews.review_id` is not on the webhook side, so the key is the tuple the
     // consumer itself keys on plus the reviewer — coarser, and honest about it.
@@ -116,8 +132,21 @@ export const COMPARE_SPEC = Object.freeze(COMPARE_SPEC_DRAFT);
  * not silently ignored either.
  */
 export const KNOWN_ABSENT = Object.freeze({
-  "github.pr.merged": "CTC-691: pull_requests has no merge_commit_sha",
-  "github.check_suite.completed": "CTC-667 item 4: the mirror stores no suite row",
+  // ⭐ `github.pr.merged` LEFT THIS TABLE when CTC-691 landed (schema 0.1.17), and
+  // that removal is the point of the ticket rather than a side effect. While it was
+  // here the ledger EXCUSED its absence — so the one name whose loss silently kills
+  // the merge→deploy chain was precisely the one this instrument was configured not
+  // to notice. A ledger that cannot fail on a name is not measuring it.
+  //
+  // ⛔ `check_suite.completed` STAYS, and NOT for the reason the entry used to give.
+  // The mirror does store a suite row now. What it does not store is the association
+  // the consumer keys on — `router.mjs:1497` reaches an interest only through
+  // `detail.prNumbers`, from `check_suite.pull_requests[].number`, which the mirror
+  // drops and `check_runs` cannot supply. The only derivation is a LAST-STATE join
+  // through `pull_requests.head_sha`, measured at 93/202 (46%) on mini-2 with the
+  // misses dominated by active PR branches whose head moved after the suite ran.
+  "github.check_suite.completed":
+    "CTC-712: check_suites carries no pull_requests association; the head_sha join resolves 46%",
 });
 
 const nameOf = (e) => e?.attributes?.["event.name"];

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -174,8 +174,30 @@ describe("⛔ a consumed name that vanishes must not read as agreement", () => {
     { conclusion: "success", status: "completed", prNumbers: [7] });
 
   test("a DECLARED gap is reported as expected and stays clean", () => {
-    const r = compareGithubStreams([comment(1)], [comment(1), merged, suite]);
-    expect(r.expectedAbsent["github.pr.merged"]).toBe(1);
+    // ⚠️ The example is `check_suite.completed` alone now. `pr.merged` used to be
+    // here too and is not a declared gap any more (CTC-691 landed in schema 0.1.17),
+    // which the next test asserts from the other side.
+    const r = compareGithubStreams([comment(1)], [comment(1), suite]);
+    expect(r.expectedAbsent["github.check_suite.completed"]).toBe(1);
+    expect(r.unexplainedAbsent).toEqual({});
+    expect(r.clean).toBe(true);
+  });
+
+  test("⭐ pr.merged is NO LONGER a declared gap — a missing one now breaks clean", () => {
+    // ⛔ The inverse control, and the whole reason CTC-691 mattered: while pr.merged
+    // was declared uncovered, the ledger EXCUSED its absence, so the one name whose
+    // loss silently kills the merge→deploy chain was the one the instrument was
+    // configured not to notice. Now its absence is a finding.
+    const r = compareGithubStreams([comment(1)], [comment(1), merged]);
+    expect(r.expectedAbsent["github.pr.merged"]).toBeUndefined();
+    expect(r.unexplainedAbsent["github.pr.merged"]).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⭐ and a MATCHED pr.merged compares clean, including the join key", () => {
+    // The positive control: without it, the test above passes for a ledger that
+    // simply refuses every pr.merged.
+    const r = compareGithubStreams([comment(1), merged], [comment(1), merged]);
     expect(r.unexplainedAbsent).toEqual({});
     expect(r.clean).toBe(true);
   });
@@ -196,9 +218,12 @@ describe("⛔ a consumed name that vanishes must not read as agreement", () => {
     expect(r.inconclusive).toContain("smee-events-without-a-twin:1");
   });
 
-  test("both declared gaps name the ticket that closes them", () => {
-    expect(KNOWN_ABSENT["github.pr.merged"]).toContain("CTC-691");
-    expect(KNOWN_ABSENT["github.check_suite.completed"]).toContain("CTC-667");
+  test("the remaining declared gap names the ticket that closes it", () => {
+    // ⭐ One entry, not two. `pr.merged` left when CTC-691 landed.
+    expect(Object.keys(KNOWN_ABSENT)).toEqual(["github.check_suite.completed"]);
+    // ⚠️ And the ticket is CTC-712, not CTC-667: the suite TABLE exists now: what is
+    // missing is the pull_requests association the consumer keys on.
+    expect(KNOWN_ABSENT["github.check_suite.completed"]).toContain("CTC-712");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/github-feed-source.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.mjs
@@ -127,8 +127,6 @@ export const DEFAULT_SETTLE_MS = 600_000;
  */
 export const UNBACKED_EVENT_NAMES = Object.freeze(["github.check_suite.completed"]);
 
-/** `github.push` cannot be replayed faithfully. See gap (1) in the header. */
-export const PUSH_IS_LOSSY = true;
 
 /**
  * The streams, in the order a sweep should read them.
@@ -223,6 +221,30 @@ export const STREAMS = Object.freeze([
     where: null,
   },
   {
+    // ⭐ CTC-704 — one row per DELIVERY, which is what makes `github.push` faithful.
+    //
+    // `push_events` is keyed on GitHub's own `x-github-delivery` id, so the PK is a
+    // complete EDGE identity (unlike `pushes`, whose PK identifies the REF). That
+    // makes this an ordinary append-only stream: no `mutableRow`, no folded
+    // coordinate, and the seen-set dedups a redelivery for free because GitHub
+    // reuses the delivery id.
+    //
+    // ⚠️ IT IS NOT SNAPSHOT-SEEDED (CTC-136b §4). A fresh replica reads ref-latest
+    // from `pushes` and per-push edges forward from its cursor only, so a re-seed has
+    // a push blind spot with no rebroadcast behind it. That is CTL-1941's scenario
+    // and is measured there, not papered over here.
+    key: "pushEvent",
+    event: "github.push",
+    table: "push_events",
+    tsCol: "updated_at",
+    idExpr: "delivery_id",
+    where: null,
+    // The schema that introduced it. A host on an older pin does not have this table;
+    // `availableStreams` resolves that, rather than every caller guessing.
+    requiresTable: true,
+    supersedes: "push",
+  },
+  {
     key: "push",
     event: "github.push",
     table: "pushes",
@@ -232,6 +254,11 @@ export const STREAMS = Object.freeze([
     idExpr: "repo_id || '@' || ref",
     where: null,
     lossy: true,
+    // ⛔ SUPERSEDED BY `pushEvent` WHEREVER `push_events` EXISTS. Kept, not deleted,
+    // because a host on a pre-0.1.17 pin has no `push_events` table and would
+    // otherwise have NO push stream at all — which is worse than a lossy one while
+    // smee is still underneath. `availableStreams` picks exactly one of the two.
+    supersededBy: "pushEvent",
     // ⛔ THE ROW IS MUTATED PER PUSH, so this PK identifies the REF, not the edge.
     // Every other stream inserts a row per edge, which makes its PK a complete edge
     // identity. Here `repo_id@ref` is CONSTANT across every push to that branch — so
@@ -243,6 +270,73 @@ export const STREAMS = Object.freeze([
     mutableRow: true,
   },
 ]);
+
+/**
+ * tableExists — does this replica carry the table a stream reads?
+ *
+ * ⛔ EXISTS BECAUSE THE FLEET IS NOT ON ONE PIN AT ONCE. The 0.1.17 rollout is a
+ * canary: mini-2 first, mini after a soak, and by design a bad canary leaves the
+ * other host on the old pin indefinitely. A producer that assumed `push_events`
+ * exists would throw `no such table` on every tick of the un-pinned host — and the
+ * sweep's error path un-arms readiness, so under `enforce` that host would hand
+ * dispatch back to a smee tunnel we are trying to retire. Detected, not assumed.
+ */
+export function tableExists(db, table) {
+  try {
+    const row = db
+      .query("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = $t LIMIT 1")
+      .get({ $t: table });
+    return row?.ok === 1;
+  } catch {
+    // A database that cannot answer this question is not one to read optimistically.
+    return false;
+  }
+}
+
+/**
+ * availableStreams — the streams this replica can actually serve, with the
+ * supersession between `pushEvent` and `push` resolved to exactly ONE.
+ *
+ * ⛔ EXACTLY ONE IS THE WHOLE POINT. Both carry the name `github.push`. Running both
+ * on a pinned host emits every push twice — and the two have different identities
+ * (`delivery_id` vs the folded `repo_id@ref`), so the seen-set cannot collapse them:
+ * the duplicate reaches the router as a second, genuine-looking base-branch move and
+ * wakes every waiter again. Running neither on an un-pinned host silently drops
+ * rebase detection. The choice has to be made once, here, from the replica itself.
+ */
+export function availableStreams(db, streams = STREAMS) {
+  const present = new Map();
+  for (const s of streams) {
+    present.set(s.key, s.requiresTable ? tableExists(db, s.table) : true);
+  }
+  return streams.filter((s) => {
+    if (!present.get(s.key)) return false;
+    // A superseded stream yields only when its successor is actually available.
+    if (s.supersededBy && present.get(s.supersededBy)) return false;
+    return true;
+  });
+}
+
+/**
+ * pushIsLossy — whether `github.push` coverage is still collapse-prone on THIS replica.
+ *
+ * ⚠️ A FUNCTION OF THE REPLICA, NOT A CONSTANT, and that is the change CTC-704 makes.
+ * It was `export const PUSH_IS_LOSSY = true` — correct while every host read `pushes`,
+ * and wrong the moment one host is pinned and another is not. The dispatch gate reads
+ * this to decide whether `github.push` may suppress smee, so a constant would have the
+ * un-pinned host suppressing smee for a name it can only emit lossily.
+ */
+export function pushIsLossy(db) {
+  return !tableExists(db, "push_events");
+}
+
+/**
+ * ⚠️ DEPRECATED — the static answer, kept only for callers that have no db handle.
+ * It reports the PRE-CTC-704 world, which is the safe direction (lossy ⇒ smee keeps
+ * authority for `github.push`), so a caller that cannot ask the replica errs toward
+ * not suppressing. Prefer `pushIsLossy(db)`.
+ */
+export const PUSH_IS_LOSSY = true;
 
 /** Stream lookup by key, so callers name a stream instead of indexing an array. */
 export const STREAM_BY_KEY = Object.freeze(
@@ -419,8 +513,18 @@ export function createGithubFeedSource({ dbPath = getReplicaDbPath(), limit = DE
   return {
     /** Rows of a named stream strictly after `position`, oldest first. */
     rowsSince: (streamKey, position, batchLimit) => page(streamKey, position, batchLimit),
-    /** Every stream key, in sweep order. */
-    streamKeys: () => STREAMS.map((s) => s.key),
+    /**
+     * The stream keys this replica can actually serve, in sweep order.
+     *
+     * ⛔ RESOLVED FROM THE DATABASE, not from `STREAMS` directly. On a fleet
+     * mid-canary one host has `push_events` and the other does not, and the two push
+     * streams carry the SAME event name — so the choice between them is a property of
+     * the replica in front of us, never of this file. Serving both double-dispatches
+     * every push; serving neither kills rebase detection. See `availableStreams`.
+     */
+    streamKeys: () => availableStreams(open()).map((s) => s.key),
+    /** Whether `github.push` is still collapse-prone on THIS replica (CTC-704). */
+    pushIsLossy: () => pushIsLossy(open()),
     positionAfter,
     /**
      * `PRAGMA table_info` for a table, so a caller can verify REQUIRED_COLUMNS

--- a/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
@@ -18,8 +18,11 @@ import {
   STREAMS,
   STREAM_BY_KEY,
   UNBACKED_EVENT_NAMES,
+  availableStreams,
   buildStreamQuery,
   createGithubFeedSource,
+  pushIsLossy,
+  tableExists,
   positionAfter,
   settleCursor,
 } from "./github-feed-source.mjs";
@@ -64,7 +67,16 @@ CREATE TABLE pushes (
   repo_id text NOT NULL, ref text NOT NULL, before text, after text, forced integer,
   created integer, deleted integer, base_ref text, pusher_id text, head_commit_sha text,
   updated_at integer, PRIMARY KEY(repo_id, ref));
+-- CTC-704 (schema 0.1.17): one row per DELIVERY, PK = GitHub's x-github-delivery id.
+-- Verbatim from mini-2 after the pin.
+CREATE TABLE push_events (
+  delivery_id text PRIMARY KEY, repo_id text NOT NULL, ref text NOT NULL, before text,
+  after text, forced integer, created integer, deleted integer, base_ref text,
+  pusher_id text, head_commit_sha text, updated_at integer);
 `;
+
+/** The pre-0.1.17 DDL — every table EXCEPT push_events, for the un-pinned-host tests. */
+const DDL_PRE_0_1_17 = DDL.slice(0, DDL.indexOf("-- CTC-704"));
 
 let dbSeq = 0;
 function freshDb(seed = () => {}) {
@@ -229,10 +241,15 @@ describe("declared gaps are exported, not implied by a comment", () => {
     const produced = new Set(STREAMS.map((s) => s.event).filter(Boolean));
     for (const n of UNBACKED_EVENT_NAMES) expect(produced.has(n)).toBe(false);
   });
-  test("push is declared lossy, and is the only stream keyed on a mutable column", () => {
-    expect(PUSH_IS_LOSSY).toBe(true);
+  test("the two push streams are the only ones keyed on a mutable column", () => {
+    // ⚠️ `pushEvent` shares `updated_at` with `push` but is NOT lossy for it: its PK
+    // is the delivery id, so the mutable timestamp is only the keyset's major
+    // coordinate, never part of the row's identity. That distinction is what makes
+    // one of them collapse and the other not.
     const mutable = STREAMS.filter((s) => s.tsCol === "updated_at").map((s) => s.key);
-    expect(mutable).toEqual(["push"]);
+    expect(mutable.sort()).toEqual(["push", "pushEvent"]);
+    expect(STREAM_BY_KEY.push.mutableRow).toBe(true);
+    expect(STREAM_BY_KEY.pushEvent.mutableRow).toBeUndefined();
   });
 });
 
@@ -294,5 +311,100 @@ describe("buildStreamQuery", () => {
   });
   test("STREAM_BY_KEY covers every stream", () => {
     expect(Object.keys(STREAM_BY_KEY).sort()).toEqual(STREAMS.map((s) => s.key).sort());
+  });
+});
+
+describe("⛔ exactly ONE push stream is served, chosen from the replica (CTC-704)", () => {
+  // Both streams carry the name `github.push`. Running both on a pinned host emits
+  // every push TWICE — and their identities differ (`delivery_id` vs the folded
+  // `repo_id@ref`), so the seen-set cannot collapse them: the duplicate reaches the
+  // router as a second genuine-looking base-branch move and wakes every waiter again.
+  // Running neither on an un-pinned host silently kills rebase detection.
+  const pinned = () => { const db = new Database(":memory:"); db.exec(DDL); return db; };
+  const unpinned = () => { const db = new Database(":memory:"); db.exec(DDL_PRE_0_1_17); return db; };
+
+  test("tableExists answers from the replica, not from a version guess", () => {
+    expect(tableExists(pinned(), "push_events")).toBe(true);
+    expect(tableExists(unpinned(), "push_events")).toBe(false);
+    expect(tableExists(pinned(), "pushes")).toBe(true);
+    expect(tableExists(pinned(), "no_such_table")).toBe(false);
+  });
+
+  test("⭐ a PINNED replica (0.1.17) serves pushEvent and NOT push", () => {
+    const keys = availableStreams(pinned()).map((s) => s.key);
+    expect(keys).toContain("pushEvent");
+    expect(keys).not.toContain("push");
+  });
+
+  test("⛔ an UN-PINNED replica serves push and NOT pushEvent — it is not left with neither", () => {
+    // The canary leaves one host on the old pin by design (COORD-128 condition 2).
+    // A lossy push stream is worse than a faithful one and much better than none,
+    // while smee is still underneath.
+    const keys = availableStreams(unpinned()).map((s) => s.key);
+    expect(keys).toContain("push");
+    expect(keys).not.toContain("pushEvent");
+  });
+
+  test("⛔ exactly one `github.push` producer in EITHER world — asserted as a count", () => {
+    for (const mk of [pinned, unpinned]) {
+      const pushers = availableStreams(mk()).filter((s) => s.event === "github.push");
+      expect(pushers).toHaveLength(1);
+    }
+  });
+
+  test("every other stream is unaffected by the pin", () => {
+    const a = availableStreams(pinned()).map((s) => s.key).filter((k) => !k.startsWith("push"));
+    const b = availableStreams(unpinned()).map((s) => s.key).filter((k) => !k.startsWith("push"));
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThan(5);
+  });
+
+  test("⚠️ pushIsLossy tracks the REPLICA, so a mixed fleet cannot share one answer", () => {
+    // It was a module constant. With one host pinned and one not, a constant is
+    // wrong on exactly one of them — and the dispatch gate reads this to decide
+    // whether `github.push` may suppress smee.
+    expect(pushIsLossy(pinned())).toBe(false);
+    expect(pushIsLossy(unpinned())).toBe(true);
+  });
+
+  test("the pushEvent keyset query runs against the real 0.1.17 DDL", () => {
+    const db = pinned();
+    db.prepare(`INSERT INTO push_events
+        (delivery_id,repo_id,ref,before,after,forced,created,deleted,base_ref,pusher_id,head_commit_sha,updated_at)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`)
+      .run("d1", "o/r", "refs/heads/main", "aaa", "bbb", 0, 0, 0, null, "github:x", "bbb", 1000);
+    const rows = db.query(buildStreamQuery("pushEvent")).all({ $sinceMs: 0, $sinceId: "", $limit: 10 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].__id).toBe("d1");
+    expect(rows[0].__ts).toBe(1000);
+  });
+
+  test("⭐ two pushes to ONE ref both survive — the defect CTC-704 exists to fix", () => {
+    const db = pinned();
+    const ins = db.prepare(`INSERT INTO push_events
+        (delivery_id,repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?,?)`);
+    ins.run("d1", "o/r", "refs/heads/main", "aaa", "bbb", 1000);
+    ins.run("d2", "o/r", "refs/heads/main", "bbb", "ccc", 1001);
+    const rows = db.query(buildStreamQuery("pushEvent")).all({ $sinceMs: 0, $sinceId: "", $limit: 10 });
+    expect(rows).toHaveLength(2);
+    // ⛔ The control against the old table: the SAME two pushes in `pushes` leave one row.
+    const up = db.prepare(`INSERT INTO pushes (repo_id,ref,before,after,updated_at) VALUES (?,?,?,?,?)
+                           ON CONFLICT(repo_id,ref) DO UPDATE SET after=excluded.after, updated_at=excluded.updated_at`);
+    up.run("o/r", "refs/heads/main", "aaa", "bbb", 1000);
+    up.run("o/r", "refs/heads/main", "bbb", "ccc", 1001);
+    expect(db.query("SELECT COUNT(*) c FROM pushes").get().c).toBe(1);
+  });
+
+  test("⚠️ a force-push BACK to a previous sha is still its own row", () => {
+    // The case that collapses under COORD-127's proposed `(repo_id, ref, after)` key,
+    // and the reason backend took the delivery id instead (CTC-704 §4.1).
+    const db = pinned();
+    const ins = db.prepare(`INSERT INTO push_events
+        (delivery_id,repo_id,ref,before,after,forced,updated_at) VALUES (?,?,?,?,?,?,?)`);
+    ins.run("d1", "o/r", "refs/heads/f", "000", "X", 0, 1000);
+    ins.run("d2", "o/r", "refs/heads/f", "X", "Y", 0, 1001);
+    ins.run("d3", "o/r", "refs/heads/f", "Y", "X", 1, 1002);
+    const rows = db.query(buildStreamQuery("pushEvent")).all({ $sinceMs: 0, $sinceId: "", $limit: 10 });
+    expect(rows).toHaveLength(3);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.mjs
@@ -235,14 +235,19 @@ export function runGithubSweep({
   settleMs = DEFAULT_SETTLE_MS,
   batchLimit = DEFAULT_BATCH_LIMIT,
   maxBatches = DEFAULT_MAX_BATCHES,
-  streams = STREAMS.map((s) => s.key),
+  // ⛔ ASK THE SOURCE, don't enumerate STREAMS. The replica decides which of the two
+  // `github.push` producers is served (CTC-704 / `availableStreams`), and a default
+  // taken from the module would run both on a pinned host — the same push twice, with
+  // identities the seen-set cannot collapse. Tests still pass an explicit list.
+  streams = null,
   seams,
   cursorPathFn = streamCursorPath,
   readCursorFn = readCursor,
   writeCursorFn = writeCursor,
 }) {
   const counts = emptyCounts();
-  for (const streamKey of streams) {
+  const streamKeys = streams ?? source.streamKeys();
+  for (const streamKey of streamKeys) {
     try {
       sweepStream({
         source,

--- a/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-sweep.test.mjs
@@ -198,7 +198,12 @@ describe("⛔ P1 regression (Codex #3513): consecutive pushes to one ref both re
 });
 
 describe("⛔ declines never reach byFailure — this is the CTL-1909 property", () => {
-  test("an uncovered stream declines and readiness stays armed", () => {
+  test("a row that cannot be built declines, and readiness stays armed", () => {
+    // ⚠️ The example moved. `prMerged` was the whole-stream decline until CTC-691
+    // landed; now the decline is per ROW — a merge that predates the column and was
+    // never backfilled (COORD-124's ~4,230 rows). Same property, finer granularity,
+    // and it is still a DECLINE rather than a failure: un-arming the producer cannot
+    // repair a row that has no sha to begin with.
     const NOW = 10_000_000;
     const w = world((db) => {
       db.prepare("INSERT INTO pull_requests (repo_id,number,merged,merged_at,created_at) VALUES (?,?,?,?,?)")
@@ -208,7 +213,7 @@ describe("⛔ declines never reach byFailure — this is the CTL-1909 property",
       const c = sweep(w, NOW, { streams: ["prMerged"] });
       expect(c.declined).toBe(1);
       expect(c.failed).toBe(0);
-      expect(Object.keys(c.byReason)[0]).toContain("CTC-691");
+      expect(Object.keys(c.byReason)[0]).toContain("no-merge-commit-sha");
       // The gate the daemon actually runs, imported rather than restated — a
       // hand-built copy could agree with this fixture and disagree with production.
       expect(countsClean(c)).toBe(true);
@@ -462,5 +467,52 @@ describe("readiness reads these counts the way the daemon does", () => {
       expect(githubSweepUnreadyReason({ counts }, { healthy: false, reason: "stall" }))
         .toBe("feed-unhealthy:stall");
     } finally { w.close(); }
+  });
+});
+
+describe("⛔ the sweep asks the REPLICA which push stream to run (CTC-704)", () => {
+  test("with no explicit list it uses source.streamKeys(), not the STREAMS module", () => {
+    // The mutation this owns: defaulting to `STREAMS.map(...)` runs BOTH push streams
+    // on a pinned host — the same push emitted twice, with identities
+    // (`delivery_id` vs `repo_id@ref`) the seen-set cannot collapse, so the duplicate
+    // reaches the router as a second genuine base-branch move.
+    const asked = [];
+    const source = {
+      streamKeys: () => { asked.push("asked"); return ["prOpened"]; },
+      rowsSince: () => [],
+      positionAfter: () => null,
+    };
+    runGithubSweep({
+      source,
+      seen: { has: () => false, add: () => {}, prune: () => {}, close: () => {} },
+      sink: () => {},
+      orchDir: tmp,
+      account: "tenant-0",
+      now: 10_000_000,
+      cursorPathFn: (d, a, k) => join(tmp, `cur-ask-${k}.json`),
+      readCursorFn: () => null,
+      writeCursorFn: () => {},
+    });
+    expect(asked).toEqual(["asked"]);
+  });
+
+  test("an explicit list still wins, so tests can drive one stream", () => {
+    const source = {
+      streamKeys: () => { throw new Error("must not be consulted"); },
+      rowsSince: () => [],
+      positionAfter: () => null,
+    };
+    expect(() => runGithubSweep({
+      source,
+      seen: { has: () => false, add: () => {}, prune: () => {}, close: () => {} },
+      sink: () => {},
+      orchDir: tmp,
+      account: "tenant-0",
+      now: 10_000_000,
+      streams: ["prOpened"],
+      cursorPathFn: (d, a, k) => join(tmp, `cur-exp-${k}.json`),
+      readCursorFn: () => null,
+      writeCursorFn: () => {},
+    })).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
@@ -267,10 +267,12 @@ describe("⛔ under enforce the producer emits a REAL name only for what the gat
   });
 
   test("⛔ an EXCLUDED name stays a would-dispatch marker even under enforce", () => {
-    // pr.merged / check_suite have no replacement (CTC-691, CTC-667 item 4) and push
-    // has a lossy one (CTC-704). Emitting these for real would put two copies on the
-    // log, because the gate correctly refuses to suppress smee for them.
-    for (const n of ["github.pr.merged", "github.check_suite.completed", "github.push"]) {
+    // ⚠️ `pr.merged` is NOT in this list any more — CTC-691 landed, so it emits under
+    // its real name and the gate suppresses smee's copy. `check_suite` has no usable
+    // replacement (CTC-712) and `push` a lossy one (CTC-704); emitting either for
+    // real would put two copies on the log, because the gate correctly refuses to
+    // suppress smee for them.
+    for (const n of ["github.check_suite.completed", "github.push"]) {
       expect(drive("enforce", [n])).toEqual([EVENT_WOULD_DISPATCH]);
     }
   });

--- a/plugins/dev/scripts/lib/github-feed-names.mjs
+++ b/plugins/dev/scripts/lib/github-feed-names.mjs
@@ -56,7 +56,8 @@ export const GITHUB_CONSUMED_NAMES = Object.freeze([
 /**
  * Consumed names with NO replica stream behind them at all.
  *
- * `github.pr.merged` — `pull_requests` has no `merge_commit_sha` column, and
+ * (Historical, kept because the argument still applies to the entry below.)
+ * `github.pr.merged` — before CTC-691, `pull_requests` had no `merge_commit_sha`, and
  * `body.payload.mergeCommitSha` is a JOIN KEY: `router.mjs:1513` writes it via
  * `setFilterStateMerged` and `github.deployment.created` later matches
  * `WHERE merge_commit_sha = ?`. A twin without it routes and wakes `monitor-merge`
@@ -68,7 +69,18 @@ export const GITHUB_CONSUMED_NAMES = Object.freeze([
  * the merge gate. → CTC-667 item 4
  */
 export const GITHUB_UNCOVERED_NAMES = Object.freeze([
-  "github.pr.merged",
+  // ⛔ `github.pr.merged` LEFT THIS LIST when CTC-691 landed in schema 0.1.17 —
+  // `pull_requests.merge_commit_sha` is a real column and the producer emits the name.
+  // A row whose sha is NULL (a merge predating the pin, never backfilled) still
+  // declines, but per ROW in `classifyGithubRow`, which is the correct granularity.
+  //
+  // ⛔ `check_suite.completed` STAYS, and NOT for the reason the old entry gave. The
+  // mirror stores a suite row now. What it does not store is the association the
+  // CONSUMER keys on: `router.mjs:1497` reaches an interest only through
+  // `detail.prNumbers`, from `check_suite.pull_requests[].number`, which the mirror
+  // drops and `check_runs` cannot supply. The only derivation is a LAST-STATE join
+  // through `pull_requests.head_sha` — measured 93/202 (46%) on mini-2, misses
+  // dominated by active PR branches whose head moved after the suite ran. → CTC-712
   "github.check_suite.completed",
 ]);
 


### PR DESCRIPTION
Schema **0.1.17 is pinned and live on mini-2** — verified by content rather than by waiting for the rollout turn: `pull_requests.merge_commit_sha` present, `push_events` keyed on `delivery_id`, `check_suites` populating.

Two of the three blocking names are now wired. **The third is not, and the reason changed** — see below.

## ⭐ `github.pr.merged` emits (CTC-691)

The stream was deliberately kept paging while the column was missing, so CTC-691 would land as a **deletion** here rather than as new read-layer code. It did: `UNCOVERED_STREAM_REASONS` is now empty.

⛔ **The whole-stream refusal became a per-ROW one**, which is the only correct granularity. CTC-691 added the column **without backfilling** the ~4,230 pre-existing PR rows (COORD-124), so every merge predating the pin has it NULL. Those decline with `no-merge-commit-sha:not-backfilled`, visibly, in `byReason`.

That guard is not fastidiousness. `mergeCommitSha` is the **join key**: `router.mjs:1513` writes it via `setFilterStateMerged` and `github.deployment.created` later matches `WHERE merge_commit_sha = ?`. A twin without it **routes and wakes `monitor-merge` normally** while `monitor-deploy` stops firing — it looks exactly like success. Same posture `deploymentCreated` already takes for its own sha.

## ⭐ `github.push` comes from `push_events` (CTC-704)

One row per delivery, PK = GitHub's `x-github-delivery`. That makes it an ordinary append-only stream: no `mutableRow`, no folded coordinate, and a redelivery dedups for free because GitHub reuses the id.

⛔ **Both push streams carry the same event name, so `availableStreams` resolves the replica down to EXACTLY ONE.**

- Running **both** on a pinned host emits every push twice — and their identities differ (`delivery_id` vs the folded `repo_id@ref`), so the seen-set *cannot* collapse them: the duplicate reaches the router as a second, genuine-looking base-branch move and wakes every waiter again.
- Running **neither** on an un-pinned host silently kills rebase detection.

⚠️ This is a **live condition tonight, not a hypothetical**: the canary leaves one host on the old pin by design (COORD-128 §2). So `tableExists` asks the database rather than inferring from a version, and `PUSH_IS_LOSSY` became `pushIsLossy(db)` — a module constant is wrong on exactly one host of a mixed fleet, and the dispatch gate reads it to decide whether `github.push` may suppress smee.

## ⛔ `check_suite.completed` still does NOT emit — and the reason is not the old one

The table landed in 0.1.17. **The association the consumer keys on did not.**

`router.mjs:1497` reaches an interest **only** through `detail.prNumbers`, which the webhook fills from `check_suite.pull_requests[].number`. The mirror drops that field, and `check_runs` cannot supply it (also PR-less). The only available derivation is a **last-state** join through `pull_requests.head_sha`:

```
check_suites total = 202 · head_sha joins a PR = 93 (46%) · misses = 109
misses by branch: ryan/ctl-1944-direnv-fleet 25 · ryan/ctl-1949-ask-traps 19
                  ryan/ctl-1952-session-verdict 10 · ctc-pin-sdk-0.8.13 10
                  main + release-please 43 (legitimately no PR)
```

⭐ The sharpest row: **`ctc-pin-sdk-0.8.13` appears 10 times in the hits and 10 in the misses** — one branch, where only suites matching the PR's *current* head resolve. That is the superseded-head pattern isolated, and it is why 46% is structural rather than a sampling artifact.

Emitting on a 46% join would hang the CI wait silently, with no smee copy under `enforce`. **→ CTC-712, filed P1.** So `github.check_suite.completed` stays in `GITHUB_UNCOVERED_NAMES`, with the entry rewritten to name the real cause.

## The ledger

`github.pr.merged` gains a compare spec — including `mergeCommitSha`, with a note that it must never move to `OBSERVED_ONLY` — and **leaves `KNOWN_ABSENT`**.

⛔ That removal is the point of CTC-691, not a side effect. While `pr.merged` sat in `KNOWN_ABSENT` the ledger **excused its absence** — so the one name whose loss silently kills the merge→deploy chain was precisely the one this instrument was configured not to notice. A ledger that cannot fail on a name is not measuring it. There is now a test asserting its absence breaks `clean`, plus the positive control that a matched pair still compares clean.

## Tests

**238 pass / 0 fail** across the `github-feed` suite (+21 new). **8 mutations run, all 8 fired:**

| | |
| --- | --- |
| supersession removed (both push streams run) | 2 fail |
| table existence assumed | 1 fail |
| `pushIsLossy` always true | 1 fail |
| un-backfilled rows emit a twin with no join key | 5 fail |
| payload says `merged: false` | 1 fail |
| join key dropped from the payload | 1 fail |
| invents `action: "merged"` (GitHub never sends it) | 1 fail |
| sweep defaults to `STREAMS` instead of asking the replica | 1 fail |

New coverage includes the force-push-back-to-a-previous-sha case (which collapses under COORD-127's originally proposed `(repo_id, ref, after)` key, and is why backend's delivery-id choice was right), and a control that the two push streams produce **byte-identical envelopes** — they differ in which rows they yield, never in what an event looks like.

## ⚠️ Gate accounting

**Full gate deferred: load average was 172 at commit time**, against a rule of 40. Running it would have produced a result I could not trust and would have made the box worse for everyone else mid-rollout. Targeted suite is 238/0. **CI is authoritative.**

## What this does NOT do

⛔ Changes no host. `CATALYST_GITHUB_FEED` is `off` everywhere except mini-2 (`shadow`). The tunnel does not retire until the ledger returns CLEAN over Tuesday-morning traffic **and** CTC-712 closes — precondition P2 on the CTL-1929 runbook stays open.

⚠️ The gate's suppressible set still excludes `github.push` (it derives from the deprecated static `PUSH_IS_LOSSY`, which reports the pre-CTC-704 world). That is the **safe** direction — smee keeps authority for push, exactly one copy dispatches — and resolving it per-host is a follow-up, not something to guess at here.

Refs CTL-1929, CTC-691, CTC-704, CTC-712, CTC-667, COORD-124, COORD-128