### PR TITLE
fix(dev): CTL-1947 — an account the poller CANNOT sample now says so, instead of leaving an absent series

### DIFF
--- a/plugins/dev/scripts/catalyst-agent/usage.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.mjs
@@ -35,6 +35,46 @@ const SEVEN_DAY_MS = 7 * 86_400_000;
 
 export const RATELIMIT_EVENT_SAMPLED = "account.ratelimit.sampled";
 
+// CTL-1947. Every path below that cannot produce a sample used to `continue` after a log.warn
+// and emit NOTHING. Prometheus then shows an ABSENT series — which, as CTL-1947 puts it, "looks
+// identical to a healthy one that happens to be at zero" and is indistinguishable from the
+// exporter not running at all. Measured on mini 2026-08-18 02:2x CT: the poller had been running
+// every 300 s and logging "account email unresolvable; skipping account this run" on EVERY run,
+// with zero ratelimit events in a 2.7 MB log, while catalyst_account_ratelimit_* had carried no
+// data for 7+ days. Nothing was broken loudly; it was broken quietly.
+//
+// So a run that cannot sample now emits a POSITIVE signal saying so, carrying the reason. An
+// absent series is not evidence; a series that says "unsampled because 401" is.
+export const RATELIMIT_EVENT_UNSAMPLED = "account.ratelimit.unsampled";
+
+// The reasons, as a closed set — an alert keys on these, so they are a contract, not free text.
+export const UNSAMPLED_NO_TOKEN = "no-token";
+export const UNSAMPLED_EMAIL_UNRESOLVABLE = "email-unresolvable";
+export const UNSAMPLED_USAGE_THROTTLED = "usage-throttled";
+export const UNSAMPLED_USAGE_HTTP_ERROR = "usage-http-error";
+
+// buildUnsampledSpec — the envelope for "this account could NOT be sampled this run".
+//
+// ⛔ It deliberately carries NO utilization fields. A zero would be read as "0% used" by every
+// consumer of the sampled metric, which is the precise confusion this event exists to remove:
+// unsampled is not low usage, it is NO MEASUREMENT.
+export function buildUnsampledSpec({ email = null, reason, status = null, source = null }) {
+  return {
+    entity: "account",
+    // Normalized to null rather than left undefined: the emit layer drops both, but a
+    // deterministic shape is what lets a test assert "emitted WITHOUT an email, deliberately"
+    // instead of accidentally passing on a typo'd key.
+    label: email ?? source ?? "unknown",
+    attrs: {
+      "account.email": email,
+      "account.source": source,
+      "ratelimit.unsampled_reason": reason,
+      "ratelimit.unsampled_http_status": status,
+    },
+    payload: { email, source, reason, status },
+  };
+}
+
 // pctOf — normalize a usage bucket to its numeric utilization. The live usage
 // endpoint returns each bucket (five_hour, seven_day, seven_day_opus,
 // seven_day_sonnet) as an object { utilization, resets_at }; older docs showed
@@ -209,6 +249,22 @@ export function buildSampledSpec({
   };
 }
 
+// emitUnsampled — emit the "could not measure" signal. Never throws: an observability emit must
+// not be able to break the sampling loop it is reporting on (the loop already runs inside a
+// per-account try, but this is the one call added on the FAILURE paths, so it fails soft by
+// construction rather than by luck).
+function emitUnsampled(emit, spec, { nowIso } = {}) {
+  try {
+    if (typeof emit !== "function") return;
+    // Third argument mirrors the sampled path EXACTLY (`{ now: nowIso }` — the emit layer
+    // receives the ISO-stamp provider, not a called value). Inventing a different envelope
+    // contract for the failure path is how a signal ends up unparseable by the same consumer.
+    emit(RATELIMIT_EVENT_UNSAMPLED, buildUnsampledSpec(spec), { now: nowIso });
+  } catch {
+    /* never throw */
+  }
+}
+
 /**
  * tickUsage — sample rate-limit usage for every account this run, emitting one
  * account.ratelimit.sampled per account. On a 429 from any account it stops the
@@ -240,6 +296,7 @@ export async function tickUsage({
       const token = account?.token;
       if (!token) {
         log.warn({ source: account?.source }, "usage: account has no token; skipping");
+        emitUnsampled(emit, { reason: UNSAMPLED_NO_TOKEN, source: account?.source }, { nowIso });
         continue;
       }
 
@@ -270,24 +327,48 @@ export async function tickUsage({
           { source: account?.source },
           "usage: account email unresolvable; skipping account this run",
         );
+        // ⛔ THE ONE THAT WENT DARK FOR 7+ DAYS. /api/oauth/profile answers 401 once the stored
+        // OAuth credential stops being authorized, resolveEmail returns null, and the ambient
+        // OTEL_RESOURCE_ATTRIBUTES fallback is not present under launchd (the plist sets only
+        // CATALYST_AGENT_METRICS_ENDPOINT / HOME / PATH), so BOTH paths to an email are dead and
+        // the account is skipped forever. It is emitted with no email — the source alone
+        // identifies it, and that is exactly the fact worth alerting on.
+        emitUnsampled(
+          emit,
+          { reason: UNSAMPLED_EMAIL_UNRESOLVABLE, source: account?.source },
+          { nowIso },
+        );
         continue;
       }
 
       const { status, body } = await fetchUsage(token, { userAgent });
 
       if (status === 429) {
-        // Shared limiter: the usage endpoint throttled us. Continuing would
-        // compound the throttle for the remaining accounts, so stop the run
-        // here and emit nothing further.
+        // Shared limiter: the usage endpoint throttled us. Continuing would compound the
+        // throttle for the remaining accounts, so stop the run here and take no further
+        // SAMPLES. (CTL-1947: it does still emit the unsampled signal for THIS account first —
+        // "we were throttled" is a measurement worth having, and it is what distinguishes a
+        // throttled run from a dead poller. The accounts not reached emit nothing, which the
+        // reason field makes legible.)
         log.warn(
           { source: account?.source },
           "usage: 429 from usage endpoint; stopping remaining accounts this run",
+        );
+        emitUnsampled(
+          emit,
+          { email, reason: UNSAMPLED_USAGE_THROTTLED, status, source: account?.source },
+          { nowIso },
         );
         break;
       }
 
       if (status !== 200 || !body) {
         log.warn({ status, source: account?.source }, "usage: non-200 usage response; skipping emit");
+        emitUnsampled(
+          emit,
+          { email, reason: UNSAMPLED_USAGE_HTTP_ERROR, status, source: account?.source },
+          { nowIso },
+        );
         continue;
       }
 

--- a/plugins/dev/scripts/catalyst-agent/usage.test.mjs
+++ b/plugins/dev/scripts/catalyst-agent/usage.test.mjs
@@ -11,7 +11,17 @@
 // Run: cd plugins/dev/scripts/catalyst-agent && bun test usage.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { computePace, pctOf, tickUsage, RATELIMIT_EVENT_SAMPLED } from "./usage.mjs";
+import {
+  computePace,
+  pctOf,
+  tickUsage,
+  RATELIMIT_EVENT_SAMPLED,
+  RATELIMIT_EVENT_UNSAMPLED,
+  UNSAMPLED_NO_TOKEN,
+  UNSAMPLED_EMAIL_UNRESOLVABLE,
+  UNSAMPLED_USAGE_THROTTLED,
+  UNSAMPLED_USAGE_HTTP_ERROR,
+} from "./usage.mjs";
 
 const FIVE_HOUR_MS = 5 * 3600_000;
 const SEVEN_DAY_MS = 7 * 86_400_000;
@@ -43,7 +53,13 @@ function harness({
   now = () => Date.parse("2026-06-06T12:00:00Z"),
   nowIso = undefined,
 } = {}) {
+  // CTL-1947: `emitted` remains the SAMPLED stream, so every assertion written against it keeps
+  // its original meaning — these tests are about ghost rows (never a sampled event without an
+  // email) and about which accounts got measured. The new "could not measure" signal is a
+  // separate stream, asserted separately, rather than folded in here where it would silently
+  // change what 30-odd existing expectations mean.
   const emitted = [];
+  const unsampled = [];
   const fetchCalls = [];
   const resolveCalls = [];
   const promise = tickUsage({
@@ -56,11 +72,14 @@ function harness({
       resolveCalls.push({ token, opts });
       return resolveEmail(token, opts);
     },
-    emit: (name, spec, opts) => emitted.push({ name, spec, opts }),
+    emit: (name, spec, opts) => {
+      if (name === RATELIMIT_EVENT_UNSAMPLED) unsampled.push({ name, spec, opts });
+      else emitted.push({ name, spec, opts });
+    },
     now,
     nowIso,
   });
-  return { promise, emitted, fetchCalls, resolveCalls };
+  return { promise, emitted, unsampled, fetchCalls, resolveCalls };
 }
 
 // ─── computePace — pure unit (the locked fixtures) ───────────────────────────
@@ -499,8 +518,12 @@ describe("tickUsage — unresolvable email skips the account", () => {
       emit: (name, spec) => emitted.push({ name, spec }),
     });
     expect(n).toBe(0);
-    expect(emitted.length).toBe(0);
+    // The ghost-row invariant, stated precisely: no SAMPLED event without an email. CTL-1947 adds
+    // an unsampled event on this same path, so counting ALL emits would no longer test that.
+    expect(emitted.filter((e) => e.name === RATELIMIT_EVENT_SAMPLED).length).toBe(0);
     expect(fetchCalls.length).toBe(0); // skipped BEFORE burning a rate-limited call
+    // ...and the skip is now VISIBLE rather than silent (CTL-1947).
+    expect(emitted.filter((e) => e.name === RATELIMIT_EVENT_UNSAMPLED).length).toBe(1);
   });
 
   test("active account falls back to OTEL_RESOURCE_ATTRIBUTES user.email", async () => {
@@ -531,7 +554,12 @@ describe("tickUsage — unresolvable email skips the account", () => {
         emit: (name, spec) => emitted.push({ name, spec }),
       });
       expect(n).toBe(0);
-      expect(emitted.length).toBe(0);
+      // Same distinction as above: the backup account still produces NO sampled event (it must
+      // not borrow the active account's ambient identity), but the skip is now reported.
+      expect(emitted.filter((e) => e.name === RATELIMIT_EVENT_SAMPLED).length).toBe(0);
+      const un = emitted.filter((e) => e.name === RATELIMIT_EVENT_UNSAMPLED);
+      expect(un.length).toBe(1);
+      expect(un[0].spec.attrs["account.email"]).toBeNull();
     } finally {
       delete process.env.OTEL_RESOURCE_ATTRIBUTES;
     }
@@ -546,5 +574,152 @@ describe("parseOtelEmail", () => {
     expect(parseOtelEmail({})).toBe(null);
     expect(parseOtelEmail({ OTEL_RESOURCE_ATTRIBUTES: "a=b" })).toBe(null);
     expect(parseOtelEmail({ OTEL_RESOURCE_ATTRIBUTES: "user.email=" })).toBe(null);
+  });
+});
+
+
+// ─── CTL-1947: an account that cannot be sampled says so ────────────────────
+//
+// The metric was dark for 7+ days and nothing said a word. Measured on mini 2026-08-18 02:2x CT:
+// the poller ran every 300 s, logged "account email unresolvable; skipping account this run" on
+// EVERY run into a 2.7 MB log nobody reads, emitted zero ratelimit events, and
+// catalyst_account_ratelimit_* simply had no series. An absent series is indistinguishable from
+// an exporter that was never started — which is exactly what CTL-1947 AC 2 forbids.
+//
+// The property under test: every path that cannot produce a sample emits a POSITIVE signal
+// carrying the reason, and that signal never looks like usage data.
+describe("tickUsage — unsampled accounts are VISIBLE (CTL-1947)", () => {
+  const emitsOf = (events, name) => events.filter((e) => e.name === name);
+  const collect = () => {
+    const events = [];
+    return { events, emit: (name, spec, opts) => events.push({ name, spec, opts }) };
+  };
+
+  test("an account with NO TOKEN emits unsampled, not silence", async () => {
+    const { events, emit } = collect();
+    const n = await tickUsage({ accounts: [{ source: "active" }], emit });
+    expect(n).toBe(0);
+    const un = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED);
+    expect(un.length).toBe(1);
+    expect(un[0].spec.attrs["ratelimit.unsampled_reason"]).toBe(UNSAMPLED_NO_TOKEN);
+    expect(emitsOf(events, RATELIMIT_EVENT_SAMPLED).length).toBe(0);
+  });
+
+  // ⛔ THE ONE THAT WENT DARK. /api/oauth/profile answers 401, resolveEmail returns null, and
+  // under launchd there is no OTEL_RESOURCE_ATTRIBUTES fallback either.
+  test("an UNRESOLVABLE EMAIL emits unsampled with the reason", async () => {
+    const { events, emit } = collect();
+    const n = await tickUsage({
+      accounts: [{ source: "active", token: TOKEN_A }],
+      resolveEmail: async () => null, // the live 401 shape
+      fetchUsage: async () => {
+        throw new Error("must not reach the usage endpoint without an email");
+      },
+      emit,
+    });
+    expect(n).toBe(0);
+    const un = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED);
+    expect(un.length).toBe(1);
+    expect(un[0].spec.attrs["ratelimit.unsampled_reason"]).toBe(UNSAMPLED_EMAIL_UNRESOLVABLE);
+    expect(un[0].spec.attrs["account.source"]).toBe("active");
+  });
+
+  test("a 429 emits unsampled for the throttled account before stopping", async () => {
+    const { events, emit } = collect();
+    await tickUsage({
+      accounts: [
+        { source: "active", token: TOKEN_A },
+        { source: "backup", token: TOKEN_B },
+      ],
+      resolveEmail: async () => ({ email: "a@example.com" }),
+      fetchUsage: async () => ({ status: 429, body: null }),
+      emit,
+    });
+    const un = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED);
+    expect(un.length).toBe(1); // the reached account only — the loop stops
+    expect(un[0].spec.attrs["ratelimit.unsampled_reason"]).toBe(UNSAMPLED_USAGE_THROTTLED);
+    expect(un[0].spec.attrs["ratelimit.unsampled_http_status"]).toBe(429);
+  });
+
+  test("a non-200 emits unsampled carrying the status", async () => {
+    const { events, emit } = collect();
+    await tickUsage({
+      accounts: [{ source: "active", token: TOKEN_A }],
+      resolveEmail: async () => ({ email: "a@example.com" }),
+      fetchUsage: async () => ({ status: 503, body: null }),
+      emit,
+    });
+    const un = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED);
+    expect(un.length).toBe(1);
+    expect(un[0].spec.attrs["ratelimit.unsampled_reason"]).toBe(UNSAMPLED_USAGE_HTTP_ERROR);
+    expect(un[0].spec.attrs["ratelimit.unsampled_http_status"]).toBe(503);
+  });
+
+  // ⛔ THE CONFUSION THIS EVENT EXISTS TO REMOVE. "Unsampled" must never be readable as "0% used".
+  test("an unsampled event carries NO utilization fields at all", async () => {
+    const { events, emit } = collect();
+    await tickUsage({
+      accounts: [{ source: "active", token: TOKEN_A }],
+      resolveEmail: async () => null,
+      fetchUsage: async () => ({ status: 200, body: usageBody() }),
+      emit,
+    });
+    const spec = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED)[0].spec;
+    for (const k of Object.keys(spec.attrs)) {
+      expect(k).not.toBe("ratelimit.five_hour_pct");
+      expect(k).not.toBe("ratelimit.seven_day_pct");
+    }
+    expect(spec.payload.fiveHourPct).toBeUndefined();
+    expect(spec.payload.sevenDayPct).toBeUndefined();
+  });
+
+  // ⛔ NEGATIVE CONTROL: a healthy account must NOT emit unsampled — otherwise the new signal is
+  // noise and an alert on it fires forever.
+  test("a healthy account emits sampled ONLY", async () => {
+    const { events, emit } = collect();
+    const n = await tickUsage({
+      accounts: [{ source: "active", token: TOKEN_A }],
+      resolveEmail: async () => ({ email: "a@example.com", rateLimitTier: "t" }),
+      fetchUsage: async () => ({ status: 200, body: usageBody() }),
+      emit,
+    });
+    expect(n).toBe(1);
+    expect(emitsOf(events, RATELIMIT_EVENT_SAMPLED).length).toBe(1);
+    expect(emitsOf(events, RATELIMIT_EVENT_UNSAMPLED).length).toBe(0);
+  });
+
+  // The envelope contract must match the sampled path, or the same consumer cannot read it.
+  test("the unsampled envelope uses the same emit signature as sampled", async () => {
+    const { events, emit } = collect();
+    const nowIso = () => "2026-08-18T07:00:00Z";
+    await tickUsage({
+      accounts: [{ source: "active", token: TOKEN_A }],
+      resolveEmail: async () => null,
+      emit,
+      nowIso,
+    });
+    const un = emitsOf(events, RATELIMIT_EVENT_UNSAMPLED)[0];
+    expect(un.spec.entity).toBe("account");
+    expect(un.opts).toEqual({ now: nowIso });
+  });
+
+  // An observability emit must not be able to break the loop it reports on.
+  test("an emit that throws does not break sampling of later accounts", async () => {
+    const seen = [];
+    const emit = (name, spec, opts) => {
+      if (name === RATELIMIT_EVENT_UNSAMPLED) throw new Error("collector down");
+      seen.push({ name, spec, opts });
+    };
+    const n = await tickUsage({
+      accounts: [
+        { source: "backup" }, // no token -> unsampled -> emit throws
+        { source: "active", token: TOKEN_A },
+      ],
+      resolveEmail: async () => ({ email: "a@example.com" }),
+      fetchUsage: async () => ({ status: 200, body: usageBody() }),
+      emit,
+    });
+    expect(n).toBe(1);
+    expect(seen.filter((e) => e.name === RATELIMIT_EVENT_SAMPLED).length).toBe(1);
   });
 });


### PR DESCRIPTION
## ⛔ Root cause — and it is not what the ticket assumed

CTL-1947 attributes the dark `catalyst_account_ratelimit_*` series to **claude-limits'** credentials. The actual producer is **this repo's own poller**: `catalyst-agent/usage.mjs` (CTL-812) emits `account.ratelimit.sampled`, and the OTel collector's `signal_to_metrics` connector turns that into the metric. `claude-limits` is a different, third-party thing.

What is actually happening on `mini`, every 300 s, for 7+ days:

```
$ tail catalyst-agent.log
[catalyst-agent:warn] usage: account email unresolvable; skipping account this run   (× thousands)
$ grep -c ratelimit catalyst-agent.log
0
```

Probed directly (status codes only — the token is never printed):

| endpoint | result |
| -- | -- |
| `GET /api/oauth/profile` | **HTTP 401** → `resolveEmail()` returns null |
| `GET /api/oauth/usage` | **HTTP 429** |

The stored OAuth credential is no longer authorized for the profile endpoint, so no email resolves and the account is skipped. **The `parseOtelEmail()` fallback cannot save it either** — the launchd plist sets only `CATALYST_AGENT_METRICS_ENDPOINT` / `HOME` / `PATH`, so `OTEL_RESOURCE_ATTRIBUTES` is absent in the daemon context and that fallback is **inert in production**. Both paths to an email are dead.

## What this fixes, and what it deliberately does not

It does **not** re-authorize the credential — that is an interactive re-login, filed separately as an ask.

It fixes **the reason nobody noticed for a week.** All four un-sampleable paths (`no token`, `email unresolvable`, `429`, `non-200`) did `log.warn(...); continue` and emitted **nothing**, so Prometheus saw an *absent* series. CTL-1947's own **AC 2** is exactly this: an unauthorized account "is VISIBLE as a distinct signal — not merely an absent series, which is indistinguishable from 'the exporter is not running'". A 2.7 MB log of warnings nobody reads is not a signal.

Each path now emits **`account.ratelimit.unsampled`** carrying a reason from a closed set — `no-token` / `email-unresolvable` / `usage-throttled` / `usage-http-error` — plus the HTTP status. Dark becomes a **positive series you can alert on**, within one scrape instead of seven days.

## ⛔ It carries no utilization fields

A zero would read as "0% used" to every consumer of the sampled metric — the precise confusion this event exists to remove. **Unsampled is not low usage; it is no measurement.** There is a test that fails if a percentage ever appears on it.

The envelope mirrors the sampled path's emit signature exactly (`{ now: nowIso }`) — inventing a different shape for the failure path is how a signal ends up unparseable by the same consumer. `emitUnsampled` never throws: an observability emit must not break the loop it reports on (asserted).

## Test-harness note

`emitted` stays the **sampled** stream and the new signal is collected separately, so ~30 existing expectations keep their original meaning rather than silently changing what they assert. The two tests that built their own collector now assert the ghost-row invariant *precisely* (no **sampled** event without an email) **and** that the skip is reported — strictly stronger than the "emits nothing" they asserted before, which was itself the defect.

## Verified

- `usage.test.mjs` **44/44**
- full `catalyst-agent` suite **300/300** (the CI step's bare `bun test`)
- `check-import-graph` OK — 9 modules load under node, all imports `node:*` except the declared-optional pino

## Follow-on

The metric stays dark until the credential is re-authorized (an ask for Ryan). But when it next goes dark — for any of the four reasons — it will now be visible immediately instead of silently.