### PR TITLE
chore(dev): pin the fleet to @catalyst-cloud/sdk 0.8.14 (schema 0.1.18 / replicate 0.1.12) for CTC-712

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "catalyst-execution-core",
       "dependencies": {
         "@catalyst-cloud/read-model": "^0.1.0",
-        "@catalyst-cloud/sdk": "0.8.13",
+        "@catalyst-cloud/sdk": "0.8.14",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",
@@ -210,11 +210,11 @@
 
     "@catalyst-cloud/read-model": ["@catalyst-cloud/read-model@0.1.1", "", {}, "sha512-DFnVumOR8lB4scX3aYyh9aCLc57LmfpRyrR+BX8pVFLmg7sbBNa/4kOevbq9bgXpEJ8nzUY096hoStHbcB8b7w=="],
 
-    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.11", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.17" } }, "sha512-QtVxTng3XfP3QdUuAOv2NiSLOlZSc/JSUwyM5KPSpRC8MnKUAxXo62ClnBnjv0m8TU/ntuJgPOO2dWWfT4qBXA=="],
+    "@catalyst-cloud/replicate": ["@catalyst-cloud/replicate@0.1.12", "", { "dependencies": { "@catalyst-cloud/schema": "0.1.18" } }, "sha512-6MGQWMdWukD/fA1Ivu6dIvXj8tRzMMjv3wUvhzTgdNhLdY17YrIILQDNS0ALStcDIsZUbBhYwwdfjYnYWxGKZg=="],
 
     "@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.17", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-/e23/wXxZ4Ko7wttMpDQCWOYFfqMZtDjCSUz1BjHi2pvJo546PX/J2Qq75vGf0es1UKVNxrkVyegubIVUm56AQ=="],
 
-    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.13", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.11", "@catalyst-cloud/schema": "0.1.17" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-IMn4WS60pEtoO2ubXgx2Jw9Xh6lzxaT9pDzci+AqVXoxACvJce8lph4abl8inZISorkHoIQ2nU7Sd71QFE6ebA=="],
+    "@catalyst-cloud/sdk": ["@catalyst-cloud/sdk@0.8.14", "", { "dependencies": { "@catalyst-cloud/read-model": "^0.1.0", "@catalyst-cloud/replicate": "0.1.12", "@catalyst-cloud/schema": "0.1.18" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <2", "@sqlite.org/sqlite-wasm": "*", "better-sqlite3": "*" }, "optionalPeers": ["@opentelemetry/api", "@sqlite.org/sqlite-wasm", "better-sqlite3"] }, "sha512-ulJNniSQFDDxWBdq1e7cOnDRZjgFqkI9HYodQvi9pqNcKQxLcyhHCyhh+K/Km7INUrRlFizewF7kgK1lLpD5Vw=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@3.1.0", "", { "dependencies": { "@dagrejs/graphlib": "4.0.3" } }, "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw=="],
 
@@ -1543,6 +1543,10 @@
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@catalyst-cloud/replicate/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.18", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-w3lr2z21SLAfRb1QhFCxv+1v9JCM2epLNvvAi73tXN/ClsqV0wxCgQ+07cK/Jx+BehRXwQu3G+z+iAvqHHOdTg=="],
+
+    "@catalyst-cloud/sdk/@catalyst-cloud/schema": ["@catalyst-cloud/schema@0.1.18", "", { "dependencies": { "drizzle-orm": "0.44.7" } }, "sha512-w3lr2z21SLAfRb1QhFCxv+1v9JCM2epLNvvAi73tXN/ClsqV0wxCgQ+07cK/Jx+BehRXwQu3G+z+iAvqHHOdTg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/plugins/dev/scripts/execution-core/package.json
+++ b/plugins/dev/scripts/execution-core/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@catalyst-cloud/read-model": "^0.1.0",
-    "@catalyst-cloud/sdk": "0.8.13",
+    "@catalyst-cloud/sdk": "0.8.14",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.219.0",


### PR DESCRIPTION
Fleet pin for **CTC-712**. Carries `check_suites.pull_request_numbers` — migration `0028_burly_nemesis`, one additive `ALTER TABLE … ADD COLUMN`, no table rebuild.

## ⛔ Why

`github.check_suite.completed` **is** the CI wait, and `broker/router.mjs:1497` reaches an interest for it **exclusively** through `detail.prNumbers`. The suite table shipped in 0.1.17 with no PR association, leaving only a `head_sha` join against `pull_requests.head_sha` — a **last-state** column.

CTL measured that join on mini-2: **93 of 202 suites (46%)**, and the misses were **active PR branches** (`ryan/ctl-1944-direnv-fleet` 25, `ryan/ctl-1949-ask-traps` 19), not `main`. Under `CATALYST_GITHUB_FEED=enforce` there is no smee copy, so every miss is a CI wait that hangs and a merge gate that never resolves.

## Lockfile, verified by content

`@catalyst-cloud/sdk@0.8.14` → `@catalyst-cloud/replicate 0.1.12` → `@catalyst-cloud/schema 0.1.18`.

## ⚠️ Merging rolls out nothing (CTL-44)

Only a **cloud-sync writer restart** runs the replica migration — `plugin-refresh` does not restart it. Rollout is `git pull && bun install && launchctl kickstart` per host, **mini-2 canary first**, then `mini`.

Upstream: catalyst-cloud **#842** (`68a1006`), catalyst-cloud-sdk **#27**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)