### PR TITLE
fix(dev): CTL-1929 — the parity ledger compares only repos smee can deliver, so CLEAN is reachable

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -524,11 +524,16 @@ export function buildGithubEvent(streamKey, row, seams) {
         entity: "pr",
         action: "merged",
         label: `PR #${row.number}`,
+        // ⛔ NO `vcs.revision`, THOUGH THE MERGE SHA IS RIGHT THERE. I added it — it is
+        // the obvious attribute for a merge commit — and the parity ledger caught it
+        // on the first live window: the WEBHOOK does not set it on this name, so the
+        // feed's copy diverged on all 3 events. Reproduce the webhook, do not improve
+        // it; the same rule that keeps `threadId: 0` on pr_review_thread.resolved.
+        // The consumer reads `detail.mergeCommitSha` from the payload, which is
+        // populated below.
         attrs: {
           "vcs.repository.name": repo,
           "vcs.pr.number": row.number,
-          // The merge commit, on the attribute the deploy chain scopes by.
-          "vcs.revision": row.merge_commit_sha,
         },
         message: `${name} for ${repo} PR #${row.number}`,
         payload: {
@@ -538,7 +543,14 @@ export function buildGithubEvent(streamKey, row, seams) {
           // read the pair, so inventing an action nobody emits would leave the
           // lifecycle branch unmatched while every count still read "emitted".
           merged: true,
-          mergedAt: typeof row.merged_at === "number" ? new Date(row.merged_at).toISOString() : null,
+          // ⛔ SECOND-PRECISION, NOT MILLISECOND. `toISOString()` always emits `.000Z`;
+          // GitHub's own string omits milliseconds, so the naive form diverged on
+          // every event (`08:07:22.000Z` vs `08:07:22Z`) — caught by the ledger on the
+          // first live window, exactly where #3544's own PR body predicted it would go
+          // first. Trimming is safe because the column is whole seconds from GitHub.
+          mergedAt: typeof row.merged_at === "number"
+            ? new Date(row.merged_at).toISOString().replace(/\.\d{3}Z$/, "Z")
+            : null,
           // The join key. `classifyGithubRow` has already refused the row if it is
           // absent, so this is never null here — the guard is there, not here.
           mergeCommitSha: row.merge_commit_sha,

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -340,13 +340,18 @@ describe("⭐ github.pr.merged — the envelope the deploy chain joins on (CTC-6
   };
   const ev = () => buildGithubEvent("prMerged", row);
 
-  test("⛔ mergeCommitSha is carried on BOTH the payload and vcs.revision", () => {
+  test("⛔ mergeCommitSha is on the PAYLOAD, and vcs.revision is deliberately absent", () => {
     // `router.mjs:1513` reads `detail.mergeCommitSha` and writes it via
     // setFilterStateMerged; `github.deployment.created` later matches
-    // `WHERE merge_commit_sha = ?`. This is the join key, not a description.
+    // `WHERE merge_commit_sha = ?`. That is the join key, and it lives in the payload.
+    //
+    // ⚠️ I originally ALSO set `vcs.revision` — it is the obvious attribute for a
+    // merge commit — and the parity ledger caught it on the first live window: the
+    // webhook does not set it on this name, so all 3 events diverged. Reproduce the
+    // webhook, do not improve it. Same rule as `threadId: 0`.
     const e = ev();
     expect(e.body.payload.mergeCommitSha).toBe("deadbeefcafe");
-    expect(e.attributes["vcs.revision"]).toBe("deadbeefcafe");
+    expect(e.attributes["vcs.revision"]).toBeUndefined();
   });
 
   test("⛔ action is `closed` with merged:true — GitHub never sends action `merged`", () => {
@@ -366,8 +371,11 @@ describe("⭐ github.pr.merged — the envelope the deploy chain joins on (CTC-6
     for (const k of ["title", "body", "headRef"]) expect(p[k]).toBeUndefined();
   });
 
-  test("mergedAt renders ISO-8601 UTC from the stored epoch-ms", () => {
-    expect(ev().body.payload.mergedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  test("⛔ mergedAt is SECOND-precision, matching GitHub — not toISOString()'s .000Z", () => {
+    // The divergence the ledger found first, on all 3 live events:
+    //   feed 2026-08-18T08:07:22.000Z  vs  smee 2026-08-18T08:07:22Z
+    expect(ev().body.payload.mergedAt).toBe("2023-11-14T22:13:20Z");
+    expect(ev().body.payload.mergedAt).not.toMatch(/\.\d{3}Z$/);
     // A row with no merged_at yields null rather than "Invalid Date".
     const e = buildGithubEvent("prMerged", { ...row, merged_at: null });
     expect(e.body.payload.mergedAt).toBeNull();

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -78,7 +78,9 @@ const COMPARE_SPEC_DRAFT = {
   // here in advance.
   "github.pr.merged": {
     key: (e) => `${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}`,
-    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class", "vcs.revision"],
+    // ⚠️ `vcs.revision` is deliberately NOT compared and NOT emitted — the webhook
+    // does not set it on this name. It was in both for one round; the ledger caught it.
+    attrs: ["vcs.repository.name", "vcs.pr.number", "event.entity", "event.action", "event.label", "event.stream_class"],
     payload: ["action", "merged", "mergedAt", "mergeCommitSha", "draft", "mergeable"],
   },
   "github.pr_review.submitted": {

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -158,6 +158,45 @@ const eq = (a, b) => JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
  * Both arrays are the events already filtered to one window by the caller — the
  * windowing is deliberately not done here so the comparator stays pure and testable.
  */
+export const repoOf = (e) => e?.attributes?.["vcs.repository.name"] ?? null;
+
+/**
+ * The repos BOTH producers can see — the only population over which "did the feed
+ * miss this?" is a meaningful question.
+ *
+ * ⛔ WHY THIS EXISTS. The two producers do not cover the same repositories, and the
+ * asymmetry is not a bug on either side: the webhook subscription covers a repo set
+ * an operator configured, while the mirror ingests whatever the cloud is told to
+ * ingest. Measured on mini-2 over one live window:
+ *
+ *   smee delivers : catalyst · catalyst-cloud · ryanrozich/personal-os
+ *   feed produces : catalyst · catalyst-cloud · catalyst-cloud-sdk · thoughts
+ *
+ * ⭐ So the feed is BROADER, and retiring the tunnel EXTENDS coverage rather than
+ * shrinking it — backend's own SDK PR #26, part of tonight's 0.1.17 cascade, was
+ * visible to the feed and never to the tunnel.
+ *
+ * ⛔ But before this scoping, the ledger counted every such event as
+ * `feed-events-without-a-twin`, which forces INCONCLUSIVE. **The cutover gate was
+ * therefore unmeetable for a reason that was not a fault** — 6 unjoined events over
+ * 55 minutes, every one of them from a repo smee cannot deliver. That is the exact
+ * mirror image of the false-clean corrected in CTL-48: the same instrument, wrong in
+ * the other direction, and just as capable of driving a wrong decision.
+ *
+ * ⚠️ The scoping is deliberately derived from the SMEE side only. Taking the
+ * intersection of both would also drop a repo the feed *should* cover and silently
+ * does not — which is a real defect and must keep failing. Feed events outside the
+ * smee repo set are reported as `feedOnlyRepos`, never dropped.
+ */
+export function smeeRepos(smeeEvents) {
+  const repos = new Set();
+  for (const e of smeeEvents) {
+    const r = repoOf(e);
+    if (typeof r === "string" && r !== "") repos.add(r);
+  }
+  return repos;
+}
+
 export function compareGithubStreams(feedEvents, smeeEvents) {
   const feed = Array.isArray(feedEvents) ? feedEvents : [];
   const smee = Array.isArray(smeeEvents) ? smeeEvents : [];
@@ -165,6 +204,24 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
   const inconclusive = [];
   if (feed.length === 0) inconclusive.push("feed-side-empty");
   if (smee.length === 0) inconclusive.push("smee-side-empty");
+
+  // Partition the feed side by whether smee could have produced a twin at all.
+  const comparableRepos = smeeRepos(smee);
+  const feedOnly = [];
+  const feedComparable = [];
+  for (const e of feed) {
+    // ⚠️ An event with NO repo attribute stays COMPARABLE. Treating it as feed-only
+    // would let a malformed envelope excuse itself out of the comparison, which is
+    // the shape of every false-clean in this file's history.
+    const r = repoOf(e);
+    if (typeof r === "string" && r !== "" && !comparableRepos.has(r)) feedOnly.push(e);
+    else feedComparable.push(e);
+  }
+  const feedOnlyRepos = {};
+  for (const e of feedOnly) {
+    const r = repoOf(e);
+    feedOnlyRepos[r] = (feedOnlyRepos[r] ?? 0) + 1;
+  }
 
   // ⛔ MULTIPLICITY, NOT PRESENCE — a single-value map is a false-clean generator.
   // Some join keys are deliberately COARSE (a review keys on repo/pr/reviewer/state
@@ -189,7 +246,7 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
 
   const byName = {};
   let unkeyable = 0;
-  for (const e of feed) {
+  for (const e of feedComparable) {
     const n = nameOf(e);
     const spec = COMPARE_SPEC[n];
     if (!spec) {
@@ -268,6 +325,11 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
     byName,
     unkeyable,
     smeeUnjoined,
+    // ⭐ Reported, never dropped: an operator reading a clean verdict must still see
+    // that the feed covered repos the tunnel did not, because that is a REASON TO
+    // RETIRE rather than a caveat on retiring.
+    feedOnlyRepos,
+    comparableRepos: [...comparableRepos].sort(),
     expectedAbsent: Object.fromEntries(Object.entries(absent).filter(([n]) => n in KNOWN_ABSENT)),
     unexplainedAbsent,
     inconclusive,

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -10,6 +10,7 @@ import {
   KNOWN_ABSENT,
   OBSERVED_ONLY_FIELDS,
   compareGithubStreams,
+  smeeRepos,
   parityExitCode,
 } from "./github-feed-parity.mjs";
 
@@ -246,5 +247,81 @@ describe("coverage of the spec itself", () => {
 
   test("a null report is inconclusive, not clean", () => {
     expect(parityExitCode(null)).toBe(3);
+  });
+});
+
+describe("⛔ the comparison is scoped to repos smee can actually deliver", () => {
+  // Measured on mini-2: the two producers cover overlapping but DIFFERENT repo sets.
+  //   smee : catalyst · catalyst-cloud · ryanrozich/personal-os
+  //   feed : catalyst · catalyst-cloud · catalyst-cloud-sdk · thoughts
+  // Before scoping, every feed event from a feed-only repo counted as
+  // `feed-events-without-a-twin` and forced INCONCLUSIVE — so the cutover gate was
+  // unmeetable for a reason that was not a fault (6 such events in 55 minutes).
+  const inRepo = (repo, name, attrs, payload) =>
+    ev(name, { "vcs.repository.name": repo, ...attrs }, payload);
+
+  const smeePush = inRepo("o/shared", "github.push",
+    { "vcs.ref.name": "refs/heads/main", "vcs.revision": "a1" },
+    { baseSha: "b", headSha: "a1", commits: [] });
+  const feedPush = inRepo("o/shared", "github.push",
+    { "vcs.ref.name": "refs/heads/main", "vcs.revision": "a1" },
+    { baseSha: "b", headSha: "a1", commits: [] });
+  const feedOnly = inRepo("o/feed-only", "github.push",
+    { "vcs.ref.name": "refs/heads/main", "vcs.revision": "z9" },
+    { baseSha: "y", headSha: "z9", commits: [] });
+
+  test("⭐ a feed event from a repo smee does not deliver does NOT block clean", () => {
+    const r = compareGithubStreams([feedPush, feedOnly], [smeePush]);
+    expect(r.totals.unjoined).toBe(0);
+    expect(r.clean).toBe(true);
+  });
+
+  test("⛔ but it is REPORTED, never silently dropped", () => {
+    // The feed covering more than the tunnel is a REASON TO RETIRE, not a caveat —
+    // an operator reading a clean verdict has to be able to see it.
+    const r = compareGithubStreams([feedPush, feedOnly], [smeePush]);
+    expect(r.feedOnlyRepos).toEqual({ "o/feed-only": 1 });
+    expect(r.comparableRepos).toEqual(["o/shared"]);
+  });
+
+  test("⛔ a feed event from a SHARED repo with no twin STILL blocks clean", () => {
+    // The control that keeps the scoping honest: it must excuse only the events smee
+    // could never have produced, never a genuine phantom in a repo it covers.
+    const phantom = inRepo("o/shared", "github.push",
+      { "vcs.ref.name": "refs/heads/other", "vcs.revision": "q7" },
+      { baseSha: "p", headSha: "q7", commits: [] });
+    const r = compareGithubStreams([feedPush, phantom], [smeePush]);
+    expect(r.totals.unjoined).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⛔ scoping is derived from the SMEE side only — a repo the feed SHOULD cover still fails", () => {
+    // Taking the intersection of both sides would also drop a repo the feed is
+    // supposed to cover and silently does not, which is a real defect. Here smee
+    // delivers two repos and the feed only one: the missing one must still count.
+    const smeeOther = inRepo("o/smee-only", "github.push",
+      { "vcs.ref.name": "refs/heads/main", "vcs.revision": "m3" },
+      { baseSha: "l", headSha: "m3", commits: [] });
+    const r = compareGithubStreams([feedPush], [smeePush, smeeOther]);
+    expect(r.comparableRepos).toEqual(["o/shared", "o/smee-only"]);
+    expect(r.smeeUnjoined).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⚠️ an event with NO repo attribute stays comparable", () => {
+    // Treating it as feed-only would let a malformed envelope excuse itself out of
+    // the comparison — the shape of every false-clean in this file's history.
+    const noRepo = ev("github.push",
+      { "vcs.ref.name": "refs/heads/main", "vcs.revision": "n0" },
+      { baseSha: "m", headSha: "n0", commits: [] });
+    const r = compareGithubStreams([feedPush, noRepo], [smeePush]);
+    expect(r.feedOnlyRepos).toEqual({});
+    expect(r.totals.unjoined).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("smeeRepos collects the delivered set, ignoring blanks", () => {
+    expect([...smeeRepos([smeePush, smeePush])]).toEqual(["o/shared"]);
+    expect([...smeeRepos([ev("github.push", {}, {})])]).toEqual([]);
   });
 });


### PR DESCRIPTION
⚠️ **Stacked on #3544.** Base retargets to `main` when that merges.

## ⛔ The cutover gate was unmeetable for a reason that was not a fault

Measured over a **55-minute live window** on mini-2, through the shipped ledger:

```
joined 81 / agree 81 · smee-unjoined 0 · feed-unjoined 6
clean = false · exit 3   ← blocked on "feed-events-without-a-twin: 6"
```

**81 of 81 joined events agreed on every compared field, and not one smee event lacked a twin.** The verdict was still INCONCLUSIVE. All six unjoined feed events came from repos the tunnel does not deliver:

| | repos |
| --- | --- |
| **smee delivers** | `catalyst` · `catalyst-cloud` · `ryanrozich/personal-os` |
| **feed produces** | `catalyst` · `catalyst-cloud` · **`catalyst-cloud-sdk`** · **`thoughts`** |

The webhook subscription covers a repo set an operator configured; the mirror ingests a different, larger one.

⭐ **So the feed is BROADER than the tunnel, and retiring it EXTENDS coverage rather than shrinking it.** Backend's own SDK PR #26 — the 0.8.13 leg of tonight's cascade — was visible to the feed and never to the tunnel.

⛔ But `feed-events-without-a-twin` was conflating two things that need **opposite** verdicts:

- the feed emitted a **phantom** → a real defect, must block CLEAN;
- the feed covers a repo smee **cannot** → correct behaviour, and it blocked CLEAN **forever**.

That is the mirror image of the false-clean corrected in CTL-48 — the same instrument, wrong in the other direction, and just as capable of driving a wrong decision. A gate that can never be met is not a safety property; it is a gate someone eventually overrides.

## The fix

The comparison is scoped to the repos **smee actually delivered in the window**. Feed events outside that set are reported as `feedOnlyRepos` and `comparableRepos` — **never dropped**, because an operator reading a clean verdict has to see that the feed covered more. That is a reason to retire, not a caveat on retiring.

⚠️ **The scope is derived from the SMEE side only.** Taking the intersection of both sides would also excuse a repo the feed *should* cover and silently does not — a real defect that must keep failing. Driven by its own test.

⚠️ **An event with no repo attribute stays COMPARABLE.** Letting a malformed envelope excuse itself out of the comparison is the shape of every false-clean in this file's history.

## Verified against the window that motivated it

```
before: feed-unjoined 6 · clean=false
after : feed-unjoined 0 · feedOnlyRepos {catalyst-cloud-sdk: 5, thoughts: 1}
                         comparableRepos [catalyst, catalyst-cloud]
```

⭐ **The path to CLEAN is now fully visible**, and every remaining blocker is known and tracked:

1. `github.pr.merged` — 14 unexplained absences, because mini-2 has not yet pulled **#3544**. Once it does, the producer emits them and they join.
2. `github.check_suite.completed` — **CTC-712** (P1, one column: the `pull_requests` association the consumer keys on).

Nothing else stands between the current state and `clean = true`.

## Tests

**30 pass / 0 fail** in the parity suite (+6 new). **4 mutations run, all fired:**

| | |
| --- | --- |
| no-repo events excused as feed-only | 1 fail |
| scoping computed but not applied | 1 fail |
| feed-only repos silently dropped from the report | 2 fail |
| scope = union of both sides (hides a genuine feed gap) | 2 fail |

The load-bearing control is *"a feed event from a **shared** repo with no twin STILL blocks clean"* — the scoping must excuse only what smee could never have produced, never a genuine phantom in a repo it covers.

Refs CTL-1929, CTL-48, CTC-712