### PR TITLE
feat(dev): CTL-1889 inc 3 — the cluster fence + heartbeat go through the cloud attachment proxy (CTC-692)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -989,6 +989,9 @@ jobs:
             checkout-sync.test.mjs \
             cluster-claim-sync.test.mjs \
             cluster-claim.test.mjs \
+            cluster-attachment-transport.test.mjs \
+            cluster-heartbeat.test.mjs \
+            cluster-heartbeat-capacity.test.mjs \
             comms-drain.test.mjs \
             codex-run-phase-agent.test.mjs \
             daemon-watchdog-alert.test.mjs \

--- a/plugins/dev/scripts/execution-core/cluster-attachment-transport.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-attachment-transport.mjs
@@ -1,0 +1,271 @@
+// cluster-attachment-transport.mjs — CTL-1889 increment 3 / CTC-692.
+//
+// The seam that lets `cluster-claim.mjs` (the fleet's soft-CAS mutex) and
+// `cluster-heartbeat.mjs` (per-host liveness) reach Linear's attachment verb EITHER
+// directly with this host's own app-actor (the pre-CTL-1889 path) OR through the Catalyst
+// Cloud write proxy under the ONE cloud-held grant. These are the last two app-actor
+// writers in execution-core; increments 1 and 2 moved the issue-field writes and comments.
+//
+// ══════════════════════════════════════════════════════════════════════════════════════
+// ⛔⛔ THE ONE INVARIANT THIS MODULE EXISTS TO ENFORCE: EVERY FAILURE THROWS.
+// ══════════════════════════════════════════════════════════════════════════════════════
+//
+// Not "returns null". Not "returns an empty list". Not "returns {ok:false}". THROWS.
+//
+// This is not defensive style — it is the difference between a mutex and a corruption,
+// and both callers depend on it in ways that are invisible at their call sites:
+//
+// ⛔ A READ THAT RETURNED `null`/`[]` ON FAILURE SILENTLY DOUBLE-CLAIMS. `claimTicket`
+//    opens with `const current = await readClaim(ticket)` and then computes
+//    `nextGen = (current?.generation ?? 0) + 1`. A failed read reported as "no claim
+//    exists" therefore does not merely lose information — it RESETS THE FENCING TOKEN TO
+//    1 on a ticket another host may hold at generation 7. The read-back then shows our
+//    owner and our generation, so the CAS reports `won:true`, and `isFenceCurrent` starts
+//    answering FALSE for the legitimate owner, which aborts the real worker mid-flight.
+//    Two hosts, one ticket, no error anywhere. The direct GraphQL path gets this right
+//    only because `defaultPost` throws on a non-2xx; the proxy's `send`/`read` NEVER
+//    throw (they return tagged verdicts), so re-establishing the throw here is the whole
+//    job of this file.
+//
+// ⛔ A WRITE THAT DID NOT THROW DECLARES A WIN IT NEVER EARNED. `claimTicket`'s stale
+//    preemption branch is:
+//        await writeClaim(...);  return { won: true, generation: nextGen };
+//    There is NO read-back on that path — it is `writeClaim`'s throw, and nothing else,
+//    that stands between a refused write and a host believing it owns a ticket it never
+//    wrote to. A proxy result of `{applied:false, reason:"budget:day-exhausted"}` handed
+//    back as a quiet no-op turns the host's own write budget into a fleet-wide
+//    double-dispatch.
+//
+// So: `succeeded` yields a value; EVERYTHING else throws with a named reason. A caller
+// that cannot distinguish "no claim" from "I could not find out" must be given the only
+// safe answer, and for a claim that answer is an exception.
+//
+// ── ⭐ MEASURED, NOT ASSUMED: THE PROXY PATH NEEDS NO UUID RESOLUTION ──
+// `cluster-claim.mjs`'s header states that `attachmentCreate` "needs the UUID, not the
+// identifier", and `resolveIssueId` exists to satisfy that. Probed against the LIVE cloud
+// route on 2026-08-18 from a per-host org key, that is NOT true of this path:
+//
+//   POST /api/v1/agent/attachment  {"issueId":"CTL-1889", url:"catalyst://probe/…", …}
+//     → 200 {"outcome":"succeeded","attachment":{"id":"d9918a35-…", …}}
+//   POST again, SAME url, metadata {n:2}
+//     → 200 same id "d9918a35-…", metadata replaced      ← the upsert, re-verified
+//   GET  /api/v1/agent/attachments?issueId=CTL-1889
+//     → 200 exactly ONE node at that url, metadata intact ← the read-back
+//
+// So the proxy transport passes the IDENTIFIER through unchanged and performs no
+// resolution at all. ⭐ That is not a micro-optimisation: `resolveIssueId` is a third
+// Linear call, and the only credential-free way to answer it on-host would be the
+// freshness-gated replica resolver — which would couple every cluster claim to the
+// replica writer's heartbeat, so a dead replica writer would stop the fleet from
+// claiming ANY ticket. Passing the identifier removes that coupling entirely.
+//
+// ⚠️ The stale header note in `cluster-claim.mjs` is corrected in place rather than left
+// to be re-derived. If the identifier form ever stops working the failure is LOUD (a
+// `rejected` outcome → a throw → a lost claim → the host backs off), never silent.
+//
+// ── ⚠️ WHAT STAYS THE SAME, AND WHY THAT MATTERS FOR REVIEW ──
+// The GraphQL transport below is the pre-existing code path, moved and not rewritten: it
+// calls the same `post` seam with the same three documents. Every existing test that
+// injects `post` therefore exercises it unchanged, which is what makes the claim "the
+// direct path is byte-equivalent" checkable rather than asserted.
+
+import { PROXY_ROUTE_IDS, READ_ROUTE_IDS } from "./linear-write-proxy.mjs";
+
+/** The fence/heartbeat write route id and the read-back route id, as DATA. */
+export const ATTACHMENT_WRITE_ROUTE = "attachment";
+export const ATTACHMENT_READ_ROUTE = "attachments";
+
+// A boot-time assertion rather than a comment: if either id is dropped from the proxy
+// module's frozen sets, this fails at import with a name — instead of every cluster claim
+// failing at runtime with `unknown-route`, which reads like a cloud outage.
+if (!PROXY_ROUTE_IDS.includes(ATTACHMENT_WRITE_ROUTE)) {
+  throw new Error(
+    `cluster-attachment-transport: "${ATTACHMENT_WRITE_ROUTE}" is not in PROXY_ROUTE_IDS`
+  );
+}
+if (!READ_ROUTE_IDS.has(ATTACHMENT_READ_ROUTE)) {
+  throw new Error(
+    `cluster-attachment-transport: "${ATTACHMENT_READ_ROUTE}" is not in READ_ROUTE_IDS`
+  );
+}
+
+/**
+ * The error every failure in this module raises. A distinct class (rather than a bare
+ * Error) so a caller CAN tell a transport refusal from a programming mistake — while the
+ * default handling for both stays the same: fail the claim, back off.
+ */
+export class AttachmentTransportError extends Error {
+  constructor(reason, { route = null, ticket = null, detail = null } = {}) {
+    const where = [route && `route=${route}`, ticket && `ticket=${ticket}`, detail && `detail=${detail}`]
+      .filter(Boolean)
+      .join(" ");
+    // ⚠️ `no-issue` KEEPS ITS ORIGINAL WORDING — "no issue found for identifier <t>". Both
+    // cluster test suites assert on /no issue found/, and more importantly an operator
+    // grepping host logs for that phrase has been able to find this failure since CTL-1363.
+    // A tidier message would have been a silent break in the one string humans use.
+    // Same rule for `write-not-succeeded`: both cluster suites (and any operator grep) look
+    // for "success=false", the string this failure has printed since the modules were written.
+    const preserved = {
+      "no-issue": `no issue found for identifier ${ticket}`,
+      "write-not-succeeded": `attachmentCreate success=false for ${ticket}`,
+    };
+    const text = `cluster-attachment: ${preserved[reason] ?? reason}${where ? ` (${where})` : ""}`;
+    super(text);
+    this.name = "AttachmentTransportError";
+    this.reason = reason;
+    this.route = route;
+    this.ticket = ticket;
+  }
+}
+
+// ─── the direct GraphQL transport (pre-CTL-1889, unchanged behaviour) ────────────────
+
+// ⚠️ THE OPERATION NAMES ARE `ReadFence` / `UpsertFence` AND MUST STAY THAT WAY. These three
+// documents are lifted VERBATIM from `cluster-claim.mjs` and `cluster-heartbeat.mjs`, which
+// carried byte-identical copies of them (the modules' no-cross-import rule). Both test suites
+// discriminate the mocked `post` calls by matching on the operation NAME, so renaming these to
+// something more descriptive silently routes every mocked call to the "unexpected query" branch
+// — which is how this was caught. The name is part of the contract, not a label.
+const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
+  issue(id: $id) { id }
+}`;
+
+const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
+  issue(id: $id) { attachments { nodes { id url metadata } } }
+}`;
+
+const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreateInput!) {
+  attachmentCreate(input: $input) { success attachment { id url metadata } }
+}`;
+
+/**
+ * createGraphqlAttachmentTransport — talks to Linear directly with this host's own
+ * app-actor, via the injected `post`. `post` already throws on a transport error, a
+ * non-2xx, or a GraphQL `errors[]` body, so the throw-on-failure invariant holds here by
+ * inheritance; the only additions are the two cases `post` cannot see (a missing issue,
+ * and `success:false`).
+ */
+export function createGraphqlAttachmentTransport({ post }) {
+  return {
+    via: "app-actor",
+
+    async resolveIssueId(ticket) {
+      const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
+      return data?.issue?.id ?? null;
+    },
+
+    async readAttachments(ticket) {
+      const data = await post(READ_ATTACHMENTS_QUERY, { id: ticket });
+      // ⛔ `issue` absent is NOT "no attachments" — it is "we did not get an answer about
+      // this issue", and the two must not collapse. See the module header.
+      if (!data?.issue) {
+        throw new AttachmentTransportError("no-issue", { ticket, route: "graphql" });
+      }
+      return data.issue.attachments?.nodes ?? [];
+    },
+
+    async upsertAttachment({ ticket, issueId, url, title, metadata }) {
+      const resolved = issueId || (await this.resolveIssueId(ticket));
+      if (!resolved) {
+        throw new AttachmentTransportError("no-issue", { ticket, route: "graphql" });
+      }
+      const data = await post(WRITE_ATTACHMENT_MUTATION, {
+        input: { issueId: resolved, title, url, metadata },
+      });
+      if (!data?.attachmentCreate?.success) {
+        throw new AttachmentTransportError("write-not-succeeded", { ticket, route: "graphql" });
+      }
+      return data.attachmentCreate.attachment ?? null;
+    },
+  };
+}
+
+// ─── the cloud write-proxy transport (CTL-1889 increment 3) ──────────────────────────
+
+/**
+ * createProxyAttachmentTransport — every attachment read and write goes to the Catalyst
+ * Cloud proxy under the per-host cloud key. No Linear credential is used, resolved, or
+ * required on this path.
+ *
+ * ⛔ NO FALL-BACK TO THE APP-ACTOR ON FAILURE, for the reason increments 1 and 2 give: a
+ * fall-back means the host keeps writing with its own app-actor exactly when the proxy is
+ * broken, so the shadow window that gates retirement would read "zero host-originated
+ * writes" while the host was still writing. A failure here is a failure.
+ */
+export function createProxyAttachmentTransport({ proxy, caller = "cluster-attachment" }) {
+  if (!proxy || typeof proxy.send !== "function" || typeof proxy.read !== "function") {
+    throw new AttachmentTransportError("no-proxy");
+  }
+  return {
+    via: "proxy",
+
+    /**
+     * ⭐ The identity function, and deliberately so — see the module header's measurement.
+     * Kept as a method rather than deleted from the interface so the two transports stay
+     * substitutable and `cluster-claim.mjs`'s `resolve-issue-id` CLI verb keeps answering.
+     */
+    async resolveIssueId(ticket) {
+      return ticket;
+    },
+
+    async readAttachments(ticket) {
+      const res = proxy.read({
+        routeId: ATTACHMENT_READ_ROUTE,
+        ticket,
+        query: { issueId: ticket },
+        caller,
+      });
+      // ⛔ THE LOAD-BEARING LINE OF THIS FILE. `read` reports a refusal as `{ok:false}`;
+      // returning `[]` here would tell `claimTicket` that no host holds this ticket.
+      if (!res?.ok) {
+        throw new AttachmentTransportError(res?.reason ?? "read-refused", {
+          ticket,
+          route: ATTACHMENT_READ_ROUTE,
+          detail: res?.status ?? null,
+        });
+      }
+      return res.attachments;
+    },
+
+    async upsertAttachment({ ticket, issueId, url, title, metadata }) {
+      const res = proxy.send({
+        routeId: ATTACHMENT_WRITE_ROUTE,
+        ticket,
+        // The identifier is accepted by the live route (header measurement); a caller that
+        // already holds a UUID may still pass one and it is used verbatim.
+        payload: { issueId: issueId || ticket, url, title, metadata },
+        caller,
+      });
+      // ⛔ THE OTHER LOAD-BEARING LINE. `send` returns `{applied:false}` for a budget
+      // refusal, a 5xx, a rejected body and a missing credential alike. `claimTicket`'s
+      // stale-preemption branch returns `won:true` with NO read-back, so a non-throwing
+      // failed write is a claim the host never made and believes it holds.
+      if (!res?.handled || res.applied !== true) {
+        throw new AttachmentTransportError(res?.reason ?? "write-refused", {
+          ticket,
+          route: ATTACHMENT_WRITE_ROUTE,
+          detail: res?.detail ?? null,
+        });
+      }
+      return null;
+    },
+  };
+}
+
+/**
+ * resolveAttachmentTransport — pick the transport for one call.
+ *
+ * `enforce` → the proxy, with NO fall-back. `off` and `shadow` → the direct app-actor
+ * path, unchanged.
+ *
+ * ⚠️ SHADOW DOES NOT DOUBLE-WRITE HERE, and that is a departure from how shadow reads
+ * elsewhere in this repo. For an idempotent upsert a second write would be harmless, but
+ * `claimTicket` is a CAS: writing the claim twice through two different credentials would
+ * make the host race ITSELF, and the read-back would then be deciding between two of its
+ * own writes. Shadow therefore observes via the proxy's own `send` accounting on the
+ * routes that already support it and leaves this path alone.
+ */
+export function resolveAttachmentTransport({ mode = "off", post, proxy = null, caller } = {}) {
+  if (mode === "enforce" && proxy) return createProxyAttachmentTransport({ proxy, caller });
+  return createGraphqlAttachmentTransport({ post });
+}

--- a/plugins/dev/scripts/execution-core/cluster-attachment-transport.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-attachment-transport.test.mjs
@@ -1,0 +1,429 @@
+// cluster-attachment-transport.test.mjs — CTL-1889 increment 3 / CTC-692.
+// Run: cd plugins/dev/scripts/execution-core && bun test cluster-attachment-transport.test.mjs
+//
+// ⛔ WHAT THIS SUITE IS FOR. `cluster-claim.mjs` is the fleet's cross-host mutex. Moving its
+// two Linear calls onto the cloud proxy swaps a transport that THROWS on failure
+// (`defaultPost`) for one that NEVER throws (`proxy.send`/`proxy.read` return tagged
+// verdicts). Every test below exists because that swap has a specific way of turning a
+// refusal into a silent double claim, and each one is written to FAIL if the throw is
+// removed — the mutation controls at the bottom prove that rather than assume it.
+import { describe, expect, test } from "bun:test";
+import {
+  ATTACHMENT_READ_ROUTE,
+  ATTACHMENT_WRITE_ROUTE,
+  AttachmentTransportError,
+  createGraphqlAttachmentTransport,
+  createProxyAttachmentTransport,
+  resolveAttachmentTransport,
+} from "./cluster-attachment-transport.mjs";
+import { claimTicket, fenceUrl, readClaim, writeClaim } from "./cluster-claim.mjs";
+
+/** A proxy double. Records calls; the verdicts are supplied per test. */
+function fakeProxy({ sendResult, readResult } = {}) {
+  const calls = { send: [], read: [] };
+  return {
+    calls,
+    send(args) {
+      calls.send.push(args);
+      return typeof sendResult === "function" ? sendResult(args) : sendResult;
+    },
+    read(args) {
+      calls.read.push(args);
+      return typeof readResult === "function" ? readResult(args) : readResult;
+    },
+  };
+}
+
+const OK_SEND = { handled: true, applied: true, reason: null, status: 200 };
+const okRead = (attachments = []) => ({ ok: true, attachments, reason: null, status: 200 });
+
+/** A fence node as the cloud reports it. */
+const fenceNode = (ticket, meta) => ({
+  id: `att-${ticket}`,
+  url: fenceUrl(ticket),
+  metadata: meta,
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 1. THE READ — a refusal must THROW, never become "no claim exists"
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("the read-back refuses LOUDLY (the fencing-token reset)", () => {
+  // Every refusal shape `proxy.read` can produce. Each must throw; none may yield [].
+  const refusals = [
+    ["no-cloud-token", { ok: false, reason: "no-cloud-token", status: null }],
+    ["server-error", { ok: false, reason: "server-error", status: 503 }],
+    ["rate-limited", { ok: false, reason: "rate-limited", status: 429 }],
+    ["unauthorized", { ok: false, reason: "unauthorized", status: 403 }],
+    ["read-unreadable (a 200 whose body we cannot read)", { ok: false, reason: "read-unreadable", status: 200 }],
+    ["cloud:failed — the MAX_ATTACHMENT_PAGES bound was hit", { ok: false, reason: "cloud:failed", status: 502 }],
+    ["cloud:rejected — no such issue", { ok: false, reason: "cloud:rejected", status: 404 }],
+    ["a malformed verdict (undefined)", undefined],
+  ];
+
+  for (const [label, readResult] of refusals) {
+    test(`readAttachments THROWS on ${label}`, async () => {
+      const t = createProxyAttachmentTransport({ proxy: fakeProxy({ readResult }) });
+      await expect(t.readAttachments("CTL-1")).rejects.toBeInstanceOf(AttachmentTransportError);
+    });
+  }
+
+  test("⛔ a refused read does NOT reset the fencing token — claimTicket propagates, it does not claim at generation 1", async () => {
+    // The scenario that makes this the most dangerous line in the increment: another host
+    // holds CTL-1 at generation 7, and our read-back fails. If the failure became `[]`,
+    // `nextGen` would be 1 and the CAS would report a WIN on a ticket we do not own.
+    const proxy = fakeProxy({
+      readResult: { ok: false, reason: "server-error", status: 503 },
+      sendResult: OK_SEND,
+    });
+    const transport = createProxyAttachmentTransport({ proxy });
+
+    await expect(claimTicket("CTL-1", "mini", "triage", { transport })).rejects.toThrow(
+      /server-error/,
+    );
+    // ⛔ THE ASSERTION THAT OWNS THIS TEST: no write was attempted at all. A claim we could
+    // not even read is a claim we must not write, because the generation we would write is
+    // a fabrication.
+    expect(proxy.calls.send).toHaveLength(0);
+  });
+
+  test("NEGATIVE CONTROL — the same path SUCCEEDS when the read answers, so the test above is not passing on a broken harness", async () => {
+    const store = new Map();
+    const proxy = upsertingProxy(store);
+    const transport = createProxyAttachmentTransport({ proxy });
+    const res = await claimTicket("CTL-1", "mini", "triage", { transport });
+    expect(res).toEqual({ won: true, generation: 1 });
+  });
+
+  test("an EMPTY list is a real answer and stays one — 'no fence' must not be collapsed into the failure case", async () => {
+    const transport = createProxyAttachmentTransport({ proxy: fakeProxy({ readResult: okRead([]) }) });
+    await expect(transport.readAttachments("CTL-1")).resolves.toEqual([]);
+    await expect(readClaim("CTL-1", { transport })).resolves.toBeNull();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 2. THE WRITE — a refusal must THROW, or the stale-preemption branch invents a win
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("the write refuses LOUDLY (the unearned win)", () => {
+  const refusals = [
+    ["budget:day-exhausted", { handled: true, applied: false, reason: "budget:day-exhausted" }],
+    ["budget:ticket-cap", { handled: true, applied: false, reason: "budget:ticket-cap" }],
+    ["no-cloud-token", { handled: true, applied: false, reason: "no-cloud-token" }],
+    ["server-error", { handled: true, applied: false, reason: "server-error" }],
+    ["cloud:rejected", { handled: true, applied: false, reason: "cloud:rejected" }],
+    ["handled:false (a mode this path excludes)", { handled: false, applied: false, reason: "shadow" }],
+    ["a malformed verdict (undefined)", undefined],
+  ];
+
+  for (const [label, sendResult] of refusals) {
+    test(`upsertAttachment THROWS on ${label}`, async () => {
+      const t = createProxyAttachmentTransport({ proxy: fakeProxy({ sendResult }) });
+      await expect(
+        t.upsertAttachment({ ticket: "CTL-1", url: "catalyst://fence/CTL-1", title: "m", metadata: {} }),
+      ).rejects.toBeInstanceOf(AttachmentTransportError);
+    });
+  }
+
+  test("⛔ THE STALE-PREEMPTION BRANCH: a refused write must NOT return won:true — there is no read-back on that path to catch it", async () => {
+    // A stale claim held by ANOTHER host takes the preemption branch, which is:
+    //     await writeClaim(...); return { won: true, generation: nextGen };
+    // Nothing verifies the write. The throw is the only guard, so this is the test that
+    // proves a budget refusal cannot become a fleet-wide double dispatch.
+    const stale = {
+      owner_host: "mini-2",
+      catalyst_generation: 7,
+      phase: "triage",
+      claimed_at: new Date(1_000).toISOString(),
+    };
+    const proxy = fakeProxy({
+      readResult: okRead([fenceNode("CTL-1", stale)]),
+      sendResult: { handled: true, applied: false, reason: "budget:day-exhausted" },
+    });
+    const transport = createProxyAttachmentTransport({ proxy });
+
+    const claim = claimTicket("CTL-1", "mini", "triage", {
+      transport,
+      staleMs: 1,
+      now: () => 10_000_000,
+    });
+    await expect(claim).rejects.toThrow(/budget:day-exhausted/);
+    // The preemption branch WAS taken (one write attempted, no read-back after it) — so this
+    // test is exercising the unguarded path and not some earlier bail-out.
+    expect(proxy.calls.send).toHaveLength(1);
+    expect(proxy.calls.read).toHaveLength(1);
+  });
+
+  test("NEGATIVE CONTROL — the same stale preemption WINS when the write is applied", async () => {
+    const stale = {
+      owner_host: "mini-2",
+      catalyst_generation: 7,
+      phase: "triage",
+      claimed_at: new Date(1_000).toISOString(),
+    };
+    const proxy = fakeProxy({ readResult: okRead([fenceNode("CTL-1", stale)]), sendResult: OK_SEND });
+    const transport = createProxyAttachmentTransport({ proxy });
+    await expect(
+      claimTicket("CTL-1", "mini", "triage", { transport, staleMs: 1, now: () => 10_000_000 }),
+    ).resolves.toEqual({ won: true, generation: 8 });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 3. THE SOFT-CAS ITSELF, THROUGH THE PROXY — a lost race is a refusal
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+/**
+ * An upsert-on-url proxy double that behaves like the LIVE route as measured on 2026-08-18:
+ * the same url replaces the same node's metadata and never duplicates. Interleaving is
+ * driven by the test, so the race is deterministic rather than timing-dependent.
+ */
+function upsertingProxy(store) {
+  return {
+    calls: { send: [], read: [] },
+    send({ payload }) {
+      store.set(payload.url, { id: `att-${payload.url}`, url: payload.url, metadata: payload.metadata });
+      return OK_SEND;
+    },
+    read() {
+      return okRead([...store.values()]);
+    },
+  };
+}
+
+describe("the soft-CAS survives the proxy", () => {
+  test("⛔ two claimers, WRITES INTERLEAVED BEFORE EITHER READS BACK — exactly one wins", async () => {
+    // The true-race ordering: A writes, B writes, then both read back. B wrote last, so B's
+    // read-back shows B and A's shows B — one winner, one refusal. This is the ordering the
+    // mechanism is designed for, and it must hold identically through the proxy.
+    const store = new Map();
+    const proxy = upsertingProxy(store);
+    const transport = createProxyAttachmentTransport({ proxy });
+
+    const [a, b] = await Promise.all([
+      claimTicket("CTL-1", "host-a", "triage", { transport }),
+      claimTicket("CTL-1", "host-b", "triage", { transport }),
+    ]);
+
+    const winners = [a, b].filter((r) => r.won);
+    expect(winners).toHaveLength(1);
+    // ⛔ And the LOSER is a refusal, not a silent success: `won:false` is what makes the
+    // caller back off rather than dispatch.
+    expect([a, b].filter((r) => !r.won)).toHaveLength(1);
+  });
+
+  test("the winner's generation is the one written, and the fence carries the winner's host", async () => {
+    const store = new Map();
+    const transport = createProxyAttachmentTransport({ proxy: upsertingProxy(store) });
+    const [a, b] = await Promise.all([
+      claimTicket("CTL-1", "host-a", "triage", { transport }),
+      claimTicket("CTL-1", "host-b", "triage", { transport }),
+    ]);
+    const winner = [a, b].find((r) => r.won);
+    const fence = await readClaim("CTL-1", { transport });
+    expect(fence.generation).toBe(winner.generation);
+    expect(["host-a", "host-b"]).toContain(fence.owner_host);
+  });
+
+  test("the upsert never duplicates the fence node — one url, one node, as measured live", async () => {
+    const store = new Map();
+    const transport = createProxyAttachmentTransport({ proxy: upsertingProxy(store) });
+    await writeClaim("CTL-1", { owner_host: "a", generation: 1, phase: "p" }, { transport });
+    await writeClaim("CTL-1", { owner_host: "a", generation: 2, phase: "p" }, { transport });
+    expect([...store.keys()]).toEqual([fenceUrl("CTL-1")]);
+    await expect(readClaim("CTL-1", { transport })).resolves.toMatchObject({ generation: 2 });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 4. THE ROUTE CONTRACT — what is sent, and what is deliberately NOT
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("the proxy transport's wire contract", () => {
+  test("⭐ the IDENTIFIER is passed through with NO UUID resolution — the measured property this increment depends on", async () => {
+    const proxy = fakeProxy({ sendResult: OK_SEND, readResult: okRead([]) });
+    const transport = createProxyAttachmentTransport({ proxy });
+    await transport.upsertAttachment({
+      ticket: "CTL-1889",
+      url: "catalyst://fence/CTL-1889",
+      title: "catalyst-meta",
+      metadata: { a: 1 },
+    });
+    expect(proxy.calls.send[0].payload.issueId).toBe("CTL-1889");
+    // And the read-back asks by the same identifier, on the read route.
+    await transport.readAttachments("CTL-1889");
+    expect(proxy.calls.read[0]).toMatchObject({
+      routeId: ATTACHMENT_READ_ROUTE,
+      query: { issueId: "CTL-1889" },
+    });
+  });
+
+  test("a caller-supplied UUID is used verbatim when present (the cluster-claim-sync cache path)", async () => {
+    const proxy = fakeProxy({ sendResult: OK_SEND });
+    const transport = createProxyAttachmentTransport({ proxy });
+    await transport.upsertAttachment({
+      ticket: "CTL-1889",
+      issueId: "8fd311c5-uuid",
+      url: "u",
+      title: "t",
+      metadata: {},
+    });
+    expect(proxy.calls.send[0].payload.issueId).toBe("8fd311c5-uuid");
+  });
+
+  test("the write goes to the write route and the read to the read route — never crossed", async () => {
+    const proxy = fakeProxy({ sendResult: OK_SEND, readResult: okRead([]) });
+    const transport = createProxyAttachmentTransport({ proxy });
+    await transport.upsertAttachment({ ticket: "T", url: "u", title: "t", metadata: {} });
+    await transport.readAttachments("T");
+    expect(proxy.calls.send[0].routeId).toBe(ATTACHMENT_WRITE_ROUTE);
+    expect(proxy.calls.read[0].routeId).toBe(ATTACHMENT_READ_ROUTE);
+  });
+
+  test("⛔ the read-back goes through `read`, NOT `send` — that is what keeps it off the write budget", async () => {
+    const proxy = fakeProxy({ readResult: okRead([]) });
+    await createProxyAttachmentTransport({ proxy }).readAttachments("T");
+    // If a future edit routed the read through `send`, every claim would spend TWO budget
+    // units and an exhausted host could no longer VERIFY a claim — so it would stop
+    // dispatching entirely. Asserting the absence positively.
+    expect(proxy.calls.send).toHaveLength(0);
+    expect(proxy.calls.read).toHaveLength(1);
+  });
+
+  test("a proxy missing either half is refused at construction, by name", () => {
+    expect(() => createProxyAttachmentTransport({ proxy: { send() {} } })).toThrow(/no-proxy/);
+    expect(() => createProxyAttachmentTransport({ proxy: null })).toThrow(/no-proxy/);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 5. MODE SELECTION — enforce uses the proxy, everything else is the untouched old path
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("resolveAttachmentTransport", () => {
+  const post = async () => ({ issue: { id: "u", attachments: { nodes: [] } } });
+
+  test("enforce + a proxy → the proxy transport", () => {
+    const t = resolveAttachmentTransport({ mode: "enforce", post, proxy: fakeProxy({}) });
+    expect(t.via).toBe("proxy");
+  });
+
+  for (const mode of ["off", "shadow"]) {
+    test(`${mode} → the app-actor transport, unchanged`, () => {
+      expect(resolveAttachmentTransport({ mode, post, proxy: fakeProxy({}) }).via).toBe("app-actor");
+    });
+  }
+
+  test("enforce with NO proxy falls back to the app-actor path rather than returning undefined", () => {
+    expect(resolveAttachmentTransport({ mode: "enforce", post, proxy: null }).via).toBe("app-actor");
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 6. THE GRAPHQL TRANSPORT still throws where it always did
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("the app-actor transport keeps its own failure contract", () => {
+  test("a missing issue on READ throws rather than reporting zero attachments", async () => {
+    const t = createGraphqlAttachmentTransport({ post: async () => ({ issue: null }) });
+    await expect(t.readAttachments("CTL-1")).rejects.toThrow(/no issue found/);
+  });
+
+  test("success:false on WRITE throws, with the string operators have grepped for since CTL-1363", async () => {
+    const t = createGraphqlAttachmentTransport({
+      post: async (q) =>
+        q.includes("ResolveIssueId")
+          ? { issue: { id: "u" } }
+          : { attachmentCreate: { success: false } },
+    });
+    await expect(
+      t.upsertAttachment({ ticket: "CTL-1", url: "u", title: "t", metadata: {} }),
+    ).rejects.toThrow(/success=false/);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// 7. ⛔ MUTATION CONTROLS — proof the assertions above can actually FAIL
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("mutation controls", () => {
+  test("⛔ a transport that swallows a TRANSIENT failed read into [] produces the full silent double claim — won:true at generation 1 over a live generation 7", async () => {
+    // The honest reproduction, and the reason the throw is not merely tidy. The failure is
+    // TRANSIENT: the FIRST read (the one that computes `nextGen`) fails and is swallowed
+    // into `[]`; the read-back that follows succeeds. So:
+    //   • `current` reads as "no claim"          → nextGen = 1, past a LIVE generation 7
+    //   • we write our claim at generation 1     → the fence now says mini/1
+    //   • the read-back sees mini/1, which is us → won: TRUE
+    // Two hosts now believe they own CTL-1, and mini-2's `isFenceCurrent(CTL-1, 7)` starts
+    // answering false, so the host actually doing the work aborts mid-flight. No error is
+    // raised anywhere. If this control ever stops reproducing, the tests above are vacuous.
+    const store = new Map([
+      [
+        fenceUrl("CTL-1"),
+        fenceNode("CTL-1", {
+          owner_host: "mini-2",
+          catalyst_generation: 7,
+          phase: "implement",
+          claimed_at: new Date().toISOString(),
+        }),
+      ],
+    ]);
+    let firstRead = true;
+    const swallowing = {
+      via: "broken",
+      async resolveIssueId(t) {
+        return t;
+      },
+      async readAttachments() {
+        if (firstRead) {
+          firstRead = false;
+          return []; // ⛔ THE BUG: a transport error swallowed into "no claim exists"
+        }
+        return [...store.values()];
+      },
+      async upsertAttachment({ url, metadata }) {
+        store.set(url, { id: `att-${url}`, url, metadata });
+        return null;
+      },
+    };
+
+    const res = await claimTicket("CTL-1", "mini", "triage", { transport: swallowing });
+    expect(res).toEqual({ won: true, generation: 1 }); // ⛔ the unearned win, over generation 7
+    // And the damage is durable: the fence now names us at a LOWER generation than the host
+    // that legitimately held it, so the real owner's fencing check will start failing.
+    expect(store.get(fenceUrl("CTL-1")).metadata.catalyst_generation).toBe(1);
+  });
+
+  test("a transport that swallows a failed WRITE lets the stale-preemption branch return won:true with nothing written", async () => {
+    const writes = [];
+    const swallowing = {
+      via: "broken",
+      async resolveIssueId(t) {
+        return t;
+      },
+      async readAttachments() {
+        return [
+          fenceNode("CTL-1", {
+            owner_host: "mini-2",
+            catalyst_generation: 7,
+            phase: "triage",
+            claimed_at: new Date(1_000).toISOString(),
+          }),
+        ];
+      },
+      async upsertAttachment() {
+        writes.push("refused-but-silent"); // ⛔ the bug: no throw
+        return null;
+      },
+    };
+    const res = await claimTicket("CTL-1", "mini", "triage", {
+      transport: swallowing,
+      staleMs: 1,
+      now: () => 10_000_000,
+    });
+    // THE UNEARNED WIN, reproduced. This is what the throw in the real transport prevents.
+    expect(res).toEqual({ won: true, generation: 8 });
+    expect(writes).toEqual(["refused-but-silent"]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -15,6 +15,15 @@
 // leaf; cluster-sync.mjs and doctor.mjs already set this precedent). Folds
 // defaultPost's own LINEAR_API_TOKEN/LINEAR_API_KEY ladder below.
 import { resolveSecret } from "../lib/secret-contract.mjs";
+// CTL-1889 increment 3 — the transport seam. Read its header before changing anything
+// here: it is the file that re-establishes "every failure throws" on the proxy path, and
+// both the soft-CAS below and the stale-preemption branch depend on that and on nothing else.
+import {
+  createGraphqlAttachmentTransport,
+  resolveAttachmentTransport,
+} from "./cluster-attachment-transport.mjs";
+import { createLinearWriteProxy } from "./linear-write-proxy.mjs";
+import { readLinearWriteProxyConfig } from "./config.mjs";
 //
 // ─── The storage mechanism (VERIFIED via live Linear API probe, 2026-06-08) ──
 // Linear has no custom fields and labels can't model a counter, so the claim +
@@ -28,6 +37,10 @@ import { resolveSecret } from "../lib/secret-contract.mjs";
 //   • attachmentCreate with the SAME url is an UPSERT — it returns the same
 //     attachment id with new metadata. (attachmentUpdate requires `title` and
 //     does NOT accept `metadata`, so create is the only upsert path.)
+//     ⭐ RE-VERIFIED 2026-08-18 through the CTC-692 cloud route: a second POST to
+//     the same url returned the SAME attachment id with the metadata replaced,
+//     and the read-back showed exactly ONE node. This is the measurement the
+//     whole soft-CAS rests on, so it is re-checked whenever the path changes.
 //   • The write produces ZERO issue.history entries → invisible to the human
 //     activity feed (no notification spam).
 //   • READ via issue.attachments and pick the node whose url starts with
@@ -105,6 +118,18 @@ async function defaultPost(query, variables) {
   return json?.data ?? {};
 }
 
+/**
+ * transportFor — the attachment transport for one call. CTL-1889 increment 3.
+ *
+ * ⚠️ THE DEFAULT IS THE PRE-EXISTING PATH, BY CONSTRUCTION. When no `transport` is
+ * injected this wraps whatever `post` the caller supplied — so every existing test that
+ * injects `post` keeps exercising the direct GraphQL path with the same documents and the
+ * same assertions, and "the app-actor path is unchanged" is checkable rather than claimed.
+ */
+function transportFor({ post = defaultPost, transport = null } = {}) {
+  return transport ?? createGraphqlAttachmentTransport({ post });
+}
+
 // ─── identifier → issue UUID ─────────────────────────────────────────────────
 
 // CTL-1363: resolve via the `issue(id:)` query, which accepts the human
@@ -118,23 +143,35 @@ async function defaultPost(query, variables) {
 // invisible at INFO). Same bug + fix as cluster-heartbeat.mjs (CTL-1255).
 // READ_ATTACHMENTS_QUERY below already uses `issue(id:)` — which is why reads
 // worked while writes silently 400'd.
-const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
-  issue(id: $id) { id }
-}`;
+// ⚠️ The GraphQL document that used to live here now lives in
+// cluster-attachment-transport.mjs, which is the ONE place both cluster modules and
+// both transports agree on the wire format. The history above is kept because it is
+// the reason the document reads the way it does, not because the text is still here.
 
-// resolveIssueId — a ticket identifier (e.g. "CTL-842") → its issue UUID, or
-// null when no issue matches. attachmentCreate needs the UUID, not the
-// identifier. Exported for unit coverage + reuse.
-export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
-  const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
-  return data?.issue?.id ?? null;
+// resolveIssueId — a ticket identifier (e.g. "CTL-842") → its issue UUID, or null when no
+// issue matches. Exported for unit coverage + reuse.
+//
+// ⚠️ THE CLAIM THIS FUNCTION WAS WRITTEN FOR — "attachmentCreate needs the UUID, not the
+// identifier" — IS NOT TRUE OF THE PROXY PATH, measured 2026-08-18 against the live CTC-692
+// route: a POST carrying `issueId: "CTL-1889"` returned `succeeded`, and the cloud passes
+// that value STRAIGHT to `attachmentCreate` without resolving it. So on the proxy transport
+// this is the identity function and no resolution happens at all.
+//
+// ⚠️ It is left in place, and still resolves, for the DIRECT app-actor path — where the
+// original claim has not been re-measured and where `cluster-claim-sync.mjs`'s permanent
+// UUID cache (CTL-863) calls the `resolve-issue-id` CLI verb expecting a real answer. Do
+// not "simplify" it away on the strength of the proxy measurement: those are two different
+// call paths and only one of them has been checked.
+export async function resolveIssueId(ticket, { post = defaultPost, transport = null } = {}) {
+  return transportFor({ post, transport }).resolveIssueId(ticket);
 }
 
 // ─── read ────────────────────────────────────────────────────────────────────
 
-const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
-  issue(id: $id) { attachments { nodes { id url metadata } } }
-}`;
+// ⚠️ The GraphQL document that used to live here now lives in
+// cluster-attachment-transport.mjs, which is the ONE place both cluster modules and
+// both transports agree on the wire format. The history above is kept because it is
+// the reason the document reads the way it does, not because the text is still here.
 
 // parseClaimMetadata — normalise an attachment's metadata into the flat claim
 // record callers consume. `catalyst_generation` is coerced to a Number; a
@@ -163,9 +200,13 @@ export function parseClaimMetadata(metadata) {
 // issue UUID when the caller already resolved it; a bare identifier is resolved
 // transparently is NOT done here (Linear's `issue(id:)` accepts an identifier
 // like "CTL-842" directly), so we pass `ticket` straight through.
-export async function readClaim(ticket, { post = defaultPost } = {}) {
-  const data = await post(READ_ATTACHMENTS_QUERY, { id: ticket });
-  const nodes = data?.issue?.attachments?.nodes ?? [];
+export async function readClaim(ticket, { post = defaultPost, transport = null } = {}) {
+  // ⛔ A THROWN read must stay thrown. `null` here means "there is no fence on this
+  // ticket", which `claimTicket` reads as "nobody holds it, claim at generation 1" — so
+  // swallowing a transport failure into `null` would reset the fencing token on a ticket
+  // another host owns. The transport's contract is that only a SUCCESSFUL read returns;
+  // this function must not add a catch. See cluster-attachment-transport.mjs's header.
+  const nodes = await transportFor({ post, transport }).readAttachments(ticket);
   const node = nodes.find((n) => typeof n?.url === "string" && n.url.startsWith(FENCE_URL_PREFIX));
   if (!node) return null;
   return parseClaimMetadata(node.metadata);
@@ -173,9 +214,10 @@ export async function readClaim(ticket, { post = defaultPost } = {}) {
 
 // ─── write / upsert ──────────────────────────────────────────────────────────
 
-const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreateInput!) {
-  attachmentCreate(input: $input) { success attachment { id url metadata } }
-}`;
+// ⚠️ The GraphQL document that used to live here now lives in
+// cluster-attachment-transport.mjs, which is the ONE place both cluster modules and
+// both transports agree on the wire format. The history above is kept because it is
+// the reason the document reads the way it does, not because the text is still here.
 
 // writeClaim — upsert the claim/fence attachment for a ticket. Always uses
 // attachmentCreate (the VERIFIED upsert path — the same url returns the same
@@ -197,12 +239,8 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 export async function writeClaim(
   ticket,
   { owner_host, generation, phase, triage_attempt_count = 0 },
-  { post = defaultPost, issueId: issueIdOverride = null, preserveClaimedAt = null } = {},
+  { post = defaultPost, transport = null, issueId: issueIdOverride = null, preserveClaimedAt = null } = {},
 ) {
-  const issueId = issueIdOverride || (await resolveIssueId(ticket, { post }));
-  if (!issueId) {
-    throw new Error(`cluster-claim: no issue found for identifier ${ticket}`);
-  }
   // preserveClaimedAt allows a count-only bump to avoid resetting the CTL-1297
   // staleness clock — a mere triage_attempt_count increment is not a takeover.
   const claimed_at = preserveClaimedAt ?? new Date().toISOString();
@@ -213,17 +251,19 @@ export async function writeClaim(
     claimed_at,
     triage_attempt_count,
   };
-  const data = await post(WRITE_ATTACHMENT_MUTATION, {
-    input: {
-      issueId,
-      title: FENCE_ATTACHMENT_TITLE,
-      url: fenceUrl(ticket),
-      metadata,
-    },
+  // ⛔ MUST THROW ON ANY NON-SUCCESS, and this is the single most important line in the
+  // file. `claimTicket`'s stale-preemption branch returns `{won:true}` with NO read-back
+  // — the throw from here is the ONLY thing between a refused write and a host that
+  // believes it owns a ticket it never wrote to. The transport guarantees the throw for
+  // both paths (`success:false` on GraphQL, `applied:false` on the proxy); do not wrap
+  // this call in a try/catch that returns a value.
+  await transportFor({ post, transport }).upsertAttachment({
+    ticket,
+    issueId: issueIdOverride,
+    title: FENCE_ATTACHMENT_TITLE,
+    url: fenceUrl(ticket),
+    metadata,
   });
-  if (!data?.attachmentCreate?.success) {
-    throw new Error(`cluster-claim: attachmentCreate returned success=false for ${ticket}`);
-  }
   return parseClaimMetadata(metadata);
 }
 
@@ -234,8 +274,8 @@ export async function writeClaim(
 // catalyst://fence/ attachment is found (fence-absent → caller fails open to
 // host-local counting). A zero count is a valid result (fence exists but no
 // attempts have been bumped yet, e.g. immediately after a fresh claim).
-export async function readTriageAttemptCount(ticket, { post = defaultPost } = {}) {
-  const c = await readClaim(ticket, { post });
+export async function readTriageAttemptCount(ticket, { post = defaultPost, transport = null } = {}) {
+  const c = await readClaim(ticket, { post, transport });
   return c ? (c.triage_attempt_count ?? 0) : null;
 }
 
@@ -243,8 +283,11 @@ export async function readTriageAttemptCount(ticket, { post = defaultPost } = {}
 // fence attachment. Preserves owner_host, catalyst_generation, phase, and
 // claimed_at (does NOT bump the generation — this is not a takeover). Returns
 // the new count on success, or null when no fence exists (best-effort no-op).
-export async function bumpTriageAttemptCount(ticket, { post = defaultPost, issueId = null } = {}) {
-  const current = await readClaim(ticket, { post });
+export async function bumpTriageAttemptCount(
+  ticket,
+  { post = defaultPost, transport = null, issueId = null } = {},
+) {
+  const current = await readClaim(ticket, { post, transport });
   if (!current) return null; // no fence — no-op, fail-open
   const newCount = (current.triage_attempt_count ?? 0) + 1;
   await writeClaim(
@@ -255,7 +298,7 @@ export async function bumpTriageAttemptCount(ticket, { post = defaultPost, issue
       phase: current.phase,
       triage_attempt_count: newCount,
     },
-    { post, issueId, preserveClaimedAt: current.claimed_at },
+    { post, transport, issueId, preserveClaimedAt: current.claimed_at },
   );
   return newCount;
 }
@@ -284,9 +327,15 @@ export async function claimTicket(
   ticket,
   hostName,
   phase,
-  { post = defaultPost, staleMs = CLAIM_STALE_MS_DEFAULT, now = () => Date.now(), issueId = null } = {},
+  {
+    post = defaultPost,
+    transport = null,
+    staleMs = CLAIM_STALE_MS_DEFAULT,
+    now = () => Date.now(),
+    issueId = null,
+  } = {},
 ) {
-  const current = await readClaim(ticket, { post });
+  const current = await readClaim(ticket, { post, transport });
   const nextGen = (current?.generation ?? 0) + 1;
 
   // CTL-1297: stale cross-host preemption. If a claim is held by a DIFFERENT host
@@ -298,15 +347,23 @@ export async function claimTicket(
   if (current && current.owner_host && current.owner_host !== hostName) {
     const claimedAtMs = current.claimed_at ? Date.parse(current.claimed_at) : NaN;
     if (Number.isFinite(claimedAtMs) && now() - claimedAtMs > staleMs) {
-      await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post, issueId });
+      await writeClaim(
+        ticket,
+        { owner_host: hostName, generation: nextGen, phase },
+        { post, transport, issueId },
+      );
       return { won: true, generation: nextGen };
     }
   }
 
   // Normal soft-CAS (unchanged): write then read-back; a concurrent host that
   // wrote last wins the read-back and we back off.
-  await writeClaim(ticket, { owner_host: hostName, generation: nextGen, phase }, { post, issueId });
-  const readback = await readClaim(ticket, { post });
+  await writeClaim(
+    ticket,
+    { owner_host: hostName, generation: nextGen, phase },
+    { post, transport, issueId },
+  );
+  const readback = await readClaim(ticket, { post, transport });
   const won = readback?.owner_host === hostName && readback?.generation === nextGen;
   return { won, generation: nextGen };
 }
@@ -319,8 +376,8 @@ export async function claimTicket(
 // false ⇒ a takeover bumped the generation past us (we're a stale zombie) →
 // abort the side-effect. A missing claim (null) yields false — there is nothing
 // authorising our generation, so the conservative answer is "not current".
-export async function isFenceCurrent(ticket, generation, { post = defaultPost } = {}) {
-  const current = await readClaim(ticket, { post });
+export async function isFenceCurrent(ticket, generation, { post = defaultPost, transport = null } = {}) {
+  const current = await readClaim(ticket, { post, transport });
   return current?.generation === generation;
 }
 
@@ -351,37 +408,61 @@ export async function isFenceCurrent(ticket, generation, { post = defaultPost } 
 //                                    every `claim`.
 const FENCE_STALE_EXIT = 10;
 
-export async function runCli(argv, { post = defaultPost } = {}) {
+/**
+ * defaultTransport — build the transport this PROCESS should use. CTL-1889 increment 3.
+ *
+ * ⛔ WHY THE PROXY IS CONSTRUCTED HERE AND NOT READ FROM THE INSTALL SLOT.
+ * `linear-write-proxy-install.mjs` holds a PROCESS-WIDE slot the daemon fills at startup.
+ * This module is not run in the daemon's process — `cluster-claim-sync.mjs` drives it by
+ * `spawnSync("node cluster-claim.mjs …")`, so the slot in this child is always empty.
+ * Reaching for `getLinearWriteProxy()` here would therefore find `null` on every real
+ * invocation and silently fall through to the app-actor path, which would look exactly
+ * like a working migration while retiring nothing. The child re-reads the mode from its
+ * inherited env instead.
+ *
+ * ⚠️ A mode of `enforce` with no constructible proxy yields the app-actor transport, and
+ * that is NOT a silent fall-back of the kind increments 1-2 forbid: `createLinearWriteProxy`
+ * returns null only for a mode that is not shadow/enforce, so this branch is unreachable
+ * under enforce. It is here so a future mode cannot produce an undefined transport.
+ */
+export function defaultTransport({ env = process.env, post = defaultPost } = {}) {
+  const { mode, routes } = readLinearWriteProxyConfig(env);
+  const proxy = mode === "enforce" ? createLinearWriteProxy({ mode, env, routes }) : null;
+  return resolveAttachmentTransport({ mode, post, proxy, caller: "cluster-claim" });
+}
+
+export async function runCli(argv, { post = defaultPost, transport = null } = {}) {
+  const t = transport ?? defaultTransport({ post });
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case "claim": {
       const [ticket, hostName, phase, issueIdRaw] = rest;
       const issueId = issueIdRaw != null && issueIdRaw !== "" ? issueIdRaw : null;
-      const res = await claimTicket(ticket, hostName, phase, { post, issueId });
+      const res = await claimTicket(ticket, hostName, phase, { post, transport: t, issueId });
       process.stdout.write(JSON.stringify(res) + "\n");
       return 0;
     }
     case "fence-check": {
       const [ticket, gen] = rest;
-      const current = await isFenceCurrent(ticket, Number(gen), { post });
+      const current = await isFenceCurrent(ticket, Number(gen), { post, transport: t });
       process.stdout.write(JSON.stringify({ current }) + "\n");
       return current ? 0 : FENCE_STALE_EXIT;
     }
     case "resolve-issue-id": {
       const [ticket] = rest;
-      const issueId = await resolveIssueId(ticket, { post });
+      const issueId = await resolveIssueId(ticket, { post, transport: t });
       process.stdout.write(JSON.stringify({ issueId }) + "\n");
       return 0;
     }
     case "read-triage-attempt": {
       const [ticket] = rest;
-      const count = await readTriageAttemptCount(ticket, { post });
+      const count = await readTriageAttemptCount(ticket, { post, transport: t });
       process.stdout.write(JSON.stringify({ count }) + "\n");
       return 0;
     }
     case "bump-triage-attempt": {
       const [ticket] = rest;
-      const count = await bumpTriageAttemptCount(ticket, { post });
+      const count = await bumpTriageAttemptCount(ticket, { post, transport: t });
       process.stdout.write(JSON.stringify({ count }) + "\n");
       return 0;
     }

--- a/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat.mjs
@@ -23,6 +23,15 @@
 // cluster-sync.mjs and doctor.mjs already set, to fold this file's own
 // LINEAR_API_TOKEN/LINEAR_API_KEY ladder onto the shared contract.
 import { resolveSecret } from "../lib/secret-contract.mjs";
+// CTL-1889 increment 3 — the shared attachment transport (see its header). Heartbeat is
+// single-writer-per-host, so it has no CAS to protect; what it shares with cluster-claim is
+// the VERB (attachmentCreate + read-back) and therefore the credential this ticket retires.
+import {
+  createGraphqlAttachmentTransport,
+  resolveAttachmentTransport,
+} from "./cluster-attachment-transport.mjs";
+import { createLinearWriteProxy } from "./linear-write-proxy.mjs";
+import { readLinearWriteProxyConfig } from "./config.mjs";
 
 const HEARTBEAT_URL_PREFIX = "catalyst://heartbeat/";
 const HEARTBEAT_ATTACHMENT_TITLE = "catalyst-liveness";
@@ -96,20 +105,33 @@ async function defaultPost(query, variables) {
 // issue found". This is why cross-host liveness never published (CTL-1251).
 // READ_ATTACHMENTS_QUERY below already uses `issue(id:)`, which is why reads
 // worked while writes silently failed.
-const RESOLVE_ISSUE_QUERY = `query ResolveIssueId($id: String!) {
-  issue(id: $id) { id }
-}`;
+/** See cluster-claim.mjs's transportFor — same contract, same default-is-the-old-path rule. */
+function transportFor({ post = defaultPost, transport = null } = {}) {
+  return transport ?? createGraphqlAttachmentTransport({ post });
+}
 
-export async function resolveIssueId(ticket, { post = defaultPost } = {}) {
-  const data = await post(RESOLVE_ISSUE_QUERY, { id: ticket });
-  return data?.issue?.id ?? null;
+/**
+ * defaultTransport — this PROCESS's transport. Constructed from the inherited env for the
+ * same reason cluster-claim.mjs does it: `cluster-heartbeat-sync.mjs` drives this module by
+ * `spawnSync("node cluster-heartbeat.mjs …")`, so the daemon's process-wide install slot is
+ * always empty in this child and reading it would silently keep the app-actor path alive.
+ */
+export function defaultTransport({ env = process.env, post = defaultPost } = {}) {
+  const { mode, routes } = readLinearWriteProxyConfig(env);
+  const proxy = mode === "enforce" ? createLinearWriteProxy({ mode, env, routes }) : null;
+  return resolveAttachmentTransport({ mode, post, proxy, caller: "cluster-heartbeat" });
+}
+
+export async function resolveIssueId(ticket, { post = defaultPost, transport = null } = {}) {
+  return transportFor({ post, transport }).resolveIssueId(ticket);
 }
 
 // ─── read ────────────────────────────────────────────────────────────────────
 
-const READ_ATTACHMENTS_QUERY = `query ReadFence($id: String!) {
-  issue(id: $id) { attachments { nodes { id url metadata } } }
-}`;
+// ⚠️ The GraphQL document that used to live here now lives in
+// cluster-attachment-transport.mjs, which is the ONE place both cluster modules and
+// both transports agree on the wire format. The history above is kept because it is
+// the reason the document reads the way it does, not because the text is still here.
 
 // parseHeartbeatMetadata — normalise an attachment's metadata into the flat
 // liveness record callers consume. `in_flight_tickets` is normalised to a
@@ -154,14 +176,22 @@ export function parseHeartbeatMetadata(metadata, { now = Date.now() } = {}) {
 // max_parallel, in_flight_count } } (the full parseHeartbeatMetadata record).
 // Best-effort: a missing/erroring anchor yields {}. The caller filters out
 // `self` to avoid treating its own attachment as a peer.
-export async function readPeerHeartbeats({ anchorIssue }, { post = defaultPost } = {}) {
-  let data;
+export async function readPeerHeartbeats(
+  { anchorIssue },
+  { post = defaultPost, transport = null } = {},
+) {
+  let nodes;
   try {
-    data = await post(READ_ATTACHMENTS_QUERY, { id: anchorIssue });
+    nodes = await transportFor({ post, transport }).readAttachments(anchorIssue);
   } catch {
+    // ⚠️ BEST-EFFORT, PRESERVED VERBATIM — and deliberately NOT changed by CTL-1889 inc 3.
+    // Unlike `readClaim`, a failed read here returns `{}` (no peers) rather than throwing.
+    // That asymmetry is pre-existing and is a real hazard worth its own ticket (an empty
+    // peer map reads as "every peer is dead", which is the permissive direction for
+    // dead-host takeover) — but this increment changes the TRANSPORT, not the failure
+    // policy, so the proxy path fails exactly the way the app-actor path already did.
     return {};
   }
-  const nodes = data?.issue?.attachments?.nodes ?? [];
   const out = {};
   for (const n of nodes) {
     if (typeof n?.url !== "string" || !n.url.startsWith(HEARTBEAT_URL_PREFIX)) continue;
@@ -173,9 +203,10 @@ export async function readPeerHeartbeats({ anchorIssue }, { post = defaultPost }
 
 // ─── write / upsert ──────────────────────────────────────────────────────────
 
-const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreateInput!) {
-  attachmentCreate(input: $input) { success attachment { id url metadata } }
-}`;
+// ⚠️ The GraphQL document that used to live here now lives in
+// cluster-attachment-transport.mjs, which is the ONE place both cluster modules and
+// both transports agree on the wire format. The history above is kept because it is
+// the reason the document reads the way it does, not because the text is still here.
 
 // publishHeartbeat — upsert THIS host's `catalyst://heartbeat/<host>` attachment
 // on the anchor issue. Single-writer-per-host ⇒ no CAS. Mirrors writeClaim
@@ -193,10 +224,9 @@ const WRITE_ATTACHMENT_MUTATION = `mutation UpsertFence($input: AttachmentCreate
 // is supplied — this is purely additive.
 export async function publishHeartbeat(
   { anchorIssue, host, inFlightTickets = [], maxParallel = null, lastAdvanceAt = null },
-  { post = defaultPost, now, issueId: issueIdOverride = null } = {},
+  { post = defaultPost, transport = null, now, issueId: issueIdOverride = null } = {},
 ) {
-  const issueId = issueIdOverride || (await resolveIssueId(anchorIssue, { post }));
-  if (!issueId) throw new Error(`cluster-heartbeat: no issue found for anchor ${anchorIssue}`);
+  const t = transportFor({ post, transport });
   const last_seen = now ? now() : new Date().toISOString();
   const metadata = {
     host,
@@ -206,17 +236,15 @@ export async function publishHeartbeat(
     in_flight_count: inFlightTickets.length,
   };
   if (lastAdvanceAt != null) metadata.last_advance_at = lastAdvanceAt;
-  const data = await post(WRITE_ATTACHMENT_MUTATION, {
-    input: {
-      issueId,
-      title: HEARTBEAT_ATTACHMENT_TITLE,
-      url: heartbeatUrl(host),
-      metadata,
-    },
+  // Throws on a resolution miss or any non-success, exactly as before — the transport owns
+  // both cases now, so the two callers cannot drift on what "the publish failed" means.
+  await t.upsertAttachment({
+    ticket: anchorIssue,
+    issueId: issueIdOverride,
+    title: HEARTBEAT_ATTACHMENT_TITLE,
+    url: heartbeatUrl(host),
+    metadata,
   });
-  if (!data?.attachmentCreate?.success) {
-    throw new Error(`cluster-heartbeat: attachmentCreate success=false for ${host}`);
-  }
   return parseHeartbeatMetadata(metadata);
 }
 
@@ -235,7 +263,8 @@ export async function publishHeartbeat(
 // with ONE small subprocess call (instead of the resolution being buried inside every
 // `publish`), then pass the resolved UUID back into `publish`'s optional 5th arg on every
 // subsequent call — skipping that call's own ResolveIssueId round-trip.
-export async function runCli(argv, { post = defaultPost, now } = {}) {
+export async function runCli(argv, { post = defaultPost, transport = null, now } = {}) {
+  const t = transport ?? defaultTransport({ post });
   const [cmd, ...rest] = argv;
   switch (cmd) {
     case "publish": {
@@ -262,20 +291,20 @@ export async function runCli(argv, { post = defaultPost, now } = {}) {
       const issueId = issueIdRaw != null && issueIdRaw !== "" ? issueIdRaw : null;
       const rec = await publishHeartbeat(
         { anchorIssue: anchor, host, inFlightTickets, maxParallel, lastAdvanceAt },
-        { post, now, issueId },
+        { post, transport: t, now, issueId },
       );
       process.stdout.write(JSON.stringify(rec) + "\n");
       return 0;
     }
     case "read": {
       const [anchor] = rest;
-      const map = await readPeerHeartbeats({ anchorIssue: anchor }, { post });
+      const map = await readPeerHeartbeats({ anchorIssue: anchor }, { post, transport: t });
       process.stdout.write(JSON.stringify(map) + "\n");
       return 0;
     }
     case "resolve-anchor": {
       const [anchor] = rest;
-      const issueId = await resolveIssueId(anchor, { post });
+      const issueId = await resolveIssueId(anchor, { post, transport: t });
       process.stdout.write(JSON.stringify({ issueId }) + "\n");
       return 0;
     }

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -103,7 +103,16 @@ export const LINEAR_WRITE_PROXY_MODES = Object.freeze(new Set(["off", "shadow", 
  * shares this module's credential handling, budget ledger, and event names — but it is
  * the ONE route sent through `sendAsync` rather than `send`; see NON_BLOCKING_ROUTE_IDS.
  */
-export const PROXY_ROUTE_IDS = Object.freeze(["issue-state", "label", "comment", "session"]);
+export const PROXY_ROUTE_IDS = Object.freeze([
+  "issue-state",
+  "label",
+  "comment",
+  "session",
+  // CTL-1889 inc 3 / CTC-692 — the cluster serializer's fence + heartbeat record. This is a
+  // WRITE and it is DISPATCH-CRITICAL: `cluster-claim.mjs`'s soft-CAS decides whether this
+  // host may work a ticket at all, so it is emphatically NOT in NON_BLOCKING_ROUTE_IDS.
+  "attachment",
+]);
 
 /**
  * ⛔ THE ASYMMETRY, AS DATA — read this before adding an id.
@@ -141,6 +150,35 @@ export const DEFAULT_ROUTES = Object.freeze({
   // CTL-1943 / CTC-682, read off the merged handler rather than guessed — the earlier
   // cut of this module shipped guessed paths and was wrong on every one of them.
   session: "/agent/session",
+  // CTL-1889 inc 3 / CTC-692, read off the merged handler AND probed live (see
+  // READ_ROUTE_IDS below for the measurements this pair depends on).
+  attachment: "/agent/attachment",
+});
+
+/**
+ * ⛔ THE READ ROUTES — SEPARATE FROM THE WRITES, AND NOT FOR TIDINESS.
+ *
+ * `/agent/attachments` is the soft-CAS READ-BACK. It is a GET, it carries no body, and the
+ * cloud deliberately spends NO write-budget unit on it (`resolveReadOnlyAgentContext`
+ * skips the budget half of `resolveWriteContext` on purpose). This module must mirror
+ * that, and the reason is not symmetry — it is availability:
+ *
+ * ⛔ IF THE READ-BACK SPENT HOST BUDGET, A HOST THAT EXHAUSTED ITS DAILY WRITES COULD NO
+ * LONGER *VERIFY* A CLAIM. `claimTicket` treats an unverifiable claim as a lost race, so
+ * every claim on that host would return `won:false` and the host would stop dispatching
+ * entirely — a total work stoppage caused by a budget designed to bound WRITES. Reads are
+ * bounded by the cloud's own 429 instead.
+ *
+ * ⛔ AND THE READ IS NEVER CONVERGENCE-SUPPRESSED. Convergence means "the desired state is
+ * already reached, skip the call". Applied to a read that would return a CACHED VERDICT
+ * for a live fencing question — the one question whose answer must be current — so
+ * `read()` never consults the ledger at all.
+ */
+export const READ_ROUTE_IDS = Object.freeze(new Set(["attachments"]));
+
+/** Read-route paths. Same Layer-2 override mechanism as DEFAULT_ROUTES. */
+export const DEFAULT_READ_ROUTES = Object.freeze({
+  attachments: "/agent/attachments",
 });
 
 /** Mirrors cloud-sync.mjs:127 — one default, one env override, no third rung. */
@@ -213,10 +251,11 @@ export function resolveHostKey(env = process.env) {
  * caller refuses with `unknown-route` instead of POSTing to a fabricated URL.
  */
 export function resolveRoutePath(routeId, routes = null) {
-  if (!PROXY_ROUTE_IDS.includes(routeId)) return null;
+  const isRead = READ_ROUTE_IDS.has(routeId);
+  if (!isRead && !PROXY_ROUTE_IDS.includes(routeId)) return null;
   const override = routes && typeof routes === "object" ? routes[routeId] : undefined;
   if (typeof override === "string" && override.startsWith("/")) return override;
-  return DEFAULT_ROUTES[routeId];
+  return isRead ? DEFAULT_READ_ROUTES[routeId] : DEFAULT_ROUTES[routeId];
 }
 
 /**
@@ -248,14 +287,36 @@ export function resolveProxyAccount(env = process.env) {
  * because that too is loud, and the account is provisioned from the same bundle as the
  * token it accompanies.
  */
-export function buildProxyRequest({ routeId, payload, baseUrl, routes = null, account = null }) {
+export function buildProxyRequest({
+  routeId,
+  payload,
+  baseUrl,
+  routes = null,
+  account = null,
+  query = null,
+}) {
   const path = resolveRoutePath(routeId, routes);
   if (path === null) return { url: null, method: null, body: null, reason: "unknown-route" };
-  const query = account ? `?account=${encodeURIComponent(account)}` : "";
+  // A READ route is a GET with its arguments in the query string and NO body. Building it
+  // here rather than in a second function keeps ONE place that knows how `?account=` is
+  // appended — a second one would be the obvious place for the two to drift on escaping.
+  const isRead = READ_ROUTE_IDS.has(routeId);
+  const params = new URLSearchParams();
+  if (query && typeof query === "object") {
+    for (const [k, v] of Object.entries(query)) {
+      if (v === undefined || v === null) continue;
+      params.set(k, String(v));
+    }
+  }
+  if (account) params.set("account", account);
+  const qs = params.toString();
   return {
-    url: `${baseUrl}${path}${query}`,
-    method: "POST",
-    body: JSON.stringify(payload ?? {}),
+    url: `${baseUrl}${path}${qs ? `?${qs}` : ""}`,
+    method: isRead ? "GET" : "POST",
+    // ⛔ `null`, not `""`. A GET must carry no body at all: curl's config `data = ""` turns
+    // the request into a POST-with-empty-body regardless of `request = "GET"`, which would
+    // reach the cloud as a method the read route does not serve and 404.
+    body: isRead ? null : JSON.stringify(payload ?? {}),
     reason: null,
   };
 }
@@ -286,7 +347,10 @@ export function buildCurlConfig({ url, method, token, body }) {
       `header = "Authorization: Bearer ${curlConfigEscape(token)}"`,
       'header = "Content-Type: application/json"',
       'header = "Accept: application/json"',
-      `data = "${curlConfigEscape(body)}"`,
+      // ⛔ A null body emits NO `data` line. `data = ""` would make curl send a body, and a
+      // request with a body is a POST to curl no matter what `request` says — so the GET
+      // read-back would arrive at the cloud as a POST and 404 on a route that exists.
+      ...(body === null || body === undefined ? [] : [`data = "${curlConfigEscape(body)}"`]),
       "silent",
       "show-error",
       // Trailing "\n<code>" so the caller can split the status off the body without
@@ -892,6 +956,76 @@ export function createLinearWriteProxy({
       counts.applied += 1;
       emit(EVENT_APPLIED, { ticket, routeId, reason: null, status: verdict.status, applied: true, caller, labels });
       return { handled: true, applied: true, reason: null, status: verdict.status };
+    },
+
+    /**
+     * read — the soft-CAS READ-BACK. CTL-1889 increment 3 / CTC-692.
+     *
+     * ⛔ THE THIRD PEER, AND IT IS A READ. `send`/`sendAsync` spend budget, consult the
+     * convergence ledger and emit write events. This one does NONE of those — see
+     * READ_ROUTE_IDS for why each omission is a correctness requirement rather than an
+     * optimisation. It shares the closure only for the credential, the base url and the
+     * account, which is the whole reason it lives here instead of in the caller.
+     *
+     * ⛔ SHADOW MODE STILL PERFORMS THE READ. This is the one place shadow does reach the
+     * cloud, and the asymmetry is deliberate: shadow refuses to WRITE because writing
+     * twice would double-apply the board, but a read has no such hazard — and a caller
+     * that could not read in shadow could not exercise the read path at all, so the shadow
+     * window would prove nothing about the half of the mechanism most likely to break.
+     *
+     * Returns `{ ok, attachments?, reason, status }`. ⛔ NEVER `{ok:true}` with a
+     * fabricated empty list: every non-2xx, unparseable or non-`succeeded` answer is
+     * `ok:false` with a NAMED reason, because the caller's whole safety argument is that
+     * it can tell "no claim exists" from "I could not find out".
+     */
+    read({ routeId, ticket = null, query = null, caller = null }) {
+      const ctx = { ticket, route: routeId, caller };
+
+      if (!READ_ROUTE_IDS.has(routeId)) {
+        log?.error?.(ctx, "linear-write-proxy: read REFUSED — route is not a declared read route");
+        return { ok: false, reason: "route-not-read-eligible", status: null };
+      }
+
+      const refuse = (reason, status = null, detail = null) => {
+        log?.warn?.(
+          { ...ctx, reason, status, detail: detail ? scrub(detail) : undefined },
+          "linear-write-proxy: read-back NOT answered — the caller must treat this as unverified"
+        );
+        return { ok: false, reason, status };
+      };
+
+      const req = buildProxyRequest({ routeId, payload: null, baseUrl, routes, account, query });
+      if (req.reason) return refuse(req.reason);
+
+      const key = resolveHostKey(env);
+      if (key.value === null) {
+        log?.error?.(
+          { ...ctx, token_env: key.envVar },
+          "linear-write-proxy: no per-host cloud key — read-back REFUSED (reason=no-cloud-token)"
+        );
+        return refuse("no-cloud-token");
+      }
+
+      let raw;
+      try {
+        raw = httpFn({ url: req.url, method: req.method, token: key.value, body: req.body });
+      } catch (err) {
+        log?.warn?.({ ...ctx, err: scrub(err?.message ?? "") }, "linear-write-proxy: read transport threw");
+        return refuse("spawn-failed");
+      }
+
+      const verdict = classifyProxyResponse(raw);
+      if (!verdict.applied) return refuse(verdict.reason, verdict.status, verdict.detail ?? null);
+
+      // A 2xx is necessary and NOT sufficient. The cloud answers `{outcome, attachments}`;
+      // a 200 whose body we cannot read as `succeeded` with a real array is an answer we do
+      // not have, and reporting it as an empty list is precisely the "read a truncated page
+      // as no-claim-exists" failure the cloud's own MAX_ATTACHMENT_PAGES guard exists to stop.
+      const body = parseProxyBody(verdict.body ?? "");
+      if (!body || body.outcome !== "succeeded" || !Array.isArray(body.attachments)) {
+        return refuse("read-unreadable", verdict.status, typeof body?.reason === "string" ? body.reason : null);
+      }
+      return { ok: true, attachments: body.attachments, reason: null, status: verdict.status };
     },
 
     /**

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -20,6 +20,7 @@ import {
   PROXY_EVENT_NAMES,
   NON_BLOCKING_ROUTE_IDS,
   PROXY_ROUTE_IDS,
+  READ_ROUTE_IDS,
   buildCurlConfig,
   buildProxyRequest,
   classifyProxyResponse,
@@ -125,12 +126,16 @@ describe("resolveHostKey — through the secret contract, not a hand-rolled ladd
 
 describe("routes", () => {
   test("the supported routes are exactly the set below — fails in both directions", () => {
-    // CTL-1943 added `session` (CTC-682). The exact-equality shape is deliberate: a new
-    // route must be argued for HERE, because every id in this set is a path the daemon
-    // will send a Linear write to.
-    const expected = ["comment", "issue-state", "label", "session"];
+    // CTL-1943 added `session` (CTC-682); CTL-1889 inc 3 added `attachment` (CTC-692) — the
+    // cluster fence + heartbeat record. The exact-equality shape is deliberate: a new route
+    // must be argued for HERE, because every id in this set is a path the daemon will send a
+    // Linear write to.
+    const expected = ["attachment", "comment", "issue-state", "label", "session"];
     expect([...PROXY_ROUTE_IDS].sort()).toEqual(expected);
     expect(Object.keys(DEFAULT_ROUTES).sort()).toEqual(expected);
+    // The READ routes are a SEPARATE set on purpose (they spend no write budget), and they
+    // must not leak into the write set — asserted in both directions.
+    expect([...READ_ROUTE_IDS].sort()).toEqual(["attachments"]);
   });
 
   test("⛔ exactly ONE route is non-blocking, and it is not a dispatch-critical one", () => {
@@ -154,9 +159,20 @@ describe("routes", () => {
   });
 
   test("an unknown route id yields null → buildProxyRequest refuses with a named reason", () => {
-    expect(resolveRoutePath("attachment")).toBeNull();
-    const r = buildProxyRequest({ routeId: "attachment", payload: {}, baseUrl: "http://h" });
+    // ⚠️ This test used to use "attachment" as its example of an unknown route. CTL-1889
+    // inc 3 made that a REAL route, and the assertion inverted — so the id here is now a
+    // deliberately unimplementable one. A plausible-sounding placeholder is a trap: it
+    // turns "we added the route you asked for" into a red test in an unrelated file.
+    expect(resolveRoutePath("not-a-route-and-never-will-be")).toBeNull();
+    const r = buildProxyRequest({
+      routeId: "not-a-route-and-never-will-be",
+      payload: {},
+      baseUrl: "http://h",
+    });
     expect(r).toMatchObject({ url: null, reason: "unknown-route" });
+    // NEGATIVE CONTROL — a real id resolves, so this is measuring the refusal and not a
+    // resolver that returns null for everything.
+    expect(resolveRoutePath("comment")).toBe(DEFAULT_ROUTES.comment);
   });
 });
 
@@ -381,7 +397,7 @@ describe("enforce — the proxy IS the write", () => {
   test("an unusable route id refuses before resolving the key", () => {
     const http = recorder();
     const p = createLinearWriteProxy({ mode: "enforce", env: {}, httpFn: http, appendEvent: eventSink(), log: silentLog });
-    expect(p.send({ routeId: "attachment", ticket: "CTL-8", payload: {} })).toEqual({
+    expect(p.send({ routeId: "not-a-route-and-never-will-be", ticket: "CTL-8", payload: {} })).toEqual({
       handled: true,
       applied: false,
       reason: "unknown-route",
@@ -557,5 +573,150 @@ describe("defaultHttpFn round-trip against a real server", () => {
     const req = buildProxyRequest({ routeId: "label", payload: {}, baseUrl: `http://127.0.0.1:${port}/api/v1` });
     const res = defaultHttpFn({ url: req.url, method: req.method, token: TOKEN, body: req.body });
     expect(classifyProxyResponse(res)).toMatchObject({ applied: false, reason: "unauthorized", status: 401 });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════════════
+// CTL-1889 increment 3 / CTC-692 — the attachment write route and the GET read-back.
+// ══════════════════════════════════════════════════════════════════════════════════════
+
+describe("the attachment pair (CTL-1889 inc 3)", () => {
+  test("`attachment` is a WRITE route and is NOT async-eligible — the claim is dispatch-critical", () => {
+    expect(PROXY_ROUTE_IDS).toContain("attachment");
+    // ⛔ The asymmetry that matters: a lost narration costs an observation, a lost claim
+    // costs the mutex. If someone adds "attachment" to the non-blocking set to make dispatch
+    // feel faster, this fails.
+    expect(NON_BLOCKING_ROUTE_IDS.has("attachment")).toBe(false);
+    expect(resolveRoutePath("attachment")).toBe("/agent/attachment");
+  });
+
+  test("`attachments` is a READ route and is NOT in the write route ids", () => {
+    expect(READ_ROUTE_IDS.has("attachments")).toBe(true);
+    // A read must never be reachable through `send`, which would spend a write-budget unit
+    // on it and let an exhausted host stop being able to VERIFY a claim.
+    expect(PROXY_ROUTE_IDS).not.toContain("attachments");
+    expect(resolveRoutePath("attachments")).toBe("/agent/attachments");
+  });
+
+  test("the read route builds a GET with issueId in the query string and NO body", () => {
+    const req = buildProxyRequest({
+      routeId: "attachments",
+      baseUrl: "https://c/api/v1",
+      query: { issueId: "CTL-1889" },
+      account: "acct-1",
+    });
+    expect(req.method).toBe("GET");
+    expect(req.body).toBeNull();
+    expect(req.url).toBe("https://c/api/v1/agent/attachments?issueId=CTL-1889&account=acct-1");
+  });
+
+  test("⛔ the GET's curl config emits NO `data` line — a body would make curl send a POST", () => {
+    const cfg = buildCurlConfig({ url: "https://c/x", method: "GET", token: TOKEN, body: null });
+    // Asserting the ABSENCE, positively: curl treats any request carrying a body as a POST
+    // regardless of `request = "GET"`, so a stray `data = ""` would 404 on a live route.
+    expect(cfg).not.toContain("data =");
+    expect(cfg).toContain('request = "GET"');
+    // NEGATIVE CONTROL — the same builder DOES emit `data` for a write, so the assertion
+    // above is measuring the branch and not a broken matcher.
+    expect(buildCurlConfig({ url: "https://c/x", method: "POST", token: TOKEN, body: "{}" })).toContain(
+      'data = "{}"',
+    );
+  });
+
+  test("the write route still POSTs a body, unchanged", () => {
+    const req = buildProxyRequest({
+      routeId: "attachment",
+      payload: { issueId: "CTL-1", url: "catalyst://fence/CTL-1" },
+      baseUrl: "https://c/api/v1",
+    });
+    expect(req.method).toBe("POST");
+    expect(JSON.parse(req.body).issueId).toBe("CTL-1");
+  });
+
+  test("read() returns the attachments on a succeeded body", () => {
+    const rec = recorder({
+      code: 0,
+      stdout: JSON.stringify({ outcome: "succeeded", attachments: [{ id: "a", url: "u" }] }) + "\n200",
+      stderr: "",
+    });
+    const p = createLinearWriteProxy({ mode: "enforce", env: envWithKey(), httpFn: rec });
+    const res = p.read({ routeId: "attachments", ticket: "CTL-1", query: { issueId: "CTL-1" } });
+    expect(res.ok).toBe(true);
+    expect(res.attachments).toEqual([{ id: "a", url: "u" }]);
+    expect(rec.calls[0].method).toBe("GET");
+  });
+
+  test("⛔ read() NEVER fabricates an empty list — a 200 with an unreadable body is ok:false", () => {
+    // The specific way a read can lie: HTTP 200, but the body is not the answer we asked for
+    // (a proxy error page, a truncated write, a route that moved). Reporting `[]` here would
+    // tell the soft-CAS that nobody holds the ticket.
+    for (const stdout of ["<html>oops</html>\n200", '{"outcome":"succeeded"}\n200', "\n200"]) {
+      const p = createLinearWriteProxy({
+        mode: "enforce",
+        env: envWithKey(),
+        httpFn: recorder({ code: 0, stdout, stderr: "" }),
+      });
+      const res = p.read({ routeId: "attachments", query: { issueId: "CTL-1" } });
+      expect(res.ok).toBe(false);
+      expect(res.attachments).toBeUndefined();
+    }
+  });
+
+  test("read() refuses a non-read route BY NAME rather than quietly performing a write", () => {
+    const p = createLinearWriteProxy({ mode: "enforce", env: envWithKey(), httpFn: recorder() });
+    expect(p.read({ routeId: "comment", query: {} })).toMatchObject({
+      ok: false,
+      reason: "route-not-read-eligible",
+    });
+  });
+
+  test("read() with no per-host key refuses LOUDLY — the negative control, same as the writes", () => {
+    const p = createLinearWriteProxy({ mode: "enforce", env: {}, httpFn: recorder() });
+    expect(p.read({ routeId: "attachments", query: { issueId: "X" } })).toMatchObject({
+      ok: false,
+      reason: "no-cloud-token",
+    });
+  });
+
+  test("⛔ read() spends NO write budget — an exhausted host must still be able to VERIFY a claim", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wp-read-budget-"));
+    const ledgerPath = join(dir, "budget.json");
+    try {
+      const rec = recorder({
+        code: 0,
+        stdout: JSON.stringify({ outcome: "succeeded", attachments: [] }) + "\n200",
+        stderr: "",
+      });
+      const p = createLinearWriteProxy({
+        mode: "enforce",
+        env: envWithKey(),
+        httpFn: rec,
+        budgetPath: ledgerPath,
+      });
+      for (let i = 0; i < 5; i++) p.read({ routeId: "attachments", ticket: "CTL-1", query: { issueId: "CTL-1" } });
+      // Five reads, and the ledger was never even created — reads do not touch it.
+      expect(existsSync(ledgerPath)).toBe(false);
+
+      // NEGATIVE CONTROL — one WRITE through the same proxy does create and spend it, so the
+      // assertion above is about reads and not about a ledger that never works.
+      p.send({ routeId: "attachment", ticket: "CTL-1", payload: { issueId: "CTL-1" } });
+      expect(JSON.parse(readFileSync(ledgerPath, "utf8")).total).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("SHADOW still performs the read — a read has no double-apply hazard, and a shadow window that cannot read proves nothing", () => {
+    const rec = recorder({
+      code: 0,
+      stdout: JSON.stringify({ outcome: "succeeded", attachments: [] }) + "\n200",
+      stderr: "",
+    });
+    const p = createLinearWriteProxy({ mode: "shadow", env: envWithKey(), httpFn: rec });
+    expect(p.read({ routeId: "attachments", query: { issueId: "CTL-1" } }).ok).toBe(true);
+    expect(rec.calls).toHaveLength(1);
+    // NEGATIVE CONTROL — the same proxy in shadow makes NO call for a write.
+    p.send({ routeId: "attachment", ticket: "CTL-1", payload: {} });
+    expect(rec.calls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Increment 3 of **CTL-1889**, and the half of **CTC-692** that lives in this repo. Increment 1 moved `issue-state` + `label`, increment 2 moved comments; this moves the last two execution-core app-actor writers: `cluster-claim.mjs` (the fleet's cross-host soft-CAS mutex) and `cluster-heartbeat.mjs` (per-host liveness).

## ⛔ The entire risk of this change is that the proxy NEVER THROWS

`defaultPost` throws on a transport error, a non-2xx, or a GraphQL `errors[]` body. `proxy.send` / `proxy.read` return **tagged verdicts and never throw**. `cluster-claim.mjs` depends on that throw in two places where nothing else is watching:

**1. A failed READ swallowed into `[]` resets the fencing token.**
```js
const current = await readClaim(ticket);        // fails → []  → null
const nextGen = (current?.generation ?? 0) + 1; // 1, on a ticket held at generation 7
```
We then write our claim at generation 1, and the read-back confirms *our own write* → `won: true`. Two hosts own the ticket, `isFenceCurrent(ticket, 7)` starts answering false for the host actually doing the work, and **no error is raised anywhere.**

**2. A failed WRITE that does not throw invents a win.** The stale-preemption branch is:
```js
await writeClaim(...); return { won: true, generation: nextGen };   // ⛔ no read-back
```
`writeClaim`'s throw is the *only* thing between a refused write and a host believing it owns a ticket it never wrote to. A `{applied:false, reason:"budget:day-exhausted"}` handed back quietly turns this host's own write budget into a fleet-wide double dispatch.

So `cluster-attachment-transport.mjs` re-establishes **one invariant — every non-success throws, with a named reason** — and both mutation controls in its suite *reproduce the defect* when the invariant is removed, so the assertions cannot go vacuous.

## ⭐ Measured live, not assumed: no UUID resolution is needed

`cluster-claim.mjs`'s header said `attachmentCreate` "needs the UUID, not the identifier". Probed against the **live** route with a per-host org key:

| probe | result |
| -- | -- |
| `POST /agent/attachment {"issueId":"CTL-1889", …}` | `200 succeeded` — **the identifier is accepted** |
| same `url` again, new metadata | **same attachment id** `d9918a35…`, metadata replaced |
| `GET /agent/attachments?issueId=CTL-1889` | exactly **one** node at that url, metadata intact |

⭐ This matters beyond tidiness. The only credential-free way to resolve a UUID on-host is the freshness-gated replica resolver — which would have coupled **every cluster claim to the replica writer's heartbeat**, so a dead replica writer would have stopped the fleet claiming *any* ticket. Passing the identifier removes that coupling entirely. The stale header claim is corrected in place; `resolveIssueId` is kept for the direct path, where it has **not** been re-measured.

## The read-back is a THIRD peer, not a fourth write route

`/agent/attachments` is a GET and the cloud spends **no** write-budget unit on it. `read()` mirrors that — no budget, no convergence suppression — and both omissions are correctness requirements, not tidiness:

- ⛔ **if the read-back spent budget**, a host that exhausted its daily writes could no longer *verify* a claim → every claim returns `won:false` → **that host stops dispatching entirely**, a total work stoppage caused by a budget designed to bound writes;
- ⛔ **convergence** means "skip the call, the state is already right", which applied to a live fencing question would answer from a cache.

`buildProxyRequest` grew GET support, and `buildCurlConfig` now emits **no `data` line** for a bodyless request — curl treats any request carrying a body as a POST regardless of `request = "GET"`, so a stray `data = ""` would 404 on a route that exists. Asserted as an absence, with a negative control that the builder *does* emit `data` for a write.

## Live verification — real route, per-host org key

**Two concurrent claimers × 4 rounds → exactly one winner every time.** Generations strictly monotonic `1 → 2 → 3 → 4`, the fence always naming the winner, the loser always `won:false`:

```
host-a => {"won":false,"generation":4}
host-b => {"won":true,"generation":4}
fence  => {"owner_host":"probe-host-b","generation":4,…}
winners=1  RESULT: PASS
```

⚠️ This proves *exactly one winner*, **not fairness** — `host-b` won all four rounds because the harness's interleaving is deterministic.

**Negative controls — all three throw with a named reason**, never a silent `won:false` and never a fall-back to the app-actor:

| credential | result |
| -- | -- |
| none | `THREW reason=no-cloud-token` |
| the tenant-wide `ADMIN_TOKEN` | `THREW reason=unauthorized` (401) |
| a bogus key | `THREW reason=unauthorized` (401) |

And `claimDispatchSync` already maps a non-zero CLI exit to `{won:false}`, so a thrown claim reaches the scheduler as "did not win" — fail-closed end to end.

## ⚠️ Two suites that were never in CI, and one assertion that inverted

- **`cluster-heartbeat.test.mjs` and `cluster-heartbeat-capacity.test.mjs` were NOT in the workflow's hand-enumerated list.** The list is not globbed (the workflow says so), so a module this PR changes had **zero** CI coverage. Both are added, with the new suite.
- **`linear-write-proxy.test.mjs` used `"attachment"` as its example of an UNKNOWN route.** Making that route real inverted the assertion. It now uses an id that cannot become real — a plausible-sounding placeholder turns "we shipped the route you asked for" into a red test in an unrelated file.

## Verification

| | |
| -- | -- |
| targeted suites (9 files, incl. all cluster + proxy) | **364 pass · 0 fail** |
| new `cluster-attachment-transport.test.mjs` | 36 tests, incl. 2 mutation controls that reproduce the defect |
| live CAS, real route | 4/4 rounds, exactly one winner, monotonic generations |
| live negative controls | 3/3 throw with named reasons |

⚠️ **On the full local gate: it is NOT being reported as green, because it was invalidated mid-run.** A post-commit hook auto-rebased the branch onto `origin/main` while `run-tests.sh` was still executing, so the shell suites before and after that point ran against different trees. The targeted suites above were re-run to completion on the final rebased tree. **CI is the authority here.** Three suites were already red on clean `origin/main` before this branch existed, verified in a detached baseline worktree at `457f0254d` with byte-identical failing assertions: `catalyst-join.test.sh` (T3.4), `catalyst-legacy-plugin.test.sh` (version 1.0.0), `catalyst-stack.test.sh` (59/68).

## ⛔ Not armed on the fleet by this PR

Both minis are in `CATALYST_LINEAR_WRITE_PROXY=enforce`, so loading this code arms the new path immediately. It is deliberately **not** loaded: **#3548 (the 0.1.18 / sdk 0.8.14 fleet pin) is still open**, and the sequencing on CTL-1889 is pin-first.

The preflight for whoever loads it is measured and recorded on CTL-1889 — both hosts' **live** `CATALYST_CLOUD_TOKEN` (read from the running daemon's process env, not a config file) returns **HTTP 200** on `/agent/attachments`, so neither will lose the ability to claim. ⚠️ That also corrects a stale note in `linear-write-proxy.mjs`'s header saying mini still carries the `ADMIN_TOKEN`; it carries a 58-char per-host org key.

Refs CTL-1889, CTC-692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
