### PR TITLE
feat(dev): CTL-1929 — wire check_suite.completed, and make BOTH remaining names' coverage a property of the replica

### DIFF
--- a/plugins/dev/scripts/broker/tailer.mjs
+++ b/plugins/dev/scripts/broker/tailer.mjs
@@ -157,11 +157,15 @@ export function readNewEvents() {
       // log; the gate picks one per event and the loser is CAPTURED, not dropped, so
       // "did the feed miss this edge?" stays answerable after the fact.
       //
-      // ⛔ SUPPRESSION IS PER NAME. Nine of the twelve names the router consumes have
-      // a faithful feed replacement; `github.pr.merged` (CTC-691),
-      // `github.check_suite.completed` (CTC-667 item 4) and `github.push` (CTC-704)
-      // do not, and for those the gate never suppresses smee no matter how healthy
-      // the producer is. See github-feed-gate.mjs.
+      // ⛔ SUPPRESSION IS PER NAME, AND HOW MANY NAMES IS A PROPERTY OF THIS HOST.
+      // `github.pr.merged` joined the suppressible set when CTC-691 shipped (0.1.17);
+      // `github.push` and `github.check_suite.completed` join it only on a replica
+      // that has `push_events` (CTC-704) and `check_suites.pull_request_numbers`
+      // (CTC-712, 0.1.18) respectively. The gate resolves both from the replica and
+      // re-reads them on a TTL, because they arrive at a cloud-sync writer restart
+      // this process never observes. A host missing either keeps smee authoritative
+      // for that name no matter how healthy the producer is. See github-feed-gate.mjs
+      // and github-feed-gate-install.mjs.
       //
       // ⚠️ Placed BEFORE processEvent and before the timing block, so a suppressed
       // event is neither routed nor counted as a route — a suppressed event that

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -75,7 +75,7 @@
 // quiet at the exact moment we became its only producer.
 
 import { buildCanonicalEvent } from "./lib/canonical-event.mjs";
-import { STREAM_BY_KEY } from "./github-feed-source.mjs";
+import { STREAM_BY_KEY, unbackedEventNames } from "./github-feed-source.mjs";
 import {
   GITHUB_CONSUMED_NAMES,
   GITHUB_UNCOVERED_NAMES as LEAF_UNCOVERED_NAMES,
@@ -96,17 +96,31 @@ export const SOURCE_CLOUD_FEED = "cloud-feed";
  *                            The sha is a join key for the whole deploy chain, so a
  *                            twin without it routes and wakes while silently
  *                            breaking `monitor-deploy`. A named gap beats that.
- *   `check_suite.completed`— the mirror stores no suite row (CTC-667 item 4), and
- *                            `check_runs` cannot stand in: one head sha carried 10
- *                            distinct suite ids, several incomplete, so "every run
- *                            I can see finished" fires early and GREEN on the merge
- *                            gate.
+ *   `check_suite.completed`— ⭐ UNBLOCKED BY CTC-712 (schema 0.1.18) on a replica that
+ *                            has `check_suites.pull_request_numbers`. It is the one
+ *                            name whose coverage is a property of the HOST rather than
+ *                            of this file, because the pin rolls as a canary — so the
+ *                            static list here keeps naming it (the safe direction) and
+ *                            `githubDispatchClassNames(db)` is what a caller with a
+ *                            replica handle should ask.
  * Exported so the parity ledger accounts for them as EXPECTED absences rather than
  * as unexplained diffs, and so nothing can claim coverage this producer lacks.
  */
 export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze(
   GITHUB_CONSUMED_NAMES.filter((n) => !LEAF_UNCOVERED_NAMES.includes(n)),
 );
+
+/**
+ * The same list, resolved against a replica. See `unbackedEventNames`.
+ *
+ * ⭐ Default (no handle) is the STATIC list, which reports LESS coverage than a
+ * 0.1.18 host has — the safe direction, since under-reporting coverage leaves smee
+ * authoritative and over-reporting silently drops dispatch.
+ */
+export function githubDispatchClassNames(db = null) {
+  const unbacked = unbackedEventNames(db);
+  return Object.freeze(GITHUB_CONSUMED_NAMES.filter((n) => !unbacked.includes(n)));
+}
 
 /**
  * ⛔ RE-EXPORTED FROM `lib/github-feed-names.mjs`, NOT DECLARED HERE.
@@ -124,6 +138,12 @@ export const GITHUB_DISPATCH_CLASS_NAMES = Object.freeze(
  * One source or it drifts — this file now derives.
  */
 export const GITHUB_UNCOVERED_NAMES = LEAF_UNCOVERED_NAMES;
+
+/**
+ * Re-exported for the same one-source reason as the list above: a caller asking "does
+ * the router consume this name" must not be answered from a second copy.
+ */
+export { GITHUB_CONSUMED_NAMES };
 
 /**
  * Streams the source can PAGE but this file cannot turn into a faithful event, keyed
@@ -208,10 +228,50 @@ export function githubEdgeId(streamKey, row) {
   // which is what the settle-window re-read requires.
   if (s.mutableRow) {
     const ts = Number.isInteger(row.__ts) ? row.__ts : "?";
-    const at = typeof row.after === "string" && row.after !== "" ? row.after : "?";
-    return `gh:${streamKey}:${String(id)}:${ts}:${at}`;
+    // ⛔ THE COLUMNS COME FROM THE STREAM, not from this function. `push` folds in
+    // `after` and `checkSuiteCompleted` folds in `conclusion`, and hard-coding
+    // `after` here — as this did while `push` was the only mutable stream — silently
+    // yields `?` for every other one, collapsing its identity back to the PK and
+    // re-introducing the exact suppression bug the fold exists to prevent.
+    const extra = (Array.isArray(s.edgeIdCols) ? s.edgeIdCols : [])
+      .map((c) => {
+        const v = row[c];
+        return typeof v === "string" && v !== "" ? v : "?";
+      })
+      .join(":");
+    return `gh:${streamKey}:${String(id)}:${ts}:${extra}`;
   }
   return `gh:${streamKey}:${String(id)}`;
+}
+
+/**
+ * `check_suites.pull_request_numbers` → the number array the webhook carries.
+ *
+ * The column is TEXT (`0028_burly_nemesis`), so the wire form is a serialised list
+ * rather than a typed column, and this is the one place that shape is interpreted.
+ *
+ * ⛔ EVERY UNUSABLE FORM YIELDS `[]`, WHICH IS A DECLINE — never a partial or a
+ * guess. A malformed association is indistinguishable, to the consumer, from a
+ * fabricated one: both produce an event that routes to the wrong interest or to
+ * none, and only the decline is counted. Positive filtering (`Number.isInteger`,
+ * `> 0`) mirrors the webhook parser's own `getNum(entry, "number") > 0` guard, so a
+ * `0`, a `null`, or a string entry is dropped on both sides identically.
+ */
+export function parseCheckSuitePrNumbers(raw) {
+  if (Array.isArray(raw)) return raw.filter((n) => Number.isInteger(n) && n > 0);
+  if (typeof raw !== "string" || raw === "") return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  // The mirror may serialise either bare numbers or the webhook's `{number}` objects;
+  // both are accepted, anything else is not.
+  return parsed
+    .map((e) => (e && typeof e === "object" ? e.number : e))
+    .filter((n) => Number.isInteger(n) && n > 0);
 }
 
 /**
@@ -265,6 +325,22 @@ export function classifyGithubRow(streamKey, row) {
   // exactly the posture `deploymentCreated` takes for its own sha below.
   if (streamKey === "prMerged" && (typeof row.merge_commit_sha !== "string" || row.merge_commit_sha === "")) {
     return { emit: false, reason: "no-merge-commit-sha:not-backfilled" };
+  }
+  // ⛔ THE PR ASSOCIATION IS THE ROUTE, and a suite event without it is unroutable
+  // while still counting as emitted. `router.mjs:1497` reaches an interest ONLY
+  // through `detail.prNumbers`; an empty array matches nothing, so the event lands
+  // in the log, wakes no waiter, and the merge gate keeps waiting for a CI pass that
+  // has already happened — with no smee copy under `enforce`.
+  //
+  // ⚠️ These rows are real, not hypothetical, and they are the majority today:
+  // migration `0028_burly_nemesis` is an additive `ADD COLUMN` with NO backfill, so
+  // all 760 suite rows that predate the 0.1.18 pin carry NULL. Same two-level posture
+  // as `prMerged`: the STREAM is gated on the column existing at all
+  // (`requiresColumn`), and the ROW is gated on that column being populated. They
+  // decline visibly in `byReason` rather than emitting a twin that cannot route.
+  if (streamKey === "checkSuiteCompleted") {
+    const prs = parseCheckSuitePrNumbers(row.pull_request_numbers);
+    if (prs.length === 0) return { emit: false, reason: "no-pr-association:not-backfilled" };
   }
   if (streamKey === "pushEvent" && (typeof row.ref !== "string" || row.ref === "")) {
     return { emit: false, reason: "no-ref" };
@@ -510,6 +586,54 @@ export function buildGithubEvent(streamKey, row, seams) {
           // reads it (`router.mjs:1582` reads only `vcs.ref.name`) — which is what
           // makes the absence survivable, and is measured rather than assumed.
           commits: [],
+        },
+      }, seams);
+    }
+
+    case "checkSuiteCompleted": {
+      // ⭐ CTC-712. The row-level guard in `classifyGithubRow` has already refused a
+      // suite with no association, so `prs` is non-empty here.
+      const prs = parseCheckSuitePrNumbers(row.pull_request_numbers);
+      // ⛔ `prNumbers[0]`, NOT the whole list. The webhook picks the FIRST entry for
+      // the attribute and carries the full array in the payload; reproducing only one
+      // half of that would diverge on whichever field the ledger compares.
+      const effectivePr = prs[0];
+      const conclusion = typeof row.conclusion === "string" && row.conclusion !== "" ? row.conclusion : null;
+      const status = typeof row.status === "string" ? row.status : "";
+      const headSha = typeof row.head_sha === "string" ? row.head_sha : "";
+      // The webhook's `conclusionSeverity`: only these two are WARN.
+      const warn = conclusion === "failure" || conclusion === "timed_out";
+      return envelope({
+        name,
+        entity: "check_suite",
+        // ⚠️ The webhook's action is the STATUS, not the literal "completed" — the
+        // name is built as `github.check_suite.${status}` and `action` is the same
+        // value. They coincide for the one name we emit, and reading it from the row
+        // keeps that a fact rather than a coincidence.
+        action: status,
+        label: `PR #${effectivePr}`,
+        attrs: {
+          "vcs.repository.name": repo,
+          "cicd.pipeline.run.status": status,
+          // ⛔ CONDITIONAL, exactly as the webhook is: it sets `vcs.revision` only for
+          // a truthy sha and `cicd.pipeline.run.conclusion` only for a non-null
+          // conclusion. Emitting `""`/`null` unconditionally would be a divergence on
+          // every event carrying neither — the `pr.merged` `vcs.revision` mistake in
+          // the other direction.
+          ...(headSha ? { "vcs.revision": headSha } : {}),
+          "vcs.pr.number": effectivePr,
+          ...(conclusion !== null ? { "cicd.pipeline.run.conclusion": conclusion } : {}),
+        },
+        message: `${name} for ${repo}${conclusion ? ` (${conclusion})` : ""}`,
+        severityText: warn ? "WARN" : "INFO",
+        severityNumber: warn ? 13 : 9,
+        payload: {
+          conclusion,
+          status,
+          // ⚠️ `head_branch` IS stored and is NOT emitted. The webhook parses it into
+          // `headRef` and then drops it — no attribute, no payload key. Adding it
+          // would be an improvement, and an improvement is a divergence.
+          prNumbers: prs,
         },
       }, seams);
     }

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -6,6 +6,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  GITHUB_CONSUMED_NAMES,
   GITHUB_DISPATCH_CLASS_NAMES,
   GITHUB_SERVICE_NAME,
   GITHUB_UNCOVERED_NAMES,
@@ -18,6 +19,7 @@ import {
   githubEdgeId,
   githubEventName,
   loginOf,
+  parseCheckSuitePrNumbers,
 } from "./github-feed-event.mjs";
 
 // Deterministic seams so the envelope is byte-stable across runs.
@@ -39,6 +41,10 @@ describe("envelope invariants shared by every name", () => {
     deploymentCreated: { repo_id: "o/r", id: "55", sha: "abc", ref: "main", environment: "production" },
     deploymentStatus: { repo_id: "o/r", id: "9", deployment_id: "55", state: "success", environment: "production" },
     push: { repo_id: "o/r", ref: "refs/heads/main", before: "b1", after: "a1" },
+    checkSuiteCompleted: {
+      repo_id: "o/r", check_suite_id: "cs1", head_sha: "abc", head_branch: "topic",
+      status: "completed", conclusion: "success", pull_request_numbers: "[7]",
+    },
   };
 
   for (const [key, row] of Object.entries(rows)) {
@@ -70,8 +76,17 @@ describe("envelope invariants shared by every name", () => {
       // summarizeEvent puts body.message into every wake an agent reads, so it must
       // not collapse to the bare name the way the generic builder leaves it.
       expect(ev.body.message).toContain("o/r");
-      expect(ev.attributes["event.name"]).toBe(ev.attributes["event.name"]);
-      expect(GITHUB_DISPATCH_CLASS_NAMES).toContain(ev.attributes["event.name"]);
+      // ⚠️ WAS `expect(x).toBe(x)` — a tautology that could not fail. It intended to
+      // pin the name onto the envelope, so it now compares against the stream's own
+      // declared name.
+      expect(ev.attributes["event.name"]).toBe(githubEventName(key, { __ts: 1, __id: "k", ...row }));
+      // ⛔ CONSUMED, not DISPATCH-CLASS. This asserted `GITHUB_DISPATCH_CLASS_NAMES`,
+      // which is `consumed − uncovered` evaluated with NO replica handle — the safe
+      // static answer. `check_suite.completed` is deliberately absent from it while
+      // still being a name this producer builds on a 0.1.18 host, so the old form
+      // would force the static list to over-claim coverage in order to stay green.
+      // What every built envelope must satisfy is that the ROUTER consumes its name.
+      expect(GITHUB_CONSUMED_NAMES).toContain(ev.attributes["event.name"]);
     });
   }
 });
@@ -416,5 +431,162 @@ describe("⭐ github.push from push_events is byte-identical to the pushes copy 
 
   test("a row with no ref declines", () => {
     expect(classifyGithubRow("pushEvent", { __ts: 5, __id: "d1", repo_id: "o/r", ref: "" }).emit).toBe(false);
+  });
+});
+
+describe("CTC-712 — github.check_suite.completed reproduces the webhook, and routes", () => {
+  const row = (over = {}) => ({
+    __ts: 1000, __id: "cs1",
+    repo_id: "o/r", check_suite_id: "cs1", head_sha: "abc", head_branch: "topic",
+    status: "completed", conclusion: "success", pull_request_numbers: "[7]",
+    ...over,
+  });
+  const ev = (over) => buildGithubEvent("checkSuiteCompleted", row(over), SEAMS);
+
+  test("the attributes the consumer and the ledger read", () => {
+    const a = ev().attributes;
+    expect(a["event.name"]).toBe("github.check_suite.completed");
+    expect(a["vcs.repository.name"]).toBe("o/r");
+    // ⛔ THE ROUTE. router.mjs:1497 reaches an interest only through the PR number.
+    expect(a["vcs.pr.number"]).toBe(7);
+    expect(a["cicd.pipeline.run.status"]).toBe("completed");
+    expect(a["cicd.pipeline.run.conclusion"]).toBe("success");
+    expect(a["vcs.revision"]).toBe("abc");
+    expect(a["event.entity"]).toBe("check_suite");
+    expect(a["event.action"]).toBe("completed");
+    expect(a["event.label"]).toBe("PR #7");
+  });
+
+  test("the payload the webhook carries — and nothing it does not", () => {
+    const p = ev().body.payload;
+    expect(p.conclusion).toBe("success");
+    expect(p.status).toBe("completed");
+    expect(p.prNumbers).toEqual([7]);
+    // ⛔ `head_branch` IS in the row and the webhook parses it into `headRef` and then
+    // DROPS it. Emitting it would be an improvement, and an improvement is a
+    // divergence the ledger would report on every event. Same rule as threadId: 0.
+    expect(p.headRef).toBeUndefined();
+    expect(p.headBranch).toBeUndefined();
+  });
+
+  test("⛔ vcs.pr.number is the FIRST entry, and the payload keeps the whole list", () => {
+    // The webhook sets the attribute from prNumbers[0] and carries the full array in
+    // the payload. Reproducing only one half diverges on whichever the ledger compares.
+    const e = ev({ pull_request_numbers: "[11,12]" });
+    expect(e.attributes["vcs.pr.number"]).toBe(11);
+    expect(e.body.payload.prNumbers).toEqual([11, 12]);
+    expect(e.attributes["event.label"]).toBe("PR #11");
+  });
+
+  test("⚠️ conditional attributes are ABSENT, not empty, when their source is", () => {
+    // The webhook sets vcs.revision only for a truthy sha and the conclusion attribute
+    // only for a non-null conclusion. Emitting "" / null unconditionally is the
+    // `pr.merged` vcs.revision mistake pointing the other way.
+    const e = ev({ head_sha: "", conclusion: null });
+    expect("vcs.revision" in e.attributes).toBe(false);
+    expect("cicd.pipeline.run.conclusion" in e.attributes).toBe(false);
+    expect(e.body.payload.conclusion).toBeNull();
+    expect(e.body.message).toBe("github.check_suite.completed for o/r");
+  });
+
+  test("severity follows the webhook's conclusionSeverity — only failure/timed_out WARN", () => {
+    expect(ev({ conclusion: "success" }).severityText).toBe("INFO");
+    expect(ev({ conclusion: "cancelled" }).severityText).toBe("INFO");
+    expect(ev({ conclusion: "failure" }).severityText).toBe("WARN");
+    expect(ev({ conclusion: "timed_out" }).severityText).toBe("WARN");
+  });
+
+  test("the message reproduces the webhook's template, conclusion in parentheses", () => {
+    expect(ev().body.message).toBe("github.check_suite.completed for o/r (success)");
+  });
+});
+
+describe("CTC-712 — a suite with no PR association DECLINES, visibly", () => {
+  const base = {
+    __ts: 1000, __id: "cs1", repo_id: "o/r", check_suite_id: "cs1", head_sha: "abc",
+    status: "completed", conclusion: "success",
+  };
+
+  test("⛔ the 760 un-backfilled rows decline by name, they do not emit unroutable events", () => {
+    // Migration 0028 is an additive ADD COLUMN with no backfill, so every suite row
+    // predating the 0.1.18 pin has this NULL. An event without a PR number still
+    // LOOKS emitted and reaches no interest — worse than a decline, which is counted.
+    for (const v of [null, undefined, "", "[]", "null", "not json", "{}", "[0]", '["7"]']) {
+      const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: v });
+      expect(c.emit).toBe(false);
+      expect(c.reason).toBe("no-pr-association:not-backfilled");
+    }
+  });
+
+  test("a populated association emits — the positive control on the decline above", () => {
+    const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: "[7]" });
+    expect(c.emit).toBe(true);
+    expect(c.reason).toBeNull();
+  });
+
+  test("the decline is a DECLINE, never fatal — un-arming the producer would not fix a row", () => {
+    const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: null });
+    expect(c.fatal).toBeUndefined();
+  });
+
+  test("parseCheckSuitePrNumbers accepts both serialisations and rejects everything else", () => {
+    expect(parseCheckSuitePrNumbers("[7]")).toEqual([7]);
+    expect(parseCheckSuitePrNumbers("[7,9]")).toEqual([7, 9]);
+    // the webhook's own object form, in case the mirror serialises it verbatim
+    expect(parseCheckSuitePrNumbers('[{"number":7},{"number":9}]')).toEqual([7, 9]);
+    expect(parseCheckSuitePrNumbers([7, 9])).toEqual([7, 9]);
+    // ⛔ every unusable form is [], which is a decline — never a partial or a guess
+    expect(parseCheckSuitePrNumbers("[0]")).toEqual([]);
+    expect(parseCheckSuitePrNumbers('["7"]')).toEqual([]);
+    expect(parseCheckSuitePrNumbers("{}")).toEqual([]);
+    expect(parseCheckSuitePrNumbers("nonsense")).toEqual([]);
+    expect(parseCheckSuitePrNumbers(null)).toEqual([]);
+    // a mixed list keeps only the usable entries rather than failing whole
+    expect(parseCheckSuitePrNumbers('[7,"x",0,9]')).toEqual([7, 9]);
+  });
+});
+
+describe("CTC-712 — the edge identity survives a re-read and distinguishes a re-run", () => {
+  const row = (ts, conclusion) => ({
+    __ts: ts, __id: "cs1", repo_id: "o/r", check_suite_id: "cs1",
+    status: "completed", conclusion, pull_request_numbers: "[7]",
+  });
+
+  test("a re-read of the same completion is byte-identical", () => {
+    // The settle window re-reads every row each tick; an unstable id would make the
+    // seen-set useless and every suite would emit once per tick.
+    expect(githubEdgeId("checkSuiteCompleted", row(1000, "success")))
+      .toBe(githubEdgeId("checkSuiteCompleted", row(1000, "success")));
+  });
+
+  test("⛔ a rerequested suite REUSES its id and must still be a distinct edge", () => {
+    // GitHub's `rerequested` reuses check_suite_id, so the PK alone would suppress the
+    // re-run's completion as a re-read — and under enforce the merge gate would wait
+    // forever on a CI pass that already happened. The COORDINATE is what separates
+    // them, which is what `mutableRow` folds in.
+    const first = githubEdgeId("checkSuiteCompleted", row(1000, "failure"));
+    const rerun = githubEdgeId("checkSuiteCompleted", row(2000, "success"));
+    expect(rerun).not.toBe(first);
+    // ⛔ PINNED EXACTLY. `not.toBe` alone passed even with the fold hard-coded back to
+    // `row.after` — the timestamps differed, so the assertion was satisfied by
+    // something other than the mechanism it named. A mutation caught that; the exact
+    // string is what closes it.
+    expect(first).toBe("gh:checkSuiteCompleted:cs1:1000:");
+    expect(rerun).toBe("gh:checkSuiteCompleted:cs1:2000:");
+  });
+
+  test("⛔ WITHOUT the coordinate fold, a re-run would be suppressed — the control", () => {
+    // Proves the previous test is about `mutableRow` and not about the id happening to
+    // vary: a stream with no fold yields the SAME id for both completions.
+    const bare = (ts) => githubEdgeId("prOpened", { __ts: ts, __id: "o/r#7", repo_id: "o/r", number: 7 });
+    expect(bare(1000)).toBe(bare(2000));
+  });
+
+  test("⛔ the fold reads the STREAM's columns — a push id is unchanged by this change", () => {
+    // Regression guard on the generalisation: `githubEdgeId` used to hard-code
+    // `row.after`, and a stream-driven version that dropped push's column would
+    // collapse push identity back to the ref and kill github.push after one push.
+    const push = { __ts: 1000, __id: "o/r@refs/heads/main", repo_id: "o/r", ref: "refs/heads/main", after: "sha-a" };
+    expect(githubEdgeId("push", push)).toBe("gh:push:o/r@refs/heads/main:1000:sha-a");
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
@@ -19,6 +19,8 @@ import { readGithubFeedConfig } from "./config.mjs";
 import { createCaptureSink } from "./cloud-feed-capture.mjs";
 import { defaultReadyPath, readReadyState } from "./github-feed-ready.mjs";
 import { resolveAccount } from "./github-feed-timer.mjs";
+import { githubSuppressibleNames, GITHUB_SUPPRESSIBLE_NAMES } from "./github-feed-gate.mjs";
+import { createGithubFeedSource } from "./github-feed-source.mjs";
 import { join } from "node:path";
 
 /**
@@ -30,6 +32,52 @@ import { join } from "node:path";
  * longer latch on top of the one the staleness bound exists to break.
  */
 export const READY_CACHE_MS = 1000;
+
+/**
+ * How long this host's COVERAGE answer is reused.
+ *
+ * ⛔ IT MUST BE RE-READ, NOT RESOLVED ONCE AT BOOT, and the rollout is exactly why.
+ * Both capabilities appear when the cloud-sync WRITER restarts and runs its
+ * migrations — an event this process does not participate in and is not notified of.
+ * A boot-only read would leave a broker that started before the 0.1.18 restart
+ * believing `check_suite.completed` is uncovered for the rest of its life, and the
+ * operator would have to know to restart a second daemon to collect a capability
+ * that had already arrived.
+ *
+ * 30 s: two orders of magnitude cheaper than the readiness read it sits beside (a
+ * `PRAGMA table_info` on an open handle, not a file read), and it bounds how long a
+ * newly-migrated host keeps under-reporting its own coverage.
+ */
+export const COVERAGE_CACHE_MS = 30_000;
+
+/**
+ * Probe this replica for the two capabilities the suppressible set depends on.
+ *
+ * ⛔ FAILS CLOSED, AND "CLOSED" HERE MEANS THE PRE-CAPABILITY ANSWER — `pushIsLossy:
+ * true`, `checkSuiteHasPrAssociation: false` — which yields the smallest suppressible
+ * set and therefore leaves smee authoritative for both names. Every failure mode
+ * (no replica file, a locked or corrupt database, a throwing PRAGMA) lands there.
+ * The opposite default would let an unreadable database silently license suppression.
+ */
+export function readGithubCoverage({ sourceFactory = createGithubFeedSource } = {}) {
+  let src = null;
+  try {
+    // ⛔ THROUGH THE SOURCE HANDLE, not a hand-rolled `new Database(...)`. The handle
+    // already owns the read-only open, the busy timeout and the two capability
+    // predicates, and it is the object the producer's own tests drive — so the gate
+    // and the producer cannot come to different conclusions about the same replica.
+    src = sourceFactory();
+    return {
+      pushIsLossy: src.pushIsLossy(),
+      checkSuiteHasPrAssociation: src.checkSuiteHasPrAssociation(),
+      ok: true,
+    };
+  } catch {
+    return { pushIsLossy: true, checkSuiteHasPrAssociation: false, ok: false };
+  } finally {
+    try { src?.close(); } catch { /* best effort */ }
+  }
+}
 
 export function defaultGithubCapturePath(orchDir, account = "tenant-0") {
   return join(orchDir, "capture", `github-suppressed-${account}.jsonl`);
@@ -51,6 +99,7 @@ export function createGithubFeedGate({
   now = () => Date.now(),
   readState = readReadyState,
   captureFactory = createCaptureSink,
+  readCoverage = readGithubCoverage,
   logger = null,
 } = {}) {
   if (config.mode === "off") return null;
@@ -73,10 +122,56 @@ export function createGithubFeedGate({
     return cached;
   };
 
+  let coverageAt = -Infinity;
+  let coverageSet = GITHUB_SUPPRESSIBLE_NAMES;
+  let coverageState = { pushIsLossy: true, checkSuiteHasPrAssociation: false, ok: false };
+
+  const resolveSuppressible = () => {
+    const t = now();
+    if (t - coverageAt < COVERAGE_CACHE_MS) return coverageSet;
+    // ⛔ THIS RUNS ON THE BROKER'S TAIL, WHICH SEES EVERY EVENT THE FLEET APPENDS.
+    // `readGithubCoverage` catches internally, but this seam is injectable and the
+    // caller's implementation is not this module's to trust — an escaping throw here
+    // would take down routing for the whole fleet to answer a question whose safe
+    // answer is already known. Caught, and degraded to the pre-capability set: the
+    // same verdict an unreadable replica produces.
+    let next;
+    try {
+      next = readCoverage();
+    } catch {
+      next = { pushIsLossy: true, checkSuiteHasPrAssociation: false, ok: false };
+    }
+    coverageAt = t;
+    // Announce only on CHANGE. This runs on the broker's hot tail; a line per event —
+    // or even per cache miss — is the flood, and the thing an operator needs to see is
+    // the moment a host's coverage moved, which is rare and load-bearing.
+    if (
+      next.pushIsLossy !== coverageState.pushIsLossy ||
+      next.checkSuiteHasPrAssociation !== coverageState.checkSuiteHasPrAssociation ||
+      next.ok !== coverageState.ok
+    ) {
+      coverageSet = githubSuppressibleNames(next);
+      logger?.info?.(
+        { ...next, suppressible: coverageSet.length, names: coverageSet },
+        "github-feed gate: coverage changed",
+      );
+      coverageState = next;
+    }
+    return coverageSet;
+  };
+
   logger?.info?.(
     { mode: config.mode, readyFile, capture: capture.path, cacheMs: READY_CACHE_MS },
     "github-feed gate: armed",
   );
 
-  return { mode: config.mode, isReady, capture, readyPath: readyFile };
+  const gate = { mode: config.mode, isReady, capture, readyPath: readyFile };
+  // ⭐ A GETTER, so `decideDispatch`'s destructure re-resolves it. A plain property
+  // would freeze this host's coverage at gate-construction time, which is boot — and
+  // both capabilities arrive later, at a writer restart this process never sees.
+  Object.defineProperty(gate, "suppressible", {
+    enumerable: true,
+    get: resolveSuppressible,
+  });
+  return gate;
 }

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
@@ -4,7 +4,13 @@ import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { READY_CACHE_MS, createGithubFeedGate, defaultGithubCapturePath } from "./github-feed-gate-install.mjs";
+import {
+  COVERAGE_CACHE_MS,
+  READY_CACHE_MS,
+  createGithubFeedGate,
+  defaultGithubCapturePath,
+  readGithubCoverage,
+} from "./github-feed-gate-install.mjs";
 import { staleWindowMs } from "./github-feed-ready.mjs";
 import { decideDispatch } from "./github-feed-gate.mjs";
 
@@ -111,12 +117,19 @@ describe("the installed gate composes with decideDispatch as one decision", () =
     body: { payload: {} },
   });
 
-  const gateWith = (ready) =>
+  // ⛔ `readCoverage` IS INJECTED, and it must be. Without it the factory falls back
+  // to the real `readGithubCoverage`, which opens THIS MACHINE's replica — so the
+  // suite's verdict would depend on which schema the host running CI happens to be
+  // pinned to, and every assertion below would silently change meaning the day
+  // 0.1.18 rolled. The default path is exercised deliberately, once, further down.
+  const COVERAGE_0117 = () => ({ pushIsLossy: false, checkSuiteHasPrAssociation: false, ok: true });
+  const gateWith = (ready, readCoverage = COVERAGE_0117) =>
     createGithubFeedGate({
       orchDir: tmp,
       config: { mode: "enforce", intervalSec: 30 },
       captureFactory: stubCapture,
       readState: () => ready,
+      readCoverage,
     });
 
   test("ready producer → a covered name is suppressed", () => {
@@ -136,7 +149,7 @@ describe("the installed gate composes with decideDispatch as one decision", () =
     // now; check_suite's TABLE landed but the PR association did not (CTC-712).
     const v = decideDispatch(smee("github.check_suite.completed"), gateWith({ ready: true, reason: "producer-ready" }));
     expect(v.suppress).toBe(false);
-    expect(v.reason).toContain("CTC-667");
+    expect(v.reason).toContain("CTC-712");
   });
 });
 
@@ -156,5 +169,102 @@ describe("the capture path is per account and is not the event log", () => {
         capturePath: join(tmp, "events", "2026-08.jsonl"),
       }),
     ).toThrow();
+  });
+});
+
+describe("CTC-712 — the gate's coverage tracks the replica, and re-reads it", () => {
+  const stubCapture2 = () => ({ path: join(tmp, "cap2.jsonl"), append: () => {} });
+  const smee2 = (name) => ({
+    attributes: { "event.name": name, "webhook.delivery.id": "d1" },
+    body: { payload: {} },
+  });
+
+  const at = (checkSuiteHasPrAssociation, pushIsLossy = false) =>
+    () => ({ pushIsLossy, checkSuiteHasPrAssociation, ok: true });
+
+  const mk = (readCoverage, now = () => 0) =>
+    createGithubFeedGate({
+      orchDir: tmp,
+      config: { mode: "enforce", intervalSec: 30 },
+      captureFactory: stubCapture2,
+      readState: () => ({ ready: true, reason: "producer-ready" }),
+      readCoverage,
+      now,
+    });
+
+  test("a 0.1.18 host suppresses check_suite; a 0.1.17 host does not", () => {
+    expect(decideDispatch(smee2("github.check_suite.completed"), mk(at(true))).suppress).toBe(true);
+    expect(decideDispatch(smee2("github.check_suite.completed"), mk(at(false))).suppress).toBe(false);
+  });
+
+  test("⛔ the coverage is RE-READ after the TTL — a writer restart is invisible to this process", () => {
+    // Both capabilities appear when the cloud-sync writer restarts and migrates. This
+    // process is never told. A boot-only read would leave a broker that started before
+    // the 0.1.18 restart under-reporting its own coverage for the rest of its life,
+    // and an operator would have to know to bounce a second daemon to collect it.
+    let assoc = false;
+    let t = 0;
+    const gate = mk(() => ({ pushIsLossy: false, checkSuiteHasPrAssociation: assoc, ok: true }), () => t);
+
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(false);
+    assoc = true;                       // the migration lands
+    t = COVERAGE_CACHE_MS - 1;          // still inside the cache window
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(false);
+    t = COVERAGE_CACHE_MS + 1;          // past it
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(true);
+  });
+
+  test("⚠️ and it re-reads in the LOSING direction too — a rollback is picked up", () => {
+    let assoc = true;
+    let t = 0;
+    const gate = mk(() => ({ pushIsLossy: false, checkSuiteHasPrAssociation: assoc, ok: true }), () => t);
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(true);
+    assoc = false;
+    t = COVERAGE_CACHE_MS + 1;
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(false);
+  });
+
+  test("⛔ a throwing coverage probe leaves smee authoritative for BOTH gated names", () => {
+    const gate = mk(() => { throw new Error("replica locked"); });
+    // The whole point of failing closed: an unreadable database must not license
+    // suppression. It must also not take the gate down for names that are covered
+    // regardless — pr.opened still suppresses.
+    expect(() => decideDispatch(smee2("github.check_suite.completed"), gate)).not.toThrow();
+    expect(decideDispatch(smee2("github.check_suite.completed"), gate).suppress).toBe(false);
+    expect(decideDispatch(smee2("github.push"), gate).suppress).toBe(false);
+    expect(decideDispatch(smee2("github.pr.opened"), gate).suppress).toBe(true);
+  });
+
+  test("⛔ readGithubCoverage FAILS CLOSED on an unusable replica — and says ok:false", () => {
+    const bad = readGithubCoverage({ sourceFactory: () => { throw new Error("no replica"); } });
+    expect(bad).toEqual({ pushIsLossy: true, checkSuiteHasPrAssociation: false, ok: false });
+    // ⚠️ `ok` is what separates "measured as uncovered" from "could not look". Without
+    // it the two are byte-identical to every caller, which is the defect class this
+    // repo keeps re-learning.
+    const good = readGithubCoverage({
+      sourceFactory: () => ({
+        pushIsLossy: () => false, checkSuiteHasPrAssociation: () => true, close: () => {},
+      }),
+    });
+    expect(good).toEqual({ pushIsLossy: false, checkSuiteHasPrAssociation: true, ok: true });
+  });
+
+  test("⭐ THE DEFAULT PATH RUNS — readGithubCoverage() with no arguments at all", () => {
+    // ⛔ Every test above injects `sourceFactory`, so none of them would notice if the
+    // real default could not execute. It could not: the first cut reached for
+    // `require("bun:sqlite")` inside an ESM module, which throws on every call and is
+    // caught by the same handler that catches a missing replica — so the probe would
+    // have returned ok:false forever, on every host, and the gate would have silently
+    // refused to ever suppress either name. Nothing else here can see that.
+    const r = readGithubCoverage();
+    expect(typeof r.ok).toBe("boolean");
+    expect(typeof r.pushIsLossy).toBe("boolean");
+    expect(typeof r.checkSuiteHasPrAssociation).toBe("boolean");
+    if (!r.ok) {
+      console.log("INCONCLUSIVE: no readable replica on this host — the default path could not be proven to reach one.");
+      return;
+    }
+    // A replica IS present and was opened by the default factory: that is the claim.
+    expect(r.ok).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-gate.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.mjs
@@ -89,6 +89,42 @@ export function githubLossyNames(pushIsLossy = PUSH_IS_LOSSY) {
 
 export const GITHUB_LOSSY_NAMES = githubLossyNames();
 
+/**
+ * ⛔ THE UNCOVERED LIST IS A PROPERTY OF THE REPLICA, NOT OF THIS FILE — the same
+ * correction CTC-704 forced on `PUSH_IS_LOSSY`, owed again one name over.
+ *
+ * `github.check_suite.completed` is emittable exactly when this host's replica has
+ * `check_suites.pull_request_numbers` (CTC-712, schema 0.1.18). The pin rolls as a
+ * CANARY — mini-2, then mini — so between the two writer restarts one host can emit
+ * it and the other cannot, and a constant is necessarily wrong on one of them. Wrong
+ * in the dangerous direction it means: smee suppressed for a name this host produces
+ * nothing for, so the CI wait hangs with no second copy.
+ *
+ * ⭐ Default `false` ⇒ UNCOVERED. A caller with no replica handle reports less
+ * coverage than it may have, which leaves smee authoritative — the recoverable error.
+ */
+export function githubUncoveredNames(checkSuiteHasPrAssociation = false) {
+  return Object.freeze(checkSuiteHasPrAssociation ? [] : ["github.check_suite.completed"]);
+}
+
+/**
+ * The suppressible set for ONE host, derived from that host's two capabilities.
+ *
+ * ⚠️ BOTH DEFAULTS ARE THE PRE-CAPABILITY ANSWER, so calling this with no arguments
+ * reproduces today's static set exactly. That is what makes the injection safe to add
+ * before anything is wired to it: the wiring changes behaviour, the seam does not.
+ */
+export function githubSuppressibleNames({
+  pushIsLossy = PUSH_IS_LOSSY,
+  checkSuiteHasPrAssociation = false,
+} = {}) {
+  return leafComputeSuppressible({
+    consumed: LEAF_CONSUMED_NAMES,
+    uncovered: githubUncoveredNames(checkSuiteHasPrAssociation),
+    lossy: githubLossyNames(pushIsLossy),
+  });
+}
+
 /** Re-exported from the leaf so producer, gate and doctor read ONE source. */
 export const GITHUB_CONSUMED_NAMES = LEAF_CONSUMED_NAMES;
 export const GITHUB_UNCOVERED_NAMES = LEAF_UNCOVERED_NAMES;
@@ -151,9 +187,21 @@ export function sourceOf(event) {
  * `suppress: true` means "do not route this event; write it to the capture sink
  * instead". It never means "discard".
  */
-export function decideDispatch(event, { mode, isReady = null } = {}) {
+export function decideDispatch(event, { mode, isReady = null, suppressible = null } = {}) {
   const name = getEventName(event);
   const source = sourceOf(event);
+  // ⛔ THE HOST'S SET, OR THE STATIC ONE — never a merge of the two. `suppressible`
+  // is this replica's answer (see `githubSuppressibleNames`); omitting it keeps the
+  // module constant, which under-reports coverage and therefore leaves smee
+  // authoritative. Falling back on ANY non-Set value is deliberate: a caller that
+  // passes something malformed gets the safe set rather than a crash in the tailer's
+  // hot path or, worse, an empty set that suppresses nothing and dispatches both.
+  const suppressibleSet =
+    suppressible instanceof Set
+      ? suppressible
+      : Array.isArray(suppressible)
+        ? new Set(suppressible)
+        : SUPPRESSIBLE_SET;
 
   if (!DISPATCH_CLASS_SET.has(name)) {
     return { suppress: false, reason: "not-dispatch-class", source, name };
@@ -183,7 +231,7 @@ export function decideDispatch(event, { mode, isReady = null } = {}) {
     // dispatching (smee is unsuppressed for excluded names by the branch below).
     // Refusing on both sides makes the two halves of the exclusion agree by
     // construction rather than by everyone remembering to change them together.
-    if (!SUPPRESSIBLE_SET.has(name)) {
+    if (!suppressibleSet.has(name)) {
       return {
         suppress: true,
         reason: `feed-excluded:${EXCLUSION_REASONS[name] ?? "unknown"}`,
@@ -207,7 +255,7 @@ export function decideDispatch(event, { mode, isReady = null } = {}) {
   // producer ready" first would imply that a ready producer could earn the right to
   // suppress `github.pr.merged` — which is the single worst outcome this feature
   // has (the merge→deploy chain, fleet-wide, with no second copy).
-  if (!SUPPRESSIBLE_SET.has(name)) {
+  if (!suppressibleSet.has(name)) {
     return {
       suppress: false,
       reason: EXCLUSION_REASONS[name] ?? "no-replacement:unknown",

--- a/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate.test.mjs
@@ -9,6 +9,8 @@ import {
   computeSuppressible,
   decideDispatch,
   githubLossyNames,
+  githubSuppressibleNames,
+  githubUncoveredNames,
   isGithubDispatchClass,
   sourceOf,
 } from "./github-feed-gate.mjs";
@@ -118,10 +120,10 @@ describe("⛔ enforce must NOT suppress smee for a name with no faithful replace
     expect(v.reason).toBe("smee-captured");
   });
 
-  test("github.check_suite.completed survives — no suite row (CTC-667 item 4)", () => {
+  test("github.check_suite.completed survives — no PR association until 0.1.18 (CTC-712)", () => {
     const v = decideDispatch(smee("github.check_suite.completed"), armed);
     expect(v.suppress).toBe(false);
-    expect(v.reason).toBe("no-replacement:no-suite-row:CTC-667-item-4");
+    expect(v.reason).toBe("no-replacement:no-pr-association-until-0.1.18:CTC-712");
   });
 
   test("⛔ github.push survives — the collapse loses an ARRIVAL, not a value (CTC-704)", () => {
@@ -150,7 +152,7 @@ describe("⛔ enforce must NOT suppress smee for a name with no faithful replace
     //    whenever the producer happens to be un-armed, and the two collapse.
     const v = decideDispatch(smee("github.check_suite.completed"), { mode: "enforce", isReady: () => false });
     expect(v.suppress).toBe(false);
-    expect(v.reason).toBe("no-replacement:no-suite-row:CTC-667-item-4");
+    expect(v.reason).toBe("no-replacement:no-pr-association-until-0.1.18:CTC-712");
     expect(v.reason).not.toMatch(/^enforce-not-armed/);
   });
 });
@@ -203,7 +205,7 @@ describe("the feed side is decided by its OWN stamp (CTL-1901's asymmetry), neve
     // dispatch — the double-dispatch the gate exists to prevent.
     const v = decideDispatch(feed("github.check_suite.completed"), { mode: "enforce", isReady: () => true });
     expect(v.suppress).toBe(true);
-    expect(v.reason).toBe("feed-excluded:no-replacement:no-suite-row:CTC-667-item-4");
+    expect(v.reason).toBe("feed-excluded:no-replacement:no-pr-association-until-0.1.18:CTC-712");
   });
 });
 
@@ -278,5 +280,77 @@ describe("⛔ ONE source of truth for the name lists — CI caught the half-done
     const excluded = GITHUB_CONSUMED_NAMES.filter((n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n));
     for (const n of GITHUB_UNCOVERED_NAMES) expect(excluded).toContain(n);
     expect(GITHUB_UNCOVERED_NAMES).not.toContain("github.pr.merged");
+  });
+});
+
+describe("CTC-712 / CTC-704 — coverage is a property of the HOST, not of this file", () => {
+  test("⛔ both defaults are the PRE-capability answer, so an un-wired caller is safe", () => {
+    // The single most important property of this seam: adding it changed nothing.
+    // A caller with no replica handle gets exactly today's static set.
+    expect(githubSuppressibleNames()).toEqual(GITHUB_SUPPRESSIBLE_NAMES);
+    expect(githubUncoveredNames()).toEqual(["github.check_suite.completed"]);
+    expect(githubLossyNames()).toEqual(["github.push"]);
+  });
+
+  test("⭐ a 0.1.18 replica with push_events covers ALL TWELVE consumed names", () => {
+    // This is the retirement gate stated as an assertion: the smee tunnel can only be
+    // switched off when nothing is left for it to carry.
+    const full = githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: true });
+    expect([...full].sort()).toEqual([...GITHUB_CONSUMED_NAMES].sort());
+    expect(full.length).toBe(12);
+  });
+
+  test("each capability independently un-blocks exactly its own name", () => {
+    const onlyPush = githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: false });
+    expect(onlyPush).toContain("github.push");
+    expect(onlyPush).not.toContain("github.check_suite.completed");
+
+    const onlySuite = githubSuppressibleNames({ pushIsLossy: true, checkSuiteHasPrAssociation: true });
+    expect(onlySuite).toContain("github.check_suite.completed");
+    expect(onlySuite).not.toContain("github.push");
+  });
+
+  test("⛔ a host WITHOUT the capability keeps smee authoritative for that name", () => {
+    // The mixed-pin case, which is a live condition during the canary. Suppressing
+    // here would leave the CI wait with no producer and no tunnel.
+    const set = githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: false });
+    const v = decideDispatch(smee("github.check_suite.completed"), {
+      mode: "enforce", isReady: () => true, suppressible: set,
+    });
+    expect(v.suppress).toBe(false);
+    expect(v.reason).toContain("CTC-712");
+  });
+
+  test("⭐ and WITH it, the same event on the same host is suppressed", () => {
+    // The positive control on the test above — otherwise "not suppressed" could be
+    // coming from anywhere in the gate.
+    const set = githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: true });
+    const v = decideDispatch(smee("github.check_suite.completed"), {
+      mode: "enforce", isReady: () => true, suppressible: set,
+    });
+    expect(v.suppress).toBe(true);
+    expect(v.reason).toBe("smee-captured");
+  });
+
+  test("⛔ a malformed suppressible argument falls back to the SAFE set, never to empty", () => {
+    // An empty set suppresses nothing on the smee side AND refuses every feed event —
+    // survivable. A caller passing junk that got coerced to `new Set()` on the FEED
+    // side while smee also dispatched would be the double-dispatch. Falling back to
+    // the module constant keeps both halves agreeing.
+    for (const junk of [undefined, null, 0, "github.push", {}]) {
+      const v = decideDispatch(smee("github.pr.opened"), {
+        mode: "enforce", isReady: () => true, suppressible: junk,
+      });
+      expect(v.suppress).toBe(true);
+    }
+  });
+
+  test("an ARRAY is accepted as well as a Set — the source of truth is a frozen array", () => {
+    expect(Array.isArray(githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: true }))).toBe(true);
+    const v = decideDispatch(smee("github.push"), {
+      mode: "enforce", isReady: () => true,
+      suppressible: githubSuppressibleNames({ pushIsLossy: false, checkSuiteHasPrAssociation: true }),
+    });
+    expect(v.suppress).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+// github-feed-parity-run.mjs — CTL-1929. The ledger's CLI: window the two streams and
+// hand them to `compareGithubStreams`.
+//
+// ⛔ IT STREAMS BOTH FILES, AND THAT IS NOT A STYLE CHOICE. The ad-hoc runner this
+// replaces read the month's event log with `readFileSync`. That worked until
+// 2026-08-18, when `~/catalyst/events/2026-08.jsonl` passed **1.59 GB** and Node's
+// 512 MB string cap turned every run into `ERR_STRING_TOO_LONG`. The instrument the
+// cutover is judged by stopped working, mid-cutover, for a reason unrelated to the
+// thing it measures — so the fix is committed rather than left in /tmp.
+//
+// ⚠️ THE WINDOW IS THE CALLER'S, deliberately. `compareGithubStreams` is pure and
+// takes two already-windowed arrays; keeping the windowing out here is what lets the
+// comparator be unit-tested without a filesystem.
+//
+// Usage: bun github-feed-parity-run.mjs <ISO-lo> <ISO-hi> [--json]
+// Exit:  0 clean · 2 diverged · 3 inconclusive (the Linear leg's contract).
+
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { compareGithubStreams, parityExitCode } from "./github-feed-parity.mjs";
+
+const [lo, hi, ...rest] = process.argv.slice(2);
+const asJson = rest.includes("--json");
+if (!lo || !hi) {
+  console.error("usage: github-feed-parity-run.mjs <ISO-lo> <ISO-hi> [--json]");
+  process.exit(3);
+}
+
+const CATALYST = process.env.CATALYST_DIR ?? join(homedir(), "catalyst");
+const account = process.env.CATALYST_GITHUB_FEED_ACCOUNT ?? "tenant-0";
+const shadowPath = process.env.CATALYST_GITHUB_FEED_SHADOW
+  ?? join(CATALYST, "execution-core", "shadow", `github-feed-${account}.jsonl`);
+const eventsPath = process.env.CATALYST_EVENT_LOG
+  ?? join(CATALYST, "events", `${new Date(lo).toISOString().slice(0, 7)}.jsonl`);
+
+const inWindow = (e) => {
+  const t = e?.ts;
+  return typeof t === "string" && t >= lo && t < hi;
+};
+
+let torn = 0;
+
+async function* jsonl(path) {
+  const rl = createInterface({ input: createReadStream(path), crlfDelay: Infinity });
+  for await (const line of rl) {
+    if (!line) continue;
+    // ⚠️ A torn line is SKIPPED, never fatal — the same posture every other reader of
+    // this log takes (see docs/architecture.md). It is also counted, so a window full
+    // of damage cannot read as a window full of agreement.
+    try { yield JSON.parse(line); } catch { torn++; }
+  }
+}
+
+const feed = [];
+let feedLines = 0;
+let feedLast = null;
+for await (const e of jsonl(shadowPath)) {
+  feedLines++;
+  if (typeof e?.ts === "string") feedLast = e.ts;
+  if (inWindow(e)) feed.push(e);
+}
+
+const smee = [];
+let smeeSeen = 0;
+let smeeLast = null;
+for await (const e of jsonl(eventsPath)) {
+  const n = e?.attributes?.["event.name"];
+  if (typeof n !== "string" || !n.startsWith("github.")) continue;
+  // Our own copy is excluded by its positive provenance stamp, never by elimination.
+  if (e?.body?.payload?.source === "cloud-feed") continue;
+  smeeSeen++;
+  if (typeof e?.ts === "string") smeeLast = e.ts;
+  if (inWindow(e)) smee.push(e);
+}
+
+const report = compareGithubStreams(feed, smee);
+const code = parityExitCode(report);
+
+// ⛔ THE INSTRUMENT REPORTS ON ITSELF FIRST. An empty window is the ledger's most
+// dangerous output — `[].every()` is true — and "no events happened" is not
+// distinguishable from "I read the wrong file" without these lines. `*Last` is the
+// positive control: it should track real GitHub activity.
+const instrument = {
+  shadowPath, eventsPath,
+  feedLinesTotal: feedLines, feedLastTs: feedLast,
+  smeeGithubTotal: smeeSeen, smeeLastTs: smeeLast,
+  tornLines: torn,
+};
+
+if (asJson) {
+  console.log(JSON.stringify({ window: { lo, hi }, instrument, report, exit: code }, null, 2));
+} else {
+  console.log(`instrument: shadow lines=${feedLines} last=${feedLast} · smee github=${smeeSeen} last=${smeeLast} · torn=${torn}`);
+  console.log(`WINDOW ${lo} -> ${hi}`);
+  console.log(`feed ${feed.length} · smee ${smee.length}`);
+  console.log(`joined ${report.totals.joined} / agree ${report.totals.agree} · feed-unjoined ${report.totals.unjoined} · smee-unjoined ${report.smeeUnjoined} · unkeyable ${report.unkeyable}`);
+  for (const [n, v] of Object.entries(report.byName)) {
+    console.log(`   ${n.padEnd(38)} joined=${v.joined} agree=${v.agree} unjoined=${v.unjoined}`);
+  }
+  console.log("comparableRepos  :", JSON.stringify(report.comparableRepos));
+  console.log("feedOnlyRepos    :", JSON.stringify(report.feedOnlyRepos), "(superset — never blocks CLEAN)");
+  console.log("expectedAbsent   :", JSON.stringify(report.expectedAbsent));
+  console.log("unexplainedAbsent:", JSON.stringify(report.unexplainedAbsent));
+  console.log("inconclusive     :", JSON.stringify(report.inconclusive));
+  console.log(`clean = ${report.clean} · exit ${code}`);
+}
+process.exit(code);

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -105,6 +105,34 @@ const COMPARE_SPEC_DRAFT = {
     attrs: ["vcs.repository.name", "vcs.revision", "vcs.ref.name", "deployment.environment", "deployment.id", "event.label"],
     payload: ["deploymentId"],
   },
+  // ⭐ CTC-712 (schema 0.1.18). ⛔ `vcs.pr.number` is compared and must never move to
+  // OBSERVED_ONLY: it IS the route. `router.mjs:1497` reaches an interest only through
+  // `detail.prNumbers`, and a suite event whose PR association disagrees with the
+  // webhook's is one that wakes the wrong waiter or none — while every count still
+  // reads "emitted". That is the whole failure CTC-712 exists to close, so the ledger
+  // has to be able to see it.
+  //
+  // ⚠️ THE KEY IS COARSE, AND DELIBERATELY SO. Neither side carries `check_suite_id`
+  // (the webhook payload has no suite id in the envelope), and one head sha carried
+  // **10 distinct suite ids** on mini-2 — so no exact per-suite key is constructible
+  // from what both producers emit. The tuple below can therefore bucket several real
+  // suites together. That is safe ONLY because the index compares by MULTIPLICITY:
+  // N feed events under a key must meet N smee events under it, so a dropped or
+  // duplicated suite still surfaces as an unjoined count rather than being absorbed.
+  // With a single-value index this key would be a false-clean generator.
+  "github.check_suite.completed": {
+    key: (e) =>
+      `cs:${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}` +
+      `|${e.attributes?.["vcs.revision"] ?? ""}|${e.attributes?.["cicd.pipeline.run.conclusion"] ?? ""}`,
+    attrs: [
+      "vcs.repository.name", "vcs.pr.number", "vcs.revision",
+      "cicd.pipeline.run.status", "cicd.pipeline.run.conclusion",
+      "event.entity", "event.action", "event.label", "event.stream_class",
+    ],
+    // `prNumbers` is compared as a whole array, not just its head: the attribute
+    // carries only `[0]`, so a disagreement in the tail would otherwise be invisible.
+    payload: ["conclusion", "status", "prNumbers"],
+  },
   "github.push": {
     key: (e) => `p:${e.attributes?.["vcs.repository.name"]}|${e.attributes?.["vcs.ref.name"]}|${e.body?.payload?.headSha}`,
     attrs: ["vcs.repository.name", "vcs.ref.name", "vcs.revision", "event.entity", "event.action", "event.label"],
@@ -140,15 +168,18 @@ export const KNOWN_ABSENT = Object.freeze({
   // the merge→deploy chain was precisely the one this instrument was configured not
   // to notice. A ledger that cannot fail on a name is not measuring it.
   //
-  // ⛔ `check_suite.completed` STAYS, and NOT for the reason the entry used to give.
-  // The mirror does store a suite row now. What it does not store is the association
-  // the consumer keys on — `router.mjs:1497` reaches an interest only through
-  // `detail.prNumbers`, from `check_suite.pull_requests[].number`, which the mirror
-  // drops and `check_runs` cannot supply. The only derivation is a LAST-STATE join
-  // through `pull_requests.head_sha`, measured at 93/202 (46%) on mini-2 with the
-  // misses dominated by active PR branches whose head moved after the suite ran.
-  "github.check_suite.completed":
-    "CTC-712: check_suites carries no pull_requests association; the head_sha join resolves 46%",
+  // ⭐ `github.check_suite.completed` LEFT THIS TABLE when CTC-712 landed (schema
+  // 0.1.18, migration `0028_burly_nemesis`), and — exactly as with `pr.merged` before
+  // it — the removal IS the point rather than a side effect. While it sat here the
+  // ledger EXCUSED its absence, so the last name still keeping the smee tunnel alive
+  // was the one name the instrument was configured not to be able to fail on. A
+  // ledger that cannot fail on a name is not measuring it.
+  //
+  // ⚠️ THE TABLE IS NOW EMPTY, AND THAT IS LOAD-BEARING, not tidiness. `unexplained
+  // Absent` is computed as `absent − KNOWN_ABSENT`, so every consumed name that goes
+  // missing from the feed now blocks CLEAN. Adding an entry here is therefore a
+  // deliberate act of blinding the instrument, and should be argued for on those
+  // terms.
 });
 
 const nameOf = (e) => e?.attributes?.["event.name"];

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -174,14 +174,22 @@ describe("⛔ a consumed name that vanishes must not read as agreement", () => {
     { "vcs.repository.name": "o/r", "vcs.revision": "abc" },
     { conclusion: "success", status: "completed", prNumbers: [7] });
 
-  test("a DECLARED gap is reported as expected and stays clean", () => {
-    // ⚠️ The example is `check_suite.completed` alone now. `pr.merged` used to be
-    // here too and is not a declared gap any more (CTC-691 landed in schema 0.1.17),
-    // which the next test asserts from the other side.
+  test("⭐ check_suite.completed is NO LONGER a declared gap — a missing one breaks clean", () => {
+    // ⛔ THE LAST EXCUSED NAME. While it sat in KNOWN_ABSENT the ledger could not fail
+    // on the one name still keeping the smee tunnel alive, so a CLEAN verdict was
+    // silent about exactly the thing the cutover turns on. CTC-712 removed the reason
+    // for the excuse; this asserts the excuse went with it.
     const r = compareGithubStreams([comment(1)], [comment(1), suite]);
-    expect(r.expectedAbsent["github.check_suite.completed"]).toBe(1);
-    expect(r.unexplainedAbsent).toEqual({});
-    expect(r.clean).toBe(true);
+    expect(r.expectedAbsent["github.check_suite.completed"]).toBeUndefined();
+    expect(r.unexplainedAbsent["github.check_suite.completed"]).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⛔ KNOWN_ABSENT is EMPTY, and that is the invariant — not a tidy-up", () => {
+    // `unexplainedAbsent` is `absent − KNOWN_ABSENT`, so every entry here is a name
+    // the ledger is configured to be unable to fail on. An empty table means every
+    // consumed name that goes missing now blocks CLEAN.
+    expect(Object.keys(KNOWN_ABSENT)).toEqual([]);
   });
 
   test("⭐ pr.merged is NO LONGER a declared gap — a missing one now breaks clean", () => {
@@ -219,12 +227,10 @@ describe("⛔ a consumed name that vanishes must not read as agreement", () => {
     expect(r.inconclusive).toContain("smee-events-without-a-twin:1");
   });
 
-  test("the remaining declared gap names the ticket that closes it", () => {
-    // ⭐ One entry, not two. `pr.merged` left when CTC-691 landed.
-    expect(Object.keys(KNOWN_ABSENT)).toEqual(["github.check_suite.completed"]);
-    // ⚠️ And the ticket is CTC-712, not CTC-667: the suite TABLE exists now: what is
-    // missing is the pull_requests association the consumer keys on.
-    expect(KNOWN_ABSENT["github.check_suite.completed"]).toContain("CTC-712");
+  test("⛔ every consumed name is now failable — none is excused", () => {
+    // The general form of the two tests above, so a future re-added excuse has to be
+    // argued for against an assertion rather than slipped into a frozen object.
+    for (const n of Object.keys(COMPARE_SPEC)) expect(KNOWN_ABSENT[n]).toBeUndefined();
   });
 });
 
@@ -323,5 +329,56 @@ describe("⛔ the comparison is scoped to repos smee can actually deliver", () =
   test("smeeRepos collects the delivered set, ignoring blanks", () => {
     expect([...smeeRepos([smeePush, smeePush])]).toEqual(["o/shared"]);
     expect([...smeeRepos([ev("github.push", {}, {})])]).toEqual([]);
+  });
+});
+
+describe("CTC-712 — the check_suite compare spec can join, and can DIVERGE", () => {
+  const suiteEv = (over = {}) => ev(
+    "github.check_suite.completed",
+    {
+      "vcs.repository.name": "o/r", "vcs.pr.number": 7, "vcs.revision": "abc",
+      "cicd.pipeline.run.status": "completed", "cicd.pipeline.run.conclusion": "success",
+      "event.entity": "check_suite", "event.action": "completed",
+      "event.label": "PR #7", "event.stream_class": "coordination",
+      ...(over.attrs ?? {}),
+    },
+    { conclusion: "success", status: "completed", prNumbers: [7], ...(over.payload ?? {}) },
+  );
+
+  test("a matched pair joins and agrees", () => {
+    const r = compareGithubStreams([suiteEv()], [suiteEv()]);
+    expect(r.byName["github.check_suite.completed"].joined).toBe(1);
+    expect(r.byName["github.check_suite.completed"].agree).toBe(1);
+    expect(r.totals.smeeUnjoined).toBe(0);
+  });
+
+  test("⛔ a disagreeing PR association is a DIVERGENCE, not a pass", () => {
+    // The positive control that matters most: `vcs.pr.number` IS the route, so a
+    // ledger that could not fail on it would certify the exact defect CTC-712 fixed.
+    const feed = suiteEv();
+    const smeeSide = suiteEv({ payload: { prNumbers: [7, 9] } });
+    const r = compareGithubStreams([feed], [smeeSide]);
+    expect(r.byName["github.check_suite.completed"].joined).toBe(1);
+    expect(r.byName["github.check_suite.completed"].agree).toBe(0);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⛔ a conclusion disagreement is caught", () => {
+    const r = compareGithubStreams(
+      [suiteEv()],
+      [suiteEv({ attrs: { "cicd.pipeline.run.conclusion": "failure" }, payload: { conclusion: "failure" } })],
+    );
+    // A different conclusion changes the KEY as well, so this surfaces as two
+    // unjoined events rather than a disagreeing pair — either way, never as clean.
+    expect(r.clean).toBe(false);
+  });
+
+  test("⚠️ the coarse key still counts MULTIPLICITY — a dropped suite cannot hide", () => {
+    // Two real suites bucket under one key (no suite id is on either side). If the
+    // feed emits one where smee emitted two, that must surface, not be absorbed.
+    const r = compareGithubStreams([suiteEv()], [suiteEv(), suiteEv()]);
+    expect(r.totals.smeeUnjoined).toBe(1);
+    expect(r.clean).toBe(false);
+    expect(r.inconclusive.join("|")).toContain("smee-events-without-a-twin");
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-source.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.mjs
@@ -95,15 +95,29 @@
 //    "did this ref move", not "how many times" — so the collapse is survivable.
 //    It is declared here rather than discovered later, and `PUSH_IS_LOSSY` exists
 //    so a caller can assert on the fact rather than on a comment.
-// 2. `github.check_suite.completed` HAS NO STREAM AT ALL. The mirror accepts the
-//    `check_suite` payload and deliberately stores no row (`return []`), so there
-//    is nothing to page over. `check_runs` holds the constituent data (60,249 rows)
-//    but a suite is not reconstructable from it safely: one head sha carried **10
-//    distinct `check_suite_id`s** on mini-2, several with runs still incomplete, so
-//    "every run I can see has completed" fires early and green on a partial view —
-//    a false CI-pass on the merge gate. The derivation is CTC-667 item 4 and is
-//    theirs to declare; this module exports the gap as `UNBACKED_EVENT_NAMES`
-//    rather than inventing a second answer.
+// 2. `github.check_suite.completed` IS BACKED ONLY ON A 0.1.18 REPLICA, and the
+//    discriminator is a COLUMN, not a table. CTC-667 item 4 gave the suite a row
+//    (`check_suites`, 760 on mini-2) but not the association the consumer keys on;
+//    CTC-712 added `pull_request_numbers` in migration `0028_burly_nemesis`, an
+//    additive `ALTER TABLE ... ADD`.
+//
+//    ⛔ SO A HOST CAN HAVE THE TABLE AND STILL NOT BE ABLE TO EMIT. `tableExists`
+//    cannot see that: `buildStreamQuery` uses `SELECT *`, so on a 0.1.17 replica the
+//    query SUCCEEDS and every row simply lacks the column — the producer would emit
+//    suite events carrying no `vcs.pr.number`, which `router.mjs:1497` can reach no
+//    interest with. Those route-looking-but-unroutable events are worse than an
+//    absence, because an absence is counted. `requiresColumn` + `columnExists`
+//    resolve it from the replica, exactly as `requiresTable` does one level up.
+//
+//    ⚠️ AND THE MIGRATION DOES NOT BACKFILL. The 760 rows that predate it keep a
+//    NULL association forever, so a row-level decline is owed on top of the stream-
+//    level gate — the same two-level posture `prMerged` took for CTC-691's 4,230
+//    un-backfilled PR rows. See `classifyGithubRow`.
+//
+//    ⚠️ `check_runs` is still NOT a fallback: one head sha carried **10 distinct
+//    `check_suite_id`s** on mini-2, several with runs incomplete, so "every run I can
+//    see has completed" fires early and GREEN on a partial view — a false CI-pass on
+//    the merge gate.
 
 import { Database } from "bun:sqlite";
 import { getReplicaDbPath } from "./config.mjs";
@@ -126,6 +140,39 @@ export const DEFAULT_SETTLE_MS = 600_000;
  * can account for them as EXPECTED absences instead of as unexplained diffs.
  */
 export const UNBACKED_EVENT_NAMES = Object.freeze(["github.check_suite.completed"]);
+
+/**
+ * The same list, resolved against a REPLICA rather than asserted statically.
+ *
+ * ⛔ THE STATIC ANSWER IS WRONG ON A MIXED-PIN FLEET, and the fleet is mixed by
+ * design: the 0.1.18 rollout is a canary (mini-2, then mini), so between the two
+ * writer restarts one host can emit `github.check_suite.completed` and the other
+ * cannot. A constant would be wrong on exactly one of them — the identical failure
+ * `PUSH_IS_LOSSY` had before CTC-704 made it `pushIsLossy(db)`.
+ *
+ * ⭐ The default (no handle ⇒ UNBACKED) is the safe direction: a caller that cannot
+ * ask the replica reports less coverage than it may have, and less coverage means
+ * smee keeps authority. Over-reporting coverage is the one that silently drops
+ * dispatch.
+ */
+export function unbackedEventNames(db = null) {
+  if (!db) return UNBACKED_EVENT_NAMES;
+  return Object.freeze(checkSuiteHasPrAssociation(db) ? [] : ["github.check_suite.completed"]);
+}
+
+/**
+ * Can THIS replica carry the PR association a `check_suite` event needs to route?
+ *
+ * `router.mjs:1497` reaches an interest only through `detail.prNumbers`, which the
+ * webhook fills from `check_suite.pull_requests[].number`. Before CTC-712 the mirror
+ * dropped it; the only derivation was a last-state join through
+ * `pull_requests.head_sha`, measured at **93/202 (46%)** on mini-2 with the misses
+ * dominated by active branches whose head moved after the suite ran — a race that,
+ * under `enforce` with no smee copy, hangs the CI wait.
+ */
+export function checkSuiteHasPrAssociation(db) {
+  return columnExists(db, "check_suites", "pull_request_numbers");
+}
 
 
 /**
@@ -221,6 +268,46 @@ export const STREAMS = Object.freeze([
     where: null,
   },
   {
+    // ⭐ CTC-712 — the suite row plus the association the CONSUMER keys on.
+    //
+    // ⚠️ `updated_at` IS A MUTABLE COORDINATE — `check_suites` has no once-set
+    // `completed_at`, because the row IS the suite's current state (queued →
+    // in_progress → completed, rewritten in place). That is survivable here in a way
+    // it is not for `pushes`, and the difference is the PRIMARY KEY: `check_suite_id`
+    // identifies the SUITE, and a suite completes once, so the PK is very nearly an
+    // edge identity already.
+    //
+    // ⛔ "Very nearly" is not "is". A `rerequested` suite REUSES its id and completes
+    // AGAIN — a second genuine edge the webhook delivers twice. Keyed on the PK alone
+    // the seen-set would suppress the re-run's completion as a re-read, and under
+    // `enforce` the merge gate would wait forever on a CI pass that had already
+    // happened. `mutableRow` folds the COORDINATE in (see `githubEdgeId`), so a
+    // re-read is byte-identical and a re-run is not.
+    //
+    // ⚠️ AND THE COORDINATE ALONE IS SUFFICIENT HERE — no `edgeIdCols`. `push` also
+    // folds `after`, because its PK is the REF and two pushes can share a millisecond
+    // while carrying different shas. A suite is ONE ROW IN ONE STATE: it cannot
+    // complete twice at the same `updated_at`, so there is no same-timestamp pair to
+    // separate. An earlier cut folded `conclusion` in "so the two edges are
+    // distinguishable" — a mutation proved that claim empty (the ids already differed
+    // by timestamp, and dropping the column changed nothing that any test could see).
+    // Removed rather than kept as harmless: an unused discriminator reads as a
+    // load-bearing one to the next person.
+    key: "checkSuiteCompleted",
+    event: "github.check_suite.completed",
+    table: "check_suites",
+    tsCol: "updated_at",
+    idExpr: "check_suite_id",
+    // Only the terminal edge is consumed. `github.check_suite.<status>` is a real
+    // family on the webhook side (the name is built from `status`), but `completed`
+    // is the only member any consumer reads.
+    where: "status = 'completed'",
+    // ⛔ THE COLUMN, NOT THE TABLE — see gap (2) in the header. `check_suites` exists
+    // on 0.1.17 without this; serving the stream there emits unroutable events.
+    requiresColumn: "pull_request_numbers",
+    mutableRow: true,
+  },
+  {
     // ⭐ CTC-704 — one row per DELIVERY, which is what makes `github.push` faithful.
     //
     // `push_events` is keyed on GitHub's own `x-github-delivery` id, so the PK is a
@@ -268,6 +355,9 @@ export const STREAMS = Object.freeze([
     // base-branch rebase detection and plugin-refresh's auto-pull with it.
     // `githubEdgeId` therefore folds the mutable coordinate in for this stream.
     mutableRow: true,
+    // Stated explicitly rather than left to a default, now that a second `mutableRow`
+    // stream exists. The id this produces is byte-identical to what it was before.
+    edgeIdCols: ["after"],
   },
 ]);
 
@@ -294,6 +384,33 @@ export function tableExists(db, table) {
 }
 
 /**
+ * columnExists — does this replica's table carry the column a stream needs?
+ *
+ * ⛔ THE SIBLING `tableExists` CANNOT ANSWER FOR, and the distinction is not academic.
+ * `buildStreamQuery` selects `*`, so a stream whose table exists but whose column does
+ * not runs WITHOUT ERROR and yields rows with the field simply `undefined`. There is no
+ * `no such column` to catch — the failure is silent and shaped like data. That is how
+ * `check_suites` on a 0.1.17 replica would have produced suite events carrying no PR
+ * association: emitted, counted as emitted, and unroutable.
+ *
+ * ⚠️ `PRAGMA table_info` cannot be parameterised, so the table name is interpolated.
+ * Every caller passes a name from the frozen `STREAMS` list in this file — never
+ * caller input — which is what makes that safe here and would not make it safe
+ * elsewhere.
+ */
+export function columnExists(db, table, column) {
+  try {
+    const rows = db.prepare(`PRAGMA table_info(${table})`).all();
+    // An absent table yields zero rows rather than throwing, so this fails closed for
+    // the missing-table case too without needing to ask twice.
+    return rows.some((r) => r?.name === column);
+  } catch {
+    // A replica that cannot answer this question is not one to read optimistically.
+    return false;
+  }
+}
+
+/**
  * availableStreams — the streams this replica can actually serve, with the
  * supersession between `pushEvent` and `push` resolved to exactly ONE.
  *
@@ -307,7 +424,12 @@ export function tableExists(db, table) {
 export function availableStreams(db, streams = STREAMS) {
   const present = new Map();
   for (const s of streams) {
-    present.set(s.key, s.requiresTable ? tableExists(db, s.table) : true);
+    // ⛔ BOTH gates, and a stream may declare either or both. `requiresTable` catches a
+    // schema that predates the table; `requiresColumn` catches one that has the table
+    // and not the association — a distinction `SELECT *` erases (see `columnExists`).
+    const hasTable = s.requiresTable ? tableExists(db, s.table) : true;
+    const hasColumn = s.requiresColumn ? columnExists(db, s.table, s.requiresColumn) : true;
+    present.set(s.key, hasTable && hasColumn);
   }
   return streams.filter((s) => {
     if (!present.get(s.key)) return false;
@@ -371,6 +493,16 @@ export const REQUIRED_COLUMNS = Object.freeze({
   deployment_statuses: [
     "id", "repo_id", "deployment_id", "state", "environment", "target_url",
     "environment_url", "description", "creator_id", "created_at",
+  ],
+  // ⚠️ BASE COLUMNS ONLY — `pull_request_numbers` is deliberately NOT here. This list
+  // is asserted unconditionally against the live replica, and the association column
+  // is precisely the one whose absence is EXPECTED on a pre-0.1.18 host. Listing it
+  // would turn a correctly-detected capability gap into a failing conformance test on
+  // every host until the pin rolls. Its presence is the `requiresColumn` gate's job,
+  // and `checkSuiteHasPrAssociation` is where a caller asks.
+  check_suites: [
+    "repo_id", "check_suite_id", "head_sha", "head_branch", "status", "conclusion",
+    "app_slug", "latest_check_runs_count", "updated_at",
   ],
   pushes: [
     "repo_id", "ref", "before", "after", "forced", "created", "deleted",
@@ -525,6 +657,10 @@ export function createGithubFeedSource({ dbPath = getReplicaDbPath(), limit = DE
     streamKeys: () => availableStreams(open()).map((s) => s.key),
     /** Whether `github.push` is still collapse-prone on THIS replica (CTC-704). */
     pushIsLossy: () => pushIsLossy(open()),
+    /** Whether `check_suite.completed` can carry its PR association here (CTC-712). */
+    checkSuiteHasPrAssociation: () => checkSuiteHasPrAssociation(open()),
+    /** Consumed names with no usable stream on THIS replica. See `unbackedEventNames`. */
+    unbackedEventNames: () => unbackedEventNames(open()),
     positionAfter,
     /**
      * `PRAGMA table_info` for a table, so a caller can verify REQUIRED_COLUMNS

--- a/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-source.test.mjs
@@ -19,6 +19,9 @@ import {
   STREAM_BY_KEY,
   UNBACKED_EVENT_NAMES,
   availableStreams,
+  columnExists,
+  checkSuiteHasPrAssociation,
+  unbackedEventNames,
   buildStreamQuery,
   createGithubFeedSource,
   pushIsLossy,
@@ -73,10 +76,30 @@ CREATE TABLE push_events (
   delivery_id text PRIMARY KEY, repo_id text NOT NULL, ref text NOT NULL, before text,
   after text, forced integer, created integer, deleted integer, base_ref text,
   pusher_id text, head_commit_sha text, updated_at integer);
+-- CTC-712 (schema 0.1.18): the suite row plus pull_request_numbers, migration
+-- 0028_burly_nemesis. Verbatim from mini-2's DDL plus the additive column.
+-- (No backticks in here: this block lives inside a template literal.)
+CREATE TABLE check_suites (
+  repo_id text NOT NULL, check_suite_id text PRIMARY KEY NOT NULL, head_sha text,
+  head_branch text, status text, conclusion text, app_slug text,
+  latest_check_runs_count integer, updated_at integer, pull_request_numbers text);
 `;
 
 /** The pre-0.1.17 DDL — every table EXCEPT push_events, for the un-pinned-host tests. */
 const DDL_PRE_0_1_17 = DDL.slice(0, DDL.indexOf("-- CTC-704"));
+
+/**
+ * The 0.1.17 shape: `check_suites` EXISTS but has no `pull_request_numbers`.
+ *
+ * ⛔ THIS IS THE CASE `tableExists` CANNOT SEE, and it is the one every mini was in
+ * this morning. Derived by deleting exactly the one column from the real DDL — not by
+ * hand-writing a second table, which would drift from the first and could agree with
+ * a broken `columnExists` for the wrong reason.
+ */
+const DDL_PRE_0118 = DDL.replace(", pull_request_numbers text)", ")");
+// ⛔ Positive control on the FIXTURE: a derivation that silently matched nothing would
+// make every "pre-0.1.18" test below run against a 0.1.18 replica and pass vacuously.
+if (DDL_PRE_0118 === DDL) throw new Error("DDL_PRE_0118 derivation matched nothing");
 
 let dbSeq = 0;
 function freshDb(seed = () => {}) {
@@ -237,9 +260,36 @@ describe("declared gaps are exported, not implied by a comment", () => {
   test("check_suite.completed is named as unbacked", () => {
     expect(UNBACKED_EVENT_NAMES).toContain("github.check_suite.completed");
   });
-  test("no stream claims to produce an unbacked name", () => {
-    const produced = new Set(STREAMS.map((s) => s.event).filter(Boolean));
-    for (const n of UNBACKED_EVENT_NAMES) expect(produced.has(n)).toBe(false);
+  test("⛔ an unbacked name is unbacked ON A REPLICA, not in the abstract", () => {
+    // ⚠️ THIS INVARIANT CHANGED SHAPE WITH CTC-712 AND THE OLD FORM WOULD NOW BE
+    // WRONG IN THE DANGEROUS DIRECTION. It read "no stream produces a name in
+    // UNBACKED_EVENT_NAMES" — true only while an unbacked name had no stream at all.
+    // `checkSuiteCompleted` produces `github.check_suite.completed` AND that name is
+    // still in the STATIC list, because the static list is the answer for a caller
+    // with no replica handle and the safe answer there is "uncovered". Keeping the
+    // old assertion would have forced deleting the name from the static list, which
+    // is exactly what suppresses smee on a host that cannot emit it.
+    //
+    // The real invariant is per replica: a name is unbacked here iff no stream this
+    // replica SERVES produces it.
+    const withCol = new Database(":memory:");
+    withCol.run(DDL);
+    const servedNames = new Set(availableStreams(withCol).map((x) => x.event).filter(Boolean));
+    for (const n of unbackedEventNames(withCol)) expect(servedNames.has(n)).toBe(false);
+    // Positive control: the resolution is not vacuous — this replica DOES serve it.
+    expect(servedNames.has("github.check_suite.completed")).toBe(true);
+    expect(unbackedEventNames(withCol)).toEqual([]);
+
+    const noCol = new Database(":memory:");
+    noCol.run(DDL_PRE_0118);
+    const servedPre = new Set(availableStreams(noCol).map((x) => x.event).filter(Boolean));
+    for (const n of unbackedEventNames(noCol)) expect(servedPre.has(n)).toBe(false);
+    expect(servedPre.has("github.check_suite.completed")).toBe(false);
+    expect(unbackedEventNames(noCol)).toEqual(["github.check_suite.completed"]);
+
+    // ⛔ And with NO handle the answer is the SAFE one, not the optimistic one.
+    expect(unbackedEventNames()).toEqual(["github.check_suite.completed"]);
+    expect(UNBACKED_EVENT_NAMES).toEqual(["github.check_suite.completed"]);
   });
   test("the two push streams are the only ones keyed on a mutable column", () => {
     // ⚠️ `pushEvent` shares `updated_at` with `push` but is NOT lossy for it: its PK
@@ -247,9 +297,88 @@ describe("declared gaps are exported, not implied by a comment", () => {
     // coordinate, never part of the row's identity. That distinction is what makes
     // one of them collapse and the other not.
     const mutable = STREAMS.filter((s) => s.tsCol === "updated_at").map((s) => s.key);
-    expect(mutable.sort()).toEqual(["push", "pushEvent"]);
+    expect(mutable.sort()).toEqual(["checkSuiteCompleted", "push", "pushEvent"]);
+    // ⛔ SHARING THE COORDINATE IS NOT SHARING THE HAZARD, and the split is by PK.
+    // `push` is keyed on the REF, so its PK is constant across every push and the
+    // identity MUST fold the coordinate in. `checkSuiteCompleted` is keyed on the
+    // SUITE, which is nearly per-edge — but a `rerequested` suite reuses its id and
+    // completes twice, so it folds too. `pushEvent` is keyed on the DELIVERY, a
+    // complete edge identity, so it must NOT fold: doing so would make a redelivery
+    // of the same push look like a new one.
     expect(STREAM_BY_KEY.push.mutableRow).toBe(true);
+    expect(STREAM_BY_KEY.checkSuiteCompleted.mutableRow).toBe(true);
     expect(STREAM_BY_KEY.pushEvent.mutableRow).toBeUndefined();
+    // ⚠️ `edgeIdCols` is declared by `push` ALONE, and the asymmetry is the point.
+    // Folding the coordinate is what both need; folding an extra COLUMN is needed only
+    // where two distinct edges can share a millisecond. Two pushes to one ref can;
+    // one suite cannot complete twice at one `updated_at`. A mutation showed the
+    // conclusion-fold this stream briefly carried was unobservable, so it is gone.
+    expect(STREAM_BY_KEY.push.edgeIdCols).toEqual(["after"]);
+    expect(STREAM_BY_KEY.checkSuiteCompleted.edgeIdCols).toBeUndefined();
+  });
+});
+
+describe("CTC-712 — a COLUMN is a capability, and its absence is not a table's absence", () => {
+  const mk = (ddl) => { const db = new Database(":memory:"); db.run(ddl); return db; };
+
+  test("columnExists distinguishes present / absent / no-such-table", () => {
+    const at0118 = mk(DDL);
+    const at0117 = mk(DDL_PRE_0118);
+    expect(columnExists(at0118, "check_suites", "pull_request_numbers")).toBe(true);
+    expect(columnExists(at0117, "check_suites", "pull_request_numbers")).toBe(false);
+    // Positive control: the 0.1.17 fixture still HAS the table and its other columns,
+    // so a `false` above is about the column and not about a missing fixture.
+    expect(columnExists(at0117, "check_suites", "head_sha")).toBe(true);
+    // A table that does not exist yields false rather than throwing.
+    expect(columnExists(at0118, "no_such_table", "anything")).toBe(false);
+  });
+
+  test("⛔ a broken column probe would be INVISIBLE without this: SELECT * does not throw", () => {
+    // The reason `tableExists` cannot stand in. On a 0.1.17 replica the stream's own
+    // query runs happily and simply yields rows with the field undefined — there is no
+    // `no such column` for anything to catch, so the producer would emit suite events
+    // with no PR association and every count would read "emitted".
+    const at0117 = mk(DDL_PRE_0118);
+    at0117.run(
+      "INSERT INTO check_suites (repo_id, check_suite_id, head_sha, status, conclusion, updated_at) VALUES ('o/r','s1','abc','completed','success',1000)",
+    );
+    const rows = at0117.prepare(buildStreamQuery("checkSuiteCompleted")).all({ $sinceMs: 0, $sinceId: "", $limit: 10 });
+    expect(rows.length).toBe(1);                       // the query SUCCEEDED
+    expect(rows[0].pull_request_numbers).toBeUndefined(); // and the association is simply gone
+  });
+
+  test("availableStreams serves checkSuiteCompleted only where the column exists", () => {
+    expect(availableStreams(mk(DDL)).map((x) => x.key)).toContain("checkSuiteCompleted");
+    expect(availableStreams(mk(DDL_PRE_0118)).map((x) => x.key)).not.toContain("checkSuiteCompleted");
+    // ⚠️ And the rest of the streams are UNAFFECTED — a capability gate that quietly
+    // shed its neighbours would look identical in the assertion above.
+    const a = availableStreams(mk(DDL)).map((x) => x.key).filter((k) => k !== "checkSuiteCompleted");
+    const b = availableStreams(mk(DDL_PRE_0118)).map((x) => x.key);
+    expect(b).toEqual(a);
+  });
+
+  test("checkSuiteHasPrAssociation answers per replica", () => {
+    expect(checkSuiteHasPrAssociation(mk(DDL))).toBe(true);
+    expect(checkSuiteHasPrAssociation(mk(DDL_PRE_0118))).toBe(false);
+    // A replica with no check_suites table at all is also "cannot", not a throw.
+    expect(checkSuiteHasPrAssociation(mk(DDL_PRE_0_1_17))).toBe(false);
+  });
+
+  test("the keyset query pages completed suites in order and skips other statuses", () => {
+    const db = mk(DDL);
+    const ins = (id, ts, status) => db.run(
+      `INSERT INTO check_suites (repo_id, check_suite_id, head_sha, status, conclusion, updated_at, pull_request_numbers)
+       VALUES ('o/r','${id}','sha','${status}','success',${ts},'[7]')`,
+    );
+    ins("s1", 1000, "completed");
+    ins("s2", 2000, "in_progress");   // must never page
+    ins("s3", 3000, "completed");
+    const rows = db.prepare(buildStreamQuery("checkSuiteCompleted")).all({ $sinceMs: 0, $sinceId: "", $limit: 10 });
+    expect(rows.map((r) => r.__id)).toEqual(["s1", "s3"]);
+    expect(rows.map((r) => r.__ts)).toEqual([1000, 3000]);
+    // and the keyset advances past what it read
+    const after = db.prepare(buildStreamQuery("checkSuiteCompleted")).all({ $sinceMs: 1000, $sinceId: "s1", $limit: 10 });
+    expect(after.map((r) => r.__id)).toEqual(["s3"]);
   });
 });
 
@@ -353,8 +482,14 @@ describe("⛔ exactly ONE push stream is served, chosen from the replica (CTC-70
   });
 
   test("every other stream is unaffected by the pin", () => {
-    const a = availableStreams(pinned()).map((s) => s.key).filter((k) => !k.startsWith("push"));
-    const b = availableStreams(unpinned()).map((s) => s.key).filter((k) => !k.startsWith("push"));
+    // ⚠️ `checkSuiteCompleted` is excluded alongside the push pair, and for the SAME
+    // reason rather than as a convenience: the "unpinned" fixture is pre-0.1.17, which
+    // has no `check_suites` table at all, so that stream is legitimately capability-
+    // gated between these two replicas too. What this test asserts is the narrower and
+    // still-important claim — that the push supersession disturbs nothing ELSE.
+    const gated = (k) => k.startsWith("push") || k === "checkSuiteCompleted";
+    const a = availableStreams(pinned()).map((s) => s.key).filter((k) => !gated(k));
+    const b = availableStreams(unpinned()).map((s) => s.key).filter((k) => !gated(k));
     expect(a).toEqual(b);
     expect(a.length).toBeGreaterThan(5);
   });

--- a/plugins/dev/scripts/lib/github-feed-names.mjs
+++ b/plugins/dev/scripts/lib/github-feed-names.mjs
@@ -74,13 +74,17 @@ export const GITHUB_UNCOVERED_NAMES = Object.freeze([
   // A row whose sha is NULL (a merge predating the pin, never backfilled) still
   // declines, but per ROW in `classifyGithubRow`, which is the correct granularity.
   //
-  // ⛔ `check_suite.completed` STAYS, and NOT for the reason the old entry gave. The
-  // mirror stores a suite row now. What it does not store is the association the
-  // CONSUMER keys on: `router.mjs:1497` reaches an interest only through
-  // `detail.prNumbers`, from `check_suite.pull_requests[].number`, which the mirror
-  // drops and `check_runs` cannot supply. The only derivation is a LAST-STATE join
-  // through `pull_requests.head_sha` — measured 93/202 (46%) on mini-2, misses
-  // dominated by active PR branches whose head moved after the suite ran. → CTC-712
+  // ⛔ `check_suite.completed` STAYS IN THE STATIC LIST — and that is now a statement
+  // about THIS FILE's ignorance, not about the schema. CTC-712 landed the association
+  // (`check_suites.pull_request_numbers`, migration 0028, schema 0.1.18), so on a
+  // migrated replica the name IS covered.
+  //
+  // This leaf is zero-import and has no database handle, so it cannot know whether the
+  // host in front of it has run that migration — and the 0.1.18 pin rolls as a CANARY,
+  // so at any moment one host has it and another does not. The static answer therefore
+  // stays the SAFE one (uncovered ⇒ smee keeps authority) and the real answer comes
+  // from `githubUncoveredNames(db)` in `github-feed-gate.mjs`. Deleting this entry
+  // would suppress smee on a host that cannot emit the name.
   "github.check_suite.completed",
 ]);
 
@@ -121,6 +125,12 @@ export const GITHUB_SUPPRESSIBLE_NAMES = computeSuppressible({
 /** Why an excluded name is excluded — for capture records and doctor output. */
 export const EXCLUSION_REASONS = Object.freeze({
   "github.pr.merged": "no-replacement:no-merge-commit-sha:CTC-691",
-  "github.check_suite.completed": "no-replacement:no-suite-row:CTC-667-item-4",
+  // ⚠️ THE REASON CHANGED WITH THE SCHEMA, twice. It was "no suite row" (CTC-667
+  // item 4), then "a suite row with no PR association" (CTC-712). On schema 0.1.18
+  // neither is true and the name is covered — but only on a host whose replica has
+  // actually run migration 0028, which is why coverage is resolved per host by
+  // `githubUncoveredNames(db)` and this string is only ever read for a host where it
+  // still IS excluded.
+  "github.check_suite.completed": "no-replacement:no-pr-association-until-0.1.18:CTC-712",
   "github.push": "lossy-replacement:pushes-keyed-per-ref:CTC-704",
 });


### PR DESCRIPTION
## The finding this PR is actually about

I had been carrying the plan as "wire `check_suite.completed` → ledger CLEAN → enforce → retire the tunnel". **That is not sufficient**, and I got the real number by running the gate rather than reading its lists:

```
consumed 12 · SUPPRESSIBLE 10 of 12
⛔ NOT suppressible (smee stays load-bearing):
   github.check_suite.completed → no-replacement:no-suite-row:CTC-667-item-4
   github.push                  → lossy-replacement:pushes-keyed-per-ref:CTC-704
```

Under `enforce` today, smee is authoritative for **both**. Wiring `check_suite` alone would have left webhook `616654741` as the only delivery path for every push, so the tunnel could not have been disabled regardless of what the ledger said.

⭐ And the `github.push` half was already fixed everywhere except the gate. Measured on mini-2's live replica:

```
push_events table exists            : true
pushIsLossy(db) [false = faithful]  : false
streams served                      : [... "pushEvent"]   ← per-delivery, not the lossy one
```

The producer emits `github.push` from `push_events` (one row per `x-github-delivery`) and the ledger agrees on it — **8 joined / 8 agree / 0 unjoined** this morning, **14/14/0** over CTL-56's 55-minute window. The gate excluded it anyway, because `githubLossyNames()` was called with its **default** `PUSH_IS_LOSSY = true` — the deprecated static answer, correct only for a host with no `push_events`.

⚠️ I flagged this in CTL-55 as "the safe direction — a follow-up rather than a guess". That framing was wrong. It is safe, but it is not a follow-up: it is a **precondition of retiring the tunnel**, and it had been sitting unlabelled in the critical path since #3535.

## The shape of the fix: coverage is a property of the REPLICA

| name | covered when | the gate used to read |
| --- | --- | --- |
| `github.push` | `push_events` exists | static `true` (lossy) — **stale** |
| `github.check_suite.completed` | `check_suites.pull_request_numbers` exists (0.1.18) | static uncovered — correct until ~14:00 today |

⛔ **Per-host, not fleet-wide.** The 0.1.18 pin rolls as a canary (mini-2, then mini), so a mixed fleet is a live condition *by design* and a constant is necessarily wrong on one of the two hosts. Wrong in the dangerous direction it means smee suppressed for a name that host emits nothing for — the CI wait hangs with no second copy.

⭐ **Every default is the pre-capability answer**, so adding the seam changes nothing until it is wired: `githubSuppressibleNames()` with no arguments returns exactly today's static set, asserted directly.

## A COLUMN is not a TABLE, and `SELECT *` erases the difference

`availableStreams`/`tableExists` (#3544) resolves a missing *table*. `check_suites` **exists** on 0.1.17 without the association column, and `buildStreamQuery` selects `*` — so the stream's query **succeeds**, yields rows with `pull_request_numbers` simply `undefined`, and there is no `no such column` for anything to catch. The producer would have emitted suite events with no `vcs.pr.number`, which `router.mjs:1497` can reach no interest with: counted as emitted, and unroutable. There is a test that asserts exactly this — the query runs and returns a row on a 0.1.17 fixture — because the failure it guards is silent.

Hence `columnExists` + a `requiresColumn` gate, and a **per-row** decline on top of it: migration `0028_burly_nemesis` is an additive `ADD COLUMN` with **no backfill**, so all **760** existing suite rows stay NULL and decline as `no-pr-association:not-backfilled`. Same two-level posture `prMerged` took for CTC-691's un-backfilled PR rows — visible in `byReason` every tick rather than being a number in a turn.

## The ledger can now fail on the last name it was excusing

`KNOWN_ABSENT` is **empty**. While `check_suite.completed` sat there, the ledger *excused its absence* — so the one name still keeping the tunnel alive was precisely the name the instrument was configured to be unable to fail on. That is the CTC-691 lesson (`pr.merged`) applied to the last excused name, and a test now pins the table empty rather than pinning its contents.

⚠️ **Expect the ledger to read NOT-CLEAN between this merging and the ~14:00 pin.** That is the intended behaviour, not a regression: the name is no longer excused and the producer cannot emit it until 0028 has run. It goes clean again once both minis are on 0.1.18 and suites start emitting.

## The envelope reproduces the webhook and does not improve it

`cicd.pipeline.run.status`/`.conclusion`, `vcs.revision`, `vcs.pr.number` = `prNumbers[0]` with the **full array** in the payload, `event.action` read from the row's status, severity via the webhook's own `conclusionSeverity` (only `failure`/`timed_out` are WARN). Conditional attributes stay **absent** rather than empty, exactly as the webhook builds them — the `pr.merged` `vcs.revision` mistake pointing the other way. `head_branch` is stored, parsed by the webhook into `headRef`, and **dropped** — so we drop it too, with a test.

⚠️ **One declared divergence:** the webhook falls back to a SHA→PR cache (`cachedPrNumber`, CTL-396) when a payload carries no PR association. The feed has no such cache and declines instead. Those become `smee-unjoined` in the ledger — honest, and visible.

## Mutations: 19 run, 1 survived, and the CODE was wrong

`githubEdgeId hard-codes row.after again` survived. The suite stream folded `conclusion` into its edge id "so a re-run is distinguishable" — but the two ids **already differed by timestamp**, so dropping the column changed nothing any test could see. The comment named a mechanism that was not doing anything.

Fixed at the shape rather than by strengthening the test around it: the empty discriminator is **removed** (an unused discriminator reads as a load-bearing one to the next person), the asymmetry with `push` is stated (two pushes can share a millisecond; one suite cannot complete twice at one `updated_at`), and both edge ids are now **pinned exactly** rather than asserted with `not.toBe`. Re-run: caught.

Also caught by a new test and fixed in the source: a **throwing coverage probe propagated into the broker's hot tail**, which sees every event the fleet appends. It is now caught and degraded to the pre-capability set.

Also fixed a pre-existing `expect(x).toBe(x)` tautology in the shared envelope sweep.

## The runner is committed, because it broke this morning

`~/catalyst/events/2026-08.jsonl` passed **1.59 GB** overnight and Node's 512 MB string cap turned the ad-hoc `readFileSync` runner into `ERR_STRING_TOO_LONG`. It worked at 02:33 and did not at 06:20 — the instrument the cutover is judged by stopped working, mid-cutover, for a reason unrelated to what it measures. `github-feed-parity-run.mjs` streams both files and reports on itself first (`shadow lines`/`smee github`/`last` timestamps), so an empty window is distinguishable from a misread file.

Verified against mini-2's live data:

```
instrument: shadow lines=352 last=11:39:44Z · smee github=100293 last=11:39:49Z · torn=0
joined 13 / agree 13 · feed-unjoined 0 · smee-unjoined 0
feedOnlyRepos: {"coalesce-labs/thoughts":2}   (superset — never blocks CLEAN)
clean = true · exit 0
```

## Not armed

⛔ Nothing on any host changes. mini-2 stays `shadow`, mini unset, webhook `616654741` alive. `catalyst doctor` deliberately keeps reading the **static** list — it runs under bare Node and cannot open the replica, so it under-reports coverage, which is the safe direction. Making it replica-aware needs a bare-Node sqlite path and is a follow-up.

**746 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)