### PR TITLE
feat(dev): CTL-1893 — the replica path derives from the ACCOUNT (increment 1: the resolver)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -664,6 +664,38 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/catalyst-deployment-mode.test.sh
 
+      - name: replica-path resolver unit tests (bun, CTL-1893)
+        # lib/replica-path.mjs derives the replica database path from the cloud ACCOUNT
+        # (today `cloud-sync.mjs` resolves account and dbPath independently, so a second
+        # account on one host targets the same file). Own step, not the "Run stable unit
+        # tests" allowlist below, for the same reason the deployment-mode /
+        # catalyst-runtime-root / event-name steps carry: that step's working-directory is
+        # execution-core/ and this is a deliberately ZERO-IMPORT leaf outside that tree.
+        #
+        # ⛔ Registered in the SAME change that adds the suite. This workflow's suite list
+        # is hand-enumerated, and an unlisted suite ships inert — the trap the ask-verb and
+        # event-name steps above each document after finding it the hard way. Verified with
+        # the instrument note on the event-name step (a `run:`-anchored grep is invalid for
+        # the multi-line allowlist block): `grep -n replica-path .github/workflows/`
+        # returned nothing before this step, against a positive control of
+        # `deployment-mode-parity`, which returns its `run:` line.
+        working-directory: plugins/dev/scripts/lib
+        run: bun test replica-path.test.mjs
+
+      - name: replica-path cross-stack parity test (CTL-1893)
+        # bash == node == a hand-written expected value at every fixture cell, including
+        # the NAMED FAILURES (account-absent vs account-invalid route to different operator
+        # actions, so failing for the wrong reason is a failure), plus an assertion that the
+        # DEFAULT_ACCOUNT constant agrees across all three files that carry it
+        # (replica-path.mjs, catalyst-replica-path.sh, cloud-sync.mjs).
+        #
+        # Mutation-verified before landing, since a parity suite that passes first try is
+        # exactly the kind that can be vacuous: breaking the bash derivation for the default
+        # account failed 3 cells, removing the JS named-failure guard failed 2, and removing
+        # the bash account-name validation failed 6. Restored, it is 35/35.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/replica-path-parity.test.sh
+
       - name: deployment-mode cross-stack parity test (CTL-1617)
         # The fixture-matrix parity test asserting bash == node == the
         # design-spec-computed expected value at every cell (168 fixture

--- a/plugins/dev/scripts/__tests__/replica-path-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/replica-path-parity.test.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Cross-stack parity test for lib/replica-path.mjs vs lib/catalyst-replica-path.sh
+# (CTL-1893).
+#
+# Built on the proven mechanism in __tests__/secret-contract-parity.test.sh and
+# __tests__/deployment-mode-parity.test.sh: run identical inputs through both engines and
+# compare BOTH against a computed expectation.
+#
+#   1. THREE-WAY ASSERTION — bash == expected AND node == expected, never merely
+#      bash == node. Two engines can agree with each other while both disagree with the
+#      spec, which is a false-green on the exact property this file exists to guard. Every
+#      row below therefore carries its own expected value, written out by hand.
+#   2. NAMED FAILURES ARE COMPARED TOO — "account-absent" and "account-invalid" are part
+#      of the contract, not error text. A resolver that fails for the wrong REASON is a
+#      failure, because the two reasons route to different operator actions.
+#   3. THE DEFAULT-ACCOUNT CONSTANT IS ASSERTED, NOT TRUSTED — it is duplicated across
+#      three files (replica-path.mjs, catalyst-replica-path.sh, cloud-sync.mjs) and a
+#      silent drift there re-points a whole host.
+#
+# Every cell runs under `env -i` so a developer's real CATALYST_DIR / CATALYST_REPLICA_DB /
+# HOME cannot leak into a fixture and make a row pass for the wrong reason.
+#
+# Run: bash plugins/dev/scripts/__tests__/replica-path-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SH_LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-replica-path.sh"
+JS_LIB="${REPO_ROOT}/plugins/dev/scripts/lib/replica-path.mjs"
+
+FAILURES=0
+PASSES=0
+
+ok() { PASSES=$((PASSES + 1)); }
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $1"
+  echo "    $2"
+}
+
+[ -f "$SH_LIB" ] || { echo "FATAL: missing $SH_LIB"; exit 1; }
+[ -f "$JS_LIB" ] || { echo "FATAL: missing $JS_LIB"; exit 1; }
+
+NODE_BIN="$(command -v node || true)"
+[ -n "$NODE_BIN" ] || { echo "FATAL: node not on PATH — parity cannot be asserted"; exit 1; }
+
+# run_sh <account> <CATALYST_DIR> <HOME> <CATALYST_REPLICA_DB>
+# Emits one line: "<ok|reason>|<value>|<source>|<disagrees>"
+run_sh() {
+  env -i PATH="$PATH" \
+    CATALYST_DIR="$2" HOME="$3" CATALYST_REPLICA_DB="$4" \
+    bash -c '
+      set -uo pipefail
+      # shellcheck disable=SC1090
+      . "'"$SH_LIB"'"
+      # NOTE: called DIRECTLY, never as $(...) — the named reason lives in a global and a
+      # subshell would discard it. This is the contract the library header describes, and
+      # exercising it here is deliberate.
+      if catalyst_replica_path "$1"; then
+        printf "ok|%s|%s|%s\n" "$CATALYST_REPLICA_PATH_VALUE" "$CATALYST_REPLICA_PATH_SOURCE" "$CATALYST_REPLICA_PATH_DISAGREES"
+      else
+        printf "%s|%s|%s|%s\n" "$CATALYST_REPLICA_PATH_REASON" "$CATALYST_REPLICA_PATH_VALUE" "$CATALYST_REPLICA_PATH_SOURCE" "$CATALYST_REPLICA_PATH_DISAGREES"
+      fi
+    ' _ "$1" 2>/dev/null
+}
+
+run_js() {
+  env -i PATH="$PATH" \
+    CATALYST_DIR="$2" HOME="$3" CATALYST_REPLICA_DB="$4" ACCOUNT="$1" \
+    "$NODE_BIN" --input-type=module -e '
+      import { resolveReplicaPath } from "'"$JS_LIB"'";
+      const r = resolveReplicaPath({ account: process.env.ACCOUNT, env: process.env });
+      if (r.ok) process.stdout.write(`ok|${r.path}|${r.source}|${r.overrideDisagrees ? 1 : 0}\n`);
+      else process.stdout.write(`${r.reason}|||0\n`);
+    ' 2>/dev/null
+}
+
+# ─── the fixture matrix ──────────────────────────────────────────────────────────────
+# account | CATALYST_DIR | HOME | CATALYST_REPLICA_DB | EXPECTED
+# EXPECTED is hand-written, never derived by running either engine.
+run_row() {
+  local name="$1" account="$2" dir="$3" home="$4" override="$5" expected="$6"
+  local got_sh got_js
+  got_sh="$(run_sh "$account" "$dir" "$home" "$override")"
+  got_js="$(run_js "$account" "$dir" "$home" "$override")"
+  if [ "$got_sh" != "$expected" ]; then
+    fail "$name [bash vs expected]" "expected: $expected
+    bash got: $got_sh"
+  else ok; fi
+  if [ "$got_js" != "$expected" ]; then
+    fail "$name [node vs expected]" "expected: $expected
+    node got: $got_js"
+  else ok; fi
+}
+
+echo "replica-path parity (CTL-1893)"
+
+run_row "default account keeps the legacy path" \
+  "tenant-0" "/c" "/h" "" "ok|/c/catalyst-replica.db|derived-default|0"
+
+run_row "non-default account derives its own file" \
+  "tenant-7" "/c" "/h" "" "ok|/c/replicas/tenant-7.db|derived|0"
+
+run_row "CATALYST_DIR absent falls back to HOME/catalyst" \
+  "tenant-0" "" "/h" "" "ok|/h/catalyst/catalyst-replica.db|derived-default|0"
+
+run_row "CATALYST_DIR absent, non-default account" \
+  "acme.eu-1" "" "/h" "" "ok|/h/catalyst/replicas/acme.eu-1.db|derived|0"
+
+run_row "override is honoured and flagged as disagreeing" \
+  "tenant-7" "/c" "/h" "/tmp/x.db" "ok|/tmp/x.db|override|1"
+
+run_row "override that agrees is not a disagreement" \
+  "tenant-7" "/c" "/h" "/c/replicas/tenant-7.db" "ok|/c/replicas/tenant-7.db|override-agrees|0"
+
+run_row "override on the default account, disagreeing" \
+  "tenant-0" "/c" "/h" "/tmp/x.db" "ok|/tmp/x.db|override|1"
+
+run_row "an EMPTY override is not an override" \
+  "tenant-0" "/c" "/h" "" "ok|/c/catalyst-replica.db|derived-default|0"
+
+# Named failures — the reason itself is the contract.
+run_row "empty account is account-absent" \
+  "" "/c" "/h" "" "account-absent|||0"
+
+run_row "whitespace-only account is account-absent" \
+  "   " "/c" "/h" "" "account-absent|||0"
+
+run_row "traversal is account-invalid" \
+  "../etc" "/c" "/h" "" "account-invalid|||0"
+
+run_row "a separator is account-invalid" \
+  "a/b" "/c" "/h" "" "account-invalid|||0"
+
+run_row "a leading dot is account-invalid" \
+  ".hidden" "/c" "/h" "" "account-invalid|||0"
+
+run_row "a leading hyphen is account-invalid (reads as a CLI flag downstream)" \
+  "-flag" "/c" "/h" "" "account-invalid|||0"
+
+run_row "an inner space is account-invalid, NOT silently trimmed" \
+  "te nant" "/c" "/h" "" "account-invalid|||0"
+
+run_row "a padded-but-real account is account-invalid, NOT silently trimmed" \
+  " tenant-0 " "/c" "/h" "" "account-invalid|||0"
+
+# ─── the shared constant, asserted rather than trusted ────────────────────────────────
+SH_DEFAULT="$(env -i PATH="$PATH" bash -c '. "'"$SH_LIB"'"; printf "%s" "$CATALYST_REPLICA_DEFAULT_ACCOUNT"')"
+JS_DEFAULT="$(env -i PATH="$PATH" "$NODE_BIN" --input-type=module -e '
+  import { DEFAULT_ACCOUNT } from "'"$JS_LIB"'";
+  process.stdout.write(DEFAULT_ACCOUNT);
+')"
+CS_DEFAULT="$(/usr/bin/grep -oE 'const DEFAULT_ACCOUNT = "[^"]+"' "${REPO_ROOT}/plugins/dev/scripts/execution-core/cloud-sync.mjs" | head -1 | sed 's/.*"\(.*\)"/\1/')"
+
+for pair in "bash:$SH_DEFAULT" "node:$JS_DEFAULT" "cloud-sync:$CS_DEFAULT"; do
+  engine="${pair%%:*}"; value="${pair#*:}"
+  if [ "$value" != "tenant-0" ]; then
+    fail "DEFAULT_ACCOUNT [$engine]" "expected tenant-0, got '${value}'"
+  else ok; fi
+done
+# Fails CLOSED if the cloud-sync anchor disappears: an empty CS_DEFAULT is caught above as
+# a mismatch, so a rename there breaks this test rather than silently skipping it.
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+  echo "replica-path parity: ${PASSES} passed, ${FAILURES} FAILED"
+  exit 1
+fi
+echo "replica-path parity: ${PASSES} passed, 0 failed"

--- a/plugins/dev/scripts/lib/catalyst-replica-path.sh
+++ b/plugins/dev/scripts/lib/catalyst-replica-path.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# catalyst-replica-path.sh — CTL-1893. The bash half of the replica-path resolver.
+#
+# Independently maintained mirror of `lib/replica-path.mjs`, held byte-identical to it by
+# `__tests__/replica-path-parity.test.sh` (the one-registry / two-engines / cross-stack
+# parity-suite discipline `lib/secret-contract.mjs` and `lib/deployment-mode.mjs` already
+# use). Read the JS header for the design; this file carries only what differs in bash.
+#
+# ⛔ WHY THIS CANNOT JUST `echo` THE PATH.
+#
+# The resolver is THREE-VALUED: ok-with-a-path, a named failure with NO path, and
+# ok-but-the-override-disagrees. A `$(...)` capture flattens all three into a string, and
+# an empty capture reads exactly like "no account named" AND like "the command crashed" —
+# the failure class this repo has now hit four times in one night. So the result is
+# published in GLOBALS and the function is called DIRECTLY, never in a subshell:
+#
+#   catalyst_replica_path "$account" || { echo "$CATALYST_REPLICA_PATH_REASON" >&2; exit 1; }
+#   db="$CATALYST_REPLICA_PATH_VALUE"
+#
+# Return code: 0 = resolved, 1 = named failure (REASON is always set, VALUE is always
+# cleared). A caller that ignores the return code and reads VALUE gets an empty string,
+# which cannot be mistaken for a real database path.
+#
+# shellcheck shell=bash
+
+# The account a host serves when it declares none. MUST match replica-path.mjs's
+# DEFAULT_ACCOUNT and cloud-sync.mjs's; the parity suite asserts it rather than trusting it.
+CATALYST_REPLICA_DEFAULT_ACCOUNT="tenant-0"
+
+# catalyst_replica_is_account_name <name> — usable as a path segment?
+# Mirrors ACCOUNT_RE: alphanumeric first character, then [A-Za-z0-9._-], and no "..".
+catalyst_replica_is_account_name() {
+  local name="${1-}"
+  [ -n "$name" ] || return 1
+  case "$name" in
+    *..*) return 1 ;;
+  esac
+  # Bracket expressions inside a `case` pattern are glob character classes, not a regex —
+  # this is the portable form (no [[ =~ ]], which bash 3.2 on stock macOS handles but
+  # `sh` does not).
+  case "$name" in
+    [A-Za-z0-9]) return 0 ;;
+    [A-Za-z0-9]*)
+      case "$name" in
+        *[!A-Za-z0-9._-]*) return 1 ;;
+        *) return 0 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# _catalyst_replica_dir — the CATALYST_DIR ladder, identical to the JS catalystDir():
+# a non-empty CATALYST_DIR wins, else ${HOME}/catalyst. An EMPTY CATALYST_DIR is not a
+# declaration (`:-`, not `-`).
+_catalyst_replica_dir() {
+  printf '%s' "${CATALYST_DIR:-${HOME:-}/catalyst}"
+}
+
+# catalyst_replica_path <account>
+#
+# Publishes:
+#   CATALYST_REPLICA_PATH_VALUE      the path to use ("" on a named failure)
+#   CATALYST_REPLICA_PATH_DERIVED    the account-derived path ("" on a named failure)
+#   CATALYST_REPLICA_PATH_ACCOUNT    the account as given
+#   CATALYST_REPLICA_PATH_SOURCE     override | override-agrees | derived | derived-default
+#   CATALYST_REPLICA_PATH_REASON     "" on success; account-absent | account-invalid
+#   CATALYST_REPLICA_PATH_DISAGREES  1 when an explicit override != the derived path
+catalyst_replica_path() {
+  local account="${1-}" dir derived override trimmed
+
+  CATALYST_REPLICA_PATH_VALUE=""
+  CATALYST_REPLICA_PATH_DERIVED=""
+  CATALYST_REPLICA_PATH_ACCOUNT="$account"
+  CATALYST_REPLICA_PATH_SOURCE=""
+  CATALYST_REPLICA_PATH_REASON=""
+  CATALYST_REPLICA_PATH_DISAGREES=0
+
+  # An all-whitespace account is ABSENT, matching the JS `account.trim() === ""`.
+  # ⚠️ The trim is used ONLY for that emptiness test — the name check below runs against
+  # the ORIGINAL string, exactly as the JS does. " tenant-0 " must therefore come back
+  # `account-invalid` (a space is not in the alphabet), never a silently-trimmed success.
+  trimmed="${account#"${account%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  if [ -z "$trimmed" ]; then
+    CATALYST_REPLICA_PATH_REASON="account-absent"
+    return 1
+  fi
+  if ! catalyst_replica_is_account_name "$account"; then
+    CATALYST_REPLICA_PATH_REASON="account-invalid"
+    return 1
+  fi
+
+  dir="$(_catalyst_replica_dir)"
+  if [ "$account" = "$CATALYST_REPLICA_DEFAULT_ACCOUNT" ]; then
+    derived="${dir}/catalyst-replica.db"
+  else
+    derived="${dir}/replicas/${account}.db"
+  fi
+  CATALYST_REPLICA_PATH_DERIVED="$derived"
+
+  override="${CATALYST_REPLICA_DB:-}"
+  if [ -n "$override" ]; then
+    CATALYST_REPLICA_PATH_VALUE="$override"
+    if [ "$override" = "$derived" ]; then
+      CATALYST_REPLICA_PATH_SOURCE="override-agrees"
+    else
+      CATALYST_REPLICA_PATH_SOURCE="override"
+      CATALYST_REPLICA_PATH_DISAGREES=1
+    fi
+    return 0
+  fi
+
+  CATALYST_REPLICA_PATH_VALUE="$derived"
+  if [ "$account" = "$CATALYST_REPLICA_DEFAULT_ACCOUNT" ]; then
+    CATALYST_REPLICA_PATH_SOURCE="derived-default"
+  else
+    CATALYST_REPLICA_PATH_SOURCE="derived"
+  fi
+  return 0
+}

--- a/plugins/dev/scripts/lib/replica-path.mjs
+++ b/plugins/dev/scripts/lib/replica-path.mjs
@@ -1,0 +1,176 @@
+// replica-path.mjs — CTL-1893: the replica path derives from the ACCOUNT.
+//
+// ## What this fixes
+//
+// `cloud-sync.mjs` resolves the account and the database path INDEPENDENTLY:
+//
+//     const { account } = resolveAccountProvenance(process.env, DEFAULT_ACCOUNT);
+//     const dbPath = getReplicaDbPath();   // ← no account dimension, anywhere
+//
+// `getReplicaDbPath()` is `CATALYST_REPLICA_DB || <catalystDir>/catalyst-replica.db`.
+// So a second `cloud-sync` started with a different `CATALYST_CLOUD_ACCOUNT` targets the
+// SAME file, and the writer lock at `<dbPath>.writer.lock` makes the two either refuse or
+// fight over one tenant-mixed database. `account` reaches the writer guard's `ownerKey`;
+// it never reaches the path that guard is guarding.
+//
+// ## The one design decision worth reading: the DEFAULT account keeps the LEGACY path
+//
+// `tenant-0` resolves to `<catalystDir>/catalyst-replica.db` — the existing file — and
+// only a NON-default account derives `<catalystDir>/replicas/<account>.db`.
+//
+// This is deliberate and it is the whole reason this change is safe to land incrementally.
+// Deriving `replicas/tenant-0.db` for everyone would point every host's writer at a NEW,
+// EMPTY file: a fleet-wide cold re-seed, and — until all 14 readers move in the same
+// instant — every reader still on the old path silently serving a frozen mirror. Measured
+// on the fleet 2026-08-18: both minis run `CATALYST_CLOUD_ACCOUNT=tenant-0` with
+// `CATALYST_REPLICA_DB` UNSET, and both replicas are already stamped
+// `sync_meta.account = tenant-0`. Under the rule above, nothing on those hosts moves.
+//
+// The ticket's Gherkin still holds: two accounts on one host resolve to two different
+// files, each derived from its account, each with its own lock (the lock is
+// `dbPath + '.writer.lock'`, so it follows the path for free — see cli.ts:140 upstream).
+//
+// ## What guards a wrong path, and why it is NOT this module
+//
+// The ticket proposed a host-side refusal — "an explicit override that disagrees with the
+// derived path is refused" — because at filing time nothing checked that the database a
+// writer opened belonged to the account it was syncing. **That guard has since shipped
+// upstream** (CTC-582 / catalyst-cloud-sdk#18, in SDK 0.8.7; the fleet pins 0.8.14): the
+// SDK stamps `sync_meta.account` on first open and refuses a mismatched one with
+// `ReplicaAccountMismatchError`, which `cloud-sync.mjs` already handles by name. Verified
+// present on the live fleet: `sync_meta` carries `account=tenant-0` and
+// `account_source=default` on mini and on the laptop.
+//
+// So this module REPORTS a disagreement (`overrideDisagrees`) rather than refusing on its
+// own. Two reasons:
+//
+//   1. Refusing here would break `CATALYST_REPLICA_DB` as a redirection mechanism, which
+//      31 call sites (mostly tests) depend on and which no production host uses.
+//   2. The writer half is already fenced upstream by a stamp — a strictly better guard
+//      than a path comparison, because it survives two hosts pointed at one file, which a
+//      path check cannot see. The half that is still UNGUARDED is the READER: a reader
+//      has no stamp check at all, which is the "silently reads another tenant's replica"
+//      case. That belongs with the caller migration, not here.
+//
+// ⚠️ `overrideDisagrees()` therefore has NO production caller in this increment, by
+// design. It is the predicate the writer gates on when the callers are migrated. Saying so
+// out loud because an unwired check that looks wired is how this repo has shipped
+// guarantees that could not fire.
+//
+// ## Zero-import leaf
+//
+// No imports at all — not even `node:path`. `catalyst doctor` loads this class of module
+// under bare Node, and the bash mirror (`lib/catalyst-replica-path.sh`) has to reproduce
+// the answer byte-for-byte, which is far easier against explicit string joins than against
+// `path.resolve`'s normalisation. Paths are joined the way the existing bash helper joins
+// them (`${CATALYST_DIR:-$HOME/catalyst}/catalyst-replica.db`), so the two agree by
+// construction rather than by review. Held there by
+// `__tests__/replica-path-parity.test.sh`.
+
+/** The account a host serves when it declares none. Mirrors cloud-sync.mjs. */
+export const DEFAULT_ACCOUNT = "tenant-0";
+
+// An account name becomes a PATH SEGMENT, so it must not be able to escape the directory
+// it is placed in. Leading character is constrained separately so a name can never start
+// with `.` (a dotfile, or the `..` traversal) or `-` (which reads as a flag to any CLI
+// that later handles it). Everything else is the conservative id alphabet.
+const ACCOUNT_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/**
+ * Is this a usable account name — i.e. one that can safely become a path segment?
+ * @param {unknown} account
+ * @returns {boolean}
+ */
+export function isAccountName(account) {
+  return typeof account === "string" && ACCOUNT_RE.test(account) && !account.includes("..");
+}
+
+// catalystDir — the same ladder as config.mjs's catalystDir() and the bash helper's
+// `${CATALYST_DIR:-${HOME:-}/catalyst}`. An empty CATALYST_DIR is not a declaration.
+function catalystDir(env) {
+  const dir = env?.CATALYST_DIR;
+  if (typeof dir === "string" && dir !== "") return dir;
+  const home = typeof env?.HOME === "string" ? env.HOME : "";
+  return `${home}/catalyst`;
+}
+
+/**
+ * Resolve the replica database path for ONE account.
+ *
+ * Never throws and never guesses: an absent or unusable account yields a NAMED failure
+ * with no `path` at all, so a mis-wired caller cannot read another tenant's rows and call
+ * it a default.
+ *
+ * @param {{account?: unknown, env?: Record<string, string|undefined>}} [opts]
+ * @returns {{ok: true, path: string, derived: string, account: string,
+ *            source: "override"|"override-agrees"|"derived"|"derived-default",
+ *            overrideDisagrees: boolean}
+ *          | {ok: false, reason: "account-absent"|"account-invalid", message: string,
+ *             account: unknown, path?: undefined}}
+ */
+export function resolveReplicaPath({ account, env = process.env } = {}) {
+  if (typeof account !== "string" || account.trim() === "") {
+    return {
+      ok: false,
+      reason: "account-absent",
+      account,
+      message:
+        "replica path: no account named. Pass the resolved cloud account (e.g. from " +
+        "resolveAccountProvenance); this resolver will not default to " +
+        `${DEFAULT_ACCOUNT} on your behalf.`,
+    };
+  }
+  if (!isAccountName(account)) {
+    return {
+      ok: false,
+      reason: "account-invalid",
+      account,
+      message:
+        `replica path: account ${JSON.stringify(account)} is not a usable path segment ` +
+        "(allowed: alphanumeric start, then letters, digits, dot, underscore, hyphen; no " +
+        "separators and no '..').",
+    };
+  }
+
+  const dir = catalystDir(env);
+  const derived =
+    account === DEFAULT_ACCOUNT
+      ? `${dir}/catalyst-replica.db`
+      : `${dir}/replicas/${account}.db`;
+
+  const override = env?.CATALYST_REPLICA_DB;
+  if (typeof override === "string" && override !== "") {
+    const agrees = override === derived;
+    return {
+      ok: true,
+      path: override,
+      derived,
+      account,
+      source: agrees ? "override-agrees" : "override",
+      overrideDisagrees: !agrees,
+    };
+  }
+
+  return {
+    ok: true,
+    path: derived,
+    derived,
+    account,
+    source: account === DEFAULT_ACCOUNT ? "derived-default" : "derived",
+    overrideDisagrees: false,
+  };
+}
+
+/**
+ * The refusal predicate for a WRITER: an explicit override pointing somewhere other than
+ * this account's derived path. A named failure is NOT a disagreement — the caller handles
+ * that as its own case, because "no account" and "wrong path" want different messages.
+ *
+ * ⚠️ Unwired in increment 1, by design — see this module's header.
+ *
+ * @param {ReturnType<typeof resolveReplicaPath>} result
+ * @returns {boolean}
+ */
+export function overrideDisagrees(result) {
+  return result?.ok === true && result.overrideDisagrees === true;
+}

--- a/plugins/dev/scripts/lib/replica-path.test.mjs
+++ b/plugins/dev/scripts/lib/replica-path.test.mjs
@@ -1,0 +1,164 @@
+// replica-path.test.mjs — CTL-1893 increment 1.
+//
+// The resolver is a pure function over (account, env), so every case here is a
+// table row. Two rows are CONTROLS and are labelled as such:
+//
+//   * the POSITIVE CONTROL the ticket asks for ("the defect is observable") —
+//     today's account-blind resolver gives two distinct accounts the SAME path.
+//     It is written against a local re-implementation of the OLD rule, so it
+//     keeps asserting the defect exists after the new resolver replaces it.
+//   * the NAMED-FAILURE control — an absent account must never silently become
+//     tenant-0. This is the one the AC calls out, and it is the rule that makes
+//     a mis-wired caller loud instead of plausible.
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_ACCOUNT,
+  isAccountName,
+  overrideDisagrees,
+  resolveReplicaPath,
+} from "./replica-path.mjs";
+
+const ENV = (over) => ({ CATALYST_DIR: "/c", ...over });
+
+describe("resolveReplicaPath — derivation", () => {
+  test("the DEFAULT account keeps the legacy path (no host moves on upgrade)", () => {
+    const r = resolveReplicaPath({ account: DEFAULT_ACCOUNT, env: ENV() });
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe("/c/catalyst-replica.db");
+    expect(r.source).toBe("derived-default");
+  });
+
+  test("a NON-default account derives its own file", () => {
+    const r = resolveReplicaPath({ account: "tenant-7", env: ENV() });
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe("/c/replicas/tenant-7.db");
+    expect(r.source).toBe("derived");
+  });
+
+  test("two accounts on one host resolve to DIFFERENT paths (the fix)", () => {
+    const a = resolveReplicaPath({ account: DEFAULT_ACCOUNT, env: ENV() });
+    const b = resolveReplicaPath({ account: "tenant-7", env: ENV() });
+    expect(a.path).not.toBe(b.path);
+  });
+
+  test("CATALYST_DIR absent falls back to $HOME/catalyst, matching getReplicaDbPath", () => {
+    const r = resolveReplicaPath({
+      account: DEFAULT_ACCOUNT,
+      env: { HOME: "/h" },
+    });
+    expect(r.path).toBe("/h/catalyst/catalyst-replica.db");
+  });
+});
+
+describe("resolveReplicaPath — named failures (never a silent default)", () => {
+  // NAMED-FAILURE CONTROL: the AC's "a caller naming no account gets a named
+  // failure, never a silent default to tenant-0".
+  test.each([undefined, null, "", "   "])("account %p is account-absent, and yields NO path", (account) => {
+    const r = resolveReplicaPath({ account, env: ENV() });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("account-absent");
+    expect(r.path).toBeUndefined();
+    expect(r.message).toMatch(/account/i);
+  });
+
+  test.each(["../etc", "a/b", "/abs", "..", "te nant", "a b"])(
+    "account %p is account-invalid (separators and traversal cannot reach the filesystem)",
+    (account) => {
+      const r = resolveReplicaPath({ account, env: ENV() });
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe("account-invalid");
+      expect(r.path).toBeUndefined();
+    },
+  );
+
+  test("a backslash is rejected too (Windows-style separator)", () => {
+    const r = resolveReplicaPath({ account: String.raw`a\b`, env: ENV() });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("account-invalid");
+  });
+
+  test("a non-string account is a named failure, not a coercion", () => {
+    for (const account of [42, {}, [], true]) {
+      const r = resolveReplicaPath({ account, env: ENV() });
+      expect(r.ok).toBe(false);
+      expect(r.reason).toBe("account-absent");
+    }
+  });
+
+  test("isAccountName accepts the real fleet account and rejects traversal", () => {
+    expect(isAccountName("tenant-0")).toBe(true);
+    expect(isAccountName("acme_corp.eu-1")).toBe(true);
+    expect(isAccountName("../x")).toBe(false);
+    expect(isAccountName("-lead-dash")).toBe(false);
+  });
+});
+
+describe("resolveReplicaPath — CATALYST_REPLICA_DB override", () => {
+  test("override is HONOURED (test redirection and operator intent both keep working)", () => {
+    const r = resolveReplicaPath({
+      account: DEFAULT_ACCOUNT,
+      env: ENV({ CATALYST_REPLICA_DB: "/tmp/x.db" }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.path).toBe("/tmp/x.db");
+    expect(r.source).toBe("override");
+  });
+
+  test("an override that DISAGREES with the derived path is reported, not hidden", () => {
+    const r = resolveReplicaPath({
+      account: "tenant-7",
+      env: ENV({ CATALYST_REPLICA_DB: "/tmp/x.db" }),
+    });
+    expect(r.ok).toBe(true);
+    expect(r.overrideDisagrees).toBe(true);
+    expect(r.derived).toBe("/c/replicas/tenant-7.db");
+  });
+
+  test("an override that AGREES is not reported as a disagreement", () => {
+    const r = resolveReplicaPath({
+      account: "tenant-7",
+      env: ENV({ CATALYST_REPLICA_DB: "/c/replicas/tenant-7.db" }),
+    });
+    expect(r.overrideDisagrees).toBe(false);
+    expect(r.source).toBe("override-agrees");
+  });
+
+  test("an EMPTY override is not an override (empty string is not a declaration)", () => {
+    const r = resolveReplicaPath({
+      account: DEFAULT_ACCOUNT,
+      env: ENV({ CATALYST_REPLICA_DB: "" }),
+    });
+    expect(r.source).toBe("derived-default");
+    expect(r.path).toBe("/c/catalyst-replica.db");
+  });
+
+  test("overrideDisagrees() is the refusal predicate a writer will gate on", () => {
+    const bad = resolveReplicaPath({
+      account: "tenant-7",
+      env: ENV({ CATALYST_REPLICA_DB: "/tmp/x.db" }),
+    });
+    expect(overrideDisagrees(bad)).toBe(true);
+    expect(overrideDisagrees(resolveReplicaPath({ account: "tenant-7", env: ENV() }))).toBe(false);
+    // A named failure is NOT a disagreement — the caller must handle it as its own case.
+    expect(overrideDisagrees(resolveReplicaPath({ account: "", env: ENV() }))).toBe(false);
+  });
+});
+
+describe("POSITIVE CONTROL — the defect this ticket exists to fix is observable", () => {
+  // The old rule, re-implemented locally so it survives the resolver replacing it.
+  // `cloud-sync.mjs:268` is `const dbPath = getReplicaDbPath()`, and
+  // `getReplicaDbPath()` is `CATALYST_REPLICA_DB || <catalystDir>/catalyst-replica.db`
+  // — no account dimension anywhere.
+  const oldRule = (_account, env) =>
+    env.CATALYST_REPLICA_DB || `${env.CATALYST_DIR}/catalyst-replica.db`;
+
+  test("account-blind resolution gives two DIFFERENT accounts the SAME file", () => {
+    expect(oldRule("tenant-0", ENV())).toBe(oldRule("tenant-7", ENV()));
+  });
+
+  test("...and the new resolver does not", () => {
+    expect(resolveReplicaPath({ account: "tenant-0", env: ENV() }).path).not.toBe(
+      resolveReplicaPath({ account: "tenant-7", env: ENV() }).path,
+    );
+  });
+});


### PR DESCRIPTION
## What and why

`cloud-sync.mjs` resolves the account and the database path **independently** — `resolveAccountProvenance(...)`, then `getReplicaDbPath()`, which is `CATALYST_REPLICA_DB || <catalystDir>/catalyst-replica.db` with **no account dimension anywhere**. So a second writer started with a different `CATALYST_CLOUD_ACCOUNT` targets the *same file*, and the writer lock at `<dbPath>.writer.lock` makes the two either refuse or fight over one tenant-mixed database. `account` reaches the writer guard's `ownerKey`; it never reaches the path that guard is guarding.

This lands **the resolver, its bash mirror, and their parity — and wires NO callers.** The 14 cross-language call sites move in increment 2, as one atomic change, because a writer that moves while its readers do not is strictly worse than the defect.

## ⭐ The one decision worth reviewing: the DEFAULT account keeps the LEGACY path

`tenant-0` → the existing `<catalystDir>/catalyst-replica.db`. Only a **non**-default account derives `<catalystDir>/replicas/<account>.db`.

Deriving `replicas/tenant-0.db` for everyone would point every host's writer at a new, empty file — a fleet-wide cold re-seed, plus every reader still on the old path silently serving a frozen mirror until all 14 move in the same instant. **Measured on the fleet 2026-08-18:** both minis run `CATALYST_CLOUD_ACCOUNT=tenant-0` with `CATALYST_REPLICA_DB` **unset**, and both replicas are already stamped `sync_meta.account=tenant-0`. Under this rule **nothing on those hosts moves**.

The ticket's Gherkin still holds: two accounts on one host get two files, each derived from its account, each with its own lock (the lock is `dbPath + '.writer.lock'`, so it follows the path for free).

## ⛔ The guard this ticket asked for has already shipped upstream — so this module reports instead of refusing

CTL-1893 says *"do NOT ship the derivation without a guard"* and names two: a host-side override-disagreement **refusal**, and an upstream account **stamp**. The upstream one is **live**: CTC-582 / catalyst-cloud-sdk#18 (SDK **0.8.7**; the fleet pins 0.8.14) stamps `sync_meta.account` and refuses a mismatch with `ReplicaAccountMismatchError`, which `cloud-sync.mjs` already handles by name. Verified on the live replicas, not from a changelog — `sync_meta` carries `account=tenant-0` / `account_source=default` on mini and on the laptop.

So `resolveReplicaPath` **reports** the disagreement (`overrideDisagrees`) rather than refusing:

1. Refusing here would break `CATALYST_REPLICA_DB` as a redirection mechanism — 31 call sites depend on it and, measured, **no production host sets it**.
2. A stamp is a strictly better guard than a path comparison: it survives *two hosts pointed at one file*, which a path check structurally cannot see.

⚠️ `overrideDisagrees()` therefore has **no production caller in this increment, by design**, and the module header says so out loud — an unwired check that looks wired is how this repo has shipped guarantees that could not fire.

**The half that is still unguarded is the READER** — `replica-read.mjs`, the bash `lib/linear-read-replica.sh` and the orch-monitor readers all open a path and trust it, with no stamp check. That is the ticket's own stated fear (*"a bash reader silently reads another tenant's replica — worse than failing, because it returns plausible data"*). It belongs with the caller migration; recorded on the ticket with a recommendation to restate the AC accordingly.

## Named failures, never a silent default

An absent or unusable account returns a named failure with **no `path` at all** — `account-absent` or `account-invalid`, never a fallback to tenant-0. That is the AC's rule and what makes a mis-wired caller loud rather than plausible. An account becomes a path segment, so traversal, separators, and a leading `.` or `-` are refused.

The bash mirror publishes its result in **globals** and is called **directly**, never as `$(...)`: a subshell capture flattens ok / named-failure / disagreement into one string, and an empty capture reads identically to "no account named" and to "the command crashed".

## Tests

* **24 unit assertions** (`lib/replica-path.test.mjs`).
* **35-assertion three-way parity suite** (`__tests__/replica-path-parity.test.sh`): bash == node == a **hand-written** expected value at every cell, never merely bash == node. Covers the named failures — `account-absent` and `account-invalid` route to different operator actions, so failing for the wrong *reason* is a failure — and asserts `DEFAULT_ACCOUNT` across all three files that carry it (`replica-path.mjs`, `catalyst-replica-path.sh`, `cloud-sync.mjs`), failing closed if the `cloud-sync` anchor is renamed.
* **The positive control the ticket asks for**, written against a local re-implementation of the old account-blind rule so it keeps asserting the defect *after* the resolver replaces it.
* **Mutation-verified** — a parity suite that passes on the first run is exactly the kind that can be vacuous:

  | mutation | cells failed |
  | -- | -- |
  | bash derives `replicas/<acct>` for the default account too | 3 |
  | JS silently defaults an absent account to tenant-0 | 2 |
  | bash skips account-name validation | 6 |
  | *restored* | **0 (35/35)** |

* **Both suites are registered in `execution-core-tests.yml` in this same commit.** That list is hand-enumerated and an unlisted suite ships inert — the trap the ask-verb and event-name steps in that file each document after finding it the hard way. Verified with the instrument note those steps carry (a `run:`-anchored grep is invalid against the multi-line allowlist block): `grep -n replica-path .github/workflows/` returned nothing beforehand, against a positive control of `deployment-mode-parity`, which returns its `run:` line.

## Risk

Additive. A new zero-import leaf, a new bash lib, two new test files, and two new CI steps. **No existing code path changes**, no caller is re-pointed, and no database moves on any host.

Refs CTL-1893
