### PR TITLE
fix(dev): CTL-1929 — the parity ledger says when its WINDOW, not the feed, produced the gap

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
@@ -77,6 +77,26 @@ for await (const e of jsonl(eventsPath)) {
 }
 
 const report = compareGithubStreams(feed, smee);
+
+// ⛔ A WINDOW THAT OUTRUNS THE PRODUCER MANUFACTURES ITS OWN SMEE-UNJOINED COUNT, and
+// it does so at exactly the moment someone is deciding whether a tunnel can be
+// retired. The producer ticks every ~30 s; smee is a webhook and arrives immediately.
+// So every edge between the producer's last tick and `hi` is on the smee side ALONE,
+// with a twin that simply has not been written yet.
+//
+// Measured this morning: 09:00→12:00 reported `github.push` feed 10 / smee 11 and one
+// unjoined event. Re-run with the window closed at 11:45 — before the producer's last
+// tick at 11:51:40 — it was 9/9 and zero. The "gap" was the clock.
+//
+// It is reported rather than auto-corrected: silently clamping `hi` would hide a
+// producer that had genuinely stopped, which looks identical from here. The operator
+// is told which one they are looking at, and the verdict stays INCONCLUSIVE either way.
+const trailingSkew = typeof feedLast === "string" && feedLast < hi;
+if (trailingSkew) {
+  report.inconclusive.push(`window-outruns-producer:feed-last=${feedLast}`);
+  report.clean = false;
+}
+
 const code = parityExitCode(report);
 
 // ⛔ THE INSTRUMENT REPORTS ON ITSELF FIRST. An empty window is the ledger's most
@@ -105,6 +125,13 @@ if (asJson) {
   console.log("expectedAbsent   :", JSON.stringify(report.expectedAbsent));
   console.log("unexplainedAbsent:", JSON.stringify(report.unexplainedAbsent));
   console.log("inconclusive     :", JSON.stringify(report.inconclusive));
+  if (trailingSkew) {
+    console.log(
+      `⚠️  WINDOW OUTRUNS THE PRODUCER — its last emission is ${feedLast}, the window ends ${hi}.\n` +
+      "    Every smee edge in that tail has no twin YET. Re-run with --hi at or before the\n" +
+      "    producer's last emission before reading any smee-unjoined count as a gap.",
+    );
+  }
   console.log(`clean = ${report.clean} · exit ${code}`);
 }
 process.exit(code);


### PR DESCRIPTION
## The near-miss this prevents

A ledger window that ends **after the producer's last tick** manufactures its own `smee-unjoined` count. The producer sweeps every ~30 s; smee is a webhook and arrives immediately. So every edge between the last tick and `hi` sits on the smee side alone, with a twin that simply has not been written yet.

Measured on mini-2 this morning, on the same data:

| window (UTC) | `github.push` | smee-unjoined |
| --- | --- | ---: |
| 09:00 → **12:00** | feed 10 / smee 11 | 46 |
| 09:00 → **11:45** | feed 9 / smee 9 | 39 |

The 11:45 window closes before the producer's last tick (11:51:40) and the push "gap" disappears. **It was the clock, not a dropped edge.**

⛔ Read without that control, it is indistinguishable from the feed silently losing a base-branch move — which is the single finding most likely to stop the tunnel retirement, on the day it is scheduled. I found it by chasing one unaccounted event (`smee-unjoined 46` against 45 expected `check_suite` absences) rather than rounding it off, and the answer took two runs to establish.

## Reported, deliberately not auto-corrected

Clamping `hi` to the producer's last emission would make the warning go away — and would **hide a producer that had genuinely stopped**, which looks identical from this side of the comparison. The operator is told which of the two they are looking at:

```
⚠️  WINDOW OUTRUNS THE PRODUCER — its last emission is 2026-08-18T11:53:10Z, the window ends 2026-08-18T13:00:00Z.
    Every smee edge in that tail has no twin YET. Re-run with --hi at or before the
    producer's last emission before reading any smee-unjoined count as a gap.
```

The verdict stays **INCONCLUSIVE** either way — this only ever adds a reason, never removes one, so it cannot turn a red window green.

## Verified live, both directions

```
A: 09:00 → 13:00  → inconclusive: [... , "window-outruns-producer:feed-last=2026-08-18T11:53:10Z"]  ⚠️ warned
B: 09:00 → 11:45  → inconclusive: ["smee-events-without-a-twin:39"]                                  silent
```

35 parity tests pass. No behaviour change to the comparator itself — this is the runner only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)