### PR TITLE
fix(dev): CTL-1929 — an EMPTY check_suite association is a fact, not a gap; emit it, and put the recovered PR where nothing routes on it

### DIFF
--- a/plugins/dev/scripts/execution-core/ctl1929-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/ctl1929-preflight.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// CTL-1929 rollout preflight — the runbook's P2/P6/P7 gates, run on ONE host.
+//
+// ⛔ EVERY GATE IS THREE-VALUED. "could not look" is never "covered": a probe that
+// throws, a replica that will not open, or a zero-row count each report their own
+// verdict rather than degrading to a pass. That is the property the whole cutover
+// rests on, so it is the property this script is built around.
+import { Database } from "bun:sqlite";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { githubSuppressibleNames, GITHUB_CONSUMED_NAMES } from "./github-feed-gate.mjs";
+import { readGithubCoverage } from "./github-feed-gate-install.mjs";
+import { availableStreams } from "./github-feed-source.mjs";
+
+const DB = process.env.CATALYST_REPLICA_DB ?? join(homedir(), "catalyst", "catalyst-replica.db");
+const out = [];
+const say = (gate, verdict, detail) => { out.push({ gate, verdict, detail }); };
+
+let db = null;
+try { db = new Database(DB, { readonly: true }); }
+catch (e) { say("replica-open", "INCONCLUSIVE", `cannot open ${DB}: ${e.message}`); }
+
+// ── P6: migration 0028 ran HERE. Not the SDK version, not the lockfile — the column.
+if (db) {
+  try {
+    const cols = db.prepare("PRAGMA table_info(check_suites)").all().map((r) => r.name);
+    if (cols.length === 0) say("P6-migration-0028", "FAIL", "check_suites table absent");
+    else if (cols.includes("pull_request_numbers")) say("P6-migration-0028", "PASS", `${cols.length} columns, pull_request_numbers present`);
+    else say("P6-migration-0028", "FAIL", `check_suites present but NO pull_request_numbers (still 0.1.17) — cols: ${cols.join(",")}`);
+  } catch (e) { say("P6-migration-0028", "INCONCLUSIVE", e.message); }
+
+  // ── P7: MIGRATED IS NOT WRITTEN. The DDL comes from @catalyst-cloud/schema; the
+  // row binding comes from @catalyst-cloud/replicate, and the engine DROPS columns the
+  // bundled schema does not know. So a present column proves nothing about content.
+  // 0028 is additive with no backfill: the ~760 pre-existing rows stay NULL forever and
+  // only suites arriving after the restart carry an association.
+  try {
+    const t = db.prepare("SELECT COUNT(*) n FROM check_suites").get().n;
+    let populated = 0;
+    try {
+      populated = db.prepare("SELECT COUNT(*) n FROM check_suites WHERE pull_request_numbers IS NOT NULL AND pull_request_numbers != ''").get().n;
+    } catch { populated = -1; }
+    if (populated < 0) say("P7-association-written", "FAIL", `column not queryable; ${t} suite rows`);
+    else if (populated === 0) say("P7-association-written", "INCONCLUSIVE", `${t} suite rows, 0 with an association — expected until fresh CI runs post-restart (no backfill). NOT a pass.`);
+    else say("P7-association-written", "PASS", `${populated}/${t} suite rows carry an association`);
+  } catch (e) { say("P7-association-written", "INCONCLUSIVE", e.message); }
+
+  // ── The stream is actually served here.
+  try {
+    const keys = availableStreams(db).map((s) => s.key);
+    say("streams-served", keys.includes("checkSuiteCompleted") ? "PASS" : "FAIL",
+      `${keys.includes("checkSuiteCompleted") ? "checkSuiteCompleted served" : "checkSuiteCompleted NOT served"} · ${keys.join(",")}`);
+  } catch (e) { say("streams-served", "INCONCLUSIVE", e.message); }
+}
+
+// ── P2: 12 of 12, resolved from THIS host's replica.
+const cov = readGithubCoverage();
+if (!cov.ok) {
+  // ⛔ ok:false is "could not read the replica", which is not a covered host and must
+  // never be counted as one — the safe set it returns would otherwise read as a real
+  // measurement of a 10/12 host.
+  say("P2-coverage", "INCONCLUSIVE", "readGithubCoverage ok:false — the replica could not be read, so coverage is UNKNOWN, not 10/12");
+} else {
+  const s = githubSuppressibleNames(cov);
+  const missing = GITHUB_CONSUMED_NAMES.filter((n) => !s.includes(n));
+  say("P2-coverage", missing.length === 0 ? "PASS" : "FAIL",
+    `${s.length}/${GITHUB_CONSUMED_NAMES.length} · ${JSON.stringify(cov)}${missing.length ? " · missing: " + missing.join(", ") : ""}`);
+}
+
+try { db?.close(); } catch {}
+
+const width = Math.max(...out.map((o) => o.gate.length));
+for (const o of out) console.log(`${o.verdict.padEnd(13)} ${o.gate.padEnd(width)}  ${o.detail}`);
+const fail = out.filter((o) => o.verdict === "FAIL").length;
+const inc = out.filter((o) => o.verdict === "INCONCLUSIVE").length;
+console.log(`\n${out.filter((o) => o.verdict === "PASS").length} pass · ${fail} FAIL · ${inc} INCONCLUSIVE`);
+// 0 all-pass · 2 a real failure · 3 could not determine. Same contract as the ledger.
+process.exit(fail > 0 ? 2 : inc > 0 ? 3 : 0);

--- a/plugins/dev/scripts/execution-core/github-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.mjs
@@ -275,6 +275,29 @@ export function parseCheckSuitePrNumbers(raw) {
 }
 
 /**
+ * The PR number GitHub encodes in a suite's `head_branch`, or null.
+ *
+ * ⭐ MEASURED, NOT ASSUMED. A suite whose `pull_requests` array is empty often ran on
+ * the pull-request ref, whose branch is literally `refs/pull/<N>/head`. Checked against
+ * every case where the WEBHOOK attached a PR to an empty-association suite from its
+ * SHA→PR cache (CTL-396) and the replica had the suite row: **66 agreed, 0 disagreed.**
+ * Where this fires it is exact.
+ *
+ * ⛔ IT FEEDS THE ATTRIBUTE ONLY, NEVER THE PAYLOAD — see the emitter. The webhook's
+ * cache does the same, and the asymmetry is load-bearing: `router.mjs:1497` routes on
+ * `detail.prNumbers` (the payload array), so writing a derived number there would make
+ * the feed WAKE waiters the webhook does not. That is a behavioural change wearing the
+ * costume of better coverage.
+ */
+export function checkSuitePrFromHeadBranch(headBranch) {
+  if (typeof headBranch !== "string") return null;
+  const m = /^refs\/pull\/(\d+)\/head$/.exec(headBranch);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
  * Decide whether a row is emittable, and say why when it is not.
  *
  * The decline/fail split follows the Linear leg's rule verbatim, because readiness
@@ -339,8 +362,27 @@ export function classifyGithubRow(streamKey, row) {
   // (`requiresColumn`), and the ROW is gated on that column being populated. They
   // decline visibly in `byReason` rather than emitting a twin that cannot route.
   if (streamKey === "checkSuiteCompleted") {
-    const prs = parseCheckSuitePrNumbers(row.pull_request_numbers);
-    if (prs.length === 0) return { emit: false, reason: "no-pr-association:not-backfilled" };
+    // ⛔ ONLY AN ABSENT COLUMN DECLINES — an EMPTY array emits. This distinction was
+    // wrong in the first cut and the measurement is what corrected it.
+    //
+    // `NULL` means the writer never wrote the column: a row predating migration 0028,
+    // about which we know nothing. `[]` means GitHub SAID there are no pull requests —
+    // a fact, and the commonest one on this fleet: **983 of 3,654** live suite events
+    // since 2026-08-17 (26.9%) carry `prNumbers: []`, dominated by `main`-branch runs.
+    //
+    // ⚠️ AND DECLINING THOSE COSTS NO DISPATCH, which is why it is safe to emit them.
+    // `router.mjs:1497` reaches an interest through `eventPrs.find(...)` over
+    // `detail.prNumbers` — `getEventPayload` = `body.payload`, never the attributes —
+    // so an event with an empty array wakes NOTHING on the webhook side either. The
+    // 355 of those the webhook decorates with a cache-derived `vcs.pr.number` are
+    // routing-inert too: that attribute is bridged only into `scope`, and this name's
+    // branch never reads `scope`. Verified in the router source, not inferred.
+    //
+    // So declining them bought nothing and cost parity: 27% of the smee side would be
+    // permanently unjoinable and the ledger could never read CLEAN.
+    if (row.pull_request_numbers === null || row.pull_request_numbers === undefined) {
+      return { emit: false, reason: "no-pr-association:not-backfilled" };
+    }
   }
   if (streamKey === "pushEvent" && (typeof row.ref !== "string" || row.ref === "")) {
     return { emit: false, reason: "no-ref" };
@@ -597,7 +639,16 @@ export function buildGithubEvent(streamKey, row, seams) {
       // ⛔ `prNumbers[0]`, NOT the whole list. The webhook picks the FIRST entry for
       // the attribute and carries the full array in the payload; reproducing only one
       // half of that would diverge on whichever field the ledger compares.
-      const effectivePr = prs[0];
+      //
+      // ⭐ The fallback mirrors the webhook's own: when the array is empty it reaches
+      // for its SHA→PR cache (`cachedPrNumber`, CTL-396). We cannot reproduce that
+      // cache — it is an in-memory HISTORICAL map of sha→PR, and the replica's
+      // `pull_requests` is a LAST-STATE projection that forgets a PR's old heads
+      // (measured: only 18 of 88 empty-association suites still match a current head).
+      // What we can read exactly is the pull-request ref GitHub put in `head_branch`.
+      const effectivePr = prs.length > 0
+        ? prs[0]
+        : checkSuitePrFromHeadBranch(row.head_branch);
       const conclusion = typeof row.conclusion === "string" && row.conclusion !== "" ? row.conclusion : null;
       const status = typeof row.status === "string" ? row.status : "";
       const headSha = typeof row.head_sha === "string" ? row.head_sha : "";
@@ -611,7 +662,9 @@ export function buildGithubEvent(streamKey, row, seams) {
         // value. They coincide for the one name we emit, and reading it from the row
         // keeps that a fact rather than a coincidence.
         action: status,
-        label: `PR #${effectivePr}`,
+        // The webhook passes `undefined` (no label) when it has no PR, and the
+        // envelope builder omits the key entirely for `undefined`.
+        label: effectivePr !== null && effectivePr !== undefined ? `PR #${effectivePr}` : undefined,
         attrs: {
           "vcs.repository.name": repo,
           "cicd.pipeline.run.status": status,
@@ -621,7 +674,11 @@ export function buildGithubEvent(streamKey, row, seams) {
           // every event carrying neither — the `pr.merged` `vcs.revision` mistake in
           // the other direction.
           ...(headSha ? { "vcs.revision": headSha } : {}),
-          "vcs.pr.number": effectivePr,
+          // ⛔ CONDITIONAL, like the webhook: it omits the attribute entirely when it
+          // has no PR from either the payload or its cache. A `main`-branch suite
+          // legitimately has none (56 of 88 empty-association rows measured), and
+          // emitting `null` there would diverge on every one of them.
+          ...(effectivePr !== null && effectivePr !== undefined ? { "vcs.pr.number": effectivePr } : {}),
           ...(conclusion !== null ? { "cicd.pipeline.run.conclusion": conclusion } : {}),
         },
         message: `${name} for ${repo}${conclusion ? ` (${conclusion})` : ""}`,
@@ -633,6 +690,12 @@ export function buildGithubEvent(streamKey, row, seams) {
           // ⚠️ `head_branch` IS stored and is NOT emitted. The webhook parses it into
           // `headRef` and then drops it — no attribute, no payload key. Adding it
           // would be an improvement, and an improvement is a divergence.
+          //
+          // ⛔ GITHUB'S ARRAY, VERBATIM — `effectivePr` is deliberately NOT folded in.
+          // THIS FIELD IS THE ROUTE (`router.mjs:1497` reads `detail.prNumbers`), so a
+          // derived entry here would wake waiters the webhook never wakes. The derived
+          // number belongs in the attribute, where the webhook's own cache puts it and
+          // where nothing routes on it.
           prNumbers: prs,
         },
       }, seams);

--- a/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-event.test.mjs
@@ -17,6 +17,7 @@ import {
   buildGithubEvent,
   classifyGithubRow,
   githubEdgeId,
+  checkSuitePrFromHeadBranch,
   githubEventName,
   loginOf,
   parseCheckSuitePrNumbers,
@@ -507,18 +508,30 @@ describe("CTC-712 — a suite with no PR association DECLINES, visibly", () => {
     status: "completed", conclusion: "success",
   };
 
-  test("⛔ the 760 un-backfilled rows decline by name, they do not emit unroutable events", () => {
-    // Migration 0028 is an additive ADD COLUMN with no backfill, so every suite row
-    // predating the 0.1.18 pin has this NULL. An event without a PR number still
-    // LOOKS emitted and reaches no interest — worse than a decline, which is counted.
-    for (const v of [null, undefined, "", "[]", "null", "not json", "{}", "[0]", '["7"]']) {
+  test("⛔ ONLY an ABSENT column declines — a row predating migration 0028", () => {
+    // 0028 is an additive ADD COLUMN with no backfill, so a row from before the pin has
+    // NULL here and we know NOTHING about its association. Emitting it would assert
+    // "no PR" on a row we cannot read.
+    for (const v of [null, undefined]) {
       const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: v });
       expect(c.emit).toBe(false);
       expect(c.reason).toBe("no-pr-association:not-backfilled");
     }
   });
 
-  test("a populated association emits — the positive control on the decline above", () => {
+  test("⭐ an EMPTY association EMITS — GitHub saying 'no PRs' is a fact, not a gap", () => {
+    // The correction that measurement forced. `[]` is the commonest case on this fleet
+    // (983 of 3,654 live suite events, 26.9%, dominated by main-branch runs), and
+    // declining it costs no dispatch — the router routes on `detail.prNumbers`, so an
+    // empty array wakes nothing on the WEBHOOK side either — while making 27% of the
+    // smee side permanently unjoinable, so the ledger could never read CLEAN.
+    for (const v of ["[]", "[0]", '["7"]', "{}", "not json"]) {
+      const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: v });
+      expect(c.emit).toBe(true);
+    }
+  });
+
+  test("a populated association emits — the positive control", () => {
     const c = classifyGithubRow("checkSuiteCompleted", { ...base, pull_request_numbers: "[7]" });
     expect(c.emit).toBe(true);
     expect(c.reason).toBeNull();
@@ -588,5 +601,60 @@ describe("CTC-712 — the edge identity survives a re-read and distinguishes a r
     // collapse push identity back to the ref and kill github.push after one push.
     const push = { __ts: 1000, __id: "o/r@refs/heads/main", repo_id: "o/r", ref: "refs/heads/main", after: "sha-a" };
     expect(githubEdgeId("push", push)).toBe("gh:push:o/r@refs/heads/main:1000:sha-a");
+  });
+});
+
+describe("CTC-712 — an empty association reproduces the webhook, including its silence", () => {
+  const row = (over = {}) => ({
+    __ts: 1000, __id: "cs1", repo_id: "o/r", check_suite_id: "cs1", head_sha: "abc",
+    status: "completed", conclusion: "success", pull_request_numbers: "[]",
+    head_branch: "main", ...over,
+  });
+  const ev = (over) => buildGithubEvent("checkSuiteCompleted", row(over), SEAMS);
+
+  test("⛔ a main-branch suite emits with NO vcs.pr.number and NO label", () => {
+    // 56 of 88 empty-association rows measured are `main`. The webhook omits both keys
+    // for these; emitting null would diverge on every one.
+    const e = ev();
+    expect(e).not.toBeNull();
+    expect("vcs.pr.number" in e.attributes).toBe(false);
+    expect("event.label" in e.attributes).toBe(false);
+    expect(e.body.payload.prNumbers).toEqual([]);
+  });
+
+  test("⭐ a refs/pull/<N>/head suite recovers the PR into the ATTRIBUTE", () => {
+    const e = ev({ head_branch: "refs/pull/3468/head" });
+    expect(e.attributes["vcs.pr.number"]).toBe(3468);
+    expect(e.attributes["event.label"]).toBe("PR #3468");
+  });
+
+  test("⛔⛔ the recovered PR NEVER reaches the payload — the payload is the ROUTE", () => {
+    // `router.mjs:1497` routes on `detail.prNumbers`. Folding a derived number in there
+    // would make the feed WAKE waiters the webhook does not — a behavioural change
+    // wearing the costume of better coverage. The attribute is where the webhook's own
+    // SHA→PR cache puts its answer, and nothing routes on it.
+    const e = ev({ head_branch: "refs/pull/3468/head" });
+    expect(e.body.payload.prNumbers).toEqual([]);
+  });
+
+  test("a real association always WINS over the head_branch derivation", () => {
+    const e = ev({ pull_request_numbers: "[99]", head_branch: "refs/pull/3468/head" });
+    expect(e.attributes["vcs.pr.number"]).toBe(99);
+    expect(e.body.payload.prNumbers).toEqual([99]);
+  });
+
+  test("checkSuitePrFromHeadBranch is exact — it matches the ref form and nothing else", () => {
+    expect(checkSuitePrFromHeadBranch("refs/pull/3468/head")).toBe(3468);
+    expect(checkSuitePrFromHeadBranch("refs/pull/1/head")).toBe(1);
+    // ⛔ Anything else is null rather than a guess. A wrong PR number on a CI-completion
+    // event is worse than an absent one: absent routes nowhere, wrong routes somewhere.
+    expect(checkSuitePrFromHeadBranch("main")).toBeNull();
+    expect(checkSuitePrFromHeadBranch("refs/pull/3468/merge")).toBeNull();
+    expect(checkSuitePrFromHeadBranch("refs/heads/refs/pull/9/head")).toBeNull();
+    expect(checkSuitePrFromHeadBranch("refs/pull/abc/head")).toBeNull();
+    expect(checkSuitePrFromHeadBranch("refs/pull/0/head")).toBeNull();
+    expect(checkSuitePrFromHeadBranch("ryan/ctl-1929")).toBeNull();
+    expect(checkSuitePrFromHeadBranch(null)).toBeNull();
+    expect(checkSuitePrFromHeadBranch(undefined)).toBeNull();
   });
 });

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -105,12 +105,37 @@ const COMPARE_SPEC_DRAFT = {
     attrs: ["vcs.repository.name", "vcs.revision", "vcs.ref.name", "deployment.environment", "deployment.id", "event.label"],
     payload: ["deploymentId"],
   },
-  // ⭐ CTC-712 (schema 0.1.18). ⛔ `vcs.pr.number` is compared and must never move to
-  // OBSERVED_ONLY: it IS the route. `router.mjs:1497` reaches an interest only through
-  // `detail.prNumbers`, and a suite event whose PR association disagrees with the
-  // webhook's is one that wakes the wrong waiter or none — while every count still
-  // reads "emitted". That is the whole failure CTC-712 exists to close, so the ledger
-  // has to be able to see it.
+  // ⭐ CTC-712 (schema 0.1.18).
+  //
+  // ⛔ `body.payload.prNumbers` IS THE ROUTE and is compared. `router.mjs:1497` reaches
+  // an interest through `eventPrs.find(...)` over `detail.prNumbers`, and
+  // `getEventPayload` resolves that to `body.payload` — never to the attributes. A
+  // suite event whose payload association disagrees with the webhook's wakes the wrong
+  // waiter or none, while every count still reads "emitted". That is the failure
+  // CTC-712 exists to close, so the ledger must be able to see it.
+  //
+  // ⚠️ `attributes["vcs.pr.number"]` is NOT compared, and an earlier version of this
+  // comment asserted the opposite — that it "IS the route and must never move to
+  // OBSERVED_ONLY". **That was wrong**, and reading the router rather than repeating
+  // the claim is what corrected it: the attribute is bridged only into `getEventScope`,
+  // and this name's branch never reads `scope`. It is display and observability.
+  //
+  // It is excluded because the two producers fill it from sources that cannot be made
+  // to agree, on a measured population. When GitHub sends an empty `pull_requests`
+  // array — **983 of 3,654 live suite events since 2026-08-17, 26.9%** — the webhook
+  // falls back to an in-memory SHA→PR cache (CTL-396) and resolves **355** of them.
+  // That cache is a HISTORICAL sha→PR map; the replica's `pull_requests` is a
+  // LAST-STATE projection that forgets a PR's earlier heads, so only 18 of 88 such
+  // suites still match a current head. The producer therefore reproduces the exact
+  // subset it can read exactly — `refs/pull/<N>/head`, measured 66 agreements and 0
+  // disagreements — and leaves the attribute absent otherwise, as the webhook does for
+  // a `main`-branch suite (56 of those 88).
+  //
+  // ⛔ Comparing it anyway would leave ~27% of the smee side permanently unjoinable and
+  // the ledger unable to reach CLEAN for a difference that changes no dispatch. That is
+  // a false BLOCKER, the same shape as the repo-scoping one #3551 fixed — and excluding
+  // a field that DID route would be the false-clean in the other direction, which is
+  // why the routing question was settled in the router's source before this line moved.
   //
   // ⚠️ THE KEY IS COARSE, AND DELIBERATELY SO. Neither side carries `check_suite_id`
   // (the webhook payload has no suite id in the envelope), and one head sha carried
@@ -121,13 +146,21 @@ const COMPARE_SPEC_DRAFT = {
   // duplicated suite still surfaces as an unjoined count rather than being absorbed.
   // With a single-value index this key would be a false-clean generator.
   "github.check_suite.completed": {
+    // ⛔ THE KEY CANNOT USE `vcs.pr.number` EITHER. It is exactly the field the two
+    // producers may legitimately differ on, so keying with it would split an agreeing
+    // pair into two unjoined singletons — a divergence reported as an ABSENCE, which is
+    // the harder failure to diagnose. Keyed on what both sides derive identically.
     key: (e) =>
-      `cs:${e.attributes?.["vcs.repository.name"]}#${e.attributes?.["vcs.pr.number"]}` +
-      `|${e.attributes?.["vcs.revision"] ?? ""}|${e.attributes?.["cicd.pipeline.run.conclusion"] ?? ""}`,
+      `cs:${e.attributes?.["vcs.repository.name"]}|${e.attributes?.["vcs.revision"] ?? ""}` +
+      `|${e.attributes?.["cicd.pipeline.run.conclusion"] ?? ""}` +
+      `|${JSON.stringify(e.body?.payload?.prNumbers ?? [])}`,
     attrs: [
-      "vcs.repository.name", "vcs.pr.number", "vcs.revision",
+      // ⚠️ `vcs.pr.number` and `event.label` are absent BY DESIGN — see above. The label
+      // is `PR #<n>` built from the same value, so comparing it would re-introduce the
+      // divergence through the back door.
+      "vcs.repository.name", "vcs.revision",
       "cicd.pipeline.run.status", "cicd.pipeline.run.conclusion",
-      "event.entity", "event.action", "event.label", "event.stream_class",
+      "event.entity", "event.action", "event.stream_class",
     ],
     // `prNumbers` is compared as a whole array, not just its head: the attribute
     // carries only `[0]`, so a disagreement in the tail would otherwise be invisible.

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -352,26 +352,43 @@ describe("CTC-712 — the check_suite compare spec can join, and can DIVERGE", (
     expect(r.totals.smeeUnjoined).toBe(0);
   });
 
-  test("⛔ a disagreeing PR association is a DIVERGENCE, not a pass", () => {
-    // The positive control that matters most: `vcs.pr.number` IS the route, so a
-    // ledger that could not fail on it would certify the exact defect CTC-712 fixed.
-    const feed = suiteEv();
-    const smeeSide = suiteEv({ payload: { prNumbers: [7, 9] } });
-    const r = compareGithubStreams([feed], [smeeSide]);
-    expect(r.byName["github.check_suite.completed"].joined).toBe(1);
-    expect(r.byName["github.check_suite.completed"].agree).toBe(0);
+  test("⛔ a disagreeing PAYLOAD association is never clean — that field IS the route", () => {
+    // `router.mjs:1497` routes on `detail.prNumbers`, so a ledger that could not fail
+    // on it would certify the exact defect CTC-712 exists to close. The key includes it
+    // (see the spec), so a disagreement surfaces as unjoined rather than as a
+    // disagreeing pair — either way, never as clean.
+    const r = compareGithubStreams([suiteEv()], [suiteEv({ payload: { prNumbers: [7, 9] } })]);
     expect(r.clean).toBe(false);
+    expect(r.totals.smeeUnjoined).toBe(1);
   });
 
-  test("⛔ a conclusion disagreement is caught", () => {
+  test("⭐ a vcs.pr.number-only difference JOINS and AGREES — it changes no dispatch", () => {
+    // The measured case: the webhook decorates an empty-association suite from its
+    // SHA→PR cache (355 of 983 live events) and the replica cannot reproduce that
+    // historical map. Comparing it would leave 27% of the smee side permanently
+    // unjoinable for a difference nothing routes on — a false BLOCKER, the same shape
+    // as the repo-scoping one #3551 fixed.
+    const feed = suiteEv({ attrs: { "vcs.pr.number": undefined, "event.label": undefined },
+                           payload: { prNumbers: [] } });
+    const smeeSide = suiteEv({ attrs: { "vcs.pr.number": 3468, "event.label": "PR #3468" },
+                               payload: { prNumbers: [] } });
+    const r = compareGithubStreams([feed], [smeeSide]);
+    expect(r.byName["github.check_suite.completed"].joined).toBe(1);
+    expect(r.byName["github.check_suite.completed"].agree).toBe(1);
+    expect(r.totals.smeeUnjoined).toBe(0);
+  });
+
+  test("⛔ but a CONCLUSION difference still breaks clean — the exclusion is narrow", () => {
+    // The control on the test above: excluding one display field must not have
+    // loosened the comparison generally.
     const r = compareGithubStreams(
       [suiteEv()],
       [suiteEv({ attrs: { "cicd.pipeline.run.conclusion": "failure" }, payload: { conclusion: "failure" } })],
     );
-    // A different conclusion changes the KEY as well, so this surfaces as two
-    // unjoined events rather than a disagreeing pair — either way, never as clean.
     expect(r.clean).toBe(false);
   });
+
+
 
   test("⚠️ the coarse key still counts MULTIPLICITY — a dropped suite cannot hide", () => {
     // Two real suites bucket under one key (no suite id is on either side). If the


### PR DESCRIPTION
## The measurement that forced this, and the wrong fix I nearly built

Over **3,654** live `github.check_suite.completed` events since 2026-08-17 on mini-2:

```
total                        3654
payload.prNumbers = []        983   (26.9%)
  ...of those, WITH vcs.pr.number (the webhook's SHA->PR cache fired):  355
payload.prNumbers non-empty  2671
```

#3560 declined **every one of those 983** as `no-pr-association:not-backfilled`. That would have left **27% of the smee side permanently unjoinable** — the ledger could never have reached CLEAN and the tunnel could never have been retired, for something that is not a defect.

⛔ **And the first reading of the 355 looked far worse than that.** The webhook decorates them with a PR from an in-memory SHA→PR cache (CTL-396) which the replica cannot reproduce — its `pull_requests` is a **last-state** projection that forgets a PR's earlier heads (measured: only **18 of 88** empty-association suites still match a current head). So it looked like ~10% of CI-completion dispatches would be silently lost at `enforce`, which is a retirement blocker and would have justified building a whole sha→PR resolution layer.

**Reading the router instead of assuming settled it:**

```
router.mjs:1497   const eventPrs = Array.isArray(detail.prNumbers) ? detail.prNumbers : [];
                  const matchedPr = eventPrs.find((n) => prList.includes(n));
router.mjs:973    getEventPayload(event) => event.detail ?? event.body?.payload ?? {}
```

`detail.prNumbers` is the **payload array**. The `vcs.pr.number` attribute is bridged only into `getEventScope`, and this name's branch never reads `scope`. ⭐ **So an empty-array suite event wakes nothing on the webhook side either — cache-decorated or not.** No dispatch is at stake. It is a ledger-parity problem, and the honest fix is much smaller than the one the raw numbers argued for.

## What changed

- **Only an ABSENT column declines.** `NULL` means the writer never wrote it — a row predating migration 0028, about which we know nothing, so emitting would *assert* "no PR" on unread data. `[]` means GitHub **said** there are no pull requests: a fact, and **56 of 88** such rows are `main`-branch runs that correctly have no PR on either side.
- **Where the association is empty, the PR is recovered from `head_branch`.** GitHub puts the pull-request ref there in the `refs/pull/<N>/head` form. Checked against every case where the webhook's cache resolved a PR for an empty-association suite and the replica had the suite row: **66 agreed, 0 disagreed.** Where it fires, it is exact; everything else returns `null` rather than a guess, because a *wrong* PR number on a CI-completion event is worse than an absent one — absent routes nowhere, wrong routes somewhere.
- ⛔ **The recovered number goes to the ATTRIBUTE ONLY, never the payload.** The payload is the route. Folding a derived entry in there would make the feed **wake waiters the webhook does not** — a behavioural change wearing the costume of better coverage. The webhook's own cache fills exactly the same attribute, and nothing routes on it. There is a dedicated test, and a mutation that puts it in the payload is caught.
- **`attributes["vcs.pr.number"]` and `event.label` leave the compare spec**, and the join key stops using `vcs.pr.number` — keying on a field the two producers may legitimately differ on would split an agreeing pair into two unjoined singletons, reporting a *divergence* as an *absence*, which is the harder failure to diagnose. `payload.prNumbers` **stays compared**, because that is what routes, and a test asserts a conclusion difference still breaks clean so the exclusion cannot be read as a general loosening.

⚠️ **A comment I wrote three hours ago in #3560 asserted the opposite** — that `vcs.pr.number` "IS the route and must never move to OBSERVED_ONLY". It is corrected in place with the router citation rather than quietly deleted, because the next person will otherwise re-derive the same wrong conclusion from it.

## Verified end to end against a REAL 0.1.18 replica

The laptop's cloud-sync writer has already restarted onto schema 0.1.18 (boot record: sdk 0.8.14 / schema 0.1.18, pid live), so migration 0028 is applied and the association column is populated there — a real one, ahead of the fleet pin:

```
rows paged            836
declined              {"no-pr-association:not-backfilled": 531}   <- pre-0028 rows, correct
emitted               305
  with vcs.pr.number  235
    ...of those, DERIVED from refs/pull with the payload still []:  22
  without (main etc)   70
sample: {"hb":"refs/pull/3544/head","attrPr":3544,"payload":[]}
```

The payload-leak invariant is asserted inside that run and held.

## Also in this PR

`ctl1929-preflight.mjs` — the runbook's P2/P6/P7 gates as one command per host, every gate three-valued so "could not look" can never read as "covered" (an unreadable replica reports **INCONCLUSIVE**, not a 10/12 host). It is committed rather than hand-placed because `plugin-refresh` runs `git reset --hard`, which silently clobbers untracked files. Positive control: it returns `4 pass / 0 FAIL` on the laptop's 0.1.18 replica and `0 pass / 4 FAIL` on both minis' 0.1.17 ones, so it demonstrably distinguishes the states.

**7 further mutations run, all caught. 753 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)