### PR TITLE
fix(dev): CTL-1929 — set aside the suite conclusions the mirror cannot store (CTC-719), and collapse an observation node's duplicated deliveries

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity-run.mjs
@@ -64,8 +64,10 @@ for await (const e of jsonl(shadowPath)) {
 }
 
 const smee = [];
+const seenDelivery = new Set();
 let smeeSeen = 0;
 let smeeLast = null;
+let smeeDuplicates = 0;
 for await (const e of jsonl(eventsPath)) {
   const n = e?.attributes?.["event.name"];
   if (typeof n !== "string" || !n.startsWith("github.")) continue;
@@ -73,7 +75,25 @@ for await (const e of jsonl(eventsPath)) {
   if (e?.body?.payload?.source === "cloud-feed") continue;
   smeeSeen++;
   if (typeof e?.ts === "string") smeeLast = e.ts;
-  if (inWindow(e)) smee.push(e);
+  if (!inWindow(e)) continue;
+  // ⛔ ONE ROW PER GITHUB DELIVERY. On a worker node this changes nothing — the host's
+  // own log holds one copy. On an OBSERVATION node it is the difference between a
+  // clean verdict and a fabricated gap: event-mirror fans in every worker's log, and
+  // each mini runs its OWN smee tunnel, so every delivery appears once per host.
+  // Measured on the laptop over one 70-minute window: 166 events, 83 distinct delivery
+  // ids, 83 per host — which reported `smee-unjoined 77` against a feed that had
+  // reproduced every single one of them.
+  //
+  // ⚠️ Collapsed on GitHub's OWN delivery id, never on content: two genuinely distinct
+  // deliveries are two events, and a redelivery of one is one. An event with no
+  // delivery id is kept rather than dropped — absence of the key is not evidence of a
+  // duplicate, and dropping it would be the silent direction.
+  const delivery = e?.attributes?.["webhook.delivery.id"];
+  if (typeof delivery === "string" && delivery !== "") {
+    if (seenDelivery.has(delivery)) { smeeDuplicates++; continue; }
+    seenDelivery.add(delivery);
+  }
+  smee.push(e);
 }
 
 const report = compareGithubStreams(feed, smee);
@@ -108,12 +128,16 @@ const instrument = {
   feedLinesTotal: feedLines, feedLastTs: feedLast,
   smeeGithubTotal: smeeSeen, smeeLastTs: smeeLast,
   tornLines: torn,
+  smeeDuplicateDeliveries: smeeDuplicates,
 };
 
 if (asJson) {
   console.log(JSON.stringify({ window: { lo, hi }, instrument, report, exit: code }, null, 2));
 } else {
   console.log(`instrument: shadow lines=${feedLines} last=${feedLast} · smee github=${smeeSeen} last=${smeeLast} · torn=${torn}`);
+  if (smeeDuplicates > 0) {
+    console.log(`            ${smeeDuplicates} duplicate webhook deliveries collapsed (an observation node mirrors every worker's copy — see the source)`);
+  }
   console.log(`WINDOW ${lo} -> ${hi}`);
   console.log(`feed ${feed.length} · smee ${smee.length}`);
   console.log(`joined ${report.totals.joined} / agree ${report.totals.agree} · feed-unjoined ${report.totals.unjoined} · smee-unjoined ${report.smeeUnjoined} · unkeyable ${report.unkeyable}`);
@@ -122,6 +146,7 @@ if (asJson) {
   }
   console.log("comparableRepos  :", JSON.stringify(report.comparableRepos));
   console.log("feedOnlyRepos    :", JSON.stringify(report.feedOnlyRepos), "(superset — never blocks CLEAN)");
+  console.log("mirrorUnstorable :", JSON.stringify(report.mirrorUnstorable), "(CTC-719 — conclusions the mirror drops; self-retires when it stops)");
   console.log("expectedAbsent   :", JSON.stringify(report.expectedAbsent));
   console.log("unexplainedAbsent:", JSON.stringify(report.unexplainedAbsent));
   console.log("inconclusive     :", JSON.stringify(report.inconclusive));

--- a/plugins/dev/scripts/execution-core/github-feed-parity.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.mjs
@@ -263,6 +263,47 @@ export function smeeRepos(smeeEvents) {
   return repos;
 }
 
+/**
+ * Suite conclusions the MIRROR does not store, so the producer cannot emit them.
+ *
+ * ⛔ MEASURED, AND IT IS A REAL GAP — CTC-719, not a quirk. The replica's
+ * `check_suites` holds only `success` / `cancelled` / `failure`; it has never held a
+ * `neutral` or `skipped` one. Live counts (deduped by webhook delivery id, since
+ * 2026-08-17): smee `success 3298 · neutral 245 · failure 114 · cancelled 84 ·
+ * skipped 3` against a replica of `success 858 · cancelled 13 · failure 3`.
+ * **248 of 3,748 (6.6%)** are structurally invisible. The control that makes it a
+ * `check_suites` bug rather than a replica limitation is `check_runs` in the SAME
+ * database, which stores `neutral 2366` and `skipped 1152` happily.
+ *
+ * ⚠️ Excluded here so the retirement gate is reachable, NOT because the gap is
+ * closed. `router.mjs:1497` treats `neutral` as non-failing, so those events DO wake
+ * a waiter today. Measured blast radius: 234 of the 245 carry a PR, across 62 PRs —
+ * but **0 of 227 PRs had ONLY neutral conclusions**, so every one of them also got a
+ * replicable suite and no PR would actually hang. That is a statistical property of
+ * this fleet's CI configuration, not a structural guarantee, and it is why CTC-719 is
+ * open rather than closed-as-acceptable.
+ */
+export const MIRROR_UNSTORED_SUITE_CONCLUSIONS = Object.freeze(["neutral", "skipped"]);
+
+const suiteConclusionOf = (e) => e?.attributes?.["cicd.pipeline.run.conclusion"] ?? null;
+
+/**
+ * Is this a smee event the mirror provably cannot carry?
+ *
+ * ⭐ SELF-RETIRING, and that is the design's whole point. The exclusion applies only
+ * while the FEED side produced none of these conclusions. The moment CTC-719 lands and
+ * the producer emits its first `neutral` suite, this returns false for every event and
+ * the two sides are compared normally again — with no line for anyone to remember to
+ * delete, and no window in which a fixed mirror is still being excused. An exclusion
+ * that cannot switch itself off is the shape of every stale `KNOWN_ABSENT` entry this
+ * file has had to remove.
+ */
+function mirrorCannotCarry(e, feedHasThoseConclusions) {
+  if (feedHasThoseConclusions) return false;
+  if (nameOf(e) !== "github.check_suite.completed") return false;
+  return MIRROR_UNSTORED_SUITE_CONCLUSIONS.includes(suiteConclusionOf(e));
+}
+
 export function compareGithubStreams(feedEvents, smeeEvents) {
   const feed = Array.isArray(feedEvents) ? feedEvents : [];
   const smee = Array.isArray(smeeEvents) ? smeeEvents : [];
@@ -299,8 +340,24 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
   // which is the single worst thing this file could do. `linear-feed-parity.mjs`
   // already compares by multiplicity for exactly this reason; that lesson is carried
   // here rather than re-learned.
-  const index = new Map();
+  // ⛔ NARROW, ENUMERATED, AND REPORTED — never a silent drop. See `mirrorCannotCarry`.
+  const feedHasThoseConclusions = feed.some(
+    (e) => nameOf(e) === "github.check_suite.completed"
+      && MIRROR_UNSTORED_SUITE_CONCLUSIONS.includes(suiteConclusionOf(e)),
+  );
+  const mirrorUnstorable = {};
+  const smeeComparable = [];
   for (const e of smee) {
+    if (mirrorCannotCarry(e, feedHasThoseConclusions)) {
+      const c = suiteConclusionOf(e);
+      mirrorUnstorable[c] = (mirrorUnstorable[c] ?? 0) + 1;
+      continue;
+    }
+    smeeComparable.push(e);
+  }
+
+  const index = new Map();
+  for (const e of smeeComparable) {
     const n = nameOf(e);
     const spec = COMPARE_SPEC[n];
     if (!spec) continue;
@@ -395,6 +452,10 @@ export function compareGithubStreams(feedEvents, smeeEvents) {
     // that the feed covered repos the tunnel did not, because that is a REASON TO
     // RETIRE rather than a caveat on retiring.
     feedOnlyRepos,
+    // ⭐ Reported on every run, never dropped: an operator reading a clean verdict must
+    // see that a measured slice of the webhook side was set aside, and which ticket
+    // closes it. Symmetric with `feedOnlyRepos` — the count that explains itself.
+    mirrorUnstorable,
     comparableRepos: [...comparableRepos].sort(),
     expectedAbsent: Object.fromEntries(Object.entries(absent).filter(([n]) => n in KNOWN_ABSENT)),
     unexplainedAbsent,

--- a/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-parity.test.mjs
@@ -8,6 +8,7 @@ import { describe, expect, test } from "bun:test";
 import {
   COMPARE_SPEC,
   KNOWN_ABSENT,
+  MIRROR_UNSTORED_SUITE_CONCLUSIONS,
   OBSERVED_ONLY_FIELDS,
   compareGithubStreams,
   smeeRepos,
@@ -397,5 +398,89 @@ describe("CTC-712 — the check_suite compare spec can join, and can DIVERGE", (
     expect(r.totals.smeeUnjoined).toBe(1);
     expect(r.clean).toBe(false);
     expect(r.inconclusive.join("|")).toContain("smee-events-without-a-twin");
+  });
+});
+
+describe("CTC-719 — the conclusions the mirror drops are SET ASIDE, reported, and self-retiring", () => {
+  const suite = (conclusion, extra = {}) => ev(
+    "github.check_suite.completed",
+    {
+      "vcs.repository.name": "o/r", "vcs.revision": "abc",
+      "cicd.pipeline.run.status": "completed",
+      ...(conclusion === null ? {} : { "cicd.pipeline.run.conclusion": conclusion }),
+      "event.entity": "check_suite", "event.action": "completed",
+      "event.stream_class": "coordination",
+    },
+    { conclusion, status: "completed", prNumbers: [7] },
+    extra,
+  );
+
+  test("a neutral smee suite does NOT count as unjoined, and IS reported", () => {
+    // 6.6% of the smee side. Counted as unjoined it makes CLEAN unreachable forever,
+    // for a gap the producer provably cannot close (CTC-719).
+    const r = compareGithubStreams([suite("success")], [suite("success"), suite("neutral"), suite("skipped")]);
+    expect(r.totals.smeeUnjoined).toBe(0);
+    expect(r.mirrorUnstorable).toEqual({ neutral: 1, skipped: 1 });
+    expect(r.clean).toBe(true);
+  });
+
+  test("⭐ SELF-RETIRING — once the FEED emits one, the exclusion switches off entirely", () => {
+    // The property that makes this safe to add: when CTC-719 lands and the producer
+    // starts emitting neutral suites, they are compared normally again, with no line
+    // for anyone to remember to delete and no window in which a fixed mirror is still
+    // being excused. Here the feed emits a neutral one that smee did NOT — which must
+    // now surface rather than be waved through.
+    const r = compareGithubStreams([suite("success"), suite("neutral")], [suite("success"), suite("neutral")]);
+    expect(r.mirrorUnstorable).toEqual({});
+    expect(r.byName["github.check_suite.completed"].joined).toBe(2);
+  });
+
+  test("⛔ with the feed emitting neutral, a MISSING smee neutral is a finding again", () => {
+    const r = compareGithubStreams([suite("success"), suite("neutral")], [suite("success")]);
+    expect(r.mirrorUnstorable).toEqual({});
+    expect(r.totals.unjoined).toBe(1);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⛔ the exclusion is NARROW — it touches only this name and only these conclusions", () => {
+    // A cancelled suite is stored by the mirror and must keep blocking; and the
+    // conclusion set is exactly two entries, not a category.
+    const r = compareGithubStreams([suite("success")], [suite("success"), suite("cancelled")]);
+    expect(r.totals.smeeUnjoined).toBe(1);
+    expect(r.clean).toBe(false);
+    expect(MIRROR_UNSTORED_SUITE_CONCLUSIONS).toEqual(["neutral", "skipped"]);
+  });
+
+  test("⛔ it does not leak to other names — a missing pr.merged still blocks", () => {
+    const merged = ev("github.pr.merged",
+      { "vcs.repository.name": "o/r", "vcs.pr.number": 7 },
+      { action: "closed", merged: true, mergeCommitSha: "abc" });
+    const r = compareGithubStreams([suite("success")], [suite("success"), merged]);
+    expect(r.clean).toBe(false);
+  });
+
+  test("⛔ the NAME guard is load-bearing — another compared name carrying the same attribute is NOT excluded", () => {
+    // ⚠️ SYNTHETIC BY NECESSITY, and deliberately so. The test above cannot reach this
+    // branch: `github.pr.merged` carries no `cicd.pipeline.run.conclusion`, so deleting
+    // the name check changes nothing for it and a mutation of that check SURVIVED. The
+    // guard matters because `github.check_suite.completed` is one member of a
+    // `github.check_suite.<status>` family the webhook really emits — if a sibling ever
+    // joins COMPARE_SPEC, the exclusion must not silently widen onto it.
+    //
+    // So this drives the predicate directly, with a compared name that carries the
+    // attribute. It is not a claim that the fleet emits this event.
+    const ds = (extra) => ev(
+      "github.deployment_status.success",
+      { "vcs.repository.name": "o/r", "deployment.environment": "prod", "deployment.id": 5,
+        "event.entity": "deployment_status", "event.action": "success",
+        "cicd.pipeline.run.conclusion": "neutral" },
+      { deploymentId: 5, state: "success", targetUrl: null, environmentUrl: null },
+      extra,
+    );
+    const r = compareGithubStreams([suite("success")], [suite("success"), ds()]);
+    // Not swallowed by the suite exclusion: it is a different name, so it stays a finding.
+    expect(r.mirrorUnstorable).toEqual({});
+    expect(r.totals.smeeUnjoined).toBe(1);
+    expect(r.clean).toBe(false);
   });
 });


### PR DESCRIPTION
Two measured false-gaps, both of which would have read as *"the feed is losing CI completions"* during today's cutover window.

## 1. ⛔ CTC-719 — the mirror drops `neutral` and `skipped` check suites entirely

```
replica check_suites:  success 858 · cancelled 13 · failure 3 · neutral 0 · skipped 0
smee (deduped, 08-17): success 3298 · neutral 245 · failure 114 · cancelled 84 · skipped 3
```

**248 of 3,748 (6.6%)** are structurally invisible to the producer.

⭐ **The control that makes this a `check_suites` bug and not a replica limitation:** `check_runs`, in the **same database**, through the same ingestion, stores `neutral 2366` and `skipped 1152` happily. The column can hold them and the pipeline can carry them.

Counted as unjoined, that made CLEAN **permanently unreachable** for a gap the producer cannot close. They are now **set aside and reported** as `mirrorUnstorable` on every run — the same posture as `feedOnlyRepos`: a count that explains itself rather than an excuse that hides.

### ⭐ The exclusion is SELF-RETIRING

It applies **only while the feed side produced none of those conclusions**. The moment CTC-719 lands and the producer emits its first neutral suite, both sides are compared normally again — with no line for anyone to remember to delete, and no window in which a fixed mirror is still being excused.

Every stale `KNOWN_ABSENT` entry this file has had to remove lacked exactly that property, which is why the design is worth the extra predicate. There are tests for both directions: with the feed emitting neutral, a *missing* smee neutral becomes a finding again.

### ⚠️ Not closed — and the ticket carries the numbers

`router.mjs:1497` treats `neutral` as **non-failing**, so those events do wake a waiter today. 234 of the 245 carry a PR, across 62 PRs. But:

```
PRs with any suite event                                        227
  ...whose ONLY conclusions are neutral/skipped (feed silent)     0
  ...with neutral AND a replicable conclusion (currently masked) 62
```

**No PR would hang today.** That is a property of this fleet's CI configuration, not a structural guarantee — which is why CTC-719 is open rather than closed-as-acceptable.

## 2. ⛔ An observation node mirrors every worker's copy of the same delivery

The laptop's event-mirror fans in **both** minis' logs, and **each mini runs its own smee tunnel**, so every GitHub delivery appears once per host. Measured over one 70-minute window:

```
166 events · 83 distinct delivery ids · 83 per host {mini-2: 83, mini: 83}
```

The ledger correctly — and uselessly — reported `smee-unjoined 77` against a feed that had reproduced every single one of them.

The runner now collapses on GitHub's own `webhook.delivery.id` and **reports how many it collapsed**. ⛔ Never on content: two genuinely distinct deliveries are two events, and an event with **no** delivery id is **kept** — absence of the key is not evidence of a duplicate, and dropping it would be the silent direction.

## ⭐ Verified end to end on a REAL 0.1.18 replica — the ~14:00 gate, seven hours early

The laptop's cloud-sync writer restarted onto schema 0.1.18 at ~06:33 today, so migration 0028 is applied and the association column is populated there. Running the producer's own classify+build path over that replica against the live webhook arm:

```
replica rows 77 · feed built 77 · smee 83 (deduped)
joined 77 / agree 77 · feed-unjoined 0 · smee-unjoined 0
mirrorUnstorable {"neutral": 6}
clean = true · exit 0
```

**Every field of every event agrees.** No host was touched to get this.

## Mutations

5 run. One survived, and **the test was the weak part, not the code**: *"does not leak to other names"* used a `pr.merged` event that carries no `cicd.pipeline.run.conclusion`, so deleting the name guard changed nothing for it. Replaced with one that drives the predicate through a *compared* name that does carry the attribute — and labelled synthetic in the test itself rather than dressed up as fleet traffic. Re-run: caught.

**759 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)