### PR TITLE
fix(dev): CTL-1929 — the preflight checks EVERY repo on the tunnel, because the ledger structurally cannot

### DIFF
--- a/plugins/dev/scripts/execution-core/ctl1929-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/ctl1929-preflight.mjs
@@ -53,6 +53,54 @@ if (db) {
   } catch (e) { say("streams-served", "INCONCLUSIVE", e.message); }
 }
 
+// ── P8: EVERY REPO ON THE TUNNEL, not just the ones that were noisy today.
+//
+// ⛔ THIS IS THE GATE THE PARITY LEDGER STRUCTURALLY CANNOT BE. The ledger scopes its
+// comparison to the repos that appear IN THE WINDOW, so a repo with no activity
+// contributes no smee events and can never show up as unjoined. A CLEAN verdict over
+// a morning's traffic therefore says NOTHING about a dormant repo — and the smee
+// channel `smee.io/WDgeZys5ST0uqtL` carries EIGHT webhooks, six of them for
+// fleet-orchestrated teams, of which only two were active enough to measure.
+//
+// Measured 2026-08-18: catalyst (99 push_events / 898 suites) and catalyst-cloud
+// (43 / 71) are covered; `ryanrozich/personal-os` is ACTIVE (82 PRs updated in 48 h)
+// with its PRs and reviews ingested and **0 pushes / 0 suites** — a confirmed partial
+// ingestion gap; Adva, catalyst-otel, slides, evergreen and adva-crm have been dormant
+// for 7–8 days, so their zeroes prove nothing in either direction. → CTL-1965.
+//
+// ⚠️ A dormant repo is INCONCLUSIVE, never a pass. "No traffic to disprove it" is the
+// oldest false-clean in this repository.
+const DORMANT_MS = 48 * 60 * 60 * 1000;
+
+function repoCoverage(db, repos) {
+  const out = [];
+  for (const repo of repos) {
+    let r;
+    try {
+      r = db.prepare(`
+        SELECT (SELECT COUNT(*) FROM pull_requests p WHERE p.repo_id = $r) AS prs,
+               (SELECT MAX(updated_at) FROM pull_requests p WHERE p.repo_id = $r) AS newest,
+               (SELECT COUNT(*) FROM push_events e WHERE e.repo_id = $r) AS pushes,
+               (SELECT COUNT(*) FROM check_suites c WHERE c.repo_id = $r) AS suites
+      `).get({ $r: repo });
+    } catch (e) {
+      out.push({ repo, verdict: "INCONCLUSIVE", detail: `cannot query: ${e.message}` });
+      continue;
+    }
+    const active = Number.isInteger(r?.newest) && Date.now() - r.newest < DORMANT_MS;
+    if (r.pushes > 0 && r.suites > 0) {
+      out.push({ repo, verdict: "PASS", detail: `push_events ${r.pushes} · suites ${r.suites}` });
+    } else if (!active) {
+      // ⛔ The honest verdict. The repo may be perfectly ingested and simply quiet;
+      // nothing here can tell, and a retirement decision must not read this as a pass.
+      out.push({ repo, verdict: "INCONCLUSIVE", detail: `dormant (newest PR activity ${r.newest ? new Date(r.newest).toISOString().slice(0, 10) : "never"}), push_events ${r.pushes} · suites ${r.suites} — quiet, so coverage is UNPROVEN either way` });
+    } else {
+      out.push({ repo, verdict: "FAIL", detail: `ACTIVE (${r.prs} PRs, newest ${new Date(r.newest).toISOString().slice(0, 16)}) but push_events ${r.pushes} · suites ${r.suites} — partial ingestion` });
+    }
+  }
+  return out;
+}
+
 // ── P2: 12 of 12, resolved from THIS host's replica.
 const cov = readGithubCoverage();
 if (!cov.ok) {
@@ -65,6 +113,41 @@ if (!cov.ok) {
   const missing = GITHUB_CONSUMED_NAMES.filter((n) => !s.includes(n));
   say("P2-coverage", missing.length === 0 ? "PASS" : "FAIL",
     `${s.length}/${GITHUB_CONSUMED_NAMES.length} · ${JSON.stringify(cov)}${missing.length ? " · missing: " + missing.join(", ") : ""}`);
+}
+
+/**
+ * The repos whose webhooks share the retiring smee channel `smee.io/WDgeZys5ST0uqtL`,
+ * measured 2026-08-18 by walking `gh api repos/<owner>/<repo>/hooks`.
+ *
+ * ⛔ FROZEN AND REPORTED AS FROZEN, not enumerated. GitHub has no "list every webhook
+ * pointing at this URL" endpoint — the only way to build this is to iterate candidate
+ * repos, which means the list is exactly as complete as the guess behind it. The first
+ * cut of this file wrapped a `gh` call around it that could only ever fall through to
+ * this same list; a code path that pretends to check and always defaults is the shape
+ * of every check-that-cannot-fire in this codebase, so it is gone and the staleness is
+ * declared instead.
+ *
+ * ⚠️ RE-ENUMERATE BEFORE ACTING ON THIS GATE:
+ *   for r in <repos>; do gh api "repos/$r/hooks" --jq '.[]|select(.active)|.id'; done
+ */
+const TUNNEL_REPOS = Object.freeze([
+  "coalesce-labs/catalyst",        // webhook 616654741 — CTL
+  "coalesce-labs/catalyst-cloud",  // webhook 657402518 — CTC
+  "ryanrozich/personal-os",        // webhook 661338344 — not in the registry
+  "rightsite-cloud/Adva",          // webhook 616654744 — ADV
+  "coalesce-labs/catalyst-otel",   // webhook 657402515 — OTL
+  "ryanrozich/slides",             // webhook 616654742 — SLI
+  "coalesce-labs/evergreen",       // webhook 657402511 — EVR
+  "rightsite-cloud/adva-crm",      // webhook 657251876 — CRM
+]);
+
+if (db) {
+  for (const c of repoCoverage(db, TUNNEL_REPOS)) say(`P8-repo:${c.repo}`, c.verdict, c.detail);
+  say(
+    "P8-repo-list-source",
+    "INCONCLUSIVE",
+    `frozen list of ${TUNNEL_REPOS.length} repos measured 2026-08-18 — re-enumerate the channel's webhooks before acting; a stale list silently shrinks what is checked`,
+  );
 }
 
 try { db?.close(); } catch {}


### PR DESCRIPTION
## The finding

The smee channel `smee.io/WDgeZys5ST0uqtL` carries **eight** active webhooks, **six of them for fleet-orchestrated teams**. Every turn on this initiative — my own runbook included — has said *"disable webhook `616654741`"* as if the tunnel were one subscription for one repo.

| repo | webhook | team | `push_events` | `check_suites` | activity |
| --- | --- | --- | ---: | ---: | --- |
| coalesce-labs/catalyst | 616654741 | CTL | 99 | 898 | today |
| coalesce-labs/catalyst-cloud | 657402518 | CTC | 43 | 71 | today |
| ryanrozich/personal-os | 661338344 | — | **0** | **0** | **today** |
| rightsite-cloud/Adva | 616654744 | ADV | 0 | 0 | 2026-08-11 |
| coalesce-labs/catalyst-otel | 657402515 | OTL | 0 | 0 | 2026-08-10 |
| ryanrozich/slides | 616654742 | SLI | 0 | 0 | 2026-08-10 |
| coalesce-labs/evergreen | 657402511 | EVR | 0 | 0 | 2026-08-10 |
| rightsite-cloud/adva-crm | 657251876 | CRM | 0 | 0 | 2026-08-10 |

## ⛔ The parity ledger structurally cannot see this

The ledger scopes its comparison to the repos that appear **in the window**. A repo with no activity contributes no smee events, so it can never surface as unjoined. **A CLEAN verdict over Tuesday-morning traffic says nothing whatsoever about six of the eight repos on the channel.**

That is a check that cannot fail, sitting inside the instrument the cutover is judged by — the same class as CTL-48's false-clean and #3551's false-blocker, and the reason this gate is a separate one rather than a tweak to the ledger.

## The gate is three-valued, because the two zeroes mean different things

- **`personal-os` FAILS.** It is **active** — 82 PRs updated in 48 h — and its PRs and reviews **are** ingested while pushes and suites are **zero**. That is a confirmed *partial ingestion* gap, not quietness.
- **The five dormant repos are INCONCLUSIVE, never PASS.** They may be perfectly ingested and simply idle for 7–8 days. Nothing here can tell, and *"no traffic to disprove it"* is the oldest false-clean in this repository.

Operator decision and options: **CTL-1965** (default = probe one dormant orchestrated repo before runbook step 4, converting five INCONCLUSIVEs into a measurement for ~20 minutes of work).

## ⚠️ The repo list is FROZEN, and says so

GitHub has no *"list every webhook pointing at this URL"* endpoint — the only way to build this is to iterate candidate repos, so the list is exactly as complete as the guess behind it. It is declared stale with the re-enumeration command in its own verdict line.

⛔ The first cut wrapped a `gh` call around it that could only ever fall through to the same frozen list. A path that pretends to check and always defaults is precisely the shape this file exists to catch, so it is deleted rather than shipped.

## Verified

On the laptop's real 0.1.18 replica: **6 pass · 1 FAIL · 6 INCONCLUSIVE**, with every verdict landing on the repo the measurement says it should — including the two PASSes, which are the positive control that the gate can return something other than doubt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)