### PR TITLE
fix(dev): CTL-1963 — doctor asserts the cloud-sync launchd label resolves to ~/Library/LaunchAgents

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-replica.test.mjs
@@ -17,6 +17,9 @@ function deps(over = {}) {
     laDir: "/tmp/la",
     agentInstalled: () => true,
     processAlive: () => true,
+    // CTL-1963: the launchd label-binding seam. Injected here for the reason this file's header
+    // states — the suite must touch no launchctl. Healthy default = bound to the expected plist.
+    labelPath: () => "/tmp/la/ai.coalesce.catalyst-cloud-sync.plist",
     dbPath: DB,
     fileExists: (p) => p === DB || p === `${DB}.writer.lock`,
     statFile: () => ({ size: 64_000_000, mtimeMs: NOW - 5_000 }),
@@ -301,5 +304,75 @@ describe("CTL-1913 — the never-seeded FAIL capability", () => {
     expect(m["replica-fresh"].status).toBe("warn"); // null age ⇒ no escalation
     expect(recs.every((r) => r.status !== "fail")).toBe(true);
     expect(LA).toBe("/tmp/la"); // (fixture sanity; keeps the constant referenced)
+  });
+});
+
+// ── CTL-1963: the launchd label BINDING ────────────────────────────────────────────────────────
+//
+// The incident these cover, measured twice on the laptop 2026-08-18 (04:01 and 07:19): a
+// sealed-prefix install run bootstraps the REAL gui/$UID domain from a scratch HOME, rebinding
+// `ai.coalesce.catalyst-cloud-sync` to /var/folders/…/T/tmp.XXXX/…, then exits and lets its temp
+// dir be reaped. The writer dies; ~/Library/LaunchAgents/<label>.plist is still present and
+// unchanged, so every pre-existing signal reads normal while the replica silently freezes.
+describe("checkCloudSync — launchd label binding (CTL-1963)", () => {
+  const EXPECTED = "/tmp/la/ai.coalesce.catalyst-cloud-sync.plist";
+  const SQUAT = "/private/var/folders/h6/xxxx/T/tmp.dOCLr1E2bn/Library/LaunchAgents/ai.coalesce.catalyst-cloud-sync.plist";
+
+  test("bound to the expected plist → PASS", () => {
+    const m = byName(checkCloudSync(deps()));
+    expect(m["cloud-sync-label"].status).toBe("pass");
+    expect(m["cloud-sync-label"].detail).toContain(EXPECTED);
+  });
+
+  test("⛔ squatted by a temp path → WARN, and names the actual binding", () => {
+    const recs = checkCloudSync(deps({ labelPath: () => SQUAT }));
+    const m = byName(recs);
+    expect(m["cloud-sync-label"].status).toBe("warn");
+    expect(m["cloud-sync-label"].detail).toContain(SQUAT);
+    expect(m["cloud-sync-label"].detail).toContain(EXPECTED);
+    // The load-bearing invariant of this whole check: never FAIL, or doctor's exit code blocks
+    // the catalyst-join that would re-bootstrap the label — blocking the self-heal.
+    expect(noFail(recs)).toBe(true);
+  });
+
+  test("⛔ THE 07:19 SHAPE — squatting plist is GONE ⇒ says it cannot be restarted, only rebound", () => {
+    const m = byName(checkCloudSync(deps({
+      labelPath: () => SQUAT,
+      // the squat path is absent from the fs; the CORRECT plist is still present
+      fileExists: (p) => p === DB || p === `${DB}.writer.lock`,
+    })));
+    expect(m["cloud-sync-label"].status).toBe("warn");
+    expect(m["cloud-sync-label"].detail).toContain("NO LONGER EXISTS");
+    expect(m["cloud-sync-label"].detail).toContain("bootstrap");
+  });
+
+  test("squatted but the squatting file still exists ⇒ WARN without the unrecoverable wording", () => {
+    const m = byName(checkCloudSync(deps({
+      labelPath: () => SQUAT,
+      fileExists: (p) => p === DB || p === `${DB}.writer.lock` || p === SQUAT,
+    })));
+    expect(m["cloud-sync-label"].status).toBe("warn");
+    expect(m["cloud-sync-label"].detail).not.toContain("NO LONGER EXISTS");
+  });
+
+  test("⛔ unmeasurable binding is INFO, NOT pass — 'could not measure' must never read as healthy", () => {
+    const m = byName(checkCloudSync(deps({ labelPath: () => null })));
+    expect(m["cloud-sync-label"].status).toBe("info");
+    expect(m["cloud-sync-label"].detail).toContain("UNVERIFIED");
+    expect(m["cloud-sync-label"].status).not.toBe("pass");
+  });
+
+  test("⛔ the regression this check exists for: plist present + writer alive still WARNs when squatted", () => {
+    // Precisely the state both incidents presented: agentInstalled() true (the correct plist is
+    // on disk, untouched) — the pre-CTL-1963 doctor had nothing to say here.
+    const recs = checkCloudSync(deps({ agentInstalled: () => true, processAlive: () => true, labelPath: () => SQUAT }));
+    const m = byName(recs);
+    expect(m["cloud-sync"].status).toBe("pass"); // branch (a) is still happy — that is the point
+    expect(m["cloud-sync-label"].status).toBe("warn"); // ...and (a2) is the only one that objects
+  });
+
+  test("no agent installed ⇒ the binding check does not run at all", () => {
+    const m = byName(checkCloudSync(deps({ agentInstalled: () => false, labelPath: () => SQUAT })));
+    expect(m["cloud-sync-label"]).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -3204,6 +3204,8 @@ export function checkCloudSync(deps = {}) {
     laDir = defaultLaunchAgentsDir(),
     agentInstalled = defaultAgentInstalled,
     processAlive = defaultCloudSyncProcessAlive,
+    // CTL-1963: which plist the live label is actually bound to. Injectable so tests touch no launchctl.
+    labelPath = defaultLaunchdLabelPath,
     dbPath = getReplicaDbPath(),
     fileExists = (p) => existsSync(p),
     statFile = (p) => statSync(p),
@@ -3269,6 +3271,41 @@ export function checkCloudSync(deps = {}) {
     checks.push(mkCheck("cloud-sync", STATUS.PASS, `agent installed + running${lockHeld ? " (writer-lock held)" : ""}`));
   } else {
     checks.push(mkCheck("cloud-sync", STATUS.WARN, "agent installed but no writer process found — KeepAlive may be retrying; check ~/catalyst/cloud-sync.log"));
+  }
+
+  // (a2) launchd LABEL BINDING — CTL-1963. Does `ai.coalesce.catalyst-cloud-sync` in the live
+  // per-user domain resolve to ~/Library/LaunchAgents/<label>.plist, or to somebody else's file?
+  //
+  // Branch (a) above proves the CORRECT plist exists and whether A writer process is running. It
+  // cannot see that launchd is bound to a DIFFERENT plist — which is exactly the observed failure:
+  // a sealed-prefix install run bootstraps the real gui/$UID domain from a temp HOME, rebinds the
+  // label to /var/folders/…/T/tmp.XXXX/…, then exits and lets its temp dir be reaped. The writer
+  // dies, the correct plist is still sitting there untouched, and every other signal reads normal.
+  //
+  // ⚠️ WARN, never FAIL — deliberately, and for the reason this function documents at length above:
+  // doctor's exit code IS the catalyst-join activation gate, and `do_doctor_gate` runs BEFORE
+  // `install-services`. Failing here would block the very join that would re-bootstrap the label,
+  // i.e. it would block the self-heal for the condition it is reporting.
+  if (installed) {
+    const bound = labelPath(label);
+    const expected = resolve(laDir, `${label}.plist`);
+    if (bound === null) {
+      // ⛔ Not a pass. "Could not measure" and "measured, correct" must never render the same —
+      // an unmeasurable binding is precisely the state the squat produces on a host where the
+      // label was booted out entirely.
+      checks.push(mkCheck("cloud-sync-label", STATUS.INFO,
+        `could not resolve launchd label ${label} (launchctl unavailable or label not bootstrapped) — binding UNVERIFIED, not confirmed healthy`));
+    } else if (bound === expected) {
+      checks.push(mkCheck("cloud-sync-label", STATUS.PASS, `launchd label resolves to ${expected}`));
+    } else {
+      // Name whether the squatting file still exists: if it does not, no kickstart/bootstrap/reboot
+      // can revive the writer, which changes the remedy from "restart it" to "rebind it".
+      const gone = !fileExists(bound);
+      checks.push(mkCheck("cloud-sync-label", STATUS.WARN,
+        `launchd label ${label} is bound to ${bound}${gone ? " (WHICH NO LONGER EXISTS — the writer cannot be restarted, only rebound)" : ""}, ` +
+        `not ${expected} — a sealed-prefix install run squatted the per-user domain (gui/$UID is per-user, not per-HOME). ` +
+        `Rebind: launchctl bootout gui/$(id -u)/${label}; launchctl bootstrap gui/$(id -u) ${expected}`));
+    }
   }
 
   // (b) replica freshness + writer liveness. KEY INSIGHT: the DB + -wal mtime only advance
@@ -5261,6 +5298,45 @@ function defaultCloudSyncProcessAlive() {
   // not the launcher (`.../cloud-sync/launch.sh` has no `.mjs`).
   const r = spawnSync("pgrep", ["-f", "cloud-sync\\.mjs"], { timeout: 5_000 });
   return !r.error && r.status === 0;
+}
+
+// defaultLaunchdLabelPath — which plist is the RUNNING launchd label actually bound to? (CTL-1963)
+//
+// ⛔ THE DEFECT THIS EXISTS FOR: `gui/$UID` is a PER-USER domain, not a per-HOME one. A sealed-prefix
+// install run under a scratch HOME still bootstraps into the REAL user domain, so the label
+// `ai.coalesce.catalyst-cloud-sync` gets rebound to a plist under /var/folders/…/T/tmp.XXXX/. The
+// squatting run then exits and its temp dir is reaped — leaving the label pointing at a path that NO
+// LONGER EXISTS. Measured twice on the laptop 2026-08-18: 04:01 (tmp.p3Tb3ig3kS) and 07:19
+// (tmp.dOCLr1E2bn), ~3h18m apart.
+//
+// ⛔ WHY plist-on-disk IS NOT THE SAME QUESTION. `defaultAgentInstalled` answers "is
+// ~/Library/LaunchAgents/<label>.plist present?" — and in BOTH incidents it was, unchanged. The
+// correct file existed the whole time; launchd was simply bound to a different one. So the existing
+// check reads PASS while the writer is dead. Only the resolved binding distinguishes them.
+//
+// ⛔ AND WHY THE EXIT-CODE FIX DOES NOT COVER IT. The 04:01 instance was diagnosed as launchd's
+// `KeepAlive={SuccessfulExit:false}` contract keeping a cleanly-exited writer down. The 07:19 instance
+// is NOT an exit-code problem: the bound path is gone, so no kickstart, bootstrap, or reboot can
+// revive it. The invariant that catches both shapes is "the label resolves to ~/Library/LaunchAgents".
+//
+// Returns the resolved path string, or null when it cannot be measured (launchctl absent, label not
+// bootstrapped, unparseable output). ⛔ null means UNKNOWN, never "fine" — the caller must not grade a
+// failure to measure as a pass. Honors CATALYST_ASSUME_NO_DAEMONS so tests touch no launchctl.
+function defaultLaunchdLabelPath(label) {
+  if (process.env.CATALYST_ASSUME_NO_DAEMONS === "1") return null;
+  try {
+    const r = spawnSync("launchctl", ["print", `gui/${process.getuid()}/${label}`], {
+      timeout: 5_000,
+      encoding: "utf8",
+    });
+    if (r.error || r.status !== 0 || typeof r.stdout !== "string") return null;
+    // `launchctl print` emits a tab-indented `path = /abs/path.plist` line. Anchor on the field name
+    // so the many other `... path = ...` keys in that output (stdout path, stderr path) cannot match.
+    const m = r.stdout.match(/^\s*path\s*=\s*(\S.*?)\s*$/m);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
 }
 
 // checkAgentsForClass — assert the correct launchd agent SET for the class. The two discriminators


### PR DESCRIPTION
## What

`catalyst-doctor` now asserts that the per-user launchd label `ai.coalesce.catalyst-cloud-sync` resolves to `~/Library/LaunchAgents/<label>.plist` — and not to somebody else's file.

Closes the doctor half of **CTL-1963** (COORD-152's ask).

## Why — it happened twice this morning and doctor was silent both times

| | first | second |
| -- | -- | -- |
| bound to | `…/T/tmp.p3Tb3ig3kS/…` | `…/T/tmp.dOCLr1E2bn/…` |
| registered | ~04:01 CT | ~07:19 CT |
| replica frozen at | 04:02 | **07:18:09** |

`gui/$UID` is a **per-user** domain, not a per-HOME one, so a sealed-prefix install run under a scratch HOME still bootstraps the real domain and rebinds the label. The squatting run then exits and its temp dir is reaped.

**Why nothing caught it:** `defaultAgentInstalled` asks *"is `~/Library/LaunchAgents/<label>.plist` present?"* — and in both incidents it was, untouched. The correct file sat on disk the whole time; launchd was simply bound to a different one. So `cloud-sync` read `PASS` while the writer was dead and the replica was silently serving hours-old data.

**Why the exit-code framing is not sufficient:** the 04:01 instance fit launchd's `KeepAlive={SuccessfulExit:false}` contract. The 07:19 instance did not — its bound path **no longer existed**, so no `kickstart`, `bootstrap`, or reboot could have revived it. The one invariant that catches both shapes is the resolved binding.

## How

- `defaultLaunchdLabelPath(label)` reads the live binding from `launchctl print gui/$UID/<label>`, anchored on the `path =` field so the sibling `stdout path` / `stderr path` keys cannot match. Returns `null` for *could not measure*, never a sentinel.
- New `cloud-sync-label` record in `checkCloudSync`:
  - **PASS** — bound to the expected plist
  - **WARN** — squatted; names the actual binding, and whether it still exists (which decides *restart* vs *rebind*), plus the exact `bootout`/`bootstrap` remedy
  - **INFO** — unmeasurable; explicitly *"binding UNVERIFIED, not confirmed healthy"*

### WARN, deliberately not FAIL

Per the contract `checkCloudSync` already documents at length: doctor's exit code **is** the `catalyst-join` activation gate, and `do_doctor_gate` runs *before* `install-services`. A FAIL here would block the very join that re-bootstraps the label — blocking the self-heal for the condition being reported.

## Tests — 7 new, and one seam repaired

`doctor-replica.test.mjs` did not inject this dependency, so the new check would have made that suite spawn `launchctl` on every run — violating its own header invariant (*"All deps are injected so the test touches no fs/pgrep/launchctl"*). The seam is now injected there. **Suite: 516ms → 48ms**, which is the proof it stopped shelling out.

Covered: both incident shapes; the squatting-file-still-exists variant; unmeasurable is INFO and asserted **not** `pass`; no-agent short-circuits; and the regression proper — plist present + writer alive + squatted binding, where `cloud-sync` still reads PASS and only `cloud-sync-label` objects.

```
35 pass, 0 fail (28 pre-existing + 7 new)
```

## Verified live

```
PASS | cloud-sync-label | launchd label resolves to
       /Users/ryan/Library/LaunchAgents/ai.coalesce.catalyst-cloud-sync.plist
```

Predicate also read directly on both minis — each resolves to its own `~/Library/LaunchAgents/…` with a live pid (mini 19794, mini-2 89167). The check itself reaches those hosts on the next fleet refresh after merge.

## Not in scope

The **root cause** — the installer bootstrapping the real domain from a sealed prefix — stays with @CTL-INSTALL on CTL-1963/CTL-1844. This PR makes the symptom detectable within one doctor run instead of by someone noticing a stale replica; it does not stop the squat from happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
