### PR TITLE
fix(dev): CTL-1968 — a scratch HOME is not a launchd sandbox, so the install paths refuse it

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -527,7 +527,10 @@ run "uninstall-services removes all three plists" bash -c "
     mkdir -p '${SCRATCH}/uninst_bin'
     printf '#!/usr/bin/env bash\nexit 0\n' > '${SCRATCH}/uninst_bin/launchctl'
     chmod +x '${SCRATCH}/uninst_bin/launchctl'
-    PATH='${SCRATCH}/uninst_bin:${REAL_PATH}' HOME=\"\$fh\" '${STACK}' uninstall-services >/dev/null 2>&1 || true
+    # CTL-1968: launchctl is stubbed one line above and HOME is a scratch dir, so
+    # this case deliberately drives the uninstall path. The product now refuses to
+    # touch gui/<uid> from a foreign HOME; declaring the seal opts back in.
+    CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1 PATH='${SCRATCH}/uninst_bin:${REAL_PATH}' HOME=\"\$fh\" '${STACK}' uninstall-services >/dev/null 2>&1 || true
     [[ ! -e \"\$fh/Library/LaunchAgents/ai.coalesce.catalyst-stack.plist\" ]] && \
     [[ ! -e \"\$fh/Library/LaunchAgents/ai.coalesce.catalyst-thoughts-sync.plist\" ]] && \
     [[ ! -e \"\$fh/Library/LaunchAgents/ai.coalesce.catalyst-log-shipper.plist\" ]]

--- a/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack.test.sh
@@ -73,6 +73,20 @@ EOF
 exit 0
 EOF
   chmod +x "$dir/brew"
+  # ⛔ CTL-1968: `catalyst-stack start` calls start_event_mirror, which bootouts
+  # and bootstraps ai.coalesce.catalyst-event-mirror. HOME here is the REAL home,
+  # so this is not the foreign-HOME case the launchd guard covers — an unstubbed
+  # launchctl reaches the live per-user domain and bounces THIS MACHINE's
+  # event-mirror agent, which on a monitor-class node is the fleet event feed.
+  # Measured on the laptop before this stub: one run of this file issued 7
+  # bootouts and 5 bootstraps against ~/Library/LaunchAgents — an asymmetry that
+  # can leave the agent DOWN, the same way the health-responder was left unloaded
+  # for 3h47m on 2026-08-18.
+  cat > "$dir/launchctl" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/launchctl"
 }
 
 STUBDIR="${SCRATCH}/stubs"

--- a/plugins/dev/scripts/__tests__/health-responder.test.sh
+++ b/plugins/dev/scripts/__tests__/health-responder.test.sh
@@ -29,6 +29,13 @@ mkdir -p "$HOME"
 MOCKBIN="${SCRATCH}/bin"
 mkdir -p "$MOCKBIN"
 export PATH="${MOCKBIN}:${PATH}"
+
+# CTL-1968: launchctl above is a PATH-shadowed mock and HOME is a scratch dir, so
+# this suite deliberately exercises the bootstrap path. The product now refuses to
+# mutate gui/<uid> from a foreign HOME (a scratch HOME does NOT sandbox launchd —
+# two full gates re-bound the live cloud-sync label on 2026-08-18). Declaring the
+# seal is how a test opts back in; a suite that FORGOT to seal is what refuses.
+export CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1
 export RESPONDER_RUN_ID="testrun"
 
 # All responder inputs live in scratch — nothing on the real host is probed.

--- a/plugins/dev/scripts/__tests__/install-orphan-sweep.test.sh
+++ b/plugins/dev/scripts/__tests__/install-orphan-sweep.test.sh
@@ -87,6 +87,13 @@ EOF
 chmod +x "$MOCKBIN/uname"
 
 export PATH="${MOCKBIN}:${PATH}"
+
+# CTL-1968: launchctl above is a PATH-shadowed mock and HOME is a scratch dir, so
+# this suite deliberately exercises the bootstrap path. The product now refuses to
+# mutate gui/<uid> from a foreign HOME (a scratch HOME does NOT sandbox launchd —
+# two full gates re-bound the live cloud-sync label on 2026-08-18). Declaring the
+# seal is how a test opts back in; a suite that FORGOT to seal is what refuses.
+export CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1
 export LAUNCHCTL_LOG
 
 # Override HOME so we don't touch the real ~/Library/LaunchAgents

--- a/plugins/dev/scripts/__tests__/launchd-domain-guard.test.sh
+++ b/plugins/dev/scripts/__tests__/launchd-domain-guard.test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# CTL-1968 — the launchd domain guard.
+#
+# `launchctl bootstrap gui/$(id -u) <plist>` targets a PER-USER domain. Every
+# install path here derives its plist from "$HOME/Library/LaunchAgents/…", so a
+# caller under a scratch HOME does not get a sandbox — it re-binds the REAL label
+# to a temporary path. On 2026-08-18 two full shell-suite runs on the primary
+# laptop did exactly that, and BOTH reported all tests passing.
+#
+# ⚠️ The load-bearing cases here are the MUTATION CONTROLS (G8/G9b). A test that
+# merely asserts "no launchctl call was made" is satisfied just as well by a
+# command that never ran at all, which is the failure mode this whole ticket is
+# about. Each "zero" is therefore paired with a run of the SAME command that must
+# produce a NON-zero count.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GUARD="${SCRIPTS_DIR}/lib/launchd-domain-guard.sh"
+
+PASSES=0; FAILURES=0
+ok()  { PASSES=$((PASSES+1));   echo "  ok   — $1"; }
+bad() { FAILURES=$((FAILURES+1)); echo "  FAIL — $1"; }
+chk() { if [[ $1 == "$2" ]]; then ok "$3"; else bad "$3 (expected '$2', got '$1')"; fi; }
+
+echo "CTL-1968 — launchd domain guard"
+
+[[ -f $GUARD ]] || { echo "FAIL: guard missing at $GUARD"; exit 1; }
+# shellcheck source=../lib/launchd-domain-guard.sh
+. "$GUARD"
+
+# ─── G1: the real HOME is accepted ───────────────────────────────────────────
+( launchd_guard_ok "unit" ) >/dev/null 2>&1
+chk "$?" "0" "G1: the invoking user's real HOME is accepted"
+
+# ─── G2: a scratch HOME is REFUSED, and the reason names both paths ──────────
+G2_OUT=$(
+  scratch="$(mktemp -d)"
+  export HOME="$scratch"
+  unset CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD
+  . "$GUARD"
+  launchd_guard_ok "unit"; rc=$?
+  printf '%s\n%s\n' "$rc" "$CATALYST_LAUNCHD_GUARD_REASON"
+)
+chk "$(printf '%s' "$G2_OUT" | sed -n 1p)" "1" "G2a: a scratch HOME is refused"
+G2_REASON="$(printf '%s' "$G2_OUT" | sed -n 2p)"
+if [[ $G2_REASON == *"is not this user's real home"* ]]; then
+  ok "G2b: the refusal names the mismatch"
+else bad "G2b: reason did not name the mismatch (got: $G2_REASON)"; fi
+
+# ─── G3: an explicit seal declaration opts back in ───────────────────────────
+G3=$( scratch="$(mktemp -d)"; export HOME="$scratch" CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1
+      . "$GUARD"; launchd_guard_ok "unit"; echo $? )
+chk "$G3" "0" "G3: CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1 opts back in"
+
+# ─── G4: an unset HOME is refused (never assume the real one) ────────────────
+G4=$( unset HOME; unset CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD; . "$GUARD"
+      launchd_guard_ok "unit"; echo $? )
+chk "$G4" "1" "G4: an unset HOME is refused"
+
+# ─── G5: /var vs /private/var must NOT read as a mismatch ────────────────────
+# macOS symlinks /var -> /private/var. A literal string compare would refuse a
+# legitimate install (or accept a scratch one) purely on which spelling it got.
+launchd_guard_resolve_real_home
+REAL="$CATALYST_LAUNCHD_GUARD_REAL_HOME"
+if [[ -n $REAL ]]; then
+  ok "G5a: a resolver produced a real home ($REAL)"
+  G5=$( export HOME="$REAL"; unset CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD
+        . "$GUARD"; launchd_guard_ok "unit"; echo $? )
+  chk "$G5" "0" "G5b: the resolved real home is accepted verbatim"
+  # A path that resolves to the same physical dir via a symlinked prefix.
+  if [[ -d /private/var ]]; then
+    G5c=$( link="$(mktemp -d)/homelink"; ln -s "$REAL" "$link" 2>/dev/null
+           export HOME="$link"; unset CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD
+           . "$GUARD"; launchd_guard_ok "unit"; echo $? )
+    chk "$G5c" "0" "G5c: a symlink to the real home is accepted (physical compare)"
+  fi
+else
+  bad "G5a: no resolver produced a real home — the guard would refuse every install"
+fi
+
+# ─── recording launchctl, shared by the integration cases ────────────────────
+SEAL="$(mktemp -d)"; mkdir -p "$SEAL/bin"; LCLOG="$SEAL/launchctl.log"
+cat >"$SEAL/bin/launchctl" <<EOF
+#!/bin/bash
+echo "launchctl \$*" >> "$LCLOG"
+exit 0
+EOF
+chmod +x "$SEAL/bin/launchctl"
+# The seal must itself be proven reachable, or every "zero" below is vacuous.
+: > "$LCLOG"; ( PATH="$SEAL/bin:$PATH" launchctl list >/dev/null 2>&1 )
+if grep -q '^launchctl list' "$LCLOG"; then ok "G6: the recording launchctl is reached (seal verified)"
+else bad "G6: seal NOT reached — every mutation count below would be a false zero"; fi
+
+# mutations_for HOME_DIR ALLOW -> prints the bootout+bootstrap count
+mutations_for() {
+  local home="$1" allow="$2"
+  : > "$LCLOG"
+  mkdir -p "$home"
+  (
+    export HOME="$home" PATH="$SEAL/bin:$PATH"
+    if [[ $allow == "1" ]]; then export CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1
+    else unset CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD; fi
+    bash "${SCRIPTS_DIR}/install-health-responder.sh" >/dev/null 2>&1
+  ) || true
+  grep -cE '^launchctl (bootout|bootstrap)' "$LCLOG" 2>/dev/null || true
+}
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  # ─── G7: the DEFAULT shape refuses — no env var set by anyone ─────────────
+  N_GUARDED=$(mutations_for "$(mktemp -d)/home" 0)
+  chk "${N_GUARDED:-x}" "0" "G7: install-health-responder under a scratch HOME issues ZERO launchd mutations"
+
+  # ─── G8: MUTATION CONTROL — the same command, guard disabled, DOES mutate ──
+  # Without this, G7 passes just as well if the script simply never ran.
+  N_UNGUARDED=$(mutations_for "$(mktemp -d)/home" 1)
+  if [[ ${N_UNGUARDED:-0} -gt 0 ]]; then
+    ok "G8: mutation control — with the guard opted out the SAME command issues ${N_UNGUARDED} mutation(s), so G7's zero is caused by the guard"
+  else
+    bad "G8: mutation control FAILED — the command issues no mutations even unguarded, so G7 proves nothing"
+  fi
+else
+  ok "G7/G8: skipped — not Darwin (install paths never reach launchctl here)"
+fi
+
+# ─── G9: the incident's own vector stays sealed ───────────────────────────────
+# setup-cloud-replica.test.sh seals HOME but keeps the real PATH; before CTL-1968
+# its cases resolved the REAL installed catalyst-stack and ran adopt-cloud-sync.
+SCR="${SCRIPT_DIR}/setup-cloud-replica.test.sh"
+if [[ -f $SCR ]]; then
+  if grep -q 'seal_stack' "$SCR"; then ok "G9a: setup-cloud-replica.test.sh plants a catalyst-stack seal"
+  else bad "G9a: setup-cloud-replica.test.sh no longer seals catalyst-stack — the 2026-08-18 vector is reopened"; fi
+  # every case that sets a scratch HOME must be preceded by a seal
+  if grep -q 'seal_stack "\$H7/.stub-bin"' "$SCR"; then
+    ok "G9b: the case-7 bypass (its own HOME/PATH, not run_case) is sealed too"
+  else
+    bad "G9b: case 7 rolls its own HOME/PATH and is NOT sealed — it escaped the first fix"
+  fi
+else
+  bad "G9: setup-cloud-replica.test.sh not found"
+fi
+
+echo
+if ((FAILURES)); then echo "Results: $PASSES passed, $FAILURES failed"; exit 1; fi
+echo "Results: $PASSES passed, 0 failed"

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -103,6 +103,7 @@ run_case() {
 	local home="$1" token="$2" account="$3" code="${4:-200}"
 	local bindir="$home/.stub-bin"
 	make_curl_stub "$bindir" "$code"
+	seal_stack "$bindir"
 	(
 		export HOME="$home"
 		export PATH="$bindir:$PATH"
@@ -125,6 +126,29 @@ run_case() {
 
 # stub_was_called HOME -> 0 when the sealed transport handled the request.
 stub_was_called() { [[ -s "$1/.stub-bin/stub_calls" ]]; }
+
+# ⛔ seal_stack BINDIR — CTL-1968. THE SINGLE MOST IMPORTANT LINE IN THIS FILE.
+#
+# Every case here sets HOME to a `mktemp -d`, but PATH keeps a trailing ":$PATH",
+# so `setup_cloud_replica`'s `command -v catalyst-stack` resolved the REAL
+# INSTALLED binary and ran its `adopt-cloud-sync`. That renders LaunchAgent
+# plists under the scratch HOME and then bootstraps them into `gui/$(id -u)` —
+# a domain that is per-USER, not per-HOME. On 2026-08-18 two full gates on the
+# primary laptop (04:01, 07:19 CT) thereby re-bound the live
+# `ai.coalesce.catalyst-cloud-sync` label to a temp path and left
+# `ai.coalesce.catalyst-health-responder` UNLOADED for 3h47m.
+#
+# ⚠️ Every one of those cases reported PASS while doing it. A scratch HOME is not
+# a sandbox for launchd, and rc=0 was never evidence that nothing escaped.
+#
+# So a stack stub is planted for EVERY case by default. Cases that want a
+# specific rc/message still call make_stack_stub first — this only fills the gap.
+seal_stack() {
+	local bindir="$1"
+	mkdir -p "$bindir"
+	[[ -x "$bindir/catalyst-stack" ]] && return 0
+	make_stack_stub "$bindir" 0 "stubbed catalyst-stack (CTL-1968: the real one mutates gui/\$(id -u))"
+}
 
 # make_stack_stub BINDIR RC MESSAGE — a `catalyst-stack` on PATH that exits RC
 # after printing MESSAGE on stderr. Needed because `adopt-cloud-sync` is the other
@@ -151,6 +175,7 @@ run_case_capturing() {
 	local home="$1" token="$2" account="$3" code="${4:-200}"
 	local bindir="$home/.stub-bin"
 	make_curl_stub "$bindir" "$code"
+	seal_stack "$bindir"
 	(
 		export HOME="$home"
 		export PATH="$bindir:$PATH"
@@ -330,6 +355,11 @@ scrub "$H6"
 # silent idle as case 6.
 H7=$(mktemp -d)
 make_curl_stub "$H7/.stub-bin" 200
+# CTL-1968: this case rolls its own HOME/PATH instead of going through run_case,
+# so it needs the stack seal explicitly — it was the one case still reaching the
+# real `catalyst-stack adopt-cloud-sync`, and a verification run that only fixed
+# run_case still recorded 4 escaped launchctl calls against gui/$(id -u).
+seal_stack "$H7/.stub-bin"
 (
 	export HOME="$H7" CATALYST_SETUP_LIB_ONLY=1
 	export PATH="$H7/.stub-bin:$PATH"

--- a/plugins/dev/scripts/catalyst-agent/install.sh
+++ b/plugins/dev/scripts/catalyst-agent/install.sh
@@ -9,6 +9,19 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain — a scratch HOME does not
+# sandbox it. Refuse rather than re-bind the REAL label to a temporary path.
+[[ -f "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh" ]] || {
+  echo "catalyst-agent/install.sh: missing ../lib/launchd-domain-guard.sh" >&2; exit 1; }
+# shellcheck source=../lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the catalyst-agent LaunchAgent" && return 0
+  launchd_guard_message "the catalyst-agent LaunchAgent" >&2
+  echo "catalyst-agent/install.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
 TEMPLATE="${SCRIPT_DIR}/com.catalyst.agent.plist"
 AGENT="${SCRIPT_DIR}/catalyst-agent.mjs"
 LABEL="com.catalyst.agent"
@@ -89,6 +102,7 @@ echo "install.sh: wrote ${DEST}"
 # Reload idempotently: bootout any existing instance (ignore failure when not
 # loaded), then bootstrap the fresh plist.
 DOMAIN="gui/$(id -u)"
+launchd_agent_guard
 launchctl bootout "${DOMAIN}/${LABEL}" 2>/dev/null || true
 launchctl bootstrap "${DOMAIN}" "${DEST}"
 echo "install.sh: loaded ${LABEL} into ${DOMAIN}"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -172,6 +172,14 @@ unset _SRC
 source "$SCRIPT_DIR/lib/catalyst-agent-path.sh"
 # shellcheck source=lib/cloud-sync-token-probe.sh
 [[ -f "${SCRIPT_DIR}/lib/cloud-sync-token-probe.sh" ]] && . "${SCRIPT_DIR}/lib/cloud-sync-token-probe.sh"
+# shellcheck source=lib/launchd-domain-guard.sh
+# CTL-1968: refuses to mutate gui/<uid> from a scratch HOME. Hard requirement,
+# not best-effort — a missing guard is how the laptop lost its replica writer
+# twice in one morning, so an absent file must fail loudly rather than silently
+# restore the old behaviour.
+[[ -f "${SCRIPT_DIR}/lib/launchd-domain-guard.sh" ]] || {
+  printf '[catalyst-stack] ERROR: missing lib/launchd-domain-guard.sh next to catalyst-stack\n' >&2; exit 1; }
+. "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
 
 # ─── Proxy env (used only under --proxy) ─────────────────────────────────────
 PROXY_HOST="http://127.0.0.1:8080"
@@ -237,6 +245,17 @@ CLOUD_SYNC_LAUNCHER="${SCRIPT_DIR}/execution-core/cloud-sync/launch.sh"
 log()  { printf '[catalyst-stack] %s\n' "$*"; }
 warn() { printf '[catalyst-stack] WARN: %s\n' "$*" >&2; }
 fail() { printf '[catalyst-stack] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# CTL-1968: every command below that bootstraps/boots-out a LaunchAgent whose
+# plist path is derived from $HOME must clear this first. `gui/$(id -u)` is a
+# PER-USER domain, so a scratch HOME does not sandbox it — it just renders the
+# plist somewhere temporary and then re-binds the REAL label to it.
+stack_launchd_guard() {
+  local ctx="${1:-launchd agent}"
+  launchd_guard_ok "$ctx" && return 0
+  launchd_guard_message "$ctx" >&2
+  fail "launchd domain guard refused ${ctx} (${CATALYST_LAUNCHD_GUARD_REASON})"
+}
 
 pid_alive() {
   local pid="${1:-}"
@@ -865,7 +884,9 @@ start_event_mirror() {
   render_event_mirror_plist "$EVENT_MIRROR_LAUNCHER" > "$EVENT_MIRROR_AGENT_PLIST"
   local guid; guid="gui/$(id -u)"
   # Idempotent (re)load: bootout any existing instance, then bootstrap fresh.
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$EVENT_MIRROR_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if ! launchctl bootstrap "$guid" "$EVENT_MIRROR_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     rm -f "$EVENT_MIRROR_AGENT_PLIST"
     warn "launchctl bootstrap failed for $EVENT_MIRROR_AGENT_PLIST — event-mirror not started"
@@ -888,6 +909,7 @@ stop_event_mirror() {
   command -v launchctl >/dev/null 2>&1 || { rm -f "$EVENT_MIRROR_AGENT_PLIST"; return 0; }
   local guid; guid="gui/$(id -u)"
   log "stopping event-mirror LaunchAgent ($EVENT_MIRROR_AGENT_LABEL)"
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$EVENT_MIRROR_AGENT_PLIST" 2>/dev/null || true
   rm -f "$EVENT_MIRROR_AGENT_PLIST"
   log "  → event-mirror stopped and uninstalled"
@@ -2050,7 +2072,9 @@ cmd_install_services() {
 
   local guid; guid="gui/$(id -u)"
   # idempotent (re)load: bootout any existing instance, then bootstrap fresh.
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$STACK_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if launchctl bootstrap "$guid" "$STACK_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     log "loaded $STACK_AGENT_LABEL — RunAtLoad fired 'catalyst-stack start'"
   else
@@ -2060,7 +2084,9 @@ cmd_install_services() {
   render_thoughts_sync_plist "$sync_cmd" "$sync_interval" > "$SYNC_AGENT_PLIST"
   log "wrote $SYNC_AGENT_PLIST (exec: $sync_cmd, keep-alive ${sync_interval}s)"
 
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$SYNC_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if launchctl bootstrap "$guid" "$SYNC_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     log "loaded $SYNC_AGENT_LABEL — RunAtLoad fired thoughts-pull-sync"
   else
@@ -2074,7 +2100,9 @@ cmd_install_services() {
   render_shipper_plist "$shipper_launcher" "$host_name" "$_shipper_config_resolved" > "$SHIPPER_AGENT_PLIST"
   log "wrote $SHIPPER_AGENT_PLIST (exec: launch.sh, KeepAlive foreground)"
 
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$SHIPPER_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if launchctl bootstrap "$guid" "$SHIPPER_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     log "loaded $SHIPPER_AGENT_LABEL — KeepAlive supervising alloy"
   else
@@ -2158,6 +2186,7 @@ cmd_uninstall_services() {
   [[ "$(uname -s)" == "Darwin" ]] || fail "uninstall-services is macOS-only (launchd); this host is $(uname -s)"
   local guid; guid="gui/$(id -u)"
   if [[ -f "$STACK_AGENT_PLIST" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$STACK_AGENT_PLIST" 2>/dev/null || true
     rm -f "$STACK_AGENT_PLIST"
     log "removed $STACK_AGENT_LABEL ($STACK_AGENT_PLIST)"
@@ -2166,6 +2195,7 @@ cmd_uninstall_services() {
     log "$STACK_AGENT_LABEL not installed (no $STACK_AGENT_PLIST)"
   fi
   if [[ -f "$SYNC_AGENT_PLIST" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$SYNC_AGENT_PLIST" 2>/dev/null || true
     rm -f "$SYNC_AGENT_PLIST"
     log "removed $SYNC_AGENT_LABEL ($SYNC_AGENT_PLIST)"
@@ -2185,6 +2215,7 @@ cmd_uninstall_services() {
     bash "${SCRIPT_DIR}/install-dependabot-escalate.sh" --uninstall 2>&1 | sed 's/^/  /' || true
   fi
   if [[ -f "$SHIPPER_AGENT_PLIST" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$SHIPPER_AGENT_PLIST" 2>/dev/null || true
     rm -f "$SHIPPER_AGENT_PLIST"
     log "removed $SHIPPER_AGENT_LABEL ($SHIPPER_AGENT_PLIST)"
@@ -2198,6 +2229,7 @@ cmd_uninstall_services() {
   # with no pull authority, so no owner-reset ritual (unlike the updater below).
   local agent_plist="${HOME}/Library/LaunchAgents/com.catalyst.agent.plist"
   if [[ -f "$agent_plist" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$agent_plist" 2>/dev/null || true
     rm -f "$agent_plist"
     log "removed com.catalyst.agent ($agent_plist)"
@@ -2216,6 +2248,7 @@ cmd_uninstall_services() {
     warn "could NOT reset pluginPullOwner=broker in $cfg — LEAVING the $UPDATER_AGENT_LABEL agent in place (it is still the only puller). Fix the config write, then re-run uninstall-services."
   else
     if [[ -f "$UPDATER_AGENT_PLIST" ]]; then
+      stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
       launchctl bootout "$guid" "$UPDATER_AGENT_PLIST" 2>/dev/null || true
       rm -f "$UPDATER_AGENT_PLIST"
       log "removed $UPDATER_AGENT_LABEL ($UPDATER_AGENT_PLIST)"
@@ -2231,6 +2264,7 @@ cmd_uninstall_services() {
   # side effects, so a plain bootout + rm is safe. The local replica file is left on disk
   # (it just goes stale; the scheduler read tier is mtime-gated + fail-open).
   if [[ -f "$CLOUD_SYNC_AGENT_PLIST" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$CLOUD_SYNC_AGENT_PLIST" 2>/dev/null || true
     rm -f "$CLOUD_SYNC_AGENT_PLIST"
     log "removed $CLOUD_SYNC_AGENT_LABEL ($CLOUD_SYNC_AGENT_PLIST)"
@@ -2358,7 +2392,9 @@ cmd_adopt_updater() {
   render_updater_plist "$launcher" "$host_name" > "$UPDATER_AGENT_PLIST"
   log "wrote $UPDATER_AGENT_PLIST (exec: launch.sh, KeepAlive foreground)"
 
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$UPDATER_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if ! launchctl bootstrap "$guid" "$UPDATER_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     rm -f "$UPDATER_AGENT_PLIST"
     _reset_owner_broker_if_updater "$cfg" || true
@@ -2374,6 +2410,7 @@ cmd_adopt_updater() {
     sleep 1
   done
   if [[ "$confirmed" != "yes" ]]; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$UPDATER_AGENT_PLIST" 2>/dev/null || true
     rm -f "$UPDATER_AGENT_PLIST"
     _reset_owner_broker_if_updater "$cfg" || true
@@ -2385,6 +2422,7 @@ cmd_adopt_updater() {
   # now — with the updater confirmed up — does the broker defer. Fail-closed: any write
   # failure backs out the agent AND reconciles ownership to broker, so we never strand.
   if ! _write_plugin_pull_owner "$cfg" "updater"; then
+    stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$UPDATER_AGENT_PLIST" 2>/dev/null || true
     rm -f "$UPDATER_AGENT_PLIST"
     _reset_owner_broker_if_updater "$cfg" || true
@@ -2440,7 +2478,9 @@ cmd_adopt_thoughts_sync() {
   render_thoughts_sync_plist "$sync_cmd" "$sync_interval" > "$SYNC_AGENT_PLIST"
   log "wrote $SYNC_AGENT_PLIST (exec: $sync_cmd, interval ${sync_interval}s)"
   local guid; guid="gui/$(id -u)"
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$SYNC_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if launchctl bootstrap "$guid" "$SYNC_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     log "loaded $SYNC_AGENT_LABEL — RunAtLoad fired thoughts-pull-sync"
   else
@@ -2604,7 +2644,9 @@ cmd_adopt_cloud_sync() {
   render_cloud_sync_plist "$launcher" "$host_name" > "$CLOUD_SYNC_AGENT_PLIST"
   log "wrote $CLOUD_SYNC_AGENT_PLIST (exec: launch.sh, KeepAlive on crash)"
 
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   launchctl bootout "$guid" "$CLOUD_SYNC_AGENT_PLIST" 2>/dev/null || true
+  stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
   if ! launchctl bootstrap "$guid" "$CLOUD_SYNC_AGENT_PLIST" 2>&1 | sed 's/^/  /'; then
     rm -f "$CLOUD_SYNC_AGENT_PLIST"
     fail "launchctl bootstrap failed for $CLOUD_SYNC_AGENT_PLIST — agent backed out"

--- a/plugins/dev/scripts/channel-watcher/install.sh
+++ b/plugins/dev/scripts/channel-watcher/install.sh
@@ -12,6 +12,19 @@ set -uo pipefail
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain — a scratch HOME does not
+# sandbox it. Refuse rather than re-bind the REAL label to a temporary path.
+[[ -f "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh" ]] || {
+  echo "channel-watcher/install.sh: missing ../lib/launchd-domain-guard.sh" >&2; exit 1; }
+# shellcheck source=../lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the channel-watcher LaunchAgent" && return 0
+  launchd_guard_message "the channel-watcher LaunchAgent" >&2
+  echo "channel-watcher/install.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
 unset _SRC
 
 LABEL="ai.coalesce.catalyst-channel-watcher"
@@ -52,6 +65,7 @@ case "${1:-}" in
 
   --uninstall)
     if launchctl list "$LABEL" >/dev/null 2>&1; then
+      launchd_agent_guard
       launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || \
         launchctl unload "$PLIST_DST" 2>/dev/null || true
       log "unloaded $LABEL"
@@ -73,6 +87,7 @@ case "${1:-}" in
     # launchd domain) the job never registers, so verify it actually loaded rather
     # than telling the operator "loaded" while no supervised watcher — and thus no
     # heartbeat / dead-man coverage — is running.
+    launchd_agent_guard
     launchctl bootstrap "gui/$(id -u)" "$PLIST_DST" 2>/dev/null || \
       launchctl load -w "$PLIST_DST" 2>/dev/null || true
     if launchctl list "$LABEL" >/dev/null 2>&1; then

--- a/plugins/dev/scripts/install-dependabot-escalate.sh
+++ b/plugins/dev/scripts/install-dependabot-escalate.sh
@@ -27,6 +27,20 @@ set -euo pipefail
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain, so a scratch HOME does
+# NOT sandbox it — it renders the plist somewhere temporary and then re-binds the
+# REAL label to that path. Refuse rather than damage the live domain.
+[[ -f "${SCRIPT_DIR}/lib/launchd-domain-guard.sh" ]] || {
+  echo "install-dependabot-escalate.sh: missing lib/launchd-domain-guard.sh next to this script" >&2; exit 1; }
+# shellcheck source=lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the dependabot-escalate agent" && return 0
+  launchd_guard_message "the dependabot-escalate agent" >&2
+  echo "install-dependabot-escalate.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
 unset _SRC
 
 DEST="${HOME}/Library/LaunchAgents/ai.coalesce.catalyst-dependabot-escalate.plist"
@@ -155,6 +169,7 @@ _substitute() {
 }
 
 if [[ "$UNINSTALL" -eq 1 ]]; then
+  launchd_agent_guard
   launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
   rm -f "$DEST"
   echo "install-dependabot-escalate.sh: uninstalled ${LABEL}"
@@ -197,6 +212,7 @@ _substitute > "$local_tmp"
 mv "$local_tmp" "$DEST"
 echo "install-dependabot-escalate.sh: wrote ${DEST}"
 
+launchd_agent_guard
 launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$DEST"
 echo "install-dependabot-escalate.sh: loaded ${LABEL} into gui/$(id -u)"

--- a/plugins/dev/scripts/install-health-responder.sh
+++ b/plugins/dev/scripts/install-health-responder.sh
@@ -24,6 +24,20 @@ set -euo pipefail
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain, so a scratch HOME does
+# NOT sandbox it — it renders the plist somewhere temporary and then re-binds the
+# REAL label to that path. Refuse rather than damage the live domain.
+[[ -f "${SCRIPT_DIR}/lib/launchd-domain-guard.sh" ]] || {
+  echo "install-health-responder.sh: missing lib/launchd-domain-guard.sh next to this script" >&2; exit 1; }
+# shellcheck source=lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the health-responder agent" && return 0
+  launchd_guard_message "the health-responder agent" >&2
+  echo "install-health-responder.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
 unset _SRC
 
 # DEST + LABEL do NOT depend on BAKE_DIR — define them up front so --uninstall
@@ -244,6 +258,7 @@ _remove_cron_backstop() {
 }
 
 if [[ "$UNINSTALL" -eq 1 ]]; then
+  launchd_agent_guard
   launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
   rm -f "$DEST"
   _remove_cron_backstop
@@ -307,6 +322,7 @@ echo "install-health-responder.sh: wrote ${DEST}"
 
 # Reload idempotently: bootout any existing instance (ignore failure when not
 # loaded), then bootstrap the fresh plist.
+launchd_agent_guard
 launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$DEST"
 echo "install-health-responder.sh: loaded ${LABEL} into gui/$(id -u)"

--- a/plugins/dev/scripts/install-orphan-sweep.sh
+++ b/plugins/dev/scripts/install-orphan-sweep.sh
@@ -18,6 +18,20 @@ set -euo pipefail
 _SRC="${BASH_SOURCE[0]}"
 while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain, so a scratch HOME does
+# NOT sandbox it — it renders the plist somewhere temporary and then re-binds the
+# REAL label to that path. Refuse rather than damage the live domain.
+[[ -f "${SCRIPT_DIR}/lib/launchd-domain-guard.sh" ]] || {
+  echo "install-orphan-sweep.sh: missing lib/launchd-domain-guard.sh next to this script" >&2; exit 1; }
+# shellcheck source=lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the orphan-sweep agent" && return 0
+  launchd_guard_message "the orphan-sweep agent" >&2
+  echo "install-orphan-sweep.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
 unset _SRC
 
 # DEST + LABEL do NOT depend on BAKE_DIR — define them up front so --uninstall
@@ -245,6 +259,7 @@ _substitute() {
 # worktree (CTL-1306). The guard never gates uninstall.
 
 if [[ "$UNINSTALL" -eq 1 ]]; then
+  launchd_agent_guard
   launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
   rm -f "$DEST"
   echo "install-orphan-sweep.sh: uninstalled ${LABEL}"
@@ -303,6 +318,7 @@ echo "install-orphan-sweep.sh: wrote ${DEST}"
 
 # Reload idempotently: bootout any existing instance (ignore failure when not
 # loaded), then bootstrap the fresh plist.
+launchd_agent_guard
 launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$DEST"
 echo "install-orphan-sweep.sh: loaded ${LABEL} into gui/$(id -u)"

--- a/plugins/dev/scripts/lib/launchd-domain-guard.sh
+++ b/plugins/dev/scripts/lib/launchd-domain-guard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# ─── launchd domain guard (CTL-1968) ─────────────────────────────────────────
+#
+# `launchctl bootstrap gui/$(id -u) <plist>` targets a domain that is PER-USER,
+# not per-HOME. Every install path in this repo derives its plist path from
+# "${HOME}/Library/LaunchAgents/…" but bootstraps into gui/<uid>, so a caller
+# running under a scratch HOME registers the REAL label bound to a temp path —
+# and, when the plist's directory is later cleaned up, leaves a dangling label
+# that `launchctl kickstart` can never revive.
+#
+# That is not hypothetical. On 2026-08-18 two full shell-suite runs on the
+# primary laptop (04:01 and 07:19 CT) squatted `ai.coalesce.catalyst-cloud-sync`
+# and left `ai.coalesce.catalyst-health-responder` UNLOADED for 3h47m — the
+# self-heal that exists to fix exactly this was itself a casualty. The vector was
+# __tests__/setup-cloud-replica.test.sh, which seals HOME but keeps the real
+# PATH, so `setup_cloud_replica` resolved the REAL installed `catalyst-stack` and
+# ran its `adopt-cloud-sync`. The test PASSED while doing it: the damage is
+# entirely invisible to the caller, which is why this guard lives in the product
+# rather than in any one test.
+#
+# ⚠️ The guard is deliberately NOT "is launchctl stubbed?" — that question cannot
+# be answered reliably from inside a shell. It asks the answerable one: is $HOME
+# the invoking user's real home? A caller that HAS sealed launchctl and wants to
+# exercise the bootstrap path declares so with
+# CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1. Sealing therefore becomes an explicit
+# statement; forgetting to seal is what refuses.
+#
+# Contract (house discipline: value + reason globals, never `$(fn)` — a command
+# substitution discards the named reason, which is how this class of bug hides):
+#
+#   CATALYST_LAUNCHD_GUARD_REAL_HOME  the resolved real home (when resolvable)
+#   CATALYST_LAUNCHD_GUARD_REASON     why the last call decided what it decided
+#
+#   launchd_guard_resolve_real_home   rc 0 = resolved
+#   launchd_guard_ok <context>        rc 0 = safe to mutate gui/<uid>
+#   launchd_guard_message <context>   the operator-facing refusal text
+
+CATALYST_LAUNCHD_GUARD_REAL_HOME=""
+CATALYST_LAUNCHD_GUARD_REASON=""
+
+# Normalize a path to its physical form when it exists; otherwise return it
+# unchanged. macOS makes this load-bearing: /var is a symlink to /private/var,
+# so a scratch HOME reads as /var/folders/… from mktemp and /private/var/folders/…
+# from launchd, and a literal string compare on those two is a false match risk
+# in both directions.
+_ldg_physical() {
+	local p="${1:-}"
+	if [[ -d $p ]]; then (cd "$p" 2>/dev/null && pwd -P) || printf '%s' "$p"; else printf '%s' "$p"; fi
+}
+
+# Resolve the invoking user's real home WITHOUT trusting $HOME. Three
+# independent resolvers, tried in order; each is authoritative on its own, so
+# "cannot resolve" means all three failed, which on a macOS host is genuinely
+# anomalous rather than merely unusual.
+launchd_guard_resolve_real_home() {
+	CATALYST_LAUNCHD_GUARD_REAL_HOME=""
+	CATALYST_LAUNCHD_GUARD_REASON=""
+	local user home
+	user="$(id -un 2>/dev/null)"
+	if [[ -z $user ]]; then
+		CATALYST_LAUNCHD_GUARD_REASON="could not resolve the current user name (id -un)"
+		return 1
+	fi
+
+	# 1. Directory Services — the authority on macOS.
+	if command -v dscl >/dev/null 2>&1; then
+		home="$(dscl . -read "/Users/${user}" NFSHomeDirectory 2>/dev/null | sed -n 's/^NFSHomeDirectory: //p' | head -1)"
+		if [[ -n $home ]]; then
+			CATALYST_LAUNCHD_GUARD_REAL_HOME="$home"
+			CATALYST_LAUNCHD_GUARD_REASON="real home resolved via dscl"
+			return 0
+		fi
+	fi
+
+	# 2. getpwuid(3) — perl ships with macOS and is not shadowed by $HOME.
+	if command -v perl >/dev/null 2>&1; then
+		home="$(perl -e 'my @p = getpwuid($<); print $p[7] if @p' 2>/dev/null)"
+		if [[ -n $home ]]; then
+			CATALYST_LAUNCHD_GUARD_REAL_HOME="$home"
+			CATALYST_LAUNCHD_GUARD_REASON="real home resolved via getpwuid"
+			return 0
+		fi
+	fi
+
+	# 3. `~user` tilde expansion consults the passwd database, NOT $HOME.
+	#    (A bare `~` WOULD read $HOME, which is exactly the value under suspicion.)
+	home="$(eval printf '%s' "~${user}" 2>/dev/null)"
+	if [[ -n $home && $home != "~${user}" ]]; then
+		CATALYST_LAUNCHD_GUARD_REAL_HOME="$home"
+		CATALYST_LAUNCHD_GUARD_REASON="real home resolved via ~${user} expansion"
+		return 0
+	fi
+
+	CATALYST_LAUNCHD_GUARD_REASON="could not resolve the real home for '${user}' (dscl, getpwuid and ~${user} all failed)"
+	return 1
+}
+
+# rc 0 = safe to mutate gui/<uid>. Fails CLOSED: an unresolvable real home
+# refuses rather than assuming the current $HOME is fine.
+launchd_guard_ok() {
+	local ctx="${1:-launchd agent install}"
+	CATALYST_LAUNCHD_GUARD_REASON=""
+
+	if [[ ${CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD:-0} == "1" ]]; then
+		CATALYST_LAUNCHD_GUARD_REASON="allowed: CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1 (caller declares launchctl is sealed)"
+		return 0
+	fi
+
+	if ! launchd_guard_resolve_real_home; then
+		# REASON already names which resolvers failed.
+		return 1
+	fi
+
+	local real cur
+	real="$(_ldg_physical "$CATALYST_LAUNCHD_GUARD_REAL_HOME")"
+	cur="$(_ldg_physical "${HOME:-}")"
+
+	if [[ -z ${HOME:-} ]]; then
+		CATALYST_LAUNCHD_GUARD_REASON="HOME is unset, so the plist path for ${ctx} cannot be trusted"
+		return 1
+	fi
+
+	if [[ $cur != "$real" ]]; then
+		CATALYST_LAUNCHD_GUARD_REASON="HOME (${cur}) is not this user's real home (${real})"
+		return 1
+	fi
+
+	CATALYST_LAUNCHD_GUARD_REASON="HOME matches the real home (${real})"
+	return 0
+}
+
+# The operator-facing refusal. Says what was refused, why, both paths, and the
+# two ways forward — because "refused" with no route is how a guard gets deleted.
+launchd_guard_message() {
+	local ctx="${1:-launchd agent install}"
+	printf '%s\n' \
+		"REFUSING to bootstrap ${ctx} into gui/$(id -u 2>/dev/null)." \
+		"  reason: ${CATALYST_LAUNCHD_GUARD_REASON}" \
+		"  The launchd per-user domain is per-USER, not per-HOME: bootstrapping a" \
+		"  plist rendered under a scratch HOME would re-bind the REAL label to a" \
+		"  path that disappears when that HOME is cleaned up (CTL-1968)." \
+		"  If you are a test that has already sealed launchctl, declare it:" \
+		"    export CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1" \
+		"  If you meant to install for real, run with your own HOME."
+}


### PR DESCRIPTION
## The problem

`launchctl bootstrap gui/$(id -u) <plist>` targets a domain that is **per-USER, not per-HOME**. Every install path in this repo derives its plist from `"$HOME/Library/LaunchAgents/…"` but bootstraps into `gui/<uid>`, so a caller under a scratch `HOME` does not get a sandbox — it renders the plist somewhere temporary and then **re-binds the REAL label to it**.

On 2026-08-18 two full shell-suite runs on the primary laptop (04:01 and 07:19 CT — `/tmp/gate-inc3.log`, `/tmp/ctl1893-gate.log`, both containing `PASS … setup-cloud-replica.test.sh`) squatted `ai.coalesce.catalyst-cloud-sync` and left `ai.coalesce.catalyst-health-responder` **UNLOADED for 3h47m** — the self-heal that exists to fix exactly this was itself a casualty. ⛔ Every one of those cases reported **PASS** while doing it.

## The vector

`__tests__/setup-cloud-replica.test.sh` seals `HOME` but keeps the real `PATH`:

1. `run_case` → `HOME=$(mktemp -d)`, `PATH="$bindir:$PATH"` — stubs **only `curl`**
2. `source setup-catalyst.sh` → `setup_cloud_replica`
3. `setup-catalyst.sh:2045` `stack=$(command -v catalyst-stack)` → resolves the **real installed** binary off the retained `:$PATH`
4. `catalyst-stack:2607` renders under the temp HOME, then bootstraps into `gui/$(id -u)`

### Why the two casualties look different

`install-health-responder.sh:310` boots the responder out **BY LABEL**, which always hits the real service; the following bootstrap then collides with a label an earlier case already registered (three `Caller tried to import service with same label` errors in the unified log at 07:19:22/33/41) and **fails**. So cloud-sync ends up squatted and health-responder ends up merely **unloaded** — one mechanism, two different-looking failures, and the reason neither self-healed.

## The fix — two halves, covering different windows

**1. `lib/launchd-domain-guard.sh` (new)** refuses to mutate `gui/<uid>` when `$HOME` is not the invoking user's real home. It resolves the real home **without trusting `$HOME`** (`dscl` → `getpwuid` → `~user` expansion — `~user` reads passwd, a bare `~` would read the very value under suspicion) and fails **CLOSED** when none resolve. Wired into all **23** binding-mutation sites in `catalyst-stack` plus the five standalone install scripts.

It is deliberately **not** "is `launchctl` stubbed?" — that is unanswerable from inside a shell. It asks the answerable question, and a caller that *has* sealed `launchctl` declares it with `CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1`. **Forgetting to seal is what refuses.**

**2. The test now plants a `catalyst-stack` stub for every case.** ⭐ This is the load-bearing near-term half — the test invokes the **installed** `catalyst-stack`, so the guard protects no host until it is deployed.

## Measured, not asserted

Before/after under a recording `launchctl`, with the seal proven reachable by a negative control first and **both arms proven to have actually reached their assertions**:

| | result | escaped `bootout`/`bootstrap` |
| -- | -- | -- |
| BEFORE (`origin/main`) | 53 passed, 0 failed | **24**, across **6** temp HOMEs |
| AFTER | 53 passed, 0 failed | **0** |

Those 6 temp HOMEs independently match the six distinct `tmp.*` paths the unified log recorded at 07:19.

`__tests__/launchd-domain-guard.test.sh` (13 cases) pairs every "zero mutations" assertion with a **mutation control** that runs the same command with the guard opted out — a bare "no launchctl call was made" is satisfied just as well by a command that never ran, which is this ticket's whole failure mode. G8 measures **2 unguarded vs 0 guarded**.

## Two things I got wrong on the way

Both caught only because the harness asserts the test actually ran:

- my first AFTER run **still escaped 4 calls** — case 7 rolls its own `HOME`/`PATH` and bypasses `run_case`, so fixing `run_case` alone missed it;
- my first BEFORE arm was **inconclusive, not clean** — the test had been copied out of its directory so `REPO_ROOT` never resolved.

## Placement and baseline

Guards sit at the **mutation lines, not function tops**: `install-services --print` is pure and must not be gated on a guard only the mutation needs. Caught by baseline comparison against a clean `origin/main` worktree — `catalyst-stack.test.sh` is **68 passed / 9 failed on `origin/main`** (pre-existing), went to 68/10 with the guard misplaced, and is back to **68/9**. `install-cli.test.sh` (70/3) and `verify-node.test.sh` (rc=1) were likewise verified pre-existing, not regressions.

Three already-sealed suites now declare the hatch next to their existing mock: `install-orphan-sweep.test.sh`, `health-responder.test.sh`, and `catalyst-stack.test.sh`'s uninstall case (scoped to that one invocation — the rest of that file is pure `--print`).

⭐ **CI is unaffected and could never have caught this**: `execution-core-tests.yml` is `ubuntu-latest`, where the install scripts never reach `launchctl`. This is macOS-dev-box-only, which is why it only ever damaged the laptop.

Closes CTL-1968.