### PR TITLE
fix(dev): CTL-1976 — the gate reads the readiness file the PRODUCER writes, not one under the caller's dir

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.mjs
@@ -15,7 +15,7 @@
 // for a short window. The cache is bounded far below the staleness window it feeds,
 // so it can delay an un-arm by at most `READY_CACHE_MS` — not defeat it.
 
-import { readGithubFeedConfig } from "./config.mjs";
+import { getExecutionCoreDir, readGithubFeedConfig } from "./config.mjs";
 import { createCaptureSink } from "./cloud-feed-capture.mjs";
 import { defaultReadyPath, readReadyState } from "./github-feed-ready.mjs";
 import { resolveAccount } from "./github-feed-timer.mjs";
@@ -84,6 +84,34 @@ export function defaultGithubCapturePath(orchDir, account = "tenant-0") {
 }
 
 /**
+ * producerReadyPath — where the PRODUCER writes its readiness file.
+ *
+ * ⛔ CTL-1976: RESOLVED FROM THE PRODUCER'S DIRECTORY, NEVER THE CALLER'S. This
+ * gate's other artifact — the capture sink — is owned by whichever process installs
+ * the gate, so `orchDir` is the right root for it. The readiness file is NOT: it is
+ * written by `github-feed-timer` inside the daemon, under `getExecutionCoreDir()`,
+ * and this side only ever READS it. Deriving it from the installer's `orchDir` meant
+ * the broker (whose `orchDir` is `CATALYST_DIR`, one level up) read
+ * `~/catalyst/shadow/...` while the daemon wrote `~/catalyst/execution-core/shadow/...`.
+ *
+ * ⚠️ AND THAT MISS IS NOT SYMMETRIC, WHICH IS WHY IT IS A `readFileSync` AWAY FROM
+ * SILENT. `readReadyState` answers `ready:false` for an absent file, and in
+ * `decideDispatch` readiness gates ONLY the smee branch — the feed branch is gated on
+ * the `feedAuthority` stamp, which the producer computes from ITS OWN (correct) path.
+ * So a mismatched path does not fail closed on both sides: smee keeps routing AND the
+ * feed routes, i.e. every covered name dispatches TWICE, while every log line on both
+ * processes reads healthy. The readiness lever exists to make `enforce` refusable; a
+ * lever wired to a file nobody writes is a check that cannot fire.
+ *
+ * Measured on mini-2 (2026-08-18 11:15 CT) with the gate armed in shadow: broker
+ * `readyFile` `/Users/ryan/catalyst/shadow/github-feed-ready-tenant-0.json` — absent;
+ * daemon's, under `execution-core/`, fresh on every 30 s tick.
+ */
+export function producerReadyPath(account = resolveAccount(), executionCoreDir = getExecutionCoreDir()) {
+  return defaultReadyPath(executionCoreDir, account);
+}
+
+/**
  * createGithubFeedGate — the object `decideDispatch` takes as its second argument.
  *
  * Returns `null` when the mode is `off`, so the caller can skip the gate entirely
@@ -104,7 +132,8 @@ export function createGithubFeedGate({
 } = {}) {
   if (config.mode === "off") return null;
 
-  const readyFile = readyPath ?? defaultReadyPath(orchDir, account);
+  // ⛔ producerReadyPath, NOT defaultReadyPath(orchDir, ...) — see its header (CTL-1976).
+  const readyFile = readyPath ?? producerReadyPath(account);
   const capture = captureFactory({ path: capturePath ?? defaultGithubCapturePath(orchDir, account) });
 
   let cachedAt = -Infinity;

--- a/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-gate-install.test.mjs
@@ -12,6 +12,8 @@ import {
   readGithubCoverage,
 } from "./github-feed-gate-install.mjs";
 import { staleWindowMs } from "./github-feed-ready.mjs";
+import { startGithubFeedTimer } from "./github-feed-timer.mjs"; // CTL-1976
+import { getExecutionCoreDir } from "./config.mjs"; // CTL-1976
 import { decideDispatch } from "./github-feed-gate.mjs";
 
 const tmp = mkdtempSync(join(tmpdir(), "gh-gate-install-"));
@@ -266,5 +268,125 @@ describe("CTC-712 — the gate's coverage tracks the replica, and re-reads it", 
     }
     // A replica IS present and was opened by the default factory: that is the claim.
     expect(r.ok).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTL-1976 — the readiness file is written by the PRODUCER and read by the GATE,
+// in two different processes. Every test above injects `readState`, so until this
+// block the DEFAULT `readyPath` — the only one production uses — was never
+// asserted, and it pointed at a file nothing writes.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("⛔ CTL-1976: the gate reads the file the PRODUCER writes, not one under the caller's dir", () => {
+  const withCatalystDir = (dir, fn) => {
+    const prev = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+    try { return fn(); } finally {
+      if (prev === undefined) delete process.env.CATALYST_DIR;
+      else process.env.CATALYST_DIR = prev;
+    }
+  };
+
+  test("⭐ the default readyPath is the producer's, and does NOT follow the installer's orchDir", () => {
+    const root = mkdtempSync(join(tmpdir(), "gh-ready-path-"));
+    try {
+      withCatalystDir(root, () => {
+        // The broker's REAL call shape (broker/tailer.mjs:52): orchDir = CATALYST_DIR.
+        const g = createGithubFeedGate({
+          orchDir: root,
+          account: "tenant-0",
+          config: { mode: "enforce", intervalSec: 30 },
+          captureFactory: stubCapture,
+        });
+        // The producer writes under execution-core/, one level DOWN from CATALYST_DIR.
+        expect(g.readyPath).toBe(join(root, "execution-core", "shadow", "github-feed-ready-tenant-0.json"));
+        // ⛔ The mutation this block owns: the pre-CTL-1976 code produced exactly the
+        // path below, which nothing ever writes. Asserted as a NON-match so the test
+        // fails if the derivation is ever put back on the caller's dir.
+        expect(g.readyPath).not.toBe(join(root, "shadow", "github-feed-ready-tenant-0.json"));
+      });
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test("⭐ equal BY CONSTRUCTION to what the producer's own timer writes — not to a second string literal", () => {
+    const root = mkdtempSync(join(tmpdir(), "gh-ready-parity-"));
+    try {
+      // ⚠️ SYNCHRONOUS ON PURPOSE. An `async` body here would return a promise to
+      // withCatalystDir, whose `finally` then restores CATALYST_DIR *before* the body
+      // runs — so both sides would resolve the ambient hermetic dir and agree for a
+      // reason the test does not name. Caught by running this block under the mutation.
+      withCatalystDir(root, () => {
+        const noopClock = { setInterval: () => ({ unref() {} }), clearInterval: () => {} };
+        // daemon.mjs's own argument shape: orchDir = getExecutionCoreDir().
+        const timer = startGithubFeedTimer({
+          mode: "shadow",
+          orchDir: getExecutionCoreDir(),
+          account: "tenant-0",
+          eventLogPath: join(root, "events.jsonl"),
+          appendFn: () => {},
+          clock: noopClock,
+        });
+        const gate = createGithubFeedGate({
+          orchDir: root, // the BROKER's dir — deliberately different from the producer's
+          account: "tenant-0",
+          config: { mode: "enforce", intervalSec: 30 },
+          captureFactory: stubCapture,
+        });
+        // Positive control: the two dirs really are different, so an accidental
+        // pass-because-both-are-the-same-root is not possible here.
+        expect(getExecutionCoreDir()).not.toBe(root);
+        expect(gate.readyPath).toBe(timer.readyPath);
+        timer.stop();
+      });
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test("the CAPTURE sink still follows the installer's orchDir — it is the broker's artifact, not the producer's", () => {
+    const root = mkdtempSync(join(tmpdir(), "gh-capture-path-"));
+    try {
+      withCatalystDir(root, () => {
+        let seen = null;
+        createGithubFeedGate({
+          orchDir: root,
+          account: "tenant-0",
+          config: { mode: "enforce", intervalSec: 30 },
+          captureFactory: ({ path }) => { seen = path; return stubCapture(); },
+        });
+        expect(seen).toBe(defaultGithubCapturePath(root, "tenant-0"));
+      });
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  test("an explicit readyPath still wins — the seam the existing tests depend on is untouched", () => {
+    const g = createGithubFeedGate({
+      orchDir: tmp,
+      readyPath: "/explicit/ready.json",
+      config: { mode: "enforce", intervalSec: 30 },
+      captureFactory: stubCapture,
+    });
+    expect(g.readyPath).toBe("/explicit/ready.json");
+  });
+
+  test("⛔ a missing ready file leaves smee AUTHORITATIVE — the failure mode this bug hid", () => {
+    const root = mkdtempSync(join(tmpdir(), "gh-ready-absent-"));
+    try {
+      withCatalystDir(root, () => {
+        const g = createGithubFeedGate({
+          orchDir: root,
+          account: "tenant-0",
+          config: { mode: "enforce", intervalSec: 30 },
+          captureFactory: stubCapture,
+        });
+        // Nothing has written the producer's file, so the probe must decline.
+        const verdict = g.isReady();
+        expect(verdict.ready).toBe(false);
+        expect(verdict.reason).toBe("ready-file-absent");
+        // …and the smee copy therefore keeps routing rather than being suppressed.
+        const smee = { attributes: { "event.name": "github.pr.merged" }, resource: {} };
+        const d = decideDispatch(smee, g);
+        expect(d.suppress).toBe(false);
+        expect(d.reason).toContain("enforce-not-armed");
+      });
+    } finally { rmSync(root, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
## The measurement, on mini-2, live, 2026-08-18 11:15 CT

Arming the GitHub feed gate in `shadow` for tonight's CTL-1929 cutover surfaced this. One writer, two readers, **two different paths**:

| process | path | exists? |
| -- | -- | -- |
| execution-core daemon (**writes** it) | `~/catalyst/execution-core/shadow/github-feed-ready-tenant-0.json` | ⭐ fresh, every 30 s |
| broker dispatch gate (**reads** it) | `~/catalyst/shadow/github-feed-ready-tenant-0.json` | ⛔ **never created** |

`defaultReadyPath(orchDir, account)` joins `shadow/` onto whatever dir the **caller** owns. The daemon passes `getExecutionCoreDir()`; `broker/tailer.mjs:52` passes `CATALYST_DIR`, one level up.

## ⛔ Why this is not a cosmetic path bug

`readReadyState` answers `{ready:false, reason:"ready-file-absent"}` for an absent file. In `decideDispatch` at `enforce`, readiness gates **only the smee branch** — the feed branch is gated on the `feedAuthority` stamp, which the **producer** computes from **its own (correct)** path. So the miss is **not symmetric** and does not fail closed on both sides:

- **smee copy** → `!ready` → `suppress: false` → **routes**
- **feed copy** → stamp is `true` → `suppress: false, reason: "feed-authoritative"` → **routes**

**Every covered name dispatches twice** — two `monitor-merge` wakes, two CI-wait resolutions, two `filter_state` transitions. That is the exact outcome `github-feed-timer.mjs`'s header exists to refuse.

It also leaves the **readiness-fails-to-smee rollback lever inoperative**: latched not-ready forever, so it can never withhold anything while the producer keeps emitting.

## ⭐ Why nothing would have caught it

The daemon logs `armed · effective: enforce`. The ready file says `{"ready":true}`. The broker logs `gate: armed` and `coverage changed · suppressible: 12`. **Every surface reads green.** The gate logs nothing when it declines — and the cutover's own verification step ("prove a real dispatch rode the feed") **passes during double dispatch**, because the feed's dispatch is genuinely real.

## The fix

`producerReadyPath()` resolves from `getExecutionCoreDir()` — the producer's dir — and is the gate's default. `orchDir` still owns the **capture sink**, which really is the installing process's own artifact. There is exactly one production caller (`broker/tailer.mjs`), so no call-site change is needed and no future caller can get it wrong.

## Tests

⛔ **Every pre-existing test injects `readState`, so the DEFAULT `readyPath` — the only one production uses — was never asserted. That is why this shipped.** Five cases added, including one that compares the gate's path to what the producer's own timer reports **by construction** (`startGithubFeedTimer` with `daemon.mjs`'s argument shape) rather than to a second hand-written literal.

**Mutation-controlled.** Reverting the one-line default makes exactly **2 of the new tests fail**, with the bug's signature:

```
Expected: ".../gh-ready-parity-1OxMxe/execution-core/shadow/github-feed-ready-tenant-0.json"
Received: ".../gh-ready-parity-1OxMxe/shadow/github-feed-ready-tenant-0.json"
```

⚠️ The parity test is deliberately **synchronous**. An `async` body returns a promise to the env-restoring helper, whose `finally` fires *before* the body runs — so both sides would have resolved the ambient hermetic dir and agreed **for a reason the test does not name**. Caught by running the mutation and reading *why* it failed, not just *that* it failed.

| suite | result |
| -- | -- |
| `execution-core` github-feed (10 files) | ⭐ **322 pass · 0 fail** |
| `broker` (39 files) | **1028 pass · 1 fail** — byte-identical to a clean `origin/main` baseline worktree, same test (`held-label literals stay in lock-step with the board`), **pre-existing** |

## ⛔ Deliberately NOT done

CTL-1976's filed AC also asked that an absent/stale ready file refuse the **feed** copy too. That would add **consumption-time revocation** of authority, which CTL-1901 explicitly refused — *"authority is stamped at emission… a later readiness change must not retroactively grant OR revoke authority for a line already on disk."* With the path fixed, both sides read one signal and the asymmetry is gone. Re-opening CTL-1901's decision is not this PR's call; recorded on the ticket instead.

## Review

⚠️ Codex is out of quota (CTL-1954), so this needs a **peer read** per COORD-137. It is on the dispatch path.

Closes CTL-1976. Blocks the CTL-1929 enforce flip (COORD-174).

🤖 Generated with [Claude Code](https://claude.com/claude-code)