### PR TITLE
feat(dev): CTL-1975 — the uninstall could not remove two agents its own verify-clean fails on

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -281,6 +281,27 @@ jobs:
         working-directory: .
         run: bash plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
 
+      - name: archive + uninstall test (CTL-1975)
+        # ⛔ PINNED DELIBERATELY, and the reason is the PR that added it. CI runs an EXPLICIT list
+        # of shell suites — there is no glob runner and no run-tests.sh here — so a suite that is
+        # merely present in __tests__/ runs only in the local full gate, which is banned on the
+        # primary laptop. This suite certifies that `catalyst uninstall` can actually remove every
+        # ai.coalesce.* agent; shipping it unpinned would make the next such regression exactly as
+        # invisible as the one it was written for (usage-page + event-mirror, unremovable on all
+        # three hosts, failing verify-clean at its final phase with no code path able to clear it).
+        #
+        # It mocks launchctl via a PATH stub and never touches the runner's real launchd domain.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
+
+      - name: catalyst-backup capture/restore test (CTL-1369 PR2)
+        # Pinned alongside the suite above: CTL-1975 changed ~300 lines of catalyst-backup (the
+        # replica capture, the tarball, the manifest, rel_to_dest), and its own regression suite
+        # was likewise present-but-unpinned. A capture path whose only coverage runs on one laptop
+        # is a capture path with no coverage.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/catalyst-backup.test.sh
+
       - name: direnv fleet readiness test (CTL-1944)
         # The property under test is not "is direnv installed" — it is that every way of being
         # NOT-owner-ready renders RED. Two regression guards carry the weight: a BLOCKED .envrc

--- a/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
@@ -215,11 +215,20 @@ FAKE="$SCRATCH/fake-scripts"
 mkdir -p "$FAKE/usage-page"
 cp "$SCRIPT_DIR/../catalyst-account-usage-page.sh" "$FAKE/"
 cp "$INSTALLER" "$FAKE/"
+# CTL-1975: the installer now loads lib/launchd-domain-guard.sh (CTL-1968 family), so the fake
+# scripts dir has to carry it or the script refuses before it ever renders the template — and this
+# control would then "pass" on the WRONG refusal.
+mkdir -p "$FAKE/lib"
+cp "$SCRIPT_DIR/../lib/launchd-domain-guard.sh" "$FAKE/lib/"
 sed 's|__SCRIPT__|__NEVER_SUBSTITUTED__|' "$SCRIPT_DIR/../usage-page/ai.coalesce.catalyst-usage-page.plist" \
 	>"$FAKE/usage-page/ai.coalesce.catalyst-usage-page.plist"
 OUT="$(bash "$FAKE/install-usage-page.sh" --print-only 2>&1)"
 RC=$?
-[ "$RC" -ne 0 ] && grep -q "REFUSING" <<<"$OUT" && pass "an unsubstituted token is refused" || fail "an unsubstituted token is refused" "rc=$RC: $OUT"
+# ⛔ Matched on the TOKEN-SPECIFIC line, not a bare "REFUSING": this script now has a second refusal
+# (the launchd domain guard), so the loose needle would let a run that never reached the template
+# check certify the template check. That is not hypothetical — it is exactly what a missing
+# lib/launchd-domain-guard.sh produced here before the copy above was added.
+[ "$RC" -ne 0 ] && grep -q "unsubstituted token(s) remain" <<<"$OUT" && pass "an unsubstituted token is refused" || fail "an unsubstituted token is refused" "rc=$RC: $OUT"
 
 echo ""
 echo "  PASSED: $PASSES   FAILED: $FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
@@ -217,6 +217,11 @@ expect_eq "⭐ pos. ctrl — the extractor really reads the body" "yes" \
   "$([[ "$BODY" == *'CLOUD_SYNC_AGENT_PLIST'* ]] && echo yes || echo no)"
 expect_contains "delegates the usage-page teardown" "$BODY" 'install-usage-page.sh" --uninstall' 
 expect_contains "calls the event-mirror teardown"   "$BODY" "stop_event_mirror"
+# FLEET-37 note 1: the delegation keeps `|| true` (one agent's teardown must not abort the other
+# eight), so the rc has to be captured and warned about or the operator sees only "residual plist
+# found" at the final phase and reconstructs which teardown failed.
+expect_contains "captures the usage-page teardown rc"  "$BODY" "PIPESTATUS"
+expect_contains "and warns when it is non-zero"        "$BODY" "may remain"
 
 echo
 echo "  ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Tests for CTL-1975 — `catalyst-backup archive|state` (the teardown-grade capture + the pre/post
+# diff instrument) and the two launchd agents `uninstall-services` could not previously remove.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-archive-uninstall.test.sh
+#
+# ── Why the harness is shaped this way ───────────────────────────────────────────────────────────
+#
+# ⛔ `launchctl` is MOCKED via a PATH stub (MOCKBIN) that appends every invocation to a log, and the
+# real `launchctl list` is never consulted. That is not merely hygiene: `launchctl bootout gui/<uid>`
+# targets a domain that is PER-USER and not per-HOME (CTL-1968), so a test that seals HOME but keeps
+# the real PATH boots out THIS machine's live agents while reporting PASS. That incident is exactly
+# how the guard under test came to exist.
+#
+# ⭐ Every "nothing happened" assertion here is paired with a POSITIVE CONTROL that makes the same
+# instrument return non-zero on a case known to be present — because an empty mock log, an empty
+# grep and a broken probe are the same bytes to an assertion:
+#   * the refusal case (zero bootouts) is paired with the allowed case (a recorded bootout);
+#   * the "no secret VALUE in the manifest" grep is paired with the same grep finding that secret
+#     in the bundle's captured config, where it legitimately IS;
+#   * the label filter's two catalyst labels are paired with a third, non-catalyst label the mock
+#     also emits and the probe must exclude.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP="${SCRIPT_DIR}/../catalyst-backup"
+STACK="${SCRIPT_DIR}/../catalyst-stack"
+USAGE_PAGE="${SCRIPT_DIR}/../install-usage-page.sh"
+
+FAILURES=0
+PASSES=0
+ok()   { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq()       { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_contains() { if [[ "$2" == *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' lacks '$3'"; fi; }
+expect_lacks()    { if [[ "$2" != *"$3"* ]]; then ok "$1"; else fail "$1" "'$2' should not contain '$3'"; fi; }
+expect_file()     { if [[ -f "$2" ]]; then ok "$1"; else fail "$1" "missing file: $2"; fi; }
+expect_absent()   { if [[ ! -e "$2" ]]; then ok "$1"; else fail "$1" "should not exist: $2"; fi; }
+# count_in FILE NEEDLE — occurrences, and 0 for an absent/unreadable file. NOT `grep -c || echo 0`:
+# grep -c already PRINTS 0 and then exits 1, so the fallback appends a second line and the caller
+# compares against "0\n0". A counter whose zero is two lines is not a counter.
+count_in() { local c; c="$(grep -c "$2" "$1" 2>/dev/null)"; [[ "$c" =~ ^[0-9]+$ ]] || c=0; printf '%s' "$c"; }
+
+command -v jq      >/dev/null 2>&1 || { echo "jq required — skipping";      exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "sqlite3 required — skipping"; exit 0; }
+
+SB="$(mktemp -d)"
+trap 'rm -rf "$SB"' EXIT
+mkdir -p "$SB/home/Library/LaunchAgents" "$SB/.config/catalyst" "$SB/catalyst/execution-core" \
+         "$SB/catalyst/wt" "$SB/catalyst/logs" "$SB/bin" "$SB/target/catalyst" "$SB/target/config"
+
+SECRET="sk-CTL1975-SECRET"
+printf '{"catalyst":{"node":{"class":"developer"},"apiToken":"%s"}}\n' "$SECRET" > "$SB/.config/catalyst/config.json"
+printf '{"token":"%s"}\n' "$SECRET"                > "$SB/.config/catalyst/config-CTL.json"
+printf '<plist>stack</plist>\n'                    > "$SB/home/Library/LaunchAgents/ai.coalesce.catalyst-stack.plist"
+printf '<plist>usage</plist>\n'                    > "$SB/home/Library/LaunchAgents/ai.coalesce.catalyst-usage-page.plist"
+printf '<plist>other</plist>\n'                    > "$SB/home/Library/LaunchAgents/com.example.other.plist"
+printf '{"orchestrators":[]}\n'                    > "$SB/catalyst/state.json"
+printf 'some log bytes\n'                          > "$SB/catalyst/logs/broker.log"
+sqlite3 "$SB/catalyst/catalyst.db"         "CREATE TABLE sessions(id TEXT); INSERT INTO sessions VALUES('s1');"
+sqlite3 "$SB/catalyst/catalyst-replica.db" "CREATE TABLE issues(id TEXT); INSERT INTO issues VALUES('CTL-1975');"
+
+# ── MOCKBIN launchctl ────────────────────────────────────────────────────────────────────────────
+# `list` emits THREE labels: two ai.coalesce.catalyst-* and one that must be filtered out. The
+# third is the positive control for the filter — without it, "the probe returned our two labels"
+# is also what a probe that returns everything would produce.
+cat > "$SB/bin/launchctl" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "list" ]]; then
+  printf '%s\t%s\t%s\n' 4242 0 ai.coalesce.catalyst-stack
+  printf '%s\t%s\t%s\n' -    0 ai.coalesce.catalyst-usage-page
+  printf '%s\t%s\t%s\n' 99   0 com.example.other
+  exit 0
+fi
+printf '%s\n' "$*" >> "${MOCK_LAUNCHCTL_LOG:-/dev/null}"
+exit 0
+MOCK
+chmod +x "$SB/bin/launchctl"
+
+src_env() {
+  env PATH="$SB/bin:$PATH" MOCK_LAUNCHCTL_LOG="$SB/lc.log" \
+      CATALYST_DIR="$SB/catalyst" \
+      CATALYST_LAYER2_CONFIG_FILE="$SB/.config/catalyst/config.json" \
+      CATALYST_LAUNCHAGENTS_DIR="$SB/home/Library/LaunchAgents" \
+      CATALYST_HUMANLAYER_CONFIG="$SB/.config/humanlayer/humanlayer.json" \
+      CATALYST_DB_FILE="$SB/catalyst/catalyst.db" \
+      CATALYST_REPLICA_DB="$SB/catalyst/catalyst-replica.db" \
+      CATALYST_BACKUPS_DIR="$SB/backups" \
+      CATALYST_WT_DIR="$SB/catalyst/wt" \
+      CATALYST_LOGS_DIR="$SB/catalyst/logs" \
+      CATALYST_ASSUME_NO_DAEMONS=1 \
+      "$@"
+}
+
+echo "catalyst-backup state — the pre/post diff instrument"
+STATE="$(src_env bash "$BACKUP" state 2>/dev/null)"
+expect_eq "state emits valid JSON" "yes" "$(printf '%s' "$STATE" | jq -e . >/dev/null 2>&1 && echo yes || echo no)"
+expect_contains "reads LOADED labels from launchctl"      "$STATE" "ai.coalesce.catalyst-usage-page"
+expect_lacks    "filters non-catalyst labels (pos. ctrl)" "$STATE" "com.example.other"
+expect_contains "inventories plists on disk"              "$STATE" "ai.coalesce.catalyst-stack.plist"
+expect_contains "inventories the replica DB"              "$STATE" "catalyst-replica.db"
+expect_contains "inventories logs by name"                "$STATE" "broker.log"
+expect_contains "lists per-project secret files by BASENAME only" "$STATE" "config-CTL.json"
+expect_contains "records the config KEY path"             "$STATE" "catalyst.apiToken"
+expect_lacks    "⭐ carries NO secret VALUE"               "$STATE" "$SECRET"
+
+echo "catalyst-backup archive — teardown-grade capture"
+AOUT="$(src_env bash "$BACKUP" archive 2>/dev/null)"; arc=$?
+TARBALL="$(printf '%s\n' "$AOUT" | tail -1)"
+expect_eq "archive exits 0" "0" "$arc"
+expect_eq "⭐ last stdout line is the TARBALL" "yes" "$([[ "$TARBALL" == *.tar.gz ]] && echo yes || echo no)"
+expect_file "tarball exists" "$TARBALL"
+BUNDLE="${TARBALL%.tar.gz}"
+expect_file "manifest.json in the staging bundle"   "$BUNDLE/manifest.json"
+expect_file "host-state.json in the staging bundle" "$BUNDLE/host-state.json"
+expect_file "replica captured"                      "$BUNDLE/runtime/catalyst-replica.db"
+MEMBERS="$(tar -tzf "$TARBALL" 2>/dev/null)"
+expect_contains "tarball holds manifest.json"       "$MEMBERS" "/manifest.json"
+expect_contains "tarball holds host-state.json"     "$MEMBERS" "/host-state.json"
+expect_contains "tarball holds the replica DB"      "$MEMBERS" "/runtime/catalyst-replica.db"
+expect_eq "manifest schemaVersion 2"  "2"    "$(jq -r '.schemaVersion' "$BUNDLE/manifest.json")"
+expect_eq "manifest withReplica true" "true" "$(jq -r '.withReplica'   "$BUNDLE/manifest.json")"
+expect_eq "manifest hostState true"   "true" "$(jq -r '.hostState'     "$BUNDLE/manifest.json")"
+expect_eq "manifest names the tarball" "$TARBALL" "$(jq -r '.tarball'  "$BUNDLE/manifest.json")"
+# ⭐ POSITIVE CONTROL for the two secret greps above and below: the SAME needle in the SAME shape
+# must be findable where the secret legitimately lives, or a clean manifest proves nothing.
+expect_eq "⭐ pos. ctrl — the secret IS in the captured config" "1" \
+  "$(count_in "$BUNDLE/config/config.json" "$SECRET")"
+expect_eq "⛔ manifest.json holds no secret VALUE"   "0" "$(count_in "$BUNDLE/manifest.json"   "$SECRET")"
+expect_eq "⛔ host-state.json holds no secret VALUE" "0" "$(count_in "$BUNDLE/host-state.json" "$SECRET")"
+
+echo "catalyst-backup backup — the lean default is UNCHANGED"
+BOUT="$(src_env bash "$BACKUP" backup --label plain 2>/dev/null)"
+PBUNDLE="$(printf '%s\n' "$BOUT" | tail -1)"
+# install-lifecycle.mjs reads this with `tail -1`; if archive's tarball line leaked into the plain
+# path the install lifecycle would take a restore point it could never restore from.
+expect_eq "⭐ last stdout line is still the BUNDLE dir" "yes" "$([[ -d "$PBUNDLE" ]] && echo yes || echo no)"
+expect_eq "withReplica false by default" "false" "$(jq -r '.withReplica' "$PBUNDLE/manifest.json")"
+expect_eq "tarball null by default"      "null"  "$(jq -r '.tarball'     "$PBUNDLE/manifest.json")"
+expect_absent "replica NOT captured by default" "$PBUNDLE/runtime/catalyst-replica.db"
+
+echo "catalyst-backup restore — the replica is restorable, not just captured"
+RESTORED="$(env PATH="$SB/bin:$PATH" MOCK_LAUNCHCTL_LOG="$SB/lc.log" \
+  CATALYST_DIR="$SB/target/catalyst" \
+  CATALYST_LAYER2_CONFIG_FILE="$SB/target/config/config.json" \
+  CATALYST_LAUNCHAGENTS_DIR="$SB/target/LaunchAgents" \
+  CATALYST_HUMANLAYER_CONFIG="$SB/target/humanlayer.json" \
+  CATALYST_DB_FILE="$SB/target/catalyst/catalyst.db" \
+  CATALYST_REPLICA_DB="$SB/target/catalyst/catalyst-replica.db" \
+  CATALYST_ASSUME_NO_DAEMONS=1 \
+  bash "$BACKUP" restore "$BUNDLE" 2>&1)"
+expect_file "replica restored to the live resolver's path" "$SB/target/catalyst/catalyst-replica.db"
+expect_eq "restored replica is a readable DB with its row" "CTL-1975" \
+  "$(sqlite3 "$SB/target/catalyst/catalyst-replica.db" "SELECT id FROM issues;" 2>/dev/null)"
+# Before CTL-1975 the replica had no rel_to_dest mapping, so restore SKIPPED it with this message
+# while reporting overall success — a half-restore that looked clean.
+expect_lacks "restore does not call the replica an unknown artifact" "$RESTORED" "unknown artifact, skipping: runtime/catalyst-replica.db"
+
+echo "catalyst-backup archive — an unverifiable tarball FAILS, it does not pass quietly"
+# `tar` exiting 0 does not prove the archive is readable. This stub writes a file and exits 0 for
+# the create, then lists NOTHING for the verify — the exact shape where success and failure are
+# byte-identical to the caller unless the verify is real.
+cat > "$SB/bin/tar" <<'MOCKTAR'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -czf) : > "$2"; exit 0 ;;   # "created" — but empty
+  -tzf) exit 0 ;;             # lists no members at all
+esac
+exit 0
+MOCKTAR
+chmod +x "$SB/bin/tar"
+BADOUT="$(src_env bash "$BACKUP" archive --label badtar 2>&1)"; badrc=$?
+expect_eq "⭐ archive exits NON-zero when the tarball cannot be verified" "yes" "$([[ $badrc -ne 0 ]] && echo yes || echo no)"
+expect_contains "and says so by name" "$BADOUT" "FAILED to create or verify tarball"
+expect_absent "the unverifiable tarball is REMOVED, not left for 'list' to offer" \
+  "$(ls -1 "$SB"/backups/*badtar*.tar.gz 2>/dev/null | head -1)"
+rm -f "$SB/bin/tar"
+
+# ── the two agents uninstall-services could not remove ───────────────────────────────────────────
+echo "install-usage-page.sh --uninstall — CTL-1968 guard + MOCKBIN bootout"
+: > "$SB/lc.log"
+UOUT="$(env PATH="$SB/bin:$PATH" MOCK_LAUNCHCTL_LOG="$SB/lc.log" HOME="$SB/home" \
+        bash "$USAGE_PAGE" --uninstall 2>&1)"; urc=$?
+expect_eq "⛔ REFUSES under a scratch HOME with no declaration" "yes" "$([[ $urc -ne 0 ]] && echo yes || echo no)"
+expect_contains "names the refusal"      "$UOUT" "REFUSED"
+expect_eq "⛔ zero launchctl calls made"  "0" "$(wc -l < "$SB/lc.log" | tr -d ' ')"
+expect_file "the plist is left alone"    "$SB/home/Library/LaunchAgents/ai.coalesce.catalyst-usage-page.plist"
+
+# ⭐ POSITIVE CONTROL: the same command, same mock, same scratch HOME — only the declaration
+# differs. Without this case, "zero launchctl calls" above is equally consistent with a mock that
+# never records anything.
+: > "$SB/lc.log"
+UOUT2="$(env PATH="$SB/bin:$PATH" MOCK_LAUNCHCTL_LOG="$SB/lc.log" HOME="$SB/home" \
+         CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1 bash "$USAGE_PAGE" --uninstall 2>&1)"; urc2=$?
+expect_eq "⭐ pos. ctrl — proceeds when the caller declares launchctl is sealed" "0" "$urc2"
+expect_contains "⭐ pos. ctrl — the mock DID record a bootout" "$(cat "$SB/lc.log")" "bootout gui/$(id -u)/ai.coalesce.catalyst-usage-page"
+expect_absent "the usage-page plist is removed" "$SB/home/Library/LaunchAgents/ai.coalesce.catalyst-usage-page.plist"
+
+: > "$SB/lc.log"
+UOUT3="$(env PATH="$SB/bin:$PATH" MOCK_LAUNCHCTL_LOG="$SB/lc.log" HOME="$SB/home" \
+         CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1 bash "$USAGE_PAGE" --uninstall 2>&1)"; urc3=$?
+expect_eq "idempotent — a second uninstall still exits 0" "0" "$urc3"
+
+echo "cmd_uninstall_services reaches both previously-unremovable agents"
+# A SOURCE-EXTRACTION check, and named as one: it is the instrument that FOUND this gap (the
+# function's body reached 9 agents and neither of these two). It fails closed — if the awk range
+# ever stops matching, the positive control below goes to 0 and the whole block fails rather than
+# silently reporting two absences.
+# ⛔ FULL-LINE COMMENTS ARE STRIPPED, and that is load-bearing rather than tidy. The first cut of
+# this check matched the raw body — and the comment introducing the call literally contains the
+# word `stop_event_mirror`, so DELETING THE CALL still passed. Caught by mutation, not by reading:
+# the mutant was verified applied and the suite stayed green. Only full-line comments are removed
+# (never `sed 's/#.*//'`), so a `#` inside real code can't be mangled into a false absence.
+BODY="$(awk '/^cmd_uninstall_services\(\)/,/^}/' "$STACK" | grep -v '^[[:space:]]*#')"
+expect_eq "⭐ pos. ctrl — the extractor really reads the body" "yes" \
+  "$([[ "$BODY" == *'CLOUD_SYNC_AGENT_PLIST'* ]] && echo yes || echo no)"
+expect_contains "delegates the usage-page teardown" "$BODY" 'install-usage-page.sh" --uninstall' 
+expect_contains "calls the event-mirror teardown"   "$BODY" "stop_event_mirror"
+
+echo
+echo "  ${PASSES} passed, ${FAILURES} failed"
+[[ $FAILURES -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/catalyst-backup
+++ b/plugins/dev/scripts/catalyst-backup
@@ -3,6 +3,9 @@
 #
 # Usage:
 #   catalyst-backup backup [--out <dir>] [--label <name>]   capture a timestamped bundle
+#         [--with-replica] [--tar]                          ... incl. the replica DB / a tarball
+#   catalyst-backup archive [--label <name>]                teardown-grade (CTL-1975)
+#   catalyst-backup state                                   observable host state as JSON
 #   catalyst-backup restore <bundle> [--force] [--dry-run]   restore a bundle's files
 #   catalyst-backup list [--json]                            list available bundles
 #
@@ -42,6 +45,12 @@ launchagents_dir()  { printf '%s' "${CATALYST_LAUNCHAGENTS_DIR:-$HOME/Library/La
 humanlayer_config() { printf '%s' "${CATALYST_HUMANLAYER_CONFIG:-$HOME/.config/humanlayer/humanlayer.json}"; }
 db_file()           { printf '%s' "${CATALYST_DB_FILE:-$(catalyst_dir)/catalyst.db}"; }
 backups_root()      { printf '%s' "${CATALYST_BACKUPS_DIR:-$(catalyst_dir)/backups}"; }
+# CTL-1975. Resolved IDENTICALLY to lib/linear-read-replica.sh (and config.mjs getReplicaDbPath):
+# CATALYST_REPLICA_DB overrides, else $CATALYST_DIR/catalyst-replica.db. Two resolvers disagreeing
+# here would archive one tenant's replica while the host reads another's.
+replica_db()        { printf '%s' "${CATALYST_REPLICA_DB:-$(catalyst_dir)/catalyst-replica.db}"; }
+worktrees_dir()     { printf '%s' "${CATALYST_WT_DIR:-$(catalyst_dir)/wt}"; }
+logs_dir()          { printf '%s' "${CATALYST_LOGS_DIR:-$(catalyst_dir)/logs}"; }
 
 err() { printf 'catalyst-backup: %s\n' "$*" >&2; }
 log() { printf '  %s\n' "$*"; }
@@ -59,16 +68,135 @@ plugin_version() {
 node_host()  { if declare -F catalyst_host_name >/dev/null 2>&1; then catalyst_host_name; else hostname -s 2>/dev/null || echo node; fi; }
 node_class() { if declare -F catalyst_node_class >/dev/null 2>&1; then catalyst_node_class; else echo unknown; fi; }
 
+# ── observable host state (CTL-1975) ─────────────────────────────────────────
+#
+# emit_state_json — a snapshot of what an operator can OBSERVE about this node's install, on stdout.
+# This is the pre/post diff instrument for an archive+uninstall: run it before, run it after, `diff`
+# the two, and every agent that survived a teardown is a line in that diff.
+#
+# ⛔ NO SECRET VALUES, structurally rather than by filtering. The config section emits jq
+# `paths(scalars)` — leaf key PATHS only — so a value cannot reach the output even if a new secret
+# key appears tomorrow. The per-project config-<key>.json files (which hold API/webhook tokens) are
+# listed by BASENAME only; their key paths are never walked.
+#
+# Every probe degrades to a named empty/absent rather than to silence: a section that could not be
+# read reports `"unreadable"`, never `[]`, because an empty list and a failed probe are the same
+# bytes to a diff and that is exactly how a teardown gets certified clean by an instrument that was
+# never able to look.
+emit_state_json() {
+  local la ldir cfg
+  la="$(launchagents_dir)"; ldir="$(logs_dir)"; cfg="$(layer2_config)"
+
+  # 1. plists on disk — the fleet's two prefixes, matched by NAME not by any hardcoded label list.
+  #    A registry-driven probe cannot see an agent the registry forgot; a prefix probe can.
+  local plists="[]"
+  if [[ -d "$la" ]]; then
+    plists="$(cd "$la" 2>/dev/null && ls -1 2>/dev/null \
+      | grep -E '^(ai\.coalesce\.catalyst-.*|com\.catalyst\.agent)\.plist$' \
+      | sort | jq -R . | jq -s . 2>/dev/null)" || plists='"unreadable"'
+    [[ -z "$plists" ]] && plists="[]"
+  fi
+
+  # 2. what launchd has LOADED. Disk and launchd disagree in both directions — a booted-out label
+  #    with its plist still on disk, and a squatted label whose plist is long gone — so both are
+  #    recorded and neither is inferred from the other.
+  local loaded='"unavailable"'
+  if command -v launchctl >/dev/null 2>&1; then
+    loaded="$(launchctl list 2>/dev/null \
+      | awk '$3 ~ /^(ai\.coalesce\.catalyst-|com\.catalyst\.agent)/ {print $3"\t"$1"\t"$2}' \
+      | sort | jq -R 'split("\t") | {label:.[0], pid:.[1], status:.[2]}' | jq -s . 2>/dev/null)" \
+      || loaded='"unreadable"'
+    [[ -z "$loaded" ]] && loaded="[]"
+  fi
+
+  # 3. Layer-2 config — key PATHS only (see the no-secrets note above), plus the basenames of the
+  #    per-project secret files so their presence/absence is diffable without reading them.
+  local cfgkeys='"absent"' cfgfiles="[]"
+  if [[ -r "$cfg" ]]; then
+    cfgkeys="$(jq -c '[paths(scalars) | join(".")] | sort' "$cfg" 2>/dev/null)" || cfgkeys='"unreadable"'
+    [[ -z "$cfgkeys" ]] && cfgkeys='"unreadable"'
+  fi
+  local l2dir; l2dir="$(layer2_dir)"
+  if [[ -d "$l2dir" ]]; then
+    cfgfiles="$(cd "$l2dir" 2>/dev/null && ls -1 2>/dev/null | sort | jq -R . | jq -s . 2>/dev/null)" || cfgfiles='"unreadable"'
+    [[ -z "$cfgfiles" ]] && cfgfiles="[]"
+  fi
+
+  # 4. databases — presence + byte size (a reinstall that rebuilds an empty replica is visible here).
+  local dbs; dbs="$(
+    { for pair in "catalyst.db:$(db_file)" "catalyst-replica.db:$(replica_db)"; do
+        nm="${pair%%:*}"; p="${pair#*:}"; sz=0
+        if [[ -r "$p" ]]; then sz="$(wc -c <"$p" 2>/dev/null | tr -d ' ')"; fi
+        [[ "$sz" =~ ^[0-9]+$ ]] || sz=0
+        jq -n --arg n "$nm" --argjson present "$([[ -e $p ]] && echo true || echo false)" \
+              --argjson bytes "${sz:-0}" '{name:$n, present:$present, bytes:$bytes}'
+      done; } | jq -s . 2>/dev/null)" || dbs='"unreadable"'
+  [[ -z "$dbs" ]] && dbs='"unreadable"'
+
+  # 5. worktrees — the INVENTORY (name, HEAD, branch, dirty), never the trees themselves. An
+  #    uncommitted worktree is unrecoverable work, so "dirty" is the field that matters here: it is
+  #    what tells an operator a teardown is about to destroy something not pushed anywhere.
+  local wts="[]" wtd; wtd="$(worktrees_dir)"
+  if [[ -d "$wtd" ]]; then
+    wts="$(
+      { for d in "$wtd"/*/; do
+          [[ -d "$d" ]] || continue
+          dirty=false
+          nm="$(basename "$d")"
+          head="$(git -C "$d" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          br="$(git -C "$d" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+          [[ -n "$(git -C "$d" status --porcelain 2>/dev/null)" ]] && dirty=true
+          jq -n --arg n "$nm" --arg h "$head" --arg b "$br" --argjson d "$dirty" \
+                '{name:$n, head:$h, branch:$b, dirty:$d}'
+        done; } | jq -s . 2>/dev/null)" || wts='"unreadable"'
+    [[ -z "$wts" ]] && wts="[]"
+  fi
+
+  # 6. logs — inventory only (name + bytes). The bytes themselves are deliberately NOT archived:
+  #    they are large, transient, and already shipped to Loki by Alloy.
+  local logs='"absent"'
+  if [[ -d "$ldir" ]]; then
+    logs="$(
+      { for f in "$ldir"/*; do
+          [[ -f "$f" ]] || continue
+          jq -n --arg n "$(basename "$f")" --argjson b "$(wc -c <"$f" 2>/dev/null | tr -d ' ')" '{name:$n, bytes:$b}'
+        done; } | jq -s . 2>/dev/null)" || logs='"unreadable"'
+    [[ -z "$logs" ]] && logs="[]"
+  fi
+
+  jq -n --arg host "$(node_host)" --arg nc "$(node_class)" --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --argjson plists "$plists" --argjson loaded "$loaded" --argjson cfgkeys "$cfgkeys" \
+        --argjson cfgfiles "$cfgfiles" --argjson dbs "$dbs" --argjson wts "$wts" --argjson logs "$logs" \
+        '{probedAt:$at, host:$host, nodeClass:$nc,
+          launchAgents:{plists:$plists, loaded:$loaded},
+          config:{keys:$cfgkeys, files:$cfgfiles},
+          databases:$dbs, worktrees:$wts, logs:$logs}'
+}
+
+# cmd_state — the same probe as a standalone command, so `catalyst-backup state > pre.json`,
+# uninstall, `catalyst-backup state > post.json`, `diff pre.json post.json` is the whole ritual.
+cmd_state() {
+  command -v jq >/dev/null 2>&1 || { err "jq is required"; return 3; }
+  emit_state_json
+}
+
 # cmd_backup — capture a bundle. Prints progress; LAST stdout line is the bundle path so a
 # caller (the install command) can `bundle="$(catalyst-backup backup ... | tail -1)"`. Exits
 # NON-ZERO if any PRESENT source failed to capture — so the install lifecycle aborts before it
 # overwrites a node it couldn't back up (an absent source is a legitimate, silent skip).
 cmd_backup() {
-  local out="" label="node"
+  local out="" label="node" with_replica=0 do_tar=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --out)   out="$2"; shift 2 ;;
       --label) label="$2"; shift 2 ;;
+      # CTL-1975: the replica is ~200 MB on a live node (measured 204 MB), so it is opt-in rather
+      # than a cost every install-lifecycle backup pays. `archive` turns it on; `backup` (the
+      # inline restore point install/uninstall/reinstall take) stays lean. Either way the manifest
+      # records which happened, so an archive can never LOOK like it holds a replica it does not.
+      --with-replica) with_replica=1; shift ;;
+      --no-replica)   with_replica=0; shift ;;
+      --tar)   do_tar=1; shift ;;
       -h|--help) usage; return 0 ;;
       *) err "backup: unknown flag: $1"; return 2 ;;
     esac
@@ -83,6 +211,10 @@ cmd_backup() {
   if [[ -z "$out" && -e "$bundle" ]]; then n=1; while [[ -e "${bundle}-${n}" ]]; do n=$((n+1)); done; bundle="${bundle}-${n}"; fi
   mkdir -p "$bundle"/config "$bundle"/humanlayer "$bundle"/launchagents "$bundle"/runtime \
     || { err "cannot create bundle dir: $bundle"; return 1; }
+  # The tarball name is DERIVED from the bundle dir (which already carries host + UTC timestamp and
+  # is collision-resolved above), so "dated" is a property of the bundle naming rather than a second
+  # clock read that could disagree with the manifest's `created`.
+  local tarball=""; [[ $do_tar -eq 1 ]] && tarball="${bundle}.tar.gz"
 
   local -a captured=() failed=() degraded=()
   local f l2dir l2base la db cdir plist sx
@@ -126,32 +258,42 @@ cmd_backup() {
     if [[ -s "$bundle/launchagents/launchctl-snapshot.txt" ]]; then captured+=("launchagents/launchctl-snapshot.txt"); else rm -f "$bundle/launchagents/launchctl-snapshot.txt"; fi
   fi
 
-  # 4. catalyst.db — WAL-safe snapshot via `.backup` (one consistent file, no sidecars). If that
-  # is unavailable/fails, DEGRADE to a plain copy of the db PLUS its -wal/-shm sidecars (a live
+  # 4. SQLite databases — WAL-safe snapshot via `.backup` (one consistent file, no sidecars). If
+  # that is unavailable/fails, DEGRADE to a plain copy of the db PLUS its -wal/-shm sidecars (a live
   # WAL db copied without them loses un-checkpointed commits) and mark it degraded. If BOTH fail,
   # record it as failed (the both-fail path is real: a full disk dooms .backup and cp alike).
-  db="$(db_file)"
-  if [[ -e "$db" && ! -r "$db" ]]; then
-    failed+=("runtime/catalyst.db"); err "FAILED — present but unreadable: $db"
-  elif [[ -r "$db" ]]; then
-    if command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$db" ".backup '$bundle/runtime/catalyst.db'" 2>/dev/null; then
-      captured+=("runtime/catalyst.db")
-    else
-      local db_ok=true
-      cp -p "$db" "$bundle/runtime/catalyst.db" 2>/dev/null || db_ok=false
-      for sx in -wal -shm; do
-        if [[ -r "${db}${sx}" ]]; then cp -p "${db}${sx}" "$bundle/runtime/catalyst.db${sx}" 2>/dev/null || db_ok=false; fi
-      done
-      if $db_ok; then
-        captured+=("runtime/catalyst.db"); degraded+=("runtime/catalyst.db")
-        [[ -r "${db}-wal" ]] && captured+=("runtime/catalyst.db-wal")
-        [[ -r "${db}-shm" ]] && captured+=("runtime/catalyst.db-shm")
-        err "WARN: sqlite3 .backup unavailable/failed — copied catalyst.db + WAL sidecars (DEGRADED snapshot)"
-      else
-        rm -f "$bundle/runtime/catalyst.db" "$bundle/runtime/catalyst.db-wal" "$bundle/runtime/catalyst.db-shm"
-        failed+=("runtime/catalyst.db"); err "FAILED to capture catalyst.db (sqlite3 .backup AND cp both failed)"
-      fi
+  #
+  # CTL-1975: extracted from the catalyst.db-only body so the replica gets the IDENTICAL treatment.
+  # The replica is a live WAL database with a writer holding it open, so a plain `cp` of it is the
+  # exact un-checkpointed-commit loss this degrade path was written for — a second hand-rolled
+  # copy would have re-introduced the bug the first one already solved.
+  capture_sqlite() {
+    local src="$1" rel="$2" base ok=true sx
+    base="$(basename "$rel")"
+    if [[ -e "$src" && ! -r "$src" ]]; then
+      failed+=("$rel"); err "FAILED — present but unreadable: $src"; return 0
     fi
+    [[ -r "$src" ]] || return 0
+    if command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$src" ".backup '$bundle/$rel'" 2>/dev/null; then
+      captured+=("$rel"); return 0
+    fi
+    cp -p "$src" "$bundle/$rel" 2>/dev/null || ok=false
+    for sx in -wal -shm; do
+      if [[ -r "${src}${sx}" ]]; then cp -p "${src}${sx}" "$bundle/${rel}${sx}" 2>/dev/null || ok=false; fi
+    done
+    if $ok; then
+      captured+=("$rel"); degraded+=("$rel")
+      [[ -r "${src}-wal" ]] && captured+=("${rel}-wal")
+      [[ -r "${src}-shm" ]] && captured+=("${rel}-shm")
+      err "WARN: sqlite3 .backup unavailable/failed — copied ${base} + WAL sidecars (DEGRADED snapshot)"
+    else
+      rm -f "$bundle/$rel" "$bundle/${rel}-wal" "$bundle/${rel}-shm"
+      failed+=("$rel"); err "FAILED to capture ${base} (sqlite3 .backup AND cp both failed)"
+    fi
+  }
+  capture_sqlite "$(db_file)" "runtime/catalyst.db"
+  if [[ $with_replica -eq 1 ]]; then
+    capture_sqlite "$(replica_db)" "runtime/catalyst-replica.db"
   fi
 
   # 5. runtime pointers (small, denormalized — NOT the events log)
@@ -159,16 +301,64 @@ cmd_backup() {
   capture "$cdir/state.json" "runtime/state.json"
   capture "$cdir/execution-core/registry.json" "runtime/registry.json"
 
+  # 6. host-state snapshot (CTL-1975) — the pre/post DIFF instrument, and the reason this bundle can
+  # certify a teardown rather than merely precede one. Produced by the SAME emit_state_json the
+  # standalone `catalyst-backup state` prints, so
+  #   diff <(jq -S . <bundle>/host-state.json) <(catalyst-backup state | jq -S .)
+  # after an uninstall is a real differential and not two probes that merely resemble each other.
+  #
+  # Deliberately NOT `runtime/state.json` — that name is already the orchestrator registry captured
+  # two lines above, and colliding them would overwrite a restorable artifact with a diagnostic one.
+  # Deliberately NOT added to `captured` either: `captured` is the RESTORABLE set that cmd_restore
+  # iterates, and a diagnostic in that list would make every restore print "unknown artifact".
+  local host_state=false
+  if emit_state_json > "$bundle/host-state.json" 2>/dev/null && jq -e . "$bundle/host-state.json" >/dev/null 2>&1; then
+    host_state=true
+  else
+    rm -f "$bundle/host-state.json"
+    err "FAILED to capture host-state.json — without it this bundle cannot certify a teardown"
+    failed+=("host-state.json")
+  fi
+
   # manifest (validated) — entries are recorded ONLY for successful copies, so it never overstates.
   local cap_json deg_json
   cap_json="[]"; [[ ${#captured[@]} -gt 0 ]] && cap_json="$(printf '%s\n' "${captured[@]}" | jq -R . | jq -s .)"
   deg_json="[]"; [[ ${#degraded[@]} -gt 0 ]] && deg_json="$(printf '%s\n' "${degraded[@]}" | jq -R . | jq -s .)"
-  jq -n --argjson sv 1 --arg ts "$ts" --arg host "$host" --arg nc "$(node_class)" \
+  # CTL-1975 adds three self-describing fields so a bundle can never LOOK like it holds something it
+  # does not: withReplica (the ~200 MB opt-in), hostState (the diff instrument), tarball (or null).
+  # `tarball` names the path this run INTENDED — the archive is written below and a failure there is
+  # a hard rc=1, so a manifest naming an absent tarball only ever accompanies a run that said so.
+  jq -n --argjson sv 2 --arg ts "$ts" --arg host "$host" --arg nc "$(node_class)" \
         --arg label "$label" --arg ver "$(plugin_version)" --argjson cap "$cap_json" --argjson deg "$deg_json" \
-        '{schemaVersion:$sv, created:$ts, host:$host, nodeClass:$nc, label:$label, pluginVersion:$ver, captured:$cap, degraded:$deg}' \
+        --argjson wr "$([[ $with_replica -eq 1 ]] && echo true || echo false)" \
+        --argjson hs "$host_state" --arg tarball "$tarball" \
+        '{schemaVersion:$sv, created:$ts, host:$host, nodeClass:$nc, label:$label, pluginVersion:$ver,
+          captured:$cap, degraded:$deg, withReplica:$wr, hostState:$hs,
+          tarball:(if $tarball == "" then null else $tarball end)}' \
         > "$bundle/manifest.json" 2>/dev/null
   if ! jq -e . "$bundle/manifest.json" >/dev/null 2>&1; then err "FAILED to write a valid manifest.json"; return 1; fi
   chmod -R go-rwx "$bundle" 2>/dev/null || true
+
+  # 7. the dated tarball (--tar; what `archive` turns on). One file to move off-host, which a
+  # directory bundle is not. The staging directory is KEPT: cmd_restore reads a directory, and
+  # deleting the only readable copy to save disk is the wrong trade on a teardown.
+  #
+  # VERIFIED by listing manifest.json back OUT of the archive. `tar` exiting 0 does not prove the
+  # member is readable — a truncated or empty-membered tarball is the failure that looks exactly
+  # like success to the caller, and it would be discovered at restore time, which is the worst
+  # possible moment. On any failure the partial tarball is REMOVED (a half-written archive on disk
+  # is worse than none, because `list` would offer it) and the run reports rc=1.
+  if [[ $do_tar -eq 1 ]]; then
+    if tar -czf "$tarball" -C "$(dirname "$bundle")" "$(basename "$bundle")" 2>/dev/null \
+       && tar -tzf "$tarball" 2>/dev/null | grep -q '/manifest\.json$'; then
+      chmod go-rwx "$tarball" 2>/dev/null || true
+      log "tarball → $tarball"
+    else
+      rm -f "$tarball"
+      err "FAILED to create or verify tarball: $tarball"
+      failed+=("$(basename "$tarball")")
+    fi
+  fi
 
   if [[ ${#failed[@]} -gt 0 ]]; then
     err "backup INCOMPLETE — ${#failed[@]} present artifact(s) could not be captured: ${failed[*]}"
@@ -178,6 +368,37 @@ cmd_backup() {
   [[ ${#captured[@]} -eq 0 ]] && err "WARN: backup captured 0 artifacts — nothing present to back up at this node"
   log "backup complete — ${#captured[@]} artifact(s)$([[ ${#degraded[@]} -gt 0 ]] && printf ' (%s degraded)' "${#degraded[@]}") → $bundle"
   printf '%s\n' "$bundle"
+}
+
+# cmd_archive — the teardown-grade capture: replica included, dated tarball, host-state snapshot.
+# This is what an operator takes BEFORE `catalyst uninstall`, and it is `backup` with the two
+# expensive options turned on rather than a second implementation — a parallel capture path is
+# exactly how one of the two ends up missing a WAL sidecar the other has.
+#
+# Output contract: cmd_backup's own last stdout line is the BUNDLE dir (install-lifecycle reads it
+# with `tail -1`, so that invariant is not negotiable). archive therefore replays cmd_backup's
+# output verbatim and then prints the TARBALL as its own last line — so `archive | tail -1` is the
+# tarball and `backup | tail -1` is still the bundle. Progress is buffered for the duration
+# (stderr — every err/WARN — still streams live).
+cmd_archive() {
+  local -a pass=(); local labelled=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --label)   labelled=1; pass+=("$1" "$2"); shift 2 ;;
+      -h|--help) usage; return 0 ;;
+      *)         pass+=("$1"); shift ;;
+    esac
+  done
+  [[ $labelled -eq 1 ]] || pass+=(--label "archive-$(node_class)")
+
+  # Separate declaration + assignment: `local out="$(cmd)"` would make rc the rc of `local`, which
+  # is always 0 — a failed capture would be reported as a successful archive (house rule).
+  local out rc=0
+  out="$(cmd_backup --with-replica --tar "${pass[@]}")" || rc=$?
+  [[ -n "$out" ]] && printf '%s\n' "$out"
+  [[ $rc -eq 0 ]] || return $rc
+  local bundle; bundle="$(printf '%s\n' "$out" | tail -1)"
+  printf '%s.tar.gz\n' "$bundle"
 }
 
 # ── restore ──────────────────────────────────────────────────────────────────
@@ -204,6 +425,14 @@ rel_to_dest() {
     runtime/catalyst.db)        printf '%s' "$(db_file)" ;;
     runtime/catalyst.db-wal)    printf '%s-wal' "$(db_file)" ;;
     runtime/catalyst.db-shm)    printf '%s-shm' "$(db_file)" ;;
+    # CTL-1975: the replica restores to the SAME resolver the live readers use (replica_db), so a
+    # bundle captured here cannot be replayed into a path nothing reads. Its WAL sidecars are mapped
+    # too — the degraded capture path emits them, and an unmapped sidecar would be reported by
+    # restore as "unknown artifact, skipping" while the db it belongs to restored, which is the
+    # silent half-restore this table exists to prevent.
+    runtime/catalyst-replica.db)     printf '%s' "$(replica_db)" ;;
+    runtime/catalyst-replica.db-wal) printf '%s-wal' "$(replica_db)" ;;
+    runtime/catalyst-replica.db-shm) printf '%s-shm' "$(replica_db)" ;;
     runtime/state.json)         printf '%s/state.json' "$(catalyst_dir)" ;;
     runtime/registry.json)      printf '%s/execution-core/registry.json' "$(catalyst_dir)" ;;
     launchagents/*.plist)       printf '%s/%s' "$(launchagents_dir)" "$(basename "$1")" ;;
@@ -265,7 +494,12 @@ cmd_restore() {
         # unclean shutdown. (Doing this before the no-clobber decision would drop live WAL data
         # on a skipped restore — Codex P1.) Bundle-carried sidecars, if any, restore in later
         # iterations and overwrite these.
-        [[ "$rel" == "runtime/catalyst.db" ]] && rm -f "${dest}-wal" "${dest}-shm" 2>/dev/null
+        # CTL-1975: BOTH sqlite databases, not just catalyst.db. A replica restored from a clean
+        # .backup snapshot with the node's stale -wal left beside it is a corrupt read, and the
+        # replica is the one an operator restores precisely because it is expensive to rebuild.
+        case "$rel" in
+          runtime/catalyst.db|runtime/catalyst-replica.db) rm -f "${dest}-wal" "${dest}-shm" 2>/dev/null ;;
+        esac
         ;;
       11) skipped=$((skipped+1)) ;;
       10) failures=$((failures+1)); err "manifest lists $rel but it is missing/unreadable in the bundle" ;;
@@ -316,6 +550,9 @@ catalyst-backup — capture / restore a Catalyst node's restorable state.
 
 Usage (direct, or via the router as 'catalyst backup …'):
   catalyst-backup [backup] [--out <dir>] [--label <name>]   capture a timestamped bundle (default)
+        [--with-replica] [--tar]                            ... incl. the replica DB / a tarball
+  catalyst-backup archive [--label <name>]                  teardown-grade: backup --with-replica --tar
+  catalyst-backup state                                     print observable host state as JSON
   catalyst-backup restore <bundle> [--force] [--dry-run]    restore a bundle's files
   catalyst-backup list [--json]                             list available bundles
 
@@ -326,6 +563,21 @@ Captures: Layer-2 config (secrets), thoughts creds (secrets), launchd agents,
 catalyst.db (WAL-safe), and runtime pointers (state.json, registry.json).
 Bundles are 0700/0600 (they hold secrets). restore refuses to clobber without --force
 and refuses a live node (running daemons) without --force.
+
+archive (CTL-1975) additionally captures ~/catalyst/catalyst-replica.db (WAL-safe, same
+degrade path as catalyst.db), a worktree + log INVENTORY, and host-state.json — then emits a
+dated .tar.gz beside the bundle and VERIFIES it by reading manifest.json back out. `archive`
+prints the tarball as its last line; `backup` still prints the bundle dir.
+
+The pre/post ritual around a teardown:
+  catalyst-backup archive                       # -> <bundle>.tar.gz, holds host-state.json
+  catalyst uninstall
+  catalyst-backup state > /tmp/post.json
+  diff <(jq -S . <bundle>/host-state.json) <(jq -S . /tmp/post.json)
+Every launchd label, plist, database and worktree that survived the teardown is a line in that
+diff. host-state.json carries NO secret VALUES — the config section emits jq `paths(scalars)`,
+i.e. leaf key paths only, so a value cannot reach the output even if a new secret key is added
+later; the per-project config-<key>.json secret files are listed by BASENAME only.
 EOF
 }
 
@@ -337,10 +589,12 @@ EOF
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   case "${1:-}" in
     backup)        shift; cmd_backup "$@" ;;
+    archive)       shift; cmd_archive "$@" ;;
+    state)         shift; cmd_state "$@" ;;
     restore)       shift; cmd_restore "$@" ;;
     list)          shift; cmd_list "$@" ;;
     -h|--help)     usage ;;
     ""|--*)        cmd_backup "$@" ;;
-    *) err "unknown command: $1 (try: backup | restore | list)"; usage >&2; exit 2 ;;
+    *) err "unknown command: $1 (try: backup | archive | state | restore | list)"; usage >&2; exit 2 ;;
   esac
 fi

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -2219,8 +2219,16 @@ cmd_uninstall_services() {
   # three hosts. `catalyst uninstall`'s verify-clean probes the plist dir with a PREFIX regex
   # (^ai\.coalesce\.catalyst-.*\.plist$), so the orphan it left behind failed the teardown at its
   # last phase with no code path anywhere able to clear it.
+  # ⚠️ rc is LOGGED rather than swallowed (FLEET-37 note 1 on #3606). The overall path stays
+  # fail-closed either way — verify-clean's prefix regex catches a residual plist — but without this
+  # line the operator sees "residual plist found" at the FINAL phase and has to reconstruct which
+  # teardown failed and why. `|| true` is kept: one agent's teardown must not abort the other eight.
   if [[ -x "${SCRIPT_DIR}/install-usage-page.sh" ]]; then
-    bash "${SCRIPT_DIR}/install-usage-page.sh" --uninstall 2>&1 | sed 's/^/  /' || true
+    # The `|| true` wraps the GROUP, not the pipeline: `pipeline || true` would run `true` whenever
+    # the pipeline failed, and `true` resets PIPESTATUS — under-reporting the very rc being captured.
+    local up_rc=0
+    { bash "${SCRIPT_DIR}/install-usage-page.sh" --uninstall 2>&1 | sed 's/^/  /'; up_rc=${PIPESTATUS[0]}; } || true
+    [[ $up_rc -eq 0 ]] || warn "install-usage-page.sh --uninstall exited $up_rc — ai.coalesce.catalyst-usage-page may remain (verify-clean will refuse the teardown)"
   fi
   # CTL-1975: event-mirror (monitor/developer nodes). stop_event_mirror already boots out, removes
   # the plist, is idempotent and carries the CTL-1968 domain guard — it was simply never called from

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -2214,6 +2214,18 @@ cmd_uninstall_services() {
   if [[ -x "${SCRIPT_DIR}/install-dependabot-escalate.sh" ]]; then
     bash "${SCRIPT_DIR}/install-dependabot-escalate.sh" --uninstall 2>&1 | sed 's/^/  /' || true
   fi
+  # CTL-1975: account-usage pager (delegated; idempotent, safe if not installed). This agent was
+  # installed on every node by install-services and removed by NOTHING — measured 2026-08-18 on all
+  # three hosts. `catalyst uninstall`'s verify-clean probes the plist dir with a PREFIX regex
+  # (^ai\.coalesce\.catalyst-.*\.plist$), so the orphan it left behind failed the teardown at its
+  # last phase with no code path anywhere able to clear it.
+  if [[ -x "${SCRIPT_DIR}/install-usage-page.sh" ]]; then
+    bash "${SCRIPT_DIR}/install-usage-page.sh" --uninstall 2>&1 | sed 's/^/  /' || true
+  fi
+  # CTL-1975: event-mirror (monitor/developer nodes). stop_event_mirror already boots out, removes
+  # the plist, is idempotent and carries the CTL-1968 domain guard — it was simply never called from
+  # a teardown path. Same orphaned-plist consequence as usage-page above, on observation nodes.
+  stop_event_mirror
   if [[ -f "$SHIPPER_AGENT_PLIST" ]]; then
     stack_launchd_guard "${FUNCNAME[0]:-catalyst-stack}"
     launchctl bootout "$guid" "$SHIPPER_AGENT_PLIST" 2>/dev/null || true

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -251,9 +251,23 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
     steps: [{ label: "plugin-source", kind: "run", argv: [scripts.pluginSrc, "--no-interactive-wrapper"] }],
   });
 
+  // CTL-1975 --archive: the SAME `backup` verb with two flags, deliberately NOT catalyst-backup's
+  // `archive` verb. `archive` prints the TARBALL as its last stdout line; this step's result is read
+  // with `tail -1` into ctx.bundlePath and handed to `catalyst-backup restore <path>`, which needs a
+  // DIRECTORY. Routing --archive through the archive verb would therefore produce a rollback that
+  // fails with "not a backup bundle" at exactly the moment a rollback is what is left — so the
+  // tarball is a side artifact here and the bundle dir stays the step's answer.
   const backup = (label) => ({
     phase: "backup",
-    steps: [{ label: "backup", kind: "backup", argv: [scripts.backup, "backup", "--label", label] }],
+    steps: [
+      {
+        label: "backup",
+        kind: "backup",
+        argv: opts.archive
+          ? [scripts.backup, "backup", "--label", label, "--with-replica", "--tar"]
+          : [scripts.backup, "backup", "--label", label],
+      },
+    ],
   });
 
   const writeConfig = () => {
@@ -1244,7 +1258,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 export function parseArgs(argv) {
-  const a = { operation: null, class: null, readReplica: null, executor: null, force: false, dryRun: false, json: false, help: false, errors: [] };
+  const a = { operation: null, class: null, readReplica: null, executor: null, force: false, archive: false, dryRun: false, json: false, help: false, errors: [] };
   const rest = [...argv];
   // takeValue — consume the next token as FLAG's value; a missing value (end of args, or the next
   // token is itself a flag) is an error, not a silent null — otherwise `catalyst install --class`
@@ -1267,6 +1281,13 @@ export function parseArgs(argv) {
         break;
       case "--force":
         a.force = true;
+        break;
+      // CTL-1975: promote the lifecycle's inline restore point to a teardown-grade ARCHIVE —
+      // the replica DB, the worktree/log inventory, host-state.json, and a dated tarball. Opt-in
+      // because the replica is ~200 MB: an install that pays that on every run is an install
+      // operators start skipping.
+      case "--archive":
+        a.archive = true;
         break;
       case "--dry-run":
       case "--print":
@@ -1312,7 +1333,7 @@ export function usage() {
 
 Usage (normally via the router: 'catalyst install|uninstall|reinstall …'):
   catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--dry-run]
-  catalyst-install uninstall [--force] [--dry-run]
+  catalyst-install uninstall [--force] [--archive] [--dry-run]
   catalyst-install reinstall [--class …] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--force] [--dry-run]
 
 Options:
@@ -1321,6 +1342,9 @@ Options:
   --executor <e>       durably provision the daemon executor (bg|sdk|oneshot-legacy) into
                        execution-core.env; omit to leave the node's existing executor untouched
   --force              teardown a live, non-drained node (uninstall/reinstall guard override)
+  --archive            take a teardown-grade archive instead of the lean restore point:
+                       + the replica DB, a worktree/log inventory, host-state.json (the pre/post
+                       diff instrument), and a dated .tar.gz beside the bundle
   --dry-run, --print   resolve + print the per-class step plan; run NOTHING (no side effects)
   --json               machine-readable output (with --dry-run, prints the plan as JSON)
   -h, --help           this help
@@ -1402,7 +1426,7 @@ export async function main(argv, depsOverride) {
     errOut(`catalyst-install: --executor must be one of ${VALID_EXECUTORS.join(" | ")} (got '${args.executor}')`);
     return 2;
   }
-  const opts = { force: args.force, readReplica, executor: args.executor, execCoreEnv: execCoreEnvPath(env) };
+  const opts = { force: args.force, archive: args.archive, readReplica, executor: args.executor, execCoreEnv: execCoreEnvPath(env) };
 
   if (args.dryRun) {
     const plan = planPhases({ operation: args.operation, nodeClass, scripts: deps.scripts, opts });

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -147,6 +147,8 @@ describe("parseArgs", () => {
   test("--print is an alias for --dry-run; --force/--json/-h flags", () => {
     expect(parseArgs(["install", "--print"]).dryRun).toBe(true);
     expect(parseArgs(["uninstall", "--force"]).force).toBe(true);
+    expect(parseArgs(["uninstall", "--archive"]).archive).toBe(true);
+    expect(parseArgs(["uninstall"]).archive).toBe(false);
     expect(parseArgs(["install", "--json"]).json).toBe(true);
     expect(parseArgs(["-h"]).help).toBe(true);
   });
@@ -269,6 +271,27 @@ describe("planPhases — per-class correctness (pure)", () => {
   test("uninstall / reinstall phase orders match their exported enums", () => {
     expect(phaseNames(planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }))).toEqual([...UNINSTALL_PHASES]);
     expect(phaseNames(planPhases({ operation: "reinstall", nodeClass: "developer", scripts: SCRIPTS }))).toEqual([...REINSTALL_PHASES]);
+  });
+  // CTL-1975 — `catalyst uninstall --archive`. Both directions are asserted: the flag must ADD the
+  // two capture flags, and its ABSENCE must leave the lean restore point byte-identical, because a
+  // default that silently started copying a ~200 MB replica on every install is the regression this
+  // opt-in exists to avoid.
+  test("--archive upgrades the backup step to a teardown-grade capture", () => {
+    const plan = planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS, opts: { archive: true } });
+    const step = plan.find((p) => p.phase === "backup").steps[0];
+    expect(step.argv).toContain("--with-replica");
+    expect(step.argv).toContain("--tar");
+    // ⛔ NOT the `archive` verb: this step's stdout tail is read into ctx.bundlePath and handed to
+    // `catalyst-backup restore <path>`, which needs the bundle DIRECTORY. `archive` prints the
+    // tarball last, so routing through it would break rollback at the one moment it is all that is
+    // left. Pinned here so a later "simplification" to the archive verb fails loudly.
+    expect(step.argv).toContain("backup");
+    expect(step.argv).not.toContain("archive");
+  });
+  test("without --archive the backup step is unchanged (no replica, no tarball)", () => {
+    const step = planPhases({ operation: "uninstall", nodeClass: "worker", scripts: SCRIPTS }).find((p) => p.phase === "backup").steps[0];
+    expect(step.argv).not.toContain("--with-replica");
+    expect(step.argv).not.toContain("--tar");
   });
   test("reinstall backs up exactly ONCE (one top-of-run snapshot covers teardown+provision)", () => {
     const plan = planPhases({ operation: "reinstall", nodeClass: "worker", scripts: SCRIPTS });

--- a/plugins/dev/scripts/install-usage-page.sh
+++ b/plugins/dev/scripts/install-usage-page.sh
@@ -21,6 +21,11 @@ unset _SRC
 # so a caller under a scratch HOME either squats the real label or boots the real agent OUT. The
 # uninstall branch is guarded too, deliberately: booting out the fleet's live pager from a sealed
 # test is the same incident as squatting it.
+# Same shape as install-orphan-sweep.sh / install-health-responder.sh / install-dependabot-escalate.sh:
+# a MISSING guard library is a NAMED hard refusal, never a silent continue. An unguarded bootstrap is
+# invisible to its caller by construction, so "the guard could not be loaded" has to fail closed.
+[[ -f "${SCRIPT_DIR}/lib/launchd-domain-guard.sh" ]] || {
+  echo "install-usage-page.sh: missing lib/launchd-domain-guard.sh next to this script" >&2; exit 1; }
 # shellcheck source=lib/launchd-domain-guard.sh
 . "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
 launchd_agent_guard() {

--- a/plugins/dev/scripts/install-usage-page.sh
+++ b/plugins/dev/scripts/install-usage-page.sh
@@ -16,6 +16,20 @@ while [[ -L "$_SRC" ]]; do _SRC="$(readlink "$_SRC")"; done
 SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
 unset _SRC
 
+# CTL-1975 / CTL-1968: this was the one install path #3576 did not cover — verified against that
+# PR's own file list. Both branches below mutate gui/$(id -u), which is PER-USER and not per-HOME,
+# so a caller under a scratch HOME either squats the real label or boots the real agent OUT. The
+# uninstall branch is guarded too, deliberately: booting out the fleet's live pager from a sealed
+# test is the same incident as squatting it.
+# shellcheck source=lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
+launchd_agent_guard() {
+  launchd_guard_ok "the account-usage pager agent" && return 0
+  launchd_guard_message "the account-usage pager agent" >&2
+  echo "install-usage-page: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+}
+
 LABEL="ai.coalesce.catalyst-usage-page"
 DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 TEMPLATE="${SCRIPT_DIR}/usage-page/${LABEL}.plist"
@@ -37,6 +51,7 @@ case "${1:-}" in
 esac
 
 if [[ "$MODE" == "uninstall" ]]; then
+  launchd_agent_guard
   launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
   rm -f "$DEST"
   echo "install-usage-page: uninstalled ${LABEL}"
@@ -74,6 +89,7 @@ plutil -lint "$DEST" >/dev/null || {
   exit 1
 }
 
+launchd_agent_guard
 launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$DEST"
 echo "install-usage-page: installed and loaded ${LABEL} (every 600s, threshold 80%)"


### PR DESCRIPTION
Closes CTL-1975. Per **COORD-174** (Ryan): Tuesday's rehearsal is a REAL soup-to-nuts fresh install — archive, uninstall, reinstall, *"codified: an `archive+uninstall` script, not hand `rm`"*.

`catalyst uninstall` already exists (CTL-1369 PR3 — `execution-core/install-lifecycle.mjs`: `backup → stop-daemons → remove-agents → remove-config → verify-clean`) and `catalyst-backup` already captures Layer-2 config, plists, `catalyst.db` and runtime pointers. **So this is not a new script — it closes the measured gaps that would have failed the rehearsal at step 1.**

## 1. ⛔ The teardown could not remove two agents its own verify-clean fails on

`cmd_uninstall_services` touched exactly 9 agents. Measured 2026-08-18 at `b70211bbe` on all three hosts:

| agent | mini | mini-2 | laptop | removed by uninstall-services |
| -- | -- | -- | -- | -- |
| `ai.coalesce.catalyst-usage-page` | yes | yes | yes | ⛔ **no** |
| `ai.coalesce.catalyst-event-mirror` | no | no | yes | ⛔ **no** (teardown fn existed; nothing called it) |

`verifyClean`'s residual probe is a **prefix regex** over the plist dir (`/^ai\.coalesce\.catalyst-.*\.plist$/`, `install-lifecycle.mjs:597`), so it is honest and it **will** match the orphaned usage-page plist: `catalyst uninstall` fails at its **last** phase with **no code path anywhere able to clear the residual**. Both teardowns (`install-usage-page.sh --uninstall`, `stop_event_mirror`) already existed, were already idempotent, and were simply never called from a teardown path.

## 2. ⛔ `install-usage-page.sh` had no CTL-1968 launchd guard

It is the one install path #3576 did not cover (verified against that PR's own file list). Both branches mutate `gui/$(id -u)`, which is per-USER and not per-HOME. The **uninstall** branch is guarded too, deliberately: booting the fleet's live pager OUT from a sealed test is the same incident as squatting it.

## 3. ⭐ `catalyst uninstall --archive` + `catalyst-backup archive|state`

| piece | before | now |
| -- | -- | -- |
| Layer-2 config, plists + launchctl snapshot, `catalyst.db` (WAL-safe), `state.json`, `registry.json` | ⭐ captured | unchanged |
| `~/catalyst/catalyst-replica.db` | ⛔ absent | ⭐ captured (opt-in) |
| worktree inventory (name, HEAD, branch, **dirty**) | ⛔ absent | ⭐ `host-state.json` |
| log inventory (name + bytes, never the bytes) | ⛔ absent | ⭐ `host-state.json` |
| dated tarball | ⛔ dir bundle only | ⭐ `<bundle>.tar.gz`, **verified** |
| pre/post-diffable host state | ⛔ captured PATHS only | ⭐ `state` / `host-state.json` |

The operator ritual the rehearsal runs:

```
catalyst-backup archive                 # -> <bundle>.tar.gz, holds host-state.json
catalyst uninstall                      # (or: catalyst uninstall --archive, one command)
catalyst-backup state > /tmp/post.json
diff <(jq -S . <bundle>/host-state.json) <(jq -S . /tmp/post.json)
```

Every launchd label, plist, database and worktree that survived the teardown is a line in that diff.

### Three decisions worth reading, because the obvious version of each is wrong

⭐ **`--archive` routes through the `backup` VERB, not the `archive` verb.** The backup step's stdout tail becomes `ctx.bundlePath` and is handed to `catalyst-backup restore <path>`, which needs a **directory**. `archive` prints the **tarball** last — so the symmetric-looking wiring would produce a rollback that dies with *"not a backup bundle"* at exactly the moment a rollback is all that is left. Pinned by a test that asserts the argv contains `backup` and **not** `archive`.

⭐ **The tarball is VERIFIED by reading `manifest.json` back out of it.** `tar` exiting 0 does not prove the member is readable, and a truncated archive is discovered at restore time — the worst possible moment. On any failure the partial tarball is **removed** (so `list` cannot offer it) and the run reports rc=1.

⭐ **No secret VALUES in the manifest, structurally rather than by filtering.** The config section emits jq `paths(scalars)` — leaf key **paths** only — so a value cannot reach the output even if a new secret key is added tomorrow; per-project `config-<key>.json` files are listed by **basename** only.

⭐ **The replica reuses `catalyst.db`'s WAL-safe/degrade path** (extracted into `capture_sqlite`, not re-hand-rolled) and is mapped in `rel_to_dest` **with its sidecars** — a captured-but-unmapped artifact restores as *"unknown artifact, skipping"* while the run reports success. Restore's stale-sidecar clear now covers both databases.

The replica is ~200 MB on a live node, so it is **opt-in**: `archive` turns it on, the install lifecycle's inline restore point stays lean, and the manifest records `withReplica` / `hostState` / `tarball` so a bundle can never *look* like it holds something it does not.

## Tests — 46 new (`catalyst-archive-uninstall.test.sh`) + 2 in `install-lifecycle.test.mjs`

MOCKBIN `launchctl` (a PATH stub logging every call; the real one is never consulted) and a scratch prefix — which is only safe because #3576 landed.

⭐ **Every "nothing happened" assertion is paired with a positive control**, because an empty mock log, an empty grep and a broken probe are the same bytes to an assertion:

- the refusal case (**zero** launchctl calls under a scratch HOME) is paired with the allowed case (`CATALYST_ALLOW_FOREIGN_HOME_LAUNCHD=1` → a **recorded** `bootout gui/<uid>/ai.coalesce.catalyst-usage-page`);
- the "no secret value in the manifest" grep is paired with the **same grep finding that secret** in the bundle's captured config, where it legitimately is;
- the label filter's two catalyst labels are paired with a third, non-catalyst label the mock also emits and the probe must exclude;
- the source-extraction check is paired with the extractor's own control, so a broken `awk` range fails **closed** rather than reporting two clean absences.

**Mutation-verified.** Each of these turns the suite red: removing the CTL-1968 guard, removing the tarball verify, removing the replica `rel_to_dest` mapping, removing the usage-page delegation, removing the `stop_event_mirror` call, removing the `--archive` wiring; and breaking the source extractor fails closed.

⛔ **One mutant survived the first pass and the fix is in the diff.** The assertion that `cmd_uninstall_services` calls `stop_event_mirror` matched the **comment** introducing the call — so *deleting the call still passed*. The mutant was verified applied and the suite stayed green; only full-line comments are stripped now (never `sed 's/#.*//'`, which could mangle a `#` inside real code into a false absence).

## Verification run

| suite | result |
| -- | -- |
| `catalyst-archive-uninstall.test.sh` (new) | 46 passed, 0 failed (rc 0) |
| `catalyst-backup.test.sh` | 47 passed, 0 failed |
| `install-lifecycle.test.mjs` (bun) | 138 pass, 0 fail |
| `catalyst-install.test.sh` | 17 passed, 0 failed |
| `setup-catalyst-installers.test.sh` | 73 passed, 0 failed |
| `install-orphan-sweep-guard.test.sh` | 6 passed, 0 failed |
| `cli-reference-drift.test.sh` | 135 passed, 0 failed |

⚠️ The **full** shell gate was NOT run locally — it is still banned on this laptop pending FLEET's #3576 positive control (COORD-168), and the full gate is the vector that squatted the fleet's labels twice (CTLI-19/20). **CI is authoritative here**; the new suite is auto-discovered by `run-tests.sh`'s `__tests__/*.test.sh` glob, so no registration was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)