### PR TITLE
feat(dev): CTL-1993/CTL-2001 — the steward skill, and one canonical copy of the threading contract

### DIFF
--- a/.github/workflows/skills-gate.yml
+++ b/.github/workflows/skills-gate.yml
@@ -1,0 +1,34 @@
+name: skills-gate
+
+# Guards the progressive-disclosure shape of the catalyst skills (CTL-1993):
+# a skill that has a references/ dir keeps SKILL.md within budget, every
+# reference is linked from SKILL.md (an unlinked reference is never read), and
+# no skill takes a RESERVED name that collides with live machinery vocabulary.
+#
+# ⚠️ WHY THIS IS ITS OWN WORKFLOW, AND WHY IT HAS NO `paths:` FILTER.
+# The suite first shipped discovered by nothing at all — run-tests.sh globs only
+# scripts/__tests__ and scripts/lib/__tests__, and no workflow named it. The
+# obvious home, execution-core-tests.yml, would have been NO BETTER: its
+# detect-changes step is an explicit ALLOW-LIST of paths that names five
+# individual skill dirs and does NOT include plugins/dev/skills/** — so the job
+# reports `skipped` on exactly the PRs that change a skill, which is every PR
+# this gate exists for. A filter that excludes the change it guards is a guard on
+# the wrong axis; it reads as working and never fires.
+#
+# So: every PR, no path filter, seconds to run. Same shape as agents-md-gate.
+# The local half of the same fix is SKILLS_SHELL_TEST_DIR in run-tests.sh — both
+# are required, neither is sufficient.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  skills-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check skill progressive-disclosure shape
+        run: bash plugins/dev/skills/__tests__/skill-shape.test.sh

--- a/plugins/dev/scripts/__tests__/run-tests.test.sh
+++ b/plugins/dev/scripts/__tests__/run-tests.test.sh
@@ -44,6 +44,15 @@ if [[ -x $RUNNER ]]; then
 	pass "run-tests.sh exists and is executable"
 else fail "run-tests.sh missing or not executable" "$RUNNER"; fi
 
+# CTL-1993: run-tests.sh ALSO globs SKILLS_SHELL_TEST_DIR
+# (plugins/dev/skills/__tests__/*.test.sh). Same hazard, same fix — every case
+# below pins it to the shared EMPTY dir. Left at its real default it globs in the
+# REAL skills suites alongside each fixture, and EVERY exact-count assertion in
+# tests 2-6 goes wrong at once. That is exactly what happened when the glob was
+# added without this line: 17 passed / 0 failed became 11 passed / 6 failed.
+# ⭐ Third occurrence of this shape (round 7 below, round 9, now this) — so if you
+# add a FOURTH test directory to run-tests.sh, pin it here IN THE SAME COMMIT.
+#
 # CTL-1612 round 7: run-tests.sh now ALSO globs LIB_SHELL_TEST_DIR
 # (lib/__tests__/*.test.sh) in addition to SHELL_TEST_DIR. Every fixture case
 # below must pin LIB_SHELL_TEST_DIR to this shared EMPTY directory too — left
@@ -56,19 +65,19 @@ EMPTY_LIB_DIR="$(mktemp -d)"
 # Test 2: all-pass fixture exits 0
 FIX="$(make_fixture "aaa:0" "bbb:0")"
 trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4" "$FIX5" "$EMPTY_LIB_DIR"' EXIT
-if SHELL_TEST_DIR="$FIX" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+if SHELL_TEST_DIR="$FIX" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
 	pass "all-pass fixture exits 0"
 else fail "all-pass fixture should exit 0"; fi
 
 # Test 3: a failing test (exit 1) makes the runner exit non-zero
 FIX2="$(make_fixture "ok:0" "bad:1")"
-if SHELL_TEST_DIR="$FIX2" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+if SHELL_TEST_DIR="$FIX2" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
 	fail "fixture with a failing test should exit non-zero"
 else pass "failing test makes runner exit non-zero"; fi
 
 # Test 4: exit-with-count pattern (exit 3) is treated as failure, not pass
 FIX3="$(make_fixture "ok:0" "counted:3")"
-if SHELL_TEST_DIR="$FIX3" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
+if SHELL_TEST_DIR="$FIX3" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" >/dev/null 2>&1; then
 	fail "exit-code 3 should count as failure"
 else pass "any rc>0 (exit 3) counts as failure"; fi
 
@@ -77,7 +86,7 @@ else pass "any rc>0 (exit 3) counts as failure"; fi
 # always contains the word "skipped", so a bare substring grep would pass even
 # if SKIP detection were broken and the suite miscounted as a pass.
 FIX4="$(make_fixture "ok:0" "skipme:0:SKIP: dependency absent")"
-OUT="$(SHELL_TEST_DIR="$FIX4" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX4" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 RC=$?
 if [[ $RC -eq 0 ]]; then
 	pass "SKIP test does not fail the runner"
@@ -92,17 +101,28 @@ else fail "summary skip/pass/fail count wrong" "$OUT"; fi
 # Test 6: SKIP detection is anchored to '^SKIP:'. A passing suite that merely
 # mentions SKIP mid-line (indented, or with leading text) must stay PASS.
 FIX5="$(make_fixture "ok:0" "mentions:0:  note: SKIP: handling exercised")"
-OUT="$(SHELL_TEST_DIR="$FIX5" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX5" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 if grep -q 'shell 2 passed / 0 failed / 0 skipped' <<<"$OUT"; then
 	pass "indented 'SKIP:' does not trigger skip classification (^SKIP: anchored)"
 else fail "non-column-0 'SKIP:' wrongly classified" "$OUT"; fi
+
+# Test 7b (CTL-1993): SKILLS_SHELL_TEST_DIR is genuinely wired, not merely
+# accepted and ignored. Without this, pinning it empty above would silence the
+# glob and the suite would pass whether or not the skills dir is ever discovered
+# — which is the "a cap is never silent" failure the skills gate itself is about.
+FIX6B="$(make_fixture "skills_fixture:0")"
+OUT="$(SHELL_TEST_DIR="$EMPTY_LIB_DIR" LIB_SHELL_TEST_DIR="$EMPTY_LIB_DIR" SKILLS_SHELL_TEST_DIR="$FIX6B" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+if grep -q "skills_fixture" <<<"$OUT"; then
+	pass "SKILLS_SHELL_TEST_DIR fixture is discovered and run"
+else fail "SKILLS_SHELL_TEST_DIR override was not wired into the shell suite" "$OUT"; fi
+rm -rf "$FIX6B"
 
 # Test 7 (CTL-1612 round 7): LIB_SHELL_TEST_DIR is genuinely wired, not just
 # harmlessly ignored — a fixture placed there is discovered and run, proving
 # it is not a dead override.
 FIX6="$(make_fixture "libok:0")"
 trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4" "$FIX5" "$FIX6" "$FIX7" "$FIX7_LIB" "$EMPTY_LIB_DIR"' EXIT
-OUT="$(SHELL_TEST_DIR="$EMPTY_LIB_DIR" LIB_SHELL_TEST_DIR="$FIX6" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$EMPTY_LIB_DIR" LIB_SHELL_TEST_DIR="$FIX6" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 if grep -q 'shell 1 passed / 0 failed / 0 skipped' <<<"$OUT"; then
 	pass "LIB_SHELL_TEST_DIR fixture is discovered and run"
 else fail "LIB_SHELL_TEST_DIR override was not wired into the shell suite" "$OUT"; fi
@@ -148,7 +168,7 @@ exit 0
 FIX7EOF
 FIX7_LIB="$(mktemp -d)"
 cp "${FIX7}/secrets-hygiene.test.sh" "${FIX7_LIB}/secrets-hygiene.test.sh"
-OUT="$(SHELL_TEST_DIR="$FIX7" LIB_SHELL_TEST_DIR="$FIX7_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX7" LIB_SHELL_TEST_DIR="$FIX7_LIB" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 MARKER_COUNT="$(grep -c 'PASS .*secrets-hygiene\.test\.sh' <<<"$OUT")"
 if [[ "$MARKER_COUNT" -eq 1 ]]; then
 	pass "wrapped basename (secrets-hygiene.test.sh) runs exactly once, present under both SHELL_TEST_DIR and LIB_SHELL_TEST_DIR"
@@ -168,7 +188,7 @@ else fail "aggregate summary miscounted the wrapped-basename fixture" "$OUT"; fi
 FIX9_SHELL="$(mktemp -d)"
 FIX9_LIB="$(make_fixture "secrets-hygiene:0")"
 trap 'rm -rf "$FIX" "$FIX2" "$FIX3" "$FIX4" "$FIX5" "$FIX6" "$FIX7" "$FIX7_LIB" "$FIX9_SHELL" "$FIX9_LIB" "$FIX10_SHELL" "$FIX10_LIB" "$EMPTY_LIB_DIR"' EXIT
-OUT="$(SHELL_TEST_DIR="$FIX9_SHELL" LIB_SHELL_TEST_DIR="$FIX9_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX9_SHELL" LIB_SHELL_TEST_DIR="$FIX9_LIB" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 if grep -q 'shell 1 passed / 0 failed / 0 skipped' <<<"$OUT"; then
 	pass "wrapped-basename lib suite runs directly when no wrapper is present under the active SHELL_TEST_DIR"
 else fail "wrapped-basename lib suite was wrongly skipped with no active wrapper (0 tests, silent PASS)" "$OUT"; fi
@@ -196,7 +216,7 @@ exit 0
 FIX10EOF
 FIX10_LIB="$(mktemp -d)"
 cp "${FIX10_SHELL}/brand-new-lib-suite.test.sh" "${FIX10_LIB}/brand-new-lib-suite.test.sh"
-OUT="$(SHELL_TEST_DIR="$FIX10_SHELL" LIB_SHELL_TEST_DIR="$FIX10_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX10_SHELL" LIB_SHELL_TEST_DIR="$FIX10_LIB" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 MARKER_COUNT="$(grep -c 'PASS .*brand-new-lib-suite\.test\.sh' <<<"$OUT")"
 if [[ "$MARKER_COUNT" -eq 1 ]]; then
 	pass "a brand-new wrapper/basename never in any hardcoded list is self-registering and dedupes correctly"
@@ -224,7 +244,7 @@ cat >"${FIX11_SHELL}/commentmention.test.sh" <<'FIX11EOF'
 exit 0
 FIX11EOF
 FIX11_LIB="$(make_fixture "totally-fake-suite:0")"
-OUT="$(SHELL_TEST_DIR="$FIX11_SHELL" LIB_SHELL_TEST_DIR="$FIX11_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX11_SHELL" LIB_SHELL_TEST_DIR="$FIX11_LIB" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 if grep -q 'PASS .*totally-fake-suite\.test\.sh' <<<"$OUT"; then
 	pass "a comment-only mention of a lib/__tests__ path does not suppress the real lib suite"
 else fail "comment-only mention wrongly suppressed the lib suite (0 tests, silently skipped)" "$OUT"; fi
@@ -252,7 +272,7 @@ exit 0
 exec bash "${SCRIPT_DIR}/../lib/__tests__/dead-code-wrapper.test.sh"
 FIX12EOF
 FIX12_LIB="$(make_fixture "dead-code-wrapper:1")"
-OUT="$(SHELL_TEST_DIR="$FIX12_SHELL" LIB_SHELL_TEST_DIR="$FIX12_LIB" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
+OUT="$(SHELL_TEST_DIR="$FIX12_SHELL" LIB_SHELL_TEST_DIR="$FIX12_LIB" SKILLS_SHELL_TEST_DIR="$EMPTY_LIB_DIR" EXTRA_SHELL_TESTS="" SKIP_BUN=1 bash "$RUNNER" 2>&1)"
 RC=$?
 if grep -q 'FAIL .*dead-code-wrapper\.test\.sh' <<<"$OUT"; then
 	pass "an unreachable (post-exit) invocation-shaped reference does not suppress the real lib suite"

--- a/plugins/dev/scripts/run-tests.sh
+++ b/plugins/dev/scripts/run-tests.sh
@@ -3,7 +3,9 @@
 # suite, prints one summary line, exits non-zero if any suite failed. (CTL-528)
 #
 # Env overrides (used by the smoke test):
-#   SHELL_TEST_DIR     dir of *.test.sh files     (default: <scripts>/__tests__)
+#   SHELL_TEST_DIR        dir of *.test.sh files  (default: <scripts>/__tests__)
+#   LIB_SHELL_TEST_DIR    dir of lib suites       (default: <scripts>/lib/__tests__)
+#   SKILLS_SHELL_TEST_DIR dir of skill suites     (default: <repo>/plugins/dev/skills/__tests__)
 #   EXTRA_SHELL_TESTS  space-separated extra files (default: test-workflow-context.sh)
 #   SKIP_BUN=1         skip the bun surfaces entirely
 set -uo pipefail
@@ -23,6 +25,19 @@ SHELL_TEST_DIR="${SHELL_TEST_DIR:-${SCRIPT_DIR}/__tests__}"
 # before wiring this in (one, escalate-emitters.test.sh, was fixed alongside —
 # pre-existing shellcheck debt in orphan-sweep.sh unrelated to CTL-1612).
 LIB_SHELL_TEST_DIR="${LIB_SHELL_TEST_DIR:-${SCRIPT_DIR}/lib/__tests__}"
+# CTL-1993 (FLEET peer read): plugins/dev/SKILLS/__tests__ is a THIRD test
+# directory — it is neither SHELL_TEST_DIR (scripts/__tests__) nor
+# LIB_SHELL_TEST_DIR (scripts/lib/__tests__), so skill-shape.test.sh shipped
+# discovered by NOTHING: not this runner, and not CI. That is the same defect as
+# round 7 above and as CTL-1978, now for the third time — and it landed on the
+# one suite whose own subject is "a cap is never silent", which would have made
+# the cap enforcing that principle the silent one.
+#
+# ⚠️ The local glob is HALF the fix. A suite that runs only here still never runs
+# on a PR, so .github/workflows/skills-gate.yml pins it in CI. Neither half is
+# sufficient: the glob alone leaves it outside CI, the pin alone leaves it
+# outside the local gate. If you add another suite here, do BOTH.
+SKILLS_SHELL_TEST_DIR="${SKILLS_SHELL_TEST_DIR:-${REPO_ROOT}/plugins/dev/skills/__tests__}"
 # CTL-1612 round 9 (Codex P2 follow-up): 6 of the 13 lib/__tests__ suites
 # ALREADY run via a one-line SHELL_TEST_DIR wrapper
 # (`exec bash ".../lib/__tests__/<name>.test.sh"`, predating the round-7
@@ -185,6 +200,12 @@ for f in "$LIB_SHELL_TEST_DIR"/*.test.sh; do
 	if _lib_suite_wrapper_present "$_f_basename"; then
 		continue
 	fi
+	run_shell_test "$f"
+done
+# CTL-1993: the skills shape suite (see SKILLS_SHELL_TEST_DIR above). No
+# wrapper-dedup pass is needed the way LIB_SHELL_TEST_DIR needs one — nothing
+# under scripts/__tests__ exec's these, so they cannot be double-discovered.
+for f in "$SKILLS_SHELL_TEST_DIR"/*.test.sh; do
 	run_shell_test "$f"
 done
 for f in $EXTRA_SHELL_TESTS; do

--- a/plugins/dev/skills/__tests__/skill-shape.test.sh
+++ b/plugins/dev/skills/__tests__/skill-shape.test.sh
@@ -18,6 +18,20 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# ⚠️ THESE TWO NUMBERS ARE A PROXY, AND THE PROXY IS GAMEABLE. The property we
+# actually want is "SKILL.md alone is sufficient for the common path, and detail
+# is one hop away" — and NO line count can assert that. A skill can satisfy both
+# budgets with longer lines and denser prose and be strictly worse to read.
+#
+# They are kept because a forcing function that is checkable beats an intent that
+# is not: 80 lines is roughly the point at which an author stops appending and
+# starts asking what belongs in references/. That editorial pressure is the
+# product; the number is only how it is applied.
+#
+# So if you are here to raise one of these: raising it is not automatically
+# wrong, but it IS the wrong first move. Defend the intent, not the number —
+# move the detail into references/ first, and change the budget only if the
+# common path genuinely does not fit. (FLEET peer read, CTL-1993.)
 MAX_SKILL_LINES=80
 MAX_REFERENCE_LINES=150
 
@@ -91,16 +105,42 @@ for skill_dir in "${SKILLS[@]}"; do
   done
 done
 
-# 3. No skill may be named `worker` (CTL-1997): `worker` is live execution-core
-#    machinery vocabulary (worker-dir-gc, sdk-worker-registry, worker-label,
-#    worker-transition-event, workers/<ticket>/ …). The ROLE word stays; the
-#    skill name would read as "the worker machinery skill".
+# 3. RESERVED SKILL NAMES (CTL-1997). A skill name that collides with live
+#    machinery vocabulary reads as "the <machinery> skill" and mis-routes both
+#    agents and greps. This is a LIST, not a single hardcoded name, because the
+#    first version of this check tested exactly one name and therefore offered
+#    the next collision no protection at all — someone would have re-litigated
+#    it from scratch without this reasoning (FLEET peer read, CTL-1993).
+#
+#    TO ADD AN ENTRY: one line, and a comment saying WHAT it collides with. The
+#    reason is the load-bearing half — it is what lets a future reader tell a
+#    real collision from a name someone merely disliked.
+#
+#    ⚠️ Only reserve a name NOTHING is currently called: `broker`, `teardown`
+#    and `linear` are all live machinery words that are ALSO existing skills,
+#    so reserving them would go red on arrival and the fix would be to delete
+#    the entry, not to rename 50 call sites.
+RESERVED_SKILL_NAMES=(
+  # execution-core machinery: worker-dir-gc, sdk-worker-registry, worker-label,
+  # worker-transition-event, abort-worker, workers/<ticket>/,
+  # worker.session.started. The ROLE word stays — role and code agree; it is the
+  # SKILL name that collides. Use phase-agent-contract.
+  "worker"
+)
+
 echo "── naming"
-if [[ -d "${SKILLS_DIR}/worker" ]]; then
-  fail "a skill named 'worker' exists — use phase-agent-contract (CTL-1997)"
-else
-  pass "no skill is named 'worker'"
+# An empty list would make this whole section pass vacuously, exactly like the
+# zero-skills case guarded above.
+if [[ ${#RESERVED_SKILL_NAMES[@]} -eq 0 ]]; then
+  fail "RESERVED_SKILL_NAMES is empty — the naming check would pass vacuously"
 fi
+for reserved in "${RESERVED_SKILL_NAMES[@]}"; do
+  if [[ -d "${SKILLS_DIR}/${reserved}" ]]; then
+    fail "a skill named '${reserved}' exists — it is a RESERVED name (see RESERVED_SKILL_NAMES for what it collides with, CTL-1997)"
+  else
+    pass "no skill is named '${reserved}' (reserved)"
+  fi
+done
 
 echo
 echo "skill-shape.test.sh: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/skills/__tests__/skill-shape.test.sh
+++ b/plugins/dev/skills/__tests__/skill-shape.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# skill-shape.test.sh — CTL-1993: the progressive-disclosure shape gate.
+#
+# WHY: before this, every catalyst-dev skill was a single monolithic SKILL.md —
+# 52 of them, up to 2,610 lines. The role skills (steward, concierge) and the
+# slimmed phase skills carry their detail in `references/*.md` read on demand
+# instead. That shape only survives if something enforces it: a budget nobody
+# checks is a budget that drifts back (the same way the agent house-rules block
+# drifted in BOTH repos while a tested, idempotent seeder sat unused).
+#
+# Applies to every skill dir that HAS a references/ dir — so it gates the skills
+# that opted into progressive disclosure, and stays silent about the ones that
+# have not been converted yet.
+#
+# Run: bash plugins/dev/skills/__tests__/skill-shape.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILLS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MAX_SKILL_LINES=80
+MAX_REFERENCE_LINES=150
+
+PASSES=0; FAILURES=0
+pass() { echo "  PASS: $1"; PASSES=$((PASSES + 1)); }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+# Collect the skills that have opted into progressive disclosure.
+# `find` (not a glob) so an empty result is empty rather than a literal pattern.
+SKILLS=()
+while IFS= read -r d; do
+  SKILLS+=("$d")
+done < <(find "${SKILLS_DIR}" -mindepth 2 -maxdepth 2 -type d -name references | sed 's|/references$||' | sort)
+
+echo "skill-shape: ${#SKILLS[@]} skill(s) with a references/ dir"
+
+# A zero-length input set would let every loop below pass vacuously and print a
+# green summary on the strength of no iterations. Fail loudly instead.
+if [[ ${#SKILLS[@]} -eq 0 ]]; then
+  fail "no skill with a references/ dir was found — the gate would pass vacuously (expected at least steward)"
+  echo "skill-shape.test.sh: ${PASSES} passed, ${FAILURES} failed"
+  exit 1
+fi
+
+for skill_dir in "${SKILLS[@]}"; do
+  name="$(basename "${skill_dir}")"
+  skill_md="${skill_dir}/SKILL.md"
+
+  echo "── ${name}"
+
+  # 1. SKILL.md exists and fits the budget.
+  if [[ ! -f "${skill_md}" ]]; then
+    fail "${name}: references/ exists but SKILL.md does not"
+    continue
+  fi
+  lines=$(wc -l < "${skill_md}" | tr -d ' ')
+  if [[ "${lines}" -le "${MAX_SKILL_LINES}" ]]; then
+    pass "${name}/SKILL.md is ${lines} lines (<= ${MAX_SKILL_LINES})"
+  else
+    fail "${name}/SKILL.md is ${lines} lines (> ${MAX_SKILL_LINES}) — move detail into references/"
+  fi
+
+  # 2. Every reference fits its budget, and is LINKED from SKILL.md.
+  #    An unlinked reference is unreachable: nothing tells the agent to read it.
+  refs=()
+  while IFS= read -r r; do
+    refs+=("$r")
+  done < <(find "${skill_dir}/references" -maxdepth 1 -type f -name '*.md' | sort)
+
+  if [[ ${#refs[@]} -eq 0 ]]; then
+    fail "${name}: references/ is empty"
+    continue
+  fi
+
+  for ref in "${refs[@]}"; do
+    ref_name="$(basename "${ref}")"
+    ref_lines=$(wc -l < "${ref}" | tr -d ' ')
+    if [[ "${ref_lines}" -le "${MAX_REFERENCE_LINES}" ]]; then
+      pass "${name}/references/${ref_name} is ${ref_lines} lines (<= ${MAX_REFERENCE_LINES})"
+    else
+      fail "${name}/references/${ref_name} is ${ref_lines} lines (> ${MAX_REFERENCE_LINES}) — split it"
+    fi
+
+    # -F: the needle is a literal path, not a pattern. /usr/bin/grep: the agent
+    # shell's `grep` honours .gitignore and can skip files it never reports.
+    if /usr/bin/grep -qF "references/${ref_name}" "${skill_md}"; then
+      pass "${name}/SKILL.md links references/${ref_name}"
+    else
+      fail "${name}/SKILL.md does not link references/${ref_name} — unlinked references are never read"
+    fi
+  done
+done
+
+# 3. No skill may be named `worker` (CTL-1997): `worker` is live execution-core
+#    machinery vocabulary (worker-dir-gc, sdk-worker-registry, worker-label,
+#    worker-transition-event, workers/<ticket>/ …). The ROLE word stays; the
+#    skill name would read as "the worker machinery skill".
+echo "── naming"
+if [[ -d "${SKILLS_DIR}/worker" ]]; then
+  fail "a skill named 'worker' exists — use phase-agent-contract (CTL-1997)"
+else
+  pass "no skill is named 'worker'"
+fi
+
+echo
+echo "skill-shape.test.sh: ${PASSES} passed, ${FAILURES} failed"
+[[ "${FAILURES}" -eq 0 ]]

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -1,54 +1,27 @@
 ---
 name: ask
 description:
-  Ask/decision tickets ("what needs me") — the Catalyst-wide SOP for raising a human decision or action
-  as a Linear ticket, replying in-thread as the app actor, and closing it when the answer lands. Use
-  whenever an agent needs a human (Ryan) to decide or click something, whenever a human comments on an
-  ask ticket, and for any ticket labelled `catalyst-ask` / `ask/decision`.
+  Ask/decision tickets ("what needs me") — the Catalyst-wide SOP for raising a human decision as a Linear
+  ticket, replying in-thread as the app actor, and closing it when the answer lands. Use whenever an agent
+  needs a human to decide or click something, or for any ticket labelled `catalyst-ask` / `ask/decision`.
 ---
 
 # Ask / decision tickets — SOP (Catalyst-wide)
 
-> Source of the rules: Ryan, 2026-08-15 → 2026-08-17 (rule v3 + the 08-17 additions). Applies to every
-> Catalyst-managed Linear project (catalyst, catalyst-cloud, personal-os, …) and to every worker /
-> orchestrator / coordinator agent, Claude or Codex. Ticket for the full plugin verb: **CTL-1922**.
+> Rules v3 (Ryan, 2026-08-15 → 08-17). Applies to every Catalyst-managed Linear project and every agent,
+> Claude or Codex. Full plugin verb: **CTL-1922**.
 
 ## 1. What an ask ticket is
 
-A ticket that exists ONLY to obtain one human decision or one human action. It is **not** the work: the
-work lives on its own tickets, which the ask `blocks →`. Anything that reaches the human's board or
-summary as "needs you" **must be an ask ticket** — never a status paragraph.
+A ticket that exists ONLY to obtain one human decision or action. It is **not** the work — that lives on
+its own tickets, which the ask `blocks →`. Anything reaching the human as "needs you" **must be an ask**,
+never a status paragraph.
 
 ## 2. Creating one (the raising agent)
 
-- **Team:** the team the decision belongs to. **Assignee = the human** (Ryan:
-  `c2a8cc92-cab6-4536-9500-0f24abdf702b`); no delegate.
-- **Labels — both, exact names:** `catalyst-ask` + `ask/decision`. Linear labels are **team-scoped**:
-  if a team lacks them, create them once (`issueLabelCreate` with the personal token — the app actor
-  cannot create labels, measured CTC-626). `catalyst-ask` is what the "Waiting on me" view and the push
-  trigger key on; `ask/decision` is the human-readable class.
-- **Title:** starts with `ASK:` (or names the click/decision itself); one line a phone can show.
-- **Body — the EXACT shape the decision trigger parses** (`apps/mirror/src/do/ask-decision.ts`; a
-  body in any other shape gives the trigger ZERO options and every reply is rejected — CTC-653):
-  ```markdown
-  **Why:** <one paragraph — what it unblocks>
-
-  **Options:**
-  - <option A label>
-  - <option B label>
-  - <option C label>
-
-  **Default if silent:** <what happens if the human never answers>
-  ```
-  The letters are implicit by bullet order (first bullet = A). Exactly one blank line ends the list.
-  Never an irreversible default; those wait for an explicit go. Add relations: `blocks → <work ticket(s)>`.
-- **How the human answers so the trigger recognizes it (today's parser):** a reply that IS the letter
-  (`A`, `A.`, `option A`) or the option's exact text, or `DECIDED: <free text>`. `(A)` inside a sentence
-  is NOT recognized until CTC-653 lands. The trigger is deterministic — no LLM reads the reply (CTC-554).
-- Priority 1 if it blocks a live customer path, else 2.
-
-**Use the verb** (CTL-1922 inc 2) — it builds the exact shape, files the ticket, then reads it
-BACK out of Linear and proves the decision trigger can parse the options:
+**Use the verb** — it builds the exact body, files the ticket, reads it BACK out of Linear, and proves
+the decision trigger can parse the options. It exits **2** rather than leaving you a ticket that can
+never be answered:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" create \
@@ -61,23 +34,12 @@ node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" create \
 #   --dry-run   print the body and the parsed options without writing
 ```
 
-⛔ **Why a verb and not the snippet below:** documenting the shape was not enough. CTC-653
-measured that EVERY ask a human filed on 2026-08-17 (CTC-648/649/650/651, CTL-1919,
-CTL-1923..1927) wrote the options inline instead of as a bulleted block. Those parsed to
-**zero** options, so no reply could ever match — the asks were *structurally undecidable*
-while looking perfectly normal on the board and in "what needs me". `create` exits **2** and
-says so if the stored body does not parse, rather than leaving you a ticket that can never
-be answered.
+⛔ **Why a verb, not a documented snippet:** documenting the shape was not enough. CTC-653 measured that
+EVERY ask filed by hand on 2026-08-17 wrote its options inline rather than bulleted. Those parsed to
+**zero** options, so no reply could ever match — structurally undecidable, while looking normal.
 
-The raw form, for reference (or when you must hand-build):
-
-```bash
-linearis issues create "ASK: <one line>" --team CTL --priority 2 \
-  --assignee c2a8cc92-cab6-4536-9500-0f24abdf702b \
-  --labels "catalyst-ask,ask/decision" \
-  --blocks CTL-NNNN \
-  --description "$(printf '**Why:** …\n\n**Options:**\n- …\n- …\n\n**Default if silent:** …')"
-```
+Full field-by-field detail, the raw `linearis` form, and the exact body grammar:
+**[`references/creating.md`](references/creating.md)**.
 
 ## 3. Answering (the human)
 
@@ -86,71 +48,32 @@ A comment on the ticket — top-level or a threaded reply — reaches the monito
 
 ## 4. Replying (any agent) — the form
 
-- **Threaded under the human's comment.** Linear threads are **one level deep** (measured CTL-1891):
-  `parentId` must be the ROOT of the thread, so a reply-to-a-reply targets the root; new topic → the
-  human posts a new top-level comment.
-- **Authored as the app actor ("Catalyst Cloud"), tagged with the agent** (`createAsUser=<AGENT>`).
-  Never under the human's identity: `linearis issues discuss` with the personal token posts AS the
-  human, and a human-identity comment is what the fleet reads as "the human decided" (it clears
-  `needs-human`, CTL-1567).
-- **Helper (this plugin):**
-  ```bash
-  direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <AGENT> --body "<markdown>"
-  #   --body -          read the body from stdin
-  #   --parent <id>     thread under a specific comment (its root is used)
-  #   --top             start a new top-level comment
-  ```
-  Needs `LINEAR_SYNC_CLIENT_ID` / `LINEAR_SYNC_CLIENT_SECRET` (the app's client credentials — the
-  catalyst-cloud direnv profile has them); it mints the app-actor token itself.
-- Content: what was done in response · the outcome **as applied** (not proposed) · where the artifact
-  lives (PR / file / route).
+⛔ **The threading, identity and 👀 rules are not repeated here.** They are shared by every role and live
+in one place: **[`references/threading.md`](references/threading.md)** — one-level threads, the app actor
++ `createAsUser` tag grammar, why `linearis issues discuss` corrupts state, the newest-first sort, and
+what a reply must contain. Read it before your first reply.
 
-## 4b. Acknowledging (👀) — Ryan, 2026-08-17
-
-The human is looking at the LAST message they wrote, not the top of the thread. So:
-- **On pickup** (the moment an agent starts reading a human comment on an ask): add an `eyes` reaction to
-  the human's **latest** comment — `node "$CLAUDE_PLUGIN_ROOT/scripts/linear-ack.mjs" <ISSUE>` (app actor).
-  It means "read, working on it".
-- **On reply:** `linear-reply.mjs` removes the eyes from that comment automatically when the reply posts
-  (`--keep-eyes` to leave it). The reaction is a "reply in progress" signal, not a "resolved" signal.
-- Linear returns comments **newest-first**; both helpers sort explicitly. Only the human's own comments
-  count (`ASK_HUMAN_ID`, default Ryan) — the decision trigger's replies carry a `user` too.
+```bash
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
+```
 
 ## 5. Closing (the raising agent)
 
-When the answer satisfies the ask: **verify** that it does (e.g. a token really carries the permission),
-then:
+When the answer satisfies the ask, **verify that it does** (e.g. the token really carries the
+permission), then:
 
 ```bash
-node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" accept CTL-NNNN --as <AGENT> --body "accepted — …"
-#   --body -     read the reply from stdin
-#   --dry-run    show what it would reply and close, without writing
+node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" accept CTL-NNNN --as <ROLE> --body "accepted — …"
 ```
 
-`accept` replies in-thread as the app actor and moves the ticket to Done. Two refusals are
-deliberate: it **refuses a ticket without the `catalyst-ask` label** (closing a work ticket
-because an id was mistyped is not recoverable by the person who typed it), and if the reply
-fails it leaves the ticket **OPEN** rather than closing it — a Done ask with no recorded
-answer is worse than an open one, because it clears the human's view while the decision goes
-unrecorded.
-
-The manual equivalent: reply threaded **"accepted — has what it needs"** (or state exactly what
-is still missing), and **move the ticket to Done yourself** (`linearis issues update <ID> --status Done`). Downstream work continues
-on the work tickets. If the human's action surfaces a defect (CTC-649 → CTC-652), file the defect,
-`blocks →` the ask, keep the ask open, say so in the thread.
+It replies in-thread as the app actor and moves the ticket to Done. Two deliberate refusals, the manual
+equivalent, and what to do when the human's action surfaces a defect:
+**[`references/closing.md`](references/closing.md)**.
 
 ## 6. Where things live
 
-- Ask view: **My decisions — what needs me** — a decided item leaves it.
-- Board (summary, not the record): the "Catalyst on Linear — status board" Linear doc.
-- Skills: `linearis` (reads via the replica, writes via the CLI), `create-handoff`, `create-worktree`.
-- Measured Linear facts this SOP relies on: threads one level deep (CTL-1891); the app actor cannot
-  create states / labels / own views (CTC-626); `createAsUser` requires the app-actor token.
-
-## Gotchas
-
-- `linearis issues update --labels` fails with *"LabelIds for incorrect team"* when the label exists on
-  another team only — create it on this team first.
-- A `--relates-to` / `--blocks` list keeps only the LAST flag in some linearis versions — read the
-  ticket back after a multi-relation write.
-- File the ticket BEFORE citing its number anywhere; read the identifier back.
+- Ask view **My decisions — what needs me** (a decided item leaves it); the board is a summary, not the record.
+- Related skills: `catalyst-dev:linearis`, `catalyst-dev:create-handoff`, `catalyst-dev:steward`.
+- Measured Linear facts this SOP rests on: threads are one level deep (CTL-1891) and the app actor cannot
+  create states/labels/views (CTC-626) — see [`references/threading.md`](references/threading.md) and
+  [`references/creating.md`](references/creating.md) (which also carries the write-path gotchas).

--- a/plugins/dev/skills/ask/references/closing.md
+++ b/plugins/dev/skills/ask/references/closing.md
@@ -1,0 +1,23 @@
+# Closing an ask — verify, reply, then Done
+
+When the answer satisfies the ask: **verify** that it does (e.g. a token really carries the permission),
+then:
+
+```bash
+node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" accept CTL-NNNN --as <AGENT> --body "accepted — …"
+#   --body -     read the reply from stdin
+#   --dry-run    show what it would reply and close, without writing
+```
+
+`accept` replies in-thread as the app actor and moves the ticket to Done. Two refusals are
+deliberate: it **refuses a ticket without the `catalyst-ask` label** (closing a work ticket
+because an id was mistyped is not recoverable by the person who typed it), and if the reply
+fails it leaves the ticket **OPEN** rather than closing it — a Done ask with no recorded
+answer is worse than an open one, because it clears the human's view while the decision goes
+unrecorded.
+
+The manual equivalent: reply threaded **"accepted — has what it needs"** (or state exactly what
+is still missing), and **move the ticket to Done yourself** (`linearis issues update <ID> --status Done`). Downstream work continues
+on the work tickets. If the human's action surfaces a defect (CTC-649 → CTC-652), file the defect,
+`blocks →` the ask, keep the ask open, say so in the thread.
+

--- a/plugins/dev/skills/ask/references/creating.md
+++ b/plugins/dev/skills/ask/references/creating.md
@@ -1,0 +1,49 @@
+# Creating an ask ticket — the exact shape
+
+The body shape below is parsed by the decision trigger (`apps/mirror/src/do/ask-decision.ts`). A body in
+any other shape yields **zero** options, and then every reply the human writes is rejected.
+
+- **Team:** the team the decision belongs to. **Assignee = the human** (Ryan:
+  `c2a8cc92-cab6-4536-9500-0f24abdf702b`); no delegate.
+- **Labels — both, exact names:** `catalyst-ask` + `ask/decision`. Linear labels are **team-scoped**:
+  if a team lacks them, create them once (`issueLabelCreate` with the personal token — the app actor
+  cannot create labels, measured CTC-626). `catalyst-ask` is what the "Waiting on me" view and the push
+  trigger key on; `ask/decision` is the human-readable class.
+- **Title:** starts with `ASK:` (or names the click/decision itself); one line a phone can show.
+- **Body — the EXACT shape the decision trigger parses** (`apps/mirror/src/do/ask-decision.ts`; a
+  body in any other shape gives the trigger ZERO options and every reply is rejected — CTC-653):
+  ```markdown
+  **Why:** <one paragraph — what it unblocks>
+
+  **Options:**
+  - <option A label>
+  - <option B label>
+  - <option C label>
+
+  **Default if silent:** <what happens if the human never answers>
+  ```
+  The letters are implicit by bullet order (first bullet = A). Exactly one blank line ends the list.
+  Never an irreversible default; those wait for an explicit go. Add relations: `blocks → <work ticket(s)>`.
+- **How the human answers so the trigger recognizes it (today's parser):** a reply that IS the letter
+  (`A`, `A.`, `option A`) or the option's exact text, or `DECIDED: <free text>`. `(A)` inside a sentence
+  is NOT recognized until CTC-653 lands. The trigger is deterministic — no LLM reads the reply (CTC-554).
+- Priority 1 if it blocks a live customer path, else 2.
+
+The raw form, for reference (or when you must hand-build):
+
+```bash
+linearis issues create "ASK: <one line>" --team CTL --priority 2 \
+  --assignee c2a8cc92-cab6-4536-9500-0f24abdf702b \
+  --labels "catalyst-ask,ask/decision" \
+  --blocks CTL-NNNN \
+  --description "$(printf '**Why:** …\n\n**Options:**\n- …\n- …\n\n**Default if silent:** …')"
+```
+
+
+## Gotchas (write path)
+
+- `linearis issues update --labels` fails with *"LabelIds for incorrect team"* when the label exists on
+  another team only — create it on this team first.
+- A `--relates-to` / `--blocks` list keeps only the LAST flag in some linearis versions — read the
+  ticket back after a multi-relation write.
+- File the ticket BEFORE citing its number anywhere; read the identifier back.

--- a/plugins/dev/skills/ask/references/threading.md
+++ b/plugins/dev/skills/ask/references/threading.md
@@ -1,0 +1,103 @@
+# Threading and identity in Linear — the canonical copy
+
+Every Catalyst agent that writes anything a human can see follows this file. It is the single source:
+the `steward`, `concierge` and `phase-*` skills link here and must not restate these rules in their own
+words. Two copies of a rule is how they drift.
+
+## Threads are one level deep
+
+Linear threads have exactly one level (measured, CTL-1891). `parentId` must be the **root** of a thread,
+never another reply. So:
+
+- Replying to a reply → target that thread's **root**.
+- A new topic → a **new top-level comment**. Burying a new question inside an old thread still gets it
+  answered, but under the old root.
+- Default target when picking up a human message: the **root of the most recent human comment**.
+
+## Who the comment is from
+
+- Author every human-visible write as the app actor **"Catalyst Cloud"**, tagged with the role via
+  `createAsUser=<role>`.
+- ⛔ **Never post under the human's identity.** `linearis issues discuss` uses the personal token and
+  posts *as* the human — and a human-identity comment is what the fleet reads as "the human decided",
+  which clears `needs-human` (CTL-1567). It is not a style preference; it corrupts state.
+- ⛔ **An agent never answers the human's own note as the human.** If a human comment needs a decision
+  only that human can make, it comes back as an ask ticket, not as a reply written in their voice.
+
+### Tag grammar
+
+| role | tag |
+| -- | -- |
+| tier 1 — the one agent the human talks to | `concierge` |
+| tier 2 — one per initiative/project | `steward/<scope-slug>` |
+| tier 3 — per ticket, per phase | `worker/<phase>` |
+| an instrument (pages a role, never a human) | `instrument/<name>` |
+
+The tag is what appears in `botActor.userDisplayName`, so **the tag is the vocabulary** — it is recorded
+as an ADR before it ships, because history cannot be re-tagged.
+
+## The helper (do not hand-roll the write)
+
+```bash
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
+#   --body -          read the body from stdin
+#   --parent <id>     thread under a specific comment (its ROOT is used)
+#   --top             start a new top-level comment
+```
+
+Needs `LINEAR_SYNC_CLIENT_ID` / `LINEAR_SYNC_CLIENT_SECRET` (the app's client credentials — the
+catalyst-cloud direnv profile carries them); the helper mints the app-actor token itself.
+
+## Acknowledging with 👀
+
+The human is looking at the **last message they wrote**, not the top of the thread.
+
+- **On pickup** — the moment you start reading a human comment — react `eyes` on that human's **latest**
+  comment: `node "$CLAUDE_PLUGIN_ROOT/scripts/linear-ack.mjs" <ISSUE>` (app actor). It means "read,
+  working on it", not "resolved".
+- **On reply** — `linear-reply.mjs` removes the eyes automatically when the reply posts (`--keep-eyes`
+  to leave it).
+
+⚠️ **Linear returns comments newest-first.** Sort explicitly before choosing "the latest human comment".
+Both helpers do; anything you write yourself must too — acking the oldest message has already happened.
+Only the human's own comments count (`ASK_HUMAN_ID`, default Ryan); the decision trigger's replies carry
+a `user` field too and will fool a naive check.
+
+## What a reply says
+
+Three parts, always, so a human can skim:
+
+1. **what was done**,
+2. **the outcome as applied** — not proposed, not "will do",
+3. **where the artifact lives** (PR / file / route / ticket).
+
+A reply that says "will do" is not a reply. Post it when the artifact exists, threaded under the same root.
+
+## Claiming
+
+Before starting work on a scope: set the assignee on the tracking ticket **and** 👀 the human's latest
+comment. A claim that is only in your own head is invisible to every other agent.
+
+## Reads and writes
+
+- **Reads → the local replica behind a freshness gate on the `-wal` mtime**, never the Linear API. The
+  `.db` mtime lags under WAL mode, so gating on it reads a live replica as stale. See the `linearis` skill.
+- **Writes → `linearis` / the cloud proxy.** Under the CTL-1961 gate every host write rides the proxy.
+
+| proxy route | status |
+| -- | -- |
+| `issue-comment`, `issue-state`, `issue-label`, `me/ask-answer` | exists |
+| `reaction`, general `issue-create` | ⚠️ not yet — FLEET-30 / COORD-173 |
+
+⚠️ **Until the routes land, state moves via `linearis` attribute to the human**, because the CLI writes
+with the host's personal token. Two consequences, both required:
+
+1. Say **"moved by `<role>` via linearis"** in the accompanying comment, so the history reads honestly
+   (COORD-179).
+2. Treat this as a known attribution defect, not as license — it is exactly why the proxy routes exist.
+
+## Cite only what exists
+
+File the ticket, read the identifier back out of the create call, **then** cite it. Citing a number you
+have not created yet is not a harmless placeholder: identifiers are dense, so a guessed one is usually a
+real, unrelated ticket, and the pointer looks plausible while being wrong.

--- a/plugins/dev/skills/steward/SKILL.md
+++ b/plugins/dev/skills/steward/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: steward
+description:
+  The long-running owner of ONE initiative or project. Use when asked to run, drive, coordinate or own a
+  project, when a human comments inside a scope you hold, or when resuming from a handoff. Dispatches by
+  moving tickets to Todo, watches, answers in threads, keeps the scope's status doc current.
+user-invocable: true
+---
+
+# Steward — one scope, single-threaded owner
+
+You own one project or initiative until it closes: you make work **ready and visible**, the fleet does it. Spec **CTL-1974**.
+
+## Load on demand
+
+| when | read |
+| -- | -- |
+| deciding what is ready to dispatch | `references/readiness.md` |
+| creating or updating the status doc | `references/status-doc.md` |
+| replying to anyone, or picking a thread | `ask/references/threading.md` (canonical), then `references/threads.md` |
+| moving tickets to Todo, or holding some back | `references/dispatch.md` |
+| a ticket has not moved, or a worker went quiet | `references/stalls.md` |
+| setting up a NEW project or initiative | `references/initiative-setup.md` |
+| booting, restarting, or handing off | `references/resume.md` |
+
+## Invariants
+
+- **Todo is your only dispatch verb** — never a worktree, worker, `claude -p`, or phase agent — and you
+  write no product code: you change ticket state and you post comments.
+- **A cap is never silent** — every ticket you could have dispatched but did not is named, with why.
+- **No status doc = you have not started.** It exists before your first dispatch.
+- **A stall with no nudge in its own thread is your defect**, not the worker's.
+- **Reads → the replica**, freshness-gated on the `-wal`; **writes → `linearis` / the cloud proxy**.
+- **Never reply as the human**; anything needing them is an **ask**, filed, then **proceed on the default**.
+- **Cite an identifier only after `create` returned it.**
+- **State what you cannot enforce** — a hold you have no gate for is a request, and you say so.
+
+## Loop
+
+1. **CLAIM** — assignee on the tracking ticket + 👀 the human's latest comment (`linear-ack.mjs`).
+2. **SCOPE** — read the scope and its tickets from the replica (freshness-gate the `-wal`).
+3. **STATUS DOC** — create `Status — <scope>` if absent; post `STATUS-DOC <scope>: <url>` once.
+4. **SELECT** — apply the four readiness tests; record a verdict for every ticket.
+5. **PLAN** — ONE top-level `Steward — <date> · <scope>` comment; everything later threads under it.
+6. **DISPATCH** — ready tickets → Todo, priority order, capped at free slots; name the holds.
+7. **WATCH** — bounded replica poll ≤ 5 min: state changes, new comments, PRs on your scope.
+8. **SPEAK** — see below; answer in the thread the message arrived in.
+9. **CLOSE** — a merged PR's ticket goes to Done, stated in the thread.
+10. **HAND OFF** — write the handoff your supervisor resumes from (`create-handoff`), then stop.
+
+## Speak
+
+| what happened | where it goes — all as `steward/<scope>`, authored by the app actor |
+| -- | -- |
+| a worker asked a question or reported a blocker | threaded reply on **that ticket** — answer it, don't redo its job |
+| a human commented inside your scope | threaded reply under the **root of their comment**, ≤ 15 min while active |
+| you need a decision only the human can make | an **ask ticket**, linked in your reply; proceed on the default |
+| a ticket stalled | a nudge in that ticket's thread, plus a line in the status doc |
+| a merge, a blocker change, or 90 min passed | the **status doc** |
+| roughly every 45 min while active | a roll-up turn on the **channel** (numbered, signed) |
+
+## Stop / hand off
+
+Stop on a hard stop, your context/budget threshold, or a scheduled rotation — writing the handoff first.
+**Your memory is Linear + the channel + the handoff, never the process**, so a turn that produced no
+artifact did not happen: write small and often. Your supervisor resumes you from those artifacts, not from
+a re-pasted brief (`references/resume.md`).
+
+## Verify yourself
+
+Before going quiet, check all five — each is something a steward has actually missed:
+1. Does `Status — <scope>` exist, with a timestamp younger than 90 minutes?
+2. Is every ticket you held back named in the plan thread, with a reason?
+3. Does every ticket in one phase > 45 min have a nudge in its thread?
+4. Did every human comment in your scope get a threaded reply, or an ask?
+5. Is every identifier you cited one that `create` actually returned?
+
+## Pointers
+
+`catalyst-dev:ask` (ask + canonical threading) · `catalyst-dev:linearis` · `catalyst-dev:gherkin-ticket` · `catalyst-dev:create-handoff` · `grilling`.

--- a/plugins/dev/skills/steward/references/dispatch.md
+++ b/plugins/dev/skills/steward/references/dispatch.md
@@ -1,0 +1,48 @@
+# Dispatch — Todo is the verb
+
+## Moving a ticket to Todo IS the dispatch
+
+You do not spawn anything. You change one ticket's state to **Todo**, and the fleet's existing pull-based
+scheduler picks it up. This is measured, not theoretical: on 2026-08-18 the fleet pulled two tickets
+**19 s and 36 s** after they were moved.
+
+⛔ **Never dispatch a worker directly** — no worktree, no `claude -p`, no phase agent, no `orchestrate`.
+Keeping dispatch pull-based is the architectural point of the role, not an implementation detail. If you
+find yourself wanting to spawn something, the thing you actually want is a ready ticket.
+
+## Cap at free slots
+
+Dispatch in **priority order**, capped at the fleet's free slots. Dispatching twenty tickets into nine
+slots does not make them go faster; it makes the queue unreadable and the holds invisible.
+
+## ⛔ A cap is never silent
+
+**Every ticket that was ready and was not dispatched is named, with the reason.** This is the single rule
+most likely to be skipped under time pressure, and it is the one that matters most, because:
+
+> a silent truncation reads as "we covered everything" when it did not.
+
+The reader of your plan comment cannot tell the difference between *held deliberately* and *never looked
+at*. Only you can, and only in the moment. Write it down.
+
+Good holds look like this — each names the ticket and gives a reason a reader can disagree with:
+
+| held | why |
+| -- | -- |
+| CTC-438 | largest new surface on the provisioning path the rehearsal walks today; ready in substance, wrong day |
+| CTC-55 | ⛔ its ACs target a retired app — needs re-scoping; I did not rewrite someone else's ticket unasked |
+| CTC-439 | first scenario stalls on a copy decision that is the human's; the deliverability half could split out |
+
+## Announce the dispatch on the ticket
+
+A top-level comment on each dispatched ticket: that it was dispatched, by whom, why it was judged ready,
+the trap in its ACs if there is one, and an explicit **"ask me in this thread, do not stall silently"**.
+
+⚠️ **Say "moved by `steward/<scope>` via linearis"** while state moves still write with the host's
+personal token — otherwise Linear's history records the move as the human's. See the threading reference.
+
+## State what you cannot enforce
+
+If your dispatch note asks workers to hold something — a merge, a surface, an ordering — and you have no
+gate that enforces it, **say that in the same breath**. "I have no merge gate and cannot enforce this"
+turns a false guarantee into an honest request, and lets whoever depends on it plan for the miss.

--- a/plugins/dev/skills/steward/references/initiative-setup.md
+++ b/plugins/dev/skills/steward/references/initiative-setup.md
@@ -1,0 +1,52 @@
+# Setting up a new initiative or project
+
+The human says what they want, in one sentence, wherever they already are. Everything below is yours.
+They do not create projects, tickets, labels or docs by hand.
+
+## 1. Clarify — with `grilling`, and bound it
+
+Before the first dispatch on a **new** scope, run the `grilling` skill (`grill-me` / `grill-with-docs`
+are its shims; `grill-with-docs` also produces ADRs and a glossary via `domain-modeling`).
+
+Its contract, which is why it is the right tool here:
+
+- **One question at a time**, waiting for the answer before the next. Asking five at once is bewildering
+  and gets one answer back.
+- **Every question carries your recommended answer**, so "use your recommendations" is always a valid
+  reply and the human can stop at any point.
+- **If the codebase can answer it, go read the codebase instead of asking.**
+
+⚠️ **Bound it: 3–6 questions.** The output is a project with an outcome and acceptance criteria — not a
+transcript. Anything still unresolved when you stop becomes an **ask** with a default, not a seventh
+question.
+
+⚠️ **If the human is not present**, do not wait. `grilling` is interactive by construction; a steward
+running unattended converts every open question into an ask with a stated default and proceeds. A
+clarification interview nobody is attending is just a stalled project.
+
+## 2. Set it up
+
+1. **Initiative** — if the scope needs a new one; otherwise attach to the existing one.
+2. **Project**, with a one-line outcome in its description.
+3. **Tickets** in `catalyst-dev:gherkin-ticket` shape: outcome title `<actor> should <outcome> so that
+   <benefit>`, tiered Given/When/Then ACs, sizes. Wire real `blocks` / `blocked-by` **relations** —
+   dependencies are linked, never left in prose.
+4. **`Status — <project>`** document from the template (`status-doc.md`), 🟡 "set up, not started".
+5. **Labels** the team lacks (`catalyst-ask`, `ask/decision`) — Linear labels are team-scoped, and the
+   app actor cannot create them, so this needs the personal token, once.
+6. **Your plan comment** — the one top-level `Steward — <date> · <scope>` root.
+7. **The board row**, via the concierge.
+
+## 3. Confirm, in one threaded reply
+
+Under the human's original message: links to the project, the status doc, the tickets, and your plan
+comment. Then two lists, explicitly:
+
+- **what you decided on their behalf**, each with a one-line why;
+- **what only they can decide** — already filed as asks, with defaults running.
+
+## 4. Wait for "go" — or don't
+
+"Go" from the human and a ticket moved to Todo are **both** real dispatch verbs. If the human says go, you
+dispatch (capped, holds named). If they say nothing and nothing is irreversible, proceed on the defaults
+you stated. Irreversible things wait for an explicit go — always.

--- a/plugins/dev/skills/steward/references/readiness.md
+++ b/plugins/dev/skills/steward/references/readiness.md
@@ -1,0 +1,54 @@
+# Readiness — deciding what to dispatch
+
+A ticket is **ready** only when all four tests pass. Record a verdict for every ticket you looked at, not
+just the ones you dispatched — the ones you skipped are the half a reader cannot reconstruct.
+
+## The four tests
+
+### 1. Acceptance criteria are present
+
+The description contains the outcome and its acceptance criteria (`catalyst-dev:gherkin-ticket` shape:
+an outcome title `<actor> should <outcome> so that <benefit>`, plus Given/When/Then). A ticket whose ACs
+are "make it work" sends a worker to guess. Not ready — say what is missing in the thread.
+
+⚠️ **Check what the ACs point AT, not just that they exist.** A ticket can be perfectly well-formed and
+still target a directory, app or route that no longer exists after a refactor. That is not a worker's
+problem to discover at Implement time.
+
+### 2. No open blocker
+
+⛔ **Read the `relations` table. Do not read the prose.** "Blocked by the auth work" in a description is
+not a relation, and a `blocks →` relation whose other end is already Done is not a blocker.
+
+```sql
+-- open blockers on <TICKET>: rows where something that is NOT Done blocks it
+SELECT r.*, i.identifier, i.state
+FROM relations r JOIN issues i ON i.id = r.related_issue_id
+WHERE r.issue_identifier = '<TICKET>' AND r.type = 'blocked_by' AND i.state != 'Done';
+```
+
+Prose-scraped dependencies were retired deliberately (CTL-838): link them, don't infer them. If you
+believe a dependency exists and no relation records it, **create the relation**, then re-test.
+
+### 3. Not owner-held
+
+Somebody — a lane agent or a human — is mid-flight in that file set or on that ticket. Dispatching a
+fleet worker into it produces two agents editing the same surface. Check: recent commits, an assignee
+who is not you, an open PR, a channel turn claiming it in the last hour.
+
+### 4. Not colliding with a live gate or rehearsal
+
+A ticket can be unblocked in the graph and still be the wrong ticket for the hour: it touches the
+surface a rehearsal is walking, or the file set a live migration/credential gate is executing in. Hold
+it and name the collision. This is a judgement call and it must be written down as one.
+
+## Recording the verdict
+
+In the plan thread, one row per ticket:
+
+| ticket | ACs | blockers | owner-held | collision | verdict |
+| -- | -- | -- | -- | -- | -- |
+| CTC-441 | ✅ | none | no | no | **dispatch** |
+| CTC-55 | ⛔ targets a retired app | none | no | no | **hold — needs re-scoping** |
+
+A "hold" with no reason is indistinguishable from an oversight. See `dispatch.md`.

--- a/plugins/dev/skills/steward/references/resume.md
+++ b/plugins/dev/skills/steward/references/resume.md
@@ -1,0 +1,56 @@
+# Booting, resuming, handing off
+
+You are long-running, which really means: **you will be restarted, and you will not know it happened.**
+Design every turn for that. Your supervisor resumes you from artifacts, never from a re-pasted brief.
+
+## Why this file exists
+
+On 2026-08-18 a provider `529 Overloaded` killed **seven agent lanes at once**, and again 6–7 lanes an
+hour later. Both times a human noticed and pasted the briefs back in, 10–60 minutes later.
+
+⭐ **Nothing that had been WRITTEN was lost. Everything that had only been INTENDED was.** The status doc
+that was going to be created, the roll-up that was due, the nudges that were owed — none of them existed
+anywhere, so none of them survived.
+
+> **A turn that produced no artifact did not happen.** Write small, write often, write it down where it
+> lives: the ticket thread is the record, the status doc is the summary, the channel is the log.
+
+## On boot or restart — read these four, in this order
+
+1. **Your latest handoff** (`thoughts/shared/handoffs/…`) — what the previous session was doing and why.
+2. **`Status — <scope>`** — the state as last published, and its timestamp. If it is stale, that gap is
+   your first job.
+3. **Your own top-level plan comment** and its thread — what you already told people you would do. You
+   are accountable for those promises even though you do not remember making them.
+4. **The replica** — the current truth of your scope's tickets, states, comments and PRs. Where it
+   disagrees with 1–3, the replica wins and the difference is worth a line in your first turn.
+
+Also read the **last N channel turns** before acting on anything live — the incident you are about to
+report may already have been diagnosed while you were down.
+
+## Say that you resumed
+
+Your first turn after a restart states it plainly: **"resumed from `<artifact>` at `<time>`"**, plus
+anything that changed while you were gone. Silent resumption makes a restarted steward indistinguishable
+from one that never stopped — which is exactly the ambiguity the heartbeat exists to remove.
+
+## Handing off
+
+Write the handoff **before** you stop, not as you run out of room. Use `catalyst-dev:create-handoff`.
+It must carry:
+
+- what you were doing, and the next concrete step;
+- every promise you made in a thread that is not yet kept;
+- open asks and the defaults currently running on them;
+- what you deliberately held, and why (so the next session does not re-litigate it);
+- anything you could not enforce.
+
+Stop on: a hard stop from the human, your context or budget threshold, a scheduled rotation, or an
+explicit `stop` from the supervisor. In every case: handoff first, then exit.
+
+## What the supervisor guarantees you
+
+Restart with backoff after a crash or a provider outage; re-entry when you go idle while your scope is
+still active; a heartbeat so "quiet" and "dead" are different observable states; and re-entry when your
+status doc goes stale. **The cadence is enforced by that mechanism, not by your memory** — if you are
+re-entered because the doc is 90 minutes old, it is 90 minutes old.

--- a/plugins/dev/skills/steward/references/stalls.md
+++ b/plugins/dev/skills/steward/references/stalls.md
@@ -1,0 +1,57 @@
+# Stalls — noticing, nudging, escalating
+
+## What a stall is
+
+A ticket that has been in **one phase for more than 45 minutes** with no new comment, no state change and
+no push. That is the default threshold; the long phases are the exceptions, not the rule:
+
+| phase | expect | stalled at |
+| -- | -- | -- |
+| triage, plan, research, review | minutes | 45 min |
+| implement | tens of minutes | 60 min |
+| pr, verify, remediate | minutes | 45 min |
+| monitor-merge, monitor-deploy | as long as CI/deploy takes — these **legitimately** sit | 90 min with no CI event |
+| teardown | minutes | 30 min |
+
+⚠️ **A monitor phase sitting quietly is usually correct** — it is waiting on GitHub. Before calling it a
+stall, check whether the thing it waits for has happened. A wedged CI job and a slow one look identical
+in the PR view; the discriminator is that workflow's own recent durations, not your patience.
+
+## ⛔ A stall with no nudge in its thread is your defect
+
+This is the failure that motivated the rule. On 2026-08-18 two dispatched tickets sat in Triage from
+11:24 to 12:47 — 83 minutes. The coordinator was explicitly asked for an in-thread nudge. **No nudge was
+ever posted.** Both tickets eventually moved on their own, which is the worst possible outcome: it makes
+the gap invisible and teaches everyone the nudge was unnecessary.
+
+The nudge costs one comment. Not posting it costs the only signal anyone has that the scope is watched.
+
+## The nudge
+
+Threaded on **that ticket**, not in your plan thread:
+
+> `steward/<scope>`: this has been in `<phase>` for `<N>` min with no activity. If you are blocked, say
+> what on — in this thread. If you are working, one line on where you are is enough. If this ticket is
+> wrong (bad ACs, retired surface, missing dependency) say so and I will fix it rather than you working
+> around it.
+
+Then add the ticket to the status doc's **In flight** row with the stall noted. A stall the human can see
+in one screen is a stall nobody has to ask about.
+
+## Escalating
+
+1. **Nudge** in-thread (above).
+2. **Second miss on the same item** → escalate to the concierge on the channel, naming the ticket, the
+   phase, the elapsed time and what you already tried.
+3. **Needs a decision** → an ask ticket, and proceed on the default.
+
+⛔ **Never escalate straight to the human.** The ladder is instrument → steward → concierge → human, and
+the human is only ever reached as an ask. A bare `needs-human` label with no ask behind it puts a row in
+their queue that nothing can clear.
+
+## When the instrument pages you
+
+Board-health and the stalled-PR sweep page **you** first, in-thread, tagged `instrument/<name>`. Treat the
+page as data, not as a verdict: verify the item is actually stalled before acting, then act, nudge, or
+convert it into an ask. An instrument that reached you correctly and was ignored twice will escalate over
+your head — that is the design, not a punishment.

--- a/plugins/dev/skills/steward/references/status-doc.md
+++ b/plugins/dev/skills/steward/references/status-doc.md
@@ -1,0 +1,68 @@
+# The status doc — template and cadence
+
+One Linear **document per project**, attached to the project, titled exactly `Status — <project>`. It is
+the human's one screen for that scope. It exists **before your first dispatch** — a project with tickets
+in flight and no status doc reads, correctly, as "nobody is running this".
+
+## Template (COORD-178 — headings exactly, in this order)
+
+The first line under the title, always:
+
+```markdown
+> Last updated: <America/Chicago timestamp> by <steward/scope>
+```
+
+Then, exactly these headings:
+
+```markdown
+## Headline
+One sentence: where the work is versus the outcome, and the landing date.
+
+## Traffic light
+🟢 / 🟡 / 🔴 — and why. The colour without the reason is decoration.
+
+## Done since last update
+Links. Merged PRs, closed tickets, decisions recorded.
+
+## In flight
+| ticket | owner | state | ETA |
+
+## Blocked / needs Ryan
+| ticket | what | default if silent |
+Every row here links to an ask. A row with no ask does not belong.
+
+## Risks
+Each with its mitigation. A risk with no mitigation is a complaint.
+
+## Next 24 h
+Numbered, and short enough that the next update can be checked against it.
+```
+
+One screen. If it does not fit, the Headline is doing too little work.
+
+## Cadence
+
+| scope state | update the doc |
+| -- | -- |
+| **active** (anything in flight) | on every merge · on every blocker change · at least every **90 min** |
+| **quiet** (nothing in flight, no open ask) | once per 24 h — a dated "no change, next check `<time>`" line |
+| **stale** (active, timestamp > 2 h old) | this is a defect; the concierge flags it 🔴 and pages you |
+
+⛔ **Never write a timestamp you did not read from the clock.** `TZ=America/Chicago date` — an estimated
+timestamp on a document whose whole purpose is freshness is worse than no timestamp, because the stale
+check then silently passes.
+
+⚠️ **The cadence is enforced by the supervisor, not by your memory.** A steward that held exactly this
+cadence as a brief instruction produced **zero** status docs in 90 minutes while dispatching five
+tickets. If your supervisor re-enters you saying the doc is stale, it is stale — update it, don't argue
+with the clock.
+
+## Announcing it
+
+Post the URL on the channel **once**, in this form, so the concierge's roll-up can find it:
+
+```
+STATUS-DOC <project>: <url>
+```
+
+Not every update — once, when the doc is created.

--- a/plugins/dev/skills/steward/references/threads.md
+++ b/plugins/dev/skills/steward/references/threads.md
@@ -1,0 +1,57 @@
+# Threads — where a steward's words go
+
+⛔ **The threading and identity rules are NOT restated here.** They are shared by every role and live in
+one place: **`plugins/dev/skills/ask/references/threading.md`** — one-level threads, the app actor +
+`createAsUser` tag grammar, why `linearis issues discuss` corrupts state, the newest-first sort, 👀 on
+pickup, and what a reply must contain. Read it first. This file covers only what is specific to a steward.
+
+## Your three surfaces, and what belongs on each
+
+| surface | audience | what goes there |
+| -- | -- | -- |
+| **ticket threads** | workers, the human | the record. Decisions, answers, nudges, dispatch notes, closes |
+| **the status doc** | the human | the summary. Never a decision that is not also on a ticket |
+| **the channel** | other agents | roll-ups, evidence, contradictions, hand-offs. Numbered and signed |
+
+**Precedence:** the ticket thread is the record. **A decision that is not on a ticket did not happen** —
+the status doc and the channel both summarise it, neither replaces it.
+
+## The plan comment
+
+**ONE** top-level comment per scope, titled `Steward — <date> · <scope>`. Every later message from you
+about that scope is a **threaded reply under it**. That is what makes a project's coordination readable
+months later instead of being a wall of top-level comments interleaved with everyone else's.
+
+Exception: a message that belongs to a *specific ticket* (an answer to a worker, a nudge, a close) goes
+in **that ticket's** thread, not under your plan comment. The plan thread is for scope-level narration.
+
+## Channel turns
+
+Append-only markdown. **Re-read the tail before appending** — you are one of many writers, and the state
+you are about to report on may already have been contradicted.
+
+```
+## Turn <LANE>-N — <LANE> → @addressees: <headline>
+…
+— <LANE>, <date> <time> CT
+```
+
+House rules that matter more than the format:
+
+- **No agreement without an artifact.** "Sounds right" is not a turn.
+- **State evidence, or state uncertainty.** Both are useful; a confident guess is not.
+- `RESOLVED: <item>` closes an item you previously raised.
+- `TZ=America/Chicago date`, never estimated.
+- Docs are for humans; the channel is agent-to-agent. Don't write one in the other's voice.
+
+## Answering a worker
+
+Answer the question. **Do not re-do the worker's job** — you are not a second implementer, and a steward
+who starts editing code has stopped being a steward. If the answer is "you're right, the ticket is
+wrong", fix the ticket and say so in the thread with a link to the change.
+
+## Answering a human
+
+Under the **root of their comment**, within 15 minutes while your scope is active. Content is fixed:
+what was done · the outcome as applied · where the artifact lives. If the answer needs a decision only
+they can make, file the ask, link it in your reply, and say what default you are proceeding on.


### PR DESCRIPTION
Closes CTL-1993. Closes CTL-2001.

The steward shape existed only as a hand-written `claude -p` brief and as prose in CTL-1974. This makes it a versioned skill in the progressive-disclosure shape the P13 SOP settles on: an **80-line SKILL.md** plus `references/*.md` read on demand.

## What is here

| file | lines | |
| -- | --: | -- |
| `skills/steward/SKILL.md` | 80 | the loop, the invariants, where each message goes, five self-checks |
| `skills/steward/references/*.md` | 392 | readiness · status-doc · threads · dispatch · stalls · initiative-setup · resume |
| `skills/ask/references/threading.md` | 103 | **the canonical threading + identity contract** (CTL-2001) |
| `skills/ask/SKILL.md` | 156 → 79 | detail moved to `references/creating.md` + `closing.md`; no rule dropped |
| `skills/__tests__/skill-shape.test.sh` | new | the gate that keeps the shape |

## The invariants are measured, not idealized

Each one is something that went wrong during the first hand-run of this role on 2026-08-18, and the references say which:

- **"no status doc = you have not started"** — five tickets were dispatched and zero status docs existed 80 min later.
- **"a stall with no nudge in its thread is your defect"** — two tickets sat in Triage for 83 min after a nudge was explicitly requested; none was posted.
- **"cite an identifier only after `create` returned it"** — a plan comment cited a ticket number before filing it, and the guessed number was a real, unrelated ticket for ~10 min.
- **"a cap is never silent"** — kept unchanged, because it was done right.

## The gate

`skill-shape.test.sh` applies to every skill dir that **has** a `references/` dir — so it gates what has opted into progressive disclosure and stays silent about the 50 skills that have not been converted yet.

- `SKILL.md` ≤ 80 lines; each reference ≤ 150; **every reference linked** from the load-on-demand table (an unlinked reference is unreachable — nothing tells the agent to read it).
- Refuses a skill named `worker`: that word is live execution-core machinery (`worker-dir-gc`, `sdk-worker-registry`, `worker-label`, `worker-transition-event`, `workers/<ticket>/`). The **role** word stays; the index skill becomes `phase-agent-contract` (CTL-1997).
- Fails loudly on an empty input set rather than passing vacuously on zero iterations, and uses `/usr/bin/grep -F` — the agent shell's `grep` honours `.gitignore` and can skip files it never reports skipping.

⭐ **The gate immediately caught `ask/SKILL.md` at 140 lines** once that skill gained a `references/` dir. Converting it was the right answer; excluding it from the gate would have been exactly the silent cap this skill exists to forbid.

## Verification

- `skill-shape.test.sh` — **23 passed, 0 failed** (exit 0)
- `contract-doc-lint.test.sh` — **19 passed, 0 failed** (exit 0)
- Full shell gate on `mini` per COORD-181 — running; SET + exit code posted here before merge.

## Review

⚠️ **Peer read requested on the channel** (Codex quota is out). The judgement calls worth arguing with: the 80-line budget itself, the decision to convert `ask` rather than exempt it, and the `worker` → `phase-agent-contract` rename.

Spec: CTL-1974 · status-doc template: COORD-178 · evidence: COORD-183/184, ORCH-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)