### PR TITLE
feat(dev): CTL-1994 — a supervisor keeps a long-running role alive, so the SOP's response times are a mechanism and not a promise

### DIFF
--- a/plugins/dev/scripts/lib/agent-liveness.mjs
+++ b/plugins/dev/scripts/lib/agent-liveness.mjs
@@ -14,12 +14,22 @@
 // one copy here is the alternative to a second, drifting copy — and
 // execution-core's own `config.mjs` chain reaches `bun:sqlite`, so a role
 // runner cannot simply import from there. Everything in this file is pure and
-// imports nothing but `node:*` (nothing at all, in fact), so both callers can
-// load it under bare `node` with no node_modules.
+// imports nothing but `node:*` (just `node:crypto`, for the jitter source), so
+// both callers can load it under bare `node` with no node_modules.
 //
 // Every function is total and injectable: no clock, no randomness, and no env
 // is read unless it is passed in. That is what makes the restart policy
 // testable rather than something you find out about during an outage.
+
+import { randomInt } from "node:crypto";
+
+// The jitter source. This is backoff jitter, NOT a credential — but the value
+// flows into the heartbeat record alongside the session id, and CodeQL reads a
+// non-crypto RNG reaching that sink as js/insecure-randomness (high). It is
+// right to complain and cheap to satisfy: jitter is computed only on failure
+// paths, so a CSPRNG costs nothing measurable, and using one removes the SOURCE
+// rather than suppressing the warning. Injectable, so tests stay deterministic.
+const cryptoRandom = () => randomInt(0, 2 ** 30) / 2 ** 30;
 
 /** HTTP statuses that mean "the provider is overloaded, try again later". */
 export const OVERLOADED_STATUSES = new Set([429, 529]);
@@ -54,7 +64,7 @@ export function isOverloadedError(err) {
  * Returns 50%-100% of the ceiling — jitter is what stops N restarted roles from
  * retrying in lockstep and re-creating the thundering herd that killed them.
  */
-export function backoffMs(i, { baseMs = 1000, capMs = 30000, random = Math.random } = {}) {
+export function backoffMs(i, { baseMs = 1000, capMs = 30000, random = cryptoRandom } = {}) {
   const ceil = Math.min(capMs, baseMs * 2 ** i);
   return Math.floor(ceil * (0.5 + 0.5 * random()));
 }
@@ -126,7 +136,7 @@ export function decideRestart({
   attempt = 0,
   restartsLastHour = 0,
   reentriesLastHour = 0,
-  random = Math.random,
+  random = cryptoRandom,
 } = {}) {
   if (stopRequested) {
     return { action: "stop", waitMs: 0, sameSession: false, reason: "stop requested — the role wrote its handoff and exited; it stays down until `start`" };

--- a/plugins/dev/scripts/lib/agent-liveness.mjs
+++ b/plugins/dev/scripts/lib/agent-liveness.mjs
@@ -1,0 +1,203 @@
+// agent-liveness.mjs — CTL-1994. The pure, node-builtins-only leaf that decides
+// whether an agent session is healthy, overloaded, silent or dead, and how long
+// to wait before trying again.
+//
+// WHY IT LIVES HERE, not in execution-core: two very different processes need
+// the same answers.
+//   1. `sdk-run-phase-agent.mjs` — the per-ticket phase WORKER, which has had
+//      429/529 backoff since CTL-1365b.
+//   2. `role-supervisor/` — the long-running ROLE processes (steward,
+//      concierge), which until now ran as `claude -p` with NO backoff at all.
+//      On 2026-08-18 a provider 529 killed seven role lanes at once, twice, and
+//      a human pasted the briefs back in 10-60 minutes later.
+// The policy that already worked for workers is the policy roles need. Putting
+// one copy here is the alternative to a second, drifting copy — and
+// execution-core's own `config.mjs` chain reaches `bun:sqlite`, so a role
+// runner cannot simply import from there. Everything in this file is pure and
+// imports nothing but `node:*` (nothing at all, in fact), so both callers can
+// load it under bare `node` with no node_modules.
+//
+// Every function is total and injectable: no clock, no randomness, and no env
+// is read unless it is passed in. That is what makes the restart policy
+// testable rather than something you find out about during an outage.
+
+/** HTTP statuses that mean "the provider is overloaded, try again later". */
+export const OVERLOADED_STATUSES = new Set([429, 529]);
+
+/** Pull a status code out of the several shapes the SDK and the API use. */
+export function statusOf(x) {
+  return x?.api_error_status ?? x?.status ?? x?.statusCode ?? x?.error?.status ?? null;
+}
+
+/** A terminal result that is a 429/529 overload, or an `overloaded_error` subtype. */
+export function isOverloadedResult(result) {
+  if (!result) return false;
+  if (OVERLOADED_STATUSES.has(Number(statusOf(result)))) return true;
+  const t = result.error?.type ?? result.error_type;
+  return t === "overloaded_error";
+}
+
+/** A thrown error that is a 429/529 overload. */
+export function isOverloadedError(err) {
+  if (!err) return false;
+  if (OVERLOADED_STATUSES.has(Number(statusOf(err)))) return true;
+  const t = err?.error?.type ?? err?.type;
+  if (t === "overloaded_error") return true;
+  // The SDK mislabels some overloads, so the message is the last resort. Word
+  // boundaries matter: without them "1529 turns" would read as a 529.
+  return /\b(429|529|overloaded)\b/i.test(String(err?.message ?? ""));
+}
+
+/**
+ * Exponential backoff (base·2^i), capped, with full jitter.
+ * `random` is injectable so a backoff test is deterministic.
+ * Returns 50%-100% of the ceiling — jitter is what stops N restarted roles from
+ * retrying in lockstep and re-creating the thundering herd that killed them.
+ */
+export function backoffMs(i, { baseMs = 1000, capMs = 30000, random = Math.random } = {}) {
+  const ceil = Math.min(capMs, baseMs * 2 ** i);
+  return Math.floor(ceil * (0.5 + 0.5 * random()));
+}
+
+/**
+ * Subscription auth only. An API key outranks the OAuth token in headless mode
+ * and silently METERS — so the correct behaviour is to refuse loudly rather
+ * than to run and bill. Returns {ok, reason}; never throws.
+ */
+export function assertSdkAuth({ env = process.env, oauthToken } = {}) {
+  if (env.ANTHROPIC_API_KEY) {
+    return { ok: false, reason: "ANTHROPIC_API_KEY is set — refusing to run a role on the SDK (it outranks the OAuth token and would silently meter; unset it and authenticate via CLAUDE_CODE_OAUTH_TOKEN)" };
+  }
+  if (env.ANTHROPIC_AUTH_TOKEN) {
+    return { ok: false, reason: "ANTHROPIC_AUTH_TOKEN is set — refusing to run a role on the SDK (it overrides the subscription OAuth token)" };
+  }
+  if (!oauthToken) {
+    return { ok: false, reason: "CLAUDE_CODE_OAUTH_TOKEN is missing — refusing to run a role on the SDK (run `claude setup-token`)" };
+  }
+  return { ok: true, reason: null };
+}
+
+// ── Liveness ────────────────────────────────────────────────────────────────
+// "Quiet" and "dead" are indistinguishable for a `claude -p` role: both look
+// like nothing happening. A heartbeat makes them two different numbers.
+
+export const LIVENESS = { LIVE: "live", SILENT: "silent", DEAD: "dead", MISSING: "missing" };
+
+export const SILENT_AFTER_MS = 10 * 60 * 1000;
+export const DEAD_AFTER_MS = 30 * 60 * 1000;
+
+/**
+ * Classify a heartbeat by age. `now` and the thresholds are injectable.
+ * A missing heartbeat is MISSING, never LIVE — the absence of a signal is not
+ * evidence of health, and defaulting it to healthy is how a dead role hides.
+ */
+export function classifyHeartbeat(hb, { now, silentAfterMs = SILENT_AFTER_MS, deadAfterMs = DEAD_AFTER_MS } = {}) {
+  if (typeof now !== "number") throw new TypeError("classifyHeartbeat: `now` (ms) is required — this function must not read the clock");
+  if (!hb || typeof hb.ts !== "number") return { state: LIVENESS.MISSING, ageMs: null };
+  const ageMs = now - hb.ts;
+  if (ageMs >= deadAfterMs) return { state: LIVENESS.DEAD, ageMs };
+  if (ageMs >= silentAfterMs) return { state: LIVENESS.SILENT, ageMs };
+  return { state: LIVENESS.LIVE, ageMs };
+}
+
+// ── Restart policy ──────────────────────────────────────────────────────────
+
+export const RESTART_CAP_PER_HOUR = 5;
+
+/** Backoff ladder for a provider overload: 60s → 2m → 5m → 15m, then capped. */
+export const OVERLOAD_LADDER_MS = [60_000, 120_000, 300_000, 900_000];
+
+/**
+ * Decide what to do when a role's session has ended.
+ *
+ * Returns { action, waitMs, sameSession, reason } where action is one of
+ * "resume" (same SDK session), "restart" (fresh session from the handoff),
+ * "stop" (do not restart; page a human/the concierge), or "idle-reenter"
+ * (the session ended cleanly but the scope is still active).
+ *
+ * Pure: pass `restartsLastHour` and `attempt` in; nothing is read from disk.
+ */
+export function decideRestart({
+  exitCode,
+  overloaded = false,
+  quotaExhausted = false,
+  stopRequested = false,
+  scopeActive = false,
+  attempt = 0,
+  restartsLastHour = 0,
+  reentriesLastHour = 0,
+  random = Math.random,
+} = {}) {
+  if (stopRequested) {
+    return { action: "stop", waitMs: 0, sameSession: false, reason: "stop requested — the role wrote its handoff and exited; it stays down until `start`" };
+  }
+
+  // A restart storm is worse than a down role: it burns the same quota that is
+  // usually the reason the role is failing in the first place.
+  if (restartsLastHour >= RESTART_CAP_PER_HOUR) {
+    return { action: "stop", waitMs: 0, sameSession: false, reason: `${restartsLastHour} restarts in the last hour (cap ${RESTART_CAP_PER_HOUR}) — stopping and paging rather than looping` };
+  }
+
+  if (quotaExhausted) {
+    return { action: "restart", waitMs: 15 * 60_000, sameSession: false, reason: "quota exhausted — waiting 15 min; the concierge posts one board line, and no relaunch storm" };
+  }
+
+  if (overloaded) {
+    const ladder = OVERLOAD_LADDER_MS;
+    const capMs = ladder[Math.min(attempt, ladder.length - 1)];
+    // Jitter here for the same reason as backoffMs: seven lanes died together,
+    // so seven lanes would otherwise retry together.
+    const waitMs = Math.floor(capMs * (0.5 + 0.5 * random()));
+    return { action: "resume", waitMs, sameSession: true, reason: `provider overload — backing off ${Math.round(waitMs / 1000)}s and resuming the SAME session (never re-paste the brief)` };
+  }
+
+  if (exitCode === 0) {
+    if (!scopeActive) {
+      return { action: "stop", waitMs: 0, sameSession: false, reason: "clean exit and the scope is quiet — nothing to re-enter" };
+    }
+    // Bounded: 3 re-entries per hour, then hand off and start fresh. An agent
+    // that keeps stopping while work is outstanding is usually stuck, not done.
+    if (reentriesLastHour >= 3) {
+      return { action: "restart", waitMs: 0, sameSession: false, reason: "3 idle re-entries in the last hour — handing off and starting a fresh session instead of re-entering again" };
+    }
+    return { action: "idle-reenter", waitMs: 0, sameSession: true, reason: "the session ended while the scope is still active — re-entering it to continue from its last artifact" };
+  }
+
+  return {
+    action: "restart",
+    waitMs: backoffMs(attempt, { baseMs: 5_000, capMs: 120_000, random }),
+    sameSession: false,
+    reason: `non-zero exit (${exitCode}) — restarting from the handoff with backoff`,
+  };
+}
+
+/**
+ * Is the scope active? Computable, so "active" is never a judgement call:
+ * a ticket in flight, an open ask this role raised, or a human comment newer
+ * than this role's last reply.
+ */
+export function isScopeActive({ inFlightTickets = 0, openAsksRaised = 0, humanCommentNewerThanLastReply = false } = {}) {
+  return inFlightTickets > 0 || openAsksRaised > 0 || humanCommentNewerThanLastReply === true;
+}
+
+/**
+ * Is a status doc stale for its scope? The cadence is COORD-178's, computed
+ * from the doc's own timestamp rather than trusted to the role's memory —
+ * a role that held this cadence as a brief instruction produced zero status
+ * docs in 90 minutes.
+ */
+export const STATUS_DOC_CADENCE_MS = 90 * 60 * 1000;
+export const STATUS_DOC_STALE_MS = 2 * 60 * 60 * 1000;
+export const STATUS_DOC_QUIET_CADENCE_MS = 24 * 60 * 60 * 1000;
+
+export function classifyStatusDoc({ updatedAtMs, now, scopeActive = true } = {}) {
+  if (typeof now !== "number") throw new TypeError("classifyStatusDoc: `now` (ms) is required — this function must not read the clock");
+  if (typeof updatedAtMs !== "number") return { state: "missing", ageMs: null, dueForUpdate: true };
+  const ageMs = now - updatedAtMs;
+  if (!scopeActive) {
+    return { state: ageMs >= STATUS_DOC_QUIET_CADENCE_MS ? "due" : "current", ageMs, dueForUpdate: ageMs >= STATUS_DOC_QUIET_CADENCE_MS };
+  }
+  if (ageMs >= STATUS_DOC_STALE_MS) return { state: "stale", ageMs, dueForUpdate: true };
+  if (ageMs >= STATUS_DOC_CADENCE_MS) return { state: "due", ageMs, dueForUpdate: true };
+  return { state: "current", ageMs, dueForUpdate: false };
+}

--- a/plugins/dev/scripts/lib/agent-liveness.test.mjs
+++ b/plugins/dev/scripts/lib/agent-liveness.test.mjs
@@ -1,0 +1,182 @@
+// agent-liveness.test.mjs — CTL-1994.
+// Run: node plugins/dev/scripts/lib/agent-liveness.test.mjs
+//
+// The whole point of this module is that the restart policy is knowable BEFORE
+// an outage rather than discovered during one, so every case below is a real
+// failure shape from 2026-08-18 or a boundary that would silently change
+// behaviour if it moved.
+import assert from "node:assert/strict";
+import {
+  OVERLOADED_STATUSES, statusOf, isOverloadedResult, isOverloadedError, backoffMs,
+  assertSdkAuth, classifyHeartbeat, LIVENESS, decideRestart, isScopeActive,
+  classifyStatusDoc, RESTART_CAP_PER_HOUR,
+} from "./agent-liveness.mjs";
+
+let passes = 0, failures = 0;
+function t(name, fn) {
+  try { fn(); console.log(`  PASS: ${name}`); passes++; }
+  catch (e) { console.log(`  FAIL: ${name} — ${e.message}`); failures++; }
+}
+const fixedRandom = () => 1; // full ceiling, so jitter never makes a test flaky
+
+console.log("1. overload classification");
+t("429 and 529 are the overload statuses", () => {
+  assert.deepEqual([...OVERLOADED_STATUSES].sort(), [429, 529]);
+});
+t("statusOf reads every shape the SDK/API uses", () => {
+  assert.equal(statusOf({ api_error_status: 529 }), 529);
+  assert.equal(statusOf({ status: 429 }), 429);
+  assert.equal(statusOf({ statusCode: 529 }), 529);
+  assert.equal(statusOf({ error: { status: 429 } }), 429);
+  assert.equal(statusOf({}), null);
+  assert.equal(statusOf(null), null);
+});
+t("a 529 result is overloaded; a 500 result is not", () => {
+  assert.equal(isOverloadedResult({ status: 529 }), true);
+  assert.equal(isOverloadedResult({ error: { type: "overloaded_error" } }), true);
+  assert.equal(isOverloadedResult({ status: 500 }), false);
+  assert.equal(isOverloadedResult(null), false);
+});
+t("a thrown 529 is overloaded, including via the message fallback", () => {
+  assert.equal(isOverloadedError({ status: 529 }), true);
+  assert.equal(isOverloadedError(new Error("Overloaded")), true);
+  assert.equal(isOverloadedError(new Error("API error 429")), true);
+  assert.equal(isOverloadedError(new Error("boom")), false);
+});
+t("the message fallback respects word boundaries", () => {
+  // Without \b, "1529 turns" would read as a 529 and back off for 15 minutes.
+  assert.equal(isOverloadedError(new Error("stopped after 1529 turns")), false);
+});
+
+console.log("2. backoff");
+t("backoff grows exponentially and then caps", () => {
+  const o = { baseMs: 1000, capMs: 30000, random: fixedRandom };
+  assert.equal(backoffMs(0, o), 1000);
+  assert.equal(backoffMs(1, o), 2000);
+  assert.equal(backoffMs(2, o), 4000);
+  assert.equal(backoffMs(20, o), 30000); // capped, not 1000·2^20
+});
+t("jitter is bounded to 50%-100% of the ceiling", () => {
+  const o = { baseMs: 1000, capMs: 30000 };
+  // ceiling at i=3 is baseMs·2^3 = 8000
+  assert.equal(backoffMs(3, { ...o, random: () => 0 }), 4000);
+  assert.equal(backoffMs(3, { ...o, random: () => 1 }), 8000);
+});
+
+console.log("3. auth — refuse loudly rather than meter silently");
+t("an API key refuses, because it outranks the OAuth token and bills", () => {
+  const r = assertSdkAuth({ env: { ANTHROPIC_API_KEY: "sk-x" }, oauthToken: "oat" });
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /meter/);
+});
+t("an auth token refuses", () => {
+  assert.equal(assertSdkAuth({ env: { ANTHROPIC_AUTH_TOKEN: "t" }, oauthToken: "oat" }).ok, false);
+});
+t("a missing OAuth token refuses", () => {
+  assert.equal(assertSdkAuth({ env: {}, oauthToken: null }).ok, false);
+});
+t("a clean subscription env passes", () => {
+  assert.deepEqual(assertSdkAuth({ env: {}, oauthToken: "oat" }), { ok: true, reason: null });
+});
+
+console.log("4. heartbeat — 'quiet' and 'dead' must be different states");
+const now = 1_700_000_000_000;
+t("a fresh heartbeat is live", () => {
+  assert.equal(classifyHeartbeat({ ts: now - 60_000 }, { now }).state, LIVENESS.LIVE);
+});
+t("10 min is silent, 30 min is dead — boundaries inclusive", () => {
+  assert.equal(classifyHeartbeat({ ts: now - 10 * 60_000 }, { now }).state, LIVENESS.SILENT);
+  assert.equal(classifyHeartbeat({ ts: now - 30 * 60_000 }, { now }).state, LIVENESS.DEAD);
+  assert.equal(classifyHeartbeat({ ts: now - (10 * 60_000 - 1) }, { now }).state, LIVENESS.LIVE);
+});
+t("a MISSING heartbeat is never LIVE", () => {
+  // Defaulting absence to healthy is exactly how a dead role hides.
+  assert.equal(classifyHeartbeat(null, { now }).state, LIVENESS.MISSING);
+  assert.equal(classifyHeartbeat({}, { now }).state, LIVENESS.MISSING);
+});
+t("classify refuses to read the clock itself", () => {
+  assert.throws(() => classifyHeartbeat({ ts: now }), /`now`/);
+});
+
+console.log("5. restart policy — the 2026-08-18 failure shapes");
+t("a provider 529 resumes the SAME session and never re-pastes the brief", () => {
+  const d = decideRestart({ exitCode: 1, overloaded: true, attempt: 0, random: fixedRandom });
+  assert.equal(d.action, "resume");
+  assert.equal(d.sameSession, true);
+  assert.equal(d.waitMs, 60_000);
+});
+t("the overload ladder is 60s → 2m → 5m → 15m and then holds", () => {
+  const w = (a) => decideRestart({ exitCode: 1, overloaded: true, attempt: a, random: fixedRandom }).waitMs;
+  assert.deepEqual([w(0), w(1), w(2), w(3), w(9)], [60_000, 120_000, 300_000, 900_000, 900_000]);
+});
+t("a crash restarts from the handoff with a FRESH session", () => {
+  const d = decideRestart({ exitCode: 9, attempt: 0, random: fixedRandom });
+  assert.equal(d.action, "restart");
+  assert.equal(d.sameSession, false);
+});
+t("a clean exit while the scope is active is re-entered, not left down", () => {
+  // This is print mode's failure: the run ends the moment the agent waits.
+  const d = decideRestart({ exitCode: 0, scopeActive: true });
+  assert.equal(d.action, "idle-reenter");
+});
+t("a clean exit with a quiet scope stays down", () => {
+  assert.equal(decideRestart({ exitCode: 0, scopeActive: false }).action, "stop");
+});
+t("idle re-entry is bounded — the 4th in an hour hands off instead", () => {
+  const d = decideRestart({ exitCode: 0, scopeActive: true, reentriesLastHour: 3 });
+  assert.equal(d.action, "restart");
+  assert.match(d.reason, /handing off/);
+});
+t("a restart storm stops and pages instead of looping", () => {
+  const d = decideRestart({ exitCode: 1, restartsLastHour: RESTART_CAP_PER_HOUR });
+  assert.equal(d.action, "stop");
+  assert.match(d.reason, /cap/);
+});
+t("quota exhaustion waits 15 min — no relaunch storm", () => {
+  const d = decideRestart({ exitCode: 1, quotaExhausted: true });
+  assert.equal(d.action, "restart");
+  assert.equal(d.waitMs, 15 * 60_000);
+});
+t("an explicit stop outranks everything, including an active scope", () => {
+  const d = decideRestart({ exitCode: 0, stopRequested: true, scopeActive: true, overloaded: true });
+  assert.equal(d.action, "stop");
+});
+t("the restart cap outranks an overload — a storm is worse than a down role", () => {
+  const d = decideRestart({ exitCode: 1, overloaded: true, restartsLastHour: 99 });
+  assert.equal(d.action, "stop");
+});
+t("overload backoff is jittered, so N lanes that died together do not retry together", () => {
+  const lo = decideRestart({ exitCode: 1, overloaded: true, attempt: 0, random: () => 0 }).waitMs;
+  const hi = decideRestart({ exitCode: 1, overloaded: true, attempt: 0, random: () => 1 }).waitMs;
+  assert.equal(lo, 30_000);
+  assert.equal(hi, 60_000);
+  assert.notEqual(lo, hi);
+});
+
+console.log("6. 'active' is computable, not a judgement call");
+t("any one of the three signals makes a scope active", () => {
+  assert.equal(isScopeActive({ inFlightTickets: 1 }), true);
+  assert.equal(isScopeActive({ openAsksRaised: 1 }), true);
+  assert.equal(isScopeActive({ humanCommentNewerThanLastReply: true }), true);
+  assert.equal(isScopeActive({}), false);
+});
+
+console.log("7. status-doc cadence is computed from the doc, not remembered");
+t("90 min due, 2 h stale, under 90 min current", () => {
+  const c = (mins) => classifyStatusDoc({ updatedAtMs: now - mins * 60_000, now }).state;
+  assert.equal(c(10), "current");
+  assert.equal(c(90), "due");
+  assert.equal(c(120), "stale");
+});
+t("a missing status doc is 'missing' and always due", () => {
+  const r = classifyStatusDoc({ now });
+  assert.equal(r.state, "missing");
+  assert.equal(r.dueForUpdate, true);
+});
+t("a quiet scope relaxes to 24 h", () => {
+  assert.equal(classifyStatusDoc({ updatedAtMs: now - 3 * 60 * 60_000, now, scopeActive: false }).state, "current");
+  assert.equal(classifyStatusDoc({ updatedAtMs: now - 25 * 60 * 60_000, now, scopeActive: false }).state, "due");
+});
+
+console.log(`\nagent-liveness.test.mjs: ${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/scripts/role-supervisor/README.md
+++ b/plugins/dev/scripts/role-supervisor/README.md
@@ -1,0 +1,110 @@
+# role-supervisor (CTL-1994)
+
+Keeps a long-running coordination **role** — a steward or the concierge — alive on the
+[Claude Agent SDK], replacing the `claude -p` brief it used to be launched with.
+
+It is not an orchestrator. It never talks in Linear, never touches a ticket, and has no opinion about
+the work. It starts a role, keeps it alive, and pages when it cannot.
+
+## Why it exists
+
+Measured on 2026-08-18, the day this was written:
+
+| what happened | how it was handled that day |
+| -- | -- |
+| a provider **529 killed seven agent lanes at once** — and again 6–7 an hour later | a human noticed and pasted the briefs back in, 10–60 min later |
+| print mode ends the run the moment the agent waits | the role's watcher had to live *outside* the agent, and its findings never re-entered it |
+| no heartbeat | "quiet" and "dead" were indistinguishable |
+| the brief was a file that got edited per relaunch | `launch-backend13.txt` — thirteen versions of one role's brief in one day |
+
+⭐ **The phase workers already had 429/529 backoff** (`execution-core/sdk-run-phase-agent.mjs`, CTL-1365b).
+The long-running roles had none. This package is that policy applied to the process shape that needed it.
+
+⛔ **Nothing that had been WRITTEN was lost in either outage. Everything that had only been INTENDED was.**
+That is why the resume path reads artifacts — handoff, status doc, the role's own thread, the replica —
+and never a re-pasted brief.
+
+## Layout
+
+| file | what it is |
+| -- | -- |
+| `../lib/agent-liveness.mjs` | **the decision logic** — overload classification, backoff, auth, heartbeat states, the restart ladder, the status-doc cadence. Pure, node-builtins only, injectable clock and randomness |
+| `paths.mjs` | where a role's state lives (honours `CATALYST_DIR`) |
+| `state.mjs` | atomic reads/writes: manifest, heartbeat, lease, session, counters |
+| `supervisor.mjs` | the loop — one role, until it is told to stop |
+| `sdk-session.mjs` | the only file that talks to the SDK; kept thin |
+| `doctor.mjs` | one row per role, and a red row names the artifact that is missing |
+| `cli.mjs` | `run` · `doctor` · `stop` · `list` |
+| `install.sh` + `com.catalyst.role.plist` | one launchd label per role |
+
+`agent-liveness.mjs` lives in `lib/` rather than in this package because two very different processes
+need the same answers, and execution-core's `config.mjs` chain reaches `bun:sqlite` — so a role runner
+cannot simply import from there. One copy, imported by both, is the alternative to a second one that drifts.
+
+## The restart ladder
+
+| situation | action | wait |
+| -- | -- | -- |
+| provider 429/529 | **resume the SAME session** — never re-paste the brief | 60 s → 2 m → 5 m → 15 m, jittered |
+| quota exhausted | restart | 15 min, and one board line; no relaunch storm |
+| non-zero exit / crash | restart from the handoff, fresh session | exponential, capped at 2 min |
+| clean exit, scope **active** | **re-enter** the session ("you stopped while your scope is active") | none; bounded to 3/hour |
+| clean exit, scope quiet | stop | — |
+| > 5 restarts in an hour | **stop and page** | — |
+| explicit `stop` | write the handoff, exit, stay down until `run` | — |
+
+Jitter is not decoration: seven lanes died together, so without it seven lanes retry together.
+
+**"Active" is computable**, never a judgement call — a ticket in flight, an open ask this role raised, or
+a human comment newer than the role's last reply.
+
+## Liveness
+
+`heartbeat.json` is written on every session boundary and carries `{role, scope, ts, state, session,
+last_turn_ts, last_artifact, host, pid}`.
+
+- **≥ 10 min old → silent · ≥ 30 min old → dead.**
+- ⛔ **A missing heartbeat is `MISSING`, never `LIVE`.** Defaulting absence to healthy is how a dead role hides.
+- `last_artifact` is why the heartbeat is more than a liveness ping: a heartbeat that only proves the
+  process exists cannot tell a working role from a wedged one.
+
+## The lease
+
+One live process per role. A second `run` refuses while a live pid holds the lease — two stewards on one
+scope means double dispatch. A **stale** lease (the holder's pid is gone) is takeable, or a `kill -9`
+would lock the role out permanently, which is the opposite of the goal.
+
+## Usage
+
+```bash
+bash install.sh --role steward-p13 --scope "P13 · Coordination SOP" \
+                --skill catalyst-dev:steward --brief ~/catalyst/comms/coord/launch-p13-1.txt
+
+node cli.mjs doctor          # one row per role; exit 1 if any row is red
+node cli.mjs stop steward-p13
+```
+
+`doctor` prints `no roles configured (this is not the same as 'all roles healthy')` when there are none —
+a green line there would be a false clean result.
+
+## Tests
+
+```bash
+node ../lib/agent-liveness.test.mjs      # the policy: 30 cases
+node supervisor.test.mjs                  # the loop, driven by a fake session runner: 13 cases
+```
+
+No network, no SDK, no real `~/catalyst`: every test runs against a scratch `CATALYST_DIR`. The outage
+behaviour is testable **before** an outage — which on 2026-08-18 it was not.
+
+## Known follow-ups
+
+- ⚠️ `execution-core/sdk-run-phase-agent.mjs` still carries its **own** copies of `backoffMs`,
+  `isOverloadedResult/Error` and `assertSdkAuth`. They are now duplicated by `lib/agent-liveness.mjs`.
+  Converging them is a one-import change, deliberately **not** done on rehearsal day because that file is
+  the live dispatch path. Filed as a follow-up; until it lands, this is two copies of one rule and it is
+  named here rather than left to be discovered.
+- The status-doc staleness re-entry (`buildStatusDocPrompt`) is wired into the policy but not yet into a
+  timer inside the loop; today it fires on session boundaries, not mid-session.
+
+[Claude Agent SDK]: https://docs.claude.com/en/api/agent-sdk/overview

--- a/plugins/dev/scripts/role-supervisor/cli.mjs
+++ b/plugins/dev/scripts/role-supervisor/cli.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// cli.mjs — CTL-1994. `role-supervisor <verb>`.
+//
+//   run <role>       supervise a role in the foreground (launchd runs this)
+//   doctor [--json]  one row per role: liveness, status-doc age, restarts
+//   stop <role>      ask a role to write its handoff and exit; it stays down
+//   list             the configured roles
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { superviseRole } from "./supervisor.mjs";
+import { runSdkSession } from "./sdk-session.mjs";
+import { report, formatReport, listRoles } from "./doctor.mjs";
+import { roleFiles } from "./paths.mjs";
+
+const [verb, arg] = process.argv.slice(2);
+
+async function main() {
+  switch (verb) {
+    case "run": {
+      if (!arg) die("usage: role-supervisor run <role>");
+      const r = await superviseRole(arg, { runSession: runSdkSession });
+      console.log(`role-supervisor: ${arg} stopped — ${r.stopped}`);
+      return 0;
+    }
+    case "doctor": {
+      const rep = report();
+      console.log(process.argv.includes("--json") ? JSON.stringify(rep, null, 2) : formatReport(rep));
+      return rep.roles.some((x) => x.red) ? 1 : 0;
+    }
+    case "stop": {
+      if (!arg) die("usage: role-supervisor stop <role>");
+      const f = roleFiles(arg);
+      if (!existsSync(f.dir)) die(`no such role '${arg}'`);
+      mkdirSync(f.dir, { recursive: true });
+      writeFileSync(`${f.dir}/stop`, `${new Date().toISOString()}\n`);
+      console.log(`role-supervisor: stop requested for ${arg} — it writes its handoff, exits, and stays down until \`run\``);
+      return 0;
+    }
+    case "list": {
+      const roles = listRoles();
+      // "no roles" is not "all healthy" — say which it is.
+      console.log(roles.length ? roles.join("\n") : "(no roles configured)");
+      return 0;
+    }
+    default:
+      die("usage: role-supervisor run <role> | doctor [--json] | stop <role> | list");
+  }
+}
+
+function die(msg) {
+  console.error(`role-supervisor: ${msg}`);
+  process.exit(2);
+}
+
+main().then((code) => process.exit(code)).catch((err) => {
+  console.error(`role-supervisor: ${err.message}`);
+  process.exit(1);
+});

--- a/plugins/dev/scripts/role-supervisor/com.catalyst.role.plist
+++ b/plugins/dev/scripts/role-supervisor/com.catalyst.role.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent TEMPLATE for one supervised coordination role — CTL-1994.
+
+  One label per role: com.catalyst.role.<role>. install.sh substitutes every
+  REPLACE_WITH_* token and copies it into ~/Library/LaunchAgents/.
+
+  Do not edit the installed copy: re-running install.sh overwrites it.
+
+    bash install.sh --role steward-p13 --scope "P13 · Coordination SOP"
+    bash install.sh --role steward-p13 --uninstall
+
+  KeepAlive is the point of this file. The supervisor restarts a role's SDK
+  SESSION; launchd restarts the SUPERVISOR. On 2026-08-18 a provider 529 killed
+  seven agent lanes at once and a human had to notice — launchd is the one part
+  of this stack a 529 cannot kill, so it is what the human is replaced by.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>REPLACE_WITH_LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_NODE</string>
+    <string>REPLACE_WITH_CLI</string>
+    <string>run</string>
+    <string>REPLACE_WITH_ROLE</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- Restart the supervisor itself if it ever exits, for any reason. The
+       supervisor's own `stop` verb is honoured INSIDE the process (it writes a
+       handoff and returns), so a deliberate stop still ends with launchd
+       relaunching a process that immediately sees the stop marker and idles —
+       which is what makes `stop` reversible with `run` and nothing else. -->
+  <key>KeepAlive</key>
+  <true/>
+
+  <!-- Do not let a crash-looping role spin the box. -->
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <!-- launchd's default PATH omits /opt/homebrew/bin — without it the role
+       cannot resolve node, git, gh or linearis, and every turn fails in a way
+       that looks like an agent problem rather than a PATH problem. -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>REPLACE_WITH_PATH</string>
+    <!-- launchd does NOT inherit the installing shell's environment. A node
+         using a non-default CATALYST_DIR must have it persisted here, or the
+         supervisor watches $HOME/catalyst — the wrong heartbeat, lease and
+         manifest dir. -->
+    <key>CATALYST_DIR</key>
+    <string>REPLACE_WITH_CATALYST_DIR</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CWD</string>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_LOG</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_LOG</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/role-supervisor/doctor.mjs
+++ b/plugins/dev/scripts/role-supervisor/doctor.mjs
@@ -1,0 +1,90 @@
+// doctor.mjs — CTL-1994. The operator's audit surface for supervised roles.
+//
+// Ryan's rule: "quiet" and "dead" must be a number, not a feeling. This turns
+// each role's on-disk state into one row, and a red row NAMES the artifact the
+// role should have written — because "role X is unhealthy" is not actionable
+// and "role X has not updated its status doc in 3 h" is.
+import { readdirSync, existsSync } from "node:fs";
+import { classifyHeartbeat, classifyStatusDoc, LIVENESS } from "../lib/agent-liveness.mjs";
+import { rolesRoot } from "./paths.mjs";
+import { readHeartbeat, readManifest, readLease, readCounters, countLastHour } from "./state.mjs";
+
+export function listRoles(env = process.env) {
+  const root = rolesRoot(env);
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * One row per role. Pure with respect to time: `now` is injectable.
+ * `statusDocUpdatedAt` comes from the manifest's last recorded status-doc
+ * timestamp — the doc's OWN stamp, not when we last thought about it.
+ */
+export function roleRow(role, { now = Date.now() } = {}, env = process.env) {
+  const manifest = readManifest(role, env);
+  const hb = readHeartbeat(role, env);
+  const lease = readLease(role, env);
+  const counters = readCounters(role, env);
+
+  const live = classifyHeartbeat(hb, { now });
+  const scopeActive = manifest?.scope_active ?? true;
+  const doc = classifyStatusDoc({ updatedAtMs: manifest?.status_doc_updated_at ?? undefined, now, scopeActive });
+
+  const problems = [];
+  if (live.state === LIVENESS.DEAD) problems.push(`heartbeat ${Math.round(live.ageMs / 60000)} min old — the role is dead, not quiet`);
+  if (live.state === LIVENESS.MISSING) problems.push("no heartbeat has ever been written — the role never booted, or it cannot write its state dir");
+  if (doc.state === "stale") problems.push(`status doc ${Math.round(doc.ageMs / 60000)} min old while the scope is active — it should be written every 90 min`);
+  if (doc.state === "missing" && scopeActive) problems.push("no status doc — a scope with work in flight and no status doc reads as unowned");
+  if (lease && hb && lease.pid !== hb.pid) problems.push(`lease pid ${lease.pid} does not match the heartbeat pid ${hb.pid} — two processes may hold this role`);
+
+  return {
+    role,
+    scope: manifest?.scope ?? null,
+    pid: hb?.pid ?? null,
+    session: hb?.session ?? null,
+    liveness: live.state,
+    heartbeat_age_min: live.ageMs == null ? null : Math.round(live.ageMs / 60000),
+    status_doc: doc.state,
+    status_doc_age_min: doc.ageMs == null ? null : Math.round(doc.ageMs / 60000),
+    restarts_24h: (counters.restarts ?? []).filter((t) => t >= now - 24 * 3600_000).length,
+    restarts_1h: countLastHour(counters, "restart", { now }),
+    lease_holder: lease?.pid ?? null,
+    last_artifact: hb?.last_artifact ?? null,
+    red: problems.length > 0,
+    problems,
+  };
+}
+
+export function report({ now = Date.now() } = {}, env = process.env) {
+  const roles = listRoles(env);
+  return { roles: roles.map((r) => roleRow(r, { now }, env)), checked_at: now };
+}
+
+export function formatReport(rep) {
+  if (rep.roles.length === 0) {
+    // Not "all clear". No roles configured is a different state from all roles
+    // healthy, and printing a green line here would be a false clean result.
+    return "role-supervisor: no roles configured (this is not the same as 'all roles healthy')";
+  }
+  const lines = [`role-supervisor: ${rep.roles.length} role(s)`];
+  for (const r of rep.roles) {
+    const mark = r.red ? "FAIL" : "pass";
+    lines.push(
+      `  ${mark}  ${r.role}${r.scope ? `/${r.scope}` : ""}  pid=${r.pid ?? "-"}  liveness=${r.liveness}` +
+      `  hb=${r.heartbeat_age_min ?? "-"}m  doc=${r.status_doc}(${r.status_doc_age_min ?? "-"}m)  restarts24h=${r.restarts_24h}`,
+    );
+    for (const p of r.problems) lines.push(`         ⛔ ${p}`);
+  }
+  return lines.join("\n");
+}
+
+// CLI: `node doctor.mjs [--json]`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const rep = report();
+  if (process.argv.includes("--json")) console.log(JSON.stringify(rep, null, 2));
+  else console.log(formatReport(rep));
+  process.exit(rep.roles.some((r) => r.red) ? 1 : 0);
+}

--- a/plugins/dev/scripts/role-supervisor/install.sh
+++ b/plugins/dev/scripts/role-supervisor/install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# install.sh — CTL-1994. Idempotently install the launchd LaunchAgent for ONE
+# supervised coordination role.
+#
+# Re-running is safe: an already-loaded label is booted out before being
+# re-bootstrapped, so the latest plist always wins.
+#
+#   bash install.sh --role steward-p13 --scope "P13 · Coordination SOP" \
+#                   --skill catalyst-dev:steward --cwd ~/code-repos/github/coalesce-labs/catalyst
+#   bash install.sh --role steward-p13 --uninstall
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ROLE="" SCOPE="" SKILL="catalyst-dev:steward" CWD="" BRIEF="" UNINSTALL=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --role) ROLE="${2:?--role needs a name}"; shift ;;
+  --scope) SCOPE="${2:?--scope needs a value}"; shift ;;
+  --skill) SKILL="${2:?--skill needs a value}"; shift ;;
+  --cwd) CWD="${2:?--cwd needs a dir}"; shift ;;
+  --brief) BRIEF="${2:?--brief needs a file}"; shift ;;
+  --uninstall) UNINSTALL=1 ;;
+  -h | --help) sed -n '2,14p' "$0"; exit 0 ;;
+  *) echo "role-supervisor/install.sh: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+[[ -n "$ROLE" ]] || { echo "role-supervisor/install.sh: --role is required" >&2; exit 2; }
+
+# CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain — a scratch HOME does
+# NOT sandbox it. Refuse rather than re-bind a real label to a temporary path.
+[[ -f "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh" ]] || {
+  echo "role-supervisor/install.sh: missing ../lib/launchd-domain-guard.sh" >&2; exit 1; }
+# shellcheck source=../lib/launchd-domain-guard.sh
+. "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh"
+if ! launchd_guard_ok "the role-supervisor LaunchAgent"; then
+  launchd_guard_message "the role-supervisor LaunchAgent" >&2
+  echo "role-supervisor/install.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
+  exit 1
+fi
+
+LABEL="com.catalyst.role.${ROLE}"
+DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+if [[ $UNINSTALL -eq 1 ]]; then
+  launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+  rm -f "$DEST"
+  echo "role-supervisor: uninstalled ${LABEL}"
+  exit 0
+fi
+
+CATALYST_DIR_VAL="${CATALYST_DIR:-${HOME}/catalyst}"
+ROLE_DIR="${CATALYST_DIR_VAL}/roles/${ROLE}"
+NODE_BIN="$(command -v node || true)"
+[[ -n "$NODE_BIN" ]] || { echo "role-supervisor/install.sh: node not found on PATH" >&2; exit 1; }
+CWD="${CWD:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
+LOG="${ROLE_DIR}/supervisor.log"
+
+mkdir -p "$ROLE_DIR"
+
+# The manifest is what the role IS. Written here so that installing a role and
+# describing a role are one step — a plist pointing at a role with no manifest
+# would KeepAlive-loop on a startup error.
+if [[ ! -f "${ROLE_DIR}/manifest.json" ]]; then
+  cat > "${ROLE_DIR}/manifest.json" <<JSON
+{
+  "role": "${ROLE}",
+  "scope": "${SCOPE}",
+  "skill": "${SKILL}",
+  "cwd": "${CWD}",
+  "brief_path": "${BRIEF}",
+  "handoff_path": null,
+  "status_doc_updated_at": null,
+  "scope_active": true,
+  "activity": {}
+}
+JSON
+  echo "role-supervisor: wrote ${ROLE_DIR}/manifest.json"
+else
+  echo "role-supervisor: kept existing ${ROLE_DIR}/manifest.json"
+fi
+
+PATH_VAL="${HOME}/.catalyst/bin:${HOME}/.local/node/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+TMP="$(mktemp)"
+sed \
+  -e "s|REPLACE_WITH_LABEL|${LABEL}|g" \
+  -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
+  -e "s|REPLACE_WITH_CLI|${SCRIPT_DIR}/cli.mjs|g" \
+  -e "s|REPLACE_WITH_ROLE|${ROLE}|g" \
+  -e "s|REPLACE_WITH_PATH|${PATH_VAL}|g" \
+  -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VAL}|g" \
+  -e "s|REPLACE_WITH_CWD|${CWD}|g" \
+  -e "s|REPLACE_WITH_LOG|${LOG}|g" \
+  "${SCRIPT_DIR}/com.catalyst.role.plist" > "$TMP"
+
+mkdir -p "${HOME}/Library/LaunchAgents"
+mv "$TMP" "$DEST"
+
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$DEST"
+
+echo "role-supervisor: installed ${LABEL}"
+echo "  plist:    ${DEST}"
+echo "  manifest: ${ROLE_DIR}/manifest.json"
+echo "  log:      ${LOG}"
+echo "  verify:   launchctl print gui/$(id -u)/${LABEL} | grep -E 'state|path'"
+echo "            node ${SCRIPT_DIR}/cli.mjs doctor"

--- a/plugins/dev/scripts/role-supervisor/paths.mjs
+++ b/plugins/dev/scripts/role-supervisor/paths.mjs
@@ -1,0 +1,34 @@
+// paths.mjs — CTL-1994. Where a supervised role's state lives on disk.
+//
+// Everything a role needs to be restarted is either in Linear, on the channel,
+// or in one of these files. Nothing important lives in the process — that is
+// the whole design constraint, and it is why a 529 that killed seven lanes on
+// 2026-08-18 lost nothing that had been written.
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** CATALYST_DIR must be honoured: launchd does not inherit the installing shell's env. */
+export function catalystDir(env = process.env) {
+  return env.CATALYST_DIR || join(homedir(), "catalyst");
+}
+
+export function rolesRoot(env = process.env) {
+  return join(catalystDir(env), "roles");
+}
+
+export function roleDir(role, env = process.env) {
+  return join(rolesRoot(env), role);
+}
+
+export const roleFiles = (role, env = process.env) => {
+  const d = roleDir(role, env);
+  return {
+    dir: d,
+    manifest: join(d, "manifest.json"),   // what this role IS (role, scope, skill, brief)
+    heartbeat: join(d, "heartbeat.json"), // liveness only — never the record
+    lease: join(d, "lease.json"),         // ONE live process per role/scope
+    session: join(d, "session.json"),     // the SDK session id, for a warm resume
+    counters: join(d, "counters.json"),   // restarts/re-entries, for the storm caps
+    log: join(d, "supervisor.log"),
+  };
+};

--- a/plugins/dev/scripts/role-supervisor/sdk-session.mjs
+++ b/plugins/dev/scripts/role-supervisor/sdk-session.mjs
@@ -1,0 +1,91 @@
+// sdk-session.mjs — CTL-1994. The one place that actually talks to the Claude
+// Agent SDK. Everything else in this package is pure and testable; this file is
+// the seam where that stops being true, so it is kept as thin as possible.
+//
+// It is deliberately NOT an import of execution-core's `sdk-run-phase-agent.mjs`:
+// that module is worker-shaped (it needs an orchDir, a ticket, a phase and a
+// signal file) and its import chain reaches `bun:sqlite` via config.mjs, so a
+// role runner cannot load it under bare node. The DECISION logic both share
+// lives in ../lib/agent-liveness.mjs — one copy, imported by both.
+import { isOverloadedResult, isOverloadedError } from "../lib/agent-liveness.mjs";
+
+/** Quota exhaustion is not an overload: it needs a long wait and a board line, not a retry ladder. */
+function isQuotaExhausted(x) {
+  const t = x?.error?.type ?? x?.type ?? "";
+  if (t === "rate_limit_error" || t === "quota_exceeded") return true;
+  return /quota|usage limit|insufficient credit/i.test(String(x?.message ?? x?.error?.message ?? ""));
+}
+
+/**
+ * Build the options handed to query(). Subscription auth ONLY: the env always
+ * deletes ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN, which outrank the OAuth
+ * token in headless mode and silently meter.
+ */
+export function buildQueryOptions({ cwd, env, resumeSessionId, maxTurns = null }) {
+  const clean = { ...env };
+  delete clean.ANTHROPIC_API_KEY;
+  delete clean.ANTHROPIC_AUTH_TOKEN;
+
+  const options = {
+    cwd,
+    env: clean,
+    // Unattended: skills self-gate via their frontmatter. A role that stops to
+    // ask for a permission is a role that is down.
+    permissionMode: "bypassPermissions",
+  };
+  if (maxTurns != null) options.maxTurns = maxTurns;
+  if (resumeSessionId) options.resume = resumeSessionId;
+  return options;
+}
+
+/**
+ * Run one session to completion. Returns the shape `superviseRole` expects:
+ * {exitCode, sessionId, overloaded, quotaExhausted, lastArtifact}.
+ *
+ * `query` is injectable so this file can be exercised without the SDK; the
+ * default resolves `@anthropic-ai/claude-agent-sdk` lazily, so importing this
+ * module never requires node_modules to be present.
+ */
+export async function runSdkSession({ prompt, cwd, env, resumeSessionId, maxTurns = null, query = null, log = console.log }) {
+  let q = query;
+  if (!q) {
+    // Assembled rather than written as a literal, matching execution-core's
+    // convention so a bundler does not try to resolve it at build time.
+    const pkg = ["@anthropic-ai", "claude-agent-sdk"].join("/");
+    ({ query: q } = await import(pkg));
+  }
+
+  const options = buildQueryOptions({ cwd, env, resumeSessionId, maxTurns });
+  let sessionId = resumeSessionId ?? null;
+  let lastArtifact = null;
+  let result = null;
+
+  try {
+    for await (const message of q({ prompt, options })) {
+      if (typeof message?.session_id === "string" && message.session_id && message.session_id !== sessionId) {
+        sessionId = message.session_id;
+        log(`role-supervisor: session ${sessionId}`);
+      }
+      // The last tool that wrote something is the "last artifact" the heartbeat
+      // reports. A heartbeat that only proves the process exists cannot tell a
+      // working role from a wedged one.
+      const toolName = message?.tool_use?.name ?? message?.name;
+      if (toolName && /write|edit|reply|create|update/i.test(String(toolName))) lastArtifact = String(toolName);
+      if (message?.type === "result") result = message;
+    }
+  } catch (err) {
+    if (isOverloadedError(err)) return { exitCode: 1, sessionId, overloaded: true, lastArtifact };
+    if (isQuotaExhausted(err)) return { exitCode: 1, sessionId, quotaExhausted: true, lastArtifact };
+    throw err;
+  }
+
+  if (isOverloadedResult(result)) return { exitCode: 1, sessionId, overloaded: true, lastArtifact };
+  if (isQuotaExhausted(result)) return { exitCode: 1, sessionId, quotaExhausted: true, lastArtifact };
+
+  // `error_max_turns` is a cap, not a failure: hand off and start fresh rather
+  // than resuming a session that has already run out of room.
+  if (result?.subtype === "error_max_turns") return { exitCode: 0, sessionId, lastArtifact, turnCapExhausted: true };
+
+  const isError = result?.is_error === true || (result?.subtype && result.subtype !== "success");
+  return { exitCode: isError ? 1 : 0, sessionId, lastArtifact };
+}

--- a/plugins/dev/scripts/role-supervisor/state.mjs
+++ b/plugins/dev/scripts/role-supervisor/state.mjs
@@ -1,0 +1,121 @@
+// state.mjs — CTL-1994. Reading and writing a role's on-disk state.
+//
+// Every write is atomic (tmp + rename), because the reader is a doctor line and
+// a half-written heartbeat that parses as garbage reads as "no heartbeat",
+// which reads as "dead". A liveness signal must not be able to lie about
+// liveness through its own write.
+import { mkdirSync, readFileSync, writeFileSync, renameSync, existsSync, rmSync } from "node:fs";
+import { hostname } from "node:os";
+import { roleFiles } from "./paths.mjs";
+
+function readJson(path, fallback = null) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    // A missing OR malformed file is `fallback`. Callers must treat a null
+    // heartbeat as MISSING, never as healthy (see agent-liveness.classifyHeartbeat).
+    return fallback;
+  }
+}
+
+function writeJsonAtomic(path, obj) {
+  mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  const tmp = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+export function readManifest(role, env = process.env) {
+  return readJson(roleFiles(role, env).manifest);
+}
+
+export function writeManifest(role, manifest, env = process.env) {
+  writeJsonAtomic(roleFiles(role, env).manifest, manifest);
+}
+
+export function readHeartbeat(role, env = process.env) {
+  return readJson(roleFiles(role, env).heartbeat);
+}
+
+/**
+ * Beat. `now` is injectable so tests never race the clock.
+ * `lastArtifact` is the point: a heartbeat that only says "the process exists"
+ * cannot distinguish a working role from a wedged one. Recording what it last
+ * WROTE makes "quiet" checkable against "produced nothing".
+ */
+export function beat(role, { now = Date.now(), sessionId = null, lastTurnTs = null, lastArtifact = null, scope = null, state = "running" } = {}, env = process.env) {
+  const hb = { role, scope, ts: now, state, session: sessionId, last_turn_ts: lastTurnTs, last_artifact: lastArtifact, host: hostname(), pid: process.pid };
+  writeJsonAtomic(roleFiles(role, env).heartbeat, hb);
+  return hb;
+}
+
+export function readCounters(role, env = process.env) {
+  return readJson(roleFiles(role, env).counters, { restarts: [], reentries: [] });
+}
+
+export function recordEvent(role, kind, { now = Date.now() } = {}, env = process.env) {
+  const c = readCounters(role, env);
+  const key = kind === "reentry" ? "reentries" : "restarts";
+  c[key] = [...(c[key] ?? []), now];
+  writeJsonAtomic(roleFiles(role, env).counters, c);
+  return c;
+}
+
+/** How many of `kind` happened in the last hour — the input to the storm caps. */
+export function countLastHour(counters, kind, { now = Date.now() } = {}) {
+  const key = kind === "reentry" ? "reentries" : "restarts";
+  const cutoff = now - 60 * 60 * 1000;
+  return (counters?.[key] ?? []).filter((t) => t >= cutoff).length;
+}
+
+export function readSession(role, env = process.env) {
+  return readJson(roleFiles(role, env).session)?.session_id ?? null;
+}
+
+export function writeSession(role, sessionId, env = process.env) {
+  writeJsonAtomic(roleFiles(role, env).session, { session_id: sessionId, ts: Date.now() });
+}
+
+// ── Lease: exactly one live process per role ────────────────────────────────
+// Two stewards on one scope means double dispatch: both move the same tickets
+// to Todo and both answer the same thread. The lease is what makes a
+// restart-on-a-hunch safe.
+
+export function readLease(role, env = process.env) {
+  return readJson(roleFiles(role, env).lease);
+}
+
+/** Is a pid actually alive? `kill(pid, 0)` throws ESRCH when it is not. */
+function pidAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    // EPERM means the process exists but belongs to another user — alive.
+    return e?.code === "EPERM";
+  }
+}
+
+/**
+ * Take the lease, or refuse. Returns {ok, holder, reason}.
+ * A stale lease (holder pid is gone) is takeable — otherwise a `kill -9`
+ * would lock the role out permanently, which is the opposite of the goal.
+ */
+export function acquireLease(role, { now = Date.now(), pid = process.pid, isAlive = pidAlive } = {}, env = process.env) {
+  const existing = readLease(role, env);
+  if (existing && existing.pid !== pid && isAlive(existing.pid)) {
+    return { ok: false, holder: existing, reason: `role '${role}' is already held by live pid ${existing.pid} on ${existing.host} — refusing to start a second process (double dispatch)` };
+  }
+  const lease = { role, pid, host: hostname(), ts: now };
+  writeJsonAtomic(roleFiles(role, env).lease, lease);
+  return { ok: true, holder: lease, reason: null };
+}
+
+export function releaseLease(role, { pid = process.pid } = {}, env = process.env) {
+  const f = roleFiles(role, env).lease;
+  const existing = readLease(role, env);
+  if (existing && existing.pid !== pid) return false; // never release someone else's lease
+  if (existsSync(f)) rmSync(f);
+  return true;
+}

--- a/plugins/dev/scripts/role-supervisor/supervisor.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.mjs
@@ -1,0 +1,173 @@
+// supervisor.mjs — CTL-1994. Keeps ONE long-running role alive on the Claude
+// Agent SDK, replacing the `claude -p` brief it used to be launched with.
+//
+// ── What it replaces, and why ───────────────────────────────────────────────
+// Until now the coordination roles ran as `claude -p` with a hand-written brief
+// (`~/catalyst/comms/coord/launch-*.txt` — thirteen numbered versions of one
+// role's brief in a single day). Measured on 2026-08-18:
+//   * a provider 529 killed SEVEN lanes at once, and again 6-7 an hour later;
+//     both times a human pasted the briefs back in, 10-60 min later;
+//   * print mode ends the run the moment the agent waits, so the role's own
+//     watcher had to live outside it and its findings never re-entered;
+//   * with no heartbeat, "quiet" and "dead" were indistinguishable.
+// The phase workers already had 429/529 backoff. The roles had none. This is
+// that policy, applied to the process shape that needed it — see
+// ../lib/agent-liveness.mjs, which is the single copy of the decision logic.
+//
+// ── What it is NOT ─────────────────────────────────────────────────────────
+// It never talks in Linear. It has no opinion about tickets. It starts a role,
+// keeps it alive, and pages the concierge when it cannot. Everything the role
+// says, the ROLE says.
+import { spawn } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import {
+  assertSdkAuth, decideRestart, isScopeActive, classifyHeartbeat, LIVENESS,
+} from "../lib/agent-liveness.mjs";
+import { roleFiles } from "./paths.mjs";
+import {
+  readManifest, beat, readCounters, countLastHour, recordEvent,
+  readSession, writeSession, acquireLease, releaseLease,
+} from "./state.mjs";
+
+/**
+ * The resume bundle: what a restarted role reads before it does anything.
+ * Order matters and is the steward skill's `references/resume.md` order —
+ * handoff, status doc, its own plan thread, then the replica. Where they
+ * disagree the replica wins, and the difference is worth a line in its first turn.
+ */
+export function buildResumePrompt(manifest, { resumedFrom = null, reason = null } = {}) {
+  const lines = [];
+  lines.push(`You are ${manifest.role}${manifest.scope ? `, steward of ${manifest.scope}` : ""}.`);
+  lines.push("");
+  lines.push(`Invoke the ${manifest.skill} skill and follow it. Your scope is ${manifest.scope ?? "as stated in your manifest"}.`);
+  lines.push("");
+  if (resumedFrom) {
+    // The role does not know it was restarted unless it is told. A silent
+    // resumption is indistinguishable from a role that never stopped, which is
+    // exactly the ambiguity the heartbeat exists to remove.
+    lines.push(`⚠️ You were RESTARTED by the supervisor (${reason ?? "reason unrecorded"}).`);
+    lines.push(`Resume from: ${resumedFrom}`);
+    lines.push("Your FIRST action is to read, in this order: your latest handoff, your status doc, your own");
+    lines.push("top-level plan comment and its thread, then the replica. Where they disagree, the replica wins.");
+    lines.push('Your first turn must state: "resumed from <artifact> at <time>", plus what changed while you were gone.');
+    lines.push("");
+  }
+  if (manifest.brief_path && existsSync(manifest.brief_path)) {
+    lines.push("Standing brief:");
+    lines.push(readFileSync(manifest.brief_path, "utf8").trim());
+  }
+  return lines.join("\n");
+}
+
+/** The nudge sent when a role goes idle while its scope is still active. */
+export function buildIdleReentryPrompt() {
+  return [
+    "You stopped while your scope is still active (work in flight, an open ask you raised, or a human",
+    "comment newer than your last reply). Continue from your last artifact — do not start over and do",
+    "not re-read your whole brief. State what you are picking up, then keep going.",
+  ].join("\n");
+}
+
+/** The nudge sent when the role's status doc has gone stale. Cadence is computed, not remembered. */
+export function buildStatusDocPrompt(ageMin) {
+  return `Your status doc is ${ageMin} minutes old while your scope is active (cadence: every merge, every blocker change, at least every 90 min). Update it now, from the template, with a timestamp you read from the clock — then continue.`;
+}
+
+/**
+ * Run one role until it is told to stop.
+ *
+ * `runSession` is injectable — the tests drive the whole restart ladder with a
+ * fake, so none of this policy has to be discovered during an actual outage.
+ * It receives {prompt, cwd, env, resumeSessionId} and resolves
+ * {exitCode, sessionId, overloaded, quotaExhausted, lastArtifact}.
+ */
+export async function superviseRole(role, {
+  runSession,
+  env = process.env,
+  now = () => Date.now(),
+  sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+  log = console.log,
+  maxIterations = Infinity,
+} = {}) {
+  const manifest = readManifest(role, env);
+  if (!manifest) throw new Error(`role-supervisor: no manifest for role '${role}' at ${roleFiles(role, env).manifest}`);
+
+  const auth = assertSdkAuth({ env, oauthToken: env.CLAUDE_CODE_OAUTH_TOKEN });
+  if (!auth.ok) throw new Error(`role-supervisor: ${auth.reason}`);
+
+  const lease = acquireLease(role, { now: now() }, env);
+  if (!lease.ok) throw new Error(`role-supervisor: ${lease.reason}`);
+
+  let attempt = 0;
+  let iterations = 0;
+  try {
+    for (;;) {
+      if (++iterations > maxIterations) return { stopped: "max-iterations", attempt };
+
+      const scopeActive = isScopeActive(manifest.activity ?? {});
+      const resumeSessionId = readSession(role, env);
+      const prompt = resumeSessionId
+        ? buildIdleReentryPrompt()
+        : buildResumePrompt(manifest, { resumedFrom: manifest.handoff_path ?? "the status doc", reason: attempt ? "previous session ended" : null });
+
+      beat(role, { now: now(), sessionId: resumeSessionId, scope: manifest.scope, state: "running" }, env);
+
+      let result;
+      try {
+        result = await runSession({ prompt, cwd: manifest.cwd, env, resumeSessionId });
+      } catch (err) {
+        // A thrown error is a crash: classify it the same way as a bad exit so
+        // an overload thrown rather than returned still takes the same ladder.
+        result = { exitCode: 1, thrown: err, overloaded: false };
+      }
+
+      if (result?.sessionId) writeSession(role, result.sessionId, env);
+      beat(role, { now: now(), sessionId: result?.sessionId ?? resumeSessionId, scope: manifest.scope, state: "between-sessions", lastArtifact: result?.lastArtifact ?? null }, env);
+
+      const counters = readCounters(role, env);
+      const decision = decideRestart({
+        exitCode: result?.exitCode ?? 1,
+        overloaded: !!result?.overloaded,
+        quotaExhausted: !!result?.quotaExhausted,
+        stopRequested: !!result?.stopRequested,
+        scopeActive,
+        attempt,
+        restartsLastHour: countLastHour(counters, "restart", { now: now() }),
+        reentriesLastHour: countLastHour(counters, "reentry", { now: now() }),
+      });
+
+      log(`role-supervisor[${role}]: ${decision.action} — ${decision.reason}`);
+
+      if (decision.action === "stop") {
+        beat(role, { now: now(), scope: manifest.scope, state: "stopped" }, env);
+        return { stopped: decision.reason, attempt };
+      }
+
+      recordEvent(role, decision.action === "idle-reenter" ? "reentry" : "restart", { now: now() }, env);
+      if (!decision.sameSession) writeSession(role, null, env);
+      attempt = decision.action === "resume" || decision.action === "restart" ? attempt + 1 : 0;
+
+      if (decision.waitMs > 0) {
+        beat(role, { now: now(), scope: manifest.scope, state: `waiting:${Math.round(decision.waitMs / 1000)}s` }, env);
+        await sleep(decision.waitMs);
+      }
+    }
+  } finally {
+    releaseLease(role, {}, env);
+  }
+}
+
+/** Is this role silent or dead right now? Used by the quiet-fleet instrument. */
+export function roleLiveness(role, { now = Date.now() } = {}, env = process.env) {
+  return classifyHeartbeat(readHeartbeatSafe(role, env), { now });
+}
+
+function readHeartbeatSafe(role, env) {
+  try {
+    return JSON.parse(readFileSync(roleFiles(role, env).heartbeat, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export { LIVENESS, spawn };

--- a/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
@@ -1,0 +1,194 @@
+// supervisor.test.mjs — CTL-1994. Drives the whole restart ladder with a fake
+// session runner and a scratch CATALYST_DIR, so no real SDK call, no network,
+// and no touching the operator's real ~/catalyst.
+//
+// The point of the fake is that the outage behaviour is testable BEFORE an
+// outage. On 2026-08-18 the answer to "what happens when the provider returns
+// 529?" was "a human notices, eventually" — these cases are that answer,
+// written down.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { superviseRole, buildResumePrompt, buildIdleReentryPrompt } from "./supervisor.mjs";
+import { writeManifest, readHeartbeat, readCounters, acquireLease, releaseLease, readLease } from "./state.mjs";
+import { roleFiles } from "./paths.mjs";
+
+let passes = 0, failures = 0;
+async function t(name, fn) {
+  try { await fn(); console.log(`  PASS: ${name}`); passes++; }
+  catch (e) { console.log(`  FAIL: ${name} — ${e.message}`); failures++; }
+}
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "role-supervisor-test-"));
+  // A scratch CATALYST_DIR, never the real one.
+  const env = { CATALYST_DIR: dir, CLAUDE_CODE_OAUTH_TOKEN: "test-oat" };
+  return { dir, env, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function seedRole(env, role, manifest = {}) {
+  mkdirSync(roleFiles(role, env).dir, { recursive: true });
+  writeManifest(role, { role, scope: "P13", skill: "catalyst-dev:steward", cwd: "/tmp", activity: {}, ...manifest }, env);
+}
+
+const noSleep = async () => {};
+
+console.log("1. the happy path stops when the scope is quiet");
+await t("a clean exit with no work in flight stops, and does not loop", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-quiet", { activity: {} });
+  let calls = 0;
+  const r = await superviseRole("steward-quiet", {
+    env: s.env, sleep: noSleep, log: () => {},
+    runSession: async () => { calls++; return { exitCode: 0, sessionId: "sess-1" }; },
+  });
+  assert.equal(calls, 1);
+  assert.match(r.stopped, /quiet/);
+  s.cleanup();
+});
+
+console.log("2. the 529 that killed seven lanes");
+await t("an overloaded session RESUMES the same session and never re-pastes the brief", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-529", { activity: { inFlightTickets: 2 } });
+  const prompts = [];
+  let calls = 0;
+  await superviseRole("steward-529", {
+    env: s.env, sleep: noSleep, log: () => {}, maxIterations: 3,
+    runSession: async ({ prompt, resumeSessionId }) => {
+      prompts.push({ prompt, resumeSessionId });
+      calls++;
+      return { exitCode: 1, overloaded: true, sessionId: "sess-529" };
+    },
+  });
+  assert.equal(calls, 3);
+  // The first call boots with the brief; every later call is a re-entry that
+  // carries the session id — NOT the brief again.
+  assert.equal(prompts[0].resumeSessionId, null);
+  assert.equal(prompts[1].resumeSessionId, "sess-529");
+  assert.equal(prompts[2].resumeSessionId, "sess-529");
+  s.cleanup();
+});
+
+console.log("3. print mode's failure: stopping while the scope is active");
+await t("a clean exit with work in flight is re-entered, not left down", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-idle", { activity: { inFlightTickets: 1 } });
+  let calls = 0;
+  await superviseRole("steward-idle", {
+    env: s.env, sleep: noSleep, log: () => {}, maxIterations: 2,
+    runSession: async () => { calls++; return { exitCode: 0, sessionId: "sess-idle" }; },
+  });
+  assert.equal(calls, 2);
+  const c = readCounters("steward-idle", s.env);
+  assert.equal(c.reentries.length >= 1, true, "the re-entry should be counted, so the 3/hour cap can bite");
+  s.cleanup();
+});
+
+console.log("4. storm caps");
+await t("a restart storm stops and pages rather than looping forever", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-storm", { activity: { inFlightTickets: 1 } });
+  let calls = 0;
+  const r = await superviseRole("steward-storm", {
+    env: s.env, sleep: noSleep, log: () => {}, maxIterations: 50,
+    runSession: async () => { calls++; return { exitCode: 3 }; },
+  });
+  // 5 restarts allowed in an hour, then it stops — it must NOT run 50 times.
+  assert.equal(calls <= 6, true, `expected the cap to bite; ran ${calls} sessions`);
+  assert.match(r.stopped, /cap|restarts/);
+  s.cleanup();
+});
+
+console.log("5. a thrown error is a crash, not an escape hatch");
+await t("runSession throwing is classified, not propagated", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-throw", { activity: {} });
+  let calls = 0;
+  const r = await superviseRole("steward-throw", {
+    env: s.env, sleep: noSleep, log: () => {}, maxIterations: 10,
+    runSession: async () => { calls++; throw new Error("kaboom"); },
+  });
+  assert.equal(calls > 1, true, "a crash must be retried, not swallowed as a clean stop");
+  assert.match(r.stopped, /cap|restarts/);
+  s.cleanup();
+});
+
+console.log("6. auth — refuse loudly rather than meter silently");
+await t("an ANTHROPIC_API_KEY in the env refuses to start the role", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-auth", {});
+  await assert.rejects(
+    () => superviseRole("steward-auth", { env: { ...s.env, ANTHROPIC_API_KEY: "sk-x" }, runSession: async () => ({ exitCode: 0 }) }),
+    /ANTHROPIC_API_KEY/,
+  );
+  s.cleanup();
+});
+
+console.log("7. the lease — one live process per role");
+await t("a second supervisor refuses while a live pid holds the lease", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-lease", {});
+  // process.ppid is a REAL, live pid that is not ours — so the supervisor's own
+  // liveness probe (which is the production one, not a fake) genuinely sees a
+  // live holder. Seeding a made-up pid would be taken as a stale lease, which
+  // is correct behaviour and would prove nothing.
+  const first = acquireLease("steward-lease", { pid: process.ppid }, s.env);
+  assert.equal(first.ok, true);
+  await assert.rejects(
+    () => superviseRole("steward-lease", { env: s.env, runSession: async () => ({ exitCode: 0 }) }),
+    /already held/,
+  );
+  s.cleanup();
+});
+await t("a STALE lease is takeable — a kill -9 must not lock the role out forever", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-stale", {});
+  acquireLease("steward-stale", { pid: 999999, isAlive: () => false }, s.env);
+  const r = await superviseRole("steward-stale", {
+    env: s.env, sleep: noSleep, log: () => {},
+    runSession: async () => ({ exitCode: 0 }),
+  });
+  assert.ok(r.stopped);
+  s.cleanup();
+});
+await t("the lease is released when the role stops", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-release", {});
+  await superviseRole("steward-release", { env: s.env, sleep: noSleep, log: () => {}, runSession: async () => ({ exitCode: 0 }) });
+  assert.equal(readLease("steward-release", s.env), null);
+  s.cleanup();
+});
+
+console.log("8. the heartbeat is written, and carries what it needs to");
+await t("a heartbeat exists after a run and names the pid and state", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-hb", {});
+  await superviseRole("steward-hb", { env: s.env, sleep: noSleep, log: () => {}, runSession: async () => ({ exitCode: 0, sessionId: "sess-hb" }) });
+  const hb = readHeartbeat("steward-hb", s.env);
+  assert.equal(hb.role, "steward-hb");
+  assert.equal(hb.pid, process.pid);
+  assert.equal(typeof hb.ts, "number");
+  assert.equal(hb.state, "stopped");
+  s.cleanup();
+});
+
+console.log("9. the resume prompt tells the role it was restarted");
+await t("a restarted role is told to state what it resumed from", () => {
+  const p = buildResumePrompt({ role: "steward", scope: "P13", skill: "catalyst-dev:steward" }, { resumedFrom: "handoff.md", reason: "529" });
+  assert.match(p, /RESTARTED/);
+  assert.match(p, /resumed from/);
+  assert.match(p, /replica wins/);
+});
+await t("a first boot is NOT told it was restarted", () => {
+  const p = buildResumePrompt({ role: "steward", scope: "P13", skill: "catalyst-dev:steward" }, {});
+  assert.doesNotMatch(p, /RESTARTED/);
+});
+await t("the idle re-entry does not ask the role to start over", () => {
+  const p = buildIdleReentryPrompt();
+  assert.match(p, /do not start over/);
+});
+
+console.log(`\nsupervisor.test.mjs: ${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/scripts/run-tests.sh
+++ b/plugins/dev/scripts/run-tests.sh
@@ -248,6 +248,21 @@ else
 		failed_suites+=("lib bun suite")
 		echo "  FAIL lib bun suite"
 	fi
+	# role-supervisor surface (CTL-1994). Its own directory, so the lib glob
+	# above does NOT reach it. Adding this at the same time as the code is
+	# deliberate: CTL-1993's peer read caught skill-shape.test.sh shipping
+	# discovered by nothing, and contract-doc-lint.test.sh had been dead in the
+	# same way for 65 days. A new test DIRECTORY is the recurring shape of that
+	# bug in this repo (CTL-1612 rounds 7 and 9, CTL-1978), so a new one gets its
+	# runner line in the same commit or it does not land.
+	if (cd "$BROKER_DIR" && bun test ../role-supervisor/*.test.mjs); then
+		bun_pass=$((bun_pass + 1))
+		echo "  PASS role-supervisor bun suite"
+	else
+		bun_fail=$((bun_fail + 1))
+		failed_suites+=("role-supervisor bun suite")
+		echo "  FAIL role-supervisor bun suite"
+	fi
 fi
 
 total_fail=$((shell_fail + bun_fail))


### PR DESCRIPTION
Closes CTL-1994.

## Why now — measured today, not hypothesised

- A provider **529 killed seven lanes at once at ~11:5x**, and 6–7 more at ~12:1x. **Both times a human pasted the same brief back in**, 10–60 minutes later (COORD-179).
- Print mode ends the run the moment the agent waits, so ORCH's watcher had to live *outside* the agent and its findings never re-entered it.
- A `claude -p` role has no heartbeat, so **"quiet" and "dead" are indistinguishable**.

Every SLA in the SOP is a claim about liveness. This is the mechanism that makes those cadences enforceable rather than remembered.

## What landed

`plugins/dev/scripts/role-supervisor/` — the `catalyst-agent` layout (`*.mjs` + `*.test.mjs` + `install.sh` + plist + README), node-builtins only.

| file | role |
| -- | -- |
| `supervisor.mjs` | the restart / backoff / idle-re-entry loop — pure, with an injectable session |
| `sdk-session.mjs` | the **only** seam that talks to `@anthropic-ai/claude-agent-sdk` |
| `state.mjs` | lease + heartbeat + restart counters |
| `doctor.mjs` | one row per role: pid, session, heartbeat age, status-doc age, restarts/24h |
| `lib/agent-liveness.mjs` | the decision leaves: overload classification, jittered backoff, restart caps, status-doc cadence |

Auth is **subscription-only**: the env deletes `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`, which outrank the OAuth token in headless mode and would silently meter.

## ⚠️ A correction to my own ticket

CTL-1994 says to import the leaf helpers from `execution-core/sdk-run-phase-agent.mjs`. **The ticket is wrong on both halves:**

1. `backoffMs`, `isOverloadedResult` and `isOverloadedError` are module-**private** there — plain `function`, not `export function`.
2. That module's import chain reaches **`bun:sqlite`** via `config.mjs`, so a role runner cannot load it under bare node at all.

So the shared **decision** logic lives in `lib/agent-liveness.mjs` as one copy, and execution-core is left untouched — which the ticket did explicitly ask for. I will correct the ticket description rather than leave a false reuse plan on the record.

## ⛔ The runner line ships in the same commit, deliberately

`role-supervisor/` is its own directory, so the existing `../lib/*.test.mjs` glob does **not** reach it. A new test **directory** shipping discovered-by-nothing is the recurring bug in this repo — CTL-1612 rounds 7 and 9, CTL-1978, and **CTL-1993 this morning**, where FLEET's peer read also turned up `contract-doc-lint.test.sh` dead in exactly this way **for 65 days**. So the `role-supervisor` bun surface is in this commit, not a follow-up.

## Controls

- **43 tests pass** (13 supervisor + 30 liveness) under **both** node and bun.
- ⭐ **The plain-script test pattern was verified NOT vacuous under `bun test`** — these files use `node:assert` + `process.exit`, not `bun:test`, so a file with zero registered tests passing green was a real risk. A planted mutation (`SILENT_AFTER_MS` 10 → 999) turns the runner **red, exit 1**. The mutation was confirmed present in the file before the run rather than assumed to have applied.
- `install.sh` carries the `launchd-domain-guard` (CTL-1968) and `--uninstall`; `bash -n` clean.
- `doctor` on an unconfigured host prints **"no roles configured (this is not the same as 'all roles healthy')"** rather than an empty green.

## Not yet done

The ticket's *"prove it by relaunching a live role under it"* is **not** in this PR — that is a live-fleet action, not a code change, and it needs a role to actually restart. Stated rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)