### PR TITLE
feat(dev): CTL-1996 — AGENTS.md teaches the coordination roles, and CI catches the block drifting

### DIFF
--- a/.github/workflows/agents-md-gate.yml
+++ b/.github/workflows/agents-md-gate.yml
@@ -18,3 +18,40 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check AGENTS.md / CLAUDE.md bridge invariant
         run: bash scripts/ci/check-agents-md-bridge.sh
+
+      # CTL-1996: the house-rules block is seeded from plugins/dev/templates/
+      # agents-house-rules.md by ensure-agent-house-rules.sh. Nothing re-ran that
+      # seeder after the template changed, so BOTH repos silently fell behind —
+      # measured 2026-08-18, catalyst-cloud was 82 lines short, including the whole
+      # background-process rule written from a real incident (4 CPU cores, 16.5 h).
+      #
+      # ⛔ WORSE, AND THE REASON THIS GATE IS A DRY RUN AND NOT AN AUTO-FIX: the
+      # seeder is a one-way sync. It overwrites the block with the template and says
+      # nothing about what it removed. This repo's AGENTS.md carried a 28-line
+      # "run a positive control before reporting a negative" rule that existed in NO
+      # other copy, and `--fix` deleted it silently. The rule has been promoted into
+      # the template so that can no longer happen here — but the general hazard is
+      # why CI reports drift for a human to resolve rather than rewriting the doc.
+      #
+      # Exit codes: 0 = already current, 10 = drifted, anything else = broken setup.
+      - name: Check the agent house-rules block is current
+        run: |
+          set +e
+          bash plugins/dev/scripts/ensure-agent-house-rules.sh --repo . --quiet
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "house-rules block is current."
+            exit 0
+          fi
+          if [ "$rc" -eq 10 ]; then
+            echo "::error::The agent house-rules block has drifted from plugins/dev/templates/agents-house-rules.md."
+            echo "Re-run:  bash plugins/dev/scripts/ensure-agent-house-rules.sh --repo . --fix"
+            echo "⚠️  DIFF THE RESULT BEFORE COMMITTING — the seeder overwrites the block with the"
+            echo "    template and does not report what it removed. Repo-local rules worth keeping"
+            echo "    belong in the template, not only in AGENTS.md."
+            bash plugins/dev/scripts/ensure-agent-house-rules.sh --repo .
+            exit 1
+          fi
+          echo "::error::ensure-agent-house-rules.sh exited ${rc} (broken template or setup)."
+          exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,28 @@ replica-read rule below is absolute).
   Scoping applies too: write only inside your own worktree, and chain with `cd <dir> && <cmd>` — a
   bare `cd` on its own line that silently fails will apply your edits to whichever worktree the
   shell happened to be in.
+- **Coordination has THREE roles, and "orchestrator" is not one of them.** Long-running coordination is
+  done by single-threaded owners: a **concierge** (the one agent a human talks to — owns the status board,
+  the ask inbox, routing and project scaffolding, and holds **no authority over stewards**), a **steward**
+  (owns ONE initiative or project end-to-end until it closes; makes work ready and visible, the fleet does
+  it), and **workers** (one phase of one ticket, driven by the pipeline). Invoke the `concierge` and
+  `steward` skills by name; the phase pipeline's shared contract is `phase-agent-contract`. ⚠️ Reserve
+  **"orchestrator"** for the pipeline MACHINERY — never for an agent or a person: this repo already calls
+  the phase runners *workers* in code (`workers/<ticket>/`, `worker.session.started`), so a role by that
+  name reads as the scheduler. Three rules bind you even when you are none of these roles:
+  - **Reply where the message arrived, threaded, and never as the human.** A comment inside a scope is
+    answered by that scope's **steward**, in-thread and tagged. Anything only a human can decide becomes
+    an **ask ticket** (`catalyst-dev:ask`) with Options + a Default if silent — and you **proceed on the
+    default**. Never answer someone else's ask, and never post as the human.
+  - **Escalate inward, never outward:** instrument → steward → concierge → human (as an ask). An agent or
+    instrument that pages a human directly is a defect, and a bare label in a human's queue is a defect.
+  - **Cite an identifier only after `create` returned it.** A guessed ticket number is usually a real,
+    unrelated ticket — worse than no number at all.
+- **Skills here use progressive disclosure — read the reference you need, not all of them.** A skill is a
+  short `SKILL.md` covering the common path, plus `references/*.md` loaded **on demand**; the SKILL.md
+  names which reference answers which situation. Follow that table rather than reading the whole tree.
+  `plugins/dev/skills/__tests__/skill-shape.test.sh` enforces the shape and `skills-gate` runs it on
+  every PR, so the budget is real.
 <!-- catalyst-house-rules:end -->
 
 ## Build & Test

--- a/plugins/dev/templates/agents-house-rules.md
+++ b/plugins/dev/templates/agents-house-rules.md
@@ -24,6 +24,34 @@ plugin) rather than routing around it. For GitHub state only, a single **bounded
 acceptable last resort while you do; never a poll loop, and never a raw Linear API read (the
 replica-read rule below is absolute).
 
+- **Reporting a negative → run a positive control first, or report inconclusive.** A negative result
+  is only evidence if you can state what a positive one would have looked like **and you ran the same
+  instrument against a case known to be present and saw it come back non-zero.** Before you report
+  "zero", "absent", "unrelated", "clean", or "not owned", ask the question that separates *the thing
+  is not there* from *I could not look* — and if you cannot separate them, say **inconclusive**. The
+  five mechanisms that have actually produced a false clean result here, all of them silent:
+  (1) an unstructured match over structured data — a substring `grep` for an event name counted the
+  name where it appeared inside a commit message, reporting events that did not exist; (2) a
+  malformed call returning a falsy sentinel — an ownership helper invoked with its arguments
+  transposed returned `undefined` for every ticket, which reads as "not owned"; (3) an empty input
+  set feeding a loop, so the body never ran and the trailing all-clear line printed on the strength
+  of zero iterations (`[].every(p)` is `true`); (4) the right question asked of the wrong surface —
+  counting a bot's issue comments returned zero while an unresolved *review thread* was the thing
+  blocking the merge; (5) **the search tool skipping files it never says it skipped** — in the agent
+  shell `grep` is a wrapper around `ugrep --ignore-files`, which honours `.gitignore`, and
+  `~/.config/catalyst/.gitignore` excludes `config*.json`, so **a recursive grep never reads any live
+  Catalyst config** and answers "not configured anywhere" for a value sitting in `config.json`. It is
+  convincing because the `.bak-*` copies do NOT match that pattern, so you get plausible hits from
+  stale backups while the live file is skipped. A recursive-grep zero over config, secrets, or
+  build output is **inconclusive** until re-run with `/usr/bin/grep` or an explicit file list.
+  (Sibling traps in the same family: `find` does not follow symlinks, so it misses what
+  `cat`/`readFileSync` read straight through — e.g. bun's `.bun` store entries; and zsh kills an
+  unquoted `--include=*.mjs` with "no matches found", returning nothing, which also reads as a real
+  zero.) Prefer the verified helpers in `plugins/dev/scripts/lib/verified-checks.mjs`
+  (count events by exact `event.name`, resolve ticket ownership under named rosters, enumerate every
+  merge blocker) — each returns a verdict that can be explicitly **inconclusive** and throws on
+  malformed input rather than degrading to a falsy answer. This rule governs the bullets below: a
+  check that cannot fail loudly is not evidence for any of them.
 - **Waiting on GitHub / CI / Linear state → subscribe to the event log, don't poll.** To block on a
   state change (a PR merged, CI turning green, a review posted, a push to a branch, a ticket
   transition), wait on the unified Catalyst event log instead of re-querying in a loop. Reach for
@@ -78,3 +106,25 @@ replica-read rule below is absolute).
   Scoping applies too: write only inside your own worktree, and chain with `cd <dir> && <cmd>` — a
   bare `cd` on its own line that silently fails will apply your edits to whichever worktree the
   shell happened to be in.
+- **Coordination has THREE roles, and "orchestrator" is not one of them.** Long-running coordination is
+  done by single-threaded owners: a **concierge** (the one agent a human talks to — owns the status board,
+  the ask inbox, routing and project scaffolding, and holds **no authority over stewards**), a **steward**
+  (owns ONE initiative or project end-to-end until it closes; makes work ready and visible, the fleet does
+  it), and **workers** (one phase of one ticket, driven by the pipeline). Invoke the `concierge` and
+  `steward` skills by name; the phase pipeline's shared contract is `phase-agent-contract`. ⚠️ Reserve
+  **"orchestrator"** for the pipeline MACHINERY — never for an agent or a person: this repo already calls
+  the phase runners *workers* in code (`workers/<ticket>/`, `worker.session.started`), so a role by that
+  name reads as the scheduler. Three rules bind you even when you are none of these roles:
+  - **Reply where the message arrived, threaded, and never as the human.** A comment inside a scope is
+    answered by that scope's **steward**, in-thread and tagged. Anything only a human can decide becomes
+    an **ask ticket** (`catalyst-dev:ask`) with Options + a Default if silent — and you **proceed on the
+    default**. Never answer someone else's ask, and never post as the human.
+  - **Escalate inward, never outward:** instrument → steward → concierge → human (as an ask). An agent or
+    instrument that pages a human directly is a defect, and a bare label in a human's queue is a defect.
+  - **Cite an identifier only after `create` returned it.** A guessed ticket number is usually a real,
+    unrelated ticket — worse than no number at all.
+- **Skills here use progressive disclosure — read the reference you need, not all of them.** A skill is a
+  short `SKILL.md` covering the common path, plus `references/*.md` loaded **on demand**; the SKILL.md
+  names which reference answers which situation. Follow that table rather than reading the whole tree.
+  `plugins/dev/skills/__tests__/skill-shape.test.sh` enforces the shape and `skills-gate` runs it on
+  every PR, so the budget is real.


### PR DESCRIPTION
Closes CTL-1996. **Stacked on #3615 → #3612.**

Two halves, because the second is what makes the first survive.

## 1. The template gains the coordination vocabulary

Every agent — interactive too — now learns from `AGENTS.md`: **concierge** (the one door; **no authority over stewards**), **steward** (one scope, end to end), **workers** (one phase), and ⚠️ **"orchestrator" is the pipeline MACHINERY, never a role** — this repo already calls the phase runners *workers* in code, so a role by that name reads as the scheduler.

Plus the three rules that bind agents who are **none** of those roles: reply threaded and never as the human · escalate **inward** (instrument → steward → concierge → human, as an ask) · cite an identifier only after `create` returned it. And the progressive-disclosure convention, so an agent reads the **one** reference its `SKILL.md` names rather than the whole tree.

## 2. `agents-md-gate` gains a drift check

The block is seeded from the template by `ensure-agent-house-rules.sh` — but **nothing re-ran that seeder after the template changed**, so both repos silently fell behind. Measured today: **catalyst-cloud is 82 lines short**, including the entire background-process rule, written from a real incident (4 CPU cores burned for 16.5 h while the script that spawned them reported `cleanup verified`).

## ⛔ The finding that changed this PR

**`--fix` is a ONE-WAY SYNC, not the idempotent updater its header claims.** It overwrites the block with the template and says **nothing** about what it removed.

This repo's `AGENTS.md` carried a **28-line** *"run a positive control before reporting a negative, or report inconclusive"* rule — five named mechanisms that have actually produced false clean results here. It existed in **no other copy**:

| surface | copies |
| -- | -- |
| `plugins/dev/templates/agents-house-rules.md` | **0** |
| `catalyst/AGENTS.md` | **1** |
| `catalyst-cloud/AGENTS.md` | **0** |

**Running `--fix` deleted it.** I caught it only by reading the diff instead of trusting the exit code.

So the rule is **promoted into the template**, where it belongs — it is general, hard-won, and leaving it repo-local is precisely what made it deletable. With it there, `--fix` on this repo is now **purely additive: 22 insertions, 0 deletions**, verified.

⚠️ **And it is why the CI gate DRY-RUNS and asks a human to resolve, rather than auto-fixing.** An auto-fix step would have quietly deleted that rule on the next template change in any repo that had a local one. The error message says so explicitly, so the next person hits the warning before the deletion.

## Controls

- **Positive:** gate reads `rc=0` on the current tree.
- **Negative:** `rc=10` with a planted mutation in the block — and the mutation was confirmed present in the file before the run, not assumed to have applied.
- **Idempotence:** a second dry run after `--fix` returns 0.

⚠️ An earlier measurement in this session read **exit 0 for a drifted repo** because `$?` came from a `tail` in the pipeline, not the script. The real code is **10**. Same trap as a backgrounded gate whose completion notice carries the wrapper's status.

## Not in this PR

`catalyst-cloud`'s own 82-line update is a **separate PR in that repo** — this one cannot touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)