### PR TITLE
fix(dev): CTL-2004 — a joining host got the smee CHANNEL and not the MODE that shuts the tunnel, so it came up on smee looking healthy

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -703,6 +703,20 @@ jobs:
         working-directory: plugins/dev/scripts/lib
         run: bun test replica-path.test.mjs
 
+      - name: install-lifecycle + join-bundle tests (CTL-2004)
+        # ⛔ PINNED DELIBERATELY, same reason as the archive+uninstall suite above (CTL-1975,
+        # FLEET-37): CI runs an EXPLICIT list — there is no glob runner — so a suite that merely
+        # exists in the tree runs only in the local full gate. Verified before adding this step:
+        # `grep -n join-bundle .github/workflows/` returned NOTHING, and `grep -n install-lifecycle`
+        # returned only the bun-build import-graph check, never a test run. Positive control:
+        # the same grep for `deployment-mode-parity` returns its own `run:` line.
+        #
+        # These two carry CTL-2004, whose whole defect was a posture that travelled nowhere and
+        # failed by looking healthy. Shipping its regression tests unpinned would reproduce the
+        # shape of the bug in its own guard.
+        working-directory: plugins/dev/scripts/execution-core
+        run: bun test install-lifecycle.test.mjs join-bundle.test.mjs
+
       - name: replica-path cross-stack parity test (CTL-1893)
         # bash == node == a hand-written expected value at every fixture cell, including
         # the NAMED FAILURES (account-absent vs account-invalid route to different operator

--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -643,6 +643,29 @@ cat > "$MULTIHOST_WH_BUNDLE" <<'BEOF'
 }
 BEOF
 
+# CTL-2004: the same multi-host bundle, but carrying the seed's GitHub-ingestion
+# posture. The bundle above hands a joiner monitor.github.smeeChannel — a tunnel
+# CHANNEL — while nothing carried the MODE that decides whether it opens
+# (githubFeedIsAuthoritative() is mode==="enforce"; the ladder defaults to "off"),
+# so a host joining after the cutover came up on smee, healthy and green.
+GHFEED_WH_BUNDLE="${SCRATCH}/ghfeed-wh.json"
+cat > "$GHFEED_WH_BUNDLE" <<'BEOF'
+{
+  "layer1Identity": {"projectKey": "CTL", "teamKey": "T1", "stateMap": {}},
+  "thoughtsOrg": "CTL",
+  "botCreds": {"orchestrator": "tok_orch", "worker": "tok_worker"},
+  "hostsRoster": ["mini", "mini-2"],
+  "livenessAnchorIssue": "CTL-1",
+  "repoUrl": "https://github.com/example/repo",
+  "pluginSourceUrl": "https://github.com/example/plugins",
+  "githubFeed": {"mode": "enforce"},
+  "monitorWebhooks": {
+    "github": {"smeeChannel": "https://smee.io/GH"},
+    "linear": {"smeeChannel": "https://smee.io/LIN", "ctl": {"webhookId": "wh-ctl"}}
+  }
+}
+BEOF
+
 SINGLEHOST_WH_BUNDLE="${SCRATCH}/singlehost-wh.json"
 cat > "$SINGLEHOST_WH_BUNDLE" <<'BEOF'
 {
@@ -758,6 +781,69 @@ run "T2.8f an already-declared cloudFeed.mode is NOT clobbered by the join (CTL-
   cfg=\"\$h/.config/catalyst/config.json\"
   jq -e '.catalyst.cloudFeed.mode == \"shadow\"' \"\$cfg\" >/dev/null && \
   echo \"\$out\" | grep -qF 'cloudFeed=shadow'"
+
+# ─── CTL-2004: the GitHub half of the very rule T2.8e/f pin for Linear ───────────
+# The join already provisions the Linear REPLACEMENT in the same write that removes
+# the Linear route. The GitHub leg never got that treatment: the joiner received the
+# smee CHANNEL and no MODE, the ladder defaulted to "off", githubFeedIsAuthoritative()
+# read false, orch-monitor did not suppress the tunnel — and the node came up on smee
+# while looking perfectly healthy.
+
+run "T2.8g the join writes the seed's githubFeed.mode, so a member inherits the fleet posture (CTL-2004)" bash -c "
+  h='${SCRATCH}/h28g'
+  out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28g' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$GHFEED_WH_BUNDLE' 2>&1)
+  cfg=\"\$h/.config/catalyst/config.json\"
+  jq -e '.catalyst.githubFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null && \
+  echo \"\$out\" | grep -qF 'githubFeed=enforce'"
+
+run "T2.8h an already-declared githubFeed.mode is NOT clobbered by the join (CTL-2004)" bash -c "
+  h='${SCRATCH}/h28h'
+  mkdir -p \"\$h/.config/catalyst\"
+  printf '{\"catalyst\":{\"githubFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/config.json\"
+  out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28h' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$GHFEED_WH_BUNDLE' 2>&1)
+  cfg=\"\$h/.config/catalyst/config.json\"
+  jq -e '.catalyst.githubFeed.mode == \"shadow\"' \"\$cfg\" >/dev/null && \
+  echo \"\$out\" | grep -qF 'githubFeed=shadow'"
+
+# ⛔ INVERSION GUARD. An older seed carries no githubFeed; the join must write NOTHING
+# rather than inventing a posture. Without this the previous two tests would still pass
+# against an implementation that hardcoded a mode.
+run "T2.8i a bundle with NO githubFeed writes no key at all (CTL-2004 inversion guard)" bash -c "
+  h='${SCRATCH}/h28i'
+  out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28i' \
+    CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
+    CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
+    CATALYST_JOIN_SETUP_SCRIPT='${STUBS2}/stub-setup-catalyst.sh' \
+    CATALYST_JOIN_INSTALL_CLI_SCRIPT='${STUBS2}/stub-install-cli.sh' \
+    CATALYST_JOIN_PLUGIN_SRC_SCRIPT='${STUBS2}/stub-setup-plugin-source.sh' \
+    CATALYST_JOIN_PROVISION_THOUGHTS_SCRIPT='${STUBS2}/stub-provision-thoughts.sh' \
+    CATALYST_JOIN_STACK_BIN='${STUBS2}/stub-catalyst-stack' \
+    CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
+    CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
+    bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' 2>&1)
+  cfg=\"\$h/.config/catalyst/config.json\"
+  jq -e '((.catalyst // {}) | has(\"githubFeed\")) | not' \"\$cfg\" >/dev/null && \
+  echo \"\$out\" | grep -qF 'githubFeed=unset'"
 
 # T2.9 (fixture updated for CTL-1617 PR5 — see T2.8's note): same inferred-mode
 # fallback, but SINGLEHOST_WH_BUNDLE's roster=1 makes the heuristic (and hence

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -938,18 +938,50 @@ merge_shared_config() {
     # Linear dispatch. Note the live minis carry this as an ENV var in
     # execution-core.env rather than in Layer-2, so this fills a genuinely
     # empty key on a joining node rather than fighting an existing one.
-    jq --argjson wh "$monitor_wh_stripped" '
+    #
+    # ⛔ CTL-2004: the GITHUB half of the very same rule, which the Linear half above
+    # has had since CTL-1928 and this leg never got. The write directly above hands a
+    # joining node `monitor.github.smeeChannel` — a tunnel CHANNEL. What decides whether
+    # it OPENS is `.catalyst.githubFeed.mode`: `githubFeedIsAuthoritative()` is
+    # `mode === "enforce"`, orch-monitor suppresses the tunnel only on that, and the mode
+    # resolves env -> Layer-2 -> default "off". Layer-1 does not carry it. So a node
+    # joining a fleet that has already cut over was handed the channel and no mode, read
+    # the "off" default as not-authoritative, and came up on SMEE — healthy, green, and on
+    # the exact transport the cutover retired. Same shape as the Linear comment above:
+    # carrying a route without carrying the posture that governs it is how a node ends up
+    # silently on the wrong one.
+    #
+    # ⚠️ Deliberately the SEED'S value, never a hardcoded "enforce". The Linear leg can
+    # safely default to enforce because its producer's readiness gate fails CLOSED. The
+    # GitHub feed is mid-rollout, so pinning a joining host to "enforce" while the fleet
+    # is still in shadow would shut its tunnel BEFORE the cloud feed is authoritative for
+    # it and drop github.* events wholesale — the CI wait, monitor-merge and the broker's
+    # PR-lifecycle routing. Inheriting the seed's declared posture is the only value that
+    # is correct at every point of the rollout.
+    #
+    # `//=` so it is NON-CLOBBER, matching the line above: an operator's existing value
+    # wins, only an ABSENT key is filled. A bundle with no githubFeed writes nothing at
+    # all — `$gf` is null and the `//=` is guarded — so an older seed degrades to exactly
+    # today's behaviour rather than being pinned to a posture nobody declared.
+    local bundle_gf
+    bundle_gf="$(echo "$BUNDLE_JSON" | jq -c '.githubFeed // null')" || bundle_gf="null"
+    jq --argjson wh "$monitor_wh_stripped" --argjson gf "$bundle_gf" '
         .catalyst //= {}
         | .catalyst.monitor = ($wh * (.catalyst.monitor // {}))
         | .catalyst.cloudFeed //= {}
         | .catalyst.cloudFeed.mode //= "enforce"
+        | if ($gf | type) == "object" and ($gf.mode | type) == "string"
+          then .catalyst.githubFeed //= {} | .catalyst.githubFeed.mode //= $gf.mode
+          else . end
       ' "$cfg" > "$tmp2" && mv "$tmp2" "$cfg" || { rm -f "$tmp2"; return 1; }
     local cf_mode
     cf_mode="$(jq -r '.catalyst.cloudFeed.mode // "unset"' "$cfg" 2>/dev/null)"
+    local gf_mode
+    gf_mode="$(jq -r '.catalyst.githubFeed.mode // "unset"' "$cfg" 2>/dev/null)"
     if [[ "$github_wired" == "no" ]]; then
-      info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928); cloudFeed=${cf_mode}"
+      info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928); cloudFeed=${cf_mode} githubFeed=${gf_mode}"
     else
-      info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0} github-only=yes linear-stripped=${stripped_linear} cloudFeed=${cf_mode} CTL-1928)"
+      info "webhook ingestion wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0} github-only=yes linear-stripped=${stripped_linear} cloudFeed=${cf_mode} githubFeed=${gf_mode} CTL-1928/CTL-2004)"
     fi
   else
     info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0})"

--- a/plugins/dev/scripts/execution-core/install-lifecycle.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.mjs
@@ -37,6 +37,13 @@ import { homedir } from "node:os";
 import { InstallRun, makeInstallEmitFn, INSTALL_SERVICE_NAME } from "./lib/install-telemetry.mjs";
 import { initTracing, shutdownTracing } from "./tracing.mjs";
 import { NODE_CLASSES } from "./config.mjs";
+// CTL-2004: the mode vocabulary only. Deliberately NOT resolveGithubFeedMode() — that
+// resolver DEFAULTS to "off" and applies CAT-57's containment rule (a set-but-invalid env
+// var overrides Layer-2 down to "off"). Both are right for a daemon deciding whether to
+// actuate, and both are wrong for a CARRY-FORWARD, which must be three-valued: a value to
+// re-write, or NOTHING. Collapsing "absent" to "off" would manufacture a key the host never
+// had and freeze it there.
+import { GITHUB_FEED_MODES } from "../lib/github-feed-mode.mjs";
 
 // ── phase enums ───────────────────────────────────────────────────────────────
 // install: the PR1 locked set (acquire → backup → write-config → install-agents →
@@ -73,6 +80,12 @@ export const INSTALL_MANAGED_KEYS = Object.freeze([
   "catalyst.node.class",
   "catalyst.orchestration.pluginPullOwner",
   "catalyst.readReplica.baseUrl",
+  // CTL-2004. Added because the install now SETS it (see the github-feed step in planPhases):
+  // this list's contract is "set on install, stripped on uninstall", so leaving it out would let
+  // the install write a key teardown then orphans — the half-state the list exists to prevent.
+  // Safe only because resolveGithubFeed() captures the current value BEFORE any phase runs, so a
+  // reinstall re-asserts what the node already declared. Order matters: capture, then strip.
+  "catalyst.githubFeed.mode",
 ]);
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url)); // …/plugins/dev/scripts/execution-core
@@ -215,6 +228,38 @@ export function resolveReadReplica({ flag = null, env = process.env, layer2 } = 
   }
 }
 
+/**
+ * resolveGithubFeed — CTL-2004. The GitHub-ingestion posture for this run, with the SAME
+ * default-to-current precedence as the node class and the read replica: explicit --github-feed >
+ * CATALYST_GITHUB_FEED env > the value already in Layer-2. Returns a mode string, or null meaning
+ * "write no key".
+ *
+ * ⛔ WHY THIS EXISTS. `catalyst.githubFeed.mode` is the ONLY thing that shuts the smee tunnel:
+ * `githubFeedIsAuthoritative()` is `mode === "enforce"`, orch-monitor suppresses the tunnel only on
+ * that, and the mode resolves env -> Layer-2 -> default `"off"`. Layer-1 does not carry it and
+ * `join-bundle.mjs` DOES propagate `monitor.github.smeeChannel`. So without this, a reinstall (whose
+ * teardown strips Layer-2) hands the host a channel and no mode, the default `off` reads as
+ * not-authoritative, and the rebuilt node silently comes back up on SMEE — healthy, green, and fed
+ * by the exact transport v1 says is gone. Same failure `readReplica` above was given this same
+ * treatment for; the difference is that dropping a read endpoint FAILS a rubric, while dropping
+ * this one passes every check we have.
+ *
+ * An INVALID value is never silently coerced here — `parseArgs` rejects a bad flag outright, and a
+ * junk env var or a corrupt Layer-2 value returns null (write nothing, leave the daemon's own
+ * resolver to apply its containment rule) rather than inventing a posture.
+ */
+export function resolveGithubFeed({ flag = null, env = process.env, layer2 } = {}) {
+  if (flag) return GITHUB_FEED_MODES.includes(flag) ? flag : null;
+  const raw = env.CATALYST_GITHUB_FEED;
+  if (typeof raw === "string" && raw.trim() && GITHUB_FEED_MODES.includes(raw.trim())) return raw.trim();
+  try {
+    const v = readLayer2(layer2)?.catalyst?.githubFeed?.mode;
+    return typeof v === "string" && GITHUB_FEED_MODES.includes(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
 // A worker is the only class that runs the full work stack (broker/exec-core/monitor); every
 // other class is daemonless-with-updater. Centralized so the plan and the tests agree.
 function isWorker(nodeClass) {
@@ -306,6 +351,13 @@ export function planPhases({ operation, nodeClass, scripts, opts = {} }) {
       // reads its own local replica, so the key is meaningless there.) A missing endpoint is
       // surfaced by the developer verify-node rubric, not a hard install failure.
       steps.push({ label: "read-replica", kind: "setkey", key: "catalyst.readReplica.baseUrl", value: opts.readReplica });
+    }
+    // CTL-2004: re-assert the GitHub-ingestion posture. Deliberately OUTSIDE the worker/else-if
+    // above — the tunnel this key gates lives in orch-monitor, which runs on worker AND monitor
+    // nodes, so scoping it to one class would leave the other silently on smee. No resolved value
+    // ⇒ no step ⇒ the node keeps whatever the daemon's own resolver decides, exactly as before.
+    if (opts.githubFeed) {
+      steps.push({ label: "github-feed", kind: "setkey", key: "catalyst.githubFeed.mode", value: opts.githubFeed });
     }
     // CTL-1401: when an executor is requested, durably provision the lever into execution-core.env —
     // the file the launcher sources on every start and whose CATALYST_EXECUTOR value arms CTL-1398's
@@ -1258,7 +1310,7 @@ export async function runInstallLifecycle({ operation, nodeClass, opts = {} }, d
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
 export function parseArgs(argv) {
-  const a = { operation: null, class: null, readReplica: null, executor: null, force: false, archive: false, dryRun: false, json: false, help: false, errors: [] };
+  const a = { operation: null, class: null, readReplica: null, executor: null, githubFeed: null, force: false, archive: false, dryRun: false, json: false, help: false, errors: [] };
   const rest = [...argv];
   // takeValue — consume the next token as FLAG's value; a missing value (end of args, or the next
   // token is itself a flag) is an error, not a silent null — otherwise `catalyst install --class`
@@ -1305,6 +1357,9 @@ export function parseArgs(argv) {
       case "--executor":
         [a.executor, i] = takeValue(i, "--executor");
         break;
+      case "--github-feed":
+        [a.githubFeed, i] = takeValue(i, "--github-feed");
+        break;
       default:
         if (v.startsWith("--class=")) {
           const val = v.slice("--class=".length);
@@ -1318,6 +1373,10 @@ export function parseArgs(argv) {
           const val = v.slice("--executor=".length);
           if (val === "") a.errors.push("--executor requires a value");
           else a.executor = val;
+        } else if (v.startsWith("--github-feed=")) {
+          const val = v.slice("--github-feed=".length);
+          if (val === "") a.errors.push("--github-feed requires a value");
+          else a.githubFeed = val;
         } else if (!v.startsWith("-") && a.operation == null) {
           a.operation = v;
         }
@@ -1332,9 +1391,9 @@ export function usage() {
   return `catalyst-install — provision / tear down this node for its class (CTL-1369).
 
 Usage (normally via the router: 'catalyst install|uninstall|reinstall …'):
-  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--dry-run]
+  catalyst-install install   [--class developer|worker|monitor] [--read-replica <url>] [--github-feed off|shadow|enforce] [--executor bg|sdk|oneshot-legacy] [--dry-run]
   catalyst-install uninstall [--force] [--archive] [--dry-run]
-  catalyst-install reinstall [--class …] [--read-replica <url>] [--executor bg|sdk|oneshot-legacy] [--force] [--dry-run]
+  catalyst-install reinstall [--class …] [--read-replica <url>] [--github-feed off|shadow|enforce] [--executor bg|sdk|oneshot-legacy] [--force] [--dry-run]
 
 Options:
   --class <c>          target node class (install: declares it; un/reinstall: defaults to current)
@@ -1426,7 +1485,19 @@ export async function main(argv, depsOverride) {
     errOut(`catalyst-install: --executor must be one of ${VALID_EXECUTORS.join(" | ")} (got '${args.executor}')`);
     return 2;
   }
-  const opts = { force: args.force, archive: args.archive, readReplica, executor: args.executor, execCoreEnv: execCoreEnvPath(env) };
+  // CTL-2004: reject a typo'd feed mode outright rather than coercing it. The whole point of the
+  // key is that "which transport feeds this host" is DECLARED; an operator who mistypes --github-feed
+  // must not get a node that quietly reverts to the `off` default and opens a tunnel. Same posture
+  // as --executor above.
+  if (args.githubFeed != null && !GITHUB_FEED_MODES.includes(args.githubFeed)) {
+    errOut(`catalyst-install: --github-feed must be one of ${GITHUB_FEED_MODES.join(" | ")} (got '${args.githubFeed}')`);
+    return 2;
+  }
+  // Captured BEFORE any phase runs — remove-config strips Layer-2, so reading it later would read
+  // the hole this exists to fill.
+  const githubFeed = resolveGithubFeed({ flag: args.githubFeed, env, layer2: deps.layer2 });
+
+  const opts = { force: args.force, archive: args.archive, readReplica, githubFeed, executor: args.executor, execCoreEnv: execCoreEnvPath(env) };
 
   if (args.dryRun) {
     const plan = planPhases({ operation: args.operation, nodeClass, scripts: deps.scripts, opts });

--- a/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/install-lifecycle.test.mjs
@@ -19,6 +19,7 @@ import {
   isDrainedStatus,
   resolveRequestedClass,
   resolveReadReplica,
+  resolveGithubFeed,
   setDeepKey,
   deleteDeepKey,
   planPhases,
@@ -1314,5 +1315,110 @@ describe("invariants", () => {
   });
   test("INSTALL_MANAGED_KEYS contains no unsafe segments", () => {
     for (const k of INSTALL_MANAGED_KEYS) for (const seg of k.split(".")) expect(["__proto__", "prototype", "constructor"]).not.toContain(seg);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTL-2004 — the GitHub-ingestion posture must survive a rebuild, and a NEW member
+// must inherit it. The defect this pins: `join-bundle` hands a joiner
+// `monitor.github.smeeChannel` (a tunnel CHANNEL) while nothing carries the MODE that
+// decides whether it opens. The mode resolves env -> Layer-2 -> default "off",
+// `githubFeedIsAuthoritative()` is `mode === "enforce"`, and orch-monitor suppresses the
+// tunnel only on that — so the joiner came up on smee looking perfectly healthy.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("resolveGithubFeed — CTL-2004 carry-forward precedence", () => {
+  const tmpCfg = (obj) => {
+    const p = join(tmpdir(), `ctl2004-${Math.random().toString(36).slice(2)}.json`);
+    writeFileSync(p, JSON.stringify(obj));
+    return p;
+  };
+
+  test("flag WINS over env and Layer-2", () => {
+    const cfg = tmpCfg({ catalyst: { githubFeed: { mode: "off" } } });
+    expect(resolveGithubFeed({ flag: "enforce", env: { CATALYST_GITHUB_FEED: "shadow" }, layer2: cfg })).toBe("enforce");
+    rmSync(cfg, { force: true });
+  });
+
+  test("env WINS over Layer-2 when no flag", () => {
+    const cfg = tmpCfg({ catalyst: { githubFeed: { mode: "off" } } });
+    expect(resolveGithubFeed({ flag: null, env: { CATALYST_GITHUB_FEED: "shadow" }, layer2: cfg })).toBe("shadow");
+    rmSync(cfg, { force: true });
+  });
+
+  test("⭐ THE DEFECT: falls back to the value already in Layer-2 — captured BEFORE teardown strips it", () => {
+    const cfg = tmpCfg({ catalyst: { githubFeed: { mode: "enforce" } } });
+    expect(resolveGithubFeed({ flag: null, env: {}, layer2: cfg })).toBe("enforce");
+    rmSync(cfg, { force: true });
+  });
+
+  test("⛔ absent everywhere returns null — it must NOT manufacture an 'off' the host never declared", () => {
+    const cfg = tmpCfg({ catalyst: {} });
+    expect(resolveGithubFeed({ flag: null, env: {}, layer2: cfg })).toBeNull();
+    rmSync(cfg, { force: true });
+  });
+
+  test("⛔ a junk value in ANY tier is refused rather than coerced (flag, env, Layer-2)", () => {
+    const cfg = tmpCfg({ catalyst: { githubFeed: { mode: "banana" } } });
+    // A bad Layer-2 value is not a posture — write nothing, leave the daemon's resolver to decide.
+    expect(resolveGithubFeed({ flag: null, env: {}, layer2: cfg })).toBeNull();
+    // A bad env var likewise does not become a written key.
+    expect(resolveGithubFeed({ flag: null, env: { CATALYST_GITHUB_FEED: "banana" }, layer2: cfg })).toBeNull();
+    // A bad flag returns null here; parseArgs/main reject it outright with exit 2 (asserted below).
+    expect(resolveGithubFeed({ flag: "banana", env: {}, layer2: cfg })).toBeNull();
+    rmSync(cfg, { force: true });
+  });
+
+  test("an unreadable/missing Layer-2 degrades to null rather than throwing", () => {
+    expect(resolveGithubFeed({ flag: null, env: {}, layer2: join(tmpdir(), "ctl2004-nope.json") })).toBeNull();
+  });
+
+  test("all three modes round-trip from Layer-2", () => {
+    for (const mode of ["off", "shadow", "enforce"]) {
+      const cfg = tmpCfg({ catalyst: { githubFeed: { mode } } });
+      expect(resolveGithubFeed({ flag: null, env: {}, layer2: cfg })).toBe(mode);
+      rmSync(cfg, { force: true });
+    }
+  });
+});
+
+describe("planPhases — CTL-2004 github-feed step", () => {
+  const scripts = { setup: "/s/setup", stack: "/s/stack", doctor: "/s/doctor", execCore: "/s/ec", updater: "/s/up" };
+  const stepFor = (plan, label) => plan.flatMap((p) => p.steps).find((s) => s.label === label);
+
+  test("⭐ the step is emitted for EVERY class — the tunnel it gates runs on worker AND monitor", () => {
+    for (const nodeClass of ["worker", "monitor", "developer"]) {
+      const plan = planPhases({ operation: "install", nodeClass, scripts, opts: { githubFeed: "enforce" } });
+      const step = stepFor(plan, "github-feed");
+      expect(step).toBeDefined();
+      expect(step.kind).toBe("setkey");
+      expect(step.key).toBe("catalyst.githubFeed.mode");
+      expect(step.value).toBe("enforce");
+    }
+  });
+
+  test("⛔ INVERSION GUARD — no resolved value ⇒ NO step (the node keeps today's behaviour exactly)", () => {
+    for (const nodeClass of ["worker", "monitor", "developer"]) {
+      const plan = planPhases({ operation: "install", nodeClass, scripts, opts: {} });
+      expect(stepFor(plan, "github-feed")).toBeUndefined();
+    }
+  });
+
+  test("the step rides reinstall too — the operation the carry-forward exists for", () => {
+    const plan = planPhases({ operation: "reinstall", nodeClass: "worker", scripts, opts: { githubFeed: "shadow" } });
+    expect(stepFor(plan, "github-feed")?.value).toBe("shadow");
+  });
+
+  test("a worker gets BOTH pull-owner and github-feed — the new step does not displace the else-if branch", () => {
+    const plan = planPhases({ operation: "install", nodeClass: "worker", scripts, opts: { githubFeed: "enforce", readReplica: "http://x" } });
+    expect(stepFor(plan, "pull-owner")).toBeDefined();
+    expect(stepFor(plan, "github-feed")).toBeDefined();
+  });
+});
+
+describe("INSTALL_MANAGED_KEYS — CTL-2004 ownership", () => {
+  test("⭐ includes catalyst.githubFeed.mode, because the install now SETS it", () => {
+    // The list's contract is "set on install, stripped on uninstall". A key the install writes
+    // but teardown never removes is the half-state the list exists to prevent.
+    expect(INSTALL_MANAGED_KEYS).toContain("catalyst.githubFeed.mode");
   });
 });

--- a/plugins/dev/scripts/execution-core/join-bundle.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.mjs
@@ -115,6 +115,18 @@ function extractMonitorWebhooks(l2) {
   return Object.keys(out).length > 0 ? out : null;
 }
 
+// CTL-2004: the seed's declared GitHub-ingestion mode, or null. Read as a plain value with a
+// vocabulary check rather than through resolveGithubFeedMode(): that resolver consults the SEED
+// PROCESS's own env and defaults to "off", and neither belongs in a bundle describing the cluster
+// — a seed running with a one-off CATALYST_GITHUB_FEED in its shell must not pin every future
+// member to it, and "the seed declares nothing" must stay distinguishable from "the seed declares
+// off". Kept import-free for the same reason the rest of this module is.
+const GITHUB_FEED_BUNDLE_MODES = ["off", "shadow", "enforce"];
+function extractGithubFeed(l2) {
+  const mode = l2?.catalyst?.githubFeed?.mode;
+  return typeof mode === "string" && GITHUB_FEED_BUNDLE_MODES.includes(mode) ? { mode } : null;
+}
+
 // CTL-1231: carry a SHARED-only, secret-free slice of the seed's
 // ~/.claude/settings.json so a member's interactive `claude` sessions inherit
 // the cluster's telemetry posture + autonomy defaults. Built from an EXPLICIT
@@ -234,6 +246,17 @@ export function assembleJoinBundle() {
     // posture + autonomy defaults). null when the seed has no settings. Optional
     // (existence-only) — an older seed degrades gracefully.
     claudeSettings: extractClaudeSettings(),
+    // ⛔ CTL-2004: the seed's GitHub-ingestion posture. This bundle already propagates
+    // `monitor.github.smeeChannel` above (deliberately — the GitHub leg is still smee-fed per
+    // CTL-1928), so a member was handed a TUNNEL CHANNEL and no mode. The mode resolves
+    // env -> Layer-2 -> default "off", `githubFeedIsAuthoritative()` is `mode === "enforce"`, and
+    // orch-monitor suppresses the tunnel only on that — so every host joining after the fleet's
+    // cutover silently came up on smee while looking perfectly healthy. Carrying the seed's mode
+    // makes a member inherit the fleet's declared posture instead of the off default.
+    //
+    // null when the seed declares nothing — the member then behaves exactly as before rather than
+    // being pinned to a posture the seed never held.
+    githubFeed: extractGithubFeed(l2),
   };
 }
 

--- a/plugins/dev/scripts/execution-core/join-bundle.test.mjs
+++ b/plugins/dev/scripts/execution-core/join-bundle.test.mjs
@@ -201,6 +201,59 @@ describe("assembleJoinBundle", () => {
     expect(b.otlpEndpointHint).toBe("http://from-l2:4318");
   });
 
+  // ⛔ CTL-2004: the bundle hands a joiner monitor.github.smeeChannel — a tunnel CHANNEL.
+  // What decides whether it OPENS is catalyst.githubFeed.mode, which nothing carried:
+  // githubFeedIsAuthoritative() is mode==="enforce", orch-monitor suppresses the tunnel only
+  // on that, and the mode resolves env -> Layer-2 -> default "off". So a host joining after
+  // the cutover came up on SMEE, healthy and green, on the transport v1 retires.
+  test("⭐ githubFeed carries the seed's declared mode, so a member inherits the fleet's posture", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: { ...LAYER2_FIXTURE.catalyst, githubFeed: { mode: "enforce" } },
+    });
+    expect(assembleJoinBundle().githubFeed).toEqual({ mode: "enforce" });
+  });
+
+  test("⛔ INVERSION GUARD — a seed declaring nothing carries null, NOT a manufactured 'off'", () => {
+    // "the seed declares nothing" must stay distinguishable from "the seed declares off":
+    // the consumer writes non-clobber, and a fabricated posture would pin every future member.
+    expect(assembleJoinBundle().githubFeed).toBeNull();
+  });
+
+  test("⛔ a junk mode is refused rather than travelling to every member", () => {
+    for (const bad of ["banana", "", 7, null, {}]) {
+      writeLayer2({
+        ...LAYER2_FIXTURE,
+        catalyst: { ...LAYER2_FIXTURE.catalyst, githubFeed: { mode: bad } },
+      });
+      expect(assembleJoinBundle().githubFeed).toBeNull();
+    }
+  });
+
+  test("all three modes travel", () => {
+    for (const mode of ["off", "shadow", "enforce"]) {
+      writeLayer2({
+        ...LAYER2_FIXTURE,
+        catalyst: { ...LAYER2_FIXTURE.catalyst, githubFeed: { mode } },
+      });
+      expect(assembleJoinBundle().githubFeed).toEqual({ mode });
+    }
+  });
+
+  test("⛔ the CHANNEL and the MODE travel together — the pairing whose absence was the defect", () => {
+    writeLayer2({
+      ...LAYER2_FIXTURE,
+      catalyst: {
+        ...LAYER2_FIXTURE.catalyst,
+        githubFeed: { mode: "enforce" },
+        monitor: { github: { smeeChannel: "https://smee.io/GH" } },
+      },
+    });
+    const b = assembleJoinBundle();
+    expect(b.monitorWebhooks.github).toEqual({ smeeChannel: "https://smee.io/GH" });
+    expect(b.githubFeed).toEqual({ mode: "enforce" });
+  });
+
   // CTL-1284: non-secret webhook wiring (smee channels + per-team webhookId map).
   test("monitorWebhooks is null when the seed has no monitor block", () => {
     expect(assembleJoinBundle().monitorWebhooks).toBeNull();


### PR DESCRIPTION
## What was wrong

`join-bundle.mjs` propagates `catalyst.monitor.github.smeeChannel` — a tunnel **channel** — deliberately, because the GitHub leg is still smee-fed (CTL-1928). **Nothing carried `catalyst.githubFeed.mode`, which is the only thing that shuts the tunnel.**

Every link read off the source:

| | |
| -- | -- |
| `lib/github-feed-mode.mjs:66` | `DEFAULT_GITHUB_FEED_MODE = "off"` |
| `lib/github-feed-mode.mjs:155` | `githubFeedIsAuthoritative()` is `mode === "enforce"` ⇒ default is **false** |
| `orch-monitor/server.ts:5724` | the tunnel is suppressed **only** when that reader is `true` |
| `__tests__/github-feed-tunnel-gate.test.ts:91` | the gate's own test: *"no reader injected (production wiring, feed unset) → the tunnel DOES open"* |
| `join-bundle.mjs` | carries **no** `githubFeed` key; Layer-1 has none either |
| `install-lifecycle.mjs` | mentioned `githubFeed` **0 times** — no flag, no carry-forward, no write |

⛔ **Net: every host joining after the fleet's cutover came up on SMEE** — healthy, green, board moving, on the exact transport v1 says is gone. *(Positive control on that last row: `readReplica` appears 13 times in the same file, so the instrument discriminates.)*

⚠️ It fails in the direction that looks like success, which is why it survived: nothing is red.

## This is not a new argument — it is an existing ruling, one field over

`catalyst-join.sh:918-940` **already solves this exact defect for the Linear leg**, under CTL-1928 / Codex #3485 P1, with the reasoning written out:

> *"provision the REPLACEMENT in the same write that removes the original … Removing a path without enabling its successor is how a node ends up silently blind."*

The GitHub leg never got that treatment. This PR is that rule applied to its sibling, **in the same jq write**.

## The change

1. ⭐ **`join-bundle.mjs` + `catalyst-join.sh` — the load-bearing half.** The bundle carries the seed's `githubFeed`; the join writes it non-clobber (`//=`) beside the existing `cloudFeed.mode` line.
   - ⚠️ **The SEED's value, never a hardcoded `enforce`.** The Linear leg can safely default to enforce because its producer's readiness gate fails closed. The GitHub feed is mid-rollout, so pinning a joiner to `enforce` while the fleet is still in `shadow` would shut its tunnel *before* the cloud feed is authoritative for it and drop `github.*` wholesale — the CI wait, monitor-merge, the broker's PR-lifecycle routing. Inheriting the seed's declared posture is the only value correct at every point of the rollout.
   - A bundle with no `githubFeed` writes **nothing**, so an older seed degrades to exactly today's behaviour rather than being pinned to a posture nobody declared.
2. **`resolveGithubFeed` in `install-lifecycle.mjs`** — `flag > env > current Layer-2`, captured **before any phase runs**, mirroring `resolveReadReplica` exactly. Plus `--github-feed off|shadow|enforce`, which **rejects a typo outright** (exit 2) rather than coercing it to the `off` default — the whole point of the key is that the transport is *declared*.
3. `catalyst.githubFeed.mode` joins `INSTALL_MANAGED_KEYS`, **because the install now sets it** and that list's contract is "set on install, stripped on uninstall". Safe only because (2) captures before (3) strips.

## ⛔ A correction I made to myself mid-build, since it changes how you should read this

I originally claimed `remove-config` strips Layer-2 and therefore erases a host's `enforce` on reinstall. **That is false.** `removeConfig` deletes **only the three named `INSTALL_MANAGED_KEYS`**, and `githubFeed.mode` was not among them — so it *survived* an uninstall. I had generalised a comment that accurately said "remove-config strips readReplica" into "strips Layer-2", and only caught it when I went to write the test.

**So the defect is a NEW-HOST defect, not a reinstall defect.** That is why part 1 is load-bearing and part 2 is belt-and-braces. Corrected on the channel (CTLI-25) and on the ticket before this PR opened.

## Verification

- **175 pass / 0 fail** on `install-lifecycle.test.mjs` + `join-bundle.test.mjs`, run from the exact CI working-directory and command.
- **The bash consumer is covered too** — T2.8g (writes the seed's mode), T2.8h (non-clobber: an operator's declared value wins), T2.8i (**inversion guard** — a bundle with no `githubFeed` writes no key at all; without it, the first two would pass against an implementation that hardcoded a mode).
- ⭐ **Mutation-tested, because a guard that passes on the broken code is not a guard.** Deleting the `setkey` step → **3 fail**. Making `resolveGithubFeed` stop reading Layer-2 → **2 fail**. Making `extractGithubFeed` always return null → **3 fail**. Restored → green.
- ⭐ **The jq expression was tested against five real inputs before I trusted it** — bundle-enforce onto a bare config, a null bundle writing nothing, non-clobber vs a host declaring `shadow`, a malformed `mode` writing nothing, a deliberate `off` preserved. `if … then A | B else . end` is easy to get subtly wrong; I did not assume it.

## ⚠️ Two things I am NOT doing silently

- **`catalyst-join.test.sh` is not pinned into CI**, even though I added tests to it. Its **T3.4 fails on clean `origin/main`** — verified in a separate baseline worktree (54 pass/1 fail there, 57 pass/1 fail here, same test failing in both), so pinning it would turn main red. Filed as **CTL-2007**, which owns the fix *and* the pin.
- **The two suites this PR touches that ARE green are pinned** (`install-lifecycle.test.mjs`, `join-bundle.test.mjs`). `grep -n join-bundle .github/workflows/` returned nothing beforehand and `install-lifecycle` returned only a bun-build import-graph check — never a test run. Same lesson as CTL-1975/FLEET-37, one ticket later; shipping this fix's guards unpinned would reproduce the shape of the bug inside its own regression test.

⚠️ **Codex is out of quota on this repo today**, so there will be no automated review — that is "could not look", not a clean pass. **Peer read requested.**

Closes CTL-2004.
