### PR TITLE
fix(dev): CTL-1997 — two out-of-date skill instructions, each verified at file:line, and one the audit got wrong

### DIFF
--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -3,10 +3,12 @@ name: _phase-agent-template
 description: |
   Reference template every phase-agent skill copies (CTL-448). The leading
   underscore on the directory name prevents the skill loader from picking this
-  up — it is NOT a runnable skill, only a structural template the nine real
+  up — it is NOT a runnable skill, only a structural template the eleven real
   phase agents (phase-triage, phase-research, phase-plan, phase-implement,
-  phase-verify, phase-review, phase-pr, phase-monitor-merge, phase-monitor-deploy)
-  clone and specialize. The real phase skills MUST set `user-invocable: true`
+  phase-verify, phase-remediate, phase-review, phase-pr, phase-monitor-merge,
+  phase-monitor-deploy, phase-teardown) clone and specialize. The count and the
+  list are both load-bearing: a phase agent authored from a template that does
+  not know phase-remediate exists will not wire the verify -> remediate cycle. The real phase skills MUST set `user-invocable: true`
   so `phase-agent-dispatch`'s `claude --bg "/catalyst-dev:phase-X ..."` slash
   command resolves (CTL-490).
 user-invocable: true

--- a/plugins/dev/skills/gherkin-ticket/SKILL.md
+++ b/plugins/dev/skills/gherkin-ticket/SKILL.md
@@ -28,7 +28,7 @@ or update the issue. CLI syntax lives in `/catalyst-dev:linearis`.
 Auto-invoked whenever a ticket is being born or rewritten — you do **not** need to say "gherkin":
 
 - "file a ticket for X", "create tickets for A and B", "open an issue", "log this bug"
-- breaking a PRD/plan into tickets (pair with `/catalyst-pm:create-tickets`)
+- breaking a PRD/plan into tickets (pair with `/catalyst-pm-ops:create-tickets`)
 - "rewrite this ticket", "clean up these ticket titles", "this backlog is unreadable"
 
 If the user is mid-creation in another skill (`linear`, `create-tickets`, `phase-triage`), apply
@@ -327,7 +327,7 @@ conventions.
 
 - `/catalyst-dev:linear` — does the actual Linear create/update. This skill produces the title +
   body it consumes.
-- `/catalyst-pm:create-tickets` — when exploding a PRD into many tickets, apply these title/body
+- `/catalyst-pm-ops:create-tickets` — when exploding a PRD into many tickets, apply these title/body
   rules to each. (Its legacy `[Component] Action:` title format is superseded by outcome titles +
   component labels.)
 - `/catalyst-dev:phase-triage` — triage reads tickets; a ticket authored to this standard makes


### PR DESCRIPTION
Part of CTL-1997. From the P13 phase-skills review. **Every item was checked against the tree before being changed, and one of the three did not survive that check.**

## 1. `_phase-agent-template/SKILL.md:6` — "nine real phase agents"

It says nine and then **enumerates nine by name**. There are **eleven**: the list is missing **`phase-remediate`** (CTL-653) and **`phase-teardown`** (CTL-703).

Both the count and the list are load-bearing, and the fix says so: *a phase agent authored from a template that does not know `phase-remediate` exists will not wire the verify → remediate cycle.*

## 2. `gherkin-ticket/SKILL.md:31,330` — a skill that does not exist

Pointed at `/catalyst-pm:create-tickets`.

| path | exists |
| -- | -- |
| `plugins/pm/skills/create-tickets` | ❌ |
| `plugins/pm-ops/skills/create-tickets` | ✅ |

Both references repointed at `/catalyst-pm-ops:create-tickets`.

## 3. ⛔ NOT CHANGED — the audit was wrong

The audit flagged `phase-remediate/SKILL.md:225`'s **"eight-gate verify suite"** as stale. It is **correct**. `phase-verify/SKILL.md:194-203` lists exactly eight gates: type check · reward-hacking scan · unit tests · lint · security review · code review · test coverage · silent failures.

The text stands, and the commit message records **why**, so nobody re-applies that audit row in a month.

## ⚠️ A gap worth its own ticket, found while controlling item 2

`audit-references` **already runs on every PR** — and it would never have caught this:

1. It checks **path** references, not `/<plugin>:<skill>` **slash-command** references. A skill pointing at a non-existent skill is invisible to it.
2. It **exits 0 with warnings** — advisory-only. On `main` right now it prints warnings for six missing paths and still passes.

So the class of breakage this PR fixes can currently only be found by hand. I verified this by running the script against `main` **with the broken reference still in place**: exit 0, and no mention of `catalyst-pm:create-tickets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)