### PR TITLE
fix(dev): CTL-2008 — the broker folds github.pr.* into pr_status_cache, because retiring smee left the table with no writer

### DIFF
--- a/plugins/dev/scripts/broker/broker-state.mjs
+++ b/plugins/dev/scripts/broker/broker-state.mjs
@@ -17,6 +17,7 @@
 // one SQLite handle.
 
 import { Database } from "bun:sqlite";
+import { PR_STATUSES } from "./pr-status-fold.mjs";
 import { homedir } from "node:os";
 import { resolve, dirname } from "node:path";
 import { mkdirSync } from "node:fs";
@@ -698,6 +699,46 @@ export function getAllTicketDescriptors({ includeRemoved = false } = {}) {
     ? `SELECT * FROM ticket_state ORDER BY ticket`
     : `SELECT * FROM ticket_state WHERE removed_at IS NULL ORDER BY ticket`;
   return ensure().prepare(sql).all().map(rowToTicketDescriptor);
+}
+
+// putPrStatus — CTL-2008. The WRITE half of `pr_status_cache`, so the table survives
+// the GitHub smee retirement (CTL-1929).
+//
+// ⛔ UNTIL THIS EXISTED, `pr_status_cache` HAD EXACTLY ONE WRITER AND IT WAS IN
+// ANOTHER PROCESS: orch-monitor's HTTP webhook handler (`lib/pr-cache.ts`). Retiring
+// the tunnel on 2026-08-18 stopped that handler being reached and the table froze.
+// The comment above `getAllPrStatuses` still calls this store "webhook-populated";
+// it is now populated by the broker's own tail as well, from either event source.
+//
+// ⛔ THE `merged` LATCH IS THE POINT, not incidental. `getAllPrStatuses` is
+// newest-wins, so one late `open` row for an already-merged PR hides it from
+// `checkPhantomMergedPr` and then presents it to `checkOrphanedOpenPr` as an orphan —
+// the CTL-1606 bug. Events are not delivered in commit order (a boot replay walks the
+// month's log front to back), so "the newest event is the newest truth" is false here
+// and the latch, not the ordering, is what holds. Byte-for-byte the same
+// `WHERE ... status != 'merged'` guard `pr-cache.ts` uses, because BOTH processes
+// write this table whenever the smee path is rolled back and a guard that exists on
+// only one of them is not a guard.
+//
+// Returns true when a row was written or updated, false when the latch declined or
+// the status was unrecognised — a caller that wants to count applied folds can, and
+// a silent no-op is never reported as a write.
+export function putPrStatus(repo, prNumber, status) {
+  // An unrecognised status is REFUSED rather than written. `board-health.mjs` matches
+  // this column with `PR_MERGED_RE` / an === "open" test, so a typo would not throw
+  // anywhere — it would sit in the table reading as neither merged nor open and
+  // quietly remove that PR from both cohorts.
+  if (!PR_STATUSES.includes(status)) return false;
+  if (typeof repo !== "string" || repo.length === 0) return false;
+  if (!Number.isInteger(prNumber) || prNumber <= 0) return false;
+  const result = ensure().run(
+    `INSERT INTO pr_status_cache (repo, pr_number, status, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(repo, pr_number) DO UPDATE SET status = excluded.status, updated_at = excluded.updated_at
+       WHERE pr_status_cache.status != 'merged'`,
+    [repo, prNumber, status, nowIso()],
+  );
+  return result.changes > 0;
 }
 
 // getAllPrStatuses — CTL-1157: one batch read of the filter_state lifecycle

--- a/plugins/dev/scripts/broker/pr-status-fold-wiring.test.mjs
+++ b/plugins/dev/scripts/broker/pr-status-fold-wiring.test.mjs
@@ -1,0 +1,195 @@
+// pr-status-fold-wiring.test.mjs — CTL-2008. Does `processEvent` actually fold, and
+// does it fold where it has to?
+//
+// Run: cd plugins/dev/scripts/broker && bun test pr-status-fold-wiring.test.mjs
+//
+// ⛔ WHY THIS IS SEPARATE FROM pr-status-fold.test.mjs. The classifier being right
+// proves nothing about the defect. `processEvent` returns at
+// `if (!interests.size) return`, and on an execution-core host the interest table is
+// PERMANENTLY empty — the daemon runs no `filter.register` producer. A fold placed one
+// line below that gate passes every value test ever written and writes zero rows on
+// every production host. That is the shape CTL-1929 was bitten by twice in one day (a
+// gate reading a file nobody writes; an env pin only one of three readers sees), and
+// router.mjs's own CTL-822 comment records a verify panel catching the identical
+// placement mistake on the Linear fold.
+//
+// The load-bearing assertion is therefore: **with the interest table EMPTY, a
+// github.pr.* event still writes the row.** This module never registers an interest,
+// so `interests` stays at its natural size 0 for the whole file.
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import {
+  openBrokerStateDb,
+  closeBrokerStateDb,
+  putPrStatus,
+  getAllPrStatuses,
+} from "./broker-state.mjs";
+import { processEvent } from "./router.mjs";
+
+let dir;
+let dbPath;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctl2008-"));
+  dbPath = join(dir, "filter-state.db");
+  openBrokerStateDb(dbPath);
+});
+
+afterEach(() => {
+  closeBrokerStateDb();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const rows = () => {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    return db.prepare("SELECT repo, pr_number, status FROM pr_status_cache ORDER BY pr_number").all();
+  } finally {
+    db.close();
+  }
+};
+
+const feedMerge = (pr) => ({
+  ts: "2026-08-18T19:00:10Z",
+  id: `evt-${pr}`,
+  resource: { "service.name": "catalyst.github" },
+  attributes: {
+    "event.name": "github.pr.merged",
+    "vcs.repository.name": "coalesce-labs/catalyst-cloud",
+    "vcs.pr.number": pr,
+    "event.channel": "cloud-feed",
+  },
+  body: {
+    message: `github.pr.merged for coalesce-labs/catalyst-cloud PR #${pr}`,
+    payload: {
+      action: "closed",
+      merged: true,
+      mergeCommitSha: "c7c255ccd200febc935c76ef32d22368ece14c81",
+      source: "cloud-feed",
+      feedAuthority: true,
+    },
+  },
+});
+
+describe("⛔ the fold runs with the interest table EMPTY", () => {
+  test("a cloud-feed github.pr.merged writes pr_status_cache with zero interests", () => {
+    expect(rows()).toEqual([]);
+    processEvent(feedMerge(882));
+    expect(rows()).toEqual([
+      { repo: "coalesce-labs/catalyst-cloud", pr_number: 882, status: "merged" },
+    ]);
+  });
+
+  test("the row is visible through getAllPrStatuses — the board-health read path", () => {
+    // Proves the fold reaches the actual consumer, not just a table nobody reads.
+    processEvent(feedMerge(882));
+    const byRepo = getAllPrStatuses().get(882);
+    expect(byRepo?.get("coalesce-labs/catalyst-cloud")?.status).toBe("merged");
+  });
+});
+
+describe("the SMEE-shaped envelope folds identically — the rollback path", () => {
+  test("a webhook-channel github.pr.opened writes `open`", () => {
+    processEvent({
+      ts: "2026-08-18T19:00:11Z",
+      id: "evt-webhook",
+      attributes: {
+        "event.name": "github.pr.opened",
+        "vcs.repository.name": "coalesce-labs/catalyst",
+        "vcs.pr.number": 3629,
+        "event.channel": "webhook",
+      },
+      body: { payload: { action: "opened", merged: false } },
+    });
+    expect(rows()).toEqual([{ repo: "coalesce-labs/catalyst", pr_number: 3629, status: "open" }]);
+  });
+
+  test("a LEGACY top-level `scope` + `detail` envelope folds too", () => {
+    // The v1 envelope puts repo/pr under `scope` and the payload under `detail`.
+    // ⚠️ The repo here is deliberately NOT `coalesce-labs/catalyst`: processEvent's
+    // CTL-993 plugin-refresh side-channel reacts to a merge on the CONFIGURED repo by
+    // running a real `git fetch`, which turned this one test into a 2.3 s network call.
+    // The fold's repo handling is repo-agnostic, so the realism is not worth the fetch.
+    processEvent({
+      ts: "2026-08-18T19:00:12Z",
+      id: "evt-legacy",
+      event: "github.pr.merged",
+      scope: { repo: "coalesce-labs/catalyst-otel", pr: 3585 },
+      detail: { merged: true },
+    });
+    expect(rows()).toEqual([
+      { repo: "coalesce-labs/catalyst-otel", pr_number: 3585, status: "merged" },
+    ]);
+  });
+});
+
+describe("⛔ merged is terminal through the whole path", () => {
+  test("a later `opened` for the same PR cannot walk a merged row back", () => {
+    processEvent(feedMerge(882));
+    processEvent({
+      ts: "2026-08-18T19:05:00Z",
+      id: "evt-late-open",
+      attributes: {
+        "event.name": "github.pr.opened",
+        "vcs.repository.name": "coalesce-labs/catalyst-cloud",
+        "vcs.pr.number": 882,
+      },
+      body: { payload: { merged: false } },
+    });
+    expect(rows()).toEqual([
+      { repo: "coalesce-labs/catalyst-cloud", pr_number: 882, status: "merged" },
+    ]);
+  });
+
+  test("putPrStatus reports the latch rather than silently no-opping", () => {
+    expect(putPrStatus("o/r", 1, "open")).toBe(true);
+    expect(putPrStatus("o/r", 1, "merged")).toBe(true);
+    expect(putPrStatus("o/r", 1, "open")).toBe(false); // declined by the latch
+    expect(putPrStatus("o/r", 1, "closed")).toBe(false);
+  });
+});
+
+describe("putPrStatus refuses input board-health could not interpret", () => {
+  test("an unrecognised status is refused, not written", () => {
+    // It would throw nowhere: PR_MERGED_RE simply stops matching and the PR silently
+    // leaves both cohorts.
+    for (const bad of ["deploying", "MERGED", "", null, undefined, 1]) {
+      expect(putPrStatus("o/r", 7, bad)).toBe(false);
+    }
+    expect(rows()).toEqual([]);
+  });
+
+  test("a missing repo or a non-positive PR number is refused", () => {
+    expect(putPrStatus("", 7, "open")).toBe(false);
+    expect(putPrStatus(null, 7, "open")).toBe(false);
+    expect(putPrStatus("o/r", 0, "open")).toBe(false);
+    expect(putPrStatus("o/r", -1, "open")).toBe(false);
+    expect(rows()).toEqual([]);
+  });
+});
+
+describe("non-PR events leave the table alone", () => {
+  test("check_suite, push and a phase event write nothing", () => {
+    for (const n of [
+      "github.check_suite.completed",
+      "github.push",
+      "phase.implement.complete.CTL-1",
+    ]) {
+      processEvent({
+        ts: "2026-08-18T19:00:13Z",
+        id: `evt-${n}`,
+        attributes: {
+          "event.name": n,
+          "vcs.repository.name": "coalesce-labs/catalyst",
+          "vcs.pr.number": 3585,
+        },
+        body: { payload: { merged: true } },
+      });
+    }
+    expect(rows()).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/broker/pr-status-fold.mjs
+++ b/plugins/dev/scripts/broker/pr-status-fold.mjs
@@ -1,0 +1,102 @@
+// pr-status-fold.mjs — CTL-2008. Derive a PR's lifecycle status from a `github.pr.*`
+// event, so `pr_status_cache` stays current with NO webhook receiver in the path.
+//
+// ── WHY THIS FILE EXISTS ───────────────────────────────────────────────────
+// `pr_status_cache` was written in exactly ONE place: orch-monitor's HTTP webhook
+// handler (`orch-monitor/lib/pr-cache.ts`, called from `lib/webhook-handler.ts`).
+// CTL-1929 retired the GitHub smee tunnel on 2026-08-18, so that handler stopped
+// being reached and the table FROZE — measured by A/B at 14:02 CT with one variable
+// (the tunnel) and the same merge (`catalyst-cloud#882`): `mini` (tunnel open)
+// recorded it `merged` at 18:59:42Z; `mini-2` (tunnel closed) still read `open` from
+// 18:42:27Z, with ZERO rows written to the table after its flip.
+//
+// ⛔ A FROZEN MAP IS WORSE THAN AN EMPTY ONE, which is why this is a fold and not a
+// staleness check. `board-health.mjs`'s `checkPhantomMergedPr` and
+// `checkOrphanedOpenPr` both guard on `map.size === 0 -> observable:false` — the safe
+// degradation. A frozen NON-EMPTY map defeats that guard: it looks observable and
+// answers wrong, and it rots monotonically. A PR merging after the freeze stays
+// `open`, so phantom-merged goes blind (the exact detector CTL-1606 exists to serve)
+// while orphaned-open-PR accumulates false positives.
+//
+// ── WHY THE BROKER, AND NOT THE PRODUCER ───────────────────────────────────
+// The broker's tail sees EVERY event this fleet appends, from either source. Folding
+// here means the table is maintained identically at `enforce` (cloud feed) and after
+// a rollback to smee (webhook events carry the same names and the same payload
+// fields), so the rollback lever in `docs/runbooks/cloud-feed-cutover.md` does not
+// have to also un-break this. A producer-side write would only work in one mode.
+//
+// ⚠️ THE CALLER MUST FOLD ABOVE THE `if (!interests.size) return` GATE. This is not
+// a style note: on an execution-core host the interest table is permanently EMPTY
+// (the daemon runs no `filter.register` producer), so anything below that gate never
+// runs at all. `router.mjs`'s CTL-822 Linear-descriptor fold sits above it for this
+// same reason and its comment records that a verify panel caught the mistake once
+// already. `pr-status-fold-wiring.test.mjs` asserts the placement rather than the
+// value, because a correct classifier wired below the gate is a silent no-op.
+
+/** The three `github.pr.*` names that carry a PR's lifecycle state. */
+export const PR_LIFECYCLE_EVENT_NAMES = Object.freeze([
+  "github.pr.opened",
+  "github.pr.closed",
+  "github.pr.merged",
+]);
+
+/**
+ * The status values `board-health.mjs` expects. Kept as a frozen set so a typo in a
+ * future branch fails a test rather than writing an unrecognised status that
+ * `PR_MERGED_RE` silently declines to match.
+ */
+export const PR_STATUSES = Object.freeze(["open", "closed", "merged"]);
+
+/**
+ * classifyPrStatusEvent — pure. `(name, detail, scope) -> {repo, prNumber, status}`
+ * or `null` when the event is not a PR-lifecycle edge or is missing an identity.
+ *
+ * ⛔ THE ONE RULE: NOTHING MAY WALK A MERGED PR BACK TO `open`. That is the
+ * phantom-orphan bug CTL-1606 fixed — under `getAllPrStatuses`'s newest-wins, one
+ * later `open` row hides a merged PR from `checkPhantomMergedPr` and then presents it
+ * to `checkOrphanedOpenPr` as an orphan. `webhook-handler.ts` states the same rule and
+ * satisfies it by reading the PR's STATE (`merged`) rather than the webhook ACTION,
+ * because a raw `pull_request` webhook fires `labeled` / `edited` on already-merged
+ * PRs and an action-keyed derivation would flip them.
+ *
+ * ⭐ THIS FUNCTION SEES ALREADY-CLASSIFIED NAMES, so it reads BOTH and takes the union:
+ * `merged` when the state says so OR when the event is literally `github.pr.merged`.
+ * State alone is not enough here — a `github.pr.merged` whose payload lost its
+ * `merged` field would classify `open`, which is exactly the walk-back. Name alone is
+ * not enough either — `github.pr.closed` with `merged: true` is a merge. Taking the
+ * union means the only route to `open` is `github.pr.opened` on a PR that is not
+ * merged, so a walk-back is not constructible from any single event.
+ *
+ * ⚠️ The `putPrStatus` writer ALSO refuses to overwrite a `merged` row. The two guards
+ * are deliberate belt-and-braces at different altitudes and neither is redundant: this
+ * one stops a wrong value being derived, the latch stops a correct-but-stale value
+ * being applied out of order (events are not delivered in commit order).
+ *
+ * ⛔ IDENTITY IS (repo, pr_number) AND BOTH ARE REQUIRED. `getAllPrStatuses` buckets
+ * a null repo under the `""` repoKey, which `lookupPrStatus` treats as the
+ * "single UNATTRIBUTED row" legacy case and will hand to a ticket in ANY repo. One
+ * repo-less row therefore does not degrade to "less data" — it can attach a wrong
+ * repo's status to a ticket. Declining is the only safe answer.
+ */
+export function classifyPrStatusEvent(name, detail, scope) {
+  if (typeof name !== "string" || !PR_LIFECYCLE_EVENT_NAMES.includes(name)) return null;
+
+  const d = detail && typeof detail === "object" ? detail : {};
+  const s = scope && typeof scope === "object" ? scope : {};
+
+  const repo = typeof s.repo === "string" && s.repo.length > 0 ? s.repo : null;
+  if (repo === null) return null;
+
+  // Number(), not a truthiness check: PR #0 does not exist, but a string "3585" off a
+  // legacy envelope does, and dropping it would make the rollback path lossy.
+  const prNumber = Number(s.pr);
+  if (!Number.isInteger(prNumber) || prNumber <= 0) return null;
+
+  const status =
+    d.merged === true || name === "github.pr.merged"
+      ? "merged"
+      : name === "github.pr.closed"
+        ? "closed"
+        : "open";
+  return { repo, prNumber, status };
+}

--- a/plugins/dev/scripts/broker/pr-status-fold.test.mjs
+++ b/plugins/dev/scripts/broker/pr-status-fold.test.mjs
@@ -1,0 +1,157 @@
+// pr-status-fold.test.mjs — CTL-2008. The pure classifier.
+//
+// Run: cd plugins/dev/scripts/broker && bun test pr-status-fold.test.mjs
+//
+// The WIRING (that router.mjs folds this ABOVE the interests gate) is asserted
+// separately in pr-status-fold-wiring.test.mjs — a correct classifier called below
+// that gate is a silent no-op on every execution-core host, so proving the value is
+// not proving the fix.
+
+import { describe, test, expect } from "bun:test";
+import {
+  classifyPrStatusEvent,
+  PR_LIFECYCLE_EVENT_NAMES,
+  PR_STATUSES,
+} from "./pr-status-fold.mjs";
+
+const scope = { repo: "coalesce-labs/catalyst", pr: 3585 };
+
+describe("classifyPrStatusEvent — the three lifecycle edges", () => {
+  test("github.pr.opened on an unmerged PR is `open`", () => {
+    expect(classifyPrStatusEvent("github.pr.opened", { merged: false }, scope)).toEqual({
+      repo: "coalesce-labs/catalyst",
+      prNumber: 3585,
+      status: "open",
+    });
+  });
+
+  test("github.pr.closed WITHOUT a merge is `closed`", () => {
+    expect(classifyPrStatusEvent("github.pr.closed", { merged: false }, scope)?.status).toBe(
+      "closed",
+    );
+  });
+
+  test("github.pr.merged is `merged`", () => {
+    // The real payload shape the cloud feed emits (measured on mini-2, 19:00:10Z).
+    const detail = {
+      action: "closed",
+      merged: true,
+      mergedAt: "2026-08-18T18:59:40Z",
+      mergeCommitSha: "c7c255ccd200febc935c76ef32d22368ece14c81",
+      source: "cloud-feed",
+      feedAuthority: true,
+    };
+    expect(classifyPrStatusEvent("github.pr.merged", detail, scope)?.status).toBe("merged");
+  });
+});
+
+describe("⛔ a merged PR can never be walked back to `open`", () => {
+  test("github.pr.closed with merged:true is `merged`, not `closed`", () => {
+    // GitHub delivers a merge AS a `closed` action. Reading the name alone would
+    // record `closed`, and board-health's PR_MERGED_RE would stop matching it —
+    // phantom-merged goes blind on every merge.
+    expect(classifyPrStatusEvent("github.pr.closed", { merged: true }, scope)?.status).toBe(
+      "merged",
+    );
+  });
+
+  test("github.pr.merged with the `merged` field MISSING is still `merged`", () => {
+    // State-only derivation returns `open` here — a literal walk-back emitted by the
+    // event whose whole purpose is to record the merge. The union with the name is
+    // what stops it, so this asserts the union rather than the happy path.
+    expect(classifyPrStatusEvent("github.pr.merged", {}, scope)?.status).toBe("merged");
+    expect(classifyPrStatusEvent("github.pr.merged", { merged: false }, scope)?.status).toBe(
+      "merged",
+    );
+  });
+
+  test("`open` is reachable ONLY from github.pr.opened on an unmerged PR", () => {
+    // Exhaustive over the closed name set x the merged tri-state, so a future edit
+    // that adds an `open` route fails here rather than in production.
+    const opens = [];
+    for (const name of PR_LIFECYCLE_EVENT_NAMES) {
+      for (const merged of [true, false, undefined]) {
+        if (classifyPrStatusEvent(name, { merged }, scope)?.status === "open") {
+          opens.push(`${name}|merged=${String(merged)}`);
+        }
+      }
+    }
+    expect(opens.sort()).toEqual([
+      "github.pr.opened|merged=false",
+      "github.pr.opened|merged=undefined",
+    ]);
+  });
+});
+
+describe("⛔ identity is (repo, pr_number) and both are required", () => {
+  // A repo-less row is bucketed under the "" repoKey by getAllPrStatuses, which
+  // lookupPrStatus treats as the legacy "single UNATTRIBUTED row" case and will hand
+  // to a ticket in ANY repo. That is not less data — it is a wrong repo's status
+  // attached to a ticket, so declining is the only safe answer.
+  test("a missing or empty repo declines", () => {
+    expect(classifyPrStatusEvent("github.pr.merged", { merged: true }, { pr: 1 })).toBeNull();
+    expect(
+      classifyPrStatusEvent("github.pr.merged", { merged: true }, { repo: "", pr: 1 }),
+    ).toBeNull();
+  });
+
+  test("a missing, zero, negative or non-numeric PR number declines", () => {
+    for (const pr of [undefined, null, 0, -3, "abc", NaN, 1.5, {}]) {
+      expect(
+        classifyPrStatusEvent("github.pr.merged", { merged: true }, { repo: "o/r", pr }),
+      ).toBeNull();
+    }
+  });
+
+  test("a NUMERIC-STRING pr number is accepted — the legacy envelope carries one", () => {
+    // Dropping it would make the smee rollback path lossy for no reason.
+    expect(
+      classifyPrStatusEvent("github.pr.merged", { merged: true }, { repo: "o/r", pr: "3585" })
+        ?.prNumber,
+    ).toBe(3585);
+  });
+});
+
+describe("declines everything that is not a PR-lifecycle edge", () => {
+  test("other github.* names, phase names, junk and non-strings all decline", () => {
+    for (const name of [
+      "github.check_suite.completed",
+      "github.push",
+      "github.pr_review.submitted",
+      "phase.implement.complete.CTL-1",
+      "",
+      null,
+      undefined,
+      42,
+    ]) {
+      expect(classifyPrStatusEvent(name, { merged: true }, scope)).toBeNull();
+    }
+  });
+
+  test("a null/absent detail does not throw — it classifies from the name", () => {
+    expect(classifyPrStatusEvent("github.pr.merged", null, scope)?.status).toBe("merged");
+    expect(classifyPrStatusEvent("github.pr.opened", undefined, scope)?.status).toBe("open");
+  });
+
+  test("a null/absent scope declines rather than throwing", () => {
+    expect(classifyPrStatusEvent("github.pr.merged", { merged: true }, null)).toBeNull();
+    expect(classifyPrStatusEvent("github.pr.merged", { merged: true }, undefined)).toBeNull();
+  });
+});
+
+describe("the exported vocabularies are the ones the classifier can produce", () => {
+  // PR_STATUSES is load-bearing: putPrStatus rejects anything outside it, so a typo
+  // here would be written to a column board-health's PR_MERGED_RE silently declines
+  // to match. Assert the classifier's whole range is inside the declared set.
+  test("every status the classifier can emit is in PR_STATUSES", () => {
+    const produced = new Set();
+    for (const name of PR_LIFECYCLE_EVENT_NAMES) {
+      for (const merged of [true, false, undefined]) {
+        const r = classifyPrStatusEvent(name, { merged }, scope);
+        if (r) produced.add(r.status);
+      }
+    }
+    expect([...produced].sort()).toEqual(["closed", "merged", "open"]);
+    for (const s of produced) expect(PR_STATUSES).toContain(s);
+  });
+});

--- a/plugins/dev/scripts/broker/router.mjs
+++ b/plugins/dev/scripts/broker/router.mjs
@@ -72,6 +72,7 @@ import {
 import {
   upsertFilterStateOpen,
   setFilterStateMerged,
+  putPrStatus,
   setFilterStateClosed,
   setFilterStateDeploying,
   setFilterStateDeployed,
@@ -102,6 +103,7 @@ import {
 } from "./plugin-refresh.mjs";
 import { handleStackReloadEvent } from "./stack-reload.mjs";
 import { getEventName } from "../lib/event-name.mjs"; // CTL-1834: THE shared event-name boundary
+import { classifyPrStatusEvent } from "./pr-status-fold.mjs"; // CTL-2008: PR-status write-through
 import { getLastByteOffset } from "./tailer.mjs";
 import {
   severityNumber,
@@ -2812,6 +2814,39 @@ export function processEvent(event) {
       foldDetail.identifier ??
       null;
     foldLinearIssueDescriptor(name, foldDetail, foldTicket);
+  }
+
+  // CTL-2008: PR-status write-through. MUST run for every `github.pr.*` event
+  // REGARDLESS of registered interests — for exactly the reason the CTL-822 Linear
+  // fold above states, plus one that is stronger here: on an execution-core host the
+  // interest table is PERMANENTLY empty (the daemon runs no `filter.register`
+  // producer), so `if (!interests.size) return` below is not an idle-period edge case
+  // for this fold, it is every single tick. `pr_status_cache` is the primary source
+  // for `getAllPrStatuses()` -> board-health's phantom-merged and orphaned-open-PR
+  // cohorts, and until CTL-1929 retired the GitHub smee tunnel its only writer lived
+  // in orch-monitor's HTTP webhook handler, in another process, on a path that no
+  // longer runs. Measured A/B, 2026-08-18 14:02 CT: the enforce host wrote ZERO rows
+  // after its flip while the still-tunnelled host recorded the same merge correctly.
+  if (typeof name === "string" && name.startsWith("github.pr.")) {
+    // ⛔ `getEventScope` resolves pr/ref/sha/environment and NOT `repo` — passing it
+    // straight through made the classifier decline every event and the fold was a
+    // silent no-op with 13 green classifier tests behind it. `summarizeEvent` already
+    // spells this two-key ladder (attributes-then-legacy-scope) a few hundred lines
+    // above; it is repeated here rather than widening the shared helper, whose other
+    // callers do not want a new key. `pr-status-fold-wiring.test.mjs` is what caught
+    // it, which is the argument for that file existing.
+    const prScope = {
+      repo: event.attributes?.["vcs.repository.name"] ?? event.scope?.repo ?? null,
+      pr: event.attributes?.["vcs.pr.number"] ?? event.scope?.pr ?? null,
+    };
+    const prStatus = classifyPrStatusEvent(name, getEventPayload(event), prScope);
+    if (prStatus) {
+      try {
+        putPrStatus(prStatus.repo, prStatus.prNumber, prStatus.status);
+      } catch {
+        /* DB not opened — same posture as every other fold in this function */
+      }
+    }
   }
 
   if (name === "heartbeat") {


### PR DESCRIPTION
## The defect

`pr_status_cache` had exactly **one** writer and it lived in **another process**: orch-monitor's HTTP webhook handler (`orch-monitor/lib/pr-cache.ts`, called from `lib/webhook-handler.ts`). CTL-1929 retired the GitHub smee tunnel at **14:15 CT on 2026-08-18**, that handler stopped being reached, and the table **froze fleet-wide**. `lib/pr-status-backfill.ts` does not cover it — it is one-shot by design (*"skipped entirely when the table already has rows … a migration step, not a poll"*).

**Measured A/B — one variable (the tunnel), same minute, the same merge (`catalyst-cloud#882`):**

| host | mode | tunnel | rows written after 18:58:16Z | `pr_cache` | #882 reads |
| --- | --- | --- | --- | --- | --- |
| `mini` | shadow | **OPEN** | **2** | **1** | ⭐ `merged` @ 18:59:42Z |
| `mini-2` | enforce | **CLOSED** | **0** | **0** | ⛔ `open` @ 18:42:27Z |

`mini` is the positive control: the same query returns non-zero on a host that still has the tunnel, so `mini-2`'s zero is a real zero and not a broken query.

## Why a frozen map is worse than an empty one

`getAllPrStatuses()` reads this table as its **primary** source (`filter_state` is empty on every execution-core host) and feeds `scheduler.mjs` and `board-health.mjs`. Both PR invariants guard on `map.size === 0 → observable:false` — the safe degradation. **A frozen non-empty map defeats that guard**: it looks observable and answers wrong, and it rots monotonically.

- `checkPhantomMergedPr` — a PR merging after the freeze stays `open` → **never flagged**. Blind. The exact detector CTL-1606 exists to serve.
- `checkOrphanedOpenPr` — a since-merged PR still reads `open` → **false positives that accumulate**.
- The no-actuation invariant spares any ticket whose PR reads `open` → blind.

## The fix

`broker/pr-status-fold.mjs` (a pure classifier) + `putPrStatus` in `broker-state.mjs` + a fold in `router.mjs`.

**The broker, not the producer** — the broker's tail sees every event from **either** source, so the table is maintained identically at `enforce` and after a rollback to smee. The runbook's rollback lever does not have to also un-break this.

Three things the design turns on:

1. **The fold sits ABOVE `if (!interests.size) return`.** Not a style choice: on an execution-core host the interest table is **permanently** empty (the daemon runs no `filter.register` producer), so anything below that gate never runs at all. `router.mjs`'s CTL-822 Linear fold sits there for the same reason, and its comment records a verify panel catching the identical mistake once already.
2. **A merged PR can never be walked back to `open`, guarded at two altitudes.** The classifier takes the **union** of state and name (`merged` when `detail.merged` says so **or** the event is `github.pr.merged`), so the only route to `open` is `github.pr.opened` on an unmerged PR. The writer keeps `pr-cache.ts`'s `WHERE status != 'merged'` latch, because events are **not** delivered in commit order (a boot replay walks the month front to back) and newest-wins would otherwise hide a merge. Neither guard is redundant: one stops a wrong value being *derived*, the other stops a correct-but-stale value being *applied out of order*.
3. **Identity is `(repo, pr_number)` and both are required.** `getAllPrStatuses` buckets a null repo under the `""` repoKey, which `lookupPrStatus` treats as the legacy "single UNATTRIBUTED row" case and will hand to a ticket in **any** repo — so a repo-less row is not *less data*, it is a **wrong repo's status attached to a ticket**. Declining is the only safe answer.

## ⛔ The wiring test earned its keep immediately

With **13 green classifier tests**, the fold was a **silent no-op**: `getEventScope` resolves `pr`/`ref`/`sha`/`environment` and **not `repo`**, so the classifier declined every real event. Only `pr-status-fold-wiring.test.mjs` — which drives `processEvent` with the interest table empty — caught it.

(My first attempt to "prove" it worked in isolation was itself contaminated: I called `putPrStatus` directly before `processEvent` in the same script and read one combined result. The clean re-run returned 0 entries.)

**Mutation-tested both directions**, so the placement is asserted rather than assumed:

| mutation | wiring file | value file |
| --- | --- | --- |
| fold moved BELOW the interests gate | ⛔ **5 fail** | ✅ 13 pass |
| fold in its correct position | ✅ 9 pass | ✅ 13 pass |

## Deferred, stated rather than silently dropped

**CTL-2008's AC2** — board-health reporting `observable:false` on a *stale* map rather than answering from it — is **not** in this PR. A naive "newest `updated_at` is old" rule fires on a legitimately **quiet** fleet and would break two working detectors; doing it correctly needs a writer heartbeat so the predicate is *writer-silence*, not *data-quiet*. Follow-up filed. This PR restores the data, which is the part that makes the cutover cost-free.

`pr_cache` (the `head_sha → pr_number` map) is also not folded here. Its only reader is the webhook handler's own check_suite→PR resolution, and the feed's `check_suite.completed` already carries `prNumbers` directly (CTC-712) — so it has no live consumer on the feed path. (Worth recording against the stale comment at `github-feed-source.mjs:169`: I re-measured `pull_requests.head_sha` coverage on the live replica and it is **4322/4322 = 100%**, not the 46% that comment claims — so folding it later is cheap if a consumer appears.)

## Verification

| gate | result |
| --- | --- |
| `pr-status-fold.test.mjs` | ✅ 13 pass |
| `pr-status-fold-wiring.test.mjs` | ✅ 9 pass |
| broker bun suite (all 41 files) | **1050 pass / 1 fail** |
| that 1 failure | `fence-held-fold.test.mjs` — **pre-existing**: red on a separate clean worktree at the same commit, and one of the 42 suites `main` already fails |
| full shell gate (COORD-181) | ⏳ queued on `mini` behind P13's run — result + pass/fail SET posted before merge |

Closes CTL-2008 (AC1). Refs CTL-1929, CTL-1606.
