### PR TITLE
fix(dev): CTL-2019 — setup wrote the cloud account to a file and then refused to read it, so the whole install aborted

### DIFF
--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -570,6 +570,105 @@ else
 fi
 scrub "$HA"
 
+# ── CTL-2019: the account CARRY-FORWARD ──────────────────────────────────────
+# ⛔ THE DEFECT THIS PINS, MEASURED ON MINI-2 DURING THE CTL-1975 REHEARSAL.
+# setup_cloud_replica WRITES the account into ~/.config/catalyst/cloud-sync.env and,
+# before this, never read it back — resolution was flag-then-env only. The account
+# lives in a FILE, not in the environment, so on every host after its first install
+# the function found a token, found no account, and returned 1. That call site is
+# `setup_cloud_replica || exit 1`, so all of setup aborted — and with it every step
+# `catalyst install` runs afterwards: set-class, pull-owner, install-cli,
+# install-services, adopt-cloud-sync, start-stack, verify-node, doctor.
+#
+# The rebuilt node came up with 1 of 8 launchd agents, 0 daemons, node.class unset
+# and NO REPLICA WRITER — which falls back to live `linearis` and burns the shared,
+# rate-limited Linear quota. Nothing was red.
+#
+# ⚠️ These cases must not weaken Case 2's refusal, which is the load-bearing safety
+# property of this whole file. A carry-forward re-uses what THIS host already recorded
+# for itself; it is not a default, and "tenant-0" is still never guessed.
+echo ""
+echo "── CTL-2019: cloud account carry-forward ──"
+
+# The happy path the defect broke: account absent from flag AND env, but present in
+# the file this function itself wrote on a previous run.
+HCF=$(mktemp -d)
+mkdir -p "$HCF/.config/catalyst"
+cat >"$HCF/.config/catalyst/cloud-sync.env" <<'CFEOF'
+# Written by setup-catalyst.sh (CTL-1836).
+export CATALYST_CLOUD_TOKEN=tok_from_a_previous_run
+export CATALYST_CLOUD_ACCOUNT=tenant-carried
+export CATALYST_CLOUD_BASE_URL=https://staging.catalystcloud.dev/api/v1
+CFEOF
+rc=$(run_case "$HCF" "tok_test_abc" "" 200)
+if [[ $rc == "0" ]]; then
+	ok "⭐ account absent from flag+env but recorded in cloud-sync.env → provisions (rc=0)"
+else
+	bad "account carry-forward → rc=$rc; the recorded account was ignored (this is the CTL-2019 defect)"
+fi
+# and it must have used the CARRIED value, not some other one
+if grep -q '^export CATALYST_CLOUD_ACCOUNT=tenant-carried$' "$HCF/.config/catalyst/cloud-sync.env" 2>/dev/null; then
+	ok "the carried account is the one written back (tenant-carried)"
+else
+	bad "the carried account was not preserved in the rewritten env file"
+fi
+scrub "$HCF"
+
+# ⛔ INVERSION GUARD — the refusal must SURVIVE. Without this, a fix that simply
+# defaulted the account would pass every case above.
+HNF=$(mktemp -d)
+mkdir -p "$HNF/.config/catalyst"
+rc=$(run_case "$HNF" "tok_test_abc" "" 200)
+if [[ $rc != "0" ]]; then
+	ok "⛔ INVERSION GUARD: no flag, no env, NO file → still refuses (rc=$rc), never guesses tenant-0"
+else
+	bad "no account anywhere → returned 0; the carry-forward became a default"
+fi
+scrub "$HNF"
+
+# A file with no account line is the same as no file — not an empty-string account.
+HEL=$(mktemp -d)
+mkdir -p "$HEL/.config/catalyst"
+printf 'export CATALYST_CLOUD_TOKEN=tok_only\nexport CATALYST_CLOUD_BASE_URL=https://x/api/v1\n' \
+	>"$HEL/.config/catalyst/cloud-sync.env"
+rc=$(run_case "$HEL" "tok_test_abc" "" 200)
+if [[ $rc != "0" ]]; then
+	ok "cloud-sync.env present but carrying NO account line → still refuses"
+else
+	bad "an account-less env file was treated as an account"
+fi
+scrub "$HEL"
+
+# Precedence: an explicit env account must still beat the recorded file.
+HPR=$(mktemp -d)
+mkdir -p "$HPR/.config/catalyst"
+printf 'export CATALYST_CLOUD_ACCOUNT=tenant-from-file\n' >"$HPR/.config/catalyst/cloud-sync.env"
+rc=$(run_case "$HPR" "tok_test_abc" "tenant-from-env" 200)
+if [[ $rc == "0" ]] && grep -q '^export CATALYST_CLOUD_ACCOUNT=tenant-from-env$' \
+	"$HPR/.config/catalyst/cloud-sync.env" 2>/dev/null; then
+	ok "precedence holds: env account beats the recorded file"
+else
+	bad "precedence broken: the file overrode an explicitly supplied account"
+fi
+scrub "$HPR"
+
+# ⛔ The carry-forward must not drag the TOKEN out of that file. It reads one named
+# non-secret field; sourcing the file would pull a live credential into this shell and
+# every child it spawns. Proven by giving the file a DIFFERENT token from the caller's
+# and asserting the caller's is the one that survives.
+HTK=$(mktemp -d)
+mkdir -p "$HTK/.config/catalyst"
+printf 'export CATALYST_CLOUD_TOKEN=tok_STALE_from_file\nexport CATALYST_CLOUD_ACCOUNT=tenant-carried\n' \
+	>"$HTK/.config/catalyst/cloud-sync.env"
+rc=$(run_case "$HTK" "tok_CALLER_wins" "" 200)
+if grep -q 'tok_CALLER_wins' "$HTK/.config/catalyst/cloud-sync.env" 2>/dev/null &&
+	! grep -q 'tok_STALE_from_file' "$HTK/.config/catalyst/cloud-sync.env" 2>/dev/null; then
+	ok "⭐ reads the ACCOUNT only — the caller's token wins, the file's stale token is not adopted"
+else
+	bad "the carry-forward pulled the token out of the env file (it must read one named field)"
+fi
+scrub "$HTK"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1914,6 +1914,48 @@ validate_cloud_token() {
 # reads off: the exact "install finished ≠ system works" gap CTL-1918 exists to close,
 # reintroduced by the fix for it. Flags win over env; the configured name wins over the
 # default (CTL-1668).
+# resolve_cloud_account — CTL-2019. flag > env > THIS HOST'S OWN previously-recorded
+# account, read back out of the cloud-sync.env that setup_cloud_replica itself wrote.
+#
+# ⛔ WHY. The account was WRITTEN here (`export CATALYST_CLOUD_ACCOUNT=...` below) and
+# never READ back: resolution was flag-then-env only. So on any host that already has a
+# discoverable cloud token but no account exported in its shell — which is every host
+# after its first install, because the account lives in a file rather than the
+# environment — `setup_cloud_replica` found a token, found no account, and returned 1.
+# That line is `setup_cloud_replica || exit 1`, so the whole of setup aborted, and with
+# it every step `catalyst install` runs afterwards: set-class, pull-owner, install-cli,
+# install-services, adopt-cloud-sync, start-stack, verify-node, doctor.
+#
+# Measured on mini-2 during the CTL-1975 rehearsal (2026-08-18): a reinstalled node came
+# up with 1 of 8 launchd agents, 0 daemons, `node.class` unset and NO REPLICA WRITER —
+# which silently falls back to live `linearis` and burns the shared, rate-limited Linear
+# quota. Nothing was red. The value that would have prevented all of it was sitting in
+# ~/.config/catalyst/cloud-sync.env, one directory from the code that refused to look.
+#
+# ⚠️ This is a CARRY-FORWARD, not a default, and the distinction is the safety property
+# the original comment was protecting: we re-use the account THIS host already recorded
+# for itself. We still never fall back to "tenant-0" — pointing a host at the
+# maintainer's tenant on a guess is exactly the 403-with-no-explanation this refuses.
+# An absent/unreadable file still yields empty, and the hard error below still fires.
+#
+# Deliberately NOT `source`d: that file also carries the cloud TOKEN, and sourcing it
+# would pull a live credential into this shell (and into every child it spawns) to read
+# a non-secret identifier. One field is extracted by name instead.
+resolve_cloud_account() {
+	local acct="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"
+	if [[ -z $acct ]]; then
+		local env_file="$HOME/.config/catalyst/cloud-sync.env"
+		if [[ -r $env_file ]]; then
+			acct="$(sed -n 's/^[[:space:]]*export[[:space:]]\{1,\}CATALYST_CLOUD_ACCOUNT=//p' "$env_file" 2>/dev/null | tail -1)"
+			acct="${acct%\"}"
+			acct="${acct#\"}"
+			acct="${acct%\'}"
+			acct="${acct#\'}"
+		fi
+	fi
+	printf '%s' "$acct"
+}
+
 resolve_cloud_token() {
 	local _tv="${CATALYST_CLOUD_TOKEN_ENV-}"
 	if [[ -z $_tv ]] && [[ -r "$HOME/.config/catalyst/config.json" ]] && command -v jq >/dev/null 2>&1; then
@@ -1933,7 +1975,7 @@ setup_cloud_replica() {
 	# byte-identical to before CTL-1836.
 	local token account
 	token="$(resolve_cloud_token)"
-	account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"
+	account="$(resolve_cloud_account)"
 	[[ -n $token ]] || return 0
 
 	print_header "Provisioning Catalyst Cloud Replica"

--- a/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
+++ b/website/src/content/docs/getting-started/remote-and-unattended-hosts.md
@@ -17,13 +17,29 @@ The page you were sent here from presents step 1 as interactive. It does not hav
 `setup-catalyst.sh` has a full headless contract, so the entire install over SSH is:
 
 ```bash
+cd /path/to/your/repo   # ⛔ required — see below
 curl -fsSL https://raw.githubusercontent.com/coalesce-labs/catalyst/main/setup-catalyst.sh \
   | bash -s -- --non-interactive \
       --cloud-token "$CATALYST_CLOUD_TOKEN" --cloud-account "$CATALYST_CLOUD_ACCOUNT"
 ```
 
+**Run it from inside the repo you are enrolling.** Setup configures Catalyst *for a project*, so a
+non-interactive run refuses rather than guessing which one:
+
+```
+✗ Not in a git repository. Run setup from inside the target repo when using --non-interactive.
+```
+
+This page previously showed the `curl` line alone and called it "the entire install", which is why
+this note exists: run from `$HOME` on a fresh host — the most natural thing to do over SSH — and the
+install stops there. Clone the repo first if the host does not have it yet.
+
 `-s --` is required — without it `bash` eats the flags and the script tries to open `/dev/tty` on a
 host that has none. `CATALYST_AUTONOMOUS=1` is an equivalent env-var form.
+
+`--cloud-account` is required the first time a cloud token is supplied, and there is deliberately no
+default (guessing would point the host at another tenant's workspace). **On later runs you can omit
+it** — setup records the account in `~/.config/catalyst/cloud-sync.env` and reads it back from there.
 
 Setup finishes the job rather than printing a list: it installs the `catalyst-*` CLIs, provisions
 `plugin-source`, turns on replica reads, and enrols the project. Anything it could not do is printed


### PR DESCRIPTION
## The defect, and how it was found

Found by **running the rehearsal**, not by reading code. `catalyst uninstall --archive` + the documented install on mini-2 produced a node with **1 of 8 launchd agents, 0 daemons, `node.class` unset, and no replica writer** — and nothing was red.

Root cause is one line. `setup_cloud_replica` resolved the account **flag-then-env only**, while *writing* it to `~/.config/catalyst/cloud-sync.env` itself:

```bash
account="${CLOUD_ACCOUNT:-${CATALYST_CLOUD_ACCOUNT-}}"    # ← never reads the file it wrote
...
echo "export CATALYST_CLOUD_ACCOUNT=${account}" >> "$env_file"   # ← writes it here
```

The account lives in a **file**, not the environment. So on every host after its first install the function finds a token, finds no account, and `return 1`. That call site is:

```bash
setup_cloud_replica || exit 1
```

⛔ **So the whole of setup aborts** — and with it every step `catalyst install` runs after `write-config`: `set-class`, `pull-owner`, `install-cli`, `install-services`, **`adopt-cloud-sync`**, `start-stack`, `verify-node`, `doctor`.

**The value that would have prevented all of it was in a file one directory from the code that refused to look.**

⚠️ **Why it matters beyond a failed install:** the missing agent is `cloud-sync`, the **replica writer**. `doctor` grades its absence as *"reads fall back to live linearis"* — i.e. the node burns the **shared, rate-limited** Linear quota on every read. It fails in the direction that looks healthy.

## The fix

`resolve_cloud_account` — `flag > env > this host's own recorded account` — mirroring `resolve_cloud_token` right above it.

⭐ **It is a CARRY-FORWARD, not a default, and that distinction is the whole safety property.** CTL-1836 refuses to guess `tenant-0` because that is the maintainer's tenant and guessing would point a stranger's host at someone else's workspace (an opaque 403). This re-uses only what **this host already recorded for itself**; `tenant-0` is still never guessed, and an absent/unreadable/account-less file still yields empty and still hits the loud refusal. **Pinned by an inversion guard**, so a fix that merely defaulted the account would fail.

⭐ **The file is parsed for ONE named field, never `source`d.** It also carries the cloud **token**; sourcing it to read a non-secret identifier would pull a live credential into this shell and every child it spawns. There is a test that proves the caller's token wins and the file's stale token is not adopted.

**Third instance of one pattern:** `resolveReadReplica` (CTL-1369) and `resolveGithubFeed` (CTL-2004) are the same shape — a key that is stripped or absent on rebuild, whose absence fails silently.

## Also: the docs promised something the script refuses

`remote-and-unattended-hosts.md` said *"the entire install over SSH is:"* and gave the `curl` line. Run exactly that way — from `$HOME` on a fresh host, the most natural thing to do over SSH — and it stops at `✗ Not in a git repository`. The script's refusal is **correct** (setup configures Catalyst *for a project* and must not guess which), so the page is what was wrong. Now shows the `cd`, explains why, and documents that `--cloud-account` may be omitted on later runs.

## Verification

- **59 passed / 0 failed** in `setup-cloud-replica.test.sh` — a suite that is **already pinned in CI**, so these guards actually run.
- ⭐ **Mutation-tested.** Reverting to the flag-then-env line fails exactly 2 cases with their own diagnostics (`the recorded account was ignored`; `the carry-forward pulled the token out of the env file`). Restored → 59/0.
- ⭐ **Live positive control on the real fleet:** sourced against **mini-2's actual config**, `resolve_cloud_account` returns `tenant-0` — the exact value whose absence aborted the install. Before the fix it returned empty.
- Six new cases: the carry-forward happy path · the value written back is the carried one · **inversion guard** (nothing anywhere → still refuses) · an account-less file is not an empty account · env still beats the file · the token is not adopted from the file.

## Scope note

This fixes the *abort*, which is what caused the missing agents, the unset `node.class`, and the absent `githubFeed.mode` — all three were downstream of it. **Two rehearsal findings are deliberately NOT in this PR**: the non-interactive team auto-selection picking a scratch team (`ZCTC163`) is [CTL-1893](https://linear.app/coalesce-labs/issue/CTL-1893)'s territory, and re-running the full rehearsal to re-verify end-to-end is the follow-up — mini-2 is currently green and serving, and I am not taking a production worker down twice in an afternoon without a reason.

⚠️ **Codex is out of quota**, so there will be no automated review — that is "could not look", not a clean pass. **Peer read requested.**

Closes CTL-2019.
