### PR TITLE
fix(dev): CTL-2018 — the producer resolves its suppressible set at runtime, because a constant cannot see a migration

### DIFF
--- a/plugins/dev/scripts/execution-core/github-feed-suppressible-parity.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-suppressible-parity.test.mjs
@@ -1,0 +1,164 @@
+// github-feed-suppressible-parity.test.mjs — CTL-2018.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test github-feed-suppressible-parity.test.mjs
+//
+// ⛔ WHY THIS FILE EXISTS. Two processes answer one question — "which `github.*` names
+// may smee be suppressed for?" — and until 2026-08-18 they answered it differently
+// while every log line on both read healthy:
+//
+//   • the broker's dispatch gate (`github-feed-gate-install.mjs`) resolved it at
+//     RUNTIME from the replica, re-probed every COVERAGE_CACHE_MS → 12 names;
+//   • the producer (`github-feed-timer.mjs`) read the STATIC constant of the same
+//     stem, frozen at import → 10 names.
+//
+// The producer's own header asserted they could not disagree ("Both sides read
+// `GITHUB_SUPPRESSIBLE_NAMES`, so they cannot disagree"). That sentence was the only
+// thing holding the invariant, it was false, and the cost was 153 dropped dispatch
+// edges on mini-2 in 46 minutes (125 `check_suite.completed` + 28 `push`).
+//
+// A comment cannot hold an invariant that spans two files. This does: both sides are
+// driven off ONE coverage fixture and compared to EACH OTHER — never each to its own
+// constant, which is exactly how the pre-existing test stayed green through the
+// divergence. Same discipline as `assertion-evidence-parity.test.mjs`.
+
+import { describe, expect, test } from "bun:test";
+import { resolveSuppressibleForTick } from "./github-feed-timer.mjs";
+import { readGithubCoverage } from "./github-feed-gate-install.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+  githubSuppressibleNames,
+} from "./github-feed-gate.mjs";
+
+/** A replica handle that reports a chosen coverage. */
+const replica = ({ pushIsLossy, checkSuiteHasPrAssociation }) => ({
+  close() {},
+  pushIsLossy: () => pushIsLossy,
+  checkSuiteHasPrAssociation: () => checkSuiteHasPrAssociation,
+});
+
+/** The gate's answer, through its own production entry point. */
+const gateSide = (sourceFactory) =>
+  [...githubSuppressibleNames(readGithubCoverage({ sourceFactory }))].sort();
+
+/** The producer's answer, through its own production entry point. */
+const producerSide = (sourceFactory) => [...resolveSuppressibleForTick(sourceFactory()).names].sort();
+
+// Every combination, so the parity claim is exhaustive over the input space rather
+// than anecdotal on today's fleet.
+const COVERAGES = [
+  { label: "migrated (0.1.18) — both capabilities", pushIsLossy: false, checkSuiteHasPrAssociation: true },
+  { label: "pre-CTC-712 — push covered, no PR association", pushIsLossy: false, checkSuiteHasPrAssociation: false },
+  { label: "pre-CTC-704 — PR association, push still lossy", pushIsLossy: true, checkSuiteHasPrAssociation: true },
+  { label: "pre-capability — neither", pushIsLossy: true, checkSuiteHasPrAssociation: false },
+];
+
+describe("⛔ the producer and the gate resolve ONE suppressible set", () => {
+  for (const c of COVERAGES) {
+    test(`they agree on: ${c.label}`, () => {
+      const factory = () => replica(c);
+      expect(producerSide(factory)).toEqual(gateSide(factory));
+    });
+  }
+
+  test("⭐ and the four coverages are not all the same answer — the comparison has range", () => {
+    // Without this, "they agree" could hold because the fixture space is degenerate.
+    const sizes = new Set(COVERAGES.map((c) => producerSide(() => replica(c)).length));
+    expect(sizes.size).toBeGreaterThan(1);
+    expect(Math.max(...sizes)).toBe(GITHUB_CONSUMED_NAMES.length);
+  });
+});
+
+describe("⛔ they fail closed IDENTICALLY — agreement must survive the error path too", () => {
+  // The dangerous asymmetry is not two different happy answers; it is one side
+  // degrading and the other not. A gate that fails closed while the producer keeps
+  // emitting is a double dispatch; the reverse is a dropped edge.
+  const broken = [
+    { label: "a handle with no capability methods", factory: () => ({ close() {} }) },
+    {
+      label: "a handle whose probes throw",
+      factory: () => ({
+        close() {},
+        pushIsLossy: () => { throw new Error("locked"); },
+        checkSuiteHasPrAssociation: () => { throw new Error("locked"); },
+      }),
+    },
+  ];
+  for (const b of broken) {
+    test(`both degrade to the pre-capability set: ${b.label}`, () => {
+      expect(producerSide(b.factory)).toEqual(gateSide(b.factory));
+      // And it really is the SMALLEST set, not merely a matching one.
+      expect(producerSide(b.factory)).toEqual([...GITHUB_SUPPRESSIBLE_NAMES].sort());
+    });
+  }
+});
+
+describe("⛔ the static constant is NOT the runtime answer on the fleet's own replica", () => {
+  test("a migrated replica yields strictly MORE names than the frozen constant", () => {
+    // The assertion that would have failed before the flip. If this ever stops being
+    // true because the constant caught up, the parity tests above still hold and this
+    // one becomes trivially true — so it is pinned to the NAMES, which is the claim.
+    const migrated = () => replica({ pushIsLossy: false, checkSuiteHasPrAssociation: true });
+    const runtime = producerSide(migrated);
+    const gap = GITHUB_CONSUMED_NAMES.filter((n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n));
+    expect(gap.sort()).toEqual(["github.check_suite.completed", "github.push"]);
+    for (const n of gap) expect(runtime).toContain(n);
+  });
+});
+
+describe("⛔ a degraded enforce reports UNREADY, which un-suppresses smee at the broker", () => {
+  // `decideDispatch`'s `isReady` gates the SMEE side only, so `ready: false` is what
+  // makes the broker stop suppressing smee's copies. On a gapped host that is the
+  // correct outcome — the producer emits markers and smee keeps carrying the edges.
+  test("a pre-capability replica yields ready:false with a named reason", async () => {
+    const { runGithubFeedTick } = await import("./github-feed-timer.mjs");
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const r = runGithubFeedTick({
+      mode: "enforce",
+      orchDir: mkdtempSync(join(tmpdir(), "gh-degraded-")),
+      dbPath: ":memory:",
+      authorityAtEntry: true,
+      appendEventFn: () => {},
+      appendShadowFn: () => {},
+      sourceFactory: () => replica({ pushIsLossy: true, checkSuiteHasPrAssociation: false }),
+      seenFactory: () => ({ close() {} }),
+      // `countsClean` reads `failed` + `byFailure` (NOT `failures`/`byReason`), and an
+      // absent census reads as dirty — so a sloppy fixture would make `ready:false` for
+      // the wrong reason and the control below would prove nothing.
+      sweepFn: () => ({ emitted: 0, failed: 0, byFailure: {} }),
+    });
+    expect(r.mode.effective).toBe("shadow");
+    expect(r.mode.degraded).toBe(true);
+    expect(r.ready).toBe(false);
+    expect(r.unready).toBe("mode-degraded:shadow");
+  });
+
+  test("⭐ positive control — a migrated replica on the same path is READY", () => {
+    // Without this, `ready:false` above could be an artefact of the fixture rather
+    // than of the degradation.
+    return import("./github-feed-timer.mjs").then(async ({ runGithubFeedTick }) => {
+      const { mkdtempSync } = await import("node:fs");
+      const { tmpdir } = await import("node:os");
+      const { join } = await import("node:path");
+      const r = runGithubFeedTick({
+        mode: "enforce",
+        orchDir: mkdtempSync(join(tmpdir(), "gh-ok-")),
+        dbPath: ":memory:",
+        authorityAtEntry: true,
+        appendEventFn: () => {},
+        appendShadowFn: () => {},
+        sourceFactory: () => replica({ pushIsLossy: false, checkSuiteHasPrAssociation: true }),
+        seenFactory: () => ({ close() {} }),
+        // `countsClean` reads `failed` + `byFailure` (NOT `failures`/`byReason`), and an
+      // absent census reads as dirty — so a sloppy fixture would make `ready:false` for
+      // the wrong reason and the control below would prove nothing.
+      sweepFn: () => ({ emitted: 0, failed: 0, byFailure: {} }),
+      });
+      expect(r.mode.effective).toBe("enforce");
+      expect(r.mode.degraded).toBe(false);
+      expect(r.ready).toBe(true);
+    });
+  });
+});

--- a/plugins/dev/scripts/execution-core/github-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.mjs
@@ -17,8 +17,17 @@
 // The two sides are the same invariant read from opposite ends — the producer
 // decides what to emit, the gate decides what to suppress, and if they disagree the
 // result is either a double dispatch (feed emits, gate does not suppress smee) or a
-// dropped edge (gate suppresses smee, feed declined to emit). Both sides read
-// `GITHUB_SUPPRESSIBLE_NAMES`, so they cannot disagree.
+// dropped edge (gate suppresses smee, feed declined to emit).
+//
+// ⛔ CTL-2018: THIS COMMENT USED TO END "Both sides read `GITHUB_SUPPRESSIBLE_NAMES`,
+// so they cannot disagree." That was FALSE and it is what shipped the dropped-edge
+// half. Both sides read the same NAME, but the gate calls the runtime FUNCTION
+// `githubSuppressibleNames(coverage)` while this file read the static CONSTANT of the
+// same stem — 12 vs 10 on a 0.1.18 replica, differing by exactly
+// `{github.check_suite.completed, github.push}`. They now share the FUNCTION, resolved
+// per tick from this producer's own replica handle. The invariant is asserted, not
+// asserted-in-a-comment: `github-feed-suppressible-parity.test.mjs` drives both sides
+// off one coverage fixture and fails if they ever differ.
 //
 // An excluded name still goes out as a `would-dispatch` marker under enforce, so
 // the parity ledger keeps observing it and the gap stays measurable while it lasts.
@@ -45,6 +54,7 @@ import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
 import {
   GITHUB_CONSUMED_NAMES,
   GITHUB_SUPPRESSIBLE_NAMES,
+  githubSuppressibleNames,
 } from "./github-feed-gate.mjs";
 import { defaultReadyPath, writeReadyState } from "./github-feed-ready.mjs";
 
@@ -69,10 +79,53 @@ export function resolveAccount(envObj = process.env) {
 export const EVENT_WOULD_DISPATCH = "github-feed.would-dispatch";
 
 /**
- * The names this producer may emit under their REAL name. Derived from the gate's
- * export, never re-typed — see the header's "same invariant from opposite ends".
+ * The names this producer may emit under their REAL name.
+ *
+ * ⛔ CTL-2018: THIS USED TO BE `new Set(GITHUB_SUPPRESSIBLE_NAMES)` — a module-level
+ * constant, frozen at import — and that made `enforce` silently lossy. The BROKER's
+ * dispatch gate resolves the same question at RUNTIME
+ * (`github-feed-gate-install.mjs`'s `resolveSuppressible` → `readGithubCoverage()` →
+ * `githubSuppressibleNames()`, re-probed every `COVERAGE_CACHE_MS`), because both
+ * capabilities arrive when the cloud-sync WRITER restarts and runs its migrations —
+ * an event neither process participates in. The static constant here could not.
+ *
+ * On a schema-0.1.18 replica the two answers differ by exactly
+ * `{github.check_suite.completed, github.push}`: the gate says 12, the constant said
+ * 10. At `enforce` that meant the producer wrote a `would-dispatch` MARKER for those
+ * two while the gate suppressed smee's copy and the tunnel was closed — so nothing
+ * dispatched. Measured on mini-2 over a 46-minute enforce window on 2026-08-18: the
+ * shadow file carried 125 `check_suite.completed` + 28 `push`, the event log's
+ * `cloud-feed` channel carried **0** of each, and 153 markers were written instead.
+ *
+ * ⚠️ AND THE PARITY LEDGER COULD NOT SEE IT — `github-feed-parity-run.mjs` reads the
+ * SHADOW FILE as its feed side, and the shadow file had all 153. It reported
+ * `clean = true · exit 0` throughout the outage. Shadow and enforce take different
+ * branches of the same sink and only the shadow branch is compared, so no soak on
+ * shadow — of any length — can test this path.
+ *
+ * The set is therefore resolved PER TICK from the replica handle this producer
+ * already opens, through the SAME `githubSuppressibleNames` the gate calls. One
+ * derivation, two callers.
  */
-const SUPPRESSIBLE_SET = new Set(GITHUB_SUPPRESSIBLE_NAMES);
+export function resolveSuppressibleForTick(source) {
+  // ⛔ FAILS CLOSED TO THE PRE-CAPABILITY SET, matching `readGithubCoverage`'s posture
+  // exactly: `pushIsLossy: true, checkSuiteHasPrAssociation: false` yields the SMALLEST
+  // suppressible set. For the gate that means "smee keeps authority"; for the producer
+  // it means "emit a marker, not a real event". Both are the non-dispatching direction
+  // — but they are only SAFE TOGETHER when both sides land on the same answer, which is
+  // the whole point of sharing the derivation rather than the constant.
+  let coverage = { pushIsLossy: true, checkSuiteHasPrAssociation: false, ok: false };
+  try {
+    coverage = {
+      pushIsLossy: source.pushIsLossy(),
+      checkSuiteHasPrAssociation: source.checkSuiteHasPrAssociation(),
+      ok: true,
+    };
+  } catch {
+    /* pre-capability answer retained */
+  }
+  return { names: githubSuppressibleNames(coverage), coverage };
+}
 
 export function defaultShadowPath(orchDir, account = resolveAccount()) {
   return join(orchDir, "shadow", `github-feed-${account}.jsonl`);
@@ -110,18 +163,40 @@ export function resolveEffectiveMode(
   { suppressible = GITHUB_SUPPRESSIBLE_NAMES, consumed = GITHUB_CONSUMED_NAMES } = {},
 ) {
   if (requested === "enforce") {
-    // ⚠️ NOT degraded, but not unqualified either — the reason is retained and now
-    // states the residual, because an operator who reads `mode: enforce` and infers
-    // "the tunnel can go" would be wrong until all three gaps close. A mode that is
-    // partially honoured has to say which part.
+    const gaps = consumed.filter((n) => !suppressible.includes(n));
+    // ⛔ CTL-2018: A PARTIAL ENFORCE IS NOT SAFE, and this used to return
+    // `degraded: false` for one. The old reason string said it out loud — "smee stays
+    // authoritative for N ... and the tunnel cannot retire until they close" — and
+    // then returned a fully-honoured verdict anyway, so the sentence had no consumer.
+    // It was true and inert, the same shape as CTL-1659's `restart_needed`.
+    //
+    // Why partial cannot work: the two gates are at DIFFERENT GRANULARITIES. The
+    // broker's dispatch gate is PER NAME, so it can leave smee authoritative for an
+    // uncovered one. The TUNNEL gate in orch-monitor is BINARY — `enforce` means the
+    // smee tunnel never starts at all. So on a host with any gap, `enforce` closes the
+    // only transport those names have and the producer emits markers for them: the
+    // edges are dropped, whether or not the two sides agree about the gap. Agreement
+    // was never the property that made it safe; FULL coverage is.
+    //
+    // Measured 2026-08-18: 153 dropped edges on mini-2 in 46 minutes
+    // (125 check_suite.completed + 28 push) with both sides in perfect agreement.
+    if (gaps.length > 0) {
+      return {
+        requested,
+        effective: "shadow",
+        degraded: true,
+        reason:
+          `enforce refused: this host can emit ${suppressible.length} of ${consumed.length} ` +
+          `consumed names and the smee tunnel is closed for ALL of them at enforce, so ` +
+          `${gaps.join(", ")} would be dropped. Running as shadow. ` +
+          `Coverage arrives with the replica schema pin (CTC-691, CTC-712, CTC-704).`,
+      };
+    }
     return {
       requested,
       effective: "enforce",
       degraded: false,
-      reason:
-        `enforce is authoritative for ${suppressible.length} of ${consumed.length} consumed names; ` +
-        `smee stays authoritative for ${consumed.length - suppressible.length} ` +
-        `(CTC-691, CTC-667 item 4, CTC-704) and the tunnel cannot retire until they close.`,
+      reason: `enforce is authoritative for all ${consumed.length} consumed names.`,
     };
   }
   return { requested, effective: requested, degraded: false, reason: null };
@@ -175,9 +250,14 @@ export function runGithubFeedTick({
   seams,
   logger = null,
 }) {
-  const resolved = resolveEffectiveMode(mode);
-  if (resolved.effective === "off") {
-    return { skipped: "mode-off", mode: resolved, counts: null, ready: false };
+  // ⚠️ TWO RESOLUTIONS, AND THE ORDER MATTERS. `off` has to short-circuit BEFORE the
+  // replica handle is opened (opening it is the one thing `off` promises not to do),
+  // but the honest `enforce` answer needs the runtime coverage that only that handle
+  // can give. So resolve cheaply here to answer `off`, then resolve again below with
+  // the real suppressible set once the source exists. Only the second one is reported.
+  const provisional = resolveEffectiveMode(mode);
+  if (provisional.effective === "off") {
+    return { skipped: "mode-off", mode: provisional, counts: null, ready: false };
   }
 
   // Readiness AS THIS TICK BEGAN. Captured before the sweep runs, so every event
@@ -197,7 +277,7 @@ export function runGithubFeedTick({
     try { source?.close?.(); } catch { /* best effort */ }
     return {
       skipped: null,
-      mode: resolved,
+      mode: provisional,
       error: `open-failed:${err?.code ?? err?.name ?? "unknown"}`,
       counts: null,
       ready: false,
@@ -205,6 +285,15 @@ export function runGithubFeedTick({
   }
 
   try {
+    // ⛔ CTL-2018: the suppressible set comes from THIS REPLICA, right now, through the
+    // same function the broker's gate calls — not from a constant frozen at import.
+    const { names: tickSuppressibleNames, coverage } = resolveSuppressibleForTick(source);
+    const tickSuppressible = new Set(tickSuppressibleNames);
+    // The reported mode is the one resolved against the real set, so `reason`'s
+    // "authoritative for N of M" is a measurement of this host rather than of a
+    // constant. Under-reporting it is how "10 of 12" read as a healthy enforce.
+    const resolved = resolveEffectiveMode(mode, { suppressible: tickSuppressibleNames });
+
     const emitted = [];
     const counts = sweepFn({
       source,
@@ -222,7 +311,7 @@ export function runGithubFeedTick({
         // export so the producer and the gate cannot drift: emitting a real name the
         // gate will not suppress double-dispatches that name, and declining a name
         // the gate DOES suppress drops the edge entirely.
-        if (resolved.effective === "enforce" && SUPPRESSIBLE_SET.has(name)) {
+        if (resolved.effective === "enforce" && tickSuppressible.has(name)) {
           // ⛔ AUTHORITY IS STAMPED AT EMISSION, not read at consumption (CTL-1901).
           // A later readiness change must not retroactively grant OR revoke authority
           // for a line already on disk — the sweep's cursor has advanced past the
@@ -258,7 +347,25 @@ export function runGithubFeedTick({
     });
 
     const report = { counts, stoppedEarly: false };
-    const unready = githubSweepUnreadyReason(report, feedHealth);
+    // ⛔ CTL-2018: A DEGRADED ENFORCE MUST ALSO REPORT UNREADY, and this is a real
+    // safety lever rather than cosmetics. `decideDispatch`'s `isReady` gates the SMEE
+    // side ONLY ("Omitted/absent ⇒ NOT ready, so a wiring mistake keeps smee
+    // authoritative"), so `ready: false` makes the broker STOP suppressing smee's
+    // copies. On a host whose replica cannot cover every consumed name that is exactly
+    // the right outcome: the producer emits markers, and smee keeps carrying the real
+    // edges instead of being switched off underneath them.
+    //
+    // ⚠️ RESIDUAL, NAMED BECAUSE IT IS NOT CLOSED HERE: this lever reaches the BROKER,
+    // not orch-monitor. The tunnel gate resolves `enforce` straight from Layer-2
+    // (`githubFeedIsAuthoritative`) and never starts the tunnel, so on a gapped host
+    // there is nothing for the un-suppressed smee branch to route. Making all three
+    // readers agree about coverage — not just about the flag — is CTL-2011's scope.
+    // Until it lands, the operator rule stands: do not set `enforce` on a host whose
+    // replica is not migrated, and `catalyst doctor` should FAIL it.
+    const sweepUnready = githubSweepUnreadyReason(report, feedHealth);
+    const unready = resolved.degraded
+      ? `mode-degraded:${resolved.effective}`
+      : sweepUnready;
     if (resolved.degraded && logger?.warn) {
       // Once per tick is deliberate here rather than latched: this state is a
       // deliberate operator-visible refusal, not a flapping alarm, and it ends the

--- a/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.test.mjs
@@ -18,7 +18,11 @@ import { DEFAULT_ACCOUNT } from "./linear-feed-run.mjs";
 import { defaultSeenPath } from "./github-feed-seen.mjs";
 import { streamCursorPath } from "./github-feed-sweep.mjs";
 import { readGithubFeedConfig } from "./config.mjs";
-import { GITHUB_CONSUMED_NAMES, GITHUB_SUPPRESSIBLE_NAMES } from "./github-feed-gate.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+  githubSuppressibleNames,
+} from "./github-feed-gate.mjs";
 
 const tmp = mkdtempSync(join(tmpdir(), "gh-feed-timer-"));
 afterAll(() => { try { rmSync(tmp, { recursive: true, force: true }); } catch { /* never fail in cleanup */ } });
@@ -73,42 +77,71 @@ describe("⛔ P2 (Codex #3524): the account is resolved, never hard-coded", () =
   });
 });
 
-describe("enforce is honoured PER NAME, and says which part it cannot honour", () => {
-  // ⚠️ THIS REPLACES "enforce degrades to shadow". That refusal was all-or-nothing:
-  // nine fully-covered names sat behind two uncovered ones. github-feed-gate.mjs
-  // suppresses per NAME, so the gaps now hold back only themselves. The property
-  // being asserted is no longer "enforce is refused" but "enforce is qualified".
-  test("enforce is effective, undegraded, and names the residual", () => {
-    const r = resolveEffectiveMode("enforce");
-    expect(r.effective).toBe("enforce");
-    expect(r.degraded).toBe(false);
+describe("⛔ enforce is REFUSED unless this host can emit every consumed name (CTL-2018)", () => {
+  // ⚠️ THIS REVERSES A DELIBERATE EARLIER DECISION, and the reversal is the ticket.
+  // The block this replaces said: "THIS REPLACES 'enforce degrades to shadow'. That
+  // refusal was all-or-nothing: nine fully-covered names sat behind two uncovered
+  // ones. github-feed-gate.mjs suppresses per NAME, so the gaps now hold back only
+  // themselves." Every sentence of that is true ABOUT THE DISPATCH GATE, and it is
+  // still the wrong conclusion, because there are TWO gates at different
+  // granularities:
+  //
+  //   • the broker's DISPATCH gate is per NAME — it can leave smee authoritative
+  //     for an uncovered one;
+  //   • orch-monitor's TUNNEL gate is BINARY — `enforce` means the smee tunnel never
+  //     starts, for every name at once.
+  //
+  // So "the gaps hold back only themselves" is false in production: at enforce the
+  // gaps hold back nothing, because the transport they were relying on is gone while
+  // the producer emits them as markers. Measured on mini-2, 2026-08-18: 153 dropped
+  // edges in 46 minutes (125 check_suite.completed + 28 push) with BOTH sides in
+  // perfect agreement about the gap. Agreement was never the safety property; full
+  // coverage is.
+  test("a coverage gap makes enforce degraded, effective SHADOW, and names the gaps", () => {
+    const r = resolveEffectiveMode("enforce", {
+      suppressible: ["github.pr.opened"],
+      consumed: ["github.pr.opened", "github.check_suite.completed", "github.push"],
+    });
     expect(r.requested).toBe("enforce");
-    // ⛔ The reason must still name every open gap. An operator who reads
-    // `mode: enforce` and infers "the tunnel can go" is wrong until all three close,
-    // so a partially-honoured mode has to say which part.
-    for (const ticket of ["CTC-691", "CTC-667", "CTC-704"]) {
-      expect(r.reason).toContain(ticket);
-    }
+    expect(r.effective).toBe("shadow");
+    expect(r.degraded).toBe(true);
+    // The gaps are NAMED, not counted — an operator has to know which transport just
+    // became load-bearing again, and "2 names" does not say that.
+    expect(r.reason).toContain("github.check_suite.completed");
+    expect(r.reason).toContain("github.push");
   });
 
-  test("⛔ the counts in the reason are DERIVED — driven with a DIFFERENT name set", () => {
-    // ⚠️ My first version compared the reason against the real constants, and the
-    // mutation (hand-writing "9 of 12") PASSED — the literal and the computed value
-    // are the same string today. It asserted a tautology. The only way to observe a
-    // derivation is to change its inputs, so this drives the post-CTC-704 world:
-    // one more name covered, one fewer excluded.
+  test("FULL coverage is honoured — enforce, undegraded", () => {
     const r = resolveEffectiveMode("enforce", {
-      suppressible: [...GITHUB_SUPPRESSIBLE_NAMES, "github.push"],
+      suppressible: [...GITHUB_CONSUMED_NAMES],
       consumed: GITHUB_CONSUMED_NAMES,
     });
-    expect(r.reason).toContain(`${GITHUB_SUPPRESSIBLE_NAMES.length + 1} of ${GITHUB_CONSUMED_NAMES.length}`);
-    expect(r.reason).toContain(
-      `smee stays authoritative for ${GITHUB_CONSUMED_NAMES.length - GITHUB_SUPPRESSIBLE_NAMES.length - 1}`,
-    );
-    // and the shipped default still reports today's real partition
-    expect(resolveEffectiveMode("enforce").reason).toContain(
-      `${GITHUB_SUPPRESSIBLE_NAMES.length} of ${GITHUB_CONSUMED_NAMES.length}`,
-    );
+    expect(r.effective).toBe("enforce");
+    expect(r.degraded).toBe(false);
+    expect(r.reason).toContain(`all ${GITHUB_CONSUMED_NAMES.length}`);
+  });
+
+  test("⛔ the verdict is DERIVED from the inputs, not from the shipped constants", () => {
+    // Inherited discipline from the block this replaces: comparing against the real
+    // constants asserts a tautology, and the only way to observe a derivation is to
+    // change its inputs. Two synthetic worlds, opposite verdicts, neither matching
+    // today's real partition.
+    const covered = resolveEffectiveMode("enforce", { suppressible: ["a", "b"], consumed: ["a", "b"] });
+    const gapped = resolveEffectiveMode("enforce", { suppressible: ["a"], consumed: ["a", "b"] });
+    expect(covered.effective).toBe("enforce");
+    expect(gapped.effective).toBe("shadow");
+    expect(gapped.reason).toContain("1 of 2");
+    expect(gapped.reason).toContain("b");
+  });
+
+  test("⚠️ the SHIPPED default still refuses — the static constant is short by two", () => {
+    // `GITHUB_SUPPRESSIBLE_NAMES` is the pre-capability partition, so the no-argument
+    // call is the "host with an unmigrated replica" case and must refuse. This is the
+    // assertion that would have failed on 2026-08-18 before the flip.
+    const r = resolveEffectiveMode("enforce");
+    expect(r.effective).toBe("shadow");
+    expect(r.degraded).toBe(true);
+    expect(GITHUB_SUPPRESSIBLE_NAMES.length).toBeLessThan(GITHUB_CONSUMED_NAMES.length);
   });
 
   test("shadow and off are not degraded", () => {
@@ -243,7 +276,24 @@ describe("⛔ under enforce the producer emits a REAL name only for what the gat
     body: { payload: { source: "cloud-feed" } },
   });
 
-  const drive = (mode, names, { authorityAtEntry = true } = {}) => {
+  // ⛔ CTL-2018: THE FIXTURE SOURCE MUST ANSWER THE COVERAGE PROBES, because the
+  // producer now resolves its suppressible set from the replica handle rather than
+  // from a constant. `migrated` is a schema-0.1.18 replica (both capabilities), which
+  // is what the fleet actually runs; `preCapability` is the older one. A fixture that
+  // answers NEITHER (the old `{ close() {} }`) is a third, real case — a replica the
+  // producer cannot probe — and it is covered on its own below.
+  const migrated = () => ({
+    close() {},
+    pushIsLossy: () => false,
+    checkSuiteHasPrAssociation: () => true,
+  });
+  const preCapability = () => ({
+    close() {},
+    pushIsLossy: () => true,
+    checkSuiteHasPrAssociation: () => false,
+  });
+
+  const drive = (mode, names, { authorityAtEntry = true, sourceFactory = migrated } = {}) => {
     const log = [];
     runGithubFeedTick({
       mode,
@@ -252,7 +302,7 @@ describe("⛔ under enforce the producer emits a REAL name only for what the gat
       authorityAtEntry,
       appendEventFn: (e) => log.push(e),
       appendShadowFn: () => {},
-      sourceFactory: () => ({ close() {} }),
+      sourceFactory,
       seenFactory: () => ({ close() {} }),
       sweepFn: ({ sink }) => {
         for (const n of names) sink(ghEvent(n));
@@ -266,15 +316,35 @@ describe("⛔ under enforce the producer emits a REAL name only for what the gat
     expect(drive("enforce", ["github.pr.opened"])).toEqual(["github.pr.opened"]);
   });
 
-  test("⛔ an EXCLUDED name stays a would-dispatch marker even under enforce", () => {
-    // ⚠️ `pr.merged` is NOT in this list any more — CTC-691 landed, so it emits under
-    // its real name and the gate suppresses smee's copy. `check_suite` has no usable
-    // replacement (CTC-712) and `push` a lossy one (CTC-704); emitting either for
-    // real would put two copies on the log, because the gate correctly refuses to
-    // suppress smee for them.
+  test("⭐ ON A MIGRATED REPLICA check_suite and push go out under their REAL names", () => {
+    // ⛔ THIS IS THE REGRESSION TEST FOR THE 2026-08-18 OUTAGE. Before CTL-2018 the
+    // producer read the STATIC suppressible set, so these two were downgraded to
+    // markers on a host whose replica covers them and whose broker gate was
+    // suppressing smee for them — 153 dropped edges in 46 minutes on mini-2.
     for (const n of ["github.check_suite.completed", "github.push"]) {
-      expect(drive("enforce", [n])).toEqual([EVENT_WOULD_DISPATCH]);
+      expect(drive("enforce", [n])).toEqual([n]);
     }
+  });
+
+  test("⛔ a PRE-CAPABILITY replica refuses enforce outright — every name becomes a marker", () => {
+    // Not "these two stay markers while the rest go out". A gap means the whole mode
+    // degrades to shadow, because the TUNNEL gate is binary: at enforce the smee
+    // tunnel never starts, so a name the producer declines to emit has no transport
+    // left at all. See the resolveEffectiveMode block above.
+    const all = ["github.pr.opened", "github.check_suite.completed", "github.push"];
+    expect(drive("enforce", all, { sourceFactory: preCapability })).toEqual(
+      all.map(() => EVENT_WOULD_DISPATCH),
+    );
+  });
+
+  test("⛔ a replica the producer CANNOT PROBE refuses enforce — absent is not covered", () => {
+    // The probe throws (no such method). Failing closed to the pre-capability answer
+    // is what makes "I could not look" behave like "not covered" rather than like
+    // "fine" — the direction every other absent probe in this feature takes.
+    const unprobeable = () => ({ close() {} });
+    expect(drive("enforce", ["github.pr.opened"], { sourceFactory: unprobeable })).toEqual([
+      EVENT_WOULD_DISPATCH,
+    ]);
   });
 
   test("shadow emits would-dispatch for EVERYTHING, including suppressible names", () => {
@@ -282,15 +352,29 @@ describe("⛔ under enforce the producer emits a REAL name only for what the gat
       .toEqual([EVENT_WOULD_DISPATCH, EVENT_WOULD_DISPATCH]);
   });
 
-  test("⭐ the real-name set is exactly the gate's suppressible set — asserted over ALL consumed names", () => {
-    // The control that makes the two tests above non-anecdotal: drive every name the
-    // router consumes through one tick and compare the partition to the gate's.
+  test("⭐ the real-name set is exactly the GATE'S RUNTIME set for the same replica", () => {
+    // The control that makes the tests above non-anecdotal — and the one whose
+    // EXPECTED VALUE is the whole ticket. It used to compare against the static
+    // `GITHUB_SUPPRESSIBLE_NAMES`, which is the very constant the producer was reading,
+    // so it agreed by construction and stayed green while the producer and the gate
+    // diverged by two names in production. The expectation is now computed from the
+    // SAME function the broker's gate calls, on the SAME coverage the fixture reports,
+    // so the two sides are compared against EACH OTHER rather than each against itself.
+    const coverage = { pushIsLossy: false, checkSuiteHasPrAssociation: true };
+    const gateWouldSuppress = githubSuppressibleNames(coverage);
     const emitted = drive("enforce", GITHUB_CONSUMED_NAMES);
     const real = emitted.filter((n) => n !== EVENT_WOULD_DISPATCH);
-    expect(real.sort()).toEqual([...GITHUB_SUPPRESSIBLE_NAMES].sort());
+    expect(real.sort()).toEqual([...gateWouldSuppress].sort());
     expect(emitted.filter((n) => n === EVENT_WOULD_DISPATCH)).toHaveLength(
-      GITHUB_CONSUMED_NAMES.length - GITHUB_SUPPRESSIBLE_NAMES.length,
+      GITHUB_CONSUMED_NAMES.length - gateWouldSuppress.length,
     );
+    // ⚠️ Positive control on the instrument. On a migrated replica the marker count is
+    // ZERO, so the assertions above would also pass for a producer that emitted
+    // everything unconditionally. Pin the other end: the gate's runtime answer must
+    // really be all twelve here, and it must really differ from the static constant —
+    // otherwise this test is back to comparing the producer with itself.
+    expect(gateWouldSuppress.length).toBe(GITHUB_CONSUMED_NAMES.length);
+    expect(gateWouldSuppress.length).toBeGreaterThan(GITHUB_SUPPRESSIBLE_NAMES.length);
   });
 });
 
@@ -308,7 +392,13 @@ describe("⛔ the emission-time authority stamp is what crosses the process boun
       authorityAtEntry,
       appendEventFn: (e) => log.push(e),
       appendShadowFn: () => {},
-      sourceFactory: () => ({ close() {} }),
+      // CTL-2018: a migrated (0.1.18) replica, so enforce is honourable and these
+      // tests keep measuring the STAMP rather than accidentally measuring the refusal.
+      sourceFactory: () => ({
+        close() {},
+        pushIsLossy: () => false,
+        checkSuiteHasPrAssociation: () => true,
+      }),
       seenFactory: () => ({ close() {} }),
       sweepFn: ({ sink }) => {
         sink(ghEvent("github.pr.opened"));
@@ -338,7 +428,13 @@ describe("⛔ the emission-time authority stamp is what crosses the process boun
       dbPath: ":memory:",
       appendEventFn: (e) => log.push(e),
       appendShadowFn: () => {},
-      sourceFactory: () => ({ close() {} }),
+      // CTL-2018: a migrated (0.1.18) replica, so enforce is honourable and these
+      // tests keep measuring the STAMP rather than accidentally measuring the refusal.
+      sourceFactory: () => ({
+        close() {},
+        pushIsLossy: () => false,
+        checkSuiteHasPrAssociation: () => true,
+      }),
       seenFactory: () => ({ close() {} }),
       sweepFn: ({ sink }) => {
         sink(ghEvent("github.pr.opened"));


### PR DESCRIPTION
## The incident this fixes

On **2026-08-18** the GitHub cutover (CTL-1929) went to `enforce` and **silently dropped `github.check_suite.completed` and `github.push` fleet-wide**. Measured on mini-2 across its 46-minute enforce window (18:58:16Z → 19:44:15Z):

| stream | `check_suite.completed` | `push` | the other 10 |
| --- | --- | --- | --- |
| producer **shadow file** | 125 | 28 | 14 |
| **event log**, `cloud-feed` channel — what actually dispatches | ⛔ **0** | ⛔ **0** | 14 |

`would-dispatch` markers in the same window: **153** — exactly 125 + 28.

Two sides answer *"which names may smee be suppressed for"*, and they disagreed:

| side | resolution | result on a 0.1.18 replica |
| --- | --- | --- |
| broker dispatch gate | `githubSuppressibleNames(readGithubCoverage())`, re-probed every `COVERAGE_CACHE_MS` | **12** |
| **producer** | `new Set(GITHUB_SUPPRESSIBLE_NAMES)`, frozen at import | ⛔ **10** |

The static constant is the **pre-capability** partition. Both capabilities arrive when the cloud-sync **writer** restarts and runs its migrations — an event neither process participates in — which is exactly why the gate re-probes, and exactly why a frozen constant on the other side could not be right.

⛔ **The file asserted the invariant instead of testing it.** Its header said: *"Both sides read `GITHUB_SUPPRESSIBLE_NAMES`, so they cannot disagree."* They read the same **name** — one the runtime **function**, one the static **constant** of the same stem. A comment cannot hold an invariant that spans two files.

## What changes

**1. `resolveSuppressibleForTick(source)`** resolves the set **per tick** from the replica handle the producer already opens, through the **same** `githubSuppressibleNames` the gate calls. Fails closed to the pre-capability set on any throw, matching `readGithubCoverage`'s posture exactly.

**2. `resolveEffectiveMode` REFUSES a partial enforce** — degraded → `shadow`, naming the gap names.

⚠️ **This reverses a deliberate earlier decision, and the reversal is the ticket.** The prior reasoning was: *"github-feed-gate.mjs suppresses per NAME, so the gaps now hold back only themselves."* Every word of that is true **about the dispatch gate** and it is still the wrong conclusion, because there are **two gates at different granularities**:

- the broker's **dispatch** gate is per **name** — it can leave smee authoritative for an uncovered one;
- orch-monitor's **tunnel** gate is **binary** — `enforce` means the smee tunnel never starts, for every name at once.

So a gap does not "hold back itself": it **loses its only transport** while the producer emits it as a marker. Agreement was never the safety property — **full coverage** is. That is what the 153 dropped edges demonstrated, with both sides in perfect agreement about the gap.

⭐ Worth recording: the old code path returned `degraded: false` for a partial enforce while its own reason string said *"smee stays authoritative for N … and the tunnel cannot retire until they close."* The sentence was **true and inert** — gated behind `if (resolved.degraded)`, which was false, so it was never even logged. Same shape as CTL-1659's `restart_needed`.

**3. A degraded enforce reports `ready: false`** (`mode-degraded:shadow`). Not cosmetics — a working lever: `decideDispatch`'s `isReady` gates the **smee side only**, so an unready producer makes the broker **stop suppressing smee**, which is the correct outcome on a host that cannot cover every name.

## Tests

`github-feed-suppressible-parity.test.mjs` drives **both sides off one coverage fixture and compares them to each other** — over all four coverage combinations plus two failure fixtures (no capability methods; probes that throw), asserting they degrade *identically*. Same discipline as `assertion-evidence-parity.test.mjs`.

⛔ **The pre-existing partition test could not have caught this.** It compared the producer's output against `GITHUB_SUPPRESSIBLE_NAMES` — *the very constant the producer was reading* — so it agreed by construction and stayed green through the divergence. It now computes its expectation from the gate's runtime function, with a positive control pinning that the two answers really **do** differ on a migrated replica (otherwise the assertion would hold for a producer that emitted everything unconditionally).

Plus a direct regression test: on a migrated replica, `check_suite.completed` and `push` go out **under their real names**.

**Mutation-tested** — reverting the producer to the static constant:

| suite | correct | mutated |
| --- | --- | --- |
| `github-feed-suppressible-parity.test.mjs` | 10 pass | ⛔ **5 fail** |
| `github-feed-timer.test.mjs` | 31 pass | ⛔ **6 fail** |

## Verification

| gate | result |
| --- | --- |
| `github-feed-suppressible-parity.test.mjs` | ✅ 10 pass |
| `github-feed-timer.test.mjs` | ✅ 31 pass |
| + `github-feed-gate` / `github-feed-gate-install` | ✅ 106 pass / 0 fail across the four |
| **full execution-core suite** | 51 failing tests — and the failing **SET** is byte-identical to the same suite on a clean worktree at the same commit. `comm` empty in **both** directions. |
| full shell gate (COORD-181) | ⏳ queued on `mini` behind #3633's run — SET posted before merge |

## ⛔ Residual, named in the code and NOT closed here

The readiness lever reaches the **broker**, not orch-monitor. The tunnel gate resolves `enforce` straight from Layer-2 (`githubFeedIsAuthoritative`) and never starts the tunnel, so on a gapped host there is nothing for the un-suppressed smee branch to route. Making all three readers agree about **coverage** — not just about the flag — is **CTL-2011**'s scope.

**Until that lands: do not set `enforce` on a host whose replica is not migrated**, and `catalyst doctor` should FAIL it.

Fixes CTL-2018. Refs CTL-1929, CTL-2011.
