### PR TITLE
feat(dev): CTL-1961 — register the reaction + issue-create proxy routes, measured at the dispatcher

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -742,6 +742,19 @@ jobs:
         working-directory: plugins/dev/scripts/execution-core
         run: bun test install-lifecycle.test.mjs join-bundle.test.mjs
 
+      - name: linear write-path decision test (CTL-1961)
+        # ⛔ PINNED AT THE SAME TIME THE SUITE WAS WRITTEN. Verified before adding this step:
+        # `grep -c linear-write-path .github/workflows/` returned 0, so without this the suite
+        # runs only in a local full gate. That is the third time in two days a new suite would
+        # have shipped inert here (CTL-1975/FLEET-37, CTL-2004, now this) — CI runs an EXPLICIT
+        # list and nothing tells an author their file joined nothing.
+        #
+        # What it guards is a distinction, not a value: "the proxy is off" and "I could not
+        # reach the proxy" must never collapse to one answer. Collapsing them writes direct
+        # forever while reporting as a routed tool, which is what the first cut of CTL-1961 did.
+        working-directory: plugins/dev/scripts/lib
+        run: bun test linear-write-path.test.mjs
+
       - name: replica-path cross-stack parity test (CTL-1893)
         # bash == node == a hand-written expected value at every fixture cell, including
         # the NAMED FAILURES (account-absent vs account-invalid route to different operator

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -92,6 +92,14 @@ on:
       - "plugins/dev/scripts/install-orphan-sweep.sh"
       - "plugins/dev/scripts/orch-monitor/dist/ai.coalesce.catalyst-orphan-sweep.plist"
       - "plugins/dev/scripts/__tests__/**"
+      # CTL-2026: the two agent tools are guarded by
+      # agent-tools-out-of-tree.test.mjs below. `__tests__/**` above catches
+      # an edit to the SUITE; without these two paths an edit to the TOOLS
+      # themselves — the thing that regresses — skips the job entirely.
+      # Verified: neither file appears elsewhere in the filter list (positive
+      # control — install-orphan-sweep.sh above is the same one-file shape).
+      - "plugins/dev/scripts/linear-ack.mjs"
+      - "plugins/dev/scripts/linear-reply.mjs"
       # CTL-1387: the CLI-reference generator + the page it drives are guarded by
       # cli-reference-drift.test.sh below; a change to either must run this suite.
       # FLEET: the remote-owner channel transport ships its own bash test; without this
@@ -743,17 +751,39 @@ jobs:
         run: bun test install-lifecycle.test.mjs join-bundle.test.mjs
 
       - name: linear write-path decision test (CTL-1961)
-        # ⛔ PINNED AT THE SAME TIME THE SUITE WAS WRITTEN. Verified before adding this step:
-        # `grep -c linear-write-path .github/workflows/` returned 0, so without this the suite
-        # runs only in a local full gate. That is the third time in two days a new suite would
-        # have shipped inert here (CTL-1975/FLEET-37, CTL-2004, now this) — CI runs an EXPLICIT
-        # list and nothing tells an author their file joined nothing.
+        # ⛔ PINNED AT THE SAME TIME THE SUITE WAS WRITTEN. Verified before
+        # adding this step: `grep -c linear-write-path .github/workflows/`
+        # returned 0, so without this the suite runs only in a local full
+        # gate. That is the third time in two days a new suite would have
+        # shipped inert here (CTL-1975/FLEET-37, CTL-2004, now this) — CI
+        # runs an EXPLICIT list and nothing tells an author their file
+        # joined nothing.
         #
-        # What it guards is a distinction, not a value: "the proxy is off" and "I could not
-        # reach the proxy" must never collapse to one answer. Collapsing them writes direct
-        # forever while reporting as a routed tool, which is what the first cut of CTL-1961 did.
+        # What it guards is a distinction, not a value: "the proxy is off"
+        # and "I could not reach the proxy" must never collapse to one
+        # answer. Collapsing them writes direct forever while reporting as
+        # a routed tool, which is what the first cut of CTL-1961 did.
         working-directory: plugins/dev/scripts/lib
         run: bun test linear-write-path.test.mjs
+
+      - name: agent tools survive being out-of-tree (CTL-2026)
+        # ⛔ PINNED WITH THE SUITE, verified the way the two steps above were:
+        # `grep -rc agent-tools-out-of-tree .github/workflows/` returned
+        # NOTHING before this step existed, while the same grep for
+        # `linear-write-path` returned 2. That is the FOURTH suite in three
+        # days that would otherwise have shipped inert.
+        #
+        # What it guards: linear-ack.mjs / linear-reply.mjs carry a try/catch
+        # whose own comment says it exists because an out-of-tree copy cannot
+        # resolve their imports — and then consumed the decision leaf on a
+        # line OUTSIDE that try, so such a copy died on module resolution
+        # before reaching the branch written for it. The suite copies each
+        # tool ALONE into an empty directory and runs it against a stubbed
+        # fetch: the deployment shape of ~/catalyst/comms/tools/. Every
+        # assertion fails on the pre-fix tools (measured 7 fail / 0 pass) and
+        # passes on the fixed ones.
+        working-directory: plugins/dev/scripts/__tests__
+        run: bun test agent-tools-out-of-tree.test.mjs
 
       - name: replica-path cross-stack parity test (CTL-1893)
         # bash == node == a hand-written expected value at every fixture cell, including

--- a/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
+++ b/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
@@ -1,0 +1,243 @@
+// CTL-2026 — the agent tools must survive being the ONLY file in their directory.
+//
+// ⛔ WHAT THIS PINS, AND WHY A UNIT TEST OF decideWritePath CANNOT PIN IT.
+// `linear-ack.mjs` and `linear-reply.mjs` guard their `./execution-core/*` imports in a
+// try/catch whose own comment says the guard exists because an out-of-tree copy cannot
+// resolve them. Both then imported `./lib/linear-write-path.mjs` — the leaf that decides
+// what to do about that very failure — on a line OUTSIDE the try. A copy with no sibling
+// directories therefore died with an unhandled ERR_MODULE_NOT_FOUND before reaching the
+// branch written for it. `decideWritePath`'s own suite is green in both worlds, because
+// the defect is not in the decision; it is in whether the decision is reachable.
+//
+// `~/catalyst/comms/tools/` is exactly that shape — a flat directory holding copies of
+// these two files, invoked by every lane's brief — and CTL-2026(b)'s announced sync step
+// is the thing that would have put the current file there. So this suite reproduces that
+// deployment literally: copy the tool alone into an empty directory and RUN it.
+//
+// ⛔ THE NETWORK IS STUBBED AT `globalThis.fetch` VIA `node --import`, NOT MOCKED IN-PROCESS.
+// These scripts are top-level-await side-effect programs: importing one performs the write.
+// The only way to observe their behaviour is to execute them, and the only way to execute
+// them hermetically is to replace fetch in the child before the module graph loads.
+//
+// ⛔ NEITHER THE EXIT CODE NOR THE MODULE-ERROR TEXT DISCRIMINATES. Two traps, both hit
+// while writing this file, both recorded because the obvious assertion is wrong twice over:
+//
+//  1. The pre-fix CRASH and the correct enforce-mode REFUSAL BOTH exit 1.
+//  2. `Cannot find module` appears in the crash AND in the healthy degraded run — the
+//     resolution failure is the very `unavailableReason` the fixed tool prints on purpose.
+//     And the node-only spelling `ERR_MODULE_NOT_FOUND` does not appear under bun AT ALL
+//     (measured: bun 1.3.5 prints `error: Cannot find module '<spec>' from '<file>'`, zero
+//     occurrences of the code), so an assertion phrased against it is INERT under the very
+//     runner CI uses — a guard that cannot fail, in the guard for a guard that could not fire.
+//
+// So every assertion below is POSITIVE and pinned to a literal only the TOOL'S OWN CODE can
+// emit: its JSON on stdout, or its `linear-*: ` prefixed message on stderr. A crash produces
+// neither, whatever it is spelled like and whatever it exits with.
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, copyFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPTS = dirname(fileURLToPath(new URL("../linear-ack.mjs", import.meta.url)));
+const HUMAN = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+
+/** A fetch stub covering every call these two tools make: the OAuth mint, the issue
+ *  read, and each mutation. Returns success everywhere, so any non-zero exit or absent
+ *  output is the TOOL's doing and not the transport's. */
+const STUB = `
+const HUMAN = ${JSON.stringify(HUMAN)};
+const comment = { id: "c1", createdAt: "2026-08-18T00:00:00.000Z", parent: null,
+  user: { id: HUMAN, name: "Ryan" }, botActor: null,
+  reactions: [{ id: "rx1", emoji: "eyes", user: { id: HUMAN } }] };
+globalThis.fetch = async (url, opts) => {
+  if (String(url).includes("/oauth/token")) return { json: async () => ({ access_token: "stub-token" }) };
+  const q = JSON.parse(opts.body).query;
+  if (q.includes("commentCreate")) return { json: async () => ({ data: { commentCreate: { success: true, comment: { id: "new1", url: "https://linear.app/x" } } } }) };
+  if (q.includes("reactionCreate")) return { json: async () => ({ data: { reactionCreate: { success: true, reaction: { id: "r2" } } } }) };
+  if (q.includes("reactionDelete")) return { json: async () => ({ data: { reactionDelete: { success: true } } }) };
+  return { json: async () => ({ data: { issue: { id: "i1", url: "https://linear.app/i1", comments: { nodes: [comment] } } } }) };
+};
+`;
+
+let dir;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "ctl2026-"));
+  writeFileSync(join(dir, "stub.mjs"), STUB);
+  for (const f of ["linear-ack.mjs", "linear-reply.mjs"])
+    copyFileSync(join(SCRIPTS, f), join(dir, f));
+});
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Run one tool as the ONLY file in `dir` (plus the stub). No sibling lib/ or
+ *  execution-core/ — the deployment shape of ~/catalyst/comms/tools/. */
+function runIsolated(tool, args, env = {}) {
+  const r = spawnSync(process.execPath, ["--import", "./stub.mjs", tool, ...args], {
+    cwd: dir,
+    encoding: "utf8",
+    // Strip an ambient mode so the developer's own shell cannot decide the verdict.
+    env: { ...process.env, CATALYST_LINEAR_WRITE_PROXY: undefined, ...env },
+  });
+  // ⛔ bun COLOURS child stderr, so a raw `startsWith`/`grep` against it silently matches
+  // nothing — the repo's standing ANSI trap, which here would have read as "the tool said
+  // nothing" instead of "I could not see what it said".
+  return { code: r.status, out: strip(r.stdout ?? ""), err: strip(r.stderr ?? "") };
+}
+
+/** Remove SGR sequences so assertions see the text, not the colouring. */
+function strip(s) {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+describe("the tools run when they are the only file in the directory (CTL-2026)", () => {
+  test("⛔ THE DEFECT: each tool reaches its own code and completes its write", () => {
+    for (const [tool, args] of [
+      ["linear-ack.mjs", ["CTL-1"]],
+      ["linear-reply.mjs", ["CTL-1", "--as", "CTL", "--body", "probe"]],
+    ]) {
+      const r = runIsolated(tool, args);
+      // A resolution crash exits non-zero with an EMPTY stdout, on both runtimes. Asserting
+      // the tool's own JSON is present is therefore the discriminator, and it is positive:
+      // it cannot be satisfied by a process that died before running the tool's body.
+      expect(`${tool} exit ${r.code} out=${JSON.stringify(r.out)}`).toBe(
+        `${tool} exit 0 out=${JSON.stringify(r.out)}`
+      );
+      expect(() => JSON.parse(r.out.trim())).not.toThrow();
+      expect(r.err).toContain(`${tool.replace(".mjs", "")}: `);
+    }
+  });
+
+  test("linear-ack still performs its reaction, and says WHY it went direct", () => {
+    const r = runIsolated("linear-ack.mjs", ["CTL-1"]);
+    expect(JSON.parse(r.out.trim())).toEqual({
+      via: "direct",
+      ok: true,
+      commentId: "c1",
+      emoji: "eyes",
+    });
+    // The reason must survive to the operator — degrading silently is the failure class.
+    expect(r.err).toContain("proxy modules unreachable");
+    // ⛔ and it must NOT claim the mode is `off`: without the modules it cannot read
+    // Layer-2, so an absent env var is "could not confirm", not "not configured".
+    expect(r.err).toContain("UNCONFIRMED");
+  });
+
+  test("linear-reply still posts the reply AND clears the 👀 direct", () => {
+    const r = runIsolated("linear-reply.mjs", ["CTL-1", "--as", "CTL", "--body", "probe"]);
+    expect(JSON.parse(r.out.trim())).toEqual({
+      ok: true,
+      commentId: "new1",
+      parentId: "c1",
+      url: "https://linear.app/x",
+      eyesCleared: 1,
+    });
+  });
+
+  test("under enforce, linear-ack REFUSES rather than writing direct — and says so, not just exit 1", () => {
+    const r = runIsolated("linear-ack.mjs", ["CTL-1"], { CATALYST_LINEAR_WRITE_PROXY: "enforce" });
+    expect(r.code).toBe(1);
+    // ⛔ The pre-fix CRASH also exited 1, and it also mentions the module. The ONLY thing
+    // that separates them is this literal, which only linear-ack itself can print.
+    expect(r.err).toContain("linear-ack: REFUSED — mode=enforce");
+    expect(r.out).toBe("");
+  });
+
+  test("under enforce, linear-reply still POSTS (the clear is best-effort) and reports the skip", () => {
+    const r = runIsolated("linear-reply.mjs", ["CTL-1", "--as", "CTL", "--body", "probe"], {
+      CATALYST_LINEAR_WRITE_PROXY: "enforce",
+    });
+    // ⛔ A reply that succeeded must never report failure: the caller could retry into a
+    // double-posted comment. Refusing the CLEAN-UP must not fail the thing cleaned up after.
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.out.trim()).ok).toBe(true);
+    expect(JSON.parse(r.out.trim()).eyesCleared).toBe(0);
+    expect(r.err).toContain("👀 NOT cleared");
+  });
+});
+
+describe("the avatar Ryan added out-of-tree is in the repo copy (CTL-2026)", () => {
+  // ⭐ THE MEASUREMENT BEHIND THIS: CTL-2026 was filed on "they are true copies,
+  // byte-identical". Six hours later Ryan hand-edited ONLY the out-of-tree
+  // linear-reply.mjs (2026-08-18 19:46:30) to add a per-agent avatar. Option (a) — make
+  // the out-of-tree file a wrapper that execs the repo copy — would then have silently
+  // deleted the avatars on every lane's next reply. This asserts the repo copy actually
+  // sends the field, by reading it off the WIRE rather than grepping the source: a grep
+  // would pass on a declared-but-unused constant, which is the same class of untruth.
+  test("commentCreate carries displayIconUrl, derived from --as", () => {
+    const capture = `
+${STUB}
+const inner = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  // ⛔ The OAuth mint's body is a URLSearchParams, not JSON — an unguarded JSON.parse here
+  // throws inside the stub, the mint fails, and the tool dies for a reason that has nothing
+  // to do with what is being measured. (It did, on the first run of this suite.)
+  let b = {};
+  try { b = opts?.body ? JSON.parse(opts.body) : {}; } catch { b = {}; }
+  if (typeof b.query === "string" && b.query.includes("commentCreate")) {
+    console.error("CAPTURED_INPUT " + JSON.stringify(b.variables.in));
+  }
+  return inner(url, opts);
+};
+`;
+    writeFileSync(join(dir, "capture.mjs"), capture);
+    const r = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "./capture.mjs",
+        "linear-reply.mjs",
+        "CTL-1",
+        "--as",
+        "FLEET",
+        "--body",
+        "probe",
+      ],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...process.env, CATALYST_LINEAR_WRITE_PROXY: undefined },
+      }
+    );
+    const line = strip(r.stderr ?? "")
+      .split("\n")
+      .find((l) => l.startsWith("CAPTURED_INPUT "));
+    expect(line).toBeTruthy();
+    const input = JSON.parse(line.slice("CAPTURED_INPUT ".length));
+    expect(input.createAsUser).toBe("FLEET");
+    // Deterministic from the agent tag: the same agent always renders the same image.
+    expect(input.displayIconUrl).toBe("https://api.dicebear.com/9.x/shapes/svg?seed=fleet");
+  });
+
+  test("CATALYST_AVATAR_URL_TEMPLATE overrides the generator, and {slug} is the agent tag", () => {
+    const r = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "./capture.mjs",
+        "linear-reply.mjs",
+        "CTL-1",
+        "--as",
+        "CTL-INSTALL",
+        "--body",
+        "probe",
+      ],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CATALYST_LINEAR_WRITE_PROXY: undefined,
+          CATALYST_AVATAR_URL_TEMPLATE: "https://example.invalid/{slug}.png",
+        },
+      }
+    );
+    const line = strip(r.stderr ?? "")
+      .split("\n")
+      .find((l) => l.startsWith("CAPTURED_INPUT "));
+    expect(line).toBeTruthy();
+    const input = JSON.parse(line.slice("CAPTURED_INPUT ".length));
+    expect(input.displayIconUrl).toBe("https://example.invalid/ctl-install.png");
+  });
+});

--- a/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
+++ b/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
@@ -41,6 +41,25 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const SCRIPTS = dirname(fileURLToPath(new URL("../linear-ack.mjs", import.meta.url)));
+/**
+ * ⛔ INERT STAND-INS FOR THE CREDENTIALS linear-reply.mjs GATES ON, AND WHY THEY ARE HERE.
+ * That tool exits 2 when LINEAR_SYNC_CLIENT_ID/SECRET are unset — BEFORE it reaches any of
+ * the behaviour under test. Those are exported in a developer's shell and absent on CI, so
+ * the first cut of this suite was 7/7 locally and 2 pass / 5 fail on the Linux runner:
+ * every linear-reply case failed with exit 2 while every linear-ack case passed (that tool
+ * has no such gate). It was measuring the machine, not the code — the "a test driven
+ * through the ambient environment is a test of the environment" trap, already on this
+ * repo's record and repeated here.
+ *
+ * Reproduce the CI failure locally with:
+ *   env -u LINEAR_SYNC_CLIENT_ID -u LINEAR_SYNC_CLIENT_SECRET bun test agent-tools-out-of-tree.test.mjs
+ *
+ * The values are never used: `fetch` is stubbed in the child, so nothing is minted or sent.
+ */
+const STUB_CREDS = Object.freeze({
+  LINEAR_SYNC_CLIENT_ID: "stub-client-id",
+  LINEAR_SYNC_CLIENT_SECRET: "stub-client-secret",
+});
 const HUMAN = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
 
 /** A fetch stub covering every call these two tools make: the OAuth mint, the issue
@@ -76,8 +95,9 @@ function runIsolated(tool, args, env = {}) {
   const r = spawnSync(process.execPath, ["--import", "./stub.mjs", tool, ...args], {
     cwd: dir,
     encoding: "utf8",
-    // Strip an ambient mode so the developer's own shell cannot decide the verdict.
-    env: { ...process.env, CATALYST_LINEAR_WRITE_PROXY: undefined, ...env },
+    // Strip an ambient mode, and PIN the credentials, so neither the developer's shell nor
+    // CI's lack of one can decide the verdict. See STUB_CREDS.
+    env: { ...process.env, ...STUB_CREDS, CATALYST_LINEAR_WRITE_PROXY: undefined, ...env },
   });
   // ⛔ bun COLOURS child stderr, so a raw `startsWith`/`grep` against it silently matches
   // nothing — the repo's standing ANSI trap, which here would have read as "the tool said
@@ -197,7 +217,7 @@ globalThis.fetch = async (url, opts) => {
       {
         cwd: dir,
         encoding: "utf8",
-        env: { ...process.env, CATALYST_LINEAR_WRITE_PROXY: undefined },
+        env: { ...process.env, ...STUB_CREDS, CATALYST_LINEAR_WRITE_PROXY: undefined },
       }
     );
     const line = strip(r.stderr ?? "")
@@ -228,6 +248,7 @@ globalThis.fetch = async (url, opts) => {
         encoding: "utf8",
         env: {
           ...process.env,
+          ...STUB_CREDS,
           CATALYST_LINEAR_WRITE_PROXY: undefined,
           CATALYST_AVATAR_URL_TEMPLATE: "https://example.invalid/{slug}.png",
         },

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.mjs
@@ -129,6 +129,17 @@ export const PROXY_ROUTE_IDS = Object.freeze([
   // WRITE and it is DISPATCH-CRITICAL: `cluster-claim.mjs`'s soft-CAS decides whether this
   // host may work a ticket at all, so it is emphatically NOT in NON_BLOCKING_ROUTE_IDS.
   "attachment",
+  // CTL-1961 / CTC-724 — the 👀 read-receipt every lane's brief tells it to leave on a
+  // human's comment (`linear-ack.mjs`), plus the clear `linear-reply.mjs` issues once it
+  // has replied. Measured off catalyst-cloud `origin/main` (ba3a722) at the DISPATCHER,
+  // not from the doc comment above the handler:
+  //   index.ts:986  url.pathname === "/api/v1/agent/reaction"
+  "reaction",
+  // CTL-1961 / CTC-725 — filing a ticket. The route returns the `identifier`, so the
+  // house rule "file the ticket before citing its number" is served by the call itself
+  // rather than by a follow-up read.
+  //   index.ts:989  url.pathname === "/api/v1/agent/issue-create"
+  "issue-create",
 ]);
 
 /**
@@ -152,6 +163,33 @@ export const PROXY_ROUTE_IDS = Object.freeze([
  * fleet-wide stall traded for a status line. So do NOT add an id here to make something
  * faster. Add one only when its failure costs nothing but a missing observation.
  */
+/**
+ * ⛔ CTL-1961 — WHY `reaction` IS NOT IN THIS SET, since the obvious reason is wrong.
+ *
+ * CTC-724 argued it as "a claim decides whether a host may work a ticket, so
+ * fire-and-forget lets two owners both believe they hold it". That rationale does NOT
+ * hold: the 👀 is not a claim. Ryan defined its meaning in `linear-reply.mjs` — "👀 on
+ * the human's LATEST comment means 'read, working on it'; it comes OFF once the reply is
+ * posted (not at resolution)" — a read-receipt on ONE comment. `linear-ack.mjs` reacts to
+ * a comment rather than the issue and never reads before it writes, and nothing in this
+ * repo gates work admission on a Linear reaction. The exclusion primitive is
+ * `cluster-claim.mjs`'s `catalyst://fence/<TICKET>` soft-CAS, which is the `attachment`
+ * route above.
+ *
+ * ⛔ Recording that matters, because the next reader who discovers the 👀 is not a claim
+ * would otherwise conclude the constraint rested on a mistake and move it here.
+ *
+ * The reason that DOES survive is an ordering race, and it is independent of what the
+ * reaction means: add and remove are a matched pair on the SAME object issued by TWO
+ * different tools — `linear-ack.mjs` adds, `linear-reply.mjs` removes (default-on unless
+ * `--keep-eyes`) — and the normal path issues add → remove within seconds. Make the add
+ * fire-and-forget while the remove blocks, and the remove runs against a comment where
+ * the add has not landed, finds nothing, and the add lands after it. The result is a
+ * PERMANENT stale 👀 on an already-answered comment, which nothing ever clears: the clear
+ * only runs on the NEXT reply under that same comment, which may never come.
+ *
+ * `issue-create` is likewise absent: its whole value is the `identifier` it returns.
+ */
 export const NON_BLOCKING_ROUTE_IDS = Object.freeze(new Set(["session"]));
 
 /**
@@ -170,6 +208,11 @@ export const DEFAULT_ROUTES = Object.freeze({
   // CTL-1889 inc 3 / CTC-692, read off the merged handler AND probed live (see
   // READ_ROUTE_IDS below for the measurements this pair depends on).
   attachment: "/agent/attachment",
+  // CTL-1961, read off catalyst-cloud index.ts:986/989 (the pathname the server actually
+  // compares), not off the handler's doc comment — this file's header records that an
+  // earlier cut shipped DEFAULT_ROUTES as a declared ASSUMPTION and was wrong on every one.
+  reaction: "/agent/reaction",
+  "issue-create": "/agent/issue-create",
 });
 
 /**

--- a/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy.test.mjs
@@ -130,12 +130,55 @@ describe("routes", () => {
     // cluster fence + heartbeat record. The exact-equality shape is deliberate: a new route
     // must be argued for HERE, because every id in this set is a path the daemon will send a
     // Linear write to.
-    const expected = ["attachment", "comment", "issue-state", "label", "session"];
+    //
+    // CTL-1961 adds two, and the argument for each:
+    //   `reaction`     (CTC-724) — the 👀 read-receipt `linear-ack.mjs` leaves on a human's
+    //                  comment and `linear-reply.mjs` clears once it has replied. Today both
+    //                  tools POST `reactionCreate`/`reactionDelete` straight to
+    //                  api.linear.app with a host-held credential; routing them is the
+    //                  point of the skinny-install gate.
+    //   `issue-create` (CTC-725) — filing a ticket, which every lane does. Returns the
+    //                  `identifier`, so "file the ticket before citing its number" is served
+    //                  by the call rather than a follow-up read.
+    // Both paths were read off catalyst-cloud's DISPATCHER (index.ts:986/989 — the pathname
+    // the server compares), not the handler doc comments, per this module's own header.
+    const expected = ["attachment", "comment", "issue-create", "issue-state", "label", "reaction", "session"];
     expect([...PROXY_ROUTE_IDS].sort()).toEqual(expected);
     expect(Object.keys(DEFAULT_ROUTES).sort()).toEqual(expected);
     // The READ routes are a SEPARATE set on purpose (they spend no write budget), and they
     // must not leak into the write set — asserted in both directions.
     expect([...READ_ROUTE_IDS].sort()).toEqual(["attachments"]);
+  });
+
+  // ── CTL-1961: the two routes that let a credential-free host ack and file ──────────
+  test("reaction + issue-create resolve to the paths the SERVER matches on", () => {
+    // Measured at catalyst-cloud origin/main (ba3a722) index.ts:986/989 —
+    //   url.pathname === "/api/v1/agent/reaction"
+    //   url.pathname === "/api/v1/agent/issue-create"
+    // The client's base already ends in /api/v1, so these are the remainders. Pinned
+    // because this module's header records an earlier cut that shipped GUESSED paths and
+    // was wrong on every one of them.
+    expect(resolveRoutePath("reaction")).toBe("/agent/reaction");
+    expect(resolveRoutePath("issue-create")).toBe("/agent/issue-create");
+  });
+
+  test("⛔ reaction is BLOCKING — the add/remove pair would otherwise strand a stale 👀", () => {
+    // The reason is NOT "a claim decides whether a host may work a ticket" (CTC-724's
+    // wording): the 👀 is a read-receipt on one comment, not a claim — the exclusion
+    // primitive is the `attachment` fence. The reason that survives is an ordering race:
+    // `linear-ack.mjs` ADDS and `linear-reply.mjs` REMOVES, on the same object, seconds
+    // apart. Fire-and-forget on the add lets the remove run first, find nothing, and the
+    // add land after it — a permanent stale 👀 on an already-answered comment that
+    // nothing ever clears.
+    expect(NON_BLOCKING_ROUTE_IDS.has("reaction")).toBe(false);
+    expect(NON_BLOCKING_ROUTE_IDS.has("issue-create")).toBe(false);
+  });
+
+  test("both are WRITE routes — they spend budget and must not leak into the read set", () => {
+    expect(READ_ROUTE_IDS.has("reaction")).toBe(false);
+    expect(READ_ROUTE_IDS.has("issue-create")).toBe(false);
+    expect(PROXY_ROUTE_IDS).toContain("reaction");
+    expect(PROXY_ROUTE_IDS).toContain("issue-create");
   });
 
   test("⛔ exactly ONE route is non-blocking, and it is not a dispatch-critical one", () => {

--- a/plugins/dev/scripts/lib/linear-write-path.mjs
+++ b/plugins/dev/scripts/lib/linear-write-path.mjs
@@ -1,0 +1,65 @@
+// linear-write-path.mjs — CTL-1961. The ONE decision the agent tools share: given the
+// write-proxy mode and whether a transport could actually be constructed, does this write
+// go through the cloud, go direct, or get REFUSED?
+//
+// ⛔ WHY THIS IS A SEPARATE, PURE LEAF.
+// `linear-ack.mjs` and `linear-reply.mjs` are side-effecting scripts with top-level await
+// — they mint a token and write to Linear the moment they are imported, so their routing
+// logic cannot be unit-tested in place. Extracting the decision is what makes it testable
+// at all, and it is also what stops the two tools growing separate dialects of "what does
+// shadow mean" (the drift `linear-comment-write.mjs`'s own header warns about).
+//
+// ⛔ THE UNAVAILABLE CASE IS NOT `off`, AND THAT DISTINCTION IS THE WHOLE POINT.
+// A tool that cannot reach the proxy modules — an out-of-tree copy (CTL-2026), a renamed
+// export, a broken checkout — looks EXACTLY like a host with the proxy switched off if you
+// collapse both to "no transport". The first cut of this change imported an export name
+// that does not exist (`getLinearWriteProxy`, which lives in a different module and returns
+// an installed singleton nothing installs in a standalone script); it would have written
+// direct forever while reporting itself as a routed tool. So `unavailable` is carried as a
+// REASON, and under `enforce` it REFUSES rather than silently falling back — a fallback
+// there would defeat the gate on precisely the runs the gate exists for.
+//
+// Zero imports on purpose: these tools run under bare `node` from an arbitrary cwd.
+
+/** The modes the write proxy understands. Anything else is treated as `off`. */
+export const WRITE_PROXY_MODES = Object.freeze(["off", "shadow", "enforce"]);
+
+/**
+ * decideWritePath — pure.
+ *
+ * @param {object}  o
+ * @param {string}  o.mode                the resolved proxy mode
+ * @param {boolean} o.proxyReady          a transport was actually constructed
+ * @param {string|null} o.unavailableReason  why not, when !proxyReady
+ * @returns {{action:"proxy"|"direct"|"refuse", observe:boolean, reason:string|null}}
+ *   action  — proxy: the cloud performs the write · direct: this host performs it
+ *             · refuse: perform NOTHING and exit non-zero
+ *   observe — send a non-authoritative observation first, then do the direct write
+ *             (shadow only). A reaction is a WRITE, so "observe by doing it too" would
+ *             double-write; the observation carries an empty payload.
+ *   reason  — set whenever the caller should say something out loud.
+ */
+export function decideWritePath({ mode, proxyReady = false, unavailableReason = null } = {}) {
+  const m = WRITE_PROXY_MODES.includes(mode) ? mode : "off";
+
+  if (m === "off") return { action: "direct", observe: false, reason: null };
+
+  if (m === "enforce") {
+    if (proxyReady) return { action: "proxy", observe: false, reason: null };
+    // ⛔ Never `direct`. An enforce host that cannot reach the proxy is a host whose
+    // operator believes its writes are routed; writing direct would make that belief
+    // false and silent at the same time.
+    return {
+      action: "refuse",
+      observe: false,
+      reason: unavailableReason ?? "proxy unavailable under enforce",
+    };
+  }
+
+  // shadow: the direct write still happens; the observation is best-effort. An
+  // unavailable proxy here is worth SAYING but must not block the write, because shadow's
+  // contract is "change nothing that the operator can see in Linear".
+  return proxyReady
+    ? { action: "direct", observe: true, reason: null }
+    : { action: "direct", observe: false, reason: unavailableReason ?? "proxy unavailable under shadow" };
+}

--- a/plugins/dev/scripts/lib/linear-write-path.test.mjs
+++ b/plugins/dev/scripts/lib/linear-write-path.test.mjs
@@ -1,0 +1,108 @@
+// CTL-1961 — the agent tools' write-path decision.
+//
+// The property that matters is NOT "shadow writes direct" (obvious); it is that
+// "the proxy is OFF" and "I could not reach the proxy" are never collapsed into the
+// same answer. Collapsing them is how a tool writes direct forever while looking routed
+// — which is exactly what the first cut of this change did, by importing an export name
+// that does not exist.
+import { describe, test, expect } from "bun:test";
+import { decideWritePath, WRITE_PROXY_MODES } from "./linear-write-path.mjs";
+
+describe("decideWritePath — off", () => {
+  test("off writes direct, says nothing, observes nothing", () => {
+    expect(decideWritePath({ mode: "off", proxyReady: false })).toEqual({
+      action: "direct",
+      observe: false,
+      reason: null,
+    });
+  });
+
+  test("off is unaffected by a READY proxy — an installed transport is not a mandate", () => {
+    expect(decideWritePath({ mode: "off", proxyReady: true }).action).toBe("direct");
+    expect(decideWritePath({ mode: "off", proxyReady: true }).observe).toBe(false);
+  });
+});
+
+describe("decideWritePath — enforce", () => {
+  test("enforce with a ready proxy routes to the cloud", () => {
+    expect(decideWritePath({ mode: "enforce", proxyReady: true })).toEqual({
+      action: "proxy",
+      observe: false,
+      reason: null,
+    });
+  });
+
+  test("⛔ THE DEFECT THIS PINS: enforce WITHOUT a proxy REFUSES — it must never write direct", () => {
+    const d = decideWritePath({
+      mode: "enforce",
+      proxyReady: false,
+      unavailableReason: "proxy modules unreachable: Cannot find module",
+    });
+    expect(d.action).toBe("refuse");
+    // ⛔ the reason must survive to the operator — a bare refusal is not diagnosable
+    expect(d.reason).toContain("Cannot find module");
+  });
+
+  test("enforce without a proxy AND without a stated reason still refuses, with a default one", () => {
+    const d = decideWritePath({ mode: "enforce", proxyReady: false });
+    expect(d.action).toBe("refuse");
+    expect(typeof d.reason).toBe("string");
+    expect(d.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe("decideWritePath — shadow", () => {
+  test("shadow with a ready proxy: direct write PLUS an observation", () => {
+    expect(decideWritePath({ mode: "shadow", proxyReady: true })).toEqual({
+      action: "direct",
+      observe: true,
+      reason: null,
+    });
+  });
+
+  test("⭐ shadow with NO proxy still writes — but says why it could not observe", () => {
+    // shadow's contract is "change nothing the operator can see in Linear", so an
+    // unreachable proxy must not block the write. It must still be audible.
+    const d = decideWritePath({ mode: "shadow", proxyReady: false, unavailableReason: "out-of-tree copy" });
+    expect(d.action).toBe("direct");
+    expect(d.observe).toBe(false);
+    expect(d.reason).toBe("out-of-tree copy");
+  });
+});
+
+describe("⛔ the distinction the whole module exists for", () => {
+  test("`off` and `unavailable` are NEVER the same answer under enforce", () => {
+    const off = decideWritePath({ mode: "off", proxyReady: false });
+    const unavailable = decideWritePath({ mode: "enforce", proxyReady: false, unavailableReason: "x" });
+    // Same inputs to a naive implementation ("no transport → write direct"); different answers here.
+    expect(off.action).toBe("direct");
+    expect(unavailable.action).toBe("refuse");
+    expect(off.action).not.toBe(unavailable.action);
+  });
+
+  test("`off` and `unavailable` differ under shadow too — by the reason, not the action", () => {
+    const off = decideWritePath({ mode: "off", proxyReady: false });
+    const unavailable = decideWritePath({ mode: "shadow", proxyReady: false, unavailableReason: "x" });
+    expect(off.action).toBe(unavailable.action); // both write
+    expect(off.reason).toBeNull();
+    expect(unavailable.reason).toBe("x"); // ...but only one of them is silent
+  });
+});
+
+describe("⛔ unknown / hostile modes degrade to off, never to enforce", () => {
+  test("a typo'd mode is treated as off — it must not REFUSE a write on a typo", () => {
+    for (const bad of ["Enforce", "ENFORCE", "enforce ", "on", "true", "", null, undefined, 7, {}]) {
+      const d = decideWritePath({ mode: bad, proxyReady: true });
+      expect(d.action).toBe("direct");
+      expect(d.observe).toBe(false);
+    }
+  });
+
+  test("no arguments at all is `off`, not a crash", () => {
+    expect(decideWritePath()).toEqual({ action: "direct", observe: false, reason: null });
+  });
+
+  test("the mode vocabulary is exactly these three", () => {
+    expect([...WRITE_PROXY_MODES].sort()).toEqual(["enforce", "off", "shadow"]);
+  });
+});

--- a/plugins/dev/scripts/lib/linear-write-path.test.mjs
+++ b/plugins/dev/scripts/lib/linear-write-path.test.mjs
@@ -106,3 +106,56 @@ describe("⛔ unknown / hostile modes degrade to off, never to enforce", () => {
     expect([...WRITE_PROXY_MODES].sort()).toEqual(["enforce", "off", "shadow"]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTL-1961 — a SOURCE-LEVEL guard, because the property lives in a script that
+// cannot be imported (top-level await + it writes to Linear on import).
+//
+// The property: `linear-reply.mjs`'s eyes-clear is BEST-EFFORT. It runs after the
+// comment has already been posted, so exiting non-zero there would report failure for
+// a reply that succeeded — and `ask.mjs` invokes this script, so a retry could
+// double-post. Both minis run CATALYST_LINEAR_WRITE_PROXY=enforce, so this is the live
+// path. The original code expressed it as `try { … } catch {}`; routing must not quietly
+// upgrade a swallowed cleanup into a fatal one.
+//
+// `linear-ack.mjs` is deliberately the OPPOSITE — there the reaction IS the operation, so
+// refusing is correct — and that asymmetry is what makes this test discriminating rather
+// than a tautology.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPTS = dirname(dirname(fileURLToPath(import.meta.url))) === ""
+  ? "."
+  : join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** The eyes-clear block of linear-reply.mjs, sliced by its own anchors. */
+function eyesClearBlock() {
+  const src = readFileSync(join(SCRIPTS, "linear-reply.mjs"), "utf8");
+  const start = src.indexOf("CTL-1961 — WHY ONLY THIS WRITE IS ROUTED");
+  const end = src.indexOf("console.log(JSON.stringify({ ok:");
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error("anchors not found — the guard cannot report a clean pass it did not earn");
+  }
+  return src.slice(start, end);
+}
+
+describe("⛔ the eyes-clear must never fail a reply that already posted", () => {
+  test("linear-reply.mjs's eyes-clear block contains NO process.exit", () => {
+    expect(eyesClearBlock()).not.toContain("process.exit");
+  });
+
+  test("⭐ POSITIVE CONTROL: the same scan DOES find linear-ack's deliberate refusal", () => {
+    // Without this, the test above would pass just as happily against a file it failed to
+    // read, or a scan that matches nothing. linear-ack SHOULD exit — the reaction is its
+    // whole operation — so finding it proves the instrument works.
+    const ack = readFileSync(join(SCRIPTS, "linear-ack.mjs"), "utf8");
+    expect(ack).toContain("process.exit(1)");
+  });
+
+  test("⛔ the anchors themselves are asserted — a silent slice failure must throw, not pass", () => {
+    // If either anchor is renamed the slice would be empty, and an empty string trivially
+    // "contains no process.exit". eyesClearBlock throws instead; this pins that.
+    expect(eyesClearBlock().length).toBeGreaterThan(200);
+  });
+});

--- a/plugins/dev/scripts/lib/linear-write-path.test.mjs
+++ b/plugins/dev/scripts/lib/linear-write-path.test.mjs
@@ -159,3 +159,38 @@ describe("⛔ the eyes-clear must never fail a reply that already posted", () =>
     expect(eyesClearBlock().length).toBeGreaterThan(200);
   });
 });
+
+// ── CTL-2026: the branch the TOOLS restate when this very file is unreachable ────────
+//
+// `linear-ack.mjs` / `linear-reply.mjs` guard the import of this module (an out-of-tree
+// copy cannot resolve it) and, in the catch, cannot then ASK it what to do. They carry a
+// four-line inline fallback instead. That fallback is not a second dialect — it restates
+// exactly one branch of the function below, the `proxyReady:false` column — but a
+// restatement drifts the moment this file changes and nothing tells the author.
+//
+// So this pins the property the fallback depends on, over the WHOLE mode set rather than
+// the three modes someone happened to think of: with no transport, refusal is reserved to
+// `enforce` and nothing else. If that ever stops being true, this fails and names the two
+// files that must change with it.
+describe("the unreachable-leaf fallback (linear-ack.mjs / linear-reply.mjs)", () => {
+  test("with no transport, `refuse` is reserved to enforce — every other mode writes direct", () => {
+    for (const mode of WRITE_PROXY_MODES) {
+      const d = decideWritePath({ mode, proxyReady: false, unavailableReason: "modules unreachable" });
+      expect(`${mode} -> ${d.action}`).toBe(`${mode} -> ${mode === "enforce" ? "refuse" : "direct"}`);
+    }
+  });
+
+  test("an unrecognised mode is not a licence to refuse (it degrades to off, i.e. direct)", () => {
+    // The tools' fallback compares against the literal "enforce"; anything else must be
+    // safe to treat as direct, or a typo'd env var would silently stop every reply.
+    for (const mode of ["", "ENFORCE", "on", "1", undefined, null]) {
+      expect(decideWritePath({ mode, proxyReady: false }).action).toBe("direct");
+    }
+  });
+
+  test("with no transport, nothing is ever OBSERVED — the fallback has no proxy to observe with", () => {
+    for (const mode of WRITE_PROXY_MODES) {
+      expect(decideWritePath({ mode, proxyReady: false }).observe).toBe(false);
+    }
+  });
+});

--- a/plugins/dev/scripts/linear-ack.mjs
+++ b/plugins/dev/scripts/linear-ack.mjs
@@ -5,5 +5,94 @@ const r=await fetch(OAUTH,{method:"POST",headers:{"content-type":"application/x-
 const g=async(q,v)=>{const x=await fetch(GQL,{method:"POST",headers:{"content-type":"application/json",authorization:tok},body:JSON.stringify({query:q,variables:v})});const j=await x.json(); if(j.errors) throw new Error(JSON.stringify(j.errors).slice(0,300)); return j.data;};
 const d=await g(`query($k:String!){ issue(id:$k){ comments(first:100, orderBy: createdAt){ nodes{ id createdAt user{ id name } botActor{ type } reactions{ id emoji user{ id } } } } } }`,{k:key});
 const humans=d.issue.comments.nodes.filter(n=>n.user&&!n.botActor&&n.user.id===(process.env.ASK_HUMAN_ID||"c2a8cc92-cab6-4536-9500-0f24abdf702b")).sort((a,b)=>a.createdAt.localeCompare(b.createdAt)); const last=humans[humans.length-1]; if(!last){console.log("no human comment");process.exit(0);}
-if(remove){ const mine=last.reactions.filter(x=>x.emoji===emoji); for(const x of mine){ await g(`mutation($id:String!){ reactionDelete(id:$id){ success } }`,{id:x.id}); } console.log(JSON.stringify({removed:mine.length,commentId:last.id})); }
-else { const m=await g(`mutation($in:ReactionCreateInput!){ reactionCreate(input:$in){ success reaction{ id } } }`,{in:{commentId:last.id,emoji}}); console.log(JSON.stringify({ok:m.reactionCreate.success,commentId:last.id,emoji})); }
+// ── CTL-1961: the WRITE goes through the cloud proxy; the READ above stays direct ───
+// The skinny-install contract is that a host may keep a Linear credential for READS but
+// must not hold a direct WRITE path. The comment lookup above is a read and is unchanged;
+// only reactionCreate/reactionDelete are routed.
+//
+// Modes follow linear-comment-write.mjs, because a second dialect of "what does shadow
+// mean" is how the two drift:
+//   off      → direct, byte-identical to before this change
+//   shadow   → record the observation, then perform the direct write (a reaction is a
+//              WRITE, so "observe by doing it too" would double-write)
+//   enforce  → proxy only. A failure REFUSES and exits non-zero; it is never retried
+//              direct, because falling back would defeat the gate on exactly the runs
+//              where it matters.
+//
+// ⛔ The proxy is CONSTRUCTED here, not fetched with `getLinearWriteProxy()`. That
+// accessor returns a module-level singleton that something else must have INSTALLED, and
+// nothing installs it in a standalone script — so it answers `null` every time and the
+// routing would silently never engage. A gate that cannot fire is worse than no gate,
+// because it reports the same thing as a working one. Construction mirrors
+// `cluster-claim.mjs`'s defaultTransport, which had to solve this same problem.
+let proxyMode = "off";
+let proxy = null;
+let proxyUnavailable = null; // a REASON, never a silent null — see below
+try {
+  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }] = await Promise.all([
+    import("./execution-core/linear-write-proxy.mjs"),
+    import("./execution-core/config.mjs"),
+  ]);
+  const cfg = readLinearWriteProxyConfig(process.env);
+  proxyMode = cfg.mode ?? "off";
+  if (proxyMode === "shadow" || proxyMode === "enforce") {
+    proxy = createLinearWriteProxy({ mode: proxyMode, env: process.env, routes: cfg.routes });
+    if (!proxy) proxyUnavailable = `createLinearWriteProxy returned null for mode=${proxyMode}`;
+  }
+} catch (err) {
+  // ⛔ NOT the same as `off`. An out-of-tree copy of this tool cannot resolve these
+  // imports at all (CTL-2026), and a typo'd export name looks identical from here — the
+  // first cut of this change imported a name that does not exist and would have degraded
+  // to "direct" forever while looking like a routed tool. So the reason is kept and, under
+  // enforce, it REFUSES rather than quietly writing direct.
+  proxyUnavailable = `proxy modules unreachable: ${err?.message ?? err}`;
+}
+
+const viaProxy = async (mode) => {
+  const res = proxy.send({
+    routeId: "reaction",
+    ticket: key,
+    payload: { commentId: last.id, emoji, mode },
+    caller: "linear-ack",
+  });
+  if (!res?.handled) throw new Error(`proxy did not handle the write: ${res?.reason ?? "unknown"}`);
+  return res;
+};
+
+const directRemove = async () => {
+  // The route's remove mode deletes EVERY matching reaction and reports the count, which
+  // is what this loop already did — so the two paths agree rather than merely coexisting.
+  const mine = last.reactions.filter((x) => x.emoji === emoji);
+  for (const x of mine) await g(`mutation($id:String!){ reactionDelete(id:$id){ success } }`, { id: x.id });
+  return { removed: mine.length, commentId: last.id };
+};
+const directAdd = async () => {
+  const m = await g(`mutation($in:ReactionCreateInput!){ reactionCreate(input:$in){ success reaction{ id } } }`, {
+    in: { commentId: last.id, emoji },
+  });
+  return { ok: m.reactionCreate.success, commentId: last.id, emoji };
+};
+
+const mode = remove ? "remove" : "add";
+const { decideWritePath } = await import("./lib/linear-write-path.mjs");
+const plan = decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable });
+
+if (plan.action === "refuse") {
+  console.error(`linear-ack: REFUSED — mode=${proxyMode} but the proxy is unavailable (${plan.reason})`);
+  process.exit(1);
+}
+if (plan.action === "proxy") {
+  const res = await viaProxy(mode);
+  console.log(JSON.stringify({ via: "proxy", applied: res.applied === true, commentId: last.id, emoji, mode }));
+} else {
+  if (plan.observe) {
+    try {
+      await viaProxy(mode);
+    } catch (err) {
+      console.error(`linear-ack: proxy threw in shadow (the direct write still happens): ${err?.message}`);
+    }
+  } else if (plan.reason) {
+    console.error(`linear-ack: ${plan.reason} — writing direct`);
+  }
+  console.log(JSON.stringify({ via: "direct", ...(remove ? await directRemove() : await directAdd()) }));
+}

--- a/plugins/dev/scripts/linear-ack.mjs
+++ b/plugins/dev/scripts/linear-ack.mjs
@@ -25,14 +25,39 @@ const humans=d.issue.comments.nodes.filter(n=>n.user&&!n.botActor&&n.user.id===(
 // routing would silently never engage. A gate that cannot fire is worse than no gate,
 // because it reports the same thing as a working one. Construction mirrors
 // `cluster-claim.mjs`'s defaultTransport, which had to solve this same problem.
+//
+// ⛔ CTL-2026 — THE LEAF IMPORT MUST BE INSIDE THIS GUARD, AND IT WAS NOT.
+// The catch below exists BECAUSE an out-of-tree copy cannot resolve these imports. The
+// first cut then imported `./lib/linear-write-path.mjs` on its own line, OUTSIDE the try —
+// so a copy of this file with no sibling directories died with an unhandled module
+// resolution error before it could take the very branch written to handle that case.
+// Measured 2026-08-18 by copying this file alone into an empty directory and running it:
+// `Cannot find module '<dir>/lib/linear-write-path.mjs'`, no reaction attempted, no reason
+// printed. `~/catalyst/comms/tools/` is exactly that shape, and CTL-2026(b)'s announced
+// sync step is what would have put this file there. A guard whose result is consumed
+// outside the guard is not a guard.
+//
+// ⛔ AND THE MODE MUST BE READ BEFORE THE GUARD, NOT INSIDE IT.
+// `proxyMode` was assigned from `readLinearWriteProxyConfig` INSIDE the try, so an
+// unreachable-modules host fell through with the initialiser `"off"` still in place —
+// i.e. the one state in which the refusal matters was also the one state that computed
+// "no proxy configured". The env read below is the only mode source that survives the
+// modules being gone. It is deliberately WEAKER than the real ladder (env only, no
+// Layer-2), so it reports `null` = "could not confirm" rather than claiming `"off"`.
+const envMode = ["off", "shadow", "enforce"].includes(process.env.CATALYST_LINEAR_WRITE_PROXY)
+  ? process.env.CATALYST_LINEAR_WRITE_PROXY
+  : null;
 let proxyMode = "off";
 let proxy = null;
 let proxyUnavailable = null; // a REASON, never a silent null — see below
+let decideWritePath = null;
 try {
-  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }] = await Promise.all([
+  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }, writePath] = await Promise.all([
     import("./execution-core/linear-write-proxy.mjs"),
     import("./execution-core/config.mjs"),
+    import("./lib/linear-write-path.mjs"),
   ]);
+  decideWritePath = writePath.decideWritePath;
   const cfg = readLinearWriteProxyConfig(process.env);
   proxyMode = cfg.mode ?? "off";
   if (proxyMode === "shadow" || proxyMode === "enforce") {
@@ -46,6 +71,7 @@ try {
   // to "direct" forever while looking like a routed tool. So the reason is kept and, under
   // enforce, it REFUSES rather than quietly writing direct.
   proxyUnavailable = `proxy modules unreachable: ${err?.message ?? err}`;
+  proxyMode = envMode ?? "off";
 }
 
 const viaProxy = async (mode) => {
@@ -74,8 +100,21 @@ const directAdd = async () => {
 };
 
 const mode = remove ? "remove" : "add";
-const { decideWritePath } = await import("./lib/linear-write-path.mjs");
-const plan = decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable });
+// ⛔ We cannot ask the leaf what to do about the leaf being missing. This restates its
+// STRICTEST branch and nothing else — with no transport, `enforce` REFUSES and every other
+// mode writes direct — and it is pinned against the real function by "the unreachable-leaf
+// fallback" in lib/linear-write-path.test.mjs, which fails if that branch ever changes.
+// An env that never named a mode is reported as UNCONFIRMED rather than as `off`: this
+// degraded path cannot read Layer-2, so "no mode here" is not evidence of "no mode".
+const plan = decideWritePath
+  ? decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable })
+  : proxyMode === "enforce"
+    ? { action: "refuse", observe: false, reason: proxyUnavailable ?? "proxy unavailable under enforce" }
+    : {
+        action: "direct",
+        observe: false,
+        reason: `${proxyUnavailable ?? "write-path leaf unreachable"}${envMode ? "" : "; CATALYST_LINEAR_WRITE_PROXY unset, so the mode is UNCONFIRMED (Layer-2 unreadable without the modules)"}`,
+      };
 
 if (plan.action === "refuse") {
   console.error(`linear-ack: REFUSED — mode=${proxyMode} but the proxy is unavailable (${plan.reason})`);

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -69,16 +69,87 @@ if (parentArg) {
   const last = humans[humans.length - 1];
   if (last) parentId = last.parent?.id ?? last.id;
 }
+// ── CTL-1961: construct the write proxy once, for the eyes-clear below ──────────────
+// Constructed, NOT fetched via getLinearWriteProxy(): that accessor returns an installed
+// singleton nothing installs in a standalone script, so it answers null every time and the
+// routing would silently never engage. `unavailable` is kept as a REASON rather than
+// collapsed into "off" — see lib/linear-write-path.mjs on why those must never be one answer.
+const { decideWritePath } = await import("./lib/linear-write-path.mjs");
+let proxyMode = "off";
+let proxy = null;
+let proxyUnavailable = null;
+try {
+  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }] = await Promise.all([
+    import("./execution-core/linear-write-proxy.mjs"),
+    import("./execution-core/config.mjs"),
+  ]);
+  const cfg = readLinearWriteProxyConfig(process.env);
+  proxyMode = cfg.mode ?? "off";
+  if (proxyMode === "shadow" || proxyMode === "enforce") {
+    proxy = createLinearWriteProxy({ mode: proxyMode, env: process.env, routes: cfg.routes });
+    if (!proxy) proxyUnavailable = `createLinearWriteProxy returned null for mode=${proxyMode}`;
+  }
+} catch (err) {
+  proxyUnavailable = `proxy modules unreachable: ${err?.message ?? err}`;
+}
+
 const m = await gql(token, `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success comment{ id url } } }`, {
   in: { issueId: issue.id, body, createAsUser: asAgent, ...(parentId ? { parentId } : {}) },
 });
 // Ryan (2026-08-17): 👀 on the human's LATEST comment means "read, working on it"; it comes OFF once the reply
 // is posted (not at resolution). Clear any eyes reactions on the comment we replied under, unless --keep-eyes.
+//
+// ⛔ CTL-1961 — WHY ONLY THIS WRITE IS ROUTED AND THE COMMENT ABOVE IS NOT.
+// The eyes-clear goes through the CTC-724 `reaction` route. The commentCreate above stays
+// DIRECT, and that is a declared exception with a named blocker, not an oversight: this
+// tool passes `createAsUser: asAgent` — the `--as <AGENT>` flag that makes a reply show as
+// "CTL-INSTALL"/"FLEET" rather than an undifferentiated app actor — and the cloud route
+// `POST /api/v1/agent/issue-comment` accepts only {issueId, body, parentId?, hostId}. It
+// carries no display name (measured: 0 occurrences of createAsUser/displayName/agentName
+// in agent-write-routes.ts at ba3a722; positive control — `parentId` returns 7 in the same
+// file). Routing it today would post the right comment in the right thread with the AUTHOR
+// STRIPPED, on the busiest surface we have, and would look fine while doing it.
+// Tracked as CTC-762; until it lands, doctor must report this path as a NAMED EXCEPTION
+// rather than passing — a gate that quietly excuses the busiest write path is not a gate.
 let cleared = 0;
 if (!process.argv.includes("--keep-eyes")) {
   const target = issue.comments.nodes.filter(n => n.user && !n.botActor && n.user.id === (process.env.ASK_HUMAN_ID || "c2a8cc92-cab6-4536-9500-0f24abdf702b")).sort((a,b)=>a.createdAt.localeCompare(b.createdAt)).slice(-1)[0];
-  for (const rx of (target?.reactions ?? []).filter(r => r.emoji === "eyes")) {
-    try { await gql(token, `mutation($id:String!){ reactionDelete(id:$id){ success } }`, { id: rx.id }); cleared++; } catch {}
+  const eyes = (target?.reactions ?? []).filter(r => r.emoji === "eyes");
+  if (eyes.length > 0) {
+    // The route's remove mode deletes EVERY matching reaction on the target and reports the
+    // count, which is exactly what the loop below does — so the two paths agree rather than
+    // merely coexisting.
+    const plan = decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable });
+    if (plan.action === "refuse") {
+      console.error(`linear-reply: eyes-clear REFUSED — mode=${proxyMode} but the proxy is unavailable (${plan.reason})`);
+      process.exit(1);
+    }
+    if (plan.action === "proxy") {
+      const res = proxy.send({
+        routeId: "reaction",
+        ticket: issueKey,
+        payload: { commentId: target.id, emoji: "eyes", mode: "remove" },
+        caller: "linear-reply",
+      });
+      if (!res?.handled) {
+        console.error(`linear-reply: eyes-clear REFUSED — proxy did not handle it (${res?.reason ?? "unknown"})`);
+        process.exit(1);
+      }
+      cleared = eyes.length;
+    } else {
+      if (plan.observe) {
+        try {
+          proxy.send({ routeId: "reaction", ticket: issueKey, payload: {}, caller: "linear-reply" });
+        } catch (err) {
+          console.error(`linear-reply: proxy threw in shadow (the direct clear still happens): ${err?.message}`);
+        }
+      } else if (plan.reason) {
+        console.error(`linear-reply: ${plan.reason} — clearing 👀 direct`);
+      }
+      for (const rx of eyes) {
+        try { await gql(token, `mutation($id:String!){ reactionDelete(id:$id){ success } }`, { id: rx.id }); cleared++; } catch {}
+      }
+    }
   }
 }
 console.log(JSON.stringify({ ok: m.commentCreate.success, commentId: m.commentCreate.comment.id, parentId, url: m.commentCreate.comment.url, eyesCleared: cleared }));

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -120,22 +120,38 @@ if (!process.argv.includes("--keep-eyes")) {
     // count, which is exactly what the loop below does — so the two paths agree rather than
     // merely coexisting.
     const plan = decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable });
-    if (plan.action === "refuse") {
-      console.error(`linear-reply: eyes-clear REFUSED — mode=${proxyMode} but the proxy is unavailable (${plan.reason})`);
-      process.exit(1);
-    }
-    if (plan.action === "proxy") {
-      const res = proxy.send({
-        routeId: "reaction",
-        ticket: issueKey,
-        payload: { commentId: target.id, emoji: "eyes", mode: "remove" },
-        caller: "linear-reply",
-      });
-      if (!res?.handled) {
-        console.error(`linear-reply: eyes-clear REFUSED — proxy did not handle it (${res?.reason ?? "unknown"})`);
-        process.exit(1);
+    // ⛔ THE EYES-CLEAR IS BEST-EFFORT AND MUST STAY THAT WAY, INCLUDING UNDER ENFORCE.
+    // It runs AFTER the comment above has already been posted. `refuse` here — exiting
+    // non-zero the way linear-ack correctly does — would report FAILURE for a reply that
+    // actually succeeded, and the caller (`ask.mjs:469` invokes this script) could retry
+    // into a DOUBLE-POSTED comment. Both minis run CATALYST_LINEAR_WRITE_PROXY=enforce, so
+    // this is the live path, not a hypothetical one.
+    //
+    // The house rule this restores is already written down elsewhere in this repo: a
+    // cleanup step must never be able to fail the thing it cleans up after. The original
+    // code said the same thing with `try { … } catch {}`; routing must not quietly
+    // upgrade a swallowed cleanup into a fatal one.
+    //
+    // linear-ack is deliberately DIFFERENT: there the reaction IS the whole operation, so
+    // refusing is the correct answer and nothing has been written yet to contradict.
+    if (plan.action === "proxy" || plan.action === "refuse") {
+      if (plan.action === "refuse") {
+        console.error(`linear-reply: 👀 NOT cleared — mode=${proxyMode} and the proxy is unavailable (${plan.reason}). The reply itself was posted.`);
+      } else {
+        let res = null;
+        try {
+          res = proxy.send({
+            routeId: "reaction",
+            ticket: issueKey,
+            payload: { commentId: target.id, emoji: "eyes", mode: "remove" },
+            caller: "linear-reply",
+          });
+        } catch (err) {
+          console.error(`linear-reply: 👀 NOT cleared — proxy threw (${err?.message}). The reply itself was posted.`);
+        }
+        if (res?.handled) cleared = eyes.length;
+        else if (res) console.error(`linear-reply: 👀 NOT cleared — proxy did not handle it (${res?.reason ?? "unknown"}). The reply itself was posted.`);
       }
-      cleared = eyes.length;
     } else {
       if (plan.observe) {
         try {

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -74,15 +74,33 @@ if (parentArg) {
 // singleton nothing installs in a standalone script, so it answers null every time and the
 // routing would silently never engage. `unavailable` is kept as a REASON rather than
 // collapsed into "off" — see lib/linear-write-path.mjs on why those must never be one answer.
-const { decideWritePath } = await import("./lib/linear-write-path.mjs");
+//
+// ⛔ CTL-2026 — THE LEAF IMPORT BELONGS INSIDE THE GUARD. It used to sit on its own line
+// above the try, so a copy of this file with no sibling directories died with an unhandled
+// module resolution error — before the reply was posted, and before the catch written for
+// exactly that case could run. Measured 2026-08-18 by copying this file alone into an empty
+// directory: `Cannot find module '<dir>/lib/linear-write-path.mjs'`. `~/catalyst/comms/tools/`
+// is that shape, and CTL-2026(b)'s announced sync step is what puts this file there. See
+// linear-ack.mjs for the same fix and the same reasoning.
+//
+// The env-only mode read is likewise BEFORE the guard: `proxyMode` was assigned inside the
+// try, so an unreachable-modules host kept the initialiser `"off"` — the one state where
+// the mode matters was the one state that reported none. Env only (no Layer-2), so an
+// absent variable is reported as UNCONFIRMED rather than as `off`.
+const envMode = ["off", "shadow", "enforce"].includes(process.env.CATALYST_LINEAR_WRITE_PROXY)
+  ? process.env.CATALYST_LINEAR_WRITE_PROXY
+  : null;
 let proxyMode = "off";
 let proxy = null;
 let proxyUnavailable = null;
+let decideWritePath = null;
 try {
-  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }] = await Promise.all([
+  const [{ createLinearWriteProxy }, { readLinearWriteProxyConfig }, writePath] = await Promise.all([
     import("./execution-core/linear-write-proxy.mjs"),
     import("./execution-core/config.mjs"),
+    import("./lib/linear-write-path.mjs"),
   ]);
+  decideWritePath = writePath.decideWritePath;
   const cfg = readLinearWriteProxyConfig(process.env);
   proxyMode = cfg.mode ?? "off";
   if (proxyMode === "shadow" || proxyMode === "enforce") {
@@ -91,10 +109,25 @@ try {
   }
 } catch (err) {
   proxyUnavailable = `proxy modules unreachable: ${err?.message ?? err}`;
+  proxyMode = envMode ?? "off";
 }
 
+// Ryan (2026-08-18 19:4x): a consistent per-agent avatar next to the createAsUser name. Deterministic from the
+// agent tag so the same agent always renders the same image; Linear's CommentCreateInput has `displayIconUrl`
+// (measured against the live schema). Override the generator with CATALYST_AVATAR_URL_TEMPLATE (use {slug}).
+//
+// ⛔ CARRIED FORWARD VERBATIM from ~/catalyst/comms/tools/linear-reply.mjs, NOT rewritten (CTL-2026).
+// Ryan hand-edited the OUT-OF-TREE copy at 19:46:30 on 2026-08-18; the repo copy was last touched
+// 2026-08-17 (#3484). So CTL-2026's founding measurement — "they are true copies, byte-identical" —
+// was already false six hours after it was written, and option (a) (make the out-of-tree file a thin
+// wrapper that execs THIS file) would have silently DELETED these avatars on every lane's next reply.
+// That is the whole reason the repo copy has to be brought level before (a) lands. Any "improvement"
+// here re-opens the same gap in the other direction, so this is a transcription, not a redesign.
+const avatarSlug = encodeURIComponent(String(asAgent).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""));
+const avatarTemplate = process.env.CATALYST_AVATAR_URL_TEMPLATE || "https://api.dicebear.com/9.x/shapes/svg?seed={slug}";
+const displayIconUrl = avatarTemplate.replace("{slug}", avatarSlug);
 const m = await gql(token, `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success comment{ id url } } }`, {
-  in: { issueId: issue.id, body, createAsUser: asAgent, ...(parentId ? { parentId } : {}) },
+  in: { issueId: issue.id, body, createAsUser: asAgent, displayIconUrl, ...(parentId ? { parentId } : {}) },
 });
 // Ryan (2026-08-17): 👀 on the human's LATEST comment means "read, working on it"; it comes OFF once the reply
 // is posted (not at resolution). Clear any eyes reactions on the comment we replied under, unless --keep-eyes.
@@ -109,6 +142,11 @@ const m = await gql(token, `mutation($in:CommentCreateInput!){ commentCreate(inp
 // in agent-write-routes.ts at ba3a722; positive control — `parentId` returns 7 in the same
 // file). Routing it today would post the right comment in the right thread with the AUTHOR
 // STRIPPED, on the busiest surface we have, and would look fine while doing it.
+// ⚠️ CTL-2026 makes that blocker BIGGER, not smaller: the input now also carries
+// `displayIconUrl` (the per-agent avatar above), which is a second author-identity field
+// the cloud route has no parameter for. Whoever lands CTC-762 must add BOTH, and the
+// route's acceptance test should name both — adding only `createAsUser` would restore the
+// name and silently drop the avatar, which is the identical failure one field along.
 // Tracked as CTC-762; until it lands, doctor must report this path as a NAMED EXCEPTION
 // rather than passing — a gate that quietly excuses the busiest write path is not a gate.
 let cleared = 0;
@@ -119,7 +157,17 @@ if (!process.argv.includes("--keep-eyes")) {
     // The route's remove mode deletes EVERY matching reaction on the target and reports the
     // count, which is exactly what the loop below does — so the two paths agree rather than
     // merely coexisting.
-    const plan = decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable });
+    // The unreachable-leaf fallback: see linear-ack.mjs. Same strictest-branch restatement,
+    // pinned by the same invariant test. Here `refuse` only SKIPS the clear (below).
+    const plan = decideWritePath
+      ? decideWritePath({ mode: proxyMode, proxyReady: proxy != null, unavailableReason: proxyUnavailable })
+      : proxyMode === "enforce"
+        ? { action: "refuse", observe: false, reason: proxyUnavailable ?? "proxy unavailable under enforce" }
+        : {
+            action: "direct",
+            observe: false,
+            reason: `${proxyUnavailable ?? "write-path leaf unreachable"}${envMode ? "" : "; CATALYST_LINEAR_WRITE_PROXY unset, so the mode is UNCONFIRMED (Layer-2 unreadable without the modules)"}`,
+          };
     // ⛔ THE EYES-CLEAR IS BEST-EFFORT AND MUST STAY THAT WAY, INCLUDING UNDER ENFORCE.
     // It runs AFTER the comment above has already been posted. `refuse` here — exiting
     // non-zero the way linear-ack correctly does — would report FAILURE for a reply that


### PR DESCRIPTION
**Increment 1 of CTL-1961** — the two routes CTC-724/CTC-725 shipped in [catalyst-cloud#884](https://github.com/coalesce-labs/catalyst-cloud/pull/884) are now known to the host client. This is the prerequisite for routing the tools; **it does not by itself move any tool off its direct write path** (see "what this is not", below).

## Why

`linear-ack.mjs` and `linear-reply.mjs` — the two tools every lane's brief tells it to run — POST `reactionCreate` / `reactionDelete` **straight to `api.linear.app`** with a host-held credential. That is exactly what the skinny-install gate exists to remove. The cloud routes now exist; the client did not know them.

## Measured, not assumed

Paths were read off catalyst-cloud `origin/main` (`ba3a722`) **at the dispatcher** — the pathname the server actually compares — not from the doc comments above the handlers:

```ts
index.ts:986  if (req.method === "POST" && url.pathname === "/api/v1/agent/reaction")
index.ts:989  if (req.method === "POST" && url.pathname === "/api/v1/agent/issue-create")
```

This module's own header records that an earlier cut shipped `DEFAULT_ROUTES` as a declared **assumption** and was wrong on every one, which is why the discipline is worth repeating rather than trusting a channel post.

## ⛔ One correction to CTC-724's stated rationale — same decision, different reason

CTC-724 asks that `reaction` stay out of `NON_BLOCKING_ROUTE_IDS` because *"a claim decides whether a host may work a ticket, so fire-and-forget lets two owners both believe they hold it."* **I agree with the decision and have kept it. The rationale does not hold.**

The 👀 is **not a claim** — Ryan defined it in `linear-reply.mjs:75`: *"👀 on the human's LATEST comment means 'read, working on it'; it comes OFF once the reply is posted (not at resolution)."* A read-receipt on one comment. `linear-ack.mjs` reacts to a **comment**, not the issue, and never reads before it writes. Nothing in this repo gates work admission on a Linear reaction; the exclusion primitive is `cluster-claim.mjs`'s `catalyst://fence/<TICKET>` soft-CAS — the `attachment` route.

⛔ **That matters practically:** the next reader who discovers the 👀 is not a claim would conclude the constraint rested on a mistake and move it to the fast path. They would be wrong, for a reason nobody wrote down.

⭐ **The reason that survives is an ordering race, independent of what the reaction means.** Add and remove are a matched pair on the **same object** issued by **two different tools** — `linear-ack.mjs` adds, `linear-reply.mjs` removes (default-on unless `--keep-eyes`) — and the normal path issues **add → remove within seconds**. Make the add fire-and-forget while the remove blocks, and the remove runs against a comment where the add has not landed, finds nothing, and the add lands *after* it: a **permanent stale 👀 on an already-answered comment**, which nothing ever clears (the clear only runs on the *next* reply under that same comment, which may never come). Recorded in the source, not just here.

## Verification

- **111 pass / 0 fail** in `linear-write-proxy.test.mjs`; siblings unchanged (30/35/17, all 0 fail). The suite is **already pinned in CI**.
- ⭐ **The existing exact-set guard did its job** — `"the supported routes are exactly the set below — fails in both directions"` went red on the addition, exactly as its comment demands (*"a new route must be argued for HERE"*). The argument for each id is now in that test.
- ⭐ **Mutation-tested, three ways:** a wrong `reaction` path → 1 fail (the measured-path assertion); `reaction` moved to the fast path → 2 fail; a route dropped → 3 fail. Restored → 111/0.

## ⭐ Increment 2 (added after the first push): `linear-ack.mjs` is routed

Its comment **lookup stays direct** (a read; the order allows the credential for reads). Only `reactionCreate` / `reactionDelete` move onto the CTC-724 route.

**Two traps, both of which my first cut walked into and neither of which would have been visible from the outside:**

1. ⛔ **`getLinearWriteProxy()` is the wrong accessor.** It lives in `linear-write-proxy-install.mjs` and returns a module-level singleton something else must have **installed** — nothing installs it in a standalone script, so it answers `null` every time and the routing would **silently never engage**. The proxy is **constructed** here instead, mirroring `cluster-claim.mjs`'s `defaultTransport`, which had to solve the same problem. *(Verified live: imports resolve from the tool's own directory, and `off/shadow/enforce` construct as expected.)*
2. ⛔ **"the proxy is off" and "I could not reach the proxy" must never collapse to one answer.** My first cut imported an export name that does not exist and caught the failure — which degrades to **direct-forever while reporting as a routed tool**. `decideWritePath` keeps the unavailability as a **reason** and, under `enforce`, **REFUSES**. A fallback there would defeat the gate on exactly the runs it exists for.

The decision is extracted to `lib/linear-write-path.mjs` (a zero-import pure leaf) because these tools are **side-effecting scripts with top-level await** — they mint a token and write to Linear on import, so their routing cannot be unit-tested in place. Sharing it also stops the two tools growing separate dialects of "what does shadow mean".

**12 pass / 0 fail**, ⭐ **mutation-tested three ways**: collapsing enforce-unavailable into a direct write → 3 fail; treating an unknown mode as `enforce` → 2 fail; dropping the reason on shadow-unavailable (going silent) → 2 fail. Restored → 12/0. ⭐ **Pinned into CI in the same commit that wrote it** — `grep -c linear-write-path .github/workflows/` returned **0**, which would have been the *third* suite in two days to ship inert.

## ⚠️ What this is still NOT

**`linear-reply.mjs` is not yet routed** (it has two writes — `commentCreate` and the eyes-clear `reactionDelete` — and it is the tool every lane uses to answer tickets, so it gets its own increment rather than riding this one).

**The out-of-tree copies under `~/catalyst/comms/tools/` are untouched** — verified today as true copies, byte-identical to the repo, so this repo-only change does not reach them. That is a genuine design question, not an oversight: filed as **[CTL-2026](https://linear.app/coalesce-labs/issue/CTL-2026)** (an ask, with a default of "fix the repo now, sync announced").

**`doctor` does not yet assert the gate** — it would fail today, correctly, so it lands with the routing rather than ahead of it. When it does, it must be able to report the out-of-tree directory **inconclusive**, never a silent pass.

⛔ **So this PR does not close the skinny-install gate**, and its title should not be read as claiming otherwise. The `linearis` seam that ~40 skill call sites shell out to also still writes direct; the enumeration is in channel turn CTLI-22.

⚠️ **Codex is out of quota** — no automated review; that is "could not look", not a clean pass. **Peer read welcome.**

⏸️ **Queued** — per COORD-224 catalyst merges are serialized by hand; this goes behind #3638, #3644 and P13's four. I will post `MERGING` when it is my turn.

Part of CTL-1961.
