### PR TITLE
fix(dev): CTL-2024 — a cleared stall could never re-enter its phase, because the janitor's unstick left CTL-1805's advance marker standing

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1045,6 +1045,7 @@ jobs:
             worker-dir-gc.test.mjs \
             in-flight-supersede.test.mjs \
             advance-idempotency.test.mjs \
+            clear-stall-advance-reentry.test.mjs \
             boot-resume-approval.test.mjs \
             boot-resume.test.mjs \
             claim.test.mjs \

--- a/plugins/dev/scripts/execution-core/advance-guard.mjs
+++ b/plugins/dev/scripts/execution-core/advance-guard.mjs
@@ -32,7 +32,7 @@
 // advance-idempotency.test.mjs both import it without dragging in config.mjs's
 // bun:sqlite graph — same discipline as assertion-evidence.mjs / secret-contract.mjs.
 
-import { readFileSync, writeFileSync, renameSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, renameSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 
 // A field rendered explicitly so a missing value NEVER silently equals another.
@@ -60,17 +60,26 @@ export function computeAdvanceEdgeKey({ ticket, from, to, predRaw }) {
   ].join("|");
 }
 
+// The marker's name lives in ONE place, because CTL-2024 added a SECOND reader of
+// it (the janitor's retraction). A name built independently in two spots is a
+// rename away from a retraction that silently matches nothing — which is the exact
+// failure mode CTL-2024 is about, one level up.
+const MARKER_PREFIX = ".advance-";
+const MARKER_SUFFIX = ".applied";
+
+// advanceMarkerName — `.advance-<from>-to-<to>.applied`. The `-to-` infix is an
+// ANCHOR, not decoration: it is what stops a retraction for `merge` from matching
+// `...-to-monitor-merge.applied` (see the near-miss control in the CTL-2024 test).
+export function advanceMarkerName(from, to) {
+  return `${MARKER_PREFIX}${renderField(from)}-to-${renderField(to)}${MARKER_SUFFIX}`;
+}
+
 // advanceMarkerPath — one dotfile per (from,to) edge under the worker dir. The
 // name matches NONE of the tree's phase-*.json signal globs, so it is never read
 // as a phase signal (verified: no isPhaseSignalName / workerDirHasPhaseSignals
 // change needed).
 export function advanceMarkerPath(orchDir, ticket, from, to) {
-  return join(
-    orchDir,
-    "workers",
-    ticket,
-    `.advance-${renderField(from)}-to-${renderField(to)}.applied`
-  );
+  return join(orchDir, "workers", ticket, advanceMarkerName(from, to));
 }
 
 // isAdvanceAlreadyApplied — true IFF the marker exists AND its stored key is
@@ -117,4 +126,64 @@ export function recordAdvanceApplied(orchDir, ticket, from, to, key, deps = {}) 
   } catch {
     return false;
   }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// retractAdvanceMarkersInto — CTL-2024. THE MARKER IS A CLAIM ABOUT A FACT ON
+// DISK, AND ONE ACTOR CAN UNDO THAT FACT WITHOUT TOUCHING THE MARKER.
+//
+// THE BUG THIS CLOSES. The stall-janitor's unstick (defaultClearStall step 1)
+// DELETES the successor's `phase-<to>.json`, and its own header comment states the
+// intent: "lets deriveAdvancement re-derive the next phase on the next tick." That
+// sentence was FALSE. deriveAdvancement does re-derive — and the guard above then
+// suppresses the entire fanout, because the edge key is computed from the
+// PREDECESSOR (`phase-<from>.json`), which the unstick never touches. Byte-identical
+// key → byte-identical marker → suppressed. FOREVER. Measured on mini 2026-08-18:
+// CTC-427 (plan→implement) and CTC-55 (research→plan) each emitted 16 suppressed-
+// duplicate advances after a janitor clear; CTC-441, never cleared, emitted 1 — the
+// control that says 16 is not the normal idempotent case.
+//
+// ⚠️ THE ASYMMETRY THAT HID IT. The janitor already re-arms every OTHER durable
+// suppressor it can defeat — `.orphan-detected.applied` (CTL-868), the escalation
+// cooldown (CTL-1442), the durable escalation record (CTL-1643). The advance marker
+// is the one it never learned about, because CTL-1805 added it AFTER those, and it
+// is keyed on a file the janitor has no reason to think about.
+//
+// SCOPE IS DELIBERATELY NARROW. Only edges INTO the cleared phase are retracted:
+// that is the only advance whose effect the unstick actually undid. Retracting
+// anything wider would re-open the CTL-1805 replay storm on edges that are still
+// legitimately applied.
+//
+// FAIL DIRECTION, and note it INVERTS the guard's. Every read/unlink here is
+// best-effort and never throws, but the failure here is toward LEAVING a marker —
+// i.e. toward the CTL-2024 stall, not toward a storm. That is the correct direction
+// for a retraction: the pre-CTL-2024 status quo is a stuck ticket an operator can
+// see and re-arm by hand, whereas an over-eager retraction is a silent replay storm.
+//
+// Returns the list of retracted marker names (possibly empty) so the caller can log
+// what it actually did rather than what it hoped to do.
+export function retractAdvanceMarkersInto(orchDir, ticket, to, deps = {}) {
+  const readdir = deps.readdirSync ?? readdirSync;
+  const remove = deps.rmSync ?? rmSync;
+  const dir = join(orchDir, "workers", renderField(ticket));
+  // Anchored on `-to-<phase>.applied` — see advanceMarkerName.
+  const suffix = `-to-${renderField(to)}${MARKER_SUFFIX}`;
+  let names;
+  try {
+    names = readdir(dir);
+  } catch {
+    return []; // no worker dir / unreadable — nothing to retract
+  }
+  const retracted = [];
+  for (const name of names) {
+    if (!name.startsWith(MARKER_PREFIX) || !name.endsWith(suffix)) continue;
+    try {
+      remove(join(dir, name), { force: true });
+      retracted.push(name);
+    } catch {
+      /* best-effort: a marker we could not remove stays, and the ticket stays
+         stuck — visible, re-armable by hand, and never a storm. */
+    }
+  }
+  return retracted;
 }

--- a/plugins/dev/scripts/execution-core/clear-stall-advance-reentry.test.mjs
+++ b/plugins/dev/scripts/execution-core/clear-stall-advance-reentry.test.mjs
@@ -1,0 +1,228 @@
+// clear-stall-advance-reentry.test.mjs — CTL-2024.
+//
+// A CLEARED STALL COULD NEVER RE-ENTER ITS PHASE.
+//
+// The stall-janitor's unstick deletes the successor's `phase-<to>.json` and its own
+// header comment promises this "lets deriveAdvancement re-derive the next phase on the
+// next tick". It re-derived. Then CTL-1805's advance guard suppressed the entire
+// fanout — because that guard's edge key is computed from the PREDECESSOR signal
+// (`phase-<from>.json`), which the unstick does not touch. Unchanged key → the marker
+// written before the stall still matches byte-for-byte → suppressed. Forever.
+//
+// MEASURED ON mini, 2026-08-18 (the numbers these tests encode):
+//   CTC-427  plan→implement    16 suppressed-duplicate advances after a janitor clear
+//   CTC-55   research→plan     16
+//   CTC-441  implement→verify   1  ⭐ never cleared — the control that says 16 is not
+//                                    the normal idempotent case, 1 is.
+//
+// ⚠️ THE TWO-SIDED PROPERTY, and why "the marker is gone" would be a WEAK test.
+// Retraction must un-stick the ticket WITHOUT re-opening CTL-1805, whose whole reason
+// for existing is a 13-replay storm in 55 s. So the assertion is not "it advances
+// again", it is "it advances again EXACTLY ONCE across a 16-tick sweep" — the same
+// sweep length that produced the measured 16. A fix that simply stopped writing
+// markers would pass a re-entry test and fail this one.
+//
+// CI-INCLUDED (registered in .github/workflows/execution-core-tests.yml).
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test clear-stall-advance-reentry.test.mjs
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  advanceMarkerName,
+  advanceMarkerPath,
+  computeAdvanceEdgeKey,
+  isAdvanceAlreadyApplied,
+  recordAdvanceApplied,
+  retractAdvanceMarkersInto,
+} from "./advance-guard.mjs";
+import { defaultClearStall } from "./scheduler.mjs";
+
+// The real CTC-427 shape: a plan→implement edge whose predecessor never changes.
+const TICKET = "CTC-427";
+const FROM = "plan";
+const TO = "implement";
+const PRED_RAW = { generation: 1, updatedAt: "2026-08-18T13:10:00Z" };
+
+let orchDir;
+let workerDir;
+let removals;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl2024-reentry-"));
+  workerDir = join(orchDir, "workers", TICKET);
+  mkdirSync(workerDir, { recursive: true });
+  removals = [];
+});
+afterEach(() => rmSync(orchDir, { recursive: true, force: true }));
+
+const writeStatus = {
+  removeLabel: (...args) => {
+    removals.push(args);
+    return { removed: true };
+  },
+};
+const clear = (phase = TO) => defaultClearStall(orchDir, writeStatus)({ ticket: TICKET, phase });
+
+// The predecessor signal the guard keys on. NOTHING in the clear path touches this
+// file — that is the entire defect, so the test never touches it either.
+const writePredecessor = () =>
+  writeFileSync(join(workerDir, `phase-${FROM}.json`), JSON.stringify(PRED_RAW));
+// The synthetic stalled signal the janitor deletes (its step 1, "the unstick").
+const writeStalledSignal = () =>
+  writeFileSync(join(workerDir, `phase-${TO}.json`), JSON.stringify({ status: "stalled" }));
+
+const edgeKey = () =>
+  computeAdvanceEdgeKey({ ticket: TICKET, from: FROM, to: TO, predRaw: PRED_RAW });
+
+// The scheduler's guard decision, distilled: would this tick dispatch the advance?
+// Mirrors the `isAdvanceAlreadyApplied(...) → continue` chokepoint in schedulerTick.
+const wouldAdvance = () => !isAdvanceAlreadyApplied(orchDir, TICKET, FROM, TO, edgeKey());
+const applyAdvance = () => recordAdvanceApplied(orchDir, TICKET, FROM, TO, edgeKey());
+
+// One tick of the sweep: advance iff the guard allows, recording the marker on success
+// exactly as the dv.ok branch does. Returns whether it advanced.
+const tick = () => {
+  if (!wouldAdvance()) return false;
+  applyAdvance();
+  return true;
+};
+
+describe("CTL-2024 — a cleared stall re-enters its phase, exactly once", () => {
+  test("⛔ THE DEFECT, reproduced: the predecessor key survives the unstick, so the guard still matches", () => {
+    // This is the positive control for the whole ticket. It asserts the MECHANISM
+    // (an unchanged predecessor ⇒ a byte-identical key ⇒ a matching marker), which is
+    // true with or without the fix — the fix removes the marker, it does not change
+    // the key. If this ever fails, the premise of CTL-2024 has changed and the
+    // retraction below is solving a problem that no longer exists.
+    writePredecessor();
+    applyAdvance();
+    const keyBefore = edgeKey();
+    writeStalledSignal();
+    rmSync(join(workerDir, `phase-${TO}.json`), { force: true }); // the unstick, alone
+    expect(edgeKey()).toBe(keyBefore); // ⛔ the successor's death changes nothing
+    expect(isAdvanceAlreadyApplied(orchDir, TICKET, FROM, TO, keyBefore)).toBe(true);
+  });
+
+  test("⭐ 16 ticks after a janitor clear advance EXACTLY ONCE (measured: 0 before the fix, 16 suppressed)", () => {
+    writePredecessor();
+    expect(tick()).toBe(true); // the original advance into `implement`
+    writeStalledSignal(); // ... which then stalls (529 exhaustion, per CTL-2015)
+
+    expect(clear()).toBe(true); // the janitor's clear — steps 1..7
+
+    // The sweep that measured 16 on mini. Before the fix every one of these is
+    // suppressed and the count is 0; a marker-less "fix" would make it 16.
+    let advances = 0;
+    for (let i = 0; i < 16; i++) if (tick()) advances++;
+    expect(advances).toBe(1);
+  });
+
+  test("⭐ the re-entry is durable across the daemon restart the marker exists to survive", () => {
+    // The marker is file-backed precisely so a restart cannot replay the edge. Re-entry
+    // must inherit that property: after the one re-advance, a fresh guard read (no
+    // in-process state at all) still suppresses.
+    writePredecessor();
+    tick();
+    writeStalledSignal();
+    clear();
+    expect(tick()).toBe(true);
+    // Nothing in-process carries over; every read below hits the disk fresh.
+    expect(isAdvanceAlreadyApplied(orchDir, TICKET, FROM, TO, edgeKey())).toBe(true);
+    expect(existsSync(advanceMarkerPath(orchDir, TICKET, FROM, TO))).toBe(true);
+  });
+
+  test("⛔ a SECOND stall+clear re-enters again — the janitor is not a one-shot", () => {
+    // CTC-427 stalled more than once. A retraction that only worked on the first clear
+    // would look correct in a single-episode test and strand the ticket on episode two.
+    writePredecessor();
+    tick();
+    for (let episode = 0; episode < 3; episode++) {
+      writeStalledSignal();
+      expect(clear()).toBe(true);
+      expect(tick()).toBe(true); // re-enters
+      expect(tick()).toBe(false); // and is immediately idempotent again
+    }
+  });
+});
+
+describe("CTL-2024 — the retraction's blast radius", () => {
+  test("⛔ NEAR MISS: retracting `merge` must not match `-to-monitor-merge.applied`", () => {
+    // The `-to-` infix is the anchor that makes this safe. Without it, a suffix match on
+    // the bare phase name silently retracts a longer phase's marker and re-opens the
+    // CTL-1805 storm on an edge nobody cleared.
+    const decoy = advanceMarkerName("pr", "monitor-merge");
+    writeFileSync(join(workerDir, decoy), JSON.stringify({ key: "decoy" }));
+    expect(retractAdvanceMarkersInto(orchDir, TICKET, "merge")).toEqual([]);
+    expect(existsSync(join(workerDir, decoy))).toBe(true);
+    // ... and the exact-phase retraction DOES match it — the other half of the control,
+    // without which an inert matcher would also pass the assertion above.
+    expect(retractAdvanceMarkersInto(orchDir, TICKET, "monitor-merge")).toEqual([decoy]);
+    expect(existsSync(join(workerDir, decoy))).toBe(false);
+  });
+
+  test("⛔ only edges INTO the cleared phase are retracted — unrelated markers survive", () => {
+    writePredecessor();
+    const intoImplement = advanceMarkerName(FROM, TO);
+    const unrelated = advanceMarkerName("implement", "verify");
+    const alsoIntoImplement = advanceMarkerName("remediate", TO); // the CTL-653 detour edge
+    for (const n of [intoImplement, unrelated, alsoIntoImplement]) {
+      writeFileSync(join(workerDir, n), JSON.stringify({ key: `k-${n}` }));
+    }
+    writeStalledSignal();
+    clear();
+    const left = readdirSync(workerDir).filter((n) => n.startsWith(".advance-"));
+    expect(left).toEqual([unrelated]); // ⭐ the downstream edge is untouched
+  });
+
+  test("⛔ the janitor's OTHER phases retract their own edge, not `implement`'s", () => {
+    const intoImplement = advanceMarkerName(FROM, TO);
+    writeFileSync(join(workerDir, intoImplement), JSON.stringify({ key: "k" }));
+    writeFileSync(join(workerDir, `phase-verify.json`), JSON.stringify({ status: "stalled" }));
+    writePredecessor();
+    clear("verify");
+    expect(existsSync(join(workerDir, intoImplement))).toBe(true);
+  });
+
+  test("a missing worker dir returns [] and never throws (fail direction: leave, don't storm)", () => {
+    expect(retractAdvanceMarkersInto(orchDir, "NO-SUCH-TICKET", TO)).toEqual([]);
+  });
+
+  test("an unremovable marker is reported as NOT retracted rather than claimed", () => {
+    writeFileSync(join(workerDir, advanceMarkerName(FROM, TO)), JSON.stringify({ key: "k" }));
+    const out = retractAdvanceMarkersInto(orchDir, TICKET, TO, {
+      rmSync: () => {
+        throw new Error("EPERM");
+      },
+    });
+    expect(out).toEqual([]); // the caller logs what it DID, not what it attempted
+  });
+});
+
+describe("CTL-2024 — CTL-1805's storm property is preserved", () => {
+  test("⭐ CTC-441's control: an UNCLEARED edge still suppresses every replay (1 advance in 16)", () => {
+    // The regression guard on the fix itself. CTC-441 was never cleared and emitted a
+    // single suppression — the normal idempotent case. If retraction ever leaked into
+    // the ordinary tick path, this count becomes 16 and CTL-1805 is undone.
+    writePredecessor();
+    let advances = 0;
+    for (let i = 0; i < 16; i++) if (tick()) advances++;
+    expect(advances).toBe(1);
+  });
+
+  test("a legitimate re-advance at a NEWER predecessor generation is still allowed", () => {
+    // Unchanged CTL-1805 behaviour, asserted here because the retraction sits on the
+    // same seam: a differing key must pass the guard without any clear at all.
+    writePredecessor();
+    tick();
+    const newerKey = computeAdvanceEdgeKey({
+      ticket: TICKET,
+      from: FROM,
+      to: TO,
+      predRaw: { ...PRED_RAW, generation: 2 },
+    });
+    expect(isAdvanceAlreadyApplied(orchDir, TICKET, FROM, TO, newerKey)).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -76,6 +76,7 @@ import {
   computeAdvanceEdgeKey,
   isAdvanceAlreadyApplied,
   recordAdvanceApplied,
+  retractAdvanceMarkersInto,
 } from "./advance-guard.mjs"; // CTL-1805: durable once-per-edge advancement idempotency guard
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
@@ -4123,13 +4124,26 @@ function defaultJanitorKillIntentRecorder(intentDb, killBgJob = defaultKillBgJob
 // next phase on the next tick. Mirrors clearDispatchCooldown's best-effort,
 // never-throw discipline.
 //
+// ⛔ CTL-2024: that last sentence has been FALSE since CTL-1805 landed on 2026-08-15
+// (#3404) — three days — and the clear below is where it is made true. The guard and
+// this defect shipped together. deriveAdvancement DID re-derive; CTL-1805's advance
+// guard then suppressed the whole fanout, because its edge key is computed from the
+// PREDECESSOR signal, which the unstick does not touch. A cleared
+// stall could therefore NEVER re-enter its phase: CTC-427 and CTC-55 each re-derived
+// and were re-suppressed 16× (CTC-441, never cleared, 1× — the control). Step 2
+// retracts that marker, alongside the three other durable suppressors this clear
+// already re-arms.
+//
 // The clear, per the CTL-1005 Gherkin:
 //   1. delete the synthetic phase-<phase>.json stalled signal (the unstick);
-//   2. clear the needs-human label + its .linear-label-needs-human.{applied,skipped}
+//   2. retract the CTL-1805 advance marker(s) for the edge INTO <phase> (CTL-2024),
+//      because step 1 undid the very advance that marker records — without this the
+//      re-derived advance is suppressed on an unchanged predecessor key, forever;
+//   3. clear the needs-human label + its .linear-label-needs-human.{applied,skipped}
 //      marker (clearStalledLabel) so a future genuine escalation can re-apply;
-//   3. delete .orphan-detected.applied (CTL-868) so a future stall re-emits the
+//   4. delete .orphan-detected.applied (CTL-868) so a future stall re-emits the
 //      orphan-detected event instead of being silently suppressed;
-//   4. write the .janitor-cleared-<phase>.applied once-marker ON CONFIRMED label
+//   5. write the .janitor-cleared-<phase>.applied once-marker ON CONFIRMED label
 //      removal only (CTL-1045 Bug 4). Scope is the worker-dir lifetime: file-backed,
 //      survives daemon restarts, deleted only when the reaper removes the worker dir
 //      or an operator re-arms via orch-monitor respond-ticket. Storm-prevention is
@@ -4175,13 +4189,26 @@ export function defaultClearStall(orchDir, writeStatus, { rmDir = rmSync } = {})
         "stall-janitor: stalled-signal delete failed (CTL-1005)"
       );
     }
-    // 2. delete .orphan-detected.applied so a future stall re-emits (CTL-868).
+    // 2. CTL-2024: retract the advance marker(s) for the edge INTO this phase. Step 1
+    //    deleted the successor signal, which UNDOES the advance those markers record —
+    //    but the guard's key is derived from the PREDECESSOR, which nothing here
+    //    touches, so without this retraction the re-derived advance presents a
+    //    byte-identical key and is suppressed on every subsequent tick, forever.
+    //    Scoped to `-to-<phase>` only: that is the sole edge whose effect was undone.
+    const retractedAdvances = retractAdvanceMarkersInto(orchDir, ticket, phase);
+    if (retractedAdvances.length > 0) {
+      log.debug?.(
+        { ticket, phase, retracted: retractedAdvances },
+        "stall-janitor: retracted advance marker(s) so the cleared phase can re-enter (CTL-2024)"
+      );
+    }
+    // 3. delete .orphan-detected.applied so a future stall re-emits (CTL-868).
     try {
       rmSync(join(workerDir, ".orphan-detected.applied"), { force: true });
     } catch {
       /* best-effort */
     }
-    // 3. CTL-1442: re-arm the escalation ask budget. An operator re-arming a
+    // 4. CTL-1442: re-arm the escalation ask budget. An operator re-arming a
     //    stalled ticket starts a FRESH cycle — without this, a retried phase
     //    that no-progresses again hits the spent ask-cap (askCount >= cap) and
     //    is suppressed without a fresh ask or re-stall (Codex P2 on #2590).
@@ -4190,11 +4217,11 @@ export function defaultClearStall(orchDir, writeStatus, { rmDir = rmSync } = {})
     } catch {
       /* best-effort */
     }
-    // 4. CTL-1643: clear the durable escalation record so the next same-episode
+    // 5. CTL-1643: clear the durable escalation record so the next same-episode
     //    gate starts fresh. Without this, the labelAttempts > 0 guard in
     //    escalateOnce suppresses the re-escalation event after the operator re-arms.
     forgetDurableEscalation(orchDir, ticket);
-    // 5. CTL-1045 Bug 3 / CAT-24: never leave a marker-only worker dir after
+    // 6. CTL-1045 Bug 3 / CAT-24: never leave a marker-only worker dir after
     // deleting its last real phase signal. Such residue holds no slot yet excludes
     // the ticket from new-work dispatch. Tombstones are not real signals. Preserve
     // a non-empty operator inbox: the daemon writes the reply before invoking this
@@ -4222,7 +4249,7 @@ export function defaultClearStall(orchDir, writeStatus, { rmDir = rmSync } = {})
         }
       }
     };
-    // 6. clear the needs-human label; write the once-marker ONLY on confirmed removal
+    // 7. clear the needs-human label; write the once-marker ONLY on confirmed removal
     //    (CTL-1045 Bug 4 — a failed clear must NOT disarm future escalations).
     //
     //    CAT-24 (Codex P1): this runs LAST, and the empty-dir removal above hangs off


### PR DESCRIPTION
Closes CTL-2024 (P1).

## The defect

`defaultClearStall`'s unstick deletes the successor's `phase-<to>.json`, and the function's own header promises this *"lets deriveAdvancement re-derive the next phase on the next tick"*.

It re-derived. Then CTL-1805's advance guard suppressed the entire fanout — because that guard's edge key is computed from the **predecessor** signal (`phase-<from>.json`), which the unstick never touches. The key came back byte-identical, matched the marker written before the stall, and the advance was suppressed. **Forever.**

Measured on mini, 2026-08-18, from the event log:

| ticket | edge | suppressed-duplicate advances |
| -- | -- | --: |
| **CTC-427** | `plan → implement` | **16** |
| **CTC-55** | `research → plan` | **16** |
| CTC-441 | `implement → verify` | **1** ⭐ never cleared — the control that says 16 is not the normal idempotent case, and 1 is |

**The asymmetry that hid it:** the janitor already re-arms every *other* durable suppressor it can defeat — `.orphan-detected.applied` (CTL-868), the escalation cooldown (CTL-1442), the durable escalation record (CTL-1643). The advance marker is the one it never learned about, because CTL-1805 (#3404) landed **2026-08-15**, after all three. The guard and this defect shipped together, three days ago.

## The fix

`retractAdvanceMarkersInto` — a new **step 2** in the clear — removes the advance marker(s) for the edge **into** the cleared phase, alongside the three suppressors already re-armed.

- **Scope is deliberately narrow** (`-to-<phase>` only): that is the sole edge whose effect the unstick undid. Retracting wider would re-open CTL-1805's replay storm on edges nobody cleared.
- **Marker naming moves into one exported helper** (`advanceMarkerName`). This change adds a *second reader* of that name; a rename would otherwise leave a retraction that silently matches nothing — the same class of failure as CTL-2024 itself, one level up.
- **Fail direction inverts the guard's, deliberately.** The guard fails open toward *allowing* an advance; this fails toward *leaving* a marker. A failed retraction strands a ticket an operator can see and re-arm — an over-eager one is a silent replay storm.

## The control

`clear-stall-advance-reentry.test.mjs` — 11 tests, registered in `execution-core-tests.yml`.

The load-bearing assertion is that re-entry happens **exactly once across a 16-tick sweep** — the same sweep length that produced the measured 16. *"It advances again"* would be too weak: **a fix that simply stopped writing markers would pass that and fail this.** CTC-441's uncleared-edge control (1 advance in 16) is included so that a retraction leaking into the ordinary tick path fails CI.

Also covered: re-entry survives a daemon restart; a *second* stall+clear re-enters again (the janitor is not a one-shot); blast radius; and the fail-direction paths.

### Verified by mutation — each applied, run, reverted

| mutation | result |
| -- | -- |
| revert the retraction call | ⭐ **4 fail**, including the exactly-once sweep |
| drop the `-to-` scope filter (retract every marker) | 3 fail (blast radius) |
| drop the `-to-` anchor | 1 fail (near miss: `merge` vs `monitor-merge`) |

Re-run after prettier reflowed the test file.

## Gate

Full `execution-core-tests.yml` list, **exit code captured to a file rather than read from a wrapper**:

| | tests | files | fail | errors |
| -- | --: | --: | --: | --: |
| this branch | 7786 | 239 | 12 | 3 |
| pristine `origin/main` (88a7216) | 7775 | 238 | 12 | 3 |

⛔ **The 12 failures are pre-existing on `origin/main`** — the named failure sets `diff` **identical**, verified by running the same list on a clean worktree rather than by inspection. The only delta is **+11 tests / +1 file**, which is exactly this PR's new test.

Pre-existing failures are in linearis/replica reads, pino log shape, cloud-sync bundle identity, and heartbeat `host.name` — none on this seam. They are not addressed here.

## Fleet note

This is a **catalyst-main** merge — it restarts both minis within ~5½ min. Per COORD-219 it will be announced on the channel before merging, and per COORD-224/225 it enters the serialized merge queue **after #3644**.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)