### PR TITLE
fix(dev): CTL-1998 — two real phase-pipeline defects: an unbound $EMIT crash and a plan glob the dispatcher and the phase disagree about

### DIFF
--- a/plugins/dev/scripts/__tests__/phase-skill-globs.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-skill-globs.test.sh
@@ -7,6 +7,8 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 PHASE_PLAN="${REPO_ROOT}/plugins/dev/skills/phase-plan/SKILL.md"
 PHASE_RESEARCH="${REPO_ROOT}/plugins/dev/skills/phase-research/SKILL.md"
+PHASE_IMPLEMENT="${REPO_ROOT}/plugins/dev/skills/phase-implement/SKILL.md"
+PHASE_MONITOR_MERGE="${REPO_ROOT}/plugins/dev/skills/phase-monitor-merge/SKILL.md"
 
 FAILURES=0
 PASSES=0
@@ -33,7 +35,7 @@ assert_count_at_least() {
   fi
 }
 
-for f in "$PHASE_PLAN" "$PHASE_RESEARCH"; do
+for f in "$PHASE_PLAN" "$PHASE_RESEARCH" "$PHASE_IMPLEMENT" "$PHASE_MONITOR_MERGE"; do
   if [[ ! -f "$f" ]]; then
     echo "FATAL: skill file missing: $f" >&2
     exit 1
@@ -57,6 +59,44 @@ assert_grep "$PHASE_RESEARCH" 'match_thoughts_artifact' \
   "phase-research SKILL uses match_thoughts_artifact"
 assert_grep "$PHASE_RESEARCH" 'research_doc_not_written' \
   "phase-research SKILL preserves research_doc_not_written failure reason"
+
+echo ""
+echo "Test: phase-implement routes through match_thoughts_artifact (CTL-1998)"
+# CTL-1998: phase-agent-dispatch:560 gates the implement dispatch with
+# match_thoughts_artifact, which accepts BOTH `*-<ticket>.md` and
+# `*-<ticket>-<slug>.md`. phase-implement re-resolved with a strict
+# `*-<ticket>.md` glob and exited 1 "no plan found" on the slug form — the
+# dispatcher and the phase disagreeing about the same file. This asserts the
+# conversion, and that the strict glob does NOT come back.
+# ⚠️ Match the CALL, not the bare token: a comment mentioning
+# match_thoughts_artifact satisfies a token grep, and this file now contains
+# exactly such a comment. Verified by reverting the fix — the token assertion
+# still passed while the strict-glob assertion below was what actually caught it.
+assert_grep "$PHASE_IMPLEMENT" '\$\(match_thoughts_artifact thoughts/shared/plans' \
+  "phase-implement SKILL CALLS match_thoughts_artifact on thoughts/shared/plans"
+if grep -qE 'PLAN_MATCHES=\( *thoughts/shared/plans/\*-' "$PHASE_IMPLEMENT"; then
+  fail "phase-implement SKILL still carries the strict *-<ticket>.md plan glob"
+else
+  pass "phase-implement SKILL no longer uses the strict *-<ticket>.md plan glob"
+fi
+
+echo ""
+echo "Test: phase-monitor-merge assigns EMIT before it uses it (CTL-1998)"
+# CTL-1998: "$EMIT" was USED ~240 lines before it was assigned, under a
+# `set -euo pipefail` prelude — so the unresolved-human-thread branch aborted with
+# an unbound-variable error and emitted nothing, recording an undeclared
+# abandonment. Assert ORDER, not mere presence: presence was never the problem.
+EMIT_ASSIGN_LINE="$(grep -nE '^EMIT=' "$PHASE_MONITOR_MERGE" | head -1 | cut -d: -f1)"
+EMIT_FIRST_USE_LINE="$(grep -nE '"\$EMIT"' "$PHASE_MONITOR_MERGE" | head -1 | cut -d: -f1)"
+if [[ -z "$EMIT_ASSIGN_LINE" ]]; then
+  fail "phase-monitor-merge SKILL never assigns EMIT"
+elif [[ -z "$EMIT_FIRST_USE_LINE" ]]; then
+  pass "phase-monitor-merge SKILL assigns EMIT and never expands it"
+elif [[ "$EMIT_ASSIGN_LINE" -lt "$EMIT_FIRST_USE_LINE" ]]; then
+  pass "phase-monitor-merge SKILL assigns EMIT (line ${EMIT_ASSIGN_LINE}) before first use (line ${EMIT_FIRST_USE_LINE})"
+else
+  fail "phase-monitor-merge SKILL uses \$EMIT at line ${EMIT_FIRST_USE_LINE} but assigns it at ${EMIT_ASSIGN_LINE} — unbound under set -u"
+fi
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/skills/phase-implement/SKILL.md
+++ b/plugins/dev/skills/phase-implement/SKILL.md
@@ -172,12 +172,16 @@ fi
 
 # 4. Locate the approved plan. The dispatcher already validated this glob;
 #    we re-resolve to capture the actual filename for the delegated skill.
-TICKET_LC="$(printf '%s' "$TICKET" | tr '[:upper:]' '[:lower:]')"
-shopt -s nullglob
-PLAN_MATCHES=( thoughts/shared/plans/*-"${TICKET_LC}".md )
-shopt -u nullglob
-[[ ${#PLAN_MATCHES[@]} -gt 0 ]] || { echo "no plan found for ${TICKET} under thoughts/shared/plans/" >&2; exit 1; }
-PLAN_PATH="${PLAN_MATCHES[0]}"
+# CTL-1998: use the SHARED slug-tolerant matcher (CTL-1081), the same one the
+# dispatcher gates this phase with. The strict glob below it replaced accepted only
+# `*-<ticket>.md`, while phase-agent-dispatch:560 gates on match_thoughts_artifact,
+# which ALSO accepts `*-<ticket>-<slug>.md`. So a slug-named plan passed the gate and
+# then died here with "no plan found" — the dispatcher and the phase disagreeing about
+# the same file. phase-plan and phase-research were converted in CTL-1081; implement
+# was missed.
+source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"
+PLAN_PATH="$(match_thoughts_artifact thoughts/shared/plans "$TICKET" | tail -1 || true)"
+[[ -n "$PLAN_PATH" ]] || { echo "no plan found for ${TICKET} under thoughts/shared/plans/" >&2; exit 1; }
 echo "phase-implement: plan = ${PLAN_PATH}"
 
 # 5. Linear status is written by the coordinator (CTL-558): the execution-core

--- a/plugins/dev/skills/phase-monitor-merge/SKILL.md
+++ b/plugins/dev/skills/phase-monitor-merge/SKILL.md
@@ -61,6 +61,17 @@ PR_NUMBER=$(jq -r '.pr.number // empty' "$PR_SIGNAL" 2>/dev/null || echo "")
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 [[ -n "$PLUGIN_ROOT" ]] || PLUGIN_ROOT="$(dirname "$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo .)")")")"
 
+# CTL-1998: EMIT is assigned HERE, in the prelude, not in the terminal block.
+# It was previously first assigned near the end of this skill while being USED
+# ~240 lines earlier in the unresolved-human-thread branch. Under this prelude's
+# `set -euo pipefail`, that expansion aborts the shell with an unbound-variable
+# error, so the one path CTL-1680 exists to handle emitted NOTHING and the run was
+# recorded as an undeclared abandonment — the exact outcome that branch prevents.
+# Assigning once, up front, removes the ordering hazard for every later reference
+# (the failure-handling fence at the end of this file is a SEPARATE bash block and
+# had the same latent problem).
+EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+
 COMMS="${PLUGIN_ROOT}/scripts/catalyst-comms"
 [[ -x "$COMMS" ]] || COMMS="$(command -v catalyst-comms 2>/dev/null || true)"
 if [[ -n "$COMMS" && -x "$COMMS" ]]; then
@@ -168,10 +179,12 @@ this skill copies the body verbatim, substituting `phase-monitor-merge` framing 
    `ended-without-declaration` — and buys nothing else. If you want to be resumed, do not stop.
 
    ```bash
-   # Runnable as written. Do NOT use "$EMIT" here — it is assigned in the terminal
-   # block near the end of this skill, and under the prelude's `set -u` expanding it
-   # this early aborts the shell, so no yield is written and the runner records the
-   # very abandonment this path exists to prevent.
+   # Runnable as written. CTL-1998: "$EMIT" is now assigned in the PRELUDE, so it is
+   # safe here too — this line keeps the explicit path only because it is the earliest
+   # emit in the file and reads better without the indirection. (Previously EMIT was
+   # first assigned in the terminal block, which made any earlier use abort the shell
+   # under `set -u`; one such use had already crept in at the unresolved-human-thread
+   # branch.)
    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
      --phase "$PHASE" --ticket "$TICKET" --status yield
 
@@ -670,7 +683,7 @@ write_phase_thoughts_doc "monitor-merge" "$TICKET" "${MIRROR_BODY:-}" || true
 ```
 
 ```bash
-EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
+# EMIT comes from the prelude (CTL-1998).
 if [[ -x "$EMIT" ]]; then
   "$EMIT" --phase "$PHASE" --ticket "$TICKET" --status complete
 fi


### PR DESCRIPTION
Part of CTL-1998, from the P13 phase-skills review. **Both are functional breaks, not bloat** — the progressive-disclosure rewrites are a separate pass; these two would keep biting in the meantime.

## 1. `phase-monitor-merge` — a real crash on the human-review path

`"$EMIT"` was **used at :432** and first **assigned at :673**, under a `set -euo pipefail` prelude.

So the unresolved-human-thread branch — **the exact path CTL-1680 exists to handle** — aborted with an unbound-variable error, emitted **nothing**, and the run was recorded as an *undeclared abandonment*. ⚠️ The file's own comment at :171 warned about this hazard for a *different* call site, and the crash crept in 261 lines later anyway.

⭐ **Fixed by hoisting `EMIT` into the PRELUDE, not by patching the one call.** The failure-handling fence at the end of the file is a **separate bash block** with the same latent problem, so assigning once up front removes the *class* rather than an instance. The now-inverted warning comment is corrected — it told authors the opposite of what is true.

## 2. `phase-implement` — the dispatcher and the phase disagree about the same file

`phase-agent-dispatch:560` gates the implement dispatch with `match_thoughts_artifact`, which accepts **both** `*-<ticket>.md` and `*-<ticket>-<slug>.md`. `phase-implement` re-resolved with a **strict** `*-<ticket>.md` glob.

So a slug-named plan **passed the gate and then died in the phase** with `no plan found`. `phase-plan` and `phase-research` were converted in CTL-1081; implement was missed.

**Reproduced before fixing**, on a fixture holding only `2026-08-18-ctl-9999-some-slug.md`:

| resolver | result |
| -- | -- |
| shared matcher (what the dispatcher uses) | ✅ resolves it |
| implement's strict glob | ❌ **0 matches** → `exit 1` |

After the fix, **both** the slug form and the plain form resolve.

## The tests — and one thing worth reading

`phase-skill-globs.test.sh` gains both cases.

- ⭐ **EMIT is asserted by ORDER** (assignment line < first-use line), **not by presence**. Presence was never the problem — the variable was always there.
- ⭐ **The implement case is a PAIR**: the call must be present **and** the strict glob must be absent.

⚠️ **That pair exists because my first version was wrong.** I asserted the bare token `match_thoughts_artifact` — and when I reverted the fix to check the control fired, **it still passed**, because the explanatory comment I had just written contains the token. The assertion now matches the **call form**, and reverting the call turns it red with the comment still in place.

## Controls

- **8/8 pass.**
- Each new assertion verified to **FAIL when its defect is put back**: EMIT moved back to the end → red at *"uses \$EMIT at 181 but assigns it at 685"*; strict glob restored → red.
- Neighbouring suites `phase-implement-e2e`, `phase-agent-dispatch`, `execution-core-docs-shape` fail **identically** here and on `main` — compared by failure-name **set** with `diff`, not by count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)