### PR TITLE
fix(dev): CTL-1998 — main is red on a guard that could not fire for the change it guards

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -114,6 +114,24 @@ on:
       # plugins/dev/scripts/ (not covered by the scripts/** glob), so a change
       # confined to the teardown removal block would skip this workflow and the
       # ordering backstop couldn't catch a destroy-before-salvage regression.
+      # CTL-1998: THE TRIGGER MUST MATCH THE SCAN — the same lesson as the
+      # plugins/dev/scripts/** entry above, on the skills axis. 52 test files in
+      # plugins/dev/scripts/__tests__/ read a SKILL.md, and
+      # skill-plugin-root-assigned.test.sh scans `find plugins -name SKILL.md`
+      # (115 files) — while this list named FIVE skill dirs. So a change confined
+      # to any other skill ran NONE of them. That is how #3654 refactored
+      # _phase-agent-template, skipped this job on its own PR and on the push to
+      # main, and left main failing the CTL-1832 guard for an hour, blocking every
+      # PR in the repo. skills-gate.yml's header already diagnosed this exact
+      # shape: "a filter that excludes the change it guards is a guard on the
+      # wrong axis; it reads as working and never fires."
+      # Two globs because SKILL.md lives at two depths (measured, both present):
+      # plugins/<plugin>/skills/** and plugins/playground/<plugin>/skills/**.
+      - "plugins/*/skills/**"
+      - "plugins/*/*/skills/**"
+      # NOTE: the two globs above SUBSUME every plugins/*/skills path listed
+      # below. They are retained as documentation of WHICH STEP each path feeds,
+      # not as triggers — do not read the list as the trigger set.
       - "plugins/dev/skills/phase-teardown/**"
       # CTL-56: the three merge-worktree guard tests scan skills and templates
       # OUTSIDE plugins/dev/scripts/ for the --delete-branch invariant. A change
@@ -191,6 +209,13 @@ jobs:
               - "package.json"
               - "bun.lock"
               - "turbo.json"
+              # CTL-1998: mirror the two skills globs from on.push.paths — see the
+              # long note there. This mirror had ALSO already drifted: it was
+              # missing plugins/dev/skills/phase-teardown/**, which the push list
+              # carries, so the salvage-before-destroy backstop could not fire on
+              # a PR. The globs close that gap and every future one like it.
+              - "plugins/*/skills/**"
+              - "plugins/*/*/skills/**"
               - "plugins/dev/skills/phase-monitor-merge/**"
               - "plugins/dev/skills/merge-pr/**"
               - "plugins/dev/skills/recovery-pass/**"

--- a/plugins/dev/scripts/execution-core/halt-on-complete.test.mjs
+++ b/plugins/dev/scripts/execution-core/halt-on-complete.test.mjs
@@ -4,7 +4,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test halt-on-complete.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const DEV_ROOT = join(import.meta.dir, "..", "..");
@@ -20,13 +20,37 @@ const SKILLS = [
   "phase-pr",
 ];
 
+// CTL-1998: a skill is SKILL.md **plus its references/**, not SKILL.md alone.
+// This guard used to read only SKILL.md. When #3654 moved _phase-agent-template's
+// end block into references/end-block.md — where the `claude stop` line still
+// lives, verbatim — the guard reported the invariant BROKEN on a skill that
+// satisfies it. Progressive disclosure is the repo's documented direction
+// (CTL-1993, CTL-1998), so a per-skill scan pinned to one file will keep
+// mis-reporting as more skills split, and the natural way to "fix" a red build
+// would be to move the end block back — defeating the refactor.
+//
+// Reading the whole skill also STRENGTHENS the negative case below: a self-stop
+// smuggled into a long-running monitor's references/ was previously invisible to
+// that assertion. Both directions now scan the same surface.
+function readSkillBody(skill) {
+  const dir = join(DEV_ROOT, "skills", skill);
+  const parts = [readFileSync(join(dir, "SKILL.md"), "utf8")];
+  let refs = [];
+  try {
+    refs = readdirSync(join(dir, "references"))
+      .filter((f) => f.endsWith(".md"))
+      .sort();
+  } catch {
+    /* no references/ dir — SKILL.md is the whole skill */
+  }
+  for (const f of refs) parts.push(readFileSync(join(dir, "references", f), "utf8"));
+  return parts.join("\n");
+}
+
 describe("CTL-778 Step 2A: self-stop in every terminating phase skill", () => {
   for (const skill of SKILLS) {
     test(`${skill} self-stops after emit-complete`, () => {
-      const body = readFileSync(
-        join(DEV_ROOT, "skills", skill, "SKILL.md"),
-        "utf8",
-      );
+      const body = readSkillBody(skill);
       // Must read its own bg_job_id from the signal file and call `claude stop`.
       expect(body).toContain('claude stop "${_SELF_BG:0:8}"');
       expect(body).toMatch(/bg_job_id \/\/ empty/);
@@ -35,10 +59,7 @@ describe("CTL-778 Step 2A: self-stop in every terminating phase skill", () => {
 
   test("long-running monitors are NOT given self-stop", () => {
     for (const skill of ["phase-monitor-merge", "phase-monitor-deploy"]) {
-      const body = readFileSync(
-        join(DEV_ROOT, "skills", skill, "SKILL.md"),
-        "utf8",
-      );
+      const body = readSkillBody(skill);
       expect(body).not.toContain('claude stop "${_SELF_BG:0:8}"');
     }
   });

--- a/plugins/dev/skills/_phase-agent-template/SKILL.md
+++ b/plugins/dev/skills/_phase-agent-template/SKILL.md
@@ -52,8 +52,8 @@ Every phase agent:
   resolves in any shell. ⚠️ `linear_read_ticket` is a plugin **shell function**: without
   `source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/linear-read-replica.sh"` it is "command not found" and you
   fall through to the bare CLI silently. Writes and `issues list`/`search` stay on `linearis`.
-- **Resolve thoughts artifacts with the SHARED matcher**, not a hand-written glob:
-  `source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"` then
+- **Resolve thoughts artifacts with the SHARED matcher**, not a hand-written glob. The prelude
+  sources `scripts/lib/phase-artifact-gate.sh` from the root it resolved, so just call
   `match_thoughts_artifact <dir> "$TICKET"`. It accepts `*-<ticket>.md` **and** `*-<ticket>-<slug>.md`,
   which is what the dispatcher gates on. ⛔ A stricter glob here means the dispatcher green-lights a
   plan the phase then rejects with "no plan found" — that was a live bug in `phase-implement` (CTL-1998).

--- a/plugins/dev/skills/_phase-agent-template/references/prelude.md
+++ b/plugins/dev/skills/_phase-agent-template/references/prelude.md
@@ -141,5 +141,9 @@ jq --arg ts "$TS" --arg sid "${CATALYST_SESSION_ID:-}" '
   | if $sid != "" then .catalystSessionId = $sid else . end
 ' "$SIGNAL_FILE" > "$TMP" \
   && mv "$TMP" "$SIGNAL_FILE"
+
+# 4. The SHARED thoughts-artifact matcher the dispatcher gates on (CTL-1081). Hand-rolling a glob instead is the CTL-1998 "no plan found" bug, so a miss WARNS rather than falling through silently.
+ARTIFACT_GATE="${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"
+[[ -r "$ARTIFACT_GATE" ]] && source "$ARTIFACT_GATE" || echo "phase-${PHASE}: WARNING — no ${ARTIFACT_GATE}; do NOT hand-roll a glob (CTL-1998)" >&2
 ```
 


### PR DESCRIPTION
Two commits: the defect, then why nothing caught it.

## 1 — Why main is red

`execution-core-unit-tests` has failed since **16:57 CT** (#3654), blocking **every PR in the repo**:

```
FAIL: SKILL.md files expand ${PLUGIN_ROOT} without assigning it
    plugins/dev/skills/_phase-agent-template/SKILL.md (1 live use(s), 0 assignments)
```

#3654 split `_phase-agent-template` into an 80-line contract plus references, moving the
`PLUGIN_ROOT=` assignment — and its CTL-1628 fallback probe — into `references/prelude.md`. The
invariant bullet #3653 had *just* added stayed behind in `SKILL.md`, still instructing authors to
`source "${PLUGIN_ROOT}/scripts/lib/phase-artifact-gate.sh"`: an expansion whose assignment now
lives in a file progressive disclosure means the reader may never open.

**This is the guard's silent direction, not a lint.** An unassigned expansion addresses
`/scripts/lib/phase-artifact-gate.sh`, `[[ -r ]]` is simply false, and the phase falls through to
the hand-written glob that CTL-1998 exists to eliminate. Nothing crashes; the wrong path is taken
quietly. The bullet directly below it reads *"**Assign before use.**"*

### The fix — and the gap it exposed

Chasing where the correct line *should* live turned up the real gap: that guidance had **no
runnable, assignment-safe home anywhere in the tree**. Only `phase-agent-dispatch` and
`phase-agent-emit-complete` source the gate, each via its own `SCRIPT_DIR`.

- **`references/prelude.md`** gains step 4, sourcing the matcher from the `PLUGIN_ROOT` resolved 100
  lines above, beside `YIELD_CHECK`/`COMMS`/`SESSION_SCRIPT`. The lib is idempotent
  (`_PHASE_ARTIFACT_GATE_LOADED`) and defines functions only, so phases that never resolve an
  artifact pay nothing. A miss **WARNS** rather than falling through, because the fallback *is* the
  defect.
- **`SKILL.md`** states the rule and names where the root comes from, expanding nothing it does not
  assign.

## 2 — Why nothing caught it

`execution-core-unit-tests` allow-lists paths. It named **five** skill directories — each added
reactively, one at a time, after a guard was found unable to fire (CTL-1639, CTL-56). Measured now:

- **52** test files under `plugins/dev/scripts/__tests__/` read a `SKILL.md`
- `skill-plugin-root-assigned.test.sh` scans `find plugins -name 'SKILL.md'` — **115** files

A change confined to any other skill ran **none of them**. `_phase-agent-template` is in no
allow-listed directory, so the job reported `skipped` on #3654's own PR *and* on the push to main.
main then failed for an hour with **no red run anywhere to point at**, because the suite that would
have gone red never ran.

`skills-gate.yml`'s own header already diagnosed this shape, for this very workflow:

> its detect-changes step is an explicit ALLOW-LIST of paths that names five individual skill dirs
> ... **A filter that excludes the change it guards is a guard on the wrong axis; it reads as
> working and never fires.**

CTL-1993 acted on that for `skill-shape.test.sh` by giving it an unfiltered workflow; the other 52
stayed behind the allow-list. This commit matches the trigger to the scan — the same move CTL-1529
already made on this file for `plugins/dev/scripts/**`. Two globs, because SKILL.md lives at two
depths and both are populated: `plugins/<plugin>/skills/**` and
`plugins/playground/<plugin>/skills/**`. Enumerated entries stay as documentation of which step each
path feeds, per the file's existing NOTE convention.

It also closes drift the two lists had already accumulated: the `detect-changes` mirror was missing
`plugins/dev/skills/phase-teardown/**`, which the push list carries — so
`worktree-salvage-sites.test.sh`'s salvage-before-destroy ordering backstop could not fire on a PR
that changed only that skill.

**The proof is this PR.** Before the second commit, `execution-core-unit-tests` reported `skipping`
on it — a fix for a red required check, verified by nothing. After it, the suite actually runs.

## Verification

| gate | result |
| --- | --- |
| `skill-plugin-root-assigned.test.sh` | **5/5** — and its positive control still fires (a clean result from a detector that cannot fail is not evidence) |
| `skill-shape.test.sh` | **43/43** — both files inside #3654's budgets: SKILL.md **80/80**, prelude **149/150** |
| `phase-artifact-gate.test.sh` | **60/60** |

The added block was extracted from the fence and run under `set -euo pipefail` **both ways**, since
four phases use `-euo` and a startup abort there would be worse than the bug: resolved root →
function defined; empty root → warns and **does not abort**; double `source` → rc=0.

⚠️ My first cut passed the guard and **broke `skill-shape`** — SKILL.md sat at exactly 80/80 and
prelude at 145/150, so #3654's budgets left 0 and 5 lines of room. Worth knowing before editing
these two files.

## Scope note

The sibling bullet's `${CLAUDE_PLUGIN_ROOT}` (for `linear-read-replica.sh`) carries the same
documented silent-fallthrough hazard, but that lib is not sourced by the prelude and fixing it means
touching every phase agent's startup — deliberately not in a PR whose job is to unblock `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)