### PR TITLE
fix(dev): CTL-1832 — the PLUGIN_ROOT guard scans SKILL.md only, and progressive disclosure has moved the uses into references/

### DIFF
--- a/plugins/dev/scripts/__tests__/skill-plugin-root-assigned.test.sh
+++ b/plugins/dev/scripts/__tests__/skill-plugin-root-assigned.test.sh
@@ -60,6 +60,64 @@ else
 	fail "SKILL.md files expand \${PLUGIN_ROOT} without assigning it" "$OFFENDERS"
 fi
 
+# ── CTL-1832 / CTL-1998: THE SAME QUESTION, ASKED OF THE WHOLE SKILL ─────────
+# The scan above reads SKILL.md ALONE, and that is correct for what it asks: a
+# reader of SKILL.md may never open references/, so an expansion THERE whose
+# assignment lives elsewhere is a live hazard. But it means every ${PLUGIN_ROOT}
+# use that progressive disclosure moved INTO references/ is invisible to this
+# file — today _phase-agent-template/references/end-block.md has 1 and
+# escalation-explanation.md has 3, all correct only because prelude.md assigns it
+# in the same shell. Nothing checks that.
+#
+# So a second, independent question: taking a skill as SKILL.md PLUS its
+# references/, if it expands ${PLUGIN_ROOT} anywhere, does it assign it anywhere?
+# Delete prelude.md's assignment (or move the end block to a skill without one)
+# and every phase agent silently addresses /scripts/... — with the scan above
+# reporting clean, because no SKILL.md was involved.
+#
+# ⚠️ This does NOT replace the check above, and collapsing the two would
+# reintroduce the exact bug #3656 fixed: a use in SKILL.md with its assignment in
+# references/ satisfies THIS rule and must still fail THAT one. Both run.
+#
+# Raised by FLEET on #3656 (peer read, §4): ten more phase skills are queued for
+# the same conversion, so the guard built for this class was aimed at the wrong
+# files for all ten.
+echo "Test: every SKILL (SKILL.md + references/) that expands \${PLUGIN_ROOT} assigns it somewhere"
+SKILL_OFFENDERS=""
+SKILLS_CHECKED=0
+SKILLS_WITH_USES=0
+while IFS= read -r skillmd; do
+	skill_dir="$(dirname "$skillmd")"
+	SKILLS_CHECKED=$((SKILLS_CHECKED + 1))
+	uses=0
+	assigns=0
+	# SKILL.md plus every reference, counted with the SAME two helpers the scan
+	# above uses — so the two questions can never drift on what a "use" is.
+	for f in "$skillmd" "$skill_dir"/references/*.md; do
+		[ -f "$f" ] || continue
+		uses=$((uses + $(live_plugin_root_uses "$f")))
+		assigns=$((assigns + $(assigns_plugin_root "$f")))
+	done
+	[ "$uses" -gt 0 ] || continue
+	SKILLS_WITH_USES=$((SKILLS_WITH_USES + 1))
+	if [ "$assigns" -eq 0 ]; then
+		SKILL_OFFENDERS="${SKILL_OFFENDERS}
+    ${skill_dir#"$REPO_ROOT"/} (${uses} live use(s) across the skill, 0 assignments)"
+	fi
+done < <(find "$REPO_ROOT/plugins" -name 'SKILL.md' -type f 2>/dev/null)
+
+# A clean result here is only evidence if the scan actually looked at skills that
+# USE the variable. Zero such skills would make the pass vacuous, so assert the
+# denominator rather than just the verdict.
+if [ "$SKILLS_WITH_USES" -eq 0 ]; then
+	fail "whole-skill scan found NO skill using \${PLUGIN_ROOT} — the scan is vacuous" \
+		"checked ${SKILLS_CHECKED} skills; expected at least the phase skills"
+elif [ -z "$SKILL_OFFENDERS" ]; then
+	pass "no skill expands \${PLUGIN_ROOT} without assigning it somewhere (${SKILLS_WITH_USES} of ${SKILLS_CHECKED} skills use it)"
+else
+	fail "skills expand \${PLUGIN_ROOT} (in SKILL.md or references/) without assigning it anywhere" "$SKILL_OFFENDERS"
+fi
+
 # ── POSITIVE CONTROL ─────────────────────────────────────────────────────────
 # The check above reports a clean result. A clean result is only evidence if the
 # same instrument returns a DIRTY result on a case known to be defective. Build


### PR DESCRIPTION
Raised by **FLEET** as §4 of the #3656 peer read, and it is the sharper half of that turn.

#3656 taught `halt-on-complete.test.mjs` that a skill is **SKILL.md plus its `references/`** — and
that immediately found a second real break. Its sibling did not learn the same lesson:
`skill-plugin-root-assigned.test.sh` still scans `find plugins -name 'SKILL.md'` alone.

**Measured now:** `_phase-agent-template/references/end-block.md` has **1** live `${PLUGIN_ROOT}`
use and `escalation-explanation.md` has **3**. All four are correct today — `prelude.md` assigns it
in the same shell — and **nothing checks that**. Ten more phase skills are queued for the same
conversion, so the guard built for exactly this class was aimed at the wrong files for all ten.

## The added question

Taking a skill as SKILL.md **plus** its `references/`: if it expands `${PLUGIN_ROOT}` anywhere, does
it assign it anywhere? Delete `prelude.md`'s assignments today and every phase agent silently
addresses `/scripts/...` while the original scan reports **clean**, because no SKILL.md was
involved.

## ⚠️ This ADDS a rule — it does not replace one

Collapsing the two would reintroduce the exact bug #3656 fixed: a use in SKILL.md whose assignment
sits in `references/` satisfies the whole-skill rule and **must still fail** the SKILL.md-only rule,
because a reader of SKILL.md may never open `references/`. Both run — and the mutation below
*proves* they are independent rather than asserting it.

The pass is also guarded against **vacuity**: a clean result means nothing if no skill in the corpus
uses the variable, so the denominator is asserted and reported (**11 of 115** skills use it) rather
than only the verdict.

## Mutation-tested

| mutation | result |
| --- | --- |
| neutralise **both** `PLUGIN_ROOT` assignments in the skill | whole-skill rule **FAILS** |
| add a `${PLUGIN_ROOT}` use to SKILL.md, assignment left in `references/` | SKILL.md rule **FAILS**, whole-skill rule passes — *independence* |
| restored | **6 pass / 0 fail** |

⚠️ **Worth knowing:** the first attempt at mutation 1 removed **one** assignment and the guard stayed
green — which reads exactly like a dead guard. It was a **weak mutation**, not a dead guard:
`prelude.md` carries **two** assignments (the `CLAUDE_PLUGIN_ROOT` read and the CTL-1628 fallback
probe). Recorded because the difference between *"my mutation was too weak"* and *"the guard cannot
fire"* is invisible from the result alone, and only one of them is a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)