### PR TITLE
fix(dev): CTL-879 — the sixth blind gate, found by reading the first instrument: the cross-host claim declines at log.debug

### DIFF
--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1239,6 +1239,24 @@ function dispatchTriage(
         { identifier, self },
         "ctl-862: lost cross-host claim — another host owns this triage dispatch, deferring"
       );
+      // CTL-879: the SIXTH blind gate, and the one the first instrument missed.
+      // It is the ONLY silent exit left after drain/HRW, so it is where a ticket
+      // its OWNER has already accepted still fails to launch — measured on
+      // 2026-08-18: 44 held tickets, a perfect 22/22 HRW split with ZERO declined
+      // by both hosts, every held ticket owned by the host holding it, and not one
+      // `ctl-879` line from the owner. The owner passes drain and HRW and then
+      // exits here, invisibly.
+      //
+      // ⚠️ A lost claim is NOT inherently a fault — it is the normal outcome when a
+      // peer legitimately holds the fence. What makes the silence expensive is that
+      // "a peer won it" and "our claim WRITE never landed" are the same log line at
+      // a level that does not ship, and the second is a real stall (mini's Linear
+      // write budget measured 300/300 spent with 674 refusals the same day). The
+      // reason string keeps them distinguishable at the surface.
+      noteTriageSkip(identifier, "lost-cross-host-claim", {
+        self,
+        claim_reason: claim?.reason ?? null,
+      });
       return false;
     }
     clusterGeneration = claim.generation; // CTL-1028: forward to worker (mirrors CTL-864)

--- a/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
@@ -112,18 +112,25 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
     return hits[0];
   }
 
+  // [label, anchor, recorder, windowLines]. The window is per site because the
+  // claim gate carries a long explanatory comment between its `log.debug` and
+  // its recorder; a single global window would silently stop covering it.
   const SITES = [
-    ["drain gate", "drain: skipping triage dispatch — node draining", "noteTriageSkip"],
-    ["HRW ownership gate", "ctl-1091: ticket not owned by this host under HRW", "noteTriageSkip"],
-    ["sweep budget gate", "readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP", "noteTriageSkip"],
-    ["sweep already-triaged exit", "if (hasTriageArtifact(orchDir, t.identifier))", "clearTriageSkip"],
-    ["sweep in-flight gate", "if (t.fromTriageBoard && isTriageInFlight(", "noteTriageSkip"],
+    ["drain gate", "drain: skipping triage dispatch — node draining", "noteTriageSkip", 8],
+    ["HRW ownership gate", "ctl-1091: ticket not owned by this host under HRW", "noteTriageSkip", 8],
+    ["sweep budget gate", "readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP", "noteTriageSkip", 8],
+    ["sweep already-triaged exit", "if (hasTriageArtifact(orchDir, t.identifier))", "clearTriageSkip", 8],
+    ["sweep in-flight gate", "if (t.fromTriageBoard && isTriageInFlight(", "noteTriageSkip", 8],
+    // CTL-879 follow-up: the sixth gate. The first instrument missed it, and it
+    // is the only silent exit left after drain/HRW — so it is where a ticket its
+    // OWNER accepted still fails to launch.
+    ["cross-host claim gate", "ctl-862: lost cross-host claim", "noteTriageSkip", 24],
   ];
 
-  for (const [label, anchor, recorder] of SITES) {
+  for (const [label, anchor, recorder, windowLines] of SITES) {
     test(`${label} records its outcome`, () => {
       const at = lineOf(anchor);
-      const window = LINES.slice(at, at + 8).join("\n");
+      const window = LINES.slice(at, at + windowLines).join("\n");
       expect(window).toContain(recorder);
     });
   }


### PR DESCRIPTION
#3659 shipped five recorders and I read them 90 seconds after the restart. They narrowed a
five-candidate mystery to one gate in a single pass — and named a gate I had missed.

## What the instrument said (measured 18:38–18:42 CT, both minis)

| | |
| --- | --- |
| `ctl-879` lines | **44**, all INFO |
| distinct reasons | **1** — `not-owned-by-this-host` |
| distinct tickets | **44** |
| **declined by BOTH hosts** | ⭐ **0** — a perfect 22 / 22 split |

HRW is partitioning correctly: each host declines exactly the tickets its peer owns. Cross-checked
against the frozen-board record, **every ticket a host HOLDS is a ticket that host OWNS** — mini holds
CTC-766/757/763/769/776/780/775/781/782/265/234/235 + CTL-2027, all of which appear in mini's owned
set. Yet the owner emits **no `ctl-879` line at all** for them, and **zero** `phase.triage.*` events
were produced fleet-wide in the window (positive control: 23,053 event lines in the same tail, newest
timestamp current).

**The owner passes drain, passes HRW, and then exits silently.** That is the whole remaining surface.

## The sixth gate

```js
const claim = claimDispatch({ ticket: identifier, hostName: self, phase: "triage" });
if (!claim.won) {
  log.debug(...);   // ⛔ does not ship
  return false;
}
```

The CTL-862 cross-host claim soft-CAS is the **only** silent exit left after drain and HRW — the same
`log.debug` blindness those two had before #3659, in the one place a ticket its owner has already
accepted still fails to launch. Same treatment.

⚠️ **A lost claim is not inherently a fault** — it is the normal outcome when a peer legitimately holds
the fence. What makes the silence expensive is that *"a peer won it"* and *"our claim WRITE never
landed"* are the same unshipped line, and only the second is a stall. Not hypothetical: mini's Linear
write budget measured **300/300 spent with 674 `budget:day-exhausted` refusals** the same day
(FLEET-71 §4), and the claim is a Linear write. The reason string plus `claim_reason` keeps them apart.

⛔ **This does NOT claim to be the root cause.** Five mechanisms were refuted by measurement today and I
will not assert a sixth by elimination alone. This is the last place that can hide, so it stops hiding;
the next sweep after deploy says which it is.

## Tests

The wiring guard grows to **6 sites**, 14 tests. Sites now carry a **per-site window**, because this
recorder sits ~20 lines below its gate behind an explanatory comment and a single global window would
have silently stopped covering it.

Mutation-tested: delete the claim recorder → 13 pass / **1 fail**; restored → **14 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)