### PR TITLE
fix(dev): CTL-2033 — the cross-host claim could not say why it lost, so a refused write and a lost race were the same value

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -204,10 +204,25 @@ function parseClaimLine(stdout) {
 }
 
 // classifyCliReason — map the CLI's own refusal word onto this module's outcome.
-// A `budget:*` reason (linear-write-proxy's `classifyWrite` gate: `budget:day-exhausted`,
-// `budget:per-ticket-cap`, `budget:already-converged`) is named separately because
-// it is HOST-WIDE and self-clearing on the UTC day roll — an operator reading it
-// needs to lift a limit, not debug a claim.
+// A `budget:*` reason is named separately because it is raised by THIS HOST'S OWN
+// LEDGER before the request is ever sent, and self-clears on the UTC day roll.
+//
+// ⚠️ IT DOES NOT MEAN THE CLOUD REFUSED ANYTHING — and reading it that way cost a
+// lane an hour on 2026-08-18 (FLEET's peer read on #3664). The host ledger counts
+// writes that LEFT the host, success or not (`linear-write-proxy.mjs`), and gates
+// them against `DEFAULT_DAILY_BUDGET`, a constant whose own doc-comment calls it
+// "the cloud-side daily cap this MIRRORS". Attempts, not arrivals. Measured that
+// day: the host ledger read 300 with 674 refusals while the cloud's own
+// `/admin/write-budget` for the same key read **3** of 300 — it had declined
+// nothing. A P1 was issued to raise the cloud cap on the strength of the wrong
+// reading and was refused after measurement. **Read
+// `~/catalyst/linear-write-budget.json` ON THE HOST, not the cloud's limit.**
+// The underlying defect is CTL-2035.
+//
+// The real reason strings are `linear-write-budget.mjs`'s frozen `REASONS`:
+// `budget:day-exhausted`, `budget:ticket-cap`, `budget:already-converged`.
+// (Matched by prefix, so the exact members do not gate behaviour — but a comment
+// naming a string that does not exist sends the next grep nowhere.)
 function classifyCliReason(cliReason) {
   if (typeof cliReason === "string" && cliReason.startsWith("budget:")) return CLAIM_REASON.BUDGET_REFUSED;
   return CLAIM_REASON.CLI_FAILED;

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -17,6 +17,11 @@
 // dispatch this tick and reconsiders next tick. A transient Linear hiccup must
 // never cause a double-dispatch; deferring is always safe (the HRW pre-filter
 // already guarantees only the owning host even reaches the claim).
+//
+// ⚠️ FAIL-CLOSED IS NOT FAIL-SILENT (CTL-2033). Every result also carries a
+// `reason` naming WHICH of those outcomes happened, so a caller can log a refused
+// write as the stall it is instead of as the lost race it is not. See CLAIM_REASON
+// below.
 
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -119,10 +124,109 @@ export function resolveIssueIdSyncCached({ ticket }, { env = process.env, ...res
   return issueId;
 }
 
+// ── CTL-2033: the claim's discriminated outcome ──────────────────────────────
+//
+// `claimDispatchSync` used to return `{ won:false, generation:null }` for FOUR
+// structurally different things: a peer legitimately winning the fence, a
+// subprocess that failed to spawn or timed out, a non-zero exit, and stdout that
+// did not parse. Only the first is normal. The other three are a stall, and they
+// were byte-identical to it — no reason, no log, nothing to alert on.
+//
+// This is the same defect the sibling `fenceCheckSync` was written NOT to have:
+// its comment says it returns "a discriminated result the caller can act on
+// WITHOUT a second interpretation pass". This function never learned it.
+//
+// Measured 2026-08-18 (CTL-879, after #3661 instrumented the gate): 36 held
+// tickets across both minis logged `lost-cross-host-claim` — every one on a
+// ticket that host OWNS under HRW, so a race was impossible, and every one with
+// `claim_reason: null`, because the result was structurally incapable of
+// carrying one. mini was simultaneously at 300/300 Linear write budget.
+//
+// ⛔ THE FAIL DIRECTION IS TOWARD "FAILURE", NOT TOWARD "NORMAL". `isClaimFailure`
+// treats anything that is not explicitly WON or PEER_WON — including a null or an
+// unrecognised reason — as a failure. An unknown outcome logged as a loud failure
+// costs an operator one WARN; an unknown outcome logged as a normal race is
+// exactly the three hours this ticket exists to buy back.
+export const CLAIM_REASON = Object.freeze({
+  /** exit 0, stdout parsed, won:true — we hold the fence. */
+  WON: "won",
+  /** exit 0, stdout parsed, won:false — the soft-CAS RAN and a peer won the read-back. NORMAL. */
+  PEER_WON: "peer-won",
+  /** the CLI reported a HOST-BUDGET refusal (`budget:*`) — the write never left this host. */
+  BUDGET_REFUSED: "budget-refused",
+  /** the CLI ran and reported a non-budget failure (auth, transport, GraphQL, unknown route). */
+  CLI_FAILED: "cli-failed",
+  /** the process ran but its stdout could not be parsed as the contract's JSON line. */
+  UNPARSEABLE: "unparseable-stdout",
+  /** `spawn` itself threw — the subprocess never started. */
+  SPAWN_THREW: "spawn-threw",
+});
+
+/**
+ * isClaimFailure — did this claim FAIL, as opposed to legitimately lose a race?
+ * Fail-loud on the unknown (see the block comment above): only the two explicitly
+ * normal reasons return false.
+ */
+export function isClaimFailure(reason) {
+  return reason !== CLAIM_REASON.WON && reason !== CLAIM_REASON.PEER_WON;
+}
+
+// CLAIM_DETAIL_MAX — the detail carried into a log line is BOUNDED. A GraphQL
+// errors[] body can be kilobytes, and this string lands in a per-ticket log line
+// on every sweep of every held ticket.
+const CLAIM_DETAIL_MAX = 240;
+
+// scrubDetail — bound the excerpt and mask anything token-shaped before it enters
+// a log line. Deliberately LOCAL rather than imported from linear-write-proxy.mjs:
+// this module is a leaf that spawnSync's the CLI, and importing the proxy would
+// pull its budget-ledger + credential graph into every caller of the sync bridge.
+// The CLI's own errors carry no credential today; this is the guard for the day
+// one of them starts to.
+function scrubDetail(text) {
+  if (typeof text !== "string" || text === "") return null;
+  const masked = text.replace(/\b(?:lin_api_|ghp_|gho_|ghs_|github_pat_|sk-|xoxb-)[A-Za-z0-9_\-]+/g, "[redacted]");
+  return masked.length > CLAIM_DETAIL_MAX ? `${masked.slice(0, CLAIM_DETAIL_MAX)}…` : masked;
+}
+
+// parseClaimLine — the CLI prints exactly one JSON line; take the last non-empty
+// one defensively. Returns null when there is nothing parseable, so the caller can
+// tell "no JSON at all" from "JSON that says won:false".
+function parseClaimLine(stdout) {
+  if (typeof stdout !== "string") return null;
+  const line = stdout.trim().split("\n").filter(Boolean).pop();
+  if (!line) return null;
+  try {
+    const parsed = JSON.parse(line);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// classifyCliReason — map the CLI's own refusal word onto this module's outcome.
+// A `budget:*` reason (linear-write-proxy's `classifyWrite` gate: `budget:day-exhausted`,
+// `budget:per-ticket-cap`, `budget:already-converged`) is named separately because
+// it is HOST-WIDE and self-clearing on the UTC day roll — an operator reading it
+// needs to lift a limit, not debug a claim.
+function classifyCliReason(cliReason) {
+  if (typeof cliReason === "string" && cliReason.startsWith("budget:")) return CLAIM_REASON.BUDGET_REFUSED;
+  return CLAIM_REASON.CLI_FAILED;
+}
+
 // claimDispatchSync — soft-CAS claim `ticket` for `hostName` at `phase`,
-// synchronously. Returns { won, generation }. won:false on any failure
-// (fail-closed). `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the
-// unit tests never spawn a real process.
+// synchronously. Returns { won, generation, reason, detail } — `reason` is ALWAYS
+// one of CLAIM_REASON and is never null (CTL-2033); `detail` is a bounded, scrubbed
+// string on a failure and null otherwise. won:false on any failure (fail-closed).
+// `spawn`/`nodeBin`/`cli`/`env`/`timeout` are injectable so the unit tests never
+// spawn a real process.
+//
+// ⚠️ NO IN-CALL RETRY, DELIBERATELY. This runs inside the synchronous daemon tick,
+// and the measured failure is a HOST-WIDE write-budget refusal — every candidate in
+// the sweep fails for the same reason at the same instant. A hot retry would spend
+// more of the exhausted budget, block the tick on a sleep, and add fork pressure at
+// exactly the moment the host is under it. The retry is the NEXT SWEEP (measured
+// 2026-08-18: every 5-10 min), which is a real backoff that costs nothing. What was
+// missing was never the retry — it was the reason and the alarm.
 // CTL-863 follow-up: `resolveIssueId` is the injectable pre-resolve seam (defaults to
 // resolveIssueIdSyncCached) — a resolved UUID is threaded into the `claim` argv so that
 // subprocess skips its own ResolveIssueId call. A null (miss/disabled+failed) falls back
@@ -147,18 +251,56 @@ export function claimDispatchSync(
       env,
       timeout,
     });
-    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
-      return { won: false, generation: null };
+    const parsed = parseClaimLine(res?.stdout);
+    // A structured `error.reason` is authoritative wherever it appears — the CLI
+    // pairs it with CLAIM_FAILED_EXIT today, and reading it independently of the
+    // exit code means a future exit-code change cannot silently reclassify a
+    // failure as a race.
+    const cliReason = typeof parsed?.error?.reason === "string" ? parsed.error.reason : null;
+    if (cliReason) {
+      return {
+        won: false,
+        generation: null,
+        reason: classifyCliReason(cliReason),
+        detail: scrubDetail(`${cliReason}: ${parsed?.error?.message ?? ""}`.trim()),
+      };
     }
-    // The CLI prints exactly one JSON line; take the last non-empty line defensively.
-    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
-    const parsed = JSON.parse(line);
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      // Ran and failed, but said nothing structured: keep the exit status and the
+      // stderr excerpt, which is the only evidence left.
+      return {
+        won: false,
+        generation: null,
+        reason: CLAIM_REASON.CLI_FAILED,
+        detail: scrubDetail(
+          `exit=${res?.status ?? "null"}${res?.signal ? ` signal=${res.signal}` : ""}` +
+            `${res?.error?.message ? ` error=${res.error.message}` : ""}` +
+            `${typeof res?.stderr === "string" && res.stderr.trim() ? ` stderr=${res.stderr.trim()}` : ""}`,
+        ),
+      };
+    }
+    if (!parsed) {
+      return {
+        won: false,
+        generation: null,
+        reason: CLAIM_REASON.UNPARSEABLE,
+        detail: scrubDetail(res.stdout.trim()),
+      };
+    }
+    const won = parsed.won === true;
     return {
-      won: parsed?.won === true,
-      generation: Number.isFinite(parsed?.generation) ? parsed.generation : null,
+      won,
+      generation: Number.isFinite(parsed.generation) ? parsed.generation : null,
+      reason: won ? CLAIM_REASON.WON : CLAIM_REASON.PEER_WON,
+      detail: null,
     };
-  } catch {
-    return { won: false, generation: null };
+  } catch (err) {
+    return {
+      won: false,
+      generation: null,
+      reason: CLAIM_REASON.SPAWN_THREW,
+      detail: scrubDetail(String(err?.message ?? err)),
+    };
   }
 }
 

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -6,6 +6,8 @@ import { describe, it, expect, beforeEach } from "bun:test";
 
 import {
   claimDispatchSync,
+  CLAIM_REASON,
+  isClaimFailure,
   fenceCheckSync,
   fenceCheckSyncCached,
   clearFenceReadCache,
@@ -43,6 +45,8 @@ describe("claimDispatchSync — argv + parsing", () => {
     expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
       won: true,
       generation: 3,
+      reason: CLAIM_REASON.WON,
+      detail: null,
     });
   });
 
@@ -51,6 +55,8 @@ describe("claimDispatchSync — argv + parsing", () => {
     expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
       won: false,
       generation: 2,
+      reason: CLAIM_REASON.PEER_WON,
+      detail: null,
     });
   });
 });
@@ -58,36 +64,32 @@ describe("claimDispatchSync — argv + parsing", () => {
 describe("claimDispatchSync — FAIL-CLOSED on every failure mode", () => {
   it("non-zero exit → won:false", () => {
     const spawn = () => ({ status: 1, stdout: "" });
-    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
-      won: false,
-      generation: null,
-    });
+    const r = claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn });
+    expect(r.won).toBe(false);
+    expect(r.generation).toBeNull();
   });
 
   it("unparseable stdout → won:false", () => {
     const spawn = () => ({ status: 0, stdout: "not json at all" });
-    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
-      won: false,
-      generation: null,
-    });
+    const r = claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn });
+    expect(r.won).toBe(false);
+    expect(r.generation).toBeNull();
   });
 
   it("timeout / spawn error (status null) → won:false", () => {
     const spawn = () => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null });
-    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
-      won: false,
-      generation: null,
-    });
+    const r = claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn });
+    expect(r.won).toBe(false);
+    expect(r.generation).toBeNull();
   });
 
   it("spawn throws → won:false (never propagates)", () => {
     const spawn = () => {
       throw new Error("EACCES");
     };
-    expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
-      won: false,
-      generation: null,
-    });
+    const r = claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn });
+    expect(r.won).toBe(false);
+    expect(r.generation).toBeNull();
   });
 
   it("missing/garbage generation in stdout → generation null but won honoured", () => {
@@ -95,7 +97,137 @@ describe("claimDispatchSync — FAIL-CLOSED on every failure mode", () => {
     expect(claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "research" }, { spawn })).toEqual({
       won: true,
       generation: null,
+      reason: CLAIM_REASON.WON,
+      detail: null,
     });
+  });
+});
+
+// ─── CTL-2033 ────────────────────────────────────────────────────────────────
+// The whole point of this suite is that NO TWO of these outcomes may share a
+// value. Every case below asserts the exact `reason`, so collapsing any pair
+// (the pre-CTL-2033 behaviour — one `{won:false, generation:null}` for all of
+// them) fails HERE rather than three hours into an operator's evening.
+//
+// ⚠️ Mutation-verified: reverting `claimDispatchSync`'s body to the single
+// `return { won:false, generation:null }` fails 6 of these; making
+// `classifyCliReason` return CLI_FAILED unconditionally fails the budget case;
+// making `isClaimFailure` return `false` on an unknown reason fails the
+// fail-loud case.
+describe("claimDispatchSync — CTL-2033: the four outcomes are DISTINGUISHABLE", () => {
+  const claim = (spawn) => claimDispatchSync({ ticket: "CTL-1", hostName: "mini", phase: "triage" }, { spawn });
+
+  it("a peer legitimately winning the fence is `peer-won` — and is NOT a failure", () => {
+    const r = claim(() => ({ status: 0, stdout: JSON.stringify({ won: false, generation: 7 }) + "\n" }));
+    expect(r.reason).toBe(CLAIM_REASON.PEER_WON);
+    expect(isClaimFailure(r.reason)).toBe(false);
+    expect(r.detail).toBeNull();
+  });
+
+  it("a HOST-BUDGET refusal is `budget-refused`, distinct from every other failure", () => {
+    const r = claim(() => ({
+      status: 11,
+      stdout:
+        JSON.stringify({
+          won: false,
+          generation: null,
+          error: { reason: "budget:day-exhausted", message: "cluster-attachment: budget:day-exhausted (route=attachment ticket=CTL-1)" },
+        }) + "\n",
+    }));
+    expect(r.reason).toBe(CLAIM_REASON.BUDGET_REFUSED);
+    expect(r.reason).not.toBe(CLAIM_REASON.PEER_WON);
+    expect(r.reason).not.toBe(CLAIM_REASON.CLI_FAILED);
+    expect(isClaimFailure(r.reason)).toBe(true);
+    expect(r.detail).toContain("budget:day-exhausted");
+  });
+
+  it("a NON-budget CLI failure is `cli-failed`, and carries the CLI's own reason word", () => {
+    const r = claim(() => ({
+      status: 11,
+      stdout: JSON.stringify({ won: false, generation: null, error: { reason: "no-cloud-token", message: "cluster-attachment: no-cloud-token" } }) + "\n",
+    }));
+    expect(r.reason).toBe(CLAIM_REASON.CLI_FAILED);
+    expect(r.reason).not.toBe(CLAIM_REASON.BUDGET_REFUSED);
+    expect(r.detail).toContain("no-cloud-token");
+    expect(isClaimFailure(r.reason)).toBe(true);
+  });
+
+  it("a non-zero exit with NO structured error is `cli-failed` and keeps exit + stderr as evidence", () => {
+    const r = claim(() => ({ status: 1, stdout: "", stderr: "cluster-claim.mjs: linear graphql http 401\n" }));
+    expect(r.reason).toBe(CLAIM_REASON.CLI_FAILED);
+    expect(r.detail).toContain("exit=1");
+    expect(r.detail).toContain("401");
+  });
+
+  it("stdout that does not parse is its OWN outcome — never folded into cli-failed or peer-won", () => {
+    const r = claim(() => ({ status: 0, stdout: "not json at all" }));
+    expect(r.reason).toBe(CLAIM_REASON.UNPARSEABLE);
+    expect(r.reason).not.toBe(CLAIM_REASON.CLI_FAILED);
+    expect(r.reason).not.toBe(CLAIM_REASON.PEER_WON);
+    expect(r.detail).toContain("not json at all");
+  });
+
+  it("a spawn that throws is `spawn-threw`, not a lost race", () => {
+    const r = claim(() => {
+      throw new Error("EAGAIN");
+    });
+    expect(r.reason).toBe(CLAIM_REASON.SPAWN_THREW);
+    expect(isClaimFailure(r.reason)).toBe(true);
+    expect(r.detail).toContain("EAGAIN");
+  });
+
+  it("a timeout (status null, no stdout) is a failure, never `peer-won`", () => {
+    const r = claim(() => ({ status: null, error: new Error("ETIMEDOUT"), stdout: null }));
+    expect(isClaimFailure(r.reason)).toBe(true);
+    expect(r.reason).not.toBe(CLAIM_REASON.PEER_WON);
+  });
+
+  it("EVERY outcome carries a non-null reason — the field can never be null again", () => {
+    const spawns = [
+      () => ({ status: 0, stdout: JSON.stringify({ won: true, generation: 1 }) + "\n" }),
+      () => ({ status: 0, stdout: JSON.stringify({ won: false, generation: 1 }) + "\n" }),
+      () => ({ status: 11, stdout: JSON.stringify({ won: false, error: { reason: "budget:day-exhausted" } }) + "\n" }),
+      () => ({ status: 11, stdout: JSON.stringify({ won: false, error: { reason: "write-not-succeeded" } }) + "\n" }),
+      () => ({ status: 1, stdout: "" }),
+      () => ({ status: 0, stdout: "garbage" }),
+      () => {
+        throw new Error("boom");
+      },
+    ];
+    const reasons = spawns.map((sp) => claim(sp).reason);
+    expect(reasons.every((r) => typeof r === "string" && r.length > 0)).toBe(true);
+    // ...and they are not all the same value, which a `reason: "unknown"` constant
+    // would satisfy while telling an operator nothing.
+    expect(new Set(reasons).size).toBeGreaterThanOrEqual(5);
+  });
+
+  it("a structured error is authoritative even at exit 0 — an exit-code change cannot reclassify a failure as a race", () => {
+    const r = claim(() => ({ status: 0, stdout: JSON.stringify({ won: false, error: { reason: "budget:day-exhausted" } }) + "\n" }));
+    expect(r.reason).toBe(CLAIM_REASON.BUDGET_REFUSED);
+  });
+
+  it("detail is bounded and token-shaped text is masked before it reaches a log line", () => {
+    const long = "x".repeat(4000);
+    const r = claim(() => ({ status: 1, stdout: "", stderr: `token lin_api_abc123DEF456 ${long}` }));
+    expect(r.detail.length).toBeLessThanOrEqual(241);
+    expect(r.detail).toContain("[redacted]");
+    expect(r.detail).not.toContain("lin_api_abc123DEF456");
+  });
+});
+
+describe("isClaimFailure — CTL-2033: fail-loud on the unknown", () => {
+  it("only `won` and `peer-won` are non-failures", () => {
+    expect(isClaimFailure(CLAIM_REASON.WON)).toBe(false);
+    expect(isClaimFailure(CLAIM_REASON.PEER_WON)).toBe(false);
+    for (const r of [CLAIM_REASON.BUDGET_REFUSED, CLAIM_REASON.CLI_FAILED, CLAIM_REASON.UNPARSEABLE, CLAIM_REASON.SPAWN_THREW]) {
+      expect(isClaimFailure(r)).toBe(true);
+    }
+  });
+
+  it("a null reason (a pre-CTL-2033 shape, or an old injected double) reads as a FAILURE, not as normal", () => {
+    expect(isClaimFailure(null)).toBe(true);
+    expect(isClaimFailure(undefined)).toBe(true);
+    expect(isClaimFailure("something-nobody-has-written-yet")).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -391,12 +391,17 @@ export async function isFenceCurrent(ticket, generation, { post = defaultPost, t
 // runCli is exported (with an injectable `post`) so the CLI surface is unit
 // tested without the network; the main-guard below calls it with the real post.
 //
-//   claim <ticket> <host> <phase> [issueId]  → stdout JSON {won, generation}; exit 0 iff
-//                                    the soft-CAS ran (read `won` from stdout —
-//                                    a non-zero exit means the operation threw,
-//                                    which the wrapper treats as won:false). The
-//                                    optional 4th arg is a pre-resolved ticket UUID
-//                                    (CTL-863 follow-up — see claimTicket/writeClaim).
+//   claim <ticket> <host> <phase> [issueId]  → stdout JSON; the optional 4th arg is a
+//                                    pre-resolved ticket UUID (CTL-863 follow-up —
+//                                    see claimTicket/writeClaim). THREE outcomes,
+//                                    each separable by the caller (CTL-2033):
+//                                      exit 0  + {won:true,  generation}  → we hold the fence
+//                                      exit 0  + {won:false, generation}  → the soft-CAS RAN
+//                                                    and a peer won the read-back (normal)
+//                                      exit 11 + {won:false, error:{reason,message}}
+//                                                  → the soft-CAS NEVER RAN (refused write,
+//                                                    auth failure, GraphQL error) — a stall,
+//                                                    not a race.
 //   fence-check <ticket> <gen>     → stdout JSON {current}; exit 0 when current,
 //                                    FENCE_STALE_EXIT (10) when stale — mirrors
 //                                    claim.mjs's host-local fence-check contract.
@@ -407,6 +412,24 @@ export async function isFenceCurrent(ticket, generation, { post = defaultPost, t
 //                                    instead of the resolution being buried inside
 //                                    every `claim`.
 const FENCE_STALE_EXIT = 10;
+
+// CLAIM_FAILED_EXIT — CTL-2033. The `claim` subcommand's THIRD outcome, and the
+// one that had no representation at all: the soft-CAS never ran. Before this,
+// `claimTicket` throwing (a refused proxy write, a 401, a GraphQL error) fell to
+// the module's top-level catch, which printed the message to stderr and exited 1
+// — while a peer legitimately winning the fence exited 0 with `{won:false}`. The
+// synchronous wrapper collapsed BOTH into `{won:false, generation:null}`, so
+// "another host owns this" and "our claim write never landed" were the same
+// value. Measured 2026-08-18: 36 held tickets across both minis reported a lost
+// claim on tickets they OWN under HRW — impossible as a race, and invisible as a
+// failure.
+//
+// A distinct exit code (mirroring FENCE_STALE_EXIT's convention) plus a
+// machine-readable `error.reason` on STDOUT is what makes the two separable
+// WITHOUT scraping stderr prose. The reason string is the transport's own
+// (`budget:day-exhausted`, `no-cloud-token`, `write-not-succeeded`, …), passed
+// through unchanged so the operator reads the same word the proxy logged.
+const CLAIM_FAILED_EXIT = 11;
 
 /**
  * defaultTransport — build the transport this PROCESS should use. CTL-1889 increment 3.
@@ -438,9 +461,27 @@ export async function runCli(argv, { post = defaultPost, transport = null } = {}
     case "claim": {
       const [ticket, hostName, phase, issueIdRaw] = rest;
       const issueId = issueIdRaw != null && issueIdRaw !== "" ? issueIdRaw : null;
-      const res = await claimTicket(ticket, hostName, phase, { post, transport: t, issueId });
-      process.stdout.write(JSON.stringify(res) + "\n");
-      return 0;
+      // CTL-2033: REPORT the failure instead of only throwing it. The catch is
+      // scoped to `claim` alone — every other subcommand keeps the module's
+      // top-level catch (stderr + exit 1) byte-for-byte. stdout stays exactly one
+      // JSON line either way, so the wrapper's "take the last non-empty line"
+      // parse is unchanged; stderr keeps a human line for an operator grep.
+      try {
+        const res = await claimTicket(ticket, hostName, phase, { post, transport: t, issueId });
+        process.stdout.write(JSON.stringify(res) + "\n");
+        return 0;
+      } catch (err) {
+        // `err.reason` is AttachmentTransportError's structured field (the proxy's
+        // own refusal word). Anything else — a bare Error from `post`, a
+        // programming mistake — has no reason, and is named `claim-threw` rather
+        // than guessed at from its message.
+        const reason = typeof err?.reason === "string" && err.reason ? err.reason : "claim-threw";
+        process.stdout.write(
+          JSON.stringify({ won: false, generation: null, error: { reason, message: String(err?.message ?? err) } }) + "\n",
+        );
+        process.stderr.write(`cluster-claim.mjs: claim failed for ${ticket}: reason=${reason}: ${err?.message ?? err}\n`);
+        return CLAIM_FAILED_EXIT;
+      }
     }
     case "fence-check": {
       const [ticket, gen] = rest;

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -39,6 +39,31 @@ async function captureStdout(fn) {
   }
 }
 
+// captureStdio — captureStdout's sibling for CTL-2033: the claim failure path
+// writes a JSON line to stdout AND a human line to stderr, and both are part of
+// the contract. Capturing stderr also keeps the suite's output clean.
+async function captureStdio(fn) {
+  const outChunks = [];
+  const errChunks = [];
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = (s) => {
+    outChunks.push(typeof s === "string" ? s : s.toString());
+    return true;
+  };
+  process.stderr.write = (s) => {
+    errChunks.push(typeof s === "string" ? s : s.toString());
+    return true;
+  };
+  try {
+    const code = await fn();
+    return { code, out: outChunks.join(""), err: errChunks.join("") };
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+}
+
 // makeFakeLinear — an in-memory Linear that honours the three operations
 // cluster-claim issues: identifier→id resolution, attachment read, and the
 // upsert-on-url attachmentCreate. State is a Map<ticket, metadata>. Returns
@@ -513,6 +538,88 @@ describe("runCli — the spawnSync CLI surface (CTL-850)", () => {
     );
     expect(code).toBe(0);
     expect(JSON.parse(out)).toEqual({ won: false, generation: 1 });
+  });
+
+  // ─── CTL-2033 ───────────────────────────────────────────────────────────────
+  // The `claim` subcommand's THIRD outcome. Before this, a throw inside
+  // claimTicket (a refused proxy write, a 401, a GraphQL errors[] body) fell to
+  // the module's top-level catch: stderr prose + exit 1, and NOTHING on stdout.
+  // The sync wrapper therefore saw the same `{won:false, generation:null}` it saw
+  // for a peer legitimately winning the fence. These cases pin the separation.
+  it("claim: a THROWN claim exits CLAIM_FAILED (11) with a machine-readable error on stdout", async () => {
+    async function post(query) {
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
+      if (query.includes("ReadFence")) return { issue: { attachments: { nodes: [] } } };
+      if (query.includes("UpsertFence")) return { attachmentCreate: { success: false } };
+      throw new Error("unexpected");
+    }
+    const { code, out, err } = await captureStdio(() =>
+      runCli(["claim", "CTL-842", "mini", "triage"], { post }),
+    );
+    expect(code).toBe(11);
+    const parsed = JSON.parse(out);
+    expect(parsed.won).toBe(false);
+    expect(parsed.generation).toBeNull();
+    // The transport's OWN reason word survives to the caller — not a message scrape.
+    expect(parsed.error.reason).toBe("write-not-succeeded");
+    expect(parsed.error.message).toContain("success=false");
+    // stderr keeps a human line for an operator grep.
+    expect(err).toContain("reason=write-not-succeeded");
+  });
+
+  it("claim: exit 11 is DISTINCT from exit 0 — a failed claim and a lost race are not the same value", async () => {
+    // Lost race: the operation ran, a rival won the read-back.
+    let writes = 0;
+    async function lostPost(query) {
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
+      if (query.includes("UpsertFence")) {
+        writes += 1;
+        return { attachmentCreate: { success: true, attachment: {} } };
+      }
+      if (query.includes("ReadFence")) {
+        const metadata =
+          writes === 0 ? null : { owner_host: "rival", catalyst_generation: 1, phase: "triage", claimed_at: "x" };
+        return { issue: { attachments: { nodes: metadata ? [{ id: "f", url: fenceUrl("CTL-842"), metadata }] : [] } } };
+      }
+      throw new Error("unexpected");
+    }
+    // Failed claim: the write itself is refused.
+    async function failedPost(query) {
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
+      if (query.includes("ReadFence")) return { issue: { attachments: { nodes: [] } } };
+      if (query.includes("UpsertFence")) throw new Error("linear graphql http 429");
+      throw new Error("unexpected");
+    }
+    const lost = await captureStdio(() => runCli(["claim", "CTL-842", "mini", "triage"], { post: lostPost }));
+    const failed = await captureStdio(() => runCli(["claim", "CTL-842", "mini", "triage"], { post: failedPost }));
+    expect(lost.code).toBe(0);
+    expect(failed.code).toBe(11);
+    expect(lost.code).not.toBe(failed.code);
+    expect(JSON.parse(lost.out).error).toBeUndefined();
+    expect(JSON.parse(failed.out).error.reason).toBe("claim-threw");
+  });
+
+  it("claim: a non-AttachmentTransportError throw is named `claim-threw`, never guessed from its message", async () => {
+    async function post(query) {
+      if (query.includes("ResolveIssueId")) throw new Error("budget:day-exhausted looking string in a bare Error");
+      throw new Error("unexpected");
+    }
+    const { code, out } = await captureStdio(() => runCli(["claim", "CTL-842", "mini", "triage"], { post }));
+    expect(code).toBe(11);
+    // The MESSAGE contains "budget:" but the structured reason does not claim to
+    // be one — the reason comes from `err.reason`, which a bare Error lacks.
+    expect(JSON.parse(out).error.reason).toBe("claim-threw");
+  });
+
+  it("claim: stdout stays exactly ONE JSON line on the failure path (the wrapper's last-line parse is unchanged)", async () => {
+    async function post(query) {
+      if (query.includes("ResolveIssueId")) return { issue: { id: "uuid-CTL-842" } };
+      if (query.includes("ReadFence")) return { issue: { attachments: { nodes: [] } } };
+      if (query.includes("UpsertFence")) throw new Error("boom");
+      throw new Error("unexpected");
+    }
+    const { out } = await captureStdio(() => runCli(["claim", "CTL-842", "mini", "triage"], { post }));
+    expect(out.trim().split("\n").filter(Boolean).length).toBe(1);
   });
 
   it("fence-check: exits 0 and prints {current:true} when the generation matches", async () => {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -73,6 +73,7 @@ import { ownedBy } from "./hrw.mjs"; // CTL-862: HRW ownership filter
 import { getEventName } from "../lib/event-name.mjs"; // CTL-1834: THE shared event-name boundary
 import {
   claimDispatchSync,
+  isClaimFailure,
   readTriageAttemptCountSync,
   bumpTriageAttemptCountSync,
 } from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count
@@ -863,7 +864,7 @@ const _triageSkipStreaks = new Map();
 // this ticket's triage.json while it holds, so it escalates INFO → WARN and says
 // so. Never throws — an observability helper that can break admission is worse
 // than the blindness it replaces.
-export function noteTriageSkip(identifier, reason, detail = {}) {
+export function noteTriageSkip(identifier, reason, detail = {}, { alwaysWarn = false } = {}) {
   try {
     const prev = _triageSkipStreaks.get(identifier);
     const streak = prev?.reason === reason ? prev.streak + 1 : 1;
@@ -876,10 +877,23 @@ export function noteTriageSkip(identifier, reason, detail = {}) {
     const isEscalationEdge = streak === TRIAGE_SKIP_ESCALATE_AFTER;
     if (!isFirst && !isPeriodic && !isEscalationEdge) return streak;
     const context = { ticket: identifier, reason, held_sweeps: streak, ...detail };
+    // CTL-2033: `alwaysWarn` raises the SEVERITY, never the frequency. A skip that
+    // is a FAILURE (the claim write never landed) is abnormal on its very first
+    // sweep — waiting TRIAGE_SKIP_ESCALATE_AFTER sweeps to say so is 75-150 minutes
+    // at the measured 5-10 min sweep cadence. The sparse gate above still bounds
+    // how often it is written, so a 20-candidate sweep cannot flood.
     if (streak >= TRIAGE_SKIP_ESCALATE_AFTER) {
       log.warn(
         context,
         "ctl-879: triage admission blocked persistently — no triage.json can be produced for this ticket while this reason holds, so the scheduler's ctl-1150 gate will hold it indefinitely"
+      );
+    } else if (alwaysWarn) {
+      // A different sentence, not the persistence one: "persistently" would be a
+      // false statement on sweep 1, and `held_sweeps: 1` beside it reads as a bug
+      // in the counter rather than as the alarm it is.
+      log.warn(
+        context,
+        "ctl-879: triage admission FAILED (not a lost race) — the cross-host claim never landed, so no host will produce this ticket's triage.json; read claim_reason"
       );
     } else {
       log.info(context, "ctl-879: triage admission skipped this sweep");
@@ -1235,8 +1249,13 @@ function dispatchTriage(
   if (multiHost) {
     const claim = claimDispatch({ ticket: identifier, hostName: self, phase: "triage" });
     if (!claim.won) {
+      // CTL-2033: the claim now says WHICH of its outcomes this was. `failed` is
+      // fail-loud on the unknown — only an explicit `peer-won` counts as the normal
+      // race (see isClaimFailure).
+      const claimReason = claim?.reason ?? null;
+      const failed = isClaimFailure(claimReason);
       log.debug(
-        { identifier, self },
+        { identifier, self, claim_reason: claimReason },
         "ctl-862: lost cross-host claim — another host owns this triage dispatch, deferring"
       );
       // CTL-879: the SIXTH blind gate, and the one the first instrument missed.
@@ -1253,10 +1272,18 @@ function dispatchTriage(
       // a level that does not ship, and the second is a real stall (mini's Linear
       // write budget measured 300/300 spent with 674 refusals the same day). The
       // reason string keeps them distinguishable at the surface.
-      noteTriageSkip(identifier, "lost-cross-host-claim", {
-        self,
-        claim_reason: claim?.reason ?? null,
-      });
+      //
+      // ⭐ CTL-2033 measured the answer to that question: 36 of 36 held tickets were
+      // FAILED claims, not lost ones — so the two get DIFFERENT gate reasons here.
+      // `claim-write-failed` is a stall and warns on sweep 1; `lost-cross-host-claim`
+      // keeps its name and its INFO-until-persistent ladder, because a peer winning
+      // is a normal outcome that only becomes interesting if it never stops.
+      noteTriageSkip(
+        identifier,
+        failed ? "claim-write-failed" : "lost-cross-host-claim",
+        { self, claim_reason: claimReason, claim_detail: claim?.detail ?? null },
+        { alwaysWarn: failed },
+      );
       return false;
     }
     clusterGeneration = claim.generation; // CTL-1028: forward to worker (mirrors CTL-864)

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -858,6 +858,33 @@ const TRIAGE_SKIP_RELOG_EVERY = 10;
 const TRIAGE_SKIP_ESCALATE_AFTER = 15;
 const _triageSkipStreaks = new Map();
 
+// triageSkipSeverity — the PURE severity decision, extracted so it is testable
+// without the logger (CTL-2033).
+//
+// ⚠️ It was NOT extracted for tidiness. The first version of this guard asserted
+// the level by capturing `process.stdout/stderr.write` and matching the
+// `[execution-core:<level>]` prefix of config.mjs's console shim. That passes
+// locally, where pino is absent — and FAILS in CI, where pino IS installed and
+// emits `{"level":40,...}` JSON through a destination it captured at
+// construction. A severity rule tested through whichever logger happens to be
+// installed is a test of the environment, not of the rule.
+//
+// Returns "warn" | "info" | null, where null means THIS SWEEP IS NOT LOGGED —
+// the sparse gate. Callers must treat null as "count it, say nothing".
+export function triageSkipSeverity(streak, { alwaysWarn = false } = {}) {
+  const isFirst = streak === 1;
+  const isPeriodic = streak % TRIAGE_SKIP_RELOG_EVERY === 0;
+  // The escalation edge is logged explicitly: with RELOG_EVERY=10 and
+  // ESCALATE_AFTER=15 the crossing sweep is neither first nor periodic, so
+  // without this the WARN would not appear until streak 20.
+  const isEscalationEdge = streak === TRIAGE_SKIP_ESCALATE_AFTER;
+  if (!isFirst && !isPeriodic && !isEscalationEdge) return null;
+  if (streak >= TRIAGE_SKIP_ESCALATE_AFTER) return "warn";
+  // `alwaysWarn` raises SEVERITY, never FREQUENCY: it is read only AFTER the
+  // sparse gate above has already decided this sweep is written at all.
+  return alwaysWarn ? "warn" : "info";
+}
+
 // noteTriageSkip — record that `identifier` was declined by `reason` this sweep.
 // Returns the streak so callers/tests can assert on it. A streak that reaches
 // TRIAGE_SKIP_ESCALATE_AFTER is no longer a transient miss: nothing will produce
@@ -869,25 +896,21 @@ export function noteTriageSkip(identifier, reason, detail = {}, { alwaysWarn = f
     const prev = _triageSkipStreaks.get(identifier);
     const streak = prev?.reason === reason ? prev.streak + 1 : 1;
     _triageSkipStreaks.set(identifier, { reason, streak });
-    const isFirst = streak === 1;
-    const isPeriodic = streak % TRIAGE_SKIP_RELOG_EVERY === 0;
-    // The escalation edge is logged explicitly: with RELOG_EVERY=10 and
-    // ESCALATE_AFTER=15 the crossing sweep is neither first nor periodic, so
-    // without this the WARN would not appear until streak 20.
-    const isEscalationEdge = streak === TRIAGE_SKIP_ESCALATE_AFTER;
-    if (!isFirst && !isPeriodic && !isEscalationEdge) return streak;
-    const context = { ticket: identifier, reason, held_sweeps: streak, ...detail };
     // CTL-2033: `alwaysWarn` raises the SEVERITY, never the frequency. A skip that
     // is a FAILURE (the claim write never landed) is abnormal on its very first
     // sweep — waiting TRIAGE_SKIP_ESCALATE_AFTER sweeps to say so is 75-150 minutes
-    // at the measured 5-10 min sweep cadence. The sparse gate above still bounds
-    // how often it is written, so a 20-candidate sweep cannot flood.
+    // at the measured 5-10 min sweep cadence. The sparse gate inside
+    // triageSkipSeverity still bounds how often it is written, so a 20-candidate
+    // sweep cannot flood the log it exists to make readable.
+    const severity = triageSkipSeverity(streak, { alwaysWarn });
+    if (severity === null) return streak;
+    const context = { ticket: identifier, reason, held_sweeps: streak, ...detail };
     if (streak >= TRIAGE_SKIP_ESCALATE_AFTER) {
       log.warn(
         context,
         "ctl-879: triage admission blocked persistently — no triage.json can be produced for this ticket while this reason holds, so the scheduler's ctl-1150 gate will hold it indefinitely"
       );
-    } else if (alwaysWarn) {
+    } else if (severity === "warn") {
       // A different sentence, not the persistence one: "persistently" would be a
       // false statement on sweep 1, and `held_sweeps: 1` beside it reads as a bug
       // in the counter rather than as the alarm it is.

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -119,7 +119,7 @@ import {
 } from "./work-done-probes.mjs";
 import { STAGE_RANK, NEW_WORK_ENTRY_PHASE } from "../lib/workflow-descriptor.mjs";
 import { ownerForTicket } from "./hrw.mjs";
-import { claimDispatchSync } from "./cluster-claim-sync.mjs";
+import { claimDispatchSync, isClaimFailure } from "./cluster-claim-sync.mjs"; // CTL-2033: + the outcome discriminator
 import { dispatchTicket, defaultDispatch, settleDispatchSync, sdkSignalRunnable, backstopOnRejection } from "./dispatch.mjs"; // CTL-1367 P1: settle async (sdk) revive dispatch synchronously + backstop a rejected async dispatch
 import { createWorktree } from "./worktree.mjs";
 import { fenceGuard } from "./fence-guard.mjs";
@@ -4894,7 +4894,24 @@ export async function reclaimDeadHostWork(
 
       // Soft-CAS claim: bump generation to take ownership.
       const claimRes = claim(ticket, NEW_WORK_ENTRY_PHASE);
-      if (!claimRes?.won) continue;
+      if (!claimRes?.won) {
+        // CTL-2033: this was a BARE `continue` — the most silent of the three claim
+        // gates. Reclaiming a dead host's work is the path with no second actor, so
+        // a failed takeover claim strands that ticket until the next reclaim sweep
+        // with nothing written down anywhere. A lost race here is genuinely normal
+        // (a surviving peer took it) and stays at debug.
+        const claimReason = claimRes?.reason ?? null;
+        const ctx = { ticket, host: self, deadHost, claim_reason: claimReason, claim_detail: claimRes?.detail ?? null };
+        if (isClaimFailure(claimReason)) {
+          log.warn(
+            ctx,
+            "ctl-850: cross-host takeover claim FAILED (the soft-CAS never ran) — a dead host's ticket is NOT being reclaimed this sweep"
+          );
+        } else {
+          log.debug(ctx, "ctl-850: lost cross-host takeover claim — a surviving peer took it, deferring");
+        }
+        continue;
+      }
 
       // CTL-863: emit fence.claimed for the TAKEOVER bump AS SOON AS THE CLAIM
       // WINS — NOT gated on a successful redispatch (Codex P2, recovery.mjs:3358).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -419,7 +419,7 @@ import {
   openBrokerStateDb,
 } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap). CTL-1157: getAllPrStatuses = the filter_state PR-lifecycle reader for the phantom/orphaned-PR invariants. openBrokerStateDb (CTL-1157 Codex round-6): the exec-core daemon must open the broker DB handle before these readers — ensure() throws otherwise and assembleBoardState swallows it, leaving the board/PR maps empty and the cohorts inert.
 import { readReconcileHealthMarkers } from "./reconcile-health.mjs"; // CTL-1290: stranded-node reconcile signal
-import { claimDispatchSync } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS
+import { claimDispatchSync, isClaimFailure } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS (CTL-2033: + the outcome discriminator)
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
 import {
@@ -8271,10 +8271,23 @@ export function schedulerTick(
         phase: NEW_WORK_ENTRY_PHASE,
       });
       if (!claim.won) {
-        log.debug(
-          { ticket: t.identifier, host: self },
-          "ctl-850: lost cross-host claim — another host owns this dispatch, deferring"
-        );
+        // CTL-2033: the new-work claim gate had the same blindness the triage gate
+        // did — one log.debug for both "a peer won" and "our write never landed".
+        // A FAILED claim here is a silent new-work stall for this ticket on the one
+        // host HRW says may dispatch it, so it warns; a lost race stays debug.
+        const claimReason = claim?.reason ?? null;
+        const ctx = { ticket: t.identifier, host: self, claim_reason: claimReason, claim_detail: claim?.detail ?? null };
+        if (isClaimFailure(claimReason)) {
+          log.warn(
+            ctx,
+            "ctl-850: cross-host claim FAILED (the soft-CAS never ran) — new-work dispatch is deferred and nothing else will pick this ticket up"
+          );
+        } else {
+          log.debug(
+            ctx,
+            "ctl-850: lost cross-host claim — another host owns this dispatch, deferring"
+          );
+        }
         continue;
       }
       clusterGeneration = claim.generation; // CTL-864: the fencing token for this worker

--- a/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
@@ -25,6 +25,7 @@ import {
   pruneTriageSkips,
   _resetTriageSkipStreaks,
 } from "./monitor.mjs";
+import { CLAIM_REASON, isClaimFailure } from "./cluster-claim-sync.mjs";
 
 beforeEach(() => _resetTriageSkipStreaks());
 
@@ -112,9 +113,12 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
     return hits[0];
   }
 
-  // [label, anchor, recorder, windowLines]. The window is per site because the
+  // [label, anchor, recorder, after, before]. The window is per site because the
   // claim gate carries a long explanatory comment between its `log.debug` and
-  // its recorder; a single global window would silently stop covering it.
+  // its recorder; a single global window would silently stop covering it. `before`
+  // exists because CTL-2033's discriminator is READ above the gate's log line —
+  // a forward-only window cannot see it, and a guard that cannot see the thing it
+  // guards is the failure mode this whole file is about.
   const SITES = [
     ["drain gate", "drain: skipping triage dispatch — node draining", "noteTriageSkip", 8],
     ["HRW ownership gate", "ctl-1091: ticket not owned by this host under HRW", "noteTriageSkip", 8],
@@ -124,13 +128,27 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
     // CTL-879 follow-up: the sixth gate. The first instrument missed it, and it
     // is the only silent exit left after drain/HRW — so it is where a ticket its
     // OWNER accepted still fails to launch.
-    ["cross-host claim gate", "ctl-862: lost cross-host claim", "noteTriageSkip", 24],
+    // CTL-2033 grew the explanatory block between the anchor and the recorder by
+    // six lines. The window is sized with headroom rather than to the current
+    // exact distance, so the next comment does not silently un-cover the site.
+    ["cross-host claim gate", "ctl-862: lost cross-host claim", "noteTriageSkip", 36],
+    // CTL-2033: the gate must also CONSULT the discriminator — a recorder that
+    // writes the same reason for both outcomes is the defect, one level in.
+    ["cross-host claim gate discriminates", "ctl-862: lost cross-host claim", "isClaimFailure", 36, 8],
+    // ⚠️ MUTATION-DRIVEN. Asserting `isClaimFailure` is READ is not enough: a gate
+    // can consult the discriminator and then record the same reason either way,
+    // which is the pre-CTL-2033 behaviour exactly. Mutating the gate to a single
+    // literal passed all 84 tests until these two rows existed. Both literals must
+    // survive in the window, so collapsing either direction fails here.
+    ["claim gate keeps the FAILURE reason", "ctl-862: lost cross-host claim", '"claim-write-failed"', 36, 8],
+    ["claim gate keeps the RACE reason", "ctl-862: lost cross-host claim", '"lost-cross-host-claim"', 36, 8],
+    ["claim gate raises severity only for the failure", "ctl-862: lost cross-host claim", "alwaysWarn: failed", 36, 8],
   ];
 
-  for (const [label, anchor, recorder, windowLines] of SITES) {
+  for (const [label, anchor, recorder, after, before = 0] of SITES) {
     test(`${label} records its outcome`, () => {
       const at = lineOf(anchor);
-      const window = LINES.slice(at, at + windowLines).join("\n");
+      const window = LINES.slice(Math.max(0, at - before), at + after).join("\n");
       expect(window).toContain(recorder);
     });
   }
@@ -148,4 +166,126 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
     const between = LINES.slice(accumulate + 1, prune);
     expect(between.some((l) => /^ {2}\}/.test(l))).toBe(true);
   });
+});
+
+
+// ─── CTL-2033 ────────────────────────────────────────────────────────────────
+// The claim gate above records a reason — but until this ticket the reason it
+// recorded was the SAME STRING whether a peer legitimately won the fence or our
+// claim write never landed, because `claimDispatchSync` returned one
+// `{won:false, generation:null}` for both. Measured 2026-08-18: 36 of 36 held
+// tickets logged `lost-cross-host-claim` on tickets their own host OWNS under
+// HRW — a race that cannot happen — with `claim_reason: null` on every line.
+
+/**
+ * captureLogLevels — read the LEVEL a log line was written at.
+ *
+ * ⚠️ This depends on config.mjs's console shim, which prefixes each line with
+ * `[execution-core:<level>]`. pino is not a dependency of this repo, so the shim
+ * is what runs under `bun test`. The suite does NOT silently degrade if that ever
+ * changes: the info case below asserts a POSITIVE marker, so a world where no
+ * marker is emitted fails loudly instead of passing on an unobserved branch.
+ */
+function captureLogLevels(fn) {
+  const chunks = [];
+  const origOut = process.stdout.write;
+  const origErr = process.stderr.write;
+  process.stdout.write = (x) => {
+    chunks.push(typeof x === "string" ? x : x.toString());
+    return true;
+  };
+  process.stderr.write = (x) => {
+    chunks.push(typeof x === "string" ? x : x.toString());
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+  }
+  return chunks.join("");
+}
+
+describe("CTL-2033: a FAILED claim and a LOST race are different outcomes", () => {
+  test("the claim result's reasons are all distinct values — none may collapse into another", () => {
+    const values = Object.values(CLAIM_REASON);
+    expect(values.length).toBeGreaterThanOrEqual(6);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  test("only an explicit peer-win counts as normal; an unknown or absent reason is a FAILURE", () => {
+    expect(isClaimFailure(CLAIM_REASON.PEER_WON)).toBe(false);
+    expect(isClaimFailure(CLAIM_REASON.WON)).toBe(false);
+    expect(isClaimFailure(CLAIM_REASON.BUDGET_REFUSED)).toBe(true);
+    expect(isClaimFailure(null)).toBe(true);
+  });
+
+  test("POSITIVE CONTROL: a normal skip is written at INFO on its first sweep", () => {
+    const text = captureLogLevels(() => noteTriageSkip("CTL-A", "lost-cross-host-claim", { claim_reason: CLAIM_REASON.PEER_WON }));
+    // If this marker is absent the capture (or the shim) is not working, and
+    // every other assertion in this describe would be vacuous.
+    expect(text).toContain("[execution-core:info]");
+    expect(text).not.toContain("[execution-core:warn]");
+  });
+
+  test("a FAILED claim warns on sweep ONE — not after TRIAGE_SKIP_ESCALATE_AFTER sweeps", () => {
+    // At the measured 5-10 min sweep cadence, waiting for the streak escalation
+    // is 75-150 minutes of silence on a condition that is abnormal immediately.
+    const text = captureLogLevels(() =>
+      noteTriageSkip(
+        "CTL-B",
+        "claim-write-failed",
+        { claim_reason: CLAIM_REASON.BUDGET_REFUSED, claim_detail: "budget:day-exhausted" },
+        { alwaysWarn: true },
+      ),
+    );
+    expect(text).toContain("[execution-core:warn]");
+    expect(text).toContain("claim-write-failed");
+    expect(text).toContain("budget:day-exhausted");
+  });
+
+  test("alwaysWarn raises SEVERITY, never FREQUENCY — the sparse gate still bounds the write", () => {
+    // Sweeps 2..9 are neither first, periodic, nor the escalation edge, so a
+    // 20-candidate sweep on a budget-exhausted host cannot flood the log.
+    noteTriageSkip("CTL-C", "claim-write-failed", {}, { alwaysWarn: true }); // sweep 1 — logs
+    const text = captureLogLevels(() => {
+      for (let i = 2; i <= 9; i++) noteTriageSkip("CTL-C", "claim-write-failed", {}, { alwaysWarn: true });
+    });
+    expect(text).toBe("");
+  });
+
+  test("the two outcomes use DIFFERENT gate reasons, so a streak of one never masquerades as the other", () => {
+    // A shared reason string would also merge the two into one streak, so a host
+    // alternating between them would escalate on evidence about neither.
+    expect(noteTriageSkip("CTL-D", "lost-cross-host-claim")).toBe(1);
+    expect(noteTriageSkip("CTL-D", "lost-cross-host-claim")).toBe(2);
+    expect(noteTriageSkip("CTL-D", "claim-write-failed", {}, { alwaysWarn: true })).toBe(1);
+  });
+});
+
+// ── WIRING GUARD: the other two claim gates ──────────────────────────────────
+// The triage gate is not the only caller of the soft-CAS. scheduler.mjs's
+// new-work dispatch and recovery.mjs's dead-host takeover had the SAME
+// blindness — a log.debug and a bare `continue` respectively — and a fix that
+// covered only the gate we happened to be looking at would leave two silent
+// stalls behind. Anchors match on the GATE, never on the recorder.
+describe("CTL-2033 wiring: every claim gate reads the discriminator", () => {
+  const CASES = [
+    ["scheduler new-work claim", "scheduler.mjs", "ctl-850: lost cross-host claim", 8, 20],
+    ["recovery takeover claim", "recovery.mjs", "Soft-CAS claim: bump generation to take ownership", 28, 0],
+  ];
+  for (const [label, file, anchor, after, before] of CASES) {
+    test(`${label} distinguishes a failed claim from a lost race`, () => {
+      const lines = readFileSync(join(import.meta.dir, file), "utf8").split("\n");
+      const hits = lines.map((l, i) => (l.includes(anchor) ? i : -1)).filter((i) => i >= 0);
+      expect(hits.length).toBe(1);
+      const window = lines.slice(Math.max(0, hits[0] - before), hits[0] + after).join("\n");
+      expect(window).toContain("isClaimFailure");
+      // BOTH branches must survive: a gate that warns unconditionally is as blind
+      // as one that debugs unconditionally — it just fails in the noisy direction.
+      expect(window).toContain("log.warn");
+      expect(window).toContain("log.debug");
+    });
+  }
 });

--- a/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
@@ -24,6 +24,7 @@ import {
   clearTriageSkip,
   pruneTriageSkips,
   _resetTriageSkipStreaks,
+  triageSkipSeverity,
 } from "./monitor.mjs";
 import { CLAIM_REASON, isClaimFailure } from "./cluster-claim-sync.mjs";
 
@@ -143,6 +144,8 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
     ["claim gate keeps the FAILURE reason", "ctl-862: lost cross-host claim", '"claim-write-failed"', 36, 8],
     ["claim gate keeps the RACE reason", "ctl-862: lost cross-host claim", '"lost-cross-host-claim"', 36, 8],
     ["claim gate raises severity only for the failure", "ctl-862: lost cross-host claim", "alwaysWarn: failed", 36, 8],
+    // The pure rule is only worth testing if the recorder actually consults it.
+    ["noteTriageSkip routes through the pure severity rule", "const context = { ticket: identifier, reason, held_sweeps: streak", "triageSkipSeverity(streak", 4, 6],
   ];
 
   for (const [label, anchor, recorder, after, before = 0] of SITES) {
@@ -177,35 +180,14 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
 // tickets logged `lost-cross-host-claim` on tickets their own host OWNS under
 // HRW — a race that cannot happen — with `claim_reason: null` on every line.
 
-/**
- * captureLogLevels — read the LEVEL a log line was written at.
- *
- * ⚠️ This depends on config.mjs's console shim, which prefixes each line with
- * `[execution-core:<level>]`. pino is not a dependency of this repo, so the shim
- * is what runs under `bun test`. The suite does NOT silently degrade if that ever
- * changes: the info case below asserts a POSITIVE marker, so a world where no
- * marker is emitted fails loudly instead of passing on an unobserved branch.
- */
-function captureLogLevels(fn) {
-  const chunks = [];
-  const origOut = process.stdout.write;
-  const origErr = process.stderr.write;
-  process.stdout.write = (x) => {
-    chunks.push(typeof x === "string" ? x : x.toString());
-    return true;
-  };
-  process.stderr.write = (x) => {
-    chunks.push(typeof x === "string" ? x : x.toString());
-    return true;
-  };
-  try {
-    fn();
-  } finally {
-    process.stdout.write = origOut;
-    process.stderr.write = origErr;
-  }
-  return chunks.join("");
-}
+// ⛔ THE SEVERITY IS TESTED THROUGH A PURE FUNCTION, NOT THROUGH THE LOGGER.
+// The first version of these cases captured `process.stdout/stderr.write` and
+// matched config.mjs's console-shim prefix `[execution-core:<level>]`. That
+// passed locally — pino is not a dependency of this repo — and FAILED in CI,
+// where pino IS installed and emits `{"level":40,...}` JSON through a
+// destination it captured at construction, so the monkeypatch saw nothing.
+// A severity rule asserted through whichever logger happens to be installed is
+// a test of the environment. `triageSkipSeverity` is the rule itself.
 
 describe("CTL-2033: a FAILED claim and a LOST race are different outcomes", () => {
   test("the claim result's reasons are all distinct values — none may collapse into another", () => {
@@ -221,38 +203,41 @@ describe("CTL-2033: a FAILED claim and a LOST race are different outcomes", () =
     expect(isClaimFailure(null)).toBe(true);
   });
 
-  test("POSITIVE CONTROL: a normal skip is written at INFO on its first sweep", () => {
-    const text = captureLogLevels(() => noteTriageSkip("CTL-A", "lost-cross-host-claim", { claim_reason: CLAIM_REASON.PEER_WON }));
-    // If this marker is absent the capture (or the shim) is not working, and
-    // every other assertion in this describe would be vacuous.
-    expect(text).toContain("[execution-core:info]");
-    expect(text).not.toContain("[execution-core:warn]");
+  test("a normal skip is INFO on its first sweep", () => {
+    expect(triageSkipSeverity(1, { alwaysWarn: false })).toBe("info");
   });
 
   test("a FAILED claim warns on sweep ONE — not after TRIAGE_SKIP_ESCALATE_AFTER sweeps", () => {
     // At the measured 5-10 min sweep cadence, waiting for the streak escalation
     // is 75-150 minutes of silence on a condition that is abnormal immediately.
-    const text = captureLogLevels(() =>
-      noteTriageSkip(
-        "CTL-B",
-        "claim-write-failed",
-        { claim_reason: CLAIM_REASON.BUDGET_REFUSED, claim_detail: "budget:day-exhausted" },
-        { alwaysWarn: true },
-      ),
-    );
-    expect(text).toContain("[execution-core:warn]");
-    expect(text).toContain("claim-write-failed");
-    expect(text).toContain("budget:day-exhausted");
+    expect(triageSkipSeverity(1, { alwaysWarn: true })).toBe("warn");
   });
 
   test("alwaysWarn raises SEVERITY, never FREQUENCY — the sparse gate still bounds the write", () => {
     // Sweeps 2..9 are neither first, periodic, nor the escalation edge, so a
     // 20-candidate sweep on a budget-exhausted host cannot flood the log.
-    noteTriageSkip("CTL-C", "claim-write-failed", {}, { alwaysWarn: true }); // sweep 1 — logs
-    const text = captureLogLevels(() => {
-      for (let i = 2; i <= 9; i++) noteTriageSkip("CTL-C", "claim-write-failed", {}, { alwaysWarn: true });
-    });
-    expect(text).toBe("");
+    for (let streak = 2; streak <= 9; streak++) {
+      expect(triageSkipSeverity(streak, { alwaysWarn: true })).toBeNull();
+      expect(triageSkipSeverity(streak, { alwaysWarn: false })).toBeNull();
+    }
+    // ...and the sweeps that ARE written are written for both.
+    for (const streak of [1, 10, 15, 20]) {
+      expect(triageSkipSeverity(streak, { alwaysWarn: true })).not.toBeNull();
+    }
+  });
+
+  test("the persistence escalation still wins on its own, with or without alwaysWarn", () => {
+    // A long streak is a WARN even for a normal lost race — the pre-existing
+    // CTL-879 ladder, which this change must not have removed.
+    expect(triageSkipSeverity(15, { alwaysWarn: false })).toBe("warn");
+    expect(triageSkipSeverity(20, { alwaysWarn: false })).toBe("warn");
+  });
+
+  test("noteTriageSkip still returns the streak and still never throws", () => {
+    expect(noteTriageSkip("CTL-A", "lost-cross-host-claim", { claim_reason: CLAIM_REASON.PEER_WON })).toBe(1);
+    expect(() =>
+      noteTriageSkip("CTL-B", "claim-write-failed", { claim_reason: CLAIM_REASON.BUDGET_REFUSED }, { alwaysWarn: true }),
+    ).not.toThrow();
   });
 
   test("the two outcomes use DIFFERENT gate reasons, so a streak of one never masquerades as the other", () => {


### PR DESCRIPTION
## The defect

`claimDispatchSync` (`cluster-claim-sync.mjs`) returned `{won:false, generation:null}` for **four structurally different outcomes**:

1. a peer legitimately winning the fence — **normal**
2. the subprocess failing to spawn / timing out — **a stall**
3. a non-zero exit — **a stall**
4. stdout that did not parse — **a stall**

No reason, no log, nothing to alert on. The sibling `fenceCheckSync`, ten lines below in the same file, already returns *"a discriminated result the caller can act on WITHOUT a second interpretation pass"*. This function never learned it.

**Measured 2026-08-18** (CTL-879, after #3661 instrumented the gate): **36 held tickets across both minis** logged `lost-cross-host-claim` — every one on a ticket that host **OWNS** under HRW, so a race was impossible — and `claim_reason` was **null on all 36**, because the result was structurally incapable of carrying one. mini was simultaneously at 300/300 Linear write budget with 674 refusals. Two operators and three instruments spent the evening on it.

## ⛔ The wrapper could not discriminate on its own

FLEET-76 §4 asked for one change in `claimDispatchSync`. It is not sufficient, and the reason matters: a throw inside `claimTicket` fell to `cluster-claim.mjs`'s **top-level** catch, which wrote prose to stderr, exited 1, and put **nothing on stdout**. The wrapper had no structured evidence to read even in principle. So this is two halves:

| half | before | after |
| --- | --- | --- |
| `cluster-claim.mjs` `claim` | throw → top-level catch → stderr + exit 1, stdout **empty** | catches in-subcommand: **one JSON line** `{won:false, generation:null, error:{reason,message}}` + **exit 11** (`CLAIM_FAILED_EXIT`, mirroring `FENCE_STALE_EXIT`'s convention); stderr keeps a human line |
| `cluster-claim-sync.mjs` | one value ×4 | `{won, generation, reason, detail}` — `reason` **never null** |

`error.reason` is the **transport's own word** (`budget:day-exhausted`, `no-cloud-token`, `write-not-succeeded`) passed through unchanged — never a message scrape. The catch is scoped to `claim` alone; every other subcommand keeps the top-level catch byte-for-byte, and stdout stays exactly one JSON line so the wrapper's last-line parse is unchanged.

### The six reasons

`won` · `peer-won` · `budget-refused` · `cli-failed` · `unparseable-stdout` · `spawn-threw`

`budget:*` is classified **separately** because it is host-wide and self-clears on the UTC day roll: an operator reading it lifts a limit, they do not debug a claim.

`isClaimFailure` is **fail-LOUD on the unknown** — only an explicit `won`/`peer-won` is normal, so a null or unrecognised reason reads as a failure. An unknown outcome logged as a loud failure costs one WARN; an unknown outcome logged as a normal race is the three hours this ticket exists to buy back.

`detail` is bounded to 240 chars and token-shaped text is masked before it can reach a log line.

## All THREE claim gates, not just the one under the microscope

| gate | before | after |
| --- | --- | --- |
| `monitor.mjs` triage | `log.debug` + `noteTriageSkip("lost-cross-host-claim", claim_reason: null)` | `claim-write-failed` vs `lost-cross-host-claim`, **warns on sweep 1** |
| `scheduler.mjs` new-work | one `log.debug` for both | `log.warn` on failure, `log.debug` on a race |
| `recovery.mjs` dead-host takeover | ⛔ a **bare `continue`** | same split |

A failed claim warns on sweep **one** rather than after `TRIAGE_SKIP_ESCALATE_AFTER` — which is **75–150 minutes** at the measured 5–10 min sweep cadence, on a condition that is abnormal immediately. `alwaysWarn` raises **severity only**; the sparse gate still bounds frequency, so a 20-candidate sweep on a budget-blown host cannot flood the log it exists to make readable. It also gets its own sentence: "persistently" beside `held_sweeps: 1` reads as a bug in the counter, not as an alarm.

## ⚠️ No in-call retry, deliberately

COORD-277(a) asked for "retry with backoff". This ships the **do-not-silently-give-up** half and not a hot retry:

- The measured failure is **host-wide** — every candidate in the sweep fails at the same instant for the same reason, so a retry loop spends **more** of the exhausted budget (the burn COORD-236 is about).
- `claimDispatchSync` runs **inside the synchronous daemon tick** (CTL-1524). A backoff sleep blocks the tick; extra spawns add fork pressure exactly when the host is under it.
- **The next sweep is the backoff** — 5–10 min, already there, free.

The right retry, if wanted, is *host-level* (one probe when the budget window rolls), and belongs in its own ticket rather than smuggled in here.

## Testing — and the mutation that survived

Six mutations run; each must fail the suite:

| # | mutation | fails |
| -- | --- | --- |
| 1 | `budget-refused` collapsed into `cli-failed` | 2 |
| 2 | `isClaimFailure` fail-silent on a null reason | 2 |
| 3 | the result collapsed back to `{won:false, generation:null}` | 11 |
| 4 | `alwaysWarn` ignored | 1 |
| 5 | ⛔ **the gate records ONE reason for both outcomes** | **0 → SURVIVED** |
| 6 | scheduler warns unconditionally (branch collapsed) | 1 |

⛔ **#5 is the pre-CTL-2033 behaviour exactly, and the first version of the wiring guard passed it.** Asserting that a gate *reads* `isClaimFailure` is not the same as asserting the answer *changes* — a gate can consult the discriminator and then write the same string either way. Fixed by asserting both reason literals survive in the gate window; #5 now fails. `grep -c MUTANT` = 0 in all three sources after restore.

All three test files verified registered in `execution-core-tests.yml`'s stable list **by parsing the YAML** (the list is a multi-line `run: |` block, so a `run:`-anchored grep returns a false "unregistered").

### Gate

Full stable list (235 files), run once at load 42, with an `origin/main` baseline in an identical bare worktree:

| | pass | fail | errors |
| --- | --- | --- | --- |
| `origin/main` (79874f2c7) | 7791 | 12 | 3 |
| this branch | **7819** (+28) | 12 | 3 |

**Identical failure sets** (`diff` of the sorted `✗` lines is empty). All 9 distinct failures are environmental — a bare git worktree has no `node_modules`, so `pino`, `@opentelemetry/sdk-trace-base` and the schema-copy probe are absent, plus the live-`linearis`/replica cases. CI installs deps and is authoritative.

## Reading it live

```
{service_name="catalyst.execution-core"} |= "ctl-879" | reason="claim-write-failed"
```
`claim_reason` = `budget-refused` confirms COORD-277's write-budget cause; anything else names a different bug.

Closes CTL-2033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
