### PR TITLE
fix(dev): COORD-236 — the 60-second cool-down that would have stopped the label storm already existed; it could not see a budget refusal

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1172,6 +1172,7 @@ jobs:
             integration-ctl-1240.test.mjs \
             integration.test.mjs \
             job-dir-gc.test.mjs \
+            label-budget-backoff.test.mjs \
             label-guard.test.mjs \
             linear-breaker.test.mjs \
             linear-ratelimit-event.test.mjs \

--- a/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
@@ -76,7 +76,11 @@ describe("COORD-236 classification: 'never' and 'not right now' are different an
   test("every budget refusal the proxy can emit is THROTTLED, not terminal", () => {
     // The proxy's classifyWrite gate has grown twice; matching by prefix is what
     // keeps a NEW budget reason from silently reading as "retryable next tick".
-    for (const r of ["budget:day-exhausted", "budget:per-ticket-cap", "budget:already-converged", "budget:something-nobody-has-written-yet"]) {
+    // The real constants are linear-write-budget.mjs's frozen REASONS. The last entry
+    // is deliberately NOT one of them: an unknown budget reason must still classify,
+    // which is the whole argument for matching by prefix. (FLEET's #3667 P3: this
+    // list used to say `budget:per-ticket-cap`, a string that does not exist.)
+    for (const r of ["budget:day-exhausted", "budget:ticket-cap", "budget:already-converged", "budget:something-nobody-has-written-yet"]) {
       expect(r.startsWith(BUDGET_REASON_PREFIX)).toBe(true);
       expect(isThrottledLabelReason(r)).toBe(true);
       expect(isTerminalLabelReason(r)).toBe(false);
@@ -88,6 +92,28 @@ describe("COORD-236 classification: 'never' and 'not right now' are different an
     expect(THROTTLED_LABEL_REASONS.has("rate-limited")).toBe(true);
     expect(shouldCoolDownLabel("rate-limited")).toBe(true);
     expect(isTerminalLabelReason("rate-limited")).toBe(false);
+  });
+
+  test("⛔ a 403 `unauthorized` is THROTTLED, never TERMINAL — the marker would outlive the re-mint", () => {
+    // FLEET's #3667 P2-b. It was in NEITHER class, so a 403 retried every tick and
+    // each attempt spent a host budget unit. Terminal would be worse than the storm:
+    // `.skipped` lives under workers/<ticket>/ and survives a restart, so it would
+    // outlive the credential fix that clears the 403.
+    expect(shouldCoolDownLabel("unauthorized")).toBe(true);
+    expect(isThrottledLabelReason("unauthorized")).toBe(true);
+    expect(isTerminalLabelReason("unauthorized")).toBe(false);
+    expect(TERMINAL_LABEL_REASONS.has("unauthorized")).toBe(false);
+  });
+
+  test("⚠️ Object.freeze does not seal a Set — the exact-contents assertions are what pin these", () => {
+    // Stated as a test rather than only as a comment, so the reassurance the
+    // `Object.freeze` wrapper gives a reader is calibrated: it seals the object's own
+    // properties, not the Set's contents. The two exact-contents cases above are the
+    // real guard.
+    expect(Object.isFrozen(TERMINAL_LABEL_REASONS)).toBe(true);
+    const probe = new Set(TERMINAL_LABEL_REASONS);
+    probe.add("x");
+    expect(probe.has("x")).toBe(true); // a frozen Set would still have accepted this
   });
 
   test("a genuinely transient reason is NEITHER — it must keep retrying next tick", () => {

--- a/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
@@ -1,0 +1,236 @@
+// label-budget-backoff.test.mjs — COORD-236.
+//
+// mini's admission converger re-issued `applyLabel` for the same three tickets
+// ~220 times each in 20 minutes and spent the host's ENTIRE 300-write daily
+// Linear budget by lunchtime on 2026-08-18. The exhausted budget then refused the
+// cross-host CLAIM writes, and 36 held tickets across both minis reported a lost
+// claim on tickets they owned (CTL-2033 / CTL-879). One retry loop froze fleet
+// dispatch for the rest of the UTC day.
+//
+// ⛔ The 60-second cool-down that would have stopped it ALREADY EXISTED (CTL-834).
+// It simply could not see a budget refusal: `UNRECOVERABLE_LABEL_REASONS` answers
+// "can this EVER land?", and a budget refusal answers "not right now" — a
+// different question. So the converger read "retryable next tick" and did exactly
+// that, for hours.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test label-budget-backoff.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  TERMINAL_LABEL_REASONS,
+  THROTTLED_LABEL_REASONS,
+  BUDGET_REASON_PREFIX,
+  isTerminalLabelReason,
+  isThrottledLabelReason,
+  shouldCoolDownLabel,
+} from "./label-failure-class.mjs";
+import { convergeHeldLabel, convergeDispositionLabel } from "./scheduler.mjs";
+import { labelOnce } from "./label-guard.mjs";
+
+let orchDir;
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "coord236-"));
+});
+
+/** labelOnce writes its marker under workers/<ticket>/, which production always
+ *  has by the time it runs. Create it, or every marker write silently ENOENTs
+ *  inside labelOnce's try/catch and the test measures nothing. */
+function withWorkerDir(ticket) {
+  mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+  return ticket;
+}
+afterEach(() => {
+  try {
+    rmSync(orchDir, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+/** a writeStatus double whose applyLabel always fails with `reason`, counting calls. */
+function failingWriter(reason) {
+  const calls = [];
+  return {
+    calls,
+    applyLabel({ ticket, label }) {
+      calls.push({ ticket, label });
+      return { applied: false, reason };
+    },
+    removeLabel() {},
+  };
+}
+
+describe("COORD-236 classification: 'never' and 'not right now' are different answers", () => {
+  test("the terminal set is exactly the three CTL-834/CTL-1085 reasons", () => {
+    expect([...TERMINAL_LABEL_REASONS].sort()).toEqual([
+      "exclusive-conflict",
+      "missing-label",
+      "team-mismatch",
+    ]);
+  });
+
+  test("every budget refusal the proxy can emit is THROTTLED, not terminal", () => {
+    // The proxy's classifyWrite gate has grown twice; matching by prefix is what
+    // keeps a NEW budget reason from silently reading as "retryable next tick".
+    for (const r of ["budget:day-exhausted", "budget:per-ticket-cap", "budget:already-converged", "budget:something-nobody-has-written-yet"]) {
+      expect(r.startsWith(BUDGET_REASON_PREFIX)).toBe(true);
+      expect(isThrottledLabelReason(r)).toBe(true);
+      expect(isTerminalLabelReason(r)).toBe(false);
+      expect(shouldCoolDownLabel(r)).toBe(true);
+    }
+  });
+
+  test("a 429 rate-limit is THROTTLED — re-issuing into it next tick is the same storm", () => {
+    expect(THROTTLED_LABEL_REASONS.has("rate-limited")).toBe(true);
+    expect(shouldCoolDownLabel("rate-limited")).toBe(true);
+    expect(isTerminalLabelReason("rate-limited")).toBe(false);
+  });
+
+  test("a genuinely transient reason is NEITHER — it must keep retrying next tick", () => {
+    // `transient` / `verify-failed` are cheap to retry and self-correct fast;
+    // cooling them down for 60 s would delay every legitimate recovery.
+    for (const r of ["transient", "verify-failed", null, undefined, "", 42]) {
+      expect(shouldCoolDownLabel(r)).toBe(false);
+    }
+  });
+});
+
+describe("COORD-236: the converger backs off on a budget refusal", () => {
+  // The measured storm: three tickets × ~220 applies in 20 minutes.
+  test("convergeHeldLabel issues ONE apply, then makes ZERO writes for the cool-down window", () => {
+    const w = failingWriter("budget:day-exhausted");
+    let clock = 1_000_000;
+    const opts = { orchDir, now: () => clock };
+    // Tick 1: the write is attempted and fails.
+    expect(convergeHeldLabel("CTL-1", [], "needs-human", w, opts)).toBe(1);
+    expect(w.calls.length).toBe(1);
+    // Ticks 2..60, one per second inside the 60 s window: ZERO further writes.
+    for (let i = 0; i < 59; i++) {
+      clock += 1_000;
+      convergeHeldLabel("CTL-1", [], "needs-human", w, opts);
+    }
+    expect(w.calls.length).toBe(1);
+  });
+
+  test("...and retries once the window elapses — the back-off is time-boxed, never permanent", () => {
+    // ⛔ The critical half. A budget refusal clears at 00:00 UTC without anyone
+    // doing anything; a back-off that never expired would abandon the label.
+    const w = failingWriter("budget:day-exhausted");
+    let clock = 1_000_000;
+    const opts = { orchDir, now: () => clock };
+    convergeHeldLabel("CTL-1", [], "needs-human", w, opts);
+    expect(w.calls.length).toBe(1);
+    clock += 61_000;
+    convergeHeldLabel("CTL-1", [], "needs-human", w, opts);
+    expect(w.calls.length).toBe(2);
+  });
+
+  test("convergeDispositionLabel backs off on the same reason", () => {
+    const w = failingWriter("budget:day-exhausted");
+    let clock = 1_000_000;
+    const opts = { orchDir, now: () => clock };
+    expect(convergeDispositionLabel("CTL-2", [], "queued", w, opts)).toBe(1);
+    for (let i = 0; i < 30; i++) {
+      clock += 1_000;
+      convergeDispositionLabel("CTL-2", [], "queued", w, opts);
+    }
+    expect(w.calls.length).toBe(1);
+  });
+
+  test("REGRESSION SHAPE: without the fix this is ~60 writes, not 1", () => {
+    // The pre-COORD-236 behaviour, expressed as the number it produced. A
+    // `transient` reason is NOT cooled down, so this is the storm the budget
+    // reason used to be part of — and it doubles as a positive control that the
+    // harness really does drive 60 ticks.
+    const w = failingWriter("transient");
+    let clock = 1_000_000;
+    const opts = { orchDir, now: () => clock };
+    for (let i = 0; i < 60; i++) {
+      convergeHeldLabel("CTL-3", [], "needs-human", w, opts);
+      clock += 1_000;
+    }
+    expect(w.calls.length).toBe(60);
+  });
+
+  test("a TERMINAL reason still cools down — the widening removed nothing", () => {
+    const w = failingWriter("missing-label");
+    let clock = 1_000_000;
+    const opts = { orchDir, now: () => clock };
+    convergeHeldLabel("CTL-4", [], "needs-human", w, opts);
+    clock += 1_000;
+    convergeHeldLabel("CTL-4", [], "needs-human", w, opts);
+    expect(w.calls.length).toBe(1);
+  });
+});
+
+describe("⛔ COORD-236: labelOnce must NOT treat a throttled reason as permanent", () => {
+  // The asymmetry is the whole point of two predicates. `.skipped` is forever;
+  // a budget refusal is not. Folding them would permanently abandon a
+  // needs-human label refused during one exhausted minute — the operator it
+  // exists to page would never be paged. That is strictly worse than the storm.
+  test("a budget refusal writes NO .skipped marker, so the next tick retries", () => {
+    const w = failingWriter("budget:day-exhausted");
+    withWorkerDir("CTL-5");
+    expect(labelOnce(orchDir, "CTL-5", "needs-human", w)).toBe(true);
+    expect(w.calls.length).toBe(1);
+    // No terminal marker ⇒ labelOnce runs the write again.
+    expect(labelOnce(orchDir, "CTL-5", "needs-human", w)).toBe(true);
+    expect(w.calls.length).toBe(2);
+  });
+
+  test("a TERMINAL reason still writes .skipped and stops — unchanged", () => {
+    const w = failingWriter("missing-label");
+    withWorkerDir("CTL-6");
+    expect(labelOnce(orchDir, "CTL-6", "needs-human", w)).toBe(true);
+    expect(labelOnce(orchDir, "CTL-6", "needs-human", w)).toBe(false);
+    expect(w.calls.length).toBe(1);
+  });
+
+  test("the two predicates are NOT the same function — a merge is caught here", () => {
+    // If someone "simplifies" labelOnce onto shouldCoolDownLabel, this fails.
+    expect(isTerminalLabelReason("budget:day-exhausted")).toBe(false);
+    expect(shouldCoolDownLabel("budget:day-exhausted")).toBe(true);
+  });
+});
+
+// ── WIRING GUARD ─────────────────────────────────────────────────────────────
+// The classifier is worthless if a converger still consults the narrow set.
+describe("COORD-236 wiring: the cool-down is armed by the WIDE predicate", () => {
+  const SCHED = readFileSync(join(import.meta.dir, "scheduler.mjs"), "utf8");
+  const GUARD = readFileSync(join(import.meta.dir, "label-guard.mjs"), "utf8");
+
+  test("both converger arming sites call shouldCoolDownLabel", () => {
+    const armings = SCHED.split("\n").filter((l) => l.includes("recordLabelCooldown(orchDir, ticket, desired"));
+    expect(armings.length).toBe(2);
+    // Each arming is guarded by the wide predicate on the line above it.
+    const lines = SCHED.split("\n");
+    for (const [i, l] of lines.entries()) {
+      if (!l.includes("recordLabelCooldown(orchDir, ticket, desired")) continue;
+      expect(lines.slice(Math.max(0, i - 3), i).join("\n")).toContain("shouldCoolDownLabel");
+    }
+  });
+
+  test("neither file re-declares its own copy of the terminal set", () => {
+    // The two files carried byte-identical hand-written copies; one owner now.
+    for (const src of [SCHED, GUARD]) {
+      expect(src).not.toContain('new Set([\n  "missing-label",');
+      expect(src).toContain("TERMINAL_LABEL_REASONS");
+    }
+  });
+
+  test("label-guard does not IMPORT the wide predicate — the asymmetry is structural", () => {
+    // Asserted on the import statement, not on the file text: the header
+    // deliberately NAMES `shouldCoolDownLabel` to explain why it is not used
+    // here, and a prose match would make that explanation fail the build.
+    const imports = GUARD.split("\n").filter((l) => /^import /.test(l));
+    expect(imports.join("\n")).toContain("TERMINAL_LABEL_REASONS");
+    expect(imports.join("\n")).not.toContain("shouldCoolDownLabel");
+    // ...and no code line calls it.
+    const code = GUARD.split("\n").filter((l) => !l.trimStart().startsWith("//"));
+    expect(code.join("\n")).not.toContain("shouldCoolDownLabel(");
+  });
+});

--- a/plugins/dev/scripts/execution-core/label-failure-class.mjs
+++ b/plugins/dev/scripts/execution-core/label-failure-class.mjs
@@ -49,9 +49,18 @@ export const TERMINAL_LABEL_REASONS = Object.freeze(
 );
 
 /**
- * BUDGET_REASON_PREFIX — every host-budget refusal the write proxy emits shares
- * this prefix (`linear-write-proxy.mjs`'s `classifyWrite` gate:
- * `budget:day-exhausted`, `budget:per-ticket-cap`, `budget:already-converged`).
+ * BUDGET_REASON_PREFIX — every host-budget refusal shares this prefix. The real
+ * members are `linear-write-budget.mjs`'s frozen `REASONS`: `budget:day-exhausted`,
+ * `budget:ticket-cap`, `budget:already-converged`.
+ *
+ * ⚠️ A `budget:*` refusal is raised by THIS HOST'S OWN LEDGER before the request
+ * is sent — it does NOT mean the cloud refused anything. The ledger counts writes
+ * that LEFT the host and gates them against `DEFAULT_DAILY_BUDGET`, a constant its
+ * own doc-comment calls "the cloud-side daily cap this MIRRORS". Attempts, not
+ * arrivals. On 2026-08-18 the host ledger read 300 with 674 refusals while the
+ * cloud's `/admin/write-budget` for the same key read 3 of 300, and a P1 to raise
+ * the cloud cap was issued on that misreading and then refused after measurement.
+ * Read `~/catalyst/linear-write-budget.json` on the HOST. Defect: CTL-2035.
  *
  * Matched by PREFIX rather than enumerated, deliberately: the gate's reason set
  * has grown twice, and an enumeration that falls behind fails in the SILENT

--- a/plugins/dev/scripts/execution-core/label-failure-class.mjs
+++ b/plugins/dev/scripts/execution-core/label-failure-class.mjs
@@ -1,0 +1,96 @@
+// label-failure-class.mjs — ONE classification of `applyLabel`'s failure reasons,
+// and the answer to a single question: may this write be re-issued on the very
+// next tick, or must the caller back off?
+//
+// ⛔ THE MEASURED DEFECT (COORD-236, 2026-08-18). mini's admission converger
+// re-issued `applyLabel` for the same three tickets ~220 times each in 20 minutes
+// and spent the host's ENTIRE 300-write daily Linear budget by lunchtime. The
+// downstream damage was not the labels: the exhausted budget then refused the
+// cross-host CLAIM writes, and 36 held tickets across both minis reported a lost
+// claim on tickets they owned (CTL-2033/CTL-879). One retry loop froze fleet
+// dispatch for the rest of the UTC day.
+//
+// ⛔ WHY THE EXISTING GUARD DID NOT FIRE. `convergeHeldLabel` and
+// `convergeDispositionLabel` already arm a 60-second, time-boxed cool-down
+// (CTL-834) — but ONLY for reasons in `UNRECOVERABLE_LABEL_REASONS`, a set
+// written before the write proxy existed. A budget refusal
+// (`budget:day-exhausted`) and a rate-limit (`rate-limited`) are in NEITHER set,
+// so the converger read "retryable next tick" and did exactly that, every tick,
+// for hours. The mechanism COORD-236 asked for ("≤1 retry per minute") was
+// already built and simply could not see the reason that needed it.
+//
+// ⚠️ THE TWO CLASSES ARE NOT THE SAME AND MUST NOT BE MERGED.
+//
+//   TERMINAL   — cannot land this daemon lifetime (the workspace has no such
+//                label; an exclusive sibling holds the slot; the name resolved
+//                against the wrong team). Correct response: STOP retrying, and
+//                for `labelOnce`, write the permanent `.skipped` marker.
+//
+//   THROTTLED  — will land later without anyone doing anything: the host budget
+//                rolls at 00:00 UTC, an operator lifts a limit, a rate-limit
+//                window passes. Correct response: back off, then retry.
+//
+// ⛔ Writing `.skipped` for a THROTTLED reason would be a strictly WORSE bug than
+// the storm: a `needs-human` label refused during one exhausted minute would be
+// permanently abandoned for the rest of the daemon's life, and the operator it
+// exists to page would never be paged. `labelOnce` therefore takes ONLY the
+// terminal set — that is the reason these are two exported predicates and not one
+// "should I back off" boolean, and there is a test pinning it.
+
+/**
+ * TERMINAL_LABEL_REASONS — cannot land this daemon lifetime (CTL-834).
+ *
+ * "team-mismatch" was split out of "missing-label" by CTL-1085 and MUST stay
+ * here: dropping it loses the cool-down on cross-team label failures and
+ * re-introduces the original per-tick retry storm.
+ */
+export const TERMINAL_LABEL_REASONS = Object.freeze(
+  new Set(["missing-label", "exclusive-conflict", "team-mismatch"]),
+);
+
+/**
+ * BUDGET_REASON_PREFIX — every host-budget refusal the write proxy emits shares
+ * this prefix (`linear-write-proxy.mjs`'s `classifyWrite` gate:
+ * `budget:day-exhausted`, `budget:per-ticket-cap`, `budget:already-converged`).
+ *
+ * Matched by PREFIX rather than enumerated, deliberately: the gate's reason set
+ * has grown twice, and an enumeration that falls behind fails in the SILENT
+ * direction — the new reason reads as "retryable next tick" and the storm comes
+ * back with no test failing. A prefix cannot fall behind.
+ */
+export const BUDGET_REASON_PREFIX = "budget:";
+
+/**
+ * THROTTLED_LABEL_REASONS — the non-budget reasons that also need a cool-down.
+ * `rate-limited` is the cloud's own 429 (`classifyProxyResponse`) and the
+ * linearis rate-cap (`classifyLabelFailure`); re-issuing into a 429 next tick is
+ * the same storm by another name.
+ */
+export const THROTTLED_LABEL_REASONS = Object.freeze(new Set(["rate-limited"]));
+
+/** isTerminalLabelReason — may never land this run; stop retrying entirely. */
+export function isTerminalLabelReason(reason) {
+  return typeof reason === "string" && TERMINAL_LABEL_REASONS.has(reason);
+}
+
+/** isThrottledLabelReason — will land later on its own; back off, then retry. */
+export function isThrottledLabelReason(reason) {
+  if (typeof reason !== "string") return false;
+  return reason.startsWith(BUDGET_REASON_PREFIX) || THROTTLED_LABEL_REASONS.has(reason);
+}
+
+/**
+ * shouldCoolDownLabel — should the caller arm the time-boxed cool-down?
+ *
+ * TRUE for both classes, because the cool-down is the right response to each:
+ * it is time-boxed and self-healing, so a terminal reason simply re-fails after
+ * the window (and `labelOnce`'s permanent marker is what actually stops those),
+ * while a throttled reason gets exactly the "≤1 retry per minute" COORD-236
+ * asked for.
+ *
+ * ⚠️ Deliberately NOT the predicate `labelOnce` uses. See the header: `.skipped`
+ * is permanent, and a throttled reason must never earn it.
+ */
+export function shouldCoolDownLabel(reason) {
+  return isTerminalLabelReason(reason) || isThrottledLabelReason(reason);
+}

--- a/plugins/dev/scripts/execution-core/label-failure-class.mjs
+++ b/plugins/dev/scripts/execution-core/label-failure-class.mjs
@@ -71,11 +71,26 @@ export const BUDGET_REASON_PREFIX = "budget:";
 
 /**
  * THROTTLED_LABEL_REASONS — the non-budget reasons that also need a cool-down.
- * `rate-limited` is the cloud's own 429 (`classifyProxyResponse`) and the
- * linearis rate-cap (`classifyLabelFailure`); re-issuing into a 429 next tick is
- * the same storm by another name.
+ *
+ * `rate-limited` is the cloud's own 429 (`classifyProxyResponse`) and the linearis
+ * rate-cap (`classifyLabelFailure`); re-issuing into a 429 next tick is the same
+ * storm by another name.
+ *
+ * `unauthorized` is the cloud's 403 (`linear-write-proxy.mjs`'s
+ * `classifyProxyResponse`). ⛔ IT BELONGS HERE AND NOT IN THE TERMINAL SET, and the
+ * reason is the marker's lifetime: `labelOnce`'s `.skipped` lives under
+ * `workers/<ticket>/` and SURVIVES A RESTART, so a terminal classification would
+ * outlive the very re-mint that clears the 403 — the label would stay unwritten
+ * after the credential was fixed. "Not right now" is the honest reading of an auth
+ * failure a human is about to repair. Found by FLEET's peer read on #3667; it was in
+ * NEITHER class, so a 403 retried every tick and each attempt spent a budget unit.
+ *
+ * ⚠️ `Object.freeze` on a Set does NOT prevent `.add()`/`.delete()` — it only seals
+ * the object's own properties. It is kept as a statement of intent; the thing that
+ * actually pins these contents is the exact-contents test in
+ * `label-budget-backoff.test.mjs`. Same caveat applies to TERMINAL_LABEL_REASONS.
  */
-export const THROTTLED_LABEL_REASONS = Object.freeze(new Set(["rate-limited"]));
+export const THROTTLED_LABEL_REASONS = Object.freeze(new Set(["rate-limited", "unauthorized"]));
 
 /** isTerminalLabelReason — may never land this run; stop retrying entirely. */
 export function isTerminalLabelReason(reason) {

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -22,6 +22,7 @@ import { log } from "./config.mjs";
 import { coerceExplanation } from "./escalation-explanation.mjs";
 import { DISPOSITIONS } from "./worker-disposition.mjs";
 import { YIELDED_STATUS } from "../lib/phase-yield.mjs"; // CTL-1854
+import { TERMINAL_LABEL_REASONS } from "./label-failure-class.mjs"; // COORD-236: one owner for the terminal set
 
 // ─── labelOnce — moved from scheduler.mjs (CTL-585, then CTL-638 re-home) ───
 //
@@ -49,16 +50,21 @@ export function labelMarkerBase(orchDir, ticket, label) {
   return join(orchDir, "workers", ticket, `.linear-label-${label}`);
 }
 
-// UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
-// daemon lifetime (CTL-834); labelOnce writes its .skipped marker for these to
-// stop the per-tick retry storm. "missing-label": the workspace lacks the label;
-// "exclusive-conflict": the label's exclusive-group sibling is already present;
-// "team-mismatch": name resolution used the wrong team's UUID context (CTL-1085).
-const UNRECOVERABLE_LABEL_REASONS = new Set([
-  "missing-label",
-  "exclusive-conflict",
-  "team-mismatch",
-]);
+// UNRECOVERABLE_LABEL_REASONS — the TERMINAL class, now owned by
+// label-failure-class.mjs (scheduler.mjs carried a byte-identical hand-written
+// copy of this set; one owner, two readers). Kept under its original name so
+// every existing reader here still resolves.
+//
+// ⛔ COORD-236 — READ THIS BEFORE WIDENING THE SET. `.skipped` is a PERMANENT
+// marker: labelOnce early-returns for the rest of the daemon's life once it
+// exists. So this predicate must stay TERMINAL-only. Adding the budget/rate-limit
+// class here — the tempting "fix" for the same incident that motivated the
+// converger's cool-down — would permanently abandon a `needs-human` label refused
+// during one exhausted minute, and the operator it exists to page would never be
+// paged. The converger uses the WIDER `shouldCoolDownLabel` because its cool-down
+// is time-boxed and self-healing; this marker is not. There is a test pinning the
+// asymmetry.
+const UNRECOVERABLE_LABEL_REASONS = TERMINAL_LABEL_REASONS;
 
 // CTL-936: labelOnce now accepts an optional `appendEvent` seam. When provided
 // AND CATALYST_INTENTS_ENFORCE=1, an unrecoverable label-write failure emits an

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -420,6 +420,12 @@ import {
 } from "../broker/broker-state.mjs"; // CTL-1290: board snapshot (reads only). bun:sqlite-backed — safe here: scheduler.mjs is daemon-only and NOT in the orch-monitor vite/UI graph (see MEMORY vite_config_bun_sqlite_trap). CTL-1157: getAllPrStatuses = the filter_state PR-lifecycle reader for the phantom/orphaned-PR invariants. openBrokerStateDb (CTL-1157 Codex round-6): the exec-core daemon must open the broker DB handle before these readers — ensure() throws otherwise and assembleBoardState swallows it, leaving the board/PR maps empty and the cohorts inert.
 import { readReconcileHealthMarkers } from "./reconcile-health.mjs"; // CTL-1290: stranded-node reconcile signal
 import { claimDispatchSync, isClaimFailure } from "./cluster-claim-sync.mjs"; // CTL-850: cross-host claim soft-CAS (CTL-2033: + the outcome discriminator)
+// COORD-236: one owner for "may this label write be re-issued next tick?"
+import {
+  TERMINAL_LABEL_REASONS,
+  shouldCoolDownLabel,
+  isThrottledLabelReason,
+} from "./label-failure-class.mjs";
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
 import {
@@ -2579,28 +2585,34 @@ export function convergeHeldLabel(
         );
       }
     }
-    if (orchDir && res && res.applied === false && UNRECOVERABLE_LABEL_REASONS.has(res.reason)) {
+    if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
       recordLabelCooldown(orchDir, ticket, desired, now());
+      // COORD-236: the two classes get DIFFERENT sentences, because an operator
+      // reading "unrecoverable" for a budget refusal would go looking for a
+      // missing label that is not missing.
+      const throttled = isThrottledLabelReason(res.reason);
       log.warn(
-        { ticket, label: desired, reason: res.reason },
-        "ctl-834: held-label apply unrecoverable — backing off (cool-down)"
+        { ticket, label: desired, reason: res.reason, label_failure_class: throttled ? "throttled" : "terminal" },
+        throttled
+          ? "coord-236: held-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses"
+          : "ctl-834: held-label apply unrecoverable — backing off (cool-down)"
       );
     }
   }
   return writes;
 }
 
-// UNRECOVERABLE_LABEL_REASONS — applyLabel reasons that can never land this
-// daemon lifetime, so convergeHeldLabel arms a cool-down instead of re-issuing
-// the write every tick (CTL-834). Mirrors label-guard.labelOnce's .skipped set.
-// "team-mismatch": CTL-1085 split it out of "missing-label" in classifyLabelFailure;
-// it MUST stay in this set or convergeHeldLabel loses its cool-down on cross-team
-// (ADV) label failures and re-introduces the CTL-834 per-tick retry storm.
-const UNRECOVERABLE_LABEL_REASONS = new Set([
-  "missing-label",
-  "exclusive-conflict",
-  "team-mismatch",
-]);
+// UNRECOVERABLE_LABEL_REASONS — the TERMINAL class, now owned by
+// label-failure-class.mjs so this file and label-guard.mjs cannot drift apart
+// (they carried byte-identical hand-written copies). Kept under its original
+// name so every existing reader of this identifier still resolves.
+//
+// ⛔ COORD-236: this set was never the whole answer, and reading it as such is
+// what cost the fleet a day's write budget. It answers "can this EVER land?" —
+// a budget refusal answers "not right now", which is a different question, and
+// falling out of this set meant the converger re-issued the write every tick for
+// hours. `shouldCoolDownLabel` is the predicate the cool-down actually wants.
+const UNRECOVERABLE_LABEL_REASONS = TERMINAL_LABEL_REASONS;
 
 // convergeDispositionLabel — generalised version of convergeHeldLabel covering the
 // full worker-status disposition set (CTL-764 Phase 4). Like convergeHeldLabel it
@@ -2656,11 +2668,14 @@ export function convergeDispositionLabel(
       );
     }
     writes++;
-    if (orchDir && res && res.applied === false && UNRECOVERABLE_LABEL_REASONS.has(res.reason)) {
+    if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
       recordLabelCooldown(orchDir, ticket, desired, now());
+      const throttled = isThrottledLabelReason(res.reason);
       log.warn(
-        { ticket, label: desired, reason: res.reason },
-        "ctl-764: disposition-label apply unrecoverable — backing off (cool-down)"
+        { ticket, label: desired, reason: res.reason, label_failure_class: throttled ? "throttled" : "terminal" },
+        throttled
+          ? "coord-236: disposition-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses"
+          : "ctl-764: disposition-label apply unrecoverable — backing off (cool-down)"
       );
     }
   }


### PR DESCRIPTION
## The incident

mini's admission converger re-issued `applyLabel` for the same **three tickets ~220 times each in 20 minutes** on 2026-08-18 and spent the host's entire **300-write daily Linear budget by lunchtime** (COORD-236). The downstream damage was not the labels: the exhausted budget then refused the cross-host **claim** writes, and **36 held tickets across both minis** reported a lost claim on tickets they own under HRW (CTL-2033 / CTL-879). **One retry loop froze fleet dispatch for the rest of the UTC day.**

## ⛔ The guard was already built — it could not see the reason

`convergeHeldLabel` and `convergeDispositionLabel` arm a **60-second, time-boxed** cool-down (CTL-834). `LABEL_COOLDOWN_MS` is `60_000` — literally COORD-236's "≤1 retry per minute". It arms only for reasons in `UNRECOVERABLE_LABEL_REASONS`, a set written before the write proxy existed:

```js
const UNRECOVERABLE_LABEL_REASONS = new Set(["missing-label", "exclusive-conflict", "team-mismatch"]);
```

That set answers **"can this EVER land?"**. A budget refusal answers **"not right now"** — a different question. `budget:day-exhausted` is in neither the unrecoverable set nor any other special case, so the converger read "retryable next tick" and did exactly that, every tick, for hours.

## The change

New leaf `label-failure-class.mjs` owns **both** classes:

| class | members | correct response |
| --- | --- | --- |
| **TERMINAL** | `missing-label`, `exclusive-conflict`, `team-mismatch` | stop retrying; `labelOnce` writes the permanent `.skipped` |
| **THROTTLED** | `budget:*` (**by prefix**), `rate-limited` | back off, then retry — it lands later with nobody doing anything |

`budget:*` is matched **by prefix, not enumeration**: the proxy's `classifyWrite` gate reasons have grown twice, and an enumeration that falls behind fails in the **silent** direction — a new budget reason reads as "retryable next tick" and the storm returns with no test failing.

`scheduler.mjs` and `label-guard.mjs` carried **byte-identical hand-written copies** of the terminal set; both now read the one owner. Both converger arming sites use the wide `shouldCoolDownLabel` and log `label_failure_class` with a class-appropriate sentence — an operator told "unrecoverable" for a budget refusal goes hunting for a missing label that is not missing.

## ⛔ Why `labelOnce` deliberately keeps the NARROW predicate

Its `.skipped` marker is **permanent** — `labelOnce` early-returns for the rest of the daemon's life once it exists. Folding the throttled class in there is the tempting one-line "fix" for this same incident, and it would be **strictly worse than the storm**: a `needs-human` label refused during one exhausted minute would be permanently abandoned, and the operator it exists to page would never be paged. That asymmetry is why there are two exported predicates and not one boolean, and there is a test pinning it (`the two predicates are NOT the same function — a merge is caught here`).

## Testing

Four mutations, each must fail:

| mutation | fails |
| --- | --- |
| revert the arming to the narrow set (**the actual defect**) | 3 |
| match budget reasons by enumeration instead of prefix | 1 |
| fold `labelOnce` onto the wide predicate | 1 |
| make the cool-down permanent (never expires) | 1 |

The suite also carries the regression *shape* as a number: a non-cooled reason driven over 60 one-second ticks produces **60 writes**, the cooled one produces **1** — which doubles as a positive control that the harness really drives 60 ticks rather than asserting `1` against a loop that never ran.

`label-budget-backoff.test.mjs` registered in `execution-core-tests.yml`'s stable list, verified by **parsing the YAML** (the list is a multi-line `run: |` block, so a `run:`-anchored grep returns a false "unregistered"), and the file re-parsed as YAML after the edit.

### Gate

Full stable list (236 files) run once at load 11, against an `origin/main` baseline in an identical bare worktree:

| | pass | fail | errors |
| --- | --- | --- | --- |
| `origin/main` (79874f2c7) | 7791 | 12 | 3 |
| this branch | **7806** (+15) | 12 | 3 |

**Identical failure sets** — all environmental (a bare worktree has no `node_modules`, so `pino` / `@opentelemetry/sdk-trace-base` / the schema-copy probe are absent, plus the live-`linearis` and replica cases). CI installs deps and is authoritative.

## What this does NOT fix

The cool-down stops the **post-exhaustion re-issue storm**. It does not by itself explain the **first 300 writes** — the converger only re-issues because the label never appears in `current` on the following tick, so something upstream is either not landing the label or reading back a stale label set. That is a separate question and it is called out here rather than quietly assumed away.

Relates to COORD-236, CTL-2033, CTL-879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
