### PR TITLE
fix(dev): CTL-2030 — doctor graded whether smee was CONFIGURED, so after the cutover it reported a dead route as wired

### DIFF
--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -45,7 +45,14 @@ import { spawnSync, execFileSync } from "node:child_process";
 // REJECTS). The alternative was a hand-maintained copy here, which would keep
 // reporting three uncovered names after CTC-691/CTC-667/CTC-704 close.
 import { resolveGithubFeedMode } from "../lib/github-feed-mode.mjs";
-import { GITHUB_CONSUMED_NAMES, GITHUB_SUPPRESSIBLE_NAMES } from "../lib/github-feed-names.mjs";
+import {
+  GITHUB_CONSUMED_NAMES,
+  GITHUB_SUPPRESSIBLE_NAMES,
+  resolveGithubFeedAccount, // CTL-2030: hoisted here so bare-node doctor shares the producer's answer
+} from "../lib/github-feed-names.mjs";
+// CTL-2030: the producer's readiness heartbeat. `github-feed-ready.mjs` imports only
+// node:fs + node:path, so it loads under bare node (unlike github-feed-gate.mjs).
+import { defaultReadyPath, readReadyState } from "./github-feed-ready.mjs";
 import {
   getHostName,
   getClusterHosts,
@@ -1174,6 +1181,45 @@ function defaultLinearSecretEnvName() {
   }
 }
 
+// defaultReadGithubFeedReady — read the GitHub-feed producer's readiness heartbeat.
+//
+// ⛔ THE PATH IS RESOLVED THE PRODUCER'S WAY, NOT THE READER'S. CTL-1976 already paid
+// for this once: the broker derived the readiness path from ITS orchDir
+// (`~/catalyst/shadow/...`) while the daemon wrote `~/catalyst/execution-core/shadow/...`,
+// and the miss is silent because `readReadyState` answers `ready:false` for an absent
+// file — indistinguishable from "the producer is down". Same rule for the ACCOUNT: it
+// comes from the hoisted `resolveGithubFeedAccount`, the one the producer itself calls.
+//
+// Returns the verdict object unchanged (`{ ready, reason, state }`) plus the path it
+// looked at, because "I could not look" and "it is not there" must be separable in the
+// message — a check that cannot tell those apart is the class this ticket is about.
+function defaultReadGithubFeedReady() {
+  const path = defaultReadyPath(getExecutionCoreDir(), resolveGithubFeedAccount());
+  try {
+    return { ...readReadyState(path), path };
+  } catch (err) {
+    return { ready: false, reason: `ready-read-threw:${err?.message ?? "unknown"}`, state: null, path };
+  }
+}
+
+// githubFeedCoverageFromReady — the RUNTIME coverage, read off the producer's own
+// heartbeat (CTL-2030). Returns null when the record predates this field or the tick
+// threw; callers must treat null as UNKNOWN and must NOT fall back to
+// GITHUB_SUPPRESSIBLE_NAMES, which is the frozen constant whose staleness is half of
+// what this ticket fixes.
+function githubFeedCoverageFromReady(state) {
+  const c = state?.coverage;
+  if (!c || typeof c !== "object") return null;
+  const suppressible = Number(c.suppressible);
+  const consumed = Number(c.consumed);
+  if (!Number.isFinite(suppressible) || !Number.isFinite(consumed)) return null;
+  return {
+    suppressible,
+    consumed,
+    uncovered: Array.isArray(c.uncovered) ? c.uncovered : [],
+  };
+}
+
 export function checkWebhookIngestion(deps = {}) {
   const {
     resolveRoster = resolveClusterHosts,
@@ -1201,6 +1247,10 @@ export function checkWebhookIngestion(deps = {}) {
     // it, and driving it through the real env would make these tests mutate a
     // process-wide flag that four readers in three processes consult.
     resolveGithubFeedModeFn = resolveGithubFeedMode,
+    // CTL-2030: the producer's readiness heartbeat, and the ONLY evidence this check
+    // has about whether the live GitHub route is actually delivering. Injectable for
+    // the same reason the two resolvers above are.
+    readGithubFeedReadyFn = defaultReadGithubFeedReady,
   } = deps;
 
   const roster = resolveRoster();
@@ -1235,7 +1285,62 @@ export function checkWebhookIngestion(deps = {}) {
     githubSecretEnvName === "CATALYST_WEBHOOK_SECRET" &&
     secretFileNonEmpty(configDir, "webhook-secret");
   const ghSecret = ghEnvSecret || ghFileSecret;
-  const githubWired = ghSmee.length > 0 && ghSecret;
+  const smeeWired = ghSmee.length > 0 && ghSecret;
+
+  // ─── CTL-2030: grade the route this host ACTUALLY USES ─────────────────────
+  //
+  // ⛔ THE FEED MODE IS NOW RESOLVED UNCONDITIONALLY. It used to be read only inside
+  // the declared-`cloud` branch, so on the two production minis — which declare
+  // `cluster`, not `cloud` — this check never looked at the feed at all and reported
+  //
+  //     [PASS] webhook-ingestion: webhook ingestion wired (github=true, ...)
+  //
+  // while BOTH hosts received zero GitHub webhooks: the tunnel is suppressed at
+  // `enforce` and all eight webhooks are `active:false` (CTL-1929, 17:36 CT
+  // 2026-08-18). `githubWired` is CONFIGURATION PRESENCE — smeeChannel + an HMAC
+  // secret — and both are deliberately retained because they are the rollback lever.
+  // So the check answered "is the smee route configured?" (yes, on purpose) and
+  // printed it as "ingestion wired".
+  //
+  // ⛔ That is not merely cosmetic, and the second failure is the one that matters:
+  // if the FEED breaks on an enforce host, this check still PASSes, because it never
+  // looks at the feed. The one condition under which GitHub ingestion is actually
+  // dead is the one condition it could not detect.
+  //
+  // A throwing resolver grades as `off` — the pre-cutover reading — for the same
+  // fail-closed reason the declared-cloud branch already used: an unreadable config
+  // must never be why doctor tells an operator the route is whole.
+  let ghFeed;
+  try {
+    ghFeed = resolveGithubFeedModeFn();
+  } catch {
+    ghFeed = { mode: "off", source: "resolver-threw" };
+  }
+  // At `enforce` the smee wiring is INERT: the tunnel is suppressed and the webhooks
+  // are disabled, so its configuration says nothing about whether events arrive.
+  const feedIsLiveRoute = ghFeed.mode === "enforce";
+  const githubWired = feedIsLiveRoute ? false : smeeWired;
+  // Read once. Consulted by the enforce branch below AND by the declared-cloud
+  // branch's runtime-coverage read, so a single read keeps the two from disagreeing
+  // about the same file within one run.
+  // Resolved once, here, because BOTH the enforce branch below and the
+  // no-route branch after it need it. Same fail-closed handling as before:
+  // an unresolvable mode keeps the original FAIL guarantee.
+  let declaredMode;
+  try {
+    declaredMode = resolveDeploymentModeFn();
+  } catch {
+    declaredMode = undefined;
+  }
+  const declaredTail = declaredMode?.recognized
+    ? ` [declared deployment mode "${declaredMode.mode}", source=${declaredMode.source}]`
+    : "";
+  let feedReady;
+  try {
+    feedReady = readGithubFeedReadyFn();
+  } catch (err) {
+    feedReady = { ready: false, reason: `ready-read-threw:${err?.message ?? "unknown"}`, state: null, path: null };
+  }
 
   // CTL-1616 PR2: shadow comparison for the github webhook-secret leg only —
   // the linear-webhook-secret family has no single scalar contract value (it's
@@ -1281,6 +1386,103 @@ export function checkWebhookIngestion(deps = {}) {
   const danglingKeys = webhookKeys.filter((k) => !keySecretWired(k));
   const linearWired = linSmee.length > 0 && wiredKeys.length > 0;
 
+  // ─── CTL-2030: the GitHub feed is the live route — grade IT ────────────────
+  //
+  // Placed before every smee-shaped branch below, because at `enforce` those
+  // branches are reasoning about a route that is deliberately dead: they would
+  // either PASS on retained rollback config (the live defect) or FAIL with
+  // "NO webhook route enabled", which is equally wrong in the other direction.
+  //
+  // ⚠️ THE THREE OUTCOMES ARE KEPT APART ON PURPOSE. "the feed is delivering",
+  // "the feed is NOT delivering", and "I could not observe the feed" are different
+  // answers, and collapsing the third into either of the others is the failure this
+  // whole ticket is about. An absent/unparseable/unstamped record means the producer
+  // never wrote one OR doctor is looking in the wrong directory (CTL-1976 shipped
+  // exactly that bug once) — that is INCONCLUSIVE, so it WARNs and names the path.
+  // A record we CAN read that says stale/unready/wrong-mode is a real negative and
+  // FAILs.
+  if (feedIsLiveRoute) {
+    // Config residue still fails, matching the declared-cloud branch's (a) rule: a
+    // dangling Linear webhookId without its secret is residue no mode excuses.
+    if (danglingKeys.length > 0) {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.FAIL,
+          `multiHost member with half-wired Linear webhook(s): ${danglingKeys.join(", ")} configured (webhookId) but missing HMAC secret file (linear-webhook-secret-<key>) — GitHub feed at enforce does not excuse config residue`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    const linTail = `linear(smee=${linSmee ? "set" : "unset"},wiredKeys=${wiredKeys.length})`;
+    // INCONCLUSIVE: we could not observe the producer at all.
+    if (feedReady.state === null) {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.WARN,
+          `GitHub feed is the live route (CATALYST_GITHUB_FEED=enforce, source=${ghFeed.source}) and smee is inert${declaredTail}, but the producer's readiness could NOT be observed: ${feedReady.reason} at ${feedReady.path ?? "(unresolved path)"} — this is "could not look", not "ingestion is fine"; ${linTail}`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    // ⛔ A FRESH RECORD WITH THE WRONG MODE READS HEALTHY UNLESS THIS IS CHECKED.
+    // The producer stamps the mode it RESOLVED (`mode.effective`), which degrades to
+    // shadow when enforce is not honourable. A host whose flag says enforce while its
+    // producer runs as shadow emits markers, not events — and its heartbeat is
+    // perfectly fresh the whole time.
+    const producerMode = feedReady.state?.mode ?? null;
+    if (feedReady.ready === true && producerMode !== "enforce") {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.FAIL,
+          `GitHub feed readers DISAGREE${declaredTail}: this host's flag resolves "enforce" (source=${ghFeed.source}) but the producer's readiness record says mode="${producerMode ?? "absent"}" — smee is suppressed while the producer is not emitting real github.* names; ${linTail}`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    if (feedReady.ready !== true) {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.FAIL,
+          `GitHub ingestion is DOWN${declaredTail}: the feed is the live route (enforce, source=${ghFeed.source}), smee is suppressed, and the producer is not ready — ${feedReady.reason} (${feedReady.path ?? "path unresolved"}); monitor-merge, CI waits and PR-lifecycle routing have no github.* source; ${linTail}`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    const rtCoverage = githubFeedCoverageFromReady(feedReady.state);
+    if (rtCoverage === null) {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.WARN,
+          `GitHub feed is live and the producer is ready (enforce, source=${ghFeed.source}), but its readiness record carries no runtime coverage — cannot confirm which consumed github.* names have a source; ${linTail}`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    if (rtCoverage.uncovered.length > 0) {
+      return [
+        mkCheck(
+          "webhook-ingestion",
+          STATUS.WARN,
+          `GitHub feed is live and ready (enforce, source=${ghFeed.source}) but covers ${rtCoverage.suppressible}/${rtCoverage.consumed} consumed github.* names — ${rtCoverage.uncovered.length} have NO source on this node: ${rtCoverage.uncovered.join(", ")}; ${linTail}`,
+        ),
+        ...webhookShadow,
+      ];
+    }
+    return [
+      mkCheck(
+        "webhook-ingestion",
+        STATUS.PASS,
+        `GitHub ingestion via the cloud feed at enforce (source=${ghFeed.source})${declaredTail}, producer ready, covering all ${rtCoverage.consumed} consumed github.* names; smee is intentionally inert (rollback lever retained: smee=${ghSmee ? "set" : "unset"}, secret=${ghSecret ? "set" : "unset"}); ${linTail}`,
+      ),
+      ...webhookShadow,
+    ];
+  }
+
   if (!githubWired && !linearWired) {
     // Mode-alignment: a DECLARED (recognized, not inferred) non-cluster mode
     // means the join gate intentionally skipped wiring — no-route is the
@@ -1290,12 +1492,6 @@ export function checkWebhookIngestion(deps = {}) {
     // declared-cluster node this FAIL is the intentional loud signal for a
     // missed activation step 2b (docs/cluster-onboarding.md), and a
     // pre-migration node must keep its original guarantee.
-    let declaredMode;
-    try {
-      declaredMode = resolveDeploymentModeFn();
-    } catch {
-      declaredMode = undefined;
-    }
     if (
       declaredMode &&
       declaredMode.inferred === false &&
@@ -1350,35 +1546,13 @@ export function checkWebhookIngestion(deps = {}) {
         // Same fail-closed direction the deployment-mode resolver above takes: an
         // unreadable config must never be the reason doctor tells an operator the
         // GitHub route is whole.
-        let ghFeed;
-        try {
-          ghFeed = resolveGithubFeedModeFn();
-        } catch {
-          ghFeed = { mode: "off", source: "resolver-threw" };
-        }
-        if (ghFeed.mode === "enforce") {
-          const uncovered = GITHUB_CONSUMED_NAMES.filter(
-            (n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n),
-          );
-          if (uncovered.length === 0) {
-            return [
-              mkCheck(
-                "webhook-ingestion",
-                STATUS.PASS,
-                `declared deployment mode "cloud" (source=${declaredMode.source}) — smee ingestion intentionally not wired; Linear ingestion is replaced by the cloud feed (CTL-1928) and GitHub ingestion by the GitHub feed at enforce (CTL-1929), covering all ${GITHUB_CONSUMED_NAMES.length} consumed github.* names`,
-              ),
-              ...webhookShadow,
-            ];
-          }
-          return [
-            mkCheck(
-              "webhook-ingestion",
-              STATUS.WARN,
-              `declared deployment mode "cloud" (source=${declaredMode.source}) — GitHub feed at enforce (source=${ghFeed.source}) covers ${GITHUB_SUPPRESSIBLE_NAMES.length}/${GITHUB_CONSUMED_NAMES.length} consumed github.* names, but ${uncovered.length} have NO source on this node: ${uncovered.join(", ")} — the merge→deploy join, the CI wait and rebase detection degrade`,
-            ),
-            ...webhookShadow,
-          ];
-        }
+        // ⛔ CTL-2030: THE `enforce` SUB-BRANCH THAT USED TO LIVE HERE IS GONE, NOT
+        // MOVED-AND-DUPLICATED. The unified enforce branch near the top of this
+        // function now answers for EVERY host whose feed is at enforce — cluster or
+        // cloud — so anything written here for that case would be unreachable, and
+        // unreachable grading code is how the static-vs-runtime comparison it
+        // contained went unnoticed in the first place (its PASS could not be reached
+        // by any input). Reaching this point means the feed is off or shadow.
         return [
           mkCheck(
             "webhook-ingestion",

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -733,10 +733,151 @@ describe("checkWebhookIngestion", () => {
     expect(checks[0].detail).toContain("single-host");
   });
 
+  // ─── CTL-2030: the check grades the route the host ACTUALLY USES ───────────
+  //
+  // Live on both minis on 2026-08-18 after the CTL-1929 cutover:
+  //   [PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false)
+  // while both hosts received ZERO GitHub webhooks — the tunnel suppressed at
+  // enforce, all eight webhooks active:false. `githubWired` was configuration
+  // PRESENCE (smeeChannel + HMAC secret), both deliberately retained as the
+  // rollback lever. The check answered "is smee configured?" and printed it as
+  // "ingestion wired" — and, worse, would have kept PASSing if the FEED broke,
+  // because it never looked at the feed.
+  describe("CTL-2030: an enforce host is graded on the feed, not on smee's config", () => {
+    const cluster = () => ({ mode: "cluster", source: "layer1", inferred: false, recognized: true });
+    // The minis' real shape: smee CONFIGURED (rollback lever) and the feed at enforce.
+    const monitorWithSmee = { github: { smeeChannel: "catalyst-gh" }, linear: {} };
+    const ready = (over = {}) => () => ({
+      ready: true,
+      reason: "producer-ready",
+      path: "/x/github-feed-ready-tenant-0.json",
+      state: {
+        ready: true,
+        mode: "enforce",
+        coverage: { suppressible: GITHUB_CONSUMED_NAMES.length, consumed: GITHUB_CONSUMED_NAMES.length, uncovered: [] },
+      },
+      ...over,
+    });
+    const run = (readFn, ghFeedMode = "enforce") =>
+      checkWebhookIngestion({
+        resolveDeploymentModeFn: cluster,
+        resolveRoster: multiHost,
+        monitor: monitorWithSmee,
+        secretFileNonEmpty: () => true, // the HMAC secret IS on disk — the rollback lever
+        resolveSecretContract: agreeingSecretContract(true),
+        resolveGithubFeedModeFn: () => ({ mode: ghFeedMode, source: "layer2" }),
+        readGithubFeedReadyFn: readFn,
+      })[0];
+
+    it("⭐ THE REGRESSION: retained smee config no longer reads as 'ingestion wired'", () => {
+      // Same inputs that produced the live false PASS, plus a HEALTHY feed. The
+      // verdict is still PASS — but for the feed, and it says so. If the message
+      // ever goes back to claiming the smee route is wired, this fails.
+      const c = run(ready());
+      expect(c.status).toBe(STATUS.PASS);
+      expect(c.detail).toContain("cloud feed at enforce");
+      expect(c.detail).toContain("smee is intentionally inert");
+      expect(c.detail).not.toContain("webhook ingestion wired");
+    });
+
+    it("⛔ a BROKEN feed on an enforce host does NOT pass — the condition it could not detect", () => {
+      const c = run(() => ({ ready: false, reason: "producer-unready:sweep-behind", path: "/x/r.json", state: { ready: false, mode: "enforce" } }));
+      expect(c.status).toBe(STATUS.FAIL);
+      expect(c.detail).toContain("GitHub ingestion is DOWN");
+      expect(c.detail).toContain("producer-unready:sweep-behind");
+    });
+
+    it("⛔ a STALE readiness record is a FAIL, and the message names what it read", () => {
+      const c = run(() => ({ ready: false, reason: "ready-file-stale:412s", path: "/x/r.json", state: { ready: true, mode: "enforce" } }));
+      expect(c.status).toBe(STATUS.FAIL);
+      expect(c.detail).toContain("ready-file-stale:412s");
+    });
+
+    it("⚠️ an UNOBSERVABLE producer is a WARN naming the path — 'could not look' is not 'fine'", () => {
+      // Absent means the producer never ran OR doctor is looking in the wrong
+      // directory (CTL-1976 shipped exactly that bug once). Grading it FAIL would
+      // page an operator for a reader bug; grading it PASS is the defect this
+      // ticket fixes. It is inconclusive, and it says so.
+      const c = run(() => ({ ready: false, reason: "ready-file-absent", path: "/some/where/r.json", state: null }));
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("could NOT be observed");
+      expect(c.detail).toContain("/some/where/r.json");
+      expect(c.detail).toContain('"could not look", not "ingestion is fine"');
+    });
+
+    it("⛔ a FRESH record with the WRONG MODE is a FAIL — freshness alone reads healthy", () => {
+      // The producer stamps the mode it RESOLVED, which degrades to shadow when
+      // enforce is not honourable. A host whose flag says enforce while its producer
+      // runs as shadow emits markers, not events — with a perfectly fresh heartbeat
+      // the whole time. Checking only `ready` would pass it.
+      const c = run(ready({ state: { ready: true, mode: "shadow", coverage: { suppressible: 12, consumed: 12, uncovered: [] } } }));
+      expect(c.status).toBe(STATUS.FAIL);
+      expect(c.detail).toContain("readers DISAGREE");
+      expect(c.detail).toContain('mode="shadow"');
+    });
+
+    it("⚠️ a ready producer with uncovered names is a WARN that names them", () => {
+      const c = run(ready({ state: { ready: true, mode: "enforce", coverage: { suppressible: 10, consumed: 12, uncovered: ["github.push", "github.check_suite.completed"] } } }));
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("10/12");
+      expect(c.detail).toContain("github.push");
+    });
+
+    it("a SHADOW host is unchanged — it still grades the smee route exactly as before", () => {
+      // The feed replaces nothing at shadow, so smee is still the live route and the
+      // pre-CTL-2030 grade must be preserved byte-for-byte.
+      const c = run(ready(), "shadow");
+      expect(c.status).toBe(STATUS.PASS);
+      expect(c.detail).toContain("webhook ingestion wired");
+      expect(c.detail).toContain("github=true");
+    });
+
+    it("⛔ half-wired Linear config still FAILs at enforce — no mode excuses residue", () => {
+      const c = checkWebhookIngestion({
+        resolveDeploymentModeFn: cluster,
+        resolveRoster: multiHost,
+        monitor: { github: { smeeChannel: "g" }, linear: { smeeChannel: "l", workspace: { webhookId: "w1" } } },
+        secretFileNonEmpty: (_dir, name) => name === "webhook-secret",
+        resolveSecretContract: agreeingSecretContract(true),
+        resolveGithubFeedModeFn: () => ({ mode: "enforce", source: "layer2" }),
+        readGithubFeedReadyFn: ready(),
+      })[0];
+      expect(c.status).toBe(STATUS.FAIL);
+      expect(c.detail).toContain("half-wired");
+    });
+
+    it("⛔ a THROWING readiness reader does not pass and does not throw", () => {
+      const c = run(() => {
+        throw new Error("EACCES");
+      });
+      expect(c.status).not.toBe(STATUS.PASS);
+      expect(c.detail).toContain("could NOT be observed");
+    });
+  });
+
   // ─── CTL-1929: the declared-cloud grade now depends on the GitHub feed ──────
   describe("declared cloud + the GitHub feed (CTL-1929)", () => {
     const cloud = () => ({ mode: "cloud", source: "layer2", inferred: false, recognized: true });
-    const run = (ghFeed) =>
+    // CTL-2030: coverage now comes from the PRODUCER'S readiness record, not from the
+    // frozen constants. These cases keep exercising today's real gap by publishing it
+    // as the producer would, so they still fail when the derivation is hand-written —
+    // and they no longer depend on doctor reading a file off the real filesystem.
+    const readyWith = (uncovered) => () => ({
+      ready: true,
+      reason: "producer-ready",
+      path: "/x/github-feed-ready-tenant-0.json",
+      state: {
+        ready: true,
+        mode: "enforce",
+        coverage: {
+          suppressible: GITHUB_CONSUMED_NAMES.length - uncovered.length,
+          consumed: GITHUB_CONSUMED_NAMES.length,
+          uncovered,
+        },
+      },
+    });
+    const todaysGaps = GITHUB_CONSUMED_NAMES.filter((x) => !GITHUB_SUPPRESSIBLE_NAMES.includes(x));
+    const run = (ghFeed, readGithubFeedReadyFn = readyWith(todaysGaps)) =>
       checkWebhookIngestion({
         resolveDeploymentModeFn: cloud,
         resolveRoster: multiHost,
@@ -744,6 +885,7 @@ describe("checkWebhookIngestion", () => {
         secretFileNonEmpty: noSecrets,
         resolveSecretContract: agreeingSecretContract(false),
         resolveGithubFeedModeFn: () => ghFeed,
+        readGithubFeedReadyFn,
       })[0];
 
     it("feed OFF → WARN naming the mode, because github.* has no source at all", () => {
@@ -769,21 +911,48 @@ describe("checkWebhookIngestion", () => {
       // rebase detection are the parts that are missing.
       const c = run({ mode: "enforce", source: "env" });
       expect(c.status).toBe(STATUS.WARN);
-      for (const n of GITHUB_CONSUMED_NAMES.filter((x) => !GITHUB_SUPPRESSIBLE_NAMES.includes(x))) {
+      for (const n of todaysGaps) {
         expect(c.detail).toContain(n);
       }
-      expect(c.detail).toContain(`${GITHUB_SUPPRESSIBLE_NAMES.length}/${GITHUB_CONSUMED_NAMES.length}`);
+      expect(c.detail).toContain(`${GITHUB_CONSUMED_NAMES.length - todaysGaps.length}/${GITHUB_CONSUMED_NAMES.length}`);
+    });
+
+    it("⛔ CTL-2030: a FULLY-COVERED node reaches the PASS branch — it was UNREACHABLE before", () => {
+      // The static comparison could never yield zero on a 0.1.18 replica (the frozen
+      // constant is 10 of 12), so this PASS existed in the source and could not be
+      // reached by any input. Driving it from the producer's own runtime answer is
+      // what makes it real.
+      const c = run({ mode: "enforce", source: "env" }, readyWith([]));
+      expect(c.status).toBe(STATUS.PASS);
+      expect(c.detail).toContain(`all ${GITHUB_CONSUMED_NAMES.length} consumed github.* names`);
+    });
+
+    it("⚠️ CTL-2030: unknown runtime coverage is a WARN, NOT a fall-back to the constant", () => {
+      // A pre-CTL-2030 readiness record (or a thrown tick) carries no coverage.
+      // Degrading to GITHUB_SUPPRESSIBLE_NAMES here would re-introduce the stale
+      // reading this ticket removes, wearing a fresh-looking verdict.
+      const noCoverage = () => ({
+        ready: true,
+        reason: "producer-ready",
+        path: "/x/r.json",
+        state: { ready: true, mode: "enforce" },
+      });
+      const c = run({ mode: "enforce", source: "env" }, noCoverage);
+      expect(c.status).toBe(STATUS.WARN);
+      expect(c.detail).toContain("carries no runtime coverage");
     });
 
     it("⭐ the counts and names are DERIVED — the WARN stops warning by itself when the gaps close", () => {
       // Drives the post-CTC-691/667/704 world through the same code path. A
       // hand-written detail string passes every test above and keeps reporting three
       // uncovered names forever.
-      const uncovered = GITHUB_CONSUMED_NAMES.filter((x) => !GITHUB_SUPPRESSIBLE_NAMES.includes(x));
-      expect(uncovered.length).toBeGreaterThan(0); // precondition: gaps are open today
+      expect(todaysGaps.length).toBeGreaterThan(0); // precondition: gaps are open today
       expect(GITHUB_SUPPRESSIBLE_NAMES.length).toBeLessThan(GITHUB_CONSUMED_NAMES.length);
       const c = run({ mode: "enforce", source: "env" });
-      expect(c.detail).toContain(`${uncovered.length} have NO source`);
+      expect(c.detail).toContain(`${todaysGaps.length} have NO source`);
+      // ...and with ONE gap published instead of today's set, the number follows.
+      const one = run({ mode: "enforce", source: "env" }, readyWith([todaysGaps[0]]));
+      expect(one.detail).toContain("1 have NO source");
     });
 
     it("⛔ a THROWING feed resolver grades as NO REPLACEMENT, not as a degraded enforce", () => {

--- a/plugins/dev/scripts/execution-core/github-feed-timer.mjs
+++ b/plugins/dev/scripts/execution-core/github-feed-timer.mjs
@@ -56,6 +56,7 @@ import {
   GITHUB_SUPPRESSIBLE_NAMES,
   githubSuppressibleNames,
 } from "./github-feed-gate.mjs";
+import { resolveGithubFeedAccount } from "../lib/github-feed-names.mjs"; // CTL-2030
 import { defaultReadyPath, writeReadyState } from "./github-feed-ready.mjs";
 
 /**
@@ -71,9 +72,11 @@ import { defaultReadyPath, writeReadyState } from "./github-feed-ready.mjs";
  * gives the rule: this must match `cloud-sync.mjs`'s resolution "so the two cannot
  * disagree about which account this host is".
  */
-export function resolveAccount(envObj = process.env) {
-  return envObj.CATALYST_CLOUD_ACCOUNT || DEFAULT_ACCOUNT;
-}
+// CTL-2030: the implementation moved to the zero-import leaf `lib/github-feed-names.mjs`
+// so `catalyst doctor` (bare node — this file's `bun:sqlite` graph is unloadable there)
+// can resolve the SAME account rather than keeping a copy. Re-exported under the
+// original name so every existing caller is untouched.
+export const resolveAccount = resolveGithubFeedAccount;
 
 /** The shadow-only marker name. Deliberately NOT a `github.*` name — see the header. */
 export const EVENT_WOULD_DISPATCH = "github-feed.would-dispatch";
@@ -373,7 +376,27 @@ export function runGithubFeedTick({
       logger.warn({ requested: resolved.requested, effective: resolved.effective, reason: resolved.reason },
         "github-feed: enforce requested but not honourable — running as shadow");
     }
-    return { skipped: null, mode: resolved, counts, emitted: emitted.length, ready: unready === null, unready };
+    // CTL-2030: the RUNTIME coverage, carried out of the tick so the readiness file
+    // can publish it. `catalyst doctor` runs under bare node and cannot open the
+    // replica (`bun:sqlite`), so without this it can only compare the frozen
+    // GITHUB_SUPPRESSIBLE_NAMES constant — the exact static-vs-runtime split CTL-2018
+    // fixed in this file. The producer already resolved the honest answer three lines
+    // into this try; publishing it is strictly cheaper than a second reader.
+    const coverageReport = {
+      suppressible: tickSuppressibleNames.length,
+      consumed: GITHUB_CONSUMED_NAMES.length,
+      uncovered: GITHUB_CONSUMED_NAMES.filter((n) => !tickSuppressible.has(n)),
+      ok: coverage.ok === true,
+    };
+    return {
+      skipped: null,
+      mode: resolved,
+      counts,
+      emitted: emitted.length,
+      ready: unready === null,
+      unready,
+      coverage: coverageReport,
+    };
   } finally {
     try { source.close(); } catch { /* best effort */ }
     try { seen.close(); } catch { /* best effort */ }
@@ -449,7 +472,16 @@ export function startGithubFeedTimer({
         authorityAtEntry: authority,
       });
       authority = last?.ready === true;
-      publishReady({ ready: authority, unready: last?.unready ?? null, mode: last?.mode?.effective ?? null });
+      // CTL-2030: `coverage` rides the heartbeat so a bare-node reader (doctor) gets
+      // the producer's OWN runtime answer instead of re-deriving it from a constant.
+      // Absent on the pre-CTL-2030 record shape and on a throwing tick — readers must
+      // treat missing coverage as UNKNOWN, never as full.
+      publishReady({
+        ready: authority,
+        unready: last?.unready ?? null,
+        mode: last?.mode?.effective ?? null,
+        coverage: last?.coverage ?? null,
+      });
     } catch (err) {
       // A guardrail that can wedge the daemon tick is not a guardrail.
       logger?.error?.({ err: err?.message }, "github-feed: tick threw");
@@ -459,7 +491,7 @@ export function startGithubFeedTimer({
       // there until the staleness window expired and the gate would keep suppressing
       // smee for up to 90 s on the authority of a tick that crashed.
       authority = false;
-      publishReady({ ready: false, unready: `tick-threw:${err?.name ?? "unknown"}`, mode: null });
+      publishReady({ ready: false, unready: `tick-threw:${err?.name ?? "unknown"}`, mode: null, coverage: null });
     }
   };
 

--- a/plugins/dev/scripts/lib/github-feed-names.mjs
+++ b/plugins/dev/scripts/lib/github-feed-names.mjs
@@ -134,3 +134,27 @@ export const EXCLUSION_REASONS = Object.freeze({
   "github.check_suite.completed": "no-replacement:no-pr-association-until-0.1.18:CTC-712",
   "github.push": "lossy-replacement:pushes-keyed-per-ref:CTC-704",
 });
+
+// ─── CTL-2030: the account name, hoisted into this leaf ──────────────────────
+//
+// ⛔ WHY IT MOVED. `resolveAccount` lived in `github-feed-timer.mjs`, which imports
+// `github-feed-source.mjs` → `bun:sqlite`. `catalyst doctor` runs under BARE NODE
+// and cannot load that graph (the same measured constraint that put
+// GITHUB_CONSUMED_NAMES here in CTL-1929: config.mjs loads under bare node,
+// github-feed-gate.mjs REJECTS). Doctor needs the account to resolve the
+// producer's readiness-file path, so the choice was hoist-or-copy.
+//
+// ⚠️ A COPY WOULD HAVE BEEN THE DEFECT, NOT THE SHORTCUT. `github-feed-timer.mjs`'s
+// own comment gives the rule this function exists to satisfy: it "must match
+// cloud-sync.mjs's resolution so the two cannot disagree about which account this
+// host is". A doctor with its own copy would read a DIFFERENT host's readiness
+// file the first time anyone sets CATALYST_CLOUD_ACCOUNT — and report
+// `ready-file-absent`, i.e. "the producer never ran", about a producer that is
+// running perfectly. `github-feed-timer.mjs` re-exports this one; there is no
+// second implementation.
+export const GITHUB_FEED_DEFAULT_ACCOUNT = "tenant-0";
+
+/** The cloud account this host is. See the block comment above before copying it. */
+export function resolveGithubFeedAccount(envObj = process.env) {
+  return envObj?.CATALYST_CLOUD_ACCOUNT || GITHUB_FEED_DEFAULT_ACCOUNT;
+}


### PR DESCRIPTION
## The live false clean

Measured on both minis on 2026-08-18, after the CTL-1929 cutover at 17:36 CT:

```
[PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false, linear keys=7)
```

**Both hosts received zero GitHub webhooks.** The tunnel is suppressed at `enforce` and all eight webhooks are `active:false`. `githubWired` is computed from **configuration presence** — `catalyst.monitor.github.smeeChannel` plus the HMAC secret — and *both are deliberately retained, because they are the rollback lever*. So the check answered "is the smee route configured?" (yes, on purpose) and printed the answer as "ingestion wired".

⛔ **The second failure is the one that matters.** If the **feed** breaks on an `enforce` host, this check still PASSes — because it never looks at the feed. **The one condition under which GitHub ingestion is actually dead is the one condition it could not detect.**

## Why it never looked

`resolveGithubFeedModeFn()` was read **only inside the `declaredMode.mode === "cloud"` branch**. The minis declare `cluster`. So on the two hosts this was live on, the feed was never consulted at all. It is now resolved **unconditionally**, next to the smee wiring it replaces.

## The grade at `enforce`

At `enforce` the smee wiring is **inert** (tunnel suppressed, webhooks disabled), so its configuration says nothing about whether events arrive. The check grades the **producer's readiness heartbeat** instead — and keeps **three** outcomes apart:

| producer state | verdict | why |
| --- | --- | --- |
| ready, mode `enforce`, full coverage | **PASS** | the live route is delivering; the message says *feed*, not *smee* |
| stale / `producer-unready:*` | **FAIL** | we could look, and it says ingestion is down |
| ready but record's `mode` ≠ `enforce` | **FAIL** | the readers disagree |
| absent / unparseable / unstamped / reader threw | **WARN** | ⚠️ *"could not look"*, naming the path it read |

⚠️ **The inconclusive case is deliberately not a FAIL.** An absent record means the producer never ran **or** doctor is looking in the wrong directory — **CTL-1976 shipped exactly that bug once** (the broker read `~/catalyst/shadow/…` while the daemon wrote `~/catalyst/execution-core/shadow/…`), and `readReadyState` answers `ready:false` for an absent file, which is indistinguishable from "the producer is down". Grading it FAIL would page an operator for a reader bug; grading it PASS is the defect this PR fixes.

⛔ **The record's `mode` is checked, not just its freshness.** The producer stamps the mode it *resolved* (`mode.effective`), which degrades to shadow when enforce is not honourable. A host whose flag says `enforce` while its producer runs as `shadow` emits markers instead of events — **with a perfectly fresh heartbeat the whole time.** Checking `ready` alone passes it.

## Coverage is now resolved at runtime

The cloud branch compared two frozen constants:

```js
const uncovered = GITHUB_CONSUMED_NAMES.filter((n) => !GITHUB_SUPPRESSIBLE_NAMES.includes(n));
if (uncovered.length === 0) { /* PASS */ }
```

That is the **third** instance of the static-vs-runtime split CTL-2018 fixed in the producer (the broker's gate was already runtime). On a 0.1.18 replica the constant is 10 of 12, so `uncovered.length` was permanently 2 and **that PASS branch was unreachable by any input**.

The producer already resolves the honest set per tick (`resolveSuppressibleForTick`). It now **publishes it on the readiness heartbeat**, and doctor reads the producer's own answer. ⛔ **Missing coverage is UNKNOWN and does NOT fall back to the constant** — that fallback would re-introduce the stale reading wearing a fresh-looking verdict.

## Two structural moves

- **`resolveAccount` hoisted** to the zero-import leaf `lib/github-feed-names.mjs`, re-exported from `github-feed-timer.mjs`. doctor runs under **bare node** and cannot load that file's `bun:sqlite` graph (the same measured constraint that put `GITHUB_CONSUMED_NAMES` in the leaf in CTL-1929). A hand copy would read a **different host's** readiness file the first time anyone set `CATALYST_CLOUD_ACCOUNT`, and report `ready-file-absent` — "the producer never ran" — about a producer running perfectly.
- **The declared-cloud block's `enforce` sub-branch is DELETED, not duplicated.** The unified branch answers for every enforce host, cluster or cloud, so anything left there would be unreachable — and unreachable grading code is precisely how its unreachable PASS went unnoticed in the first place.

## Testing

Four mutations, each must fail:

| mutation | fails |
| --- | --- |
| grade smee config at enforce (**the live defect**) | **11** |
| skip the record's `mode` check (freshness alone) | 1 |
| fall back to the frozen constant on unknown coverage | 1 |
| treat an absent/unready record as a pass | 4 |

Nine new cases cover the enforce branch, including the exact inputs that produced the live false PASS (smee configured **and** its secret on disk) plus a healthy feed, asserting the verdict is now PASS *for the feed* and that the message no longer says "webhook ingestion wired". A shadow host is asserted **unchanged**.

### Gate

Full stable list run once at load 9, against the `origin/main` baseline in an identical bare worktree:

| | pass | fail | errors |
| --- | --- | --- | --- |
| `origin/main` baseline | 7791 | 12 | 3 |
| this branch | **7833** | 12 | 3 |

**Identical failure sets** (`diff` of sorted `✗` lines is empty) — all environmental (a bare worktree has no `node_modules`: `pino`, `@opentelemetry/sdk-trace-base`, the schema-copy probe, plus the live-`linearis`/replica cases). CI installs deps and is authoritative.

## Not in scope

CTL-2011 ("tell the operator when the three readers disagree about the MODE") is the sibling. This PR's `readers DISAGREE` FAIL covers the flag-vs-producer pair only; the tunnel gate's Layer-2-alone read stays CTL-2011's.

Closes CTL-2030.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
