### PR TITLE
fix(dev): CTL-2028 — a pid file naming a LIVE peer was clobbered on start and deleted on exit, so two brokers ran for 85 minutes and every status read clean

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -899,6 +899,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/orphan-sweep.test.sh
 
+      - name: broker pid-file identity test (CTL-2028)
+        # ⚠️ NOT hermetic in the orphan-sweep sense: this suite STARTS REAL
+        # `node` processes, because the defect is that a pid-file-derived status
+        # cannot see a second process — and a mocked `ps` would let the detector
+        # pass while counting nothing. Every fixture is short-lived, killed in a
+        # trap, and the trap ASSERTS they are gone (fail-closed) rather than
+        # probing with something that fails open.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/broker-pid-identity.test.sh
+
       - name: orphan-sweep LaunchAgent plist test (CTL-1531)
         working-directory: plugins/dev/scripts
         run: bash __tests__/orphan-sweep-plist.test.sh
@@ -1201,6 +1211,7 @@ jobs:
             reaper.test.mjs \
             reconcile-health-event.test.mjs \
             recovery.test.mjs \
+            pid-file-identity.test.mjs \
             registry.test.mjs \
             replica-read.test.mjs \
             replica-supplemental-reads.test.mjs \

--- a/plugins/dev/scripts/__tests__/broker-pid-identity.test.sh
+++ b/plugins/dev/scripts/__tests__/broker-pid-identity.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# broker-pid-identity.test.sh — CTL-2028.
+#
+# On mini-2 on 2026-08-18 two brokers ran for 85 minutes — both alive, both
+# heartbeating, both tailing the same event log — and `catalyst-broker status`
+# reported ONE the entire time, because it reads the pid file and the newer
+# process had overwritten it. A status derived from the pid file can only ever
+# report 0 or 1; the number that matters is how many processes exist.
+#
+# ⚠️ EVERY CASE HERE STARTS A REAL PROCESS. A count assertion whose fixture never
+# ran reads exactly like a working detector reporting a healthy host, so each
+# "should NOT be counted" case is paired with a positive control in the same run.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BROKER_CLI="$SCRIPT_DIR/../catalyst-broker"
+FAIL=0
+pids=()
+
+pass() { echo "  ok  — $1"; }
+fail() { echo "  FAIL — $1" >&2; FAIL=1; }
+cleanup() {
+  for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null || true; done
+  # Fail closed: assert the fixtures are gone rather than probing with something
+  # that fails open (the house rule — `kill -0 && echo` prints nothing when the
+  # probe itself errors, and self-certifies success either way).
+  sleep 0.3
+  for p in "${pids[@]:-}"; do
+    if ps -p "$p" >/dev/null 2>&1; then echo "LEAKED: $p" >&2; FAIL=1; fi
+  done
+  rm -rf "$TMP" 2>/dev/null || true
+}
+TMP="$(mktemp -d)"
+trap cleanup EXIT
+
+# The function under test, extracted by sourcing the CLI with a guard that stops
+# it before it dispatches on "$1". Sourcing is what keeps this a test OF THE
+# SHIPPED CODE rather than of a copy.
+load_fn() {
+  # shellcheck disable=SC1090
+  set -- status
+  source "$BROKER_CLI" >/dev/null 2>&1 || true
+}
+
+# A broker-SHAPED process: a real runtime, whose script path ends in the marker.
+spawn_fake_broker() {
+  local dir="$TMP/$1"
+  mkdir -p "$dir/broker"
+  printf 'setTimeout(() => {}, 30000);\n' > "$dir/broker/index.mjs"
+  node "$dir/broker/index.mjs" >/dev/null 2>&1 &
+  local p=$!
+  pids+=("$p")
+  echo "$p"
+}
+
+count_now() {
+  ( load_fn; broker_count_by_identity )
+}
+pids_now() {
+  ( load_fn; broker_pids_by_identity )
+}
+
+echo "CTL-2028: count brokers by identity, not by the pid file"
+
+# ── 1. POSITIVE CONTROL ─────────────────────────────────────────────────────
+# Without this, every "not counted" assertion below could pass on a detector
+# that counts nothing at all.
+base="$(count_now)"
+p1="$(spawn_fake_broker one)"
+sleep 0.5
+after_one="$(count_now)"
+if [[ "$after_one" -eq $((base + 1)) ]]; then
+  pass "POSITIVE CONTROL: a running broker-shaped process is counted ($base → $after_one)"
+else
+  fail "POSITIVE CONTROL: expected $((base + 1)), got $after_one — every other case in this file is now meaningless"
+fi
+
+if pids_now | grep -qx "$p1"; then
+  pass "the counted pid is the one we started ($p1)"
+else
+  fail "pid $p1 was not in the identity list"
+fi
+
+# ── 2. TWO is reported as TWO — the case the pid file cannot see ────────────
+p2="$(spawn_fake_broker two)"
+sleep 0.5
+after_two="$(count_now)"
+if [[ "$after_two" -eq $((base + 2)) ]]; then
+  pass "two running brokers are counted as two ($after_two)"
+else
+  fail "expected $((base + 2)) with two fixtures, got $after_two"
+fi
+
+kill "$p2" 2>/dev/null; sleep 0.4
+back_to_one="$(count_now)"
+if [[ "$back_to_one" -eq $((base + 1)) ]]; then
+  pass "the count follows the processes back down ($back_to_one)"
+else
+  fail "expected $((base + 1)) after killing one, got $back_to_one"
+fi
+
+# ── 3. ⛔ THE MATCHER MUST NOT COUNT ITSELF ─────────────────────────────────
+# The first cut passed the marker as `awk -v m=...`, which puts the literal
+# string into AWK'S OWN command line — which `ps -eo command=` lists and the
+# matcher then matches. Measured on a host with NO broker and NO pid file: it
+# reported "1 broker process(es) are running (pids: 23661)", and 23661 was the
+# awk. `grep -v grep` wearing a different hat.
+#
+# The control for this case is §1 above: the detector demonstrably CAN count.
+kill "$p1" 2>/dev/null; sleep 0.4
+zero="$(count_now)"
+if [[ "$zero" -eq "$base" ]]; then
+  pass "with no fixtures the count returns to baseline ($zero) — the matcher does not count itself"
+else
+  fail "expected baseline $base with no fixtures, got $zero (the matcher is counting its own pipeline)"
+fi
+
+# ── 4. ⛔ A MENTION IS NOT AN INVOCATION ────────────────────────────────────
+# Excluding awk's argv is necessary but NOT sufficient. Measured right after
+# that fix: the remaining match was the wrapping `/bin/zsh -c ...` whose argv
+# merely QUOTED the marker. A shell, an editor or a log path that names the
+# entrypoint must not be counted.
+bash -c 'sleep 3 # broker/index.mjs' >/dev/null 2>&1 &
+mention=$!
+pids+=("$mention")
+sleep 0.5
+with_mention="$(count_now)"
+if [[ "$with_mention" -eq "$base" ]]; then
+  pass "a shell whose argv merely MENTIONS broker/index.mjs is not counted"
+else
+  fail "a mere mention was counted (got $with_mention, baseline $base) — the match is not requiring a runtime invocation"
+fi
+kill "$mention" 2>/dev/null
+
+# ── 5. status reports the anomaly the pid file is blind to ──────────────────
+p3="$(spawn_fake_broker three)"
+sleep 0.5
+out="$(BROKER_PID_FILE="$TMP/absent.pid" bash "$BROKER_CLI" status 2>&1)"
+if grep -q "UNMANAGED" <<<"$out"; then
+  pass "no usable pid file + a running broker is reported as an ERROR, not as a clean 'stopped'"
+else
+  fail "expected an UNMANAGED error; got: $out"
+fi
+
+# ⚠️ The exit code is DELIBERATELY unchanged (0). orchestrate-register-interests.sh
+# treats any non-zero from `catalyst-broker status` as "no broker — skip", so
+# widening the exit contract here would silently stop the legacy-wave path from
+# registering interests on a host that merely has a duplicate.
+BROKER_PID_FILE="$TMP/absent.pid" bash "$BROKER_CLI" status >/dev/null 2>&1
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  pass "the status exit code is unchanged (0) — orchestrate-register-interests.sh's guard is untouched"
+else
+  fail "status exited $rc; a caller reads non-zero as 'no broker' and would skip interest registration"
+fi
+kill "$p3" 2>/dev/null
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then echo "PASS — broker-pid-identity"; else echo "FAIL — broker-pid-identity" >&2; fi
+exit "$FAIL"

--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -16,6 +16,13 @@
 // index.mjs is the thin daemon entrypoint (main/shutdown, PID + key-health)
 // plus the re-export barrel that preserves the public import surface.
 
+// CTL-2028: a pid file may only be written over, or removed, by a process that can
+// prove it is not pointing at a LIVE peer.
+import {
+  classifyPidFile,
+  shouldRemovePidFile,
+  duplicateDaemonAlarm,
+} from "../lib/pid-file-identity.mjs";
 import { writeFileSync, unlinkSync, mkdirSync, openSync, fstatSync, closeSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -313,8 +320,44 @@ function parsePidFilePath() {
 
 const PID_FILE_PATH = parsePidFilePath();
 
+// BROKER_IDENTITY_MARKER — the substring that identifies a broker in a command
+// line. Deliberately the ENTRYPOINT PATH, not the word "broker": the bare word
+// appears in `catalyst-broker`, in log paths, and in any shell that merely
+// mentions it, so matching on it would classify unrelated processes as live peers
+// and make the pid file permanently un-writable.
+const BROKER_IDENTITY_MARKER = "broker/index.mjs";
+
 function writePidFile() {
   if (!PID_FILE_PATH) return;
+  // ⛔ CTL-2028: LOOK BEFORE CLOBBERING. This used to be an unconditional
+  // writeFileSync, and on mini-2 that made a live second broker invisible for 85
+  // minutes while `catalyst-stack status` reported one healthy broker — because
+  // status reads this file, and this file had just been overwritten.
+  //
+  // ⚠️ It still WRITES. Refusing to start on a live-peer verdict would let a
+  // mis-read identity check (an unreadable `ps`, an unexpected launcher) wedge a
+  // host whose pid file is merely stale — and a daemon that refuses to write its
+  // pid file at all is unmanaged, which is the state this whole change exists to
+  // prevent. So the fail direction is: write, and be LOUD.
+  try {
+    const verdict = classifyPidFile(PID_FILE_PATH, BROKER_IDENTITY_MARKER);
+    const alarm = duplicateDaemonAlarm(verdict, { name: "broker" });
+    if (alarm) {
+      log.error(
+        { pid_file: PID_FILE_PATH, existing_pid: verdict.pid, existing_command: verdict.command, self_pid: process.pid },
+        alarm
+      );
+    } else if (verdict.kind === "stale" || verdict.kind === "unknown") {
+      log.warn(
+        { pid_file: PID_FILE_PATH, existing_pid: verdict.pid, kind: verdict.kind },
+        "broker: overwriting a pid file that names another pid (not a live broker)"
+      );
+    }
+  } catch (err) {
+    // A guardrail that can stop the daemon from writing its pid file is worse
+    // than the gap it guards.
+    log.warn({ err: err.message }, "broker: pid-file identity check threw — writing anyway");
+  }
   try {
     mkdirSync(dirname(PID_FILE_PATH), { recursive: true });
     writeFileSync(PID_FILE_PATH, `${process.pid}\n`);
@@ -325,6 +368,31 @@ function writePidFile() {
 
 function removePidFile() {
   if (!PID_FILE_PATH) return;
+  // ⛔ CTL-2028: UNLINK ONLY OUR OWN. This used to be an unconditional unlinkSync,
+  // and it is step 3 of the measured failure: when the orphaned broker finally
+  // exited it deleted the SURVIVOR's pid file, leaving a healthy broker that every
+  // status check reported as DOWN and that the next supervisor pass would have
+  // duplicated again. Reproduced, not theorised.
+  //
+  // ⚠️ Opposite fail direction to writePidFile, on purpose: anything other than a
+  // confirmed "this file names me" leaves the file alone. A wrongly-kept stale file
+  // is cleared by the next start; a wrongly-deleted live one orphans a daemon.
+  let verdict;
+  try {
+    verdict = classifyPidFile(PID_FILE_PATH, BROKER_IDENTITY_MARKER);
+  } catch (err) {
+    log.warn({ err: err.message }, "broker: pid-file identity check threw on shutdown — leaving the pid file");
+    return;
+  }
+  if (!shouldRemovePidFile(verdict)) {
+    if (verdict.kind !== "absent") {
+      log.warn(
+        { pid_file: PID_FILE_PATH, names_pid: verdict.pid, kind: verdict.kind, self_pid: process.pid },
+        "broker: pid file names another process — leaving it in place rather than orphaning whoever owns it"
+      );
+    }
+    return;
+  }
   try {
     unlinkSync(PID_FILE_PATH);
   } catch {

--- a/plugins/dev/scripts/catalyst-broker
+++ b/plugins/dev/scripts/catalyst-broker
@@ -70,6 +70,75 @@ DAEMON_SCRIPT="${BROKER_DAEMON_SCRIPT:-$SCRIPT_DIR/broker/index.mjs}"
 
 is_alive() { kill -0 "$1" 2>/dev/null; }
 
+# ─── CTL-2028: count brokers by IDENTITY, not by the pid file ────────────────
+#
+# ⛔ THE PID FILE CANNOT COUNT. On mini-2 on 2026-08-18 two brokers ran for 85
+# minutes — both alive, both heartbeating, both tailing the same event log — and
+# `catalyst-broker status` reported ONE the entire time, because the newer process
+# had overwritten the file the status reads. A status derived from the pid file can
+# only ever report 0 or 1; the number that matters is how many processes exist.
+#
+# ⚠️ `-ww` IS LOAD-BEARING: Linux procps wraps `ps` output at 80 columns when stdout
+# is not a tty, and a bun-launched daemon's command line is longer than that — so
+# without it the marker below is truncated away and the count silently reads 0.
+# That exact truncation shipped once in catalyst-monitor.sh and reproduced only on
+# Linux, because macOS ps does not truncate.
+#
+# ⚠️ MATCHES THE ENTRYPOINT PATH, NOT THE WORD "broker": the bare word appears in
+# this very script's own command line, in log paths, and in any shell that mentions
+# it.
+BROKER_IDENTITY_MARKER="broker/index.mjs"
+
+# broker_pids_by_identity — newline-separated pids of every running broker.
+# Prints nothing when there are none. Fails OPEN (prints nothing) when ps cannot
+# be read, because a status command must never be the thing that breaks.
+#
+# ⛔ THE MARKER IS PASSED THROUGH THE ENVIRONMENT, NOT AS AN AWK ARGUMENT, AND THAT
+# IS THE WHOLE CORRECTNESS OF THIS FUNCTION.
+#
+# The first version used `awk -v m="$BROKER_IDENTITY_MARKER"`. That puts the literal
+# string `broker/index.mjs` into AWK'S OWN COMMAND LINE — which `ps -eo command=` then
+# lists, and which the matcher then matches. Measured on a laptop with NO broker
+# running and NO pid file: it reported `1 broker process(es) are running (pids: 23661)`,
+# and 23661 was the awk. It is the `grep -v grep` bug wearing a different hat, and the
+# comment two lines above warned about exactly this class before the code walked into
+# it.
+#
+# ⚠️ It is a FALSE POSITIVE, which is the dangerous direction here: this detector's
+# whole job is to report duplicates, so an unconditional +1 makes a single healthy
+# broker read as two and would send an operator hunting a phantom.
+#
+# `ENVIRON[]` keeps the string out of argv entirely; awk's own command line is then
+# just the program text, which contains no marker. `ps` itself never contains it.
+# There is a regression test for this exact shape.
+# ⛔ AND A MENTION IS NOT AN INVOCATION. Excluding awk's own argv is necessary but
+# NOT sufficient: any shell whose command line merely CONTAINS the marker matches
+# too. Measured immediately after the ENVIRON fix, on a host with no broker: the
+# remaining match was the wrapping `/bin/zsh -c ...` whose argv quoted the marker.
+# So the match additionally requires the command to BE a runtime invocation — the
+# first token's basename must be `bun` or `node`. A shell, an editor, a grep, or a
+# log path that names the entrypoint is a mention and is not counted.
+broker_pids_by_identity() {
+  BROKER_IDENTITY_MARKER="$BROKER_IDENTITY_MARKER" ps -ww -eo pid=,command= 2>/dev/null \
+    | BROKER_IDENTITY_MARKER="$BROKER_IDENTITY_MARKER" awk '
+        {
+          line = $0
+          if (index(line, ENVIRON["BROKER_IDENTITY_MARKER"]) == 0) next
+          # $1 is the pid; $2 is the executable as invoked (absolute or bare).
+          exe = $2
+          n = split(exe, parts, "/")
+          base = parts[n]
+          if (base == "bun" || base == "node") print $1
+        }
+      ' 2>/dev/null || true
+}
+
+broker_count_by_identity() {
+  local pids; pids="$(broker_pids_by_identity)"
+  [[ -z "$pids" ]] && { echo 0; return 0; }
+  printf '%s\n' "$pids" | grep -c . || echo 0
+}
+
 read_pid() {
   if [[ -f "$PID_FILE" ]]; then
     local pid
@@ -167,24 +236,60 @@ cmd_status() {
     esac
   done
 
+  # CTL-2028: the identity count is computed FIRST and reported in BOTH shapes,
+  # because it is the only number that can see a duplicate. A count > 1 is an
+  # ERROR — two brokers process the same event log, double-applying
+  # handleAgentCheckin's upsertAgent/_autoRegisterPrLifecycle and emitting every
+  # filter.wake twice — and it must not be hidden behind a pid file that can only
+  # ever say 0 or 1.
+  local count pids
+  count="$(broker_count_by_identity)"
+  pids="$(broker_pids_by_identity | tr '\n' ' ' | sed 's/ *$//')"
+
   local pid
   if pid=$(read_pid); then
     if [[ $json -eq 1 ]]; then
       if [[ -f "$STATE_FILE" ]] && jq -e . "$STATE_FILE" >/dev/null 2>&1; then
-        jq --argjson pid "$pid" '. + {running: true, pid: $pid}' "$STATE_FILE"
+        jq --argjson pid "$pid" --argjson n "$count" --arg pids "$pids" \
+          '. + {running: true, pid: $pid, processCount: $n, processPids: ($pids | split(" ") | map(select(length > 0))), duplicate: ($n > 1)}' "$STATE_FILE"
       else
-        jq -n --argjson pid "$pid" '{running: true, pid: $pid, keyHealth: null, gateway: null}'
+        jq -n --argjson pid "$pid" --argjson n "$count" --arg pids "$pids" \
+          '{running: true, pid: $pid, processCount: $n, processPids: ($pids | split(" ") | map(select(length > 0))), duplicate: ($n > 1), keyHealth: null, gateway: null}'
       fi
     else
       echo "running (pid $pid)"
+      if [[ "$count" -gt 1 ]]; then
+        echo "ERROR: $count brokers are running (pids: $pids) — the pid file names only $pid, so every pid-based check sees ONE. Two brokers route the same event log. Stop the extras by pid." >&2
+      fi
     fi
+    # ⚠️ THE EXIT CODE IS DELIBERATELY UNCHANGED — 0, exactly as before.
+    #
+    # My first cut returned 2 on a duplicate and 1 when stopped, which reads as
+    # obviously better and is a silent behaviour change on an unrelated path:
+    # `orchestrate-register-interests.sh:62` does `if ! catalyst-broker status
+    # >/dev/null 2>&1 ... then exit 0`, i.e. it treats ANY non-zero as "no broker,
+    # skip registration". Under that cut a DUPLICATED broker — which is running —
+    # would have made the legacy-wave path silently stop registering interests.
+    # A pid-file fix has no business changing that contract. The anomaly is
+    # reported on stderr and in --json; widening the exit contract is its own
+    # ticket, with its own audit of the two callers.
     return 0
   fi
   if [[ $json -eq 1 ]]; then
-    jq -n '{running: false, pid: null, keyHealth: null, gateway: null}'
+    jq -n --argjson n "$count" --arg pids "$pids" \
+      '{running: false, pid: null, processCount: $n, processPids: ($pids | split(" ") | map(select(length > 0))), duplicate: ($n > 1), keyHealth: null, gateway: null}'
   else
     echo "stopped"
+    # ⭐ The case the pid file is BLIND to, and the one that stranded mini-2: no
+    # usable pid file, yet brokers are running. Reported as an error rather than
+    # as a clean "stopped", which is what a supervisor would act on by starting
+    # yet another one.
+    if [[ "$count" -gt 0 ]]; then
+      echo "ERROR: no usable pid file, but $count broker process(es) are running (pids: $pids) — they are UNMANAGED; starting another would add to them." >&2
+    fi
   fi
+  # Unchanged (0), for the reason given in the running branch above.
+  return 0
 }
 
 cmd_logs() {

--- a/plugins/dev/scripts/execution-core/pid-file-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/pid-file-identity.test.mjs
@@ -1,0 +1,137 @@
+// pid-file-identity.test.mjs — CTL-2028.
+//
+// Two brokers on mini-2 for 85 minutes, both alive, both heartbeating, while
+// every status surface reported one — because the newer process had clobbered
+// the pid file. And when the orphan finally exited, its unconditional
+// `unlinkSync` deleted the SURVIVOR's pid file, leaving a healthy broker that
+// status reported as DOWN. Both halves are covered here.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test pid-file-identity.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  readPidFrom,
+  processCommand,
+  classifyPidFile,
+  shouldRemovePidFile,
+  duplicateDaemonAlarm,
+} from "../lib/pid-file-identity.mjs";
+
+const MARKER = "broker/index.mjs";
+/** a readFn returning `text`, or throwing to simulate an absent file. */
+const reads = (text) => (text === null ? () => { throw new Error("ENOENT"); } : () => text);
+/** an execFn answering `cmd` for any pid, or throwing (ps could not answer). */
+const execs = (cmd) => (cmd === null ? () => { throw new Error("no such process"); } : () => cmd);
+
+describe("readPidFrom — anything unreadable is 'I cannot tell', never 'nobody'", () => {
+  test("a plain pid parses", () => {
+    expect(readPidFrom("/x", { readFn: reads("4242\n") })).toBe(4242);
+  });
+  test("absent, empty, non-numeric, zero and negative all yield null", () => {
+    for (const raw of [null, "", "   ", "not-a-pid", "0", "-5", "\n"]) {
+      expect(readPidFrom("/x", { readFn: reads(raw) })).toBeNull();
+    }
+  });
+});
+
+describe("classifyPidFile — the four answers must stay apart", () => {
+  test("the file names THIS process → self", () => {
+    const v = classifyPidFile("/x", MARKER, { readFn: reads("77\n"), execFn: execs("irrelevant"), selfPid: 77 });
+    expect(v.kind).toBe("self");
+  });
+
+  test("a DIFFERENT live process running the same daemon → live-peer", () => {
+    const v = classifyPidFile("/x", MARKER, {
+      readFn: reads("17643\n"),
+      execFn: execs("bun /Users/ryan/catalyst/plugin-source/plugins/dev/scripts/broker/index.mjs --pid-file /Users/ryan/catalyst/broker.pid"),
+      selfPid: 53448,
+    });
+    expect(v.kind).toBe("live-peer");
+    expect(v.pid).toBe(17643);
+  });
+
+  test("⛔ a RECYCLED pid — alive, but a different program — is STALE, not a peer", () => {
+    // Treating this as a live peer would make a legitimately stale pid file
+    // permanently un-writable and wedge the daemon.
+    const v = classifyPidFile("/x", MARKER, {
+      readFn: reads("17643\n"),
+      execFn: execs("/usr/bin/vim notes.txt"),
+      selfPid: 53448,
+    });
+    expect(v.kind).toBe("stale");
+    expect(v.reason).toBe("recycled-pid");
+  });
+
+  test("ps cannot answer → unknown, which is neither 'peer' nor 'nobody'", () => {
+    const v = classifyPidFile("/x", MARKER, { readFn: reads("999\n"), execFn: execs(null), selfPid: 1 });
+    expect(v.kind).toBe("unknown");
+  });
+
+  test("no file at all → absent", () => {
+    expect(classifyPidFile("/x", MARKER, { readFn: reads(null), execFn: execs("x"), selfPid: 1 }).kind).toBe("absent");
+  });
+
+  test("all five kinds are distinct values — none may collapse into another", () => {
+    const kinds = [
+      classifyPidFile("/x", MARKER, { readFn: reads(null), execFn: execs("x"), selfPid: 1 }).kind,
+      classifyPidFile("/x", MARKER, { readFn: reads("1\n"), execFn: execs("x"), selfPid: 1 }).kind,
+      classifyPidFile("/x", MARKER, { readFn: reads("2\n"), execFn: execs(`bun ${MARKER}`), selfPid: 1 }).kind,
+      classifyPidFile("/x", MARKER, { readFn: reads("2\n"), execFn: execs("/usr/bin/vim"), selfPid: 1 }).kind,
+      classifyPidFile("/x", MARKER, { readFn: reads("2\n"), execFn: execs(null), selfPid: 1 }).kind,
+    ];
+    expect(new Set(kinds).size).toBe(5);
+  });
+});
+
+describe("⛔ shouldRemovePidFile — the step-3 damage, and it was REPRODUCED", () => {
+  // When the orphaned broker exited, its unconditional unlinkSync deleted the
+  // LIVE one's pid file; status then reported the healthy survivor as DOWN and
+  // the next supervisor pass would have started a third.
+  test("only 'self' may unlink", () => {
+    expect(shouldRemovePidFile({ kind: "self", pid: 1 })).toBe(true);
+  });
+
+  test("a live peer's file is LEFT ALONE — this is the reproduced incident", () => {
+    expect(shouldRemovePidFile({ kind: "live-peer", pid: 17643 })).toBe(false);
+  });
+
+  test("⚠️ stale, unknown and absent are ALSO left alone — remove fails toward keeping", () => {
+    // Opposite fail direction to writePidFile, deliberately: a wrongly-kept stale
+    // file is cleared by the next start; a wrongly-deleted live one orphans a
+    // daemon. "I could not tell" must therefore not unlink.
+    for (const kind of ["stale", "unknown", "absent"]) {
+      expect(shouldRemovePidFile({ kind, pid: 5 })).toBe(false);
+    }
+    expect(shouldRemovePidFile(undefined)).toBe(false);
+    expect(shouldRemovePidFile(null)).toBe(false);
+  });
+});
+
+describe("duplicateDaemonAlarm — names BOTH pids, because 'there are two' is not actionable", () => {
+  test("a live peer produces an alarm naming both", () => {
+    const msg = duplicateDaemonAlarm({ kind: "live-peer", pid: 17643 }, { name: "broker", selfPid: 53448 });
+    expect(msg).toContain("17643");
+    expect(msg).toContain("53448");
+    expect(msg).toContain("duplicate broker");
+  });
+
+  test("every other kind produces NO alarm — the detector must sit silent when healthy", () => {
+    for (const kind of ["self", "stale", "unknown", "absent"]) {
+      expect(duplicateDaemonAlarm({ kind, pid: 1 }, { name: "broker" })).toBeNull();
+    }
+  });
+});
+
+describe("processCommand — reads the real ps, with a positive control", () => {
+  test("POSITIVE CONTROL: this process's own command line is readable and names a runtime", () => {
+    // Without this, the two 'returns null' assertions below could pass on a
+    // helper that never manages to read anything at all.
+    const cmd = processCommand(process.pid);
+    expect(typeof cmd).toBe("string");
+    expect(cmd.length).toBeGreaterThan(0);
+  });
+
+  test("a pid that cannot exist returns null rather than throwing", () => {
+    expect(processCommand(2 ** 30)).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/lib/pid-file-identity.mjs
+++ b/plugins/dev/scripts/lib/pid-file-identity.mjs
@@ -1,0 +1,144 @@
+// pid-file-identity.mjs — a pid file may only be written over, or removed, by a
+// process that can prove the file is not pointing at a LIVE peer.
+//
+// ⛔ THE MEASURED INCIDENT (CTL-2028, mini-2, 2026-08-18 16:20 CT). Two brokers,
+// both alive, both heartbeating, both tailing the same event log and folding into
+// the same `filter-state.db`. The orphan had survived a `catalyst-stack restart`
+// and had been running for EIGHTY-FIVE MINUTES — and `catalyst-stack status`
+// reported ONE healthy broker the entire time, because it reads the pid file and
+// the pid file had been overwritten by the newer process.
+//
+// The mechanism was two unconditional lines:
+//
+//   writeFileSync(PID_FILE_PATH, `${process.pid}\n`);  // clobbers a LIVE peer
+//   unlinkSync(PID_FILE_PATH);                         // unlinks SOMEONE ELSE's
+//
+// so the failure composes:
+//   1. a restart leaves the old daemon alive        → two daemons;
+//   2. the new one CLOBBERS the file                → the old one is invisible to
+//      every pid-based check, supervisor and status command;
+//   3. the old one eventually exits and REMOVES the → the survivor is unmanaged,
+//      live daemon's pid file                          and the next supervisor
+//                                                      pass may start a THIRD.
+// Step 3 was reproduced, not theorised: terminating the orphan left the pid file
+// absent with a healthy broker still running, and status then reported DOWN.
+//
+// ⚠️ WHY IDENTITY AND NOT `kill -0`. Pids are recycled. A liveness-only check
+// would let an unrelated same-user process that inherited the recorded pid look
+// like a live peer — which would make a legitimately stale pid file permanently
+// un-writable and wedge the daemon. This is the same lesson `catalyst-monitor.sh`'s
+// `_forward_pid_is_ours` already paid for on the bash side; the rule there and here
+// is identical: match the COMMAND LINE, and be explicit about the fail direction.
+//
+// ⛔ THE TWO FAIL DIRECTIONS ARE OPPOSITE, AND THAT IS DELIBERATE.
+//   • REMOVE fails toward LEAVING THE FILE. Deleting a live peer's pid file is the
+//     step-3 damage above; leaving a stale file behind is a cosmetic mess a
+//     restart clears. So "I could not read the file" or "the contents are not a
+//     number" means DO NOT UNLINK.
+//   • WRITE fails toward WRITING. Refusing to write on an unreadable `ps` would
+//     leave a healthy daemon with no pid file at all — unmanaged, exactly the
+//     state this module exists to prevent. So an unresolvable identity is a
+//     WARNING plus a write, never a refusal.
+
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+/**
+ * readPidFrom — the pid a file names, or null.
+ *
+ * Returns null for absent, unreadable, empty, non-numeric and non-positive
+ * contents. Every one of those is "I cannot tell whose file this is", and the
+ * caller must treat them as such rather than as "nobody's".
+ */
+export function readPidFrom(path, { readFn = readFileSync } = {}) {
+  let raw;
+  try {
+    raw = readFn(path, "utf8");
+  } catch {
+    return null;
+  }
+  const n = Number.parseInt(String(raw).trim(), 10);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/**
+ * processCommand — the full command line of `pid`, or null when it cannot be read.
+ *
+ * ⚠️ `-ww` IS LOad-BEARING. Linux procps wraps at 80 columns when stdout is not a
+ * tty, and a bun-launched daemon's command line is comfortably longer than that —
+ * so without it the marker the identity match depends on is TRUNCATED AWAY and the
+ * check answers "not the same daemon" about a process that is. That exact
+ * truncation shipped once on the bash side (`_forward_pid_is_ours`) and reproduced
+ * only on Linux, because macOS `ps` does not truncate.
+ */
+export function processCommand(pid, { execFn = execFileSync } = {}) {
+  try {
+    const out = execFn("ps", ["-ww", "-o", "command=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const cmd = String(out).trim();
+    return cmd.length > 0 ? cmd : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * classifyPidFile — who does this pid file name?
+ *
+ * `marker` is a substring that identifies THIS daemon in a command line (e.g.
+ * "broker/index.mjs"). Returns a discriminated verdict — never a bare boolean —
+ * so a caller can act differently on "a live peer" and "I could not look", which
+ * are the two answers that must not be collapsed:
+ *
+ *   { kind: "absent" }                    no file, or nothing parseable in it
+ *   { kind: "self", pid }                 the file names THIS process
+ *   { kind: "live-peer", pid, command }   a DIFFERENT, live process, same daemon
+ *   { kind: "stale", pid, reason }        names a pid that is gone, or alive but a
+ *                                         DIFFERENT program (a recycled pid)
+ *   { kind: "unknown", pid }              the pid exists but `ps` would not answer
+ */
+export function classifyPidFile(path, marker, { readFn = readFileSync, execFn = execFileSync, selfPid = process.pid } = {}) {
+  const pid = readPidFrom(path, { readFn });
+  if (pid === null) return { kind: "absent" };
+  if (pid === selfPid) return { kind: "self", pid };
+  const command = processCommand(pid, { execFn });
+  if (command === null) {
+    // `ps` said nothing. Either the process is gone (the common case) or `ps`
+    // itself failed. These are not distinguishable from here, and the two callers
+    // want opposite defaults — so the ambiguity is REPORTED, not resolved.
+    return { kind: "unknown", pid };
+  }
+  // A recycled pid: alive, but running something else entirely. Treating this as a
+  // live peer would make the file permanently un-writable.
+  if (!command.includes(marker)) return { kind: "stale", pid, reason: "recycled-pid", command };
+  return { kind: "live-peer", pid, command };
+}
+
+/**
+ * shouldRemovePidFile — may this process unlink `path`?
+ *
+ * ONLY when the file names this process. Everything else — a live peer, a stale
+ * entry, an unreadable file — is left alone, because the cost of a wrong unlink
+ * (an unmanaged live daemon) is strictly worse than the cost of a wrong keep (a
+ * stale file the next start overwrites).
+ */
+export function shouldRemovePidFile(verdict) {
+  return verdict?.kind === "self";
+}
+
+/**
+ * duplicateDaemonAlarm — the operator-facing sentence for a `live-peer` verdict,
+ * or null. Both pids are named, because "there are two" is not actionable and
+ * "17643 and 53448 are both running" is.
+ */
+export function duplicateDaemonAlarm(verdict, { name = "daemon", selfPid = process.pid } = {}) {
+  if (verdict?.kind !== "live-peer") return null;
+  return (
+    `duplicate ${name}: the pid file names ${verdict.pid}, which is ALIVE and is also a ${name} — ` +
+    `this process (${selfPid}) is about to overwrite it, so ${verdict.pid} becomes invisible to every ` +
+    `pid-based status check and supervisor. Two ${name}s are processing the same inputs. ` +
+    `Stop one by identity, then restart.`
+  );
+}


### PR DESCRIPTION
## The incident

Measured on **mini-2, 2026-08-18 16:20 CT**:

```
17643  Tue Aug 18 14:55:29  bun .../broker/index.mjs --pid-file /Users/ryan/catalyst/broker.pid   ppid=1
53448  Tue Aug 18 16:19:59  bun .../broker/index.mjs --pid-file /Users/ryan/catalyst/broker.pid
pid file: 53448
```

Both **alive**, both **heartbeating**, both tailing the same event log and folding into the same `filter-state.db`. The orphan had survived a `catalyst-stack restart` and had been running for **85 minutes** — and ⛔ **`catalyst-stack status` reported one healthy broker the entire time**, because it reads the pid file and the pid file had been overwritten by the newer process.

## The mechanism: two unconditional lines

```js
writeFileSync(PID_FILE_PATH, `${process.pid}\n`);  // clobbers, even if the file names a LIVE peer
unlinkSync(PID_FILE_PATH);                         // unlinks, even if the file names SOMEONE ELSE
```

So the failure **composes**:

1. a restart leaves the old daemon alive → **two daemons**;
2. the new one **clobbers** the file → the old one is invisible to every pid-based check, supervisor and status command;
3. the old one eventually exits and **removes the live one's pid file** → the survivor is unmanaged, and the next supervisor pass may start a **third**.

⭐ **Step 3 was reproduced, not theorised**: terminating the orphan left `~/catalyst/broker.pid` absent with a healthy broker still running, and status then reported the broker DOWN.

## ⛔ The two fail directions are OPPOSITE, deliberately

| | fails toward | why |
| --- | --- | --- |
| `removePidFile` | **keeping the file** | a wrongly-deleted live one orphans a daemon (step 3); a wrongly-kept stale one is cleared by the next start |
| `writePidFile` | **writing** | refusing on an unreadable `ps` leaves a healthy daemon with **no pid file at all** — the exact unmanaged state this prevents |

So a live peer on start is a **loud ERROR naming both pids** and the write proceeds; anything other than a confirmed *"this file names me"* on exit **leaves the file alone**.

A **recycled pid** — alive, but running a different program — is classified `stale`, not `live-peer`. Treating it as a peer would make a legitimately stale pid file permanently un-writable and wedge the daemon. `unknown` (ps would not answer) is its own verdict, because the two callers want opposite defaults and the ambiguity must be *reported*, not resolved.

## The detection half — count by identity

⛔ **A pid-file-derived status can only ever report 0 or 1.** The number that matters is how many processes exist. `catalyst-broker status` now counts by identity and reports:

- an **ERROR** line when >1 broker is running (with all pids), even while it prints `running (pid N)`;
- ⭐ the case the pid file is entirely blind to — **no usable pid file with brokers running** ("UNMANAGED"), which is the state that stranded mini-2 and which a supervisor would otherwise "fix" by starting another;
- `processCount` / `processPids` / `duplicate` in `--json`.

### ⚠️ The exit code is deliberately UNCHANGED (0)

My first cut returned `2` on a duplicate and `1` when stopped. That reads as obviously better and is a **silent behaviour change on an unrelated path**: `orchestrate-register-interests.sh:62` does `if ! catalyst-broker status >/dev/null 2>&1 ... then exit 0` — it treats **any** non-zero as *"no broker, skip registration"*. Under that cut a **duplicated** broker (which is running) would have silently stopped the legacy-wave path from registering interests. A pid-file fix has no business changing that contract; widening it is its own ticket with its own audit of the two callers. There is a test pinning the 0.

## ⛔ Two false positives I created and then measured

Both are recorded in the code with the numbers, because both are the same class the rest of this PR is about:

1. **`awk -v m="$MARKER"` puts the marker into AWK'S OWN command line**, which `ps -eo command=` lists and the matcher then matches. Measured on a host with **no broker and no pid file**: it reported `1 broker process(es) are running (pids: 23661)` — and 23661 was the awk. It is `grep -v grep` wearing a different hat, and the comment two lines above the code warned about exactly this class before the code walked into it. Fixed by passing the marker through `ENVIRON[]`.
2. **A mention is not an invocation.** Excluding awk is necessary but not sufficient — the remaining match was the wrapping `/bin/zsh -c …` whose argv merely *quoted* the marker. The match now additionally requires the first token's basename to be `bun` or `node`.

⚠️ Both were false positives, which is the dangerous direction for a duplicate detector: an unconditional +1 makes a single healthy broker read as two and sends an operator hunting a phantom.

## Testing

**Three JS mutations**, each fails 2 cases: unlink unconditionally (the original defect) · a recycled pid read as a live peer · `unknown` collapsed into `absent`.

**The shell suite starts REAL processes.** ⚠️ Not hermetic in the `orphan-sweep.test.sh` sense, and that is the point: the defect is that a pid-file-derived status cannot see a second process, so a mocked `ps` would let the detector pass while counting nothing. Every "should NOT be counted" case is paired with a **positive control in the same run** (`0 → 1` before asserting a mention yields `0`), fixtures are short-lived, and the trap **asserts** they are gone (`ps -p … && LEAKED`) rather than probing with something that fails open.

Both suites registered in `execution-core-tests.yml`, verified by re-parsing the YAML.

### Gate

Full stable list run once at load 25, against the `origin/main` baseline in an identical bare worktree — **identical failure sets** (all environmental: a bare worktree has no `node_modules`). Both new suites run green standalone (15 pass / 0 fail, and `PASS — broker-pid-identity` rc=0).

## Scope note

The ticket asks to "audit the other daemons together". A repo-wide search for `writePidFile|removePidFile` finds **exactly one** implementation — `broker/index.mjs` — so there is no second copy to fix here. The other daemons use the bash pid handling in `catalyst-monitor.sh`, which already does an identity check (`_forward_pid_is_ours`, and this module's header cites the lesson it paid for). `lib/pid-file-identity.mjs` is the reusable seam if a future JS daemon needs one.

Closes CTL-2028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
