### PR TITLE
fix(dev): CTL-2026 — doctor could certify a host whose live Linear write path is a directory it never looks at

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1123,6 +1123,7 @@ jobs:
             doctor-cloud-sync-skew.test.mjs \
             dispatch.test.mjs \
             doctor.test.mjs \
+            agent-tools-write-path-health.test.mjs \
             doctor-replica.test.mjs \
             __tests__/replica-health.test.mjs \
             __tests__/replica-health-event.test.mjs \

--- a/plugins/dev/scripts/execution-core/agent-tools-write-path-health.mjs
+++ b/plugins/dev/scripts/execution-core/agent-tools-write-path-health.mjs
@@ -1,0 +1,245 @@
+// agent-tools-write-path-health.mjs — CTL-2026, the `catalyst doctor` half.
+//
+// ── THE GATE THIS SERVES, AND THE HOLE IT CLOSES ──
+// CTL-1889's gate is "`doctor` asserts no skill/tool holds a direct Linear write path".
+// The two tools every lane's brief actually invokes are NOT in the repo:
+//
+//     ~/catalyst/comms/tools/linear-reply.mjs   ← every lane's ticket replies
+//     ~/catalyst/comms/tools/linear-ack.mjs     ← every lane's 👀 claim
+//
+// ⛔ A check that walks only the repo would CERTIFY a host that is still writing around
+// the proxy — a green gate over the exact thing it exists to catch. So this check looks at
+// the out-of-tree directory and REPORTS ON IT, and the one outcome it may never produce is
+// a silent PASS earned by not looking.
+//
+// ── WHY A DIGEST COMPARISON AND NOT A SOURCE GREP ──
+// The tempting check is "does the out-of-tree file mention the write proxy". That passes on
+// a declared-but-unused import — the same class of untruth as a gate that reads a
+// discriminator and ignores it. What can be stated falsifiably is IDENTITY: is the file
+// out there the file this repo tests? A SHA-256 answers that and nothing else, and it
+// cannot be satisfied by a plausible-looking edit.
+//
+// ⭐ THE DRIFT IS MEASURED, NOT HYPOTHETICAL. CTL-2026 was filed on the observation that the
+// copies were "byte-identical" — and stopped being so SIX HOURS LATER, when the out-of-tree
+// linear-reply.mjs was hand-edited (2026-08-18 19:46:30) to add a per-agent avatar the repo
+// copy did not have. Nothing reported that. This is what reports it.
+//
+// ── ADVISORY — never FAIL ──
+// doctor's FAIL count gates worker activation. An out-of-tree copy is a provenance problem,
+// not a reason to take a host out of service, and during the CTL-2026(b) interim EVERY host
+// legitimately has one. Same posture and same reason as checkLinearWriteBudget and
+// checkRegistryTeamIdentity. Flipping it to FAIL is a decision for after (a) lands.
+
+import { createHash } from "node:crypto";
+import { readFileSync, lstatSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+
+/** The tools whose out-of-tree copies are load-bearing for every lane. */
+export const AGENT_TOOLS = Object.freeze(["linear-reply.mjs", "linear-ack.mjs"]);
+
+/** Where the repo's canonical copies live — resolved from THIS file's URL, so the answer
+ *  does not depend on the caller's cwd (the CTL-1641 rule). */
+export function repoScriptsDir() {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+/** The out-of-tree directory, honouring CATALYST_DIR the way the rest of the fleet does. */
+export function defaultOutOfTreeDir(env = process.env) {
+  const base = env.CATALYST_DIR || join(env.HOME || homedir(), "catalyst");
+  return join(base, "comms", "tools");
+}
+
+export const VERDICT = Object.freeze({
+  ABSENT: "absent",
+  WRAPPER: "wrapper",
+  COPY_MATCHES: "copy-matches",
+  COPY_DRIFTED: "copy-drifted",
+  INCONCLUSIVE: "inconclusive",
+});
+
+/**
+ * classifyAgentToolCopy — pure. One out-of-tree file's relationship to its repo counterpart.
+ *
+ * ⛔ EVERY UNKNOWN RESOLVES TO `INCONCLUSIVE`, NEVER TO A MATCH. An unreadable file, a
+ * missing repo counterpart, or a throwing probe are all "I could not look" — reporting any
+ * of them as agreement is the false-clean this whole ticket is about, and `[].every(p)` is
+ * `true` is how it usually arrives.
+ *
+ * @param {object} o
+ * @param {string} o.name              the tool's filename
+ * @param {string|null} o.linkTarget   realpath of the out-of-tree entry when it is a symlink
+ * @param {string|null} o.outDigest    sha256 of the out-of-tree file, null if unreadable
+ * @param {string|null} o.repoDigest   sha256 of the repo copy, null if unreadable
+ * @param {boolean} o.outPresent       does the out-of-tree entry exist at all
+ * @param {string|null} o.reason       why a digest is null, when it is
+ */
+export function classifyAgentToolCopy({
+  name,
+  linkTarget = null,
+  outDigest = null,
+  repoDigest = null,
+  outPresent = false,
+  reason = null,
+  repoDir = repoScriptsDir(),
+} = {}) {
+  if (!outPresent) {
+    return { name, verdict: VERDICT.ABSENT, detail: `${name}: no out-of-tree copy` };
+  }
+  if (linkTarget) {
+    // The CTL-2026(a) end state: one implementation, kept current by the fleet refresh.
+    // Recognised by RESOLUTION, not by the link's text — a relative link and an absolute
+    // one are the same fact, and only the resolved path can be checked against the repo.
+    const inRepo = resolve(linkTarget) === resolve(join(repoDir, name));
+    return inRepo
+      ? { name, verdict: VERDICT.WRAPPER, detail: `${name}: symlink → the repo copy` }
+      : {
+          name,
+          verdict: VERDICT.INCONCLUSIVE,
+          detail: `${name}: symlink resolves OUTSIDE the repo scripts dir (${linkTarget}) — its write path is unknown here`,
+        };
+  }
+  if (outDigest == null || repoDigest == null) {
+    return {
+      name,
+      verdict: VERDICT.INCONCLUSIVE,
+      detail: `${name}: could not compare (${reason ?? (outDigest == null ? "out-of-tree copy unreadable" : "repo copy unreadable")})`,
+    };
+  }
+  return outDigest === repoDigest
+    ? {
+        name,
+        verdict: VERDICT.COPY_MATCHES,
+        detail: `${name}: a byte-identical copy of the repo file`,
+      }
+    : { name, verdict: VERDICT.COPY_DRIFTED, detail: `${name}: DRIFTED from the repo copy` };
+}
+
+/** sha256 of a file, or null plus the reason it could not be read. */
+function digestOf(path, readFn) {
+  try {
+    return { digest: createHash("sha256").update(readFn(path)).digest("hex"), reason: null };
+  } catch (err) {
+    return { digest: null, reason: `${err?.code ?? "read failed"}` };
+  }
+}
+
+/**
+ * checkAgentToolsWritePath — the doctor row.
+ *
+ * ⛔ The grade is the WORST verdict across the tools, and the detail always NAMES the
+ * directory that was examined. "I looked at X and found Y" is checkable by the reader;
+ * a bare "ok" is not.
+ */
+export function checkAgentToolsWritePath(deps = {}) {
+  const {
+    env = process.env,
+    outDir = defaultOutOfTreeDir(env),
+    repoDir = repoScriptsDir(),
+    tools = AGENT_TOOLS,
+    readFile = readFileSync,
+    lstat = lstatSync,
+    realpath = realpathSync,
+  } = deps;
+
+  // ⛔ BOTH SIDES OF THE SYMLINK COMPARISON MUST BE CANONICAL, OR NEITHER.
+  // `realpathSync` on a link resolves every component — on macOS that turns /var into
+  // /private/var — while a plain `join(repoDir, name)` does not. Comparing one against the
+  // other made a correct wrapper read as "resolves OUTSIDE the repo", i.e. the CTL-2026(a)
+  // end state would have graded WARN on the very host that had adopted it. Caught by the
+  // suite's symlink case on macOS; it would have passed on a Linux runner, which is exactly
+  // the kind of half-true green this check exists to refuse.
+  let canonicalRepoDir = repoDir;
+  try {
+    canonicalRepoDir = realpath(repoDir);
+  } catch {
+    // A repo dir that cannot be canonicalised is left as-is: the comparison may then fail
+    // to recognise a wrapper, which lands on INCONCLUSIVE — the safe direction.
+  }
+
+  const results = tools.map((name) => {
+    const outPath = join(outDir, name);
+    let outPresent = false;
+    let linkTarget = null;
+    try {
+      const st = lstat(outPath);
+      outPresent = true;
+      if (st.isSymbolicLink()) {
+        try {
+          linkTarget = realpath(outPath);
+        } catch (err) {
+          // A DANGLING symlink is present-but-unresolvable. Reporting it as "absent"
+          // would hide a tool every lane invokes and that currently cannot run at all.
+          return classifyAgentToolCopy({
+            name,
+            outPresent: true,
+            reason: `symlink does not resolve (${err?.code ?? "unknown"})`,
+            canonicalRepoDir,
+          });
+        }
+      }
+    } catch {
+      // ENOENT is the only benign reason to be here, and it is the common one. Any other
+      // errno also lands here; it is reported as absent rather than inconclusive because
+      // an entry doctor cannot even lstat is not one the lanes are invoking either.
+      return classifyAgentToolCopy({ name, outPresent: false, repoDir: canonicalRepoDir });
+    }
+    if (linkTarget)
+      return classifyAgentToolCopy({ name, outPresent, linkTarget, repoDir: canonicalRepoDir });
+
+    const out = digestOf(outPath, readFile);
+    const repo = digestOf(join(repoDir, name), readFile);
+    return classifyAgentToolCopy({
+      name,
+      outPresent,
+      outDigest: out.digest,
+      repoDigest: repo.digest,
+      reason: out.reason
+        ? `out-of-tree copy: ${out.reason}`
+        : repo.reason
+          ? `repo copy: ${repo.reason}`
+          : null,
+      repoDir: canonicalRepoDir,
+    });
+  });
+
+  const has = (v) => results.some((r) => r.verdict === v);
+  const summary = results.map((r) => r.detail).join("; ");
+
+  if (results.every((r) => r.verdict === VERDICT.ABSENT)) {
+    return mkCheck(
+      "agent-tools-write-path",
+      STATUS.PASS,
+      `no out-of-tree agent tools under ${outDir} — nothing outside this repo's tests to certify`
+    );
+  }
+  if (results.every((r) => r.verdict === VERDICT.WRAPPER || r.verdict === VERDICT.ABSENT)) {
+    return mkCheck(
+      "agent-tools-write-path",
+      STATUS.PASS,
+      `${outDir}: every present tool is a symlink to the repo copy (CTL-2026(a)) — ${summary}`
+    );
+  }
+  if (has(VERDICT.INCONCLUSIVE)) {
+    return mkCheck(
+      "agent-tools-write-path",
+      STATUS.WARN,
+      `${outDir}: INCONCLUSIVE — this directory's write path could not be established, which is not the same as it being routed. ${summary}`
+    );
+  }
+  if (has(VERDICT.COPY_DRIFTED)) {
+    return mkCheck(
+      "agent-tools-write-path",
+      STATUS.WARN,
+      `${outDir}: a copy has DRIFTED from the repo — its write path is NOT the one this repo's tests cover, so no CI result here is evidence about it. ${summary}`
+    );
+  }
+  return mkCheck(
+    "agent-tools-write-path",
+    STATUS.WARN,
+    `${outDir}: byte-identical copies, not wrappers — inconclusive by design until CTL-2026(a) makes them symlinks. They also cannot resolve the proxy modules from that directory, so their writes go direct (or, under enforce, refuse). ${summary}`
+  );
+}

--- a/plugins/dev/scripts/execution-core/agent-tools-write-path-health.mjs
+++ b/plugins/dev/scripts/execution-core/agent-tools-write-path-health.mjs
@@ -181,11 +181,24 @@ export function checkAgentToolsWritePath(deps = {}) {
           });
         }
       }
-    } catch {
-      // ENOENT is the only benign reason to be here, and it is the common one. Any other
-      // errno also lands here; it is reported as absent rather than inconclusive because
-      // an entry doctor cannot even lstat is not one the lanes are invoking either.
-      return classifyAgentToolCopy({ name, outPresent: false, repoDir: canonicalRepoDir });
+    } catch (err) {
+      // ⛔ ABSENT IS RESERVED FOR ENOENT (Codex P2 on #3679). The first cut caught every
+      // errno here and called it absent, reasoning that an unlistable entry is not one the
+      // lanes are invoking. That is the false-clean this whole row exists to refuse: with
+      // both probes failing EACCES — a directory whose permissions changed, an unreadable
+      // mount — every tool reports absent, the all-absent branch returns PASS, and doctor
+      // states "no out-of-tree agent tools" about a directory it could not open. "The
+      // tools are not there" and "I could not look" must not share an outcome, and lstat
+      // is the one probe where the distinction is carried by the errno alone.
+      if (err?.code === "ENOENT") {
+        return classifyAgentToolCopy({ name, outPresent: false, repoDir: canonicalRepoDir });
+      }
+      return classifyAgentToolCopy({
+        name,
+        outPresent: true,
+        reason: `could not stat the out-of-tree entry (${err?.code ?? "unknown"})`,
+        repoDir: canonicalRepoDir,
+      });
     }
     if (linkTarget)
       return classifyAgentToolCopy({ name, outPresent, linkTarget, repoDir: canonicalRepoDir });

--- a/plugins/dev/scripts/execution-core/agent-tools-write-path-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/agent-tools-write-path-health.test.mjs
@@ -148,6 +148,58 @@ describe("checkAgentToolsWritePath", () => {
   });
 });
 
+describe("lstat failures (Codex P2 on #3679)", () => {
+  // ⛔ THE FALSE CLEAN THIS PINS: catching every errno as "absent" means a directory whose
+  // permissions changed reports "no out-of-tree agent tools" — a PASS about a directory
+  // doctor could not open. ENOENT is the ONLY errno that means absent.
+  const failingLstat = (code) => () => {
+    throw Object.assign(new Error(code), { code });
+  };
+
+  test("EACCES on BOTH tools must NOT produce the all-absent PASS", () => {
+    const c = checkAgentToolsWritePath({
+      outDir: "/nonexistent/tools",
+      repoDir: "/nonexistent/scripts",
+      lstat: failingLstat("EACCES"),
+    });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("INCONCLUSIVE");
+    expect(c.detail).toContain("EACCES");
+  });
+
+  test("EIO is inconclusive too — the list of bad errnos is not enumerated, ENOENT is", () => {
+    const c = checkAgentToolsWritePath({
+      outDir: "/nonexistent/tools",
+      repoDir: "/nonexistent/scripts",
+      lstat: failingLstat("EIO"),
+    });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("EIO");
+  });
+
+  test("ENOENT still means absent — the benign, overwhelmingly common case still PASSes", () => {
+    const c = checkAgentToolsWritePath({
+      outDir: "/nonexistent/tools",
+      repoDir: "/nonexistent/scripts",
+      lstat: failingLstat("ENOENT"),
+    });
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain("no out-of-tree agent tools");
+  });
+
+  test("an errno-less throw is inconclusive, not absent — an unknown failure is still a failure", () => {
+    const c = checkAgentToolsWritePath({
+      outDir: "/nonexistent/tools",
+      repoDir: "/nonexistent/scripts",
+      lstat: () => {
+        throw new Error("no code property");
+      },
+    });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("INCONCLUSIVE");
+  });
+});
+
 describe("classifyAgentToolCopy — the pure core", () => {
   test("every unknown resolves to INCONCLUSIVE, never to a match", () => {
     const cases = [

--- a/plugins/dev/scripts/execution-core/agent-tools-write-path-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/agent-tools-write-path-health.test.mjs
@@ -1,0 +1,198 @@
+// CTL-2026 — the out-of-tree agent tools must be VISIBLE to doctor, and never silently pass.
+//
+// ⛔ THE PROPERTY UNDER TEST IS THE ABSENCE OF A FALSE CLEAN. Each case below pins the
+// STATUS *and* a literal from the detail, because a check that returns the right grade with
+// a detail nobody can act on is only half a check — and because pinning the grade alone
+// lets a mutation that swaps two branches' messages survive.
+//
+// ⛔ AND THE NO-ARGS SHAPE IS TESTED. Every other case injects `readFile`/`lstat`, so the
+// PRODUCTION call — `checkAgentToolsWritePath()` with no deps, which is how doctor.mjs
+// invokes it — would otherwise be the one shape nothing exercises. That exact gap shipped a
+// doctor check in this repo that crashed on every host behind ten green tests.
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AGENT_TOOLS,
+  VERDICT,
+  checkAgentToolsWritePath,
+  classifyAgentToolCopy,
+  defaultOutOfTreeDir,
+  repoScriptsDir,
+} from "./agent-tools-write-path-health.mjs";
+
+/** A throwaway pair of directories standing in for ~/catalyst/comms/tools + the repo. */
+function fixture({ out = {}, repo = {} } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "ctl2026-doctor-"));
+  const outDir = join(root, "tools");
+  const repoDir = join(root, "scripts");
+  mkdirSync(outDir);
+  mkdirSync(repoDir);
+  for (const [name, body] of Object.entries(repo)) writeFileSync(join(repoDir, name), body);
+  for (const [name, body] of Object.entries(out)) {
+    if (body?.symlinkTo !== undefined) symlinkSync(body.symlinkTo, join(outDir, name));
+    else writeFileSync(join(outDir, name), body);
+  }
+  return { root, outDir, repoDir, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+const BOTH = { "linear-reply.mjs": "reply-source", "linear-ack.mjs": "ack-source" };
+
+describe("checkAgentToolsWritePath", () => {
+  test("no out-of-tree copies at all → PASS, and it names the directory it looked in", () => {
+    const f = fixture({ repo: BOTH });
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain(f.outDir);
+    f.cleanup();
+  });
+
+  test("byte-identical copies → WARN 'inconclusive by design', NOT pass", () => {
+    const f = fixture({ out: { ...BOTH }, repo: BOTH });
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    // ⛔ THE HOLE THIS CHECK EXISTS FOR: identical bytes are NOT evidence that the
+    // directory is routed — the copies cannot resolve the proxy modules from there.
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("inconclusive by design");
+    f.cleanup();
+  });
+
+  test("⭐ a DRIFTED copy → WARN that says so — this is the live 2026-08-18 state", () => {
+    const f = fixture({
+      out: { ...BOTH, "linear-reply.mjs": "reply-source + Ryan's avatar" },
+      repo: BOTH,
+    });
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("DRIFTED");
+    // The drifted tool must be NAMED — "something drifted" is not actionable.
+    expect(c.detail).toContain("linear-reply.mjs: DRIFTED");
+    // …and the tool that did NOT drift must not be smeared with it.
+    expect(c.detail).toContain("linear-ack.mjs: a byte-identical copy");
+    f.cleanup();
+  });
+
+  test("symlinks into the repo → PASS (the CTL-2026(a) end state is recognised in advance)", () => {
+    const f = fixture({ repo: BOTH });
+    for (const n of AGENT_TOOLS) symlinkSync(join(f.repoDir, n), join(f.outDir, n));
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain("symlink to the repo copy");
+    f.cleanup();
+  });
+
+  test("a symlink pointing OUTSIDE the repo is INCONCLUSIVE, not a wrapper", () => {
+    const f = fixture({ repo: BOTH });
+    const stranger = join(f.root, "elsewhere.mjs");
+    writeFileSync(stranger, "who knows");
+    symlinkSync(stranger, join(f.outDir, "linear-reply.mjs"));
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("INCONCLUSIVE");
+    expect(c.detail).toContain("resolves OUTSIDE");
+    f.cleanup();
+  });
+
+  test("a DANGLING symlink is inconclusive — never reported as absent", () => {
+    const f = fixture({ repo: BOTH });
+    symlinkSync(join(f.root, "does-not-exist.mjs"), join(f.outDir, "linear-ack.mjs"));
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("does not resolve");
+    f.cleanup();
+  });
+
+  test("⛔ an UNREADABLE file is INCONCLUSIVE — it must never read as agreement", () => {
+    const f = fixture({ out: { ...BOTH }, repo: BOTH });
+    const c = checkAgentToolsWritePath({
+      outDir: f.outDir,
+      repoDir: f.repoDir,
+      readFile: (p) => {
+        if (String(p).includes("tools")) throw Object.assign(new Error("nope"), { code: "EACCES" });
+        return "repo";
+      },
+    });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("INCONCLUSIVE");
+    expect(c.detail).toContain("EACCES");
+    f.cleanup();
+  });
+
+  test("a MISSING repo counterpart is inconclusive, not a match", () => {
+    const f = fixture({ out: { ...BOTH } }); // repo dir exists but is empty
+    const c = checkAgentToolsWritePath({ outDir: f.outDir, repoDir: f.repoDir });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("INCONCLUSIVE");
+    expect(c.detail).toContain("repo copy");
+    f.cleanup();
+  });
+
+  test("INCONCLUSIVE outranks DRIFT — the louder of the two unknowns wins the grade", () => {
+    const f = fixture({
+      out: { "linear-reply.mjs": "drifted", "linear-ack.mjs": "ack-source" },
+      repo: BOTH,
+    });
+    const c = checkAgentToolsWritePath({
+      outDir: f.outDir,
+      repoDir: f.repoDir,
+      readFile: (p) => {
+        if (String(p).endsWith("linear-ack.mjs"))
+          throw Object.assign(new Error("x"), { code: "EIO" });
+        return "differs-from-repo";
+      },
+    });
+    expect(c.detail).toContain("INCONCLUSIVE");
+    f.cleanup();
+  });
+});
+
+describe("classifyAgentToolCopy — the pure core", () => {
+  test("every unknown resolves to INCONCLUSIVE, never to a match", () => {
+    const cases = [
+      { outDigest: null, repoDigest: "a" },
+      { outDigest: "a", repoDigest: null },
+      { outDigest: null, repoDigest: null },
+    ];
+    for (const c of cases) {
+      expect(classifyAgentToolCopy({ name: "x.mjs", outPresent: true, ...c }).verdict).toBe(
+        VERDICT.INCONCLUSIVE
+      );
+    }
+  });
+
+  test("equal digests match; unequal digests drift", () => {
+    const base = { name: "x.mjs", outPresent: true };
+    expect(classifyAgentToolCopy({ ...base, outDigest: "a", repoDigest: "a" }).verdict).toBe(
+      VERDICT.COPY_MATCHES
+    );
+    expect(classifyAgentToolCopy({ ...base, outDigest: "a", repoDigest: "b" }).verdict).toBe(
+      VERDICT.COPY_DRIFTED
+    );
+  });
+});
+
+describe("the production shape — no deps injected", () => {
+  // ⛔ This is the call doctor.mjs actually makes. Everything above drives seams; if the
+  // defaults are wrong (a bad path join, a missing import, a throw on a host with no
+  // ~/catalyst) none of it would notice.
+  test("checkAgentToolsWritePath() runs with no arguments and returns a well-formed row", () => {
+    const c = checkAgentToolsWritePath();
+    expect(c.name).toBe("agent-tools-write-path");
+    expect(["pass", "warn", "fail", "info"]).toContain(c.status);
+    expect(typeof c.detail).toBe("string");
+    expect(c.detail.length).toBeGreaterThan(0);
+    // ⛔ Never FAIL: doctor's FAIL count gates worker activation and this is advisory.
+    expect(c.status).not.toBe("fail");
+  });
+
+  test("the default paths resolve to real, distinct locations", () => {
+    expect(defaultOutOfTreeDir({ HOME: "/home/x" })).toBe("/home/x/catalyst/comms/tools");
+    expect(defaultOutOfTreeDir({ CATALYST_DIR: "/srv/cat", HOME: "/home/x" })).toBe(
+      "/srv/cat/comms/tools"
+    );
+    // repoScriptsDir must point at the directory that actually holds the tools.
+    expect(repoScriptsDir().endsWith("/plugins/dev/scripts")).toBe(true);
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -34,6 +34,7 @@ import { STATUS, mkCheck } from "./doctor-status.mjs";
 import { checkInstallCompleteness } from "./install-completeness.mjs";
 // CTL-1936 AC5: the standing answer to "is this host write-exhausted".
 import { checkLinearWriteBudget } from "./write-budget-health.mjs";
+import { checkAgentToolsWritePath } from "./agent-tools-write-path-health.mjs";
 import { checkIndexServingRoot } from "./index-serving-root-health.mjs";
 import { fileURLToPath } from "node:url";
 import { spawnSync, execFileSync } from "node:child_process";
@@ -185,6 +186,7 @@ export { STATUS, mkCheck } from "./doctor-status.mjs";
 export { checkInstallCompleteness };
 
 export { checkLinearWriteBudget };
+export { checkAgentToolsWritePath };
 export { checkIndexServingRoot };
 
 // ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
@@ -6223,6 +6225,13 @@ export function checksForClass(nc, opts = {}) {
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
     () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
     () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
+    // CTL-2026: the two agent tools every lane invokes live OUTSIDE this repo
+    // (~/catalyst/comms/tools/), so a rubric that walks only the checkout would certify a
+    // host that is still writing around the proxy. This row makes that directory visible
+    // and can never PASS by not looking. Advisory only (never FAIL) — during the CTL-2026(b)
+    // interim EVERY host legitimately holds a copy, and doctor's FAIL count gates worker
+    // activation.
+    () => checkAgentToolsWritePath(),
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
     () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
   ];

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -6053,6 +6053,14 @@ export function checksForClass(nc, opts = {}) {
   // checkPeerUniqueness/checkCloudTokenEnv/checkWorkerLabels) emits is
   // STATUS.INFO — zero grade change (design §7/§9). PR3 flips this to graded.
   const secretContractCheck = () => checkSecretContract();
+  // CTL-2026 (Codex P2): class-INDEPENDENT, for the same reason deploymentModeCheck is.
+  // The out-of-tree agent tools are invoked by an operator's skills, and a `developer`
+  // node is defined a few lines below as one whose "operator's skills write
+  // transitions/comments to Linear" — so a developer is precisely where these tools run.
+  // Registering this only on the worker arm would have left the class that HOLDS the live
+  // copies reporting clean: measured on this laptop (node class `developer`), whose
+  // ~/catalyst/comms/tools/linear-reply.mjs is the drifted file this row exists to name.
+  const agentToolsWritePathCheck = () => checkAgentToolsWritePath();
 
   // Unrecognized explicit class → a single hard FAIL; grade no profile (CTL-1355).
   if (!nc.recognized) {
@@ -6118,6 +6126,7 @@ export function checksForClass(nc, opts = {}) {
       deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
       layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
       secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
+      agentToolsWritePathCheck, // CTL-2026: out-of-tree agent tools, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkSecretsHygiene(),
       developerBotCredentials,
@@ -6163,6 +6172,7 @@ export function checksForClass(nc, opts = {}) {
       deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
       layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
       secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
+      agentToolsWritePathCheck, // CTL-2026: out-of-tree agent tools, graded for every class
       () => checkConnectivity({ seed, otel, fetch: _fetch }),
       () => checkHrwPartition(), // would-own count (visibility)
       agentsThunk, // CTL-1369 PR4: updater agent installed, no worker stack (monitor is adopt-updater-shaped)
@@ -6191,6 +6201,7 @@ export function checksForClass(nc, opts = {}) {
     deploymentModeCheck, // CTL-1617: fleet-topology fact, graded for every class
       layer2PathDivergenceCheck, // CTL-1616 PR6 follow-up: split-brain Layer-2 layout FAILs until the sweep
     secretContractCheck, // CTL-1616 PR2: secret-contract shadow pass, INFO-only, graded for every class
+    agentToolsWritePathCheck, // CTL-2026: out-of-tree agent tools, graded for every class
     () => checkHostIdentity(),
     () => checkHrwPartition(),
     () => checkPeerUniqueness(),
@@ -6225,13 +6236,6 @@ export function checksForClass(nc, opts = {}) {
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
     () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
     () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
-    // CTL-2026: the two agent tools every lane invokes live OUTSIDE this repo
-    // (~/catalyst/comms/tools/), so a rubric that walks only the checkout would certify a
-    // host that is still writing around the proxy. This row makes that directory visible
-    // and can never PASS by not looking. Advisory only (never FAIL) — during the CTL-2026(b)
-    // interim EVERY host legitimately holds a copy, and doctor's FAIL count gates worker
-    // activation.
-    () => checkAgentToolsWritePath(),
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
     () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
   ];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -2863,6 +2863,36 @@ describe("checksForClass — checkSdkDaemonEnv registration (CTL-1396)", () => {
   });
 });
 
+describe("checksForClass — checkAgentToolsWritePath registration (CTL-2026)", () => {
+  // ⛔ THE DEFECT THIS PINS (Codex P2 on #3679): the row was first registered only on the
+  // worker arm. `developer` and `monitor` return from their own branches ABOVE it, so it
+  // never ran there — and a `developer` is defined a few lines away as a node whose
+  // "operator's skills write transitions/comments to Linear", i.e. exactly the class that
+  // HOLDS the live out-of-tree copies. Measured: the laptop carrying the drifted
+  // linear-reply.mjs this row exists to name is node class `developer`.
+  //
+  // ⭐ And this asserts BEHAVIOUR, not a source match. The sibling suites above check that
+  // a function NAME appears in the stringified thunks; that passes on a mention inside a
+  // comment, and it cannot tell a registered thunk from a renamed one. Here the matching
+  // thunks are INVOKED and the returned row's `name` is pinned — the only form of the
+  // assertion that a mis-wired registration can fail.
+  const rowsFor = (cls) =>
+    checksForClass(nodeClassOf({ class: cls, raw: cls }))
+      .filter((f) => f.toString().includes("checkAgentToolsWritePath"))
+      .map((f) => f());
+
+  for (const cls of ["worker", "developer", "monitor"]) {
+    it(`${cls} suite registers exactly one agent-tools-write-path row, and it grades`, () => {
+      const rows = rowsFor(cls);
+      expect(rows.length).toBe(1);
+      expect(rows[0].name).toBe("agent-tools-write-path");
+      // Advisory: doctor's FAIL count gates worker activation and every host
+      // legitimately holds a copy during the CTL-2026(b) interim.
+      expect(rows[0].status).not.toBe("fail");
+    });
+  }
+});
+
 describe("checksForClass — checkDeploymentModeConsistency registration (CTL-1617)", () => {
   const src = (nc, opts = {}) => checksForClass(nc, opts).map((f) => f.toString()).join("\n");
 


### PR DESCRIPTION
Closes CTL-2026 (the `doctor` half of option **(b)**; the repo-copy half is #3647).

## The hole

CTL-1889's gate is *"`doctor` asserts no skill/tool holds a direct Linear write path"*. The two tools every lane's brief actually invokes are **not in this repo**:

```
~/catalyst/comms/tools/linear-reply.mjs   ← every lane's ticket replies
~/catalyst/comms/tools/linear-ack.mjs     ← every lane's 👀 claim
```

A rubric that walks only the checkout grades those **zero** times and reports PASS — a green gate over the exact thing it exists to catch.

## ⭐ The drift is measured, and it happened while the ticket was open

CTL-2026 was filed on the observation that the copies were *"byte-identical to `plugins/dev/scripts/linear-{reply,ack}.mjs` today"*. **Six hours later** the out-of-tree `linear-reply.mjs` was hand-edited (2026-08-18 19:46:30) to add a per-agent avatar the repo copy does not have. Nothing reported it.

Run against this host, the new row says:

```
warn  agent-tools-write-path
      /Users/ryan/catalyst/comms/tools: a copy has DRIFTED from the repo — its write
      path is NOT the one this repo's tests cover, so no CI result here is evidence
      about it. linear-reply.mjs: DRIFTED from the repo copy; linear-ack.mjs: a
      byte-identical copy of the repo file
```

## Design

- **⛔ Identity, not a source grep.** The tempting check is *"does the file mention the write proxy"* — that passes on a declared-but-unused import, the same class of untruth as a gate that reads a discriminator and ignores it. A SHA-256 answers *"is the file out there the file this repo tests"* and nothing else can satisfy it.
- **⛔ Every unknown is INCONCLUSIVE, and outranks drift in the grade.** An unreadable copy, a missing repo counterpart, a dangling symlink, and a link resolving outside the repo each report *"I could not establish this directory's write path"* — never agreement. "I did not look" and "it is routed" must not share an outcome.
- **Recognises the (a) end state in advance.** Out-of-tree entries that are symlinks to the repo copies grade **PASS**, so tomorrow's wrapper change lands green rather than needing a second doctor change.
- **Advisory only, never FAIL.** doctor's FAIL count gates worker activation, and during the (b) interim every host legitimately holds a copy. Same posture and reason as `checkLinearWriteBudget` / `checkRegistryTeamIdentity`.

## Two defects the suite caught

- **⛔ The symlink comparison canonicalised only one side.** `realpathSync` resolves every component (on macOS `/var` → `/private/var`) while `join(repoDir, name)` does not — so a correct wrapper read as *"resolves OUTSIDE the repo"*, meaning the (a) end state would have graded WARN on the very host that adopted it. **It would have passed on a Linux runner**, which is the kind of half-true green this row exists to refuse.
- **The production call shape is tested.** `checkAgentToolsWritePath()` with no deps is how `doctor.mjs` invokes it; every other case drives an injected seam, so without that case the one shape production uses would be the only untested one — the gap that previously shipped a doctor check crashing on every host behind ten green tests.

## Verification

| | |
| --- | --- |
| new suite | 13 pass / 0 fail |
| `doctor.test.mjs` (regression) | 453 pass / 0 fail |
| combined | **466 pass / 0 fail** |
| live host | the row correctly names `linear-reply.mjs` as drifted **and** `linear-ack.mjs` as not — the drift I found by hand, reproduced by the instrument |

CI wiring verified the way this workflow's own comments demand: `grep -rc agent-tools-write-path .github/workflows/` returned nothing before the list entry was added, with `doctor.test.mjs` (1) as the positive control. **No path-filter change** — `plugins/dev/scripts/execution-core/**` already appears in both filter blocks, and #3647 owns the two tool paths (so the two PRs do not collide there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)