### PR TITLE
fix(dev): CTL-2047 — a triage budget held by a failed scan printed the same line as a busy one

### DIFF
--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -940,6 +940,36 @@ export function triageBudgetSkip(budget) {
   return { reason: "sweep-budget-exhausted", detail: { budget_remaining: remaining }, alwaysWarn: false };
 }
 
+/**
+ * The FIRST-SWEEP warn sentence, per reason (Codex P2 on #3682).
+ *
+ * ⛔ THE DEFECT THIS EXISTS FOR. `alwaysWarn` was introduced by CTL-2033 when the claim
+ * failure was its only caller, so the branch it selects hardcoded that cause: "the
+ * cross-host claim never landed … read claim_reason". The moment a SECOND reason set
+ * `alwaysWarn` — the CTL-2047 scan hold — it inherited that sentence and the log named a
+ * definite WRONG cause, pointing the operator at a `claim_reason` the payload does not even
+ * carry. That is strictly worse than the ambiguity CTL-2047 set out to remove: an operator
+ * can act on "I cannot tell"; they cannot act on a confident misattribution.
+ *
+ * ⛔ THE DEFAULT IS DELIBERATELY VAGUE AND TRUE, NOT SPECIFIC AND POSSIBLY FALSE. A future
+ * caller that sets `alwaysWarn` without registering a sentence gets a generic line that
+ * tells the reader to look at `reason`. Falling back to any concrete cause would rebuild
+ * this defect for the next reason added.
+ */
+export const TRIAGE_SKIP_WARN_MESSAGES = Object.freeze({
+  "claim-write-failed":
+    "ctl-879: triage admission FAILED (not a lost race) — the cross-host claim never landed, so no host will produce this ticket's triage.json; read claim_reason",
+  "sweep-budget-held-scan-failed":
+    "ctl-879: triage admission HELD — the yielded-occupancy scan failed host-wide, so this host's triage budget is fail-closed at zero and does NOT refill on its own; this is not a busy fleet, read held_reason (CTL-1854)",
+});
+
+export function triageSkipWarnMessage(reason) {
+  return (
+    TRIAGE_SKIP_WARN_MESSAGES[reason] ??
+    "ctl-879: triage admission declined on its FIRST sweep for a reason flagged abnormal, with no registered explanation — read `reason` and add one to TRIAGE_SKIP_WARN_MESSAGES"
+  );
+}
+
 // noteTriageSkip — record that `identifier` was declined by `reason` this sweep.
 // Returns the streak so callers/tests can assert on it. A streak that reaches
 // TRIAGE_SKIP_ESCALATE_AFTER is no longer a transient miss: nothing will produce
@@ -966,13 +996,12 @@ export function noteTriageSkip(identifier, reason, detail = {}, { alwaysWarn = f
         "ctl-879: triage admission blocked persistently — no triage.json can be produced for this ticket while this reason holds, so the scheduler's ctl-1150 gate will hold it indefinitely"
       );
     } else if (severity === "warn") {
-      // A different sentence, not the persistence one: "persistently" would be a
-      // false statement on sweep 1, and `held_sweeps: 1` beside it reads as a bug
-      // in the counter rather than as the alarm it is.
-      log.warn(
-        context,
-        "ctl-879: triage admission FAILED (not a lost race) — the cross-host claim never landed, so no host will produce this ticket's triage.json; read claim_reason"
-      );
+      // A different sentence from the persistence one: "persistently" would be a false
+      // statement on sweep 1, and `held_sweeps: 1` beside it reads as a bug in the counter
+      // rather than as the alarm it is. And a different sentence PER REASON — see
+      // triageSkipWarnMessage; a single hardcoded cause here misattributed every
+      // alwaysWarn reason but the first.
+      log.warn(context, triageSkipWarnMessage(reason));
     } else {
       log.info(context, "ctl-879: triage admission skipped this sweep");
     }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -827,9 +827,27 @@ export function computeTriageBudget({
   }
   if (!y.ok) {
     log.warn({ orchDir, reason: y.reason ?? null }, "computeTriageBudget: yielded-occupancy scan failed host-wide — holding triage admission (CTL-1854)");
-    return { remaining: 0 };
+    // ⛔ `held` IS THE WHOLE POINT OF THIS RETURN. Both this branch and the one below can
+    // answer `remaining: 0`, and until now they were indistinguishable to every consumer:
+    // the sweep's skip line printed the identical `sweep-budget-exhausted /
+    // budget_remaining: 0` under either. Their prognoses are OPPOSITE — capacity is
+    // recomputed every sweep and frees itself as soon as a worker finishes, whereas this
+    // fail-closed hold NEVER clears on its own; it holds until the scan starts succeeding.
+    // A host in this branch produces no triage.json no matter how long anyone waits, and
+    // an operator reading the log could not tell that from a busy fleet.
+    //
+    // The gate itself is correct and stays exactly as it was — inability to inspect must
+    // not read as free capacity (the comment above says so, and the scheduler's twin gate
+    // agrees). The defect was only that its silent state and its healthy state printed the
+    // same number.
+    return { remaining: 0, held: true, heldReason: y.reason ?? "yielded-occupancy-scan-failed" };
   }
-  return { remaining: computeFreeSlots(maxParallel, live + sdkInflight + y.count) };
+  // ⛔ `held: false` even when `remaining` is 0. "Held" means THE SCAN FAILED, not "the
+  // number is zero" — a budget that is legitimately at capacity, or one decremented to 0
+  // by dispatches during this very sweep, is healthy and must keep reading that way.
+  // Deriving `held` from `remaining === 0` would re-merge the two branches at the consumer
+  // and hand back the ambiguity this field exists to remove.
+  return { remaining: computeFreeSlots(maxParallel, live + sdkInflight + y.count), held: false, heldReason: null };
 }
 
 // ── CTL-879: triage-admission observability ──────────────────────────────────
@@ -883,6 +901,43 @@ export function triageSkipSeverity(streak, { alwaysWarn = false } = {}) {
   // `alwaysWarn` raises SEVERITY, never FREQUENCY: it is read only AFTER the
   // sparse gate above has already decided this sweep is written at all.
   return alwaysWarn ? "warn" : "info";
+}
+
+/**
+ * triageBudgetSkip — CTL-879 / INIT-34. Turn a zero budget into the skip it deserves.
+ *
+ * ⛔ WHY THIS IS A FUNCTION AND NOT A TERNARY AT THE CALL SITE. `sweepMissingTriage`
+ * cannot be driven from a unit test without standing up the project registry and the
+ * eligible set, and `dispatchTriage` is not exported — so an expression inlined there is
+ * unreachable by any test, and the only available assertion would be that the right
+ * literal appears somewhere in the file. That is the "asserting a discriminator is READ is
+ * not asserting the answer CHANGES" trap this repo has now shipped twice. Extracted, the
+ * decision is ordinary testable code.
+ *
+ * ⛔ A DISTINCT `reason`, NOT A FLAG IN THE DETAIL. `reason` is what noteTriageSkip keys
+ * its streak on, so folding both mechanisms into one reason merges their streaks: a host
+ * alternating between busy and held would report one unbroken run of a single cause. It is
+ * also what a Loki query selects on, while `held_reason` in the payload is stripped
+ * off-machine by otel-forward.
+ *
+ * `alwaysWarn` on the held branch for the CTL-2033 reason: a hold that structurally never
+ * self-clears is abnormal on its FIRST sweep, and waiting TRIAGE_SKIP_ESCALATE_AFTER
+ * sweeps to say so is 75-150 minutes at the measured cadence. The sparse gate inside
+ * triageSkipSeverity still bounds how often it is written.
+ */
+export function triageBudgetSkip(budget) {
+  const remaining = budget?.remaining;
+  if (budget?.held === true) {
+    return {
+      reason: "sweep-budget-held-scan-failed",
+      detail: { budget_remaining: remaining, held_reason: budget.heldReason ?? null },
+      alwaysWarn: true,
+    };
+  }
+  // Everything else — genuine capacity, a budget decremented to 0 mid-sweep, and an
+  // INJECTED budget from a caller that predates `held` — is the pre-existing healthy
+  // throttle, byte-identical to before. A missing `held` must never read as held.
+  return { reason: "sweep-budget-exhausted", detail: { budget_remaining: remaining }, alwaysWarn: false };
 }
 
 // noteTriageSkip — record that `identifier` was declined by `reason` this sweep.
@@ -1138,10 +1193,21 @@ function dispatchTriage(
     return false;
   }
   if (budget && budget.remaining <= 0) {
-    log.info(
-      { identifier },
-      "monitor: triage dispatch deferred — no free slots (maxParallel); sweepMissingTriage will retry (CTL-716)"
-    );
+    // The retry promise in the pre-existing sentence ("sweepMissingTriage will retry") is
+    // TRUE for capacity and MISLEADING for a held budget: the sweep does retry, and gets
+    // held again every time, forever. Two sentences, because one of them is a lie in the
+    // other's case.
+    if (budget.held) {
+      log.warn(
+        { identifier, held_reason: budget.heldReason ?? null },
+        "monitor: triage dispatch deferred — the yielded-occupancy scan failed host-wide, so admission is HELD, not merely full; this does not clear on its own (CTL-1854)"
+      );
+    } else {
+      log.info(
+        { identifier },
+        "monitor: triage dispatch deferred — no free slots (maxParallel); sweepMissingTriage will retry (CTL-716)"
+      );
+    }
     return false;
   }
   // CTL-781/CTL-1174: respect-assignment + delegate gate. A →Triage/→Todo
@@ -1786,9 +1852,11 @@ export function sweepMissingTriage({
         // CTL-879: was a bare `continue`. This is the gate that makes a busy
         // fleet look identical to a broken one — dispatchTriage is never called,
         // so its own info-level budget line never fires either.
-        noteTriageSkip(t.identifier, "sweep-budget-exhausted", {
-          budget_remaining: budget.remaining,
-        });
+        // CTL-879 / INIT-34: which of the two zero-budget mechanisms this is. See
+        // triageBudgetSkip — the reason must DIFFER, not carry a flag, because `reason` is
+        // the streak key and the Loki selector.
+        const bs = triageBudgetSkip(budget);
+        noteTriageSkip(t.identifier, bs.reason, bs.detail, { alwaysWarn: bs.alwaysWarn });
         continue;
       }
       if (hasTriageArtifact(orchDir, t.identifier)) {

--- a/plugins/dev/scripts/execution-core/phase-yield-expiry.test.mjs
+++ b/plugins/dev/scripts/execution-core/phase-yield-expiry.test.mjs
@@ -317,6 +317,78 @@ describe("⚠️ every admission budget charges the yield, not just the schedule
     });
     expect(out.remaining).toBe(0);
   });
+
+  // ── CTL-879 / INIT-34: the two zero paths must be TELLABLE APART ───────────────
+  //
+  // ⛔ `remaining: 0` had two producers with OPPOSITE prognoses and one observable.
+  // Capacity is recomputed every sweep and frees itself as soon as a worker finishes;
+  // the fail-closed scan hold NEVER clears on its own. Both printed the identical
+  // `sweep-budget-exhausted / budget_remaining: 0`, so an operator reading the log could
+  // not tell a busy fleet from a host that will produce no triage.json for the rest of the
+  // night. Third instrument in one evening with that shape, after the cross-host claim
+  // (CTL-2033) and doctor's webhook row (CTL-2030).
+  //
+  // These pin the DISCRIMINATOR, not the gate. The fail-closed behaviour above is correct
+  // and unchanged — `remaining` is still 0 on both paths.
+  test("⭐ a failed scan reports held:true WITH a reason; capacity-zero reports held:false", async () => {
+    const { computeTriageBudget } = await import("./monitor.mjs");
+    const base = {
+      orchDir: "/orch",
+      readMaxParallelFn: () => 1,
+      liveBackgroundCount: () => 0,
+      dispatchMode: "phase-agents",
+      countSdkInflight: () => 0,
+    };
+
+    const held = computeTriageBudget({
+      ...base,
+      countYieldedOccupancy: () => ({ count: 0, ok: false, reason: "workers/ unreadable: EACCES" }),
+    });
+    expect(held.remaining).toBe(0);
+    expect(held.held).toBe(true);
+    // The reason must survive — a hold with no diagnostic is the failure this replaces.
+    expect(held.heldReason).toBe("workers/ unreadable: EACCES");
+
+    // ⛔ THE HALF THAT IS EASY TO GET WRONG: genuinely at capacity is ALSO zero, and must
+    // NOT be held. Deriving `held` from `remaining === 0` would re-merge the branches.
+    const full = computeTriageBudget({
+      ...base,
+      countYieldedOccupancy: () => ({ count: 1, ok: true }),
+    });
+    expect(full.remaining).toBe(0);
+    expect(full.held).toBe(false);
+    expect(full.heldReason).toBe(null);
+  });
+
+  test("a healthy budget with free slots is not held either", async () => {
+    const { computeTriageBudget } = await import("./monitor.mjs");
+    const out = computeTriageBudget({
+      orchDir: "/orch",
+      readMaxParallelFn: () => 4,
+      liveBackgroundCount: () => 0,
+      dispatchMode: "phase-agents",
+      countSdkInflight: () => 0,
+      countYieldedOccupancy: () => ({ count: 0, ok: true }),
+    });
+    expect(out.remaining).toBe(4);
+    expect(out.held).toBe(false);
+  });
+
+  test("a THROWING reader is held too, and names that it threw rather than reporting no reason", async () => {
+    const { computeTriageBudget } = await import("./monitor.mjs");
+    const out = computeTriageBudget({
+      orchDir: "/orch",
+      readMaxParallelFn: () => 2,
+      liveBackgroundCount: () => 0,
+      dispatchMode: "phase-agents",
+      countSdkInflight: () => 0,
+      countYieldedOccupancy: () => { throw new Error("scan failed"); },
+    });
+    expect(out.remaining).toBe(0);
+    expect(out.held).toBe(true);
+    expect(typeof out.heldReason).toBe("string");
+    expect(out.heldReason.length).toBeGreaterThan(0);
+  });
 });
 
 describe("⚠️ expiry EXECUTES — not merely appears in the right place", () => {

--- a/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
@@ -25,6 +25,7 @@ import {
   pruneTriageSkips,
   _resetTriageSkipStreaks,
   triageSkipSeverity,
+  triageBudgetSkip,
 } from "./monitor.mjs";
 import { CLAIM_REASON, isClaimFailure } from "./cluster-claim-sync.mjs";
 
@@ -123,7 +124,15 @@ describe("CTL-879 wiring: every blind triage-admission gate records a reason", (
   const SITES = [
     ["drain gate", "drain: skipping triage dispatch — node draining", "noteTriageSkip", 8],
     ["HRW ownership gate", "ctl-1091: ticket not owned by this host under HRW", "noteTriageSkip", 8],
-    ["sweep budget gate", "readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP", "noteTriageSkip", 8],
+    // CTL-879/INIT-34 grew the explanatory block between this anchor and its recorder,
+    // and an 8-line window stopped covering the site — the same drift CTL-2033 hit two
+    // rows down. Sized with headroom rather than to the current exact distance.
+    ["sweep budget gate", "readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP", "noteTriageSkip", 20],
+    // ⛔ And the gate must CONSULT the two-mechanism discriminator, exactly as the claim
+    // gate below must consult isClaimFailure. Without this row the site could record one
+    // reason for both a busy fleet and a fail-closed hold — which is the pre-change
+    // behaviour, and the whole defect.
+    ["sweep budget gate discriminates", "readTriageDispatchCount(orchDir, t.identifier) < TRIAGE_DISPATCH_CAP", "triageBudgetSkip(budget)", 20],
     ["sweep already-triaged exit", "if (hasTriageArtifact(orchDir, t.identifier))", "clearTriageSkip", 8],
     ["sweep in-flight gate", "if (t.fromTriageBoard && isTriageInFlight(", "noteTriageSkip", 8],
     // CTL-879 follow-up: the sixth gate. The first instrument missed it, and it
@@ -273,4 +282,95 @@ describe("CTL-2033 wiring: every claim gate reads the discriminator", () => {
       expect(window).toContain("log.debug");
     });
   }
+});
+
+
+// ── CTL-879 / INIT-34: `remaining: 0` had two producers and one observable ──────
+//
+// `computeTriageBudget` answers 0 from the fail-closed yielded-occupancy hold AND from
+// genuine capacity. Their prognoses are OPPOSITE — capacity is recomputed every sweep and
+// frees itself when a worker finishes; the hold NEVER clears on its own — yet both printed
+// the identical `sweep-budget-exhausted / budget_remaining: 0`. An operator could not tell
+// a busy fleet from a host that will produce no triage.json for the rest of the night.
+//
+// ⛔ WHAT EACH LAYER HERE PROVES, STATED PLAINLY. `sweepMissingTriage` cannot be driven
+// without the project registry and the eligible set, and `dispatchTriage` is not exported —
+// so there is no way to observe the sweep's call directly. Instead the decision was
+// EXTRACTED into `triageBudgetSkip`, which these tests exercise as ordinary code, and the
+// single-source test below pins that the reason literals exist nowhere else in monitor.mjs,
+// so no call site can hand-roll one past this function. That is a real constraint, not a
+// mention-scan: it fails if someone re-inlines the ternary.
+describe("triageBudgetSkip — the two zero-budget mechanisms", () => {
+  test("⭐ a HELD budget gets its own reason, the held reason, and warns immediately", () => {
+    const s = triageBudgetSkip({ remaining: 0, held: true, heldReason: "workers/ unreadable: EACCES" });
+    expect(s.reason).toBe("sweep-budget-held-scan-failed");
+    expect(s.detail).toEqual({ budget_remaining: 0, held_reason: "workers/ unreadable: EACCES" });
+    expect(s.alwaysWarn).toBe(true);
+  });
+
+  test("⛔ capacity-zero keeps the pre-existing reason and does NOT warn immediately", () => {
+    const s = triageBudgetSkip({ remaining: 0, held: false, heldReason: null });
+    expect(s.reason).toBe("sweep-budget-exhausted");
+    expect(s.detail).toEqual({ budget_remaining: 0 });
+    expect(s.alwaysWarn).toBe(false);
+    // ⛔ and it carries NO held_reason key — a null one would render in Loki as a held
+    // budget with an unknown cause, which is the confusion this change removes.
+    expect("held_reason" in s.detail).toBe(false);
+  });
+
+  test("a budget from a caller that predates `held` reads as healthy, never as held", () => {
+    // sweepMissingTriage's sibling call site accepts an INJECTED budget; an older shape
+    // must keep its exact previous behaviour rather than silently escalating.
+    for (const b of [{ remaining: 0 }, { remaining: 3 }, {}, undefined, null]) {
+      expect(triageBudgetSkip(b).reason).toBe("sweep-budget-exhausted");
+      expect(triageBudgetSkip(b).alwaysWarn).toBe(false);
+    }
+  });
+
+  test("only the boolean true holds — a truthy value is not a hold", () => {
+    for (const held of ["true", 1, {}, []]) {
+      expect(triageBudgetSkip({ remaining: 0, held }).reason).toBe("sweep-budget-exhausted");
+    }
+  });
+
+  test("⭐ the two reasons produce DIFFERENT severities on sweep 1 — the answer changes, not just the label", () => {
+    const held = triageBudgetSkip({ remaining: 0, held: true, heldReason: "x" });
+    const busy = triageBudgetSkip({ remaining: 0, held: false });
+    // This is the composition that matters: alwaysWarn is only meaningful if it reaches
+    // triageSkipSeverity and changes what comes out on the very first sweep.
+    expect(triageSkipSeverity(1, { alwaysWarn: held.alwaysWarn })).toBe("warn");
+    expect(triageSkipSeverity(1, { alwaysWarn: busy.alwaysWarn })).not.toBe("warn");
+  });
+
+  test("the two reasons keep SEPARATE streaks — a host flipping between them does not read as one episode", () => {
+    _resetTriageSkipStreaks();
+    const held = triageBudgetSkip({ remaining: 0, held: true, heldReason: "x" }).reason;
+    const busy = triageBudgetSkip({ remaining: 0, held: false }).reason;
+    expect(noteTriageSkip("CTL-1", busy)).toBe(1);
+    expect(noteTriageSkip("CTL-1", busy)).toBe(2);
+    // Switching mechanism must RESET the streak — the escalation sentence claims
+    // persistence of one cause, and it would be a false statement across a switch.
+    expect(noteTriageSkip("CTL-1", held)).toBe(1);
+  });
+});
+
+describe("the reason literals have exactly one home", () => {
+  // ⛔ This is the wiring half, and it is a CONSTRAINT rather than a mention-scan: if the
+  // ternary is ever re-inlined at a call site, that literal appears a second time and this
+  // fails. It does not prove the sweep calls triageBudgetSkip — nothing available here can —
+  // but it does prove no OTHER code can emit these reasons behind its back.
+  const src = readFileSync(join(import.meta.dirname, "monitor.mjs"), "utf8");
+  for (const literal of ['"sweep-budget-held-scan-failed"', '"sweep-budget-exhausted"']) {
+    test(`${literal} appears exactly once in monitor.mjs`, () => {
+      expect(src.split(literal).length - 1).toBe(1);
+    });
+  }
+  test("...and both occurrences are inside triageBudgetSkip", () => {
+    const start = src.indexOf("export function triageBudgetSkip");
+    const end = src.indexOf("\n}", src.indexOf("return { reason: \"sweep-budget-exhausted\""));
+    expect(start).toBeGreaterThan(-1);
+    const body = src.slice(start, end);
+    expect(body).toContain('"sweep-budget-held-scan-failed"');
+    expect(body).toContain('"sweep-budget-exhausted"');
+  });
 });

--- a/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-admission-observability.test.mjs
@@ -26,8 +26,14 @@ import {
   _resetTriageSkipStreaks,
   triageSkipSeverity,
   triageBudgetSkip,
+  triageSkipWarnMessage,
+  TRIAGE_SKIP_WARN_MESSAGES,
 } from "./monitor.mjs";
 import { CLAIM_REASON, isClaimFailure } from "./cluster-claim-sync.mjs";
+// The SAME logger object monitor.mjs imports — module bindings share the instance, so
+// replacing a method here is observed there. This is how the emitted SENTENCE is captured
+// without parsing stdout (which would test whichever logger the environment installed).
+import { log } from "./config.mjs";
 
 beforeEach(() => _resetTriageSkipStreaks());
 
@@ -360,9 +366,24 @@ describe("the reason literals have exactly one home", () => {
   // fails. It does not prove the sweep calls triageBudgetSkip — nothing available here can —
   // but it does prove no OTHER code can emit these reasons behind its back.
   const src = readFileSync(join(import.meta.dirname, "monitor.mjs"), "utf8");
+  // ⛔ The reason strings legitimately have TWO homes: `triageBudgetSkip`, which PRODUCES
+  // them, and TRIAGE_SKIP_WARN_MESSAGES, which is KEYED by them. The registry is a lookup
+  // table, not a call site, so it is excised before counting rather than being allowed to
+  // relax the count to "2" — a bare `toBe(2)` would then silently accept a genuine
+  // hand-rolled third occurrence at a call site.
+  const registryStart = src.indexOf("export const TRIAGE_SKIP_WARN_MESSAGES");
+  const registryEnd = src.indexOf("});", registryStart) + 3;
+  const outsideRegistry = src.slice(0, registryStart) + src.slice(registryEnd);
+  test("the registry block was actually located (else the excision is a no-op)", () => {
+    // Positive control: without this, a renamed registry would make every count below
+    // pass for the wrong reason.
+    expect(registryStart).toBeGreaterThan(-1);
+    expect(registryEnd).toBeGreaterThan(registryStart);
+    expect(src.length - outsideRegistry.length).toBeGreaterThan(100);
+  });
   for (const literal of ['"sweep-budget-held-scan-failed"', '"sweep-budget-exhausted"']) {
-    test(`${literal} appears exactly once in monitor.mjs`, () => {
-      expect(src.split(literal).length - 1).toBe(1);
+    test(`${literal} appears exactly once outside the message registry`, () => {
+      expect(outsideRegistry.split(literal).length - 1).toBe(1);
     });
   }
   test("...and both occurrences are inside triageBudgetSkip", () => {
@@ -372,5 +393,118 @@ describe("the reason literals have exactly one home", () => {
     const body = src.slice(start, end);
     expect(body).toContain('"sweep-budget-held-scan-failed"');
     expect(body).toContain('"sweep-budget-exhausted"');
+  });
+});
+
+
+// ── Codex P2 on #3682: the first-sweep WARN sentence must match the REASON ───────
+//
+// ⛔ `alwaysWarn` was introduced by CTL-2033 when the claim failure was its only caller, so
+// the branch it selects hardcoded that cause. The moment CTL-2047's scan hold set
+// `alwaysWarn`, it inherited "the cross-host claim never landed … read claim_reason" — a
+// confident, specific, WRONG attribution, pointing at a `claim_reason` its payload does not
+// even carry. That is worse than the ambiguity CTL-2047 removes: an operator can act on
+// "I cannot tell"; they cannot act on a misattribution.
+//
+// ⚠️ MY OWN TESTS MISSED THIS. They asserted `alwaysWarn === true` and that
+// triageSkipSeverity(1, {alwaysWarn:true}) is "warn" — the SEVERITY — and never once looked
+// at the SENTENCE that severity selects. Pinning a flag is not pinning the output.
+describe("triageSkipWarnMessage — the sentence follows the reason", () => {
+  test("each registered reason gets its OWN sentence, and they are distinct", () => {
+    const claim = triageSkipWarnMessage("claim-write-failed");
+    const held = triageSkipWarnMessage("sweep-budget-held-scan-failed");
+    expect(claim).not.toBe(held);
+    expect(claim).toContain("cross-host claim never landed");
+    expect(claim).toContain("claim_reason");
+    expect(held).toContain("yielded-occupancy scan failed host-wide");
+    expect(held).toContain("held_reason");
+  });
+
+  test("⛔ the scan hold must NEVER be described as a claim failure", () => {
+    const held = triageSkipWarnMessage("sweep-budget-held-scan-failed");
+    expect(held).not.toContain("cross-host claim");
+    expect(held).not.toContain("claim_reason");
+    // It must also say the thing an operator needs: this is not a busy fleet.
+    expect(held).toContain("does NOT refill");
+  });
+
+  test("an UNREGISTERED reason gets a vague-but-true default, never a concrete cause", () => {
+    const d = triageSkipWarnMessage("some-future-reason");
+    expect(d).not.toContain("cross-host claim");
+    expect(d).not.toContain("yielded-occupancy");
+    // It must point the reader at the field that actually distinguishes.
+    expect(d).toContain("reason");
+    // …and every unregistered reason gets the same default, so this cannot silently
+    // become a per-reason guess.
+    expect(triageSkipWarnMessage("another-one")).toBe(d);
+    expect(triageSkipWarnMessage(undefined)).toBe(d);
+  });
+
+  test("every reason that triageBudgetSkip flags alwaysWarn HAS a registered sentence", () => {
+    // The rule that keeps the default from being reached in production: if a producer
+    // raises severity, it owes the reader an explanation.
+    const held = triageBudgetSkip({ remaining: 0, held: true, heldReason: "x" });
+    expect(held.alwaysWarn).toBe(true);
+    expect(Object.keys(TRIAGE_SKIP_WARN_MESSAGES)).toContain(held.reason);
+  });
+});
+
+describe("the claim sentence has exactly one home", () => {
+  // Same constraint as the reason literals: if the warn branch ever hardcodes a cause
+  // again, that sentence appears twice and this fails.
+  test("'the cross-host claim never landed' appears once in monitor.mjs", () => {
+    const src = readFileSync(join(import.meta.dirname, "monitor.mjs"), "utf8");
+    expect(src.split("the cross-host claim never landed").length - 1).toBe(1);
+  });
+});
+
+
+describe("noteTriageSkip EMITS the reason-specific sentence", () => {
+  // ⛔⛔ THE MUTATION THAT SURVIVED EVERYTHING ELSE. With the pure selector fully tested and
+  // the literals single-homed, reverting the warn branch to
+  // `log.warn(context, TRIAGE_SKIP_WARN_MESSAGES["claim-write-failed"])` — i.e. exactly the
+  // pre-fix misattribution — still passed 45/45. Every test proved the selector was CORRECT
+  // and none proved it was CALLED. That is "asserting a discriminator is READ is not
+  // asserting the answer CHANGES", one level up from where it was caught before, in the fix
+  // for a defect of that same shape.
+  const capture = (fn) => {
+    const seen = [];
+    const orig = log.warn;
+    log.warn = (ctx, msg) => seen.push({ ctx, msg });
+    try {
+      fn();
+    } finally {
+      log.warn = orig; // restored in `finally` — a leaked stub silently mutes every later suite
+    }
+    return seen;
+  };
+
+  test("the scan hold emits the HOLD sentence, not the claim one", () => {
+    _resetTriageSkipStreaks();
+    const seen = capture(() =>
+      noteTriageSkip("CTL-H", "sweep-budget-held-scan-failed", { held_reason: "EACCES" }, { alwaysWarn: true })
+    );
+    expect(seen.length).toBe(1);
+    expect(seen[0].msg).toContain("yielded-occupancy scan failed host-wide");
+    expect(seen[0].msg).not.toContain("cross-host claim");
+    expect(seen[0].ctx.held_reason).toBe("EACCES");
+  });
+
+  test("the claim failure still emits the CLAIM sentence — the fix must not break the first caller", () => {
+    _resetTriageSkipStreaks();
+    const seen = capture(() =>
+      noteTriageSkip("CTL-C", "claim-write-failed", { claim_reason: "cli-failed" }, { alwaysWarn: true })
+    );
+    expect(seen.length).toBe(1);
+    expect(seen[0].msg).toContain("cross-host claim never landed");
+    expect(seen[0].ctx.claim_reason).toBe("cli-failed");
+  });
+
+  test("the two callers get DIFFERENT sentences from the same code path", () => {
+    _resetTriageSkipStreaks();
+    const held = capture(() => noteTriageSkip("CTL-H", "sweep-budget-held-scan-failed", {}, { alwaysWarn: true }));
+    _resetTriageSkipStreaks();
+    const claim = capture(() => noteTriageSkip("CTL-C", "claim-write-failed", {}, { alwaysWarn: true }));
+    expect(held[0].msg).not.toBe(claim[0].msg);
   });
 });


### PR DESCRIPTION
Closes CTL-2047. Raised by **@INIT-STEWARD** in channel turn **INIT-34** against **@ORCH**'s ORCH-41 candidate; verified independently at `origin/main` @ `814605663`.

## The defect

`computeTriageBudget` returns `{remaining: 0}` from **two** places with **opposite prognoses**, and every consumer saw the same value:

| | path | refills? |
| -- | --- | --- |
| **A** | `computeFreeSlots(...)` — genuinely at capacity | **Yes** — recomputed every sweep; frees itself as soon as a worker finishes |
| **B** | `if (!y.ok) return { remaining: 0 }` — the CTL-1854 fail-closed yielded-occupancy hold | ⛔ **Never on its own** — held until the scan starts succeeding |

Both reached the identical `noteTriageSkip(t, "sweep-budget-exhausted", { budget_remaining: 0 })`. **A host in branch B produces no `triage.json` no matter how long anyone waits**, and the log said exactly what a busy fleet says.

On the night of 2026-08-18 the Triage interim, the batch gates and 11 frozen tickets were all waiting on one artifact — mini-2's first `triage.json` since Aug 14 — and the only way to tell whether the wait was legitimate was an `ssh` + `grep` no steward is permitted to run.

## ⛔ The gate itself is unchanged, and correct

Inability to inspect must not read as free capacity — its own comment says so, and the scheduler's twin gate (`scheduler.mjs:6467-6475`) already keeps and logs its reason. `remaining` is still `0` on both paths. **The defect was only that the silent state and the healthy state printed the same number.**

## Changes

- `computeTriageBudget` returns **`held` + `heldReason`**. `held: true` **only** on the `!y.ok` branch — deliberately *not* "was zero", because a budget legitimately at capacity, or decremented to 0 mid-sweep, is healthy and must keep reading that way. Deriving `held` from `remaining === 0` would re-merge the branches at the consumer.
- The sweep records **`sweep-budget-held-scan-failed`** vs `sweep-budget-exhausted` — a **distinct reason, not a flag in the detail**: `reason` is the streak key in `noteTriageSkip` and the Loki selector, while payload fields are stripped off-machine by otel-forward. Folding both into one reason also merges their **streaks**, so a host alternating between them would read as one unbroken episode of a single cause.
- The held branch passes **`alwaysWarn: true`** — a hold that structurally never self-clears is abnormal on its *first* sweep, and waiting `TRIAGE_SKIP_ESCALATE_AFTER` sweeps is 75–150 min at the measured cadence. Same argument as CTL-2033.
- `dispatchTriage`'s deferral gets its own sentence: the existing one promises *"sweepMissingTriage will retry"*, which is true for capacity and **misleading** for a hold — the sweep does retry, and is held again every time.

## ⛔ Why the decision is extracted rather than inlined

`sweepMissingTriage` cannot be driven from a unit test without standing up the project registry and the eligible set, and `dispatchTriage` is **not exported** — so a ternary at either call site is unreachable by any test, and the only available assertion would be *"the right literal appears somewhere in the file"*. That is the **"asserting a discriminator is READ is not asserting the answer CHANGES"** trap this repo shipped twice this week.

`triageBudgetSkip` is a pure exported function the production path calls. The reason literals now appear **exactly once each** in `monitor.mjs` — inside it — so no call site can hand-roll one past it, and a re-inlined ternary fails that test. The suite says plainly what that constraint does and does not prove.

## Verification

| | |
| --- | --- |
| affected suites | **97 pass / 0 fail** (triage-admission-observability, phase-yield-expiry, sdk-slot-gate, integration-ctl-705) |
| mutation — collapse both reasons to one | **5 tests fail**, including the single-home constraint |
| mutation — `alwaysWarn` true→false | **2 tests fail**, including the composition test that runs the flag through `triageSkipSeverity` — so the assertion is that the **answer** changes, not that a field is set |
| `scheduler.test.mjs` | 8 failures, **all pre-existing**: the identical set runs red at `origin/main` in a second bare worktree (the CTL-868 orphan-detected group — COORD-253's known red `main`), and the two sorted `✗` lists diff clean |

⚠️ This does **not** fix an underlying scan failure — it makes the branch legible. And it only helps after a merge + daemon restart, so it does not retire tonight's wait by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)