### PR TITLE
fix(dev): CTL-2048 — a fence the worker could not READ was reported as a fence it read and found STALE

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -595,6 +595,24 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash lib/__tests__/worktree-salvage.test.sh
 
+      - name: cluster fence-guard unit tests (CTL-864, CTL-2048)
+        # ⛔ PINNED BECAUSE IT WAS NOT. Verified before adding this step:
+        # `grep -rn cluster-fence-guard .github/workflows/` returned NOTHING,
+        # while the same grep for `worktree-salvage.test.sh` (right above,
+        # same lib/__tests__ directory) returns its own run line. So this
+        # suite has only ever run in a local full gate — the FIFTH inert
+        # suite found in three days.
+        #
+        # What it guards: the guard decides whether a worker may perform an
+        # irreversible side-effect. Its CTL-2048 cases pin that a fence it
+        # could not READ is never reported as a fence it read and found
+        # STALE, that the unreadable case is retried and the answered stale
+        # case is not, and that a transient failure recovers instead of
+        # writing a terminal status. Measured 6 fail / 12 pass against the
+        # pre-fix guard.
+        working-directory: plugins/dev/scripts
+        run: bash lib/__tests__/cluster-fence-guard.test.sh
+
       - name: worktree-salvage destroy-site wiring tests (CTL-1639)
         # Deterministic source-order invariant: each destructive bash site
         # (phase-agent-dispatch L3, orphan-sweep, phase-teardown SKILL.md) must

--- a/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
@@ -5,6 +5,11 @@
 #   A — CATALYST_CLUSTER_GENERATION unset → silent no-op, exit 0, emit NOT called
 #   B — generation set + fence current (fence-check exit 0) → exit 0, emit NOT called
 #   C — generation set + fence stale (fence-check exit 10) → exit 10, emit called
+#   D — fence UNREADABLE on every attempt (exit 1) → exit 10, emit reason
+#       cluster_fence_unverified — NOT cluster_fence_stale (CTL-2048)
+#   E — fence unreadable ONCE then current → exit 0, emit NOT called (the retry
+#       recovers the transient case that was measured on mini-2)
+#   F — a stale answer is NOT retried (exactly one fence-check call)
 #
 # Stubs: a fake PLUGIN_ROOT with stub cluster-claim.mjs and phase-agent-emit-complete
 # so the guard never touches Linear or the real dispatcher.
@@ -50,11 +55,29 @@ setup_stubs() {
 	local fence_exit="${2:-0}"
 	FAKE_ROOT="${SCRATCH}/${tag}"
 	EMIT_LOG="${FAKE_ROOT}/emit.log"
+	FENCE_CALL_LOG="${FAKE_ROOT}/fence-calls.log"
 	mkdir -p "${FAKE_ROOT}/scripts/execution-core"
 
 	# Stub cluster-claim.mjs: ignore all args, exit with configurable code.
+	#
+	# CTL-2048: it also COUNTS its invocations (FENCE_CALL_LOG) and can fail a fixed
+	# number of times before succeeding (FENCE_STUB_FAIL_TIMES), which is what makes the
+	# retry observable at all — without the counter, "the retry ran" and "the first call
+	# happened to succeed" look identical from the guard's exit code.
 	cat >"${FAKE_ROOT}/scripts/execution-core/cluster-claim.mjs" <<EOF
 #!/usr/bin/env node
+import { appendFileSync, readFileSync } from "node:fs";
+const log = process.env.FENCE_CALL_LOG;
+let n = 0;
+if (log) {
+  try { n = readFileSync(log, "utf8").split("\n").filter(Boolean).length; } catch {}
+  appendFileSync(log, "call\n");
+}
+const failTimes = parseInt(process.env.FENCE_STUB_FAIL_TIMES ?? "0");
+if (n < failTimes) {
+  process.stderr.write("transport-error route=attachments caller=cluster-claim\n");
+  process.exit(1);
+}
 const exitCode = parseInt(process.env.FENCE_STUB_EXIT ?? "${fence_exit}");
 process.exit(exitCode);
 EOF
@@ -104,6 +127,65 @@ C_EMIT_LOG="$(cat "$EMIT_LOG" 2>/dev/null || echo "")"
 assert_contains "$C_EMIT_LOG" "--status" "stale gen → emit-complete called with --status"
 assert_contains "$C_EMIT_LOG" "failed" "stale gen → emit-complete called with failed status"
 assert_contains "$C_EMIT_LOG" "cluster_fence_stale" "stale gen → emit-complete reason=cluster_fence_stale"
+
+# ─── Case D: fence UNREADABLE on every attempt → unverified, NOT stale ──────
+#
+# ⛔ THE DEFECT (CTL-2048). `fence-check` exits 10 for a genuinely stale generation and 1
+# when it THREW. The guard branched on `if …; then exit 0; fi` and called everything else
+# stale, so a transport error was recorded as a definite takeover by another host. Measured
+# on mini-2 on 2026-08-18: two real triage.json artifacts, both signals written
+# `cluster_fence_stale`, and neither fence was stale.
+echo ""
+echo "Case D: fence unreadable (exit 1) on every attempt → exit 10, reason=cluster_fence_unverified"
+setup_stubs D 1
+CATALYST_CLUSTER_GENERATION=1 FENCE_STUB_EXIT=1 CATALYST_FENCE_CHECK_RETRIES=1 \
+	CLAUDE_PLUGIN_ROOT="${FAKE_ROOT}" EMIT_LOG="${EMIT_LOG}" FENCE_CALL_LOG="${FENCE_CALL_LOG}" \
+	bash "$GUARD" --phase pr --ticket CTL-1 2>/dev/null
+D_RC=$?
+assert_eq "10" "$D_RC" "unreadable fence → exit 10 (side-effect still declined)"
+D_EMIT_LOG="$(cat "$EMIT_LOG" 2>/dev/null || echo "")"
+assert_contains "$D_EMIT_LOG" "cluster_fence_unverified" "unreadable fence → reason=cluster_fence_unverified"
+# ⛔ The whole point: it must NOT assert a fact it did not establish.
+D_SAID_STALE="$([[ $D_EMIT_LOG == *"cluster_fence_stale"* ]] && echo yes || echo no)"
+assert_eq "no" "$D_SAID_STALE" "unreadable fence → does NOT report cluster_fence_stale"
+D_CALLS="$(wc -l <"$FENCE_CALL_LOG" 2>/dev/null | tr -d ' ')"
+assert_eq "2" "$D_CALLS" "unreadable fence → retried (1 retry ⇒ 2 fence-check calls)"
+
+# ─── Case E: unreadable ONCE, then current → the retry recovers it ──────────
+#
+# The measured mini-2 case: one transport error, then {"current":true} on re-run 3/3.
+# One retry would have avoided both real failures.
+echo ""
+echo "Case E: fence unreadable once then current → exit 0, no emit (retry recovers)"
+setup_stubs E 0
+CATALYST_CLUSTER_GENERATION=1 FENCE_STUB_EXIT=0 FENCE_STUB_FAIL_TIMES=1 \
+	CLAUDE_PLUGIN_ROOT="${FAKE_ROOT}" EMIT_LOG="${EMIT_LOG}" FENCE_CALL_LOG="${FENCE_CALL_LOG}" \
+	bash "$GUARD" --phase pr --ticket CTL-1 2>/dev/null
+E_RC=$?
+assert_eq "0" "$E_RC" "transient unreadable → exit 0 (proceed after retry)"
+E_EMIT_CALLED="$([[ -f $EMIT_LOG && -s $EMIT_LOG ]] && echo yes || echo no)"
+assert_eq "no" "$E_EMIT_CALLED" "transient unreadable → NO failure emitted"
+E_CALLS="$(wc -l <"$FENCE_CALL_LOG" 2>/dev/null | tr -d ' ')"
+# ⛔ Without this the case passes even if the guard never retried and the stub simply
+# succeeded first time — the assertion has to see the failed attempt.
+assert_eq "2" "$E_CALLS" "transient unreadable → the FIRST call really did fail (2 calls)"
+
+# ─── Case F: a STALE answer is not retried ─────────────────────────────────
+#
+# Exit 10 is an ANSWER, not a failure to read. Retrying it asks a settled question again
+# and delays a real zombie's bow-out.
+echo ""
+echo "Case F: stale (exit 10) is answered, not retried → exactly one fence-check call"
+setup_stubs F 10
+CATALYST_CLUSTER_GENERATION=1 FENCE_STUB_EXIT=10 CATALYST_FENCE_CHECK_RETRIES=3 \
+	CLAUDE_PLUGIN_ROOT="${FAKE_ROOT}" EMIT_LOG="${EMIT_LOG}" FENCE_CALL_LOG="${FENCE_CALL_LOG}" \
+	bash "$GUARD" --phase pr --ticket CTL-1 2>/dev/null
+F_RC=$?
+assert_eq "10" "$F_RC" "stale → exit 10"
+F_CALLS="$(wc -l <"$FENCE_CALL_LOG" 2>/dev/null | tr -d ' ')"
+assert_eq "1" "$F_CALLS" "stale → exactly ONE fence-check call (no retry)"
+F_EMIT_LOG="$(cat "$EMIT_LOG" 2>/dev/null || echo "")"
+assert_contains "$F_EMIT_LOG" "cluster_fence_stale" "stale → still reason=cluster_fence_stale"
 
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/cluster-fence-guard.test.sh
@@ -187,6 +187,58 @@ assert_eq "1" "$F_CALLS" "stale → exactly ONE fence-check call (no retry)"
 F_EMIT_LOG="$(cat "$EMIT_LOG" 2>/dev/null || echo "")"
 assert_contains "$F_EMIT_LOG" "cluster_fence_stale" "stale → still reason=cluster_fence_stale"
 
+# ─── Case G: a zero-padded retry count must not create an UNBOUNDED loop ───
+#
+# ⛔ Codex on #3685. The all-digits validation accepts `08`, and bash reads a leading zero
+# as OCTAL: `[[ $attempt -gt 08 ]]` errors with "value too great for base" and evaluates
+# FALSE, so the break fires at NO attempt count — measured, not even at 99. The loop then
+# runs forever with `sleep $attempt` growing without limit, on a blocked worker.
+#
+# The assertion is TERMINATION, and it is made by a wall-clock bound: with 8 retries the
+# guard sleeps 1+2+…+8 = 36s, so a correct run finishes well inside the window while the
+# defective one never returns at all.
+echo ""
+echo "Case G: CATALYST_FENCE_CHECK_RETRIES=08 (octal trap) → still terminates, still bounded"
+setup_stubs G 1
+# ⛔ `sleep` is stubbed and the guard runs under a WATCHDOG, for two reasons.
+# (1) Speed: the real backoff for 8 retries is 1+2+…+8 = 36s of pure waiting, in a suite
+#     that otherwise finishes in under a second.
+# (2) Correctness of the FAILURE MODE: with the defect present this loop never terminates,
+#     so a plain foreground call would HANG the suite rather than fail it — and a test that
+#     hangs reports nothing at all. The watchdog kills it and the exit-code assertion then
+#     fails loudly with a number. (No `timeout`/`gtimeout`: stock macOS ships neither.)
+mkdir -p "${FAKE_ROOT}/bin"
+printf '#!/bin/sh\nexit 0\n' >"${FAKE_ROOT}/bin/sleep"
+chmod +x "${FAKE_ROOT}/bin/sleep"
+(
+	PATH="${FAKE_ROOT}/bin:$PATH" \
+		CATALYST_CLUSTER_GENERATION=1 FENCE_STUB_EXIT=1 CATALYST_FENCE_CHECK_RETRIES=08 \
+		CLAUDE_PLUGIN_ROOT="${FAKE_ROOT}" EMIT_LOG="${EMIT_LOG}" FENCE_CALL_LOG="${FENCE_CALL_LOG}" \
+		bash "$GUARD" --phase pr --ticket CTL-1 2>/dev/null
+) &
+G_PID=$!
+(sleep 20; kill "$G_PID" 2>/dev/null) &
+G_WD=$!
+wait "$G_PID"
+G_RC=$?
+kill "$G_WD" 2>/dev/null
+assert_eq "10" "$G_RC" "zero-padded retries → the guard TERMINATES on its own (exit 10, not killed)"
+G_CALLS="$(wc -l <"$FENCE_CALL_LOG" 2>/dev/null | tr -d ' ')"
+# 08 must be read as 8 — not as 0, and not as an error: 1 initial call + 8 retries.
+assert_eq "9" "$G_CALLS" "zero-padded retries → read as base 10 (9 fence-check calls)"
+
+# ─── Case H: an absurd retry count is CAPPED, not honoured ─────────────────
+echo ""
+echo "Case H: CATALYST_FENCE_CHECK_RETRIES=999 → capped at 10"
+setup_stubs H 1
+CATALYST_CLUSTER_GENERATION=1 FENCE_STUB_EXIT=10 CATALYST_FENCE_CHECK_RETRIES=999 \
+	CLAUDE_PLUGIN_ROOT="${FAKE_ROOT}" EMIT_LOG="${EMIT_LOG}" FENCE_CALL_LOG="${FENCE_CALL_LOG}" \
+	bash "$GUARD" --phase pr --ticket CTL-1 2>/dev/null
+H_RC=$?
+assert_eq "10" "$H_RC" "absurd retries + stale answer → exit 10 immediately"
+H_CALLS="$(wc -l <"$FENCE_CALL_LOG" 2>/dev/null | tr -d ' ')"
+assert_eq "1" "$H_CALLS" "absurd retries → a stale ANSWER is still not retried"
+
 echo ""
 echo "─────────────────────────────────────────────"
 echo "cluster-fence-guard: ${PASSES} passed, ${FAILURES} failed"

--- a/plugins/dev/scripts/lib/cluster-fence-guard.sh
+++ b/plugins/dev/scripts/lib/cluster-fence-guard.sh
@@ -75,6 +75,18 @@ EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 # recovered on the very next call.
 FENCE_RETRIES="${CATALYST_FENCE_CHECK_RETRIES:-2}"
 case "$FENCE_RETRIES" in ''|*[!0-9]*) FENCE_RETRIES=2 ;; esac
+# ⛔ BASE 10, EXPLICITLY — AND THIS IS AN UNBOUNDED-LOOP BUG, NOT STYLE (Codex on #3685).
+# The all-digits check above ACCEPTS a zero-padded value like `08`, and bash reads a leading
+# zero as octal: `[[ $attempt -gt 08 ]]` errors with "value too great for base" and the
+# construct evaluates FALSE. Measured — with FENCE_RETRIES=08 the break fires at NO attempt
+# count, not even 99: the loop runs forever with `sleep $attempt` growing without limit, on
+# a worker that is blocked waiting for it. This repo's own rule is that the loop must be
+# self-limiting rather than relying on a condition that can fail open.
+# `10#` forces base 10; the cap bounds the worst case an operator can ask for
+# (10 retries ⇒ 1+2+…+10 = 55s of sleep) so a fat-fingered value cannot wedge a phase.
+FENCE_RETRIES=$((10#$FENCE_RETRIES))
+[[ $FENCE_RETRIES -lt 0 ]] && FENCE_RETRIES=0
+[[ $FENCE_RETRIES -gt 10 ]] && FENCE_RETRIES=10
 
 fence_rc=0
 fence_out=""

--- a/plugins/dev/scripts/lib/cluster-fence-guard.sh
+++ b/plugins/dev/scripts/lib/cluster-fence-guard.sh
@@ -16,6 +16,42 @@
 #   generation current  (fence-check exit 0)  → exit 0  (proceed)
 #   generation stale    (fence-check exit 10) → emit `failed` (reason
 #                                               cluster_fence_stale), exit 10
+#   fence UNREADABLE    (any other exit)      → bounded retry; if it never
+#                                               answers, emit `failed` (reason
+#                                               cluster_fence_unverified), exit 10
+#
+# ⛔ CTL-2048 — WHY THE THIRD ROW EXISTS, AND WHY IT IS NOT `stale`.
+# This guard used to branch on `if node … fence-check …; then exit 0; fi` and treat
+# EVERYTHING else as stale, with `>/dev/null 2>&1` throwing away the reason that would
+# have separated them. `fence-check` exits 10 for a genuinely stale generation and 1 when
+# it THREW — a transport error, an auth failure, an unparseable response — so "the fence
+# says another host took over" and "I could not read the fence" were byte-identical to the
+# caller.
+#
+# Measured on mini-2 on 2026-08-18, minutes after it produced its first two triage.json
+# since Aug 14: both phase signals were written `failed / cluster_fence_stale`, and
+# NEITHER fence was stale. Probed read-only immediately afterwards, `fence-check CTC-266 3`
+# answered `{"current":true}` exit 0 — that ticket's fence was never even unreadable — and
+# `fence-check CTC-759 1` returned a transport error once and then `{"current":true}` on
+# three consecutive re-runs. The proxy had said so itself, in the line the guard discarded:
+#   "reason":"transport-error" … "read-back NOT answered — the caller must treat this as UNVERIFIED"
+# The guard converted UNVERIFIED into a definite negative. That is the inversion: "I could
+# not look" rendered as "I looked, and it is stale."
+#
+# It is self-concealing, which is why it survived: `cluster_fence_stale` names a plausible
+# cluster condition, so it reads as correct fencing rather than as a failed read, and mini
+# showed zero of them — making it look host-specific and benign.
+#
+# ⛔ POSTURE ON UNVERIFIED: STILL DECLINE, BUT SAY THE TRUE THING.
+# The side-effect stays blocked — proceeding on a fence we could not read would defeat the
+# guard on exactly the runs it exists for. What changes is that the recorded reason no
+# longer asserts a fact this guard did not establish, and a bounded retry runs first,
+# because the observed failure was transient (3/3 on re-run: one retry would have avoided
+# both of the measured failures).
+#
+# ⛔ A STALE ANSWER IS NOT RETRIED. Exit 10 is an ANSWER — the fence was read and another
+# host owns it. Retrying it would just ask a settled question again, and on a real takeover
+# it would delay the bow-out of a zombie worker.
 set -uo pipefail
 PHASE="" TICKET=""
 while [[ $# -gt 0 ]]; do
@@ -34,13 +70,41 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "${SELF_DIR}/../.." && pwd)}"
 CLUSTER_CLAIM_CLI="${PLUGIN_ROOT}/scripts/execution-core/cluster-claim.mjs"
 EMIT="${PLUGIN_ROOT}/scripts/phase-agent-emit-complete"
 
-if node "$CLUSTER_CLAIM_CLI" fence-check "$TICKET" "$CATALYST_CLUSTER_GENERATION" >/dev/null 2>&1; then
-  exit 0   # generation current → proceed
+# Total attempts = 1 + retries. Only an UNREADABLE fence is retried (see the header).
+# Deliberately small: a worker is blocked while this runs, and the observed failure
+# recovered on the very next call.
+FENCE_RETRIES="${CATALYST_FENCE_CHECK_RETRIES:-2}"
+case "$FENCE_RETRIES" in ''|*[!0-9]*) FENCE_RETRIES=2 ;; esac
+
+fence_rc=0
+fence_out=""
+attempt=0
+while :; do
+  # ⛔ The output is CAPTURED, never discarded. The CLI's own stderr is the only place the
+  # distinguishing reason ("transport-error", an auth message, a parse failure) exists; the
+  # old `>/dev/null 2>&1` is what made the two outcomes indistinguishable even in principle.
+  fence_out="$(node "$CLUSTER_CLAIM_CLI" fence-check "$TICKET" "$CATALYST_CLUSTER_GENERATION" 2>&1)"
+  fence_rc=$?
+  [[ $fence_rc -eq 0 ]] && exit 0    # generation current → proceed
+  [[ $fence_rc -eq 10 ]] && break    # ANSWERED stale → no retry, bow out below
+  attempt=$((attempt + 1))
+  if [[ $attempt -gt $FENCE_RETRIES ]]; then break; fi
+  echo "${PHASE}: cluster fence UNREADABLE (rc=${fence_rc}, attempt ${attempt}/${FENCE_RETRIES}) — retrying: ${fence_out}" >&2
+  sleep "$attempt"   # 1s, then 2s — bounded, and it sleeps rather than spinning
+done
+
+if [[ $fence_rc -eq 10 ]]; then
+  # The fence was READ and another host owns it. Unchanged behaviour.
+  echo "${PHASE}: cluster fence stale (gen=${CATALYST_CLUSTER_GENERATION}) — bowing out, no side-effect" >&2
+  "${EMIT}" \
+    --phase "$PHASE" --ticket "$TICKET" --status failed \
+    --reason "cluster_fence_stale" || true
+  exit 10
 fi
 
-# Stale (exit 10 or any non-current result) — bow out without the side-effect.
-echo "${PHASE}: cluster fence stale (gen=${CATALYST_CLUSTER_GENERATION}) — bowing out, no side-effect" >&2
+# The fence was NOT read. Decline the side-effect — but do not claim it was stale.
+echo "${PHASE}: cluster fence UNVERIFIED after $((FENCE_RETRIES + 1)) attempts (rc=${fence_rc}, gen=${CATALYST_CLUSTER_GENERATION}) — bowing out, no side-effect; last output: ${fence_out}" >&2
 "${EMIT}" \
   --phase "$PHASE" --ticket "$TICKET" --status failed \
-  --reason "cluster_fence_stale" || true
+  --reason "cluster_fence_unverified" || true
 exit 10


### PR DESCRIPTION
Closes CTL-2048 (P1). Filed by **@FLEET** from measurements on mini-2.

## The defect

`cluster-fence-guard.sh` branched on `if node … fence-check …; then exit 0; fi` and treated **everything else** as stale, with `>/dev/null 2>&1` discarding the reason that would have separated the cases.

`fence-check` exits **10** for a genuinely stale generation and **1** when it *threw* — a transport error, an auth failure, an unparseable response. So *"another host took over"* and *"I could not read the fence"* were **byte-identical to the caller**.

## Measured on mini-2, 2026-08-18

Minutes after mini-2 produced its **first two `triage.json` since Aug 14**, both phase signals were written `failed / cluster_fence_stale` — and **neither fence was stale**:

| probe | result | exit |
| --- | --- | --- |
| `fence-check CTC-266 3` | `{"current":true}` | **0** — never even unreadable |
| `fence-check CTC-759 1` | `transport-error`, `route=attachments` | **1** |
| `fence-check CTC-759 1` ×3 re-runs | `{"current":true}` ×3 | **0, 0, 0** |

⭐ The proxy had said so itself, in the very line the guard threw away:

```
"reason":"transport-error" … "read-back NOT answered — the caller must treat this as UNVERIFIED"
```

The write path reports **unverified**; the guard converted it into a **definite negative**. *"I could not look"* rendered as *"I looked, and it is stale."*

It is **self-concealing**: `cluster_fence_stale` names a plausible cluster condition, so it reads as correct fencing rather than a failed read — and mini showed **zero** of them, which made it look host-specific and benign.

**Why it blocks work:** `failed` gates advancement (`deriveAdvancement` requires `done`), so the ticket did not move even with a valid `triage.json` sitting beside the signal. On mini-2 this was the **third wall** behind CTL-2039 (credential) and CTL-2046 (executor pin).

## The fix

- The exit code is examined: `0` proceed · `10` stale (**unchanged**) · anything else **UNREADABLE**.
- An unreadable fence is **retried** (2 retries, 1s then 2s, sleeping not spinning; `CATALYST_FENCE_CHECK_RETRIES`). The measured failure recovered **3/3** on re-run — one retry would have avoided both real failures.
- ⛔ **A stale answer is NOT retried.** Exit 10 is an *answer*, not a failure to read; retrying asks a settled question again and would delay a real zombie's bow-out.
- If it never answers, the side-effect is **still declined** — proceeding on a fence we could not read defeats the guard on exactly the runs it exists for — but under **`cluster_fence_unverified`**, a reason that does not assert a fact this guard did not establish.
- The CLI's output is **captured and logged**, not discarded. Nothing downstream matches on the reason string (verified: `cluster_fence_stale` appears only in the guard and its own test), so the new reason breaks no consumer.

## Verification

| | |
| --- | --- |
| suite | **18 passed / 0 failed** |
| mutation (pre-fix guard + new tests) | **6 fail / 12 pass** — including *"does NOT report cluster_fence_stale"*: expected `no`, got `yes` |
| `cluster-fence-guard-lib.test.sh` | rc=0 here **and** at baseline |
| `phase-agent-claim-fence-e2e.test.sh` | rc=1 here **and** at baseline (pre-existing on `main`) |

The stub **counts its invocations** — without that counter, *"the retry ran"* and *"the first call happened to succeed"* are indistinguishable from the guard's exit code alone.

## ⛔ The suite was not in CI

Verified before pinning it: `grep -rn cluster-fence-guard .github/workflows/` returned **nothing**, while the same grep for `worktree-salvage.test.sh` — its neighbour in the same `lib/__tests__` directory — returns its own run line. **Fifth suite found shipping inert in three days.** No path-filter change needed: `plugins/dev/scripts/**` in the detect-changes filter already covers `lib/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)