### PR TITLE
fix(dev): CTL-1851 — an SDK worker cannot outlive its daemon, so a restart is PROOF its ghost is dead

### DIFF
--- a/plugins/dev/scripts/execution-core/phase-dispatch-deadline.test.mjs
+++ b/plugins/dev/scripts/execution-core/phase-dispatch-deadline.test.mjs
@@ -34,7 +34,9 @@ import {
   DISPATCH_DEADLINE_REASONS,
   MAX_DISPATCHED_MS,
   MIN_DISPATCH_AGE_MS,
+  IN_PROCESS_EXECUTOR_ID,
 } from "../lib/phase-dispatch-deadline.mjs";
+import { readFileSync } from "node:fs";
 import { classifyWorker, reclaimDeadWorkIfPossible } from "./recovery.mjs";
 
 const BOOT = Date.parse("2026-08-18T23:10:00Z");
@@ -47,6 +49,8 @@ const sdk = (over = {}) => ({
   phase: "implement",
   status: "dispatched",
   bg_job_id: null,
+  executor: "sdk", // CTL-1457 writes this at prelaunch; Codex #3694 P1 gates on it
+
   startedAt: iso(BOOT - 6 * 60 * 60 * 1000), // 6 h before boot — the measured ghost
   ...over,
 });
@@ -183,7 +187,7 @@ describe("the controls that protect a live worker", () => {
 
   test("startedAt absent falls back to updatedAt rather than giving up", () => {
     const v = classifyDispatchDeadline(
-      { status: "dispatched", bg_job_id: null, updatedAt: iso(BOOT - 60 * 60 * 1000) },
+      { status: "dispatched", bg_job_id: null, executor: "sdk", updatedAt: iso(BOOT - 60 * 60 * 1000) },
       { nowMs: at(60_000), bootedMs: BOOT }
     );
     expect(v.expired).toBe(true);
@@ -241,6 +245,90 @@ describe("the controls that protect a live worker", () => {
     expect(v.expired).toBe(false);
     expect(v.reason).toBe("too-young");
     expect(v.ageMs).toBeLessThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⛔ Codex #3694 P1 — the correction to my own age-floor argument.
+//
+// I had claimed the 5-minute floor covered the bash prelaunch window. It does
+// not: if the DAEMON dies inside that window, `phase-agent-dispatch` never
+// persists the job id and the signal is bg-less PERMANENTLY — so waiting longer
+// makes a live, detached `claude --bg` worker look MORE dead, not less. Rule 1
+// would then declare it dead and the reclaim could dispatch a duplicate
+// alongside it. The proof is not "no bg id", it is "ran inside the daemon".
+describe("the executor gate — the restart proof is only valid in-process", () => {
+  const wouldOtherwiseExpire = { nowMs: at(60_000), bootedMs: BOOT };
+
+  test.each([["bg"], ["codex-exec"], ["worker"], ["SDK"], ["sdk-exec"]])(
+    "⛔ executor %p is NOT declared dead by a restart, even pre-boot and past the ceiling",
+    (executor) => {
+      for (const status of ["dispatched", "running"]) {
+        const v = classifyDispatchDeadline(sdk({ executor, status }), wouldOtherwiseExpire);
+        expect(v.expired).toBe(false);
+        expect(v.reason).toBe("executor-not-in-process");
+      }
+    }
+  );
+
+  // ⭐ THE MEASURED CASE, stated as a scenario rather than as a field value: a
+  // `claude --bg` worker whose id was never persisted because the daemon died
+  // mid-launch. It is bg-less forever, it is old, its dispatch predates the boot
+  // — and it is ALIVE.
+  test("⭐ a bash worker whose job id was never persisted survives the restart", () => {
+    const v = classifyDispatchDeadline(
+      sdk({ executor: "bg", status: "running", startedAt: iso(BOOT - 6 * 60 * 60 * 1000) }),
+      wouldOtherwiseExpire
+    );
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("executor-not-in-process");
+  });
+
+  test.each([[undefined], [null], [""], [42], [{}]])(
+    "an absent/unusable executor (%p) HOLDS — it cannot prove it ran in-process",
+    (executor) => {
+      const v = classifyDispatchDeadline(sdk({ executor }), wouldOtherwiseExpire);
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("executor-unknown");
+      // ⚠️ and NOT the other executor reason — "I have no evidence" and "I have
+      // evidence it is the wrong executor" are different facts.
+      expect(v.reason).not.toBe("executor-not-in-process");
+    }
+  );
+
+  // ⛔ Rule 2 is gated too, not just Rule 1. Its input — a bg-less signal still
+  // at `dispatched` — is the SAME on-disk shape the died-mid-launch bash case
+  // produces, so leaving the timer ungated would reintroduce the duplicate by
+  // the other door.
+  test("⛔ the TIMER is gated on the executor too, not only the restart proof", () => {
+    const sameBootPastCeiling = {
+      nowMs: BOOT + 1000 + MAX_DISPATCHED_MS + 60_000,
+      bootedMs: BOOT,
+    };
+    const v = classifyDispatchDeadline(
+      sdk({ executor: "bg", startedAt: iso(BOOT + 1000) }),
+      sameBootPastCeiling
+    );
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("executor-not-in-process");
+  });
+
+  // ⭐ PARITY. This is a zero-import leaf, so the literal is a MIRROR of the
+  // production prelaunch and has to be checked mechanically rather than trusted
+  // — the same discipline as ASSERTED_BY's two bash mirrors. It also fails
+  // CLOSED: if either anchor disappears, the test errors rather than passing on
+  // a vacuous match.
+  test("⭐ executor-id-parity: the literal matches the SDK prelaunch and excludes codex", () => {
+    const sdkSrc = readFileSync("./sdk-run-phase-agent.mjs", "utf8");
+    const m = sdkSrc.match(/executorId:\s*"([^"]+)"/);
+    expect(m).not.toBeNull(); // fails closed if the anchor is renamed
+    expect(m[1]).toBe(IN_PROCESS_EXECUTOR_ID);
+
+    const codexSrc = readFileSync("./codex-run-phase-agent.mjs", "utf8");
+    const c = codexSrc.match(/CODEX_EXECUTOR_ID\s*=\s*"([^"]+)"/);
+    expect(c).not.toBeNull();
+    // ⛔ A future rename must not silently widen the proof to a SPAWNED executor.
+    expect(c[1]).not.toBe(IN_PROCESS_EXECUTOR_ID);
   });
 });
 
@@ -376,6 +464,7 @@ describe("reclaimDeadWorkIfPossible — the ghost reaches the reclaim path", () 
       orchestrator: "CTL-GHOST",
       status,
       bg_job_id: null,
+      executor: "sdk",
       startedAt: iso(dispatchedAtMs),
       catalystSessionId: "sess_ghost",
     };

--- a/plugins/dev/scripts/execution-core/phase-dispatch-deadline.test.mjs
+++ b/plugins/dev/scripts/execution-core/phase-dispatch-deadline.test.mjs
@@ -1,0 +1,453 @@
+// phase-dispatch-deadline.test.mjs — CTL-1851.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test phase-dispatch-deadline.test.mjs
+//
+// ── WHAT THIS HAS TO PROVE ───────────────────────────────────────────────────
+//
+// The feature reclassifies a live-looking worker as DEAD, which hands it to a
+// reclaim path that can revive it, complete it, or escalate it. Its risk is
+// symmetric and both directions are real:
+//
+//   TOO NARROW → the measured incident recurs: a ghost pins a slot forever and a
+//     human has to clear it by hand (that is CTL-2053, on the record).
+//   TOO WIDE   → a LIVE agent is declared dead and duplicated.
+//
+// So "it expires the ghost" is the easy half. Three things carry the weight:
+//
+//   1. THE COMPATIBILITY CONTRACT IS ASSERTED, NOT ASSUMED. `bootedMs` defaults
+//      to null and classifyWorker must then answer exactly what it answered
+//      before this ticket. A test pins the no-args shape (memory: every test
+//      injects → the default is untested).
+//   2. THE LIVE-WORKER CONTROLS. A young dispatch, a same-boot `running`, a bg
+//      worker inside the bash prelaunch window — each must survive.
+//   3. THE WIRING, NOT JUST THE PREDICATE. classifyWorker must actually CALL
+//      this, with the boot instant the reclaim path actually reads. Deleting
+//      each guard in turn must go red.
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyDispatchDeadline,
+  isDispatchExpiredReason,
+  DISPATCH_DEADLINE_REASONS,
+  MAX_DISPATCHED_MS,
+  MIN_DISPATCH_AGE_MS,
+} from "../lib/phase-dispatch-deadline.mjs";
+import { classifyWorker, reclaimDeadWorkIfPossible } from "./recovery.mjs";
+
+const BOOT = Date.parse("2026-08-18T23:10:00Z");
+const iso = (ms) => new Date(ms).toISOString();
+
+// A bg-less phase signal in the SDK shape: the prelaunch writes bg_job_id null
+// and nothing ever fills it in.
+const sdk = (over = {}) => ({
+  ticket: "CTL-1",
+  phase: "implement",
+  status: "dispatched",
+  bg_job_id: null,
+  startedAt: iso(BOOT - 6 * 60 * 60 * 1000), // 6 h before boot — the measured ghost
+  ...over,
+});
+
+const at = (offsetMs) => BOOT + offsetMs;
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("Rule 1 — a dispatch that predates the boot is PROVEN dead", () => {
+  test("⭐ the measured ghost: dispatched 6 h before boot, still `dispatched`", () => {
+    const v = classifyDispatchDeadline(sdk(), { nowMs: at(60_000), bootedMs: BOOT });
+    expect(v.expired).toBe(true);
+    expect(v.reason).toBe("dispatch-predates-boot");
+  });
+
+  // The proof does not care what the agent had got around to writing — an SDK
+  // worker that reached `running` before its daemon died is just as gone.
+  test("⭐ it applies to `running` too, which the TIMER deliberately does not", () => {
+    const v = classifyDispatchDeadline(sdk({ status: "running" }), {
+      nowMs: at(60_000),
+      bootedMs: BOOT,
+    });
+    expect(v.expired).toBe(true);
+    expect(v.reason).toBe("dispatch-predates-boot");
+  });
+
+  test("a dispatch AT the boot instant is not proven to precede it (strict <)", () => {
+    const v = classifyDispatchDeadline(sdk({ startedAt: iso(BOOT) }), {
+      nowMs: at(MIN_DISPATCH_AGE_MS + 1000),
+      bootedMs: BOOT,
+    });
+    expect(v.reason).not.toBe("dispatch-predates-boot");
+  });
+
+  test("a dispatch AFTER the boot is this daemon's own work — never Rule 1", () => {
+    const v = classifyDispatchDeadline(sdk({ startedAt: iso(BOOT + 1000), status: "running" }), {
+      nowMs: at(60 * 60 * 1000), // an hour of legitimate running
+      bootedMs: BOOT,
+    });
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("within-deadline");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("Rule 2 — still `dispatched` long past the ceiling never had a first turn", () => {
+  const sameBoot = (ageMs, over = {}) =>
+    classifyDispatchDeadline(sdk({ startedAt: iso(BOOT + 1000), ...over }), {
+      nowMs: BOOT + 1000 + ageMs,
+      bootedMs: BOOT,
+    });
+
+  test("past the ceiling → dead", () => {
+    const v = sameBoot(MAX_DISPATCHED_MS + 1000);
+    expect(v.expired).toBe(true);
+    expect(v.reason).toBe("dispatch-never-started");
+  });
+
+  test("exactly at the ceiling is still within it (strict >)", () => {
+    expect(sameBoot(MAX_DISPATCHED_MS).expired).toBe(false);
+  });
+
+  // ⛔ The control that keeps this from killing working agents. A live SDK
+  // implement phase legitimately runs for hours.
+  test("⛔ `running` on the SAME boot is NEVER expired by the timer, at any age", () => {
+    for (const hours of [1, 6, 24, 72]) {
+      const v = sameBoot(hours * 60 * 60 * 1000, { status: "running" });
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("within-deadline");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the controls that protect a live worker", () => {
+  test.each([[0], [1000], [MIN_DISPATCH_AGE_MS - 1]])(
+    "a dispatch aged %pms is too young for ANY rule, boot-predating or not",
+    (ageMs) => {
+      // ⚠️ The dispatch PREDATES the boot, so Rule 1 would fire on it — the age
+      // floor is the only thing that can be holding it. (First cut of this test
+      // kept the fixture's 6-h-old startedAt and varied only `nowMs`, which made
+      // every case 6 h old and proved nothing about the floor.)
+      const v = classifyDispatchDeadline(sdk({ startedAt: iso(BOOT - 1000) }), {
+        nowMs: BOOT - 1000 + ageMs,
+        bootedMs: BOOT,
+      });
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("too-young");
+    }
+  );
+
+  // ⛔ The bash-executor false positive named in the module header: its prelaunch
+  // also writes bg_job_id null and fills it in seconds later, and a `claude --bg`
+  // worker DOES survive a restart.
+  test("⛔ a bash prelaunch inside its fill-in window is held by the age floor", () => {
+    const v = classifyDispatchDeadline(sdk({ startedAt: iso(BOOT - 3000) }), {
+      nowMs: BOOT + 2000,
+      bootedMs: BOOT,
+    });
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("too-young");
+  });
+
+  test.each([["job-abc"], ["bg-1"]])(
+    "a signal carrying a bg id (%p) is never judged here — jobLifecycle owns it",
+    (bg_job_id) => {
+      const v = classifyDispatchDeadline(sdk({ bg_job_id }), { nowMs: at(60_000), bootedMs: BOOT });
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("has-bg-job");
+    }
+  );
+
+  test.each([[""], [null], [undefined], [0], [{}]])(
+    "a non-id bg_job_id (%p) is NOT a bg job — the signal is still judged",
+    (bg_job_id) => {
+      const v = classifyDispatchDeadline(sdk({ bg_job_id }), { nowMs: at(60_000), bootedMs: BOOT });
+      expect(v.reason).not.toBe("has-bg-job");
+    }
+  );
+
+  // ⚠️ The fail direction is the OPPOSITE of CTL-1854's yield, on purpose — and
+  // the reason is in the module header. Pinned here so a later reader does not
+  // "make the two consistent".
+  test.each([[undefined], [null], ["not a date"], [{}], [NaN]])(
+    "an undatable dispatch (%p) HOLDS — unlike a yield, which expires",
+    (startedAt) => {
+      const v = classifyDispatchDeadline(sdk({ startedAt, updatedAt: startedAt }), {
+        nowMs: at(60_000),
+        bootedMs: BOOT,
+      });
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("dispatch-start-unreadable");
+    }
+  );
+
+  test("startedAt absent falls back to updatedAt rather than giving up", () => {
+    const v = classifyDispatchDeadline(
+      { status: "dispatched", bg_job_id: null, updatedAt: iso(BOOT - 60 * 60 * 1000) },
+      { nowMs: at(60_000), bootedMs: BOOT }
+    );
+    expect(v.expired).toBe(true);
+    expect(v.reason).toBe("dispatch-predates-boot");
+  });
+
+  // ⛔ The first cut let the TIMER fire with no boot instant, which decided Rule
+  // 1's question without Rule 1's evidence AND broke the caller-side default.
+  // Both statuses now hold, and the reason names the missing fact rather than
+  // reporting a generic decline.
+  test.each([[null], [undefined], ["garbage"], [NaN], [{}]])(
+    "an unreadable boot instant (%p) disables BOTH rules, for both statuses",
+    (bootedMs) => {
+      for (const status of ["dispatched", "running"]) {
+        const v = classifyDispatchDeadline(sdk({ status }), {
+          nowMs: at(24 * 60 * 60 * 1000), // a full day past the ceiling
+          bootedMs,
+        });
+        expect(v.expired).toBe(false);
+        expect(v.reason).toBe("boot-unreadable");
+      }
+    }
+  );
+
+  test.each([["done"], ["failed"], ["stalled"], ["needs-input"], ["awaiting-work"], ["skipped"]])(
+    "status %p is not this module's business",
+    (status) => {
+      const v = classifyDispatchDeadline(sdk({ status }), { nowMs: at(60_000), bootedMs: BOOT });
+      expect(v.expired).toBe(false);
+      expect(v.reason).toBe("not-pending");
+    }
+  );
+
+  test.each([[null], [undefined], [42], [[]], ["x"]])("a non-signal (%p) is not-a-signal", (sig) => {
+    const v = classifyDispatchDeadline(sig, { nowMs: at(60_000), bootedMs: BOOT });
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("not-a-signal");
+  });
+
+  // ⚠️ `undefined` is deliberately absent from this list: it selects the
+  // parameter default (a real Date.now()), so including it would assert against
+  // the wall clock rather than against the guard.
+  test("a caller that cannot read the clock expires nothing", () => {
+    for (const nowMs of [NaN, Infinity, -Infinity]) {
+      const v = classifyDispatchDeadline(sdk(), { nowMs, bootedMs: BOOT });
+      expect(v.expired).toBe(false);
+    }
+  });
+
+  test("a future-stamped dispatch (clock skew) is too-young, never very-old", () => {
+    const v = classifyDispatchDeadline(sdk({ startedAt: iso(BOOT + 10 * 60 * 60 * 1000) }), {
+      nowMs: at(60_000),
+      bootedMs: BOOT,
+    });
+    expect(v.expired).toBe(false);
+    expect(v.reason).toBe("too-young");
+    expect(v.ageMs).toBeLessThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe("the verdict vocabulary is closed and every branch names itself", () => {
+  test("every reason produced is registered, and both expiring reasons are recognised", () => {
+    const produced = new Set();
+    const sigs = [
+      null,
+      42,
+      sdk(),
+      sdk({ status: "running" }),
+      sdk({ status: "done" }),
+      sdk({ bg_job_id: "job-1" }),
+      sdk({ startedAt: "nope", updatedAt: "nope" }),
+      sdk({ startedAt: iso(BOOT + 1000) }),
+    ];
+    for (const sig of sigs) {
+      for (const bootedMs of [BOOT, null]) {
+        for (const nowMs of [BOOT + 1000, at(MAX_DISPATCHED_MS + 60_000)]) {
+          const v = classifyDispatchDeadline(sig, { nowMs, bootedMs });
+          produced.add(v.reason);
+          expect(DISPATCH_DEADLINE_REASONS).toContain(v.reason);
+          expect(isDispatchExpiredReason(v.reason)).toBe(v.expired);
+        }
+      }
+    }
+    expect(produced.size).toBeGreaterThanOrEqual(7);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⛔ THE WIRING. The predicate above being correct proves nothing about whether
+// classifyWorker calls it — and a discriminator that is read but never changes
+// the answer is a shape this lane has shipped before.
+describe("classifyWorker — the wiring, and the compatibility contract", () => {
+  const wsig = (over = {}) => ({
+    ticket: "CTL-1",
+    phase: "implement",
+    status: "dispatched",
+    liveness: { kind: "bg", value: null }, // the SDK shape readAllPhaseSignals produces
+    raw: sdk(over),
+    ...(over.status ? { status: over.status } : {}),
+  });
+
+  // ⭐ THE COMPATIBILITY CONTRACT. Every OTHER caller of classifyWorker passes no
+  // boot instant, so the no-args shape is the one that ships to them — and a
+  // suite where every test injects is a suite in which the default is untested.
+  test("⭐ with NO options at all, a bg-less signal is still `unknown` (unchanged)", () => {
+    expect(classifyWorker(wsig())).toBe("unknown");
+    expect(classifyWorker(wsig({ status: "running" }))).toBe("unknown");
+  });
+
+  test("with only statJob (the pre-CTL-1851 call shape) it is still `unknown`", () => {
+    expect(classifyWorker(wsig(), { statJob: () => null })).toBe("unknown");
+  });
+
+  test("⭐ given the boot instant, the measured ghost becomes `dead`", () => {
+    expect(classifyWorker(wsig(), { bootedMs: BOOT, nowMs: at(60_000) })).toBe("dead");
+  });
+
+  test("⭐ a `running` SDK worker from before the boot becomes `dead` too", () => {
+    expect(
+      classifyWorker(wsig({ status: "running" }), { bootedMs: BOOT, nowMs: at(60_000) })
+    ).toBe("dead");
+  });
+
+  test("⛔ a live same-boot `running` SDK worker stays out of the dead bucket", () => {
+    const live = wsig({ status: "running", startedAt: iso(BOOT + 1000) });
+    expect(classifyWorker(live, { bootedMs: BOOT, nowMs: at(6 * 60 * 60 * 1000) })).toBe("unknown");
+  });
+
+  test("a terminal signal short-circuits before any of this", () => {
+    expect(classifyWorker(wsig({ status: "done" }), { bootedMs: BOOT, nowMs: at(60_000) })).toBe(
+      "terminal"
+    );
+  });
+
+  test("a signal WITH a live bg id is still routed through jobLifecycle, not here", () => {
+    const bg = {
+      ticket: "CTL-1",
+      phase: "implement",
+      status: "running",
+      liveness: { kind: "bg", value: "job-1" },
+      raw: { status: "running", bg_job_id: "job-1", startedAt: iso(BOOT - 60_000) },
+    };
+    // statJob is the jobLifecycle seam; a live state.json keeps it `running`
+    // even though its dispatch predates the boot — a --bg worker survives.
+    expect(
+      classifyWorker(bg, {
+        statJob: () => ({ isDirectory: () => true }),
+        bootedMs: BOOT,
+        nowMs: at(60_000),
+      })
+    ).not.toBe("dead");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ⛔ THE WIRING, ONE LEVEL UP — and the control that started GREEN.
+//
+// Every test above drives classifyWorker DIRECTLY, so deleting `bootedMs` from
+// reclaimDeadWorkIfPossible's call to it left the whole suite 50 pass / 0 fail
+// (measured, mutation M7). The predicate was proven correct and proven wired to
+// classifyWorker, and the one call site that actually runs on the fleet was
+// covered by nothing. Exactly the shape that shipped twice on this lane in the
+// last 24 hours.
+//
+// This describe drives the REAL reclaim entry point over a REAL orchDir, and
+// deliberately does NOT inject `readBootSince`: the boot instant must come from
+// the same daemon-boot.json production reads, or the test proves the seam works
+// and not the wiring.
+describe("reclaimDeadWorkIfPossible — the ghost reaches the reclaim path", () => {
+  const recorder = (returnValue) => {
+    const calls = [];
+    const fn = (...args) => {
+      calls.push(args);
+      return typeof returnValue === "function" ? returnValue(...args) : returnValue;
+    };
+    fn.calls = calls;
+    return fn;
+  };
+
+  // A real orchDir with a real boot marker, and a bg-less `dispatched` signal
+  // stamped before it: the measured mini shape from 2026-08-18 23:1x.
+  const ghostOrch = ({ dispatchedAtMs, status = "dispatched" }) => {
+    const orch = mkdtempSync(join(tmpdir(), "ctl1851-"));
+    writeFileSync(join(orch, "daemon-boot.json"), JSON.stringify({ bootedAt: iso(BOOT) }));
+    mkdirSync(join(orch, "workers", "CTL-GHOST"), { recursive: true });
+    const raw = {
+      ticket: "CTL-GHOST",
+      phase: "implement",
+      orchestrator: "CTL-GHOST",
+      status,
+      bg_job_id: null,
+      startedAt: iso(dispatchedAtMs),
+      catalystSessionId: "sess_ghost",
+    };
+    writeFileSync(join(orch, "workers", "CTL-GHOST", "phase-implement.json"), JSON.stringify(raw));
+    return {
+      orch,
+      sig: {
+        ticket: "CTL-GHOST",
+        phase: "implement",
+        status,
+        liveness: { kind: "bg", value: null },
+        signalPath: join(orch, "workers", "CTL-GHOST", "phase-implement.json"),
+        raw,
+      },
+    };
+  };
+
+  const seams = (probe, emit) => ({
+    statJob: () => null,
+    probes: { implement: probe },
+    emitComplete: emit,
+    appendEvent: recorder(undefined),
+    postReclaimMirror: () => {},
+    liveness: () => "absent",
+    now: () => BOOT + 60_000,
+  });
+
+  test("⭐ the pre-boot ghost is reclaimed — its committed work is COMPLETED, not discarded", () => {
+    const { orch, sig } = ghostOrch({ dispatchedAtMs: BOOT - 6 * 60 * 60 * 1000 });
+    const probe = recorder(true); // the work-done probe says the commits landed
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(probe, emit));
+    // ⭐ Not "the slot was freed by writing a terminal" — the EXISTING reclaim
+    // path ran, so a phase that finished before its daemon died is completed
+    // through phase-agent-emit-complete rather than thrown away.
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+    expect(emit.calls.length).toBe(1);
+  });
+
+  test("a `running` pre-boot SDK worker reaches it too", () => {
+    const { orch, sig } = ghostOrch({
+      dispatchedAtMs: BOOT - 3 * 60 * 60 * 1000,
+      status: "running",
+    });
+    const probe = recorder(true);
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(probe, recorder({ code: 0 })));
+    expect(r).toBe("reclaimed");
+    expect(probe.calls.length).toBe(1);
+  });
+
+  // ⛔ The live-worker control at the same altitude. Same orchDir, same boot
+  // marker, same bg-less shape — only the dispatch instant differs.
+  test("⛔ a live same-boot `running` SDK worker is still a noop — the probe never runs", () => {
+    const { orch, sig } = ghostOrch({ dispatchedAtMs: BOOT + 1000, status: "running" });
+    const probe = recorder(true);
+    const emit = recorder({ code: 0 });
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(probe, emit));
+    expect(r).toBe("noop");
+    expect(probe.calls.length).toBe(0);
+    expect(emit.calls.length).toBe(0);
+  });
+
+  // ⚠️ And the fail-closed half: with no boot marker on disk, the ghost is NOT
+  // reclaimed. That is the pre-CTL-1851 behaviour, preserved deliberately — the
+  // rules assert a proof and there is no evidence for it here.
+  test("no daemon-boot.json → the ghost is held, not guessed at", () => {
+    const { orch, sig } = ghostOrch({ dispatchedAtMs: BOOT - 6 * 60 * 60 * 1000 });
+    writeFileSync(join(orch, "daemon-boot.json"), "not json");
+    const probe = recorder(true);
+    const r = reclaimDeadWorkIfPossible(orch, sig, seams(probe, recorder({ code: 0 })));
+    expect(r).toBe("noop");
+    expect(probe.calls.length).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery.mjs
+++ b/plugins/dev/scripts/execution-core/recovery.mjs
@@ -31,6 +31,14 @@ import {
   YIELD_EXPIRED_REASON,
   classifyYield,
 } from "../lib/phase-yield.mjs";
+// CTL-1851: when is a worker carrying NO bg_job_id provably gone? An SDK-executor
+// worker never has one, so `classifyWorker` answered "unknown" for its entire life
+// and the reclaim path no-opped — a dead worker pinned its slot forever.
+import {
+  classifyDispatchDeadline,
+  MAX_DISPATCHED_MS,
+  MIN_DISPATCH_AGE_MS,
+} from "../lib/phase-dispatch-deadline.mjs";
 import {
   getJobsRoot,
   getEventLogPath,
@@ -365,10 +373,40 @@ export function jobLifecycle(bgJobId, { statJob = defaultStatJob } = {}) {
 // mere job-dir existence. A never-cleaned-up dir whose .state is terminal
 // (stopped/failed/done/blocked) now classifies 'dead' instead of 'running' —
 // the discard the plan called out (16,462 retained job dirs, 0 pid files).
-export function classifyWorker(signal, { statJob = defaultStatJob } = {}) {
+export function classifyWorker(
+  signal,
+  {
+    statJob = defaultStatJob,
+    // CTL-1851 — the boot instant this daemon started at, epoch-ms, or null when
+    // it cannot be read.
+    //
+    // ⚠️ IT DEFAULTS TO null, AND THAT IS THE COMPATIBILITY CONTRACT. With no
+    // boot instant and a bg-less signal inside the deadline, this function
+    // returns "unknown" exactly as it always has, so every existing caller and
+    // test is byte-identical until it opts in by passing one. The ONE production
+    // caller that opts in is reclaimDeadWorkIfPossible, which already reads the
+    // boot marker for its attempt-count window.
+    bootedMs = null,
+    nowMs = Date.now(),
+    maxDispatchedMs = MAX_DISPATCHED_MS,
+    minDispatchAgeMs = MIN_DISPATCH_AGE_MS,
+  } = {}
+) {
   if (TERMINAL.has(signal?.status)) return "terminal";
   const live = signal?.liveness;
-  if (live?.kind !== "bg" || !live?.value) return "unknown";
+  if (live?.kind !== "bg" || !live?.value) {
+    // CTL-1851: a bg-less signal is not automatically unknowable. An SDK worker
+    // runs IN-PROCESS in the daemon, so a dispatch that predates this daemon's
+    // boot is PROVABLY dead — and a signal still at `dispatched` long past the
+    // ceiling never had a first turn. Either way it is `dead`, which routes it
+    // into the existing CTL-574 reclaim path (work-done probe → emit-complete,
+    // else revive, else escalate) instead of being silently dropped.
+    const verdict = classifyDispatchDeadline(
+      { ...(signal?.raw ?? {}), status: signal?.status },
+      { nowMs, bootedMs, maxDispatchedMs, minAgeMs: minDispatchAgeMs }
+    );
+    return verdict.expired ? "dead" : "unknown";
+  }
   return jobLifecycle(live.value, { statJob }) === "alive" ? "running" : "dead";
 }
 
@@ -2603,7 +2641,18 @@ export function reclaimDeadWorkIfPossible(
     return "noop";
   }
 
-  const klass = classifyWorker(signal, { statJob });
+  // CTL-1851 — hand classifyWorker this daemon's boot instant so a bg-less
+  // (SDK-executor) worker can be judged instead of being answered "unknown"
+  // forever. `readBootSinceFn` is the seam this function already uses for its
+  // attempt-count window; it returns an ISO string or undefined, and an
+  // unreadable marker degrades to `null`, which disables the proof rule and
+  // leaves the never-started timer to answer alone.
+  const bootedIso = readBootSinceFn(orchDir);
+  const bootedMs = (() => {
+    const t = typeof bootedIso === "string" ? Date.parse(bootedIso) : NaN;
+    return Number.isFinite(t) ? t : null;
+  })();
+  const klass = classifyWorker(signal, { statJob, bootedMs, nowMs: now() });
   // CTL-662: terminal (phase finished) and unknown (no bg_job_id) still
   // short-circuit — boot-classification gating is unchanged. Everything else
   // (running, OR dead-by-missing-job-dir) is routed through the status trigger

--- a/plugins/dev/scripts/lib/phase-dispatch-deadline.mjs
+++ b/plugins/dev/scripts/lib/phase-dispatch-deadline.mjs
@@ -1,0 +1,201 @@
+// phase-dispatch-deadline.mjs — CTL-1851. When is a phase worker that carries NO
+// background-job id provably gone?
+//
+// ── THE DEFECT ──────────────────────────────────────────────────────────────
+// `classifyWorker` (recovery.mjs) answers "unknown" for any signal whose
+// liveness is not a live `bg` id, and `reclaimDeadWorkIfPossible` returns "noop"
+// for "unknown". That is the whole of it: an SDK-executor worker NEVER has a
+// bg_job_id — the prelaunch writes `bg_job_id: null` and nothing ever fills it
+// in — so when one dies, nothing reclaims it, nothing revives it, nothing
+// escalates it, and `isTicketInFlight` stays true forever. The slot is pinned by
+// a worker that does not exist.
+//
+// MEASURED. mini, 2026-08-18 23:1x: two ghost `dispatched` signals from workers
+// that had died 6 h and 3 h 38 m earlier held two of three slots, leaving the
+// host at 1/3 capacity with 14 triaged-and-ready tickets queued behind them; the
+// only live worker was CTL-2042's monitor-merge. It was cleared by a human
+// (CTL-2053). Earlier, mini-2 2026-08-14: 3 owned eligible tickets, 4 free slots
+// by the accounting, zero dispatches — the CTL-1851 report.
+//
+// ── ⭐ THE PROOF, AND WHY THIS IS NOT ONLY A TIMER ──────────────────────────
+// The SDK executor runs its `query()` **in-process in the daemon**
+// (dispatch.mjs: "the executor=sdk launch verb (in-process Agent SDK query())").
+// So a daemon restart does not merely SUGGEST an in-process worker is dead — it
+// PROVES it: the process that was running the agent no longer exists. The same
+// argument is already accepted in this codebase for the other executor;
+// readExecCoreBootEpoch's own comment reads "any --bg worker whose state.json
+// mtime predates it is provably dead."
+//
+// Hence two rules, with very different epistemics, and both say so:
+//
+//   Rule 1 — DISPATCH PREDATES BOOT (proof). `dispatched|running`, no bg id, and
+//            the dispatch instant precedes this daemon's boot. Applies to
+//            `running` too, because the proof does not care what the agent had
+//            got around to writing.
+//
+//   Rule 2 — NEVER STARTED (timer). `dispatched`, no bg id, this boot, older
+//            than the ceiling. The skill flips `dispatched`→`running` on its
+//            first turn, so a signal still at `dispatched` long after launch
+//            never had a first turn. ⛔ `running` is deliberately NOT subject to
+//            this rule: a live SDK phase legitimately runs for hours and a timer
+//            over it would kill working agents.
+//
+// ── ⚠️ WHAT THE CALLER DOES WITH `dead`, AND WHY IT IS NOT A TERMINAL ───────
+// This module never writes anything. Its verdict feeds `classifyWorker`, which
+// hands the signal to the EXISTING CTL-574 reclaim path — so a phase that
+// finished its work before the daemon died gets `phase-agent-emit-complete` via
+// its work-done probe, and only a phase with nothing to show is revived or
+// escalated. Writing a terminal here instead would have thrown away committed
+// work in order to free a slot.
+//
+// ── ⛔ THE FALSE-POSITIVE THIS MUST NOT PRODUCE ─────────────────────────────
+// The BASH executor also writes `bg_job_id: null` in its prelaunch and only
+// fills it in after the spawn returns (phase-agent-dispatch:1591; the window is
+// documented at :1435). A `claude --bg` worker DOES survive a daemon restart, so
+// a real bg worker caught inside that window would be misjudged by Rule 1. The
+// window is seconds wide and Rule 1 carries an age floor (`minAgeMs`) that is
+// orders of magnitude larger, so a signal that young is never judged at all.
+//
+// Zero-import leaf, like phase-yield.mjs: bare-Node loadable, pure, callable
+// from the daemon, the scheduler and tests alike. Every reader is injected by
+// the caller — this module does no I/O and cannot read a clock it was not given.
+
+/** Statuses a bg-less worker can be in while it still holds a slot. */
+export const DISPATCH_PENDING_STATUS = "dispatched";
+export const DISPATCH_RUNNING_STATUS = "running";
+
+/**
+ * Ceiling on time at `dispatched` before the worker is judged never to have
+ * started. The skill's flip to `running` happens on the agent's FIRST turn, so
+ * the honest window is model start-up — seconds to a couple of minutes. 30
+ * minutes is 15–30× that, and matches MAX_YIELD_MS / Linear's session-stale
+ * deadline so the fleet has one number to reason about rather than two.
+ */
+export const MAX_DISPATCHED_MS = 30 * 60 * 1000;
+
+/**
+ * Age floor below which NO rule fires. Covers the bash prelaunch window above
+ * and any dispatch racing a boot-marker read. Deliberately generous: the cost of
+ * waiting five more minutes is five minutes; the cost of reclaiming a live
+ * worker is a duplicate.
+ */
+export const MIN_DISPATCH_AGE_MS = 5 * 60 * 1000;
+
+/** Verdict reasons. Closed set — every branch names itself, none is unnamed. */
+export const DISPATCH_DEADLINE_REASONS = Object.freeze([
+  "dispatch-predates-boot", // ⭐ Rule 1 — proof: the in-process worker's daemon is gone
+  "dispatch-never-started", // Rule 2 — timer: still `dispatched` past the ceiling
+  "not-a-signal", // input was not an object
+  "not-pending", // status is neither `dispatched` nor `running`
+  "has-bg-job", // it HAS a bg id — the existing lifecycle machinery owns it
+  "dispatch-start-unreadable", // ⚠️ cannot date the dispatch — cannot judge it
+  "too-young", // inside the age floor; no rule may fire yet
+  "boot-unreadable", // ⚠️ no boot instant — NEITHER rule can be evaluated
+  "within-deadline", // dated, same boot, and not past the ceiling
+]);
+
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+function parseMs(v) {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v !== "") {
+    const t = Date.parse(v);
+    if (Number.isFinite(t)) return t;
+  }
+  return null;
+}
+
+/**
+ * Classify a bg-less phase signal's dispatch deadline.
+ *
+ * @param sig    the raw phase signal record (status / bg_job_id / startedAt).
+ * @param opts.nowMs           epoch-ms now.
+ * @param opts.bootedMs        epoch-ms of THIS daemon's boot, or null/undefined
+ *                             when it cannot be read. ⛔ An unreadable boot
+ *                             instant disables BOTH rules and the verdict is
+ *                             `boot-unreadable` — never a guess. That is also the
+ *                             DEFAULT, which is what makes every pre-existing
+ *                             `classifyWorker` caller byte-identical until it
+ *                             opts in.
+ * @param opts.maxDispatchedMs Rule 2's ceiling.
+ * @param opts.minAgeMs        the age floor below which no rule fires.
+ *
+ * @returns {{expired: boolean, reason: string, ageMs: number|null}}
+ * `reason` is ALWAYS populated, including on `expired: false`, so a caller can
+ * report WHY it declined rather than a bare false that is indistinguishable from
+ * "I could not tell".
+ */
+export function classifyDispatchDeadline(
+  sig,
+  {
+    nowMs = Date.now(),
+    bootedMs = null,
+    maxDispatchedMs = MAX_DISPATCHED_MS,
+    minAgeMs = MIN_DISPATCH_AGE_MS,
+  } = {}
+) {
+  if (!isPlainObject(sig)) return { expired: false, reason: "not-a-signal", ageMs: null };
+
+  const status = String(sig.status);
+  const pending = status === DISPATCH_PENDING_STATUS;
+  const running = status === DISPATCH_RUNNING_STATUS;
+  if (!pending && !running) return { expired: false, reason: "not-pending", ageMs: null };
+
+  // A signal that HAS a bg id is owned by jobLifecycle — this module must not
+  // second-guess it. `0` and `""` are not ids; a non-empty string is.
+  const bg = sig.bg_job_id;
+  if (typeof bg === "string" && bg !== "") {
+    return { expired: false, reason: "has-bg-job", ageMs: null };
+  }
+
+  // ⚠️ UNREADABLE START HOLDS — the opposite of CTL-1854's yield, on purpose.
+  // There, an unreadable anchor expired because the state is a PERMIT the agent
+  // asked for and an unbounded permit is the harm. Here the signal describes a
+  // worker that may be alive and working, and expiring on "I could not read the
+  // date" would reclaim it on no evidence. The two fail directions are opposite
+  // because the two risks are opposite.
+  const startedMs = parseMs(sig.startedAt) ?? parseMs(sig.updatedAt);
+  if (startedMs === null) {
+    return { expired: false, reason: "dispatch-start-unreadable", ageMs: null };
+  }
+  if (!Number.isFinite(nowMs)) {
+    // A caller that cannot tell the time cannot age anything either.
+    return { expired: false, reason: "dispatch-start-unreadable", ageMs: null };
+  }
+
+  const ageMs = nowMs - startedMs;
+  // The age floor applies to BOTH rules. A negative age (clock skew, or a
+  // signal stamped in the future) is "too young" — never "very old".
+  if (ageMs < minAgeMs) return { expired: false, reason: "too-young", ageMs };
+
+  // ⛔ NO BOOT INSTANT → NO VERDICT, FOR EITHER RULE. Rule 1 obviously needs it.
+  // Rule 2 needs it too, and the first cut of this module got that wrong: its
+  // "same boot" clause was implicit, so with `bootedMs: null` the timer happily
+  // expired a `dispatched` signal from ANY boot — which (a) is Rule 1's
+  // territory decided without Rule 1's evidence, and (b) broke the compatibility
+  // contract the caller-side default exists to keep. The
+  // no-options-at-all test in phase-dispatch-deadline.test.mjs is what caught
+  // it, on its first run, and it is there because a suite in which every test
+  // injects is a suite in which the shipped default is untested.
+  const boot = parseMs(bootedMs);
+  if (boot === null) return { expired: false, reason: "boot-unreadable", ageMs };
+
+  // Rule 1 — PROOF. Strictly `<`: a dispatch stamped at the same millisecond as
+  // the boot is not proven to precede it.
+  if (startedMs < boot) {
+    return { expired: true, reason: "dispatch-predates-boot", ageMs };
+  }
+
+  // Rule 2 — TIMER, this boot, and only for `dispatched`.
+  if (pending && ageMs > maxDispatchedMs) {
+    return { expired: true, reason: "dispatch-never-started", ageMs };
+  }
+  return { expired: false, reason: "within-deadline", ageMs };
+}
+
+/** True only for the two verdicts that mean "this worker is gone". */
+export function isDispatchExpiredReason(reason) {
+  return reason === "dispatch-predates-boot" || reason === "dispatch-never-started";
+}

--- a/plugins/dev/scripts/lib/phase-dispatch-deadline.mjs
+++ b/plugins/dev/scripts/lib/phase-dispatch-deadline.mjs
@@ -28,10 +28,10 @@
 //
 // Hence two rules, with very different epistemics, and both say so:
 //
-//   Rule 1 — DISPATCH PREDATES BOOT (proof). `dispatched|running`, no bg id, and
-//            the dispatch instant precedes this daemon's boot. Applies to
-//            `running` too, because the proof does not care what the agent had
-//            got around to writing.
+//   Rule 1 — DISPATCH PREDATES BOOT (proof). `dispatched|running`, no bg id,
+//            executor `sdk`, and the dispatch instant precedes this daemon's
+//            boot. Applies to `running` too, because the proof does not care what
+//            the agent had got around to writing.
 //
 //   Rule 2 — NEVER STARTED (timer). `dispatched`, no bg id, this boot, older
 //            than the ceiling. The skill flips `dispatched`→`running` on its
@@ -51,14 +51,53 @@
 // ── ⛔ THE FALSE-POSITIVE THIS MUST NOT PRODUCE ─────────────────────────────
 // The BASH executor also writes `bg_job_id: null` in its prelaunch and only
 // fills it in after the spawn returns (phase-agent-dispatch:1591; the window is
-// documented at :1435). A `claude --bg` worker DOES survive a daemon restart, so
-// a real bg worker caught inside that window would be misjudged by Rule 1. The
-// window is seconds wide and Rule 1 carries an age floor (`minAgeMs`) that is
-// orders of magnitude larger, so a signal that young is never judged at all.
+// documented at :1435). A `claude --bg` worker DOES survive a daemon restart.
+// ⛔ The age floor is NOT the guard for this — see IN_PROCESS_EXECUTOR_ID below;
+// a daemon that died inside that window leaves a PERMANENTLY bg-less signal, so
+// waiting longer makes it look more dead rather than less. The executor gate is
+// the guard. The age floor remains, for the narrower case it is actually good
+// for: a dispatch racing a boot-marker read.
 //
 // Zero-import leaf, like phase-yield.mjs: bare-Node loadable, pure, callable
 // from the daemon, the scheduler and tests alike. Every reader is injected by
 // the caller — this module does no I/O and cannot read a clock it was not given.
+
+/**
+ * ⛔ THE EXECUTOR THE RESTART PROOF IS VALID FOR — Codex #3694 P1, and the
+ * correction to my own age-floor argument.
+ *
+ * I originally gated nothing on the executor and claimed the 5-minute age floor
+ * covered the bash path's prelaunch window. ⛔ IT DOES NOT, and the reason is
+ * that the floor is the wrong instrument for the hazard. The floor assumes the
+ * dispatcher is still alive and about to write the job id a moment later. The
+ * case that matters is the one where **the daemon exited inside that window**:
+ * `phase-agent-dispatch` spawned `claude --bg`, the daemon died before
+ * persisting the returned id, and the signal is now bg-less **permanently** —
+ * nothing will ever fill it in. Five minutes later it is not "young"; it is a
+ * bg-less record of a worker that is very much alive, because a `claude --bg`
+ * job is detached and supervisor-managed and SURVIVES the restart. Rule 1 would
+ * have declared it dead and the reclaim could dispatch a duplicate alongside it.
+ *
+ * The proof is not "no bg id" — it is "this worker ran INSIDE the daemon
+ * process". Only one executor does:
+ *
+ *   `sdk`         in-process Agent SDK `query()` → dies with the daemon. ✅
+ *   `codex-exec`  spawns `codex exec` as a child → MAY outlive it. ✋
+ *   `bg`          detached `claude --bg`, supervisor-managed → survives. ✋
+ *
+ * The signal already records which (`executor`, written at prelaunch since
+ * CTL-1457), so this costs one field read. An ABSENT executor holds: a
+ * pre-CTL-1457 signal cannot prove it was in-process, and the cost of guessing
+ * wrong is a duplicate worker.
+ *
+ * ⚠️ The literal is mirrored from `sdk-run-phase-agent.mjs`'s prelaunch
+ * (`{ spawn, executorId: "sdk" }`) and held to it by `executor-id-parity` in
+ * phase-dispatch-deadline.test.mjs — this is a zero-import leaf and cannot
+ * import the constant, so the mirror is checked mechanically rather than
+ * trusted. That test also asserts `CODEX_EXECUTOR_ID !== "sdk"`, so a future
+ * rename cannot silently widen the proof to a spawned executor.
+ */
+export const IN_PROCESS_EXECUTOR_ID = "sdk";
 
 /** Statuses a bg-less worker can be in while it still holds a slot. */
 export const DISPATCH_PENDING_STATUS = "dispatched";
@@ -91,6 +130,8 @@ export const DISPATCH_DEADLINE_REASONS = Object.freeze([
   "dispatch-start-unreadable", // ⚠️ cannot date the dispatch — cannot judge it
   "too-young", // inside the age floor; no rule may fire yet
   "boot-unreadable", // ⚠️ no boot instant — NEITHER rule can be evaluated
+  "executor-not-in-process", // ⛔ a `bg`/`codex-exec` worker can OUTLIVE the daemon
+  "executor-unknown", // ⚠️ pre-CTL-1457 signal — cannot prove it ran in-process
   "within-deadline", // dated, same boot, and not past the ceiling
 ]);
 
@@ -148,6 +189,20 @@ export function classifyDispatchDeadline(
   const bg = sig.bg_job_id;
   if (typeof bg === "string" && bg !== "") {
     return { expired: false, reason: "has-bg-job", ageMs: null };
+  }
+
+  // ⛔ BOTH rules are gated on the executor, not just Rule 1. Rule 2's input — a
+  // bg-less signal still at `dispatched` — is the SAME on-disk shape the
+  // died-mid-launch bash case produces, so applying the timer to it would
+  // reintroduce the duplicate by the other door. A `bg` launch that never
+  // recorded its id already has its own machinery (`mark_launch_failed`,
+  // CTL-511); this module deliberately does not compete with it.
+  const executor = sig.executor;
+  if (typeof executor !== "string" || executor === "") {
+    return { expired: false, reason: "executor-unknown", ageMs: null };
+  }
+  if (executor !== IN_PROCESS_EXECUTOR_ID) {
+    return { expired: false, reason: "executor-not-in-process", ageMs: null };
   }
 
   // ⚠️ UNREADABLE START HOLDS — the opposite of CTL-1854's yield, on purpose.


### PR DESCRIPTION
Closes CTL-1851.

## The defect, in one sentence

`classifyWorker` answers **`unknown`** for any signal without a live `bg_job_id`, and `reclaimDeadWorkIfPossible` **no-ops on `unknown`** — and an **SDK-executor worker never has a `bg_job_id`**. The prelaunch writes `bg_job_id: null` and nothing ever fills it in. So when an SDK worker died: nothing reclaimed it, nothing revived it, nothing escalated it, and `isTicketInFlight` stayed true **forever**. The slot was pinned by a worker that did not exist.

**Measured.** mini, 2026-08-18 23:1x: two ghost `dispatched` signals from workers dead **6 h** and **3 h 38 m** held two of three slots, with 14 triaged-and-ready tickets queued behind them and one live worker (CTL-2042's monitor-merge). A human cleared them by hand — that is CTL-2053, on the record. Earlier, mini-2 2026-08-14: 3 owned eligible tickets, 4 free slots by the accounting, zero dispatches — the CTL-1851 report itself.

## ⭐ The discriminator is a proof, not a timer

COORD-323 scoped this as *"give `dispatched` the same deadline `awaiting-work` got in CTL-1854"*. Reading the code, there is something stronger sitting underneath:

**The SDK executor runs its `query()` IN-PROCESS in the daemon** (`dispatch.mjs:23` — *"the executor=sdk launch verb (in-process Agent SDK query())"*). A daemon restart therefore does not *suggest* an in-process worker is dead — it **proves** it. And this codebase already accepts that argument for the other executor: `readExecCoreBootEpoch`'s own comment reads *"any --bg worker whose state.json mtime predates it is provably dead."*

So: **two rules with different epistemics, and the module says which is which.**

| | rule | applies to | evidence |
| -- | -- | -- | -- |
| **1** | `dispatch-predates-boot` | `dispatched` **and** `running` | ⭐ **proof** — the process is gone |
| **2** | `dispatch-never-started` | `dispatched` **only** | timer — the skill flips `dispatched`→`running` on its first turn |

⛔ `running` is deliberately **excluded from the timer**: a live SDK phase legitimately runs for hours, and a timer over it would kill working agents.

## ⭐ The verdict is `dead`, not a terminal — and that is the point

Returning `dead` hands the signal to the **existing CTL-574 reclaim path** unchanged: the work-done probe runs, so a phase that finished its work before its daemon died is **completed** through `phase-agent-emit-complete`, and only a phase with nothing to show is revived or escalated. Writing a terminal here instead would have discarded committed work in order to free a slot.

## Fail directions — all deliberate, all tested

| input | verdict | why |
| -- | -- | -- |
| no boot instant | **hold** (`boot-unreadable`) | both rules assert a proof; there is no evidence for one |
| undatable dispatch | **hold** | ⚠️ the **opposite** of CTL-1854's yield, on purpose: there the state is a *permit the agent asked for* and an unbounded permit is the harm; here the signal may describe a live worker |
| age < 5 min | **hold** (`too-young`) | ⛔ the bash prelaunch **also** writes `bg_job_id: null` and fills it in seconds later (`phase-agent-dispatch:1591`, window documented at `:1435`) — and a real `--bg` worker **does** survive a restart |
| carries a bg id | **hold** (`has-bg-job`) | `jobLifecycle` owns it; this module must not second-guess it |
| clock-skewed future stamp | **hold** (`too-young`) | never "very old" |

## Tests — 54, and eight mutation controls, each proved applied before its result was read

⭐ **Two of them are findings, not ceremony:**

1. **The compatibility test caught a false claim in my own comment, on its first run.** I had written *"`bootedMs` defaults to null so every existing caller is byte-identical"* — and the **timer fired with no boot instant at all**, so any bg-less `dispatched` signal older than 30 minutes would have reclassified for **every** caller of `classifyWorker`. Rule 2 now requires the boot instant too, which is also more coherent (its *"same boot"* clause had been implicit). That test exists because a suite in which every test injects is a suite in which **the shipped default is untested**.

2. **The reclaim-call-site control started GREEN.** Deleting `bootedMs` from `reclaimDeadWorkIfPossible`'s call to `classifyWorker` left the suite **50 pass / 0 fail** — every test drove `classifyWorker` directly, so the predicate was proven correct, proven wired to `classifyWorker`, and the one call site that actually runs on the fleet was covered by nothing. Now covered by an e2e over a **real** orchDir with a **real** `daemon-boot.json`, deliberately **not** injecting `readBootSince`.

| mutation | red |
| -- | -- |
| age floor removed | 5 |
| the timer applies to `running` too | 3 |
| boot comparison loosened to `<=` | 1 |
| bg-job short-circuit removed | 2 |
| unreadable start EXPIRES (CTL-1854's direction) | 6 |
| `classifyWorker` ignores the verdict | 2 |
| reclaim stops passing `bootedMs` | 2 |
| reclaim fails OPEN on an unparseable boot marker | 1 |

## Baseline control

`scheduler.test.mjs`'s failure set is **identical** at `4a6d94e6` — this branch's base, verified by grep to contain no `phase-dispatch-deadline` import — 8 failures, same names, over **two full runs of each tree**. ⚠️ That suite's failure set **varies run to run in BOTH trees** (`dispatch circuit breaker (CTL-671)` and `phantom worker-dir validity sweep` each appeared in one run and not the next); the **union over two runs** is what is equal, and it contains no test this branch introduces.

## Not in scope

- **CTL-1864** (the slot-accounting disagreement) was suggested as *"the same PR or the next"*. It is untouched here — it is a separate measurement question and this diff is already the one that frees the slots.
- ⚠️ Noticed while committing and **not** fixed here: `node_modules` is **not** gitignored at the repo root (only `website/`, `orch-monitor/`, `event-mirror/` are). A worktree-local `node_modules` is stageable by `git add -A`. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)