### PR TITLE
fix(dev): CTL-1754 — the escalation card read a key written on 0 of 44 live signals, so it always said "(no reason)"

### DIFF
--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -386,6 +386,22 @@ function normalizeShape(f = {}) {
 // them into one "(no reason)" string is exactly how this defect survived 41
 // instances: an unreadable signal and a reasonless one produced byte-identical
 // cards, so no operator could tell a missing worker dir from a missing field.
+//
+// ⛔⛔ READ BOTH LEVELS — AND THIS IS WHY THE ORIGINAL BUG WAS UNCONDITIONAL.
+// The scheduler does not hand this function the on-disk JSON. It hands it the
+// CANONICAL PROJECTION from `signal-reader.mjs` `parseSignal`, which promotes
+// exactly: ticket, layout, signalPath, phase, status, liveness, updatedAt, pr,
+// worktreePath, host, raw. NO reason key is promoted — all three live only
+// under `.raw`. So `signal.stalledReason` was undefined for EVERY signal
+// regardless of what was on disk: even the one path that does write
+// `stalledReason` (unstuck-act-seams.mjs) could never have surfaced through
+// this card. The disk census explains why the field is rare; the projection
+// explains why the card was empty 41 times out of 41.
+//
+// ⚠️ A fixture shaped like the on-disk JSON therefore CANNOT prove this works —
+// the function never receives that shape in production. `signal.outcome ??
+// signal.raw?.outcome` in signal-reader.mjs is the existing precedent for
+// reading both levels, and this follows it. Credit: Codex, #3699 P1.
 
 /** Keys that carry a failure/stall reason on a phase signal, in ladder order. */
 export const SIGNAL_REASON_KEYS = Object.freeze([
@@ -410,10 +426,16 @@ export function resolveSignalReason(signal) {
   if (signal === null || signal === undefined || typeof signal !== "object") {
     return { reason: null, key: null, status: "unreadable" };
   }
+  const raw = signal.raw;
+  const nested = raw !== null && typeof raw === "object" ? raw : null;
   for (const key of SIGNAL_REASON_KEYS) {
-    const v = signal[key];
-    if (typeof v === "string" && v.trim() !== "") {
-      return { reason: v.trim(), key, status: "named" };
+    // Top level first, then `.raw` — the canonical projection carries the
+    // reason ONLY under `.raw`, while a hand-built or on-disk-shaped object
+    // carries it at the top. Both must resolve or the fix is inert.
+    for (const candidate of [signal[key], nested?.[key]]) {
+      if (typeof candidate === "string" && candidate.trim() !== "") {
+        return { reason: candidate.trim(), key, status: "named" };
+      }
     }
   }
   return { reason: null, key: null, status: "absent" };

--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -355,3 +355,78 @@ function normalizeShape(f = {}) {
 
   return base;
 }
+
+// ── CTL-1754: the reason an escalation reports ──────────────────────────────
+//
+// ⛔ THE DEFECT THIS EXISTS TO FIX. The terminal-sweep escalation built its
+// operator card from ONE key — `signal.stalledReason` — and that key is written
+// by exactly one production path (`unstuck-act-seams.mjs`, for the single value
+// `source_conflict_ctl708_unavailable`). Every other failed/stalled signal the
+// pipeline produces carries its reason under a DIFFERENT key, so the card read
+// "(no reason)" while the reason sat in the same file.
+//
+// Measured across every `failed`/`stalled` phase signal on both fleet hosts
+// (44 signals, 2026-08-19):
+//
+//     stalledReason     0     ⛔ the key the card read
+//     attentionReason  26
+//     failureReason    18
+//     no reason at all  0     ⭐ every signal HAS a reason
+//
+// 41 consecutive escalations reported "(no reason)". None of them lacked one.
+//
+// ⚠️ ORDER IS NOT LOAD-BEARING, and saying so is the honest claim: on the
+// measured population `failureReason` and `attentionReason` NEVER co-occur
+// (0 signals carry both), so their relative order is unobservable today.
+// `stalledReason` stays FIRST because it is the deliberate, specific stall
+// reason and must not be masked when a path does write it.
+//
+// ⭐ THREE-VALUED ON PURPOSE — not a `??` chain. "the signal records no reason"
+// and "I could not read the signal at all" are different facts, and collapsing
+// them into one "(no reason)" string is exactly how this defect survived 41
+// instances: an unreadable signal and a reasonless one produced byte-identical
+// cards, so no operator could tell a missing worker dir from a missing field.
+
+/** Keys that carry a failure/stall reason on a phase signal, in ladder order. */
+export const SIGNAL_REASON_KEYS = Object.freeze([
+  "stalledReason", // deliberate stall (unstuck-act-seams); rare but most specific
+  "failureReason", // the abandon/fail path — e.g. "ended-without-declaration"
+  "attentionReason", // the attention path — e.g. "sdk-overloaded-exhausted"
+]);
+
+/**
+ * Resolve why a phase signal is failed/stalled.
+ *
+ * @param {object|null|undefined} signal a parsed phase signal, or null/undefined
+ *   when the worker dir had no signal (a `signalByTicket.get()` miss).
+ * @returns {{reason: string|null, key: string|null, status: "named"|"absent"|"unreadable"}}
+ *   - `named`      a reason was found; `key` says which field supplied it
+ *   - `absent`     the signal is readable and records no reason
+ *   - `unreadable` there is no signal object to inspect
+ *   Never throws — this sits on the escalation write path, and a resolver that
+ *   throws would suppress the very card it exists to improve.
+ */
+export function resolveSignalReason(signal) {
+  if (signal === null || signal === undefined || typeof signal !== "object") {
+    return { reason: null, key: null, status: "unreadable" };
+  }
+  for (const key of SIGNAL_REASON_KEYS) {
+    const v = signal[key];
+    if (typeof v === "string" && v.trim() !== "") {
+      return { reason: v.trim(), key, status: "named" };
+    }
+  }
+  return { reason: null, key: null, status: "absent" };
+}
+
+/**
+ * The parenthetical an operator card shows for a signal's reason. Keeps the
+ * three states distinguishable in the rendered text — an operator reading
+ * "signal unreadable" knows to look for a missing worker dir, where
+ * "no reason recorded" says the dir is there and the field is not.
+ */
+export function describeSignalReason(signal) {
+  const r = resolveSignalReason(signal);
+  if (r.status === "named") return r.reason;
+  return r.status === "unreadable" ? "signal unreadable" : "no reason recorded";
+}

--- a/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
@@ -6,6 +6,9 @@ import {
   coerceExplanation,
   buildRemediateCapExplanation,
   tierProducer,
+  resolveSignalReason,
+  describeSignalReason,
+  SIGNAL_REASON_KEYS,
 } from "./escalation-explanation.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -572,5 +575,98 @@ describe("CLI shim (escalation-explain.mjs)", () => {
     const r3 = spawnSync("node", [SHIM_PATH, "--can-execute", "false"], { encoding: "utf8" });
     expect(JSON.parse(r3.stdout).escalation_type).toBe("decision");
     expect(JSON.parse(r3.stdout).escalation_type).not.toBe("manual");
+  });
+});
+
+// ── CTL-1754: the reason an escalation reports ──────────────────────────────
+//
+// ⛔ THE FIXTURE TRAP THIS SUITE EXISTS TO AVOID. The broken code read
+// `signal.stalledReason`. A test whose fixture carries `stalledReason` PASSES
+// against that broken code — so a suite built from invented fixtures cannot
+// detect this bug at all. Every fixture below is therefore taken from the
+// measured key distribution on the live fleet (44 failed/stalled phase signals,
+// both hosts, 2026-08-19): attentionReason 26, failureReason 18,
+// stalledReason 0, no-reason-at-all 0. The values are the real ones too.
+describe("CTL-1754 — resolveSignalReason", () => {
+  // The exact shapes that produced "(no reason)" cards on the fleet.
+  const LIVE_FIXTURES = [
+    { sig: { status: "failed", failureReason: "ended-without-declaration" }, want: "ended-without-declaration", key: "failureReason" },
+    { sig: { status: "failed", failureReason: "worker-vanished" }, want: "worker-vanished", key: "failureReason" },
+    { sig: { status: "failed", failureReason: "rebase_refused_dirty_tree" }, want: "rebase_refused_dirty_tree", key: "failureReason" },
+    { sig: { status: "stalled", attentionReason: "sdk-overloaded-exhausted" }, want: "sdk-overloaded-exhausted", key: "attentionReason" },
+    { sig: { status: "stalled", attentionReason: "codex-rate-park-exhausted" }, want: "codex-rate-park-exhausted", key: "attentionReason" },
+  ];
+
+  test("⭐ every live failed/stalled shape resolves to a NAMED reason", () => {
+    for (const { sig, want, key } of LIVE_FIXTURES) {
+      const r = resolveSignalReason(sig);
+      expect(r.status).toBe("named");
+      expect(r.reason).toBe(want);
+      expect(r.key).toBe(key);
+      // The card must not fall back to the "(no reason)" text for any of these.
+      expect(describeSignalReason(sig)).toBe(want);
+    }
+  });
+
+  test("⛔ MUTATION CONTROL: a stalledReason-only ladder fails every live fixture", () => {
+    // This is the OLD behaviour, inlined. If someone reverts the ladder to the
+    // single key, this is what the fleet gets — and this assertion documents
+    // that it is wrong for 100% of real signals, not merely incomplete.
+    const oldBehaviour = (sig) => sig?.stalledReason ?? "no reason";
+    // ⚠️ The assertion that matters is the SECOND one, and it must compare
+    // against the text the code actually renders for a reasonless signal. An
+    // earlier draft compared against the literal "no reason" while
+    // describeSignalReason returns "no reason recorded" — so it passed whether
+    // or not the ladder was broken. A mutation control that cannot fail is the
+    // same defect class as the bug it is guarding.
+    const ABSENT_TEXT = describeSignalReason({ status: "failed" });
+    for (const { sig, want } of LIVE_FIXTURES) {
+      expect(oldBehaviour(sig)).toBe("no reason");
+      expect(describeSignalReason(sig)).not.toBe(ABSENT_TEXT);
+      expect(describeSignalReason(sig)).toBe(want);
+      expect(resolveSignalReason(sig).status).toBe("named");
+    }
+  });
+
+  test("stalledReason stays FIRST — a deliberate stall reason is never masked", () => {
+    const r = resolveSignalReason({
+      stalledReason: "source_conflict_ctl708_unavailable",
+      failureReason: "ended-without-declaration",
+    });
+    expect(r.reason).toBe("source_conflict_ctl708_unavailable");
+    expect(r.key).toBe("stalledReason");
+    expect(SIGNAL_REASON_KEYS[0]).toBe("stalledReason");
+  });
+
+  test("⭐ THREE-VALUED: absent and unreadable are different facts", () => {
+    // A readable signal that records no reason...
+    const absent = resolveSignalReason({ status: "failed" });
+    expect(absent.status).toBe("absent");
+    expect(absent.reason).toBeNull();
+
+    // ...is NOT the same as having no signal to read at all.
+    for (const missing of [null, undefined, "not-an-object", 42]) {
+      const r = resolveSignalReason(missing);
+      expect(r.status).toBe("unreadable");
+      expect(r.reason).toBeNull();
+    }
+
+    // ⛔ The rendered text must keep them distinguishable — collapsing both to
+    // one string is how 41 escalations became indistinguishable from each other.
+    expect(describeSignalReason({ status: "failed" })).toBe("no reason recorded");
+    expect(describeSignalReason(undefined)).toBe("signal unreadable");
+    expect(describeSignalReason({ status: "failed" })).not.toBe(describeSignalReason(undefined));
+  });
+
+  test("a blank or non-string reason is NOT a named reason", () => {
+    for (const bad of [{ failureReason: "   " }, { failureReason: "" }, { failureReason: null }, { failureReason: 7 }]) {
+      expect(resolveSignalReason(bad).status).toBe("absent");
+    }
+  });
+
+  test("never throws on hostile input — it sits on the escalation write path", () => {
+    for (const hostile of [Object.create(null), [], new Map(), { get failureReason() { return "lazy"; } }]) {
+      expect(() => resolveSignalReason(hostile)).not.toThrow();
+    }
   });
 });

--- a/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
@@ -670,3 +670,66 @@ describe("CTL-1754 — resolveSignalReason", () => {
     }
   });
 });
+
+// ── CTL-1754 / #3699 P1: the shape the scheduler ACTUALLY passes ────────────
+//
+// ⛔ THE MISTAKE THIS SUITE EXISTS TO PREVENT. The first cut of this fix was
+// verified against 44 real signal FILES and was still inert, because the
+// scheduler never passes the on-disk JSON — it passes the canonical projection
+// from signal-reader.mjs `parseSignal`, which promotes ticket/layout/phase/
+// status/liveness/updatedAt/pr/worktreePath/host/raw and NO reason key. A
+// census of the disk is a positive control on the WRONG SURFACE.
+//
+// So this block builds the fixture by writing a real signal file and reading it
+// back through the real `readWorkerSignals` — no hand-built object can prove
+// the projection is handled, because a hand-built object is exactly what got
+// this wrong the first time.
+describe("CTL-1754 — the canonical projection, end to end", () => {
+  const REAL_CASES = [
+    { file: "phase-monitor-merge.json", key: "failureReason", value: "ended-without-declaration" },
+    { file: "phase-implement.json", key: "attentionReason", value: "sdk-overloaded-exhausted" },
+    { file: "phase-pr.json", key: "stalledReason", value: "source_conflict_ctl708_unavailable" },
+  ];
+
+  test("⭐ a reason written to disk survives readWorkerSignals and reaches the card", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { readWorkerSignals } = await import("./signal-reader.mjs");
+
+    for (const { file, key, value } of REAL_CASES) {
+      const orchDir = mkdtempSync(join(tmpdir(), "ctl1754-"));
+      const wd = join(orchDir, "workers", "CTC-266");
+      mkdirSync(wd, { recursive: true });
+      writeFileSync(
+        join(wd, file),
+        JSON.stringify({
+          ticket: "CTC-266",
+          phase: file.replace(/^phase-|\.json$/g, ""),
+          status: "failed",
+          bg_job_id: null,
+          updatedAt: new Date(0).toISOString(),
+          [key]: value,
+        })
+      );
+
+      const signals = readWorkerSignals(orchDir);
+      // Positive control: the reader found the signal at all. Without this, an
+      // empty list would make every assertion below pass vacuously.
+      expect(signals.length).toBeGreaterThan(0);
+      const sig = signals.find((s) => s.ticket === "CTC-266");
+      expect(sig).toBeDefined();
+
+      // ⛔ The projection really does hide it at the top level — assert that,
+      // so this test still means something if parseSignal ever changes.
+      expect(sig[key]).toBeUndefined();
+      expect(sig.raw[key]).toBe(value);
+
+      // ...and the resolver must find it anyway.
+      expect(resolveSignalReason(sig).reason).toBe(value);
+      expect(resolveSignalReason(sig).key).toBe(key);
+      expect(describeSignalReason(sig)).toBe(value);
+      expect(describeSignalReason(sig)).not.toBe(describeSignalReason({ status: "failed" }));
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -443,7 +443,9 @@ import {
   buildExplanation,
   buildRemediateCapExplanation,
   coerceExplanation,
-} from "./escalation-explanation.mjs"; // CTL-1130
+  describeSignalReason,
+  resolveSignalReason,
+} from "./escalation-explanation.mjs"; // CTL-1130, CTL-1754
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -8839,16 +8841,21 @@ export function schedulerTick(
             )
           ) {
             const stalledSig = signalByTicket.get(ticket);
+            // CTL-1754: resolve the reason across every key the pipeline
+            // actually writes. This line used to read `stalledSig?.stalledReason`
+            // alone — a key present on 0 of 44 live failed/stalled signals — so
+            // every card said "(no reason)" while the reason sat in the same file.
+            const stalledReason = resolveSignalReason(stalledSig);
             const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
               site: "terminal-sweep",
-              reason: stalledSig?.stalledReason ?? "stalled",
+              reason: stalledReason.reason ?? "stalled",
               boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
               applyLabel: writeStatus,
               env,
               log,
               appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
               explanation: {
-                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${stalledSig?.stalledReason ?? "no reason"}) and is not terminal`,
+                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${describeSignalReason(stalledSig)}) and is not terminal`,
                 call_to_action: `decide whether to retry ${ticket} or close it`,
               },
               // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large


### PR DESCRIPTION
Closes CTL-1754.

## The defect

The terminal-sweep escalation built its operator card from **one** field — `signal.stalledReason` (`scheduler.mjs:8851`, and again for the delegate reason at `:8844`). That field has exactly **one** production writer: `unstuck-act-seams.mjs`, for the single value `source_conflict_ctl708_unavailable`. Every other failed/stalled signal the pipeline produces carries its reason under a different key.

So the card read `(no reason)` while the reason sat in the same file, 11 seconds older.

## The measurement

Every `failed`/`stalled` phase signal on both fleet hosts (44 signals, 2026-08-19):

| key | mini | mini-2 | total |
| -- | -- | -- | -- |
| ⛔ `stalledReason` — **what the card read** | 0 | 0 | **0** |
| `attentionReason` | 12 | 14 | 26 |
| `failureReason` | 11 | 7 | 18 |
| **no reason at all** | 0 | 0 | **0** |

**Positive control:** the two populated keys were returned by the *same loop over the same files*, so the zero is a real absence and not a broken instrument. Raw grep agrees independently — `stalledReason` matches **0** signal files on both hosts, `failureReason` matches **78** and **68**.

**41 consecutive escalations reported `(no reason)`. Not one of them lacked one.** The live values are all transients: `sdk-overloaded-exhausted` (11), `ended-without-declaration` (5), `codex-rate-park-exhausted` (3), `worker-vanished`, `rebase_refused_dirty_tree`.

## ⛔ This refutes the fix previously proposed on the ticket

The earlier proposal was "add `attentionReason` to the ladder". **There was no ladder to extend** — and that change would have repaired 26 of 44 while leaving the 18 `failureReason` cases still reading `(no reason)`, *including CTC-239/266/772, the three tickets that motivated the ticket*. It would have looked like it worked.

## The change

`resolveSignalReason` / `describeSignalReason` in `escalation-explanation.mjs` (the existing pure, no-I/O single source of truth for escalation write sites), used at both scheduler call sites.

**Three-valued, deliberately not a `??` chain.** "the signal records no reason" and "there is no signal to read" are different facts. Collapsing them is *how this survived 41 instances*: an unreadable signal and a reasonless one rendered byte-identical cards, so no operator could distinguish a missing worker dir from a missing field.

⚠️ **Ladder order is explicitly not claimed to be load-bearing.** On the measured population `failureReason` and `attentionReason` **never co-occur** (0 of 44 carry both), so their relative order is unobservable today. `stalledReason` stays first because it is the deliberate, specific stall reason and must not be masked where a path does write it.

## Why this is safe in a core-dispatch file

**Non-behavioral.** The `reason` string at the delegate call site feeds only event payloads (`delegate.would-route` / `delegate.routed`) and enqueue metadata — **nothing branches on it**. The `q.reason` that *is* branched on (`delegate-first.mjs:117`) is the queue result’s own reason, not this input. The `problem` string is card text.

## Tests

Fixtures are taken from the **measured** key distribution and the real values, not invented — **a fixture carrying `stalledReason` passes against the broken code**, so an invented-fixture suite cannot detect this bug at all.

Two **source** mutations, each proved applied before its result was read:

| mutation | result |
| -- | -- |
| ladder reverted to `["stalledReason"]` | **2 red** |
| three-valued `describe` collapsed to one string | **1 red** |
| restored | **58 green** |

⛔ **The first draft of the mutation-control test could not fail.** It asserted `not.toBe("no reason")` while the code renders `"no reason recorded"`, so it passed with the ladder broken. It now compares against the rendered absent-text resolved at runtime. *A mutation control that cannot fail is the same defect class as the bug it guards.*

## Baseline

`scheduler.test.mjs` is **669 pass / 6 fail on clean `origin/main` (`61587c86d`)** — the same six test names — measured in a separate worktree sharing the same `node_modules`. This change moves neither number. ⚠️ Those six pre-existing failures on `main` are worth a separate look.

## Peer read requested

`scheduler.mjs` is core dispatch path and a merge here restarts both minis. I am the instrument owner, not the dispatch-path author — **requesting a peer read before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)