### PR TITLE
fix(dev): CTL-2045 — the install proved the credential could READ, and the incident was a WRITE it never tested

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -520,6 +520,25 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/setup-cloud-replica.test.sh
 
+      - name: host write-credential classifier parity (CTL-2045)
+        # ⛔ Codex P2 on #3706, and the important one. This suite is
+        # the ONLY thing holding lib/host-write-credential.mjs (the
+        # doctor engine) and lib/catalyst-host-write-credential.sh
+        # (the installer engine) in agreement.
+        #
+        # Shell suites here are ALLOWLISTED, not globbed — so a suite
+        # that is written but never invoked is a guard that cannot
+        # fail, and the two engines could drift apart through a green
+        # merge. That is the exact defect class the guard exists to
+        # prevent, one level up.
+        #
+        # Drives BOTH engines over the shared fixture table, checking
+        # each against a COMPUTED-EXPECTED verdict rather than against
+        # the other — two engines agreeing on a wrong answer is what a
+        # bare A-vs-B comparison cannot see.
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/host-write-credential-parity.test.sh
+
       - name: SKILL.md ${PLUGIN_ROOT} assignment guard (CTL-1832)
         # CTL-1832: a SKILL.md that EXPANDS ${PLUGIN_ROOT} must also ASSIGN it, or
         # the expansion is empty and the command silently addresses a bogus path.

--- a/plugins/dev/scripts/__tests__/fixtures/host-write-credential-cases.txt
+++ b/plugins/dev/scripts/__tests__/fixtures/host-write-credential-cases.txt
@@ -1,0 +1,15 @@
+# CTL-2045 — the ONE fixture table both credential-class engines are driven over.
+# Format:  <verdict><TAB><token>
+# A blank token is expressed as the literal <EMPTY> (a trailing tab is unreadable in a diff).
+#
+# ⛔ Every row is a shape that has been OBSERVED or is explicitly named in the incident
+# record — not invented coverage. The `unrecognized` 64-char row IS the mini-2 arm.
+org-key	ctc_acct_sk_fixture_49characterbodyxxxxxxxxxxxxxxxxxxxxxxxxx
+org-key	ctc_acct_x
+user-key	ctc_user_sk_fixture_49characterbodyxxxxxxxxxxxxxxxxxxxxxxxxx
+raw-issuer	sk_fixture_49characterbodyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+unrecognized	0123456789012345678901234567890123456789012345678901234567890123
+unrecognized	ctc_something_else
+unrecognized	tok_test_abc
+unrecognized	Bearer ctc_acct_leading_prefix_must_not_match
+absent	<EMPTY>

--- a/plugins/dev/scripts/__tests__/host-write-credential-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/host-write-credential-parity.test.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# CTL-2045 — cross-stack parity for the host write-credential classifier.
+#
+# Two engines classify the credential that decides whether a host can take a fence:
+# lib/host-write-credential.mjs (JS — `catalyst doctor`) and
+# lib/catalyst-host-write-credential.sh (bash — `setup-catalyst.sh`, which runs before
+# node is guaranteed present). They must not drift.
+#
+# ⛔ EACH ENGINE IS CHECKED AGAINST THE TABLE'S EXPECTED VERDICT, NOT AGAINST THE OTHER.
+# A bare bash-vs-JS comparison passes when both are wrong the same way, which is the
+# likeliest drift (someone "fixes" one and mirrors the fix). The table is the third party.
+# Row-count equality is asserted too, so a silently-skipped row cannot read as a pass:
+# a loop over an empty input set prints an all-clear on the strength of zero iterations.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/../lib" && pwd)"
+CASES="${SCRIPT_DIR}/fixtures/host-write-credential-cases.txt"
+
+PASS=0
+FAIL=0
+ok() {
+	PASS=$((PASS + 1))
+	echo "  ok   — $1"
+}
+bad() {
+	FAIL=$((FAIL + 1))
+	echo "  FAIL — $1"
+}
+
+[[ -r $CASES ]] || {
+	echo "FAIL: fixture table not readable at $CASES"
+	exit 1
+}
+# shellcheck source=../lib/catalyst-host-write-credential.sh disable=SC1091
+source "${LIB_DIR}/catalyst-host-write-credential.sh"
+
+NODE_BIN="$(command -v node || command -v bun || true)"
+[[ -n $NODE_BIN ]] || {
+	echo "FAIL: neither node nor bun on PATH — cannot drive the JS engine"
+	exit 1
+}
+
+echo "CTL-2045 — host write-credential classifier parity"
+
+# ── The JS engine, driven ONCE over the whole table ───────────────────────────────────
+# One process for the whole table rather than one per row: 9 node boots is ~2s of pure
+# startup, and this suite runs in every gate.
+JS_OUT="$(mktemp)"
+trap 'rm -f "$JS_OUT"' EXIT
+# One process for the whole table rather than one per row: 9 node boots is ~2s of pure
+# startup, and this suite runs in every gate. The module path arrives via the environment
+# (a dynamic import) because a static `import … from <expr>` is not valid syntax.
+CRED_MOD="file://${LIB_DIR}/host-write-credential.mjs" CRED_CASES="$CASES" \
+	"$NODE_BIN" --input-type=module -e '
+import { readFileSync } from "node:fs";
+const { classifyHostWriteCredential } = await import(process.env.CRED_MOD);
+const rows = readFileSync(process.env.CRED_CASES, "utf8").split("\n")
+  .filter((l) => l.trim() !== "" && !l.startsWith("#"));
+for (const line of rows) {
+  const rest = line.slice(line.indexOf("\t") + 1);
+  process.stdout.write(classifyHostWriteCredential(rest === "<EMPTY>" ? "" : rest).verdict + "\n");
+}
+' >"$JS_OUT" || {
+	echo "FAIL: the JS engine could not be driven over the table"
+	exit 1
+}
+
+# ── Walk the table: bash-vs-expected, JS-vs-expected, row alignment ───────────────────
+row=0
+while IFS= read -r line; do
+	[[ -z ${line// /} ]] && continue
+	[[ $line == \#* ]] && continue
+	row=$((row + 1))
+	expected="${line%%$'\t'*}"
+	token="${line#*$'\t'}"
+	[[ $token == "<EMPTY>" ]] && token=""
+
+	# bash engine — called DIRECTLY, never in $(…): the verdict rides globals, and a
+	# command substitution would run it in a subshell and discard every one of them.
+	CATALYST_CREDENTIAL_VERDICT=""
+	CATALYST_CREDENTIAL_SHAPE=""
+	catalyst_classify_host_write_credential "$token"
+	sh_rc=$?
+	sh_verdict="$CATALYST_CREDENTIAL_VERDICT"
+
+	js_verdict="$(sed -n "${row}p" "$JS_OUT")"
+
+	label="row ${row} (expected ${expected})"
+	if [[ $sh_verdict == "$expected" ]]; then ok "bash  ${label}"; else bad "bash  ${label} — got '${sh_verdict}'"; fi
+	if [[ $js_verdict == "$expected" ]]; then ok "js    ${label}"; else bad "js    ${label} — got '${js_verdict}'"; fi
+
+	# The RETURN CODE is the thing setup-catalyst.sh actually branches on, so assert it
+	# independently of the verdict string. A mirror that names the class correctly and
+	# returns 0 for it anyway would let the install proceed on an admin bearer.
+	if [[ $expected == "org-key" ]]; then
+		if [[ $sh_rc -eq 0 ]]; then ok "bash  ${label} returns 0"; else bad "bash  ${label} returned ${sh_rc}, expected 0"; fi
+	else
+		if [[ $sh_rc -ne 0 ]]; then ok "bash  ${label} returns non-zero"; else bad "bash  ${label} returned 0 — a non-org-key MUST refuse"; fi
+	fi
+
+	# ⛔ The shape must never carry the secret. Asserted on every row, not just the ones
+	# whose message an operator is likely to see: the redaction lives in the classifier
+	# precisely so no caller can leak it, and a row that leaks proves the opposite.
+	if [[ -n $token && $CATALYST_CREDENTIAL_SHAPE == *"$token"* ]]; then
+		bad "bash  ${label} — SHAPE LEAKS THE TOKEN VALUE"
+	else
+		ok "bash  ${label} shape carries no secret body"
+	fi
+done <"$CASES"
+
+# ── Row alignment + a non-empty denominator ──────────────────────────────────────────
+js_rows=$(grep -c . "$JS_OUT" 2>/dev/null || echo 0)
+if [[ $row -eq 0 ]]; then
+	bad "the fixture table yielded ZERO rows — every assertion above is vacuous"
+elif [[ $js_rows -eq $row ]]; then
+	ok "both engines classified all ${row} rows (no silently skipped row)"
+else
+	bad "row misalignment: bash walked ${row}, js emitted ${js_rows} — verdicts above were compared off-by-one"
+fi
+
+# ── Mutation control ─────────────────────────────────────────────────────────────────
+# ⭐ Proves this suite can actually fail. The table contains a row whose token differs
+# from an accepted one ONLY by the prefix; if the bash engine matched on a substring
+# rather than the start, "Bearer ctc_acct_…" would classify as org-key and the install
+# would accept a mangled credential. A GREEN control is the "easy fixture" trap.
+CATALYST_CREDENTIAL_VERDICT=""
+catalyst_classify_host_write_credential "Bearer ctc_acct_x"
+if [[ $CATALYST_CREDENTIAL_VERDICT == "unrecognized" ]]; then
+	ok "control — the prefix must match at the START, not anywhere in the string"
+else
+	bad "control — a leading-garbage token classified as '${CATALYST_CREDENTIAL_VERDICT}', not 'unrecognized'"
+fi
+
+echo ""
+echo "  PASS=${PASS} FAIL=${FAIL}"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-cloud-replica.test.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 SETUP="${REPO_ROOT}/setup-catalyst.sh"
-[[ -f "$SETUP" ]] || {
+[[ -f $SETUP ]] || {
 	echo "FAIL: setup-catalyst.sh not found at $SETUP"
 	exit 1
 }
@@ -72,12 +72,21 @@ file_mode() {
 #
 # The stub speaks the ONE contract validate_cloud_token relies on: honour
 # `-w '%{http_code}'` by printing the code on stdout, and send the body to -o.
+#
+# ⛔ CTL-2045: THE STUB IS ROUTE-AWARE, AND IT HAS TO BE. setup_cloud_replica now makes
+# TWO authenticated calls — `GET /issues` (generic read, CTL-1913) and
+# `GET /agent/attachments` (the per-host binding preflight) — and the 2026-08-18 incident
+# is the case where those two answer DIFFERENTLY: the admin bearer read 200 from /issues
+# and 403 from every /agent/* route. A single-code stub cannot express that signature at
+# all, so a suite built on one would be structurally incapable of failing for the exact
+# defect this ticket exists to prevent. AGENT_CODE defaults to CODE, so every pre-existing
+# case keeps its old meaning.
 make_curl_stub() {
-	local bindir="$1" code="$2"
+	local bindir="$1" code="$2" agent_code="${3:-$2}"
 	mkdir -p "$bindir"
 	cat >"$bindir/curl" <<STUB
 #!/usr/bin/env bash
-# Records every invocation, then answers with a fixed HTTP code.
+# Records every invocation, then answers with a fixed HTTP code per route family.
 echo "\$*" >>"$bindir/stub_calls"
 # validate_cloud_token feeds the auth header on stdin via --config -; drain it so
 # the writer never blocks on a full pipe, and prove the token never hit argv.
@@ -86,7 +95,8 @@ for a in "\$@"; do
   if [[ \$a == "-o" ]]; then next=out; continue; fi
   if [[ \${next:-} == out ]]; then : >"\$a" 2>/dev/null; next=; fi
 done
-printf '%s' "$code"
+# The route family decides the answer: /agent/* is the per-host binding path.
+if [[ " \$* " == *"/agent/"* ]]; then printf '%s' "$agent_code"; else printf '%s' "$code"; fi
 exit 0
 STUB
 	chmod +x "$bindir/curl"
@@ -100,9 +110,9 @@ STUB
 # only care about the FILE the function writes leave it at 200; the CTL-1913 cases
 # drive it to 401/403/000.
 run_case() {
-	local home="$1" token="$2" account="$3" code="${4:-200}"
+	local home="$1" token="$2" account="$3" code="${4:-200}" agent_code="${5:-${4:-200}}"
 	local bindir="$home/.stub-bin"
-	make_curl_stub "$bindir" "$code"
+	make_curl_stub "$bindir" "$code" "$agent_code"
 	seal_stack "$bindir"
 	(
 		export HOME="$home"
@@ -113,7 +123,7 @@ run_case() {
 		# Deliberately NOT pinned by default: the base URL is left unset so the
 		# cases below exercise the REAL shipped default (CTL-1910's whole subject).
 		# Set CASE_BASE_URL to test the override path.
-		[[ -n ${CASE_BASE_URL:-} ]] && export CATALYST_CLOUD_BASE_URL="$CASE_BASE_URL"
+		[[ -n ${CASE_BASE_URL-} ]] && export CATALYST_CLOUD_BASE_URL="$CASE_BASE_URL"
 		# shellcheck disable=SC1090
 		source "$SETUP" >/dev/null 2>&1
 		# setup-catalyst.sh sets -e; re-disable AFTER sourcing so a deliberate
@@ -147,7 +157,7 @@ seal_stack() {
 	local bindir="$1"
 	mkdir -p "$bindir"
 	[[ -x "$bindir/catalyst-stack" ]] && return 0
-	make_stack_stub "$bindir" 0 "stubbed catalyst-stack (CTL-1968: the real one mutates gui/\$(id -u))"
+	make_stack_stub "$bindir" 0 'stubbed catalyst-stack (CTL-1968: the real one mutates gui/$(id -u))'
 }
 
 # make_stack_stub BINDIR RC MESSAGE — a `catalyst-stack` on PATH that exits RC
@@ -172,9 +182,9 @@ STACKSTUB
 # deliberately drives a NON-ZERO return (every rejection case does) aborts the whole
 # suite mid-run instead of asserting. Cost one debugging round.
 run_case_capturing() {
-	local home="$1" token="$2" account="$3" code="${4:-200}"
+	local home="$1" token="$2" account="$3" code="${4:-200}" agent_code="${5:-${4:-200}}"
 	local bindir="$home/.stub-bin"
-	make_curl_stub "$bindir" "$code"
+	make_curl_stub "$bindir" "$code" "$agent_code"
 	seal_stack "$bindir"
 	(
 		export HOME="$home"
@@ -188,6 +198,13 @@ run_case_capturing() {
 		setup_cloud_replica 2>&1
 	)
 }
+
+# ⛔ CTL-2045: every fixture token below is now a WELL-SHAPED per-host organization key.
+# Provisioning refuses any other class outright, so the old `tok_test_abc` fixtures would
+# have made every case below exercise the class refusal rather than the behaviour it was
+# written to assert — a suite that stays green while testing nothing it names.
+OK_TOKEN="ctc_acct_sk_fixture_testonly_000000000000000000000000000000"
+OK_TOKEN_2="ctc_acct_sk_fixture_testonly_111111111111111111111111111111"
 
 echo "CTL-1836 — setup-catalyst.sh cloud replica provisioning"
 
@@ -206,7 +223,7 @@ scrub "$H1"
 # This is the tenant-0 footgun. It must fail, and it must not leave a half-written
 # credential behind.
 H2=$(mktemp -d)
-rc=$(run_case "$H2" "tok_test_abc" "")
+rc=$(run_case "$H2" "$OK_TOKEN" "")
 if [[ $rc != "0" ]]; then ok "token without account → non-zero exit (refuses to guess the tenant)"; else bad "token without account → returned 0; it defaulted instead of refusing"; fi
 if [[ ! -e "$H2/.config/catalyst/cloud-sync.env" ]]; then
 	ok "token without account → no cloud-sync.env written"
@@ -217,10 +234,10 @@ scrub "$H2"
 
 # ── Case 3: token + account → env file written, 0600, explicit values ────────
 H3=$(mktemp -d)
-rc=$(run_case "$H3" "tok_test_abc" "tenant-7")
+rc=$(run_case "$H3" "$OK_TOKEN" "tenant-7")
 ENV_FILE="$H3/.config/catalyst/cloud-sync.env"
 if [[ $rc == "0" ]]; then ok "token + account → returns 0"; else bad "token + account → expected rc 0, got $rc"; fi
-if [[ -f "$ENV_FILE" ]]; then
+if [[ -f $ENV_FILE ]]; then
 	ok "token + account → cloud-sync.env written"
 
 	mode=$(file_mode "$ENV_FILE")
@@ -255,7 +272,7 @@ if [[ -f "$ENV_FILE" ]]; then
 		bad "expected the staging.catalystcloud.dev default, got: $(grep '^export CATALYST_CLOUD_BASE_URL=' "$ENV_FILE")"
 	fi
 
-	if grep -q '^export CATALYST_CLOUD_TOKEN=tok_test_abc$' "$ENV_FILE"; then
+	if grep -q "^export CATALYST_CLOUD_TOKEN=${OK_TOKEN}$" "$ENV_FILE"; then
 		ok "token written"
 	else
 		bad "token missing from cloud-sync.env"
@@ -267,7 +284,7 @@ scrub "$H3"
 
 # ── Case 4: CATALYST_CLOUD_BASE_URL override is honoured ─────────────────────
 H4=$(mktemp -d)
-CASE_BASE_URL="https://example.invalid/api/v1" rc=$(CASE_BASE_URL="https://example.invalid/api/v1" run_case "$H4" "t" "a")
+CASE_BASE_URL="https://example.invalid/api/v1" rc=$(CASE_BASE_URL="https://example.invalid/api/v1" run_case "$H4" "$OK_TOKEN" "a")
 if grep -q '^export CATALYST_CLOUD_BASE_URL=https://example.invalid/api/v1$' "$H4/.config/catalyst/cloud-sync.env" 2>/dev/null; then
 	ok "explicit CATALYST_CLOUD_BASE_URL override is honoured"
 else
@@ -294,7 +311,7 @@ mkdir -p "$H5/.config/catalyst"
 : >"$H5/.config/catalyst/cloud-sync.env"
 chmod 644 "$H5/.config/catalyst/cloud-sync.env"
 pre_mode=$(file_mode "$H5/.config/catalyst/cloud-sync.env")
-rc=$(run_case "$H5" "tok_test_abc" "tenant-9")
+rc=$(run_case "$H5" "$OK_TOKEN" "tenant-9")
 post_mode=$(file_mode "$H5/.config/catalyst/cloud-sync.env")
 if [[ $pre_mode == "644" ]]; then
 	ok "precondition established: env file started 0644 (proves this case can discriminate)"
@@ -324,7 +341,7 @@ scrub "$H5"
 # This is not theoretical bookkeeping — it is the exact silent-death shape of
 # CTL-1844, which cost hours to diagnose on a live host.
 H6=$(mktemp -d)
-rc=$(run_case "$H6" "tok_export_check" "tenant-3")
+rc=$(run_case "$H6" "$OK_TOKEN_2" "tenant-3")
 E6="$H6/.config/catalyst/cloud-sync.env"
 if [[ -f $E6 ]]; then
 	assigns=$(grep -cE '^[A-Za-z_][A-Za-z0-9_]*=' "$E6" || true)
@@ -339,7 +356,7 @@ if [[ -f $E6 ]]; then
 	if (
 		# shellcheck disable=SC1090
 		. "$E6"
-		env | grep -q '^CATALYST_CLOUD_TOKEN=tok_export_check$'
+		env | grep -q "^CATALYST_CLOUD_TOKEN=${OK_TOKEN_2}$"
 	); then
 		ok "sourcing the file puts the token in the ENVIRONMENT (env|grep, not just set)"
 	else
@@ -364,7 +381,7 @@ seal_stack "$H7/.stub-bin"
 	export HOME="$H7" CATALYST_SETUP_LIB_ONLY=1
 	export PATH="$H7/.stub-bin:$PATH"
 	export CATALYST_CLOUD_TOKEN_ENV="MY_CUSTOM_CLOUD_TOKEN"
-	export MY_CUSTOM_CLOUD_TOKEN="tok_custom_name"
+	export MY_CUSTOM_CLOUD_TOKEN="ctc_acct_tok_custom_name"
 	export CATALYST_CLOUD_ACCOUNT="tenant-4"
 	# shellcheck disable=SC1090
 	source "$SETUP" >/dev/null 2>&1
@@ -372,7 +389,7 @@ seal_stack "$H7/.stub-bin"
 	setup_cloud_replica >/dev/null 2>&1
 )
 E7="$H7/.config/catalyst/cloud-sync.env"
-if grep -q '^export MY_CUSTOM_CLOUD_TOKEN=tok_custom_name$' "$E7" 2>/dev/null; then
+if grep -q '^export MY_CUSTOM_CLOUD_TOKEN=ctc_acct_tok_custom_name$' "$E7" 2>/dev/null; then
 	ok "token written under the CONFIGURED name, not the hardcoded default"
 else
 	bad "configured token name ignored — writer would resolve a name the file never sets"
@@ -416,7 +433,7 @@ for spec in "401:a garbage or revoked token:REJECTED by the hub" \
 	desc="${rest%%:*}"
 	expect_msg="${rest#*:}"
 	HB=$(mktemp -d)
-	out=$(run_case_capturing "$HB" "FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code" || true)
+	out=$(run_case_capturing "$HB" "ctc_acct_FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code" || true)
 	if grep -qF "$expect_msg" <<<"$out"; then
 		ok "HTTP $code → the message names its own cause (\"$expect_msg\")"
 	else
@@ -424,7 +441,7 @@ for spec in "401:a garbage or revoked token:REJECTED by the hub" \
 	fi
 	scrub "$HB"
 	HB=$(mktemp -d)
-	rc=$(run_case "$HB" "FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code")
+	rc=$(run_case "$HB" "ctc_acct_FAKE-TOKEN-NOT-REAL" "acme-tenant" "$code")
 	if [[ $rc != "0" ]]; then
 		ok "HTTP $code ($desc) → non-zero exit"
 	else
@@ -451,7 +468,7 @@ done
 # above would pass on a function that refused unconditionally — which would break
 # every real install rather than fix it.
 HOK=$(mktemp -d)
-rc=$(run_case "$HOK" "tok_good" "tenant-1" 200)
+rc=$(run_case "$HOK" "ctc_acct_tok_good" "tenant-1" 200)
 if [[ $rc == "0" ]]; then
 	ok "POSITIVE CONTROL: HTTP 200 → returns 0 (the refusal is driven by the CODE, not unconditional)"
 else
@@ -467,14 +484,14 @@ fi
 # A probe that omits the token would return 401 for a perfectly good token, and an
 # unauthenticated reachability ping would pass for a garbage one — the exact
 # "correct and garbage are indistinguishable" defect, reintroduced.
-if [[ -f "$HOK/.stub-bin/stub_stdin" ]] && grep -q 'Authorization: Bearer tok_good' "$HOK/.stub-bin/stub_stdin"; then
+if [[ -f "$HOK/.stub-bin/stub_stdin" ]] && grep -q 'Authorization: Bearer ctc_acct_tok_good' "$HOK/.stub-bin/stub_stdin"; then
 	ok "the validation call carries the bearer token (authenticated, not a reachability ping)"
 else
 	bad "no Authorization header reached the transport — validation is unauthenticated"
 fi
 # ⛔ and the token must NOT be on argv: `ps` is world-readable, so a bearer token in
 # the command line is visible to every local user for the life of the call.
-if grep -q 'tok_good' "$HOK/.stub-bin/stub_calls" 2>/dev/null; then
+if grep -q 'ctc_acct_tok_good' "$HOK/.stub-bin/stub_calls" 2>/dev/null; then
 	bad "the token appears in curl's ARGV — readable by any local user via ps"
 else
 	ok "the token is never on curl's argv (passed via --config on stdin)"
@@ -494,7 +511,7 @@ scrub "$HOK"
 # none of them is evidence the token works.
 for code in 500 502 404 302 418; do
 	HU=$(mktemp -d)
-	rc=$(run_case "$HU" "tok_unknown_code" "tenant-2" "$code")
+	rc=$(run_case "$HU" "ctc_acct_tok_unknown_code" "tenant-2" "$code")
 	if [[ $rc != "0" ]]; then
 		ok "HTTP $code (unlisted) → non-zero exit"
 	else
@@ -515,7 +532,7 @@ done
 HD=$(mktemp -d)
 mkdir -p "$HD/.stub-bin"
 make_stack_stub "$HD/.stub-bin" 3 "launchctl: Bootstrap failed: 5: Input/output error"
-out=$(run_case_capturing "$HD" "tok_adopt" "tenant-5" 200 || true)
+out=$(run_case_capturing "$HD" "ctc_acct_tok_adopt" "tenant-5" 200 || true)
 if grep -q 'Bootstrap failed: 5: Input/output error' <<<"$out"; then
 	ok "adopt-cloud-sync's stderr reaches the operator (not discarded to /dev/null)"
 else
@@ -536,7 +553,7 @@ fi
 HS=$(mktemp -d)
 mkdir -p "$HS/.stub-bin"
 make_stack_stub "$HS/.stub-bin" 0 "some ordinary chatter on stderr"
-out=$(run_case_capturing "$HS" "tok_adopt" "tenant-6" 200 || true)
+out=$(run_case_capturing "$HS" "ctc_acct_tok_adopt" "tenant-6" 200 || true)
 if grep -qi 'writer adopted' <<<"$out" && ! grep -q 'ordinary chatter' <<<"$out"; then
 	ok "NEGATIVE CONTROL: a successful adopt prints the success line and stays quiet"
 else
@@ -562,7 +579,7 @@ scrub "$HN"
 # first would be wasted work and would send the token somewhere before we had
 # decided the input was even usable.
 HA=$(mktemp -d)
-rc=$(run_case "$HA" "tok_test_abc" "" 200)
+rc=$(run_case "$HA" "$OK_TOKEN" "" 200)
 if ! stub_was_called "$HA"; then
 	ok "token without account → refused BEFORE any network call"
 else
@@ -600,7 +617,7 @@ export CATALYST_CLOUD_TOKEN=tok_from_a_previous_run
 export CATALYST_CLOUD_ACCOUNT=tenant-carried
 export CATALYST_CLOUD_BASE_URL=https://staging.catalystcloud.dev/api/v1
 CFEOF
-rc=$(run_case "$HCF" "tok_test_abc" "" 200)
+rc=$(run_case "$HCF" "$OK_TOKEN" "" 200)
 if [[ $rc == "0" ]]; then
 	ok "⭐ account absent from flag+env but recorded in cloud-sync.env → provisions (rc=0)"
 else
@@ -618,7 +635,7 @@ scrub "$HCF"
 # defaulted the account would pass every case above.
 HNF=$(mktemp -d)
 mkdir -p "$HNF/.config/catalyst"
-rc=$(run_case "$HNF" "tok_test_abc" "" 200)
+rc=$(run_case "$HNF" "$OK_TOKEN" "" 200)
 if [[ $rc != "0" ]]; then
 	ok "⛔ INVERSION GUARD: no flag, no env, NO file → still refuses (rc=$rc), never guesses tenant-0"
 else
@@ -631,7 +648,7 @@ HEL=$(mktemp -d)
 mkdir -p "$HEL/.config/catalyst"
 printf 'export CATALYST_CLOUD_TOKEN=tok_only\nexport CATALYST_CLOUD_BASE_URL=https://x/api/v1\n' \
 	>"$HEL/.config/catalyst/cloud-sync.env"
-rc=$(run_case "$HEL" "tok_test_abc" "" 200)
+rc=$(run_case "$HEL" "$OK_TOKEN" "" 200)
 if [[ $rc != "0" ]]; then
 	ok "cloud-sync.env present but carrying NO account line → still refuses"
 else
@@ -643,7 +660,7 @@ scrub "$HEL"
 HPR=$(mktemp -d)
 mkdir -p "$HPR/.config/catalyst"
 printf 'export CATALYST_CLOUD_ACCOUNT=tenant-from-file\n' >"$HPR/.config/catalyst/cloud-sync.env"
-rc=$(run_case "$HPR" "tok_test_abc" "tenant-from-env" 200)
+rc=$(run_case "$HPR" "$OK_TOKEN" "tenant-from-env" 200)
 if [[ $rc == "0" ]] && grep -q '^export CATALYST_CLOUD_ACCOUNT=tenant-from-env$' \
 	"$HPR/.config/catalyst/cloud-sync.env" 2>/dev/null; then
 	ok "precedence holds: env account beats the recorded file"
@@ -660,14 +677,153 @@ HTK=$(mktemp -d)
 mkdir -p "$HTK/.config/catalyst"
 printf 'export CATALYST_CLOUD_TOKEN=tok_STALE_from_file\nexport CATALYST_CLOUD_ACCOUNT=tenant-carried\n' \
 	>"$HTK/.config/catalyst/cloud-sync.env"
-rc=$(run_case "$HTK" "tok_CALLER_wins" "" 200)
-if grep -q 'tok_CALLER_wins' "$HTK/.config/catalyst/cloud-sync.env" 2>/dev/null &&
+rc=$(run_case "$HTK" "ctc_acct_tok_CALLER_wins" "" 200)
+if grep -q 'ctc_acct_tok_CALLER_wins' "$HTK/.config/catalyst/cloud-sync.env" 2>/dev/null &&
 	! grep -q 'tok_STALE_from_file' "$HTK/.config/catalyst/cloud-sync.env" 2>/dev/null; then
 	ok "⭐ reads the ACCOUNT only — the caller's token wins, the file's stale token is not adopted"
 else
 	bad "the carry-forward pulled the token out of the env file (it must read one named field)"
 fi
 scrub "$HTK"
+
+# ══════════════════════════════════════════════════════════════════════════════════════
+# CTL-2045 — the credential CLASS gate and the per-host BINDING preflight
+# ══════════════════════════════════════════════════════════════════════════════════════
+#
+# The 2026-08-18 incident: mini-2's reinstall provisioned the tenant-wide ADMIN_TOKEN as
+# this host's write credential. Every cross-host claim 403'd and the board froze for four
+# hours — while `catalyst doctor` passed, the daemons ran, the heartbeat stayed fresh, and
+# the local write ledger showed ZERO refusals.
+#
+# ⚠️ EVERY CASE BELOW WOULD HAVE PASSED BEFORE THIS TICKET. That is the point: the suite
+# above is 59 green assertions that are all blind to a mis-provisioned credential class.
+echo ""
+echo "CTL-2045 — credential class + per-host binding"
+
+# ── §1: the class gate refuses, BEFORE any packet leaves the host ────────────────────
+# ⭐ Each row is a shape the cloud treats differently, and the `sk_` row is the one a
+# blacklist implementation would let through (BE-12: the cloud ACCEPTS a bare sk_ key but
+# derives no per-host binding from it). Implementing the ticket's TITLE — "refuse an admin
+# bearer" — passes that row and reopens the hole one credential over.
+while IFS='|' read -r label token expect_fragment; do
+	[[ -z ${label// /} ]] && continue
+	HC=$(mktemp -d)
+	# ⛔ The transport answers 200 for EVERYTHING. So if the install still refuses, the
+	# refusal cannot have come from the network — it came from the class gate. A case
+	# that drove the stub to 403 could not tell the two apart.
+	out=$(run_case_capturing "$HC" "$token" "tenant-1" 200 200 || true)
+	rc=$(run_case "$HC" "$token" "tenant-1" 200 200)
+
+	if [[ $rc != "0" ]]; then
+		ok "class gate: ${label} → non-zero exit"
+	else
+		bad "class gate: ${label} → returned 0; a wrong-class credential was provisioned"
+	fi
+	if [[ ! -e "$HC/.config/catalyst/cloud-sync.env" ]]; then
+		ok "class gate: ${label} → wrote NO cloud-sync.env"
+	else
+		bad "class gate: ${label} → wrote a credential it had already classified as unusable"
+	fi
+	# The operator has to be told WHICH class arrived, or the message is just another 403.
+	if printf '%s' "$out" | grep -q "$expect_fragment"; then
+		ok "class gate: ${label} → names the class it received (\"${expect_fragment}\")"
+	else
+		bad "class gate: ${label} → generic diagnostic; expected \"${expect_fragment}\", got: $(printf '%s' "$out" | tr '\n' '|' | head -c 160)"
+	fi
+	# ⛔ THE SECRET MUST NOT REACH THE TERMINAL. The refusal echoes a SHAPE precisely so
+	# it never echoes a value; a message that pasted the token would leak it into every
+	# CI log and support thread that carries a failed install.
+	if printf '%s' "$out" | grep -q -- "$token"; then
+		bad "class gate: ${label} → THE REFUSAL PRINTED THE TOKEN VALUE"
+	else
+		ok "class gate: ${label} → refusal carries the shape, never the secret"
+	fi
+	# ⭐ Refused with NO network call at all — the class is decidable on-host.
+	if stub_was_called "$HC"; then
+		bad "class gate: ${label} → made a network call before classifying (the class needs no round trip)"
+	else
+		ok "class gate: ${label} → refused before any network call"
+	fi
+	scrub "$HC"
+done <<'CLASSCASES'
+admin-bearer shape (64 chars, no prefix)|0123456789012345678901234567890123456789012345678901234567890123|no recognized prefix
+a USER key (ctc_user_)|ctc_user_sk_fixture_000000000000000000000000000000000000|USER key
+a bare issuer key (sk_)|sk_fixture_00000000000000000000000000000000000000000|RAW issuer key
+CLASSCASES
+
+# ── §2: the per-host BINDING preflight — the incident's exact signature ──────────────
+# ⭐⭐ THE CASE THAT WOULD HAVE CAUGHT mini-2, and the reason the stub is route-aware.
+# A well-SHAPED credential, `GET /issues` → 200, `GET /agent/attachments` → 403. That is
+# byte-for-byte what the admin bearer did: it authenticated for generic reads and was
+# refused on every agent route. CTL-1913's validation passes it; only this gate does not.
+HB2=$(mktemp -d)
+out=$(run_case_capturing "$HB2" "$OK_TOKEN" "tenant-1" 200 403 || true)
+rc=$(run_case "$HB2" "$OK_TOKEN" "tenant-1" 200 403)
+if [[ $rc != "0" ]]; then
+	ok "⭐ binding: generic read 200 + agent route 403 → install REFUSES (the mini-2 signature)"
+else
+	bad "⭐ binding: generic read 200 + agent route 403 → returned 0 — this IS the four-hour freeze"
+fi
+if [[ ! -e "$HB2/.config/catalyst/cloud-sync.env" ]]; then
+	ok "binding: refused → wrote NO cloud-sync.env"
+else
+	bad "binding: refused → still wrote the credential to disk"
+fi
+if printf '%s' "$out" | grep -q "agent write path"; then
+	ok "binding: names the agent write path, not a generic auth failure"
+else
+	bad "binding: generic diagnostic; got: $(printf '%s' "$out" | tr '\n' '|' | head -c 160)"
+fi
+# Seal + route proof: the verdict came from the stub AND the stub was asked the /agent/
+# route. Without the route assertion this case could pass on a probe that never ran.
+if grep -q '/agent/attachments' "$HB2/.stub-bin/stub_calls" 2>/dev/null; then
+	ok "binding: the preflight really requested /agent/attachments (sealed transport)"
+else
+	bad "binding: no /agent/attachments request recorded — the refusal came from somewhere else"
+fi
+scrub "$HB2"
+
+# ── §2 positive controls: the pass arm must be WIDE, or every real install breaks ─────
+# ⛔ 404 IS THE AUTHORIZED ANSWER on a probe issue id that does not exist. Measured
+# 2026-08-18: a per-host key against its own account returns 404 for an absent issue,
+# while the admin bearer returned 403 for the identical request. A gate pinned to
+# "200 only" would refuse every correctly-provisioned host — a fix worse than the bug.
+for agent_code in 200 404 400; do
+	HP=$(mktemp -d)
+	rc=$(run_case "$HP" "$OK_TOKEN" "tenant-1" 200 "$agent_code")
+	if [[ $rc == "0" ]]; then
+		ok "POSITIVE CONTROL: agent route ${agent_code} → install proceeds (authorized, past the binding check)"
+	else
+		bad "POSITIVE CONTROL: agent route ${agent_code} → rc ${rc}; a correctly-provisioned host was refused"
+	fi
+	scrub "$HP"
+done
+
+# An unreachable agent route is UNVERIFIED, and unverified is fatal here — the same
+# posture CTL-1913 already takes for the generic read. Reporting success on a check that
+# did not run is what produced green installs with permanently dead writers.
+HN=$(mktemp -d)
+rc=$(run_case "$HN" "$OK_TOKEN" "tenant-1" 200 000)
+if [[ $rc != "0" ]]; then
+	ok "binding: agent route unreachable (000) → refuses as UNVERIFIED, never assumes"
+else
+	bad "binding: agent route unreachable → returned 0; the binding was never proven"
+fi
+scrub "$HN"
+
+# ── ⭐ THE ORDERING ASSERTION — §1 must run before §2, and §2 before the write ────────
+# A well-shaped token whose agent route 403s reaches the network; a wrong-class token must
+# not. Proving both in one place is what makes "cheapest gate first" a tested property
+# rather than a comment. Without it, someone could reorder the three gates and every other
+# case above would stay green.
+HO=$(mktemp -d)
+rc=$(run_case "$HO" "0123456789012345678901234567890123456789012345678901234567890123" "tenant-1" 403 403)
+if [[ $rc != "0" ]] && ! stub_was_called "$HO"; then
+	ok "⭐ ordering: a wrong-CLASS credential never reaches the network, even when the hub would also refuse it"
+else
+	bad "⭐ ordering: the class gate did not run first (stub called=$(stub_was_called "$HO" && echo yes || echo no), rc=$rc)"
+fi
+scrub "$HO"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -33,6 +33,7 @@ import { homedir } from "node:os";
 import { STATUS, mkCheck } from "./doctor-status.mjs";
 import { checkInstallCompleteness } from "./install-completeness.mjs";
 // CTL-1936 AC5: the standing answer to "is this host write-exhausted".
+import { checkHostWriteCredentialClass } from "./host-credential-health.mjs";
 import { checkLinearWriteBudget } from "./write-budget-health.mjs";
 import { checkAgentToolsWritePath } from "./agent-tools-write-path-health.mjs";
 import { checkExecutionCoreEnvDrift } from "./execution-core-env-drift-health.mjs";
@@ -186,6 +187,7 @@ export { STATUS, mkCheck } from "./doctor-status.mjs";
 
 export { checkInstallCompleteness };
 
+export { checkHostWriteCredentialClass };
 export { checkLinearWriteBudget };
 export { checkAgentToolsWritePath };
 export { checkExecutionCoreEnvDrift };
@@ -6241,6 +6243,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkDrainDisabled(), // CTL-1678: surface the per-node drain override + the draining-but-ignored third state — advisory only (never FAIL)
     () => checkRegistryTeamIdentity(), // CAT-52: registry team ↔ checkout teamKey contract — advisory only
     () => checkInstallCompleteness(), // CTL-1918: did the install FINISH — CLIs, plugin-source, sweep, enrolment — advisory only (never FAIL)
+    () => checkHostWriteCredentialClass(), // CTL-2045: is this host's cloud WRITE credential a per-host org key, or the admin bearer that froze the board for 4h? — advisory only (never FAIL)
     () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
     () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)

--- a/plugins/dev/scripts/execution-core/host-credential-health.mjs
+++ b/plugins/dev/scripts/execution-core/host-credential-health.mjs
@@ -26,6 +26,20 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 
 import { classifyHostWriteCredential } from "../lib/host-write-credential.mjs";
+// ⛔ Codex P2 on #3706. The token's env-var NAME is CONFIGURABLE, and the installer
+// resolves it through env → Layer-2 `catalyst.cloud.tokenEnv` → default before writing
+// the file. Hardcoding the default here meant that on a host using a custom name this
+// check read a variable the file does not set and reported "the writer would receive no
+// token" — grading the wrong variable instead of the credential actually in use, and
+// reporting a WARN that says the opposite of what is wrong.
+//
+// ⚠️ It is also precisely the "every test injects, so the DEFAULT is untested" trap: the
+// suite covered `tokenVar` injection and therefore never exercised the default path.
+//
+// resolveCloudTokenName is the canonical resolver (config.mjs's resolveNodeCloudTokenEnv
+// is a thin delegate onto it) and lives in the ZERO-IMPORT secret-contract leaf, so
+// importing it here keeps this module loadable under doctor's bare-Node runtime.
+import { resolveCloudTokenName } from "../lib/secret-contract.mjs";
 import { STATUS, mkCheck } from "./doctor-status.mjs";
 
 const CHECK = "host-write-credential-class";
@@ -66,7 +80,8 @@ export function checkHostWriteCredentialClass(deps = {}) {
       resolve(homedir(), ".config", "catalyst", "cloud-sync.env"),
     exists = existsSync,
     readFile = (p) => readFileSync(p, "utf8"),
-    tokenVar = process.env.CATALYST_CLOUD_TOKEN_ENV || "CATALYST_CLOUD_TOKEN",
+    // NAME-only resolution — never reads the secret VALUE, so it is safe to render.
+    tokenVar = resolveCloudTokenName(process.env).envVar,
     classify = classifyHostWriteCredential,
   } = deps;
 

--- a/plugins/dev/scripts/execution-core/host-credential-health.mjs
+++ b/plugins/dev/scripts/execution-core/host-credential-health.mjs
@@ -1,0 +1,123 @@
+// host-credential-health.mjs — CTL-2045 §3, the `catalyst doctor` half.
+//
+// "Given an already-provisioned host whose write credential is later replaced by an admin
+//  bearer, when catalyst doctor runs, then the check does NOT pass, and names the
+//  credential class it found."
+//
+// §1's gate lives at PROVISIONING and can only see an install. This is the standing
+// answer for a host that DRIFTS into the bad state afterwards — a re-mint, a restore from
+// a backup, a hand-edit, or an installer that predates the gate. mini-2 spent four hours
+// in exactly that state on 2026-08-18 with every existing check green: doctor passed, the
+// daemons ran, the heartbeat was fresh, and the local write ledger showed ZERO refusals,
+// because nothing ever got far enough to be refused locally.
+//
+// ⛔ ADVISORY — never FAIL. doctor's FAIL count gates worker activation, and a host with
+// the wrong write credential is ALREADY unable to claim; failing it here would convert a
+// visible degradation into a second, differently-shaped outage while fixing nothing. Same
+// posture and same reason as checkLinearWriteBudget and checkRegistryTeamIdentity.
+//
+// ⚠️ THREE-VALUED, AND IT CAN NEVER PASS ON ABSENCE. A missing or unreadable
+// cloud-sync.env, or a file with no token line, is reported as INFO/WARN — never PASS.
+// "I could not look" and "I looked and it is fine" are different answers, and collapsing
+// them is how a check that cannot fail gets shipped.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+import { classifyHostWriteCredential } from "../lib/host-write-credential.mjs";
+import { STATUS, mkCheck } from "./doctor-status.mjs";
+
+const CHECK = "host-write-credential-class";
+
+/**
+ * extractExportedValue(text, varName) -> string | null
+ *
+ * cloud-sync.env is a shell file of `export NAME=value` lines (every line MUST be
+ * exported — launch.sh sources it then execs bun, so a bare assignment would leave the
+ * writer tokenless). Parsed rather than sourced: doctor must never execute a file it is
+ * inspecting, and a `$(…)` in a hand-edited env file would run as this process.
+ *
+ * ⚠️ Takes the LAST match, not the first. A file that was appended to rather than
+ * replaced carries several assignments and the shell would honour the last one — so the
+ * last is the credential the writer actually receives, and grading the first would grade
+ * a value nothing uses.
+ */
+export function extractExportedValue(text, varName) {
+  if (typeof text !== "string" || !varName) return null;
+  let found = null;
+  for (const line of text.split("\n")) {
+    const m = line.match(/^\s*export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m || m[1] !== varName) continue;
+    let v = m[2].trim();
+    // Strip one layer of surrounding quotes if present; the writer's own output is
+    // unquoted, but a hand-edited file may not be.
+    if (v.length >= 2 && ((v[0] === '"' && v.endsWith('"')) || (v[0] === "'" && v.endsWith("'")))) {
+      v = v.slice(1, -1);
+    }
+    found = v;
+  }
+  return found;
+}
+
+export function checkHostWriteCredentialClass(deps = {}) {
+  const {
+    envPath = process.env.CATALYST_CLOUD_SYNC_ENV ||
+      resolve(homedir(), ".config", "catalyst", "cloud-sync.env"),
+    exists = existsSync,
+    readFile = (p) => readFileSync(p, "utf8"),
+    tokenVar = process.env.CATALYST_CLOUD_TOKEN_ENV || "CATALYST_CLOUD_TOKEN",
+    classify = classifyHostWriteCredential,
+  } = deps;
+
+  if (!exists(envPath)) {
+    // The normal state for a host with no cloud replica provisioned. Not health, not a
+    // problem — and explicitly NOT a pass.
+    return mkCheck(
+      CHECK,
+      STATUS.INFO,
+      `no cloud-sync.env at ${envPath} — this host has no provisioned cloud write credential`
+    );
+  }
+
+  let text;
+  try {
+    text = readFile(envPath);
+  } catch (err) {
+    return mkCheck(
+      CHECK,
+      STATUS.WARN,
+      `cloud-sync.env present but UNREADABLE at ${envPath} (${err?.message ?? err}) — ` +
+        `this host's write-credential class could NOT be determined (CTL-2045)`
+    );
+  }
+
+  const token = extractExportedValue(text, tokenVar);
+  if (token === null) {
+    return mkCheck(
+      CHECK,
+      STATUS.WARN,
+      `cloud-sync.env carries no 'export ${tokenVar}=' line — the writer resolves that name ` +
+        `and would receive no token, so this host cannot write to the cloud at all (CTL-2045)`
+    );
+  }
+
+  const { verdict, shape, detail } = classify(token);
+  if (verdict === "org-key") {
+    return mkCheck(
+      CHECK,
+      STATUS.PASS,
+      `host write credential is a per-host organization key (${shape})`
+    );
+  }
+
+  // ⛔ `shape`, never `token`. The classifier pre-redacts precisely so that no caller —
+  // including a doctor report an operator will paste into a thread — can leak the secret.
+  return mkCheck(
+    CHECK,
+    STATUS.WARN,
+    `WRONG CREDENTIAL CLASS — got ${shape} (${verdict}): ${detail}. ` +
+      `Every cross-host claim write from this host is refused, so it will claim no ticket ` +
+      `on any phase while looking healthy in every other check (CTL-2045).`
+  );
+}

--- a/plugins/dev/scripts/execution-core/host-credential-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/host-credential-health.test.mjs
@@ -75,6 +75,80 @@ describe("checkHostWriteCredentialClass", () => {
     expect(noLine.detail).toContain("no 'export CATALYST_CLOUD_TOKEN=' line");
   });
 
+  // ══════════════════════════════════════════════════════════════════════════════════
+  // Codex P2 on #3706 — the DEFAULT token-name resolution, exercised with NO injection.
+  // ══════════════════════════════════════════════════════════════════════════════════
+  //
+  // ⛔ The injected-`tokenVar` test below passed the whole time the default was a
+  // hardcoded "CATALYST_CLOUD_TOKEN". On a host that sets `catalyst.cloud.tokenEnv` in
+  // Layer-2, the installer writes the credential under THAT name, and this check read a
+  // variable the file does not set — reporting "the writer would receive no token" while
+  // the real credential sat unread one line away. Every test injected the seam, so the
+  // default was untested; these two do not inject it.
+  describe("resolves the token env-var NAME through the canonical ladder (not hardcoded)", () => {
+    const swapEnv = (patch, body) => {
+      const saved = {};
+      for (const k of Object.keys(patch)) saved[k] = process.env[k];
+      Object.assign(process.env, patch);
+      try {
+        return body();
+      } finally {
+        for (const [k, v] of Object.entries(saved)) {
+          if (v === undefined) delete process.env[k];
+          else process.env[k] = v;
+        }
+      }
+    };
+
+    test("env override (CATALYST_CLOUD_TOKEN_ENV) — no tokenVar injected", () => {
+      const c = swapEnv({ CATALYST_CLOUD_TOKEN_ENV: "MY_TOKEN" }, () =>
+        checkHostWriteCredentialClass({
+          envPath: "/seal/cloud-sync.env",
+          exists: () => true,
+          readFile: () =>
+            `export MY_TOKEN=${ADMIN_BEARER}\nexport CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`,
+        })
+      );
+      // Grading the DEFAULT name would read the good ORG_KEY and report PASS on a host
+      // whose writer actually loads the admin bearer.
+      expect(c.status).toBe("warn");
+      expect(c.detail).toContain("WRONG CREDENTIAL CLASS");
+    });
+
+    test("Layer-2 catalyst.cloud.tokenEnv, read off a REAL file — no tokenVar injected", () => {
+      const dir = mkdtempSync(join(tmpdir(), "ctl2045-l2-"));
+      const cfg = join(dir, "config.json");
+      writeFileSync(cfg, JSON.stringify({ catalyst: { cloud: { tokenEnv: "L2_TOKEN" } } }));
+      const c = swapEnv(
+        { CATALYST_LAYER2_CONFIG_FILE: cfg, CATALYST_CLOUD_TOKEN_ENV: undefined },
+        () =>
+          checkHostWriteCredentialClass({
+            envPath: "/seal/cloud-sync.env",
+            exists: () => true,
+            readFile: () =>
+              `export L2_TOKEN=${ADMIN_BEARER}\nexport CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`,
+          })
+      );
+      expect(c.status).toBe("warn");
+      expect(c.detail).toContain("WRONG CREDENTIAL CLASS");
+    });
+
+    test("positive control — with no override the ladder still yields the default name", () => {
+      const c = swapEnv(
+        { CATALYST_CLOUD_TOKEN_ENV: undefined, CATALYST_LAYER2_CONFIG_FILE: "/seal/absent.json" },
+        () =>
+          checkHostWriteCredentialClass({
+            envPath: "/seal/cloud-sync.env",
+            exists: () => true,
+            readFile: () => `export CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`,
+          })
+      );
+      // Without this the two cases above would also pass on a resolver that returned a
+      // constant custom name and never fell back.
+      expect(c.status).toBe("pass");
+    });
+  });
+
   test("honours a configured token env-var NAME (the writer resolves that name, not the default)", () => {
     const body = `export MY_TOKEN=${ADMIN_BEARER}\nexport CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`;
     // Grading the DEFAULT name here would read the good key and report a healthy host

--- a/plugins/dev/scripts/execution-core/host-credential-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/host-credential-health.test.mjs
@@ -1,0 +1,135 @@
+// host-credential-health.test.mjs — CTL-2045 §3 (the doctor half).
+//
+// The acceptance criterion is a DRIFT case: "an already-provisioned host whose write
+// credential is later replaced by an admin bearer … the check does NOT pass, and names
+// the credential class it found."
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { checkHostWriteCredentialClass, extractExportedValue } from "./host-credential-health.mjs";
+
+const ADMIN_BEARER = "0123456789012345678901234567890123456789012345678901234567890123";
+const ORG_KEY = "ctc_acct_sk_fixture_testonly_000000000000000000000000000000";
+
+const withEnvFile = (body, over = {}) =>
+  checkHostWriteCredentialClass({
+    envPath: "/seal/cloud-sync.env",
+    exists: () => true,
+    readFile: () => body,
+    ...over,
+  });
+
+describe("checkHostWriteCredentialClass", () => {
+  test("a per-host org key PASSES and reports the shape, never the value", () => {
+    const c = withEnvFile(`export CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`);
+    expect(c.status).toBe("pass");
+    expect(c.detail).toContain("ctc_acct_…");
+    expect(c.detail).not.toContain(ORG_KEY);
+  });
+
+  // ⭐ THE ACCEPTANCE CRITERION. This is mini-2's 2026-08-18 state exactly.
+  test("an admin bearer does NOT pass and names the class it found", () => {
+    const c = withEnvFile(`export CATALYST_CLOUD_TOKEN=${ADMIN_BEARER}\n`);
+    expect(c.status).not.toBe("pass");
+    expect(c.detail).toContain("WRONG CREDENTIAL CLASS");
+    expect(c.detail).toContain("no recognized prefix");
+    expect(c.detail).toContain("ADMIN_TOKEN");
+    // ⛔ The operator pastes this line into a thread. It must not carry the secret.
+    expect(c.detail).not.toContain(ADMIN_BEARER);
+  });
+
+  test("advisory only — a wrong class never returns FAIL (doctor's FAIL count gates activation)", () => {
+    for (const tok of [ADMIN_BEARER, "ctc_user_abc", "sk_fixture_abc", "tok_whatever"]) {
+      const c = withEnvFile(`export CATALYST_CLOUD_TOKEN=${tok}\n`);
+      expect(c.status).toBe("warn");
+    }
+  });
+
+  test("a user key and a raw issuer key are each named distinctly, not lumped together", () => {
+    expect(withEnvFile("export CATALYST_CLOUD_TOKEN=ctc_user_abc\n").detail).toContain("USER key");
+    expect(withEnvFile("export CATALYST_CLOUD_TOKEN=sk_fixture_abc\n").detail).toContain(
+      "RAW issuer key"
+    );
+  });
+
+  // ⛔ THREE-VALUED. "I could not look" must never render as "it is fine".
+  test("absent / unreadable / token-less files never PASS", () => {
+    expect(checkHostWriteCredentialClass({ envPath: "/seal/x", exists: () => false }).status).toBe(
+      "info"
+    );
+    const thrown = checkHostWriteCredentialClass({
+      envPath: "/seal/x",
+      exists: () => true,
+      readFile: () => {
+        throw new Error("EACCES");
+      },
+    });
+    expect(thrown.status).toBe("warn");
+    expect(thrown.detail).toContain("UNREADABLE");
+    const noLine = withEnvFile("export CATALYST_CLOUD_ACCOUNT=tenant-0\n");
+    expect(noLine.status).toBe("warn");
+    expect(noLine.detail).toContain("no 'export CATALYST_CLOUD_TOKEN=' line");
+  });
+
+  test("honours a configured token env-var NAME (the writer resolves that name, not the default)", () => {
+    const body = `export MY_TOKEN=${ADMIN_BEARER}\nexport CATALYST_CLOUD_TOKEN=${ORG_KEY}\n`;
+    // Grading the DEFAULT name here would read the good key and report a healthy host
+    // while the writer loads the admin bearer from MY_TOKEN.
+    const c = withEnvFile(body, { tokenVar: "MY_TOKEN" });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("WRONG CREDENTIAL CLASS");
+  });
+
+  test("an appended file is graded on the LAST assignment — the one the shell honours", () => {
+    const body = `export CATALYST_CLOUD_TOKEN=${ORG_KEY}\nexport CATALYST_CLOUD_TOKEN=${ADMIN_BEARER}\n`;
+    const c = withEnvFile(body);
+    expect(c.status).toBe("warn");
+  });
+
+  // ⚠️ Every test above INJECTS every seam, so the zero-argument shape — the one the
+  // doctor registry actually calls — is exercised by none of them. A check that throws
+  // on its own defaults is a check that crashes doctor on every host.
+  test("the ZERO-ARGUMENT call — the shape doctor's registry uses — does not throw", () => {
+    expect(() => checkHostWriteCredentialClass()).not.toThrow();
+    const c = checkHostWriteCredentialClass();
+    expect(["pass", "warn", "info"]).toContain(c.status);
+    expect(c.name).toBe("host-write-credential-class");
+  });
+
+  // Reads a real file off a real disk: the injected `readFile` above cannot catch a
+  // path/encoding mistake in the default reader.
+  test("reads a REAL file from disk end to end", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl2045-"));
+    const p = join(dir, "cloud-sync.env");
+    writeFileSync(p, `export CATALYST_CLOUD_TOKEN=${ADMIN_BEARER}\n`, { mode: 0o600 });
+    const c = checkHostWriteCredentialClass({ envPath: p });
+    expect(c.status).toBe("warn");
+    expect(c.detail).toContain("WRONG CREDENTIAL CLASS");
+  });
+});
+
+describe("extractExportedValue", () => {
+  test("ignores a BARE assignment — launch.sh sources this file, so only exports reach bun", () => {
+    expect(extractExportedValue("CATALYST_CLOUD_TOKEN=abc\n", "CATALYST_CLOUD_TOKEN")).toBeNull();
+  });
+
+  test("does not match a variable whose name merely CONTAINS the target", () => {
+    expect(
+      extractExportedValue("export NOT_CATALYST_CLOUD_TOKEN=abc\n", "CATALYST_CLOUD_TOKEN")
+    ).toBeNull();
+  });
+
+  test("strips one layer of surrounding quotes", () => {
+    expect(extractExportedValue(`export T="abc"\n`, "T")).toBe("abc");
+    expect(extractExportedValue(`export T='abc'\n`, "T")).toBe("abc");
+    expect(extractExportedValue(`export T=abc\n`, "T")).toBe("abc");
+  });
+
+  test("never executes the file — a command substitution is returned as literal text", () => {
+    expect(extractExportedValue("export T=$(rm -rf /)\n", "T")).toBe("$(rm -rf /)");
+  });
+});

--- a/plugins/dev/scripts/lib/catalyst-host-write-credential.sh
+++ b/plugins/dev/scripts/lib/catalyst-host-write-credential.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# catalyst-host-write-credential.sh — CTL-2045 §1, the BASH mirror of
+# lib/host-write-credential.mjs.
+#
+# Two engines exist because the two consumers cannot share one: `catalyst doctor` is JS,
+# and `setup-catalyst.sh` is the INSTALLER — it runs before node/bun are guaranteed to be
+# on the host, so it cannot shell out to the JS leaf for the one check that decides
+# whether provisioning proceeds. Same one-registry/hand-written-mirror/cross-stack-parity
+# shape as lib/secret-contract.mjs + lib/catalyst-secret-contract.sh.
+#
+# ⛔ THE MIRROR IS NOT TRUSTED TO STAY IN SYNC BY REVIEW. Both engines are driven over the
+# SAME fixture table (__tests__/fixtures/host-write-credential-cases.txt) by
+# __tests__/host-write-credential-parity.test.sh, which compares each against a
+# COMPUTED-EXPECTED verdict — never merely against each other. Two engines agreeing on a
+# wrong answer is the failure mode a bare A-vs-B comparison cannot see.
+#
+# See the JS leaf's header for WHY this is a positive allow-list and why it does not gate
+# on length. Do not re-derive that reasoning here; change both or neither.
+
+CATALYST_HOST_WRITE_CREDENTIAL_PREFIX="ctc_acct_"
+CATALYST_USER_CREDENTIAL_PREFIX="ctc_user_"
+
+# catalyst_classify_host_write_credential TOKEN
+#
+# Sets three globals and returns 0 when the token is an org key, 1 otherwise:
+#   CATALYST_CREDENTIAL_VERDICT  org-key | user-key | raw-issuer | unrecognized | absent
+#   CATALYST_CREDENTIAL_SHAPE    ⭐ SAFE TO PRINT — prefix + length, never secret bytes
+#   CATALYST_CREDENTIAL_DETAIL   one operator-facing clause
+#
+# ⛔ GLOBALS, NOT STDOUT, AND CALLED DIRECTLY — NEVER `$(…)`. A command substitution runs
+# the function in a SUBSHELL, so every global it sets is discarded the moment it returns
+# and the caller reads a stale/empty verdict. That exact mistake has been made four times
+# in this repo, three of them inside fixes for it (see the reference note in AGENTS.md's
+# knowledge store). The return code carries the pass/fail; the globals carry the reason.
+# shellcheck disable=SC2034  # the three globals below ARE this function's return channel;
+# shellcheck cannot see the callers (setup-catalyst.sh, the parity suite) from this file.
+catalyst_classify_host_write_credential() {
+	local token="${1-}"
+	local len=${#token}
+
+	if [[ -z $token ]]; then
+		CATALYST_CREDENTIAL_VERDICT="absent"
+		CATALYST_CREDENTIAL_SHAPE="<empty>"
+		CATALYST_CREDENTIAL_DETAIL="no credential supplied"
+		return 1
+	fi
+
+	case "$token" in
+	"${CATALYST_HOST_WRITE_CREDENTIAL_PREFIX}"*)
+		CATALYST_CREDENTIAL_VERDICT="org-key"
+		CATALYST_CREDENTIAL_SHAPE="${CATALYST_HOST_WRITE_CREDENTIAL_PREFIX}… (len ${len})"
+		CATALYST_CREDENTIAL_DETAIL="per-host organization key"
+		return 0
+		;;
+	"${CATALYST_USER_CREDENTIAL_PREFIX}"*)
+		CATALYST_CREDENTIAL_VERDICT="user-key"
+		CATALYST_CREDENTIAL_SHAPE="${CATALYST_USER_CREDENTIAL_PREFIX}… (len ${len})"
+		CATALYST_CREDENTIAL_DETAIL="a USER key — bound to a person, not to this host; the cloud derives no per-host binding from it"
+		return 1
+		;;
+	sk_*)
+		# ⚠️ BE-12: the cloud ACCEPTS a bare sk_ key. A blacklist would pass it.
+		CATALYST_CREDENTIAL_VERDICT="raw-issuer"
+		CATALYST_CREDENTIAL_SHAPE="sk_… (len ${len})"
+		CATALYST_CREDENTIAL_DETAIL="a RAW issuer key — the cloud accepts it but derives no per-host binding, so every claim write is refused"
+		return 1
+		;;
+	*)
+		CATALYST_CREDENTIAL_VERDICT="unrecognized"
+		CATALYST_CREDENTIAL_SHAPE="<no recognized prefix> (len ${len})"
+		CATALYST_CREDENTIAL_DETAIL="no recognized Catalyst Cloud key prefix — this is the shape the tenant-wide ADMIN_TOKEN presents"
+		return 1
+		;;
+	esac
+}

--- a/plugins/dev/scripts/lib/host-write-credential.mjs
+++ b/plugins/dev/scripts/lib/host-write-credential.mjs
@@ -1,0 +1,121 @@
+// host-write-credential.mjs — CTL-2045 §1. What CLASS of credential is this host
+// trying to write to Catalyst Cloud with?
+//
+// ⛔ THE INCIDENT THIS EXISTS FOR. mini-2's 2026-08-18 reinstall provisioned the
+// tenant-wide `ADMIN_TOKEN` as the host's write credential instead of a per-host org
+// key. The cloud's agent routes correctly refuse an admin bearer for writes, so every
+// cross-host claim 403'd and the board froze from ~15:00 CT. ⚠️ The host looked healthy
+// the entire time — `catalyst doctor` passed, the daemons ran, the heartbeat was fresh,
+// and the local write ledger read `2` with ZERO refusals, because nothing ever got far
+// enough to be refused locally. Only CTL-2033's discriminated claim result named it, and
+// only after it shipped at 19:46 — four hours in.
+//
+// ══════════════════════════════════════════════════════════════════════════════════════
+// ⭐ POSITIVE ALLOW-LIST, NEVER A BLACKLIST. Implement the ticket's §2, not its title.
+// ══════════════════════════════════════════════════════════════════════════════════════
+//
+// The ticket is titled "refuse an admin bearer". Implementing THAT — a blacklist of known
+// -bad shapes — reintroduces the hole one credential over. Measured (@backend BE-12):
+// **a bare `sk_…` WorkOS key is also accepted by the cloud** and is also not per-host
+// bound. A blacklist of "ADMIN_TOKEN-shaped things" passes it; an allow-list of
+// `ctc_acct_` refuses it for free, and refuses the next unknown class too.
+//
+// ⛔ AND DO NOT GATE ON LENGTH. mini's key is 58 chars and the admin bearer is 64, so a
+// `length != 64` check would have caught this incident — and would be wrong. 58-vs-64 is
+// an observation about two samples on one day, not a contract; a length check passes
+// silently until the format changes, which is a failure in the dangerous direction. The
+// issuer defines a PREFIX, and the prefix is what we gate on. From the cloud's own
+// validator:
+//
+//     for (const [type, prefix] of [["organization", "ctc_acct_"], ["user", "ctc_user_"]])
+//       if (value.startsWith(prefix)) { … }
+//
+// ── ⚠️ WHAT THIS CANNOT TELL YOU ────────────────────────────────────────────────────
+// A shape check is a PROXY. It would have caught this incident and it will catch the next
+// mis-provisioned class, but it cannot see a well-shaped key with the wrong grants, the
+// wrong tenant, or the wrong endpoint — all three of which were live hypotheses that
+// night. That is why CTL-2045 §2 pairs it with an authenticated preflight against the
+// `/agent/*` route family (setup-catalyst.sh's `validate_cloud_agent_binding`), which
+// tests the CAPABILITY rather than the shape. Neither half replaces the other.
+//
+// Zero-import leaf on purpose: `catalyst doctor` runs under bare Node and must be able to
+// import this without pulling in a bun:sqlite graph, and the bash mirror
+// (lib/catalyst-host-write-credential.sh) is held byte-honest against it by
+// __tests__/host-write-credential-parity.test.sh over a SHARED fixture table.
+
+/** The one shape a host write credential may have: a per-host ORGANIZATION key. */
+export const HOST_WRITE_CREDENTIAL_PREFIX = "ctc_acct_";
+
+/** Recognized-but-wrong: a USER key. Bound to a person, not to this host. */
+export const USER_CREDENTIAL_PREFIX = "ctc_user_";
+
+/**
+ * classifyHostWriteCredential(token) -> { verdict, shape, detail }
+ *
+ * verdict is one of:
+ *   "org-key"      — ✅ the only accepted class
+ *   "user-key"     — recognized vendor shape, WRONG class (not per-host bound)
+ *   "raw-issuer"   — a bare `sk_…`; accepted by the cloud, NOT per-host bound (BE-12)
+ *   "unrecognized" — no recognized prefix at all (the ADMIN_TOKEN arm of the incident)
+ *   "absent"       — empty/missing
+ *
+ * ⛔ `shape` is SAFE TO PRINT and the value is NOT. It carries the recognized prefix (or
+ * an explicit "no recognized prefix") plus the length — never any bytes of the secret
+ * body. Every caller renders `shape`; no caller may render the token. Echoing "what I
+ * got" is the whole point of the refusal message, and it is exactly where a credential
+ * leaks into a terminal, a CI log, or a support paste if the shape is not pre-redacted
+ * here, at the one place that has the token.
+ */
+export function classifyHostWriteCredential(token) {
+  const raw = typeof token === "string" ? token : "";
+  const len = raw.length;
+
+  if (len === 0) {
+    return {
+      verdict: "absent",
+      shape: "<empty>",
+      detail: "no credential supplied",
+    };
+  }
+
+  if (raw.startsWith(HOST_WRITE_CREDENTIAL_PREFIX)) {
+    return {
+      verdict: "org-key",
+      shape: `${HOST_WRITE_CREDENTIAL_PREFIX}… (len ${len})`,
+      detail: "per-host organization key",
+    };
+  }
+
+  if (raw.startsWith(USER_CREDENTIAL_PREFIX)) {
+    return {
+      verdict: "user-key",
+      shape: `${USER_CREDENTIAL_PREFIX}… (len ${len})`,
+      detail:
+        "a USER key — bound to a person, not to this host; the cloud derives no per-host binding from it",
+    };
+  }
+
+  // ⚠️ BE-12: the cloud ACCEPTS a bare `sk_…`, so this arm is not academic. Named
+  // separately from "unrecognized" because the operator remediation differs — a raw
+  // issuer key means someone pasted the upstream secret instead of minting a host key.
+  if (raw.startsWith("sk_")) {
+    return {
+      verdict: "raw-issuer",
+      shape: `sk_… (len ${len})`,
+      detail:
+        "a RAW issuer key — the cloud accepts it but derives no per-host binding, so every claim write is refused",
+    };
+  }
+
+  return {
+    verdict: "unrecognized",
+    shape: `<no recognized prefix> (len ${len})`,
+    detail:
+      "no recognized Catalyst Cloud key prefix — this is the shape the tenant-wide ADMIN_TOKEN presents",
+  };
+}
+
+/** The one predicate every caller gates on. Anything that is not an org key is refused. */
+export function isHostWriteCredential(token) {
+  return classifyHostWriteCredential(token).verdict === "org-key";
+}

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1904,6 +1904,151 @@ validate_cloud_token() {
 	esac
 }
 
+# ── CTL-2045 §1: refuse the wrong credential CLASS before anything reaches disk ──
+#
+# assert_host_write_credential_shape TOKEN — 0 when TOKEN is a per-host org key.
+#
+# ⛔ THE INCIDENT. mini-2's 2026-08-18 reinstall provisioned the tenant-wide ADMIN_TOKEN
+# as this host's write credential. The cloud's agent routes correctly refuse an admin
+# bearer for writes, so every cross-host claim 403'd and the board froze from ~15:00 CT
+# — and `catalyst doctor` passed, the daemons ran, the heartbeat stayed fresh, and the
+# local write ledger read `2` with ZERO refusals the whole time, because nothing ever got
+# far enough to be refused locally.
+#
+# The classification itself lives in ONE place (lib/host-write-credential.mjs, mirrored
+# for bash in lib/catalyst-host-write-credential.sh, held honest over a shared fixture
+# table by __tests__/host-write-credential-parity.test.sh). Read that header for why this
+# is a positive ALLOW-LIST rather than a blacklist of admin-bearer shapes, and why it does
+# not gate on the token's LENGTH.
+#
+# ⚠️ FAILS CLOSED WHEN THE CLASSIFIER CANNOT BE LOADED. A guard that silently skips itself
+# when its helper is missing is worse than no guard: it reports the same green install as
+# a passing check, which is the precise shape of the bug being fixed here.
+assert_host_write_credential_shape() {
+	local token="$1"
+
+	catalyst_helper_path "lib/catalyst-host-write-credential.sh" >/dev/null || {
+		print_error "Cannot verify the cloud credential's class — the classifier is unavailable."
+		echo ""
+		echo "  Reason: ${CATALYST_SOURCE_REASON:-unknown}"
+		echo ""
+		echo "  This check refuses rather than skips. Provisioning a host write credential"
+		echo "  without classifying it is what put mini-2 into a silent dispatch deadlock"
+		echo "  for four hours on 2026-08-18 (CTL-2045) — every existing check stayed green."
+		return 1
+	}
+	# shellcheck disable=SC1090
+	source "$CATALYST_HELPER_PATH"
+
+	# ⛔ Called DIRECTLY, never as `$(…)`. The verdict rides globals; a command
+	# substitution runs the function in a subshell and discards all of them.
+	if catalyst_classify_host_write_credential "$token"; then
+		print_success "cloud credential is a per-host organization key (${CATALYST_CREDENTIAL_SHAPE})"
+		return 0
+	fi
+
+	print_error "The cloud token is NOT a per-host write credential — got ${CATALYST_CREDENTIAL_SHAPE}."
+	echo ""
+	echo "  Class:  ${CATALYST_CREDENTIAL_VERDICT}"
+	echo "  Detail: ${CATALYST_CREDENTIAL_DETAIL}"
+	echo ""
+	echo "  A host write credential must be a per-host ORGANIZATION key — it begins"
+	echo "  '${CATALYST_HOST_WRITE_CREDENTIAL_PREFIX}'. The cloud derives this host's identity from that key;"
+	echo "  a credential it cannot bind to a host is refused on every claim write, so the"
+	echo "  host installs green and then claims NOTHING, on any phase, forever."
+	echo ""
+	echo "  Mint a per-host key for this host and re-run with it. Nothing has been written."
+	return 1
+}
+
+# ── CTL-2045 §2: prove this host can actually take a fence ──────────────────────────
+#
+# validate_cloud_agent_binding TOKEN ACCOUNT BASE_URL
+#
+# ⭐ THE HALF THAT ACTUALLY CLOSES THE HOLE, and it is NOT what validate_cloud_token does.
+# That function calls `GET /issues` — the GENERIC read route, which never goes through the
+# cloud's `resolveAgentPrincipal`. mini-2's admin bearer sailed through it with a 200 and
+# then 403'd on every single claim. ⛔ A shape check plus a generic read is still two
+# checks that both pass on the broken credential.
+#
+# The `/agent/*` family is the one the claim actually uses, and the cloud's own code
+# settles which call is sufficient — plugins/dev/scripts/execution-core/linear-write-proxy.mjs:83:
+#
+#     "The GET read-back is NOT a weaker check than a write … resolveReadOnlyAgentContext
+#      calls the SAME resolveAgentPrincipal as resolveWriteContext, including
+#      hostId = authz.keyId and the `if (!hostId) -> 403` refusal. Only the BUDGET half
+#      differs. So `GET /agent/attachments` -> 200 already proves a per-host binding, and
+#      it is the right preflight before arming a host."
+#
+# ⭐ So the preflight is a GET, and that is a strictly better install-time probe than the
+# real write the ticket's AC2 describes: it exercises the identical per-host binding
+# refusal, while creating nothing, needing no scratch ticket, requiring no release step
+# that could fail and leave residue, and spending ZERO of the host's daily write budget.
+#
+# ⚠️ THE VERDICT IS THREE-VALUED, and the pass arm is deliberately wide.
+#   401/403 → REFUSE. This is the incident's exact signature: the credential is rejected
+#             at the agent route family. Nothing else here is evidence of anything.
+#   2xx/404/400 → PASS. The request got PAST authorization to issue resolution, which is
+#             all this probe claims. A 404 on a probe issue id is the AUTHORIZED answer
+#             (measured 2026-08-18: a per-host key against its own account returns 404 on
+#             an absent issue; the admin bearer returned 403 for the same request), so
+#             pinning the pass arm to "200 only" would refuse every correct install.
+#   anything else (000, 5xx) → REFUSE as UNVERIFIED, not as broken. Same posture
+#             validate_cloud_token already takes for an unreachable hub (CTL-1913):
+#             reporting success on a check that did not run is what produced green
+#             installs with permanently dead writers.
+validate_cloud_agent_binding() {
+	local token="$1" account="$2" base_url="$3"
+
+	# A deliberately absent issue: this probe must never touch a real ticket, and the
+	# authorization verdict it reads is decided before issue resolution either way.
+	local probe_issue="CATALYST-INSTALL-PROBE"
+
+	echo "  Verifying this host's per-host binding on the agent write path ..."
+
+	local code
+	code=$(
+		printf 'header = "Authorization: Bearer %s"\n' "$token" |
+			curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+				--config - \
+				"${base_url}/agent/attachments?issueId=${probe_issue}&account=${account}" 2>/dev/null
+	) || code=""
+
+	case "$code" in
+	401 | 403)
+		print_error "This credential is REFUSED on the agent write path (HTTP ${code})."
+		echo ""
+		echo "  It authenticated for generic reads but the cloud derives NO per-host"
+		echo "  binding from it, so every cross-host claim this host attempts will be"
+		echo "  refused. That is a silent dispatch deadlock: the daemons run, the"
+		echo "  heartbeat stays fresh, doctor passes, and the host claims no ticket on"
+		echo "  any phase. It cost the fleet four hours on 2026-08-18 (CTL-2045)."
+		echo ""
+		echo "  Use a per-host organization key minted for THIS host and account"
+		echo "  '${account}'. Nothing has been written."
+		return 1
+		;;
+	2?? | 404 | 400)
+		print_success "per-host binding proven on the agent write path (HTTP ${code})"
+		return 0
+		;;
+	000 | "")
+		print_error "Could not reach ${base_url}/agent/attachments — the binding was NOT verified."
+		echo ""
+		echo "  Refusing rather than assuming: an unverified binding is exactly the state"
+		echo "  this check exists to make impossible. Re-run once the hub is reachable."
+		return 1
+		;;
+	*)
+		print_error "The hub returned HTTP ${code} on the agent write path — binding NOT verified."
+		echo ""
+		echo "  Nothing has been written. A 5xx is not evidence the credential is good OR"
+		echo "  bad; re-run once the hub recovers."
+		return 1
+		;;
+	esac
+}
+
 # resolve_cloud_token — the ONE answer to "did this run get a cloud token".
 #
 # ⛔ Codex #3500 P1: this resolution used to live only inside setup_cloud_replica, as a
@@ -2038,7 +2183,21 @@ setup_cloud_replica() {
 	# replica that never appeared. (Why it stays silent: a tokenless/rejected writer
 	# `process.exit(0)`s, and under `KeepAlive={SuccessfulExit:false}` a clean exit
 	# is PERMANENT — launchd never retries.)
+	# ⛔ CTL-2045 — THREE GATES, CHEAPEST FIRST, AND NONE OF THEM WRITES.
+	#
+	# §1 the credential's CLASS (local, no network): refuses the admin bearer / a user key
+	#    / a bare sk_ issuer key before a single packet leaves the host.
+	# §2 the credential AUTHENTICATES at all (CTL-1913's generic read).
+	# §3 the credential is PER-HOST BOUND on the agent write path (CTL-2045).
+	#
+	# ⚠️ The order is load-bearing and §3 is not redundant with §2. A well-SHAPED key can
+	# still carry the wrong grants, the wrong tenant, or the wrong endpoint — all three were
+	# live hypotheses during the 2026-08-18 incident — and a generic read cannot see any of
+	# them. Conversely §1 catches the mis-provisioned class with no round trip at all, and
+	# names it precisely, rather than leaving the operator to interpret a bare 403.
+	assert_host_write_credential_shape "$token" || return 1
 	validate_cloud_token "$token" "$account" "$base_url" || return 1
+	validate_cloud_agent_binding "$token" "$account" "$base_url" || return 1
 
 	# ⛔ EVERY LINE MUST BE `export` (Codex P1 on #3365). launch.sh SOURCES this file
 	# and then `exec`s bun. A bare `FOO=bar` in a sourced file is a SHELL-LOCAL


### PR DESCRIPTION
Closes CTL-2045.

## The hole

mini-2's 2026-08-18 reinstall provisioned the tenant-wide `ADMIN_TOKEN` as this host's cloud **write** credential. Every cross-host claim 403'd and the board froze for four hours — while `catalyst doctor` passed, the daemons ran, the heartbeat stayed fresh, and the local write ledger read `2` with **zero refusals**, because nothing ever got far enough to be refused locally. Only CTL-2033's discriminated claim result named it, at 19:46.

⛔ **The install's own validation could not see it, and the reason is exact.** CTL-1913's `validate_cloud_token` calls `GET /issues` — the **generic** read route, which never goes through the cloud's `resolveAgentPrincipal`. An admin bearer passes it with a 200. The route family the claim actually uses is `/agent/*`, and nothing at install time touched it.

## Three gates, cheapest first, none of them writes

| # | gate | cost | catches |
| - | -- | -- | -- |
| 1 | **CLASS** — `lib/host-write-credential.mjs` | local, zero network | the mis-provisioned credential class |
| 2 | **AUTHENTICATION** — CTL-1913's generic read, unchanged | 1 round trip | wrong/expired/revoked token |
| 3 | **PER-HOST BINDING** — `GET /agent/attachments` | 1 round trip | ⭐ **the incident** |

**§1 is a positive ALLOW-LIST on `ctc_acct_`, not a blacklist.** The ticket's *title* says "refuse an admin bearer", and implementing that reopens the hole one credential over — the cloud also accepts a bare `sk_` key that is equally unbound (@backend BE-12). An allow-list refuses it for free. It also does **not** gate on LENGTH: 58-vs-64 would have caught this exact incident and is a coincidence of today's format, which fails in the dangerous direction.

**§3 is a GET, and that is deliberate — and better than AC2's literal "one real claim write".** The cloud's own code settles that it is sufficient (`linear-write-proxy.mjs:83`):

> The GET read-back is NOT a weaker check than a write … `resolveReadOnlyAgentContext` calls the SAME `resolveAgentPrincipal` as `resolveWriteContext`, including `hostId = authz.keyId` and the `if (!hostId) -> 403` refusal. Only the BUDGET half differs. So `GET /agent/attachments` -> 200 already proves a per-host binding, and it is the right preflight before arming a host.

So it exercises the identical refusal a claim would hit, while **creating nothing, needing no scratch ticket, requiring no release step that could fail and leave residue, and spending zero of the host's daily write budget.** ⚠️ **This is a deliberate deviation from AC2's wording** — flagged for @COORD rather than silently substituted.

**The binding verdict is three-valued and its pass arm is deliberately wide.** `401/403` refuse (the incident's signature); `2xx/404/400` pass — **404 IS the authorized answer** for an absent probe issue (measured 2026-08-18: a per-host key returns 404 where the admin bearer returned 403), so pinning to "200 only" would refuse every correctly-provisioned host, a fix worse than the bug; `000/5xx` refuse as **UNVERIFIED**, the same posture CTL-1913 already takes for an unreachable hub.

## §3 — doctor grades a host that DRIFTS in

For a re-mint, a restore, or a hand-edit. **Advisory, never FAIL** — such a host is already unable to claim, and failing it would convert a visible degradation into a second outage (same posture as `checkLinearWriteBudget`). **Three-valued:** absent / unreadable / token-less never render as PASS.

## Redaction

Every refusal echoes a **redacted shape** (`ctc_user_… (len 58)`, `<no recognized prefix> (len 64)`) and never the value. The redaction lives in the classifier so no caller can leak it, and both suites assert it **on every row** — a failed install gets pasted into threads.

## Coverage — and why the stub had to change

⛔ **The curl stub in `setup-cloud-replica.test.sh` is now route-aware, because the incident is precisely the case where `/issues` and `/agent/*` answer differently.** A single-code stub cannot express `read 200 / agent 403` at all, so a suite built on one would be **structurally incapable of failing for the defect this ticket exists to prevent.**

Every fixture token became a well-shaped org key — including CTL-1913's `FAKE-TOKEN-NOT-REAL`, which now isolates the network leg from the shape leg.

**Mutation-tested**, since every assertion here is new and a green control is the trap:

| mutation | failures |
| -- | -- |
| delete the class gate | **13** |
| delete the binding preflight | **5** |
| narrow the pass arm to 200-only | **2** |
| reorder the gates (class runs second) | **4** |
| first-instead-of-last export match | **1** |
| render the token instead of the shape | **1** |
| PASS on an absent file | **1** |

Restore → green in every case.

The bash mirror is held honest against the JS leaf by a **shared fixture table**, each engine checked against a **computed-expected** verdict rather than against the other — two engines agreeing on a wrong answer is what a bare A-vs-B comparison cannot see.

## Suites

| suite | result |
| -- | -- |
| `setup-cloud-replica.test.sh` | **83 pass, 0 fail** (59 pre-existing, all unchanged) |
| `host-write-credential-parity.test.sh` (new) | **38 pass, 0 fail** |
| `host-credential-health.test.mjs` (new) | **13 pass, 0 fail** |
| `doctor.test.mjs` | **456 pass, 0 fail** |

Baseline confirmed before starting: the pre-existing suite was 59/0 on `origin/main`.

## Out of scope, deliberately

**§4 — the gated endpoint move to canonical.** The ticket itself scopes it as a separate change, and it contradicts CTL-2042's AC5 until that is split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)