### PR TITLE
fix(dev): CTL-2068 — a claim the pipeline can overwrite is not a claim

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1276,6 +1276,8 @@ jobs:
             linear-state-write-event.test.mjs \
             linear-write-echo.test.mjs \
             linear-write.test.mjs \
+            lane-claim.test.mjs \
+            lane-claim-wiring.test.mjs \
             linear-write-proxy.test.mjs \
             linear-write-proxy-wiring.test.mjs \
             linear-write-proxy-resolve.test.mjs \

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -172,6 +172,8 @@ import { createProxyResolver } from "./linear-write-proxy-resolve.mjs"; // CTL-1
 import { classifyTicketResolution } from "./linear-query.mjs";
 import { createGatewayReader } from "./gateway-read.mjs";
 import { createReplicaReader } from "./replica-read.mjs"; // CTL-1340: read-replica tier reader
+import { setLaneClaimGuard } from "./lane-claim-install.mjs"; // CTL-2068
+import { buildLaneClaimGuard } from "./lane-claim.mjs"; // CTL-2068
 import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
 import { reconcileSdkRegistryOnBoot } from "./sdk-worker-registry.mjs"; // CTL-1410 Phase B
 import { resolveNodeClass as _resolveNodeClass } from "./lib/node-class.mjs"; // CTL-1654: node-class heartbeat/actuation guard
@@ -1376,6 +1378,59 @@ export function startDaemon({
       });
     refreshBotIdentities();
     const linearBotWriteId = readLinearBotWriteId(configPath, layer2Path); // CTL-781
+
+    // ── CTL-2068 — install the lane-claim guard ──
+    //
+    // "A claim another automation can overwrite is not a claim." Twice in two nights a lane
+    // claimed a ticket and the pipeline dragged it BACK to a candidate state minutes later,
+    // whereupon a worker dispatched it and opened a duplicate PR.
+    //
+    // ⛔ Installed UNCONDITIONALLY, not behind a mode flag. Its refusal is narrow (only a
+    // regression, and only when a non-fleet actor made the last state change) and every case
+    // it cannot judge ALLOWS the write, so there is no posture for it to be wrong in — while
+    // a shadow default would reproduce this repo's recurring failure of shipping a correct
+    // mechanism nobody ever arms. The DISPATCH half has its own kill switch below, because
+    // that one withholds work rather than merely a status write.
+    //
+    // ⭐ `linearBotUserIds` is passed by REFERENCE on purpose: it is the stable Set filled in
+    // place by refreshBotIdentities on every cluster-sync tick, so an app-actor re-mint keeps
+    // the guard's notion of "the fleet" current instead of freezing it at boot. A copy here
+    // would make the guard read every post-rotation fleet write as a lane's.
+    //
+    // Without a replica reader the guard has no history to consult and answers INCONCLUSIVE
+    // for every ticket — allowing the write, and SAYING so in the log line below rather than
+    // silently doing nothing.
+    let laneClaimStateMap = null;
+    try {
+      laneClaimStateMap =
+        JSON.parse(readFileSync(configPath, "utf8"))?.catalyst?.linear?.stateMap ?? null;
+    } catch {
+      /* absent/malformed Layer-1 → no rank map → the guard abstains, never refuses */
+    }
+    // Only an explicit "off" disables the dispatch veto — an unset or misspelled value leaves
+    // it armed, because the failure this ticket is about is a claim quietly not being honoured.
+    const laneClaimDispatchVeto =
+      String(process.env.CATALYST_LANE_CLAIM_DISPATCH_GUARD ?? "")
+        .trim()
+        .toLowerCase() !== "off";
+    setLaneClaimGuard(
+      buildLaneClaimGuard({
+        stateMap: laneClaimStateMap,
+        botUserIds: linearBotUserIds,
+        readLastStateChange: replicaReader ? (t) => replicaReader.lastStateChange(t) : undefined,
+        readCurrentState: replicaReader ? (t) => replicaReader.lookup(t)?.state ?? null : undefined,
+        dispatchVeto: laneClaimDispatchVeto,
+      })
+    );
+    log.info(
+      {
+        ranked_states: Object.keys(laneClaimStateMap ?? {}).length,
+        history_source: replicaReader ? "replica" : "none",
+        dispatch_veto: laneClaimDispatchVeto,
+      },
+      "ctl-2068: lane-claim guard installed"
+    );
+
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     // CTL-1654 (Codex P2 "gate the daemon before starting actuators"): resolve the
     // node class BEFORE arming the actuators, and arm the monitor + scheduler ONLY on

--- a/plugins/dev/scripts/execution-core/lane-claim-install.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim-install.mjs
@@ -1,0 +1,21 @@
+// lane-claim-install.mjs — CTL-2068. The process-wide install slot for the lane-claim
+// guard. Nothing else; this module exists to be a LEAF, exactly like
+// linear-write-proxy-install.mjs and for the same reason: the guard is consulted from
+// linear-write.mjs, and its production construction needs the replica reader and the
+// bot-id set that daemon.mjs owns. A single storage location keeps the daemon and every
+// write path looking at the same guard — two `let`s would let one path read an installed
+// guard while another silently used none.
+//
+// Zero imports on purpose.
+
+let _laneClaimGuard = null;
+
+/** setLaneClaimGuard — install (or clear, with null) the CTL-2068 guard. */
+export function setLaneClaimGuard(guard) {
+  _laneClaimGuard = guard ?? null;
+}
+
+/** getLaneClaimGuard — read the installed guard (null when never installed). */
+export function getLaneClaimGuard() {
+  return _laneClaimGuard;
+}

--- a/plugins/dev/scripts/execution-core/lane-claim-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim-wiring.test.mjs
@@ -1,0 +1,314 @@
+// lane-claim-wiring.test.mjs — CTL-2068.
+//
+// ⭐ THE POINT OF THIS FILE. lane-claim.test.mjs proves the CLASSIFIER is right. That is
+// worth nothing on its own: a guard that is never consulted is a check that cannot fail,
+// which is the failure shape this repo keeps shipping. These tests assert the guard is
+// reached from the real write entry point, that a REFUSE actually stops the write, and that
+// the module-level install — the path production uses and no injected test exercises — is
+// wired.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test lane-claim-wiring.test.mjs
+import { afterEach, describe, expect, test } from "bun:test";
+import { applyPhaseStatus } from "./linear-write.mjs";
+import { setLaneClaimGuard, getLaneClaimGuard } from "./lane-claim-install.mjs";
+import { buildLaneClaimGuard, VERDICT } from "./lane-claim.mjs";
+
+const STATE_MAP = {
+  research: "Research",
+  planning: "Plan",
+  inProgress: "Implement",
+  verifying: "Validate",
+  reviewing: "Validate",
+  inReview: "PR",
+};
+const FLEET = "78f8f491-a980-4b99-91a3-8280821f0821";
+const LANE = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+
+function harness({ lastActor, currentState = "Implement" }) {
+  const execCalls = [];
+  const guard = buildLaneClaimGuard({
+    stateMap: STATE_MAP,
+    botUserIds: new Set([FLEET]),
+    readLastStateChange: () => ({ actorId: lastActor }),
+  });
+  const call = (phase = "research") =>
+    applyPhaseStatus({
+      ticket: "CTC-787",
+      phase,
+      resolveRepoRoot: () => "/tmp/repo",
+      exec: (bin, args) => {
+        execCalls.push({ bin, args });
+        return {
+          code: 0,
+          stdout: JSON.stringify({ action: "transitioned", currentState, targetState: "Research" }),
+        };
+      },
+      fetchState: () => currentState,
+      laneClaim: guard,
+    });
+  return { call, execCalls };
+}
+
+afterEach(() => setLaneClaimGuard(null));
+
+describe("the guard is reached from applyPhaseStatus", () => {
+  test("⭐ a lane-claimed regression is REFUSED and the shell is never spawned", () => {
+    const { call, execCalls } = harness({ lastActor: LANE });
+    const res = call("research"); // implement(3) -> research(1)
+    expect(res.applied).toBe(false);
+    expect(res.skipped).toBe("lane-claimed-no-regression");
+    expect(res.from_state).toBe("Implement");
+    // ⛔ The load-bearing assertion. Asserting only the return shape would pass even if the
+    // write had already gone to Linear and the refusal were cosmetic.
+    expect(execCalls).toEqual([]);
+  });
+
+  test("⛔ CONTROL — the identical regression authored by the FLEET is written", () => {
+    const { call, execCalls } = harness({ lastActor: FLEET });
+    const res = call("research");
+    expect(res.applied).toBe(true);
+    expect(execCalls.length).toBeGreaterThan(0);
+  });
+
+  test("⛔ CONTROL — a FORWARD write under the same lane claim is written", () => {
+    // Without this, a guard that refused every write would pass the first test.
+    const { call, execCalls } = harness({ lastActor: LANE });
+    const res = call("pr"); // implement(3) -> inReview(6)
+    expect(res.applied).toBe(true);
+    expect(execCalls.length).toBeGreaterThan(0);
+  });
+
+  test("⛔ CONTROL — an unranked current state (Todo) is written, so queued work still starts", () => {
+    const { call, execCalls } = harness({ lastActor: LANE, currentState: "Todo" });
+    const res = call("research");
+    expect(res.applied).toBe(true);
+    expect(execCalls.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the MODULE-LEVEL install — the path production uses", () => {
+  test("no guard installed → writes proceed exactly as before CTL-2068", () => {
+    expect(getLaneClaimGuard()).toBe(null);
+    const execCalls = [];
+    const res = applyPhaseStatus({
+      ticket: "CTC-787",
+      phase: "research",
+      resolveRepoRoot: () => "/tmp/repo",
+      exec: (bin, args) => {
+        execCalls.push({ bin, args });
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            action: "transitioned",
+            currentState: "Implement",
+            targetState: "Research",
+          }),
+        };
+      },
+      fetchState: () => "Implement",
+      // no laneClaim injected — this is the pre-CTL-2068 shape
+    });
+    expect(res.applied).toBe(true);
+    expect(execCalls.length).toBe(1);
+  });
+
+  test("⭐ a guard installed via setLaneClaimGuard refuses WITHOUT being passed as an argument", () => {
+    setLaneClaimGuard(
+      buildLaneClaimGuard({
+        stateMap: STATE_MAP,
+        botUserIds: new Set([FLEET]),
+        readLastStateChange: () => ({ actorId: LANE }),
+      })
+    );
+    const execCalls = [];
+    const res = applyPhaseStatus({
+      ticket: "CTC-787",
+      phase: "research",
+      resolveRepoRoot: () => "/tmp/repo",
+      exec: (bin, args) => {
+        execCalls.push({ bin, args });
+        return { code: 0, stdout: "{}" };
+      },
+      fetchState: () => "Implement",
+    });
+    expect(res.skipped).toBe("lane-claimed-no-regression");
+    expect(execCalls).toEqual([]);
+  });
+
+  test("the guard's botUserIds Set is held by REFERENCE, so a rotation is picked up live", () => {
+    // daemon.mjs passes the stable Set that refreshBotIdentities fills in place. Mutating
+    // it after construction must change the verdict, or a re-minted app-actor would read as
+    // a lane and the fleet would refuse its own writes.
+    const bots = new Set([FLEET]);
+    const g = buildLaneClaimGuard({
+      stateMap: STATE_MAP,
+      botUserIds: bots,
+      readLastStateChange: () => ({ actorId: "NEW-ACTOR" }),
+    });
+    const args = { ticket: "T-1", currentState: "Implement", targetKey: "research" };
+    expect(g.evaluate(args).verdict).toBe(VERDICT.REFUSE); // NEW-ACTOR unknown → looks like a lane
+    bots.add("NEW-ACTOR"); // the rotation lands
+    expect(g.evaluate(args).verdict).toBe(VERDICT.ALLOW);
+  });
+});
+
+// ── the DISPATCH veto, driven through the real schedulerTick ──────────────────
+//
+// ⛔ This block does NOT live in scheduler.test.mjs, which is where dispatchAndVerify's
+// other tests are. That suite is EXCLUDED from execution-core-tests.yml (flaky fs.watch
+// timers), so a veto test placed there would never run in CI — a guard nobody runs is a
+// check that cannot fail, which is the same shape as the defect this ticket fixes. Both
+// lane-claim files are added to the workflow's stable list in this PR.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schedulerTick } from "./scheduler.mjs";
+
+describe("the DISPATCH veto, through schedulerTick", () => {
+  let orchDir;
+
+  const seed = () => {
+    orchDir = mkdtempSync(join(tmpdir(), "ctl2068-"));
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    // A completed `research` signal, so the FSM's next owed phase is `plan`.
+    const dir = join(orchDir, "workers", "CTC-787");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "phase-research.json"),
+      JSON.stringify({ ticket: "CTC-787", phase: "research", status: "done" })
+    );
+  };
+
+  const dispatchSpy = () => {
+    const calls = [];
+    const fn = ({ ticket, phase }) => {
+      calls.push({ ticket, phase });
+      return { code: 0, stdout: "", stderr: "" };
+    };
+    fn.calls = calls;
+    return fn;
+  };
+
+  const install = ({ lastActor, currentState }) =>
+    setLaneClaimGuard(
+      buildLaneClaimGuard({
+        stateMap: STATE_MAP,
+        botUserIds: new Set([FLEET]),
+        readLastStateChange: () => ({ actorId: lastActor }),
+        readCurrentState: () => currentState,
+      })
+    );
+
+  afterEach(() => {
+    setLaneClaimGuard(null);
+    if (orchDir) rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  test("⭐ a lane-claimed ticket is NOT dispatched — the spy is never called", () => {
+    seed();
+    // The lane holds it at `Implement` (rank 3); the owed phase is `plan` (rank 2).
+    install({ lastActor: LANE, currentState: "Implement" });
+    const dispatch = dispatchSpy();
+    const r = schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 70_000 });
+    expect(dispatch.calls).toEqual([]);
+    expect(r.advanced ?? []).toEqual([]);
+  });
+
+  test("⛔ CONTROL — the SAME tick dispatches when the FLEET made the last state change", () => {
+    // Without this control, a veto that refused everything (or a harness that never
+    // dispatches at all) would pass the test above and prove nothing.
+    seed();
+    install({ lastActor: FLEET, currentState: "Implement" });
+    const dispatch = dispatchSpy();
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 70_000 });
+    expect(dispatch.calls).toContainEqual({ ticket: "CTC-787", phase: "plan" });
+  });
+
+  test("⛔ CONTROL — with NO guard installed the same tick dispatches (pre-CTL-2068 behaviour)", () => {
+    seed();
+    const dispatch = dispatchSpy();
+    schedulerTick(orchDir, { readEligible: () => [], dispatch, now: () => 70_000 });
+    expect(dispatch.calls).toContainEqual({ ticket: "CTC-787", phase: "plan" });
+  });
+});
+
+// ── the PROXY rung: the guard re-applied to the fresher `--resolve-only` state ────────
+//
+// Both rungs exist for the same reason CTL-758's guard is applied twice. The first rung
+// runs on `knownCurrentState ?? fetchState`, which is FAIL-OPEN: on an enforce host with no
+// `linearis` and a cold cache that read returns null and the guard abstains. `--resolve-only`
+// then reads the state from the replica and may well come back `Implement`. Without the
+// second rung the enforce path — the one both minis actually run — would build and send the
+// payload on evidence the first rung never saw.
+import { setLinearWriteProxy, setLinearWriteProxyResolver } from "./linear-write-proxy-install.mjs";
+
+describe("the PROXY rung — the guard on the fresher resolve-only evidence", () => {
+  const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+  const STATE_ID = "22222222-2222-4222-8222-222222222222";
+  const resolver = {
+    issue: () => ({ ok: true, issueId: ISSUE_ID, teamId: "team-1" }),
+    stateId: () => ({ ok: true, stateId: STATE_ID }),
+    labelIds: (names) => ({
+      ok: true,
+      labelIds: names.map(() => "33333333-3333-4333-8333-333333333333"),
+    }),
+  };
+  const proxy = () => {
+    const sends = [];
+    return {
+      mode: "enforce",
+      sends,
+      send: (r) => (sends.push(r), { handled: true, applied: true, reason: null }),
+    };
+  };
+
+  afterEach(() => {
+    setLinearWriteProxy(null);
+    setLinearWriteProxyResolver(null);
+    setLaneClaimGuard(null);
+  });
+
+  // The first rung cannot see the claim: fetchState returns null (the fail-open read).
+  // Only `--resolve-only` knows the ticket is at `Implement`.
+  const callWithBlindFirstRung = (lastActor) => {
+    setLinearWriteProxyResolver(resolver);
+    setLaneClaimGuard(
+      buildLaneClaimGuard({
+        stateMap: STATE_MAP,
+        botUserIds: new Set([FLEET]),
+        readLastStateChange: () => ({ actorId: lastActor }),
+      })
+    );
+    const p = proxy();
+    const res = applyPhaseStatus({
+      ticket: "CTC-787",
+      phase: "research",
+      resolveRepoRoot: () => "/tmp/repo",
+      exec: () => ({
+        code: 0,
+        stdout: JSON.stringify({
+          action: "transitioned",
+          currentState: "Implement",
+          targetState: "Research",
+        }),
+      }),
+      fetchState: () => null, // ⛔ the fail-open first read — the blind spot this rung covers
+      proxy: p,
+    });
+    return { res, sends: p.sends };
+  };
+
+  test("⭐ REFUSES on evidence the first rung never saw — and sends NOTHING to the cloud", () => {
+    const { res, sends } = callWithBlindFirstRung(LANE);
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe("resolve:lane-claimed-no-regression");
+    // The assertion that matters: no payload reached the transport.
+    expect(sends).toEqual([]);
+  });
+
+  test("⛔ CONTROL — the same call with the FLEET as last actor DOES send", () => {
+    const { res, sends } = callWithBlindFirstRung(FLEET);
+    expect(res.applied).toBe(true);
+    expect(sends.length).toBe(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/lane-claim-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim-wiring.test.mjs
@@ -29,7 +29,7 @@ function harness({ lastActor, currentState = "Implement" }) {
   const guard = buildLaneClaimGuard({
     stateMap: STATE_MAP,
     botUserIds: new Set([FLEET]),
-    readLastStateChange: () => ({ actorId: lastActor }),
+    readLastStateChange: () => ({ actorId: lastActor, toState: currentState }),
   });
   const call = (phase = "research") =>
     applyPhaseStatus({
@@ -117,7 +117,7 @@ describe("the MODULE-LEVEL install — the path production uses", () => {
       buildLaneClaimGuard({
         stateMap: STATE_MAP,
         botUserIds: new Set([FLEET]),
-        readLastStateChange: () => ({ actorId: LANE }),
+        readLastStateChange: () => ({ actorId: LANE, toState: "Implement" }),
       })
     );
     const execCalls = [];
@@ -143,7 +143,7 @@ describe("the MODULE-LEVEL install — the path production uses", () => {
     const g = buildLaneClaimGuard({
       stateMap: STATE_MAP,
       botUserIds: bots,
-      readLastStateChange: () => ({ actorId: "NEW-ACTOR" }),
+      readLastStateChange: () => ({ actorId: "NEW-ACTOR", toState: "Implement" }),
     });
     const args = { ticket: "T-1", currentState: "Implement", targetKey: "research" };
     expect(g.evaluate(args).verdict).toBe(VERDICT.REFUSE); // NEW-ACTOR unknown → looks like a lane
@@ -194,7 +194,7 @@ describe("the DISPATCH veto, through schedulerTick", () => {
       buildLaneClaimGuard({
         stateMap: STATE_MAP,
         botUserIds: new Set([FLEET]),
-        readLastStateChange: () => ({ actorId: lastActor }),
+        readLastStateChange: () => ({ actorId: lastActor, toState: currentState }),
         readCurrentState: () => currentState,
       })
     );
@@ -276,7 +276,7 @@ describe("the PROXY rung — the guard on the fresher resolve-only evidence", ()
       buildLaneClaimGuard({
         stateMap: STATE_MAP,
         botUserIds: new Set([FLEET]),
-        readLastStateChange: () => ({ actorId: lastActor }),
+        readLastStateChange: () => ({ actorId: lastActor, toState: "Implement" }),
       })
     );
     const p = proxy();

--- a/plugins/dev/scripts/execution-core/lane-claim.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.mjs
@@ -60,6 +60,7 @@ export const REASON = Object.freeze({
   UNRANKED_CURRENT: "current-state-not-in-pipeline",
   UNRANKED_TARGET: "target-state-not-in-pipeline",
   BAD_INPUT: "malformed-input",
+  STALE_HISTORY: "history-row-does-not-match-current-state",
   DISPATCH_VETO_DISABLED: "dispatch-veto-disabled",
   NO_CURRENT_STATE: "current-state-unreadable",
   PHASE_WRITES_NO_STATUS: "phase-writes-no-status",
@@ -140,10 +141,22 @@ export function buildKeyRank() {
  * @param {string|null} o.currentState  the ticket's state right now (a NAME)
  * @param {number|undefined} o.targetRank rank of the state this write would set, from
  *   buildKeyRank() — see there for why the target is ranked by key and not by name
- * @param {{actorId: string|null}|null} o.lastChange the most recent state change on the
- *   ticket, or null when history is unavailable. Only the actor is consulted: this call site
- *   already knows the ticket's CURRENT state from a fresher read than history, so re-deriving
- *   it from the history row would be a second, staler source for the same fact.
+ * @param {{actorId: string|null, toState: string|null}|null} o.lastChange the most recent
+ *   state change on the ticket, or null when history is unavailable.
+ *
+ *   ⛔ `toState` IS consulted, and that is the whole of the CTL-2068 Codex P1 fix. The two
+ *   inputs come from sources with very different latency, measured in this repo by CTL-1847
+ *   (`linear-feed-diff.mjs`): `issues.state` — where `currentState` comes from — is
+ *   webhook-fed and lands in ~11 s, while `issue_history` is RECONCILE-ONLY and lands in
+ *   ~201 s, an 18× gap. So during exactly the short claim-to-dispatch window this guard
+ *   exists for, the newest available history row is the transition BEFORE the lane's claim —
+ *   often one the fleet itself made. Trusting its actor would return LAST_CHANGE_BY_FLEET
+ *   and cheerfully permit the regression: a guard that is wrong precisely when it matters.
+ *
+ *   The row is therefore trusted ONLY when its `toState` equals the state the ticket is
+ *   actually in. A row that does not describe the current state is not evidence about who
+ *   put it there, and saying so (STALE_HISTORY) is the difference between a named blind spot
+ *   somebody can count and a silent false negative.
  * @param {Set<string>} o.botUserIds    known fleet actor ids
  * @param {Map<string,number>} o.rank   from buildStateRank
  * @returns {{verdict: string, reason: string, currentRank?: number, targetRank?: number,
@@ -170,6 +183,20 @@ export function classifyLaneClaimWrite({
   if (typeof actorId !== "string" || actorId.length === 0) {
     return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_ACTOR, actorId: null };
   }
+  // ⛔ The row must DESCRIBE the state we are judging. See the `lastChange` doc above: the
+  // history table lags the state table by ~18×, so a row whose toState is not the current
+  // state is a row from before whatever put the ticket where it is now.
+  //
+  // ⚠️ This DECLINES (inconclusive → the write proceeds); it does not refuse. That is the
+  // correct fail direction and it is also an honest admission: the ~200 s immediately after
+  // a claim is NOT covered by this guard, and no timely actor source exists in the replica
+  // to cover it (measured: `issues.bot_actor_name` is empty for 4,478 of 4,481 issues, so
+  // the one webhook-fed actor column does not discriminate). Tracked as follow-up work.
+  const rowState = lastChange.toState ?? null;
+  if (typeof rowState === "string" && rowState.length > 0 && rowState !== currentState) {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.STALE_HISTORY, actorId };
+  }
+
   if (botUserIds.has(actorId)) {
     // The fleet itself made the last move, so there is no lane claim to protect. Recovery's
     // legitimate backward moves land here — this is the branch that keeps them working.

--- a/plugins/dev/scripts/execution-core/lane-claim.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.mjs
@@ -1,0 +1,309 @@
+// lane-claim.mjs — CTL-2068. "A claim another automation can overwrite is not a claim."
+//
+// Twice in two nights (CTC-776, CTC-787) a fleet worker built a ticket a human-facing lane
+// was already building, after the lane claimed it exactly as the rule says. The second time
+// is the one that explains the mechanism, and it is on the replica:
+//
+//   1787132205283  Ryan Rozich    Validate  -> Implement     <- the lane claims it
+//   1787132279778  Catalyst Cloud Implement -> Research      <- 74 s later, the pipeline
+//                                                               drags it BACKWARDS
+//   ...                                                      <- Research is a candidate
+//                                                               state, so it dispatches
+//
+// The regression is the load-bearing step: it is what puts the ticket back into a state the
+// dispatcher looks at. CTL-758 already has a backward-write guard, but it only refuses a
+// write when the CURRENT state is TERMINAL (Done/Canceled) — Implement -> Research sails
+// straight through it. This module generalizes that guard along the one axis that makes it
+// safe to widen.
+//
+// ⛔ WHY THE ACTOR CHECK IS LOAD-BEARING, AND WHY A BLANKET "NEVER REGRESS" IS WRONG.
+// The pipeline legitimately re-runs earlier phases (the L3 destroy-and-recreate on
+// research/plan, the verify<->remediate cycle), and those writes ARE backward moves. A rule
+// that refused every regression would break recovery. The property that separates the two is
+// not the direction of the move — it is WHO last moved the ticket. So: a regression is
+// refused only when the most recent state change was made by someone who is not the fleet.
+//
+// ⭐ HOW A LANE IS DISTINGUISHED FROM THE FLEET, MEASURED RATHER THAN ASSUMED.
+// Lanes write state through `linearis` with Ryan's key, so their changes carry a HUMAN user
+// id; the daemon writes as the app-actor ("Catalyst Cloud"), whose id is the already-
+// configured botUserId. On CTC-787 those are c2a8cc92… (Ryan Rozich) and 78f8f491…
+// (Catalyst Cloud) respectively. This module takes that Set as input and never hardcodes it.
+//
+// ⛔ THE FAIL DIRECTION IS ALLOW, AND EVERY DECLINE IS NAMED.
+// This is a REFUSAL guard on the pipeline's own state writes, so a guard that cannot answer
+// must not block: a replica outage or an unconfigured botUserIds set would otherwise wedge
+// every phase transition on the fleet. Every such case returns INCONCLUSIVE with a reason
+// rather than a quiet ALLOW, so "I could not look" is never recorded as "nothing is wrong".
+//
+// ⚠️ The empty-botUserIds case deserves naming on its own: with no known fleet ids, EVERY
+// actor looks non-fleet and the guard would refuse the pipeline's every legitimate backward
+// move. That is the dangerous direction, so an empty/absent Set is INCONCLUSIVE, never a
+// licence to refuse.
+
+import { PHASES, PHASE_LINEAR_KEY } from "../lib/phase-fsm.mjs";
+
+export const VERDICT = Object.freeze({
+  ALLOW: "allow",
+  REFUSE: "refuse",
+  INCONCLUSIVE: "inconclusive",
+});
+
+// The reason a decision was reached. Named so a log line, an event and a test can all agree,
+// and so an operator reading "allow" can tell a judged allow from an unanswerable one.
+export const REASON = Object.freeze({
+  REGRESSION_AGAINST_LANE_CLAIM: "regression-against-lane-claim",
+  NOT_A_REGRESSION: "not-a-regression",
+  LAST_CHANGE_BY_FLEET: "last-change-by-fleet",
+  NO_BOT_IDS: "no-bot-ids-configured",
+  NO_HISTORY: "no-state-change-history",
+  NO_ACTOR: "last-change-has-no-actor",
+  UNRANKED_CURRENT: "current-state-not-in-pipeline",
+  UNRANKED_TARGET: "target-state-not-in-pipeline",
+  BAD_INPUT: "malformed-input",
+  DISPATCH_VETO_DISABLED: "dispatch-veto-disabled",
+  NO_CURRENT_STATE: "current-state-unreadable",
+  PHASE_WRITES_NO_STATUS: "phase-writes-no-status",
+});
+
+/**
+ * buildStateRank — pure. Orders the Linear state NAMES the pipeline itself writes, by the
+ * earliest pipeline phase that writes them.
+ *
+ * Derived from PHASE_LINEAR_KEY (phase -> linear key) composed with the caller's stateMap
+ * (linear key -> state name). Several phases share a key (pr / monitor-merge /
+ * monitor-deploy / teardown all write `inReview`), so the rank is the MINIMUM phase index —
+ * "the earliest point in the pipeline at which a ticket can legitimately hold this state".
+ *
+ * ⛔ Deliberately ranks ONLY the states the pipeline writes. `Todo`, `Backlog`, `Triage`,
+ * `Done` and anything a workspace has invented are absent, and an absent state makes the
+ * verdict INCONCLUSIVE rather than ordering it at some invented position. That is what keeps
+ * the ordinary Todo -> Research start from being read as a regression out of an unranked
+ * state, and it is why this function does not fall back to `indexOf`-style -1 defaults.
+ *
+ * ⚠️ It reads ONE rung of the state-name chain (the caller's stateMap), NOT the four-rung
+ * precedence chain that linear-transition.sh owns (per-project > global > registry >
+ * built-in). Re-implementing that chain here would make this a second source of truth for
+ * what "inProgress" means. Declining to rank an unmapped name means this guard can only ever
+ * abstain where the chain would have disagreed — it can never contradict it.
+ *
+ * @param {Record<string,string>} stateMap linear key -> Linear state name
+ * @returns {Map<string, number>} state name -> earliest phase index
+ */
+export function buildStateRank(stateMap) {
+  const rank = new Map();
+  if (stateMap === null || typeof stateMap !== "object" || Array.isArray(stateMap)) return rank;
+  for (let i = 0; i < PHASES.length; i += 1) {
+    const key = PHASE_LINEAR_KEY[PHASES[i]];
+    if (!key) continue; // triage writes no status
+    const name = stateMap[key];
+    if (typeof name !== "string" || name.length === 0) continue;
+    const prior = rank.get(name);
+    if (prior === undefined || i < prior) rank.set(name, i);
+  }
+  return rank;
+}
+
+/**
+ * buildKeyRank — pure. The TARGET side of the comparison, ranked straight off the phase
+ * this write belongs to.
+ *
+ * ⭐ Why the target is ranked by LINEAR KEY and the current state by NAME. The write path
+ * always knows the key it is writing (`research`, `inProgress`, …) — it is the function's
+ * own argument — whereas the target's state NAME only exists after `--resolve-only`, which
+ * runs on the proxy path and not on the shell path. Ranking the target from the key means
+ * the guard needs no state name for it at all, so it evaluates identically on BOTH
+ * transports with no extra subprocess. Anchoring the guard to whichever transport happened
+ * to be configured is exactly the "held by an accident of configuration" shape this ticket
+ * is about.
+ *
+ * Same MIN-index rule as buildStateRank, and derived from the same PHASE_LINEAR_KEY, so the
+ * two sides of the comparison can never disagree about where a phase sits.
+ *
+ * @returns {Map<string, number>} linear key -> earliest phase index
+ */
+export function buildKeyRank() {
+  const rank = new Map();
+  for (let i = 0; i < PHASES.length; i += 1) {
+    const key = PHASE_LINEAR_KEY[PHASES[i]];
+    if (!key) continue;
+    const prior = rank.get(key);
+    if (prior === undefined || i < prior) rank.set(key, i);
+  }
+  return rank;
+}
+
+/**
+ * classifyLaneClaimWrite — pure. Decides whether the pipeline may write `targetState` over
+ * `currentState`, given who last changed the ticket's state.
+ *
+ * @param {object} o
+ * @param {string|null} o.currentState  the ticket's state right now (a NAME)
+ * @param {number|undefined} o.targetRank rank of the state this write would set, from
+ *   buildKeyRank() — see there for why the target is ranked by key and not by name
+ * @param {{actorId: string|null}|null} o.lastChange the most recent state change on the
+ *   ticket, or null when history is unavailable. Only the actor is consulted: this call site
+ *   already knows the ticket's CURRENT state from a fresher read than history, so re-deriving
+ *   it from the history row would be a second, staler source for the same fact.
+ * @param {Set<string>} o.botUserIds    known fleet actor ids
+ * @param {Map<string,number>} o.rank   from buildStateRank
+ * @returns {{verdict: string, reason: string, currentRank?: number, targetRank?: number,
+ *            actorId?: string|null}}
+ */
+export function classifyLaneClaimWrite({
+  currentState,
+  targetRank,
+  lastChange,
+  botUserIds,
+  rank,
+} = {}) {
+  if (!(rank instanceof Map)) return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.BAD_INPUT };
+
+  // ⛔ Order matters: the unconfigured-fleet case is checked FIRST, because with no known
+  // fleet ids every actor below would read as a lane and every regression would be refused.
+  if (!(botUserIds instanceof Set) || botUserIds.size === 0) {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_BOT_IDS };
+  }
+  if (lastChange === null || lastChange === undefined) {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_HISTORY };
+  }
+  const actorId = lastChange.actorId ?? null;
+  if (typeof actorId !== "string" || actorId.length === 0) {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_ACTOR, actorId: null };
+  }
+  if (botUserIds.has(actorId)) {
+    // The fleet itself made the last move, so there is no lane claim to protect. Recovery's
+    // legitimate backward moves land here — this is the branch that keeps them working.
+    return { verdict: VERDICT.ALLOW, reason: REASON.LAST_CHANGE_BY_FLEET, actorId };
+  }
+
+  const currentRank = rank.get(currentState);
+  if (currentRank === undefined) {
+    // Todo / Backlog / Triage / Done / an unmapped name. Unordered, so "backwards" is not a
+    // question this guard can answer — and NOT answering is what lets the fleet legitimately
+    // start work a human queued into Todo.
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.UNRANKED_CURRENT, actorId };
+  }
+  if (typeof targetRank !== "number") {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.UNRANKED_TARGET, actorId, currentRank };
+  }
+
+  if (targetRank < currentRank) {
+    return {
+      verdict: VERDICT.REFUSE,
+      reason: REASON.REGRESSION_AGAINST_LANE_CLAIM,
+      actorId,
+      currentRank,
+      targetRank,
+    };
+  }
+  return {
+    verdict: VERDICT.ALLOW,
+    reason: REASON.NOT_A_REGRESSION,
+    actorId,
+    currentRank,
+    targetRank,
+  };
+}
+
+/**
+ * buildLaneClaimGuard — assembles the production guard from its three inputs. Returns a
+ * guard object with ONE method, `evaluate({ ticket, currentState, targetState })`, so the
+ * write path never has to know where any of this came from.
+ *
+ * ⛔ A guard whose inputs are missing is still a guard — it just answers INCONCLUSIVE, and
+ * the write proceeds. This is deliberately NOT a "return null if unconfigured" factory: a
+ * null guard and a guard that abstains look identical at the call site, but only the second
+ * one can say WHY in a log line, and "why" is the difference between an operator seeing
+ * "no bot ids configured" and seeing nothing at all.
+ *
+ * @param {object} o
+ * @param {Record<string,string>} o.stateMap  linear key -> Linear state name
+ * @param {Set<string>} o.botUserIds          known fleet actor ids
+ * @param {(ticket: string) => ({actorId: string|null}|undefined)} o.readLastStateChange
+ *   the newest state change on a ticket. MUST fail open (return undefined) rather than
+ *   throw — a replica outage may not wedge the pipeline's writes.
+ */
+export function buildLaneClaimGuard({
+  stateMap,
+  botUserIds,
+  readLastStateChange,
+  // CTL-2068: the ticket's CURRENT state, for the dispatch veto (the write path already
+  // holds this and passes it in; the dispatch path does not).
+  readCurrentState,
+  // ⛔ The operator kill switch, and it covers the DISPATCH veto only. Refusing a state
+  // write is benign — the write simply does not happen and the pipeline retries. Refusing
+  // a DISPATCH is not: this rides the single choke point every phase dispatch passes
+  // through, so a wrong verdict there withholds work rather than merely a status write.
+  // On by default (a guard nobody arms is this repo's recurring failure), but an operator
+  // who needs the fleet to plough through a claim can set
+  // CATALYST_LANE_CLAIM_DISPATCH_GUARD=off without giving up the write-side protection.
+  dispatchVeto = true,
+} = {}) {
+  const rank = buildStateRank(stateMap);
+  const keyRank = buildKeyRank();
+
+  const readLast = (ticket) => {
+    if (typeof readLastStateChange !== "function" || !ticket) return null;
+    try {
+      return readLastStateChange(ticket) ?? null;
+    } catch {
+      // A throwing reader is "could not look", never "nothing there".
+      return null;
+    }
+  };
+
+  return {
+    rank,
+    keyRank,
+    dispatchVeto,
+
+    // evaluate — the WRITE-path question: may the pipeline write `targetKey`'s state over
+    // `currentState`? The caller supplies the current state because it has already read it.
+    evaluate({ ticket, currentState, targetKey } = {}) {
+      return classifyLaneClaimWrite({
+        currentState,
+        targetRank: keyRank.get(targetKey),
+        lastChange: readLast(ticket),
+        botUserIds,
+        rank,
+      });
+    },
+
+    // evaluateDispatch — the DISPATCH-path question: may the pipeline run `phase` on this
+    // ticket at all?
+    //
+    // ⭐ It is deliberately the SAME question as evaluate(), asked at a different site: if
+    // the pipeline is not allowed to move a ticket back to a phase's state, it has no
+    // business running that phase either. Refusing the write alone would have made the
+    // CTC-787 collision merely VISIBLE — the state write would fail while the worker still
+    // ran and still opened the duplicate PR. One rule, two enforcement points.
+    evaluateDispatch({ ticket, phase } = {}) {
+      if (!dispatchVeto)
+        return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.DISPATCH_VETO_DISABLED };
+      const targetKey = PHASE_LINEAR_KEY[phase];
+      if (!targetKey) {
+        // `triage` writes no status, so there is no state to compare against. Nothing to
+        // judge — and triage is where fleet work legitimately BEGINS.
+        return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.PHASE_WRITES_NO_STATUS };
+      }
+      let currentState = null;
+      if (typeof readCurrentState === "function" && ticket) {
+        try {
+          currentState = readCurrentState(ticket) ?? null;
+        } catch {
+          currentState = null;
+        }
+      }
+      if (typeof currentState !== "string" || currentState.length === 0) {
+        return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_CURRENT_STATE };
+      }
+      return classifyLaneClaimWrite({
+        currentState,
+        targetRank: keyRank.get(targetKey),
+        lastChange: readLast(ticket),
+        botUserIds,
+        rank,
+      });
+    },
+  };
+}

--- a/plugins/dev/scripts/execution-core/lane-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.test.mjs
@@ -1,0 +1,349 @@
+// lane-claim.test.mjs — CTL-2068.
+// Run: cd plugins/dev/scripts/execution-core && bun test lane-claim.test.mjs
+import { describe, expect, test } from "bun:test";
+import {
+  buildStateRank,
+  buildKeyRank,
+  classifyLaneClaimWrite,
+  buildLaneClaimGuard,
+  VERDICT,
+  REASON,
+} from "./lane-claim.mjs";
+
+// The real stateMap from this workspace's Layer-1 config, not an invented one.
+const STATE_MAP = {
+  backlog: "Backlog",
+  todo: "Todo",
+  triage: "Triage",
+  research: "Research",
+  planning: "Plan",
+  inProgress: "Implement",
+  verifying: "Validate",
+  reviewing: "Validate",
+  remediating: "Remediate",
+  inReview: "PR",
+  done: "Done",
+  canceled: "Canceled",
+};
+const RANK = buildStateRank(STATE_MAP);
+const KEY_RANK = buildKeyRank();
+const tr = (key) => KEY_RANK.get(key); // target rank, exactly as the guard computes it
+
+// The two actor ids are the REAL ones read off the replica for CTC-787.
+const FLEET = "78f8f491-a980-4b99-91a3-8280821f0821"; // "Catalyst Cloud" — the app-actor
+const LANE = "c2a8cc92-cab6-4536-9500-0f24abdf702b"; // "Ryan Rozich" — how a lane's write appears
+const BOTS = new Set([FLEET]);
+
+describe("buildStateRank", () => {
+  test("ranks each pipeline-written state at its EARLIEST phase", () => {
+    expect([...RANK]).toEqual([
+      ["Research", 1],
+      ["Plan", 2],
+      ["Implement", 3],
+      ["Validate", 4],
+      ["PR", 6],
+    ]);
+  });
+
+  test("⛔ four phases write `inReview`; PR ranks at the FIRST of them (6), not the last (9)", () => {
+    // A max/last-wins rank would put PR at teardown's index, making a legitimate
+    // monitor-merge -> pr write look like a regression.
+    expect(RANK.get("PR")).toBe(6);
+  });
+
+  test("⛔ does NOT rank states the pipeline never writes — that absence is load-bearing", () => {
+    for (const name of ["Todo", "Backlog", "Triage", "Done", "Canceled"]) {
+      expect(RANK.has(name)).toBe(false);
+    }
+  });
+
+  test("a malformed stateMap yields an empty rank rather than throwing", () => {
+    for (const bad of [null, undefined, [], "x", 7]) expect(buildStateRank(bad).size).toBe(0);
+  });
+});
+
+describe("classifyLaneClaimWrite — the CTC-787 collision", () => {
+  test("⭐ REFUSES the exact write that caused it: Implement -> Research, 74 s after a lane claim", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSE);
+    expect(v.reason).toBe(REASON.REGRESSION_AGAINST_LANE_CLAIM);
+    expect(v.currentRank).toBe(3);
+    expect(v.targetRank).toBe(1);
+  });
+
+  test("⛔ NEGATIVE CONTROL — the identical regression by the FLEET is ALLOWED", () => {
+    // This is the control that proves the guard keys on the ACTOR and not on the direction.
+    // Without it, a guard that simply refused every backward write would pass the test above
+    // while breaking the L3 destroy-and-recreate and the verify<->remediate cycle.
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: { actorId: FLEET },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.ALLOW);
+    expect(v.reason).toBe(REASON.LAST_CHANGE_BY_FLEET);
+  });
+});
+
+describe("classifyLaneClaimWrite — forward moves are never refused", () => {
+  test("a lane-claimed ticket may still move FORWARD (Implement -> PR)", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("inReview"),
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.ALLOW);
+    expect(v.reason).toBe(REASON.NOT_A_REGRESSION);
+  });
+
+  test("equal rank is not a regression (verify and review both write `Validate`)", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Validate",
+      targetRank: tr("verifying"),
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.ALLOW);
+    expect(v.reason).toBe(REASON.NOT_A_REGRESSION);
+  });
+});
+
+describe("classifyLaneClaimWrite — every decline is INCONCLUSIVE and NAMED, never a silent allow", () => {
+  test("⛔ an EMPTY botUserIds set never refuses — with no known fleet ids everything looks like a lane", () => {
+    for (const bots of [new Set(), undefined, null, ["x"]]) {
+      const v = classifyLaneClaimWrite({
+        currentState: "Implement",
+        targetRank: tr("research"),
+        lastChange: { actorId: LANE },
+        botUserIds: bots,
+        rank: RANK,
+      });
+      expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+      expect(v.reason).toBe(REASON.NO_BOT_IDS);
+    }
+  });
+
+  test("absent history is INCONCLUSIVE — a replica outage must not wedge every phase write", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: null,
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.NO_HISTORY);
+  });
+
+  test("a history row with no actor is INCONCLUSIVE, not treated as a lane", () => {
+    for (const actorId of [null, undefined, ""]) {
+      const v = classifyLaneClaimWrite({
+        currentState: "Implement",
+        targetRank: tr("research"),
+        lastChange: { actorId },
+        botUserIds: BOTS,
+        rank: RANK,
+      });
+      expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+      expect(v.reason).toBe(REASON.NO_ACTOR);
+    }
+  });
+
+  test("⭐ Todo -> Research is INCONCLUSIVE, so the fleet can still start work a HUMAN queued", () => {
+    // The single most important allow: a human moving a ticket to Todo is a non-fleet state
+    // change, and Todo is unranked, so this must not read as a lane claim.
+    const v = classifyLaneClaimWrite({
+      currentState: "Todo",
+      targetRank: tr("research"),
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.UNRANKED_CURRENT);
+  });
+
+  test("an unrankable TARGET key is INCONCLUSIVE — this guard abstains rather than guess an order", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: undefined,
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.UNRANKED_TARGET);
+  });
+
+  test("a missing rank map is INCONCLUSIVE, not a crash and not a refusal", () => {
+    const v = classifyLaneClaimWrite({ currentState: "Implement", targetRank: tr("research") });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.BAD_INPUT);
+  });
+
+  test("⛔ the no-args shape does not throw (the DEFAULT path, which no other test exercises)", () => {
+    expect(() => classifyLaneClaimWrite()).not.toThrow();
+    expect(classifyLaneClaimWrite().verdict).toBe(VERDICT.INCONCLUSIVE);
+  });
+});
+
+describe("buildKeyRank — the TARGET side", () => {
+  test("ranks each linear key at its earliest phase", () => {
+    expect([...KEY_RANK]).toEqual([
+      ["research", 1],
+      ["planning", 2],
+      ["inProgress", 3],
+      ["verifying", 4],
+      ["reviewing", 5],
+      ["inReview", 6],
+    ]);
+  });
+
+  test("⛔ `inReview` is written by four phases and ranks at the FIRST (6), not teardown (9)", () => {
+    expect(KEY_RANK.get("inReview")).toBe(6);
+  });
+
+  test("takes no arguments — it is derived entirely from the workflow descriptor", () => {
+    expect(buildKeyRank()).toEqual(KEY_RANK);
+  });
+
+  test("⭐ the verify<->remediate cycle is NOT a regression under a lane claim", () => {
+    // review -> verify: current `Validate` ranks 4 (verify is the earlier of the two phases
+    // that write it); target key `verifying` ranks 4. Equal, so allowed. If either side
+    // ranked `Validate` at review's index instead, this legitimate cycle would be refused.
+    const v = classifyLaneClaimWrite({
+      currentState: "Validate",
+      targetRank: tr("verifying"),
+      lastChange: { actorId: LANE },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.ALLOW);
+  });
+});
+
+describe("buildLaneClaimGuard — the assembled production shape", () => {
+  const guard = (readLastStateChange) =>
+    buildLaneClaimGuard({ stateMap: STATE_MAP, botUserIds: BOTS, readLastStateChange });
+
+  test("⭐ end-to-end replay of CTC-787 through the assembled guard", () => {
+    const v = guard(() => ({ actorId: LANE })).evaluate({
+      ticket: "CTC-787",
+      currentState: "Implement",
+      targetKey: "research",
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSE);
+    expect(v.reason).toBe(REASON.REGRESSION_AGAINST_LANE_CLAIM);
+  });
+
+  test("⛔ a THROWING reader is 'could not look' — INCONCLUSIVE, never a refusal", () => {
+    const v = guard(() => {
+      throw new Error("replica gone");
+    }).evaluate({ ticket: "CTC-787", currentState: "Implement", targetKey: "research" });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.NO_HISTORY);
+  });
+
+  test("a reader returning undefined (replica MISS) is INCONCLUSIVE", () => {
+    const v = guard(() => undefined).evaluate({
+      ticket: "CTC-787",
+      currentState: "Implement",
+      targetKey: "research",
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+  });
+
+  test("⛔ the no-args factory produces a guard that abstains rather than throwing", () => {
+    // The DEFAULT path: no stateMap, no bot ids, no reader — the shape an unconfigured
+    // host gets. It must answer, not crash, and it must never refuse.
+    const g = buildLaneClaimGuard();
+    expect(() => g.evaluate()).not.toThrow();
+    expect(g.evaluate().verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(
+      g.evaluate({ ticket: "X-1", currentState: "Implement", targetKey: "research" }).verdict
+    ).toBe(VERDICT.INCONCLUSIVE);
+  });
+});
+
+describe("evaluateDispatch — the veto that actually stops the duplicate work", () => {
+  const mk = (o = {}) =>
+    buildLaneClaimGuard({
+      stateMap: STATE_MAP,
+      botUserIds: BOTS,
+      readLastStateChange: () => ({ actorId: LANE }),
+      readCurrentState: () => "Implement",
+      ...o,
+    });
+
+  test("⭐ REFUSES the research dispatch on a lane-claimed ticket (the CTC-787 shape)", () => {
+    const v = mk().evaluateDispatch({ ticket: "CTC-787", phase: "research" });
+    expect(v.verdict).toBe(VERDICT.REFUSE);
+    expect(v.reason).toBe(REASON.REGRESSION_AGAINST_LANE_CLAIM);
+  });
+
+  test("⛔ CONTROL — a FORWARD phase on the same claimed ticket still dispatches", () => {
+    expect(mk().evaluateDispatch({ ticket: "CTC-787", phase: "pr" }).verdict).toBe(VERDICT.ALLOW);
+  });
+
+  test("⛔ CONTROL — the same backward phase is allowed when the FLEET made the last move", () => {
+    const v = mk({ readLastStateChange: () => ({ actorId: FLEET }) }).evaluateDispatch({
+      ticket: "CTC-787",
+      phase: "research",
+    });
+    expect(v.verdict).toBe(VERDICT.ALLOW);
+  });
+
+  test("⭐ `triage` is never vetoed — it writes no status, and it is where fleet work begins", () => {
+    const v = mk().evaluateDispatch({ ticket: "CTC-787", phase: "triage" });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.PHASE_WRITES_NO_STATUS);
+  });
+
+  test("an unreadable current state is INCONCLUSIVE — a replica outage never withholds work", () => {
+    for (const reader of [
+      () => null,
+      () => "",
+      () => {
+        throw new Error("down");
+      },
+      undefined,
+    ]) {
+      const v = mk({ readCurrentState: reader }).evaluateDispatch({
+        ticket: "T-1",
+        phase: "research",
+      });
+      expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+      expect(v.reason).toBe(REASON.NO_CURRENT_STATE);
+    }
+  });
+
+  test("⛔ the kill switch disables ONLY the dispatch veto; the write guard stays armed", () => {
+    const g = mk({ dispatchVeto: false });
+    expect(g.evaluateDispatch({ ticket: "CTC-787", phase: "research" }).reason).toBe(
+      REASON.DISPATCH_VETO_DISABLED
+    );
+    // ⭐ The half that must survive the switch.
+    expect(
+      g.evaluate({ ticket: "CTC-787", currentState: "Implement", targetKey: "research" }).verdict
+    ).toBe(VERDICT.REFUSE);
+  });
+
+  test("⛔ the no-args guard does not throw and never vetoes", () => {
+    const g = buildLaneClaimGuard();
+    expect(() => g.evaluateDispatch()).not.toThrow();
+    expect(g.evaluateDispatch({ ticket: "X-1", phase: "research" }).verdict).toBe(
+      VERDICT.INCONCLUSIVE
+    );
+  });
+});

--- a/plugins/dev/scripts/execution-core/lane-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.test.mjs
@@ -67,7 +67,7 @@ describe("classifyLaneClaimWrite — the CTC-787 collision", () => {
     const v = classifyLaneClaimWrite({
       currentState: "Implement",
       targetRank: tr("research"),
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Implement" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -84,7 +84,7 @@ describe("classifyLaneClaimWrite — the CTC-787 collision", () => {
     const v = classifyLaneClaimWrite({
       currentState: "Implement",
       targetRank: tr("research"),
-      lastChange: { actorId: FLEET },
+      lastChange: { actorId: FLEET, toState: "Implement" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -98,7 +98,7 @@ describe("classifyLaneClaimWrite — forward moves are never refused", () => {
     const v = classifyLaneClaimWrite({
       currentState: "Implement",
       targetRank: tr("inReview"),
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Implement" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -110,7 +110,7 @@ describe("classifyLaneClaimWrite — forward moves are never refused", () => {
     const v = classifyLaneClaimWrite({
       currentState: "Validate",
       targetRank: tr("verifying"),
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Validate" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -125,7 +125,7 @@ describe("classifyLaneClaimWrite — every decline is INCONCLUSIVE and NAMED, ne
       const v = classifyLaneClaimWrite({
         currentState: "Implement",
         targetRank: tr("research"),
-        lastChange: { actorId: LANE },
+        lastChange: { actorId: LANE, toState: "Implement" },
         botUserIds: bots,
         rank: RANK,
       });
@@ -166,7 +166,7 @@ describe("classifyLaneClaimWrite — every decline is INCONCLUSIVE and NAMED, ne
     const v = classifyLaneClaimWrite({
       currentState: "Todo",
       targetRank: tr("research"),
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Todo" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -178,7 +178,7 @@ describe("classifyLaneClaimWrite — every decline is INCONCLUSIVE and NAMED, ne
     const v = classifyLaneClaimWrite({
       currentState: "Implement",
       targetRank: undefined,
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Implement" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -225,7 +225,7 @@ describe("buildKeyRank — the TARGET side", () => {
     const v = classifyLaneClaimWrite({
       currentState: "Validate",
       targetRank: tr("verifying"),
-      lastChange: { actorId: LANE },
+      lastChange: { actorId: LANE, toState: "Validate" },
       botUserIds: BOTS,
       rank: RANK,
     });
@@ -281,7 +281,7 @@ describe("evaluateDispatch — the veto that actually stops the duplicate work",
     buildLaneClaimGuard({
       stateMap: STATE_MAP,
       botUserIds: BOTS,
-      readLastStateChange: () => ({ actorId: LANE }),
+      readLastStateChange: () => ({ actorId: LANE, toState: "Implement" }),
       readCurrentState: () => "Implement",
       ...o,
     });
@@ -297,7 +297,9 @@ describe("evaluateDispatch — the veto that actually stops the duplicate work",
   });
 
   test("⛔ CONTROL — the same backward phase is allowed when the FLEET made the last move", () => {
-    const v = mk({ readLastStateChange: () => ({ actorId: FLEET }) }).evaluateDispatch({
+    const v = mk({
+      readLastStateChange: () => ({ actorId: FLEET, toState: "Implement" }),
+    }).evaluateDispatch({
       ticket: "CTC-787",
       phase: "research",
     });
@@ -345,5 +347,63 @@ describe("evaluateDispatch — the veto that actually stops the duplicate work",
     expect(g.evaluateDispatch({ ticket: "X-1", phase: "research" }).verdict).toBe(
       VERDICT.INCONCLUSIVE
     );
+  });
+});
+
+describe("⛔ the STALE-HISTORY decline (Codex P1) — the 18× latency gap between the two sources", () => {
+  // Measured in this repo by CTL-1847 (linear-feed-diff.mjs): `issues.state` lands in ~11 s
+  // (webhook-fed), `issue_history` in ~201 s (reconcile-only). The window this guard exists
+  // for is 74 SECONDS, so the newest available history row is the transition BEFORE the
+  // lane's claim — and on CTC-787 that earlier transition was made by the FLEET.
+  test("⭐⭐ the lag scenario: a fleet-authored row that predates the claim must NOT be trusted", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement", // the lane's claim — already visible at ~11 s
+      targetRank: tr("research"),
+      lastChange: { actorId: FLEET, toState: "Validate" }, // the PREVIOUS transition, ~201 s behind
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    // ⛔ Before this fix the call returned ALLOW / LAST_CHANGE_BY_FLEET — the guard
+    // cheerfully permitting the exact regression it was built to refuse.
+    expect(v.verdict).not.toBe(VERDICT.ALLOW);
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.STALE_HISTORY);
+  });
+
+  test("a row whose toState MATCHES the current state is trusted (the settled case)", () => {
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: { actorId: LANE, toState: "Implement" },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSE);
+  });
+
+  test("a stale row is declined even when its actor is a LANE — staleness is judged first", () => {
+    // Otherwise a coincidentally lane-authored OLDER row would be read as a live claim.
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: { actorId: LANE, toState: "Plan" },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.STALE_HISTORY);
+  });
+
+  test("a row with no toState is still judged on its actor — absent is not contradictory", () => {
+    // 140 fleet-wide issues have NO history rows at all (CTL-1847) and older rows may omit
+    // the field. Only a row that DISAGREES with the current state is declined.
+    const v = classifyLaneClaimWrite({
+      currentState: "Implement",
+      targetRank: tr("research"),
+      lastChange: { actorId: LANE, toState: null },
+      botUserIds: BOTS,
+      rank: RANK,
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSE);
   });
 });

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -17,6 +17,8 @@ import { withAuthRemint, isAuthError } from "./linear-remint.mjs";
 // backward-write guard below.
 import { isLinearTerminal } from "./terminal-state.mjs";
 import { getLinearWriteProxy as _getProxy, getLinearWriteProxyResolver as _getResolver } from "./linear-write-proxy-install.mjs";
+import { getLaneClaimGuard as _getLaneClaimGuard } from "./lane-claim-install.mjs"; // CTL-2068
+import { VERDICT as LANE_CLAIM_VERDICT } from "./lane-claim.mjs"; // CTL-2068
 
 // ─── CTL-1889: the cloud write-proxy seam ────────────────────────────────────
 //
@@ -187,6 +189,9 @@ function runTransition({
   // CTL-1889: injectable write-proxy seam. undefined → the module-level install
   // (null unless an operator lit the flag), so production behaviour is unchanged.
   proxy,
+  // CTL-2068: injectable lane-claim guard. undefined → the module-level install that
+  // daemon.mjs sets at boot. Injectable so tests never touch the replica.
+  laneClaim,
 }) {
   try {
     const repoRoot = resolveRepoRoot(ticket);
@@ -211,6 +216,40 @@ function runTransition({
     if (key !== TERMINAL_LINEAR_KEY) {
       const current =
         knownCurrentState !== undefined ? knownCurrentState : fetchState(ticket, { exec, cache });
+
+      // ⛔ CTL-2068 — LANE-CLAIM GUARD, on the state read this function already performs.
+      // CTL-758 below refuses a backward write only out of a TERMINAL state, so
+      // Implement -> Research walks straight through it. That is the exact write that
+      // collided twice in two nights (CTC-776, CTC-787): a lane claimed the ticket, the
+      // pipeline dragged it back 74 seconds later, and a worker then dispatched it.
+      //
+      // This rung covers EVERY transport (shadow proxy, proxy off, plain shell write); the
+      // second rung inside buildPayload re-applies it to the fresher `--resolve-only` state
+      // on the enforce path. A guard wired only to the enforce path would be live on both
+      // minis today purely because that is how they happen to be configured — the "held by
+      // an accident" shape this ticket exists to remove.
+      //
+      // It needs no target state NAME: the target is ranked from `key`, this function's own
+      // argument (buildKeyRank). So this rung costs ZERO extra work — it reuses the read
+      // CTL-758 already made.
+      const laneClaimGuard = laneClaim ?? _getLaneClaimGuard();
+      if (laneClaimGuard) {
+        const lc = laneClaimGuard.evaluate({ ticket, currentState: current, targetKey: key });
+        if (lc?.verdict === LANE_CLAIM_VERDICT.REFUSE) {
+          log.warn(
+            { ticket, key, current, actor_id: lc.actorId, reason: lc.reason },
+            "ctl-2068: refusing backward write — a lane holds this ticket"
+          );
+          return {
+            applied: false,
+            skipped: "lane-claimed-no-regression",
+            reason: "skipped-lane-claimed-no-regression",
+            from_state: current,
+            to_state: null,
+          };
+        }
+      }
+
       if (isLinearTerminal(current)) {
         log.warn(
           { ticket, key, current },
@@ -287,6 +326,24 @@ function runTransition({
         // verbatim — the forward terminal write is exempt, or Done could never be set.
         if (key !== TERMINAL_LINEAR_KEY && isLinearTerminal(resolvedCurrent)) {
           return { ok: false, reason: "terminal-no-backward", detail: resolvedCurrent };
+        }
+
+        // ⛔ CTL-2068 — the guard RE-APPLIED to the state we actually read, for exactly the
+        // reason the CTL-758 clause above is re-applied here: the first rung runs on a
+        // FAIL-OPEN read that returns null when it cannot answer, and `--resolve-only` then
+        // reads the state from the fresh replica and may well come back `Implement`. An
+        // enforce host with no `linearis` and a cold cache is where the first read is MOST
+        // likely to fail and the second MOST likely to succeed — i.e. both minis.
+        const laneClaimGuard = laneClaim ?? _getLaneClaimGuard();
+        if (laneClaimGuard && key !== TERMINAL_LINEAR_KEY) {
+          const lc = laneClaimGuard.evaluate({ ticket, currentState: resolvedCurrent, targetKey: key });
+          if (lc?.verdict === LANE_CLAIM_VERDICT.REFUSE) {
+            log.warn(
+              { ticket, key, current: resolvedCurrent, actor_id: lc.actorId, reason: lc.reason },
+              "ctl-2068: refusing backward write — a lane holds this ticket"
+            );
+            return { ok: false, reason: "lane-claimed-no-regression", detail: resolvedCurrent };
+          }
         }
 
         const issue = resolver.issue(ticket);
@@ -366,10 +423,37 @@ function runTransition({
 // CTL-758: `cache` is threaded through to runTransition's backward-write guard
 // so the per-tick shared TTL cache (createTicketStateCache) serves the guard's
 // pre-write read — ≤1 fetchTicketState per ticket per TTL, not a new API storm.
-export function applyPhaseStatus({ ticket, phase, resolveRepoRoot, exec, cache, proxy }) {
+// CTL-2068: `fetchState` and `laneClaim` are forwarded. They were NOT before — this
+// function accepted six named options and passed five on, so a caller supplying either was
+// silently ignored and runTransition fell back to its own defaults. That was invisible in
+// production (the defaults ARE the production values) and fatal to any test that injected
+// them: the injection appeared to work while actually measuring the default path. Caught by
+// lane-claim-wiring.test.mjs, which asserts the shell is never spawned rather than only
+// inspecting the returned shape.
+export function applyPhaseStatus({
+  ticket,
+  phase,
+  resolveRepoRoot,
+  exec,
+  cache,
+  proxy,
+  fetchState,
+  laneClaim,
+}) {
   const key = linearKeyForPhase(phase); // throws PhaseFsmError on an unknown phase
   if (key === null) return { applied: false, skipped: "no-status-key" };
-  return runTransition({ ticket, key, resolveRepoRoot, exec, cache, proxy });
+  return runTransition({
+    ticket,
+    key,
+    resolveRepoRoot,
+    exec,
+    cache,
+    proxy,
+    laneClaim,
+    // Only override runTransition's default when the caller actually supplied one, so the
+    // production path keeps its `fetchState = fetchTicketState` default.
+    ...(fetchState ? { fetchState } : {}),
+  });
 }
 
 // applyTerminalDone — write the terminal Done state on monitor-deploy completion.

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -227,6 +227,13 @@ function buildEligibleSelect({ project, label } = {}) {
 // a caller must never TRUST a null delegate from the replica — fetchTicketAssignee
 // live-confirms every null delegate and trusts only a non-null (actor-set) one,
 // matching the gateway path (see linear-query.mjs).
+// CTL-2068 — the most recent STATE change on a ticket, with the actor who made it.
+// `to_state IS NOT NULL` is what makes this a state change: issue_history carries a row
+// for every field edit (title, estimate, labels…), and those rows leave to_state null.
+// Without that predicate the newest row is usually an unrelated edit, and the guard would
+// read whoever last renamed the ticket as the actor who set its state.
+const LAST_STATE_CHANGE_SELECT = `SELECT h.actor_id AS actorId, h.to_state AS toState, h.created_at AS atMs FROM issue_history h JOIN issues i ON i.id = h.issue_id WHERE i.identifier = ? AND h.to_state IS NOT NULL ORDER BY h.created_at DESC LIMIT 1`;
+
 const OWNERSHIP_SELECT = `SELECT assignee_id, delegate_id, delegate_name FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
 // Relation enrichment, mirroring normalizeDetail in linear-cli.mjs. forward:
 // edges this issue OWNS (relatedIssue is the target); inverse: edges that point
@@ -943,9 +950,26 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
+  // lastStateChange(identifier) → { actorId, toState, atMs } | undefined
+  //   HIT  → the newest row whose to_state is set
+  //   no row / no db / any throw → undefined (fail-open; the CTL-2068 guard reads an
+  //   undefined here as "could not look" and ALLOWS the write, never refuses on it)
+  const lastStateChange = (identifier) => {
+    if (!identifier) return undefined;
+    try {
+      const row = open().prepare(LAST_STATE_CHANGE_SELECT).get(identifier);
+      if (!row) return undefined;
+      return { actorId: row.actorId ?? null, toState: row.toState ?? null, atMs: coerceMs(row.atMs) };
+    } catch {
+      dropHandle();
+      return undefined;
+    }
+  };
+
   return {
     lookup,
     freshness,
+    lastStateChange, // CTL-2068
     titles,
     estimates, // CTL-1806
     relations, // CTL-1806

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -13,6 +13,8 @@
 // Composes: lib/dependency-graph.mjs (readiness), scheduler-rank.mjs (ranking),
 // lib/phase-fsm.mjs (phase advancement, Phase 4), eligible-set.mjs (candidates).
 
+import { getLaneClaimGuard } from "./lane-claim-install.mjs"; // CTL-2068
+import { VERDICT as LANE_CLAIM_VERDICT } from "./lane-claim.mjs"; // CTL-2068
 import {
   readdirSync,
   readFileSync,
@@ -5350,6 +5352,38 @@ export function schedulerTick(
       failLogIncludePhase = true, // Pass 2's original rc!=0 log omits the phase field
     }
   ) {
+    // ⛔ CTL-2068 — LANE-CLAIM DISPATCH VETO. The single choke point every phase dispatch
+    // passes through, and the half that actually stops the collision: on CTC-787 the fleet
+    // held the ticket in its pipeline the whole time, so refusing the STATE write alone
+    // would have left the worker running and still opening the duplicate PR.
+    //
+    // Placed ABOVE the dispatch-requested emit on purpose — recording a decision we are
+    // about to refuse would put a phantom dispatch in the audit stream and feed the
+    // runaway-rate detector.
+    //
+    // Fails OPEN in every case it cannot judge (no guard installed, no replica, unranked
+    // state, `triage` — which writes no status and is where fleet work legitimately
+    // begins). Only a positive "a non-fleet actor moved this ticket, and this phase sits
+    // behind where they moved it" refuses.
+    const laneClaimGuard = getLaneClaimGuard();
+    if (laneClaimGuard) {
+      const lc = laneClaimGuard.evaluateDispatch({ ticket, phase });
+      if (lc?.verdict === LANE_CLAIM_VERDICT.REFUSE) {
+        log.warn(
+          {
+            ticket,
+            phase,
+            actor_id: lc.actorId,
+            reason: lc.reason,
+            current_rank: lc.currentRank,
+            target_rank: lc.targetRank,
+          },
+          "ctl-2068: skipping dispatch — a lane holds this ticket"
+        );
+        return { aborted: true, laneClaimed: true };
+      }
+    }
+
     // CTL-660: record the dispatch DECISION before the spawn. Best-effort.
     safeEmit(
       appendDispatchRequestedEvent,


### PR DESCRIPTION
## The collision, from the replica

Twice in two nights (CTC-776, CTC-787) a fleet worker built a ticket a human-facing lane was
already building — after the lane claimed it exactly as the rule says. `issue_history` has the
second one, and it is the whole mechanism:

| when | actor | move | |
| -- | -- | -- | -- |
| 1787132205283 | **Ryan Rozich** | `Validate → Implement` | the lane claims it |
| 1787132279778 | **Catalyst Cloud** | `Implement → Research` | ⛔ 74 seconds later, the pipeline drags it BACKWARDS |
| … | | | a worker dispatches `research` and opens the duplicate #993 |

`CTL-758` already refuses a backward Linear write — but **only out of a TERMINAL state**
(`Done`/`Canceled`), so `Implement → Research` sails straight through it. This generalizes that
guard along the one axis that makes it safe to widen.

## ⛔ Why a blanket "never regress" is wrong, and what the guard keys on instead

The pipeline **legitimately** re-runs earlier phases — the L3 destroy-and-recreate on
`research`/`plan`, the `verify ⇄ remediate` cycle — and those writes *are* backward moves. A rule
that refused every regression would break recovery.

What separates the two is not the direction of the move but **who last moved the ticket**. Lanes
write state through `linearis` with a human user id; the daemon writes as the app-actor whose id
is the already-configured `botUserId`. On CTC-787 those are `c2a8cc92…` (Ryan Rozich) and
`78f8f491…` (Catalyst Cloud) — read off the replica, not assumed. The guard takes that Set as
input and hardcodes nothing.

## Two enforcement points, because refusing the write does not stop the work

⭐ On CTC-787 the fleet held the ticket **in its pipeline the whole time**. Refusing the state
write alone would have made the collision merely *visible* — the worker would still have run and
still opened the duplicate PR. So the same question is asked at both sites:

| site | question |
| -- | -- |
| **write guard** (`linear-write.mjs`) | may the pipeline write this phase's state over the current one? |
| **dispatch veto** (`scheduler.mjs` → `dispatchAndVerify`) | may the pipeline run this phase at all? |

*If the pipeline may not move a ticket back to a phase's state, it has no business running that
phase.* One rule, two enforcement points.

The write guard is applied on **both rungs CTL-758 uses**, for the same documented reason: the
pre-read is fail-open and returns `null` when it cannot answer, so `--resolve-only`'s fresher state
gets its own re-application. The first rung also means the guard holds on **every transport**
(shadow proxy, proxy off, plain shell) — a guard wired only to the enforce path would be live on
both minis today purely because that is how they happen to be configured, which is the
"held by an accident" shape this ticket is about.

## Fails OPEN, and every decline is NAMED

This is a refusal guard on the pipeline's own writes and dispatches, so a guard that cannot answer
must not block. Every such case returns `INCONCLUSIVE` **with a reason** rather than a quiet allow,
so "I could not look" is never recorded as "nothing is wrong":

- no history · no bot ids · an unranked state · an unreadable/throwing replica
- **`triage`** — writes no status, and is where fleet work legitimately begins
- ⛔ **an EMPTY `botUserIds` set** — with no known fleet ids *every* actor looks like a lane, and the
  guard would refuse the pipeline's every legitimate backward move. That is the dangerous
  direction, so it is inconclusive, never a licence to refuse.
- ⭐ **`Todo → Research`** — `Todo` is deliberately unranked, so a human queueing work is not read as
  a claim and the fleet can still start it.

## Ordering, derived rather than declared

`buildStateRank` (current side, by state NAME) and `buildKeyRank` (target side, by linear KEY) are
both derived from `PHASE_LINEAR_KEY` at the **MIN** phase index. Four phases write `inReview`, so
`PR` ranks at 6, not teardown's 9 — a max/last-wins rank would make a legitimate
`monitor-merge → pr` write look like a regression.

Only the states the pipeline actually writes are ranked. `Todo`/`Backlog`/`Triage`/`Done` are
absent on purpose, and an absent state abstains instead of being ordered at some invented position.
It reads **one** rung of the state-name chain, never the four-rung precedence chain
`linear-transition.sh` owns — so this guard can only ever abstain where that chain would have
disagreed, never contradict it.

## Armed by default

Installed unconditionally, not shadow-first. The refusal is narrow and every unjudgeable case
allows, so there is no posture for it to be wrong in — while a shadow default would reproduce this
repo's recurring failure of shipping a correct mechanism nobody ever arms. The **dispatch** half
withholds *work* rather than just a status write, so it keeps an operator kill switch,
`CATALYST_LANE_CLAIM_DISPATCH_GUARD=off`, which leaves the write guard armed.

`botUserIds` is passed **by reference** — the stable Set `refreshBotIdentities` fills in place on
every cluster-sync tick — so an app-actor re-mint keeps the guard current instead of freezing it at
boot. A copy would make the guard read every post-rotation fleet write as a lane's. There is a test
for exactly that.

## Two things found on the way

1. ⛔ **`applyPhaseStatus` accepted six named options and passed five on**, silently dropping
   `fetchState`. Invisible in production — the default *is* the production value — and fatal to any
   test that injected it: the injection appeared to work while actually measuring the default path.
   Caught by asserting **the shell is never spawned**, not by reading the returned shape.
2. ⛔ **`scheduler.test.mjs`, where `dispatchAndVerify`'s other tests live, is EXCLUDED from
   `execution-core-tests.yml`** (flaky `fs.watch` timers) — so a veto test placed there would never
   run in CI. Both new test files carry their own harness and are **added to the workflow's stable
   list in this PR**. (A guard nobody runs is a check that cannot fail — the same shape as the
   defect being fixed.)

## Verification

**42 tests. Nine mutations red**, each with a discriminating count: the regression comparator
(`<` → `<=`), the fleet-actor branch inverted, MIN→MAX ranking, the empty-bot-ids guard removed,
unranked-current→refuse, **both** write rungs, the dispatch veto, and the option forwarding.

Controls throughout, because the interesting risk is a guard that refuses everything:

- the **identical** regression authored by the FLEET is ALLOWED
- a **forward** move under a live lane claim is ALLOWED
- `Todo → Research` is ALLOWED
- with **no guard installed** the same tick dispatches (pre-CTL-2068 behaviour)
- the kill switch disables **only** the dispatch veto; the write guard stays armed

Full CI stable suite: **8194 pass / 2 fail**. Both failures are **pre-existing and unrelated**,
verified by running them on an untouched checkout at `61587c86d`: `linear-cli.test.mjs`
"replica never consulted" and `heartbeat-event.test.mjs` "minus .local" (the latter is
hostname-dependent). Likely the red `execution-core-unit-tests` on main noted in COORD-253.

⚠️ The diff is deliberately kept to **201 insertions / 2 deletions**: `trunk fmt` wanted to rewrite
608 lines of `daemon.mjs` for a 55-line change, so the pre-existing files keep their formatting and
only the new files are formatted.

## Scope

This is the **bridge** the ticket asks for, not the durable fix. The durable one is the lease plane
(CTL-1785 / CTL-1786) — a claim that goes through an authority that can refuse.

Refs CTL-2068, CTC-787, CTC-776, CTL-758, CTL-1174