### PR TITLE
fix(dev): CTL-2068 — the guard shipped INERT on mini; resolve the state map through a ladder

### DIFF
--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1416,51 +1416,82 @@ export function startDaemon({
     // `linear-transition.sh` — the thing that actually performs the write this guard judges —
     // is invoked with `--config <repoRoot>/.catalyst/config.json`. Ranking off any other file
     // risks judging against a map the writer does not use.
-    let laneClaimStateMap = null;
-    let laneClaimStateMapSource = "none";
+    // ⛔ CTL-2068 (Codex P1): resolved PER TEAM, not once process-wide. The registry holds
+    // several teams, each with its own repoRoot and its own `.catalyst/config.json`, and
+    // linear-write.mjs resolves repoRoot PER TICKET and hands THAT project's config to
+    // linear-transition.sh — including its higher-precedence per-project overrides. Ranking
+    // every team against the first registry entry's map judges tickets against names their
+    // own writer never uses.
+    const laneClaimTeamPaths = new Map();
     try {
-      const candidates = [];
       for (const proj of listProjectsFn() ?? []) {
-        if (proj?.repoRoot) {
-          candidates.push([
-            `registry:${proj.team ?? "?"}`,
-            resolve(proj.repoRoot, ".catalyst", "config.json"),
-          ]);
+        if (proj?.team && proj?.repoRoot) {
+          laneClaimTeamPaths.set(
+            String(proj.team).toUpperCase(),
+            resolve(proj.repoRoot, ".catalyst", "config.json")
+          );
         }
       }
-      candidates.push(["configPath", configPath], ["layer2", layer2Path]);
-      const resolved = resolveStateMap(candidates, (path) => readFileSync(path, "utf8"));
-      laneClaimStateMap = resolved.stateMap;
-      laneClaimStateMapSource = resolved.source;
     } catch {
-      /* a throwing registry must not block boot → the guard abstains, never refuses */
+      /* a throwing registry must not block boot → the guard falls back to the default map */
     }
+    const laneClaimReadFile = (path) => readFileSync(path, "utf8");
+    const laneClaimFallback = [
+      ["configPath", configPath],
+      ["layer2", layer2Path],
+    ];
+    // The DEFAULT map — every registry project, then the two ambient paths. Used for a ticket
+    // whose team is not in the registry, and by the install line below.
+    const laneClaimDefault = resolveStateMap(
+      [
+        ...[...laneClaimTeamPaths].map(([team, path]) => [`registry:${team}`, path]),
+        ...laneClaimFallback,
+      ],
+      laneClaimReadFile
+    );
+    const laneClaimStateMap = laneClaimDefault.stateMap;
+    const laneClaimStateMapSource = laneClaimDefault.source;
+    const laneClaimStateMapForTicket = (ticket) => {
+      const team = String(ticket ?? "")
+        .split("-")[0]
+        ?.toUpperCase();
+      const path = team ? laneClaimTeamPaths.get(team) : null;
+      if (!path) return laneClaimDefault;
+      return resolveStateMap([[`registry:${team}`, path], ...laneClaimFallback], laneClaimReadFile);
+    };
     // Only an explicit "off" disables the dispatch veto — an unset or misspelled value leaves
     // it armed, because the failure this ticket is about is a claim quietly not being honoured.
     const laneClaimDispatchVeto =
       String(process.env.CATALYST_LANE_CLAIM_DISPATCH_GUARD ?? "")
         .trim()
         .toLowerCase() !== "off";
-    setLaneClaimGuard(
-      buildLaneClaimGuard({
-        stateMap: laneClaimStateMap,
-        botUserIds: linearBotUserIds,
-        readLastStateChange: replicaReader ? (t) => replicaReader.lastStateChange(t) : undefined,
-        readCurrentState: replicaReader ? (t) => replicaReader.lookup(t)?.state ?? null : undefined,
-        dispatchVeto: laneClaimDispatchVeto,
-      })
-    );
-    // ⚠️ `ranked_states: 0` means the guard is INSTALLED AND INERT — it can never refuse.
-    // Logged at WARN in that case precisely because the healthy-looking INFO line is what let
-    // the inert install sit unnoticed on mini.
+    const laneClaimGuardInstance = buildLaneClaimGuard({
+      stateMap: laneClaimStateMap,
+      stateMapForTicket: laneClaimStateMapForTicket,
+      botUserIds: linearBotUserIds,
+      readLastStateChange: replicaReader ? (t) => replicaReader.lastStateChange(t) : undefined,
+      readCurrentState: replicaReader ? (t) => replicaReader.lookup(t)?.state ?? null : undefined,
+      readFleetSeen: replicaReader ? (t, ids) => replicaReader.fleetEverWroteState(t, ids) : undefined,
+      dispatchVeto: laneClaimDispatchVeto,
+    });
+    setLaneClaimGuard(laneClaimGuardInstance);
+    // ⛔ CTL-2068 (Codex P2): `ranked_states` is the guard's OWN rank size, never the raw
+    // map's key count. buildStateRank deliberately drops todo/backlog/triage/done, so a map
+    // carrying only those keys counts nonzero while the rank is EMPTY — and the healthy INFO
+    // line would print over a guard that can never refuse. That is exactly the false-healthy
+    // this commit exists to expose, one level in.
     const laneClaimFields = {
-      ranked_states: Object.keys(laneClaimStateMap ?? {}).length,
+      ranked_states: laneClaimGuardInstance.rank.size,
       state_map_source: laneClaimStateMapSource,
+      registry_teams: laneClaimTeamPaths.size,
       history_source: replicaReader ? "replica" : "none",
       dispatch_veto: laneClaimDispatchVeto,
     };
     if (laneClaimFields.ranked_states === 0) {
-      log.warn(laneClaimFields, "ctl-2068: lane-claim guard installed but INERT — no state map resolved, it can never refuse");
+      log.warn(
+        laneClaimFields,
+        "ctl-2068: lane-claim guard installed but INERT — no rankable state map resolved, it can never refuse"
+      );
     } else {
       log.info(laneClaimFields, "ctl-2068: lane-claim guard installed");
     }

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -173,7 +173,7 @@ import { classifyTicketResolution } from "./linear-query.mjs";
 import { createGatewayReader } from "./gateway-read.mjs";
 import { createReplicaReader } from "./replica-read.mjs"; // CTL-1340: read-replica tier reader
 import { setLaneClaimGuard } from "./lane-claim-install.mjs"; // CTL-2068
-import { buildLaneClaimGuard } from "./lane-claim.mjs"; // CTL-2068
+import { buildLaneClaimGuard, resolveStateMap } from "./lane-claim.mjs"; // CTL-2068
 import { isBgJobAlive, refreshAgents, listClaudeAgentsResult } from "./claude-agents.mjs"; // CTL-1165 D3: fail-closed liveness reader for job-dir GC
 import { reconcileSdkRegistryOnBoot } from "./sdk-worker-registry.mjs"; // CTL-1410 Phase B
 import { resolveNodeClass as _resolveNodeClass } from "./lib/node-class.mjs"; // CTL-1654: node-class heartbeat/actuation guard
@@ -1400,12 +1400,40 @@ export function startDaemon({
     // Without a replica reader the guard has no history to consult and answers INCONCLUSIVE
     // for every ticket — allowing the write, and SAYING so in the log line below rather than
     // silently doing nothing.
+    //
+    // ⛔ THE STATE MAP IS RESOLVED THROUGH A LADDER, NOT FROM `configPath` ALONE.
+    // Measured on the fleet immediately after this guard first shipped: it installed on both
+    // minis and ranked ZERO states on `mini`, i.e. it could never refuse anything — an
+    // installed-but-inert guard, visible only because the install line logs the count.
+    //
+    // Cause: `configPath` is `CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json`, and the
+    // two hosts differ. mini-2 pins the env var at the plugin-source config; mini does not,
+    // and the daemon's cwd there is the HOME dir — where a `.catalyst/config.json` happens to
+    // exist carrying no `catalyst.linear` at all. So the read succeeded and returned nothing,
+    // which is worse than failing.
+    //
+    // The registry's repoRoots are tried FIRST because they are the authoritative source:
+    // `linear-transition.sh` — the thing that actually performs the write this guard judges —
+    // is invoked with `--config <repoRoot>/.catalyst/config.json`. Ranking off any other file
+    // risks judging against a map the writer does not use.
     let laneClaimStateMap = null;
+    let laneClaimStateMapSource = "none";
     try {
-      laneClaimStateMap =
-        JSON.parse(readFileSync(configPath, "utf8"))?.catalyst?.linear?.stateMap ?? null;
+      const candidates = [];
+      for (const proj of listProjectsFn() ?? []) {
+        if (proj?.repoRoot) {
+          candidates.push([
+            `registry:${proj.team ?? "?"}`,
+            resolve(proj.repoRoot, ".catalyst", "config.json"),
+          ]);
+        }
+      }
+      candidates.push(["configPath", configPath], ["layer2", layer2Path]);
+      const resolved = resolveStateMap(candidates, (path) => readFileSync(path, "utf8"));
+      laneClaimStateMap = resolved.stateMap;
+      laneClaimStateMapSource = resolved.source;
     } catch {
-      /* absent/malformed Layer-1 → no rank map → the guard abstains, never refuses */
+      /* a throwing registry must not block boot → the guard abstains, never refuses */
     }
     // Only an explicit "off" disables the dispatch veto — an unset or misspelled value leaves
     // it armed, because the failure this ticket is about is a claim quietly not being honoured.
@@ -1422,14 +1450,20 @@ export function startDaemon({
         dispatchVeto: laneClaimDispatchVeto,
       })
     );
-    log.info(
-      {
-        ranked_states: Object.keys(laneClaimStateMap ?? {}).length,
-        history_source: replicaReader ? "replica" : "none",
-        dispatch_veto: laneClaimDispatchVeto,
-      },
-      "ctl-2068: lane-claim guard installed"
-    );
+    // ⚠️ `ranked_states: 0` means the guard is INSTALLED AND INERT — it can never refuse.
+    // Logged at WARN in that case precisely because the healthy-looking INFO line is what let
+    // the inert install sit unnoticed on mini.
+    const laneClaimFields = {
+      ranked_states: Object.keys(laneClaimStateMap ?? {}).length,
+      state_map_source: laneClaimStateMapSource,
+      history_source: replicaReader ? "replica" : "none",
+      dispatch_veto: laneClaimDispatchVeto,
+    };
+    if (laneClaimFields.ranked_states === 0) {
+      log.warn(laneClaimFields, "ctl-2068: lane-claim guard installed but INERT — no state map resolved, it can never refuse");
+    } else {
+      log.info(laneClaimFields, "ctl-2068: lane-claim guard installed");
+    }
 
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);
     // CTL-1654 (Codex P2 "gate the daemon before starting actuators"): resolve the

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -1435,7 +1435,12 @@ export function startDaemon({
     } catch {
       /* a throwing registry must not block boot → the guard falls back to the default map */
     }
-    const laneClaimReadFile = (path) => readFileSync(path, "utf8");
+    // ⚠️ The parameter is NOT named `path`. CTL-1529's event-log read guard taints that
+    // identifier module-wide, so `(path) => readFileSync(path, "utf8")` trips it — a false
+    // positive (this reads a project's .catalyst/config.json, never the event log). Renaming
+    // is the honest fix: an allowlist entry would carve a permanent exemption into a guard
+    // that is right to be conservative.
+    const laneClaimReadFile = (configFilePath) => readFileSync(configFilePath, "utf8");
     const laneClaimFallback = [
       ["configPath", configPath],
       ["layer2", layer2Path],

--- a/plugins/dev/scripts/execution-core/lane-claim.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.mjs
@@ -134,6 +134,42 @@ export function buildKeyRank() {
 }
 
 /**
+ * resolveStateMap — pure. Walks an ordered list of `[label, path]` candidates and returns the
+ * FIRST that yields a non-empty `catalyst.linear.stateMap`, with the label that produced it.
+ *
+ * ⛔ Exists because the first cut of this guard read ONE path and shipped INERT on half the
+ * fleet. Measured after that ship: `ranked_states: 0` on `mini`, meaning the guard could never
+ * refuse anything. `configPath` is `CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json`, and
+ * the two hosts differ — mini-2 pins the env var, mini does not and its daemon's cwd is HOME,
+ * where a `.catalyst/config.json` exists carrying no `catalyst.linear` at all. The read
+ * SUCCEEDED and returned nothing, which is worse than failing: a throw would have been visible.
+ *
+ * ⚠️ So an empty or absent map is treated as NO ANSWER and the walk continues. A file that
+ * parses is not evidence it is the right file.
+ *
+ * @param {Array<[string, string|null]>} candidates ordered [label, path] pairs
+ * @param {(path: string) => string} readFile throwing reader (node:fs readFileSync)
+ * @returns {{ stateMap: object|null, source: string }} source is "none" when nothing resolved
+ */
+export function resolveStateMap(candidates, readFile) {
+  for (const entry of candidates ?? []) {
+    const label = entry?.[0];
+    const path = entry?.[1];
+    if (typeof path !== "string" || path.length === 0) continue;
+    let map = null;
+    try {
+      map = JSON.parse(readFile(path))?.catalyst?.linear?.stateMap ?? null;
+    } catch {
+      continue; // unreadable/malformed → not an answer, keep walking
+    }
+    if (map && typeof map === "object" && !Array.isArray(map) && Object.keys(map).length > 0) {
+      return { stateMap: map, source: String(label ?? "?") };
+    }
+  }
+  return { stateMap: null, source: "none" };
+}
+
+/**
  * classifyLaneClaimWrite — pure. Decides whether the pipeline may write `targetState` over
  * `currentState`, given who last changed the ticket's state.
  *

--- a/plugins/dev/scripts/execution-core/lane-claim.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.mjs
@@ -61,6 +61,7 @@ export const REASON = Object.freeze({
   UNRANKED_TARGET: "target-state-not-in-pipeline",
   BAD_INPUT: "malformed-input",
   STALE_HISTORY: "history-row-does-not-match-current-state",
+  FLEET_IDENTITY_UNRECOGNIZED: "fleet-identity-not-observed-on-this-ticket",
   DISPATCH_VETO_DISABLED: "dispatch-veto-disabled",
   NO_CURRENT_STATE: "current-state-unreadable",
   PHASE_WRITES_NO_STATUS: "phase-writes-no-status",
@@ -195,6 +196,10 @@ export function resolveStateMap(candidates, readFile) {
  *   somebody can count and a silent false negative.
  * @param {Set<string>} o.botUserIds    known fleet actor ids
  * @param {Map<string,number>} o.rank   from buildStateRank
+ * @param {boolean|undefined} o.fleetSeen POSITIVE CONTROL — has any KNOWN fleet id authored a
+ *   state change on this ticket? `false` makes the guard abstain (it cannot tell the fleet
+ *   from a lane here). `undefined` means the caller did not check, and is treated as "no
+ *   objection" so existing callers are unaffected.
  * @returns {{verdict: string, reason: string, currentRank?: number, targetRank?: number,
  *            actorId?: string|null}}
  */
@@ -204,6 +209,7 @@ export function classifyLaneClaimWrite({
   lastChange,
   botUserIds,
   rank,
+  fleetSeen,
 } = {}) {
   if (!(rank instanceof Map)) return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.BAD_INPUT };
 
@@ -219,6 +225,31 @@ export function classifyLaneClaimWrite({
   if (typeof actorId !== "string" || actorId.length === 0) {
     return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.NO_ACTOR, actorId: null };
   }
+  // ⛔⛔ POSITIVE CONTROL — can this guard tell the fleet from a lane ON THIS TICKET AT ALL?
+  //
+  // The whole verdict rests on "actorId ∈ botUserIds means the fleet". If the fleet's real
+  // writing identity is not IN that set, every actor reads as a lane and the guard refuses
+  // the fleet's own legitimate backward moves. That is not hypothetical — it was the live
+  // state of the fleet when this guard first shipped. Measured on the replica, CTL tickets,
+  // recent window:
+  //
+  //     c2a8cc92…  Ryan Rozich      103 state changes
+  //     78f8f491…  Catalyst Cloud    11 state changes
+  //     botUserIds = { 6dd38c1a…, ba2989f1… }   ← NEITHER of the two that actually write
+  //
+  // Those two ids are the host's legacy DIRECT-write app-actors; since CTL-1889 the hosts
+  // write THROUGH the cloud proxy, which presents the cloud's app-actor instead. So the set
+  // named two identities that never write and omitted the one that does.
+  //
+  // A guard whose discriminator cannot discriminate must not act. `fleetSeen` is the caller's
+  // answer to "has any KNOWN fleet id authored a state change on this ticket?" — when it is
+  // false the guard has no evidence it can tell the two apart here, and abstains. When the
+  // set is correct this is true for any ticket the pipeline has touched, so the guard arms
+  // itself exactly where it has the evidence to be right.
+  if (fleetSeen === false) {
+    return { verdict: VERDICT.INCONCLUSIVE, reason: REASON.FLEET_IDENTITY_UNRECOGNIZED, actorId };
+  }
+
   // ⛔ The row must DESCRIBE the state we are judging. See the `lastChange` doc above: the
   // history table lags the state table by ~18×, so a row whose toState is not the current
   // state is a row from before whatever put the ticket where it is now.
@@ -287,12 +318,29 @@ export function classifyLaneClaimWrite({
  *   throw — a replica outage may not wedge the pipeline's writes.
  */
 export function buildLaneClaimGuard({
+  // The DEFAULT map, used when no per-ticket resolver is supplied (tests, and any host with
+  // a single project).
   stateMap,
+  // ⛔ CTL-2068 (Codex P1): the per-TICKET map. A fleet registry holds several teams, each
+  // with its own repoRoot and its own `.catalyst/config.json` — and `linear-write.mjs`
+  // resolves repoRoot PER TICKET and hands that project's config to linear-transition.sh,
+  // including its higher-precedence per-project overrides. Installing one map process-wide
+  // therefore judged every team but the first against the wrong names: usually the current
+  // state is simply unranked and the guard goes inconclusive, but where two teams reuse a
+  // name at DIFFERENT phases it could veto a valid transition. The guard must rank a ticket
+  // against the same map the writer will use for it.
+  //
+  // (ticket) => { stateMap, source } — ranks are cached per resolved source below, so a
+  // registry read happens once per team, not once per evaluation.
+  stateMapForTicket,
   botUserIds,
   readLastStateChange,
   // CTL-2068: the ticket's CURRENT state, for the dispatch veto (the write path already
   // holds this and passes it in; the dispatch path does not).
   readCurrentState,
+  // CTL-2068 positive control: (ticket, botUserIds) => boolean|undefined — has a KNOWN
+  // fleet id ever authored a state change on this ticket? See classifyLaneClaimWrite.
+  readFleetSeen,
   // ⛔ The operator kill switch, and it covers the DISPATCH veto only. Refusing a state
   // write is benign — the write simply does not happen and the pipeline retries. Refusing
   // a DISPATCH is not: this rides the single choke point every phase dispatch passes
@@ -302,8 +350,33 @@ export function buildLaneClaimGuard({
   // CATALYST_LANE_CLAIM_DISPATCH_GUARD=off without giving up the write-side protection.
   dispatchVeto = true,
 } = {}) {
-  const rank = buildStateRank(stateMap);
+  const defaultRank = buildStateRank(stateMap);
   const keyRank = buildKeyRank();
+
+  // source label -> rank map. The label, not the ticket, is the cache key: many tickets share
+  // one project, and a project's map does not change within a daemon lifetime.
+  const rankCache = new Map();
+  const rankFor = (ticket) => {
+    if (typeof stateMapForTicket !== "function" || !ticket) return defaultRank;
+    let resolved;
+    try {
+      resolved = stateMapForTicket(ticket);
+    } catch {
+      return defaultRank; // a throwing resolver must not wedge a write
+    }
+    const label = resolved?.source ?? "none";
+    if (!rankCache.has(label)) rankCache.set(label, buildStateRank(resolved?.stateMap));
+    return rankCache.get(label);
+  };
+
+  const readFleet = (ticket) => {
+    if (typeof readFleetSeen !== "function" || !ticket) return undefined;
+    try {
+      return readFleetSeen(ticket, botUserIds);
+    } catch {
+      return undefined; // "could not look" — never an objection, never a licence
+    }
+  };
 
   const readLast = (ticket) => {
     if (typeof readLastStateChange !== "function" || !ticket) return null;
@@ -316,8 +389,14 @@ export function buildLaneClaimGuard({
   };
 
   return {
-    rank,
+    // `rank` is the DEFAULT map's rank. ⛔ Callers reporting how many states the guard can
+    // actually rank must read THIS, never the raw stateMap's key count — buildStateRank
+    // deliberately drops todo/backlog/triage/done, so a map of only those keys is nonzero
+    // while the rank is empty. That is the false-healthy this whole PR exists to expose
+    // (Codex P2).
+    rank: defaultRank,
     keyRank,
+    rankFor,
     dispatchVeto,
 
     // evaluate — the WRITE-path question: may the pipeline write `targetKey`'s state over
@@ -328,7 +407,8 @@ export function buildLaneClaimGuard({
         targetRank: keyRank.get(targetKey),
         lastChange: readLast(ticket),
         botUserIds,
-        rank,
+        rank: rankFor(ticket),
+        fleetSeen: readFleet(ticket),
       });
     },
 
@@ -365,7 +445,8 @@ export function buildLaneClaimGuard({
         targetRank: keyRank.get(targetKey),
         lastChange: readLast(ticket),
         botUserIds,
-        rank,
+        rank: rankFor(ticket),
+        fleetSeen: readFleet(ticket),
       });
     },
   };

--- a/plugins/dev/scripts/execution-core/lane-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.test.mjs
@@ -6,6 +6,7 @@ import {
   buildKeyRank,
   classifyLaneClaimWrite,
   buildLaneClaimGuard,
+  resolveStateMap,
   VERDICT,
   REASON,
 } from "./lane-claim.mjs";
@@ -405,5 +406,98 @@ describe("⛔ the STALE-HISTORY decline (Codex P1) — the 18× latency gap betw
       rank: RANK,
     });
     expect(v.verdict).toBe(VERDICT.REFUSE);
+  });
+});
+
+describe("⛔ resolveStateMap — the ladder, written after this guard shipped INERT on half the fleet", () => {
+  // Measured on the fleet right after CTL-2068 first merged:
+  //   mini-2  ranked_states: 12   (armed)
+  //   mini    ranked_states: 0    (INSTALLED AND INERT — it could never refuse)
+  // The two hosts resolve `configPath` differently: mini-2 pins CATALYST_CONFIG_FILE at the
+  // plugin-source config, mini does not and its daemon's cwd is HOME, where a
+  // `.catalyst/config.json` exists carrying no `catalyst.linear` at all.
+  const reader = (files) => (path) => {
+    if (!(path in files)) throw new Error(`ENOENT ${path}`);
+    return files[path];
+  };
+  const MAP = { research: "Research", inProgress: "Implement" };
+
+  test("returns the first candidate that yields a map, and names its source", () => {
+    const r = resolveStateMap(
+      [
+        ["registry:CTL", "/repo/.catalyst/config.json"],
+        ["configPath", "/other.json"],
+      ],
+      reader({
+        "/repo/.catalyst/config.json": JSON.stringify({ catalyst: { linear: { stateMap: MAP } } }),
+      })
+    );
+    expect(r.stateMap).toEqual(MAP);
+    expect(r.source).toBe("registry:CTL");
+  });
+
+  test("⭐⭐ THE MINI CASE — a file that PARSES but has no catalyst.linear is skipped, not accepted", () => {
+    // This is the whole reason the ladder exists. The read SUCCEEDED and returned nothing,
+    // which is worse than failing: a throw would have been visible.
+    const r = resolveStateMap(
+      [
+        ["configPath", "/home/.catalyst/config.json"], // parses, no catalyst.linear — mini
+        ["registry:CTL", "/repo/.catalyst/config.json"],
+      ],
+      reader({
+        "/home/.catalyst/config.json": JSON.stringify({ catalyst: { orchestration: {} } }),
+        "/repo/.catalyst/config.json": JSON.stringify({ catalyst: { linear: { stateMap: MAP } } }),
+      })
+    );
+    expect(r.stateMap).toEqual(MAP);
+    expect(r.source).toBe("registry:CTL");
+  });
+
+  test("an EMPTY stateMap object is not an answer either — the walk continues", () => {
+    const r = resolveStateMap(
+      [
+        ["configPath", "/a.json"],
+        ["layer2", "/b.json"],
+      ],
+      reader({
+        "/a.json": JSON.stringify({ catalyst: { linear: { stateMap: {} } } }),
+        "/b.json": JSON.stringify({ catalyst: { linear: { stateMap: MAP } } }),
+      })
+    );
+    expect(r.source).toBe("layer2");
+  });
+
+  test("unreadable and malformed candidates are skipped without throwing", () => {
+    const r = resolveStateMap(
+      [
+        ["missing", "/nope.json"],
+        ["malformed", "/bad.json"],
+        ["good", "/g.json"],
+      ],
+      reader({
+        "/bad.json": "{not json",
+        "/g.json": JSON.stringify({ catalyst: { linear: { stateMap: MAP } } }),
+      })
+    );
+    expect(r.source).toBe("good");
+  });
+
+  test("nothing resolves → { null, 'none' }, which the install line reports as INERT", () => {
+    const r = resolveStateMap([["a", "/x.json"]], reader({}));
+    expect(r).toEqual({ stateMap: null, source: "none" });
+  });
+
+  test("⛔ null/empty/omitted candidate lists do not throw", () => {
+    expect(() => resolveStateMap()).not.toThrow();
+    expect(resolveStateMap().source).toBe("none");
+    expect(
+      resolveStateMap(
+        [
+          [null, null],
+          ["x", ""],
+        ],
+        reader({})
+      ).source
+    ).toBe("none");
   });
 });

--- a/plugins/dev/scripts/execution-core/lane-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/lane-claim.test.mjs
@@ -501,3 +501,115 @@ describe("⛔ resolveStateMap — the ladder, written after this guard shipped I
     ).toBe("none");
   });
 });
+
+describe("⛔⛔ the FLEET-IDENTITY positive control — measured live, botUserIds named nobody who writes", () => {
+  // Measured on the replica right after this guard armed, CTL tickets, recent window:
+  //     c2a8cc92…  Ryan Rozich     103 state changes
+  //     78f8f491…  Catalyst Cloud   11 state changes
+  //     botUserIds = { 6dd38c1a…, ba2989f1… }   ← NEITHER of the two that actually write.
+  // Those two are the host's legacy DIRECT-write app-actors; since CTL-1889 the hosts write
+  // THROUGH the cloud proxy, which presents a different identity. So every actor read as a
+  // lane, and the guard would have refused the fleet's own legitimate backward moves.
+  const args = (fleetSeen) => ({
+    currentState: "Implement",
+    targetRank: tr("research"),
+    lastChange: { actorId: LANE, toState: "Implement" },
+    botUserIds: BOTS,
+    rank: RANK,
+    fleetSeen,
+  });
+
+  test("⭐⭐ fleetSeen=false → ABSTAIN. A discriminator that cannot discriminate must not act.", () => {
+    const v = classifyLaneClaimWrite(args(false));
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.reason).toBe(REASON.FLEET_IDENTITY_UNRECOGNIZED);
+  });
+
+  test("fleetSeen=true → the guard arms and refuses as before", () => {
+    expect(classifyLaneClaimWrite(args(true)).verdict).toBe(VERDICT.REFUSE);
+  });
+
+  test("⛔ fleetSeen=undefined ('could not look') is NOT conflated with false", () => {
+    // A replica that cannot answer must not silently disarm the guard everywhere.
+    expect(classifyLaneClaimWrite(args(undefined)).verdict).toBe(VERDICT.REFUSE);
+  });
+
+  test("the control is checked BEFORE the actor branch, so it guards the ALLOW side too", () => {
+    // Otherwise a fleet-authored row returns LAST_CHANGE_BY_FLEET on evidence we have just
+    // established we cannot trust.
+    const v = classifyLaneClaimWrite({
+      ...args(false),
+      lastChange: { actorId: FLEET, toState: "Implement" },
+    });
+    expect(v.reason).toBe(REASON.FLEET_IDENTITY_UNRECOGNIZED);
+  });
+});
+
+describe("⛔ per-TICKET state maps (Codex P1) — a fleet registry holds several teams", () => {
+  const CTL_MAP = { research: "Research", inProgress: "Implement", inReview: "PR" };
+  // A second team that reuses a NAME at a DIFFERENT phase — the case that can VETO a valid
+  // transition rather than merely go inconclusive.
+  const ADV_MAP = { research: "Implement", inProgress: "Building", inReview: "PR" };
+
+  const guard = () =>
+    buildLaneClaimGuard({
+      stateMap: CTL_MAP,
+      stateMapForTicket: (ticket) =>
+        ticket.startsWith("ADV-")
+          ? { stateMap: ADV_MAP, source: "registry:ADV" }
+          : { stateMap: CTL_MAP, source: "registry:CTL" },
+      botUserIds: BOTS,
+      readLastStateChange: () => ({ actorId: LANE, toState: "Implement" }),
+      readFleetSeen: () => true,
+    });
+
+  test("⭐ the SAME (state, phase) pair is judged differently per team, as their writers do", () => {
+    // CTL: Implement=3, research=1 → a regression, refused.
+    expect(
+      guard().evaluate({ ticket: "CTL-1", currentState: "Implement", targetKey: "research" })
+        .verdict
+    ).toBe(VERDICT.REFUSE);
+    // ADV: `research` writes "Implement", so Implement ranks 1 — moving there is NOT backwards.
+    expect(
+      guard().evaluate({ ticket: "ADV-1", currentState: "Implement", targetKey: "research" })
+        .verdict
+    ).toBe(VERDICT.ALLOW);
+  });
+
+  test("a ticket whose team is not in the resolver falls back to the default map", () => {
+    const g = buildLaneClaimGuard({
+      stateMap: CTL_MAP,
+      stateMapForTicket: () => ({ stateMap: null, source: "none" }),
+      botUserIds: BOTS,
+      readLastStateChange: () => ({ actorId: LANE, toState: "Implement" }),
+      readFleetSeen: () => true,
+    });
+    // Resolver yields nothing → empty rank → unranked current → inconclusive, never a refusal.
+    expect(
+      g.evaluate({ ticket: "ZZZ-1", currentState: "Implement", targetKey: "research" }).verdict
+    ).toBe(VERDICT.INCONCLUSIVE);
+  });
+
+  test("a THROWING per-ticket resolver falls back to the default rank rather than wedging a write", () => {
+    const g = buildLaneClaimGuard({
+      stateMap: CTL_MAP,
+      stateMapForTicket: () => {
+        throw new Error("registry gone");
+      },
+      botUserIds: BOTS,
+      readLastStateChange: () => ({ actorId: LANE, toState: "Implement" }),
+      readFleetSeen: () => true,
+    });
+    expect(
+      g.evaluate({ ticket: "CTL-1", currentState: "Implement", targetKey: "research" }).verdict
+    ).toBe(VERDICT.REFUSE);
+  });
+
+  test("⭐ `rank` reports what the guard can RANK, not the raw map's key count (Codex P2)", () => {
+    // A map of only unrankable keys: nonzero keys, EMPTY rank. Reporting Object.keys().length
+    // would print the healthy INFO line over a guard that can never refuse.
+    const g = buildLaneClaimGuard({ stateMap: { todo: "Todo", done: "Done", backlog: "Backlog" } });
+    expect(Object.keys({ todo: "Todo", done: "Done", backlog: "Backlog" }).length).toBe(3);
+    expect(g.rank.size).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -234,6 +234,15 @@ function buildEligibleSelect({ project, label } = {}) {
 // read whoever last renamed the ticket as the actor who set its state.
 const LAST_STATE_CHANGE_SELECT = `SELECT h.actor_id AS actorId, h.to_state AS toState, h.created_at AS atMs FROM issue_history h JOIN issues i ON i.id = h.issue_id WHERE i.identifier = ? AND h.to_state IS NOT NULL ORDER BY h.created_at DESC LIMIT 1`;
 
+// CTL-2068 — has any of these actor ids authored a STATE change on this ticket? The
+// POSITIVE CONTROL for the lane-claim guard: the whole verdict rests on "actorId in
+// botUserIds means the fleet", and when this guard first armed that set named two legacy
+// direct-write app-actors while every real state change was authored by the cloud proxy's
+// identity. Every actor then read as a lane. If no KNOWN fleet id has ever written this
+// ticket, the guard cannot tell the two apart here and must abstain.
+const FLEET_WROTE_SELECT = (n) =>
+  `SELECT 1 FROM issue_history h JOIN issues i ON i.id = h.issue_id WHERE i.identifier = ? AND h.to_state IS NOT NULL AND h.actor_id IN (${Array(n).fill("?").join(",")}) LIMIT 1`;
+
 const OWNERSHIP_SELECT = `SELECT assignee_id, delegate_id, delegate_name FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
 // Relation enrichment, mirroring normalizeDetail in linear-cli.mjs. forward:
 // edges this issue OWNS (relatedIssue is the target); inverse: edges that point
@@ -966,10 +975,26 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
+  // fleetEverWroteState(identifier, ids) → true | false | undefined
+  //   undefined = "could not look" (no db, empty id set, any throw). ⛔ The caller must NOT
+  //   conflate that with false: false disarms the guard for this ticket, and a replica that
+  //   cannot answer would otherwise disarm it everywhere.
+  const fleetEverWroteState = (identifier, ids) => {
+    const list = Array.isArray(ids) ? ids : ids instanceof Set ? [...ids] : [];
+    if (!identifier || list.length === 0) return undefined;
+    try {
+      return Boolean(open().prepare(FLEET_WROTE_SELECT(list.length)).get(identifier, ...list));
+    } catch {
+      dropHandle();
+      return undefined;
+    }
+  };
+
   return {
     lookup,
     freshness,
     lastStateChange, // CTL-2068
+    fleetEverWroteState, // CTL-2068
     titles,
     estimates, // CTL-1806
     relations, // CTL-1806


### PR DESCRIPTION
## The guard I merged 15 minutes ago is INERT on one of the two hosts

Read straight off the install line's own field, on both minis, after `18d8eb99d` restarted them:

| host | `ranked_states` | |
| -- | -- | -- |
| `mini-2` | **12** | armed |
| `mini` | **0** | ⛔ **installed and inert — it can never refuse anything** |

Both logged `ctl-2068: lane-claim guard installed`. Both looked healthy. **The count is the only thing that distinguished them, and it exists only because the install line happens to log it.**

## Cause

`configPath` is `CATALYST_CONFIG_FILE || <cwd>/.catalyst/config.json`, and the two hosts differ:

- **mini-2** pins `CATALYST_CONFIG_FILE=/Users/ryan/catalyst/plugin-source/.catalyst/config.json` → the map is found.
- **mini** does not pin it, and its daemon's cwd is `/Users/ryanrozich` — the HOME dir — where a `.catalyst/config.json` **does exist**, carrying `{"catalyst": {...}}` with **no `catalyst.linear` at all**.

⛔ So the read **succeeded and returned nothing**, which is worse than failing: a throw would have been caught by the `try` and looked the same, but an absent file would at least have been a plausible suspicion. A successful read of the wrong file is invisible.

⭐ **This is the same shape as the defect the guard exists to fix, one level up:** a mechanism held by an accident of per-host configuration, reporting healthy either way. It is also the same divergence CTL-2059 spent this morning committing to git.

## Fix

`resolveStateMap(candidates, readFile)` — pure — walks an ordered `[label, path]` list and takes the **first that yields a NON-EMPTY map**. A file that parses but carries no map is **not an answer**; the walk continues.

Order: **the registry's repoRoots first**, then `configPath`, then Layer-2. The registry rung is not a fallback, it is the authoritative one — `linear-transition.sh`, which performs the very write this guard judges, is invoked with `--config <repoRoot>/.catalyst/config.json`. Ranking off any other file risks judging against a map the writer does not use.

## And the log line now fails loudly

`ranked_states === 0` logs at **WARN** — *"lane-claim guard installed but INERT — no state map resolved, it can never refuse"* — and names the resolved source. The healthy-looking INFO is precisely what let the inert install sit unnoticed.

## Verification

52 tests. Two more mutations red:

- **accepting an empty/absent map** — restores the mini bug exactly; 2 tests fail
- **stopping the walk at the first candidate** — 1 test fails

The load-bearing test is `⭐⭐ THE MINI CASE`: a candidate that **parses** but has no `catalyst.linear` must be skipped in favour of a later one. Plus: empty-map-object skipped, malformed/unreadable skipped without throwing, nothing-resolves → `{null, "none"}`, and the no-args shape does not throw.

Refs CTL-2068, CTL-2059