### PR TITLE
fix(execution-core): OTL-67 — SDK-dispatched workers lose per-ticket OTEL_RESOURCE_ATTRIBUTES to settings.json pin

### DIFF
--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -987,6 +987,18 @@ export function buildQueryOptions(spec, env, { turnCap } = {}) {
     allowDangerouslySkipPermissions: true,
     systemPrompt: { type: "preset", preset: "claude_code" }, // keep CLI behavior
   };
+  // OTL-67: settingSources ["user","project"] means a host's join-provisioned
+  // ~/.claude/settings.json (catalyst-join.sh provision_claude_settings, pinned
+  // to `host.name=<self>` for interactive-session host identity, CTL-1231) wins
+  // over the plain `env` above for OTEL_RESOURCE_ATTRIBUTES specifically — every
+  // SDK-dispatched worker's per-ticket project/branch/linear.key silently
+  // collapsed to just host_name on export. `options.settings` loads into the
+  // "flag settings" layer, which per sdk.d.ts outranks user/project
+  // (user < project < local < flag < policy) — set OTEL_RESOURCE_ATTRIBUTES
+  // there too so the per-job value wins instead of the host-level pin.
+  if (typeof env.OTEL_RESOURCE_ATTRIBUTES === "string" && env.OTEL_RESOURCE_ATTRIBUTES.length > 0) {
+    options.settings = { env: { OTEL_RESOURCE_ATTRIBUTES: env.OTEL_RESOURCE_ATTRIBUTES } };
+  }
   // CTL-1367 item 6: bound the run by the per-phase turn cap. Precedence: an
   // explicit option override (tests/tuning), else the spec's turnCap (the value
   // phase-agent-dispatch resolved for this phase). Without this the SDK ran

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -204,6 +204,25 @@ describe("buildQueryOptions", () => {
     expect(o.resume).toBe("sess-abc");
     expect(o.cwd).toBe("/wt/CTL-100");
   });
+  // OTL-67: settingSources ["user","project"] means a join-provisioned
+  // ~/.claude/settings.json (host.name=<self> pin, CTL-1231) wins over plain
+  // `env` for OTEL_RESOURCE_ATTRIBUTES — mirror the per-job value into the
+  // higher-precedence "flag settings" layer (options.settings) so it isn't
+  // silently collapsed to just host_name on every SDK-dispatched worker.
+  test("OTEL_RESOURCE_ATTRIBUTES from env is mirrored into options.settings.env (flag-settings tier)", () => {
+    const o = buildQueryOptions(
+      makeSpec(),
+      { OTEL_RESOURCE_ATTRIBUTES: "host.name=mini,project=catalyst-cloud,linear.key=CTC-758" },
+      {},
+    );
+    expect(o.settings).toEqual({
+      env: { OTEL_RESOURCE_ATTRIBUTES: "host.name=mini,project=catalyst-cloud,linear.key=CTC-758" },
+    });
+  });
+  test("options.settings is omitted when env carries no OTEL_RESOURCE_ATTRIBUTES", () => {
+    expect("settings" in buildQueryOptions(makeSpec(), {}, {})).toBe(false);
+    expect("settings" in buildQueryOptions(makeSpec(), { OTEL_RESOURCE_ATTRIBUTES: "" }, {})).toBe(false);
+  });
 });
 
 // ── resolveMaxParallel + Semaphore ────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Fleet's SDK-dispatched execution-core workers export `claude_code_*` OTel
metrics with only `host_name`/`session_id`/`type` — no `project`/`branch`/
`linear_key`. Downstream, the `catalyst-otel` "Token Burn by Ticket" and
"Token Burn by Project" dashboard panels read `No data` despite real spend.

## Root cause (traced live on `mini`, ticket CTC-758)

- `buildSdkEnv()` in `sdk-run-phase-agent.mjs` composes the correct per-ticket
  `OTEL_RESOURCE_ATTRIBUTES` (confirmed via `ps eww` on the live spawned
  `claude` child's process env — the value is present and correct).
- But `query()` is always called with `settingSources: ["user","project"]`
  (required so plugin phase skills resolve), and the host's join-provisioned
  `~/.claude/settings.json` (`catalyst-join.sh provision_claude_settings`,
  CTL-1231) pins `env.OTEL_RESOURCE_ATTRIBUTES` to `host.name=<self>` only —
  intentional for *interactive* sessions to keep telemetry host identity
  honest, but nobody anticipated it also applying to SDK-dispatched per-job
  children. That pin wins over the plain `options.env` value for this key.

## Fix

Mirror the per-job `OTEL_RESOURCE_ATTRIBUTES` into `options.settings.env` as
well — the Agent SDK's "flag settings" tier, documented (`sdk.d.ts`) to
outrank `user`/`project`/`local` (`user < project < local < flag < policy`).
This is a same-day in-repo change, not an upstream SDK ask.

## Testing

- Added unit coverage in `sdk-run-phase-agent.test.mjs`: `options.settings.env`
  is set from `env.OTEL_RESOURCE_ATTRIBUTES` when present, omitted when absent
  or empty.
- Full existing suite still green: `bun test sdk-run-phase-agent.test.mjs` —
  151 pass, 0 fail.
- **Not yet verified against a live re-dispatch** — needs one real SDK worker
  cycle on `mini` post-deploy to confirm the exported Prometheus series
  actually carries `project`/`branch`/`linear_key` (tracked on OTL-67).

Refs OTL-67