### PR TITLE
fix(dev): CTL-1889 inc 4 — a status write with no linearis stopped reporting itself applied

### DIFF
--- a/plugins/dev/scripts/__tests__/linear-transition.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-transition.test.sh
@@ -833,6 +833,44 @@ run "NEGATIVE CONTROL: --dry-run on the same PATH does NOT resolve (it stops at 
     '$TRANSITION' --ticket TST-36 --transition inProgress --config '$WORK36/.catalyst/config.json' \
     --dry-run --json | grep -q 'skipped-no-linearis'"
 
+# ─── Test 37-38: --json still reports a real write on a jq-less host (CTL-1889
+# Codex P2, round 1, #3724) ─────────────────────────────────────────────────
+# jq is not a required repo dependency, so linearis-installed-but-jq-absent is a
+# supported shape — the exact one CTL-1889 migrates toward. Before this fix,
+# emit()'s jq-only JSON path silently produced no stdout on such a host, and
+# linear-write.mjs's allowlist (added earlier in this same PR) then reported a
+# REAL successful transition as `not-applied-unknown`, so the reconciliation
+# timer retried a write that had already landed. PATH here is JUST the fake
+# linearis + sed/tr (what emit()'s jq-less fallback needs) — no /usr/bin, so
+# jq is genuinely unresolvable, not merely unused. --state bypasses every
+# other jq-gated lookup (config stateMap, registry UUID cache) so this isolates
+# emit() specifically.
+WORK37="${SCRATCH}/t37"
+BIN37="${SCRATCH}/t37/bin"
+LOG37="${SCRATCH}/t37/log"
+mkdir -p "$BIN37"
+install_fake_linearis "$BIN37"
+touch "$LOG37"
+# The restricted PATH below is the ONLY PATH the script sees — it must supply
+# everything the script needs to even start (env, bash, for the #!/usr/bin/env
+# bash shebang; dirname/cat, sourced at the top) as well as what emit()'s
+# jq-less fallback uses (sed, tr) — deliberately with no jq anywhere on it.
+for _t in sed tr dirname cat env bash; do
+  ln -sf "$(command -v "$_t")" "${BIN37}/${_t}"
+done
+BASH_ABS37="$(command -v bash)"
+
+run "⭐ --json on a jq-less host still reports action=transitioned (not silently empty)" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG37' PATH='$BIN37' HOME='$HOME' \
+    '$BASH_ABS37' '$TRANSITION' --ticket TST-37 --state Done --json 2>/dev/null | grep -q '\"action\":\"transitioned\"'"
+
+run "jq-less --json output still contains ticket and targetState (manual JSON, not jq)" \
+  bash -c "FAKE_LINEARIS_LOG='$LOG37' PATH='$BIN37' HOME='$HOME' \
+    '$BASH_ABS37' '$TRANSITION' --ticket TST-37 --state Done --json 2>/dev/null | grep -q '\"ticket\":\"TST-37\".*\"targetState\":\"Done\"'"
+
+run "jq-less path: the write really happened (linearis was invoked, not skipped)" \
+  bash -c "grep -q 'linearis issues update TST-37' '$LOG37'"
+
 echo ""
 echo "Results: ${PASSES} passed, ${FAILURES} failed"
 [ "$FAILURES" = "0" ]

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -404,11 +404,27 @@ function runTransition({
     } catch {
       /* non-JSON stdout — leave action/from_state/to_state null */
     }
-    const applied = code === 0 && action !== "update-failed";
+    // CTL-1889: an ALLOWLIST, not a denylist. linear-transition.sh's `skipped`
+    // (already in target — a real success) and `transitioned` (a real write)
+    // are the only two actions that mean the ticket's Linear state is now
+    // correct. Everything else that can exit 0 — `resolve-only` (a caller
+    // deliberately asked for no write), `dry-run`, and, critically,
+    // `skipped-no-linearis` (linearis isn't installed — exactly the
+    // no-Linear-credential host CTL-1889 is migrating TOWARD) — used to fall
+    // through the OLD `action !== "update-failed"` denylist as applied:true, a
+    // fabricated success on the one host this write was supposed to prove
+    // works without a token. An allowlist also fails safe for any FUTURE
+    // action linear-transition.sh adds: unlisted defaults to not-applied
+    // rather than silently defaulting to applied.
+    const applied = code === 0 && (action === "transitioned" || action === "skipped");
     if (!applied) {
       log.warn({ ticket, key, code, action }, "linear-write: status write not applied");
     }
-    return { applied, reason: applied ? null : `exit-${code}`, action, from_state, to_state };
+    // A non-zero exit still names itself by code; a zero exit that didn't
+    // apply names the actual action so "no-linearis" is never confused with
+    // "resolve-only" or "dry-run" in the audit trail.
+    const reason = applied ? null : code === 0 ? `not-applied-${action ?? "unknown"}` : `exit-${code}`;
+    return { applied, reason, action, from_state, to_state };
   } catch (err) {
     log.warn(
       { ticket, key, err: err.message },

--- a/plugins/dev/scripts/execution-core/linear-write.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.test.mjs
@@ -295,6 +295,55 @@ describe("CTL-757: runTransition from_state/to_state propagation", () => {
     expect(r.from_state).toBe(r.to_state);
   });
 
+  // CTL-1889: the negative control. linear-transition.sh's own header names the
+  // TARGET state as "a host with NO Linear credential and no reason to have
+  // linearis installed" — exactly the host this action fires on. The OLD
+  // denylist (`action !== "update-failed"`) read a zero exit + this action as
+  // applied:true — a fabricated success on the one host that must fail loudly.
+  test("CTL-1889: linearis not installed (skipped-no-linearis) ⇒ applied:false, NAMED reason, not a fabricated success", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "skipped-no-linearis", currentState: "", targetState: "" }),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("not-applied-skipped-no-linearis");
+  });
+
+  test("CTL-1889: a caller's deliberate --resolve-only is NOT read as applied", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "resolve-only", currentState: "PR", targetState: "" }),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("not-applied-resolve-only");
+  });
+
+  test("CTL-1889: dry-run is NOT read as applied", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "dry-run", currentState: "PR", targetState: "Validate" }),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("not-applied-dry-run");
+  });
+
+  test("CTL-1889: an unrecognized future action defaults to NOT applied (fail-safe allowlist)", () => {
+    const r = applyPhaseStatus({
+      ticket: "CTL-1",
+      phase: "verify",
+      resolveRepoRoot,
+      exec: transitionExec({ action: "some-new-action-nobody-allowlisted-yet", currentState: "PR", targetState: "Validate" }),
+    });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("not-applied-some-new-action-nobody-allowlisted-yet");
+  });
+
   test("failure path (exit non-zero, update-failed) still returns from_state + reason", () => {
     const r = applyPhaseStatus({
       ticket: "CTL-1",

--- a/plugins/dev/scripts/linear-transition.sh
+++ b/plugins/dev/scripts/linear-transition.sh
@@ -187,21 +187,41 @@ if [ -z "$TARGET_STATE_ID" ] && [ -n "$TEAM_KEY" ] && [ "$DRY_RUN" -ne 1 ] && [ 
 fi
 STATUS_ARG="${TARGET_STATE_ID:-$TARGET_STATE}"
 
+# CTL-1889 Codex P2 (round 1, #3724): jq is not a required dependency, so a
+# jq-less host (linearis installed, jq absent) must still be able to emit
+# valid JSON — linear-write.mjs parses `action` from stdout to decide
+# `applied`. Before this, a jq-less emit() call under --json silently
+# produced no stdout (command-not-found), so a REAL successful transition
+# was reported as `not-applied-unknown` and retried forever by the
+# reconciliation timer. Escaping is minimal (backslash, double-quote,
+# newline) because every field here is a ticket id, a Linear state name, or
+# a static message string — never arbitrary user input.
+_json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr '\n' ' '
+}
+
 # ─── Emit a JSON or human-readable result ──────────────────────────────────
 emit() {
   local action="$1" current="$2" message="$3"
   if [ "$JSON_OUT" -eq 1 ]; then
-    jq -nc \
-      --arg ticket "$TICKET" \
-      --arg targetState "$TARGET_STATE" \
-      --arg currentState "$current" \
-      --arg transition "$TRANSITION" \
-      --arg action "$action" \
-      --arg message "$message" \
-      --arg targetStateId "$TARGET_STATE_ID" \
-      '{ticket:$ticket, targetState:$targetState, currentState:$currentState,
-        transition:$transition, action:$action, message:$message,
-        targetStateId:$targetStateId}'
+    if command -v jq >/dev/null 2>&1; then
+      jq -nc \
+        --arg ticket "$TICKET" \
+        --arg targetState "$TARGET_STATE" \
+        --arg currentState "$current" \
+        --arg transition "$TRANSITION" \
+        --arg action "$action" \
+        --arg message "$message" \
+        --arg targetStateId "$TARGET_STATE_ID" \
+        '{ticket:$ticket, targetState:$targetState, currentState:$currentState,
+          transition:$transition, action:$action, message:$message,
+          targetStateId:$targetStateId}'
+    else
+      printf '{"ticket":"%s","targetState":"%s","currentState":"%s","transition":"%s","action":"%s","message":"%s","targetStateId":"%s"}\n' \
+        "$(_json_escape "$TICKET")" "$(_json_escape "$TARGET_STATE")" "$(_json_escape "$current")" \
+        "$(_json_escape "$TRANSITION")" "$(_json_escape "$action")" "$(_json_escape "$message")" \
+        "$(_json_escape "$TARGET_STATE_ID")"
+    fi
   else
     printf '%s — %s (target=%s)' "$TICKET" "$action" "$TARGET_STATE"
     [ -n "$current" ] && printf ' (current=%s)' "$current"


### PR DESCRIPTION
## Summary

`linear-transition.sh`'s own header names the end state of CTL-1889 as *"a host with NO Linear credential and no reason to have linearis installed."* But the ticket's own negative-control acceptance criterion — *"a host attempting a direct Linear write with no token fails LOUDLY (named reason), not silently"* — was failing, silently, in exactly that scenario.

## The bug

`runTransition`'s `applied` computation in `linear-write.mjs` was a **denylist**:

```js
const applied = code === 0 && action !== "update-failed";
```

`linear-transition.sh` exits `0` and emits `action: "skipped-no-linearis"` when `linearis` isn't installed — that's not `"update-failed"`, so it read as `applied: true`. **A fabricated success on the one host this write path is supposed to prove works without a token.** The same denylist also fabricated success for `"resolve-only"` (a caller deliberately asked for no write) and `"dry-run"`.

## The fix

Flips to an **allowlist** — only `"transitioned"` (a real write) and `"skipped"` (already in the target state — a genuine no-op success) count as `applied: true`. Everything else defaults to not-applied, which fails safe for any action `linear-transition.sh` adds later too. The `reason` for a zero-exit non-apply now names the actual action (`not-applied-skipped-no-linearis`, `not-applied-resolve-only`, `not-applied-dry-run`) instead of the previously-misleading `exit-0`, satisfying "fails LOUDLY (named reason)."

## Tests

4 new tests in `linear-write.test.mjs` pin all three previously-mishandled actions plus a fail-safe check for an unrecognized future action. All 100 tests in the file pass (96 pre-existing + 4 new), including the pinned `"idempotent skip (action:skipped) — applied:true"` case that confirms the allowlist didn't regress the one legitimate no-op-success path.

## Scope note — what this PR is deliberately NOT

CTL-1889's full acceptance is "a host with no Linear credential completes a full ticket pipeline" + "doctor FAILs if a token is present." Neither is true yet, and this PR doesn't claim otherwise:

- **`applyAssignee`/`applyEstimate`/`applyBlockedByRelation`** (`linear-write.mjs`) still shell `linearis` directly with no proxy seam — they genuinely need a token today.
- **CTC-692's cluster-fence/heartbeat proxy** (inc3) defaults `CATALYST_LINEAR_WRITE_PROXY=off`, so those writes still go direct until an operator flips it per host.
- A doctor check that FAILs a worker carrying a Linear token would be a **false positive** against those two gaps right now — it needs to ship *after* they're closed, not before. Tracked as CTL-1889's remaining increment.

This PR closes the one concrete, measured silent-failure bug in isolation: it's correct regardless of when the rest lands, and it's the difference between "the negative control is broken" and "the negative control doesn't exist yet."

## Related

Part of https://linear.app/coalesce/issue/CTL-1889 (increments 1–3 already merged: #3489, #3547, #3555).