### PR TITLE
fix(dev): CTL-2076 — setup_project_config preserves committed Linear identity on regen; surface the registry team-identity mismatch (CAT-52)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -520,6 +520,16 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/setup-cloud-replica.test.sh
 
+      - name: setup-catalyst.sh stateMap preservation (CTL-2076)
+        # CTL-2076: this workflow allowlists shell suites by name rather than globbing
+        # __tests__/, so a new suite runs in required CI only once registered here.
+        # Guards both clobber paths setup_project_config / update_config_with_linear_states
+        # can take over a committed, non-empty linear.stateMap on a credentialed re-run —
+        # the regression this ticket fixes. Carries its own positive control (T5: a fresh
+        # install still refreshes the map from Linear, so the guard is not over-broad).
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/setup-catalyst-config-preserve.test.sh
+
       - name: host write-credential classifier parity (CTL-2045)
         # ⛔ Codex P2 on #3706, and the important one. This suite is
         # the ONLY thing holding lib/host-write-credential.mjs (the

--- a/plugins/dev/scripts/__tests__/setup-catalyst-config-preserve.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-config-preserve.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Tests for setup_project_config()'s ticketPrefix/teamKey/stateMap preservation
+# across a config regeneration (CTL-2076). A non-interactive setup run must NOT
+# clobber a committed CTL config back to PROJ + a generic stateMap (the mechanism
+# that rewrote mini-2's CTL checkout to team PROJ, wedging the lane-claim guard).
+#
+# Mirrors the existing thoughts.* (CTL-1214) and deployment.mode (CTL-1622)
+# preservation-vs-fresh matrices in setup-catalyst-noninteractive.test.sh.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+SETUP="${REPO_ROOT}/setup-catalyst.sh"
+FAILURES=0; PASSES=0
+pass() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1${2:+ ($2)}"; }
+
+echo "=== CTL-2076: setup_project_config preserves committed Linear identity ==="
+
+# T1: regen over a CTL config with a DIFFERING projectKey (forces the re-write
+# path) must PRESERVE the committed ticketPrefix/teamKey and the real stateMap —
+# NOT clobber them to PROJ / In Progress / In Review.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+cat > "$spc_scratch/proj/.catalyst/config.json" <<'JSON'
+{
+  "catalyst": {
+    "projectKey": "old-key",
+    "project": { "ticketPrefix": "CTL", "name": "Catalyst" },
+    "linear": {
+      "teamKey": "CTL",
+      "stateMap": {
+        "backlog": "Backlog",
+        "todo": "Todo",
+        "research": "Research",
+        "planning": "Plan",
+        "inProgress": "Implement",
+        "inReview": "PR",
+        "done": "Done",
+        "canceled": "Canceled"
+      }
+    }
+  }
+}
+JSON
+spc_out=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=coalesce-labs
+  REPO_NAME=catalyst
+  PROJECT_KEY=new-key
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.project.ticketPrefix + \"|\" + .catalyst.linear.teamKey + \"|\" + .catalyst.linear.stateMap.inProgress + \"|\" + .catalyst.linear.stateMap.inReview + \"|\" + .catalyst.linear.stateMap.research' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_out" == "CTL|CTL|Implement|PR|Research" ]] \
+  && pass "regen preserves committed ticketPrefix/teamKey/stateMap (CTL/Implement/PR/Research)" \
+  || fail "regen preserves committed ticketPrefix/teamKey/stateMap" "$spc_out"
+
+# T2: a truly-fresh setup (NO existing config) is byte-identical to today's
+# documented defaults: ticketPrefix=PROJ, teamKey=PROJ, generic 8-key stateMap
+# (inProgress=In Progress, inReview=In Review).
+spc_scratch=$(mktemp -d)
+spc_fresh=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=acme-org
+  REPO_NAME=acme-repo
+  PROJECT_KEY=acme-org
+  PROJECT_DIR='$spc_scratch/proj'
+  mkdir -p \"\$PROJECT_DIR\"
+  setup_project_config >/dev/null 2>&1
+  jq -r '.catalyst.project.ticketPrefix + \"|\" + .catalyst.linear.teamKey + \"|\" + .catalyst.linear.stateMap.inProgress + \"|\" + .catalyst.linear.stateMap.inReview + \"|\" + (.catalyst.linear.stateMap | length | tostring)' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_fresh" == 'PROJ|PROJ|In Progress|In Review|8' ]] \
+  && pass "fresh setup keeps documented defaults (PROJ/PROJ/generic 8-key stateMap)" \
+  || fail "fresh setup keeps documented defaults" "$spc_fresh"
+
+# T3: the regenerated file over a CTL config is still VALID JSON and the untouched
+# fields behave as before — projectKey updates to the detected key, repository is
+# written, and the fresh-install invariants (thoughts.*) stay non-null.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst"
+cat > "$spc_scratch/proj/.catalyst/config.json" <<'JSON'
+{
+  "catalyst": {
+    "projectKey": "old-key",
+    "project": { "ticketPrefix": "CTL", "name": "Catalyst" },
+    "linear": { "teamKey": "CTL", "stateMap": { "inProgress": "Implement", "inReview": "PR" } }
+  }
+}
+JSON
+spc_valid=$(env -i HOME="$spc_scratch/home" PATH="/usr/bin:/bin" bash -c "
+  source '$SETUP'
+  NON_INTERACTIVE=1
+  ORG_NAME=coalesce-labs
+  REPO_NAME=catalyst
+  PROJECT_KEY=new-key
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  cfg=\"\$PROJECT_DIR/.catalyst/config.json\"
+  if jq empty \"\$cfg\" 2>/dev/null; then
+    jq -r '.catalyst.projectKey + \"|\" + .catalyst.repository.name + \"|\" + (.catalyst.thoughts.directory != null and .catalyst.thoughts.directory != \"\" | tostring)' \"\$cfg\"
+  else
+    echo INVALID_JSON
+  fi
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_valid" == "new-key|catalyst|true" ]] \
+  && pass "regen writes valid JSON with untouched fields (projectKey/repo/thoughts) intact" \
+  || fail "regen writes valid JSON with untouched fields intact" "$spc_valid"
+
+echo ""
+echo "Results: $PASSES passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/setup-catalyst-config-preserve.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-catalyst-config-preserve.test.sh
@@ -111,6 +111,89 @@ rm -rf "$spc_scratch"
   && pass "regen writes valid JSON with untouched fields (projectKey/repo/thoughts) intact" \
   || fail "regen writes valid JSON with untouched fields intact" "$spc_valid"
 
+# T4: the FULL credentialed flow preserves a committed map (CTL-2076 P1). After
+# setup_project_config keeps the committed non-empty map (setting
+# CATALYST_STATEMAP_PRESERVED=1), the subsequent update_config_with_linear_states MUST
+# honor it and skip the Linear-derived refresh — otherwise the positional heuristic in
+# build_state_map_from_linear collapses research/planning/inProgress to a single started
+# name (here Plan/Plan) and rewrites inReview. fetch_linear_workflow_states is STUBBED to
+# a states array that WOULD collapse the map, proving the guard (not a failed API call) is
+# what preserves it. A secrets file with a token+team is present so the refresh would run.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst" "$spc_scratch/home/.config/catalyst"
+cat > "$spc_scratch/proj/.catalyst/config.json" <<'JSON'
+{
+  "catalyst": {
+    "projectKey": "old-key",
+    "project": { "ticketPrefix": "CTL", "name": "Catalyst" },
+    "linear": {
+      "teamKey": "CTL",
+      "stateMap": {
+        "backlog": "Backlog", "todo": "Todo",
+        "research": "Research", "planning": "Plan", "inProgress": "Implement",
+        "inReview": "PR", "done": "Done", "canceled": "Canceled"
+      }
+    }
+  }
+}
+JSON
+cat > "$spc_scratch/home/.config/catalyst/config-new-key.json" <<'JSON'
+{ "catalyst": { "linear": { "apiToken": "lin_api_dummy", "teamKey": "CTL" } } }
+JSON
+spc_full=$(env -i HOME="$spc_scratch/home" PATH="$PATH" bash -c "
+  source '$SETUP'
+  # Stub the Linear fetch so build_state_map_from_linear runs on a collapsing states set.
+  fetch_linear_workflow_states() { echo '[{\"name\":\"Backlog\",\"type\":\"backlog\",\"position\":0},{\"name\":\"Todo\",\"type\":\"unstarted\",\"position\":1},{\"name\":\"Plan\",\"type\":\"started\",\"position\":2},{\"name\":\"In Review\",\"type\":\"started\",\"position\":3},{\"name\":\"Done\",\"type\":\"completed\",\"position\":4},{\"name\":\"Canceled\",\"type\":\"canceled\",\"position\":5}]'; }
+  NON_INTERACTIVE=1
+  ORG_NAME=coalesce-labs
+  REPO_NAME=catalyst
+  PROJECT_KEY=new-key
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  update_config_with_linear_states >/dev/null 2>&1
+  jq -r '.catalyst.linear.stateMap.research + \"|\" + .catalyst.linear.stateMap.inProgress + \"|\" + .catalyst.linear.stateMap.inReview' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_full" == "Research|Implement|PR" ]] \
+  && pass "credentialed full flow preserves committed stateMap through update_config_with_linear_states" \
+  || fail "credentialed full flow preserves committed stateMap through update_config_with_linear_states" "$spc_full"
+
+# T5: the guard is NOT over-broad — a fresh install still gets its stateMap refreshed from
+# Linear. A config with NO stateMap makes setup_project_config write the generic default
+# (leaving CATALYST_STATEMAP_PRESERVED=0), so update_config_with_linear_states DOES run the
+# refresh and the same stubbed states collapse the started keys to Plan/Plan. This is the
+# positive control for T4: it proves the refresh path is intact, not merely disabled.
+spc_scratch=$(mktemp -d)
+mkdir -p "$spc_scratch/proj/.catalyst" "$spc_scratch/home/.config/catalyst"
+cat > "$spc_scratch/proj/.catalyst/config.json" <<'JSON'
+{
+  "catalyst": {
+    "projectKey": "old-key",
+    "project": { "ticketPrefix": "CTL", "name": "Catalyst" },
+    "linear": { "teamKey": "CTL" }
+  }
+}
+JSON
+cat > "$spc_scratch/home/.config/catalyst/config-new-key.json" <<'JSON'
+{ "catalyst": { "linear": { "apiToken": "lin_api_dummy", "teamKey": "CTL" } } }
+JSON
+spc_refresh=$(env -i HOME="$spc_scratch/home" PATH="$PATH" bash -c "
+  source '$SETUP'
+  fetch_linear_workflow_states() { echo '[{\"name\":\"Backlog\",\"type\":\"backlog\",\"position\":0},{\"name\":\"Todo\",\"type\":\"unstarted\",\"position\":1},{\"name\":\"Plan\",\"type\":\"started\",\"position\":2},{\"name\":\"In Review\",\"type\":\"started\",\"position\":3},{\"name\":\"Done\",\"type\":\"completed\",\"position\":4},{\"name\":\"Canceled\",\"type\":\"canceled\",\"position\":5}]'; }
+  NON_INTERACTIVE=1
+  ORG_NAME=coalesce-labs
+  REPO_NAME=catalyst
+  PROJECT_KEY=new-key
+  PROJECT_DIR='$spc_scratch/proj'
+  setup_project_config >/dev/null 2>&1
+  update_config_with_linear_states >/dev/null 2>&1
+  jq -r '.catalyst.linear.stateMap.research + \"|\" + .catalyst.linear.stateMap.inProgress + \"|\" + .catalyst.linear.stateMap.inReview' \"\$PROJECT_DIR/.catalyst/config.json\"
+" 2>/dev/null)
+rm -rf "$spc_scratch"
+[[ "$spc_refresh" == "Plan|Plan|In Review" ]] \
+  && pass "fresh install still refreshes stateMap from Linear (guard is not over-broad)" \
+  || fail "fresh install still refreshes stateMap from Linear" "$spc_refresh"
+
 echo ""
 echo "Results: $PASSES passed, $FAILURES failed"
 exit "$FAILURES"

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -53,6 +53,9 @@ import { DEP_SKEW_RESTART_EVENT, DEP_SKEW_WOULD_RESTART_EVENT } from "../executi
 // CTL-1889 — the Linear write-proxy trio, imported from its owning module so a
 // rename cannot leave a re-typed literal behind that still passes.
 import { PROXY_EVENT_NAMES } from "../execution-core/linear-write-proxy.mjs";
+// CTL-2076 — the registry team-identity mismatch (CAT-52) event, imported from its
+// owning module rather than re-typed as a literal (same precedent as CTL-1659/CTL-1889).
+import { CONFIG_TEAM_IDENTITY_MISMATCH } from "../execution-core/config-identity-event.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -99,6 +102,7 @@ const EXEC_CORE_EVENT_NAMES = [
   DEP_SKEW_RESTART_EVENT, // CTL-1659 cloud-sync.mjs — the writer restarting to load an installed dep fix
   DEP_SKEW_WOULD_RESTART_EVENT, // CTL-1659 — sustained skew that did NOT act (shadow / budget / undurable ledger)
   ...PROXY_EVENT_NAMES, // CTL-1889 linear-write-proxy.mjs — would-write / applied / failed
+  CONFIG_TEAM_IDENTITY_MISMATCH, // CTL-2076 config-identity-event.mjs — registry team-identity mismatch (CAT-52), boot telemetry
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/execution-core/config-identity-event.mjs
+++ b/plugins/dev/scripts/execution-core/config-identity-event.mjs
@@ -1,0 +1,28 @@
+// config-identity-event.mjs — CTL-2076. Surface a registry team-identity
+// mismatch (CAT-52) on the unified event log, not only in doctor's advisory WARN.
+//
+// Zero-import leaf (no node:*, no sibling imports) so the pure builder stays
+// cheap and unit-testable without booting the daemon — the same pure-core /
+// thin-wiring split lane-claim.mjs itself uses.
+export const CONFIG_TEAM_IDENTITY_MISMATCH = "config.registry-team-identity.mismatch";
+
+// Pure: registry projects (from listProjects()) → operator-event objects,
+// one per PROVEN mismatch (identity.matches === false). Unknown (matches ===
+// null) is NOT a mismatch and is skipped — the same three-valued discipline
+// teamIdentityOf and the CAT-52 doctor check use. A null / malformed entry is
+// skipped without throwing.
+export function buildTeamIdentityMismatchEvents(projects) {
+  const out = [];
+  for (const p of projects ?? []) {
+    if (p?.identity?.matches !== false) continue;
+    out.push({
+      "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+      payload: {
+        team: p.team ?? null,
+        repoRoot: p.repoRoot ?? null,
+        declared: p.identity?.declared ?? null,
+      },
+    });
+  }
+  return out;
+}

--- a/plugins/dev/scripts/execution-core/config-identity-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-identity-event.test.mjs
@@ -1,0 +1,100 @@
+// config-identity-event.test.mjs — CTL-2076.
+// Unit matrix for the pure buildTeamIdentityMismatchEvents builder + the
+// exported event-name constant. Covers empty, all-match, unknown (matches ===
+// null), single proven mismatch (exact payload shape), two mismatches
+// (order-preserving), and a malformed/null entry mixed in (skipped, no throw).
+//
+// Run: bun test plugins/dev/scripts/execution-core/config-identity-event.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import {
+  CONFIG_TEAM_IDENTITY_MISMATCH,
+  buildTeamIdentityMismatchEvents,
+} from "./config-identity-event.mjs";
+
+describe("CONFIG_TEAM_IDENTITY_MISMATCH constant", () => {
+  test("is the literal event name", () => {
+    expect(CONFIG_TEAM_IDENTITY_MISMATCH).toBe("config.registry-team-identity.mismatch");
+  });
+});
+
+describe("buildTeamIdentityMismatchEvents", () => {
+  test("empty input → []", () => {
+    expect(buildTeamIdentityMismatchEvents([])).toEqual([]);
+  });
+
+  test("null / undefined input → [] (no throw)", () => {
+    expect(buildTeamIdentityMismatchEvents(null)).toEqual([]);
+    expect(buildTeamIdentityMismatchEvents(undefined)).toEqual([]);
+  });
+
+  test("all entries matches === true → []", () => {
+    const projects = [
+      { team: "CTL", repoRoot: "/a", identity: { declared: "CTL", matches: true } },
+      { team: "CAT", repoRoot: "/b", identity: { declared: "CAT", matches: true } },
+    ];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([]);
+  });
+
+  test("matches === null (unverifiable) → [] — unknown is not a mismatch", () => {
+    const projects = [
+      { team: "CTL", repoRoot: "/a", identity: { declared: null, matches: null } },
+      { team: "CAT", repoRoot: "/b", identity: { declared: null, matches: null } },
+    ];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([]);
+  });
+
+  test("a single proven mismatch → exactly one event with the exact payload shape", () => {
+    const projects = [
+      { team: "CTL", repoRoot: "/x", identity: { declared: "PROJ", matches: false } },
+    ];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([
+      {
+        "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+        payload: { team: "CTL", repoRoot: "/x", declared: "PROJ" },
+      },
+    ]);
+  });
+
+  test("two mismatches → two events, order-preserving", () => {
+    const projects = [
+      { team: "CTL", repoRoot: "/x", identity: { declared: "PROJ", matches: false } },
+      { team: "CAT", repoRoot: "/y", identity: { declared: "OTHER", matches: false } },
+    ];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([
+      {
+        "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+        payload: { team: "CTL", repoRoot: "/x", declared: "PROJ" },
+      },
+      {
+        "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+        payload: { team: "CAT", repoRoot: "/y", declared: "OTHER" },
+      },
+    ]);
+  });
+
+  test("a null / malformed entry mixed in is skipped without throwing", () => {
+    const projects = [
+      null,
+      { team: "CTL", repoRoot: "/x", identity: { declared: "PROJ", matches: false } },
+      { team: "NOID", repoRoot: "/z" }, // no identity object at all
+      { identity: { matches: true } }, // matching, missing team/repoRoot
+    ];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([
+      {
+        "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+        payload: { team: "CTL", repoRoot: "/x", declared: "PROJ" },
+      },
+    ]);
+  });
+
+  test("a mismatch entry missing team/repoRoot/declared coerces those to null", () => {
+    const projects = [{ identity: { matches: false } }];
+    expect(buildTeamIdentityMismatchEvents(projects)).toEqual([
+      {
+        "event.name": CONFIG_TEAM_IDENTITY_MISMATCH,
+        payload: { team: null, repoRoot: null, declared: null },
+      },
+    ]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -166,6 +166,7 @@ import { setLinearWriteProxy, setLinearWriteProxyResolver } from "./linear-write
 import { createLinearWriteProxy } from "./linear-write-proxy.mjs"; // CTL-1889
 import { createAgentSessionNarrator } from "./agent-session-narrator.mjs"; // CTL-1943
 import { createProxyResolver } from "./linear-write-proxy-resolve.mjs"; // CTL-1889
+import { buildTeamIdentityMismatchEvents } from "./config-identity-event.mjs"; // CTL-2076: surface a registry team-identity mismatch (CAT-52) on the unified event log
 // CTL-671: the real phantom-sweep seams. startScheduler defaults them to safe
 // no-ops (hermetic for direct-call unit tests); the REAL daemon arms them here
 // so the phantom worker-dir validity sweep is operative in production.
@@ -1431,8 +1432,13 @@ export function startDaemon({
     // every team against the first registry entry's map judges tickets against names their
     // own writer never uses.
     const laneClaimTeamPaths = new Map();
+    // CTL-2076: read the registry identity ONCE and share it between the path map
+    // build below and the mismatch scan after guard install — a throwing registry
+    // still leaves an empty [] so both paths degrade gracefully.
+    let laneClaimProjects = [];
     try {
-      for (const proj of listProjectsFn() ?? []) {
+      laneClaimProjects = listProjectsFn() ?? [];
+      for (const proj of laneClaimProjects) {
         if (proj?.team && proj?.repoRoot) {
           laneClaimTeamPaths.set(
             String(proj.team).toUpperCase(),
@@ -1507,6 +1513,21 @@ export function startDaemon({
       );
     } else {
       log.info(laneClaimFields, "ctl-2068: lane-claim guard installed");
+    }
+
+    // CTL-2076: a registry entry whose repoRoot declares a DIFFERENT teamKey makes
+    // the lane-claim guard abstain (UNRANKED_CURRENT) for every ticket of that team.
+    // doctor's registry-team-identity (CAT-52) already WARNs, but only in an advisory
+    // section it never FAILs on — so put it on the unified event log too, where the
+    // broker/HUD/orch-monitor/Loki (a lane and a human) actually read. Best-effort:
+    // defaultAppendOperatorEvent never throws.
+    try {
+      for (const evt of buildTeamIdentityMismatchEvents(laneClaimProjects)) {
+        defaultAppendOperatorEvent(evt);
+        log.warn(evt.payload, "ctl-2076: registry entry declares a different Linear team (CAT-52)");
+      }
+    } catch {
+      /* best-effort — a mismatch scan must never block boot */
     }
 
     const commentInboxWriter = createCommentInboxWriter(orchDir, linearBotUserIds);

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -666,6 +666,18 @@ update_config_with_linear_states() {
 	fi
 	local secrets_file="$HOME/.config/catalyst/config-${PROJECT_KEY}.json"
 
+	# CTL-2076: never re-derive over a committed, PRESERVED stateMap. setup_project_config
+	# sets CATALYST_STATEMAP_PRESERVED=1 when it kept an existing non-empty committed map;
+	# honoring it here closes the second clobber path (a credentialed re-run over a real
+	# config, e.g. mini-2's CTL checkout, where fetch+build_state_map_from_linear would
+	# otherwise overwrite the curated map with the positional heuristic). A fresh install
+	# leaves the flag 0 (or unset), so the Linear-derived refresh still runs there.
+	if [[ "${CATALYST_STATEMAP_PRESERVED:-0}" == "1" ]]; then
+		echo ""
+		echo "✓ Preserving committed linear.stateMap (skipping Linear-derived refresh)"
+		return 0
+	fi
+
 	# Need both files to exist
 	if [[ ! -f $config_file ]] || [[ ! -f $secrets_file ]]; then
 		return 0
@@ -1707,10 +1719,20 @@ setup_project_config() {
 	# regeneration (CTL-2076); otherwise use today's generic 8-key default. Injected as a
 	# pre-encoded JSON blob the same way deployment_mode_json is, so a preserved map lands
 	# byte-for-byte and a fresh install keeps the exact current default.
+	#
+	# CTL-2076: signal the preservation to update_config_with_linear_states (called next in
+	# main), which would otherwise re-derive the map from Linear via the positional heuristic
+	# in build_state_map_from_linear and collapse a curated map (research/planning/inProgress =
+	# Research/Plan/Implement) back to a single started-state name — re-introducing the exact
+	# clobber this ticket fixes. The flag is deliberately NOT `local`: both functions run in
+	# the same process from main(), and a just-written generic default (flag=0) must still be
+	# refreshed from Linear on a fresh install. Defaults to 0 for a fresh/absent config.
 	local state_map_json
+	CATALYST_STATEMAP_PRESERVED=0
 	if [[ -f $config_file ]] &&
 		[[ $(jq -r '(.catalyst.linear.stateMap | objects | length) // 0' "$config_file" 2>/dev/null) -gt 0 ]]; then
 		state_map_json=$(jq -c '.catalyst.linear.stateMap' "$config_file")
+		CATALYST_STATEMAP_PRESERVED=1
 	else
 		state_map_json=$(jq -cn '{backlog:"Backlog",todo:"Todo",research:"In Progress",planning:"In Progress",inProgress:"In Progress",inReview:"In Review",done:"Done",canceled:"Canceled"}')
 	fi

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -1615,7 +1615,18 @@ setup_project_config() {
 	echo "  - PR titles (e.g., [${PROJECT_KEY}-123] Add new feature)"
 	echo "  - Commit messages and documentation"
 	echo ""
-	ticket_prefix=$(prompt_value "Enter ticket prefix (e.g., ENG, PROJ) [PROJ]:" "PROJ")
+	# Ticket prefix: default PROJ, but PRESERVE an existing committed value across a
+	# regeneration (CTL-2076) so a non-interactive re-run over a real config (e.g. the
+	# CTL checkout) does not clobber ticketPrefix back to PROJ. Mirrors the thoughts.*
+	# (CTL-1214) and deployment.mode (CTL-1622) preservation blocks below; identical
+	# preload+prompt shape to the deployment_mode block.
+	local ticket_prefix_default="PROJ"
+	if [[ -f $config_file ]]; then
+		local _existing_prefix
+		_existing_prefix=$(jq -r '.catalyst.project.ticketPrefix // empty' "$config_file" 2>/dev/null)
+		[[ -n $_existing_prefix ]] && ticket_prefix_default="$_existing_prefix"
+	fi
+	ticket_prefix=$(prompt_value "Enter ticket prefix (e.g., ENG, PROJ) [${ticket_prefix_default}]:" "${ticket_prefix_default}")
 
 	# Prompt for project name
 	echo ""
@@ -1680,6 +1691,30 @@ setup_project_config() {
 	local deployment_mode_json
 	deployment_mode_json=$(jq -Rn --arg v "$deployment_mode" '$v')
 
+	# teamKey: default to the ticket prefix (preserving today's teamKey := ticketPrefix
+	# coupling for fresh installs), but PRESERVE an existing committed linear.teamKey
+	# INDEPENDENTLY across a regeneration (CTL-2076) — a config can legitimately carry a
+	# teamKey distinct from its prefix, and clobbering it to the prefix is the exact bug
+	# that rewrote mini-2's CTL checkout to team PROJ.
+	local team_key="${ticket_prefix}"
+	if [[ -f $config_file ]]; then
+		local _existing_team
+		_existing_team=$(jq -r '.catalyst.linear.teamKey // empty' "$config_file" 2>/dev/null)
+		[[ -n $_existing_team ]] && team_key="$_existing_team"
+	fi
+
+	# stateMap: PRESERVE an existing NON-EMPTY committed linear.stateMap verbatim across a
+	# regeneration (CTL-2076); otherwise use today's generic 8-key default. Injected as a
+	# pre-encoded JSON blob the same way deployment_mode_json is, so a preserved map lands
+	# byte-for-byte and a fresh install keeps the exact current default.
+	local state_map_json
+	if [[ -f $config_file ]] &&
+		[[ $(jq -r '(.catalyst.linear.stateMap | objects | length) // 0' "$config_file" 2>/dev/null) -gt 0 ]]; then
+		state_map_json=$(jq -c '.catalyst.linear.stateMap' "$config_file")
+	else
+		state_map_json=$(jq -cn '{backlog:"Backlog",todo:"Todo",research:"In Progress",planning:"In Progress",inProgress:"In Progress",inReview:"In Review",done:"Done",canceled:"Canceled"}')
+	fi
+
 	# Create/update config
 	cat >"$config_file" <<EOF
 {
@@ -1697,17 +1732,8 @@ setup_project_config() {
       "mode": ${deployment_mode_json}
     },
     "linear": {
-      "teamKey": "${ticket_prefix}",
-      "stateMap": {
-        "backlog": "Backlog",
-        "todo": "Todo",
-        "research": "In Progress",
-        "planning": "In Progress",
-        "inProgress": "In Progress",
-        "inReview": "In Review",
-        "done": "Done",
-        "canceled": "Canceled"
-      }
+      "teamKey": "${team_key}",
+      "stateMap": ${state_map_json}
     },
     "thoughts": {
       "user": null,
@@ -1723,8 +1749,8 @@ EOF
 	echo "✓ projectKey: ${PROJECT_KEY}"
 	echo "✓ org/repo: ${ORG_NAME}/${REPO_NAME}"
 	echo "✓ ticketPrefix: ${ticket_prefix}"
-	echo "✓ linear.teamKey: ${ticket_prefix}"
-	echo "✓ linear.stateMap: defaults (will be updated with actual Linear states after API setup)"
+	echo "✓ linear.teamKey: ${team_key}"
+	echo "✓ linear.stateMap: ${state_map_json}"
 	echo "✓ deployment.mode: ${deployment_mode}"
 	echo ""
 }


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-19T21:09:50Z -->
<!-- Last updated: 2026-08-19T21:09:50Z -->
<!-- PR: #3736 -->
<!-- Previous commits: 6e1fe25c80988a4cfda524122d6726106210acf2,cbc2ba265f36f8fcb3570ef66c3dd545d11dca3a -->

## Summary

On mini-2, the CTL checkout (the registry `repoRoot` for team CTL) had a locally-modified
`.catalyst/config.json` declaring `teamKey`/`ticketPrefix` **PROJ** and a generic
`In Progress`/`In Review` stateMap instead of the committed **CTL** identity and the real
`Implement`/`PR` stateMap. Because the CTL-2068 lane-claim guard resolves the state map from that
Layer-1 config, its `REFUSE` verdict became unreachable for every CTL ticket on that host — the
ranked `In Progress`/`In Review` names never match the workspace's real `Implement`/`PR`
states, so the guard abstains (`UNRANKED_CURRENT`) and a lane's claim could be regressed and
re-dispatched. `doctor`'s `registry-team-identity` check (CAT-52) had WARNed on this for ~17.5h,
but only in an advisory section it never FAILs on.

This PR fixes the root cause (stop the rewrite) **and** raises the blind spot's visibility:

1. **Root cause** — `setup_project_config` no longer clobbers a committed Linear identity on a
   non-interactive regeneration. It now preserves an existing `ticketPrefix`, `linear.teamKey`
   (independently of the prefix), and a non-empty `linear.stateMap` verbatim, while a truly-fresh
   install keeps today's documented `PROJ` defaults byte-for-byte.
2. **Visibility** — the daemon now emits a `config.registry-team-identity.mismatch` event
   (CAT-52) to the unified event log for every *proven* registry team-identity mismatch, so the
   condition is visible to the broker / HUD / orch-monitor / Loki, not just doctor's advisory WARN.

## Changes Made

### `setup-catalyst.sh` — preserve committed Linear identity on regen (CTL-2076)

- `ticketPrefix`: defaults to `PROJ`, but preloads an existing committed value before prompting
  (mirrors the existing `thoughts.*` (CTL-1214) and `deployment.mode` (CTL-1622) preservation
  blocks).
- `linear.teamKey`: defaults to the ticket prefix (preserving the fresh-install coupling) but
  preserves an existing committed `teamKey` **independently** — a config can legitimately carry a
  teamKey distinct from its prefix, and clobbering it to the prefix was the exact bug.
- `linear.stateMap`: preserves an existing **non-empty** committed map verbatim (injected as a
  pre-encoded JSON blob, the same mechanism as `deployment_mode_json`); otherwise emits today's
  generic 8-key default.

### `execution-core` — surface the mismatch on the event log (CAT-52)

- New zero-import leaf `config-identity-event.mjs`: exports the
  `config.registry-team-identity.mismatch` event name and a pure
  `buildTeamIdentityMismatchEvents(projects)` builder — one event per **proven** mismatch
  (`identity.matches === false`); `null` (unverifiable) is skipped under the same three-valued
  discipline as the CAT-52 doctor check; null/malformed entries are skipped without throwing.
- `daemon.mjs`: reads the registry identity **once** and shares it between the lane-claim path map
  and the new mismatch scan (a throwing registry degrades to `[]` for both paths). After the guard
  is installed, it emits an operator event + a `log.warn` per proven mismatch — best-effort, never
  blocks boot.
- `broker/namespace-parity.test.mjs`: registers `CONFIG_TEAM_IDENTITY_MISMATCH` by **import**
  from its owning module (not a re-typed literal), following the CTL-1659/CTL-1889 precedent.

## How to Verify It

- [x] New: `setup-catalyst-config-preserve` 3/3 (regen-preserve, fresh-default, valid-JSON)
- [x] New: `config-identity-event` 9/9 (empty, null-input, all-match, unknown, single/two mismatch, malformed-skip, null-coercion)
- [x] Regression: `namespace-parity` 9/9, `setup-noninteractive` 41/41, `config-merge` 26/26, `statemap-gate` 3/3
- [x] `node --check` parse-validated all 3 changed `.mjs`
- [ ] Trunk-pinned prettier / eslint gate (runs in CI)

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-2076
- Relates to the CAT-52 doctor `registry-team-identity` check and the CTL-2068 lane-claim guard.

Refs: CTL-2076
