### PR TITLE
feat(dev): CTL-2074 phase 1 — cloud-proxy identity config seam (bot.cloud.botUserId)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1275,6 +1275,7 @@ jobs:
             linear-remint.test.mjs \
             linear-state-write-event.test.mjs \
             linear-write-echo.test.mjs \
+            self-echo-negative-control.test.mjs \
             linear-write.test.mjs \
             lane-claim.test.mjs \
             lane-claim-wiring.test.mjs \

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -276,7 +276,12 @@ let _eventLogLeftover = "";
 // config layers so the self-echo guard covers every app-actor identity:
 //   1. NEW:  ~/.config/catalyst/config.json  catalyst.linear.bot.worker.botUserId
 //   2. NEW:  ~/.config/catalyst/config.json  catalyst.linear.bot.orchestrator.botUserId
-//   3. OLD:  .catalyst/config.json           catalyst.monitor.linear.botUserId  (Layer-1)
+//   3. NEW:  ~/.config/catalyst/config.json  catalyst.linear.bot.cloud.botUserId (CTL-2074)
+//   4. OLD:  .catalyst/config.json           catalyst.monitor.linear.botUserId  (Layer-1)
+// The `cloud` slot names the cloud tenant's app-actor id the fleet's writes carry
+// when CATALYST_LINEAR_WRITE_PROXY=enforce (CTL-1889/ADR-0031). RECOGNITION-ONLY:
+// it enters the self-echo set but is deliberately NOT returned by readLinearBotWriteId
+// (the daemon must never self-assign as the cloud tenant).
 // Returns a Set<string>. Empty set = no filter (fail-open). Never throws. CTL-749.
 export function readLinearBotUserIds(layer1Path, layer2Path) {
   const ids = new Set();
@@ -296,6 +301,9 @@ export function readLinearBotUserIds(layer1Path, layer2Path) {
       s.add(bot.worker.botUserId);
     if (typeof bot?.orchestrator?.botUserId === "string" && bot.orchestrator.botUserId.length > 0)
       s.add(bot.orchestrator.botUserId);
+    // CTL-2074: cloud-proxy app-actor — recognition-only (never a self-assign id).
+    if (typeof bot?.cloud?.botUserId === "string" && bot.cloud.botUserId.length > 0)
+      s.add(bot.cloud.botUserId);
   });
   // OLD Layer-1 path: catalyst.monitor.linear.botUserId (back-compat). CTL-749.
   addFromPath(layer1Path, (p, s) => {

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -2790,6 +2790,45 @@ describe("readLinearBotUserIds", () => {
     const ids = readLinearBotUserIds(null, layer2);
     expect(ids.size).toBe(0);
   });
+
+  // CTL-2074: the cloud-proxy recognition slot. Since CTL-1889 both minis write
+  // through the cloud proxy (CATALYST_LINEAR_WRITE_PROXY=enforce), so their writes
+  // carry the cloud tenant's app-actor id — which must be recognised as self.
+  test("reads cloud botUserId from Layer-2 (catalyst.linear.bot.cloud.botUserId)", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({
+        catalyst: { linear: { bot: { cloud: { botUserId: "cloud-uuid-1" } } } },
+      })
+    );
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("cloud-uuid-1")).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  test("reads worker, orchestrator, and cloud botUserIds together from Layer-2", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: {
+              worker: { botUserId: "worker-uuid" },
+              orchestrator: { botUserId: "orch-uuid" },
+              cloud: { botUserId: "cloud-uuid" },
+            },
+          },
+        },
+      })
+    );
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("worker-uuid")).toBe(true);
+    expect(ids.has("orch-uuid")).toBe(true);
+    expect(ids.has("cloud-uuid")).toBe(true);
+    expect(ids.size).toBe(3);
+  });
 });
 
 // _isBotId — normalises string vs Set so guard callers are consistent
@@ -3179,6 +3218,39 @@ describe("readLinearBotWriteId (CTL-781)", () => {
     const bad = join(tmpDir, "bad.json");
     writeFileSync(bad, "not-json{{");
     expect(() => readLinearBotWriteId(bad, bad)).not.toThrow();
+  });
+
+  // CTL-2074: the cloud slot is RECOGNITION-ONLY. The daemon must never self-assign
+  // as the cloud tenant — self-assign stays the orchestrator identity. A config that
+  // names cloud but no orchestrator must resolve to null (self-assign disabled),
+  // never to the cloud id.
+  test("does NOT return the cloud id — self-assign stays orchestrator", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: {
+              orchestrator: { botUserId: "orch-uuid-1" },
+              cloud: { botUserId: "cloud-uuid-1" },
+            },
+          },
+        },
+      })
+    );
+    expect(readLinearBotWriteId(null, layer2)).toBe("orch-uuid-1");
+  });
+
+  test("returns null (not the cloud id) when only the cloud slot is configured", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({
+        catalyst: { linear: { bot: { cloud: { botUserId: "cloud-uuid-1" } } } },
+      })
+    );
+    expect(readLinearBotWriteId(null, layer2)).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -152,9 +152,13 @@ import { collectConfigDump } from "./config-dump.mjs";
 // Collects all known Linear bot user UUIDs from both config layers:
 //   1. ~/.config/catalyst/config.json  catalyst.linear.bot.worker.botUserId
 //   2. ~/.config/catalyst/config.json  catalyst.linear.bot.orchestrator.botUserId
-//   3. .catalyst/config.json           catalyst.monitor.linear.botUserId (Layer-1, back-compat)
+//   3. ~/.config/catalyst/config.json  catalyst.linear.bot.cloud.botUserId (CTL-2074,
+//        recognition-only — the cloud-proxy app-actor; kept in lockstep with the daemon)
+//   4. .catalyst/config.json           catalyst.monitor.linear.botUserId (Layer-1, back-compat)
 // Returns a Set<string>. Empty set = no filter (fail-open). Never throws.
-function readLinearBotUserIds(l1Path, l2Path) {
+// Exported so doctor.test.mjs exercises the inline twin directly and it cannot
+// silently drift from the daemon resolver (CTL-2074).
+export function readLinearBotUserIds(l1Path, l2Path) {
   const ids = new Set();
   function addFromPath(path, extractor) {
     if (!path) return;
@@ -169,6 +173,9 @@ function readLinearBotUserIds(l1Path, l2Path) {
       s.add(bot.worker.botUserId);
     if (typeof bot?.orchestrator?.botUserId === "string" && bot.orchestrator.botUserId.length > 0)
       s.add(bot.orchestrator.botUserId);
+    // CTL-2074: cloud-proxy app-actor — recognition-only (never a self-assign id).
+    if (typeof bot?.cloud?.botUserId === "string" && bot.cloud.botUserId.length > 0)
+      s.add(bot.cloud.botUserId);
   });
   addFromPath(l1Path, (p, s) => {
     const uid = p?.catalyst?.monitor?.linear?.botUserId;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -80,6 +80,11 @@ import {
   // do NOT import replica-read.mjs (it pulls bun:sqlite; doctor runs under bare node).
   getReplicaDbPath,
   readLinearReplica,
+  // CTL-2074 (Codex #3738 P2): resolve the write-proxy mode through the SAME
+  // env > Layer-2 > 'off' ladder the live write transport uses, so a host that enables
+  // enforce via Layer-2 (catalyst.linearWriteProxy.mode) without exporting the env var is
+  // not silently skipped by the self-echo cross-check. Node-safe (node:fs only).
+  readLinearWriteProxyConfig,
   resolveNodeCloudTokenEnv,
   // CTL-1659: the cloud-sync loaded-dependency boot record — doctor grades it from
   // another process, so it needs the same path the writer writes.
@@ -182,6 +187,24 @@ export function readLinearBotUserIds(l1Path, l2Path) {
     if (typeof uid === "string" && uid.length > 0) s.add(uid);
   });
   return ids;
+}
+
+// CTL-2074 (Codex #3738 P2): the CURRENT cloud-proxy app-actor id, read on its own
+// from Layer-2 catalyst.linear.bot.cloud.botUserId. The self-echo cross-check ties its
+// PASS to THIS specific actor rather than to any member of the full recognition set:
+// under proxy=enforce every daemon state write carries the cloud tenant's app-actor id,
+// so a legacy worker/orchestrator id that changed state before the cutover — and is still
+// in the general set — must NOT mask an unrecognized current cloud writer with a clean
+// PASS. Returns "" when unconfigured/unreadable (never throws) — that IS the CTL-2074
+// silent condition, surfaced as WARN by the caller, not a clean pass.
+export function readCloudBotUserId(l2Path) {
+  if (!l2Path) return "";
+  try {
+    const id = JSON.parse(readFileSync(l2Path, "utf8"))?.catalyst?.linear?.bot?.cloud?.botUserId;
+    return typeof id === "string" ? id : "";
+  } catch {
+    return "";
+  }
 }
 
 // ─── Check model ─────────────────────────────────────────────────────────────
@@ -855,8 +878,14 @@ function defaultRecentStateChangeActors({ dbPath, limit = 50, run = spawnSync } 
 export function checkSelfEchoIdentityHistory(deps = {}) {
   const name = "self-echo-identity-history";
   const {
-    proxyMode = process.env.CATALYST_LINEAR_WRITE_PROXY || "off",
+    // Codex #3738 P2: resolve the mode through the write transport's env > Layer-2 >
+    // 'off' ladder, NOT the env var alone — a Layer-2-only enforce host was silently
+    // skipped by the old `process.env.CATALYST_LINEAR_WRITE_PROXY || "off"` default.
+    proxyMode = readLinearWriteProxyConfig().mode,
     botIds = readLinearBotUserIds(layer1Path(), layer2Path()),
+    // Codex #3738 P2: the current cloud-proxy actor — the PASS is tied to THIS id, not
+    // to any historical member of botIds (see readCloudBotUserId).
+    cloudBotId = readCloudBotUserId(layer2Path()),
     recentActors = () => defaultRecentStateChangeActors({ dbPath: getReplicaDbPath() }),
   } = deps;
 
@@ -892,31 +921,59 @@ export function checkSelfEchoIdentityHistory(deps = {}) {
     );
   }
 
-  const ids = botIds instanceof Set ? botIds : new Set(Array.isArray(botIds) ? botIds : []);
-  const recognized = actors.filter((a) => a.actorId && ids.has(a.actorId));
-  if (recognized.length > 0) {
-    const who = recognized.map((a) => a.name || a.actorId).join(", ");
-    return mkCheck(
-      name,
-      STATUS.PASS,
-      `write proxy=enforce and a recognized self-echo identity writes state: ${who} ` +
-        `(${recognized.length} of ${actors.length} recent state-writers recognized)`,
-    );
-  }
-
-  // No recognized identity among the actors who actually write state — the exact
-  // silent condition that produced CTL-2074. Name the candidates so the operator can
-  // confirm the right one AT THE PROXY (users.type is unreliable — never auto-classify).
+  // Codex #3738 P2: under enforce every daemon state write carries the CLOUD proxy
+  // app-actor id, so the PASS is tied to THAT specific id — not to any member of the
+  // full recognition set. A legacy worker/orchestrator id that changed state before the
+  // cutover is still in `botIds`, and the old "any recognized member ⇒ PASS" would let it
+  // mask an unrecognized current cloud writer with a clean pass — the exact silent
+  // condition this check exists to expose. (`ids` is retained only for the diagnostic
+  // note below, distinguishing a set the cloud id is genuinely part of.)
   const candidates = actors
     .slice(0, 5)
     .map((a) => `${a.actorId}${a.name ? ` "${a.name}"` : ""} (${a.count})`)
     .join(", ");
+  const ids = botIds instanceof Set ? botIds : new Set(Array.isArray(botIds) ? botIds : []);
+  const cloudId = typeof cloudBotId === "string" && cloudBotId.length > 0 ? cloudBotId : null;
+
+  // The cloud-proxy identity isn't configured at all — nothing pins the fleet's own
+  // proxied writes, so every one of them reads as a human reply. The CTL-2074 condition.
+  if (!cloudId) {
+    return mkCheck(
+      name,
+      STATUS.WARN,
+      "write proxy=enforce but the cloud-proxy identity is not configured " +
+        "(catalyst.linear.bot.cloud.botUserId) — the fleet's own proxied writes read as human " +
+        "replies. Confirm the cloud-proxy identity AT THE PROXY (users.type is unreliable — never " +
+        "auto-classify) and set it. Recent state-writers: " +
+        candidates,
+    );
+  }
+
+  const cloudWrites = actors.filter((a) => a.actorId === cloudId);
+  if (cloudWrites.length > 0) {
+    const who = cloudWrites.map((a) => a.name || a.actorId).join(", ");
+    const inSet = ids.has(cloudId) ? "" : " (⚠ present in history but ABSENT from the recognition set)";
+    return mkCheck(
+      name,
+      // The cloud id writing state but missing from the recognition set is itself a
+      // misconfiguration — the daemon would treat these writes as human. WARN, not PASS.
+      ids.has(cloudId) ? STATUS.PASS : STATUS.WARN,
+      `write proxy=enforce and the configured cloud-proxy identity writes state: ${who}${inSet} ` +
+        `(${cloudWrites.length} of ${actors.length} recent state-writers)`,
+    );
+  }
+
+  // The cloud id is configured but never appears among the actors who ACTUALLY write
+  // state — either it is the wrong id or a legacy actor is still writing. Either way the
+  // fleet's proxied writes are not recognized. Name the candidates so the operator can
+  // confirm the right one AT THE PROXY (users.type is unreliable — never auto-classify).
   return mkCheck(
     name,
     STATUS.WARN,
-    "write proxy=enforce but NONE of the recent state-writers are in the self-echo set — the " +
-      "fleet's own proxied writes read as human replies. Confirm the cloud-proxy identity at the " +
-      "proxy and set catalyst.linear.bot.cloud.botUserId. Recent unrecognized state-writers: " +
+    "write proxy=enforce but the configured cloud-proxy identity " +
+      `(${cloudId}) is NOT among the recent state-writers — the fleet's own proxied writes read ` +
+      "as human replies. Confirm the cloud-proxy identity AT THE PROXY and correct " +
+      "catalyst.linear.bot.cloud.botUserId. Recent state-writers: " +
       candidates,
   );
 }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -802,6 +802,125 @@ export async function checkBotCredentials(deps = {}) {
   return checks;
 }
 
+// ─── CTL-2074: self-echo identity ↔ real issue_history cross-check ────────────
+//
+// `botUserIds` is the fleet's answer to "was this Linear change made by us?". Since
+// CTL-1889 both minis write THROUGH the cloud proxy (CATALYST_LINEAR_WRITE_PROXY=
+// enforce), so their writes carry the cloud tenant's app-actor id — and if that id is
+// absent from the recognition set, a proxied write mirrored back reads as "a human
+// replied on the daemon's own output". That is a SILENT failure: nothing errors, and
+// the set is resolved from config + a durable ledger, NEVER from history. This check
+// turns it loud — it verifies the recognition set against who ACTUALLY writes state,
+// from real issue_history rows (the AC's "verified by a query against real
+// issue_history rows, not by reading config"), with a positive control.
+//
+// Advisory (WARN, never FAIL): doctor's exit code is the FAIL count and gates
+// activation; this is "make it loud", not "block a node whose cloud id isn't
+// provisioned yet". Every negative carries a positive control — an undefined read or
+// an empty result is INCONCLUSIVE (WARN), never a clean PASS.
+//
+// defaultRecentStateChangeActors — read the replica via the sqlite3 CLI (an OPTIONAL
+// dependency), the SAME discipline as defaultReadDbTables (CAT-35): doctor runs under
+// bare node and must not import replica-read.mjs (bun:sqlite). This SQL is a twin of
+// replica-read.mjs's RECENT_STATE_CHANGE_ACTORS_SELECT — kept a copy precisely because
+// doctor cannot share the bun: reader. undefined = could-not-look (sqlite3 absent /
+// query failed / db missing); [] = looked-and-found-nothing. The two must stay
+// distinct — an empty read reported as clean is the silent false-clean this ends.
+function defaultRecentStateChangeActors({ dbPath, limit = 50, run = spawnSync } = {}) {
+  if (!dbPath) return undefined;
+  const n = Number.isInteger(limit) && limit > 0 ? limit : 50;
+  const sql =
+    "SELECT h.actor_id AS actorId, u.name AS name, COUNT(*) AS count " +
+    "FROM issue_history h LEFT JOIN users u ON u.id = h.actor_id " +
+    "WHERE h.to_state IS NOT NULL AND h.actor_id IS NOT NULL " +
+    `GROUP BY h.actor_id ORDER BY count DESC LIMIT ${n}`; // n is a validated integer — no injection
+  let r;
+  try {
+    r = run("sqlite3", ["-readonly", "-json", dbPath, sql], { encoding: "utf8", timeout: 10_000 });
+  } catch {
+    return undefined;
+  }
+  if (!r || r.error || r.status !== 0 || typeof r.stdout !== "string") return undefined;
+  const out = r.stdout.trim();
+  if (out === "") return []; // looked, found nothing (positive control failed downstream)
+  try {
+    const rows = JSON.parse(out);
+    if (!Array.isArray(rows)) return undefined;
+    return rows.map((x) => ({ actorId: x.actorId ?? null, name: x.name ?? null, count: Number(x.count) || 0 }));
+  } catch {
+    return undefined;
+  }
+}
+
+export function checkSelfEchoIdentityHistory(deps = {}) {
+  const name = "self-echo-identity-history";
+  const {
+    proxyMode = process.env.CATALYST_LINEAR_WRITE_PROXY || "off",
+    botIds = readLinearBotUserIds(layer1Path(), layer2Path()),
+    recentActors = () => defaultRecentStateChangeActors({ dbPath: getReplicaDbPath() }),
+  } = deps;
+
+  const mode = String(proxyMode || "off").toLowerCase();
+  // The guard only bites under enforce — off/shadow proxied writes carry the direct
+  // app-actor id already in the set, so history recognition is N/A.
+  if (mode !== "enforce") {
+    return mkCheck(
+      name,
+      STATUS.INFO,
+      `write proxy not enforcing (CATALYST_LINEAR_WRITE_PROXY=${mode}) — proxied-identity self-echo N/A`,
+    );
+  }
+
+  const actors = typeof recentActors === "function" ? recentActors() : recentActors;
+  // could-not-look — NEVER a clean pass.
+  if (actors === undefined) {
+    return mkCheck(
+      name,
+      STATUS.WARN,
+      "replica unavailable — cannot verify the self-echo identity against issue_history " +
+        "(inconclusive, not a clean pass)",
+    );
+  }
+  // looked, found nothing — the positive control failed, so a "recognized" verdict
+  // would be unfounded. Inconclusive, never PASS.
+  if (!Array.isArray(actors) || actors.length === 0) {
+    return mkCheck(
+      name,
+      STATUS.WARN,
+      "no state changes in the recent window — positive control failed; cannot confirm the " +
+        "self-echo identity against history (inconclusive, not a clean pass)",
+    );
+  }
+
+  const ids = botIds instanceof Set ? botIds : new Set(Array.isArray(botIds) ? botIds : []);
+  const recognized = actors.filter((a) => a.actorId && ids.has(a.actorId));
+  if (recognized.length > 0) {
+    const who = recognized.map((a) => a.name || a.actorId).join(", ");
+    return mkCheck(
+      name,
+      STATUS.PASS,
+      `write proxy=enforce and a recognized self-echo identity writes state: ${who} ` +
+        `(${recognized.length} of ${actors.length} recent state-writers recognized)`,
+    );
+  }
+
+  // No recognized identity among the actors who actually write state — the exact
+  // silent condition that produced CTL-2074. Name the candidates so the operator can
+  // confirm the right one AT THE PROXY (users.type is unreliable — never auto-classify).
+  const candidates = actors
+    .slice(0, 5)
+    .map((a) => `${a.actorId}${a.name ? ` "${a.name}"` : ""} (${a.count})`)
+    .join(", ");
+  return mkCheck(
+    name,
+    STATUS.WARN,
+    "write proxy=enforce but NONE of the recent state-writers are in the self-echo set — the " +
+      "fleet's own proxied writes read as human replies. Confirm the cloud-proxy identity at the " +
+      "proxy and set catalyst.linear.bot.cloud.botUserId. Recent unrecognized state-writers: " +
+      candidates,
+  );
+}
+
 // ─── Phase 5: Connectivity + Secrets hygiene ─────────────────────────────────
 
 // checkConnectivity — probes seed node, OTEL endpoint, and GitHub API.
@@ -6095,6 +6214,10 @@ export function checksForClass(nc, opts = {}) {
   const skillsDirPluginsThunk = () => checkSkillsDirPlugins({ nodeClass: nc.class });
 
   const replicaThunk = () => checkReadReplicaReachable({ baseUrl: readReplicaBaseUrl, fetch: _fetch });
+  // CTL-2074: verify the self-echo recognition set against who ACTUALLY writes state
+  // in real issue_history (not config). Advisory (never FAIL). Defaults resolve
+  // proxyMode/botIds/replica internally; graded for the classes that write to Linear.
+  const selfEchoIdentityHistoryThunk = () => checkSelfEchoIdentityHistory();
   const wontOwnThunk = () =>
     checkWontOwnWork({
       resolveRoster,
@@ -6164,6 +6287,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkCloudTokenEnv(), // advisory
       () => checkClusterSecretFreshness(), // CTL-1393: warn if running on stale rotated secrets (advisory)
       () => checkCloudSync(), // CTL-1394: developer nodes read Linear from the local replica too (advisory)
+      selfEchoIdentityHistoryThunk, // CTL-2074: does the self-echo set name the id the fleet's proxied writes actually carry? (advisory)
       () => checkCloudSyncSkew(), // CTL-1659: is the RUNNING writer serving the lockfile's modules? (advisory)
       () => checkFleetTokenExport(), // CTL-1908: does a login shell spend the FLEET's Claude budget? (advisory)
       () => checkConfigScopeLeak(), // advisory
@@ -6239,6 +6363,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkCloudTokenEnv(), // CTL-1307: cluster cloud token decrypted → projected to machine-level env (advisory)
     () => checkClusterSecretFreshness(), // CTL-1393: warn if the node is running on stale rotated secrets (advisory)
     () => checkCloudSync(), // CTL-1394: supervised cloud-sync daemon + read tier on the worker hot path (advisory)
+    selfEchoIdentityHistoryThunk, // CTL-2074: does the self-echo set name the id the fleet's proxied writes actually carry? (advisory)
     () => checkCloudSyncSkew(), // CTL-1659: a merged dependency fix that never reached the running writer (advisory)
     () => checkFleetTokenExport(), // CTL-1908: the login-shell export that stalled the fleet for 7h (advisory)
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -59,6 +59,7 @@ import {
   runDoctor,
   checkFleetTokenExport,
   readLinearBotUserIds,
+  checkSelfEchoIdentityHistory,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -402,6 +403,77 @@ describe("readLinearBotUserIds (doctor inline twin, CTL-2074)", () => {
     expect(ids.has("cloud-uuid")).toBe(true);
     expect(ids.has("worker-uuid")).toBe(true);
     expect(ids.has("orch-uuid")).toBe(true);
+  });
+});
+
+// ─── CTL-2074: checkSelfEchoIdentityHistory — the loud history cross-check ────
+// Turns the silent failure loud: compares the resolved recognition set against the
+// actors who ACTUALLY write state in real issue_history (positive control included),
+// never against config. Advisory (WARN, not FAIL) — "make it loud", not "block".
+const ORCH_ID = "ba2989f1-0000-4000-8000-000000000000";
+const CLOUD_ID = "78f8f491-0000-4000-8000-000000000000";
+const HUMAN_ID = "c2a8cc92-0000-4000-8000-000000000000";
+
+describe("checkSelfEchoIdentityHistory (CTL-2074)", () => {
+  it("WARNs when proxy=enforce and no recognized identity writes state (names the candidates)", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID]),
+      recentActors: () => [
+        { actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 },
+        { actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 },
+      ],
+    });
+    expect(check.status).toBe(STATUS.WARN);
+    // names the unrecognized state-writer so the operator has a candidate to confirm
+    expect(check.detail).toMatch(/78f8f491|cloud|proxied|Catalyst Cloud/i);
+  });
+
+  it("PASSes when a recognized identity is present in history AND in the set", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID, CLOUD_ID]),
+      recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
+    });
+    expect(check.status).toBe(STATUS.PASS);
+  });
+
+  it("WARNs when the configured cloud id never appears in recent history (misconfigured)", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID, CLOUD_ID]),
+      recentActors: () => [{ actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 }],
+    });
+    expect(check.status).toBe(STATUS.WARN);
+  });
+
+  it("is INCONCLUSIVE (never PASS) when the replica cannot be read (recentActors → undefined)", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID, CLOUD_ID]),
+      recentActors: () => undefined,
+    });
+    expect(check.status).not.toBe(STATUS.PASS); // could-not-look ≠ clean
+  });
+
+  it("is INCONCLUSIVE (never PASS) when history is present but empty (positive control failed)", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID, CLOUD_ID]),
+      recentActors: () => [],
+    });
+    expect(check.status).not.toBe(STATUS.PASS);
+  });
+
+  it("off/shadow proxy mode → INFO/skip (the guard only matters under enforce)", () => {
+    for (const mode of ["off", "shadow"]) {
+      const check = checkSelfEchoIdentityHistory({
+        proxyMode: mode,
+        botIds: new Set([ORCH_ID]),
+        recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
+      });
+      expect(check.status).toBe(STATUS.INFO);
+    }
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -59,6 +59,7 @@ import {
   runDoctor,
   checkFleetTokenExport,
   readLinearBotUserIds,
+  readCloudBotUserId,
   checkSelfEchoIdentityHistory,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
@@ -404,6 +405,23 @@ describe("readLinearBotUserIds (doctor inline twin, CTL-2074)", () => {
     expect(ids.has("worker-uuid")).toBe(true);
     expect(ids.has("orch-uuid")).toBe(true);
   });
+
+  // Codex #3738 P2: the cloud-proxy actor is read on its own so the self-echo cross-check
+  // can tie its PASS to THIS id rather than any historical set member.
+  it("readCloudBotUserId returns the cloud slot, and \"\" when absent/unreadable", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({ catalyst: { linear: { bot: { cloud: { botUserId: "cloud-uuid" } } } } })
+    );
+    expect(readCloudBotUserId(layer2)).toBe("cloud-uuid");
+    // absent slot → "" (not undefined), never throws
+    const bare = join(tmpDir, "bare.json");
+    writeFileSync(bare, JSON.stringify({ catalyst: { linear: { bot: {} } } }));
+    expect(readCloudBotUserId(bare)).toBe("");
+    expect(readCloudBotUserId(join(tmpDir, "does-not-exist.json"))).toBe("");
+    expect(readCloudBotUserId(null)).toBe("");
+  });
 });
 
 // ─── CTL-2074: checkSelfEchoIdentityHistory — the loud history cross-check ────
@@ -415,42 +433,74 @@ const CLOUD_ID = "78f8f491-0000-4000-8000-000000000000";
 const HUMAN_ID = "c2a8cc92-0000-4000-8000-000000000000";
 
 describe("checkSelfEchoIdentityHistory (CTL-2074)", () => {
-  it("WARNs when proxy=enforce and no recognized identity writes state (names the candidates)", () => {
-    const check = checkSelfEchoIdentityHistory({
-      proxyMode: "enforce",
-      botIds: new Set([ORCH_ID]),
-      recentActors: () => [
-        { actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 },
-        { actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 },
-      ],
-    });
-    expect(check.status).toBe(STATUS.WARN);
-    // names the unrecognized state-writer so the operator has a candidate to confirm
-    expect(check.detail).toMatch(/78f8f491|cloud|proxied|Catalyst Cloud/i);
-  });
-
-  it("PASSes when a recognized identity is present in history AND in the set", () => {
+  it("WARNs when proxy=enforce and the configured cloud identity never writes state (names the candidates)", () => {
     const check = checkSelfEchoIdentityHistory({
       proxyMode: "enforce",
       botIds: new Set([ORCH_ID, CLOUD_ID]),
+      cloudBotId: CLOUD_ID,
+      recentActors: () => [{ actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 }],
+    });
+    expect(check.status).toBe(STATUS.WARN);
+    // names the unrecognized state-writer so the operator has a candidate to confirm
+    expect(check.detail).toMatch(/c2a8cc92|Ryan Rozich|proxied|human replies/i);
+  });
+
+  it("PASSes when the configured cloud-proxy identity is present in history AND in the set", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID, CLOUD_ID]),
+      cloudBotId: CLOUD_ID,
       recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
     });
     expect(check.status).toBe(STATUS.PASS);
   });
 
-  it("WARNs when the configured cloud id never appears in recent history (misconfigured)", () => {
+  // Codex #3738 P2 regression: a LEGACY recognized actor (pre-cutover worker/orch id
+  // still in the set) that appears in history must NOT mask an unrecognized CURRENT
+  // cloud writer. The old "any member recognized ⇒ PASS" produced a clean PASS here.
+  it("WARNs (not PASS) when a legacy set member writes state but the cloud proxy actor does not (masking)", () => {
     const check = checkSelfEchoIdentityHistory({
       proxyMode: "enforce",
       botIds: new Set([ORCH_ID, CLOUD_ID]),
-      recentActors: () => [{ actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 }],
+      cloudBotId: CLOUD_ID,
+      // ORCH_ID is a recognized set member and writes state; CLOUD_ID (the current
+      // proxy actor) is absent — its proxied writes still read as human replies.
+      recentActors: () => [
+        { actorId: ORCH_ID, name: "Legacy Orchestrator", count: 42 },
+        { actorId: HUMAN_ID, name: "Ryan Rozich", count: 103 },
+      ],
     });
     expect(check.status).toBe(STATUS.WARN);
+    expect(check.detail).toMatch(/cloud-proxy identity|proxied writes read/i);
+  });
+
+  it("WARNs when the cloud-proxy identity is not configured at all (the CTL-2074 silent condition)", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID]),
+      cloudBotId: "",
+      recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
+    });
+    expect(check.status).toBe(STATUS.WARN);
+    expect(check.detail).toMatch(/not configured|bot\.cloud\.botUserId/i);
+  });
+
+  it("WARNs when the cloud id writes state but is ABSENT from the recognition set", () => {
+    const check = checkSelfEchoIdentityHistory({
+      proxyMode: "enforce",
+      botIds: new Set([ORCH_ID]), // cloud id NOT in the recognition set
+      cloudBotId: CLOUD_ID,
+      recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
+    });
+    expect(check.status).toBe(STATUS.WARN);
+    expect(check.detail).toMatch(/recognition set/i);
   });
 
   it("is INCONCLUSIVE (never PASS) when the replica cannot be read (recentActors → undefined)", () => {
     const check = checkSelfEchoIdentityHistory({
       proxyMode: "enforce",
       botIds: new Set([ORCH_ID, CLOUD_ID]),
+      cloudBotId: CLOUD_ID,
       recentActors: () => undefined,
     });
     expect(check.status).not.toBe(STATUS.PASS); // could-not-look ≠ clean
@@ -460,6 +510,7 @@ describe("checkSelfEchoIdentityHistory (CTL-2074)", () => {
     const check = checkSelfEchoIdentityHistory({
       proxyMode: "enforce",
       botIds: new Set([ORCH_ID, CLOUD_ID]),
+      cloudBotId: CLOUD_ID,
       recentActors: () => [],
     });
     expect(check.status).not.toBe(STATUS.PASS);
@@ -470,6 +521,7 @@ describe("checkSelfEchoIdentityHistory (CTL-2074)", () => {
       const check = checkSelfEchoIdentityHistory({
         proxyMode: mode,
         botIds: new Set([ORCH_ID]),
+        cloudBotId: CLOUD_ID,
         recentActors: () => [{ actorId: CLOUD_ID, name: "Catalyst Cloud", count: 11 }],
       });
       expect(check.status).toBe(STATUS.INFO);

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -58,6 +58,7 @@ import {
   parseArgs,
   runDoctor,
   checkFleetTokenExport,
+  readLinearBotUserIds,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -367,6 +368,40 @@ describe("checkPeerUniqueness", () => {
     expect(checks[0].name).toBe("peer-uniqueness");
     expect(checks[0].status).toBe(STATUS.WARN);
     expect(checks[0].detail).toContain("empty");
+  });
+});
+
+// ─── CTL-2074: doctor's inline readLinearBotUserIds twin picks up the cloud slot ──
+// The inline copy at doctor.mjs:157 exists to keep doctor off the daemon's bun: graph;
+// it must not drift from the daemon resolver. This exercises the copy directly so a
+// missing cloud slot fails here at CI, not silently in production.
+describe("readLinearBotUserIds (doctor inline twin, CTL-2074)", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "doctor-bot-ids-"));
+  });
+  afterEach(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("includes catalyst.linear.bot.cloud.botUserId", () => {
+    const layer2 = join(tmpDir, "config.json");
+    writeFileSync(
+      layer2,
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: {
+              worker: { botUserId: "worker-uuid" },
+              orchestrator: { botUserId: "orch-uuid" },
+              cloud: { botUserId: "cloud-uuid" },
+            },
+          },
+        },
+      })
+    );
+    const ids = readLinearBotUserIds(null, layer2);
+    expect(ids.has("cloud-uuid")).toBe(true);
+    expect(ids.has("worker-uuid")).toBe(true);
+    expect(ids.has("orch-uuid")).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-bot-identity.test.mjs
@@ -25,6 +25,7 @@ import {
 const OLD = "f51bc697-c64b-47b8-9fba-a2981fbfe652"; // retired 2026-08-10
 const NEW = "ba2989f1-f250-4273-943c-ca511c66e793"; // current, from 2026-08-10
 const HUMAN = "11111111-2222-3333-4444-555555555555"; // a genuine third party
+const CLOUD = "78f8f491-0000-4000-8000-000000000000"; // synthetic cloud-proxy identity (CTL-2074)
 
 let dir;
 let ledger;
@@ -272,6 +273,23 @@ describe("readSelfEchoIdentities — the seam the daemon actually calls", () => 
     const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: HUMAN }), ledger);
     expect(after.has(NEW)).toBe(true);
     expect(after.has(OLD)).toBe(true);
+  });
+
+  // CTL-2074: a configured cloud id flows through the same sync seam for free —
+  // rotation-durable with no ledger change, because a configured id is "an id we
+  // write as" (source: config), not an OBSERVED writer.
+  test("a configured cloud id is recorded in the identity ledger (source: config)", () => {
+    const layer2Cloud = join(dir, "layer2-cloud.json");
+    writeFileSync(
+      layer2Cloud,
+      JSON.stringify({ catalyst: { linear: { bot: { cloud: { botUserId: CLOUD } } } } }),
+    );
+    const ids = readSelfEchoIdentities(null, layer2Cloud, ledger);
+    expect(ids.has(CLOUD)).toBe(true);
+    expect(readIdentityLedger(ledger).ids.has(CLOUD)).toBe(true);
+    // and it persists after the config drops it — the rotation-durability guarantee
+    const after = readSelfEchoIdentities(null, layer2(dir, { orchestrator: NEW }), ledger);
+    expect(after.has(CLOUD)).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/replica-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.mjs
@@ -243,6 +243,23 @@ const LAST_STATE_CHANGE_SELECT = `SELECT h.actor_id AS actorId, h.to_state AS to
 const FLEET_WROTE_SELECT = (n) =>
   `SELECT 1 FROM issue_history h JOIN issues i ON i.id = h.issue_id WHERE i.identifier = ? AND h.to_state IS NOT NULL AND h.actor_id IN (${Array(n).fill("?").join(",")}) LIMIT 1`;
 
+// CTL-2074 — the distinct actors who have written a STATE change recently, with a
+// legible name and a count. This is the POSITIVE CONTROL doctor's
+// self-echo-identity-history check reads: it verifies the recognition set against who
+// ACTUALLY writes state, from real issue_history rows, never from config. Deliberately
+// NOT joined to `issues`: an inner join would silently DROP a state change whose issue
+// row has not synced yet — the exact false-empty this whole check exists to catch. The
+// `actor_id IS NOT NULL` predicate keeps a system/null-actor row from forming a bogus
+// bucket; `to_state IS NOT NULL` is the same state-change filter the two selects above use.
+const RECENT_STATE_CHANGE_ACTORS_SELECT = `
+  SELECT h.actor_id AS actorId, u.name AS name, COUNT(*) AS count
+  FROM issue_history h
+  LEFT JOIN users u ON u.id = h.actor_id
+  WHERE h.to_state IS NOT NULL AND h.actor_id IS NOT NULL
+  GROUP BY h.actor_id
+  ORDER BY count DESC
+  LIMIT ?`;
+
 const OWNERSHIP_SELECT = `SELECT assignee_id, delegate_id, delegate_name FROM issues WHERE identifier = ? AND removed_at IS NULL LIMIT 1`;
 // Relation enrichment, mirroring normalizeDetail in linear-cli.mjs. forward:
 // edges this issue OWNS (relatedIssue is the target); inverse: edges that point
@@ -990,11 +1007,35 @@ export function createReplicaReader({ dbPath = getReplicaDbPath() } = {}) {
     }
   };
 
+  // recentStateChangeActors({ limit }) → Array<{actorId, name, count}> | undefined
+  //   HIT (table present)      → the distinct recent state-change actors (possibly []).
+  //   [] = looked-and-found-nothing (positive control FAILED — the caller treats this
+  //        as inconclusive, NOT clean); undefined = could-not-look (no db / missing
+  //        table / any throw). ⛔ The two must stay distinct: a doctor check that reads
+  //        an empty array as "no problem" is the silent false-clean this ticket exists
+  //        to end. CTL-2074.
+  const recentStateChangeActors = ({ limit = 50 } = {}) => {
+    const n = Number.isInteger(limit) && limit > 0 ? limit : 50;
+    try {
+      const rows = open().prepare(RECENT_STATE_CHANGE_ACTORS_SELECT).all(n);
+      if (!Array.isArray(rows)) return undefined;
+      return rows.map((r) => ({
+        actorId: r.actorId ?? null,
+        name: r.name ?? null,
+        count: Number(r.count) || 0,
+      }));
+    } catch {
+      dropHandle();
+      return undefined;
+    }
+  };
+
   return {
     lookup,
     freshness,
     lastStateChange, // CTL-2068
     fleetEverWroteState, // CTL-2068
+    recentStateChangeActors, // CTL-2074
     titles,
     estimates, // CTL-1806
     relations, // CTL-1806

--- a/plugins/dev/scripts/execution-core/replica-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/replica-read.test.mjs
@@ -1101,3 +1101,75 @@ describe("createReplicaReader.labelsBatch", () => {
     expect(reader.labelsBatch(["CTL-200"])).toBeUndefined();
   });
 });
+
+// ── CTL-2074: recentStateChangeActors — the positive-control history read ─────
+// doctor's self-echo-identity-history check verifies the recognition set against
+// who ACTUALLY writes state, from real issue_history rows (not config). This is
+// the accessor it reads. Fail-open (undefined) on "could not look", never a false
+// empty.
+const CLOUD_ID = "78f8f491-0000-4000-8000-000000000000";
+const HUMAN_ID = "c2a8cc92-0000-4000-8000-000000000000";
+
+function seedHistory(rows) {
+  const db = new Database(dbPath, { create: true });
+  db.run(`CREATE TABLE issue_history (id TEXT, issue_id TEXT, actor_id TEXT, created_at INTEGER, to_state TEXT)`);
+  db.run(`CREATE TABLE users (id TEXT, name TEXT)`);
+  let i = 0;
+  for (const r of rows) {
+    db.run(
+      `INSERT INTO issue_history (id, issue_id, actor_id, created_at, to_state) VALUES (?, ?, ?, ?, ?)`,
+      [`h${i}`, r.issueId ?? "I1", r.actorId ?? null, r.atMs ?? 1000 + i, r.toState ?? null],
+    );
+    i += 1;
+  }
+  db.run(`INSERT INTO users (id, name) VALUES (?, ?)`, [CLOUD_ID, "Catalyst Cloud"]);
+  db.run(`INSERT INTO users (id, name) VALUES (?, ?)`, [HUMAN_ID, "Ryan Rozich"]);
+  db.close();
+}
+
+describe("createReplicaReader.recentStateChangeActors (CTL-2074)", () => {
+  test("returns distinct state-change actors with counts + names (positive control)", () => {
+    seedHistory([
+      { actorId: CLOUD_ID, toState: "Done" },
+      { actorId: HUMAN_ID, toState: "In Progress" },
+      { actorId: HUMAN_ID, toState: "Done" },
+      { actorId: null, toState: null }, // a field edit, NOT a state change → excluded
+    ]);
+    reader = createReplicaReader({ dbPath });
+    const actors = reader.recentStateChangeActors({ limit: 50 });
+    expect(actors).toBeInstanceOf(Array); // rows returned ⇒ positive control holds
+    expect(actors.find((a) => a.actorId === CLOUD_ID).count).toBe(1);
+    expect(actors.find((a) => a.actorId === CLOUD_ID).name).toBe("Catalyst Cloud");
+    expect(actors.find((a) => a.actorId === HUMAN_ID).count).toBe(2);
+    expect(actors.some((a) => a.actorId === null)).toBe(false); // to_state null excluded
+  });
+
+  test("returns [] (looked, found nothing) when the table is present but empty", () => {
+    seedHistory([]);
+    reader = createReplicaReader({ dbPath });
+    expect(reader.recentStateChangeActors({ limit: 50 })).toEqual([]);
+  });
+
+  test("returns undefined on no db (fail-open, never a false empty)", () => {
+    reader = createReplicaReader({ dbPath: "/nonexistent/replica.db" });
+    expect(reader.recentStateChangeActors({ limit: 50 })).toBeUndefined();
+  });
+
+  test("returns undefined when issue_history is absent (throw → could-not-look)", () => {
+    const db = new Database(dbPath, { create: true });
+    db.run(`CREATE TABLE unrelated (x INTEGER)`);
+    db.close();
+    reader = createReplicaReader({ dbPath });
+    expect(reader.recentStateChangeActors({ limit: 50 })).toBeUndefined();
+  });
+
+  test("honors the limit bound", () => {
+    seedHistory([
+      { actorId: "a1", toState: "Done" },
+      { actorId: "a2", toState: "Done" },
+      { actorId: "a3", toState: "Done" },
+    ]);
+    reader = createReplicaReader({ dbPath });
+    expect(reader.recentStateChangeActors({ limit: 2 })).toHaveLength(2);
+  });
+});

--- a/plugins/dev/scripts/execution-core/self-echo-negative-control.test.mjs
+++ b/plugins/dev/scripts/execution-core/self-echo-negative-control.test.mjs
@@ -120,7 +120,12 @@ describe("CTL-2074 — self-echo suppression of a proxied-identity DESCRIPTION U
     const orchDir = seedInFlightWorker("CTL-2074");
     try {
       const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud: true }));
-      writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: CLOUD_ID });
+      writer({
+        ticket: "CTL-2074",
+        description: "updated",
+        descriptionChanged: true,
+        actorId: CLOUD_ID,
+      });
       expect(readInbox(orchDir, "CTL-2074")).toEqual([]);
     } finally {
       rmSync(orchDir, { recursive: true, force: true });
@@ -131,7 +136,12 @@ describe("CTL-2074 — self-echo suppression of a proxied-identity DESCRIPTION U
     const orchDir = seedInFlightWorker("CTL-2074");
     try {
       const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud: false }));
-      writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: CLOUD_ID });
+      writer({
+        ticket: "CTL-2074",
+        description: "updated",
+        descriptionChanged: true,
+        actorId: CLOUD_ID,
+      });
       expect(readInbox(orchDir, "CTL-2074")).toHaveLength(1);
     } finally {
       rmSync(orchDir, { recursive: true, force: true });
@@ -143,7 +153,12 @@ describe("CTL-2074 — self-echo suppression of a proxied-identity DESCRIPTION U
       const orchDir = seedInFlightWorker("CTL-2074");
       try {
         const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud }));
-        writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: HUMAN_ID });
+        writer({
+          ticket: "CTL-2074",
+          description: "updated",
+          descriptionChanged: true,
+          actorId: HUMAN_ID,
+        });
         expect(readInbox(orchDir, "CTL-2074")).toHaveLength(1);
       } finally {
         rmSync(orchDir, { recursive: true, force: true });
@@ -182,12 +197,18 @@ describe("CTL-2074 — handleCommentWake needs-human clear respects the proxied 
   }
 
   test("proxied-id comment does NOT clear needs-human when the cloud id is in the set", async () => {
-    const removed = await runWake({ authorId: CLOUD_ID, botSet: setFromConfig({ withCloud: true }) });
+    const removed = await runWake({
+      authorId: CLOUD_ID,
+      botSet: setFromConfig({ withCloud: true }),
+    });
     expect(removed).not.toContain("needs-human"); // self-echo guard short-circuited
   });
 
   test("⭐ NEGATIVE CONTROL: drop the cloud id and the SAME proxied comment clears needs-human (the defect)", async () => {
-    const removed = await runWake({ authorId: CLOUD_ID, botSet: setFromConfig({ withCloud: false }) });
+    const removed = await runWake({
+      authorId: CLOUD_ID,
+      botSet: setFromConfig({ withCloud: false }),
+    });
     expect(removed).toContain("needs-human"); // the daemon's own write reads as a human
   });
 

--- a/plugins/dev/scripts/execution-core/self-echo-negative-control.test.mjs
+++ b/plugins/dev/scripts/execution-core/self-echo-negative-control.test.mjs
@@ -1,0 +1,200 @@
+// self-echo-negative-control.test.mjs — CTL-2074.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test self-echo-negative-control.test.mjs
+//
+// The ticket's teeth. `botUserIds` is the fleet's answer to "was this Linear change
+// made by us?". Since CTL-1889 both minis write THROUGH the cloud proxy
+// (CATALYST_LINEAR_WRITE_PROXY=enforce), so a mirrored-back proxied write carries the
+// cloud tenant's app-actor id — which, before CTL-2074, was absent from the set and so
+// read as "a human replied on the daemon's own output".
+//
+// This is an END-TO-END test of the config → resolved Set → guard path: it builds the
+// recognition Set from a REAL config fixture via readSelfEchoIdentities (NOT by
+// hand-constructing `new Set([CLOUD_ID])`), so it proves Phase 1's wiring, not just
+// _isBotId in isolation. Every "suppressed" assertion carries the ⭐ NEGATIVE CONTROL:
+// remove the cloud id and the SAME event leaks through — the one case a config-shaped
+// set that names nobody-who-writes would still pass, and the reason the fix has teeth.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readSelfEchoIdentities,
+  createCommentInboxWriter,
+  createUpdateInboxWriter,
+  handleCommentWake,
+} from "./daemon.mjs";
+
+// Synthetic, well-formed UUIDs. CLOUD_ID must be UUID-shaped so it flows through the
+// rotation-durable ledger (isPlausibleIdentityId gates ledger writes on UUID shape).
+const ORCH_ID = "ba2989f1-0000-4000-8000-000000000000"; // configured orchestrator app actor
+const CLOUD_ID = "78f8f491-0000-4000-8000-000000000000"; // synthetic cloud-proxy identity
+const HUMAN_ID = "c2a8cc92-0000-4000-8000-000000000000"; // synthetic human (e.g. Ryan)
+
+let dir;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "self-echo-nc-"));
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+// Build the recognition Set the SAME way the daemon does: from a real Layer-2 config
+// fixture, through readSelfEchoIdentities (config → ledger → Set). With `withCloud`
+// the cloud slot is present; without it, the negative control.
+function setFromConfig({ withCloud }) {
+  const layer2 = join(dir, `layer2-${withCloud ? "cloud" : "nocloud"}.json`);
+  const bot = { orchestrator: { botUserId: ORCH_ID } };
+  if (withCloud) bot.cloud = { botUserId: CLOUD_ID };
+  writeFileSync(layer2, JSON.stringify({ catalyst: { linear: { bot } } }));
+  const ledger = join(dir, `ledger-${withCloud ? "cloud" : "nocloud"}.json`);
+  return readSelfEchoIdentities(null, layer2, ledger);
+}
+
+// Seed an in-flight worker dir (the inbox writers only write when workers/<ticket>/
+// exists). Returns the orchDir.
+function seedInFlightWorker(ticket) {
+  const orchDir = mkdtempSync(join(tmpdir(), "self-echo-orch-"));
+  mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+  return orchDir;
+}
+
+// Read inbox.jsonl as parsed entries; [] when the file was never written.
+function readInbox(orchDir, ticket) {
+  const p = join(orchDir, "workers", ticket, "inbox.jsonl");
+  if (!existsSync(p)) return [];
+  return readFileSync(p, "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+describe("CTL-2074 — self-echo suppression of a proxied-identity COMMENT (config→Set→guard)", () => {
+  test("sanity: the Set built from config actually carries the cloud id", () => {
+    expect(setFromConfig({ withCloud: true }).has(CLOUD_ID)).toBe(true);
+    expect(setFromConfig({ withCloud: false }).has(CLOUD_ID)).toBe(false);
+  });
+
+  test("proxied-identity comment is suppressed (no inbox entry) when the cloud id is in the set", () => {
+    const orchDir = seedInFlightWorker("CTL-2074");
+    try {
+      const writer = createCommentInboxWriter(orchDir, setFromConfig({ withCloud: true }));
+      writer({ ticket: "CTL-2074", commentId: "c1", body: "mirror", authorId: CLOUD_ID });
+      expect(readInbox(orchDir, "CTL-2074")).toEqual([]); // suppressed
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+
+  // ⭐ THE NEGATIVE CONTROL — with the id removed the SAME event is recorded, so the
+  //    suppression assertion above has teeth. A set that names nobody who writes would
+  //    pass every prior config-shaped check; this is the one that fails without the id.
+  test("⭐ NEGATIVE CONTROL: remove the cloud id and the same proxied comment IS recorded", () => {
+    const orchDir = seedInFlightWorker("CTL-2074");
+    try {
+      const writer = createCommentInboxWriter(orchDir, setFromConfig({ withCloud: false }));
+      writer({ ticket: "CTL-2074", commentId: "c1", body: "mirror", authorId: CLOUD_ID });
+      const inbox = readInbox(orchDir, "CTL-2074");
+      expect(inbox).toHaveLength(1); // leaks through — proves the guard NEEDS the id
+      expect(inbox[0].authorId).toBe(CLOUD_ID);
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a genuine human reply is recorded in BOTH configurations (still wakes the worker)", () => {
+    for (const withCloud of [true, false]) {
+      const orchDir = seedInFlightWorker("CTL-2074");
+      try {
+        const writer = createCommentInboxWriter(orchDir, setFromConfig({ withCloud }));
+        writer({ ticket: "CTL-2074", commentId: "h1", body: "human", authorId: HUMAN_ID });
+        expect(readInbox(orchDir, "CTL-2074")).toHaveLength(1);
+      } finally {
+        rmSync(orchDir, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+describe("CTL-2074 — self-echo suppression of a proxied-identity DESCRIPTION UPDATE", () => {
+  test("proxied-identity description update is suppressed when the cloud id is in the set", () => {
+    const orchDir = seedInFlightWorker("CTL-2074");
+    try {
+      const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud: true }));
+      writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: CLOUD_ID });
+      expect(readInbox(orchDir, "CTL-2074")).toEqual([]);
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+
+  test("⭐ NEGATIVE CONTROL: without the cloud id the same description update IS recorded", () => {
+    const orchDir = seedInFlightWorker("CTL-2074");
+    try {
+      const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud: false }));
+      writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: CLOUD_ID });
+      expect(readInbox(orchDir, "CTL-2074")).toHaveLength(1);
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  });
+
+  test("a genuine human description update is recorded in both configurations", () => {
+    for (const withCloud of [true, false]) {
+      const orchDir = seedInFlightWorker("CTL-2074");
+      try {
+        const writer = createUpdateInboxWriter(orchDir, setFromConfig({ withCloud }));
+        writer({ ticket: "CTL-2074", description: "updated", descriptionChanged: true, actorId: HUMAN_ID });
+        expect(readInbox(orchDir, "CTL-2074")).toHaveLength(1);
+      } finally {
+        rmSync(orchDir, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+describe("CTL-2074 — handleCommentWake needs-human clear respects the proxied identity", () => {
+  // Capture every removeLabel(ticket, label) call. The needs-human clear fires only
+  // when handleCommentWake believes a human authored the comment; a proxied-identity
+  // comment recognised as self must short-circuit BEFORE the clear.
+  function runWake({ authorId, botSet }) {
+    const orchDir = mkdtempSync(join(tmpdir(), "self-echo-wake-"));
+    const removed = [];
+    return handleCommentWake(
+      { ticket: "CTL-2074", authorId },
+      {
+        orchDir,
+        botUserId: botSet,
+        dispatch: () => {},
+        removeLabel: async (_ticket, label) => {
+          removed.push(label);
+          return { removed: true, wrote: true };
+        },
+        isManagedTicket: () => true, // this installation manages the ticket
+        forgetIntent: () => {},
+        appendWorkerTransitionEvent: () => {},
+        clearDispositionEmit: () => {},
+        resolveSession: () => null,
+        clearStall: () => false,
+      }
+    )
+      .then(() => removed)
+      .finally(() => rmSync(orchDir, { recursive: true, force: true }));
+  }
+
+  test("proxied-id comment does NOT clear needs-human when the cloud id is in the set", async () => {
+    const removed = await runWake({ authorId: CLOUD_ID, botSet: setFromConfig({ withCloud: true }) });
+    expect(removed).not.toContain("needs-human"); // self-echo guard short-circuited
+  });
+
+  test("⭐ NEGATIVE CONTROL: drop the cloud id and the SAME proxied comment clears needs-human (the defect)", async () => {
+    const removed = await runWake({ authorId: CLOUD_ID, botSet: setFromConfig({ withCloud: false }) });
+    expect(removed).toContain("needs-human"); // the daemon's own write reads as a human
+  });
+
+  test("a genuine human reply DOES clear needs-human (still wakes the worker) in both configs", async () => {
+    for (const withCloud of [true, false]) {
+      const removed = await runWake({ authorId: HUMAN_ID, botSet: setFromConfig({ withCloud }) });
+      expect(removed).toContain("needs-human");
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/webhook-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import {
   loadWebhookConfig,
   loadLinearAgentConfig,
+  loadLinearBotUserIds,
   _resetWebhookDeprecationWarning,
 } from "../lib/webhook-config";
 
@@ -1431,5 +1432,43 @@ describe("loadWebhookConfig — linearAgentConfig", () => {
     const cfg = loadWebhookConfig(homeDir, projectConfigPath);
 
     expect(cfg!.linearAgentConfig).toBeNull();
+  });
+});
+
+// CTL-2074: the cloud-proxy recognition slot must be picked up here too — this
+// resolver feeds orch-monitor's Linear webhook _isBotActor. It must stay in
+// lockstep with the daemon + doctor twins.
+describe("loadLinearBotUserIds — cloud slot (CTL-2074)", () => {
+  it("includes catalyst.linear.bot.cloud.botUserId from Layer-2", () => {
+    writeFileSync(
+      join(homeDir, "config.json"),
+      JSON.stringify({
+        catalyst: {
+          linear: {
+            bot: {
+              worker: { botUserId: "worker-uuid" },
+              orchestrator: { botUserId: "orch-uuid" },
+              cloud: { botUserId: "cloud-uuid" },
+            },
+          },
+        },
+      }),
+    );
+    const ids = loadLinearBotUserIds(homeDir, projectConfigPath);
+    expect(ids.has("cloud-uuid")).toBe(true);
+    expect(ids.has("worker-uuid")).toBe(true);
+    expect(ids.has("orch-uuid")).toBe(true);
+  });
+
+  it("omits the cloud slot when absent (no phantom id)", () => {
+    writeFileSync(
+      join(homeDir, "config.json"),
+      JSON.stringify({
+        catalyst: { linear: { bot: { orchestrator: { botUserId: "orch-uuid" } } } },
+      }),
+    );
+    const ids = loadLinearBotUserIds(homeDir, projectConfigPath);
+    expect(ids.has("orch-uuid")).toBe(true);
+    expect(ids.size).toBe(1);
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/webhook-config.ts
@@ -390,8 +390,8 @@ export function loadLinearAgentConfig(
  *
  * Returns `null` if either the channel or secret cannot be resolved.
  */
-/** Linear app-actor user ids: worker + orchestrator botUserIds from the Layer-2
- *  global config.json, plus the Layer-1 back-compat
+/** Linear app-actor user ids: worker + orchestrator + cloud (CTL-2074) botUserIds
+ *  from the Layer-2 global config.json, plus the Layer-1 back-compat
  *  `catalyst.monitor.linear.botUserId`. Exported SEPARATELY from
  *  loadWebhookConfig because these ids also classify agent comments on read
  *  surfaces (the discussion timeline) — a monitor with no webhook transport
@@ -415,6 +415,12 @@ export function loadLinearBotUserIds(
         }
         if (isRecord(botSection.orchestrator) && typeof botSection.orchestrator.botUserId === "string") {
           const id = botSection.orchestrator.botUserId;
+          if (id.length > 0) linearBotUserIds.add(id);
+        }
+        // CTL-2074: cloud-proxy app-actor — recognition-only. Must stay in lockstep
+        // with the daemon + doctor twins so a proxied write's authorId is recognised.
+        if (isRecord(botSection.cloud) && typeof botSection.cloud.botUserId === "string") {
+          const id = botSection.cloud.botUserId;
           if (id.length > 0) linearBotUserIds.add(id);
         }
       }

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -330,21 +330,23 @@ setup tool manages. See the
 [Worker-status labels reference](/autonomous-workflow/worker-status-labels/) for what each label
 means and how the HUD displays them.
 
-## Linear app-actor identity (`catalyst.linear.bot.{worker,orchestrator}.botUserId`)
+## Linear app-actor identity (`catalyst.linear.bot.{worker,orchestrator,cloud}.botUserId`)
 
 Catalyst posts to Linear as a Linear OAuth **app actor** — the "Linear for Agents" identity that
 comments **as Catalyst**. Linear OAuth apps are account-level (one app serves every team), so the
 bot identity and OAuth credentials now live in the **global** `~/.config/catalyst/config.json` under
-`catalyst.linear.bot`, split into two app actors:
+`catalyst.linear.bot`, split into app actors:
 
 - `catalyst.linear.bot.worker` — the worker app that posts phase-agent mirror comments and mints
   tokens via `client_credentials`.
 - `catalyst.linear.bot.orchestrator` — the orchestrator app that posts run-level updates.
+- `catalyst.linear.bot.cloud` — the cloud tenant's app actor whose identity the fleet's writes
+  carry when `CATALYST_LINEAR_WRITE_PROXY=enforce` (CTL-1889/ADR-0031). Recognition-only.
 
 Each carries a `botUserId` (the Linear user UUID of that app actor). The daemon and orch-monitor
-read **both** `botUserId`s into a single set so the self-echo / loop-prevention guard suppresses
-comments and issue events from **either** app actor. These UUIDs aren't secret (they appear on every
-comment the app posts), but they are account-specific.
+read **all** the `botUserId`s into a single set so the self-echo / loop-prevention guard suppresses
+comments and issue events from **any** of those app actors. These UUIDs aren't secret (they appear on
+every comment the app posts), but they are account-specific.
 
 ```json
 {
@@ -363,6 +365,9 @@ comment the app posts), but they are account-specific.
           "clientSecret": "...",
           "accessToken": "...",
           "botUserId": null
+        },
+        "cloud": {
+          "botUserId": null
         }
       }
     }
@@ -374,6 +379,7 @@ comment the app posts), but they are account-specific.
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `catalyst.linear.bot.worker.botUserId`                                         | Linear user UUID of the worker app actor. Suppresses self-echo on mirror comments / description updates. Also the read ID for the daemon's self-echo filter.                                                                                                                                                                                      |
 | `catalyst.linear.bot.orchestrator.botUserId`                                   | Linear user UUID of the orchestrator app actor. **Also drives self-assign on claim (CTL-1011)** — the daemon writes this UUID as the Linear assignee when it claims a ticket. When absent, `applyAssignee` emits a single deduped `warn` and leaves the ticket unassigned. Daemon reads it **only at startup** — restart required after changing. |
+| `catalyst.linear.bot.cloud.botUserId`                                          | Linear user UUID the fleet's writes carry when `CATALYST_LINEAR_WRITE_PROXY=enforce` (the cloud tenant's app actor, ADR-0031/CTL-1889). **Recognition-only:** enters the self-echo set so proxied comments/updates are suppressed and don't read as a human reply; does **not** drive self-assign (`readLinearBotWriteId` still prefers the orchestrator id). Provisioned from a proxy-confirmed value (CTL-2074). Verify with `catalyst doctor` (the self-echo-identity-history check). |
 | `catalyst.linear.bot.worker.{clientId,clientSecret,webhookSecret,accessToken}` | OAuth app-actor credentials for the worker identity. Secrets — keep in the un-committed global config                                                                                                                                                                                                                                             |
 
 > **Self-assign activation:** `catalyst.linear.bot.orchestrator.botUserId` must be set AND the
@@ -387,7 +393,7 @@ comment the app posts), but they are account-specific.
 Every reader prefers the new global path and falls back to the old location, so a running daemon or
 webhook receiver keeps working whether the value has been migrated yet:
 
-- **Bot IDs:** `catalyst.linear.bot.{worker,orchestrator}.botUserId` (global) → fall back to
+- **Bot IDs:** `catalyst.linear.bot.{worker,orchestrator,cloud}.botUserId` (global) → fall back to
   `catalyst.monitor.linear.botUserId` (per-repo `.catalyst/config.json`, the legacy single-actor
   location).
 - **Worker OAuth creds:** `catalyst.linear.bot.worker.{clientId,clientSecret}` (global) → fall back


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-19T22:25:11Z -->
<!-- Last updated: 2026-08-19T22:25:11Z -->
<!-- PR: #3738 -->
<!-- Previous commits: 12d0e5dee1cb8f29529d13d0d0a81a1ce3d7017a,1976ecefa67192f1a7d7692ba8232b769c3053ce,859af880c0d2800ac8e0a5f3705f6613d0b43871,f75538fb912103a2f9f3f88bd2a9d4a8a3512a21 -->

## Summary

The fleet's self-echo identity set (`botUserIds`) is its answer to "was this Linear change made by
us?" — it feeds the daemon's comment/update inbox writers, the CTL-768 comment-wake `needs-human`
clear, and CTL-2068's lane-claim guard. Since CTL-1889 both minis write Linear **through the cloud
proxy** (`CATALYST_LINEAR_WRITE_PROXY=enforce`), so their writes carry the **cloud tenant's**
app-actor id — which was absent from the recognition set. A proxied write mirrored back therefore
read as "a human replied on the daemon's own output": a silent failure, because the set is resolved
from config + a durable ledger and **never from history**.

This PR closes that gap in three additive phases: (1) a `catalyst.linear.bot.cloud.botUserId` config
seam that enters the self-echo set (recognition-only — never a self-assign identity), (2) an
end-to-end negative-control test proving the config → resolved Set → guard path suppresses a proxied
identity and, with the cloud id removed, the same event leaks through, and (3) a loud `catalyst
doctor` cross-check that verifies the recognition set against who **actually** writes state in real
`issue_history` rows, with a positive control so a "could not look" result is inconclusive, never a
clean pass.

## Changes Made

### Phase 1 — cloud-proxy identity config seam (`bot.cloud.botUserId`)

- **`execution-core/daemon.mjs`** — `readLinearBotUserIds` now also reads
  `catalyst.linear.bot.cloud.botUserId` (Layer-2) into the recognition Set. It is
  **recognition-only**: deliberately NOT returned by `readLinearBotWriteId`, so the daemon never
  self-assigns as the cloud tenant (self-assign stays the orchestrator identity).
- **`orch-monitor/lib/webhook-config.ts`** — `loadLinearBotUserIds` picks up the same `cloud` slot,
  kept in lockstep with the daemon so a proxied comment/update's author is recognised on the
  read-surface (discussion timeline) path too.

### Phase 2 — end-to-end negative-control test

- **`execution-core/self-echo-negative-control.test.mjs`** (new) — builds the recognition Set from a
  **real** Layer-2 config fixture via `readSelfEchoIdentities` (not a hand-constructed `Set`), then
  drives `createCommentInboxWriter` / `createUpdateInboxWriter` / `handleCommentWake`. Every
  "suppressed" assertion carries its ⭐ negative control: remove the cloud id and the same event
  leaks through — the one case a config-shaped set that names nobody-who-writes would still pass.
- **`execution-core/linear-bot-identity.test.mjs`** — a configured cloud id flows through the same
  sync seam and is recorded in the identity ledger (`source: config`), so it is rotation-durable
  after the config drops it.
- **`.github/workflows/execution-core-tests.yml`** — adds `self-echo-negative-control.test.mjs` to
  the execution-core test allowlist so the new file actually gates CI.

### Phase 3 — loud self-echo identity ↔ `issue_history` cross-check in doctor

- **`execution-core/doctor.mjs`** — new advisory `checkSelfEchoIdentityHistory` check (WARN, never
  FAIL). Under `CATALYST_LINEAR_WRITE_PROXY=enforce`, it compares the resolved recognition set
  against the actors who actually write state, read from real `issue_history` rows. If none of the
  recent state-writers are recognised, it WARNs and names the candidate ids so an operator can
  confirm the right one **at the proxy** (never auto-classified). Every negative path carries a
  positive control — a replica that cannot be read, or an empty history window, is INCONCLUSIVE, not
  a clean pass. Doctor's inline `readLinearBotUserIds` twin is now exported and picks up the cloud
  slot so it cannot silently drift from the daemon resolver.
- **`execution-core/replica-read.mjs`** — new `recentStateChangeActors` reader (the positive-control
  history read). Returns distinct recent state-change actors with name + count; `[]` means
  looked-and-found-nothing, `undefined` means could-not-look — the two are kept strictly distinct.
  Deliberately a `LEFT JOIN` (not an inner join to `issues`) so an unsynced issue row can't silently
  drop a state change.
- **`website/src/content/docs/reference/configuration.md`** — documents the new `cloud` app-actor
  slot, its recognition-only semantics, and pointing operators at `catalyst doctor` to verify.

## How to Verify It

- [ ] Negative-control test: `cd plugins/dev/scripts/execution-core && bun test self-echo-negative-control.test.mjs`
- [ ] Daemon resolver + doctor twin: `bun test daemon.test.mjs doctor.test.mjs`
- [ ] Replica reader: `bun test replica-read.test.mjs`
- [ ] Identity-ledger durability: `bun test linear-bot-identity.test.mjs`
- [x] CI — required checks green (`quality`, `docs-gate`, `validate`, `skills-gate`, CodeQL/Analyze); `execution-core-unit-tests` running.

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-2074

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1889
skip CTL-2068
skip CTL-768