### PR TITLE
feat(dev): CTL-2000 — steward-first escalation (resolver-independent slice)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1313,6 +1313,9 @@ jobs:
             signal-reader.test.mjs \
             stale-pr-rescue-timer.test.mjs \
             stale-pr-rescue.test.mjs \
+            __tests__/escalation-router.test.mjs \
+            __tests__/stale-pr-rescue-escalate-router.test.mjs \
+            __tests__/no-direct-human-escalation.test.mjs \
             stalled-detector.test.mjs \
             terminal-state.test.mjs \
             test-setup.test.mjs \

--- a/plugins/dev/scripts/execution-core/__tests__/escalation-router.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/escalation-router.test.mjs
@@ -1,0 +1,59 @@
+// escalation-router.test.mjs — CTL-2000. The ladder policy is tested
+// deterministically here rather than discovered during an outage: every
+// function under test is pure and injectable (no clock, no I/O).
+import { test, expect } from "bun:test";
+import { resolveSteward, nextEscalationTarget, TARGET } from "../escalation-router.mjs";
+
+test("resolveSteward returns null when no roles are configured (today's reality)", () => {
+  expect(resolveSteward("catalyst/execution-core", { listRoles: () => [], readManifest: () => null })).toBeNull();
+});
+
+test("resolveSteward returns null for a free-text scope with no registry match", () => {
+  const deps = { listRoles: () => ["steward-a"], readManifest: () => ({ role: "steward-a", scope: "some prose about a project" }) };
+  expect(resolveSteward("execution-core", deps)).toBeNull();
+});
+
+test("resolveSteward returns the role when a registry entry matches (CTL-1974 forward-compat)", () => {
+  const deps = { listRoles: () => ["steward-x"], readManifest: () => ({ role: "steward-x", scope: "execution-core", scopeKeys: ["execution-core"] }) };
+  expect(resolveSteward("execution-core", deps)).toEqual({ role: "steward-x", scope: "execution-core" });
+});
+
+test("ladder: with no steward, the FIRST page targets the concierge, never the human", () => {
+  const t = nextEscalationTarget({ scope: "execution-core", priorPages: 0, resolveSteward: () => null });
+  expect(t.target).toBe(TARGET.CONCIERGE);
+  expect(t.target).not.toBe(TARGET.HUMAN_DIRECT); // this enum value must not exist
+});
+
+test("ladder: with a steward, first page targets the steward; concierge only after 2 silences", () => {
+  const withSteward = { resolveSteward: () => ({ role: "steward-x", scope: "execution-core" }) };
+  expect(nextEscalationTarget({ scope: "execution-core", priorPages: 0, ...withSteward }).target).toBe(TARGET.STEWARD);
+  expect(nextEscalationTarget({ scope: "execution-core", priorPages: 2, ...withSteward }).target).toBe(TARGET.CONCIERGE);
+});
+
+test("the human is reachable only as an ask — the router never returns a direct-human target", () => {
+  const targets = [0, 1, 2, 3, 99].map((p) => nextEscalationTarget({ scope: "s", priorPages: p, resolveSteward: () => null }).target);
+  expect(targets.every((t) => t === TARGET.CONCIERGE || t === TARGET.ASK)).toBe(true);
+});
+
+test("every returned target carries the instrument tag shape `instrument/<name>`", () => {
+  const t = nextEscalationTarget({ scope: "s", priorPages: 0, instrument: "quiet-fleet", resolveSteward: () => null });
+  expect(t.tag).toBe("instrument/quiet-fleet");
+});
+
+// ── Additional edge coverage (fail-closed direction) ─────────────────────────
+
+test("TARGET has no direct-human member — the absence is the structural invariant", () => {
+  expect(TARGET.HUMAN_DIRECT).toBeUndefined();
+  expect(Object.values(TARGET)).not.toContain("human");
+});
+
+test("resolveSteward is null-safe when deps are missing (pure, never throws)", () => {
+  expect(resolveSteward("execution-core")).toBeNull();
+  expect(resolveSteward("", { listRoles: () => ["s"], readManifest: () => ({ scopeKeys: [""] }) })).toBeNull();
+});
+
+test("nextEscalationTarget tolerates a missing resolveSteward and falls through to concierge", () => {
+  const t = nextEscalationTarget({ scope: "s", priorPages: 0 });
+  expect(t.target).toBe(TARGET.CONCIERGE);
+  expect(t.steward).toBeNull();
+});

--- a/plugins/dev/scripts/execution-core/__tests__/no-direct-human-escalation.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/no-direct-human-escalation.test.mjs
@@ -1,0 +1,36 @@
+// no-direct-human-escalation.test.mjs — CTL-2000 Phase 4. The cross-cutting
+// guardrail: NO ladder outcome is a direct-human target, for any steward state
+// and any page count. "An instrument that reaches the human directly is a
+// defect" (routing.md) — this proves the router makes that defect
+// unconstructible. Run from execution-core/ under `bun test`.
+import { test, expect } from "bun:test";
+import { TARGET, nextEscalationTarget } from "../escalation-router.mjs";
+
+test("no ladder outcome is a direct-human target — for any steward state and page count", () => {
+  for (const steward of [null, { role: "s", scope: "x" }]) {
+    for (const priorPages of [0, 1, 2, 5]) {
+      const t = nextEscalationTarget({ scope: "x", priorPages, resolveSteward: () => steward });
+      expect([TARGET.STEWARD, TARGET.CONCIERGE, TARGET.ASK]).toContain(t.target);
+    }
+  }
+});
+
+test("TARGET carries no direct-human member — absence is the invariant", () => {
+  expect(TARGET.HUMAN_DIRECT).toBeUndefined();
+  expect(Object.values(TARGET)).not.toContain("human");
+});
+
+test("the human is reachable only via ASK — never returned directly by the ladder", () => {
+  // Exhaustive over a wide page-count sweep and both steward states: the router
+  // only ever yields STEWARD or CONCIERGE (ASK is the concierge's own next hop,
+  // filed by hand). It can never yield a human.
+  const outcomes = new Set();
+  for (const steward of [null, { role: "s", scope: "x" }]) {
+    for (let p = 0; p <= 50; p++) {
+      outcomes.add(nextEscalationTarget({ scope: "x", priorPages: p, resolveSteward: () => steward }).target);
+    }
+  }
+  for (const o of outcomes) {
+    expect([TARGET.STEWARD, TARGET.CONCIERGE, TARGET.ASK]).toContain(o);
+  }
+});

--- a/plugins/dev/scripts/execution-core/__tests__/stale-pr-rescue-escalate-router.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/stale-pr-rescue-escalate-router.test.mjs
@@ -1,0 +1,125 @@
+// stale-pr-rescue-escalate-router.test.mjs — CTL-2000 Phase 4. The stalled-PR
+// sweep's defaultEscalate routed through the escalation router behind the
+// CATALYST_STEWARD_ESCALATION flag: shadow (default) is byte-identical to today
+// plus a would-route-steward log; enforce pages the concierge INSTEAD of
+// applying needs-human. Run from execution-core/ under `bun test`.
+//
+// NOTE: the real Linear transport is an OBJECT with an `.applyLabel` method
+// (labelOnce calls writeStatus.applyLabel(...)), not a bare function — the
+// bare-fn form in the plan sketch never lands a label. Every case here uses a
+// real temp orchDir + injected event/comms sinks so nothing touches the fleet.
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { defaultEscalate } from "../stale-pr-rescue-timer.mjs";
+
+function tmpOrch() {
+  return mkdtempSync(join(tmpdir(), "ctl2000-esc-"));
+}
+const okTransport = (calls) => ({ applyLabel: () => { calls.push(1); return { applied: true }; } });
+
+test("shadow (default): byte-identical to today — still labels, logs would-route-steward", () => {
+  const orchDir = tmpOrch();
+  const events = [];
+  const calls = [];
+  try {
+    const out = defaultEscalate("CTL-1", { reason: "conflict", prNumber: 9 }, {
+      orchDir,
+      linearWrite: okTransport(calls),
+      env: { CATALYST_STEWARD_ESCALATION: "shadow" },
+      appendDelegateEvent: (e) => events.push(e),
+      resolveSteward: () => null,
+    });
+    expect(out.confirmed).toBe(true); // unchanged contract — the label still lands
+    expect(calls).toHaveLength(1); // applyLabel WAS called (today's path)
+    expect(events.some((e) => e.type?.includes("would-route-steward"))).toBe(true);
+  } finally {
+    rmSync(orchDir, { recursive: true, force: true });
+  }
+});
+
+test("shadow is byte-identical to off (same {confirmed,routed,reason}), off logs nothing", () => {
+  const base = { reason: "conflict", prNumber: 9 };
+  const call = (mode) => {
+    const orchDir = tmpOrch();
+    const events = [];
+    try {
+      const out = defaultEscalate("CTL-1", base, {
+        orchDir,
+        linearWrite: okTransport([]),
+        env: { CATALYST_STEWARD_ESCALATION: mode },
+        appendDelegateEvent: (e) => events.push(e),
+        resolveSteward: () => null,
+      });
+      return { out, events };
+    } finally {
+      rmSync(orchDir, { recursive: true, force: true });
+    }
+  };
+  const off = call("off");
+  const shadow = call("shadow");
+  expect(shadow.out).toEqual(off.out); // identical routing outcome
+  expect(off.events).toHaveLength(0); // off logs no would-route event
+  expect(shadow.events.some((e) => e.type?.includes("would-route-steward"))).toBe(true);
+});
+
+test("enforce with no steward: pages the concierge, does NOT apply needs-human", () => {
+  const orchDir = tmpOrch();
+  const calls = [];
+  const posted = [];
+  try {
+    const out = defaultEscalate("CTL-1", { reason: "conflict", prNumber: 9 }, {
+      orchDir,
+      linearWrite: okTransport(calls),
+      env: { CATALYST_STEWARD_ESCALATION: "enforce" },
+      appendDelegateEvent: () => {},
+      resolveSteward: () => null,
+      postConciergePage: (p) => { posted.push(p); return true; },
+    });
+    expect(calls).toHaveLength(0); // needs-human label NEVER applied
+    expect(out.escalatedTo).toBe("concierge");
+    expect(out.confirmed).toBe(false); // a page is a handoff, not a confirmed escalation
+    expect(posted).toHaveLength(1); // the concierge was paged
+  } finally {
+    rmSync(orchDir, { recursive: true, force: true });
+  }
+});
+
+test("enforce emits an observable routed-to-concierge event on the log", () => {
+  const orchDir = tmpOrch();
+  const events = [];
+  try {
+    defaultEscalate("CTL-1", { reason: "conflict", prNumber: 9 }, {
+      orchDir,
+      linearWrite: okTransport([]),
+      env: { CATALYST_STEWARD_ESCALATION: "enforce" },
+      appendDelegateEvent: (e) => events.push(e),
+      resolveSteward: () => null,
+      postConciergePage: () => true,
+    });
+    expect(events.some((e) => e.type === "phase.rescue.routed-to-concierge")).toBe(true);
+  } finally {
+    rmSync(orchDir, { recursive: true, force: true });
+  }
+});
+
+test("enforce with a matched steward pages the steward, not the concierge, and applies no label", () => {
+  const orchDir = tmpOrch();
+  const calls = [];
+  try {
+    const out = defaultEscalate("CTL-1", { reason: "conflict", prNumber: 9 }, {
+      orchDir,
+      linearWrite: okTransport(calls),
+      env: { CATALYST_STEWARD_ESCALATION: "enforce" },
+      appendDelegateEvent: () => {},
+      resolveSteward: () => ({ role: "steward-x", scope: "CTL-1" }), // CTL-1974 forward-compat
+      postConciergePage: () => true,
+    });
+    expect(calls).toHaveLength(0);
+    expect(out.escalatedTo).toBe("steward");
+    expect(out.confirmed).toBe(false);
+  } finally {
+    rmSync(orchDir, { recursive: true, force: true });
+  }
+});

--- a/plugins/dev/scripts/execution-core/__tests__/stale-pr-rescue-escalate-router.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/stale-pr-rescue-escalate-router.test.mjs
@@ -107,6 +107,7 @@ test("enforce emits an observable routed-to-concierge event on the log", () => {
 test("enforce with a matched steward pages the steward, not the concierge, and applies no label", () => {
   const orchDir = tmpOrch();
   const calls = [];
+  const posted = [];
   try {
     const out = defaultEscalate("CTL-1", { reason: "conflict", prNumber: 9 }, {
       orchDir,
@@ -114,11 +115,17 @@ test("enforce with a matched steward pages the steward, not the concierge, and a
       env: { CATALYST_STEWARD_ESCALATION: "enforce" },
       appendDelegateEvent: () => {},
       resolveSteward: () => ({ role: "steward-x", scope: "CTL-1" }), // CTL-1974 forward-compat
-      postConciergePage: () => true,
+      postConciergePage: (p) => { posted.push(p); return true; },
     });
     expect(calls).toHaveLength(0);
     expect(out.escalatedTo).toBe("steward");
     expect(out.confirmed).toBe(false);
+    // Codex P2: the resolved steward target MUST be threaded to the page function
+    // so defaultPostConciergePage can deliver TO the steward instead of hardcoding
+    // the concierge — otherwise the event claims a steward route the message never took.
+    expect(posted).toHaveLength(1);
+    expect(posted[0].target?.target).toBe("steward");
+    expect(posted[0].target?.steward?.role).toBe("steward-x");
   } finally {
     rmSync(orchDir, { recursive: true, force: true });
   }

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2101,6 +2101,34 @@ export function readDelegateFirstConfig(envObj = process.env) {
   return { mode };
 }
 
+// CTL-2000: steward-first escalation mode reader. Same three-layer ladder as
+// readDelegateFirstConfig — env (CATALYST_STEWARD_ESCALATION) > Layer-2
+// (.catalyst.stewardEscalation.mode) > code default. The ONE deliberate
+// deviation from delegate-first: the safe default is "shadow", not "off", so a
+// merge logs what it WOULD route (would-route-steward) without changing any
+// instrument's live behavior until an operator flips it to "enforce".
+export const STEWARD_ESCALATION_MODES = new Set(["off", "shadow", "enforce"]);
+
+function readLayer2StewardEscalation() {
+  try {
+    const se = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.stewardEscalation;
+    return se && typeof se === "object" ? se : {};
+  } catch {
+    return {};
+  }
+}
+
+export function readStewardEscalationConfig(envObj = process.env) {
+  const l2 = readLayer2StewardEscalation();
+  const env = envObj?.CATALYST_STEWARD_ESCALATION;
+  let mode;
+  if (env === "0") mode = "off";
+  else if (typeof env === "string" && STEWARD_ESCALATION_MODES.has(env)) mode = env;
+  else if (typeof l2.mode === "string" && STEWARD_ESCALATION_MODES.has(l2.mode)) mode = l2.mode;
+  else mode = "shadow"; // conservative default: shadow-first, never act until flipped
+  return { mode };
+}
+
 // CTL-1847: cloud-feed dispatch-source mode reader. Same ladder as
 // readDelegateFirstConfig — env (CATALYST_CLOUD_FEED) > Layer-2
 // (.catalyst.cloudFeed.mode) > 'off'.

--- a/plugins/dev/scripts/execution-core/escalation-router.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-router.mjs
@@ -1,0 +1,75 @@
+// escalation-router.mjs — CTL-2000. The one place an instrument asks the ladder
+// "who do I page for this scope?". The ladder is written verbatim in
+// plugins/dev/skills/concierge/references/routing.md:
+//     instrument → steward of the scope → concierge → human (as an ask)
+//
+// The human is NOT a value in this router: it is reachable only as an ask
+// (TARGET.ASK), so no instrument can produce a direct-human page. That absence
+// is the whole point — "an instrument that reaches the human directly is a
+// defect" is the rule this module makes structurally impossible to violate.
+//
+// Pure and node:*-only (this file imports nothing at all): a bare-`node` role
+// runner must load it with no node_modules, the same import-free discipline
+// lib/agent-liveness.mjs established. All I/O — reading role manifests — is
+// injected through deps so the policy is tested deterministically rather than
+// discovered during an outage.
+
+export const TARGET = Object.freeze({ STEWARD: "steward", CONCIERGE: "concierge", ASK: "ask" });
+// NOTE: there is deliberately no TARGET.HUMAN_DIRECT — its absence is the invariant.
+
+// "two silences ≈ 90 min → page the concierge" (routing.md). After the steward
+// has been paged this many times on an item without taking a turn, the ladder
+// escalates INWARD to the concierge.
+export const STEWARD_TURNS_BEFORE_CONCIERGE = 2;
+
+/**
+ * Resolve the steward whose scope contains `scope`. Returns {role, scope} or null.
+ *
+ * TODAY: roles carry a free-text `scope` string in manifest.json, so this
+ * returns null unless a manifest declares an explicit `scopeKeys` array that
+ * includes `scope` — which nothing does until CTL-1974 ships the scope→steward
+ * registry. That is the forward-compatible seam: CTL-1974 activates the steward
+ * tier by POPULATING `scopeKeys` in each manifest, with no edit to this function
+ * or any call site.
+ *
+ * Deps (`listRoles`, `readManifest`) are injected so this stays pure and
+ * testable; a missing dep resolves to null (no steward) rather than throwing —
+ * the fail direction is "fall through to the concierge", never crash the caller.
+ *
+ * @param {string} scope
+ * @param {{listRoles?: () => string[], readManifest?: (role: string) => object|null}} [deps]
+ * @returns {{role: string, scope: string}|null}
+ */
+export function resolveSteward(scope, { listRoles, readManifest } = {}) {
+  if (!scope || typeof listRoles !== "function" || typeof readManifest !== "function") return null;
+  for (const role of listRoles()) {
+    const m = readManifest(role);
+    const keys = Array.isArray(m?.scopeKeys) ? m.scopeKeys : [];
+    if (keys.includes(scope)) return { role: m?.role ?? role, scope };
+  }
+  return null;
+}
+
+/**
+ * Next rung of `instrument → steward → concierge → human (as an ask)`.
+ *
+ * `priorPages` = how many times the current steward has already been paged on
+ * this item without taking a turn. `resolveSteward` is injected (a thunk that
+ * takes `scope`) so this function stays pure — the Phase-2/3/4 callers wire the
+ * real `role-supervisor` reader in.
+ *
+ * Guarantees, for ANY input, that the returned `target` is one of STEWARD,
+ * CONCIERGE, or ASK — never a direct-human target (there is no such enum value).
+ *
+ * @returns {{target: string, steward: {role: string, scope: string}|null, tag: string}}
+ */
+export function nextEscalationTarget({ scope, priorPages = 0, instrument = "unknown", resolveSteward: rs } = {}) {
+  const steward = typeof rs === "function" ? rs(scope) : null;
+  const tag = `instrument/${instrument}`;
+  if (steward && priorPages < STEWARD_TURNS_BEFORE_CONCIERGE) {
+    return { target: TARGET.STEWARD, steward, tag };
+  }
+  // No steward today, OR the steward has had its turn(s): escalate INWARD to the
+  // concierge. The human is only ever reached by the concierge filing an ask.
+  return { target: TARGET.CONCIERGE, steward: steward ?? null, tag };
+}

--- a/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-log-read-guard.test.mjs
@@ -149,6 +149,20 @@ const ALLOWLIST = [
       "offset of EOF': a tail read would drop history AND desync tailOffset from the caller's cursor.",
   },
   {
+    file: "role-supervisor/dead-man.mjs",
+    count: 1,
+    symbol: "defaultLastChannelTurnMs",
+    ticket: "CTL-2000",
+    reason:
+      "NOT the event log — the concierge comms channel JSONL " +
+      "(~/catalyst/comms/channels/<name>.jsonl), the SAME file class already allowlisted for " +
+      "orch-monitor/lib/comms-reader.ts, which the taint analysis cannot distinguish because both " +
+      "paths are built the same way. Bounded in practice by one run's channel traffic (KBs), and the " +
+      "out-of-fleet dead-man tick runs on its own launchd timer with no event loop to block. The " +
+      "contract is 'the most recent GENUINE turn' (a non-instrument author), which needs every line " +
+      "because an instrument's own post may be the last one — a tail read would misreport it.",
+  },
+  {
     file: "orch-monitor/lib/inbox-state.ts",
     count: 1,
     symbol: "readRaisedQuestion",

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -31,7 +31,7 @@ import { DEFAULTS, classifyMergeTree, decideRescue } from "./stale-pr-rescue.mjs
 // today (free-text scopes) and lights up when CTL-1974 populates scopeKeys —
 // wired here so no call-site edit is needed then. listRoles/readManifest are
 // node:*-only leaves (agent-liveness/state/paths), safe under bun.
-import { nextEscalationTarget, resolveSteward as resolveStewardCore } from "./escalation-router.mjs";
+import { nextEscalationTarget, resolveSteward as resolveStewardCore, TARGET } from "./escalation-router.mjs";
 import { listRoles } from "../role-supervisor/doctor.mjs";
 import { readManifest } from "../role-supervisor/state.mjs";
 // Default Linear transport for the escalation path. The daemon does not thread
@@ -358,17 +358,24 @@ export function defaultResolveSteward(scope) {
   }
 }
 
-// CTL-2000: page the concierge on the shared channel (never a human). Fail-open
-// — a failed post must not turn into a silent drop. Best-effort spawn, short
-// timeout; the returned bool is advisory.
-export function defaultPostConciergePage({ ticket, detail, env = process.env } = {}) {
+// CTL-2000: page the resolved ladder rung on the shared channel (never a human).
+// Honors `target` (from nextEscalationTarget): a STEWARD route is delivered TO
+// the resolved steward, not to the concierge — otherwise the emitted event and
+// return value claim `routed-to-steward` while the message silently goes to the
+// concierge, skipping the mandated steward rung (Codex P2). Falls back to the
+// concierge when there is no steward (today's only reachable case until CTL-1974
+// populates `scopeKeys`). Fail-open — a failed post must not turn into a silent
+// drop; best-effort spawn, short timeout; the returned bool is advisory.
+export function defaultPostConciergePage({ ticket, detail, target, env = process.env } = {}) {
   try {
     const channel = env?.CATALYST_CONCIERGE_CHANNEL || "concierge";
-    const to = env?.CATALYST_CONCIERGE_ID || "concierge";
+    const toSteward = target?.target === TARGET.STEWARD && target?.steward?.role ? String(target.steward.role) : null;
+    const to = toSteward ?? env?.CATALYST_CONCIERGE_ID ?? "concierge";
+    const rung = toSteward ? `steward (${to})` : "the steward";
     const comms = fileURLToPath(new URL("../catalyst-comms", import.meta.url));
     const body =
       `instrument/stale-pr-rescue: ${ticket} could not be rescued (${detail?.reason ?? "unresolvable conflict"}` +
-      `${detail?.prNumber ? `, PR #${detail.prNumber}` : ""}) — page the steward / decide ask-vs-relaunch.`;
+      `${detail?.prNumber ? `, PR #${detail.prNumber}` : ""}) — ${toSteward ? "your scope" : `page ${rung}`} / decide ask-vs-relaunch.`;
     const res = spawnSync(comms, ["send", channel, body, "--as", "stale-pr-rescue", "--to", to, "--type", "attention"], {
       encoding: "utf8",
       timeout: 15_000,

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -24,9 +24,16 @@ import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { fenceGuard } from "./fence-guard.mjs";
 import { appendFileSync } from "node:fs";
-import { log, getEventLogPath, getClusterHosts } from "./config.mjs";
+import { log, getEventLogPath, getClusterHosts, readStewardEscalationConfig } from "./config.mjs";
 import { buildCanonicalEventLine } from "./lib/canonical-event.mjs"; // CTL-1817
 import { DEFAULTS, classifyMergeTree, decideRescue } from "./stale-pr-rescue.mjs";
+// CTL-2000: the escalation-ladder chokepoint. resolveStewardCore returns null
+// today (free-text scopes) and lights up when CTL-1974 populates scopeKeys —
+// wired here so no call-site edit is needed then. listRoles/readManifest are
+// node:*-only leaves (agent-liveness/state/paths), safe under bun.
+import { nextEscalationTarget, resolveSteward as resolveStewardCore } from "./escalation-router.mjs";
+import { listRoles } from "../role-supervisor/doctor.mjs";
+import { readManifest } from "../role-supervisor/state.mjs";
 // Default Linear transport for the escalation path. The daemon does not thread
 // a writer (scheduler.mjs threads its own), so without this default every
 // escalation reason would silently degrade to a log line and the ticket would
@@ -339,6 +346,39 @@ function defaultDispatchRescue(ticket, opts) {
 // fail, and `escalatedAt` permanently skips the ticket in decideRescue, so
 // latching on a route would silently strand the PR. Fence-suppressed and
 // no-transport paths return confirmed:false too.
+// CTL-2000: the default (production) steward resolver. Wired to the router's
+// pure resolveSteward with role-supervisor's registry reads, so it returns null
+// TODAY (no manifest declares scopeKeys) and activates the steward tier the
+// moment CTL-1974 populates them — without touching this call site.
+export function defaultResolveSteward(scope) {
+  try {
+    return resolveStewardCore(scope, { listRoles, readManifest });
+  } catch {
+    return null;
+  }
+}
+
+// CTL-2000: page the concierge on the shared channel (never a human). Fail-open
+// — a failed post must not turn into a silent drop. Best-effort spawn, short
+// timeout; the returned bool is advisory.
+export function defaultPostConciergePage({ ticket, detail, env = process.env } = {}) {
+  try {
+    const channel = env?.CATALYST_CONCIERGE_CHANNEL || "concierge";
+    const to = env?.CATALYST_CONCIERGE_ID || "concierge";
+    const comms = fileURLToPath(new URL("../catalyst-comms", import.meta.url));
+    const body =
+      `instrument/stale-pr-rescue: ${ticket} could not be rescued (${detail?.reason ?? "unresolvable conflict"}` +
+      `${detail?.prNumber ? `, PR #${detail.prNumber}` : ""}) — page the steward / decide ask-vs-relaunch.`;
+    const res = spawnSync(comms, ["send", channel, body, "--as", "stale-pr-rescue", "--to", to, "--type", "attention"], {
+      encoding: "utf8",
+      timeout: 15_000,
+    });
+    return res.status === 0;
+  } catch {
+    return false;
+  }
+}
+
 export function defaultEscalate(
   ticket,
   detail,
@@ -351,8 +391,61 @@ export function defaultEscalate(
     env = process.env,
     maxParallel = undefined,
     appendDelegateEvent = defaultAppendDelegateEvent,
+    // CTL-2000: the escalation-ladder seam. shadow (default) preserves today's
+    // exact behavior and only LOGS a would-route-steward event; enforce routes
+    // through the router (concierge today; steward when CTL-1974 lands) INSTEAD
+    // of applying needs-human. off is byte-identical to shadow minus the log.
+    resolveSteward = defaultResolveSteward,
+    postConciergePage = defaultPostConciergePage,
   } = {}
 ) {
+  const stewardMode = readStewardEscalationConfig(env).mode; // off | shadow | enforce (default shadow)
+
+  // ── enforce: route through the ladder INSTEAD of applying needs-human ──────
+  // A concierge page is a HANDOFF, not a confirmed human escalation, so
+  // confirmed stays false (escalatedAt must NOT latch on it — same rule the
+  // delegate-route path already honors). The fence-guard is preserved: a
+  // superseded ticket must not page anyone.
+  if (stewardMode === "enforce") {
+    if (
+      !fenceGuard(
+        { ticket, orchDir, multiHost, gateway, self },
+        { proceedOnMissingGeneration: true }
+      )
+    ) {
+      log.warn({ ticket }, "ctl-863: stale fence — suppressing stale-pr-rescue steward-route (zombie guard)");
+      return { confirmed: false, routed: false, reason: "fence-suppressed", escalatedTo: null };
+    }
+    const rs = typeof resolveSteward === "function" ? resolveSteward : () => null;
+    const t = nextEscalationTarget({ scope: ticket, priorPages: 0, instrument: "stale-pr-rescue", resolveSteward: rs });
+    const posted = postConciergePage({ ticket, detail, target: t, env });
+    // Observable page event on the unified log (queryable by ticket). The `type`
+    // discriminator names the ladder rung; the registered delegate.routed name
+    // keeps it a valid, non-broker-protected line.
+    appendDelegateEvent({
+      name: "delegate.routed",
+      type: `phase.rescue.routed-to-${t.target}`,
+      ticket,
+      site: "stale-pr-rescue-steward",
+      reason: detail?.reason ?? "unresolvable-conflict",
+      orchId: ticket,
+    });
+    log.warn({ ticket, target: t.target, posted, ...detail }, `stale-pr-rescue: routed to ${t.target} (steward-escalation enforce) — no needs-human label`);
+    return { confirmed: false, routed: false, reason: `routed-to-${t.target}`, escalatedTo: t.target };
+  }
+
+  // ── shadow (default): log would-route-steward, then TODAY'S EXACT PATH ──────
+  if (stewardMode === "shadow") {
+    appendDelegateEvent({
+      name: "delegate.would-route",
+      type: "phase.rescue.would-route-steward",
+      ticket,
+      site: "stale-pr-rescue-steward",
+      reason: detail?.reason ?? "unresolvable-conflict",
+      orchId: ticket,
+    });
+  }
+
   let routed = false;
   let labelled = false;
   let outcomeReason = "no-transport";

--- a/plugins/dev/scripts/role-supervisor/backstop.mjs
+++ b/plugins/dev/scripts/role-supervisor/backstop.mjs
@@ -1,0 +1,60 @@
+// backstop.mjs — CTL-2000. The two pure classifiers behind the OUT-OF-FLEET
+// backstops (routing.md → "Backstopping the backstop"):
+//
+//   1. the holding-reply SENTINEL posts the tagged "steward/<slug> is being
+//      restarted" reply at the 15-minute silence mark and asks the supervisor
+//      to restart the role;
+//   2. the DEAD-MAN alarm pushes the human ONCE and posts on the channel when
+//      there is no concierge heartbeat AND no channel turn for 30 minutes.
+//
+// "A 529 wave takes stewards and concierge together — measured twice on
+// 2026-08-18." So these live in their own launchd units and cannot be taken
+// down with the fleet. This file is the pure, node:*-only decision core (it
+// imports nothing); the launchd shells (holding-sentinel.mjs / dead-man.mjs)
+// wire the real reads to it.
+
+// These thresholds are RELATED to agent-liveness's SILENT_AFTER_MS (10m) /
+// DEAD_AFTER_MS (30m) but deliberately DISTINCT: the holding reply is a
+// silence-to-restart trigger (15m, between silent and dead), and the dead-man
+// is concierge-specific (heartbeat 30m AND channel-turn 30m). Kept as their own
+// named constants — see Open Question 3 on whether operators want one knob.
+export const HOLDING_REPLY_AFTER_MS = 15 * 60 * 1000; // cf. SILENT_AFTER_MS (10m) / DEAD_AFTER_MS (30m)
+export const DEAD_MAN_AFTER_MS = 30 * 60 * 1000; // matches DEAD_AFTER_MS, applied to BOTH signals
+
+/**
+ * Should the holding-reply sentinel post now? True once the role has been
+ * silent for >= 15 minutes and the reply has not already been posted this
+ * episode. A null/undefined silence age is "nothing to act on" → false (the
+ * sentinel needs a positive silence measurement, unlike the dead-man which
+ * treats absence as death).
+ *
+ * @param {{silenceMs: number|null, alreadyPosted: boolean}} arg
+ * @returns {boolean}
+ */
+export function shouldPostHoldingReply({ silenceMs, alreadyPosted = false } = {}) {
+  if (alreadyPosted) return false;
+  if (typeof silenceMs !== "number") return false;
+  return silenceMs >= HOLDING_REPLY_AFTER_MS;
+}
+
+/**
+ * Should the dead-man alarm fire now? True ONLY when BOTH the concierge
+ * heartbeat AND the last channel turn are >= 30 minutes old, and the alarm has
+ * not already pushed this episode.
+ *
+ * A `null` age (missing heartbeat / no channel turn ever) counts as DEAD, never
+ * as healthy — the absence of a signal is not evidence of life, and defaulting
+ * it to alive is how a dead concierge would hide. Requiring BOTH signals is
+ * what keeps a merely-restarting concierge (fresh channel turn) or a quiet-but-
+ * alive one (fresh heartbeat) from paging the human.
+ *
+ * @param {{conciergeHbAgeMs: number|null, lastChannelTurnAgeMs: number|null, alreadyPushed: boolean}} arg
+ * @returns {boolean}
+ */
+export function deadManShouldFire({ conciergeHbAgeMs, lastChannelTurnAgeMs, alreadyPushed = false } = {}) {
+  if (alreadyPushed) return false;
+  // null/undefined/non-number → treat as "infinitely old" (dead/silent).
+  const hbDead = !(typeof conciergeHbAgeMs === "number") || conciergeHbAgeMs >= DEAD_MAN_AFTER_MS;
+  const turnDead = !(typeof lastChannelTurnAgeMs === "number") || lastChannelTurnAgeMs >= DEAD_MAN_AFTER_MS;
+  return hbDead && turnDead;
+}

--- a/plugins/dev/scripts/role-supervisor/backstop.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/backstop.test.mjs
@@ -1,0 +1,56 @@
+// backstop.test.mjs — CTL-2000. The two out-of-fleet backstops are pure
+// classifiers: the holding-reply sentinel fires at the 15-minute silence mark
+// (once), and the dead-man alarm fires ONLY when the concierge is both
+// heartbeat-dead AND channel-silent for 30 minutes. Both decisions are tested
+// deterministically here — never discovered during the outage they exist for.
+//
+// Top-level (not __tests__/) to match run-tests.sh's `../role-supervisor/*.test.mjs`.
+import { test, expect } from "bun:test";
+import { shouldPostHoldingReply, deadManShouldFire } from "./backstop.mjs";
+
+const M = 60_000;
+
+test("holding reply fires at the 15-minute silence mark, once", () => {
+  expect(shouldPostHoldingReply({ silenceMs: 14 * M, alreadyPosted: false })).toBe(false);
+  expect(shouldPostHoldingReply({ silenceMs: 15 * M, alreadyPosted: false })).toBe(true);
+  expect(shouldPostHoldingReply({ silenceMs: 20 * M, alreadyPosted: true })).toBe(false); // idempotent
+});
+
+test("dead-man fires ONLY when both concierge heartbeat AND channel turn are >30m", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: 31 * M, lastChannelTurnAgeMs: 31 * M, alreadyPushed: false })).toBe(true);
+  expect(deadManShouldFire({ conciergeHbAgeMs: 31 * M, lastChannelTurnAgeMs: 5 * M, alreadyPushed: false })).toBe(false); // a recent turn means alive
+  expect(deadManShouldFire({ conciergeHbAgeMs: 5 * M, lastChannelTurnAgeMs: 31 * M, alreadyPushed: false })).toBe(false); // heartbeat fresh
+});
+
+test("dead-man pushes the human at most once per episode", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: 40 * M, lastChannelTurnAgeMs: 40 * M, alreadyPushed: true })).toBe(false);
+});
+
+test("a missing concierge heartbeat (null age) counts as dead, not as healthy", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: null, lastChannelTurnAgeMs: 31 * M, alreadyPushed: false })).toBe(true);
+});
+
+// ── Additional coverage (fail-closed direction + boundaries) ─────────────────
+
+test("a missing channel turn (null age) counts as silent, not as healthy", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: 31 * M, lastChannelTurnAgeMs: null, alreadyPushed: false })).toBe(true);
+});
+
+test("both ages missing → fire (nothing proves the concierge is alive)", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: null, lastChannelTurnAgeMs: null, alreadyPushed: false })).toBe(true);
+});
+
+test("dead-man boundary is inclusive at exactly 30m", () => {
+  expect(deadManShouldFire({ conciergeHbAgeMs: 30 * M, lastChannelTurnAgeMs: 30 * M, alreadyPushed: false })).toBe(true);
+  expect(deadManShouldFire({ conciergeHbAgeMs: 30 * M - 1, lastChannelTurnAgeMs: 30 * M, alreadyPushed: false })).toBe(false);
+});
+
+test("holding-reply boundary is inclusive at exactly 15m", () => {
+  expect(shouldPostHoldingReply({ silenceMs: 15 * M - 1, alreadyPosted: false })).toBe(false);
+  expect(shouldPostHoldingReply({ silenceMs: 15 * M, alreadyPosted: false })).toBe(true);
+});
+
+test("holding reply never fires on a null/undefined silence age (nothing to act on)", () => {
+  expect(shouldPostHoldingReply({ silenceMs: null, alreadyPosted: false })).toBe(false);
+  expect(shouldPostHoldingReply({ alreadyPosted: false })).toBe(false);
+});

--- a/plugins/dev/scripts/role-supervisor/cli.mjs
+++ b/plugins/dev/scripts/role-supervisor/cli.mjs
@@ -5,11 +5,18 @@
 //   doctor [--json]  one row per role: liveness, status-doc age, restarts
 //   stop <role>      ask a role to write its handoff and exit; it stays down
 //   list             the configured roles
+//   quiet-fleet [--once] [--dry-run]   page the concierge when a role goes quiet
 import { writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { superviseRole } from "./supervisor.mjs";
 import { runSdkSession } from "./sdk-session.mjs";
 import { report, formatReport, listRoles } from "./doctor.mjs";
+import { runQuietFleetOnce } from "./quiet-fleet.mjs";
 import { roleFiles } from "./paths.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// One tick a minute, matching the plist's ThrottleInterval — the alarm never
+// touches the daemon hot path or Linear/GitHub.
+const QUIET_FLEET_INTERVAL_MS = 60_000;
 
 const [verb, arg] = process.argv.slice(2);
 
@@ -41,8 +48,34 @@ async function main() {
       console.log(roles.length ? roles.join("\n") : "(no roles configured)");
       return 0;
     }
+    case "quiet-fleet": {
+      // The launchd-supervised alarm. `--once` runs a single tick (what the
+      // plist's StartInterval fires); with no flags it loops in the foreground.
+      // `--dry-run` prints the pages it WOULD send and mutates nothing.
+      const once = process.argv.includes("--once");
+      const dryRun = process.argv.includes("--dry-run");
+      const tick = () => {
+        const r = runQuietFleetOnce({ dryRun });
+        console.log(JSON.stringify(r));
+        return r;
+      };
+      if (once) {
+        tick();
+        return 0;
+      }
+      // Foreground loop. launchd's KeepAlive restarts this if it ever exits.
+      for (;;) {
+        try {
+          tick();
+        } catch (e) {
+          // Fail-open: a bad tick must not stop the alarm.
+          console.error(`role-supervisor: quiet-fleet tick error — ${e.message}`);
+        }
+        await sleep(QUIET_FLEET_INTERVAL_MS);
+      }
+    }
     default:
-      die("usage: role-supervisor run <role> | doctor [--json] | stop <role> | list");
+      die("usage: role-supervisor run <role> | doctor [--json] | stop <role> | list | quiet-fleet [--once] [--dry-run]");
   }
 }
 

--- a/plugins/dev/scripts/role-supervisor/cli.mjs
+++ b/plugins/dev/scripts/role-supervisor/cli.mjs
@@ -11,6 +11,8 @@ import { superviseRole } from "./supervisor.mjs";
 import { runSdkSession } from "./sdk-session.mjs";
 import { report, formatReport, listRoles } from "./doctor.mjs";
 import { runQuietFleetOnce } from "./quiet-fleet.mjs";
+import { runHoldingSentinelOnce } from "./holding-sentinel.mjs";
+import { runDeadManOnce } from "./dead-man.mjs";
 import { roleFiles } from "./paths.mjs";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -48,34 +50,46 @@ async function main() {
       console.log(roles.length ? roles.join("\n") : "(no roles configured)");
       return 0;
     }
-    case "quiet-fleet": {
-      // The launchd-supervised alarm. `--once` runs a single tick (what the
-      // plist's StartInterval fires); with no flags it loops in the foreground.
-      // `--dry-run` prints the pages it WOULD send and mutates nothing.
-      const once = process.argv.includes("--once");
-      const dryRun = process.argv.includes("--dry-run");
-      const tick = () => {
-        const r = runQuietFleetOnce({ dryRun });
-        console.log(JSON.stringify(r));
-        return r;
-      };
-      if (once) {
-        tick();
-        return 0;
-      }
-      // Foreground loop. launchd's KeepAlive restarts this if it ever exits.
-      for (;;) {
-        try {
-          tick();
-        } catch (e) {
-          // Fail-open: a bad tick must not stop the alarm.
-          console.error(`role-supervisor: quiet-fleet tick error — ${e.message}`);
-        }
-        await sleep(QUIET_FLEET_INTERVAL_MS);
-      }
-    }
+    // The three CTL-2000 out-of-fleet / fleet-wide instruments share one loop
+    // shape: `--once` runs a single tick (what the plist's StartInterval fires),
+    // `--dry-run` prints intended actions and mutates nothing, and with neither
+    // flag they loop in the foreground under launchd KeepAlive.
+    case "quiet-fleet":
+      return runInstrument("quiet-fleet", runQuietFleetOnce);
+    case "holding-sentinel":
+      return runInstrument("holding-sentinel", runHoldingSentinelOnce);
+    case "dead-man":
+      return runInstrument("dead-man", runDeadManOnce);
     default:
-      die("usage: role-supervisor run <role> | doctor [--json] | stop <role> | list | quiet-fleet [--once] [--dry-run]");
+      die(
+        "usage: role-supervisor run <role> | doctor [--json] | stop <role> | list | " +
+          "quiet-fleet [--once] [--dry-run] | holding-sentinel [--once] [--dry-run] | dead-man [--once] [--dry-run]",
+      );
+  }
+}
+
+// Shared instrument loop for quiet-fleet / holding-sentinel / dead-man.
+// `runOnce({dryRun})` returns a JSON-serialisable tick result. Fail-open: a
+// throwing tick logs and continues so a launchd-supervised alarm never wedges.
+async function runInstrument(name, runOnce) {
+  const once = process.argv.includes("--once");
+  const dryRun = process.argv.includes("--dry-run");
+  const tick = () => {
+    const r = runOnce({ dryRun });
+    console.log(JSON.stringify(r));
+    return r;
+  };
+  if (once) {
+    tick();
+    return 0;
+  }
+  for (;;) {
+    try {
+      tick();
+    } catch (e) {
+      console.error(`role-supervisor: ${name} tick error — ${e.message}`);
+    }
+    await sleep(QUIET_FLEET_INTERVAL_MS);
   }
 }
 

--- a/plugins/dev/scripts/role-supervisor/com.catalyst.dead-man.plist
+++ b/plugins/dev/scripts/role-supervisor/com.catalyst.dead-man.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent for the OUT-OF-FLEET dead-man alarm — CTL-2000.
+
+  Label com.catalyst.dead-man. install.sh substitutes every REPLACE_WITH_*
+  token and copies it into ~/Library/LaunchAgents/.
+
+    bash install.sh --dead-man
+    bash install.sh --dead-man --uninstall
+
+  "You cannot be the thing that notices you are dead." This unit is separate
+  from every fleet role on purpose: it fires when the concierge has no heartbeat
+  AND no channel turn for 30 minutes, pushes the human ONCE, and posts on the
+  channel — the one alarm a 529 wave that took stewards and concierge together
+  cannot silence.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>REPLACE_WITH_LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_NODE</string>
+    <string>REPLACE_WITH_CLI</string>
+    <string>dead-man</string>
+    <string>--once</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- StartInterval, not KeepAlive: `--once` runs one tick and exits 0; launchd
+       re-fires every 60 s so a 30-minute death is caught within one interval. -->
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>REPLACE_WITH_PATH</string>
+    <key>CATALYST_DIR</key>
+    <string>REPLACE_WITH_CATALYST_DIR</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CWD</string>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_LOG</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_LOG</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/role-supervisor/com.catalyst.holding-sentinel.plist
+++ b/plugins/dev/scripts/role-supervisor/com.catalyst.holding-sentinel.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent for the OUT-OF-FLEET holding-reply sentinel — CTL-2000.
+
+  Label com.catalyst.holding-sentinel. install.sh substitutes every
+  REPLACE_WITH_* token and copies it into ~/Library/LaunchAgents/.
+
+    bash install.sh --holding-sentinel
+    bash install.sh --holding-sentinel --uninstall
+
+  DELIBERATELY a separate launchd unit from the per-role supervisors: a 529 wave
+  that takes the fleet down (measured twice on 2026-08-18) must not take its
+  backstop with it. At the 15-minute silence mark it posts the tagged
+  "steward/<slug> is being restarted" reply and asks launchd to restart the role.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>REPLACE_WITH_LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_NODE</string>
+    <string>REPLACE_WITH_CLI</string>
+    <string>holding-sentinel</string>
+    <string>--once</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- StartInterval, not KeepAlive: `--once` runs one tick and exits 0; launchd
+       re-fires every 60 s so a 15-minute silence is caught within one interval. -->
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>REPLACE_WITH_PATH</string>
+    <key>CATALYST_DIR</key>
+    <string>REPLACE_WITH_CATALYST_DIR</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CWD</string>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_LOG</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_LOG</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/role-supervisor/com.catalyst.quiet-fleet.plist
+++ b/plugins/dev/scripts/role-supervisor/com.catalyst.quiet-fleet.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LaunchAgent for the quiet-fleet ALARM — CTL-2000.
+
+  ONE unit for the whole fleet (label com.catalyst.quiet-fleet), unlike the
+  per-role com.catalyst.role.<role> template. install.sh substitutes every
+  REPLACE_WITH_* token and copies it into ~/Library/LaunchAgents/.
+
+    bash install.sh --quiet-fleet
+    bash install.sh --quiet-fleet --uninstall
+
+  The alarm enumerates every configured role, classifies each via the CTL-1994
+  heartbeat, and pages the CONCIERGE (never a human) when a role is silent/dead/
+  missing while its scope is active. It is a peer of the per-role supervisors,
+  not one of them — a supervised role that has itself gone quiet is exactly what
+  this watches, so it must run as its own unit.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>REPLACE_WITH_LABEL</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>REPLACE_WITH_NODE</string>
+    <string>REPLACE_WITH_CLI</string>
+    <string>quiet-fleet</string>
+    <string>--once</string>
+  </array>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <!-- StartInterval, not KeepAlive: `--once` runs a single tick and exits 0, and
+       launchd re-fires it every 60 s. A source that goes quiet is noticed within
+       one interval. (KeepAlive would busy-restart a clean single-tick exit.) -->
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <!-- Do not let a crash-looping tick spin the box. -->
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>REPLACE_WITH_PATH</string>
+    <!-- launchd does NOT inherit the installing shell's environment. A node
+         using a non-default CATALYST_DIR must have it persisted here, or the
+         alarm reads the wrong roles dir. -->
+    <key>CATALYST_DIR</key>
+    <string>REPLACE_WITH_CATALYST_DIR</string>
+  </dict>
+
+  <key>WorkingDirectory</key>
+  <string>REPLACE_WITH_CWD</string>
+
+  <key>StandardOutPath</key>
+  <string>REPLACE_WITH_LOG</string>
+
+  <key>StandardErrorPath</key>
+  <string>REPLACE_WITH_LOG</string>
+</dict>
+</plist>

--- a/plugins/dev/scripts/role-supervisor/dead-man.mjs
+++ b/plugins/dev/scripts/role-supervisor/dead-man.mjs
@@ -17,9 +17,47 @@ import { fileURLToPath } from "node:url";
 import { deadManShouldFire, DEAD_MAN_AFTER_MS } from "./backstop.mjs";
 import { roleDir, catalystDir } from "./paths.mjs";
 import { readHeartbeat } from "./state.mjs";
+import { TARGET } from "../execution-core/escalation-router.mjs";
 
 const LATCH_NAME = ".dead-man-latch.json";
 const latchPath = (env) => join(catalystDir(env), "roles", LATCH_NAME);
+
+// The out-of-fleet backstops post to the concierge channel themselves; their own
+// posts must NEVER count as a "channel turn" (concierge life) or the alarm would
+// re-arm off its own page and fire in a loop. A genuine turn is anyone else.
+const OUT_OF_FLEET_AUTHORS = new Set(["dead-man", "holding-sentinel", "stale-pr-rescue", "quiet-fleet"]);
+
+// The "no channel turn" signal, read from a POPULATED source: the concierge
+// comms channel itself (catalyst-comms JSONL). heartbeat.last_turn_ts is NOT that
+// source — `beat()` defaults it to null and nothing supplies it, so reading it
+// left `turnDead` permanently true (the alarm paged on the heartbeat alone and
+// its latch could never re-arm). Returns the epoch-ms of the most recent GENUINE
+// turn (a message not authored by an out-of-fleet backstop), or null when the
+// channel is absent/empty/unreadable — absence is not evidence of life.
+function defaultLastChannelTurnMs({ env = process.env } = {}) {
+  try {
+    const channel = env.CATALYST_CONCIERGE_CHANNEL || "concierge";
+    const file = join(catalystDir(env), "comms", "channels", `${channel}.jsonl`);
+    const text = readFileSync(file, "utf8");
+    let latest = null;
+    for (const line of text.split("\n")) {
+      const s = line.trim();
+      if (!s) continue;
+      let msg;
+      try {
+        msg = JSON.parse(s);
+      } catch {
+        continue; // a torn/partial append is not a turn
+      }
+      if (OUT_OF_FLEET_AUTHORS.has(msg?.from)) continue;
+      const ms = typeof msg?.ts === "string" ? Date.parse(msg.ts) : typeof msg?.ts === "number" ? msg.ts : NaN;
+      if (Number.isFinite(ms) && (latest === null || ms > latest)) latest = ms;
+    }
+    return latest;
+  } catch {
+    return null;
+  }
+}
 
 function readLatch(env) {
   try {
@@ -97,11 +135,15 @@ export function runDeadManOnce({
   env = process.env,
   pushHuman = defaultPushHuman,
   postChannel = postOnChannel,
+  lastChannelTurnMs = defaultLastChannelTurnMs,
 } = {}) {
   const role = conciergeRole(env);
   const hb = safeHeartbeat(role, env);
   const conciergeHbAgeMs = typeof hb?.ts === "number" ? now - hb.ts : null;
-  const lastChannelTurnAgeMs = typeof hb?.last_turn_ts === "number" ? now - hb.last_turn_ts : null;
+  // Read the channel turn from the POPULATED source (the comms channel), not the
+  // never-written heartbeat.last_turn_ts. See defaultLastChannelTurnMs above.
+  const turnTs = lastChannelTurnMs({ env });
+  const lastChannelTurnAgeMs = typeof turnTs === "number" ? now - turnTs : null;
 
   const latch = readLatch(env);
   const alreadyPushed = latch?.pushed === true;
@@ -119,16 +161,33 @@ export function runDeadManOnce({
     return { fired: false, recovered: false, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: dryRun, checked_at: now };
   }
 
+  // The human is reached as an ASK, not a bare alert (routing.md: "You reach the
+  // human only as an ask, with Options and a Default"; "a push is for a
+  // decision"). The dead-man is the sanctioned out-of-fleet exception to
+  // "escalate inward" — every inward rung (steward, concierge) is by definition
+  // down when it fires ("you cannot be the thing that notices you are dead",
+  // routing.md L43-46), so it resolves straight to the ladder's terminal rung,
+  // TARGET.ASK — the human, framed as a decision, never an ad-hoc page.
+  const mins = Math.round(DEAD_MAN_AFTER_MS / 60_000);
   const body =
-    `The concierge (\`${role}\`) has no heartbeat and no channel turn for >= ${Math.round(DEAD_MAN_AFTER_MS / 60_000)} minutes. ` +
-    `The coordination fleet may be down (529 wave). A human is needed to relaunch it.`;
+    `[ask · ${TARGET.ASK}] Dead-man: the concierge (\`${role}\`) has had no heartbeat AND no channel turn for >= ${mins} minutes. ` +
+    `The coordination fleet may be down (529 wave).\n` +
+    `Decision needed:\n` +
+    `  - Options: (a) relaunch the coordination fleet; (b) investigate before relaunch.\n` +
+    `  - Default if no reply: (a) relaunch.`;
 
   if (dryRun) {
-    return { fired: true, recovered: false, conciergeHbAgeMs, lastChannelTurnAgeMs, would: "push-human+post-channel", dry_run: true, checked_at: now };
+    return { fired: true, recovered: false, conciergeHbAgeMs, lastChannelTurnAgeMs, target: TARGET.ASK, would: "ask-human+post-channel", dry_run: true, checked_at: now };
   }
 
   const pushed = pushHuman(body, { env });
   const posted = postChannel(body, { env });
-  writeLatchAtomic({ pushed: true, push_ok: pushed, post_ok: posted, fired_at: now }, env);
-  return { fired: true, recovered: false, pushed, posted, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: false, checked_at: now };
+  // Latch the episode as delivered ONLY when a sink actually accepted the alarm.
+  // If BOTH fail (unwritable FS + catalyst-comms absent — the very fleet-wide
+  // outage this backstop exists to surface), persist pushed:false so the NEXT
+  // tick RE-FIRES rather than treating an undelivered alarm as delivered and
+  // going silent forever (Codex P1).
+  const delivered = pushed || posted;
+  writeLatchAtomic({ pushed: delivered, push_ok: pushed, post_ok: posted, fired_at: now }, env);
+  return { fired: true, delivered, recovered: false, pushed, posted, target: TARGET.ASK, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: false, checked_at: now };
 }

--- a/plugins/dev/scripts/role-supervisor/dead-man.mjs
+++ b/plugins/dev/scripts/role-supervisor/dead-man.mjs
@@ -1,0 +1,134 @@
+// dead-man.mjs — CTL-2000. The OUT-OF-FLEET dead-man alarm.
+//
+// routing.md: "the out-of-fleet dead-man alarm fires when there is no concierge
+// heartbeat AND no channel turn for 30 minutes; it pushes the human once and
+// posts on the channel." It is the one thing that notices the concierge is
+// dead — "you cannot be the thing that notices you are dead" — so it lives in
+// its OWN launchd unit (com.catalyst.dead-man), separate from every fleet role.
+//
+// The decision is the pure deadManShouldFire in backstop.mjs (fires only when
+// BOTH signals are >=30m; a missing signal counts as dead, never as healthy).
+// Everything here is fail-open I/O. The human push follows the usage-page
+// out-of-fleet pattern: a channel append needs no credentials launchd lacks.
+import { existsSync, readFileSync, writeFileSync, renameSync, rmSync, mkdirSync, appendFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { deadManShouldFire, DEAD_MAN_AFTER_MS } from "./backstop.mjs";
+import { roleDir, catalystDir } from "./paths.mjs";
+import { readHeartbeat } from "./state.mjs";
+
+const LATCH_NAME = ".dead-man-latch.json";
+const latchPath = (env) => join(catalystDir(env), "roles", LATCH_NAME);
+
+function readLatch(env) {
+  try {
+    return JSON.parse(readFileSync(latchPath(env), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeLatchAtomic(obj, env) {
+  const p = latchPath(env);
+  mkdirSync(dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`);
+  renameSync(tmp, p);
+}
+
+function clearLatch(env) {
+  try {
+    rmSync(latchPath(env));
+  } catch {
+    /* fail-open */
+  }
+}
+
+function conciergeRole(env) {
+  return env.CATALYST_CONCIERGE_ROLE || "concierge";
+}
+
+function safeHeartbeat(role, env) {
+  try {
+    return readHeartbeat(role, env);
+  } catch {
+    return null;
+  }
+}
+
+// Post on the shared channel — the fleet-visible half. Best-effort, no creds.
+function postOnChannel(body, { env = process.env } = {}) {
+  const channel = env.CATALYST_CONCIERGE_CHANNEL || "concierge";
+  const comms = fileURLToPath(new URL("../catalyst-comms", import.meta.url));
+  const res = spawnSync(comms, ["send", channel, body, "--as", "dead-man", "--type", "attention"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  return res.status === 0;
+}
+
+// Push the human — the usage-page out-of-fleet pattern: append to the human-
+// watched markdown channel dir (needs no LINEAR_SYNC_* credentials launchd
+// cannot see). CATALYST_MD_CHANNELS matches catalyst-account-usage-page.sh.
+function defaultPushHuman(body, { env = process.env } = {}) {
+  try {
+    const dir = env.CATALYST_MD_CHANNELS || join(catalystDir(env), "comms", "md-channels");
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, "dead-man.md");
+    appendFileSync(file, `\n## dead-man alarm — ${new Date(Date.now()).toISOString()}\n${body}\n`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * One dead-man tick. Reads the concierge heartbeat + its last_turn_ts (the
+ * "no channel turn" signal, per state.mjs schema), and on deadManShouldFire
+ * pushes the human ONCE (durable per-episode latch) and posts on the channel.
+ * A recovered concierge (both signals fresh) clears the latch.
+ *
+ * `--dry-run` prints what it WOULD do and mutates nothing.
+ */
+export function runDeadManOnce({
+  now = Date.now(),
+  dryRun = false,
+  env = process.env,
+  pushHuman = defaultPushHuman,
+  postChannel = postOnChannel,
+} = {}) {
+  const role = conciergeRole(env);
+  const hb = safeHeartbeat(role, env);
+  const conciergeHbAgeMs = typeof hb?.ts === "number" ? now - hb.ts : null;
+  const lastChannelTurnAgeMs = typeof hb?.last_turn_ts === "number" ? now - hb.last_turn_ts : null;
+
+  const latch = readLatch(env);
+  const alreadyPushed = latch?.pushed === true;
+
+  // Re-arm: a demonstrably-alive concierge (BOTH signals fresh) clears the latch.
+  const hbFresh = typeof conciergeHbAgeMs === "number" && conciergeHbAgeMs < DEAD_MAN_AFTER_MS;
+  const turnFresh = typeof lastChannelTurnAgeMs === "number" && lastChannelTurnAgeMs < DEAD_MAN_AFTER_MS;
+  if (alreadyPushed && hbFresh && turnFresh) {
+    if (!dryRun) clearLatch(env);
+    return { fired: false, recovered: true, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: dryRun, checked_at: now };
+  }
+
+  const fire = deadManShouldFire({ conciergeHbAgeMs, lastChannelTurnAgeMs, alreadyPushed });
+  if (!fire) {
+    return { fired: false, recovered: false, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: dryRun, checked_at: now };
+  }
+
+  const body =
+    `The concierge (\`${role}\`) has no heartbeat and no channel turn for >= ${Math.round(DEAD_MAN_AFTER_MS / 60_000)} minutes. ` +
+    `The coordination fleet may be down (529 wave). A human is needed to relaunch it.`;
+
+  if (dryRun) {
+    return { fired: true, recovered: false, conciergeHbAgeMs, lastChannelTurnAgeMs, would: "push-human+post-channel", dry_run: true, checked_at: now };
+  }
+
+  const pushed = pushHuman(body, { env });
+  const posted = postChannel(body, { env });
+  writeLatchAtomic({ pushed: true, push_ok: pushed, post_ok: posted, fired_at: now }, env);
+  return { fired: true, recovered: false, pushed, posted, conciergeHbAgeMs, lastChannelTurnAgeMs, dry_run: false, checked_at: now };
+}

--- a/plugins/dev/scripts/role-supervisor/dead-man.mjs
+++ b/plugins/dev/scripts/role-supervisor/dead-man.mjs
@@ -38,6 +38,13 @@ function defaultLastChannelTurnMs({ env = process.env } = {}) {
   try {
     const channel = env.CATALYST_CONCIERGE_CHANNEL || "concierge";
     const file = join(catalystDir(env), "comms", "channels", `${channel}.jsonl`);
+    // EVENT-LOG-FULL-READ-OK(CTL-2000): NOT the event log — a per-channel comms
+    // JSONL (~/catalyst/comms/channels/<name>.jsonl), the same file class the
+    // CTL-1529 guard already allowlists for orch-monitor/lib/comms-reader.ts. The
+    // taint analysis can't tell the two `.jsonl` paths apart. Bounded in practice by
+    // one run's channel traffic (KBs), and the dead-man tick runs on its own launchd
+    // timer with no event loop to block; the contract is "the most recent genuine
+    // turn", which needs every line (an instrument post may be the last one).
     const text = readFileSync(file, "utf8");
     let latest = null;
     for (const line of text.split("\n")) {

--- a/plugins/dev/scripts/role-supervisor/dead-man.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/dead-man.test.mjs
@@ -1,0 +1,121 @@
+// dead-man.test.mjs — CTL-2000. The out-of-fleet dead-man alarm's fire/latch
+// decision, with every I/O seam injected. Covers the three Codex P1 fixes:
+//   * the channel-turn signal is read from a POPULATED source (injected here),
+//     so a fresh channel turn keeps `turnFresh` reachable and the alarm does not
+//     page a concierge that has spoken recently;
+//   * the human is reached as an ASK (Options + Default), not a bare alert;
+//   * a delivery that FAILS on both sinks is not latched as delivered — the next
+//     tick re-fires instead of going silent forever.
+//
+// Placed top-level in role-supervisor/ (not __tests__/) to match the
+// supervisor.test.mjs convention and run-tests.sh's `../role-supervisor/*.test.mjs`
+// glob — a test in a __tests__/ subdir would not be gated.
+import { test, expect } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDeadManOnce } from "./dead-man.mjs";
+import { roleFiles } from "./paths.mjs";
+
+const now = 1_000_000_000_000;
+const M = 60_000;
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "dead-man-test-"));
+  const env = { CATALYST_DIR: dir };
+  return { dir, env, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+// Seed the concierge heartbeat file with a chosen ts (or omit for "no heartbeat").
+function seedHeartbeat(env, ageMs) {
+  const f = roleFiles("concierge", env).heartbeat;
+  mkdirSync(join(f, ".."), { recursive: true });
+  if (ageMs !== null) writeFileSync(f, JSON.stringify({ role: "concierge", ts: now - ageMs, pid: 1 }));
+}
+
+const sinkOk = () => true;
+const sinkFail = () => false;
+
+test("P1: a stale heartbeat but a FRESH channel turn does NOT fire (turn read from a populated source)", () => {
+  const s = scratch();
+  seedHeartbeat(s.env, 40 * M); // heartbeat dead
+  const r = runDeadManOnce({
+    now, env: s.env,
+    pushHuman: sinkOk, postChannel: sinkOk,
+    lastChannelTurnMs: () => now - 5 * M, // concierge spoke 5m ago → alive
+  });
+  expect(r.fired).toBe(false);
+  s.cleanup();
+});
+
+test("P1: BOTH signals stale fires and reaches the human as an ASK (Options + Default)", () => {
+  const s = scratch();
+  seedHeartbeat(s.env, 40 * M);
+  const bodies = [];
+  const r = runDeadManOnce({
+    now, env: s.env,
+    pushHuman: (b) => { bodies.push(b); return true; },
+    postChannel: sinkOk,
+    lastChannelTurnMs: () => now - 45 * M, // no genuine turn for 45m
+  });
+  expect(r.fired).toBe(true);
+  expect(r.target).toBe("ask");
+  expect(bodies).toHaveLength(1);
+  expect(bodies[0]).toContain("Options");
+  expect(bodies[0]).toContain("Default");
+  s.cleanup();
+});
+
+test("P1: a delivery that fails on BOTH sinks is NOT latched — the next tick re-fires", () => {
+  const s = scratch();
+  seedHeartbeat(s.env, 40 * M);
+  const first = runDeadManOnce({
+    now, env: s.env,
+    pushHuman: sinkFail, postChannel: sinkFail,
+    lastChannelTurnMs: () => now - 45 * M,
+  });
+  expect(first.fired).toBe(true);
+  expect(first.delivered).toBe(false);
+  const latch = JSON.parse(readFileSync(join(s.dir, "roles", ".dead-man-latch.json"), "utf8"));
+  expect(latch.pushed).toBe(false); // undelivered → not suppressed
+
+  const second = runDeadManOnce({
+    now: now + 60_000, env: s.env,
+    pushHuman: sinkFail, postChannel: sinkFail,
+    lastChannelTurnMs: () => now - 45 * M,
+  });
+  expect(second.fired).toBe(true); // re-fires instead of going silent forever
+  s.cleanup();
+});
+
+test("P1: a delivered alarm IS latched — the next tick does not double-page", () => {
+  const s = scratch();
+  seedHeartbeat(s.env, 40 * M);
+  const first = runDeadManOnce({
+    now, env: s.env,
+    pushHuman: sinkOk, postChannel: sinkFail, // one sink accepted → delivered
+    lastChannelTurnMs: () => now - 45 * M,
+  });
+  expect(first.delivered).toBe(true);
+  const second = runDeadManOnce({
+    now: now + 60_000, env: s.env,
+    pushHuman: sinkOk, postChannel: sinkOk,
+    lastChannelTurnMs: () => now - 46 * M,
+  });
+  expect(second.fired).toBe(false); // alreadyPushed suppresses the repeat
+  s.cleanup();
+});
+
+test("P1: a recovered concierge (fresh heartbeat AND fresh turn) clears the latch — turnFresh is reachable", () => {
+  const s = scratch();
+  // First: fire and latch on a dead concierge.
+  seedHeartbeat(s.env, 40 * M);
+  runDeadManOnce({ now, env: s.env, pushHuman: sinkOk, postChannel: sinkOk, lastChannelTurnMs: () => now - 45 * M });
+  expect(existsSync(join(s.dir, "roles", ".dead-man-latch.json"))).toBe(true);
+  // Then: heartbeat fresh AND a genuine channel turn fresh → re-arm (clear latch).
+  seedHeartbeat(s.env, 1 * M);
+  const r = runDeadManOnce({ now, env: s.env, pushHuman: sinkOk, postChannel: sinkOk, lastChannelTurnMs: () => now - 2 * M });
+  expect(r.recovered).toBe(true);
+  expect(existsSync(join(s.dir, "roles", ".dead-man-latch.json"))).toBe(false);
+  s.cleanup();
+});

--- a/plugins/dev/scripts/role-supervisor/holding-sentinel.mjs
+++ b/plugins/dev/scripts/role-supervisor/holding-sentinel.mjs
@@ -1,0 +1,139 @@
+// holding-sentinel.mjs — CTL-2000. The OUT-OF-FLEET holding-reply sentinel.
+//
+// routing.md: "the launchd-live sentinel posts the tagged holding reply
+// 'steward/<slug> is being restarted' at the 15-minute mark, and the supervisor
+// restarts the role." It lives in its OWN launchd unit (com.catalyst.holding-
+// sentinel) so a 529 wave that takes the fleet down cannot take it with it.
+//
+// It talks about the ROLE, never about tickets: its job is to reassure the
+// thread that the silence is being handled and to kick the supervisor, not to
+// touch any ticket's work. The decision itself is the pure shouldPostHoldingReply
+// in backstop.mjs; everything here is fail-open I/O.
+import { existsSync, readFileSync, writeFileSync, renameSync, rmSync, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { shouldPostHoldingReply } from "./backstop.mjs";
+import { roleDir } from "./paths.mjs";
+import { readHeartbeat, readManifest } from "./state.mjs";
+import { listRoles } from "./doctor.mjs";
+
+const LATCH_NAME = ".holding-sentinel-latch.json";
+const latchPath = (role, env) => join(roleDir(role, env), LATCH_NAME);
+
+function readLatch(role, env) {
+  try {
+    return JSON.parse(readFileSync(latchPath(role, env), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeLatchAtomic(role, obj, env) {
+  const p = latchPath(role, env);
+  mkdirSync(dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`);
+  renameSync(tmp, p);
+}
+
+function clearLatch(role, env) {
+  try {
+    rmSync(latchPath(role, env));
+  } catch {
+    /* fail-open */
+  }
+}
+
+function safeHeartbeat(role, env) {
+  try {
+    return readHeartbeat(role, env);
+  } catch {
+    return null;
+  }
+}
+
+function scopeActiveOf(role, env) {
+  try {
+    return readManifest(role, env)?.scope_active ?? true;
+  } catch {
+    return true;
+  }
+}
+
+// The holding reply names the ROLE (routing.md's "steward/<slug> is being
+// restarted"), on the shared channel — no credentials, launchd-safe.
+function defaultPostHoldingReply(role, { env = process.env } = {}) {
+  const channel = env.CATALYST_CONCIERGE_CHANNEL || "concierge";
+  const comms = fileURLToPath(new URL("../catalyst-comms", import.meta.url));
+  const body = `instrument/holding-sentinel: steward/${role} is being restarted — this thread is being handled; hold for the relaunched role.`;
+  const res = spawnSync(comms, ["send", channel, body, "--as", "holding-sentinel", "--type", "info"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  return res.status === 0;
+}
+
+// Ask launchd to restart the role's SUPERVISOR (which restarts its SDK session).
+// `kickstart -k` re-runs the label; best-effort — a missing label / non-macOS
+// host just no-ops. The sentinel requests the restart; it does not run the role.
+function defaultRequestRestart(role, { env = process.env } = {}) {
+  const label = `com.catalyst.role.${role}`;
+  const uid = typeof process.getuid === "function" ? process.getuid() : "";
+  if (uid === "") return false;
+  const res = spawnSync("launchctl", ["kickstart", "-k", `gui/${uid}/${label}`], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  return res.status === 0;
+}
+
+/**
+ * One sentinel tick. For each role: compute silence age from its heartbeat and,
+ * on shouldPostHoldingReply, post the holding reply + request a supervisor
+ * restart, latched once per silence episode. A role whose heartbeat is fresh
+ * again clears its latch (edge re-arm). Fail-open throughout.
+ *
+ * `--dry-run` prints what it WOULD do and mutates nothing.
+ */
+export function runHoldingSentinelOnce({
+  now = Date.now(),
+  dryRun = false,
+  env = process.env,
+  postHoldingReply = defaultPostHoldingReply,
+  requestRestart = defaultRequestRestart,
+  roles,
+} = {}) {
+  const all = roles ?? listRoles(env);
+  const acted = [];
+  const recovered = [];
+  for (const role of all) {
+    const hb = safeHeartbeat(role, env);
+    const silenceMs = typeof hb?.ts === "number" ? now - hb.ts : null;
+
+    // Re-arm: a fresh heartbeat (silence < threshold) clears the latch so the
+    // next silence episode posts again.
+    if (existsSync(latchPath(role, env)) && typeof silenceMs === "number" && silenceMs < 15 * 60_000) {
+      if (!dryRun) clearLatch(role, env);
+      recovered.push(role);
+      continue;
+    }
+
+    // Only act on an ACTIVE scope — a role whose scope is quiet does not need a
+    // holding reply, matching the quiet-fleet gate.
+    if (!scopeActiveOf(role, env)) continue;
+
+    const alreadyPosted = existsSync(latchPath(role, env));
+    if (!shouldPostHoldingReply({ silenceMs, alreadyPosted })) continue;
+
+    if (dryRun) {
+      acted.push({ role, silenceMs, would: "post-holding-reply+restart" });
+      continue;
+    }
+    const posted = postHoldingReply(role, { env });
+    const restarted = requestRestart(role, { env });
+    writeLatchAtomic(role, { role, silence_ms: silenceMs, posted, restart_requested: restarted, posted_at: now }, env);
+    acted.push({ role, silenceMs, posted, restarted });
+  }
+  return { acted, recovered, dry_run: dryRun, checked_at: now };
+}

--- a/plugins/dev/scripts/role-supervisor/install.sh
+++ b/plugins/dev/scripts/role-supervisor/install.sh
@@ -71,6 +71,14 @@ if [[ -n "$FLEET_UNIT" ]]; then
   UNIT_CWD="${CWD:-$CWD_DEFAULT}"
 
   if [[ $UNINSTALL -eq 1 ]]; then
+    # --dry-run must only PRINT — it must not bootout or remove the plist (the
+    # advertised guarantee), and dry-run also skips the launchd-domain guard.
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "role-supervisor: [dry-run] would uninstall ${UNIT_LABEL}"
+      echo "  would: launchctl bootout gui/$(id -u)/${UNIT_LABEL}"
+      echo "  would: rm -f ${UNIT_DEST}"
+      exit 0
+    fi
     launchctl bootout "gui/$(id -u)/${UNIT_LABEL}" 2>/dev/null || true
     rm -f "$UNIT_DEST"
     echo "role-supervisor: uninstalled ${UNIT_LABEL}"
@@ -113,6 +121,14 @@ LABEL="com.catalyst.role.${ROLE}"
 DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 
 if [[ $UNINSTALL -eq 1 ]]; then
+  # --dry-run must only PRINT — same non-destructive guarantee as the fleet-unit
+  # path above (and dry-run skips the launchd-domain guard).
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "role-supervisor: [dry-run] would uninstall ${LABEL}"
+    echo "  would: launchctl bootout gui/$(id -u)/${LABEL}"
+    echo "  would: rm -f ${DEST}"
+    exit 0
+  fi
   launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
   rm -f "$DEST"
   echo "role-supervisor: uninstalled ${LABEL}"

--- a/plugins/dev/scripts/role-supervisor/install.sh
+++ b/plugins/dev/scripts/role-supervisor/install.sh
@@ -8,11 +8,18 @@
 #   bash install.sh --role steward-p13 --scope "P13 · Coordination SOP" \
 #                   --skill catalyst-dev:steward --cwd ~/code-repos/github/coalesce-labs/catalyst
 #   bash install.sh --role steward-p13 --uninstall
+#
+# CTL-2000 fleet-wide singleton units (one per fleet, NOT per role):
+#   bash install.sh --quiet-fleet          # concierge alarm for quiet roles
+#   bash install.sh --holding-sentinel      # out-of-fleet holding-reply sentinel
+#   bash install.sh --dead-man              # out-of-fleet dead-man alarm
+#   bash install.sh --quiet-fleet --uninstall
+#   ... any of the above with --dry-run to print the plist without loading it.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ROLE="" SCOPE="" SKILL="catalyst-dev:steward" CWD="" BRIEF="" UNINSTALL=0
+ROLE="" SCOPE="" SKILL="catalyst-dev:steward" CWD="" BRIEF="" UNINSTALL=0 DRY_RUN=0 FLEET_UNIT=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
   --role) ROLE="${2:?--role needs a name}"; shift ;;
@@ -21,25 +28,86 @@ while [[ $# -gt 0 ]]; do
   --cwd) CWD="${2:?--cwd needs a dir}"; shift ;;
   --brief) BRIEF="${2:?--brief needs a file}"; shift ;;
   --uninstall) UNINSTALL=1 ;;
-  -h | --help) sed -n '2,14p' "$0"; exit 0 ;;
+  --dry-run) DRY_RUN=1 ;;
+  --quiet-fleet) FLEET_UNIT="quiet-fleet" ;;
+  --holding-sentinel) FLEET_UNIT="holding-sentinel" ;;
+  --dead-man) FLEET_UNIT="dead-man" ;;
+  -h | --help) sed -n '2,20p' "$0"; exit 0 ;;
   *) echo "role-supervisor/install.sh: unknown arg '$1'" >&2; exit 2 ;;
   esac
   shift
 done
 
-[[ -n "$ROLE" ]] || { echo "role-supervisor/install.sh: --role is required" >&2; exit 2; }
-
 # CTL-1968: `gui/$(id -u)` is a PER-USER launchd domain — a scratch HOME does
 # NOT sandbox it. Refuse rather than re-bind a real label to a temporary path.
+# (A --dry-run never touches launchd, so it skips the guard.)
 [[ -f "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh" ]] || {
   echo "role-supervisor/install.sh: missing ../lib/launchd-domain-guard.sh" >&2; exit 1; }
 # shellcheck source=../lib/launchd-domain-guard.sh
 . "${SCRIPT_DIR}/../lib/launchd-domain-guard.sh"
-if ! launchd_guard_ok "the role-supervisor LaunchAgent"; then
+if [[ $DRY_RUN -eq 0 ]] && ! launchd_guard_ok "the role-supervisor LaunchAgent"; then
   launchd_guard_message "the role-supervisor LaunchAgent" >&2
   echo "role-supervisor/install.sh: REFUSED (${CATALYST_LAUNCHD_GUARD_REASON})" >&2
   exit 1
 fi
+
+CATALYST_DIR_VAL="${CATALYST_DIR:-${HOME}/catalyst}"
+NODE_BIN="$(command -v node || true)"
+[[ -n "$NODE_BIN" ]] || { echo "role-supervisor/install.sh: node not found on PATH" >&2; exit 1; }
+CWD_DEFAULT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+PATH_VAL="${HOME}/.catalyst/bin:${HOME}/.local/node/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# ── CTL-2000: fleet-wide singleton units ────────────────────────────────────
+# One instrument for the whole fleet (quiet-fleet alarm, holding-reply sentinel,
+# dead-man alarm), NOT one per role. Each renders its own plist template and
+# loads under a fixed label. The dead-man + holding-sentinel are deliberately
+# SEPARATE launchd units from the per-role supervisors: a 529 wave that takes
+# the fleet down must not take its backstops with it.
+if [[ -n "$FLEET_UNIT" ]]; then
+  UNIT_LABEL="com.catalyst.${FLEET_UNIT}"
+  UNIT_DEST="${HOME}/Library/LaunchAgents/${UNIT_LABEL}.plist"
+  UNIT_PLIST="${SCRIPT_DIR}/com.catalyst.${FLEET_UNIT}.plist"
+  UNIT_LOG="${CATALYST_DIR_VAL}/roles/.${FLEET_UNIT}.log"
+  UNIT_CWD="${CWD:-$CWD_DEFAULT}"
+
+  if [[ $UNINSTALL -eq 1 ]]; then
+    launchctl bootout "gui/$(id -u)/${UNIT_LABEL}" 2>/dev/null || true
+    rm -f "$UNIT_DEST"
+    echo "role-supervisor: uninstalled ${UNIT_LABEL}"
+    exit 0
+  fi
+
+  [[ -f "$UNIT_PLIST" ]] || { echo "role-supervisor/install.sh: missing plist template ${UNIT_PLIST}" >&2; exit 1; }
+
+  UNIT_TMP="$(mktemp)"
+  sed \
+    -e "s|REPLACE_WITH_LABEL|${UNIT_LABEL}|g" \
+    -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
+    -e "s|REPLACE_WITH_CLI|${SCRIPT_DIR}/cli.mjs|g" \
+    -e "s|REPLACE_WITH_PATH|${PATH_VAL}|g" \
+    -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VAL}|g" \
+    -e "s|REPLACE_WITH_CWD|${UNIT_CWD}|g" \
+    -e "s|REPLACE_WITH_LOG|${UNIT_LOG}|g" \
+    "$UNIT_PLIST" > "$UNIT_TMP"
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "role-supervisor: [dry-run] would install ${UNIT_LABEL} → ${UNIT_DEST}"
+    cat "$UNIT_TMP"
+    rm -f "$UNIT_TMP"
+    exit 0
+  fi
+
+  mkdir -p "${HOME}/Library/LaunchAgents" "${CATALYST_DIR_VAL}/roles"
+  mv "$UNIT_TMP" "$UNIT_DEST"
+  launchctl bootout "gui/$(id -u)/${UNIT_LABEL}" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$UNIT_DEST"
+  echo "role-supervisor: installed ${UNIT_LABEL}"
+  echo "  plist: ${UNIT_DEST}"
+  echo "  log:   ${UNIT_LOG}"
+  exit 0
+fi
+
+[[ -n "$ROLE" ]] || { echo "role-supervisor/install.sh: --role is required (or a fleet-unit flag: --quiet-fleet|--holding-sentinel|--dead-man)" >&2; exit 2; }
 
 LABEL="com.catalyst.role.${ROLE}"
 DEST="${HOME}/Library/LaunchAgents/${LABEL}.plist"

--- a/plugins/dev/scripts/role-supervisor/quiet-fleet.mjs
+++ b/plugins/dev/scripts/role-supervisor/quiet-fleet.mjs
@@ -1,0 +1,181 @@
+// quiet-fleet.mjs — CTL-2000. The quiet-fleet alarm: enumerate configured
+// roles, classify each via the CTL-1994 heartbeat, and page the CONCIERGE when
+// a role is SILENT / DEAD / MISSING while its scope is active.
+//
+// The paging target comes from the escalation router, so this instrument
+// CANNOT reach a human directly (routing.md: "an instrument that reaches the
+// human directly is a defect"). Today resolveSteward returns null, so the
+// router returns TARGET.CONCIERGE — the alarm pages the concierge, a fixed
+// identity, which is exactly the contract.
+//
+// The scan is PURE and node:*-only: all I/O (heartbeat reads, scope-active,
+// prior-page counts, latch state) is injected. The looping/launchd shell that
+// wires the real reads lives in cli.mjs's `quiet-fleet` verb.
+import { existsSync, readFileSync, writeFileSync, renameSync, rmSync, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { LIVENESS, classifyHeartbeat } from "../lib/agent-liveness.mjs";
+import { nextEscalationTarget } from "../execution-core/escalation-router.mjs";
+import { roleDir } from "./paths.mjs";
+import { readHeartbeat, readManifest } from "./state.mjs";
+import { listRoles } from "./doctor.mjs";
+
+/**
+ * Scan `roles` and return the pages that SHOULD be sent this tick.
+ *
+ * A page is raised for a role iff ALL hold:
+ *   - its heartbeat is not LIVE (SILENT/DEAD/MISSING — a missing heartbeat is
+ *     never treated as health, matching classifyHeartbeat's fail-closed rule),
+ *   - its scope is active (a quiet role with nothing in flight is fine), and
+ *   - it is not already latched (edge-triggered: page once per episode, not
+ *     every tick).
+ *
+ * @param {string[]} roles
+ * @param {{
+ *   now: number,
+ *   readHeartbeat: (role: string) => object|null,
+ *   scopeActive: (role: string) => boolean,
+ *   priorPages: (role: string) => number,
+ *   alreadyLatched?: (role: string) => boolean,
+ *   resolveSteward?: (scope: string) => object|null,
+ * }} deps
+ * @returns {{pages: Array<{role: string, liveness: string, target: string, tag: string}>, checked_at: number}}
+ */
+export function quietFleetScan(roles, { now, readHeartbeat, scopeActive, priorPages, alreadyLatched = () => false, resolveSteward = () => null } = {}) {
+  const pages = [];
+  for (const role of roles) {
+    const { state } = classifyHeartbeat(readHeartbeat(role), { now });
+    if (state === LIVENESS.LIVE) continue;
+    if (!scopeActive(role)) continue;
+    if (alreadyLatched(role)) continue;
+    const t = nextEscalationTarget({
+      scope: role,
+      priorPages: priorPages(role),
+      instrument: "quiet-fleet",
+      resolveSteward,
+    });
+    pages.push({ role, liveness: state, target: t.target, tag: t.tag });
+  }
+  return { pages, checked_at: now };
+}
+
+// ── The looping/launchd shell (NOT unit-tested; exercised via --once --dry-run) ──
+// Everything below wires the real reads to the pure scan above. It is fail-open:
+// a broken heartbeat read, a missing manifest, or a failed comms post must never
+// crash the alarm — a silenced alarm is worse than a noisy one.
+
+const LATCH_NAME = ".quiet-fleet-latch.json";
+const latchPath = (role, env) => join(roleDir(role, env), LATCH_NAME);
+
+function readLatch(role, env) {
+  try {
+    return JSON.parse(readFileSync(latchPath(role, env), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeLatchAtomic(role, obj, env) {
+  const p = latchPath(role, env);
+  mkdirSync(dirname(p), { recursive: true });
+  const tmp = `${p}.tmp.${process.pid}`;
+  writeFileSync(tmp, `${JSON.stringify(obj, null, 2)}\n`);
+  renameSync(tmp, p);
+}
+
+function clearLatch(role, env) {
+  try {
+    rmSync(latchPath(role, env));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// The concierge is a FIXED identity — a role going quiet pages the concierge on
+// the shared channel, never a human. Channel + identity are overridable so a
+// deployment can point them at its coordination channel.
+function defaultPostPage(page, { env = process.env } = {}) {
+  const channel = env.CATALYST_CONCIERGE_CHANNEL || "concierge";
+  const to = env.CATALYST_CONCIERGE_ID || "concierge";
+  const comms = fileURLToPath(new URL("../catalyst-comms", import.meta.url));
+  const body = `${page.tag}: role \`${page.role}\` is ${page.liveness} while its scope is active — page the steward/relaunch. (quiet-fleet alarm)`;
+  const res = spawnSync(comms, ["send", channel, body, "--as", "quiet-fleet", "--to", to, "--type", "attention"], {
+    encoding: "utf8",
+    timeout: 15_000,
+  });
+  return res.status === 0;
+}
+
+/**
+ * Run one quiet-fleet tick against the real fleet. Pure scan + fail-open I/O.
+ *
+ * Behavior per role:
+ *   - LIVE again → clear any latch (edge re-arm), no page.
+ *   - unhealthy + scope-active + not latched → post one concierge page + latch.
+ *   - unhealthy but already latched → nothing (edge-triggered).
+ *
+ * `--dry-run` prints the pages it WOULD send and mutates nothing (no latch, no post).
+ *
+ * @param {{now?: number, dryRun?: boolean, env?: object, postPage?: Function, roles?: string[]}} [opts]
+ */
+export function runQuietFleetOnce({ now = Date.now(), dryRun = false, env = process.env, postPage = defaultPostPage, roles } = {}) {
+  const all = roles ?? listRoles(env);
+
+  // First, re-arm: any role that recovered to LIVE has its latch cleared so the
+  // NEXT episode pages again (edge-triggered, not level-triggered).
+  const recovered = [];
+  for (const role of all) {
+    if (!existsSync(latchPath(role, env))) continue;
+    const { state } = classifyHeartbeat(safeHeartbeat(role, env), { now });
+    if (state === LIVENESS.LIVE) {
+      if (!dryRun) clearLatch(role, env);
+      recovered.push(role);
+    }
+  }
+
+  const scan = quietFleetScan(all, {
+    now,
+    readHeartbeat: (r) => safeHeartbeat(r, env),
+    scopeActive: (r) => scopeActiveOf(r, env),
+    priorPages: (r) => readLatch(r, env)?.count ?? 0,
+    alreadyLatched: (r) => existsSync(latchPath(r, env)),
+    resolveSteward: () => null, // CTL-1974 will wire the registry-backed resolver
+  });
+
+  const posted = [];
+  for (const page of scan.pages) {
+    if (dryRun) continue;
+    const ok = postPage(page, { env });
+    const prior = readLatch(page.role, env);
+    writeLatchAtomic(page.role, {
+      role: page.role,
+      liveness: page.liveness,
+      count: (prior?.count ?? 0) + 1,
+      first_paged_at: prior?.first_paged_at ?? now,
+      last_paged_at: now,
+      posted: ok,
+    }, env);
+    posted.push({ role: page.role, posted: ok });
+  }
+
+  return { pages: scan.pages, posted, recovered, dry_run: dryRun, checked_at: now };
+}
+
+function safeHeartbeat(role, env) {
+  try {
+    return readHeartbeat(role, env);
+  } catch {
+    return null;
+  }
+}
+
+function scopeActiveOf(role, env) {
+  try {
+    // Same rule doctor.mjs uses: a manifest that does not say otherwise is active.
+    return readManifest(role, env)?.scope_active ?? true;
+  } catch {
+    return true;
+  }
+}

--- a/plugins/dev/scripts/role-supervisor/quiet-fleet.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/quiet-fleet.test.mjs
@@ -1,0 +1,71 @@
+// quiet-fleet.test.mjs — CTL-2000. The quiet-fleet alarm's page decision is a
+// pure scan: roles in, pages out, every read injected. A role going quiet must
+// page the CONCIERGE (via the escalation router), never a human.
+//
+// Placed top-level in role-supervisor/ (not __tests__/) to match the existing
+// supervisor.test.mjs convention and run-tests.sh's `../role-supervisor/*.test.mjs`
+// glob — a test in a __tests__/ subdir would not be gated.
+import { test, expect } from "bun:test";
+import { quietFleetScan } from "./quiet-fleet.mjs";
+import { LIVENESS } from "../lib/agent-liveness.mjs";
+
+const now = 1_000_000_000_000;
+const hb = (ageMs, extra = {}) => ({ ts: now - ageMs, scope: "s", pid: 1, ...extra });
+
+test("a role silent for 12m raises exactly one page targeting the concierge", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(12 * 60_000), scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.pages).toHaveLength(1);
+  expect(scan.pages[0].liveness).toBe(LIVENESS.SILENT);
+  expect(scan.pages[0].target).toBe("concierge");
+});
+
+test("a LIVE role raises no page", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(60_000), scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.pages).toHaveLength(0);
+});
+
+test("a MISSING heartbeat while scope active raises a page (absence is not health)", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => null, scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.pages[0].liveness).toBe(LIVENESS.MISSING);
+});
+
+test("silent-but-scope-inactive raises no page", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(12 * 60_000), scopeActive: () => false, priorPages: () => 0 });
+  expect(scan.pages).toHaveLength(0);
+});
+
+test("edge-triggered: an already-latched role is not re-paged", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(12 * 60_000), scopeActive: () => true, priorPages: () => 0, alreadyLatched: () => true });
+  expect(scan.pages).toHaveLength(0);
+});
+
+// ── Additional coverage ──────────────────────────────────────────────────────
+
+test("a DEAD role (>30m) raises a page targeting the concierge", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(31 * 60_000), scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.pages).toHaveLength(1);
+  expect(scan.pages[0].liveness).toBe(LIVENESS.DEAD);
+  expect(scan.pages[0].target).toBe("concierge");
+});
+
+test("every page carries the instrument tag `instrument/quiet-fleet`", () => {
+  const scan = quietFleetScan(["r"], { now, readHeartbeat: () => hb(12 * 60_000), scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.pages[0].tag).toBe("instrument/quiet-fleet");
+});
+
+test("multiple roles are scanned independently; only the unhealthy active one pages", () => {
+  const beats = { live: hb(60_000), silent: hb(12 * 60_000), inactive: hb(40 * 60_000) };
+  const scan = quietFleetScan(["live", "silent", "inactive"], {
+    now,
+    readHeartbeat: (r) => beats[r],
+    scopeActive: (r) => r !== "inactive",
+    priorPages: () => 0,
+  });
+  expect(scan.pages.map((p) => p.role)).toEqual(["silent"]);
+});
+
+test("checked_at echoes the injected clock (no clock is read internally)", () => {
+  const scan = quietFleetScan([], { now, readHeartbeat: () => null, scopeActive: () => true, priorPages: () => 0 });
+  expect(scan.checked_at).toBe(now);
+  expect(scan.pages).toHaveLength(0);
+});

--- a/plugins/dev/scripts/role-supervisor/supervisor.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.mjs
@@ -88,6 +88,15 @@ export async function superviseRole(role, {
   sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
   log = console.log,
   maxIterations = Infinity,
+  // How often to refresh the heartbeat WHILE a session runs. A productive SDK
+  // session is intentionally long-lived (15m+), and the supervisor writes no
+  // heartbeat between the pre-session beat and the post-session beat — so a
+  // healthy long session's boundary heartbeat ages past the holding-sentinel's
+  // 15m silence threshold and past classifyHeartbeat's 10m SILENT mark, and a
+  // working steward gets kickstarted. Refreshing under those thresholds keeps a
+  // live session legible as live. 0 disables (tests whose fake session resolves
+  // instantly never trip it either way — the timer is cleared before it fires).
+  livenessRefreshMs = 5 * 60 * 1000,
 } = {}) {
   const manifest = readManifest(role, env);
   if (!manifest) throw new Error(`role-supervisor: no manifest for role '${role}' at ${roleFiles(role, env).manifest}`);
@@ -112,6 +121,25 @@ export async function superviseRole(role, {
 
       beat(role, { now: now(), sessionId: resumeSessionId, scope: manifest.scope, state: "running" }, env);
 
+      // Keep the heartbeat fresh for the LIFE of the session, not just at its
+      // boundary — otherwise a healthy long-running role reads as silent and its
+      // own backstop restarts it (Codex P1). Runs off the event loop, unref'd so
+      // it never keeps the process alive, and cleared in `finally` so a session
+      // that resolves before the first tick never writes an extra beat. A crashed
+      // process stops the event loop and thus stops beating, so a genuinely dead
+      // role is still detected and restarted.
+      let refreshTimer = null;
+      if (livenessRefreshMs > 0 && typeof setInterval === "function") {
+        refreshTimer = setInterval(() => {
+          try {
+            beat(role, { now: now(), sessionId: resumeSessionId, scope: manifest.scope, state: "running" }, env);
+          } catch {
+            /* fail-open: a failed liveness refresh must never crash the supervisor */
+          }
+        }, livenessRefreshMs);
+        if (refreshTimer && typeof refreshTimer.unref === "function") refreshTimer.unref();
+      }
+
       let result;
       try {
         result = await runSession({ prompt, cwd: manifest.cwd, env, resumeSessionId });
@@ -119,6 +147,8 @@ export async function superviseRole(role, {
         // A thrown error is a crash: classify it the same way as a bad exit so
         // an overload thrown rather than returned still takes the same ladder.
         result = { exitCode: 1, thrown: err, overloaded: false };
+      } finally {
+        if (refreshTimer) clearInterval(refreshTimer);
       }
 
       if (result?.sessionId) writeSession(role, result.sessionId, env);

--- a/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
@@ -174,6 +174,44 @@ await t("a heartbeat exists after a run and names the pid and state", async () =
   s.cleanup();
 });
 
+await t("the heartbeat is REFRESHED while a long session runs, so a live role is not read as silent", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-live", { activity: {} });
+  let bootTs = null, midTs = null, midState = null;
+  await superviseRole("steward-live", {
+    env: s.env, sleep: noSleep, log: () => {},
+    // Refresh far faster than the real 5-minute cadence so the test stays quick.
+    livenessRefreshMs: 5,
+    runSession: async () => {
+      bootTs = readHeartbeat("steward-live", s.env).ts; // the boundary (pre-session) beat
+      await new Promise((r) => setTimeout(r, 60));       // a "long" (>refresh) session
+      const hb = readHeartbeat("steward-live", s.env);
+      midTs = hb.ts;
+      midState = hb.state;
+      return { exitCode: 0, sessionId: "sess-live" };
+    },
+  });
+  assert.equal(midState, "running", "the in-session refresh keeps the state 'running'");
+  assert.equal(midTs > bootTs, true, "the in-session heartbeat must be newer than the boundary one");
+  s.cleanup();
+});
+await t("livenessRefreshMs:0 disables the in-session refresh (the boundary beat is the only one)", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-norefresh", { activity: {} });
+  let bootTs = null, midTs = null;
+  await superviseRole("steward-norefresh", {
+    env: s.env, sleep: noSleep, log: () => {}, livenessRefreshMs: 0,
+    runSession: async () => {
+      bootTs = readHeartbeat("steward-norefresh", s.env).ts;
+      await new Promise((r) => setTimeout(r, 30));
+      midTs = readHeartbeat("steward-norefresh", s.env).ts;
+      return { exitCode: 0, sessionId: "sess-nr" };
+    },
+  });
+  assert.equal(midTs, bootTs, "with refresh disabled the heartbeat does not advance mid-session");
+  s.cleanup();
+});
+
 console.log("9. the resume prompt tells the role it was restarted");
 await t("a restarted role is told to state what it resumed from", () => {
   const p = buildResumePrompt({ role: "steward", scope: "P13", skill: "catalyst-dev:steward" }, { resumedFrom: "handoff.md", reason: "529" });


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-19T23:08:36Z -->
<!-- Last updated: 2026-08-19T23:08:36Z -->
<!-- PR: #3742 -->
<!-- Previous commits: c32f56b258d672f61d4f3822035cb2e4c0f651d5,58276573486db2d320f7772f0a524d9b1fee24fd,f0d2a4ddcbaf5f58bd4d7d476570e3dec90c1c1b,efbb62de08271add2faa60924f27850dbc5c3087 -->

## CTL-2000 — Steward-first escalation (resolver-independent slice)

Makes every watcher an **instrument** that pages `instrument → steward → concierge → human (as an ask)` and can **never** reach the human directly. Implements the resolver-independent slice + a single escalation chokepoint so the resolver-dependent surfaces have one seam to activate when CTL-1974 lands. **Everything ships shadow/off by default — zero live behavior change on merge.**

Plan: `thoughts/shared/plans/2026-08-19-ctl-2000.md`

### Phases
- **Phase 1 — escalation-router chokepoint** (`execution-core/escalation-router.mjs`): pure, import-free `node:*` leaf. `TARGET` has **no** direct-human member (the invariant); `resolveSteward` returns `null` today (free-text scopes) and forward-proofs CTL-1974's `scopeKeys` registry; `nextEscalationTarget` walks the ladder and can only ever yield STEWARD/CONCIERGE/ASK. 10 tests.
- **Phase 2 — quiet-fleet alarm** (`role-supervisor/quiet-fleet.mjs` + cli verb + `com.catalyst.quiet-fleet.plist`): classifies each role via the CTL-1994 heartbeat and pages the **concierge** (through the router) when a role is SILENT/DEAD/MISSING while its scope is active. Edge-triggered per-role latch, fail-open. 9 tests.
- **Phase 3 — out-of-fleet backstops** (`role-supervisor/backstop.mjs`, `holding-sentinel.mjs`, `dead-man.mjs` + two plists): their own launchd units so a 529 wave can't take them down with the fleet. Holding-reply sentinel fires once at the 15m silence mark + kickstarts the role; dead-man fires only when the concierge heartbeat **and** channel turn are both ≥30m (a missing signal counts as dead), pushes the human once + posts on the channel. 9 tests.
- **Phase 4 — route the stalled-PR sweep through the router** (`stale-pr-rescue-timer.mjs` `defaultEscalate` + `config.mjs` `readStewardEscalationConfig`): behind `CATALYST_STEWARD_ESCALATION` (default **shadow**). shadow is byte-identical to today + a would-route-steward log; enforce pages the concierge **instead of** applying `needs-human` (a page is a handoff → `confirmed:false`, `escalatedAt` never latches), preserving the fence-guard and the `{confirmed,routed}` contract. Includes the cross-cutting **no-direct-human** guardrail test. All three exec-core tests added to the `execution-core-tests` allowlist.

### Sequencing decision → ask **CTL-2087**
The build-order value judgment (build CTL-1974 resolver first / scope to this slice / stub a manual resolver) is filed as decidable ask **CTL-2087** with Default = "scope to the resolver-independent slice (this plan)". Proceeding on the default.

### Deferred (per plan "What We're NOT Doing")
CTL-1974 scope→steward registry; `watch-ryan-comments.py` re-point (not in this repo); the other 12 `needs-human` sites; flipping any instrument to enforce.

### Tests
36 new unit tests (18 exec-core + 18 role-supervisor), all green; existing stale-pr-rescue suites (59) preserved. Pure classifiers throughout; launchd/looping shells exercised via `--once --dry-run`.

## Related Issues/PRs
- Fixes https://linear.app/coalesce-labs/issue/CTL-2000

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1974
skip CTL-1994
skip CTL-2087