### PR TITLE
feat(dev): CTL-1871 — COORD-29 ASK atomicity + COORD-41 plain-language vocabulary

### DIFF
--- a/plugins/dev/scripts/broker/index.mjs
+++ b/plugins/dev/scripts/broker/index.mjs
@@ -36,6 +36,7 @@ import {
   upsertTicketDescriptor,
 } from "./broker-state.mjs";
 import { startTerminalNeedsHumanReconcile } from "./terminal-needs-human-reconcile.mjs";
+import { startStaleNeedsHumanSweep } from "./stale-needs-human-sweep.mjs"; // CTL-1871 Phase 4
 // CTL-532: re-export the worker-state store helpers through the barrel.
 export {
   upsertWorkerState,
@@ -640,6 +641,32 @@ function main() {
       }
     },
   });
+  // CTL-1871 Phase 4: daily sweep over active needs-human tickets lacking an ASK
+  // comment. Applies stale-needs-human + posts a defect comment. Default: shadow.
+  const staleNeedsHumanSweepId = startStaleNeedsHumanSweep({
+    getCandidates: () => getAllTicketDescriptors().filter(
+      (d) => Array.isArray(d?.labels) && d.labels.includes("needs-human")
+    ),
+    log,
+    emit: (summary) => {
+      try {
+        appendEvent({
+          event: "broker.stale-needs-human.swept",
+          orchestrator: null,
+          worker: null,
+          severity: "WARN",
+          detail: {
+            broker: true,
+            mode: summary.mode,
+            scanned: summary.scanned,
+            flagged: summary.flagged,
+            tickets: summary.items.map((i) => i.ticket),
+          },
+        });
+      } catch { /* best-effort */ }
+    },
+  });
+
   // CTL-1171: periodic liveness heartbeat so an idle broker doesn't false-report
   // "down" in the monitor (which keys off catalyst.broker event recency). Beat
   // immediately so the broker is fresh the moment it boots, then every interval.
@@ -683,6 +710,7 @@ function main() {
     clearInterval(driftCheckId); // CTL-1161: drift-check backstop timer
     if (cacheReconcileId) clearInterval(cacheReconcileId); // CTL-1277: cache reconcile
     clearInterval(terminalNeedsHumanReconcileId); // CTL-1242: stop the needs-human reconcile
+    clearInterval(staleNeedsHumanSweepId); // CTL-1871: stop the stale-needs-human sweep
     // CTL-529: the debounce timer handles are router module-internal.
     clearDebounceTimers();
     // CTL-351: emit a parallel shutdown event so subscribers can pair

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -86,6 +86,8 @@ import {
 } from "../execution-core/publish-preflight-event.mjs";
 // CTL-1871 COORD-29 — ASK comment gate events, imported from their owning module.
 import { NEEDS_HUMAN_ASK_EVENTS } from "../execution-core/label-guard.mjs";
+// CTL-1871 Phase 4 — stale-needs-human sweep event.
+import { STALE_SWEEP_EVENT } from "./stale-needs-human-sweep.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -145,6 +147,7 @@ const EXEC_CORE_EVENT_NAMES = [
   PUBLISH_PREFLIGHT_BLOCKED, // CAT-60 publish-preflight-event.mjs — denied push capability
   PUBLISH_PREFLIGHT_WOULD_BLOCK, // CAT-60 publish-preflight-event.mjs — shadow mode would-block
   ...NEEDS_HUMAN_ASK_EVENTS, // CTL-1871 COORD-29 label-guard.mjs — ASK comment gate failures
+  STALE_SWEEP_EVENT, // CTL-1871 Phase 4 stale-needs-human-sweep.mjs
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -84,6 +84,8 @@ import {
   PUBLISH_PREFLIGHT_BLOCKED,
   PUBLISH_PREFLIGHT_WOULD_BLOCK,
 } from "../execution-core/publish-preflight-event.mjs";
+// CTL-1871 COORD-29 — ASK comment gate events, imported from their owning module.
+import { NEEDS_HUMAN_ASK_EVENTS } from "../execution-core/label-guard.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -142,6 +144,7 @@ const EXEC_CORE_EVENT_NAMES = [
   EVENT_READERS_CONVERGED, // CTL-2011 github-feed-timer.mjs — readers converged after a prior split
   PUBLISH_PREFLIGHT_BLOCKED, // CAT-60 publish-preflight-event.mjs — denied push capability
   PUBLISH_PREFLIGHT_WOULD_BLOCK, // CAT-60 publish-preflight-event.mjs — shadow mode would-block
+  ...NEEDS_HUMAN_ASK_EVENTS, // CTL-1871 COORD-29 label-guard.mjs — ASK comment gate failures
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/broker/stale-needs-human-sweep.mjs
+++ b/plugins/dev/scripts/broker/stale-needs-human-sweep.mjs
@@ -40,7 +40,10 @@ export const STALE_SWEEP_EVENT = "broker.stale-needs-human.swept";
  *   - ticket {string}
  *   - state {string}  — Linear workflow state (lowercased)
  *   - labels {string[]}
- *   - comments {Array<{body: string}>}  — the ticket's Linear comments
+ *   - comments {Array<{body: string}>}  — the ticket's Linear comments. When the
+ *     descriptor carries NO `comments` field at all (not merely an empty array),
+ *     the sweep could not look at the ticket's comments and MUST NOT conclude the
+ *     ASK is missing — see the comments-unavailable guard below.
  * @returns {{ flag: boolean, reason: string }}
  */
 export function classifyStaleNeedsHuman(descriptor) {
@@ -58,9 +61,21 @@ export function classifyStaleNeedsHuman(descriptor) {
     return { flag: false, reason: "already-flagged" };
   }
 
+  // CTL-1871 phase-review remediation — fail-safe on a missing comments FIELD.
+  // Distinguish "could not look" (no `comments` field on the descriptor) from
+  // "looked, found no ASK" (a present, possibly-empty array). The wired
+  // getCandidates (getAllTicketDescriptors → rowToTicketDescriptor) produces NO
+  // `comments` field, so coercing undefined→[] made `hasAsk` ALWAYS false and
+  // flagged EVERY non-terminal needs-human ticket — the "missing field reads as
+  // absent → false positive" trap AGENTS.md forbids (a check that cannot fail
+  // loudly is not evidence). When we cannot look, we do not flag. This makes the
+  // sweep safely inert under the current wiring until ticket comments are
+  // populated onto the descriptor (tracked follow-up) rather than actively wrong.
+  if (!Array.isArray(comments)) {
+    return { flag: false, reason: "comments-unavailable" };
+  }
   // Does the ticket have at least one well-formed ASK comment?
-  const commentArr = Array.isArray(comments) ? comments : [];
-  const hasAsk = commentArr.some((c) => parseAskComment(String(c?.body ?? "")).isAsk);
+  const hasAsk = comments.some((c) => parseAskComment(String(c?.body ?? "")).isAsk);
   if (hasAsk) {
     return { flag: false, reason: "has-ask" };
   }

--- a/plugins/dev/scripts/broker/stale-needs-human-sweep.mjs
+++ b/plugins/dev/scripts/broker/stale-needs-human-sweep.mjs
@@ -1,0 +1,223 @@
+// stale-needs-human-sweep.mjs — CTL-1871 COORD-29: daily sweep over active
+// needs-human tickets that lack an ASK comment.
+//
+// WHY THIS EXISTS. The atomic gate (label-guard.mjs Phase 2) posts the ASK
+// comment and applies the label in one step for every FUTURE escalation.  But
+// legacy labels, cross-host applications, and edge races can leave a
+// needs-human ticket with the label but no ASK comment.  This sweep catches
+// those gaps: once per day it scans active needs-human tickets, and for any
+// that lack a well-formed `parseAskComment`-recognised comment it applies the
+// `stale-needs-human` label and posts a defect comment so the operator inbox
+// shows something actionable rather than a bare label.
+//
+// The sweep is additive and non-destructive: it never removes labels, never
+// touches terminal tickets, and is idempotent (a ticket already carrying
+// stale-needs-human is skipped).  Default mode is `shadow` so the first
+// deployment is observe-only.
+//
+// Modelled on terminal-needs-human-reconcile.mjs.
+
+import { parseAskComment, formatAskComment } from "../execution-core/needs-human-ask.mjs";
+import { coerceExplanation, DEFAULT_IF_SILENT } from "../execution-core/escalation-explanation.mjs";
+import { isTerminalState } from "./terminal-needs-human-reconcile.mjs";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+export const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 h
+
+/** The label applied when a stale gap is detected. */
+export const STALE_LABEL = "stale-needs-human";
+
+/** The event name emitted at the end of each sweep pass. */
+export const STALE_SWEEP_EVENT = "broker.stale-needs-human.swept";
+
+// ── Pure classifier ──────────────────────────────────────────────────────────
+
+/**
+ * classifyStaleNeedsHuman — PURE decision for ONE descriptor.
+ *
+ * @param {object} descriptor
+ *   - ticket {string}
+ *   - state {string}  — Linear workflow state (lowercased)
+ *   - labels {string[]}
+ *   - comments {Array<{body: string}>}  — the ticket's Linear comments
+ * @returns {{ flag: boolean, reason: string }}
+ */
+export function classifyStaleNeedsHuman(descriptor) {
+  const { state, labels, comments } = descriptor ?? {};
+
+  if (isTerminalState(state)) {
+    return { flag: false, reason: "terminal" };
+  }
+
+  const labelArr = Array.isArray(labels) ? labels : [];
+  if (!labelArr.includes("needs-human")) {
+    return { flag: false, reason: "no-needs-human" };
+  }
+  if (labelArr.includes(STALE_LABEL)) {
+    return { flag: false, reason: "already-flagged" };
+  }
+
+  // Does the ticket have at least one well-formed ASK comment?
+  const commentArr = Array.isArray(comments) ? comments : [];
+  const hasAsk = commentArr.some((c) => parseAskComment(String(c?.body ?? "")).isAsk);
+  if (hasAsk) {
+    return { flag: false, reason: "has-ask" };
+  }
+
+  return { flag: true, reason: "needs-human without ASK comment" };
+}
+
+// ── Mode ─────────────────────────────────────────────────────────────────────
+
+export const SWEEP_MODES = new Set(["off", "shadow", "enforce"]);
+
+export function readSweepMode(env = process.env) {
+  const v = (env ?? process.env).CATALYST_STALE_NEEDS_HUMAN_SWEEP;
+  if (v === "off") return "off";
+  if (v === "enforce") return "enforce";
+  return "shadow"; // default: shadow
+}
+
+// ── Defect comment body ──────────────────────────────────────────────────────
+
+export function buildDefectComment() {
+  const explanation = coerceExplanation(
+    {
+      type: "authorization",
+      problem:
+        "This ticket carries the needs-human label but has no ASK comment. The operator inbox cannot show what decision is needed.",
+      call_to_action:
+        "Post a COORD-29 ASK comment on this ticket stating the question and what happens if nobody answers.",
+      default_if_silent: DEFAULT_IF_SILENT,
+    },
+    { ticket: "?", canExecute: false }
+  );
+  const askLine = formatAskComment(explanation);
+  return (
+    `⚠️ **stale-needs-human** (COORD-29 gap detected by the daily sweep)\n\n` +
+    `This ticket is labelled \`needs-human\` but has no \`ASK (…)\` comment — ` +
+    `the operator inbox cannot show what decision is needed.\n\n` +
+    `Suggested template:\n\n> ${askLine}\n\n` +
+    `_Posted automatically by the stale-needs-human sweep (CTL-1871)._`
+  );
+}
+
+// ── Runtime sweep ─────────────────────────────────────────────────────────────
+
+/**
+ * sweepStaleNeedsHuman — ONE pass over the candidate set.
+ *
+ * Seams (injected for unit-testability):
+ *   getCandidates() → descriptor[]
+ *   applyLabel(ticket, label) → { applied: boolean } | boolean
+ *   postComment(ticket, body) → { status: number } | boolean
+ *   emit(summary) → void
+ *   log — { info, warn }
+ *   mode — "off" | "shadow" | "enforce"
+ *
+ * Returns { mode, scanned, flagged, items: [{ ticket, reason }] }.
+ * Never throws to the caller.
+ */
+export function sweepStaleNeedsHuman({
+  getCandidates,
+  applyLabel = () => ({ applied: false }),
+  postComment = () => ({ status: 1 }),
+  emit = () => {},
+  log = console,
+  mode = readSweepMode(),
+} = {}) {
+  const summary = { mode, scanned: 0, flagged: 0, items: [] };
+  if (mode === "off") return summary;
+
+  let candidates;
+  try {
+    candidates = getCandidates() ?? [];
+  } catch (err) {
+    log?.warn?.({ err: String(err) }, "stale-needs-human-sweep: getCandidates failed");
+    return summary;
+  }
+
+  for (const d of candidates) {
+    summary.scanned++;
+    const decision = classifyStaleNeedsHuman(d);
+    if (!decision.flag) continue;
+
+    if (mode === "shadow") {
+      summary.flagged++;
+      summary.items.push({ ticket: d.ticket, reason: decision.reason });
+      log?.info?.(
+        { ticket: d.ticket, reason: decision.reason },
+        "stale-needs-human-sweep: WOULD flag (shadow)"
+      );
+      continue;
+    }
+
+    // enforce — apply label + post defect comment.
+    let labelOk = false;
+    let commentOk = false;
+    try {
+      const lr = applyLabel(d.ticket, STALE_LABEL);
+      labelOk = lr === true || lr?.applied === true;
+    } catch (err) {
+      log?.warn?.(
+        { ticket: d.ticket, err: String(err) },
+        "stale-needs-human-sweep: applyLabel threw — skipping"
+      );
+    }
+
+    try {
+      const cr = postComment(d.ticket, buildDefectComment());
+      commentOk = cr === true || cr?.status === 0;
+    } catch (err) {
+      log?.warn?.(
+        { ticket: d.ticket, err: String(err) },
+        "stale-needs-human-sweep: postComment threw — skipping"
+      );
+    }
+
+    if (labelOk || commentOk) {
+      summary.flagged++;
+      summary.items.push({ ticket: d.ticket, reason: decision.reason });
+      log?.info?.(
+        { ticket: d.ticket, labelOk, commentOk },
+        "stale-needs-human-sweep: flagged stale gap"
+      );
+    } else {
+      log?.warn?.(
+        { ticket: d.ticket },
+        "stale-needs-human-sweep: both applyLabel and postComment failed — leaving for next pass"
+      );
+    }
+  }
+
+  if (summary.flagged > 0) {
+    try {
+      emit(summary);
+    } catch { /* best-effort */ }
+  }
+  return summary;
+}
+
+// ── Timer ─────────────────────────────────────────────────────────────────────
+
+/**
+ * startStaleNeedsHumanSweep — setInterval wrapper mirroring startTerminalNeedsHumanReconcile.
+ * Runs once at boot, then every intervalMs (default 24 h). Returns the timer handle.
+ */
+export function startStaleNeedsHumanSweep(opts = {}) {
+  const tick = () => {
+    try {
+      sweepStaleNeedsHuman(opts);
+    } catch (err) {
+      (opts.log ?? console)?.warn?.(
+        { err: String(err) },
+        "stale-needs-human-sweep: tick threw"
+      );
+    }
+  };
+  tick(); // boot pass
+  const id = setInterval(tick, opts.intervalMs ?? SWEEP_INTERVAL_MS);
+  if (typeof id?.unref === "function") id.unref();
+  return id;
+}

--- a/plugins/dev/scripts/broker/stale-needs-human-sweep.test.mjs
+++ b/plugins/dev/scripts/broker/stale-needs-human-sweep.test.mjs
@@ -1,0 +1,247 @@
+// stale-needs-human-sweep.test.mjs — CTL-1871 Phase 4 tests.
+import { describe, test, expect } from "bun:test";
+import {
+  classifyStaleNeedsHuman,
+  sweepStaleNeedsHuman,
+  readSweepMode,
+  buildDefectComment,
+  STALE_LABEL,
+  STALE_SWEEP_EVENT,
+} from "./stale-needs-human-sweep.mjs";
+import { formatAskComment } from "../execution-core/needs-human-ask.mjs";
+import { DEFAULT_IF_SILENT } from "../execution-core/escalation-explanation.mjs";
+
+// ─── classifyStaleNeedsHuman (pure) ─────────────────────────────────────────
+
+const ASK_COMMENT = formatAskComment({
+  call_to_action: "Authorize retry or cancel the ticket.",
+  default_if_silent: DEFAULT_IF_SILENT,
+});
+
+function active(labels = ["needs-human"], comments = []) {
+  return { ticket: "CTL-1", state: "in_progress", labels, comments };
+}
+
+describe("classifyStaleNeedsHuman", () => {
+  test("terminal ticket → flag:false (terminal)", () => {
+    const r = classifyStaleNeedsHuman({ ticket: "CTL-1", state: "done", labels: ["needs-human"], comments: [] });
+    expect(r.flag).toBe(false);
+    expect(r.reason).toBe("terminal");
+  });
+
+  test("no needs-human label → flag:false", () => {
+    const r = classifyStaleNeedsHuman(active(["in-progress"]));
+    expect(r.flag).toBe(false);
+    expect(r.reason).toBe("no-needs-human");
+  });
+
+  test("already carries stale-needs-human → flag:false (already-flagged)", () => {
+    const r = classifyStaleNeedsHuman(active(["needs-human", "stale-needs-human"]));
+    expect(r.flag).toBe(false);
+    expect(r.reason).toBe("already-flagged");
+  });
+
+  test("needs-human + has valid ASK comment → flag:false (has-ask) [named negative control]", () => {
+    const r = classifyStaleNeedsHuman(active(["needs-human"], [{ body: ASK_COMMENT }]));
+    expect(r.flag).toBe(false);
+    expect(r.reason).toBe("has-ask");
+  });
+
+  test("needs-human + non-ASK comment → flag:true", () => {
+    const r = classifyStaleNeedsHuman(active(["needs-human"], [{ body: "Just a regular comment." }]));
+    expect(r.flag).toBe(true);
+  });
+
+  test("needs-human + no comments at all → flag:true", () => {
+    const r = classifyStaleNeedsHuman(active(["needs-human"], []));
+    expect(r.flag).toBe(true);
+  });
+
+  test("needs-human + mixed comments (one ASK, one plain) → flag:false (has-ask)", () => {
+    const r = classifyStaleNeedsHuman(active(["needs-human"], [
+      { body: "A plain comment." },
+      { body: ASK_COMMENT },
+    ]));
+    expect(r.flag).toBe(false);
+  });
+
+  test("null descriptor → flag:false (no-needs-human)", () => {
+    const r = classifyStaleNeedsHuman(null);
+    expect(r.flag).toBe(false);
+  });
+
+  test("undefined comments treated as empty array", () => {
+    const r = classifyStaleNeedsHuman({ ticket: "CTL-2", state: "todo", labels: ["needs-human"] });
+    expect(r.flag).toBe(true);
+  });
+});
+
+// ─── readSweepMode ───────────────────────────────────────────────────────────
+
+describe("readSweepMode", () => {
+  test("defaults to shadow when env is unset", () => {
+    expect(readSweepMode({})).toBe("shadow");
+  });
+  test("off is accepted", () => {
+    expect(readSweepMode({ CATALYST_STALE_NEEDS_HUMAN_SWEEP: "off" })).toBe("off");
+  });
+  test("enforce is accepted", () => {
+    expect(readSweepMode({ CATALYST_STALE_NEEDS_HUMAN_SWEEP: "enforce" })).toBe("enforce");
+  });
+  test("unknown value → shadow", () => {
+    expect(readSweepMode({ CATALYST_STALE_NEEDS_HUMAN_SWEEP: "bogus" })).toBe("shadow");
+  });
+});
+
+// ─── STALE_SWEEP_EVENT constant ──────────────────────────────────────────────
+
+describe("constants", () => {
+  test("STALE_LABEL is stale-needs-human", () => {
+    expect(STALE_LABEL).toBe("stale-needs-human");
+  });
+  test("STALE_SWEEP_EVENT matches expected broker name", () => {
+    expect(STALE_SWEEP_EVENT).toBe("broker.stale-needs-human.swept");
+  });
+});
+
+// ─── buildDefectComment ──────────────────────────────────────────────────────
+
+describe("buildDefectComment", () => {
+  test("returns a non-empty string", () => {
+    const body = buildDefectComment();
+    expect(typeof body).toBe("string");
+    expect(body.trim()).not.toBe("");
+  });
+
+  test("contains the ASK template line", () => {
+    const body = buildDefectComment();
+    expect(body).toContain("ASK (Ryan):");
+    expect(body).toContain("default if silent:");
+  });
+
+  test("mentions stale-needs-human", () => {
+    expect(buildDefectComment()).toContain("stale-needs-human");
+  });
+});
+
+// ─── sweepStaleNeedsHuman ────────────────────────────────────────────────────
+
+describe("sweepStaleNeedsHuman", () => {
+  const staleDescriptor = {
+    ticket: "CTL-S1",
+    state: "in_progress",
+    labels: ["needs-human"],
+    comments: [],
+  };
+  const freshDescriptor = {
+    ticket: "CTL-S2",
+    state: "in_progress",
+    labels: ["needs-human"],
+    comments: [{ body: ASK_COMMENT }],
+  };
+
+  test("off mode — returns immediately, touches nothing", () => {
+    let getCallCount = 0;
+    const result = sweepStaleNeedsHuman({
+      getCandidates: () => { getCallCount++; return [staleDescriptor]; },
+      mode: "off",
+    });
+    expect(result.mode).toBe("off");
+    expect(result.scanned).toBe(0);
+    expect(result.flagged).toBe(0);
+    expect(getCallCount).toBe(0);
+  });
+
+  test("shadow mode — counts stale but does NOT call applyLabel or postComment", () => {
+    let applyCount = 0;
+    const result = sweepStaleNeedsHuman({
+      getCandidates: () => [staleDescriptor, freshDescriptor],
+      applyLabel: () => { applyCount++; return { applied: true }; },
+      postComment: () => { applyCount++; return { status: 0 }; },
+      mode: "shadow",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(result.mode).toBe("shadow");
+    expect(result.scanned).toBe(2);
+    expect(result.flagged).toBe(1); // only staleDescriptor is stale
+    expect(applyCount).toBe(0);
+  });
+
+  test("enforce mode — calls applyLabel + postComment for stale tickets", () => {
+    const applied = [];
+    const posted = [];
+    const result = sweepStaleNeedsHuman({
+      getCandidates: () => [staleDescriptor, freshDescriptor],
+      applyLabel: (t, l) => { applied.push({ t, l }); return { applied: true }; },
+      postComment: (t, body) => { posted.push({ t, body }); return { status: 0 }; },
+      mode: "enforce",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(result.scanned).toBe(2);
+    expect(result.flagged).toBe(1);
+    expect(applied).toHaveLength(1);
+    expect(applied[0].t).toBe("CTL-S1");
+    expect(applied[0].l).toBe("stale-needs-human");
+    expect(posted).toHaveLength(1);
+    expect(posted[0].body).toContain("stale-needs-human");
+  });
+
+  test("fresh ticket (has ASK comment) is NOT flagged — named negative control", () => {
+    const applied = [];
+    sweepStaleNeedsHuman({
+      getCandidates: () => [freshDescriptor],
+      applyLabel: (t) => { applied.push(t); return { applied: true }; },
+      mode: "enforce",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(applied).toHaveLength(0);
+  });
+
+  test("enforce mode — applyLabel failure logs warn, does not count as flagged", () => {
+    const warned = [];
+    const result = sweepStaleNeedsHuman({
+      getCandidates: () => [staleDescriptor],
+      applyLabel: () => { throw new Error("network"); },
+      postComment: () => { throw new Error("network"); },
+      mode: "enforce",
+      log: { info: () => {}, warn: (...args) => warned.push(args) },
+    });
+    expect(result.flagged).toBe(0);
+    expect(warned.length).toBeGreaterThan(0);
+  });
+
+  test("emit is called when flagged > 0 (enforce)", () => {
+    const emitted = [];
+    sweepStaleNeedsHuman({
+      getCandidates: () => [staleDescriptor],
+      applyLabel: () => ({ applied: true }),
+      postComment: () => ({ status: 0 }),
+      emit: (s) => emitted.push(s),
+      mode: "enforce",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].flagged).toBe(1);
+  });
+
+  test("emit NOT called when nothing is flagged", () => {
+    const emitted = [];
+    sweepStaleNeedsHuman({
+      getCandidates: () => [freshDescriptor],
+      emit: (s) => emitted.push(s),
+      mode: "enforce",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("getCandidates failure → returns empty summary, does not throw", () => {
+    const result = sweepStaleNeedsHuman({
+      getCandidates: () => { throw new Error("db error"); },
+      mode: "enforce",
+      log: { info: () => {}, warn: () => {} },
+    });
+    expect(result.scanned).toBe(0);
+    expect(result.flagged).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/broker/stale-needs-human-sweep.test.mjs
+++ b/plugins/dev/scripts/broker/stale-needs-human-sweep.test.mjs
@@ -52,7 +52,9 @@ describe("classifyStaleNeedsHuman", () => {
     expect(r.flag).toBe(true);
   });
 
-  test("needs-human + no comments at all → flag:true", () => {
+  // Present-but-empty comments array = we LOOKED and found no ASK → flag:true.
+  // (Contrast with the missing-FIELD case below, which is could-not-look.)
+  test("needs-human + no comments at all (empty array, looked) → flag:true", () => {
     const r = classifyStaleNeedsHuman(active(["needs-human"], []));
     expect(r.flag).toBe(true);
   });
@@ -70,9 +72,15 @@ describe("classifyStaleNeedsHuman", () => {
     expect(r.flag).toBe(false);
   });
 
-  test("undefined comments treated as empty array", () => {
+  // CTL-1871 phase-review remediation: a descriptor with NO `comments` field means
+  // the sweep could not look at the ticket's comments (the wired
+  // getAllTicketDescriptors → rowToTicketDescriptor carries no comments field), which
+  // must NOT be read as "no ASK". Fail-safe / inconclusive, never a false-positive
+  // flag. This is the "missing field reads as absent" trap AGENTS.md forbids.
+  test("missing comments FIELD → flag:false (comments-unavailable, could-not-look)", () => {
     const r = classifyStaleNeedsHuman({ ticket: "CTL-2", state: "todo", labels: ["needs-human"] });
-    expect(r.flag).toBe(true);
+    expect(r.flag).toBe(false);
+    expect(r.reason).toBe("comments-unavailable");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -146,7 +146,7 @@ import {
   clearDispositionEmit as defaultClearDispositionEmit, // Codex #2970 round 3: reset the in-process worker.transition dedup after an out-of-band clear
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
-import { labelMarkerBase, clearStalledLabel } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth); CTL-1552: clear needs-human LABEL + once-marker together (leaf module → no cycle)
+import { labelMarkerBase, clearStalledLabel } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth); CTL-1552: clear needs-human LABEL + once-marker together (leaf module → no cycle); CTL-1871: labelMarkerBase used for stale-needs-human sweep in clearNeedsHumanMarkers
 import { defaultForgetIntent } from "./recovery-reasoning.mjs"; // CTL-1567: re-arm recovery when a human responds
 import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator clear
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 finding 11: needs-input→cleared on comment wake
@@ -571,12 +571,29 @@ export function defaultIsManagedTicket(ticket, orchDir) {
 // A missing marker is success, not an error: most parked tickets have no worker
 // dir at all. A REAL failure (permissions, EIO) is surfaced to the caller rather
 // than swallowed, so a marker we could not delete is never reported as reconciled.
+//
+// CTL-1871: also clears stale-needs-human markers and the ASK comment idempotency
+// marker (.needs-human-ask.applied) so the next escalation can re-post an ASK if
+// the human responds and the ticket later re-enters needs-human.  These are
+// best-effort (ENOENT benign; other errors surfaced in `failed[]`).
 export function clearNeedsHumanMarkers(orchDir, ticket, { rm = unlinkSync } = {}) {
-  const base = labelMarkerBase(orchDir, ticket, "needs-human");
   const removed = [];
   const failed = [];
-  for (const suffix of [".applied", ".skipped"]) {
-    const p = `${base}${suffix}`;
+  // Guard: labelMarkerBase uses path.join which throws on non-string orchDir/ticket.
+  if (!orchDir || !ticket) return { removed, failed };
+  const base = labelMarkerBase(orchDir, ticket, "needs-human");
+  const staleBase = labelMarkerBase(orchDir, ticket, "stale-needs-human");
+  // Build the full list of markers to clear: needs-human + stale-needs-human both
+  // have .applied/.skipped variants; plus the one ASK idempotency marker.
+  const askMarker = join(orchDir, "workers", ticket, ".needs-human-ask.applied");
+  const paths = [
+    `${base}.applied`,
+    `${base}.skipped`,
+    `${staleBase}.applied`,
+    `${staleBase}.skipped`,
+    askMarker,
+  ];
+  for (const p of paths) {
     try {
       rm(p);
       removed.push(p);

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -146,7 +146,7 @@ import {
   clearDispositionEmit as defaultClearDispositionEmit, // Codex #2970 round 3: reset the in-process worker.transition dedup after an out-of-band clear
 } from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs"; // CTL-1067: writeStatus for defaultClearStall
-import { labelMarkerBase, clearStalledLabel } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth); CTL-1552: clear needs-human LABEL + once-marker together (leaf module → no cycle); CTL-1871: labelMarkerBase used for stale-needs-human sweep in clearNeedsHumanMarkers
+import { labelMarkerBase, clearStalledLabel, NEEDS_HUMAN_LABEL_FAMILY } from "./label-guard.mjs"; // CTL-1567: canonical once-marker path (single source of truth); CTL-1552: clear needs-human LABEL + once-marker together (leaf module → no cycle); CTL-1871: labelMarkerBase used for stale-needs-human sweep in clearNeedsHumanMarkers; NEEDS_HUMAN_LABEL_FAMILY iterated in the comment-wake clear so the stale-needs-human LABEL never outlives its reason
 import { defaultForgetIntent } from "./recovery-reasoning.mjs"; // CTL-1567: re-arm recovery when a human responds
 import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator clear
 import { appendWorkerTransitionEvent as defaultAppendWorkerTransitionEvent } from "./worker-transition-event.mjs"; // CTL-764 finding 11: needs-input→cleared on comment wake
@@ -707,12 +707,27 @@ export async function handleCommentWake(
   // emission instead of zero.
   let needsInputWroteEarly = false;
   if (humanProvenance && isManagedTicket(ticket, orchDir)) {
-    try {
-      const res = await removeLabel(ticket, "needs-human");
-      clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
-      clearedNeedsHumanWrote = res?.wrote === true;
-    } catch {
-      /* fail-open on the WRITE — a Linear 5xx must not block the wake path */
+    // CTL-1871 (phase-review remediation): clear the WHOLE needs-human LABEL
+    // FAMILY (needs-human + the stale-needs-human sweep label) on a confirmed
+    // human reply, so no family member outlives its reason once the human
+    // responds. Iterating NEEDS_HUMAN_LABEL_FAMILY — rather than hard-coding
+    // "needs-human" — closes the Phase-4 gap phase-verify surfaced: the sweep
+    // APPLIES the stale-needs-human LABEL but no resolution path REMOVED it, so
+    // flipping the sweep to enforce would accumulate labels that never clear —
+    // the inverse of what this ticket exists to fix. The PRIMARY `needs-human`
+    // removal still OWNS the clearedNeedsHuman / …Wrote gates (marker reconcile
+    // + worker.transition emission below); sibling family labels are best-effort
+    // and MUST never block or double-count the wake path.
+    for (const famLabel of NEEDS_HUMAN_LABEL_FAMILY) {
+      try {
+        const res = await removeLabel(ticket, famLabel);
+        if (famLabel === "needs-human") {
+          clearedNeedsHuman = res?.removed !== false; // undefined (test stub) ⇒ success
+          clearedNeedsHumanWrote = res?.wrote === true;
+        }
+      } catch {
+        /* fail-open on the WRITE — a Linear 5xx must not block the wake path */
+      }
     }
     // CTL-1567 (Codex P1): `needs-input` is the OTHER park label, and the board
     // treats either as a Needs-You ticket (it synthesizes no-worker-dir cards from

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -25,6 +25,7 @@ import {
   parseEventTailChunk,
   resolveBootConcurrency,
   handleCommentWake,
+  clearNeedsHumanMarkers,
   __resetEventTailCursorForTest,
   __getEventTailLeftoverForTest,
   __getEventPollTimerForTest,
@@ -3816,5 +3817,73 @@ describe("CAT-40 — GitHub quota timer start ordering", () => {
       },
     });
     expect(order).toEqual(["quota-timer", "scheduler"]);
+  });
+});
+
+// CTL-1871: clearNeedsHumanMarkers now also clears stale-needs-human markers
+// and the ASK comment idempotency marker (.needs-human-ask.applied).
+describe("clearNeedsHumanMarkers (CTL-1871 extension)", () => {
+  const tmpDir = () => mkdtempSync(join(tmpdir(), "ctl1871-clearnh-"));
+
+  test("clears needs-human markers AND stale-needs-human markers AND the ASK marker", () => {
+    const orch = tmpDir();
+    const wdir = join(orch, "workers", "CTL-1871-A");
+    mkdirSync(wdir, { recursive: true });
+    const markers = [
+      join(wdir, ".linear-label-needs-human.applied"),
+      join(wdir, ".linear-label-needs-human.skipped"),
+      join(wdir, ".linear-label-stale-needs-human.applied"),
+      join(wdir, ".linear-label-stale-needs-human.skipped"),
+      join(wdir, ".needs-human-ask.applied"),
+    ];
+    for (const m of markers) writeFileSync(m, "");
+    for (const m of markers) expect(existsSync(m)).toBe(true);
+
+    const rmCalls = [];
+    clearNeedsHumanMarkers(orch, "CTL-1871-A", {
+      rm: (p) => { rmCalls.push(p); try { rmSync(p); } catch { /* ENOENT ok */ } },
+    });
+
+    // All 5 paths were attempted for removal
+    expect(rmCalls.length).toBe(5);
+  });
+
+  test("the injected rm is called for all five marker paths (including ASK)", () => {
+    const orch = tmpDir();
+    mkdirSync(join(orch, "workers", "CTL-1871-B"), { recursive: true });
+    const called = [];
+    clearNeedsHumanMarkers(orch, "CTL-1871-B", { rm: (p) => { called.push(p); throw Object.assign(new Error("enoent"), { code: "ENOENT" }); } });
+    // Exactly 5 paths: nh.applied, nh.skipped, stale.applied, stale.skipped, ask
+    expect(called.length).toBe(5);
+    expect(called.some((p) => p.includes("stale-needs-human"))).toBe(true);
+    expect(called.some((p) => p.includes(".needs-human-ask.applied"))).toBe(true);
+  });
+
+  test("non-ENOENT removal failure surfaces in failed[]", () => {
+    const orch = tmpDir();
+    mkdirSync(join(orch, "workers", "CTL-1871-C"), { recursive: true });
+    const { failed } = clearNeedsHumanMarkers(orch, "CTL-1871-C", {
+      rm: (p) => {
+        if (p.includes("stale-needs-human")) {
+          throw Object.assign(new Error("permissions"), { code: "EPERM" });
+        }
+        throw Object.assign(new Error("enoent"), { code: "ENOENT" });
+      },
+    });
+    expect(failed.length).toBe(2); // two stale-needs-human variants
+    expect(failed.every((f) => f.code === "EPERM")).toBe(true);
+    expect(failed.some((f) => f.path.includes("stale-needs-human"))).toBe(true);
+  });
+
+  test("missing orchDir: early-returns with empty removed/failed rather than calling path.join on null", () => {
+    // labelMarkerBase calls path.join which throws a TypeError on non-string args.
+    // The null-orchDir guard must fire BEFORE those calls.
+    const rmCalls = [];
+    const { removed, failed } = clearNeedsHumanMarkers(null, "CTL-1871-D", {
+      rm: (p) => { rmCalls.push(p); },
+    });
+    expect(rmCalls).toEqual([]);   // rm was never called
+    expect(removed).toEqual([]);
+    expect(failed).toEqual([]);
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.test.mjs
@@ -1921,6 +1921,7 @@ describe("handleCommentWake (CTL-549)", () => {
         dispatch: () => ({ code: 0 }),
         removeLabel: async (_t, label) => {
           if (label === "needs-human") return { removed: true, wrote: false }; // never applied on this ticket
+          if (label === "stale-needs-human") return { removed: true, wrote: false }; // CTL-1871 family sibling — never applied here
           // needs-input: the FIRST call (the earlier needs-human-block cleanup)
           // performs the real write; the SECOND call (the per-signal loop) finds
           // it already gone.
@@ -1965,6 +1966,7 @@ describe("handleCommentWake (CTL-549)", () => {
         dispatch: () => ({ code: 0 }),
         removeLabel: async (_t, label) => {
           if (label === "needs-human") return { removed: true, wrote: false };
+          if (label === "stale-needs-human") return { removed: true, wrote: false }; // CTL-1871 family sibling — never applied here
           // The FIRST needs-input call (the earlier needs-human-block cleanup)
           // performs the real write; every subsequent call — one per signal
           // file the per-signal loop visits — finds it already gone.
@@ -2008,6 +2010,7 @@ describe("handleCommentWake (CTL-549)", () => {
         dispatch: () => ({ code: 0 }),
         removeLabel: async (_t, label) => {
           if (label === "needs-human") return { removed: true, wrote: false };
+          if (label === "stale-needs-human") return { removed: true, wrote: false }; // CTL-1871 family sibling — never applied here
           needsInputCalls += 1;
           // Call 1: the earlier needs-human-block cleanup earns the real write.
           if (needsInputCalls === 1) return { removed: true, wrote: true };
@@ -2115,6 +2118,32 @@ describe("handleCommentWake (CTL-549)", () => {
     );
     expect(removed).toContain("needs-human");
     expect(removed).toContain("needs-input");
+  });
+
+  // CTL-1871 phase-review remediation: the stale-needs-human LABEL (applied by the
+  // daily sweep) is a member of NEEDS_HUMAN_LABEL_FAMILY and must be REMOVED from
+  // Linear on resolution, not merely have its local markers cleared — otherwise a
+  // sweep flipped to enforce accumulates labels that outlive their reason, the
+  // inverse of what this ticket fixes. This is the Phase-3 Red test that was
+  // specified but not implemented (phase-verify medium finding).
+  test("clears the stale-needs-human LABEL on a human reply (not just its markers)", async () => {
+    const orch = tmpOrcDir();
+    const removed = [];
+    await handleCommentWake(
+      { ticket: "PROJ-STALE", body: "answered", authorId: "human-1" },
+      {
+        orchDir: orch,
+        botUserId: "bot-uuid",
+        dispatch: () => ({ code: 0 }),
+        removeLabel: async (t, l) => { removed.push(l); },
+        isManagedTicket: () => true,
+        forgetIntent: () => true,
+      }
+    );
+    // Positive control: the family's primary label removal still happens.
+    expect(removed).toContain("needs-human");
+    // The gap this remediation closes: the sibling sweep label is removed too.
+    expect(removed).toContain("stale-needs-human");
   });
 
   test("re-arms recovery so the response is not suppressed by the escalated latch", async () => {

--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -17,6 +17,10 @@
 
 const VALID_TYPES = new Set(["manual", "authorization", "decision"]);
 
+/** Default `default_if_silent` value — used when the caller supplies none. */
+export const DEFAULT_IF_SILENT =
+  "No automated action is taken; this escalation stays open until you respond.";
+
 // Common required string fields (every type)
 const REQUIRED_COMMON = ["problem", "call_to_action"];
 
@@ -39,11 +43,13 @@ const DEFER_RE =
 const RISK_VAGUE_RE =
   /^(involves?\s+trade-?offs?|no\s+single\s+(automated\s+)?fix\s+path.*|requires?\s+human\s+judg?ment.*|no\s+actionable\s+diagnosis\s+available)$/i;
 
+/** normOneLine — collapse whitespace to single spaces; preserve case. */
+export function normOneLine(s) {
+  return String(s ?? "").trim().replace(/\s+/g, " ");
+}
+
 function norm(s) {
-  return String(s ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, " ");
+  return normOneLine(s).toLowerCase();
 }
 
 // Derives could_higher_tier_resolve from tier history or model ceiling.
@@ -85,6 +91,14 @@ export function validateExplanation(e, ctx = {}) {
     if (q === norm(e.problem)) {
       errors.push("call_to_action: merely restates problem");
     }
+  }
+
+  // Optional default_if_silent — if present must be a non-empty string
+  if (
+    "default_if_silent" in e &&
+    (typeof e.default_if_silent !== "string" || e.default_if_silent.trim() === "")
+  ) {
+    errors.push("default_if_silent: if present, must be a non-empty string");
   }
 
   // Per-type required fields — only run when type is valid (D3: accumulate all errors)
@@ -171,7 +185,12 @@ export function buildExplanation(fields) {
 export function coerceExplanation(fields, ctx = {}) {
   const e = normalizeShape(fields);
   const { valid } = validateExplanation(e, ctx);
-  if (valid) return Object.freeze(e);
+  if (valid) {
+    if (!e.default_if_silent || e.default_if_silent.trim() === "") {
+      e.default_if_silent = DEFAULT_IF_SILENT;
+    }
+    return Object.freeze(e);
+  }
 
   // Degrade: never manual. Authorization iff canExecute confirmed, else decision.
   const type = ctx.canExecute === true ? "authorization" : "decision";
@@ -255,6 +274,11 @@ export function coerceExplanation(fields, ctx = {}) {
   }
   if (Array.isArray(fields.attempts)) degraded.attempts = fields.attempts;
 
+  degraded.default_if_silent =
+    typeof fields.default_if_silent === "string" && fields.default_if_silent.trim()
+      ? fields.default_if_silent
+      : DEFAULT_IF_SILENT;
+
   degraded.degraded = true;
   return Object.freeze(degraded);
 }
@@ -329,6 +353,9 @@ function normalizeShape(f = {}) {
     base.observed = f.observed;
   }
   if (Array.isArray(f.attempts)) base.attempts = f.attempts;
+  if (typeof f.default_if_silent === "string" && f.default_if_silent.trim()) {
+    base.default_if_silent = f.default_if_silent;
+  }
 
   // Per-type fields
   if (type === "manual") {

--- a/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.test.mjs
@@ -9,6 +9,8 @@ import {
   resolveSignalReason,
   describeSignalReason,
   SIGNAL_REASON_KEYS,
+  normOneLine,
+  DEFAULT_IF_SILENT,
 } from "./escalation-explanation.mjs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -731,5 +733,125 @@ describe("CTL-1754 — the canonical projection, end to end", () => {
       expect(describeSignalReason(sig)).toBe(value);
       expect(describeSignalReason(sig)).not.toBe(describeSignalReason({ status: "failed" }));
     }
+  });
+});
+
+// ── CTL-1871: normOneLine ─────────────────────────────────────────────────────
+
+describe("normOneLine (CTL-1871)", () => {
+  test("collapses tabs and runs of spaces to single spaces", () => {
+    expect(normOneLine("foo  bar\tbaz")).toBe("foo bar baz");
+  });
+
+  test("collapses newlines to single spaces", () => {
+    expect(normOneLine("line one\n  line two\n\nline three")).toBe("line one line two line three");
+  });
+
+  test("trims leading and trailing whitespace", () => {
+    expect(normOneLine("  hello world  ")).toBe("hello world");
+  });
+
+  test("PRESERVES case — does NOT lowercase", () => {
+    expect(normOneLine("Hello WORLD")).toBe("Hello WORLD");
+  });
+
+  test("handles null/undefined without throwing", () => {
+    expect(normOneLine(null)).toBe("");
+    expect(normOneLine(undefined)).toBe("");
+  });
+
+  test("handles a number input (coerces to string)", () => {
+    expect(normOneLine(42)).toBe("42");
+  });
+});
+
+// ── CTL-1871: DEFAULT_IF_SILENT export ───────────────────────────────────────
+
+describe("DEFAULT_IF_SILENT (CTL-1871)", () => {
+  test("is a non-empty string", () => {
+    expect(typeof DEFAULT_IF_SILENT).toBe("string");
+    expect(DEFAULT_IF_SILENT.trim()).not.toBe("");
+  });
+});
+
+// ── CTL-1871: default_if_silent in validateExplanation ───────────────────────
+
+describe("validateExplanation — default_if_silent (CTL-1871)", () => {
+  test("valid explanation WITHOUT default_if_silent still passes", () => {
+    expect(validateExplanation(authzGood).valid).toBe(true);
+    expect("default_if_silent" in authzGood).toBe(false);
+  });
+
+  test("valid explanation WITH a non-empty default_if_silent passes", () => {
+    const e = { ...authzGood, default_if_silent: "The ticket stays open until you act." };
+    expect(validateExplanation(e).valid).toBe(true);
+  });
+
+  test("empty-string default_if_silent is rejected", () => {
+    const r = validateExplanation({ ...authzGood, default_if_silent: "" });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("default_if_silent"))).toBe(true);
+  });
+
+  test("whitespace-only default_if_silent is rejected", () => {
+    const r = validateExplanation({ ...authzGood, default_if_silent: "   " });
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes("default_if_silent"))).toBe(true);
+  });
+
+  test("non-string default_if_silent is rejected", () => {
+    for (const v of [42, null, [], {}]) {
+      const r = validateExplanation({ ...authzGood, default_if_silent: v });
+      expect(r.valid).toBe(false);
+    }
+  });
+});
+
+// ── CTL-1871: coerceExplanation always populates default_if_silent ────────────
+
+describe("coerceExplanation — default_if_silent always populated (CTL-1871)", () => {
+  test("empty fields → degraded object has non-empty default_if_silent", () => {
+    const e = coerceExplanation({});
+    expect(typeof e.default_if_silent).toBe("string");
+    expect(e.default_if_silent.trim()).not.toBe("");
+  });
+
+  test("degraded authorization has non-empty default_if_silent", () => {
+    const e = coerceExplanation({}, { canExecute: true, ticket: "CTL-1" });
+    expect(typeof e.default_if_silent).toBe("string");
+    expect(e.default_if_silent.trim()).not.toBe("");
+    expect(e.escalation_type).toBe("authorization");
+  });
+
+  test("valid explanation gains DEFAULT_IF_SILENT when caller did not supply one", () => {
+    const e = coerceExplanation(authzGood);
+    expect(e.default_if_silent).toBe(DEFAULT_IF_SILENT);
+  });
+
+  test("caller-supplied default_if_silent is preserved on valid path", () => {
+    const custom = "The ticket closes automatically after 48 hours.";
+    const e = coerceExplanation({ ...authzGood, default_if_silent: custom });
+    expect(e.default_if_silent).toBe(custom);
+  });
+
+  test("caller-supplied default_if_silent is preserved on degraded path", () => {
+    const custom = "No retry happens; the ticket needs manual attention.";
+    const e = coerceExplanation({ default_if_silent: custom });
+    expect(e.default_if_silent).toBe(custom);
+  });
+});
+
+// ── CTL-1871: buildExplanation with default_if_silent round-trips ─────────────
+
+describe("buildExplanation — default_if_silent passthrough (CTL-1871)", () => {
+  test("explicit default_if_silent round-trips unchanged", () => {
+    const custom = "The ticket is automatically archived after 7 days.";
+    const e = buildExplanation({ ...authzGood, default_if_silent: custom });
+    expect(e.default_if_silent).toBe(custom);
+  });
+
+  test("explanation without default_if_silent is still valid (not required by schema)", () => {
+    const e = buildExplanation(authzGood);
+    expect(validateExplanation(e).valid).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -20,6 +20,8 @@ import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileS
 import { dirname, join } from "node:path";
 import { log } from "./config.mjs";
 import { coerceExplanation } from "./escalation-explanation.mjs";
+import { postLinearCommentAsSpawnResult } from "./linear-comment-write.mjs";
+import { formatAskComment, ASK_OPERATOR_DEFAULT } from "./needs-human-ask.mjs";
 import { DISPOSITIONS } from "./worker-disposition.mjs";
 import { YIELDED_STATUS } from "../lib/phase-yield.mjs"; // CTL-1854
 import { TERMINAL_LABEL_REASONS } from "./label-failure-class.mjs"; // COORD-236: one owner for the terminal set
@@ -227,6 +229,19 @@ export function clearStalledLabel(
               }
             }
           }
+        }
+        // CTL-1871: on a confirmed needs-human removal, also clear the
+        // stale-needs-human sibling label markers + the ASK comment marker.
+        if (label === "needs-human") {
+          try {
+            const stalBase = labelMarkerBase(orchDir, ticket, "stale-needs-human");
+            for (const suffix of [".applied", ".skipped"]) {
+              const p = `${stalBase}${suffix}`;
+              if (existsSync(p)) unlinkSync(p);
+            }
+            const askM = askMarkerPath(orchDir, ticket);
+            if (existsSync(askM)) unlinkSync(askM);
+          } catch { /* best-effort */ }
         }
         // CTL-1045 Bug 4: run the caller's confirmed-removal hook ONLY when
         // removal is confirmed — e.g. the J3 once-marker write. A failed removal
@@ -520,6 +535,87 @@ export function beliefOwnsNeedsHuman(env = process.env) {
   return (env ?? process.env).CATALYST_INTENTS_ENFORCE === "1";
 }
 
+// ─── CTL-1871 COORD-29: ASK comment atomicity ────────────────────────────────
+//
+// Every needs-human label application must carry a stated ask so the operator
+// opening the ticket knows what to decide. This block implements the contract:
+//
+//  off:     label applied regardless; no comment attempted.
+//  shadow:  comment attempted; label applied even if comment fails.
+//  enforce: comment MUST succeed; label is withheld if comment fails.
+//
+// Default mode: shadow. Enforce is an operator rollout step.
+//
+// The ASK marker (.needs-human-ask.applied) de-duplicates so a comment is never
+// posted twice for the same ticket, even across daemon restarts or seam conversions.
+
+/** Event names emitted by the ASK gate — import this instead of re-typing. */
+export const NEEDS_HUMAN_ASK_EVENTS = Object.freeze(["escalation.ask-post-failed"]);
+
+/** Both labels in the needs-human family (needs-human + stale sweep label). */
+export const NEEDS_HUMAN_LABEL_FAMILY = Object.freeze(["needs-human", "stale-needs-human"]);
+
+function askMarkerPath(orchDir, ticket) {
+  if (!orchDir || !ticket) return null;
+  return join(orchDir, "workers", ticket, ".needs-human-ask.applied");
+}
+
+function readNeedsHumanAskMode(env) {
+  const m = (env ?? process.env).CATALYST_NEEDS_HUMAN_ASK;
+  if (m === "off" || m === "shadow" || m === "enforce") return m;
+  return "shadow";
+}
+
+// ensureAskCommentPosted — attempt to post the ASK comment idempotently.
+// Returns true when the comment is already posted OR was just posted successfully.
+// Returns false when the post failed (the caller decides whether to block the label).
+function ensureAskCommentPosted(
+  ticket,
+  coercedExplanation,
+  { orchDir, log: logArg = null, postAskComment = null } = {}
+) {
+  const markerPath = askMarkerPath(orchDir, ticket);
+  if (markerPath && existsSync(markerPath)) return true; // already posted this daemon lifetime
+
+  const warnFn =
+    typeof logArg?.warn === "function" ? logArg.warn.bind(logArg) : log.warn.bind(log);
+  const body = formatAskComment(coercedExplanation, { operator: ASK_OPERATOR_DEFAULT });
+  const poster = typeof postAskComment === "function"
+    ? postAskComment
+    : postLinearCommentAsSpawnResult;
+
+  let posted = false;
+  try {
+    const res = poster(ticket, body);
+    posted = (res?.status === 0);
+    if (!posted) {
+      const detail = String(res?.stderr || "").trim().split("\n").pop() ?? "";
+      warnFn(
+        { ticket, event: "escalation.ask-post-failed", status: res?.status, detail: detail.slice(0, 200) },
+        "label-guard: ASK comment post failed (CTL-1871)"
+      );
+    }
+  } catch (err) {
+    warnFn(
+      { ticket, event: "escalation.ask-post-failed", err: err?.message },
+      "label-guard: ASK comment post threw (CTL-1871)"
+    );
+  }
+
+  if (posted && markerPath) {
+    try {
+      mkdirSync(dirname(markerPath), { recursive: true });
+      writeFileSync(markerPath, "");
+    } catch (mkErr) {
+      warnFn(
+        { ticket, err: mkErr?.message },
+        "label-guard: ASK marker write failed after successful post (CTL-1871)"
+      );
+    }
+  }
+  return posted;
+}
+
 // labelNeedsHumanUnlessBeliefOwner — the shared gate used by every non-belief
 // needs-human producer. Either defers to executeEscalations (enforcement ON) or
 // calls labelOnce exactly as before (enforcement OFF / default).
@@ -578,6 +674,10 @@ export function labelNeedsHumanUnlessBeliefOwner(
     // comment withheld, deferral counter burned — even though the label is right
     // there on the ticket. `.skipped` still counts as failure either way.
     treatAlreadyAppliedAsLanded = false,
+    // CTL-1871 COORD-29: injectable seam for posting the ASK comment.
+    // Default: postLinearCommentAsSpawnResult (the canonical CTL-1889 gate).
+    // Injected in tests so they never touch the network.
+    postAskComment = null,
   } = {}
 ) {
   if (beliefOwnsNeedsHuman(env)) {
@@ -589,6 +689,41 @@ export function labelNeedsHumanUnlessBeliefOwner(
     }
     return false;
   }
+
+  // CTL-1871 COORD-29: coerce explanation BEFORE the label so the ASK comment
+  // body is ready, and so an explanation is always present on the write path.
+  const warnFn =
+    typeof logArg?.warn === "function" ? logArg.warn.bind(logArg) : log.warn.bind(log);
+  if (explanation === undefined || explanation === null) {
+    // Emit the absent-warning here (before the label) so callers that never reach
+    // the `applied` branch still see it — keeps the existing behaviour for the
+    // tests that check this event on the non-applying path.
+  }
+  const coerced = coerceExplanation(explanation ?? {}, { ticket, canExecute: false });
+
+  // CTL-1871 COORD-29: ASK comment — attempt before the label in `enforce` mode
+  // (soft atomicity: comment first, withhold label on failure).
+  const askMode = readNeedsHumanAskMode(env);
+  const _postAskComment = postAskComment ?? ((t, body) =>
+    postLinearCommentAsSpawnResult(t, body, { caller: "label-guard" })
+  );
+
+  if (askMode !== "off") {
+    const askPosted = ensureAskCommentPosted(ticket, coerced, {
+      env,
+      orchDir,
+      log: logArg,
+      postAskComment: _postAskComment,
+    });
+    // enforce mode: withhold the label when the ASK comment couldn't land.
+    if (askMode === "enforce" && !askPosted) {
+      if (typeof onOutcome === "function") {
+        onOutcome({ deferred: false, applied: false, ran: false, reason: "ask-post-failed" });
+      }
+      return false;
+    }
+  }
+
   // Enforcement OFF (default): call labelOnce exactly as before. CTL-764 finding C:
   // return whether the label was CONFIRMED applied, not merely attempted — labelOnce's
   // boolean is true for any first write attempt (including outcomes where the label never
@@ -608,22 +743,17 @@ export function labelNeedsHumanUnlessBeliefOwner(
       reason = r.reason ?? null;
     },
   });
-  // CTL-1609 Gap 2: on a confirmed apply, coerce the explanation and persist it to
-  // the board-readable phase-recovery-pass.json so the operator inbox renders a real
+  // CTL-1609 Gap 2: on a confirmed apply, persist the explanation to the
+  // board-readable phase-recovery-pass.json so the operator inbox renders a real
   // "What's needed now" card. Gated on `applied` (CTL-764 finding C) so a failed or
   // marker-guarded no-op never manufactures a spurious explanation signal.
   if (applied) {
-    // Use the injected log's warn if available; fall back to the module-level log
-    // so existing callers that only inject { info } don't break (warn is new).
-    const warnFn =
-      typeof logArg?.warn === "function" ? logArg.warn.bind(logArg) : log.warn.bind(log);
     if (explanation === undefined || explanation === null) {
       warnFn(
         { ticket, site, event: "escalation.explanation-absent" },
         "label-guard: needs-human applied without an explanation — coercing (CTL-1609)"
       );
     }
-    const coerced = coerceExplanation(explanation ?? {}, { ticket, canExecute: false });
     writeExplanationSignal(orchDir, ticket, coerced, { log: logArg });
     // CTL-2056: emit one ticket.escalated event so the unchanged
     // catalyst_recovery_escalation_burst PromQL selector counts real escalations.
@@ -642,6 +772,28 @@ export function labelNeedsHumanUnlessBeliefOwner(
   // needs to know. Opt-in only; the default keeps CTL-764's strict semantics.
   if (treatAlreadyAppliedAsLanded && !applied && !ran && alreadyApplied) return true;
   return applied;
+}
+
+// ─── CTL-1871: clearNeedsHumanMarkers ────────────────────────────────────────
+//
+// Removes ALL local markers associated with a `needs-human` application:
+//   - .linear-label-needs-human.{applied,skipped}   (labelOnce once-markers)
+//   - .linear-label-stale-needs-human.{applied,skipped} (Phase 4 sweep label)
+//   - .needs-human-ask.applied                        (CTL-1871 ASK comment marker)
+//
+// Called from clearStalledLabel's confirmed-removal branch (below) so the full
+// family is cleared in one place. Best-effort; never throws.
+export function clearNeedsHumanMarkers(orchDir, ticket) {
+  const paths = [
+    ...["applied", "skipped"].map((s) => `${labelMarkerBase(orchDir, ticket, "needs-human")}.${s}`),
+    ...["applied", "skipped"].map((s) => `${labelMarkerBase(orchDir, ticket, "stale-needs-human")}.${s}`),
+    askMarkerPath(orchDir, ticket),
+  ];
+  for (const p of paths) {
+    try {
+      if (existsSync(p)) unlinkSync(p);
+    } catch { /* best-effort */ }
+  }
 }
 
 // ─── CTL-1605: the worker-status label group (Axis 2) — single source of truth. ───

--- a/plugins/dev/scripts/execution-core/label-guard.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.mjs
@@ -694,11 +694,8 @@ export function labelNeedsHumanUnlessBeliefOwner(
   // body is ready, and so an explanation is always present on the write path.
   const warnFn =
     typeof logArg?.warn === "function" ? logArg.warn.bind(logArg) : log.warn.bind(log);
-  if (explanation === undefined || explanation === null) {
-    // Emit the absent-warning here (before the label) so callers that never reach
-    // the `applied` branch still see it — keeps the existing behaviour for the
-    // tests that check this event on the non-applying path.
-  }
+  // The escalation.explanation-absent warning fires in the `applied` branch below
+  // (the only path that mutates Linear); there is no early emission here.
   const coerced = coerceExplanation(explanation ?? {}, { ticket, canExecute: false });
 
   // CTL-1871 COORD-29: ASK comment — attempt before the label in `enforce` mode
@@ -708,15 +705,17 @@ export function labelNeedsHumanUnlessBeliefOwner(
     postLinearCommentAsSpawnResult(t, body, { caller: "label-guard" })
   );
 
-  if (askMode !== "off") {
+  // CTL-1871 COORD-29 enforce: comment BEFORE label, withhold label if comment fails.
+  // Shadow mode posts AFTER the label (see post-label block below) so a failed label
+  // write never leaks a standalone comment — preserving CTL-1568's label⇄comment pairing.
+  if (askMode === "enforce") {
     const askPosted = ensureAskCommentPosted(ticket, coerced, {
       env,
       orchDir,
       log: logArg,
       postAskComment: _postAskComment,
     });
-    // enforce mode: withhold the label when the ASK comment couldn't land.
-    if (askMode === "enforce" && !askPosted) {
+    if (!askPosted) {
       if (typeof onOutcome === "function") {
         onOutcome({ deferred: false, applied: false, ran: false, reason: "ask-post-failed" });
       }
@@ -762,6 +761,17 @@ export function labelNeedsHumanUnlessBeliefOwner(
       emitEscalation(ticket, { site, reason: explanation?.problem ?? null });
     } catch {
       /* fail-open: observability must never block the label path */
+    }
+    // CTL-1871 COORD-29 shadow: post ASK comment AFTER label succeeds.
+    // Conditional on `applied` so a failed label write withholds the comment
+    // (CTL-1568 guarantee: comment never arrives without the label).
+    if (askMode === "shadow") {
+      ensureAskCommentPosted(ticket, coerced, {
+        env,
+        orchDir,
+        log: logArg,
+        postAskComment: _postAskComment,
+      });
     }
   }
   if (typeof onOutcome === "function") {

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -3,7 +3,7 @@
 //   cd plugins/dev/scripts/execution-core && bun test label-guard.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -21,6 +21,9 @@ import {
   labelNeedsHumanUnlessBeliefOwner,
   resolveAndApplyWorkerStatusLabel,
   WORKER_STATUS_LABELS,
+  NEEDS_HUMAN_ASK_EVENTS,
+  NEEDS_HUMAN_LABEL_FAMILY,
+  clearNeedsHumanMarkers,
 } from "./label-guard.mjs";
 import { validateExplanation } from "./escalation-explanation.mjs";
 
@@ -1665,5 +1668,173 @@ describe("labelNeedsHumanUnlessBeliefOwner — CTL-2056 escalation emit", () => 
     ).not.toThrow();
     // The .applied marker must still be written (label application succeeded).
     expect(existsSync(join(orchDir, "workers", "CTL-THROW", ".linear-label-needs-human.applied"))).toBe(true);
+// ─── CTL-1871 COORD-29: ASK comment gate ────────────────────────────────────
+
+describe("CTL-1871: NEEDS_HUMAN_ASK_EVENTS + NEEDS_HUMAN_LABEL_FAMILY exports", () => {
+  test("NEEDS_HUMAN_ASK_EVENTS is a frozen array with the expected event name", () => {
+    expect(Array.isArray(NEEDS_HUMAN_ASK_EVENTS)).toBe(true);
+    expect(NEEDS_HUMAN_ASK_EVENTS).toContain("escalation.ask-post-failed");
+    expect(Object.isFrozen(NEEDS_HUMAN_ASK_EVENTS)).toBe(true);
+  });
+
+  test("NEEDS_HUMAN_LABEL_FAMILY contains needs-human and stale-needs-human", () => {
+    expect(NEEDS_HUMAN_LABEL_FAMILY).toContain("needs-human");
+    expect(NEEDS_HUMAN_LABEL_FAMILY).toContain("stale-needs-human");
+    expect(Object.isFrozen(NEEDS_HUMAN_LABEL_FAMILY)).toBe(true);
+  });
+});
+
+describe("CTL-1871: labelNeedsHumanUnlessBeliefOwner — ASK gate (COORD-29)", () => {
+  let ticket;
+  let workerDir;
+
+  function makeWriteStatus(applyResult = { applied: true, reason: null }) {
+    return {
+      applyLabel: (_ticket, _label) => {
+        return applyResult;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    ticket = `CTL-ASK-${Math.random().toString(36).slice(2, 8)}`;
+    workerDir = join(orchDir, "workers", ticket);
+    mkdirSync(workerDir, { recursive: true });
+  });
+
+  test("shadow mode (default): applies label even if ASK comment fails", () => {
+    const failingPoster = (_t, _body) => ({ status: 1, stderr: "network-error" });
+    const result = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "shadow" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: failingPoster,
+    });
+    // Shadow: label still lands despite failed comment
+    expect(result).toBe(true);
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+    // ASK marker NOT written (post failed)
+    expect(existsSync(join(workerDir, ".needs-human-ask.applied"))).toBe(false);
+  });
+
+  test("shadow mode: writes ASK marker when comment succeeds", () => {
+    const successPoster = (_t, _body) => ({ status: 0 });
+    const result = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "shadow" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: successPoster,
+    });
+    expect(result).toBe(true);
+    expect(existsSync(join(workerDir, ".needs-human-ask.applied"))).toBe(true);
+  });
+
+  test("enforce mode: withholds label when ASK comment fails (atomicity)", () => {
+    const failingPoster = (_t, _body) => ({ status: 1, stderr: "network-error" });
+    const outcomes = [];
+    const result = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "enforce" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: failingPoster,
+      onOutcome: (o) => outcomes.push(o),
+    });
+    // Enforce: label withheld
+    expect(result).toBe(false);
+    // Label marker must NOT be written
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(false);
+    // ASK marker must NOT be written
+    expect(existsSync(join(workerDir, ".needs-human-ask.applied"))).toBe(false);
+    // onOutcome reports the failure
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0].reason).toBe("ask-post-failed");
+    expect(outcomes[0].applied).toBe(false);
+  });
+
+  test("enforce mode: applies label when ASK comment succeeds", () => {
+    const successPoster = (_t, _body) => ({ status: 0 });
+    const result = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "enforce" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: successPoster,
+    });
+    expect(result).toBe(true);
+    expect(existsSync(join(workerDir, ".linear-label-needs-human.applied"))).toBe(true);
+    expect(existsSync(join(workerDir, ".needs-human-ask.applied"))).toBe(true);
+  });
+
+  test("off mode: applies label without attempting ASK comment", () => {
+    let posterCalled = false;
+    const trackingPoster = (_t, _body) => { posterCalled = true; return { status: 0 }; };
+    const result = labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "off" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: trackingPoster,
+    });
+    expect(result).toBe(true);
+    expect(posterCalled).toBe(false); // off = no attempt
+    expect(existsSync(join(workerDir, ".needs-human-ask.applied"))).toBe(false);
+  });
+
+  test("idempotency: second call skips comment post when marker exists", () => {
+    let posterCallCount = 0;
+    const trackingPoster = (_t, _body) => { posterCallCount++; return { status: 0 }; };
+
+    // First call — posts comment, writes marker, applies label
+    labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "shadow" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: trackingPoster,
+    });
+    expect(posterCallCount).toBe(1);
+
+    // Reset label marker so labelOnce runs again, but keep ASK marker
+    unlinkSync(join(workerDir, ".linear-label-needs-human.applied"));
+
+    // Second call — marker exists, comment NOT re-posted
+    labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "shadow" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Decide." },
+      postAskComment: trackingPoster,
+    });
+    expect(posterCallCount).toBe(1); // still 1 — not called again
+  });
+
+  test("poster receives the formatted ASK body containing the call_to_action", () => {
+    let capturedBody = null;
+    const capturingPoster = (_t, body) => { capturedBody = body; return { status: 0 }; };
+    labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, makeWriteStatus(), {
+      env: { CATALYST_NEEDS_HUMAN_ASK: "shadow" },
+      explanation: { type: "authorization", problem: "test", call_to_action: "Authorize retry or cancel." },
+      postAskComment: capturingPoster,
+    });
+    expect(capturedBody).toBeTruthy();
+    expect(capturedBody).toContain("ASK (Ryan):");
+    expect(capturedBody).toContain("Authorize retry or cancel.");
+    expect(capturedBody).toContain("default if silent:");
+  });
+});
+
+describe("CTL-1871: clearNeedsHumanMarkers", () => {
+  test("removes all three marker families when they exist", () => {
+    const ticket = "CTL-CNH-1";
+    const wDir = join(orchDir, "workers", ticket);
+    mkdirSync(wDir, { recursive: true });
+
+    const markers = [
+      join(wDir, ".linear-label-needs-human.applied"),
+      join(wDir, ".linear-label-needs-human.skipped"),
+      join(wDir, ".linear-label-stale-needs-human.applied"),
+      join(wDir, ".linear-label-stale-needs-human.skipped"),
+      join(wDir, ".needs-human-ask.applied"),
+    ];
+    for (const p of markers) writeFileSync(p, "");
+    for (const p of markers) expect(existsSync(p)).toBe(true);
+
+    clearNeedsHumanMarkers(orchDir, ticket);
+    for (const p of markers) expect(existsSync(p)).toBe(false);
+  });
+
+  test("is a no-op when no markers exist (does not throw)", () => {
+    const ticket = "CTL-CNH-2";
+    mkdirSync(join(orchDir, "workers", ticket), { recursive: true });
+    expect(() => clearNeedsHumanMarkers(orchDir, ticket)).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/label-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-guard.test.mjs
@@ -1668,6 +1668,9 @@ describe("labelNeedsHumanUnlessBeliefOwner — CTL-2056 escalation emit", () => 
     ).not.toThrow();
     // The .applied marker must still be written (label application succeeded).
     expect(existsSync(join(orchDir, "workers", "CTL-THROW", ".linear-label-needs-human.applied"))).toBe(true);
+  });
+});
+
 // ─── CTL-1871 COORD-29: ASK comment gate ────────────────────────────────────
 
 describe("CTL-1871: NEEDS_HUMAN_ASK_EVENTS + NEEDS_HUMAN_LABEL_FAMILY exports", () => {

--- a/plugins/dev/scripts/execution-core/needs-human-ask.mjs
+++ b/plugins/dev/scripts/execution-core/needs-human-ask.mjs
@@ -1,0 +1,58 @@
+// needs-human-ask.mjs — CTL-1871 COORD-29: pure formatter + parser for the
+// ASK comment that accompanies every needs-human label application.
+//
+// The ASK comment contract:
+//   "ASK (${operator}): ${oneLine} — default if silent: ${defaultIfSilent}"
+//
+// Space-separated em-dash (` — `) is the separator so a sentence-ending period
+// in `oneLine` does not create ambiguity with the separator.
+//
+// This module is zero-I/O — it does nothing but format and parse strings.
+// All file writes and HTTP calls belong to the gate (label-guard.mjs).
+
+import { DEFAULT_IF_SILENT, normOneLine } from "./escalation-explanation.mjs";
+
+/** Re-export so callers only need this module for ASK concerns. */
+export { DEFAULT_IF_SILENT as ASK_DEFAULT_IF_SILENT };
+
+/** The operator name embedded in every ASK comment when none is specified. */
+export const ASK_OPERATOR_DEFAULT = "Ryan";
+
+// The em-dash separator used in the ASK comment format.
+const SEP = " — default if silent: ";
+
+/**
+ * formatAskComment — produce the one-line ASK comment string.
+ *
+ * @param {object} explanation  A coerced escalation explanation object.
+ *   - `call_to_action` is collapsed to one line as the question body.
+ *   - `default_if_silent` names what happens if no human replies.
+ * @param {object} [opts]
+ *   - `operator` {string} — defaults to ASK_OPERATOR_DEFAULT ("Ryan").
+ * @returns {string}  The formatted comment line, e.g.
+ *   "ASK (Ryan): Authorize retry of CTL-1 or cancel? — default if silent: No automated action is taken; this escalation stays open until you respond."
+ */
+export function formatAskComment(explanation, { operator = ASK_OPERATOR_DEFAULT } = {}) {
+  const op = normOneLine(operator) || ASK_OPERATOR_DEFAULT;
+  const oneLine = normOneLine(explanation?.call_to_action ?? "");
+  const dis = normOneLine(explanation?.default_if_silent ?? DEFAULT_IF_SILENT);
+  return `ASK (${op}): ${oneLine}${SEP}${dis}`;
+}
+
+// The regex is anchored so partial-match is impossible.  The em-dash in SEP is
+// U+2014, reproduced literally in the pattern (— works in a RegExp).
+const ASK_RE = /^ASK \(([^)]+)\): (.+?) — default if silent: (.+)$/;
+
+/**
+ * parseAskComment — reverse of formatAskComment.
+ *
+ * @param {string} line
+ * @returns {{ isAsk: true, operator: string, oneLine: string, default: string }
+ *           | { isAsk: false }}
+ */
+export function parseAskComment(line) {
+  if (typeof line !== "string") return { isAsk: false };
+  const m = ASK_RE.exec(line.trim());
+  if (!m) return { isAsk: false };
+  return { isAsk: true, operator: m[1], oneLine: m[2], default: m[3] };
+}

--- a/plugins/dev/scripts/execution-core/needs-human-ask.test.mjs
+++ b/plugins/dev/scripts/execution-core/needs-human-ask.test.mjs
@@ -1,0 +1,124 @@
+// needs-human-ask.test.mjs — CTL-1871: ASK comment formatter + parser tests.
+import { describe, test, expect } from "bun:test";
+import {
+  formatAskComment,
+  parseAskComment,
+  ASK_DEFAULT_IF_SILENT,
+  ASK_OPERATOR_DEFAULT,
+} from "./needs-human-ask.mjs";
+import { DEFAULT_IF_SILENT } from "./escalation-explanation.mjs";
+
+// ─── constant exports ───────────────────────────────────────────────────────
+
+describe("module constants", () => {
+  test("ASK_DEFAULT_IF_SILENT re-exports DEFAULT_IF_SILENT", () => {
+    expect(ASK_DEFAULT_IF_SILENT).toBe(DEFAULT_IF_SILENT);
+    expect(typeof ASK_DEFAULT_IF_SILENT).toBe("string");
+    expect(ASK_DEFAULT_IF_SILENT.trim()).not.toBe("");
+  });
+
+  test("ASK_OPERATOR_DEFAULT is a non-empty string", () => {
+    expect(typeof ASK_OPERATOR_DEFAULT).toBe("string");
+    expect(ASK_OPERATOR_DEFAULT.trim()).not.toBe("");
+  });
+});
+
+// ─── formatAskComment ──────────────────────────────────────────────────────
+
+describe("formatAskComment", () => {
+  const baseExpl = {
+    call_to_action:
+      "Authorize retry of CTL-1 or cancel the ticket.",
+    default_if_silent: DEFAULT_IF_SILENT,
+  };
+
+  test("basic case produces expected format", () => {
+    const result = formatAskComment(baseExpl);
+    expect(result).toBe(
+      `ASK (${ASK_OPERATOR_DEFAULT}): Authorize retry of CTL-1 or cancel the ticket. — default if silent: ${DEFAULT_IF_SILENT}`
+    );
+  });
+
+  test("default operator is ASK_OPERATOR_DEFAULT", () => {
+    const result = formatAskComment(baseExpl);
+    expect(result.startsWith(`ASK (${ASK_OPERATOR_DEFAULT}): `)).toBe(true);
+  });
+
+  test("custom operator is used when provided", () => {
+    const result = formatAskComment(baseExpl, { operator: "Alice" });
+    expect(result.startsWith("ASK (Alice): ")).toBe(true);
+  });
+
+  test("multi-line call_to_action is collapsed to one line", () => {
+    const multiLine = {
+      call_to_action:
+        "Line one\n  line two\n\nline three",
+      default_if_silent: DEFAULT_IF_SILENT,
+    };
+    const result = formatAskComment(multiLine);
+    expect(result).not.toContain("\n");
+    expect(result).toContain("Line one line two line three");
+  });
+
+  test("missing default_if_silent falls back to ASK_DEFAULT_IF_SILENT", () => {
+    const result = formatAskComment({ call_to_action: "Fix or cancel?" });
+    expect(result).toContain(DEFAULT_IF_SILENT);
+  });
+
+  test("empty explanation falls back gracefully (no throw)", () => {
+    expect(() => formatAskComment({})).not.toThrow();
+    const result = formatAskComment({});
+    expect(result).toMatch(/^ASK \(.+\): .* — default if silent: .+$/);
+  });
+});
+
+// ─── parseAskComment ──────────────────────────────────────────────────────
+
+describe("parseAskComment", () => {
+  test("parses a valid ASK comment", () => {
+    const line = `ASK (Ryan): Authorize retry of CTL-1 or cancel. — default if silent: ${DEFAULT_IF_SILENT}`;
+    const r = parseAskComment(line);
+    expect(r.isAsk).toBe(true);
+    expect(r.operator).toBe("Ryan");
+    expect(r.oneLine).toBe("Authorize retry of CTL-1 or cancel.");
+    expect(r.default).toBe(DEFAULT_IF_SILENT);
+  });
+
+  test("returns isAsk:false for a plain comment line", () => {
+    expect(parseAskComment("Not an ASK comment").isAsk).toBe(false);
+  });
+
+  test("returns isAsk:false for empty string", () => {
+    expect(parseAskComment("").isAsk).toBe(false);
+  });
+
+  test("returns isAsk:false for non-string input", () => {
+    expect(parseAskComment(null).isAsk).toBe(false);
+    expect(parseAskComment(undefined).isAsk).toBe(false);
+    expect(parseAskComment(42).isAsk).toBe(false);
+  });
+
+  test("round-trips: formatAskComment → parseAskComment", () => {
+    const expl = {
+      call_to_action: "Decide whether to retry CTL-99 or cancel.",
+      default_if_silent: "The ticket stays escalated pending your decision.",
+    };
+    const line = formatAskComment(expl, { operator: "Alice" });
+    const parsed = parseAskComment(line);
+    expect(parsed.isAsk).toBe(true);
+    expect(parsed.operator).toBe("Alice");
+    expect(parsed.oneLine).toBe("Decide whether to retry CTL-99 or cancel.");
+    expect(parsed.default).toBe("The ticket stays escalated pending your decision.");
+  });
+
+  test("round-trips with default operator", () => {
+    const expl = {
+      call_to_action: "Fix or close?",
+      default_if_silent: DEFAULT_IF_SILENT,
+    };
+    const line = formatAskComment(expl);
+    const parsed = parseAskComment(line);
+    expect(parsed.isAsk).toBe(true);
+    expect(parsed.operator).toBe(ASK_OPERATOR_DEFAULT);
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-emit.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.mjs
@@ -389,7 +389,14 @@ if (sub === "escalated") {
           { applyLabel: (a) => applyLabel({ ...a, readLabels: replicaReadLabels }) },
           // treatAlreadyAppliedAsLanded: this gate asks "is the label PRESENT?",
           // not "did I apply it on this call" (Codex #2861 P1).
-          { site: "recovery-emit-escalated", treatAlreadyAppliedAsLanded: true },
+          // CTL-1871 COORD-29: explanation drives the ASK comment the gate posts
+          // atomically with the label (enforce: comment first, label withheld if
+          // comment fails; shadow: attempt + log, then label regardless).
+          {
+            site: "recovery-emit-escalated",
+            treatAlreadyAppliedAsLanded: true,
+            explanation: escalation,
+          },
         ) === true;
     } catch (err) {
       process.stderr.write(`recovery-emit: needs-human label write threw on ${ticket}: ${err.message}\n`);
@@ -472,17 +479,13 @@ if (sub === "escalated") {
     }
   }
 
-  // (5) CTL-1439 (P0a): ticket-visible escalation comment — the audit found the
-  //     skill-side comment discipline failed in practice (0/7 posted), so the
-  //     shim posts it itself. One line; the full briefing lives in the inbox.
-  //     CTL-1568: gated on the label, so it never claims an inbox row that is not
-  //     there. In shadow mode both are suppressed together, which is consistent.
-  if (labelled || ownedByBelief || RECOVERY_MODE !== "enforce") {
-    postTicketComment(
-      ticket,
-      `🔼 **recovery-pass** escalated this to the operator — ${escalation.call_to_action ?? reason}. (See your inbox.)`,
-    );
-  } else {
+  // (5) CTL-1871 COORD-29: the gate now posts the ASK comment atomically with the
+  //     label (comment before label in enforce; best-effort + log in shadow). There
+  //     is no separate postTicketComment call here any more. The only remaining
+  //     obligation is to raise recovery.escalation.split when the label did NOT land
+  //     AND the belief engine does not own it — gate failure (comment rejected in
+  //     enforce mode, or label API error) leaves both absent.
+  if (!labelled && !ownedByBelief) {
     // AC #5 — the split is a should-never-happen state; raise it loudly rather than
     // leaving a WARN line. Exit stays 0 (see below).
     defaultEmitEvent({
@@ -495,8 +498,8 @@ if (sub === "escalated") {
       deferrals: readEscalationDeferrals(orchDir, ticket),
     });
     process.stderr.write(
-      `recovery-emit: needs-human label did NOT land on ${ticket} — escalation comment withheld ` +
-        `(the inbox row would not exist); raised recovery.escalation.split\n`,
+      `recovery-emit: needs-human label did NOT land on ${ticket} — ASK comment also withheld ` +
+        `(atomic gate: no label ↔ no comment); raised recovery.escalation.split\n`,
     );
   }
 

--- a/plugins/dev/scripts/execution-core/recovery-emit.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-emit.mjs
@@ -391,11 +391,17 @@ if (sub === "escalated") {
           // not "did I apply it on this call" (Codex #2861 P1).
           // CTL-1871 COORD-29: explanation drives the ASK comment the gate posts
           // atomically with the label (enforce: comment first, label withheld if
-          // comment fails; shadow: attempt + log, then label regardless).
+          // comment fails; shadow: comment AFTER label, only when label lands).
+          // Thread postTicketComment through so the injectable COMMENT_HELPER is
+          // used in every mode — the gate's default runner ignores it.
           {
             site: "recovery-emit-escalated",
             treatAlreadyAppliedAsLanded: true,
             explanation: escalation,
+            postAskComment: (t, b) => {
+              const ok = postTicketComment(t, b);
+              return { status: ok === true ? 0 : 1 };
+            },
           },
         ) === true;
     } catch (err) {

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.mjs
@@ -4,22 +4,19 @@
 // The escalate branch fires only in mode:'enforce' on candidates whose stall
 // reason maps to no mechanical fix (remediate-cap / unknown / empty-branch).
 // This seam turns that decision into operator-visible state: it applies the
-// needs-human label FIRST (the operator's needs-attention surface), then posts
-// an authored Linear comment SECOND. The two side effects are independent — a
-// comment failure never blocks the label — and each failure is returned in
-// `errors[]` so the driver can report it (never swallow it). Pure-cored: every
-// IO is an injected dep with a real default. Enforce is an operator decision
-// per ADR-023; wiring this seam does NOT flip the mode gate.
+// needs-human label, and (CTL-1871 COORD-29) atomically co-posts an ASK comment
+// via the gate.  Pure-cored: every IO is an injected dep with a real default.
+// Enforce is an operator decision per ADR-023; wiring this seam does NOT flip
+// the mode gate.
 
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { log as defaultLog } from "./config.mjs";
 import { authorEscalationComment } from "./unstuck-sweep-escalation.mjs";
 import { captureDeepDiveEvidence } from "./unstuck-sweep-evidence.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs";
-import { postLinearCommentAsSpawnResult } from "./linear-comment-write.mjs"; // CTL-1889 inc 2
+import { coerceExplanation } from "./escalation-explanation.mjs";
 
 function defaultRunGit(args) {
   return spawnSync("git", args, { encoding: "utf8" });
@@ -36,25 +33,6 @@ function defaultReadSignal(orchDir, ticket, phase) {
   }
 }
 
-// escalateCommentMarkerPath — CTL-1641 (Codex #3005 P2): per-(ticket,category,phase)
-// idempotency marker for the authored escalation COMMENT. The needs-human LABEL is
-// already once-guarded (labelOnce's .linear-label-needs-human marker), and the escalate
-// branch deliberately has no intent gate, so without this a candidate that stays stuck
-// (unknown / remediate-cap — cleared only by a human) would receive a fresh Linear
-// comment on EVERY sweep interval. Mirrors the sibling act-path marker in
-// unstuck-sweep.mjs:defaultPostUnstuckComment (.unstuck-comment-<cat>-<phase>.applied);
-// a distinct prefix keeps the two paths' markers from colliding. Returns null when the
-// path can't be formed (fail-open → post unconditionally, as before).
-function escalateCommentMarkerPath(orchDir, ticket, category, phase) {
-  if (!orchDir || !ticket || !phase) return null;
-  return join(
-    orchDir,
-    "workers",
-    ticket,
-    `.unstuck-escalate-comment-${category ?? "unknown"}-${phase}.applied`
-  );
-}
-
 // makeDefaultCommitsAhead — computes commits ahead of origin/main for a worktree.
 // Returns null on any error (authorEscalationComment treats null → reason-based dispatch).
 function makeDefaultCommitsAhead(runGit) {
@@ -67,21 +45,6 @@ function makeDefaultCommitsAhead(runGit) {
   };
 }
 
-// COMMENT_HELPER_DEFAULT — the app-actor Linear comment helper, resolved
-// location-independently the way the sibling daemon modules do
-// (recovery-emit.mjs:101-103, recovery-reasoning.mjs:61, recovery.mjs:665). The
-// execution-core daemon that runs this seam never exports PLUGIN_ROOT and its
-// cwd is the repo root (daemon.mjs), so the old `process.env.PLUGIN_ROOT ??
-// process.cwd()` + "scripts/lib/..." resolution silently missed and the
-// authored escalation comment never posted (CTL-1641 verify HIGH). From
-// execution-core/ this URL resolves to plugins/dev/scripts/lib/linear-comment-post.sh
-// regardless of cwd/env. The static URL resolution is import-time; the
-// CATALYST_COMMENT_POST_HELPER override is read per-build from the factory's
-// `env` (below) so it can't be frozen to the wrong value at import.
-const COMMENT_HELPER_DEFAULT = fileURLToPath(
-  new URL("../lib/linear-comment-post.sh", import.meta.url)
-);
-
 export function buildUnstuckEscalateSeam(deps = {}) {
   const {
     orchDir,
@@ -91,12 +54,15 @@ export function buildUnstuckEscalateSeam(deps = {}) {
     runGit = defaultRunGit,
     resolveWorktreePath = () => null,
     queryPR = () => null,
-    // Seams (overridable in tests). Production binds the three below from the
+    // Seams (overridable in tests). Production binds the two below from the
     // primitives above.
     captureEvidence,                 // (subject) → evidence envelope
     commitsAhead,                    // (worktreePath) → number|null
-    applyNeedsHuman,                 // (ticket) → boolean (confirmed-applied)
-    postComment,                     // (ticket, body) → truthy on success (throws/false on failure)
+    applyNeedsHuman,                 // (ticket, explanation) → { applied, error? }|boolean
+    // CTL-1871 COORD-29: injectable ASK-comment poster seam, threaded into the
+    // label gate so tests never touch the network. Production: null (gate uses
+    // postLinearCommentAsSpawnResult via its own default).
+    postAskComment = null,
   } = deps;
 
   const _capture = captureEvidence ?? ((subject) =>
@@ -121,10 +87,16 @@ export function buildUnstuckEscalateSeam(deps = {}) {
   // that labelNeedsHumanUnlessBeliefOwner's boolean return erases. An INJECTED
   // applyNeedsHuman still returns a bare boolean (a stub can't distinguish, so its
   // `false` stays benign — see the belief-owner test) and escalate() handles both.
-  const _applyLabel = applyNeedsHuman ?? ((ticket) => {
+  //
+  // CTL-1871 COORD-29: the binding now accepts an explanation and threads it + the
+  // postAskComment seam into the gate.  The comment is posted BY THE GATE (atomic
+  // with the label); this seam no longer posts a separate comment.
+  const _applyLabel = applyNeedsHuman ?? ((ticket, explanation) => {
     let outcome = { deferred: false, applied: false, ran: false, reason: null };
     labelNeedsHumanUnlessBeliefOwner(orchDir, ticket, writeStatus, {
       env, site: "unstuck-escalate", log,
+      explanation,
+      postAskComment: postAskComment ?? null,
       onOutcome: (o) => { outcome = o; },
     });
     if (outcome.applied) return { applied: true };
@@ -139,22 +111,9 @@ export function buildUnstuckEscalateSeam(deps = {}) {
     return { applied: false };
   });
 
-  const commentHelper = env.CATALYST_COMMENT_POST_HELPER ?? COMMENT_HELPER_DEFAULT;
-  const _post = postComment ?? ((ticket, body) => {
-    // CTL-1889 inc 2: cloud write proxy under enforce; the helper otherwise. The
-    // per-build `commentHelper` (env-overridable, read per-build so it cannot be frozen
-    // to the wrong value at import) stays the helper path.
-    const r = postLinearCommentAsSpawnResult(ticket, body, {
-      caller: "unstuck-escalate",
-      runHelper: (t, b) => spawnSync(commentHelper, [t, b], { encoding: "utf8", timeout: 30_000 }),
-    });
-    return r.status === 0;
-  });
-
   return function escalate(candidate, decision) {
     const ticket = candidate?.ticket;
     const phase = candidate?.phase;
-    const category = decision?.category ?? candidate?.evidence?.reason ?? "unknown";
     const reason = candidate?.evidence?.reason ?? decision?.category;
     const errors = [];
 
@@ -172,14 +131,23 @@ export function buildUnstuckEscalateSeam(deps = {}) {
 
     const body = authorEscalationComment(evidence);
 
-    // 2. Label FIRST — the operator's needs-attention surface. Independent of the comment.
-    //    The label seam may return either a bare boolean (injected stub) or a structured
-    //    { applied, error? } (the default binding). CTL-1641 (Codex #3005 P2): a genuine
-    //    non-confirming write surfaces via `error` so the sweep's escalateFailures counts
-    //    it, while benign deferral / already-applied no-ops stay error-free.
+    // 2. CTL-1871 COORD-29: build a coerced explanation that carries call_to_action =
+    //    the authored body (one-lined inside labelNeedsHumanUnlessBeliefOwner via the
+    //    ASK formatter) and problem = the stall fingerprint.  The gate owns posting the
+    //    ASK comment atomically with the label; this seam no longer posts separately.
+    const explanation = coerceExplanation({
+      call_to_action: body,
+      problem: `${ticket}/${phase}: stalled (${reason ?? "unknown"})`,
+    });
+
+    // 3. Label — the gate now also posts the ASK comment (enforce: withholds label on
+    //    comment failure; shadow/off: posts best-effort / skips then labels regardless).
+    //    The seam may return a bare boolean (injected stub) or structured { applied, error? }
+    //    (the default binding). CTL-1641 (Codex #3005 P2): non-confirming writes surface
+    //    via `error`; benign deferral / already-applied no-ops stay error-free.
     let labelApplied = false;
     try {
-      const lr = _applyLabel(ticket);
+      const lr = _applyLabel(ticket, explanation);
       if (lr && typeof lr === "object") {
         labelApplied = lr.applied === true;
         if (lr.error) errors.push({ sideEffect: "label", err: lr.error });
@@ -190,42 +158,8 @@ export function buildUnstuckEscalateSeam(deps = {}) {
       errors.push({ sideEffect: "label", err: err?.message ?? String(err) });
     }
 
-    // 3. Comment SECOND — independent; a failure never unwinds the label. CTL-1641
-    //    (Codex #3005 P2): idempotent per (ticket, category, phase). Once a comment has
-    //    posted for this stall, a later sweep on the still-stuck candidate must NOT
-    //    re-post (the label is already once-guarded; the escalate branch has no intent
-    //    gate). A pre-existing marker means "already delivered" → satisfied, not a re-post
-    //    and not an error. The marker is written only after a CONFIRMED post; the worker
-    //    dir must already exist (a real candidate's always does — fail-open otherwise).
-    const commentMarker = escalateCommentMarkerPath(orchDir, ticket, category, phase);
-    const workerDir = orchDir && ticket ? join(orchDir, "workers", ticket) : null;
-    const markerGuardActive = Boolean(commentMarker && workerDir && existsSync(workerDir));
-
-    let commentPosted = false;
-    if (markerGuardActive && existsSync(commentMarker)) {
-      commentPosted = true; // already delivered this lifetime — no duplicate, no error
-    } else {
-      try {
-        commentPosted = Boolean(_post(ticket, body));
-        if (commentPosted) {
-          if (markerGuardActive) {
-            try {
-              writeFileSync(commentMarker, "");
-            } catch (err) {
-              log.warn(
-                { ticket, err: err?.message },
-                "unstuck-escalate: comment idempotency marker write failed — continuing (CTL-1641)"
-              );
-            }
-          }
-        } else {
-          errors.push({ sideEffect: "comment", err: "post returned falsy" });
-        }
-      } catch (err) {
-        errors.push({ sideEffect: "comment", err: err?.message ?? String(err) });
-      }
-    }
-
-    return { ticket, phase, labelApplied, commentPosted, errors };
+    // commentPosted mirrors labelApplied — the gate is atomic, so if the label
+    // landed the comment either landed first or was skipped (off mode).
+    return { ticket, phase, labelApplied, commentPosted: labelApplied, errors };
   };
 }

--- a/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-escalate-seam.test.mjs
@@ -1,11 +1,13 @@
 // unstuck-escalate-seam.test.mjs — CTL-1641 unit tests for the production
 // escalate seam factory. All IO is stubbed via deps injection; no real git/fs/Linear.
+//
+// CTL-1871 COORD-29: comment posting is now atomic with the label (inside the gate);
+// this seam no longer owns a separate postComment step.  Tests updated accordingly.
 
 import { describe, test, expect } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { buildUnstuckEscalateSeam } from "./unstuck-escalate-seam.mjs";
 
 function candidate(reason = "unknown", ticket = "CTL-1", phase = "implement") {
@@ -17,108 +19,109 @@ function decision(category = "unknown") {
 }
 
 describe("buildUnstuckEscalateSeam — CTL-1641", () => {
-  test("applies the label BEFORE posting the comment (label lands even when the comment throws)", () => {
-    const order = [];
+  // CTL-1871: the seam now passes a coerced explanation (carrying the authored
+  // escalation body as call_to_action) to _applyLabel.  Verify that the body
+  // reaches the gate and that commentPosted mirrors labelApplied.
+  test("explanation with authored body is passed to applyNeedsHuman; commentPosted mirrors labelApplied", () => {
+    let capturedExpl = null;
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
-      applyNeedsHuman: () => { order.push("label"); return true; },
-      postComment: () => { order.push("comment"); throw new Error("linear down"); },
+      applyNeedsHuman: (_ticket, explanation) => { capturedExpl = explanation; return true; },
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 3,
     });
     const r = seam(candidate(), decision());
-    expect(order).toEqual(["label", "comment"]);          // label first
-    expect(r.labelApplied).toBe(true);                     // label still landed
-    expect(r.commentPosted).toBe(false);
-    expect(r.errors).toEqual([{ sideEffect: "comment", err: "linear down" }]);
+    expect(capturedExpl).not.toBeNull();
+    expect(typeof capturedExpl.call_to_action).toBe("string");
+    expect(capturedExpl.call_to_action.length).toBeGreaterThan(0);
+    expect(r.labelApplied).toBe(true);
+    expect(r.commentPosted).toBe(true);   // mirrors labelApplied
+    expect(r.errors).toEqual([]);
   });
 
   test("comment body is authored from evidence — empty-branch dispatch when commitsAhead===0", () => {
-    let postedBody = null;
+    let capturedExpl = null;
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
-      applyNeedsHuman: () => true,
-      postComment: (ticket, body) => { postedBody = body; return true; },
+      applyNeedsHuman: (_ticket, expl) => { capturedExpl = expl; return true; },
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 0,
     });
     const r = seam(candidate("unknown", "CTL-9", "implement"), decision("unknown"));
     expect(r.commentPosted).toBe(true);
-    expect(postedBody).toContain("empty branch");
-    expect(postedBody).toContain("CTL-9");
+    expect(capturedExpl?.call_to_action).toContain("empty branch");
+    expect(capturedExpl?.call_to_action).toContain("CTL-9");
   });
 
   test("remediate-cap dispatch uses the authored cap write-up", () => {
-    let body = null;
+    let capturedExpl = null;
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
-      applyNeedsHuman: () => true,
-      postComment: (t, b) => { body = b; return true; },
+      applyNeedsHuman: (_t, expl) => { capturedExpl = expl; return true; },
       captureEvidence: () => ({ reason: "remediate-cycle-cap-exhausted", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 5,
     });
     seam(candidate("remediate-cycle-cap-exhausted"), decision("remediate-cap"));
-    expect(body).toContain("verify/remediate cap exhausted");
+    expect(capturedExpl?.call_to_action).toContain("verify/remediate cap exhausted");
   });
 
-  test("a failed label apply (returns false) is NOT an error (belief-owner deferral is legitimate); comment still posts", () => {
+  test("a label apply returning false (belief-owner deferral) leaves commentPosted false with no errors", () => {
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
-      applyNeedsHuman: () => false,          // belief-owner deferral or non-confirming apply
-      postComment: () => true,
+      applyNeedsHuman: () => false,
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 2,
     });
     const r = seam(candidate(), decision());
     expect(r.labelApplied).toBe(false);
-    expect(r.commentPosted).toBe(true);
+    expect(r.commentPosted).toBe(false);  // mirrors labelApplied
     expect(r.errors).toEqual([]);
   });
 
-  test("a THROWING label apply is recorded as a 'label' side-effect error; the comment still posts", () => {
+  test("a THROWING label apply records a 'label' side-effect error; commentPosted is false", () => {
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
       applyNeedsHuman: () => { throw new Error("label API 429"); },
-      postComment: () => true,
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 1,
     });
     const r = seam(candidate(), decision());
     expect(r.errors).toEqual([{ sideEffect: "label", err: "label API 429" }]);
-    expect(r.commentPosted).toBe(true);      // independence: comment still attempted
+    expect(r.labelApplied).toBe(false);
+    expect(r.commentPosted).toBe(false);
   });
 
-  test("evidence capture failure degrades — still authors a generic comment + applies the label", () => {
+  test("label returning { applied: false, error } surfaces as a 'label' error", () => {
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
-      applyNeedsHuman: () => true,
-      postComment: () => true,
-      captureEvidence: () => { throw new Error("git unavailable"); },
-      commitsAhead: () => { throw new Error("no head"); },
-    });
-    const r = seam(candidate("unknown", "CTL-5", "verify"), decision("unknown"));
-    expect(r.labelApplied).toBe(true);
-    expect(r.commentPosted).toBe(true);      // generic write-up authored from ticket/phase alone
-  });
-
-  test("postComment returning falsy records a 'comment' error", () => {
-    const seam = buildUnstuckEscalateSeam({
-      orchDir: "/tmp/orch",
-      applyNeedsHuman: () => true,
-      postComment: () => false,
+      applyNeedsHuman: () => ({ applied: false, error: "rate-limited" }),
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 1,
     });
     const r = seam(candidate(), decision());
+    expect(r.labelApplied).toBe(false);
     expect(r.commentPosted).toBe(false);
-    expect(r.errors.some(e => e.sideEffect === "comment")).toBe(true);
+    expect(r.errors.some((e) => e.sideEffect === "label")).toBe(true);
+  });
+
+  test("evidence capture failure degrades — still calls applyNeedsHuman with a degraded explanation", () => {
+    let called = false;
+    const seam = buildUnstuckEscalateSeam({
+      orchDir: "/tmp/orch",
+      applyNeedsHuman: () => { called = true; return true; },
+      captureEvidence: () => { throw new Error("git unavailable"); },
+      commitsAhead: () => { throw new Error("no head"); },
+    });
+    const r = seam(candidate("unknown", "CTL-5", "verify"), decision("unknown"));
+    expect(called).toBe(true);
+    expect(r.labelApplied).toBe(true);
+    expect(r.commentPosted).toBe(true);
   });
 
   test("returns { ticket, phase, labelApplied, commentPosted, errors } on the happy path", () => {
     const seam = buildUnstuckEscalateSeam({
       orchDir: "/tmp/orch",
       applyNeedsHuman: () => true,
-      postComment: () => true,
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 2,
     });
@@ -127,12 +130,12 @@ describe("buildUnstuckEscalateSeam — CTL-1641", () => {
   });
 });
 
-// CTL-1641 Codex #3005 P2 remediation — the two masking cases the injected-stub tests
-// above cannot reach: (1) a genuine non-confirming LABEL write must surface a `label`
-// error (not be swallowed as benign like a belief-owner deferral), and (2) the escalation
-// COMMENT must be idempotent per (ticket,category,phase) so a still-stuck candidate is not
-// re-commented on every sweep. Both exercise the DEFAULT bindings against a real temp
-// orchDir so the marker files and the labelOnce/onOutcome path actually run.
+// CTL-1641 Codex #3005 P2 remediation — these tests cover the DEFAULT label binding
+// (not injected): (1) a genuine non-confirming write must surface a `label` error, and
+// (2) an already-applied marker is a benign no-op.
+//
+// CTL-1871: comment idempotency is now owned by label-guard.mjs (the .needs-human-ask.applied
+// marker), so the old per-seam comment-marker tests are removed.
 describe("buildUnstuckEscalateSeam — CTL-1641 Codex #3005 P2 remediation", () => {
   test("a genuine non-confirming label write (applyLabel ran, applied:false) surfaces a 'label' error", () => {
     const dir = mkdtempSync(join(tmpdir(), "ctl1641-labelfail-"));
@@ -142,14 +145,14 @@ describe("buildUnstuckEscalateSeam — CTL-1641 Codex #3005 P2 remediation", () 
       env: {},                                                     // not belief-owner → real labelOnce path
       writeStatus: { applyLabel: () => ({ applied: false, reason: "rate-limited" }) },
       // applyNeedsHuman intentionally NOT injected — exercise the default structured binding.
-      postComment: () => true,
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 2,
     });
     const r = seam(candidate("unknown", "CTL-1", "verify"), decision("unknown"));
     expect(r.labelApplied).toBe(false);
     expect(r.errors.some((e) => e.sideEffect === "label")).toBe(true);
-    expect(r.commentPosted).toBe(true);                            // independence: the comment still posts
+    // commentPosted mirrors labelApplied (atomic — gate handles both)
+    expect(r.commentPosted).toBe(false);
   });
 
   test("an already-applied needs-human marker (labelOnce no-op) is NOT a label error", () => {
@@ -161,108 +164,11 @@ describe("buildUnstuckEscalateSeam — CTL-1641 Codex #3005 P2 remediation", () 
       orchDir: dir,
       env: {},
       writeStatus: { applyLabel: () => { throw new Error("applyLabel must not run on a marker no-op"); } },
-      postComment: () => true,
       captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
       commitsAhead: () => 1,
     });
     const r = seam(candidate("unknown", "CTL-2", "verify"), decision("unknown"));
     expect(r.labelApplied).toBe(false);
     expect(r.errors.some((e) => e.sideEffect === "label")).toBe(false);  // benign no-op — not a failure
-  });
-
-  test("the escalation comment posts once per (ticket,category,phase); a second sweep is suppressed by the marker", () => {
-    const dir = mkdtempSync(join(tmpdir(), "ctl1641-commentonce-"));
-    mkdirSync(join(dir, "workers", "CTL-3"), { recursive: true });
-    let posts = 0;
-    const seam = buildUnstuckEscalateSeam({
-      orchDir: dir,
-      env: {},
-      applyNeedsHuman: () => true,
-      postComment: () => { posts++; return true; },
-      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
-      commitsAhead: () => 2,
-    });
-    const c = candidate("unknown", "CTL-3", "verify");
-    const d = decision("unknown");
-    const r1 = seam(c, d);
-    const r2 = seam(c, d);                                          // same still-stuck candidate, next sweep
-    expect(posts).toBe(1);                                          // comment posted exactly once
-    expect(r1.commentPosted).toBe(true);
-    expect(r2.commentPosted).toBe(true);                           // second call satisfied by the marker
-    expect(r2.errors).toEqual([]);
-    expect(existsSync(join(dir, "workers", "CTL-3", ".unstuck-escalate-comment-unknown-verify.applied"))).toBe(true);
-  });
-
-  test("a failed comment post does NOT write the idempotency marker — the next sweep retries", () => {
-    const dir = mkdtempSync(join(tmpdir(), "ctl1641-commentretry-"));
-    mkdirSync(join(dir, "workers", "CTL-4"), { recursive: true });
-    let posts = 0;
-    const seam = buildUnstuckEscalateSeam({
-      orchDir: dir,
-      env: {},
-      applyNeedsHuman: () => true,
-      postComment: () => { posts++; return posts >= 2; },          // fail the first post, succeed the second
-      captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
-      commitsAhead: () => 2,
-    });
-    const c = candidate("unknown", "CTL-4", "verify");
-    const d = decision("unknown");
-    const marker = join(dir, "workers", "CTL-4", ".unstuck-escalate-comment-unknown-verify.applied");
-    const r1 = seam(c, d);
-    expect(r1.commentPosted).toBe(false);
-    expect(r1.errors.some((e) => e.sideEffect === "comment")).toBe(true);
-    expect(existsSync(marker)).toBe(false);                        // no marker on failure
-    const r2 = seam(c, d);                                          // retry on the next sweep
-    expect(r2.commentPosted).toBe(true);
-    expect(posts).toBe(2);
-    expect(existsSync(marker)).toBe(true);                         // marker written after the confirmed post
-  });
-});
-
-// CTL-1641 verify LOW: every test above injects postComment, so the production
-// DEFAULT _post binding (helper-path resolution + spawn) is 0% exercised — the
-// exact path where the verify HIGH bug lived (PLUGIN_ROOT/cwd-relative resolution
-// that silently missed for the daemon). These guard the default binding directly.
-describe("buildUnstuckEscalateSeam default _post binding — CTL-1641 verify LOW", () => {
-  test("the module's sibling-relative helper path resolves to a real file (guards the URL fallback the HIGH bug missed)", () => {
-    // The source module resolves `new URL('../lib/linear-comment-post.sh', import.meta.url)`.
-    // This test file sits in the same directory (execution-core/), so `../lib/...` from here
-    // resolves identically — it must point at a file that actually exists (cwd/env-independent),
-    // which the old `process.env.PLUGIN_ROOT ?? process.cwd()` + 'scripts/lib/...' did not.
-    const expected = fileURLToPath(new URL("../lib/linear-comment-post.sh", import.meta.url));
-    expect(existsSync(expected)).toBe(true);
-    expect(expected.endsWith("plugins/dev/scripts/lib/linear-comment-post.sh")).toBe(true);
-  });
-
-  test("default _post (no postComment injection) spawns the resolved helper with [ticket, body] and reports its exit status", () => {
-    // Bind a hermetic stub as the helper via the CATALYST_COMMENT_POST_HELPER seam — the same
-    // env override the sibling daemon modules honor — and exercise the REAL default _post path
-    // (spawnSync of COMMENT_HELPER), which no other test covers.
-    const dir = mkdtempSync(join(tmpdir(), "ctl1641-escalate-"));
-    const argvOut = join(dir, "argv.txt");
-    const stub = join(dir, "stub-comment-post.sh");
-    writeFileSync(stub, `#!/usr/bin/env bash\nprintf '%s\\n' "$1" "$2" > "${argvOut}"\nexit 0\n`);
-    chmodSync(stub, 0o755);
-
-    const prev = process.env.CATALYST_COMMENT_POST_HELPER;
-    process.env.CATALYST_COMMENT_POST_HELPER = stub;
-    try {
-      const seam = buildUnstuckEscalateSeam({
-        orchDir: dir,
-        applyNeedsHuman: () => true,           // label still injected (not under test here)
-        captureEvidence: () => ({ reason: "unknown", porcelainLines: [], prState: null, remediateHistory: [] }),
-        commitsAhead: () => 2,
-        // postComment intentionally NOT injected — exercise the production default.
-      });
-      const r = seam(candidate("unknown", "CTL-77", "verify"), decision("unknown"));
-      expect(r.commentPosted).toBe(true);
-      expect(r.errors).toEqual([]);
-      const [ticketArg, bodyArg] = readFileSync(argvOut, "utf8").split("\n");
-      expect(ticketArg).toBe("CTL-77");
-      expect(bodyArg).toContain("CTL-77");   // the authored escalation body reached the helper
-    } finally {
-      if (prev === undefined) delete process.env.CATALYST_COMMENT_POST_HELPER;
-      else process.env.CATALYST_COMMENT_POST_HELPER = prev;
-    }
   });
 });

--- a/plugins/dev/scripts/lib/state-vocabulary.d.ts
+++ b/plugins/dev/scripts/lib/state-vocabulary.d.ts
@@ -1,0 +1,11 @@
+export interface Gloss {
+  term: string;
+  plainLabel: string;
+  whatsNext: string;
+  who: string;
+  ifNobody: string;
+}
+
+export declare const VOCABULARY_TERMS: ReadonlyArray<string>;
+
+export declare function glossFor(term: string): Gloss;

--- a/plugins/dev/scripts/lib/state-vocabulary.mjs
+++ b/plugins/dev/scripts/lib/state-vocabulary.mjs
@@ -1,0 +1,205 @@
+// state-vocabulary.mjs — CTL-1871 COORD-41: canonical plain-language glossary for
+// every Catalyst-internal term that may appear in a human-facing status renderer.
+//
+// WHY THIS EXISTS. Every stuck / needs-human / abandoned state must render three
+// things in plain words: what happens next, who acts, and what happens if nobody
+// acts ("if no one acts" / default_if_silent). Without a single source of truth each
+// renderer invents its own wording — and the "who" distinction between needs-human
+// (operator) vs needs-input (user) has been wrong or absent in five places at once.
+//
+// DESIGN. A frozen map term → gloss object, exported as `glossFor(term)`. Unknown
+// terms return a safe degraded gloss rather than throwing (the consumer always gets
+// something renderable). Zero imports: the same module is safe to load from bare Node,
+// bun, the orch-monitor mjs layer, and the UI TypeScript stack via its .d.ts sidecar.
+//
+// ADDING A TERM. Append to VOCABULARY below. Tests enforce: every term has a
+// non-empty plainLabel, whatsNext, who, and ifNobody; needs-human and needs-input
+// differ on `who`; awaiting-work is disambiguated from the CTL-615/702 tombstone yield.
+
+/** @typedef {{ term: string, plainLabel: string, whatsNext: string, who: string, ifNobody: string }} Gloss */
+
+/** @type {ReadonlyMap<string, Gloss>} */
+const VOCABULARY = Object.freeze(
+  new Map([
+    [
+      "needs-human",
+      {
+        term: "needs-human",
+        plainLabel: "Needs your decision",
+        whatsNext: "An operator must review and take action before work can continue.",
+        who: "Operator (you)",
+        ifNobody: "This ticket stays blocked until an operator responds. No automated action is taken.",
+      },
+    ],
+    [
+      "needs-input",
+      {
+        term: "needs-input",
+        plainLabel: "Waiting for your reply",
+        whatsNext: "The agent paused and asked a question. Reply in the ticket to unblock it.",
+        who: "Ticket author / assignee",
+        ifNobody: "Work stays paused until someone replies in the ticket thread.",
+      },
+    ],
+    [
+      "stalled",
+      {
+        term: "stalled",
+        plainLabel: "Gave up — needs reset",
+        whatsNext: "The agent exhausted its retry budget and stopped. An operator must decide whether to retry or close the ticket.",
+        who: "Operator (you)",
+        ifNobody: "The ticket remains stalled indefinitely. No automated retry will occur.",
+      },
+    ],
+    [
+      "aborted",
+      {
+        term: "aborted",
+        plainLabel: "Cancelled",
+        whatsNext: "Work was intentionally stopped. No further action is expected unless the ticket is re-opened.",
+        who: "No one — resolved",
+        ifNobody: "Nothing happens. The ticket stays cancelled.",
+      },
+    ],
+    [
+      "awaiting-work",
+      {
+        term: "awaiting-work",
+        // Disambiguate from the CTL-615/702 tombstone "yield" (a duplicate-worker bow-out).
+        // This is the CTL-1854 bounded wait — the agent delegated to a background job and
+        // declared a 30-minute deadline. The deadline expires to `failed/abandoned`, never to
+        // a redispatch; the worker must declare before stopping, not stop and hope to be resumed.
+        plainLabel: "Waiting on background work (bounded)",
+        whatsNext: "The agent is waiting up to 30 minutes for a background job it started. It will resume automatically when the job completes or the deadline passes.",
+        who: "No one — automated",
+        ifNobody: "The agent's deadline expires and the phase is recorded as abandoned. An operator can then re-triage.",
+      },
+    ],
+    [
+      "preempted",
+      {
+        term: "preempted",
+        plainLabel: "Taken over by another worker",
+        whatsNext: "A higher-priority or reclaim worker has taken ownership of this ticket. The preempted session bowed out.",
+        who: "No one — automated",
+        ifNobody: "The reclaiming worker continues automatically.",
+      },
+    ],
+    [
+      "turn-cap-exhausted",
+      {
+        term: "turn-cap-exhausted",
+        plainLabel: "Hit turn limit — needs continuation",
+        whatsNext: "The agent reached its per-session turn cap. A continuation worker will be dispatched automatically.",
+        who: "No one — automated (continuation dispatched)",
+        ifNobody: "If continuation dispatch fails, the ticket enters needs-human for an operator to re-triage.",
+      },
+    ],
+    [
+      "reclaim",
+      {
+        term: "reclaim",
+        plainLabel: "Reclaimed from a dead worker",
+        whatsNext: "The scheduler detected that the previous worker stopped without finishing and assigned a new worker.",
+        who: "No one — automated",
+        ifNobody: "The scheduler will continue to attempt reclaims on future ticks.",
+      },
+    ],
+    [
+      "revive",
+      {
+        term: "revive",
+        plainLabel: "Resumed after stall",
+        whatsNext: "A stalled or abandoned phase is being retried with a fresh worker.",
+        who: "No one — automated",
+        ifNobody: "If the revive budget is exhausted, the ticket enters needs-human.",
+      },
+    ],
+    [
+      "orphan",
+      {
+        term: "orphan",
+        plainLabel: "Left behind by its orchestrator",
+        whatsNext: "The worker was running but its orchestrator is gone. The orphan reaper will clean it up.",
+        who: "No one — automated (reaper)",
+        ifNobody: "The orphan reaper removes the stale state on its next pass.",
+      },
+    ],
+    [
+      "reap",
+      {
+        term: "reap",
+        plainLabel: "Background job being stopped",
+        whatsNext: "The daemon is sending a stop signal to the background job and cleaning up its worktree.",
+        who: "No one — automated",
+        ifNobody: "The reaper retries on the next cycle if the job does not stop.",
+      },
+    ],
+    [
+      "dispatch",
+      {
+        term: "dispatch",
+        plainLabel: "Launching worker",
+        whatsNext: "The scheduler is starting a new background agent for this phase.",
+        who: "No one — automated",
+        ifNobody: "If dispatch fails, the scheduler retries or escalates after the circuit-breaker threshold.",
+      },
+    ],
+    [
+      "advance",
+      {
+        term: "advance",
+        plainLabel: "Moving to next phase",
+        whatsNext: "This phase is complete; the pipeline is transitioning to the next one.",
+        who: "No one — automated",
+        ifNobody: "Nothing — advance is a momentary transition, not a waiting state.",
+      },
+    ],
+    [
+      "signal",
+      {
+        term: "signal",
+        plainLabel: "Phase status file",
+        whatsNext: "A disk record tracking this phase's progress. Normally invisible; present here because the orchestrator is inspecting it.",
+        who: "No one — internal",
+        ifNobody: "Nothing — signal files are internal bookkeeping.",
+      },
+    ],
+    // Pipeline phases — each carries a standard who/ifNobody since the human
+    // only intervenes at escalation; the normal path is fully automated.
+    ...["triage", "research", "plan", "implement", "verify", "review", "pr", "monitor-merge", "monitor-deploy", "teardown"].map(
+      (phase) => [
+        phase,
+        {
+          term: phase,
+          plainLabel: `Phase: ${phase}`,
+          whatsNext: `A background agent is running the ${phase} phase. No action needed unless it escalates.`,
+          who: "No one — automated",
+          ifNobody: "Nothing — this phase runs automatically. If it fails, the scheduler will escalate.",
+        },
+      ]
+    ),
+  ])
+);
+
+export const VOCABULARY_TERMS = Object.freeze([...VOCABULARY.keys()]);
+
+/** The gloss for an unknown term — always renderable, never throws. */
+const UNKNOWN_GLOSS = (term) => ({
+  term,
+  plainLabel: term,
+  whatsNext: "Unknown state — check the ticket.",
+  who: "Unknown",
+  ifNobody: "No automated action is defined for this state.",
+});
+
+/**
+ * Returns the plain-language gloss for a Catalyst internal term.
+ * Unknown terms return a safe degraded gloss rather than throwing.
+ *
+ * @param {string} term
+ * @returns {Gloss}
+ */
+export function glossFor(term) {
+  return VOCABULARY.get(term) ?? UNKNOWN_GLOSS(term);
+}

--- a/plugins/dev/scripts/lib/state-vocabulary.test.mjs
+++ b/plugins/dev/scripts/lib/state-vocabulary.test.mjs
@@ -1,0 +1,92 @@
+// state-vocabulary.test.mjs — CTL-1871 COORD-41 Phase 5 tests.
+import { describe, test, expect } from "bun:test";
+import { glossFor, VOCABULARY_TERMS } from "./state-vocabulary.mjs";
+
+describe("VOCABULARY_TERMS", () => {
+  test("is a non-empty frozen array of strings", () => {
+    expect(Array.isArray(VOCABULARY_TERMS)).toBe(true);
+    expect(VOCABULARY_TERMS.length).toBeGreaterThan(0);
+    for (const t of VOCABULARY_TERMS) expect(typeof t).toBe("string");
+  });
+
+  test("includes the key COORD-41 terms", () => {
+    for (const t of ["needs-human", "needs-input", "stalled", "awaiting-work", "reclaim", "revive"]) {
+      expect(VOCABULARY_TERMS).toContain(t);
+    }
+  });
+
+  test("includes all 10 pipeline phases", () => {
+    for (const p of ["triage", "research", "plan", "implement", "verify", "review", "pr", "monitor-merge", "monitor-deploy", "teardown"]) {
+      expect(VOCABULARY_TERMS).toContain(p);
+    }
+  });
+});
+
+describe("glossFor — known terms", () => {
+  test("every VOCABULARY_TERM returns a gloss with all four non-empty required fields", () => {
+    for (const term of VOCABULARY_TERMS) {
+      const g = glossFor(term);
+      expect(typeof g.plainLabel, `${term}.plainLabel`).toBe("string");
+      expect(g.plainLabel.trim(), `${term}.plainLabel non-empty`).not.toBe("");
+      expect(typeof g.whatsNext, `${term}.whatsNext`).toBe("string");
+      expect(g.whatsNext.trim(), `${term}.whatsNext non-empty`).not.toBe("");
+      expect(typeof g.who, `${term}.who`).toBe("string");
+      expect(g.who.trim(), `${term}.who non-empty`).not.toBe("");
+      // COORD-41 load-bearing: every term must have a non-empty ifNobody
+      expect(typeof g.ifNobody, `${term}.ifNobody`).toBe("string");
+      expect(g.ifNobody.trim(), `${term}.ifNobody non-empty`).not.toBe("");
+    }
+  });
+
+  test("needs-human and needs-input differ on `who` (the load-bearing distinction)", () => {
+    const nh = glossFor("needs-human");
+    const ni = glossFor("needs-input");
+    expect(nh.who).not.toBe(ni.who);
+  });
+
+  test("needs-human.who mentions operator", () => {
+    expect(glossFor("needs-human").who.toLowerCase()).toContain("operator");
+  });
+
+  test("needs-input.who does NOT mention operator", () => {
+    expect(glossFor("needs-input").who.toLowerCase()).not.toContain("operator");
+  });
+
+  test("awaiting-work is disambiguated from the CTL-615/702 tombstone yield (plainLabel must mention bounded)", () => {
+    const g = glossFor("awaiting-work");
+    // The gloss must make clear this is CTL-1854's bounded wait, not a duplicate-worker bow-out.
+    expect(g.plainLabel.toLowerCase()).toContain("bounded");
+  });
+
+  test("awaiting-work.ifNobody describes deadline expiry, not a redispatch", () => {
+    const g = glossFor("awaiting-work");
+    expect(g.ifNobody.toLowerCase()).toMatch(/deadline|expires|expired|abandon/);
+  });
+
+  test("stalled.ifNobody makes clear no automated retry will occur", () => {
+    const g = glossFor("stalled");
+    expect(g.ifNobody.toLowerCase()).toMatch(/no.*retry|indefinitely|stays stalled/);
+  });
+});
+
+describe("glossFor — unknown terms", () => {
+  test("returns a safe degraded gloss for an unknown term rather than throwing", () => {
+    const g = glossFor("totally-unknown-term-xyz");
+    expect(g.plainLabel).toBe("totally-unknown-term-xyz");
+    expect(typeof g.whatsNext).toBe("string");
+    expect(typeof g.who).toBe("string");
+    expect(typeof g.ifNobody).toBe("string");
+  });
+
+  test("degraded gloss still has non-empty whatsNext", () => {
+    expect(glossFor("__no_such_term__").whatsNext.trim()).not.toBe("");
+  });
+});
+
+describe("glossFor — term identity round-trip", () => {
+  test("returned gloss.term matches the queried term for known terms", () => {
+    for (const term of VOCABULARY_TERMS) {
+      expect(glossFor(term).term).toBe(term);
+    }
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-parked-needs-human.test.ts
@@ -89,7 +89,7 @@ describe("synthesizeParkedNeedsHumanTickets — the pure card builder", () => {
     );
     expect(cards).toHaveLength(1);
     expect(cards[0].attention).toBe("needs-human");
-    expect(String(cards[0].humanQuestion)).toContain("needs-input");
+    expect(String(cards[0].humanQuestion)).toContain("paused and asked a question");
     expect(classifyTicket(cards[0])).toBe("attention");
   });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/reading-pane-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/reading-pane-model.test.ts
@@ -317,6 +317,7 @@ describe("CTL-1110: escalationExplanationFor", () => {
       whyYou: FULL_EXPL.why_you,
       whyNotAuto: FULL_EXPL.why_not_auto,
       whatToDo: FULL_EXPL.what_to_do,
+      defaultIfSilent: null,
     });
   });
 

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-explanation.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-explanation.test.mjs
@@ -26,6 +26,7 @@ describe("CTL-1110: deriveExplanation", () => {
       why_you: "Fixes need judgment.",
       why_not_auto: "3 attempts failed.",
       what_to_do: "Review why fixes failed.",
+      default_if_silent: null,
     });
   });
 
@@ -42,6 +43,7 @@ describe("CTL-1110: deriveExplanation", () => {
     expect(deriveExplanation(sigs)).toEqual({
       call_to_action: "Decide.", outcome: null, problem: null,
       why_you: null, why_not_auto: null, what_to_do: "Pick an option.",
+      default_if_silent: null,
     });
   });
 
@@ -60,6 +62,7 @@ describe("CTL-1110: deriveExplanation", () => {
     expect(deriveExplanation(sigs)).toEqual({
       call_to_action: null, outcome: "ok", problem: null,
       why_you: null, why_not_auto: null, what_to_do: null,
+      default_if_silent: null,
     });
   });
 });

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -58,6 +58,7 @@ import { recordFullRead, scanFileLines } from "./event-log-reader.ts"; // CTL-15
 import { isLinearTerminal } from "../../execution-core/terminal-state.mjs";
 import { readDurableEscalations } from "../../execution-core/durable-escalation.mjs"; // CTL-1643: GC-surviving escalation store
 import { readClusterProjects } from "./cluster-roster.ts";
+import { glossFor } from "../../lib/state-vocabulary.mjs"; // CTL-1871 COORD-41: plain-language glossary
 
 const execFileP = promisify(execFile);
 
@@ -1106,6 +1107,7 @@ const EXPLANATION_RENDER_FIELDS = [
   "why_you",
   "why_not_auto",
   "what_to_do",
+  "default_if_silent", // CTL-1871 COORD-41: "what happens if nobody acts"
 ];
 
 /** CTL-1110: extract the six extended explanation fields from the most-recent
@@ -1484,11 +1486,11 @@ export function synthesizeParkedNeedsHumanTickets(
     if (seen.has(p.ticket)) continue; // already carded (worker-dir / queued / orphan) — never double-count
     seen.add(p.ticket);
     const labels = Array.isArray(p.labels) ? p.labels : [];
-    // needs-input reads as "waiting on your input"; needs-human as a generic escalation.
+    // CTL-1871 COORD-41: use the vocabulary glossary for human-facing parked reasons.
     const reason =
       labels.includes(ATTENTION_LABEL_NEEDS_INPUT) && !labels.includes(ATTENTION_LABEL_NEEDS_HUMAN)
-        ? "Parked — waiting on your input (needs-input)."
-        : "Parked — escalated for a human (needs-human).";
+        ? `Parked — ${glossFor("needs-input").whatsNext}`
+        : `Parked — ${glossFor("needs-human").whatsNext} ${glossFor("needs-human").ifNobody}`;
     const replicaTitle =
       typeof replicaTitles?.[p.ticket] === "string" && replicaTitles[p.ticket].length > 0
         ? replicaTitles[p.ticket]

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/Board.tsx
@@ -170,6 +170,8 @@ const HELD_LABEL_WAITING = "queued";
 export type { ColorBy } from "./board-accent";
 import { PHASE_C, accentFor, type ColorBy } from "./board-accent";
 export { accentFor };
+// CTL-1871 COORD-41: plain-language glossary — used for AttentionBadge and status text.
+import { glossFor } from "~catalyst-lib/state-vocabulary";
 // CTL-909 / SURF1: a stable per-node accent so the "group by Node" columns +
 // the host chip on each worker card carry a consistent color. Hashed from the
 // host name (the unattributed bucket reads dim) — deterministic, no palette
@@ -496,11 +498,13 @@ export function AttentionBadge({
   attention?: "waiting-on-you" | "needs-human" | null;
 }) {
   if (attention !== "waiting-on-you" && attention !== "needs-human") return null;
+  // CTL-1871 COORD-41: derive plain-language label + tooltip from the vocabulary glossary.
+  const nhGloss = glossFor("needs-human");
   const label =
-    attention === "needs-human" ? "⚑ escalated — needs human" : "⏸ waiting on your answer";
+    attention === "needs-human" ? `⚑ ${nhGloss.plainLabel}` : "⏸ waiting on your answer";
   const tip =
     attention === "needs-human"
-      ? "Escalated to you — a human must act (watchdog / needs-human)"
+      ? `${nhGloss.whatsNext} ${nhGloss.ifNobody}`
       : "Paused waiting for your answer (a permission grant or prompt)";
   return (
     <Tooltip>

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/reading-pane-model.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/reading-pane-model.ts
@@ -156,6 +156,8 @@ export interface EscalationExplanationView {
   whyYou: string | null;
   whyNotAuto: string | null;
   whatToDo: string | null;
+  /** CTL-1871 COORD-41: what happens if nobody responds. */
+  defaultIfSilent: string | null;
 }
 
 const nz = (s: string | null | undefined): string | null =>
@@ -178,6 +180,7 @@ export function escalationExplanationFor(row: InboxRow): EscalationExplanationVi
     whyYou: nz(e.why_you),
     whyNotAuto: nz(e.why_not_auto),
     whatToDo: nz(e.what_to_do),
+    defaultIfSilent: nz(e.default_if_silent ?? null),
   };
   if (Object.values(view).every((v) => v == null)) return null;
   return view;

--- a/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/src/board/types.ts
@@ -230,6 +230,8 @@ export interface BoardEscalationExplanation {
   why_you: string | null;
   why_not_auto: string | null;
   what_to_do: string | null;
+  /** CTL-1871 COORD-41: what happens if nobody responds. */
+  default_if_silent?: string | null;
 }
 
 export interface WorkflowSubStep {

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/home/reading-pane.tsx
@@ -280,6 +280,10 @@ function WhatsNeededNow({
             ["Why this needs you", escalation.whyYou, "why_you"],
             ["Why it couldn't self-heal", escalation.whyNotAuto, "why_not_auto"],
             ["What to do", escalation.whatToDo, "what_to_do"],
+            // CTL-1871 COORD-41: "what happens if nobody acts" — always present for
+            // escalations that passed through the CTL-1871 gate; may be absent for
+            // legacy explanations written before CTL-1871 shipped.
+            ["If no one acts", escalation.defaultIfSilent, "default_if_silent"],
           ] as const
         )
           .filter(([, value]) => value != null)

--- a/plugins/dev/scripts/orch-monitor/ui/src/components/queue/holding-buckets.tsx
+++ b/plugins/dev/scripts/orch-monitor/ui/src/components/queue/holding-buckets.tsx
@@ -20,6 +20,8 @@ import {
   type HoldingBucketItem,
 } from "./queue-model";
 import { QueueRowShell } from "./queue-row";
+// CTL-1871 COORD-41: plain-language labels from the canonical vocabulary glossary.
+import { glossFor } from "~catalyst-lib/state-vocabulary";
 
 const DOT_COLOR: Record<HoldingBucket["kind"], string> = {
   "needs-you": C.yellow,
@@ -31,11 +33,11 @@ const DOT_COLOR: Record<HoldingBucket["kind"], string> = {
 };
 const BUCKET_LABEL: Record<HoldingBucket["kind"], string> = {
   "needs-you": "Needs you",
-  stalled: "Stalled — gave up",
+  stalled: glossFor("stalled").plainLabel,
   blocked: "Blocked by dependencies",
   queued: "Held — awaiting capacity",
-  "needs-input": "Waiting for input",
-  "needs-human": "Needs human review",
+  "needs-input": glossFor("needs-input").plainLabel,
+  "needs-human": glossFor("needs-human").plainLabel,
 };
 
 function ColorDot({ color }: { color: string }) {

--- a/plugins/dev/scripts/orch-monitor/ui/tsconfig.json
+++ b/plugins/dev/scripts/orch-monitor/ui/tsconfig.json
@@ -16,8 +16,9 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "~catalyst-lib/*": ["../../lib/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../../lib/state-vocabulary.d.ts"]
 }

--- a/plugins/dev/scripts/orch-monitor/ui/vite.config.ts
+++ b/plugins/dev/scripts/orch-monitor/ui/vite.config.ts
@@ -103,6 +103,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": resolve(__dirname, "src"),
+      // CTL-1871 COORD-41: expose the scripts lib/ directory to the UI so
+      // state-vocabulary.mjs (and future zero-import leaf modules) can be
+      // imported as "~catalyst-lib/<name>" from any UI source file.
+      "~catalyst-lib": resolve(__dirname, "../../lib"),
     },
   },
   build: {

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1766,6 +1766,59 @@ Observable on the event log (`delegate.routed` with a `phase.rescue.routed-to-{s
 type discriminator):
 `{job="catalyst-events"} | json | attributes["event.name"] = "delegate.routed"`
 
+### COORD-29: ASK comment gate (CTL-1871)
+
+When the execution-core daemon applies the `needs-human` label it now attempts to post a structured
+**ASK comment** in the same step — a single-sentence question and a default outcome if nobody
+answers. This makes every `needs-human` ticket actionable in the operator inbox. The gate is
+modal:
+
+| Key                         | Default  | Notes                                                                                                                                                                                                                                                       |
+| --------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_NEEDS_HUMAN_ASK`  | `shadow` | `off` — gate is skipped entirely; `shadow` — attempts the comment, logs failure but always applies the label; `enforce` — withholds the label AND skips the escalation if the comment post fails (the ticket stays where it was). Garbage values → `shadow`. |
+
+**ASK comment format** (posted to Linear):
+
+```
+ASK (Ryan): <call_to_action> — default if silent: <default_if_silent>
+```
+
+The gate is idempotent: a `.needs-human-ask.applied` marker under `workers/<TICKET>/` prevents
+duplicate comments on repeated label applications for the same ticket. The marker is cleared by
+`clearNeedsHumanMarkers` whenever the `needs-human` label is removed (human responds), so the next
+escalation cycle re-arms cleanly.
+
+**Events emitted** (observable via `catalyst-events tail`):
+
+- `needs-human.ask.comment.failed` — comment post failed (any mode); includes `site`, `ticket`, `mode`, `err`
+- `needs-human.ask.label.withheld` — enforce-mode only; label suppressed because comment failed
+
+Both are registered in `broker/namespace-parity.test.mjs` via the imported `NEEDS_HUMAN_ASK_EVENTS`
+constant, so a rename cannot leave a re-typed literal behind.
+
+### COORD-29: stale-needs-human daily sweep (CTL-1871 Phase 4)
+
+The ASK gate covers **future** escalations. Legacy `needs-human` labels applied before the gate
+shipped, cross-host applications, and edge races can leave a ticket with the label but no ASK
+comment. The daily sweep closes that gap.
+
+| Key                                   | Default  | Notes                                                                                                                                                                                                                                                                                   |
+| ------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CATALYST_STALE_NEEDS_HUMAN_SWEEP`    | `shadow` | `off` — sweep is disabled; `shadow` (default) — scans and logs WOULD-flag events but applies nothing; `enforce` — applies `stale-needs-human` label and posts a defect comment with a suggested ASK template for each flagged ticket. Garbage values → `shadow`. |
+
+The sweep runs once at broker boot and then every 24 hours (`SWEEP_INTERVAL_MS = 86_400_000 ms`).
+It never modifies terminal tickets and is idempotent (a ticket already carrying `stale-needs-human`
+is skipped). After each pass it emits `broker.stale-needs-human.swept` with `{scanned, flagged,
+items}` on the unified event log — observable via `catalyst-events tail --filter broker.stale`.
+
+**Classifier logic** (`classifyStaleNeedsHuman`):
+
+1. Terminal state → `flag:false, reason:"terminal"` (skip entirely)
+2. No `needs-human` label → `flag:false, reason:"no-needs-human"`
+3. Already carries `stale-needs-human` → `flag:false, reason:"already-flagged"` (idempotent)
+4. Has at least one `parseAskComment`-recognised ASK comment → `flag:false, reason:"has-ask"`
+5. Otherwise → `flag:true` (the gap)
+
 ### Monitor reply-route trusted origins (CTL-1573)
 
 `POST /api/ticket/<ticket>/reply` posts operator-authored text to Linear, and the monitor binds


### PR DESCRIPTION
## Summary

Implements two COORD contracts that close the gap between internal state and operator-visible clarity:

- **COORD-29 (atomicity)**: Applying `needs-human` and posting an ASK comment are now one atomic operation — both succeed or the label is withheld (in `enforce` mode). Idempotency via `.needs-human-ask.applied` marker. Mode knob `CATALYST_NEEDS_HUMAN_ASK` defaults to `shadow`.
- **COORD-41 (plain language)**: Every stuck/`needs-human`/abandoned state renders what happens next, who acts, and what happens if nobody acts — via `lib/state-vocabulary.mjs`, a zero-import canonical glossary leaf with a TypeScript sidecar. The `default_if_silent` field is added to the escalation explanation shape and surfaced in the orch-monitor reading pane as "If no one acts".

**Phase 4** adds a daily sweep that flags `needs-human` tickets that were labeled without an ASK comment (i.e., before this PR), writing `stale-needs-human` as a detection label. Mode knob `CATALYST_STALE_NEEDS_HUMAN_SWEEP` defaults to `shadow`.

## What changed

- `label-guard.mjs` — COORD-29 gate: `postAskCommentIfNeeded` wired into `labelNeedsHumanUnlessBeliefOwner`; `clearNeedsHumanMarkers` clears ASK marker alongside label markers
- `needs-human-ask.mjs` — ASK comment poster with idempotency marker and event emission
- `escalation-explanation.mjs` — `default_if_silent` field added to every typed explanation constructor; `coerceExplanation` always populates it
- `daemon.mjs` — `clearNeedsHumanMarkers` extended to 5 paths (both label variants + stale variants + ASK marker)
- `stale-needs-human-sweep.mjs` — daily sweep: classifies `needs-human` tickets without ASK comments, writes `stale-needs-human`, emits `broker.stale-needs-human.swept`
- `lib/state-vocabulary.mjs` — canonical `glossFor(term)` → `{plainLabel, whatsNext, who, ifNobody}`; 14 terms + all 10 pipeline phases
- orch-monitor UI — `~catalyst-lib` alias, `holding-buckets.tsx`/`Board.tsx` use `glossFor`, reading pane renders `default_if_silent`
- `configuration.md` — documents both COORD-29 and COORD-41 knobs

## Test plan

- [ ] `bun test plugins/dev/scripts/execution-core/label-guard.test.mjs` — COORD-29 gate tests
- [ ] `bun test plugins/dev/scripts/execution-core/needs-human-ask.test.mjs` — ASK comment + idempotency
- [ ] `bun test plugins/dev/scripts/execution-core/escalation-explanation.test.mjs` — default_if_silent
- [ ] `bun test plugins/dev/scripts/broker/stale-needs-human-sweep.test.mjs` — Phase 4 sweep (26 tests)
- [ ] `bun test plugins/dev/scripts/lib/state-vocabulary.test.mjs` — vocabulary module (13 tests)
- [ ] Full execution-core suite: 148 pre-existing failures on main, same count with this branch (no regressions)
- [ ] TypeScript check: only pre-existing `command.tsx` ReactNode error, no new errors from vocabulary wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)