### PR TITLE
feat(dev): CTL-2095 — concierge launches stewards with role-supervisor; stewards report and complete their scope

### DIFF
--- a/plugins/dev/scripts/__tests__/getting-started-contract.test.sh
+++ b/plugins/dev/scripts/__tests__/getting-started-contract.test.sh
@@ -82,5 +82,21 @@ assert_doc_has "remote: post-reboot start documented for unattended host" \
   "$REMOTE" "catalyst-stack start"
 
 echo ""
+echo "=== Phase 4: coordination layer (CTL-2095) ==="
+
+# The concierge launch command is the ONLY agent-management act documented for the human
+assert_doc_has "index: concierge launch command present" \
+  "$GS/index.md" "role-supervisor launch-concierge"
+# The section explicitly frames the concierge as the only agent-management act
+assert_doc_has "index: frames concierge as the only agent-management act" \
+  "$GS/index.md" "only agent-management act"
+# The section cross-links the doctor command for checking health
+assert_doc_has "index: coordination section cross-links role-supervisor doctor" \
+  "$GS/index.md" "role-supervisor doctor"
+# Section uses "coordination layer" heading so readers can navigate to it
+assert_doc_has "index: coordination layer heading present" \
+  "$GS/index.md" "coordination layer"
+
+echo ""
 echo "Results: $PASSES passed, $FAILURES failed"
 exit "$FAILURES"

--- a/plugins/dev/scripts/role-supervisor/cli.mjs
+++ b/plugins/dev/scripts/role-supervisor/cli.mjs
@@ -1,15 +1,23 @@
 #!/usr/bin/env node
-// cli.mjs — CTL-1994. `role-supervisor <verb>`.
+// cli.mjs — CTL-1994 / CTL-2095. `role-supervisor <verb>`.
 //
-//   run <role>       supervise a role in the foreground (launchd runs this)
-//   doctor [--json]  one row per role: liveness, status-doc age, restarts
-//   stop <role>      ask a role to write its handoff and exit; it stays down
-//   list             the configured roles
+//   run <role>                  supervise a role in the foreground (launchd runs this)
+//   doctor [--json]             one row per role: liveness, status-doc age, restarts
+//   stop <role>                 ask a role to write its handoff and exit; it stays down
+//   list                        the configured roles
 //   quiet-fleet [--once] [--dry-run]   page the concierge when a role goes quiet
+//   launch-steward --slug <name> [--scope <str>] [--cwd <dir>] [--dry-run]
+//   launch-concierge --human <name> [--scope <str>] [--cwd <dir>] [--dry-run]
+//   activity <role> [--in-flight N] [--open-asks N] [--human-newer true|false]
+//   complete <role>             mark the role's scope done; supervisor will stop it
 import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { superviseRole } from "./supervisor.mjs";
 import { runSdkSession } from "./sdk-session.mjs";
 import { report, formatReport, listRoles } from "./doctor.mjs";
+import { writeActivity, markComplete } from "./state.mjs";
 import { runQuietFleetOnce } from "./quiet-fleet.mjs";
 import { runHoldingSentinelOnce } from "./holding-sentinel.mjs";
 import { runDeadManOnce } from "./dead-man.mjs";
@@ -19,6 +27,10 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // One tick a minute, matching the plist's ThrottleInterval — the alarm never
 // touches the daemon hot path or Linear/GitHub.
 const QUIET_FLEET_INTERVAL_MS = 60_000;
+
+const __filename = fileURLToPath(import.meta.url);
+const SCRIPT_DIR = dirname(__filename);
+const INSTALL_SH = join(SCRIPT_DIR, "install.sh");
 
 const [verb, arg] = process.argv.slice(2);
 
@@ -60,13 +72,119 @@ async function main() {
       return runInstrument("holding-sentinel", runHoldingSentinelOnce);
     case "dead-man":
       return runInstrument("dead-man", runDeadManOnce);
+
+    // CTL-2095: codified launchers. Thin, validated wrappers over install.sh that
+    // always use the skill contract and never a hand-written brief.
+    case "launch-steward":
+      return await handleLaunch({
+        argv: process.argv.slice(3),
+        requiredSkill: "catalyst-dev:steward",
+        identifierFlag: "--slug",
+        rolePrefix: "steward",
+        verbName: "launch-steward",
+      });
+    case "launch-concierge":
+      return await handleLaunch({
+        argv: process.argv.slice(3),
+        requiredSkill: "catalyst-dev:concierge",
+        identifierFlag: "--human",
+        rolePrefix: "concierge",
+        verbName: "launch-concierge",
+      });
+
+    // CTL-2095: activity reporting and completion.
+    case "activity": {
+      if (!arg) die("usage: role-supervisor activity <role> [--in-flight N] [--open-asks N] [--human-newer true|false]");
+      const flags = parseFlags(process.argv.slice(4));
+      const patch = {};
+      if (flags["in-flight"] !== undefined) patch.inFlightTickets = Number(flags["in-flight"]);
+      if (flags["open-asks"] !== undefined) patch.openAsksRaised = Number(flags["open-asks"]);
+      if (flags["human-newer"] !== undefined) patch.humanCommentNewerThanLastReply = flags["human-newer"] === "true";
+      writeActivity(arg, patch);
+      console.log(`role-supervisor: activity updated for ${arg}`);
+      return 0;
+    }
+    case "complete": {
+      if (!arg) die("usage: role-supervisor complete <role>");
+      markComplete(arg);
+      console.log(`role-supervisor: ${arg} marked complete — scope_active:false, activity zeroed`);
+      return 0;
+    }
+
     default:
       die(
         "usage: role-supervisor run <role> | doctor [--json] | stop <role> | list | " +
+          "launch-steward --slug <name> [--scope <str>] [--cwd <dir>] [--dry-run] | " +
+          "launch-concierge --human <name> [--scope <str>] [--cwd <dir>] [--dry-run] | " +
+          "activity <role> [--in-flight N] [--open-asks N] [--human-newer true|false] | " +
+          "complete <role> | " +
           "quiet-fleet [--once] [--dry-run] | holding-sentinel [--once] [--dry-run] | dead-man [--once] [--dry-run]",
       );
   }
 }
+
+// ── CTL-2095: launch helpers ─────────────────────────────────────────────────
+
+/** Parse simple --flag value / --bool-flag argv into an object. */
+function parseFlags(argv) {
+  const flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--dry-run") { flags.dryRun = true; continue; }
+    if (argv[i].startsWith("--")) {
+      const key = argv[i].slice(2);
+      flags[key] = (i + 1 < argv.length && !argv[i + 1].startsWith("--")) ? argv[++i] : true;
+    }
+  }
+  return flags;
+}
+
+/**
+ * Validate args and invoke install.sh.
+ * Exported so tests can supply a mock `spawnInstall` to capture the call.
+ */
+export function launchRole({ role, requiredSkill, scope, cwd, dryRun = false }, spawnInstall) {
+  const args = ["--role", role, "--skill", requiredSkill];
+  if (scope) args.push("--scope", scope);
+  if (cwd) args.push("--cwd", cwd);
+  if (dryRun) args.push("--dry-run");
+  if (spawnInstall) return spawnInstall(args);
+  return new Promise((resolve, reject) => {
+    const proc = spawn("bash", [INSTALL_SH, ...args], { stdio: "inherit" });
+    proc.on("close", (code) => {
+      if (code === 0) resolve(0);
+      else {
+        const err = Object.assign(new Error(`install.sh exited ${code}`), { exitCode: code });
+        reject(err);
+      }
+    });
+    proc.on("error", reject);
+  });
+}
+
+async function handleLaunch({ argv, requiredSkill, identifierFlag, rolePrefix, verbName }) {
+  const flags = parseFlags(argv);
+  // --brief is never allowed: the skill contract is the brief.
+  if (flags.brief) {
+    die(`${verbName}: --brief is not allowed — ${rolePrefix}s are launched from the skill contract (${requiredSkill}), not a brief`);
+  }
+  // --skill override is only valid if it matches the required contract.
+  if (flags.skill && flags.skill !== requiredSkill) {
+    die(`${verbName}: --skill must be ${requiredSkill} (got '${flags.skill}') — a ${rolePrefix} is launched from the skill contract, never a different skill`);
+  }
+  const identifier = flags[identifierFlag.slice(2)]; // e.g. "slug" or "human"
+  if (!identifier) {
+    die(`usage: role-supervisor ${verbName} ${identifierFlag} <name> [--scope <str>] [--cwd <dir>] [--dry-run]`);
+  }
+  const role = `${rolePrefix}-${identifier}`;
+  try {
+    await launchRole({ role, requiredSkill, scope: flags.scope, cwd: flags.cwd, dryRun: flags.dryRun });
+  } catch (e) {
+    die(e.message);
+  }
+  return 0;
+}
+
+// ── Shared instrument loop for quiet-fleet / holding-sentinel / dead-man ─────
 
 // Shared instrument loop for quiet-fleet / holding-sentinel / dead-man.
 // `runOnce({dryRun})` returns a JSON-serialisable tick result. Fail-open: a

--- a/plugins/dev/scripts/role-supervisor/cli.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/cli.test.mjs
@@ -1,0 +1,177 @@
+// cli.test.mjs — CTL-2095. Tests for the launch-steward / launch-concierge /
+// activity / complete CLI verbs added to role-supervisor.
+//
+// Design: most tests use spawnSync to drive the CLI as a subprocess.
+// All launcher tests pass --dry-run so install.sh never touches launchd.
+// All tests use a scratch CATALYST_DIR so nothing touches the real ~/catalyst.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CLI = join(__dirname, "cli.mjs");
+
+let passes = 0, failures = 0;
+async function t(name, fn) {
+  try { await fn(); console.log(`  PASS: ${name}`); passes++; }
+  catch (e) { console.log(`  FAIL: ${name} — ${e.message}`); failures++; }
+}
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "cli-test-"));
+  const env = { CATALYST_DIR: dir, CLAUDE_CODE_OAUTH_TOKEN: "test-oat" };
+  return { dir, env, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function runCli(argv, { env = {}, timeout = 10000 } = {}) {
+  return spawnSync("node", [CLI, ...argv], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    timeout,
+  });
+}
+
+// Write a minimal manifest directly for idempotency / state tests.
+function writeManifest(dir, role, obj = {}) {
+  const roleDir = join(dir, "roles", role);
+  mkdirSync(roleDir, { recursive: true });
+  writeFileSync(
+    join(roleDir, "manifest.json"),
+    JSON.stringify({ role, scope: "test", skill: "catalyst-dev:steward", cwd: "/tmp", activity: {}, scope_active: true, ...obj }, null, 2),
+  );
+}
+
+// ── Phase 1: launch verbs ───────────────────────────────────────────────────
+
+console.log("1. launch-steward: role derivation and dry-run");
+await t("--slug p13 derives role steward-p13, exits 0 in dry-run, prints manifest would-write", async () => {
+  const s = scratch();
+  const r = runCli(
+    ["launch-steward", "--slug", "p13", "--scope", "P13 · Test", "--cwd", "/tmp", "--dry-run"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr: ${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /steward-p13/, "output should name the derived role");
+  // No manifest file should have been created.
+  assert.equal(existsSync(join(s.dir, "roles", "steward-p13", "manifest.json")), false,
+    "dry-run must not create the manifest file");
+  s.cleanup();
+});
+
+console.log("2. launch-steward: contract guard — wrong skill");
+await t("--skill catalyst-dev:concierge exits 2 with a message naming the invariant", async () => {
+  const s = scratch();
+  const r = runCli(
+    ["launch-steward", "--slug", "x", "--skill", "catalyst-dev:concierge", "--cwd", "/tmp", "--dry-run"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}`);
+  assert.match(r.stderr + r.stdout, /catalyst-dev:steward/, "message must name the required skill");
+  s.cleanup();
+});
+
+await t("--brief flag is rejected with exit 2", async () => {
+  const s = scratch();
+  const r = runCli(
+    ["launch-steward", "--slug", "x", "--brief", "some-brief.txt", "--dry-run"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 2, `expected exit 2 on --brief, got ${r.status}`);
+  assert.match(r.stderr + r.stdout, /brief/, "message must mention the --brief guard");
+  s.cleanup();
+});
+
+console.log("3. launch-steward: missing required arg");
+await t("missing --slug exits 2 with a usage line", async () => {
+  const s = scratch();
+  const r = runCli(["launch-steward", "--scope", "x", "--cwd", "/tmp", "--dry-run"], { env: s.env });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}`);
+  assert.match(r.stderr + r.stdout, /usage|--slug/, "message must name --slug");
+  s.cleanup();
+});
+
+console.log("4. launch-steward: idempotency");
+await t("a second dry-run call with an existing manifest prints 'keep existing'", async () => {
+  const s = scratch();
+  // Seed the manifest so the existing-check fires.
+  writeManifest(s.dir, "steward-demo");
+  const r = runCli(
+    ["launch-steward", "--slug", "demo", "--scope", "Demo scope", "--cwd", "/tmp", "--dry-run"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr: ${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /keep.*existing|kept.*existing/i, "should report keeping the existing manifest");
+  s.cleanup();
+});
+
+console.log("5. launch-concierge: role derivation");
+await t("--human ryan derives role concierge-ryan, exits 0 in dry-run", async () => {
+  const s = scratch();
+  const r = runCli(
+    ["launch-concierge", "--human", "ryan", "--cwd", "/tmp", "--dry-run"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 0, `expected exit 0, got ${r.status}; stderr: ${r.stderr}`);
+  assert.match(r.stdout + r.stderr, /concierge-ryan/, "output should name the derived role");
+  assert.equal(existsSync(join(s.dir, "roles", "concierge-ryan", "manifest.json")), false,
+    "dry-run must not create the manifest file");
+  s.cleanup();
+});
+
+await t("launch-concierge missing --human exits 2 with usage", async () => {
+  const s = scratch();
+  const r = runCli(["launch-concierge", "--cwd", "/tmp", "--dry-run"], { env: s.env });
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}`);
+  assert.match(r.stderr + r.stdout, /usage|--human/, "message must name --human");
+  s.cleanup();
+});
+
+// ── Phase 2: activity and complete verbs ────────────────────────────────────
+
+console.log("6. activity verb: writes merged activity");
+await t("activity <role> --in-flight 2 --open-asks 1 --human-newer false merges into manifest", async () => {
+  const s = scratch();
+  writeManifest(s.dir, "steward-act", { activity: { inFlightTickets: 0 } });
+  const r = runCli(
+    ["activity", "steward-act", "--in-flight", "2", "--open-asks", "1", "--human-newer", "false"],
+    { env: s.env },
+  );
+  assert.equal(r.status, 0, `expected exit 0; stderr: ${r.stderr}`);
+  const manifest = JSON.parse(readFileSync(join(s.dir, "roles", "steward-act", "manifest.json"), "utf8"));
+  assert.equal(manifest.activity.inFlightTickets, 2, "inFlightTickets should be updated");
+  assert.equal(manifest.activity.openAsksRaised, 1, "openAsksRaised should be updated");
+  assert.equal(manifest.activity.humanCommentNewerThanLastReply, false, "humanCommentNewerThanLastReply should be false");
+  // Must not clobber other manifest fields.
+  assert.equal(manifest.scope, "test", "activity update must not clobber unrelated manifest fields");
+  s.cleanup();
+});
+
+console.log("7. complete verb: marks scope done");
+await t("complete <role> zeroes activity and sets scope_active:false", async () => {
+  const s = scratch();
+  writeManifest(s.dir, "steward-done", { activity: { inFlightTickets: 3 }, scope_active: true });
+  const r = runCli(["complete", "steward-done"], { env: s.env });
+  assert.equal(r.status, 0, `expected exit 0; stderr: ${r.stderr}`);
+  const manifest = JSON.parse(readFileSync(join(s.dir, "roles", "steward-done", "manifest.json"), "utf8"));
+  assert.equal(manifest.scope_active, false, "scope_active must be false after complete");
+  assert.equal(manifest.activity.inFlightTickets ?? 0, 0, "inFlightTickets must be zeroed");
+  assert.equal(manifest.activity.openAsksRaised ?? 0, 0, "openAsksRaised must be zeroed");
+  assert.equal(manifest.activity.humanCommentNewerThanLastReply ?? false, false);
+  s.cleanup();
+});
+
+// ── default: unknown verb ───────────────────────────────────────────────────
+console.log("8. usage includes the new verbs");
+await t("unknown verb prints usage that names launch-steward and launch-concierge", async () => {
+  const r = runCli(["unknown-verb-xyz"]);
+  assert.equal(r.status, 2, `expected exit 2, got ${r.status}`);
+  assert.match(r.stderr + r.stdout, /launch-steward/, "usage must name launch-steward");
+  assert.match(r.stderr + r.stdout, /launch-concierge/, "usage must name launch-concierge");
+});
+
+console.log(`\ncli.test.mjs: ${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/scripts/role-supervisor/doctor.mjs
+++ b/plugins/dev/scripts/role-supervisor/doctor.mjs
@@ -29,8 +29,35 @@ export function roleRow(role, { now = Date.now() } = {}, env = process.env) {
   const lease = readLease(role, env);
   const counters = readCounters(role, env);
 
-  const live = classifyHeartbeat(hb, { now });
   const scopeActive = manifest?.scope_active ?? true;
+
+  // CTL-2095: a deliberately-stopped role must NOT age into DEAD.
+  // A heartbeat with state="stopped" is terminal evidence — the role exited
+  // intentionally. Classify it here, before the age-based DEAD/MISSING logic,
+  // so a completed steward reads as "completed" or "stopped", never "dead".
+  if (hb?.state === "stopped") {
+    // scope_active:false → "completed" (scope done); still-active → "stopped" (early exit)
+    const terminalLiveness = !scopeActive ? "completed" : "stopped";
+    const doc = classifyStatusDoc({ updatedAtMs: manifest?.status_doc_updated_at ?? undefined, now, scopeActive: false });
+    return {
+      role,
+      scope: manifest?.scope ?? null,
+      pid: hb?.pid ?? null,
+      session: hb?.session ?? null,
+      liveness: terminalLiveness,
+      heartbeat_age_min: hb?.ts != null ? Math.round((now - hb.ts) / 60000) : null,
+      status_doc: doc.state,
+      status_doc_age_min: doc.ageMs == null ? null : Math.round(doc.ageMs / 60000),
+      restarts_24h: (counters.restarts ?? []).filter((t) => t >= now - 24 * 3600_000).length,
+      restarts_1h: countLastHour(counters, "restart", { now }),
+      lease_holder: lease?.pid ?? null,
+      last_artifact: hb?.last_artifact ?? null,
+      red: false,
+      problems: [],
+    };
+  }
+
+  const live = classifyHeartbeat(hb, { now });
   const doc = classifyStatusDoc({ updatedAtMs: manifest?.status_doc_updated_at ?? undefined, now, scopeActive });
 
   const problems = [];
@@ -73,7 +100,7 @@ export function formatReport(rep) {
   for (const r of rep.roles) {
     const mark = r.red ? "FAIL" : "pass";
     lines.push(
-      `  ${mark}  ${r.role}${r.scope ? `/${r.scope}` : ""}  pid=${r.pid ?? "-"}  liveness=${r.liveness}` +
+      `  ${mark}  ${r.role}${r.scope ? `/${r.scope}` : ""}  pid=${r.pid ?? "-"}  liveness=${r.liveness ?? "-"}` +
       `  hb=${r.heartbeat_age_min ?? "-"}m  doc=${r.status_doc}(${r.status_doc_age_min ?? "-"}m)  restarts24h=${r.restarts_24h}`,
     );
     for (const p of r.problems) lines.push(`         ⛔ ${p}`);

--- a/plugins/dev/scripts/role-supervisor/doctor.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/doctor.test.mjs
@@ -1,0 +1,128 @@
+// doctor.test.mjs — CTL-2095. Tests for the completed/stopped visibility fix.
+// A deliberately-stopped role must NOT be rendered as a red DEAD row.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { roleRow, formatReport, report } from "./doctor.mjs";
+import { writeManifest, beat } from "./state.mjs";
+import { roleFiles } from "./paths.mjs";
+
+let passes = 0, failures = 0;
+function t(name, fn) {
+  try { fn(); console.log(`  PASS: ${name}`); passes++; }
+  catch (e) { console.log(`  FAIL: ${name} — ${e.message}`); failures++; }
+}
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "doctor-test-"));
+  const env = { CATALYST_DIR: dir };
+  return { dir, env, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function seedRole(env, role, { manifest = {}, heartbeatState = "running", heartbeatAgeMs = 0 } = {}) {
+  mkdirSync(roleFiles(role, env).dir, { recursive: true });
+  writeManifest(role, {
+    role, scope: "P13", skill: "catalyst-dev:steward", cwd: "/tmp",
+    activity: {}, scope_active: true, status_doc_updated_at: Date.now() - 60_000,
+    ...manifest,
+  }, env);
+  const now = Date.now() - heartbeatAgeMs;
+  beat(role, { now, state: heartbeatState, scope: "P13" }, env);
+}
+
+const FORTY_FIVE_MIN_MS = 45 * 60 * 1000;
+
+// ── The load-bearing case: a stopped role must not be DEAD ──────────────────
+console.log("1. a stopped role is NOT rendered as dead");
+t("heartbeat state=stopped aged 45 min → liveness=stopped, red=false", () => {
+  const s = scratch();
+  seedRole(s.env, "done-role", {
+    manifest: { scope_active: false },
+    heartbeatState: "stopped",
+    heartbeatAgeMs: FORTY_FIVE_MIN_MS,
+  });
+  const now = Date.now();
+  const row = roleRow("done-role", { now }, s.env);
+  assert.equal(row.red, false, `stopped role must not be red; problems: ${JSON.stringify(row.problems)}`);
+  assert.notEqual(row.liveness, "dead", "liveness must not be 'dead' for a deliberately stopped role");
+  assert.ok(
+    row.liveness === "stopped" || row.liveness === "completed",
+    `liveness should be 'stopped' or 'completed', got '${row.liveness}'`,
+  );
+  assert.equal(row.problems.length, 0, `no problems expected for a completed role; got: ${JSON.stringify(row.problems)}`);
+  s.cleanup();
+});
+
+t("scope_active=false + stopped heartbeat → liveness=completed (the AC4 name)", () => {
+  const s = scratch();
+  seedRole(s.env, "completed-role", {
+    manifest: { scope_active: false },
+    heartbeatState: "stopped",
+    heartbeatAgeMs: FORTY_FIVE_MIN_MS,
+  });
+  const row = roleRow("completed-role", { now: Date.now() }, s.env);
+  // When the scope is quiet AND the heartbeat says stopped, the preferred liveness label is "completed".
+  assert.equal(row.liveness, "completed", `expected 'completed', got '${row.liveness}'`);
+  s.cleanup();
+});
+
+t("formatReport renders a completed role as a pass line, not FAIL", () => {
+  const s = scratch();
+  seedRole(s.env, "fmtdone", {
+    manifest: { scope_active: false },
+    heartbeatState: "stopped",
+    heartbeatAgeMs: FORTY_FIVE_MIN_MS,
+  });
+  const rep = report({ now: Date.now() }, s.env);
+  const out = formatReport(rep);
+  assert.match(out, /pass.*fmtdone|fmtdone.*pass/, "completed role must appear as 'pass'");
+  assert.doesNotMatch(out.toUpperCase(), /FAIL.*fmtdone|fmtdone.*FAIL/, "completed role must NOT appear as 'FAIL'");
+  s.cleanup();
+});
+
+// ── Positive control: a RUNNING role that went silent is still dead ──────────
+console.log("2. positive control: a running-but-silent role is still DEAD");
+t("heartbeat state=running aged 45 min → liveness=dead, red=true", () => {
+  const s = scratch();
+  seedRole(s.env, "wedged-role", {
+    manifest: { scope_active: true },
+    heartbeatState: "running",
+    heartbeatAgeMs: FORTY_FIVE_MIN_MS,
+  });
+  const row = roleRow("wedged-role", { now: Date.now() }, s.env);
+  assert.equal(row.liveness, "dead", `expected dead for silent running role, got '${row.liveness}'`);
+  assert.equal(row.red, true, "a dead running role must be red");
+  s.cleanup();
+});
+
+t("scope_active=true + stopped heartbeat = NOT completed (the role stopped while work was in flight)", () => {
+  const s = scratch();
+  seedRole(s.env, "premature-stop", {
+    manifest: { scope_active: true },
+    heartbeatState: "stopped",
+    heartbeatAgeMs: FORTY_FIVE_MIN_MS,
+  });
+  const row = roleRow("premature-stop", { now: Date.now() }, s.env);
+  // A role that stopped while scope was still active is NOT "completed" — it just stopped.
+  // It should still be recognisable as stopped (not dead) but may carry a warning.
+  assert.notEqual(row.liveness, "dead", "stopped heartbeat → not dead (the heartbeat is the evidence)");
+  assert.notEqual(row.liveness, "completed", "scope still active → not completed");
+  s.cleanup();
+});
+
+// ── Never-booted role stays MISSING ─────────────────────────────────────────
+console.log("3. a role that never booted stays MISSING");
+t("no heartbeat → liveness=missing, red=true", () => {
+  const s = scratch();
+  mkdirSync(roleFiles("never-booted", s.env).dir, { recursive: true });
+  writeManifest("never-booted", { role: "never-booted", scope: "x", skill: "catalyst-dev:steward", cwd: "/tmp", activity: {}, scope_active: true }, s.env);
+  // No beat() call.
+  const row = roleRow("never-booted", { now: Date.now() }, s.env);
+  assert.equal(row.liveness, "missing", `expected missing, got '${row.liveness}'`);
+  assert.equal(row.red, true, "a role that never booted must be red");
+  s.cleanup();
+});
+
+console.log(`\ndoctor.test.mjs: ${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/scripts/role-supervisor/install.sh
+++ b/plugins/dev/scripts/role-supervisor/install.sh
@@ -142,6 +142,33 @@ NODE_BIN="$(command -v node || true)"
 CWD="${CWD:-$(cd "${SCRIPT_DIR}/../../../.." && pwd)}"
 LOG="${ROLE_DIR}/supervisor.log"
 
+# CTL-2095: dry-run for the regular role install path. Print what would happen
+# and exit 0 without touching launchd, the manifest, or the LaunchAgents dir.
+if [[ $DRY_RUN -eq 1 ]]; then
+  _DRY_PATH_VAL="${HOME}/.catalyst/bin:${HOME}/.local/node/bin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  if [[ -f "${ROLE_DIR}/manifest.json" ]]; then
+    echo "role-supervisor: [dry-run] would keep existing ${ROLE_DIR}/manifest.json"
+  else
+    echo "role-supervisor: [dry-run] would write ${ROLE_DIR}/manifest.json"
+    printf '  role=%s scope="%s" skill=%s cwd=%s\n' "${ROLE}" "${SCOPE:-}" "${SKILL}" "${CWD}"
+  fi
+  _DRY_TMP="$(mktemp)"
+  sed \
+    -e "s|REPLACE_WITH_LABEL|${LABEL}|g" \
+    -e "s|REPLACE_WITH_NODE|${NODE_BIN}|g" \
+    -e "s|REPLACE_WITH_CLI|${SCRIPT_DIR}/cli.mjs|g" \
+    -e "s|REPLACE_WITH_ROLE|${ROLE}|g" \
+    -e "s|REPLACE_WITH_PATH|${_DRY_PATH_VAL}|g" \
+    -e "s|REPLACE_WITH_CATALYST_DIR|${CATALYST_DIR_VAL}|g" \
+    -e "s|REPLACE_WITH_CWD|${CWD}|g" \
+    -e "s|REPLACE_WITH_LOG|${LOG}|g" \
+    "${SCRIPT_DIR}/com.catalyst.role.plist" > "$_DRY_TMP"
+  echo "role-supervisor: [dry-run] would install ${LABEL} → ${DEST}"
+  cat "$_DRY_TMP"
+  rm -f "$_DRY_TMP"
+  exit 0
+fi
+
 mkdir -p "$ROLE_DIR"
 
 # The manifest is what the role IS. Written here so that installing a role and

--- a/plugins/dev/scripts/role-supervisor/state.mjs
+++ b/plugins/dev/scripts/role-supervisor/state.mjs
@@ -119,3 +119,37 @@ export function releaseLease(role, { pid = process.pid } = {}, env = process.env
   if (existsSync(f)) rmSync(f);
   return true;
 }
+
+// ── CTL-2095: activity reporting and completion ──────────────────────────────
+//
+// The supervisor's isScopeActive() reads manifest.activity, but nothing wrote
+// it — so the Done condition never fired. These helpers close that gap:
+// the steward writes its current activity each turn via writeActivity(), and
+// marks itself complete via markComplete() when its scope reaches Done.
+
+/**
+ * Merge `patch` into the manifest's `activity` object atomically.
+ * Does NOT clobber other manifest fields.
+ */
+export function writeActivity(role, patch, env = process.env) {
+  const manifest = readManifest(role, env);
+  if (!manifest) throw new Error(`role-supervisor: no manifest for role '${role}'`);
+  const updated = { ...manifest, activity: { ...(manifest.activity ?? {}), ...patch } };
+  writeManifest(role, updated, env);
+}
+
+/**
+ * Mark the role's scope as complete: zero all activity fields and set
+ * scope_active:false. The supervisor re-reads the manifest post-session and
+ * decides `stop` rather than `idle-reenter`.
+ */
+export function markComplete(role, env = process.env) {
+  const manifest = readManifest(role, env);
+  if (!manifest) throw new Error(`role-supervisor: no manifest for role '${role}'`);
+  const updated = {
+    ...manifest,
+    scope_active: false,
+    activity: { inFlightTickets: 0, openAsksRaised: 0, humanCommentNewerThanLastReply: false },
+  };
+  writeManifest(role, updated, env);
+}

--- a/plugins/dev/scripts/role-supervisor/state.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/state.test.mjs
@@ -1,0 +1,85 @@
+// state.test.mjs — CTL-2095. Tests for writeActivity and markComplete.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeManifest, readManifest, writeActivity, markComplete } from "./state.mjs";
+import { roleFiles } from "./paths.mjs";
+import { mkdirSync } from "node:fs";
+
+let passes = 0, failures = 0;
+function t(name, fn) {
+  try { fn(); console.log(`  PASS: ${name}`); passes++; }
+  catch (e) { console.log(`  FAIL: ${name} — ${e.message}`); failures++; }
+}
+
+function scratch() {
+  const dir = mkdtempSync(join(tmpdir(), "state-test-"));
+  const env = { CATALYST_DIR: dir };
+  return { dir, env, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function seedRole(env, role, manifest = {}) {
+  mkdirSync(roleFiles(role, env).dir, { recursive: true });
+  writeManifest(role, { role, scope: "test", skill: "catalyst-dev:steward", cwd: "/tmp", activity: {}, scope_active: true, ...manifest }, env);
+}
+
+console.log("1. writeActivity: merges into manifest.activity");
+t("writeActivity({inFlightTickets:2}) merges without clobbering other fields", () => {
+  const s = scratch();
+  seedRole(s.env, "r1", { activity: { inFlightTickets: 0, openAsksRaised: 5 } });
+  writeActivity("r1", { inFlightTickets: 2 }, s.env);
+  const m = readManifest("r1", s.env);
+  assert.equal(m.activity.inFlightTickets, 2, "inFlightTickets should be updated");
+  assert.equal(m.activity.openAsksRaised, 5, "openAsksRaised should be preserved (not clobbered)");
+  assert.equal(m.scope, "test", "top-level manifest fields must not be clobbered");
+  s.cleanup();
+});
+
+t("writeActivity result is visible via readManifest", () => {
+  const s = scratch();
+  seedRole(s.env, "r2", { activity: {} });
+  writeActivity("r2", { inFlightTickets: 7, openAsksRaised: 1, humanCommentNewerThanLastReply: true }, s.env);
+  const m = readManifest("r2", s.env);
+  assert.equal(m.activity.inFlightTickets, 7);
+  assert.equal(m.activity.openAsksRaised, 1);
+  assert.equal(m.activity.humanCommentNewerThanLastReply, true);
+  s.cleanup();
+});
+
+t("writeActivity is atomic (manifest readable after write)", () => {
+  const s = scratch();
+  seedRole(s.env, "r3", { activity: {} });
+  writeActivity("r3", { inFlightTickets: 3 }, s.env);
+  // If the write is atomic, readManifest should never return null or partial data.
+  const m = readManifest("r3", s.env);
+  assert.ok(m !== null, "manifest must be readable after writeActivity");
+  assert.equal(m.activity.inFlightTickets, 3);
+  s.cleanup();
+});
+
+console.log("2. markComplete: zeroes activity and sets scope_active:false");
+t("markComplete sets scope_active:false and zeroes all activity fields", () => {
+  const s = scratch();
+  seedRole(s.env, "r4", { activity: { inFlightTickets: 2, openAsksRaised: 1, humanCommentNewerThanLastReply: true }, scope_active: true });
+  markComplete("r4", s.env);
+  const m = readManifest("r4", s.env);
+  assert.equal(m.scope_active, false, "scope_active must be false");
+  assert.equal(m.activity.inFlightTickets ?? 0, 0, "inFlightTickets must be zeroed");
+  assert.equal(m.activity.openAsksRaised ?? 0, 0, "openAsksRaised must be zeroed");
+  assert.equal(m.activity.humanCommentNewerThanLastReply ?? false, false, "humanCommentNewerThanLastReply must be false");
+  s.cleanup();
+});
+
+t("markComplete does not clobber other manifest fields", () => {
+  const s = scratch();
+  seedRole(s.env, "r5", { scope: "P13 · MyScope", activity: { inFlightTickets: 1 }, scope_active: true });
+  markComplete("r5", s.env);
+  const m = readManifest("r5", s.env);
+  assert.equal(m.scope, "P13 · MyScope", "scope must be preserved");
+  assert.equal(m.skill, "catalyst-dev:steward", "skill must be preserved");
+  s.cleanup();
+});
+
+console.log(`\nstate.test.mjs: ${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/scripts/role-supervisor/supervisor.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.mjs
@@ -113,7 +113,6 @@ export async function superviseRole(role, {
     for (;;) {
       if (++iterations > maxIterations) return { stopped: "max-iterations", attempt };
 
-      const scopeActive = isScopeActive(manifest.activity ?? {});
       const resumeSessionId = readSession(role, env);
       const prompt = resumeSessionId
         ? buildIdleReentryPrompt()
@@ -154,13 +153,21 @@ export async function superviseRole(role, {
       if (result?.sessionId) writeSession(role, result.sessionId, env);
       beat(role, { now: now(), sessionId: result?.sessionId ?? resumeSessionId, scope: manifest.scope, state: "between-sessions", lastArtifact: result?.lastArtifact ?? null }, env);
 
+      // CTL-2095: re-read the manifest AFTER the session completes so that a steward
+      // which called `role-supervisor complete` during its turn is honoured. The
+      // top-of-iteration read (used for the resume-prompt build) may remain stale —
+      // only the DECISION must use the fresh copy. isScopeActive is computed here,
+      // replacing the stale value from the top of the loop.
+      const freshManifest = readManifest(role, env) ?? manifest;
+      const freshScopeActive = isScopeActive(freshManifest.activity ?? {});
+
       const counters = readCounters(role, env);
       const decision = decideRestart({
         exitCode: result?.exitCode ?? 1,
         overloaded: !!result?.overloaded,
         quotaExhausted: !!result?.quotaExhausted,
         stopRequested: !!result?.stopRequested,
-        scopeActive,
+        scopeActive: freshScopeActive,
         attempt,
         restartsLastHour: countLastHour(counters, "restart", { now: now() }),
         reentriesLastHour: countLastHour(counters, "reentry", { now: now() }),

--- a/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
+++ b/plugins/dev/scripts/role-supervisor/supervisor.test.mjs
@@ -228,5 +228,46 @@ await t("the idle re-entry does not ask the role to start over", () => {
   assert.match(p, /do not start over/);
 });
 
+// ── CTL-2095: manifest re-read after session ─────────────────────────────────
+console.log("10. manifest re-read: the supervisor honours a mid-session complete()");
+await t("a steward that marks itself complete mid-session is stopped, not re-entered", async () => {
+  const s = scratch();
+  // Scope starts active.
+  seedRole(s.env, "steward-complete", { activity: { inFlightTickets: 1 } });
+  let calls = 0;
+  const r = await superviseRole("steward-complete", {
+    env: s.env, sleep: noSleep, log: () => {},
+    runSession: async () => {
+      calls++;
+      // Simulate the steward calling `role-supervisor complete` during its turn.
+      const { writeActivity, markComplete } = await import("./state.mjs");
+      markComplete("steward-complete", s.env);
+      return { exitCode: 0, sessionId: "sess-complete" };
+    },
+  });
+  // The supervisor re-reads the manifest post-session, sees scope_active:false,
+  // and decides "stop" — not "idle-reenter".
+  assert.equal(calls, 1, "should run exactly one session and then stop");
+  assert.match(r.stopped, /quiet|scope/, `expected a quiet-scope stop reason, got '${r.stopped}'`);
+  s.cleanup();
+});
+
+await t("control: scope still active after session → idle-reenter, not stop", async () => {
+  const s = scratch();
+  seedRole(s.env, "steward-reenter", { activity: { inFlightTickets: 1 } });
+  let calls = 0;
+  await superviseRole("steward-reenter", {
+    env: s.env, sleep: noSleep, log: () => {}, maxIterations: 2,
+    runSession: async () => {
+      calls++;
+      // The steward does NOT call complete — scope remains active.
+      return { exitCode: 0, sessionId: "sess-active" };
+    },
+  });
+  // Should have re-entered (run more than once) because the scope stayed active.
+  assert.equal(calls, 2, "should re-enter while scope remains active");
+  s.cleanup();
+});
+
 console.log(`\nsupervisor.test.mjs: ${passes} passed, ${failures} failed`);
 process.exit(failures === 0 ? 0 : 1);

--- a/plugins/dev/skills/steward/SKILL.md
+++ b/plugins/dev/skills/steward/SKILL.md
@@ -44,9 +44,14 @@ You own one project or initiative until it closes: you make work **ready and vis
 5. **PLAN** — ONE top-level `Steward — <date> · <scope>` comment; everything later threads under it.
 6. **DISPATCH** — ready tickets → Todo, priority order, capped at free slots; name the holds.
 7. **WATCH** — bounded replica poll ≤ 5 min: state changes, new comments, PRs on your scope.
-8. **SPEAK** — see below; answer in the thread the message arrived in.
-9. **CLOSE** — a merged PR's ticket goes to Done, stated in the thread.
-10. **HAND OFF** — write the handoff your supervisor resumes from (`create-handoff`), then stop.
+8. **REPORT** — write current activity to your supervisor so the restart ladder reads real state:
+   ```bash
+   role-supervisor activity <role> --in-flight <N> --open-asks <N> --human-newer <true|false>
+   ```
+   Your role name is stated in the preamble of your brief ("You are `<role>`"). `--in-flight` = tickets not in Done/Canceled; `--open-asks` = ask tickets you raised that are still open; `--human-newer` = a human posted in your scope after your last reply.
+9. **SPEAK** — see below; answer in the thread the message arrived in.
+10. **CLOSE** — a merged PR's ticket goes to Done, stated in the thread.
+11. **HAND OFF** — write the handoff your supervisor resumes from (`create-handoff`), then stop.
 
 ## Speak
 
@@ -65,6 +70,11 @@ Stop on a hard stop, your context/budget threshold, or a scheduled rotation — 
 **Your memory is Linear + the channel + the handoff, never the process**, so a turn that produced no
 artifact did not happen: write small and often. Your supervisor resumes you from those artifacts, not from
 a re-pasted brief (`references/resume.md`).
+
+**When the scope is truly done** (every ticket Done or Canceled, no open asks, no pending human replies):
+call `role-supervisor complete <role>` **before** writing the handoff. This tells the supervisor the scope is
+finished — it will not re-enter you after your session ends. Omitting this call causes the supervisor to
+re-dispatch you on a completed scope.
 
 ## Verify yourself
 

--- a/website/src/content/docs/getting-started/index.md
+++ b/website/src/content/docs/getting-started/index.md
@@ -137,6 +137,24 @@ Start a Claude Code session and run:
 Follow the prompts. Catalyst spawns helper agents, documents what your code does, and saves the
 findings to `thoughts/shared/research/`.
 
+## 7. Start the coordination layer (optional)
+
+Catalyst's **concierge** is the only agent-management act a human takes: it starts stewards, which in
+turn dispatch tickets and keep initiative scopes moving. Start one with:
+
+```bash
+role-supervisor launch-concierge --human <your-name> --cwd <repo-path>
+```
+
+This installs a supervised LaunchAgent that keeps the concierge alive under launchd — so a provider
+overload or a session ending mid-turn does not require manual restart. The concierge itself starts
+stewards for each initiative; you do not launch stewards directly.
+
+```bash
+# Check whether the concierge is running and healthy
+role-supervisor doctor
+```
+
 ## Optional plugins
 
 Catalyst is a set of plugins. Install only what you need:


### PR DESCRIPTION
## Summary

- **`launch-steward` / `launch-concierge` verbs** — validated launchers in `role-supervisor` CLI that always use the skill contract (never a brief), with dry-run support and contract guards rejecting wrong-skill or `--brief` overrides
- **`writeActivity` / `markComplete` helpers + supervisor manifest re-read** — stewards write their current activity each turn and mark themselves complete when scope is done; supervisor re-reads the manifest post-session so the decision to stop vs re-enter uses fresh state
- **`doctor` renders completed/stopped roles as non-red** — a heartbeat with `state=stopped` short-circuits before age-based DEAD/MISSING logic; `scope_active:false` + stopped → `liveness=completed`, `red=false`
- **Getting-started docs** — new "Start the coordination layer" section with `role-supervisor launch-concierge` as the only agent-management act; 4 new contract test assertions

## Test plan

- [x] `cli.test.mjs` — 10 tests: launch-steward/concierge verbs, dry-run, contract guards, activity, complete, usage
- [x] `state.test.mjs` — 5 tests: writeActivity merge behavior, markComplete, atomicity
- [x] `doctor.test.mjs` — 6 tests: completed/stopped liveness, formatReport, positive control (running-but-silent → DEAD)
- [x] `supervisor.test.mjs` — 17 tests (15 existing + 2 new Phase 2 re-read cases): mid-session complete → stop; scope-still-active → idle-reenter
- [x] `getting-started-contract.test.sh` — 18 passed (4 new Phase 4 assertions pass; 1 pre-existing failure on main unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)