### PR TITLE
feat(dev): CTL-1864 — publish slot-based active_count on node.heartbeat

### DIFF
--- a/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-heartbeat-publisher.mjs
@@ -23,7 +23,8 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { computeLastPhaseAdvanceTs, readAllPhaseSignals, readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
+import { computeLastPhaseAdvanceTs, countYieldedOccupancy as defaultCountYieldedOccupancy, readAllPhaseSignals, readWorkerSignals, TERMINAL } from "./signal-reader.mjs";
+import { countBackgroundAgents as defaultCountBackgroundAgents } from "./claude-agents.mjs";
 import {
   getClusterHosts,
   getHostName,
@@ -106,6 +107,10 @@ export function localInFlightTickets(hostName, { orchDir } = {}) {
 // (signal-reader's SDK_INFLIGHT_STATUSES), so a peer that omitted it would
 // believe this host had a free slot the local scheduler knows it does not — the
 // cross-host version of the same disagreement CTL-1581 fixed here.
+// CTL-1864: localActiveSlotCount is the SLOT-based twin of localActiveTickets —
+// published as catalyst.node.active_count (decoupled from the deduped ticket-ID
+// list). See localActiveSlotCount() below. localActiveTickets stays unchanged
+// (the identity list for ownership/reclaim); active_tickets still carries it.
 const ACTIVE_STATUSES = new Set(["running", "dispatched", "needs-input", YIELDED_STATUS]);
 
 // localActiveTickets — the slot-OCCUPYING subset of localInFlightTickets on
@@ -132,6 +137,36 @@ export function localActiveTickets(hostName, { orchDir } = {}) {
   } catch {
     return []; // fail-open
   }
+}
+
+// localActiveSlotCount — CTL-1864: the SLOT-based occupancy this host actually holds.
+// Published as catalyst.node.active_count so a peer's freeSlots never exceeds the local
+// scheduler's. Reuses the SAME two functions the scheduler's occupancy uses
+// (countBackgroundAgents + countYieldedOccupancy), so it cannot drift into a third counter.
+// Fail-open on the live-count probe; fail-closed on the yield scan (never under-reports
+// occupancy on a scan error — mirrors the scheduler's own posture).
+export function localActiveSlotCount(
+  _hostName,
+  { orchDir, liveCountFn = defaultCountBackgroundAgents, countYieldedOccupancyFn = defaultCountYieldedOccupancy } = {},
+) {
+  if (!orchDir) return 0;
+  let live = 0;
+  try {
+    const n = liveCountFn();
+    live = Number.isInteger(n) && n >= 0 ? n : 0;
+  } catch {
+    live = 0;
+  }
+  let yielded = 0;
+  try {
+    const y = countYieldedOccupancyFn(orchDir);
+    yielded = y && Number.isInteger(y.count) && y.count >= 0 ? y.count : 0;
+    // fail-closed: an unreadable workers/ dir must not silently read as zero slots.
+    if (y && y.ok === false) return Math.max(live + yielded, live);
+  } catch {
+    // fail-open on the yield probe: fall through to live-only count
+  }
+  return live + yielded;
 }
 
 // startLivenessPublisher — arm a periodic cross-host liveness publisher.

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -85,7 +85,7 @@ import { startHeartbeat as realStartHeartbeat } from "./heartbeat-event.mjs"; //
 // Loki and Linear transports agree on what counts as a phase-boundary advance.
 import { computeLastPhaseAdvanceTs, readAllPhaseSignals } from "./signal-reader.mjs";
 import { readAdmissionState } from "./admission-state.mjs"; // CTL-1322: live admission block for the heartbeat
-import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets, localActiveTickets } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list; CTL-1581: active (slot-occupancy) list
+import { startLivenessPublisher as realStartLivenessPublisher, localInFlightTickets, localActiveTickets, localActiveSlotCount } from "./cluster-heartbeat-publisher.mjs"; // CTL-1090: cross-host liveness; CTL-1420 (#17): in-flight list; CTL-1581: active (slot-occupancy) list; CTL-1864: slot count
 import { emitBootEvent } from "./boot-event.mjs"; // CTL-1084: node.boot self-report
 import {
   recoverStartup,
@@ -1953,6 +1953,10 @@ export function startDaemon({
         // the Workers deck renders (in_flight also counts parked dirs, which
         // hold no slot).
         activeTicketsFn: () => localActiveTickets(getHostName(), { orchDir }),
+        // CTL-1864: publish the SLOT count (liveCount + countYieldedOccupancy), not the
+        // ticket count, so a peer's freeSlots matches this host's scheduler occupancy.
+        // Reuses the SAME functions the scheduler's occupancy uses — cannot drift.
+        activeSlotCountFn: () => localActiveSlotCount(getHostName(), { orchDir }),
         // CTL-1551: carry the live slot ceiling so a peer's monitor can render
         // per-host capacity from Loki (the Linear-anchor capacity transport is
         // retired in loki mode). Uses the SAME readMaxParallel chokepoint the

--- a/plugins/dev/scripts/execution-core/heartbeat-event.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.mjs
@@ -53,6 +53,11 @@ export const HEARTBEAT_EVENT = "node.heartbeat";
  *   needs-human dirs for cross-host ownership/reclaim). The Workers slot deck
  *   renders occupancy from this; conflating it with in_flight made the header
  *   count slots the deck (correctly) showed as Open.
+ * @param {Function} [opts.activeSlotCountFn]  CTL-1864: injectable fn returning the
+ *   SLOT count (liveCount + countYieldedOccupancy) for this host. When supplied,
+ *   active_count is published from this fn rather than activeTickets.length, decoupling
+ *   the count from the deduped ID list. Falls back to activeTickets.length when absent
+ *   (backward-compatible for non-daemon callers/tests).
  * @param {Function} [opts.maxParallelFn]  CTL-1551: injectable fn returning this
  *   host's live parallel-slot ceiling (positive integer, or null when unknown);
  *   the daemon supplies readLocalMaxParallel. Carried as a top-level ATTRIBUTE
@@ -68,6 +73,7 @@ export function buildHeartbeatEnvelope({
   admissionFn,
   inFlightTicketsFn,
   activeTicketsFn,
+  activeSlotCountFn,
   maxParallelFn,
   lastAdvanceAtFn,
   boardReachableFn,
@@ -147,8 +153,19 @@ export function buildHeartbeatEnvelope({
       // CTL-1581: slot-OCCUPANCY signal (running/dispatched only — parked
       // needs-human dirs are owned but hold no slot; the scheduler's own slot
       // accounting agrees). The Workers deck renders occupied boxes from this.
+      // CTL-1864: active_count is now the SLOT count (liveCount + countYieldedOccupancy)
+      // when activeSlotCountFn is wired, decoupling it from the deduped ID list length.
+      // Falls back to activeTickets.length for backward compatibility with non-daemon callers.
       "catalyst.node.active_tickets": activeTickets.join(","),
-      "catalyst.node.active_count": activeTickets.length,
+      "catalyst.node.active_count": (() => {
+        if (!activeSlotCountFn) return activeTickets.length;
+        try {
+          const n = activeSlotCountFn();
+          return Number.isInteger(n) && n >= 0 ? n : activeTickets.length;
+        } catch {
+          return activeTickets.length;
+        }
+      })(),
       // CTL-1551: Loki-queryable cross-host capacity signal (omitted when unknown).
       ...(maxParallel != null ? { "catalyst.node.max_parallel": maxParallel } : {}),
       // CAT-57: Loki-queryable cross-host productivity signal (omitted when unknown).
@@ -186,11 +203,12 @@ export async function emitHeartbeatEvent({
   admissionFn,
   inFlightTicketsFn, // CTL-1420 (#17): forward the in-flight-tickets seam to the builder
   activeTicketsFn, // CTL-1581: forward the slot-occupancy seam to the builder
+  activeSlotCountFn, // CTL-1864: forward the slot-count seam to the builder
   maxParallelFn, // CTL-1551: forward the slot-ceiling seam to the builder
   lastAdvanceAtFn, // CAT-57: forward the last-phase-advance seam to the builder
   boardReachableFn,
 } = {}) {
-  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn, activeTicketsFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn }))}\n`;
+  const line = `${JSON.stringify(buildHeartbeatEnvelope({ now, epochFn, governanceFn, admissionFn, inFlightTicketsFn, activeTicketsFn, activeSlotCountFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn }))}\n`;
   try {
     await mkdir(dirname(logPath), { recursive: true });
     await appendFile(logPath, line);
@@ -214,9 +232,10 @@ export async function emitHeartbeatEvent({
  * @param {Function} [opts.governanceFn] CTL-1062: live governance snapshot fn (optional override)
  * @param {Function} [opts.inFlightTicketsFn] CTL-1420 (#17): live in-flight-tickets fn (daemon-supplied)
  * @param {Function} [opts.activeTicketsFn] CTL-1581: live slot-occupancy fn (daemon-supplied)
+ * @param {Function} [opts.activeSlotCountFn] CTL-1864: live slot-count fn (daemon-supplied)
  * @param {Function} [opts.maxParallelFn] CTL-1551: live slot-ceiling fn (daemon-supplied)
  */
-export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn, inFlightTicketsFn, activeTicketsFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn } = {}) {
+export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, admissionFn, governanceFn, inFlightTicketsFn, activeTicketsFn, activeSlotCountFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn } = {}) {
   const tick = () => {
     // CTL-1280: deterministic liveness heartbeat to daemon.log (Alloy→Loki),
     // riding the same cadence as the node.heartbeat event but on the .log stream
@@ -226,7 +245,7 @@ export function startHeartbeat({ intervalMs = HEARTBEAT_INTERVAL_MS, logPath, ad
     // CTL-1517: per-process RSS/heap OTel gauge on the same tick (fire-and-forget; never
     // throws, never blocks) so per-daemon memory becomes attributable in Prometheus.
     emitProcessMemoryMetric({ serviceName: "catalyst.execution-core", log }).catch(() => {});
-    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn, inFlightTicketsFn, activeTicketsFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn }).catch(() => {});
+    return emitHeartbeatEvent({ logPath, admissionFn, governanceFn, inFlightTicketsFn, activeTicketsFn, activeSlotCountFn, maxParallelFn, lastAdvanceAtFn, boardReachableFn }).catch(() => {});
   };
   const started = tick(); // emit once at boot; Promise for callers that need to await it
   const timer = setInterval(tick, intervalMs);

--- a/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/heartbeat-event.test.mjs
@@ -526,3 +526,107 @@ describe("localActiveTickets (CTL-1581 — slot-occupancy subset)", () => {
     rms(dir, { recursive: true, force: true });
   });
 });
+
+// CTL-1864: localActiveSlotCount + activeSlotCountFn seam
+describe("localActiveSlotCount (CTL-1864 — slot-based active_count)", () => {
+  // Shared fixture builder: one ticket with a yielded recovery-pass AND a running
+  // implement phase. localActiveTickets sees 1 ticket; the scheduler charges 2 slots.
+  function makeFixture() {
+    const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require("node:fs");
+    const { tmpdir } = require("node:os");
+    const { join } = require("node:path");
+    const dir = mkdtempSync(join(tmpdir(), "ctl1864-"));
+    const mk = (ticket, phase, status, extra = {}) => {
+      mkdirSync(join(dir, "workers", ticket), { recursive: true });
+      writeFileSync(
+        join(dir, "workers", ticket, `phase-${phase}.json`),
+        JSON.stringify({ ticket, phase, status, host: { name: "mini" }, ...extra }),
+      );
+    };
+    // yielded ancillary — charges one slot via countYieldedOccupancy
+    mk("CTL-XYZ", "recovery-pass", "awaiting-work");
+    // running pipeline phase — charges one slot via liveCountFn
+    mk("CTL-XYZ", "implement", "running", { bg_job_id: "abc123" });
+    return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+  }
+
+  test("returns liveCount + countYieldedOccupancy (both counts, composed, not a literal)", async () => {
+    const { localActiveSlotCount } = await import("./cluster-heartbeat-publisher.mjs");
+    const { countYieldedOccupancy } = await import("./signal-reader.mjs");
+    const { dir, cleanup } = makeFixture();
+    try {
+      const liveCount = 1; // one background agent running the implement phase
+      const yieldResult = countYieldedOccupancy(dir);
+      const expected = liveCount + yieldResult.count;
+      const got = localActiveSlotCount("mini", {
+        orchDir: dir,
+        liveCountFn: () => liveCount,
+      });
+      // Assert using the COMPOSED inputs (AC2: never a hand-written literal).
+      expect(got).toBe(expected);
+      // And the concrete value for the two-phase case must be 2.
+      expect(got).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("diverges legitimately from localActiveTickets on the two-phase fixture", async () => {
+    const { localActiveSlotCount, localActiveTickets } = await import("./cluster-heartbeat-publisher.mjs");
+    const { dir, cleanup } = makeFixture();
+    try {
+      // ticket-level: one ticket, deduped
+      expect(localActiveTickets("mini", { orchDir: dir }).length).toBe(1);
+      // slot-level: two slots (yielded + running)
+      expect(localActiveSlotCount("mini", { orchDir: dir, liveCountFn: () => 1 })).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("fail direction: ok:false from yield scan never under-reports below liveCount", async () => {
+    const { localActiveSlotCount } = await import("./cluster-heartbeat-publisher.mjs");
+    const { dir, cleanup } = makeFixture();
+    try {
+      const liveCount = 1;
+      const got = localActiveSlotCount("mini", {
+        orchDir: dir,
+        liveCountFn: () => liveCount,
+        countYieldedOccupancyFn: () => ({ count: 0, ok: false }),
+      });
+      // Must never report LESS than liveCount (fail-closed: mirror the scheduler's posture).
+      expect(got).toBeGreaterThanOrEqual(liveCount);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("returns 0 when orchDir is absent or falsy", async () => {
+    const { localActiveSlotCount } = await import("./cluster-heartbeat-publisher.mjs");
+    expect(localActiveSlotCount("mini")).toBe(0);
+    expect(localActiveSlotCount("mini", { orchDir: null })).toBe(0);
+  });
+});
+
+describe("buildHeartbeatEnvelope activeSlotCountFn seam (CTL-1864)", () => {
+  test("active_count comes from activeSlotCountFn when supplied (decoupled from activeTickets.length)", () => {
+    const env = buildHeartbeatEnvelope({
+      activeTicketsFn: () => ["CTL-XYZ"],
+      activeSlotCountFn: () => 2,
+    });
+    // slot count overrides the ticket-list length
+    expect(env.attributes["catalyst.node.active_count"]).toBe(2);
+    // the ID list stays ticket-level and deduped
+    expect(env.attributes["catalyst.node.active_tickets"]).toBe("CTL-XYZ");
+  });
+
+  test("backward-compatible: falls back to activeTickets.length when no activeSlotCountFn", () => {
+    const env = buildHeartbeatEnvelope({ activeTicketsFn: () => ["A", "B"] });
+    expect(env.attributes["catalyst.node.active_count"]).toBe(2);
+  });
+
+  test("backward-compatible: no seams at all → active_count is 0 (empty list length)", () => {
+    const env = buildHeartbeatEnvelope();
+    expect(env.attributes["catalyst.node.active_count"]).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -290,3 +290,46 @@ describe("createClusterEntity forwards admissionReader through project() (CTL-13
     expect(view.nodes.find((n) => n.host === "mini")).toMatchObject({ accepting: false, holdReason: "drain" });
   });
 });
+
+// CTL-1864: consumer semantic guard — resolveCapacity stays correct under a slot-based
+// active_count. The slot count can legitimately exceed the ticket count when a yielded
+// ancillary phase + a running pipeline phase occupy the same ticket.
+describe("resolveCapacity clamp guard (CTL-1864 — slot-based active_count)", () => {
+  it("slot count=2 on maxParallel=3 yields freeSlots=1 (activeCount preferred over inFlightCount)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-XYZ")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      // active_count is slot-based (2) while inFlightCount is ticket-based (1)
+      capacityReader: () => ({ maxParallel: 3, inFlightCount: 1, activeCount: 2 }),
+      now,
+    });
+    const mini = view.nodes.find((n) => n.host === "mini");
+    expect(mini?.freeSlots).toBe(1); // max(0, 3-2)
+    expect(mini?.activeCount).toBe(2);
+    // inFlightCount is still carried unchanged
+    expect(mini?.inFlightCount).toBe(1);
+  });
+
+  it("slot count equals maxParallel → freeSlots 0 (no underflow)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-XYZ")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      capacityReader: () => ({ maxParallel: 3, inFlightCount: 1, activeCount: 3 }),
+      now,
+    });
+    expect(view.nodes.find((n) => n.host === "mini")?.freeSlots).toBe(0);
+  });
+
+  it("slot count exceeds maxParallel → freeSlots 0 (clamp holds, never negative)", () => {
+    const view = assembleClusterView({
+      board: board([ticket("CTL-XYZ")]),
+      hosts: ["mini"],
+      heartbeats: { mini: "2026-06-13T10:00:00Z" },
+      capacityReader: () => ({ maxParallel: 3, inFlightCount: 1, activeCount: 4 }),
+      now,
+    });
+    expect(view.nodes.find((n) => n.host === "mini")?.freeSlots).toBe(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/cluster-view.d.mts
@@ -19,6 +19,9 @@ export interface ClusterNode {
   maxParallel?: number;
   inFlightCount?: number;
   freeSlots?: number;
+  /** CTL-1864: slot-based occupancy (liveCount + countYieldedOccupancy). Present when activeCount
+   *  is supplied by the capacityReader (a CTL-1864+ daemon); absent for old-daemon peers. */
+  activeCount?: number;
   /** CTL-1095: drain state. Present when drainReader is wired. */
   draining?: boolean;
   /** CTL-1322: admission state from the node.heartbeat block. Present when admissionReader


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-20T11:50:00Z -->
<!-- Last updated: 2026-08-20T11:50:00Z -->
<!-- PR: #3768 -->
<!-- Previous commits: 4c7561a2398220a44f3af02c4f1b62650cfa7cbf -->

## Summary

- **Bug**: `catalyst.node.active_count` was ticket-based (`activeTickets.length`), but the scheduler counts slots as `liveCount + countYieldedOccupancy`. A ticket with a yielded recovery-pass + running implement phase charges 2 scheduler slots but the heartbeat published 1, enabling cross-host over-dispatch.
- **Fix**: New `localActiveSlotCount()` in `cluster-heartbeat-publisher.mjs` computes `countBackgroundAgents() + countYieldedOccupancy().count` — the exact same two terms the scheduler's occupancy gate uses. Wired via a new `activeSlotCountFn` seam through `buildHeartbeatEnvelope` → `emitHeartbeatEvent` → `startHeartbeat` in `daemon.mjs`.
- **Backward-compatible**: Falls back to `activeTickets.length` when `activeSlotCountFn` is absent, so non-daemon callers and old-daemon peers continue to work unchanged.
- **Fail-closed**: When `countYieldedOccupancy` returns `ok:false`, returns `max(live + yielded, live)` — never under-reports below `liveCount`.
- **No consumer migration needed**: All downstream consumers (`cluster-capacity`, `peer-liveness`, `cluster-view`, `cluster-signal`, `node-filter`, `state-reader`) already clamp `freeSlots = max(0, maxParallel - activeCount)`.

## Changes Made

### `cluster-heartbeat-publisher.mjs`
- Added `localActiveSlotCount(hostName, opts)` — the slot-based twin of `localActiveTickets`. Reuses `countBackgroundAgents` + `countYieldedOccupancy` (the same functions the scheduler's occupancy gate uses) so the two counts cannot drift.
- Exported for use by `daemon.mjs` and tests.

### `heartbeat-event.mjs`
- Added `activeSlotCountFn` parameter to `buildHeartbeatEnvelope`, `emitHeartbeatEvent`, and `startHeartbeat`.
- `catalyst.node.active_count` is now sourced from `activeSlotCountFn()` when wired; falls back to `activeTickets.length` for backward compatibility.

### `daemon.mjs`
- Threads `activeSlotCountFn: () => localActiveSlotCount(getHostName(), { orchDir })` into `startHeartbeat` so the daemon publishes slot occupancy.

### `cluster-view.d.mts`
- Added `activeCount?: number` to `ClusterNode` interface (present for CTL-1864+ daemon peers, absent for older ones).

### Tests
- `heartbeat-event.test.mjs`: 7 new tests covering `localActiveSlotCount` (composed-input assertion, divergence from `localActiveTickets`, fail-direction, empty orchDir) and `buildHeartbeatEnvelope activeSlotCountFn` seam (slot count overrides ticket count, backward-compat fallback, no-seam fallback).
- `cluster-view-capacity.test.ts`: 3 new consumer contract tests for `resolveCapacity clamp guard` (slot count=2/maxParallel=3 → freeSlots=1; at ceiling → freeSlots=0; over ceiling → freeSlots=0 clamped).

## How to Verify It

- [x] **Tests**: 88 pass / 0 fail — `heartbeat-event.test.mjs` 45, `cluster-view-capacity.test.ts` 17, `cluster-heartbeat-publisher.test.mjs` 26 ✅
- [x] **Typecheck**: `orch-monitor tsc --noEmit` 0 errors project-wide; changed `cluster-view.d.mts` + `cluster-view-capacity.test.ts` compile clean ✅
- [x] **Module load**: both changed `.mjs` modules import cleanly under bun; expected exports present; daemon threads `activeSlotCountFn` into `startHeartbeat` ✅
- [x] **Consumer chain**: `loki-liveness` → `peer-liveness` → `cluster-view.mjs:181` (`occ = activeCount`) → UI all pre-existing (CTL-1581); every consumer already treats `activeCount` as slot-occupancy ✅
- [x] **Regression risk**: 1 / 10 ✅

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-1864

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-1581