### PR TITLE
fix(comms): CTL-2097 follow-up — add per-lane hourly relaunch cap

### DIFF
--- a/scripts/comms/__tests__/lane-relaunch.test.sh
+++ b/scripts/comms/__tests__/lane-relaunch.test.sh
@@ -70,6 +70,69 @@ else
 	fail "expected launch-ctl27.txt, got '$GOT'"
 fi
 
+# Re-implement the rolling-window relaunch cap under test, mirroring lane-relaunch.sh's own
+# functions exactly (kept in sync by hand; if you change one, change both).
+RELAUNCH_HOURLY_CAP=4
+RELAUNCH_WINDOW_SECONDS=3600
+relaunch_count_in_window() {
+	local rf="$PIDDIR/$1.relaunches"
+	[ -f "$rf" ] || { echo 0; return; }
+	local now cutoff; now=$(date +%s); cutoff=$((now - RELAUNCH_WINDOW_SECONDS))
+	local kept; kept=$(awk -v cutoff="$cutoff" '$1 >= cutoff' "$rf")
+	if [ -z "$kept" ]; then : >"$rf"; echo 0; else printf '%s\n' "$kept" >"$rf"; printf '%s\n' "$kept" | grep -c .; fi
+}
+record_relaunch_attempt() { date +%s >>"$PIDDIR/$1.relaunches"; }
+
+echo "Test: a lane with no relaunch history reads as 0 attempts this hour"
+COUNT=$(relaunch_count_in_window "freshlane")
+if [ "$COUNT" -eq 0 ]; then pass "no history -> 0"; else fail "expected 0, got $COUNT"; fi
+
+echo "Test: recording CAP attempts brings the count to exactly CAP, not capped yet"
+for _ in $(seq 1 "$RELAUNCH_HOURLY_CAP"); do record_relaunch_attempt "atcap"; done
+COUNT=$(relaunch_count_in_window "atcap")
+if [ "$COUNT" -eq "$RELAUNCH_HOURLY_CAP" ]; then
+	pass "$RELAUNCH_HOURLY_CAP attempts -> count $RELAUNCH_HOURLY_CAP (caller compares >= to cap)"
+else
+	fail "expected $RELAUNCH_HOURLY_CAP, got $COUNT"
+fi
+
+echo "Test: one more attempt past the cap is still counted (the caller enforces the skip, not this fn)"
+record_relaunch_attempt "atcap"
+COUNT=$(relaunch_count_in_window "atcap")
+if [ "$COUNT" -eq $((RELAUNCH_HOURLY_CAP + 1)) ]; then
+	pass "count keeps rising past cap ($COUNT) — caller's >= check is what stops relaunching"
+else
+	fail "expected $((RELAUNCH_HOURLY_CAP + 1)), got $COUNT"
+fi
+
+echo "Test: an attempt older than the window ages OUT and does not count toward the cap"
+OLD_TS=$(($(date +%s) - RELAUNCH_WINDOW_SECONDS - 60))
+echo "$OLD_TS" >"$PIDDIR/aging.relaunches"
+COUNT=$(relaunch_count_in_window "aging")
+if [ "$COUNT" -eq 0 ]; then
+	pass "attempt older than 60min window pruned to 0"
+else
+	fail "expected 0 (pruned), got $COUNT"
+fi
+if [ -s "$PIDDIR/aging.relaunches" ]; then
+	fail "pruning should have rewritten the file empty, but it still has content"
+else
+	pass "pruning rewrote the counter file, so it doesn't grow unbounded forever"
+fi
+
+echo "Test: a mix of one stale + one fresh timestamp prunes to just the fresh one"
+FRESH_TS=$(date +%s)
+{
+	echo "$OLD_TS"
+	echo "$FRESH_TS"
+} >"$PIDDIR/mixed.relaunches"
+COUNT=$(relaunch_count_in_window "mixed")
+if [ "$COUNT" -eq 1 ]; then
+	pass "stale entry pruned, fresh entry kept -> count 1"
+else
+	fail "expected 1, got $COUNT"
+fi
+
 echo ""
 echo "== $PASSES passed, $FAILURES failed =="
 [ "$FAILURES" -eq 0 ]

--- a/scripts/comms/lane-relaunch.sh
+++ b/scripts/comms/lane-relaunch.sh
@@ -16,6 +16,14 @@
 # `ps` output. Verified with scripts/comms/__tests__/lane-relaunch.bats (or the harness pattern
 # documented in that incident's ticket) before trusting it unattended again.
 #
+# ⛔ The pid-file fix alone does NOT bound a lane that dies quickly and repeatedly on its OWN (a real
+# startup bug, not a false-dead reading) — every 15-min pass would relaunch it again, forever. Ryan's
+# post-incident monitoring plan explicitly called for a per-lane hourly relaunch cap as a circuit
+# breaker the v1/v2 pid-file fix lacked; this version adds it: RELAUNCH_HOURLY_CAP (default 4)
+# relaunches per lane per rolling 60-minute window, tracked in $PIDDIR/<lane>.relaunches (one epoch
+# timestamp per attempt, pruned to the window on each check). Past the cap, the lane is logged as
+# CAPPED and skipped until the window ages out — noisy, not catastrophic.
+#
 # Usage:
 #   scripts/comms/lane-relaunch.sh   (loops forever; run under nohup/a background job)
 #
@@ -35,6 +43,8 @@ CUR="$COMMS_DIR/fleet-account.current"
 PIDDIR="$COMMS_DIR/lane-pids"
 MANIFEST="$COMMS_DIR/lanes.manifest"
 POLL_SECONDS="${POLL_SECONDS:-900}"
+RELAUNCH_HOURLY_CAP="${RELAUNCH_HOURLY_CAP:-4}"
+RELAUNCH_WINDOW_SECONDS=3600
 mkdir -p "$PIDDIR"
 
 latest_brief() { # $1 lane-prefix -> path of highest-numbered brief, digits-only match
@@ -50,16 +60,41 @@ is_alive() { # $1 lane-prefix -> 0 iff its recorded pid is a live process
   [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
 }
 
+# $1 lane-prefix -> prunes $PIDDIR/<lane>.relaunches to the rolling window and prints the count
+# remaining. Pruning happens on every call (not just on relaunch) so a lane that has been quiet
+# for a while ages back under the cap even without a fresh attempt.
+relaunch_count_in_window() {
+  local rf="$PIDDIR/$1.relaunches"
+  [ -f "$rf" ] || { echo 0; return; }
+  local now cutoff; now=$(date +%s); cutoff=$((now - RELAUNCH_WINDOW_SECONDS))
+  local kept; kept=$(awk -v cutoff="$cutoff" '$1 >= cutoff' "$rf")
+  # `printf '%s\n' ""` writes a stray blank line, not a truly empty file — truncate explicitly
+  # instead, or the counter file never actually shrinks back to empty after the window clears.
+  if [ -z "$kept" ]; then : > "$rf"; echo 0; else printf '%s\n' "$kept" > "$rf"; printf '%s\n' "$kept" | grep -c .; fi
+}
+
+record_relaunch_attempt() { # $1 lane-prefix -> append "now" to its rolling-window counter file
+  date +%s >> "$PIDDIR/$1.relaunches"
+}
+
 while :; do
   ACCT=$(cat "$CUR" 2>/dev/null || echo acct1)
   LAUNCHER="$LAUNCHER_DIR/launch-on-$ACCT.sh"
   while read -r lane repo; do
     [ -z "$lane" ] && continue
     if is_alive "$lane"; then continue; fi
+    COUNT=$(relaunch_count_in_window "$lane")
+    if [ "$COUNT" -ge "$RELAUNCH_HOURLY_CAP" ]; then
+      echo "$(date '+%H:%M:%S') CAPPED $lane — $COUNT relaunches in the last hour (cap $RELAUNCH_HOURLY_CAP), skipping" >> "$LOG"
+      continue
+    fi
     brief=$(latest_brief "$lane")
     [ -z "$brief" ] && continue
     name=$(basename "$brief" .txt); name=${name#launch-}
-    echo "$(date '+%H:%M:%S') relaunching $name on $ACCT (pid-file said dead)" >> "$LOG"
+    # Record the attempt BEFORE launching, so a launcher that itself fails or hangs still counts
+    # toward the cap — a broken launcher must not become an unbounded tight retry either.
+    record_relaunch_attempt "$lane"
+    echo "$(date '+%H:%M:%S') relaunching $name on $ACCT (pid-file said dead, attempt $((COUNT + 1))/$RELAUNCH_HOURLY_CAP this hour)" >> "$LOG"
     OUT=$(bash "$LAUNCHER" "$name" "$repo" 2>&1)
     echo "$OUT" >> "$LOG"
     PID=$(echo "$OUT" | grep -o 'pid [0-9]*' | grep -o '[0-9]*')


### PR DESCRIPTION
## Summary
- The pid-file liveness fix (PR #3767) stopped the specific false-dead bug that caused 117 duplicate launches, but doesn't bound a lane that dies quickly and repeatedly on its own — every 15-min pass would relaunch it forever.
- Ryan's post-incident monitoring plan called for a per-lane hourly relaunch cap as a circuit breaker the pid-file fix alone lacked. This adds it: `RELAUNCH_HOURLY_CAP` (default 4) relaunches per lane per rolling 60-minute window.
- Attempt is recorded before the launcher runs, so a hanging/failing launcher still counts toward the cap.

## Test plan
- [x] `bash scripts/comms/__tests__/lane-relaunch.test.sh` — 11/11 pass, including 5 new tests for the counter/pruning logic
- [x] Caught and fixed a real bug via the new tests: pruning to empty left a stray blank line instead of a truncated file

🤖 Generated with [Claude Code](https://claude.com/claude-code)