### PR TITLE
fix(execution-core): CTL-2103 — scrub PATH so the gh-unavailable test is deterministic

### DIFF
--- a/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-cli.test.mjs
@@ -753,14 +753,27 @@ test("ENUMERATOR: reports unverifiable (ok:false, reason) when `gh` list is unav
   // No gh binary on a clean PATH ⇒ spawnSync errors ⇒ the list pass throws ⇒ the
   // enumeration is unverifiable. (Callers no longer refuse on this — they proceed.)
   // deriveBranchName/attachment stubbed so the test stays hermetic (no spawn).
-  const r = defaultCheckOpenPrs("CTL-9", {
-    cwd: tmpdir(),
-    deriveBranchName: () => null,
-    deriveAttachmentPrs: () => [],
-  });
-  expect(r.ok).toBe(false);
-  expect(r.reason).toBeTruthy();
-  expect(r.unverifiable).toBe(true); // an unparseable/failed authoritative check is unverifiable
+  //
+  // CTL-2103: the "clean PATH" this test needs was never actually enforced — it just
+  // hoped the CI runner didn't have `gh` on PATH, which is environment-dependent and
+  // failed identically on unrelated PRs once a runner variant DID have `gh` available.
+  // Scrub PATH for the duration so `spawnSync("gh", ...)` reliably fails to resolve the
+  // binary regardless of the host — this still exercises the REAL defaultRunGh/spawnSync
+  // codepath (unlike injecting a `runGh` mock, which would test a different thing).
+  const savedPath = process.env.PATH;
+  try {
+    process.env.PATH = "";
+    const r = defaultCheckOpenPrs("CTL-9", {
+      cwd: tmpdir(),
+      deriveBranchName: () => null,
+      deriveAttachmentPrs: () => [],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBeTruthy();
+    expect(r.unverifiable).toBe(true); // an unparseable/failed authoritative check is unverifiable
+  } finally {
+    process.env.PATH = savedPath;
+  }
 });
 
 // CTL-1157 (Codex GROUP-A fix #1): an attachment-discovered PR we KNOW exists but


### PR DESCRIPTION
## Summary
- The ENUMERATOR "reports unverifiable when gh list is unavailable" test relied on an unenforced environment assumption ("no gh binary on a clean PATH") — never actually scrubbed PATH itself.
- Failed identically on two unrelated open PRs tonight (#3772, #3775 — neither touches this file or gh/PATH handling) while `main`'s push-triggered CI kept passing on the same commits, pointing at `pull_request`-triggered runners sometimes having `gh` available where `push`-triggered ones don't.
- Since `execution-core-unit-tests` is one of the 6 required checks on `main`, this was very likely blocking unrelated PRs fleet-wide, silently — see CTL-2103 for the full incident trail.

## Fix
Scrub `process.env.PATH` for the duration of the test (save/restore, matching the `LINEAR_API_TOKEN` pattern already used elsewhere in this file), so `spawnSync("gh", ...)` reliably fails to resolve the binary regardless of the host. Still exercises the real `defaultRunGh`/`spawnSync` codepath — deliberately not mocking `runGh`, which would test something different.

## Test plan
- [x] `bun test linear-reconcile-cli.test.mjs` — 38/38 pass locally
- [x] Full `execution-core` suite run locally (see CI for authoritative result)

Closes CTL-2103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)