### PR TITLE
fix(execution-core): CTL-2090 — triage-capped ticket can no longer deadlock admission

### DIFF
--- a/plugins/dev/scripts/execution-core/dispatch-readiness.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-readiness.mjs
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 export const NOT_DISPATCHABLE_UNTRIAGED = "untriaged-no-triage-artifact";
@@ -11,6 +11,45 @@ export function defaultHasTriageArtifact(orchDir, ticket) {
   } catch (error) {
     if (error?.code === "ENOENT" || error?.code === "ENOTDIR") return false;
     throw error;
+  }
+}
+
+// triageCapTripped — has this ticket's triage re-dispatch cap PARKED it (CTL-1441)?
+// Reads the counter record monitor.mjs writes at orchDir/.triage-dispatch-counts/
+// <ticket>.json; `cappedAt` is stamped exactly once, when the park fires. The path
+// contract is shared with monitor.mjs (triageDispatchCountPath) — kept as a read-only
+// twin here rather than an import so the scheduler stays uncoupled from the monitor
+// daemon (same rationale as defaultHasTriageArtifact above).
+// Fail-open: absent/unreadable/malformed → not capped (mirrors readTriageDispatchRecord).
+export function triageCapTripped(orchDir, ticket) {
+  try {
+    const rec = JSON.parse(
+      readFileSync(join(orchDir, ".triage-dispatch-counts", `${ticket}.json`), "utf8")
+    );
+    return typeof rec?.cappedAt === "string";
+  } catch {
+    return false;
+  }
+}
+
+// triageReservationDeadlocked — CTL-2090. True iff reserving a slot (or preempting a
+// worker) on this ticket's behalf can never pay off: its triage re-dispatch cap has
+// tripped AND it still has no triage.json. The reservation design (CAT-36) rests on
+// "the freed slot is what lets the monitor TRIAGE this ticket" — for a capped ticket
+// the monitor's dispatchTriage refuses forever, so the reservation is a deadlock:
+// on a maxParallel=1 host it starves every triaged waiter behind it (mini-2,
+// 2026-08-20: CTC-750 held the only slot for 36h across three daemon restarts).
+// A capped ticket that DOES have its artifact is NOT deadlocked — its final attempt
+// produced the artifact and normal dispatch can consume the slot.
+// Fail-open on a probe error: an unreadable artifact probe keeps the ticket ranked
+// (never changes admission behaviour on an FS hiccup).
+export function triageReservationDeadlocked(orchDir, ticket, { hasTriageArtifact } = {}) {
+  if (!triageCapTripped(orchDir, ticket)) return false;
+  const probe = hasTriageArtifact ?? defaultHasTriageArtifact;
+  try {
+    return !probe(orchDir, ticket);
+  } catch {
+    return false;
   }
 }
 

--- a/plugins/dev/scripts/execution-core/dispatch-readiness.test.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-readiness.test.mjs
@@ -6,6 +6,8 @@ import {
   canOccupySlotNow,
   NOT_DISPATCHABLE_TRIAGE_PROBE_ERROR,
   NOT_DISPATCHABLE_UNTRIAGED,
+  triageCapTripped,
+  triageReservationDeadlocked,
 } from "./dispatch-readiness.mjs";
 
 let orchDir;
@@ -48,5 +50,69 @@ describe("canOccupySlotNow (CAT-36)", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe(NOT_DISPATCHABLE_TRIAGE_PROBE_ERROR);
     expect(result.error).toBeInstanceOf(Error);
+  });
+});
+
+// ── CTL-2090: capped-reservation deadlock predicates ─────────────────────────
+
+function seedCapRecord(ticket, rec) {
+  const dir = join(orchDir, ".triage-dispatch-counts");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${ticket}.json`), typeof rec === "string" ? rec : JSON.stringify(rec));
+}
+
+describe("triageCapTripped (CTL-2090)", () => {
+  test("no counter file → not capped", () => {
+    expect(triageCapTripped(orchDir, "CAT-10")).toBe(false);
+  });
+  test("counter without cappedAt (attempts remaining) → not capped", () => {
+    seedCapRecord("CAT-11", { count: 2, lastDispatchAt: "2026-08-19T05:01:03Z" });
+    expect(triageCapTripped(orchDir, "CAT-11")).toBe(false);
+  });
+  test("cappedAt stamped → capped (the mini-2 CTC-750 record shape)", () => {
+    seedCapRecord("CAT-12", {
+      count: 3,
+      lastDispatchAt: "2026-08-19T05:01:03Z",
+      cappedAt: "2026-08-19T05:10:51Z",
+      cap: 3,
+    });
+    expect(triageCapTripped(orchDir, "CAT-12")).toBe(true);
+  });
+  test("malformed counter file → not capped (fail-open, mirrors readTriageDispatchRecord)", () => {
+    seedCapRecord("CAT-13", "garbage{");
+    expect(triageCapTripped(orchDir, "CAT-13")).toBe(false);
+  });
+});
+
+describe("triageReservationDeadlocked (CTL-2090)", () => {
+  const capped = { count: 3, cappedAt: "2026-08-19T05:10:51Z", cap: 3 };
+
+  test("capped AND artifact-less → deadlocked (the reservation can never be consumed)", () => {
+    seedCapRecord("CAT-20", capped);
+    expect(triageReservationDeadlocked(orchDir, "CAT-20")).toBe(true);
+  });
+  test("capped but the final attempt produced triage.json → NOT deadlocked (dispatchable)", () => {
+    seedCapRecord("CAT-21", capped);
+    seedTriage("CAT-21");
+    expect(triageReservationDeadlocked(orchDir, "CAT-21")).toBe(false);
+  });
+  test("artifact-less but NOT capped → not deadlocked (the normal CAT-36 reservation)", () => {
+    expect(triageReservationDeadlocked(orchDir, "CAT-22")).toBe(false);
+  });
+  test("artifact probe throws → not deadlocked (fail-open: an FS hiccup never changes admission)", () => {
+    seedCapRecord("CAT-23", capped);
+    expect(
+      triageReservationDeadlocked(orchDir, "CAT-23", {
+        hasTriageArtifact: () => {
+          throw new Error("EACCES");
+        },
+      })
+    ).toBe(false);
+  });
+  test("honours the injected artifact probe", () => {
+    seedCapRecord("CAT-24", capped);
+    expect(
+      triageReservationDeadlocked(orchDir, "CAT-24", { hasTriageArtifact: () => true })
+    ).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1219,6 +1219,14 @@ function dispatchTriage(
         "ctl-1441: triage re-dispatch cap reached — parked needs-human; delete .triage-dispatch-counts/<ticket>.json to re-arm"
       );
     }
+    // CTL-2090: this was the ONE remaining silent exit in triage admission — the
+    // markTriageCapped WARN above fires once per park episode, and every later
+    // sweep returned with no record at any level. On mini-2 (2026-08-20) a capped
+    // ticket that a human had re-queued in Linear was routed here every sweep for
+    // 36h while the scheduler reserved the host's only slot for it, and nothing in
+    // the logs said why — the exact ctl-879 blindness class, one branch over.
+    // Count it like every other skip; the streak escalates to WARN on persistence.
+    noteTriageSkip(identifier, "triage-redispatch-capped", { cap: TRIAGE_DISPATCH_CAP });
     return false;
   }
   if (budget && budget.remaining <= 0) {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -1899,11 +1899,27 @@ describe("triage re-dispatch guard (CTL-1441)", () => {
     reconcileAll({ exec });
     const dispatch = mock(() => ({ code: 0 }));
     const labelNeedsHuman = mock(() => {});
-    sweepMissingTriage(sweepOpts(realOrchDir, dispatch, labelNeedsHuman));
+    // CTL-2090: the capped exit must never be silent — capture the shared logger
+    // (the triage-admission-observability.test.mjs pattern) across the FIRST
+    // capped sweep, where the skip streak is 1 and noteTriageSkip writes its line.
+    const infoLines = [];
+    const infoSpy = spyOn(log, "info").mockImplementation((ctx, msg) => infoLines.push({ ctx, msg }));
+    try {
+      sweepMissingTriage(sweepOpts(realOrchDir, dispatch, labelNeedsHuman));
+    } finally {
+      infoSpy.mockRestore();
+    }
     expect(dispatch).not.toHaveBeenCalled();
     expect(labelNeedsHuman).toHaveBeenCalledTimes(1);
     expect(labelNeedsHuman).toHaveBeenCalledWith(realOrchDir, "ENG-9");
     expect(JSON.parse(readFileSync(join(countsDir, "ENG-9.json"), "utf8")).cappedAt).toBeTruthy();
+    // CTL-2090: on mini-2 (2026-08-20) this exit was routed every sweep for 36h
+    // with no record at any level. The skip must be counted like every other.
+    expect(
+      infoLines.some(
+        (l) => l.ctx?.ticket === "ENG-9" && l.ctx?.reason === "triage-redispatch-capped"
+      )
+    ).toBe(true);
     // A second sweep still skips dispatch but RE-TRIES the label — a transient
     // Linear failure leaves no labelOnce marker, so the retry must reach it
     // (Codex P2); labelOnce's own markers are the idempotence guard.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -88,7 +88,11 @@ import {
 import { countRemediateCycles, countTicketEventsInWindow } from "./event-scan.mjs";
 import { tailParsedEvents } from "./event-tail.mjs"; // CTL-1514: bounded event-log tail
 import { rankTickets, compareTickets } from "./scheduler-rank.mjs";
-import { canOccupySlotNow, defaultHasTriageArtifact } from "./dispatch-readiness.mjs";
+import {
+  canOccupySlotNow,
+  defaultHasTriageArtifact,
+  triageReservationDeadlocked,
+} from "./dispatch-readiness.mjs";
 import {
   defaultDispatch,
   dispatchTicket,
@@ -984,6 +988,13 @@ export function buildGlobalRanking(orchDir, eligible) {
 
   for (const t of eligible ?? []) {
     if (started.has(t.identifier)) continue; // already in-flight (listed above)
+    // CTL-2090: a queued descriptor here is by construction untriaged (no
+    // workers/<t>/ dir), and preemption's justification is that the freed slot
+    // lets the monitor TRIAGE it (CAT-36 guard below). A triage-capped ticket
+    // (CTL-1441) will never be triaged, so preempting a live worker for it kills
+    // real work for a slot nothing can consume. Same predicate as the STEP A
+    // admission exclusion.
+    if (triageReservationDeadlocked(orchDir, t.identifier)) continue;
     descriptors.push({
       identifier: t.identifier,
       priority: t.priority,
@@ -7209,7 +7220,27 @@ export function schedulerTick(
       // "Can't start ⇒ don't spend a slot on it" is enforced where it actually
       // applies: the new-work sweep's `dispatchableReady` gate, which is what stops
       // an untriaged ticket consuming a *dispatch*.
-      const readyCandidates = rankTickets(admissionPool.filter((t) => readyIds.has(t.identifier)));
+      //
+      // CTL-2090: with ONE narrow exception — a ticket whose triage re-dispatch cap
+      // has tripped (CTL-1441) and that still lacks its triage.json. The reservation
+      // premise above ("the monitor's triage pass then spends the slot") is FALSE for
+      // it: dispatchTriage's cap gate refuses forever, so the reservation can never
+      // be consumed, and at maxParallel=1 it starves every triaged waiter behind it
+      // for the daemon's lifetime — restart-proof, because the cap file persists
+      // (mini-2, 2026-08-20: CTC-750 held the host's only slot for 36h). The
+      // starves-urgent-untriaged-work argument does not apply: capped means triage
+      // will not run regardless of how many slots are free. Triaged waiters are
+      // exempt from the probe (they own an artifact by construction).
+      const readyCandidates = rankTickets(
+        admissionPool.filter(
+          (t) =>
+            readyIds.has(t.identifier) &&
+            (triagedWaitingSet.has(t.identifier) ||
+              !triageReservationDeadlocked(orchDir, t.identifier, {
+                hasTriageArtifact: _hasTriageArtifact,
+              }))
+        )
+      );
       const admittedSlice = selectDispatchablePerProject(
         readyCandidates,
         new Set(),

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -7137,6 +7137,25 @@ describe("buildGlobalRanking (CTL-705)", () => {
     const result = buildGlobalRanking(orchDir, []);
     expect(result.find((d) => d.identifier === "CTL-X")).toBeUndefined();
   });
+
+  // CTL-2090: preemption's justification for a queued (untriaged) contender is
+  // that the freed slot lets the monitor triage it. A triage-capped ticket
+  // (CTL-1441) will never be triaged, so ranking it would kill live work for a
+  // slot nothing can consume. An uncapped sibling must be unaffected.
+  test("CTL-2090: a triage-capped artifact-less eligible ticket is dropped from the ranking; an uncapped sibling stays", () => {
+    mkdirSync(join(orchDir, ".triage-dispatch-counts"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".triage-dispatch-counts", "CTL-CAP.json"),
+      JSON.stringify({ count: 3, cappedAt: "2026-08-19T05:10:51Z", cap: 3 })
+    );
+    const result = buildGlobalRanking(orchDir, [
+      makeEligible("CTL-CAP", 1),
+      makeEligible("CTL-OK", 1),
+    ]);
+    const ids = result.map((d) => d.identifier);
+    expect(ids).not.toContain("CTL-CAP");
+    expect(ids).toContain("CTL-OK");
+  });
 });
 
 describe("schedulerTick — writeWorkerPriority at new-work dispatch (CTL-705)", () => {
@@ -8561,6 +8580,92 @@ describe("CTL-755: admission gate", () => {
     // CTL-764 Phase 4: "queued" (was "waiting") removed on pickup.
     expect(removed).toContainEqual({ ticket: "CTL-7", label: "queued" });
     expect(applied).toEqual([]);
+  });
+
+  // ── CTL-2090: a triage-capped, artifact-less eligible ticket must NOT hold the
+  // CAT-36 reservation that starves every triaged waiter behind it. Live shape:
+  // mini-2, 2026-08-20 — capped CTC-750 outranked 22 triaged waiters on a
+  // maxParallel=1 host and won the only free slot every tick for 36h, admitting
+  // nothing, across three daemon restarts (the cap file persists).
+  test("CTL-2090: a capped untriaged eligible ticket does not reserve the slot — the triaged waiter promotes", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done"); // triaged waiter, unblocked
+    // Higher-ranked eligible candidate whose triage re-dispatch cap has tripped
+    // (CTL-1441) — the monitor will never produce its triage.json.
+    mkdirSync(join(orchDir, ".triage-dispatch-counts"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".triage-dispatch-counts", "CTL-CAP.json"),
+      JSON.stringify({ count: 3, cappedAt: "2026-08-19T05:10:51Z", cap: 3 })
+    );
+    const dispatch = fakeDispatch();
+    const { ws } = labelSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [
+        { identifier: "CTL-CAP", priority: 1, createdAt: "2026-05-01T00:00:00Z" },
+      ],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0, // one slot, free
+      fetchBatch: mkBatch(() => relUnblocked()),
+    });
+    // The waiter wins the slot; the capped ticket is excluded from the ranking
+    // (Pass 2 separately keeps holding it on untriaged-no-triage-artifact).
+    expect(dispatch.calls).toEqual([{ orchDir, ticket: "CTL-7", phase: "research" }]);
+  });
+
+  // Negative control (proves the fix test exercises the cap predicate, not some
+  // other exclusion): the SAME shape with NO cap record keeps the deliberate
+  // CAT-36 reservation — the urgent untriaged candidate holds the slot for the
+  // monitor's triage pass and the waiter stays queued.
+  test("CTL-2090 control: the same UNCAPPED untriaged candidate still reserves the slot (CAT-36 preserved)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    const dispatch = fakeDispatch();
+    const { ws, applied } = labelSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [
+        { identifier: "CTL-CAP", priority: 1, createdAt: "2026-05-01T00:00:00Z" },
+      ],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch(() => relUnblocked()),
+    });
+    expect(dispatch.calls).toEqual([]); // reservation holds; nothing dispatches
+    expect(applied).toContainEqual({ ticket: "CTL-7", label: "queued" });
+  });
+
+  // A capped ticket whose FINAL attempt did produce triage.json is dispatchable —
+  // it must stay ranked (and Pass 2 can dispatch it as ordinary new work).
+  test("CTL-2090: capped WITH a triage artifact still outranks the waiter (not deadlocked)", () => {
+    writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+    writeSignal("CTL-7", "triage", "done");
+    mkdirSync(join(orchDir, ".triage-dispatch-counts"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".triage-dispatch-counts", "CTL-CAP.json"),
+      JSON.stringify({ count: 3, cappedAt: "2026-08-19T05:10:51Z", cap: 3 })
+    );
+    const dispatch = fakeDispatch();
+    const { ws } = labelSpy();
+    schedulerTick(orchDir, {
+      readEligible: () => [
+        { identifier: "CTL-CAP", priority: 1, createdAt: "2026-05-01T00:00:00Z" },
+      ],
+      dispatch,
+      writeStatus: ws,
+      verifyDispatched: verifyOk,
+      liveBackgroundCount: () => 0,
+      fetchBatch: mkBatch(() => relUnblocked()),
+      // Injected probe, not seedTriage: a real triage.json creates workers/<t>/,
+      // which listStartedTickets then excludes from the new-work pull (the
+      // CTL-1150 seam note) — the injected predicate is the documented pattern.
+      hasTriageArtifact: (od, t) => t === "CTL-CAP",
+    });
+    // The capped-but-triaged candidate takes the slot as normal new work.
+    expect(dispatch.calls.map((c) => c.ticket)).toContain("CTL-CAP");
+    expect(dispatch.calls.map((c) => c.ticket)).not.toContain("CTL-7");
   });
 
   test("steady-state held tick makes ZERO applyLabel/removeLabel calls (idempotent)", () => {


### PR DESCRIPTION
## Root cause (CTL-2090)

mini-2 admitted zero new work for 36h despite `free_slots:1` because **CTC-750 — triage-capped (CTL-1441) and therefore permanently untriageable — won the STEP A slot reservation every tick**. The CAT-36 reservation design assumes "the freed slot is what lets the monitor TRIAGE this ticket"; for a capped ticket that is false forever, so the single slot was reserved for a ticket nothing could ever consume, and all 22 triaged waiters logged `awaiting-capacity-or-priority` indefinitely. Restart-proof: the cap file (`.triage-dispatch-counts/CTC-750.json`) persists — the stall survived three full-stack restarts. The capped exit in `dispatchTriage` was also the one remaining silent path (its park WARN fires once per episode), so the ctl-879 observability sweep never recorded why.

Full evidence chain: see the CTL-2090 comment (2026-08-20).

## Changes

- **dispatch-readiness.mjs**: `triageCapTripped` + `triageReservationDeadlocked` predicates — capped AND still artifact-less; fail-open on absent/unreadable records and on artifact-probe errors.
- **scheduler.mjs STEP A**: deadlocked reservations are excluded from `readyCandidates`. Uncapped untriaged reservations keep the deliberate CAT-36 behaviour (guarded by a negative-control test); a capped ticket whose final attempt DID land triage.json stays ranked (dispatchable).
- **scheduler.mjs preemption** (`buildGlobalRanking`): a deadlocked queued contender is dropped — the same premise justifies preemption, so without this a capped urgent ticket would kill live workers for a slot nothing can consume.
- **monitor.mjs `dispatchTriage`**: the capped exit now records `noteTriageSkip("triage-redispatch-capped")` every sweep — escalates to WARN via the ctl-879 streak.

## Tests

- `dispatch-readiness.test.mjs`: 9 new cases for both predicates (mini-2's live record shape included).
- `scheduler.test.mjs`: fix test (capped candidate → waiter promotes), negative control (uncapped candidate still reserves — CAT-36 preserved), capped-with-artifact (still dispatches), buildGlobalRanking exclusion.
- `monitor.test.mjs`: the existing at-the-cap test now asserts the skip line is emitted.

`bun test dispatch-readiness.test.mjs triage-redispatch-guard.test.mjs triage-admission-observability.test.mjs` → 77 pass / 0 fail. `scheduler.test.mjs` → 674 pass / 9 fail; **all 9 failures reproduce identically on pristine origin/main** (verified in a detached baseline worktree) — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
