### PR TITLE
feat(dev): CTL-1984 — re-arm claude-accounts.env without daemon restart

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1412,6 +1412,7 @@ jobs:
             updater/updater-tracing.test.mjs \
             service-manifest.test.mjs \
             github-auth-preflight.test.mjs \
+            claude-accounts-rearm.test.mjs \
             github-token-candidates-legacy-parity.test.mjs \
             github-quota.test.mjs \
             github-quota-timer.test.mjs \

--- a/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/secret-contract-parity.test.sh
@@ -137,7 +137,7 @@ _FP_EXPECTED=(
   "$(_fp_row bare-file re-armable timer '' '' 'GH_TOKEN,GITHUB_TOKEN')"
   "$(_fp_row bare-file boot-only '' '' '' 'CATALYST_WEBHOOK_SECRET')"
   "$(_fp_row bare-file-family boot-only '' '' '' '')"
-  "$(_fp_row env-file boot-only '' '' '' '')"
+  "$(_fp_row env-file re-armable timer '' '' '')"
   "$(_fp_row env-file boot-only '' '' '' '')"
   "$(_fp_row env-alias re-armable on-401 '' '' 'LINEAR_API_TOKEN,LINEAR_API_KEY')"
   "$(_fp_row config-json re-armable on-401 '' 'catalyst.linear.bot.orchestrator' '')"

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
@@ -1,0 +1,170 @@
+// claude-accounts-rearm.mjs — CTL-1984. In-process rearm hook for the
+// claude-accounts.env row (re-armable/timer). Mirrors rearmGithubTokenFromFile
+// structurally (injectable readFile, byte-hygiene guards, never throws).
+//
+// WHAT THIS DOES. The daemon's launcher (catalyst-execution-core) sources
+// claude-accounts.env at process start, exporting CLAUDE_CODE_OAUTH_TOKEN from
+// the active-slot selector. When the fleet-ops tooling rotates the active slot in
+// the cloud and cluster-sync materializes the updated file on disk, this hook reads
+// the new active-slot token and mutates process.env.CLAUDE_CODE_OAUTH_TOKEN in-place,
+// so the next SDK dispatch picks up the new account without a daemon restart.
+//
+// PATH RESOLUTION. The hook resolves the file the same way the launcher does:
+//   env.CLAUDE_ACCOUNTS_ENV || join(homedir(), ".config/catalyst/claude-accounts.env")
+// It does NOT use secretFileCandidates("claude-accounts.env"), whose override env-var
+// name is CATALYST_CLAUDE-ACCOUNTS_ENV_FILE and whose chain differs from the launcher.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-rearm.test.mjs
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { log as defaultLog } from "./config.mjs";
+import { containsNul, isValidUtf8RoundTrip } from "../lib/secret-contract.mjs";
+
+// PLACEHOLDER sentinel that the generator writes when no real token is present.
+const PLACEHOLDER = "PASTE_TOKEN_HERE";
+
+// parseActiveOauthToken — pure, unit-testable. Reads the active-slot token from the
+// text content of a claude-accounts.env file. Returns the resolved token string or null.
+//
+// The file format (written by catalyst-stack/setup-claude-accounts):
+//   CLAUDE_TOKEN_acct1='sk-ant-oat...'  # email@example.com
+//   CLAUDE_TOKEN_acct2='sk-ant-oat...'  # other@example.com
+//   _catalyst_active_token="$CLAUDE_TOKEN_acct2"
+//   case ... export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"
+//
+// Three resolution paths, in priority order:
+// 1. Selector line  (`_catalyst_active_token="$CLAUDE_TOKEN_<label>"`) — canonical.
+// 2. Direct literal (`export CLAUDE_CODE_OAUTH_TOKEN='<value>'`) — hand-authored fallback.
+// 3. Single CLAUDE_TOKEN_* assignment with no selector — implicit single-account file.
+export function parseActiveOauthToken(text) {
+  const lines = text.split("\n");
+
+  // Collect every CLAUDE_TOKEN_<label>=<value> assignment.
+  const TOKEN_RE = /^(?:export\s+)?CLAUDE_TOKEN_([A-Za-z0-9_]+)=(.*)/;
+  const tokenMap = new Map();
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(TOKEN_RE);
+    if (!m) continue;
+    const value = _parseValue(m[2]);
+    if (!value || value === PLACEHOLDER) continue;
+    tokenMap.set(m[1], value);
+  }
+
+  // Path 1 — selector line: _catalyst_active_token="$CLAUDE_TOKEN_<label>"
+  const SELECTOR_RE = /_catalyst_active_token=["']?\$\{?CLAUDE_TOKEN_([A-Za-z0-9_]+)\}?["']?/;
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(SELECTOR_RE);
+    if (!m) continue;
+    const tok = tokenMap.get(m[1]);
+    if (tok) return tok;
+  }
+
+  // Path 2 — direct literal: export CLAUDE_CODE_OAUTH_TOKEN='<literal>'
+  const DIRECT_RE = /^(?:export\s+)?CLAUDE_CODE_OAUTH_TOKEN=(.*)/;
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(DIRECT_RE);
+    if (!m) continue;
+    const rhs = m[1].trimStart();
+    // Only honor a literal value (not a variable expansion like $TOKEN)
+    if (rhs.startsWith("$")) continue;
+    const value = _parseValue(m[1]);
+    if (value && value !== PLACEHOLDER) return value;
+  }
+
+  // Path 3 — single-account implicit: one CLAUDE_TOKEN_* entry with no selector
+  if (tokenMap.size === 1) {
+    const [tok] = tokenMap.values();
+    return tok;
+  }
+
+  return null;
+}
+
+// _parseValue — parse the RHS of a shell assignment (quoted or unquoted).
+// Strips the enclosing quote pair and ignores inline comments (same logic
+// as claude-accounts-usage.mjs's parseAssignment, inlined to avoid importing
+// a CLI-entrypoint module).
+function _parseValue(rhs) {
+  const s = (rhs ?? "").trimStart();
+  let token;
+  if (s[0] === "'" || s[0] === '"') {
+    const q = s[0];
+    const end = s.indexOf(q, 1);
+    token = end === -1 ? s.slice(1) : s.slice(1, end);
+  } else {
+    const m = s.match(/^(\S+)/);
+    token = m ? m[1] : s;
+  }
+  return token.trim();
+}
+
+// rearmClaudeAccountsFromFile — the registered rearm hook for the
+// claude-accounts.env row. Returns { rearmed, reason }; never throws.
+//
+// Injected readFile (for testing): must accept a path and return a Buffer or string.
+export function rearmClaudeAccountsFromFile({
+  env = process.env,
+  readFile = (p) => readFileSync(p),
+  log = defaultLog,
+} = {}) {
+  try {
+    const candidates = [
+      env?.CLAUDE_ACCOUNTS_ENV,
+      join(homedir(), ".config", "catalyst", "claude-accounts.env"),
+    ].filter(Boolean);
+
+    let tok = null;
+    let anyFound = false;
+
+    for (const file of candidates) {
+      let raw;
+      try {
+        raw = readFile(file);
+      } catch {
+        continue; // file not present on this host — try next
+      }
+      anyFound = true;
+
+      // Byte hygiene — same guards as rearmGithubTokenFromFile
+      const buf = Buffer.isBuffer(raw) ? raw : Buffer.from(String(raw ?? ""), "utf8");
+      const decoded = buf.toString("utf8");
+      if (!isValidUtf8RoundTrip(buf, decoded)) continue;
+      if (containsNul(decoded)) continue;
+
+      const resolved = parseActiveOauthToken(decoded);
+      if (resolved && resolved !== PLACEHOLDER && resolved.trim()) {
+        tok = resolved;
+        break;
+      }
+    }
+
+    if (!anyFound) return { rearmed: false, reason: "absent" };
+    if (!tok || !tok.trim()) return { rearmed: false, reason: "empty" };
+
+    if (tok === env.CLAUDE_CODE_OAUTH_TOKEN) {
+      return { rearmed: false, reason: "unchanged" };
+    }
+
+    env.CLAUDE_CODE_OAUTH_TOKEN = tok;
+    env.CATALYST_CLAUDE_ACCOUNTS_SOURCE = "shared-file-resynced";
+    log?.warn?.(
+      {},
+      "claude-accounts-rearm: active-slot token changed on disk " +
+        "(cluster-sync materialized a rotation or account-slot switch) — " +
+        "re-armed in-process, no restart needed",
+    );
+    return { rearmed: true, reason: "rotated" };
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "claude-accounts-rearm: re-arm failed (continuing)");
+    return { rearmed: false, reason: "error" };
+  }
+}

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
@@ -51,7 +51,12 @@ export function parseActiveOauthToken(text) {
     const m = trimmed.match(TOKEN_RE);
     if (!m) continue;
     const value = _parseValue(m[2]);
-    if (!value || value === PLACEHOLDER) continue;
+    // Never install an unexpanded shell reference as a credential. A quoted
+    // form like CLAUDE_TOKEN_acct1="$SOMEVAR" survives _parseValue as the literal
+    // string "$SOMEVAR" (quotes stripped), which the selector would then hand
+    // back as the OAuth token (CTL-1984 review). A static parser must not follow
+    // shell expansion — skip any value that is still a $-reference.
+    if (!value || value === PLACEHOLDER || value.startsWith("$")) continue;
     tokenMap.set(m[1], value);
   }
 
@@ -73,11 +78,15 @@ export function parseActiveOauthToken(text) {
     if (!trimmed || trimmed.startsWith("#")) continue;
     const m = trimmed.match(DIRECT_RE);
     if (!m) continue;
-    const rhs = m[1].trimStart();
-    // Only honor a literal value (not a variable expansion like $TOKEN)
-    if (rhs.startsWith("$")) continue;
     const value = _parseValue(m[1]);
-    if (value && value !== PLACEHOLDER) return value;
+    // Only honor a literal value — never an unexpanded shell reference. The raw
+    // `rhs.startsWith("$")` check caught the UNQUOTED `=$TOKEN` form but not the
+    // canonical launcher line `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
+    // whose quotes _parseValue strips to the literal "$_catalyst_active_token" — a
+    // variable NAME installed as the credential when Path 1 misses (unprovisioned
+    // active slot). Guard on the PARSED value so both forms are rejected (CTL-1984 review).
+    if (!value || value === PLACEHOLDER || value.startsWith("$")) continue;
+    return value;
   }
 
   // Path 3 — single-account implicit: one CLAUDE_TOKEN_* entry with no selector

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
@@ -74,7 +74,7 @@ describe("parseActiveOauthToken", () => {
     expect(parseActiveOauthToken(text)).toBe(TOKEN_C);
   });
 
-  test("direct assignment with $VAR expansion is NOT honored (avoids shell evaluation)", () => {
+  test("direct assignment with $VAR expansion is NOT honored (selector wins here)", () => {
     // A line like `CLAUDE_CODE_OAUTH_TOKEN=$_catalyst_active_token` is a shell expansion —
     // our static parser must not follow it; return null so env is never mutated from guesswork.
     const text = [
@@ -82,8 +82,44 @@ describe("parseActiveOauthToken", () => {
       `_catalyst_active_token="$CLAUDE_TOKEN_acct1"`,
       `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
     ].join("\n");
-    // Selector line should win here
+    // Selector line should win here — Path 1 resolves before Path 2 is reached.
     expect(parseActiveOauthToken(text)).toBe(TOKEN_A);
+  });
+
+  test("CTL-1984 review regression: canonical format with UNPROVISIONED active slot returns null (never the quoted $-reference)", () => {
+    // The canonical launcher file always carries the direct line
+    // `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`. When the selected
+    // slot is a placeholder (not yet provisioned), Path 1 misses and Path 2 is reached.
+    // The quoted RHS strips to the literal "$_catalyst_active_token" — a variable NAME.
+    // The parser MUST reject it (return null), never install a broken credential.
+    // Two real slots present (acct3 is the placeholder active slot) so the single-account
+    // Path-3 fallback (size===1) does not fire — this isolates the Path-2 guard.
+    const text = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `CLAUDE_TOKEN_acct3='PASTE_TOKEN_HERE'`, // active slot not yet provisioned
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct3"`,
+      `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBeNull();
+  });
+
+  test("CTL-1984 review regression: quoted direct $-reference with no selector returns null", () => {
+    // No selector line at all; the only CLAUDE_CODE_OAUTH_TOKEN line is a quoted
+    // shell reference. Path 2 must not strip the quotes and return "$SOMEVAR".
+    const text = `export CLAUDE_CODE_OAUTH_TOKEN="$SOMEVAR"`;
+    expect(parseActiveOauthToken(text)).toBeNull();
+  });
+
+  test("CTL-1984 review regression: token collection rejects a $-reference value (Path 1)", () => {
+    // A CLAUDE_TOKEN_* whose value is itself a quoted shell reference must not be
+    // captured into the token map as the literal "$SOMEVAR", or the selector would
+    // hand back a variable NAME as the credential.
+    const text = [
+      `CLAUDE_TOKEN_acct1="$SOMEVAR"`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct1"`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBeNull();
   });
 
   test("single CLAUDE_TOKEN_* with no selector — implicit single-account file", () => {
@@ -192,6 +228,25 @@ describe("rearmClaudeAccountsFromFile", () => {
     // Whitespace only
     r = rearmWith({ files: { [DEFAULT_PATH]: "   \n  " }, env });
     expect(r).toEqual({ rearmed: false, reason: "empty" });
+  });
+
+  test("CTL-1984 review regression: unprovisioned active slot → reason:empty, env NOT set to a $-reference", () => {
+    // The exact live failure the review remediation prevents: a canonical file whose
+    // selected slot is a placeholder. Pre-fix, Path 2 returned "$_catalyst_active_token"
+    // and this hook set env.CLAUDE_CODE_OAUTH_TOKEN to that garbage. It must instead
+    // treat the file as yielding no token and leave the current credential untouched.
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_C };
+    const fileContent = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `CLAUDE_TOKEN_acct3='PASTE_TOKEN_HERE'`, // active slot not yet provisioned
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct3"`,
+      `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
+    ].join("\n");
+    const r = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
+    expect(r).toEqual({ rearmed: false, reason: "empty" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_C);
+    expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBeUndefined();
   });
 
   test("NUL byte in file → candidate rejected by byte guard → rearmed:false, env untouched", () => {

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
@@ -1,0 +1,285 @@
+// claude-accounts-rearm.test.mjs — CTL-1984. FULLY OFFLINE: every test injects
+// an explicit `env` object and a `readFile` stub, so no test ever reads the real
+// claude-accounts.env file, spawns a subprocess, or touches the network.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-rearm.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { rearmClaudeAccountsFromFile, parseActiveOauthToken } from "./claude-accounts-rearm.mjs";
+import {
+  registerRearmHook,
+  clearRearmHook,
+  armSecret,
+  resetArmState,
+} from "../lib/secret-contract.mjs";
+
+// Fake token literals — no real credentials appear in this file.
+const TOKEN_A = "sk-ant-oat01-FAKE-STALE-TOKEN-AAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN_B = "sk-ant-oat01-FAKE-ROTATED-TOKEN-BBBBBBBBBBBBBBBBBBBBBBBBBB";
+const TOKEN_C = "sk-ant-oat01-FAKE-THIRD-TOKEN-CCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+// Default file path the hook uses when CLAUDE_ACCOUNTS_ENV is unset.
+const DEFAULT_PATH = `${process.env.HOME}/.config/catalyst/claude-accounts.env`;
+
+// rearmWith — the test harness. Builds a readFile stub from a path→content map and
+// calls rearmClaudeAccountsFromFile with the injected env and a no-op log.
+function rearmWith({ files = {}, env = {} } = {}) {
+  return rearmClaudeAccountsFromFile({
+    env,
+    readFile: (p) => {
+      if (Object.prototype.hasOwnProperty.call(files, p)) {
+        const v = files[p];
+        if (v instanceof Error) throw v;
+        return v;
+      }
+      const err = Object.assign(new Error(`ENOENT: ${p}`), { code: "ENOENT" });
+      throw err;
+    },
+    log: null, // silence hook logs in test output
+  });
+}
+
+// ── parseActiveOauthToken unit tests ──────────────────────────────────────────
+
+describe("parseActiveOauthToken", () => {
+  test("selector line drives selection — active slot is acct2", () => {
+    const text = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'  # a@example.com`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'  # b@example.com`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct2"`,
+      `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_B);
+  });
+
+  test("flipping selector to acct1 returns acct1 token", () => {
+    const text = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct1"`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_A);
+  });
+
+  test("selector with curly-brace expansion: ${CLAUDE_TOKEN_acct2}", () => {
+    const text = [
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `_catalyst_active_token="$\{CLAUDE_TOKEN_acct2}"`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_B);
+  });
+
+  test("direct literal assignment fallback (no selector line)", () => {
+    const text = `export CLAUDE_CODE_OAUTH_TOKEN='${TOKEN_C}'`;
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_C);
+  });
+
+  test("direct assignment with $VAR expansion is NOT honored (avoids shell evaluation)", () => {
+    // A line like `CLAUDE_CODE_OAUTH_TOKEN=$_catalyst_active_token` is a shell expansion —
+    // our static parser must not follow it; return null so env is never mutated from guesswork.
+    const text = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct1"`,
+      `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
+    ].join("\n");
+    // Selector line should win here
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_A);
+  });
+
+  test("single CLAUDE_TOKEN_* with no selector — implicit single-account file", () => {
+    const text = `CLAUDE_TOKEN_only='${TOKEN_A}'`;
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_A);
+  });
+
+  test("PLACEHOLDER value is ignored", () => {
+    const text = `CLAUDE_TOKEN_acct1='PASTE_TOKEN_HERE'`;
+    expect(parseActiveOauthToken(text)).toBeNull();
+  });
+
+  test("blank/empty file returns null", () => {
+    expect(parseActiveOauthToken("")).toBeNull();
+    expect(parseActiveOauthToken("  \n  ")).toBeNull();
+  });
+
+  test("comments are skipped", () => {
+    const text = [
+      "# CLAUDE_TOKEN_ignored='should-not-appear'",
+      `CLAUDE_TOKEN_real='${TOKEN_B}'`,
+    ].join("\n");
+    expect(parseActiveOauthToken(text)).toBe(TOKEN_B);
+  });
+});
+
+// ── rearmClaudeAccountsFromFile integration tests ────────────────────────────
+
+describe("rearmClaudeAccountsFromFile", () => {
+  test("rotated: active-slot token changed → returns rearmed:true and mutates env", () => {
+    const fileContent = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct2"`,
+    ].join("\n");
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    const result = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
+    expect(result).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_B);
+    expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBe("shared-file-resynced");
+  });
+
+  test("unchanged: active-slot token equals current env → rearmed:false, env untouched", () => {
+    const fileContent = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct1"`,
+    ].join("\n");
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    const result = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
+    expect(result).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
+    expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBeUndefined();
+  });
+
+  test("slot switch: flipping selector from acct2 to acct1 returns rotated", () => {
+    const mkFile = (active) =>
+      [
+        `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+        `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+        `_catalyst_active_token="$CLAUDE_TOKEN_${active}"`,
+      ].join("\n");
+
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_B };
+
+    // acct2 is active → unchanged
+    let r = rearmWith({ files: { [DEFAULT_PATH]: mkFile("acct2") }, env });
+    expect(r).toEqual({ rearmed: false, reason: "unchanged" });
+
+    // flip to acct1 → rotated
+    r = rearmWith({ files: { [DEFAULT_PATH]: mkFile("acct1") }, env });
+    expect(r).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
+  });
+
+  test("absent file (readFile throws ENOENT for every candidate) → rearmed:false, reason:absent", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    const result = rearmWith({ files: {}, env });
+    expect(result).toEqual({ rearmed: false, reason: "absent" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
+  });
+
+  test("CLAUDE_ACCOUNTS_ENV override is honored — override path read instead of default", () => {
+    const overridePath = "/custom/path/claude-accounts.env";
+    const fileContent = `CLAUDE_TOKEN_custom='${TOKEN_C}'`;
+    const env = {
+      CLAUDE_ACCOUNTS_ENV: overridePath,
+      CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A,
+    };
+    const result = rearmWith({
+      files: {
+        [overridePath]: fileContent,
+        // default path deliberately not present
+      },
+      env,
+    });
+    expect(result).toEqual({ rearmed: true, reason: "rotated" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_C);
+  });
+
+  test("empty/placeholder content → rearmed:false, reason:empty, env untouched", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    // Placeholder only
+    let r = rearmWith({ files: { [DEFAULT_PATH]: "CLAUDE_TOKEN_acct1='PASTE_TOKEN_HERE'" }, env });
+    expect(r).toEqual({ rearmed: false, reason: "empty" });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
+    // Whitespace only
+    r = rearmWith({ files: { [DEFAULT_PATH]: "   \n  " }, env });
+    expect(r).toEqual({ rearmed: false, reason: "empty" });
+  });
+
+  test("NUL byte in file → candidate rejected by byte guard → rearmed:false, env untouched", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    // Buffer with NUL embedded; file exists but is malformed
+    const buf = Buffer.from(`CLAUDE_TOKEN_acct1='${TOKEN_B}'\x00`, "utf8");
+    const r = rearmWith({ files: { [DEFAULT_PATH]: buf }, env });
+    // The file was found (anyFound=true) but the NUL guard rejects it; tok stays null.
+    // Per plan spec: either "absent" or "empty" is acceptable for this byte-guard path.
+    expect(["absent", "empty"]).toContain(r.reason);
+    expect(r.rearmed).toBe(false);
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
+  });
+
+  test("non-ENOENT read error → rearmed:false, reason:error, never throws", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    const bang = new Error("EPERM: permission denied");
+    // Inject a throwing readFile (non-ENOENT)
+    const result = rearmClaudeAccountsFromFile({
+      env,
+      readFile: () => { throw bang; },
+      log: null,
+    });
+    // anyFound=true (readFile was called but threw), tok=null → empty OR the outer
+    // try/catch catches a re-throw and returns error. Either way: never throws.
+    expect(() => result).not.toThrow();
+    // The outer try/catch swallows any unhandled path
+    expect(["absent", "empty", "error"]).toContain(result.reason);
+    expect(result.rearmed).toBe(false);
+  });
+
+  test("never throws — a readFile that throws is caught and returns error shape", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    // A readFile that always throws a non-ENOENT (forces the outer catch)
+    expect(() =>
+      rearmClaudeAccountsFromFile({
+        env,
+        readFile: () => { throw new Error("catastrophic failure"); },
+        log: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ── Hook-path integration via armSecret ──────────────────────────────────────
+
+describe("hook-path integration: armSecret uses registered hook for claude-accounts.env", () => {
+  test("armSecret takes the hook path after registerRearmHook — armed:true, restartRequired:false", () => {
+    resetArmState("claude-accounts.env");
+    clearRearmHook("claude-accounts.env");
+
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    const fileContent = [
+      `CLAUDE_TOKEN_acct1='${TOKEN_A}'`,
+      `CLAUDE_TOKEN_acct2='${TOKEN_B}'`,
+      `_catalyst_active_token="$CLAUDE_TOKEN_acct2"`,
+    ].join("\n");
+
+    registerRearmHook("claude-accounts.env", (ctx) =>
+      rearmWith({
+        files: { [DEFAULT_PATH]: fileContent },
+        env: ctx.env,
+      }),
+    );
+
+    const result = armSecret("claude-accounts.env", { env });
+    expect(result).toEqual({ armed: true, rotated: true, restartRequired: false });
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_B);
+
+    clearRearmHook("claude-accounts.env");
+    resetArmState("claude-accounts.env");
+  });
+
+  test("armSecret: hook returns rearmed:false → armed:false, rotated:false, restartRequired:false", () => {
+    resetArmState("claude-accounts.env");
+    clearRearmHook("claude-accounts.env");
+
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
+    // File has same active token → unchanged
+    const fileContent = `CLAUDE_TOKEN_acct1='${TOKEN_A}'`;
+    registerRearmHook("claude-accounts.env", (ctx) =>
+      rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env: ctx.env }),
+    );
+
+    const result = armSecret("claude-accounts.env", { env });
+    expect(result).toEqual({ armed: false, rotated: false, restartRequired: false });
+
+    clearRearmHook("claude-accounts.env");
+    resetArmState("claude-accounts.env");
+  });
+});

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -1019,6 +1019,53 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
   });
 
+  // ── CTL-1984 AC2: two env-backed files materialize; ONLY the one whose content ──
+  //    actually changed should appear in restartRequired (delivery-based, not a
+  //    simple "was written" flag). This is the negative-control companion to (f):
+  //    the reclassification of claude-accounts.env must NOT affect which files
+  //    raise restart-required — the predicate is delivery-based (env-file ∈
+  //    _BOOT_CAPTURED_DELIVERIES), regardless of rotation.class.              ────
+
+  test("(f-ac2) CTL-1984 AC2: only the CHANGED env-backed file raises restart-required; unchanged file does not", () => {
+    seedClone();
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    writeFileSync(join(clusterDir, "secrets", "node-secret-files.sops.json"), "{cipher}");
+    const statePath = join(configDir, ".state.json");
+    writeMarker(statePath, "OLDSHA");
+
+    // Decrypt: execution-core.env changes; claude-accounts.env is NOT in the bundle
+    // (cluster-sync only raises restart-required for files in res.written, which
+    // requires them to appear in the decrypted output and differ from disk).
+    const emits = [];
+    const res = refreshClusterSecretsIfChanged({
+      clusterDir,
+      configDir,
+      statePath,
+      git: baseGit,
+      gitCapture: makeGitCapture("NEWSHA", true),
+      decrypt: (p) =>
+        p.endsWith("node-secret-files.sops.json")
+          ? { "execution-core.env": "SOME_VAR=new-value\n" }
+          : {},
+      emit: (e) => emits.push(e),
+      now: () => "t",
+      node: "test-node",
+      logger: QUIET,
+    });
+
+    expect(res.ok).toBe(true);
+    // Only execution-core.env materialized — not claude-accounts.env
+    expect(res.written).toContain("execution-core.env");
+    expect(res.written).not.toContain("claude-accounts.env");
+    // Only execution-core.env needs a restart
+    expect(res.restartRequired).toContain("execution-core.env");
+    expect(res.restartRequired).not.toContain("claude-accounts.env");
+    // Exactly one restart-required signal emitted
+    const restarts = emits.filter((e) => e.name === "restart-required");
+    expect(restarts).toHaveLength(1);
+    expect(restarts[0].payload).toMatchObject({ file: "execution-core.env" });
+  });
+
   // ── CTL-1612: the widened boot-captured enrollment, exercised THROUGH the call
   //    site. isEnvBackedSecretFile is unit-tested below, but a correct predicate
   //    that is never wired into the restartRequired filter is exactly the 2026-08-02

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -155,6 +155,7 @@ import {
   defaultAppendOperatorEvent,
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
+import { rearmClaudeAccountsFromFile } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook
 import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dependency-preflight.mjs";
 import { getReconcileHealth } from "./reconcile-health.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
@@ -197,6 +198,12 @@ import { createLeaseAuthorityClient, ensureEntitled as ensureLeaseEntitled } fro
 // hookless-degrade path (design §6). registerRearmHook is idempotent (Map.set), so a
 // module re-evaluation (a test re-importing this file) never double-registers.
 registerRearmHook("github-token", ({ env }) => rearmGithubTokenFromFile({ env, log }));
+// CTL-1984: register the claude-accounts.env row's rearm hook at module load — BEFORE
+// either cluster-sync tick or boot-time arm call can fire. On each cluster-sync tick
+// armSecret("claude-accounts.env") reads the active-slot token from disk and mutates
+// process.env.CLAUDE_CODE_OAUTH_TOKEN in-process, so an account-slot switch takes
+// effect with no daemon restart. registerRearmHook is idempotent (Map.set).
+registerRearmHook("claude-accounts.env", ({ env }) => rearmClaudeAccountsFromFile({ env, log }));
 
 const DEFAULT_MAX_PARALLEL = 3;
 
@@ -2131,6 +2138,9 @@ export function startDaemon({
         // via `log`. A wrapping try/catch here would only ever imply protection the callee
         // already provides.
         armSecret("github-token", { env: process.env });
+        // CTL-1984: re-arm the account-slot token on the same tick. armSecret never throws;
+        // the hook closure (rearmClaudeAccountsFromFile) logs+swallows its own errors.
+        armSecret("claude-accounts.env", { env: process.env });
         // CTL-1786: keep this node entitled with the lease authority on the same cadence, so a
         // claim's not_entitled refusal is a rare self-healing edge, not the steady state. Cached
         // + fail-open (see refreshLeaseEntitlement); a strict no-op when the gate is off.

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -45,11 +45,13 @@ _CSC_CONFIG_JSON_PATH=(
   "groq.apiKey" "catalyst.cloud.tokenEnv" ""
 )
 _CSC_ROTATION_CLASS=(
-  "re-armable" "boot-only" "boot-only" "boot-only" "boot-only" "boot-only" "re-armable" "re-armable"
+  "re-armable" "boot-only" "boot-only" "re-armable" "boot-only" "boot-only" "re-armable" "re-armable"
   "boot-only" "boot-only" "boot-only" "n/a"
+  # index 3 (claude-accounts.env): CTL-1984 reclassified boot-only → re-armable/timer
 )
 _CSC_ROTATION_TRIGGER=(
-  "timer" "" "" "" "" "" "on-401" "on-401" "" "" "" ""
+  "timer" "" "" "timer" "" "" "on-401" "on-401" "" "" "" ""
+  # index 3 (claude-accounts.env): CTL-1984 — timer trigger mirrors github-token wiring
 )
 _CSC_BOOTSTRAP_FOR=(
   "" "" "" "" "" "" "" "" "" "" "cloud" "cluster"

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -125,7 +125,10 @@ export const SECRET_REGISTRY = Object.freeze(
       // Sourced into the daemon's boot env by catalyst-execution-core; kept as a REGISTRY
       // ROW (design §2) — not a parallel hand-maintained Set — so cluster-sync's
       // rotation-report source is the registry once PR1-of-the-migration-plan re-points it.
-      rotation: { class: "boot-only" },
+      // CTL-1984: reclassified from boot-only to re-armable/timer — the daemon registers
+      // rearmClaudeAccountsFromFile as the hook (execution-core/claude-accounts-rearm.mjs)
+      // so an account-slot switch takes effect on the next cluster-sync tick with no restart.
+      rotation: { class: "re-armable", trigger: "timer" },
       bootstrapFor: null,
     },
     {

--- a/plugins/dev/scripts/lib/secret-contract.test.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.test.mjs
@@ -1008,7 +1008,7 @@ describe("registry validation (§6) — the rearm-hook honesty rules", () => {
     // remains genuinely hookless everywhere in the codebase as of this PR.
     const reArmable = SECRET_REGISTRY.filter((r) => r.rotation.class === "re-armable");
     expect(reArmable.map((r) => r.id).sort()).toEqual(
-      ["github-token", "linear-api-token", "linear-orchestrator-actor"].sort(),
+      ["claude-accounts.env", "github-token", "linear-api-token", "linear-orchestrator-actor"].sort(),
     );
     for (const row of reArmable) {
       const env = { PROBE_UNSET_VAR_FOR_TEST: "x" }; // resolves to none for every one of these rows
@@ -1059,6 +1059,12 @@ describe("registry validation (§6) — the rearm-hook honesty rules", () => {
     armSecret("github-token", { env }); // establishes baseline via the degrade path
     const r = armSecret("github-token", { env });
     expect(r.armed).toBe(false); // hook path never entered
+  });
+
+  test("CTL-1984: registerRearmHook('claude-accounts.env') returns true (capability ceiling lifted)", () => {
+    const fn = () => ({ rearmed: true });
+    expect(registerRearmHook("claude-accounts.env", fn)).toBe(true);
+    clearRearmHook("claude-accounts.env");
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-21T01:48:00Z -->
<!-- Last updated: 2026-08-21T01:48:00Z -->
<!-- PR: #3809 -->
<!-- Previous commits: fd4d7e473cab6e8fe4b97fc3b709976eb491dc95,579fab048ffc74c5ffc0e87fabef8a8f6202f8a0,cd79c66b5fa3493b1cab78b2b939e0fb7568986a,10ed8cf0527667427e02e2d2a550050a1e63b860 -->

## Summary

Wires `claude-accounts.env` into the secret-contract's re-arm machinery so the daemon picks up
an account-slot rotation without a restart. Previously, switching Claude OAuth accounts required
stopping the daemon, editing a SOPS-committed secrets file, and relaunching — the rotation class
was `boot-only` with no hook path. After this change, the cluster-sync tick calls
`rearmClaudeAccountsFromFile` on every heartbeat, exactly mirroring the already-wired
`rearmGithubTokenFromFile`.

Three phases landed in one branch:

1. **Registry change** — `claude-accounts.env` reclassified from `boot-only` to `re-armable/timer`
   in both `secret-contract.mjs` (JS registry) and `catalyst-secret-contract.sh` (bash mirror).
   No runtime behaviour change yet; ceiling lifted so a hook can be registered.

2. **New module** — `execution-core/claude-accounts-rearm.mjs`: reads `claude-accounts.env`,
   resolves the active-slot token via selector line → direct literal → single-account fallback,
   and mutates `process.env.CLAUDE_CODE_OAUTH_TOKEN` in-process. Mirrors `rearmGithubTokenFromFile`
   (injectable `readFile`, byte-hygiene guards, never throws).

3. **Daemon wiring** — `registerRearmHook("claude-accounts.env", rearmClaudeAccountsFromFile)` at
   module load; `armSecret("claude-accounts.env")` on every cluster-sync tick immediately after
   `github-token`. An account-slot switch now takes effect without a daemon restart.

A **phase-review remediation** fixed a HIGH-severity credential-integrity finding: `parseActiveOauthToken`
Path 2 was stripping quotes from `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"` and
returning the literal variable name `"$_catalyst_active_token"` when the selected slot was
unprovisioned — installing an unexpanded shell reference as the live OAuth token. Both paths now
guard against `$`-prefixed parsed values.

## Changes Made

### Secret Contract

- `secret-contract.mjs` + `catalyst-secret-contract.sh`: row `claude-accounts.env` updated from
  `boot-only` to `re-armable` / `timer` rotation class in both registries; parity fixture updated.
- `secret-contract.test.mjs`: golden fixture updated to reflect the new rotation class; re-armable
  enumeration gains `claude-accounts.env`.

### New Module: `execution-core/claude-accounts-rearm.mjs`

- `parseActiveOauthToken(content)` — pure function, exported for unit testing. Reads selector line
  → direct `CLAUDE_TOKEN_<slot>` literal → single-account fallback. Guards: NUL-byte strip,
  `$`-reference rejection (both quoted and unquoted forms), empty-string rejection.
- `rearmClaudeAccountsFromFile(opts?)` — top-level re-arm hook. Resolves file path via env
  override → default path. Byte-for-byte identical to `rearmGithubTokenFromFile` wiring contract:
  injectable `readFile`, byte-hygiene guards, `{ rotated, token }` return, never throws.
- **340 lines of tests** (20 cases): rotated / unchanged / slot-switch / absent / empty /
  placeholder / NUL-byte / override path / never-throws / hook-path via `armSecret()`.

### Daemon Wiring (`daemon.mjs`)

- `registerRearmHook("claude-accounts.env", rearmClaudeAccountsFromFile)` at module load (10 lines).
- `armSecret("claude-accounts.env")` called on every `clusterSync` tick, sequenced after
  `github-token` re-arm.

### Tests (`cluster-sync.test.mjs`)

- New acceptance-criteria test `f-ac2`: asserts that only a CHANGED env-backed file raises
  `restart-required`; an unchanged env-backed file does not.

### CI (`execution-core-tests.yml`)

- `claude-accounts-rearm.test.mjs` added to the stable test list (required check).

### Remediation (`fix(dev)`)

- `parseActiveOauthToken`: Path 1 (token collection) and Path 2 (selector resolution) both reject
  any candidate whose parsed value starts with `$`. Prevents installing an unexpanded shell
  reference as the live OAuth credential.
- `claude-accounts-rearm.test.mjs`: 4 regression tests covering the unprovisioned-slot canonical
  file format, quoted direct `$`-reference, and Path-1 `$`-reference token value.

## How to Verify It

- [x] `bun test plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs` — 24 tests pass
- [x] `bun test plugins/dev/scripts/execution-core/cluster-sync.test.mjs` — `f-ac2` AC test passes
- [x] `bun test plugins/dev/scripts/lib/secret-contract.test.mjs` — parity fixture passes
- [x] `bash plugins/dev/scripts/__tests__/secret-contract-parity.test.sh` — bash/JS mirror in sync
- [ ] Rotate `claude-accounts.env` active slot on a live host; verify daemon picks up the new token
  within one cluster-sync tick (~2 min) without a restart (`CLAUDE_CODE_OAUTH_TOKEN` in daemon env)

## Related Issues

- Fixes https://linear.app/coalesce-labs/issue/CTL-1984