### PR TITLE
fix(dev): CTL-2127 — guard reply tools against file-path-as-body data loss

### DIFF
--- a/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
+++ b/plugins/dev/scripts/__tests__/agent-tools-out-of-tree.test.mjs
@@ -177,6 +177,95 @@ describe("the tools run when they are the only file in the directory (CTL-2026)"
   });
 });
 
+describe("linear-reply --body file-path guard (CTL-2127)", () => {
+  test("an EXISTING file path is auto-read and its CONTENT is posted, not the path", () => {
+    const fileContent = "# Real content\n\nline two\n";
+    writeFileSync(join(dir, "body.md"), fileContent);
+    const capture = `
+${STUB.replaceAll("`", "\\`")}
+const inner = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  let b = {};
+  try { b = opts?.body ? JSON.parse(opts.body) : {}; } catch { b = {}; }
+  if (typeof b.query === "string" && b.query.includes("commentCreate")) {
+    console.error("CAPTURED_INPUT " + JSON.stringify(b.variables.in));
+  }
+  return inner(url, opts);
+};
+`;
+    writeFileSync(join(dir, "capture-2127.mjs"), capture);
+    const r = spawnSync(
+      process.execPath,
+      ["--import", "./capture-2127.mjs", "linear-reply.mjs", "CTL-1", "--as", "CTL", "--body", "./body.md"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        env: { ...process.env, ...STUB_CREDS, CATALYST_LINEAR_WRITE_PROXY: undefined },
+      }
+    );
+    const stripped = strip(r.stderr ?? "");
+    const line = stripped.split("\n").find((l) => l.startsWith("CAPTURED_INPUT "));
+    expect(line).toBeTruthy();
+    const input = JSON.parse(line.slice("CAPTURED_INPUT ".length));
+    // The body must be the FILE CONTENT, not the path string
+    expect(input.body).toBe(fileContent);
+    expect(r.status).toBe(0);
+    // The guard must announce what it did — non-silent
+    expect(stripped).toContain("linear-reply:");
+  });
+
+  test("a path-like value that is NOT a readable file is REFUSED, nothing posted", () => {
+    const r = runIsolated("linear-reply.mjs", [
+      "CTL-1", "--as", "CTL", "--body", "/tmp/does-not-exist-ctl2127-xyz.md",
+    ]);
+    expect(r.code).not.toBe(0);
+    expect(r.err).toContain("linear-reply:");
+    expect(r.err).toMatch(/file path|--body -/);
+    // No commentCreate JSON on stdout => nothing was posted
+    expect(r.out).toBe("");
+  });
+
+  test("a normal multi-word body still posts verbatim (no false positive)", () => {
+    const r = runIsolated("linear-reply.mjs", [
+      "CTL-1", "--as", "CTL", "--body", "See the notes.md file for details",
+    ]);
+    expect(JSON.parse(r.out.trim()).ok).toBe(true);
+  });
+
+  test("--body - (stdin) is unaffected by the guard", () => {
+    const stdinContent = "Content piped from stdin\n";
+    const capture = `
+${STUB.replaceAll("`", "\\`")}
+const inner = globalThis.fetch;
+globalThis.fetch = async (url, opts) => {
+  let b = {};
+  try { b = opts?.body ? JSON.parse(opts.body) : {}; } catch { b = {}; }
+  if (typeof b.query === "string" && b.query.includes("commentCreate")) {
+    console.error("CAPTURED_INPUT " + JSON.stringify(b.variables.in));
+  }
+  return inner(url, opts);
+};
+`;
+    writeFileSync(join(dir, "capture-stdin-2127.mjs"), capture);
+    const r = spawnSync(
+      process.execPath,
+      ["--import", "./capture-stdin-2127.mjs", "linear-reply.mjs", "CTL-1", "--as", "CTL", "--body", "-"],
+      {
+        cwd: dir,
+        encoding: "utf8",
+        input: stdinContent,
+        env: { ...process.env, ...STUB_CREDS, CATALYST_LINEAR_WRITE_PROXY: undefined },
+      }
+    );
+    const stripped = strip(r.stderr ?? "");
+    const line = stripped.split("\n").find((l) => l.startsWith("CAPTURED_INPUT "));
+    expect(line).toBeTruthy();
+    const input = JSON.parse(line.slice("CAPTURED_INPUT ".length));
+    expect(input.body).toBe(stdinContent);
+    expect(r.status).toBe(0);
+  });
+});
+
 describe("the avatar Ryan added out-of-tree is in the repo copy (CTL-2026)", () => {
   // ⭐ THE MEASUREMENT BEHIND THIS: CTL-2026 was filed on "they are true copies,
   // byte-identical". Six hours later Ryan hand-edited ONLY the out-of-tree

--- a/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-comment-post.test.sh
@@ -327,6 +327,97 @@ else
   PASS=$((PASS+1))
 fi
 
+# --- CTL-2127: file-path guard tests ---
+# Restore credentials and set up a correct-format stub (issue resolution must return \n200).
+export CATALYST_LINEAR_AGENT_CLIENT_ID="test-cid"
+export CATALYST_LINEAR_AGENT_CLIENT_SECRET="test-csec"
+
+CTL2127_BODY_FILE="${TMPDIR_TEST}/body-ctl2127.md"
+printf '# File body content\n\nCTL2127 UNIQUE LINE\n' > "$CTL2127_BODY_FILE"
+
+CTL2127_CAPTURE="${TMPDIR_TEST}/capture-ctl2127.txt"
+
+# Stub that captures all args and returns correct HTTP codes.
+# Issue resolution uses `curl -w '\n%{http_code}'` so the response must include
+# the HTTP status after a newline.
+cat >"${BIN_DIR}/curl" <<CURLEOF
+#!/usr/bin/env bash
+ARGS_STR="\$*"
+printf '%s\n' "\$ARGS_STR" >> "${CTL2127_CAPTURE}"
+if printf '%s' "\$ARGS_STR" | grep -q "oauth/token"; then
+  printf '{"access_token":"test_token"}'
+elif printf '%s' "\$ARGS_STR" | grep -q "commentCreate"; then
+  printf '{"data":{"commentCreate":{"success":true}}}'
+else
+  printf '{"data":{"issue":{"id":"uuid-ctl2127"}}}\n200'
+fi
+exit 0
+CURLEOF
+chmod +x "${BIN_DIR}/curl"
+
+# Test 15 (CTL-2127): existing file path as body → auto-read, file content posted (not path).
+rm -f "${CTL2127_CAPTURE}"
+CTL2127_T15_EXIT=0
+PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "$CTL2127_BODY_FILE" >/dev/null 2>/dev/null \
+  || CTL2127_T15_EXIT=$?
+if [[ "$CTL2127_T15_EXIT" -eq 0 ]]; then
+  echo "PASS: CTL-2127: existing file path as body → exits 0 (auto-read)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: existing file path as body should exit 0 (got $CTL2127_T15_EXIT)"
+  FAIL=$((FAIL+1))
+fi
+if grep -q "CTL2127 UNIQUE LINE" "${CTL2127_CAPTURE}" 2>/dev/null; then
+  echo "PASS: CTL-2127: file CONTENT (not path) included in mutation body"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: file content not in mutation — path may have been posted verbatim"
+  FAIL=$((FAIL+1))
+fi
+CTL2127_T15_STDERR="$(rm -f "${CTL2127_CAPTURE}"; \
+  PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "$CTL2127_BODY_FILE" 2>&1 1>/dev/null || true)"
+if printf '%s' "$CTL2127_T15_STDERR" | grep -q "linear-comment-post:"; then
+  echo "PASS: CTL-2127: auto-read emits stderr note (non-silent)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: auto-read should emit a stderr note (got: $CTL2127_T15_STDERR)"
+  FAIL=$((FAIL+1))
+fi
+
+# Test 16 (CTL-2127): path-like non-file body → refused, non-zero exit, no mutation posted.
+rm -f "${CTL2127_CAPTURE}"
+CTL2127_NONFILE="/tmp/does-not-exist-ctl2127-xyz.md"
+CTL2127_T16_EXIT=0
+PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "$CTL2127_NONFILE" >/dev/null 2>/dev/null \
+  || CTL2127_T16_EXIT=$?
+if [[ "$CTL2127_T16_EXIT" -ne 0 ]]; then
+  echo "PASS: CTL-2127: path-like non-file body → non-zero exit (refused)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: path-like non-file body should be refused (got exit 0)"
+  FAIL=$((FAIL+1))
+fi
+if ! grep -q "commentCreate" "${CTL2127_CAPTURE}" 2>/dev/null; then
+  echo "PASS: CTL-2127: no mutation call when path-like non-file body is refused"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: mutation was called despite refused path-like body (data loss!)"
+  FAIL=$((FAIL+1))
+fi
+
+# Test 17 (CTL-2127): normal multi-word body still posts verbatim (no false positive).
+rm -f "${CTL2127_CAPTURE}"
+CTL2127_T17_EXIT=0
+PATH="${BIN_DIR}:$PATH" bash "$HELPER" "CTL-550" "See the notes.md file for details here" \
+  >/dev/null 2>/dev/null || CTL2127_T17_EXIT=$?
+if [[ "$CTL2127_T17_EXIT" -eq 0 ]]; then
+  echo "PASS: CTL-2127: normal multi-word body posts verbatim (no false positive)"
+  PASS=$((PASS+1))
+else
+  echo "FAIL: CTL-2127: normal multi-word body incorrectly refused (exit $CTL2127_T17_EXIT)"
+  FAIL=$((FAIL+1))
+fi
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/ask.mjs
+++ b/plugins/dev/scripts/ask.mjs
@@ -260,7 +260,7 @@ function usage() {
   console.error(`Usage:
   ask.mjs create --team <TEAM> --title <t> --why <text> [--option <label> ...]
                  [--default <text>] [--blocks <ISSUE>] [--priority <1-4>] [--dry-run]
-  ask.mjs accept <ISSUE> --as <AGENT> --body <markdown|-> [--dry-run]
+  ask.mjs accept <ISSUE> --as <AGENT> --body <literal-markdown-text|-> [--dry-run]
 
 create files a correctly-shaped ask ticket, then READS IT BACK and proves the decision
 trigger can parse its options. accept replies in-thread as the app actor and moves the
@@ -428,7 +428,7 @@ function cmdAccept(argv) {
   let body = argOf(argv, "--body");
   const dryRun = argv.includes("--dry-run");
   if (!id || !as || !body) {
-    console.error("ask accept: <ISSUE> --as <AGENT> --body <markdown|-> are required");
+    console.error("ask accept: <ISSUE> --as <AGENT> --body <literal-markdown-text|-> are required");
     return 1;
   }
   if (body === "-") body = readFileSync(0, "utf8");

--- a/plugins/dev/scripts/lib/linear-comment-post.sh
+++ b/plugins/dev/scripts/lib/linear-comment-post.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # linear-comment-post.sh — Post a Linear comment using the app-actor identity.
 #
-# Usage: linear-comment-post.sh <ticket-identifier> <comment-body>
+# Usage: linear-comment-post.sh <ticket-identifier> <literal-markdown-text>
 # E.g.:  linear-comment-post.sh CTL-550 "Hello from Catalyst agent"
+# Note:  pass the LITERAL text, never a file path — use "$(cat FILE)" or '--body - < FILE'
 #
 # Reads credentials from env vars (CATALYST_LINEAR_AGENT_CLIENT_ID /
 # CATALYST_LINEAR_AGENT_CLIENT_SECRET) or the project Layer-2 config.
@@ -12,6 +13,20 @@ set -euo pipefail
 
 TICKET="${1:?ticket identifier required (e.g. CTL-550)}"
 BODY="${2:?comment body required}"
+
+# CTL-2127: reject/auto-read a body that is actually a file path (silent data-loss guard).
+# bash 3.2-safe: uses [[ == glob ]] and [[:space:]], not =~ PCRE or mapfile.
+if [[ "$BODY" != *[[:space:]]* ]] && \
+   { [[ "$BODY" == /* || "$BODY" == ./* || "$BODY" == ../* ]] || \
+     [[ "$BODY" == *.md || "$BODY" == *.txt || "$BODY" == *.json ]]; }; then
+  if [[ -f "$BODY" && -r "$BODY" ]]; then
+    echo "linear-comment-post: '$BODY' is a readable file; posting its CONTENT. Prefer piping content instead of a path." >&2
+    BODY="$(cat "$BODY")"
+  else
+    echo "linear-comment-post: '$BODY' looks like a file path but is not a readable file. Refusing to post a bare path (silent data loss). Pass the literal text or \"\$(cat FILE)\"." >&2
+    exit 2
+  fi
+fi
 
 LINEAR_API="https://api.linear.app"
 

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -7,14 +7,14 @@
 //   • tagged with the agent's name via createAsUser (shows as botActor.userDisplayName).
 //
 // Usage:
-//   node linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown> [--parent <commentId>|--top]
-//   (body may also come from stdin: --body -)
+//   node linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <literal-markdown-text|-> [--parent <commentId>|--top]
+//   (body may also come from stdin: --body -; NEVER pass a file path — use '--body - < FILE')
 // Env: LINEAR_SYNC_CLIENT_ID / LINEAR_SYNC_CLIENT_SECRET (direnv catalyst-cloud profile).
 // Without --parent/--top: threads under the ROOT of the most recent comment authored by a HUMAN
 // (non-bot) user on the issue; if none exists, posts top-level.
 // Prints JSON {ok, commentId, parentId, url} on success; non-zero exit + message on failure.
 
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 
 const GQL = "https://api.linear.app/graphql";
 const OAUTH = "https://api.linear.app/oauth/token";
@@ -30,10 +30,30 @@ let body = arg("--body", "");
 const parentArg = arg("--parent", null);
 const top = process.argv.includes("--top");
 if (!issueKey || !body) {
-  console.error("usage: linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown|-> [--parent <id>|--top]");
+  console.error("usage: linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <literal-markdown-text|-> [--parent <id>|--top]");
   process.exit(2);
 }
 if (body === "-") body = readFileSync(0, "utf8");
+// CTL-2127: agents repeatedly pass a FILE PATH as --body; the tool used to post the path
+// string itself (silent data loss). Guard it here — INLINE, node:fs only (this file is
+// deployed standalone at ~/catalyst/comms/tools/, CTL-2026, so no ./lib import is allowed).
+else if (body && !/\s/.test(body) &&
+         (/^(\.{0,2}\/)/.test(body) || /\.(md|txt|json)$/i.test(body))) {
+  let isFile = false;
+  try { isFile = statSync(body).isFile(); } catch { /* not a path we can stat */ }
+  if (isFile) {
+    process.stderr.write(
+      `linear-reply: --body '${body}' is a readable file; posting its CONTENT. ` +
+      `Prefer '--body - < ${body}'.\n`);
+    body = readFileSync(body, "utf8");
+  } else {
+    console.error(
+      `linear-reply: --body '${body}' looks like a file path but is not a readable file. ` +
+      `Refusing to post a bare path (this silently loses the intended comment). ` +
+      `Use '--body - < FILE' or '--body "$(cat FILE)"'.`);
+    process.exit(2);
+  }
+}
 
 const cid = process.env.LINEAR_SYNC_CLIENT_ID, csec = process.env.LINEAR_SYNC_CLIENT_SECRET;
 if (!cid || !csec) { console.error("LINEAR_SYNC_CLIENT_ID/SECRET missing (run under direnv)"); process.exit(2); }

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -54,7 +54,8 @@ in one place: **[`references/threading.md`](references/threading.md)** — one-l
 what a reply must contain. Read it before your first reply.
 
 ```bash
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "literal reply text"
+# ⚠️ --body takes LITERAL text or '-' (stdin). Never pass a file path — use '--body - < FILE'.
 ```
 
 ## 5. Closing (the raising agent)

--- a/plugins/dev/skills/ask/references/threading.md
+++ b/plugins/dev/skills/ask/references/threading.md
@@ -39,8 +39,8 @@ as an ADR before it ships, because history cannot be re-tagged.
 ## The helper (do not hand-roll the write)
 
 ```bash
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
-#   --body -          read the body from stdin
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "literal reply text"
+#   --body -          read the body from stdin (NEVER pass a file path — use '--body - < FILE')
 #   --parent <id>     thread under a specific comment (its ROOT is used)
 #   --top             start a new top-level comment
 ```

--- a/plugins/dev/skills/create-plan/SKILL.md
+++ b/plugins/dev/skills/create-plan/SKILL.md
@@ -389,5 +389,6 @@ context):
 - **After plan saved**: Add a comment with the plan path — this is an agent-authored comment,
   so post it through the app actor (`linear-reply.mjs --as <role>`, or the
   `linear-comment-post.sh` helper), never bare `linearis issues discuss`/`reply` (those post as
-  the human — see the `linearis` skill's "Comment on a ticket" section).
+  the human — see the `linearis` skill's "Comment on a ticket" section). Pass the comment body
+  as LITERAL text or `--body - < FILE`; never pass a file path as `--body` (silent data loss).
 - If the tooling is not available, skip silently and continue planning

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -265,7 +265,8 @@ linearis issues update ENG-123 --project-milestone "Milestone Name"
 > with the agent via `createAsUser`:
 >
 > ```bash
-> direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-123 --as <AGENT> --body "…"
+> direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-123 --as <AGENT> --body "literal text"
+> # ⚠️ --body takes LITERAL text or '-'. Never pass a file path — use '--body - < FILE'.
 > ```
 >
 > Use `linearis issues discuss` only when you genuinely intend the comment to be the
@@ -279,7 +280,8 @@ discussion commands").
 ```bash
 # An AGENT starting a comment / discussion thread — go through linear-reply.mjs, NOT `discuss`
 # (the ⛔ callout above; `discuss` posts under the human's own identity):
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "…" --top
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "literal text" --top
+# ⚠️ --body takes LITERAL text or '-'. Never pass a file path — use '--body - < FILE'.
 
 # `linearis issues discuss` — ONLY when the comment is genuinely meant to be the human's own:
 linearis issues discuss ENG-123 --body "Starting work on this"
@@ -557,6 +559,7 @@ linearis issues update ENG-123 --status "Done"
 # With comment — an AGENT posting the "Merged" note goes through linear-reply.mjs, not `discuss`
 linearis issues update ENG-123 --status "Done"
 direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "Merged: PR #456" --top
+# ⚠️ --body takes LITERAL text or '-'. Never pass a file path — use '--body - < FILE'.
 ```
 
 ### UUID-based calls (CTL-207)
@@ -600,7 +603,8 @@ refresh is wired in.
    `linearis` subcommands authenticate with the single personal token the CLI resolves globally (see
    the ⛔ callout above) — there is no separate app-actor auth path inside `linearis` itself, so they
    ALWAYS post under the human's own identity, which the ask-resolution gate reads as the human
-   deciding (CTL-1567/CTL-2086). Use `linear-reply.mjs --as <AGENT>` for every agent-authored comment;
+   deciding (CTL-1567/CTL-2086). Use `linear-reply.mjs --as <AGENT> --body "literal text"` for every
+   agent-authored comment (pass LITERAL text or `--body - < FILE`, never a file path);
    reserve `issues discuss`/`issues reply` for when the comment is genuinely meant to be the human's
    own. List threads with `issues discussions <id>` (read-only, no identity risk). The old
    `comments create` still works but is a **deprecated compatibility facade** — don't use it. There is

--- a/plugins/dev/skills/research-codebase/SKILL.md
+++ b/plugins/dev/skills/research-codebase/SKILL.md
@@ -318,5 +318,6 @@ If a ticket is detected (provided as argument, mentioned in query, or from conte
 - **After document saved**: Add a comment with the document link — this is an agent-authored
   comment, so post it through the app actor (`linear-reply.mjs --as <role>`, or the
   `linear-comment-post.sh` helper), never bare `linearis issues discuss`/`reply` (those post as
-  the human — see the `linearis` skill's "Comment on a ticket" section).
+  the human — see the `linearis` skill's "Comment on a ticket" section). Pass the comment body
+  as LITERAL text or `--body - < FILE`; never pass a file path as `--body` (silent data loss).
 - If the tooling is not available, skip silently and continue research


### PR DESCRIPTION
## Summary

- Guards `linear-reply.mjs` against agents passing a file path as `--body` (5 confirmed recurrences causing silent data loss)
- Guards `lib/linear-comment-post.sh` with the same heuristic (bash 3.2-safe)
- Updates usage strings and skill docs in `ask`, `linearis`, `research-codebase`, `create-plan` to state the constraint clearly

The heuristic: single token (no whitespace) AND (starts with `/`, `./`, or `../`) OR (ends in `.md`, `.txt`, or `.json`). Auto-reads the file if readable; refuses with a clear error if not.

## Test plan

- [ ] 4 new JS tests in `agent-tools-out-of-tree.test.mjs` — all pass
- [ ] 6 new shell tests in `linear-comment-post.test.sh` — all pass
- [ ] Skill-shape gate: 43 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)