### PR TITLE
fix(dev): CTL-2052 — classify the refused proxy label-write, cool it down, and stop after N

### DIFF
--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -67,6 +67,10 @@ import { ENTITLEMENT_EVENT_NAMES } from "../execution-core/entitlement-event.mjs
 // CTL-2056 — the needs-human escalation event, imported from its owning module so a
 // rename cannot leave a re-typed literal behind that still passes.
 import { ESCALATION_EVENT_NEEDS_HUMAN } from "../execution-core/escalation-event.mjs";
+// CTL-2052 — the label retry-exhausted escalation, imported from its owning module
+// (not a re-typed literal). The `linear.label.` prefix is UNPROTECTED under the
+// namespace contract (a dedicated test below asserts it, alongside the salvage family).
+import { LABEL_RETRY_EXHAUSTED_EVENT } from "../execution-core/label-retry-event.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -117,6 +121,7 @@ const EXEC_CORE_EVENT_NAMES = [
   CONFIG_TEAM_IDENTITY_MISMATCH, // CTL-2076 config-identity-event.mjs — registry team-identity mismatch (CAT-52), boot telemetry
   ...ENTITLEMENT_EVENT_NAMES, // CTL-1785 entitlement-event.mjs — would-shed / shed / restored (v3 bare-name, host-suffixed)
   ESCALATION_EVENT_NEEDS_HUMAN, // CTL-2056 escalation-event.mjs — ticket.escalated (entity=ticket/action=escalated)
+  LABEL_RETRY_EXHAUSTED_EVENT, // CTL-2052 label-retry-event.mjs — the "stopped after N and said so" escalation
   ...INLINE_EVENT_NAMES,
 ];
 
@@ -285,5 +290,24 @@ describe("CTL-1639 worktree.salvage.* namespace (unprotected)", () => {
       expect(phaseSlotOf(name), `${name} must not resolve to a phase slot`).toBeNull();
       expect(PHASE_EVENT_PATTERN.test(name)).toBe(false);
     }
+  });
+});
+
+// ── CTL-2052: linear.label.retry-exhausted is UNPROTECTED ─────────────────────
+// The AC3 escalation rides the `linear.label.` prefix, which must NOT collide with
+// any broker-protected namespace and must NOT be a phase slot, so shouldSkipEvent
+// ingests it normally and it is available to wait-for / dashboards. Guards against a
+// future FORBIDDEN_PREFIXES / PROTECTED_EXACT_NAMES change swallowing it.
+describe("CTL-2052 linear.label.retry-exhausted namespace (unprotected)", () => {
+  test("it is not broker-protected", () => {
+    expect(
+      isBrokerProtectedName(LABEL_RETRY_EXHAUSTED_EVENT),
+      `${LABEL_RETRY_EXHAUSTED_EVENT} must not be broker-protected`
+    ).toBe(false);
+  });
+
+  test("it is not a phase slot — the broker never routes it as a terminal transition", () => {
+    expect(phaseSlotOf(LABEL_RETRY_EXHAUSTED_EVENT)).toBeNull();
+    expect(PHASE_EVENT_PATTERN.test(LABEL_RETRY_EXHAUSTED_EVENT)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
@@ -24,8 +24,10 @@ import {
   TERMINAL_LABEL_REASONS,
   THROTTLED_LABEL_REASONS,
   BUDGET_REASON_PREFIX,
+  CLOUD_LABEL_REJECTION_REASONS,
   isTerminalLabelReason,
   isThrottledLabelReason,
+  isCloudLabelRejection,
   shouldCoolDownLabel,
 } from "./label-failure-class.mjs";
 import { convergeHeldLabel, convergeDispositionLabel } from "./scheduler.mjs";
@@ -258,5 +260,104 @@ describe("COORD-236 wiring: the cool-down is armed by the WIDE predicate", () =>
     // ...and no code line calls it.
     const code = GUARD.split("\n").filter((l) => !l.trimStart().startsWith("//"));
     expect(code.join("\n")).not.toContain("shouldCoolDownLabel(");
+  });
+});
+
+// ── CTL-2052 ─────────────────────────────────────────────────────────────────
+// A DETERMINISTIC cloud rejection of a LABEL write (the enforce/proxy path's
+// `cloud:failed`/`cloud:rejected`, normalized to `cloud:label-rejected`) is a
+// THIRD class: cool-down-eligible (so the storm stops) but NOT terminal (so it
+// never earns labelOnce's permanent `.skipped` — COORD-236) and NOT throttled
+// (so the operator log names the right thing — AC2).
+describe("CTL-2052 classification: the deterministic cloud label rejection is its own class", () => {
+  test("the cloud-label-rejection set is EXACTLY { cloud:label-rejected }", () => {
+    expect([...CLOUD_LABEL_REJECTION_REASONS].sort()).toEqual(["cloud:label-rejected"]);
+    expect(isCloudLabelRejection("cloud:label-rejected")).toBe(true);
+  });
+
+  test("it cools down but is NEITHER terminal NOR throttled", () => {
+    expect(shouldCoolDownLabel("cloud:label-rejected")).toBe(true); // AC1: back off
+    expect(isTerminalLabelReason("cloud:label-rejected")).toBe(false); // no permanent .skipped
+    expect(isThrottledLabelReason("cloud:label-rejected")).toBe(false); // not "budget/throttled"
+  });
+
+  test("the RAW proxy reasons are still nothing on their own — normalization is what classifies", () => {
+    // The raw verdict reaches the classifier only AFTER routeThroughProxy has
+    // normalized it (linear-write.mjs). If a future refactor drops the
+    // normalization, the raw reason reads as "retryable next tick" and the storm
+    // returns — this pins that the raw strings do NOT cool down by themselves.
+    for (const raw of ["cloud:failed", "cloud:rejected"]) {
+      expect(isCloudLabelRejection(raw)).toBe(false);
+      expect(shouldCoolDownLabel(raw)).toBe(false);
+    }
+  });
+
+  test("cloud:exhausted is deliberately NOT this class — it is a budget refusal, left alone here", () => {
+    // `cloud:${outcome}` also produces cloud:exhausted (a budget exhaustion). This
+    // ticket touches only the two DETERMINISTIC label rejections; the budget one is
+    // out of scope (research Finding, plan §NOT in scope).
+    expect(isCloudLabelRejection("cloud:exhausted")).toBe(false);
+  });
+});
+
+describe("CTL-2052: the converger backs off on the normalized cloud label rejection (AC1)", () => {
+  test("convergeDispositionLabel issues ONE apply, then ZERO for the cool-down window", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 2_000_000;
+    const opts = { orchDir, now: () => clock };
+    expect(convergeDispositionLabel("CTL-20", [], "blocked", w, opts)).toBe(1);
+    expect(w.calls.length).toBe(1);
+    for (let i = 0; i < 30; i++) {
+      clock += 1_000;
+      convergeDispositionLabel("CTL-20", [], "blocked", w, opts);
+    }
+    expect(w.calls.length).toBe(1); // AC1: does NOT re-issue on the next tick
+  });
+
+  test("convergeHeldLabel backs off on the same normalized reason", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 2_000_000;
+    const opts = { orchDir, now: () => clock };
+    expect(convergeHeldLabel("CTL-21", [], "blocked", w, opts)).toBe(1);
+    for (let i = 0; i < 30; i++) {
+      clock += 1_000;
+      convergeHeldLabel("CTL-21", [], "blocked", w, opts);
+    }
+    expect(w.calls.length).toBe(1);
+  });
+
+  test("NEGATIVE CONTROL: the RAW cloud:failed is NOT cooled down — it storms (proving the test bites)", () => {
+    // If normalization were removed, the converger would see the raw reason and
+    // re-fire every tick. Feed the raw reason directly to prove the harness would
+    // catch that regression.
+    const w = failingWriter("cloud:failed");
+    let clock = 2_000_000;
+    const opts = { orchDir, now: () => clock };
+    for (let i = 0; i < 10; i++) {
+      convergeDispositionLabel("CTL-22", [], "blocked", w, opts);
+      clock += 1_000;
+    }
+    expect(w.calls.length).toBe(10);
+  });
+});
+
+describe("⛔ CTL-2052: labelOnce must NOT write .skipped for the cloud label rejection (COORD-236 asymmetry)", () => {
+  test("a cloud:label-rejected refusal leaves NO .skipped marker, so a later genuine apply is not abandoned", () => {
+    const w = failingWriter("cloud:label-rejected");
+    withWorkerDir("CTL-23");
+    expect(labelOnce(orchDir, "CTL-23", "needs-human", w)).toBe(true);
+    expect(w.calls.length).toBe(1);
+    // No terminal marker ⇒ the next call runs the write again (unprovable-terminal
+    // must never be permanently abandoned).
+    expect(labelOnce(orchDir, "CTL-23", "needs-human", w)).toBe(true);
+    expect(w.calls.length).toBe(2);
+  });
+
+  test("contrast: exclusive-conflict DOES write .skipped and stops — the asymmetry is preserved", () => {
+    const w = failingWriter("exclusive-conflict");
+    withWorkerDir("CTL-24");
+    expect(labelOnce(orchDir, "CTL-24", "needs-human", w)).toBe(true);
+    expect(labelOnce(orchDir, "CTL-24", "needs-human", w)).toBe(false);
+    expect(w.calls.length).toBe(1);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/label-budget-backoff.test.mjs
@@ -16,7 +16,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test label-budget-backoff.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -30,7 +30,12 @@ import {
   isCloudLabelRejection,
   shouldCoolDownLabel,
 } from "./label-failure-class.mjs";
-import { convergeHeldLabel, convergeDispositionLabel } from "./scheduler.mjs";
+import {
+  convergeHeldLabel,
+  convergeDispositionLabel,
+  labelCooldownPath,
+  labelRetryState,
+} from "./scheduler.mjs";
 import { labelOnce } from "./label-guard.mjs";
 
 let orchDir;
@@ -359,5 +364,151 @@ describe("⛔ CTL-2052: labelOnce must NOT write .skipped for the cloud label re
     expect(labelOnce(orchDir, "CTL-24", "needs-human", w)).toBe(true);
     expect(labelOnce(orchDir, "CTL-24", "needs-human", w)).toBe(false);
     expect(w.calls.length).toBe(1);
+  });
+});
+
+// ── CTL-2052 Phase 2 (AC3) — bound retries to N, then stop and say so ─────────
+describe("CTL-2052 labelRetryState — the pure cap arithmetic", () => {
+  const cfg = { cap: 3, exhaustedMs: 1_000 };
+  test("below the cap → not blocked, not a probe", () => {
+    expect(labelRetryState({ failedAt: 0, attempts: 2 }, 100, cfg)).toMatchObject({
+      blocked: false,
+      exhaustedProbe: false,
+      attempts: 2,
+    });
+  });
+  test("at the cap, inside the exhausted window → BLOCKED", () => {
+    expect(labelRetryState({ failedAt: 0, attempts: 3 }, 500, cfg)).toMatchObject({
+      blocked: true,
+      exhaustedProbe: false,
+    });
+  });
+  test("at the cap, PAST the exhausted window → a single self-heal probe (not blocked)", () => {
+    expect(labelRetryState({ failedAt: 0, attempts: 3 }, 2_000, cfg)).toMatchObject({
+      blocked: false,
+      exhaustedProbe: true,
+    });
+  });
+  test("a null / absent marker → nothing recorded yet, not blocked", () => {
+    expect(labelRetryState(null, 0, cfg)).toMatchObject({ blocked: false, exhaustedProbe: false, attempts: 0 });
+    expect(labelRetryState({}, 0, cfg)).toMatchObject({ blocked: false, attempts: 0 });
+  });
+});
+
+describe("CTL-2052 Phase 2: the converger counts cool-down cycles, then stops", () => {
+  const readAttempts = (ticket, label) =>
+    JSON.parse(readFileSync(labelCooldownPath(orchDir, ticket, label), "utf8")).attempts;
+
+  test("the attempt counter increments once per cool-down CYCLE, not per tick", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 3_000_000;
+    const opts = { orchDir, now: () => clock, retryCap: 100, retryExhaustedMs: 10_000_000 };
+    convergeDispositionLabel("CTL-30", [], "blocked", w, opts); // apply 1 → attempts 1
+    expect(readAttempts("CTL-30", "blocked")).toBe(1);
+    clock += 1_000; // still inside the 60 s window: 0 applies, no increment
+    convergeDispositionLabel("CTL-30", [], "blocked", w, opts);
+    expect(readAttempts("CTL-30", "blocked")).toBe(1);
+    clock += 61_000; // window elapsed → apply 2
+    convergeDispositionLabel("CTL-30", [], "blocked", w, opts);
+    expect(readAttempts("CTL-30", "blocked")).toBe(2);
+    clock += 61_000; // apply 3
+    convergeDispositionLabel("CTL-30", [], "blocked", w, opts);
+    expect(readAttempts("CTL-30", "blocked")).toBe(3);
+    expect(w.calls.length).toBe(3);
+  });
+
+  test("after the cap the converger stops re-issuing — the cap gate wins over the time gate", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 3_000_000;
+    const opts = { orchDir, now: () => clock, retryCap: 3, retryExhaustedMs: 1_800_000 };
+    for (let i = 0; i < 3; i++) {
+      convergeDispositionLabel("CTL-31", [], "blocked", w, opts);
+      clock += 61_000;
+    }
+    expect(w.calls.length).toBe(3); // reached the cap
+    // 4th convergence: the 60 s window has elapsed, but the cap gate short-circuits first.
+    convergeDispositionLabel("CTL-31", [], "blocked", w, opts);
+    expect(w.calls.length).toBe(3);
+    clock += 61_000;
+    convergeDispositionLabel("CTL-31", [], "blocked", w, opts);
+    expect(w.calls.length).toBe(3);
+  });
+
+  test("convergeHeldLabel enforces the same cap", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 3_000_000;
+    const opts = { orchDir, now: () => clock, retryCap: 2, retryExhaustedMs: 1_800_000 };
+    for (let i = 0; i < 2; i++) {
+      convergeHeldLabel("CTL-35", [], "blocked", w, opts);
+      clock += 61_000;
+    }
+    expect(w.calls.length).toBe(2);
+    convergeHeldLabel("CTL-35", [], "blocked", w, opts);
+    expect(w.calls.length).toBe(2);
+  });
+
+  test("the retry-exhausted escalation fires EXACTLY ONCE, on the cap crossing (edge-triggered)", () => {
+    const w = failingWriter("cloud:label-rejected");
+    const events = [];
+    let clock = 3_000_000;
+    const opts = {
+      orchDir,
+      now: () => clock,
+      retryCap: 3,
+      retryExhaustedMs: 1_800_000,
+      onRetryExhausted: (info) => events.push(info),
+    };
+    for (let i = 0; i < 6; i++) {
+      convergeDispositionLabel("CTL-32", [], "blocked", w, opts);
+      clock += 61_000;
+    }
+    expect(events.length).toBe(1);
+    expect(events[0]).toMatchObject({
+      ticket: "CTL-32",
+      label: "blocked",
+      attempts: 3,
+      reason: "cloud:label-rejected",
+    });
+  });
+
+  test("the stop SELF-HEALS: after the long window exactly one probe apply is allowed again", () => {
+    const w = failingWriter("cloud:label-rejected");
+    let clock = 3_000_000;
+    const opts = { orchDir, now: () => clock, retryCap: 3, retryExhaustedMs: 1_800_000 };
+    for (let i = 0; i < 3; i++) {
+      convergeDispositionLabel("CTL-33", [], "blocked", w, opts);
+      clock += 61_000;
+    }
+    expect(w.calls.length).toBe(3);
+    convergeDispositionLabel("CTL-33", [], "blocked", w, opts); // still capped inside the long window
+    expect(w.calls.length).toBe(3);
+    clock += 1_800_001; // past the exhausted window → one self-heal probe
+    convergeDispositionLabel("CTL-33", [], "blocked", w, opts);
+    expect(w.calls.length).toBe(4);
+  });
+
+  test("a SUCCESSFUL apply resets the ledger — the counter starts fresh next time", () => {
+    let mode = "fail";
+    const calls = [];
+    const w = {
+      calls,
+      applyLabel({ ticket, label }) {
+        calls.push({ ticket, label });
+        return mode === "fail"
+          ? { applied: false, reason: "cloud:label-rejected" }
+          : { applied: true, reason: null };
+      },
+      removeLabel() {},
+    };
+    let clock = 3_000_000;
+    const opts = { orchDir, now: () => clock, retryCap: 10, retryExhaustedMs: 10_000_000 };
+    convergeDispositionLabel("CTL-34", [], "blocked", w, opts); // fail → attempts 1
+    clock += 61_000;
+    convergeDispositionLabel("CTL-34", [], "blocked", w, opts); // fail → attempts 2
+    expect(readAttempts("CTL-34", "blocked")).toBe(2);
+    clock += 61_000;
+    mode = "ok";
+    convergeDispositionLabel("CTL-34", [], "blocked", w, opts); // success → ledger cleared
+    expect(existsSync(labelCooldownPath(orchDir, "CTL-34", "blocked"))).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/label-failure-class.mjs
+++ b/plugins/dev/scripts/execution-core/label-failure-class.mjs
@@ -92,6 +92,35 @@ export const BUDGET_REASON_PREFIX = "budget:";
  */
 export const THROTTLED_LABEL_REASONS = Object.freeze(new Set(["rate-limited", "unauthorized"]));
 
+/**
+ * CLOUD_LABEL_REJECTION_REASONS — CTL-2052, a THIRD class: a DETERMINISTIC cloud
+ * rejection of a LABEL write.
+ *
+ * ⛔ On the enforce/proxy path (CTL-1889) the caller cannot read WHY Linear refused.
+ * The direct `linearis` path maps stderr "not exclusive child labels" →
+ * `exclusive-conflict` (TERMINAL), but through the proxy the same rejection surfaces
+ * as the generic `cloud:failed` / `cloud:rejected` — the human string lives only in
+ * the cloud's own logs, and `routeThroughProxy` drops `status`. So this class is
+ * reason-AGNOSTIC: a deterministic label rejection is cool-down-eligible on the
+ * strength of BEING one, without proving it is specifically an exclusive conflict.
+ * The normalization to the single member below happens at the one chokepoint that
+ * knows the route (`linear-write.mjs` `normalizeLabelProxyVerdict`); this set is the
+ * classifier's view of the already-normalized reason.
+ *
+ * ⛔ Deliberately NOT TERMINAL. Being unprovable-terminal on this host, it must never
+ * earn `labelOnce`'s permanent `.skipped` (COORD-236): a `needs-human` refused during
+ * one bad minute would be abandoned for the daemon's life and the operator it exists
+ * to page would never be paged.
+ * ⛔ Deliberately NOT THROTTLED. It is not a budget/rate-limit that clears on its own,
+ * so the operator log must not say "throttled/budget" (AC2 — surface the RIGHT reason).
+ */
+export const CLOUD_LABEL_REJECTION_REASONS = Object.freeze(new Set(["cloud:label-rejected"]));
+
+/** isCloudLabelRejection — a deterministic cloud LABEL rejection (CTL-2052). */
+export function isCloudLabelRejection(reason) {
+  return typeof reason === "string" && CLOUD_LABEL_REJECTION_REASONS.has(reason);
+}
+
 /** isTerminalLabelReason — may never land this run; stop retrying entirely. */
 export function isTerminalLabelReason(reason) {
   return typeof reason === "string" && TERMINAL_LABEL_REASONS.has(reason);
@@ -116,5 +145,9 @@ export function isThrottledLabelReason(reason) {
  * is permanent, and a throttled reason must never earn it.
  */
 export function shouldCoolDownLabel(reason) {
-  return isTerminalLabelReason(reason) || isThrottledLabelReason(reason);
+  return (
+    isTerminalLabelReason(reason) ||
+    isThrottledLabelReason(reason) ||
+    isCloudLabelRejection(reason) // CTL-2052 — the deterministic cloud label rejection cools down too
+  );
 }

--- a/plugins/dev/scripts/execution-core/label-retry-event.mjs
+++ b/plugins/dev/scripts/execution-core/label-retry-event.mjs
@@ -1,0 +1,83 @@
+// label-retry-event.mjs — CTL-2052 (AC3). The "stopped after N and said so" event.
+//
+// After N cool-down cycles for the same (ticket, label) the converger STOPS
+// re-issuing (long back-off) and emits ONE `linear.label.retry-exhausted` — the
+// operator-visible record that a genuinely stuck label was bounded rather than
+// retried once-per-window forever. Edge-triggered (one per cap crossing), same
+// discipline as CTL-1817's sparse-warn.
+//
+// The `linear.label.*` prefix is UNPROTECTED under the CTL-1142 namespace contract
+// (not filter.* / broker.daemon.* / session.heartbeat / phase.<name>.<terminal>),
+// so it routes through shouldSkipEvent normally and carries no phase slot — asserted
+// in broker/namespace-parity.test.mjs, which imports THIS constant rather than a
+// re-typed literal (the CTL-1659/CTL-1889/CTL-2076 discipline).
+//
+// Mirrors capacity-event.mjs: a pure OTel envelope builder + a best-effort appender
+// that never throws.
+
+import { mkdirSync, appendFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getHostName, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const LABEL_RETRY_EXHAUSTED_EVENT = "linear.label.retry-exhausted";
+
+/**
+ * buildLabelRetryExhaustedEnvelope — pure OTel envelope for the retry-exhausted
+ * escalation. `reason` is the normalized failure class that drove the back-off
+ * (e.g. cloud:label-rejected), surfaced verbatim so AC2's "with the reason" survives.
+ */
+export function buildLabelRetryExhaustedEnvelope({ ticket, label, attempts, reason, now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  const host = getHostName();
+  return {
+    ts,
+    id: randomBytes(8).toString("hex"),
+    observedTs: ts,
+    severityText: "WARN",
+    severityNumber: 13,
+    traceId: null,
+    spanId: null,
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": LABEL_RETRY_EXHAUSTED_EVENT,
+      "event.entity": "label",
+      "event.action": "retry.exhausted",
+      "event.label": ticket,
+    },
+    body: {
+      payload: {
+        "host.name": host,
+        ticket,
+        label,
+        attempts,
+        reason,
+      },
+    },
+  };
+}
+
+/**
+ * emitLabelRetryExhaustedEvent — append one retry-exhausted envelope line. Returns
+ * true on success, false on any failure (best-effort; never throws — AC3's operator
+ * "says so" also rides the daemon log.error, so a lost event never blocks the stop).
+ */
+export function emitLabelRetryExhaustedEvent({
+  ticket,
+  label,
+  attempts,
+  reason,
+  logPath = getEventLogPath(),
+  now,
+} = {}) {
+  const line = `${JSON.stringify(buildLabelRetryExhaustedEnvelope({ ticket, label, attempts, reason, now }))}\n`;
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, line);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "label-retry-event: event append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write-proxy-wiring.test.mjs
@@ -12,6 +12,7 @@ import {
   applyPhaseStatus,
   applyTerminalDone,
   getLinearWriteProxy,
+  normalizeLabelProxyVerdict,
   removeLabel,
   setLinearWriteProxy,
   setLinearWriteProxyResolver,
@@ -553,6 +554,88 @@ describe("removeLabel — the proxied removal runs BEFORE the credentialed read"
     expect(r).toEqual({ removed: true, wrote: true });
     expect(proxy.sends).toEqual([{ routeId: "label", ticket: "CTL-8", payload: {}, caller: "removeLabel" }]);
     expect(calls[0].args).toEqual(["issues", "update", "CTL-8", "--labels", "bug", "--label-mode", "overwrite"]);
+  });
+});
+
+// ── CTL-2052 ─────────────────────────────────────────────────────────────────
+// On the enforce/proxy path the caller cannot read WHY the cloud refused a label
+// write — the verdict carries `detail:"failed"`, not "not exclusive child labels".
+// So a DETERMINISTIC cloud label rejection (`cloud:failed`/`cloud:rejected` on the
+// `label` route) is normalized to `cloud:label-rejected`, which the converger
+// cool-down recognizes, WITHOUT dropping `detail` (AC2: surfaced with the reason).
+describe("CTL-2052 normalizeLabelProxyVerdict — the pure classifier", () => {
+  test("maps the two deterministic label-rejection reasons ONLY on the label route", () => {
+    for (const reason of ["cloud:failed", "cloud:rejected"]) {
+      expect(
+        normalizeLabelProxyVerdict({ applied: false, reason, detail: "failed" }, "label")
+      ).toEqual({ applied: false, reason: "cloud:label-rejected", detail: "failed" });
+    }
+  });
+
+  test("preserves detail verbatim (AC2 — do not swallow the reason)", () => {
+    const out = normalizeLabelProxyVerdict(
+      { applied: false, reason: "cloud:rejected", detail: "some-cloud-detail" },
+      "label"
+    );
+    expect(out.detail).toBe("some-cloud-detail");
+  });
+
+  test("leaves every OTHER reason alone on the label route", () => {
+    // These already classify correctly (throttled / terminal / budget); only the
+    // two deterministic-rejection reasons are touched. cloud:exhausted is the budget
+    // refusal deliberately left out of scope.
+    for (const reason of ["unauthorized", "rate-limited", "server-error", "cloud:exhausted", "budget:ticket-cap", "not-found"]) {
+      const v = { applied: false, reason };
+      expect(normalizeLabelProxyVerdict(v, "label")).toBe(v);
+    }
+  });
+
+  test("leaves the two rejection reasons alone on a NON-label route (issue-state / comment)", () => {
+    for (const routeId of ["issue-state", "comment", "estimate"]) {
+      const v = { applied: false, reason: "cloud:failed", detail: "failed" };
+      expect(normalizeLabelProxyVerdict(v, routeId)).toBe(v);
+    }
+  });
+
+  test("never touches a SUCCESS verdict or a null/absent verdict", () => {
+    const ok = { applied: true, reason: null };
+    expect(normalizeLabelProxyVerdict(ok, "label")).toBe(ok);
+    expect(normalizeLabelProxyVerdict(null, "label")).toBe(null);
+    expect(normalizeLabelProxyVerdict(undefined, "label")).toBe(undefined);
+  });
+});
+
+describe("CTL-2052 applyLabel/removeLabel: the proxy verdict is normalized end-to-end", () => {
+  test("applyLabel enforce: cloud:failed → cloud:label-rejected (detail preserved)", () => {
+    const proxy = fakeProxy("enforce", { handled: true, applied: false, reason: "cloud:failed", detail: "failed" });
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyLabel({ ticket: "CTL-25", label: "blocked", exec: () => { throw new Error("must not exec"); }, proxy });
+    expect(r).toEqual({ applied: false, reason: "cloud:label-rejected", detail: "failed" });
+  });
+
+  test("applyLabel enforce: cloud:rejected normalizes the same way", () => {
+    const proxy = fakeProxy("enforce", { handled: true, applied: false, reason: "cloud:rejected", detail: "failed" });
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyLabel({ ticket: "CTL-25", label: "blocked", exec: () => { throw new Error("must not exec"); }, proxy });
+    expect(r.reason).toBe("cloud:label-rejected");
+  });
+
+  test("applyLabel enforce LEAVE-ALONE: unauthorized passes through unchanged", () => {
+    const proxy = fakeProxy("enforce", { handled: true, applied: false, reason: "unauthorized" });
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = applyLabel({ ticket: "CTL-25", label: "blocked", exec: () => { throw new Error("must not exec"); }, proxy });
+    expect(r).toEqual({ applied: false, reason: "unauthorized" });
+  });
+
+  test("removeLabel enforce: cloud:failed → cloud:label-rejected", async () => {
+    const proxy = fakeProxy("enforce", { handled: true, applied: false, reason: "cloud:failed", detail: "failed" });
+    setLinearWriteProxyResolver(fakeResolver());
+    const r = await removeLabel("CTL-26", "needs-human", {
+      exec: () => { throw new Error("must not exec"); },
+      readLabels: () => ({ ok: true, labels: ["needs-human", "bug"] }),
+      proxy,
+    });
+    expect(r).toEqual({ removed: false, wrote: false, reason: "cloud:label-rejected" });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/linear-write.mjs
+++ b/plugins/dev/scripts/execution-core/linear-write.mjs
@@ -67,6 +67,24 @@ export {
  * host-originated writes" while the host was still writing. Every caller below
  * already retries on the next tick.
  */
+// CTL-2052 — reason-agnostic normalization of a DETERMINISTIC cloud LABEL rejection.
+// `routeThroughProxy` is the single chokepoint both applyLabel (mode:add) and
+// removeLabel (mode:remove) flow through, and it is the only place `routeId` is known
+// (the caller below loses both routeId and status). Through the proxy an exclusive
+// conflict — which the direct path classifies as the terminal `exclusive-conflict` —
+// surfaces only as the generic `cloud:failed` / `cloud:rejected` with detail:"failed".
+// Such a rejection will not change on the next tick while the label state is unchanged,
+// so map it to the cool-down-eligible reason the converger recognizes. `detail` is
+// preserved so AC2's "surfaced WITH the reason" carries the cloud's own detail verbatim.
+// Only the label route and only these two deterministic reasons are touched; a success,
+// a null verdict, and every other reason pass through by identity (===).
+const DETERMINISTIC_LABEL_PROXY_REASONS = new Set(["cloud:failed", "cloud:rejected"]);
+export function normalizeLabelProxyVerdict(verdict, routeId) {
+  if (routeId !== "label" || !verdict || verdict.applied !== false) return verdict;
+  if (!DETERMINISTIC_LABEL_PROXY_REASONS.has(verdict.reason)) return verdict;
+  return { ...verdict, reason: "cloud:label-rejected" };
+}
+
 // CTL-1936 / AC4: `caller` names the site that issued the write. The incident could not
 // be attributed from the event stream — 302 writes on one ticket with no record of what
 // produced them, and the daemon log had rotated. It is threaded from each call site
@@ -117,11 +135,17 @@ function routeThroughProxy(proxy, { routeId, ticket, buildPayload, caller = null
     return { applied: false, reason: "proxy-threw" };
   }
   if (!res?.handled) return null;
-  return {
-    applied: res.applied === true,
-    reason: res.reason ?? null,
-    ...(res.detail ? { detail: res.detail } : {}),
-  };
+  // CTL-2052 — normalize a deterministic cloud LABEL rejection into the
+  // cool-down-eligible reason before it reaches applyLabel/removeLabel (which lose
+  // routeId). No-op for every other route/reason (identity return).
+  return normalizeLabelProxyVerdict(
+    {
+      applied: res.applied === true,
+      reason: res.reason ?? null,
+      ...(res.detail ? { detail: res.detail } : {}),
+    },
+    routeId
+  );
 }
 
 // linear-transition.sh sits one directory up from execution-core/ — mirrors the

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -445,6 +445,8 @@ import {
   isThrottledLabelReason,
   isCloudLabelRejection,
 } from "./label-failure-class.mjs";
+// CTL-2052 (AC3): the "stopped after N and said so" escalation emitter.
+import { emitLabelRetryExhaustedEvent } from "./label-retry-event.mjs";
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
 import {
@@ -2729,13 +2731,57 @@ function classifyLabelCooldownLog(reason, { cloudMsg, throttledMsg, terminalMsg 
   return { cls: "terminal", message: terminalMsg };
 }
 
+// CTL-2052 (AC3) — the cap gate, shared by both convergers. Returns true when the apply
+// must be short-circuited: the attempt count has reached the cap and we are still inside
+// the long back-off window. Once that window elapses it resets the ledger so exactly ONE
+// self-heal probe is let through (the label can still land if the sibling was removed
+// meanwhile — COORD-236 "never permanently abandon a label"). Placed BEFORE the ordinary
+// per-window cool-down gate so the cap wins over the time gate.
+function labelRetryCapBlocks(orchDir, ticket, label, now, { cap, exhaustedMs }) {
+  const st = labelRetryState(readLabelCooldownMarker(orchDir, ticket, label), now, { cap, exhaustedMs });
+  if (st.blocked) return true;
+  if (st.exhaustedProbe) clearLabelCooldown(orchDir, ticket, label); // spend one self-heal probe
+  return false;
+}
+
+// CTL-2052 (AC3) — edge-triggered retry-exhausted escalation. Fires exactly on the
+// convergence that brings the attempt count to the cap (compare the post-increment
+// value), so a genuinely stuck label logs ONE operator line + one unified-log event,
+// not one per window (same discipline as CTL-1817's sparse-warn). The log.error is the
+// REQUIRED AC3 "says so" (Alloy→Loki); the event is additive and fail-open via the
+// injected `onRetryExhausted` seam (default null so bare unit ticks stay silent).
+function maybeEscalateRetryExhausted({ ticket, label, attempts, reason, cap, onRetryExhausted }) {
+  if (attempts !== cap) return;
+  log.error(
+    { ticket, label, attempts, reason },
+    "ctl-2052: label apply refused N times — stopping re-issue for the long back-off window and escalating (linear.label.retry-exhausted)"
+  );
+  onRetryExhausted?.({ ticket, label, attempts, reason });
+}
+
 export function convergeHeldLabel(
   ticket,
   current,
   desired,
   writeStatus,
-  { orchDir, now = Date.now, onRemoveResult } = {}
+  {
+    orchDir,
+    now = Date.now,
+    onRemoveResult,
+    retryCap = LABEL_RETRY_CAP,
+    retryExhaustedMs = LABEL_RETRY_EXHAUSTED_MS,
+    onRetryExhausted = null,
+  } = {}
 ) {
+  // CTL-2052 (AC3): cap gate — after N cool-down cycles STOP re-issuing for the long
+  // back-off window (one self-heal probe once it elapses). Before the per-window gate.
+  if (
+    orchDir &&
+    desired &&
+    labelRetryCapBlocks(orchDir, ticket, desired, now(), { cap: retryCap, exhaustedMs: retryExhaustedMs })
+  ) {
+    return 0;
+  }
   // CTL-834: back off if a recent apply of `desired` failed unrecoverably.
   if (orchDir && desired && inLabelCooldown(orchDir, ticket, desired, now())) {
     return 0;
@@ -2845,7 +2891,7 @@ export function convergeHeldLabel(
       }
     }
     if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
-      recordLabelCooldown(orchDir, ticket, desired, now());
+      const attempts = recordLabelCooldown(orchDir, ticket, desired, now());
       // COORD-236 / CTL-2052: each class gets a DIFFERENT sentence, because an operator
       // reading "unrecoverable" for a budget refusal would go looking for a missing
       // label that is not missing, and reading "throttled" for a cloud rejection would
@@ -2857,7 +2903,10 @@ export function convergeHeldLabel(
           "coord-236: held-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses",
         terminalMsg: "ctl-834: held-label apply unrecoverable — backing off (cool-down)",
       });
-      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls }, message);
+      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls, attempts }, message);
+      maybeEscalateRetryExhausted({ ticket, label: desired, attempts, reason: res.reason, cap: retryCap, onRetryExhausted }); // CTL-2052 AC3
+    } else if (orchDir && desired && (res === undefined || res?.applied === true)) {
+      clearLabelCooldown(orchDir, ticket, desired); // CTL-2052: success resets the ledger
     }
   }
   return writes;
@@ -2893,7 +2942,13 @@ export function convergeDispositionLabel(
   current,
   desired,
   writeStatus,
-  { orchDir, now = Date.now } = {}
+  {
+    orchDir,
+    now = Date.now,
+    retryCap = LABEL_RETRY_CAP,
+    retryExhaustedMs = LABEL_RETRY_EXHAUSTED_MS,
+    onRetryExhausted = null,
+  } = {}
 ) {
   const have = new Set(current ?? []);
   // Precedence suppression: if needs-human is already applied AND desired is one of
@@ -2902,6 +2957,15 @@ export function convergeDispositionLabel(
   // When desired=null (clear-on-pickup), we still remove stale tick-converged labels
   // but leave needs-human alone (it is cleared only by genuine resolution).
   if (have.has(HELD_LABEL_NEEDS_HUMAN) && desired !== null && desired !== undefined) return 0;
+  // CTL-2052 (AC3): cap gate — STOP re-issuing after N cool-down cycles (one self-heal
+  // probe once the long window elapses). Before the ordinary per-window cool-down.
+  if (
+    orchDir &&
+    desired &&
+    labelRetryCapBlocks(orchDir, ticket, desired, now(), { cap: retryCap, exhaustedMs: retryExhaustedMs })
+  ) {
+    return 0;
+  }
   // CTL-834: back off if a recent apply of `desired` failed unrecoverably.
   if (orchDir && desired && inLabelCooldown(orchDir, ticket, desired, now())) {
     return 0;
@@ -2930,7 +2994,7 @@ export function convergeDispositionLabel(
     }
     writes++;
     if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
-      recordLabelCooldown(orchDir, ticket, desired, now());
+      const attempts = recordLabelCooldown(orchDir, ticket, desired, now());
       const { cls, message } = classifyLabelCooldownLog(res.reason, {
         cloudMsg:
           "ctl-2052: disposition-label apply refused by the cloud (deterministic) — backing off (cool-down); this write is not re-issued until the cool-down elapses",
@@ -2938,7 +3002,10 @@ export function convergeDispositionLabel(
           "coord-236: disposition-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses",
         terminalMsg: "ctl-764: disposition-label apply unrecoverable — backing off (cool-down)",
       });
-      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls }, message);
+      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls, attempts }, message);
+      maybeEscalateRetryExhausted({ ticket, label: desired, attempts, reason: res.reason, cap: retryCap, onRetryExhausted }); // CTL-2052 AC3
+    } else if (orchDir && desired && (res === undefined || res?.applied === true)) {
+      clearLabelCooldown(orchDir, ticket, desired); // CTL-2052: success resets the ledger
     }
   }
   return writes;
@@ -3013,18 +3080,56 @@ export function convergeStartedHeldLabels(
 export function labelCooldownPath(orchDir, ticket, label) {
   return join(orchDir, ".label-cooldowns", `${ticket}-${label}.json`);
 }
-function inLabelCooldown(orchDir, ticket, label, now) {
+// CTL-2052 — read the cool-down marker (or null). Its own owner of the parse, so the
+// attempt-counter reader and the time gate below cannot disagree about the shape.
+function readLabelCooldownMarker(orchDir, ticket, label) {
   try {
-    const marker = JSON.parse(readFileSync(labelCooldownPath(orchDir, ticket, label), "utf8"));
-    return typeof marker.failedAt === "number" && now - marker.failedAt < LABEL_COOLDOWN_MS;
+    return JSON.parse(readFileSync(labelCooldownPath(orchDir, ticket, label), "utf8"));
   } catch {
-    return false;
+    return null;
   }
 }
+// CTL-2052 — clear the ledger (on a successful apply, or when spending the single
+// self-heal probe). ENOENT is the expected case. Best-effort; never throws.
+function clearLabelCooldown(orchDir, ticket, label) {
+  try {
+    unlinkSync(labelCooldownPath(orchDir, ticket, label));
+  } catch {
+    /* ENOENT — nothing to clear */
+  }
+}
+function inLabelCooldown(orchDir, ticket, label, now) {
+  const marker = readLabelCooldownMarker(orchDir, ticket, label);
+  return marker != null && typeof marker.failedAt === "number" && now - marker.failedAt < LABEL_COOLDOWN_MS;
+}
+// CTL-2052 — the marker carries a per-(ticket,label) attempt count so AC3 can bound
+// the storm. Read the prior count, increment, persist, and RETURN the new value so the
+// caller can edge-trigger the cap-crossing escalation. Backward-compatible: an old
+// marker without `attempts` reads as 0, so the first increment is 1.
 function recordLabelCooldown(orchDir, ticket, label, now) {
   const p = labelCooldownPath(orchDir, ticket, label);
   mkdirSync(dirname(p), { recursive: true });
-  writeFileSync(p, JSON.stringify({ failedAt: now }));
+  const prior = readLabelCooldownMarker(orchDir, ticket, label);
+  const priorAttempts = prior && Number.isInteger(prior.attempts) ? prior.attempts : 0;
+  const attempts = priorAttempts + 1;
+  writeFileSync(p, JSON.stringify({ failedAt: now, attempts }));
+  return attempts;
+}
+
+// CTL-2052 (AC3) — the pure cap arithmetic, exported so it can be exercised without
+// disk. `blocked` short-circuits the apply (still inside the long back-off after the
+// cap); `exhaustedProbe` says the long window elapsed so the caller may allow ONE probe
+// (and reset the ledger, so the label can still land if the sibling was removed
+// meanwhile — it self-heals on a long timescale rather than never; COORD-236 "never
+// permanently abandon a label").
+export function labelRetryState(marker, now, { cap, exhaustedMs } = {}) {
+  const attempts = marker && Number.isInteger(marker.attempts) ? marker.attempts : 0;
+  const failedAt = marker && typeof marker.failedAt === "number" ? marker.failedAt : 0;
+  if (attempts >= cap) {
+    if (now - failedAt < exhaustedMs) return { blocked: true, attempts, exhaustedProbe: false };
+    return { blocked: false, attempts, exhaustedProbe: true };
+  }
+  return { blocked: false, attempts, exhaustedProbe: false };
 }
 
 // CTL-624: dispatch cool-down marker. Conceptually mirrors the labelOnce
@@ -7482,6 +7587,7 @@ export function schedulerTick(
           {
             orchDir,
             now,
+            onRetryExhausted: emitLabelRetryExhaustedEvent, // CTL-2052 AC3: the "stopped after N" event
             onRemoveResult: (label, removed) => {
               if (desired !== null || !removed || hasNeedsHuman) return;
               const fromHeld = label === LEGACY_HELD_LABEL_WAITING ? HELD_LABEL_WAITING : label;
@@ -9143,7 +9249,7 @@ export function schedulerTick(
           hit.labels,
           HELD_LABEL_NEEDS_INPUT,
           retractionWriteStatus,
-          { orchDir, now }
+          { orchDir, now, onRetryExhausted: emitLabelRetryExhaustedEvent } // CTL-2052 AC3
         );
         if (writes > 0) {
           recordTransition({
@@ -9361,6 +9467,15 @@ const DISPATCH_COOLDOWN_MS = Number(process.env.SCHEDULER_DISPATCH_COOLDOWN_MS) 
 // CTL-834: held-label apply cool-down window (convergeHeldLabel). Same default as
 // the dispatch cool-down; overridable for tests / quieter quota budgets.
 const LABEL_COOLDOWN_MS = Number(process.env.SCHEDULER_LABEL_COOLDOWN_MS) || 60_000;
+// CTL-2052 (AC3): after this many cool-down CYCLES for one (ticket,label), the
+// converger STOPS re-issuing (long back-off) and escalates once — so a genuinely
+// stuck label does not retry ~once-per-window forever. The current behavior is
+// effectively N=∞, so any finite cap is a strict improvement.
+const LABEL_RETRY_CAP = Number(process.env.SCHEDULER_LABEL_RETRY_CAP) || 5;
+// CTL-2052 (AC3): the long back-off held after the cap. > LABEL_COOLDOWN_MS so the cap
+// genuinely wins over the ordinary per-window gate; when it elapses, exactly one probe
+// is let through so a since-resolved conflict can still land (COORD-236 self-heal).
+const LABEL_RETRY_EXHAUSTED_MS = Number(process.env.SCHEDULER_LABEL_RETRY_EXHAUSTED_MS) || 1_800_000; // 30 min
 // CTL-713: permanent-failure cooldown. code=2 (prior_artifact_missing,
 // phase-agent-dispatch exit 2) is a structural refusal — back it off longer than
 // the 60s transient window. GC reaps the marker once the ticket leaves the eligible set.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -443,6 +443,7 @@ import {
   TERMINAL_LABEL_REASONS,
   shouldCoolDownLabel,
   isThrottledLabelReason,
+  isCloudLabelRejection,
 } from "./label-failure-class.mjs";
 // CTL-954: team estimation method — lazy-cached from Linear, used to expand
 // the allowed estimate point set beyond the hard-coded Fibonacci values.
@@ -2715,6 +2716,19 @@ function unmetBlockersFor(candidateId, edges, poolById, blockerStates) {
 // number of write calls issued (0 == idempotent no-op OR cooled-down). `orchDir`/
 // `now` are optional so legacy callers / bare unit ticks keep the prior
 // best-effort-every-tick behavior (the cool-down simply never arms).
+// CTL-2052 — the three-way operator-log discriminator, factored into ONE helper so the
+// two convergers (convergeHeldLabel / convergeDispositionLabel) cannot hand-drift their
+// class → message mapping (the header above warns they must stay in step —
+// CTL-834/CTL-764). It only chooses the class name for the structured
+// `label_failure_class` field and the human message; the caller supplies its own
+// converger-specific message trio. Order matters: cloud-rejection is checked first
+// because a `cloud:label-rejected` is neither throttled nor terminal.
+function classifyLabelCooldownLog(reason, { cloudMsg, throttledMsg, terminalMsg }) {
+  if (isCloudLabelRejection(reason)) return { cls: "cloud-rejection", message: cloudMsg };
+  if (isThrottledLabelReason(reason)) return { cls: "throttled", message: throttledMsg };
+  return { cls: "terminal", message: terminalMsg };
+}
+
 export function convergeHeldLabel(
   ticket,
   current,
@@ -2832,16 +2846,18 @@ export function convergeHeldLabel(
     }
     if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
       recordLabelCooldown(orchDir, ticket, desired, now());
-      // COORD-236: the two classes get DIFFERENT sentences, because an operator
-      // reading "unrecoverable" for a budget refusal would go looking for a
-      // missing label that is not missing.
-      const throttled = isThrottledLabelReason(res.reason);
-      log.warn(
-        { ticket, label: desired, reason: res.reason, label_failure_class: throttled ? "throttled" : "terminal" },
-        throttled
-          ? "coord-236: held-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses"
-          : "ctl-834: held-label apply unrecoverable — backing off (cool-down)"
-      );
+      // COORD-236 / CTL-2052: each class gets a DIFFERENT sentence, because an operator
+      // reading "unrecoverable" for a budget refusal would go looking for a missing
+      // label that is not missing, and reading "throttled" for a cloud rejection would
+      // hunt a non-existent budget problem (AC2 — surface the RIGHT reason).
+      const { cls, message } = classifyLabelCooldownLog(res.reason, {
+        cloudMsg:
+          "ctl-2052: held-label apply refused by the cloud (deterministic) — backing off (cool-down); this write is not re-issued until the cool-down elapses",
+        throttledMsg:
+          "coord-236: held-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses",
+        terminalMsg: "ctl-834: held-label apply unrecoverable — backing off (cool-down)",
+      });
+      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls }, message);
     }
   }
   return writes;
@@ -2915,13 +2931,14 @@ export function convergeDispositionLabel(
     writes++;
     if (orchDir && res && res.applied === false && shouldCoolDownLabel(res.reason)) {
       recordLabelCooldown(orchDir, ticket, desired, now());
-      const throttled = isThrottledLabelReason(res.reason);
-      log.warn(
-        { ticket, label: desired, reason: res.reason, label_failure_class: throttled ? "throttled" : "terminal" },
-        throttled
-          ? "coord-236: disposition-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses"
-          : "ctl-764: disposition-label apply unrecoverable — backing off (cool-down)"
-      );
+      const { cls, message } = classifyLabelCooldownLog(res.reason, {
+        cloudMsg:
+          "ctl-2052: disposition-label apply refused by the cloud (deterministic) — backing off (cool-down); this write is not re-issued until the cool-down elapses",
+        throttledMsg:
+          "coord-236: disposition-label apply THROTTLED (host write budget / rate limit) — backing off; this write is not re-issued until the cool-down elapses",
+        terminalMsg: "ctl-764: disposition-label apply unrecoverable — backing off (cool-down)",
+      });
+      log.warn({ ticket, label: desired, reason: res.reason, label_failure_class: cls }, message);
     }
   }
   return writes;

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1498,6 +1498,26 @@ outage can never quarantine a healthy, resolvable, in-flight ticket.
 `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` is the Linear-independent backstop; the runaway knobs are
 observability only.
 
+### Label-write retry cap (CTL-2052)
+
+The disposition/held-label convergers cool down a failed `applyLabel` (CTL-834/COORD-236). A
+**deterministic cloud label rejection** — an exclusive-conflict add that the write-proxy refuses,
+surfaced to the caller as the generic `cloud:failed`/`cloud:rejected` and normalized to
+`cloud:label-rejected` — is cool-down-eligible but never provably terminal on the host, so without a
+cap it would retry ~once per cool-down window forever (each refused write still spending a cloud
+write-budget unit). These env vars on the `catalyst-execution-core` process bound that:
+
+- `SCHEDULER_LABEL_RETRY_CAP` (default `5`) — after this many cool-down **cycles** for one
+  `(ticket, label)` the converger STOPS re-issuing the write and emits one
+  `linear.label.retry-exhausted` event (plus a `log.error`). Attempts are counted per cool-down
+  cycle, not per tick. The prior behavior was effectively `N=∞`, so any finite cap is a strict
+  improvement.
+- `SCHEDULER_LABEL_RETRY_EXHAUSTED_MS` (default `1800000`, 30 min) — the long back-off held after the
+  cap is reached. Must be `>` `SCHEDULER_LABEL_COOLDOWN_MS` so the cap wins over the ordinary
+  per-window cool-down. When it elapses, exactly **one** self-heal probe apply is allowed so a
+  since-resolved conflict can still land (the label is never permanently abandoned — COORD-236); a
+  successful apply resets the counter.
+
 ### Broker watchdog session eviction (CTL-1516)
 
 The broker's watchdog tick keeps per-session bookkeeping (`lastHeartbeat`, `workerToOrchestrator`)


### PR DESCRIPTION
Implements `thoughts/shared/plans/2026-08-21-ctl-2052.md`. Fixes the refused-proxy-label-write retry storm (CTL-2052).

**Problem.** On the enforce/proxy path an exclusive-conflict `applyLabel` surfaces to the caller as the generic `cloud:failed`/`cloud:rejected` (the human "not exclusive child labels" string lives only in the cloud's logs; `routeThroughProxy` drops `status`). Neither reason was terminal or throttled, so `shouldCoolDownLabel` was false and the converger re-fired the remove+add every tick forever — each refused write still spending a cloud write-budget unit (measured: 41 attempts on one issue in one evening).

**Phase 1 — classify & cool down (AC1 + AC2).**
- `label-failure-class.mjs`: a THIRD class `CLOUD_LABEL_REJECTION_REASONS` (`cloud:label-rejected`) + `isCloudLabelRejection`; `shouldCoolDownLabel` widened. Deliberately NOT terminal (never earns `labelOnce`'s permanent `.skipped` — COORD-236) and NOT throttled (operator log names the right thing — AC2).
- `linear-write.mjs`: pure exported `normalizeLabelProxyVerdict` maps `cloud:failed`/`cloud:rejected` → `cloud:label-rejected` **only** on the label route, preserving `detail`; wired into `routeThroughProxy` so both `applyLabel` and `removeLabel` get it.
- `scheduler.mjs`: the operator-log discriminator is one shared helper (cloud-rejection / throttled / terminal); the existing cool-down arms with zero change to the arming logic.

**Phase 2 — bound retries, then stop and say so (AC3).**
- The cool-down marker carries a per-`(ticket,label)` `attempts` count. A cap gate (`labelRetryState`) sits before the ordinary per-window cool-down: after `SCHEDULER_LABEL_RETRY_CAP` (default 5) cycles the converger STOPS for `SCHEDULER_LABEL_RETRY_EXHAUSTED_MS` (default 30 min), then lets exactly one self-heal probe through (COORD-236 "never permanently abandon a label"). Success resets the ledger.
- Edge-triggered on the cap crossing: one `log.error` (required AC3 "says so", Alloy→Loki) + one `linear.label.retry-exhausted` event (new `label-retry-event.mjs`, unprotected prefix, registered in `namespace-parity.test.mjs` by import).

**Testing.** Extended `label-budget-backoff.test.mjs` (classification, converger cool-down, `labelOnce`-no-`.skipped` asymmetry, attempt-cap, escalation-once, self-heal probe, success-reset) and `linear-write-proxy-wiring.test.mjs` (proxy-verdict normalization + leave-alone controls). `namespace-parity` registers the new event. scheduler.test.mjs regressions vs origin/main baseline: 0 (8 pre-existing flakes identical on both). docs-gate astro build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)