### PR TITLE
feat(dev): CTL-2133 — boot-resume pending-gate surfacing + stale-gate self-retirement

### DIFF
--- a/plugins/dev/scripts/execution-core/board-health.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.mjs
@@ -578,6 +578,12 @@ export function assembleBoardState({
   // claim evidence no ticket is ever granted grace, so an unwired daemon behaves
   // byte-identically to before this change. See checkDispatchLiveness.
   getDelegateClaims = () => new Map(),
+  // CTL-2133: the boot-resume pending-approval gates (listPendingApprovals output:
+  // { ticket, phase, ageMs, ... }). Injected so board-health.mjs stays fs-free (same
+  // seam shape as getStalledPrState / getStrandedEvidence). Empty-array default ⇒
+  // checkBootResumePending flags nothing (byte-identical until the daemon wires the
+  // real read). Never invoked in off mode so off stays byte-identical.
+  getPendingApprovals = () => [],
 } = {}) {
   const nowMs = now();
   const safe = (fn, fallback) => {
@@ -725,6 +731,19 @@ export function assembleBoardState({
     // hasTriageArtifact seam this is always an empty Set (shadow-safe, inert until
     // the daemon binds the real fs check at the scheduler call site).
     triageLaunchFailureOnlyTickets,
+    // CTL-2133: boot-resume pending-approval gates for checkBootResumePending. Off
+    // mode returns [] (byte-identical); shadow/enforce read the injected seam once.
+    // Normalized to { ticket, phase, ageMs, ageHours } so the pure invariant needs
+    // no fs and the board-scan line can render ticket · phase · ageHours.
+    pendingApprovals:
+      mode === "off"
+        ? []
+        : safe(() => getPendingApprovals(), []).map((g) => ({
+            ticket: g.ticket ?? g.identifier ?? null,
+            phase: g.phase ?? null,
+            ageMs: Number.isFinite(g.ageMs) ? g.ageMs : null,
+            ageHours: Number.isFinite(g.ageMs) ? Math.round(g.ageMs / 3600e3) : null,
+          })),
   });
 }
 
@@ -775,6 +794,12 @@ export function evaluateInvariants(boardState, { thresholds = DEFAULT_THRESHOLDS
       // gated like its siblings so the off set stays byte-identical.
       stalledPr: () => checkStalledPr(boardState, thresholds),
       nodeProductivity: () => checkNodeProductivity(boardState, thresholds),
+      // CTL-2133: visibility-only invariant — lists every boot-resume pending
+      // approval gate (ticket · phase · ageHours) so the silent pen is visible in
+      // the every-tick recovery.board-scan line. Tier-3 escalate-only (never
+      // dispatched — approval is deliberately an operator act). Cohort-gated like
+      // its siblings so the off invariant set stays byte-identical to origin/main.
+      bootResumePending: () => checkBootResumePending(boardState),
     });
   }
   const out = {};
@@ -1056,6 +1081,25 @@ function checkNodeProductivity(b, t) {
   // true here (observable:false likewise keeps Gate 3 from reading it).
   if (mode !== "enforce") return invariant(true, 0, false, flagged, `${mode}: ${note}`, { unproductive: details });
   return invariant(flagged.length === 0, flagged.length, true, flagged, note, { unproductive: details });
+}
+
+// #N — boot-resume pending-approval visibility (CTL-2133 Scenario 1). PURE over the
+// pre-read pendingApprovals list. This is NOT a recovery invariant: it never proposes
+// a per-ticket unstick move (approval is deliberately an operator act — see
+// proposeMoves, where its flagged set maps to a Tier-3 escalate-only line). It exists
+// only so the every-tick recovery.board-scan carries `ticket · phase · ageHours` for
+// each gate — the board-side half of closing the silent-pen (the per-gate event in
+// boot-resume.mjs is the other, always-on, half). observable:true always so a
+// non-empty pen is a positive-control-clean read, never an empty-loop all-clear.
+function checkBootResumePending(b) {
+  const pending = Array.isArray(b?.pendingApprovals) ? b.pendingApprovals : [];
+  const flagged = pending.map((g) => g.ticket).filter(Boolean);
+  const note = flagged.length
+    ? `${flagged.length} boot-resume approval gate(s) pending`
+    : "no boot-resume approval gates pending";
+  return invariant(flagged.length === 0, flagged.length, true, flagged, note, {
+    pending: pending.map((g) => ({ ticket: g.ticket, phase: g.phase, ageHours: g.ageHours })),
+  });
 }
 
 // CTL-1435 (C2): the skippedReason values that mean "the delegate proceeded with
@@ -1753,6 +1797,26 @@ export function proposeMoves(invariants, _b) {
   for (const p of invariants.projectSilence?.flagged ?? []) {
     if (!invariants.projectSilence.ok) tier3.push({ project: p, move: "escalate-project-silence", rationale: "no movement in expected cadence" });
   }
+  // CTL-2133: pending boot-resume approval gates are Tier-3 escalate-only — surfaced,
+  // NEVER dispatched (approval is an operator act; a recovery worker must not
+  // auto-approve an expensive-phase re-run). Carries phase + age per gate so the
+  // recovery.board-scan / HUD line names `ticket · phase · ageHours`.
+  const bootPending = invariants.bootResumePending?.pending ?? [];
+  const bootPendingByTicket = new Map(bootPending.map((g) => [g.ticket, g]));
+  for (const t of invariants.bootResumePending?.flagged ?? []) {
+    if (!invariants.bootResumePending.ok) {
+      const g = bootPendingByTicket.get(t) ?? {};
+      tier3.push({
+        ticket: t,
+        move: "escalate-boot-resume-pending",
+        phase: g.phase ?? null,
+        ageHours: g.ageHours ?? null,
+        rationale: `boot-resume approval gate pending${g.phase ? ` on ${g.phase}` : ""}${
+          g.ageHours != null ? ` for ${g.ageHours}h` : ""
+        }`,
+      });
+    }
+  }
   return { tier1, tier2, tier3 };
 }
 
@@ -2027,6 +2091,10 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
       slotFree,
       eligibleOwnedDepth: board == null ? null : board.eligible.filter((e) => owns(e.id)).length,
       unproductiveNodeCount: invariants.nodeProductivity?.flagged?.length ?? 0,
+      // CTL-2133: chartable count of boot-resume approval gates pending this scan —
+      // so an operator can watch the silent-pen depth in Grafana without parsing the
+      // per-gate list below.
+      bootResumePendingCount: invariants.bootResumePending?.flagged?.length ?? 0,
       githubCoreRemaining: githubQuota?.remaining ?? null,
       githubCoreRemainingPct: githubQuota?.remainingPct ?? null,
       invariants: Object.fromEntries(
@@ -2034,6 +2102,10 @@ export function buildBoardScanEvent({ mode, invariants, decision, act = null, bo
       ),
       // ── rosters/proposals: stay in body.payload, NEVER promoted (cardinality) ──
       flagged: dedupeFlagged(invariants),
+      // CTL-2133: the per-gate pending list (ticket · phase · ageHours). Ticket-keyed
+      // → body.payload, never a promoted scalar. This is the visibility surface that
+      // closes the silent pen on the board side.
+      bootResumePending: invariants.bootResumePending?.pending ?? [],
       // CTL-1644 (Codex P2 round 3): the full per-ticket classified route map
       // ({route, dispatchable, rationale, ...}), emitted on EVERY scan regardless
       // of whether anything dispatched. For a held-only board the anchor filter

--- a/plugins/dev/scripts/execution-core/board-health.test.mjs
+++ b/plugins/dev/scripts/execution-core/board-health.test.mjs
@@ -117,6 +117,9 @@ function mkBoard(o = {}) {
     // ticket is ever granted delegate-lands grace, so every pre-existing test
     // exercises exactly the pre-CTL-1744 behavior.
     delegateClaims: o.delegateClaims ?? new Map(),
+    // CTL-2133: boot-resume pending-approval gates. Empty default ⇒
+    // checkBootResumePending is green (inert) for every pre-existing test.
+    pendingApprovals: o.pendingApprovals ?? [],
     now: o.now ?? NOW,
   };
 }
@@ -3171,5 +3174,88 @@ describe("CAT-57 nodeProductivity invariant", () => {
     let called = 0;
     expect(() => assembleBoardState({ mode: "off", productivityMode: "enforce", getPeerProductivity: () => { called += 1; throw new Error("must not run"); } })).not.toThrow();
     expect(called).toBe(0);
+  });
+});
+
+// ─── CTL-2133: bootResumePending — the boot-resume gate visibility invariant ──
+describe("bootResumePending invariant (CTL-2133)", () => {
+  const pending = (rows) => mkBoard({ mode: "shadow", pendingApprovals: rows });
+
+  test("7. N pending markers → flagged=[tickets], observable, extra.pending, Tier-3 only", () => {
+    const rows = [
+      { ticket: "CTL-300", phase: "implement", ageHours: 4 },
+      { ticket: "CTL-301", phase: "verify", ageHours: 12 },
+    ];
+    const inv = evaluateInvariants(pending(rows)).bootResumePending;
+    expect(inv.observable).toBe(true);
+    expect(inv.ok).toBe(false);
+    expect(inv.flagged.sort()).toEqual(["CTL-300", "CTL-301"]);
+    expect(inv.pending).toEqual([
+      { ticket: "CTL-300", phase: "implement", ageHours: 4 },
+      { ticket: "CTL-301", phase: "verify", ageHours: 12 },
+    ]);
+    // Tier-3 escalate-only: appears in tier3, never tier1/tier2.
+    const moves = proposeMoves(evaluateInvariants(pending(rows)), pending(rows));
+    const t3 = moves.tier3.filter((m) => m.move === "escalate-boot-resume-pending");
+    expect(t3.map((m) => m.ticket).sort()).toEqual(["CTL-300", "CTL-301"]);
+    expect(moves.tier1.some((m) => m.move === "escalate-boot-resume-pending")).toBe(false);
+    expect(moves.tier2.some((m) => m.move === "escalate-boot-resume-pending")).toBe(false);
+    // carries phase + age on the move for the board-scan line
+    expect(t3.find((m) => m.ticket === "CTL-300").phase).toBe("implement");
+    expect(t3.find((m) => m.ticket === "CTL-300").ageHours).toBe(4);
+  });
+
+  test("8. empty pen → flagged:[], ok:true, still observable:true (positive-control clean)", () => {
+    const inv = evaluateInvariants(pending([])).bootResumePending;
+    expect(inv.flagged).toEqual([]);
+    expect(inv.ok).toBe(true);
+    expect(inv.observable).toBe(true);
+    // no tier3 move for it
+    const moves = proposeMoves(evaluateInvariants(pending([])), pending([]));
+    expect(moves.tier3.some((m) => m.move === "escalate-boot-resume-pending")).toBe(false);
+  });
+
+  test("off mode omits the invariant entirely (off set stays byte-identical)", () => {
+    const r = evaluateInvariants(mkBoard({ mode: "off", pendingApprovals: [{ ticket: "CTL-302", phase: "pr" }] }));
+    expect(r.bootResumePending).toBeUndefined();
+  });
+
+  test("a Tier-3-only pending pen does not make the gate proceed (non-actuating)", () => {
+    const board = pending([{ ticket: "CTL-303", phase: "implement", ageHours: 3 }]);
+    const dec = decideBoardHealth(evaluateInvariants(board), board);
+    expect(dec.gate.decision).toBe("skip");
+    expect(dec.gate.reason).toBe("no-actionable-moves");
+  });
+
+  test("assembleBoardState off mode never invokes getPendingApprovals; shadow does", () => {
+    let called = 0;
+    const off = assembleBoardState({
+      orchDir: "/tmp/x",
+      mode: "off",
+      getPendingApprovals: () => { called += 1; return [{ ticket: "CTL-304", phase: "pr", ageMs: HOUR }]; },
+      now: () => NOW,
+    });
+    expect(called).toBe(0);
+    expect(off.pendingApprovals).toEqual([]);
+    const shadow = assembleBoardState({
+      orchDir: "/tmp/x",
+      mode: "shadow",
+      getPendingApprovals: () => [{ ticket: "CTL-305", phase: "implement", ageMs: 2 * HOUR }],
+      now: () => NOW,
+    });
+    expect(shadow.pendingApprovals).toEqual([
+      { ticket: "CTL-305", phase: "implement", ageMs: 2 * HOUR, ageHours: 2 },
+    ]);
+  });
+
+  test("buildBoardScanEvent carries bootResumePendingCount + the per-gate list", () => {
+    const board = pending([{ ticket: "CTL-306", phase: "verify", ageHours: 6 }]);
+    const invariants = evaluateInvariants(board);
+    const decision = decideBoardHealth(invariants, board);
+    const evt = buildBoardScanEvent({ mode: "shadow", invariants, decision, board });
+    expect(evt.details.bootResumePendingCount).toBe(1);
+    expect(evt.details.bootResumePending).toEqual([
+      { ticket: "CTL-306", phase: "verify", ageHours: 6 },
+    ]);
   });
 });

--- a/plugins/dev/scripts/execution-core/boot-resume.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.mjs
@@ -41,7 +41,10 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { emitBootResumePending as defaultEmitBootResumePending } from "./dispatch-alert.mjs"; // CTL-1443
+import {
+  emitBootResumePending as defaultEmitBootResumePending, // CTL-1443 (48h throttled alert)
+  emitBootResumePendingGate as defaultEmitBootResumePendingGate, // CTL-2133 (per-gate, unthrottled)
+} from "./dispatch-alert.mjs";
 import { labelNeedsHumanUnlessBeliefOwner } from "./label-guard.mjs"; // CTL-1443 (Codex P1)
 import { applyLabel as defaultApplyLabel } from "./linear-write.mjs"; // CTL-1443 (Codex P1)
 import {
@@ -120,6 +123,23 @@ function readPendingMarker(orchDir, ticket) {
   }
 }
 
+// stampMarker — CTL-2133 refactor. The shared "read pending marker → set one field
+// → write it back" idiom used by BOTH the 48h `surfacedAt` stamp and the one-tick
+// `softSurfacedAt` stamp. Best-effort: on a read miss it seeds a minimal marker so
+// the stamp still lands (the caller only reaches here for a gate it just enumerated).
+// Returns true when the write succeeded. Never throws.
+function stampMarker(orchDir, ticket, field, iso) {
+  try {
+    const pending = readPendingMarker(orchDir, ticket) ?? { ticket };
+    pending[field] = iso;
+    writeFileSync(bootResumePendingPath(orchDir, ticket), JSON.stringify(pending));
+    return true;
+  } catch (err) {
+    log.warn({ ticket, field, err: err?.message }, "boot-resume: marker stamp failed — may re-surface next tick");
+    return false;
+  }
+}
+
 // ─── CTL-1443 (P1-loop-3): the approval gate becomes OPERABLE ───────────────
 //
 // The pending marker was written with a companion "operator (or a HUD button)"
@@ -132,6 +152,14 @@ function readPendingMarker(orchDir, ticket) {
 
 export const BOOT_RESUME_PENDING_TTL_MS =
   Number(process.env.CATALYST_BOOT_RESUME_PENDING_TTL_H) * 3600e3 || 48 * 3600e3;
+
+// CTL-2133 Scenario 1: the SOFT-surface threshold — how old a gate must be before
+// its per-gate `catalyst.boot_resume.pending` event fires. Default 0 = surface on
+// the first tick a gate exists. This is the two-threshold design: soft-surface
+// immediately (event + board-health line), keep the 48h TTL above as the loud
+// needs-human hard-park escalation. Deliberately NOT lowering the TTL.
+export const BOOT_RESUME_SURFACE_MS =
+  Number(process.env.CATALYST_BOOT_RESUME_SURFACE_MS) || 0;
 
 // listPendingApprovals — every gated ticket with its age + approval state.
 export function listPendingApprovals(orchDir, { now = () => Date.now() } = {}) {
@@ -157,6 +185,9 @@ export function listPendingApprovals(orchDir, { now = () => Date.now() } = {}) {
       ageMs: requestedMs != null ? Math.max(0, now() - requestedMs) : null,
       approved: existsSync(bootResumeApprovedPath(orchDir, ticket)),
       surfacedAt: pending.surfacedAt ?? null,
+      // CTL-2133: the one-tick soft-surface dedupe stamp (distinct from the 48h
+      // `surfacedAt`). Present once the per-gate pending event has fired.
+      softSurfacedAt: pending.softSurfacedAt ?? null,
     });
   }
   return out;
@@ -260,17 +291,57 @@ export function surfaceStalePendingApprovals({
       /* alert is best-effort; the signal is the operator surface */
     }
     // (3) dedupe stamp on the marker (approval still works; marker retained).
-    try {
-      const pending = readPendingMarker(orchDir, ticket) ?? { ticket, phase };
-      pending.surfacedAt = new Date(now()).toISOString();
-      writeFileSync(bootResumePendingPath(orchDir, ticket), JSON.stringify(pending));
-    } catch (err) {
-      log.warn({ ticket, err: err?.message }, "ctl-1443: surfacedAt stamp failed — the gate may re-surface next tick");
-    }
+    // CTL-2133: via the shared stampMarker helper (same idiom as softSurfacedAt).
+    stampMarker(orchDir, ticket, "surfacedAt", new Date(now()).toISOString());
     log.warn(
       { ticket, phase, ageHours },
       "ctl-1443: boot-resume approval gate exceeded its TTL — surfaced to Needs-You (approve with boot-resume-approve.mjs)"
     );
+    surfaced.push(ticket);
+  }
+  return surfaced;
+}
+
+// softSurfacePendingApprovals — CTL-2133 Scenario 1. The moment a gate exists it is
+// made VISIBLE outside the host: a per-gate `catalyst.boot_resume.pending` event
+// (deduped once per gate by the marker's softSurfacedAt stamp) carrying phase + age.
+// This is the SOFT tier of the two-threshold design — it does NO signal rewrite, NO
+// needs-human label, NO park. Parking every fresh gate would page on every merge-
+// restart (both minis restart and refill the pen), which is the noise regression the
+// board-health line + event exist to avoid; the 48h surfaceStalePendingApprovals
+// above remains the loud escalation tier. Structurally mirrors that function (same
+// listPendingApprovals iteration, same marker-stamp dedupe) but with only the event
+// side effect. Never throws; returns the tickets surfaced this pass.
+export function softSurfacePendingApprovals({
+  orchDir,
+  now = () => Date.now(),
+  surfaceMs = BOOT_RESUME_SURFACE_MS,
+  // ({ identifier, phase, ageMs, ageHours }) => void — the per-gate event seam.
+  // processApprovedResumes wires defaultEmitBootResumePendingGate; null = no emit.
+  emitPending = null,
+} = {}) {
+  const surfaced = [];
+  for (const gate of listPendingApprovals(orchDir, { now })) {
+    // Approved gates are about to dispatch; already-soft-surfaced gates dedupe.
+    if (gate.approved || gate.softSurfacedAt) continue;
+    // Age gate: default surfaceMs=0 surfaces on the first tick. A null age (marker
+    // with no parseable requestedAt) is treated as age 0 → surfaced, so a malformed
+    // requestedAt can never silence the pen (the failure this ticket closes).
+    const ageMs = gate.ageMs == null ? 0 : gate.ageMs;
+    if (ageMs < surfaceMs) continue;
+    const { ticket, phase } = gate;
+    const ageHours = Math.round(ageMs / 3600e3);
+    // (1) the per-gate observability event (unthrottled — dedupe is the stamp below).
+    try {
+      emitPending?.({ identifier: ticket, phase, ageMs, ageHours });
+    } catch (err) {
+      // A failed emit must NOT stamp the marker (else the gate is silently never
+      // surfaced) — skip the stamp so it retries next tick.
+      log.warn({ ticket, phase, err: err?.message }, "ctl-2133: pending-gate emit threw — will retry next tick");
+      continue;
+    }
+    // (2) dedupe stamp — one event per gate. The marker (and approval) are retained.
+    stampMarker(orchDir, ticket, "softSurfacedAt", new Date(now()).toISOString());
     surfaced.push(ticket);
   }
   return surfaced;
@@ -818,7 +889,20 @@ export function processApprovedResumes({
   surfaceStaleGates = (o) => surfaceStalePendingApprovals(o),
   emitStaleGateAlert = defaultEmitBootResumePending,
   staleGateLabelNeedsHuman = undefined, // CTL-1443 Codex P1: test seam
+  // CTL-2133 Scenario 1: the one-tick soft-surface pass rides the same every-tick
+  // call so no scheduler wiring is needed. Injectable for tests; the per-gate event
+  // emitter defaults to the real (unthrottled) dispatch-alert emitter.
+  softSurfaceGates = (o) => softSurfacePendingApprovals(o),
+  emitPendingGate = defaultEmitBootResumePendingGate,
 } = {}) {
+  // CTL-2133: soft-surface every pending gate FIRST (one event per gate, deduped by
+  // the marker) so a fresh gate is visible within one tick — independent of the 48h
+  // hard-park below. Best-effort; a throw logs and continues.
+  try {
+    softSurfaceGates({ orchDir, emitPending: emitPendingGate });
+  } catch (err) {
+    log.warn({ err: err?.message }, "ctl-2133: soft-surface sweep threw — continuing");
+  }
   try {
     surfaceStaleGates({
       orchDir,

--- a/plugins/dev/scripts/execution-core/boot-resume.test.mjs
+++ b/plugins/dev/scripts/execution-core/boot-resume.test.mjs
@@ -23,7 +23,16 @@ import {
   // CTL-1006
   isBootResumeEligible,
   supersededByTerminalPhase,
+  // CTL-2133
+  softSurfacePendingApprovals,
+  listPendingApprovals,
+  processApprovedResumes,
+  BOOT_RESUME_SURFACE_MS,
 } from "./boot-resume.mjs";
+import {
+  EVENT_BOOT_RESUME_PENDING,
+  emitBootResumePendingGate,
+} from "./dispatch-alert.mjs";
 
 let orchDir;
 
@@ -1455,5 +1464,158 @@ describe("reconcileBootResume — CTL-1422 review hardening", () => {
     }));
     expect(dispatched).toHaveLength(1);
     expect(existsSync(join(orchDir, "workers", "CTL-3", ".boot-resume-pending-approval"))).toBe(false);
+  });
+});
+
+// ─── CTL-2133: soft-surface pending approvals (Scenario 1) ───────────────────
+describe("softSurfacePendingApprovals (CTL-2133)", () => {
+  // writePending — a boot-resume pending-approval marker with a controllable
+  // requestedAt so age can be backdated.
+  function writePending(dir, ticket, phase, overrides = {}) {
+    const wdir = join(dir, "workers", ticket);
+    mkdirSync(wdir, { recursive: true });
+    writeFileSync(
+      bootResumePendingPath(dir, ticket),
+      JSON.stringify({ ticket, phase, requestedAt: new Date().toISOString(), ...overrides }),
+    );
+  }
+  function readMarker(dir, ticket) {
+    return JSON.parse(readFileSync(bootResumePendingPath(dir, ticket), "utf8"));
+  }
+
+  test("1. a fresh gate (age 0) emits exactly one {identifier,phase,ageMs} and stamps softSurfacedAt", () => {
+    writePending(orchDir, "CTL-100", "implement");
+    const calls = [];
+    const surfaced = softSurfacePendingApprovals({ orchDir, emitPending: (e) => calls.push(e) });
+    expect(surfaced).toEqual(["CTL-100"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].identifier).toBe("CTL-100");
+    expect(calls[0].phase).toBe("implement");
+    expect(typeof calls[0].ageMs).toBe("number");
+    // marker stamped so the next tick dedupes
+    expect(readMarker(orchDir, "CTL-100").softSurfacedAt).toBeTruthy();
+  });
+
+  test("2. dedup — a second call on the same gate emits nothing (once per gate)", () => {
+    writePending(orchDir, "CTL-101", "verify");
+    const calls = [];
+    softSurfacePendingApprovals({ orchDir, emitPending: (e) => calls.push(e) });
+    softSurfacePendingApprovals({ orchDir, emitPending: (e) => calls.push(e) });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("3. age carried — ageMs/ageHours reflect now - requestedAt for a backdated marker", () => {
+    const fiveHoursMs = 5 * 3600e3;
+    const base = 1_000_000_000_000;
+    writePending(orchDir, "CTL-102", "implement", {
+      requestedAt: new Date(base - fiveHoursMs).toISOString(),
+    });
+    const calls = [];
+    softSurfacePendingApprovals({ orchDir, now: () => base, emitPending: (e) => calls.push(e) });
+    expect(calls[0].ageMs).toBe(fiveHoursMs);
+    expect(calls[0].ageHours).toBe(5);
+  });
+
+  test("4. no park — the gated phase signal is unchanged (status not flipped, no needs-human)", () => {
+    writePending(orchDir, "CTL-103", "implement");
+    // the gated phase signal, running
+    writeSignal(orchDir, "CTL-103", "implement", { status: "running" });
+    softSurfacePendingApprovals({ orchDir, emitPending: () => {} });
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-103", "phase-implement.json"), "utf8"),
+    );
+    expect(sig.status).toBe("running"); // NOT stalled/needs-human
+    expect(sig.stalledReason).toBeUndefined();
+    expect(sig.explanation).toBeUndefined();
+    expect(existsSync(join(orchDir, "workers", "CTL-103", ".linear-label-needs-human.applied"))).toBe(false);
+  });
+
+  test("5. independence from the 48h path — a gate younger than the TTL soft-surfaces but is NOT hard-parked", () => {
+    writePending(orchDir, "CTL-104", "implement"); // age ~0, well under 48h
+    writeSignal(orchDir, "CTL-104", "implement", { status: "running" });
+    const calls = [];
+    softSurfacePendingApprovals({ orchDir, emitPending: (e) => calls.push(e) });
+    expect(calls).toHaveLength(1); // soft-surfaced
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", "CTL-104", "phase-implement.json"), "utf8"),
+    );
+    expect(sig.status).toBe("running"); // 48h surfaceStale did NOT stall it
+  });
+
+  test("6. multiple gates, one tick — three pending gates each emit their own event", () => {
+    writePending(orchDir, "CTL-105", "implement");
+    writePending(orchDir, "CTL-106", "verify");
+    writePending(orchDir, "CTL-107", "pr");
+    const calls = [];
+    const surfaced = softSurfacePendingApprovals({ orchDir, emitPending: (e) => calls.push(e) });
+    expect(surfaced.sort()).toEqual(["CTL-105", "CTL-106", "CTL-107"]);
+    expect(calls).toHaveLength(3);
+  });
+
+  test("surfaceMs threshold — a gate younger than surfaceMs is held", () => {
+    const base = 1_000_000_000_000;
+    writePending(orchDir, "CTL-108", "implement", {
+      requestedAt: new Date(base - 1000).toISOString(), // 1s old
+    });
+    const calls = [];
+    softSurfacePendingApprovals({ orchDir, now: () => base, surfaceMs: 60_000, emitPending: (e) => calls.push(e) });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("an emit throw does NOT stamp the marker (retries next tick)", () => {
+    writePending(orchDir, "CTL-109", "implement");
+    const surfaced = softSurfacePendingApprovals({
+      orchDir,
+      emitPending: () => { throw new Error("append failed"); },
+    });
+    expect(surfaced).toEqual([]);
+    expect(readMarker(orchDir, "CTL-109").softSurfacedAt).toBeUndefined();
+  });
+
+  test("BOOT_RESUME_SURFACE_MS defaults to 0 (surface on first tick)", () => {
+    expect(BOOT_RESUME_SURFACE_MS).toBe(0);
+  });
+
+  test("listPendingApprovals surfaces softSurfacedAt", () => {
+    writePending(orchDir, "CTL-110", "implement", { softSurfacedAt: "2026-08-21T00:00:00Z" });
+    const [row] = listPendingApprovals(orchDir);
+    expect(row.softSurfacedAt).toBe("2026-08-21T00:00:00Z");
+  });
+
+  test("processApprovedResumes runs the soft-surface pass (emits per-gate event)", () => {
+    writePending(orchDir, "CTL-111", "implement");
+    const calls = [];
+    processApprovedResumes({
+      orchDir,
+      // stub the 48h stale sweep so we isolate the soft-surface pass
+      surfaceStaleGates: () => {},
+      emitPendingGate: (e) => calls.push(e),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].identifier).toBe("CTL-111");
+  });
+});
+
+// ─── CTL-2133: the per-gate dispatch-alert emitter (v3 bare-name, unthrottled) ─
+describe("emitBootResumePendingGate (CTL-2133)", () => {
+  test("appends one v3 bare-name catalyst.boot_resume.pending line, unthrottled", () => {
+    const lines = [];
+    const append = (l) => lines.push(l);
+    emitBootResumePendingGate({ identifier: "CTL-200", phase: "implement", ageMs: 3600e3, ageHours: 1, append });
+    // unthrottled: a second immediate call also writes
+    emitBootResumePendingGate({ identifier: "CTL-201", phase: "verify", ageMs: 0, ageHours: 0, append });
+    expect(lines).toHaveLength(2);
+    const evt = JSON.parse(lines[0]);
+    expect(evt.attributes["event.name"]).toBe(EVENT_BOOT_RESUME_PENDING);
+    expect(EVENT_BOOT_RESUME_PENDING).toBe("catalyst.boot_resume.pending");
+    expect(evt.body.payload.identifier).toBe("CTL-200");
+    expect(evt.body.payload.phase).toBe("implement");
+    expect(evt.attributes["linear.ticket"]).toBe("CTL-200");
+  });
+
+  test("a throwing append never propagates (best-effort)", () => {
+    expect(() =>
+      emitBootResumePendingGate({ identifier: "CTL-202", phase: "pr", append: () => { throw new Error("nope"); } }),
+    ).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/dispatch-alert.mjs
+++ b/plugins/dev/scripts/execution-core/dispatch-alert.mjs
@@ -19,6 +19,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+import { buildCanonicalEventLine } from "./lib/canonical-event.mjs"; // CTL-2133: v3 bare-name gate events
 
 export const ALERT_ELIGIBLE_SOURCE_UNAVAILABLE = "catalyst.alert.eligible_source_unavailable";
 
@@ -205,6 +206,130 @@ export function emitGithubAuthUnusable({ tokenSource = null, reason = null, appe
     now,
     throttleMs,
   });
+}
+
+// ─── CTL-2133: boot-resume GATE observability (v3 bare-name, UNTHROTTLED) ────
+//
+// Distinct from ALERT_BOOT_RESUME_PENDING above: that is the throttled 48h loud
+// alert (one line/window/kind, the escalation tier). These three are per-GATE
+// observability events whose dedupe is the MARKER itself — the pending gate's
+// `softSurfacedAt` stamp (emitted once, on first surfacing) and the retire's
+// rename-aside (a discrete, rare act). There is deliberately NO time throttle:
+// each distinct gate must emit exactly once, and a per-kind throttle would
+// collapse three simultaneous fresh gates into one line (the silent-pen failure
+// mode this ticket closes). v3 bare-name (`catalyst.boot_resume.*`) resolved by
+// lib/event-name.mjs via attributes["event.name"]; the `catalyst.boot_resume.`
+// prefix is UNPROTECTED under the CTL-1142 namespace contract (it routes through
+// shouldSkipEvent normally — no isBrokerProtectedName collision), asserted in
+// broker/namespace-parity.test.mjs.
+export const EVENT_BOOT_RESUME_PENDING = "catalyst.boot_resume.pending";
+export const EVENT_BOOT_RESUME_RETIRED = "catalyst.boot_resume.retired";
+export const EVENT_BOOT_RESUME_WOULD_RETIRE = "catalyst.boot_resume.would-retire";
+
+export const BOOT_RESUME_GATE_EVENT_NAMES = Object.freeze([
+  EVENT_BOOT_RESUME_PENDING,
+  EVENT_BOOT_RESUME_RETIRED,
+  EVENT_BOOT_RESUME_WOULD_RETIRE,
+]);
+
+// _appendGateEvent — best-effort canonical v3 append (buildCanonicalEventLine
+// guarantees body.message + attributes["event.name"], so the record can never map
+// to an empty OTLP LogRecord). NEVER throws — a telemetry append must not break a
+// scheduler tick. `append` is injectable so tests assert the built line without
+// touching the real event log.
+function _appendGateEvent(name, payload, attributes, append = defaultAppend) {
+  try {
+    append(buildCanonicalEventLine({ name, payload, attributes }));
+    return true;
+  } catch (err) {
+    log?.error?.({ err: err?.message, name }, "boot-resume gate event append failed (continuing)");
+    return false;
+  }
+}
+
+// emitBootResumePendingGate — CTL-2133 Scenario 1. One per pending gate, the moment
+// it is soft-surfaced (deduped by the marker's softSurfacedAt). Carries phase + age
+// so an off-host consumer can render `ticket · phase · ageHours` without re-reading
+// the marker. UNTHROTTLED — dedupe is the marker stamp, not a time window.
+export function emitBootResumePendingGate({
+  identifier = null,
+  phase = null,
+  ageMs = null,
+  ageHours = null,
+  append = defaultAppend,
+} = {}) {
+  return _appendGateEvent(
+    EVENT_BOOT_RESUME_PENDING,
+    {
+      kind: "boot_resume_pending",
+      identifier,
+      phase,
+      ageMs,
+      ageHours,
+      source: "catalyst.execution-core",
+    },
+    {
+      ...(identifier ? { "linear.ticket": identifier } : {}),
+      ...(phase ? { "catalyst.phase": phase } : {}),
+      ...(ageHours != null ? { "catalyst.gate_age_hours": ageHours } : {}),
+    },
+    append,
+  );
+}
+
+// emitBootResumeRetired — CTL-2133 Scenario 2 (enforce). One per gate archived
+// because the ticket's Linear state moved strictly past the gated phase. A discrete,
+// rare, auditable act — UNTHROTTLED. `from_state` is the Linear state name that made
+// the gate moot.
+export function emitBootResumeRetired({
+  ticket = null,
+  gated_phase = null,
+  from_state = null,
+  append = defaultAppend,
+} = {}) {
+  return _appendGateEvent(
+    EVENT_BOOT_RESUME_RETIRED,
+    {
+      kind: "boot_resume_retired",
+      ticket,
+      gated_phase,
+      from_state,
+      source: "catalyst.execution-core",
+    },
+    {
+      ...(ticket ? { "linear.ticket": ticket } : {}),
+      ...(gated_phase ? { "catalyst.phase": gated_phase } : {}),
+      ...(from_state ? { "linear.state": from_state } : {}),
+    },
+    append,
+  );
+}
+
+// emitBootResumeWouldRetire — CTL-2133 Scenario 2 (shadow, the default). Same payload
+// as `retired` but the marker is LEFT IN PLACE — the shadow-first observation event an
+// operator watches for one restart-heavy evening before flipping to enforce.
+export function emitBootResumeWouldRetire({
+  ticket = null,
+  gated_phase = null,
+  from_state = null,
+  append = defaultAppend,
+} = {}) {
+  return _appendGateEvent(
+    EVENT_BOOT_RESUME_WOULD_RETIRE,
+    {
+      kind: "boot_resume_would_retire",
+      ticket,
+      gated_phase,
+      from_state,
+      source: "catalyst.execution-core",
+    },
+    {
+      ...(ticket ? { "linear.ticket": ticket } : {}),
+      ...(gated_phase ? { "catalyst.phase": gated_phase } : {}),
+      ...(from_state ? { "linear.state": from_state } : {}),
+    },
+    append,
+  );
 }
 
 // CAT-29: a daemon that cannot resolve its board/runtime dependencies stays


### PR DESCRIPTION
Surfaces every `.boot-resume-pending-approval` gate within one tick (per-gate `catalyst.boot_resume.pending` event + a board-health Tier-3 line carrying `ticket · phase · ageHours`) and self-retires moot gates whose Linear state moved past the gated phase (shadow-first behind `CATALYST_BOOT_RESUME_RETIRE`). Gap-fill on CTL-644/CTL-1443. See `thoughts/shared/plans/2026-08-21-ctl-2133.md`.

WIP — Phase 1 landed; Phases 2–3 to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)