### PR TITLE
feat(dev): CTL-1210 — split node config by lifecycle (cluster-secrets.json + node.json)

### DIFF
--- a/plugins/dev/scripts/__tests__/catalyst-join.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-join.test.sh
@@ -706,16 +706,17 @@ run "T2.8 multiHost roster + inferred mode FALLS BACK to heuristic and wires (CT
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
+  cfg_shared=\"\$h/.config/catalyst/cluster-secrets.json\"
+  cfg_node=\"\$h/.config/catalyst/node.json\"
   echo \"\$out\" | grep -qF 'decision=wire' && \
   echo \"\$out\" | grep -qF 'rule=heuristic-fallback' && \
   echo \"\$out\" | grep -qF 'inferred=true' && \
   echo \"\$out\" | grep -qF 'heuristic_would=wire' && \
-  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$cfg\" >/dev/null &&
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$cfg_shared\" >/dev/null &&
   echo \"\$out\" | grep -qF 'linear-stripped=yes' && \
-  jq -e '(.catalyst.monitor | has(\"linear\")) | not' \"\$cfg\" >/dev/null &&
-  ! grep -qF 'smee.io/LIN' \"\$cfg\" &&
-  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null"
+  jq -e '(.catalyst.monitor | has(\"linear\")) | not' \"\$cfg_shared\" >/dev/null &&
+  ! grep -qF 'smee.io/LIN' \"\$cfg_shared\" &&
+  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg_node\" >/dev/null"
 
 # T2.8e (CTL-1928): a bundle whose monitorWebhooks carries ONLY the retired
 # Linear block has nothing left to write once the strip runs. The decision must
@@ -751,11 +752,12 @@ run "T2.8e bundle carrying ONLY the retired Linear block wires nothing (CTL-1928
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$LINEAR_ONLY_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
+  cfg_shared=\"\$h/.config/catalyst/cluster-secrets.json\"
+  cfg_node=\"\$h/.config/catalyst/node.json\"
   echo \"\$out\" | grep -qF 'ONLY the retired Linear block' && \
-  ! grep -qF 'smee.io/LIN' \"\$cfg\" && \
-  jq -e '((.catalyst.monitor // {}) | has(\"linear\")) | not' \"\$cfg\" >/dev/null && \
-  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null"
+  ! grep -qF 'smee.io/LIN' \"\$cfg_shared\" && \
+  jq -e '((.catalyst.monitor // {}) | has(\"linear\")) | not' \"\$cfg_shared\" >/dev/null && \
+  jq -e '.catalyst.cloudFeed.mode == \"enforce\"' \"\$cfg_node\" >/dev/null"
 
 # T2.8f (CTL-1928, Codex #3485 P1): removing the Linear route must not leave a
 # node with NO Linear ingestion — the join provisions the cloud-feed
@@ -766,7 +768,7 @@ run "T2.8e bundle carrying ONLY the retired Linear block wires nothing (CTL-1928
 run "T2.8f an already-declared cloudFeed.mode is NOT clobbered by the join (CTL-1928)" bash -c "
   h='${SCRATCH}/h28f'
   mkdir -p \"\$h/.config/catalyst\"
-  printf '{\"catalyst\":{\"cloudFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/config.json\"
+  printf '{\"catalyst\":{\"cloudFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/node.json\"
   out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28f' \
     CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
     CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
@@ -778,8 +780,8 @@ run "T2.8f an already-declared cloudFeed.mode is NOT clobbered by the join (CTL-
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
-  jq -e '.catalyst.cloudFeed.mode == \"shadow\"' \"\$cfg\" >/dev/null && \
+  cfg_node=\"\$h/.config/catalyst/node.json\"
+  jq -e '.catalyst.cloudFeed.mode == \"shadow\"' \"\$cfg_node\" >/dev/null && \
   echo \"\$out\" | grep -qF 'cloudFeed=shadow'"
 
 # ─── CTL-2004: the GitHub half of the very rule T2.8e/f pin for Linear ───────────
@@ -802,14 +804,14 @@ run "T2.8g the join writes the seed's githubFeed.mode, so a member inherits the 
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$GHFEED_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
-  jq -e '.catalyst.githubFeed.mode == \"enforce\"' \"\$cfg\" >/dev/null && \
+  cfg_node=\"\$h/.config/catalyst/node.json\"
+  jq -e '.catalyst.githubFeed.mode == \"enforce\"' \"\$cfg_node\" >/dev/null && \
   echo \"\$out\" | grep -qF 'githubFeed=enforce'"
 
 run "T2.8h an already-declared githubFeed.mode is NOT clobbered by the join (CTL-2004)" bash -c "
   h='${SCRATCH}/h28h'
   mkdir -p \"\$h/.config/catalyst\"
-  printf '{\"catalyst\":{\"githubFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/config.json\"
+  printf '{\"catalyst\":{\"githubFeed\":{\"mode\":\"shadow\"}}}' > \"\$h/.config/catalyst/node.json\"
   out=\$(env -i HOME=\"\$h\" CATALYST_DIR='${SCRATCH}/c28h' \
     CATALYST_JOIN_TOKEN='$GOOD_TOKEN' \
     CATALYST_JOIN_GITHUB_TOKEN='ghp_TEST_DUMMY_0000' \
@@ -821,8 +823,8 @@ run "T2.8h an already-declared githubFeed.mode is NOT clobbered by the join (CTL
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$GHFEED_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
-  jq -e '.catalyst.githubFeed.mode == \"shadow\"' \"\$cfg\" >/dev/null && \
+  cfg_node=\"\$h/.config/catalyst/node.json\"
+  jq -e '.catalyst.githubFeed.mode == \"shadow\"' \"\$cfg_node\" >/dev/null && \
   echo \"\$out\" | grep -qF 'githubFeed=shadow'"
 
 # ⛔ INVERSION GUARD. An older seed carries no githubFeed; the join must write NOTHING
@@ -841,8 +843,8 @@ run "T2.8i a bundle with NO githubFeed writes no key at all (CTL-2004 inversion 
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS2}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS2}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$MULTIHOST_WH_BUNDLE' 2>&1)
-  cfg=\"\$h/.config/catalyst/config.json\"
-  jq -e '((.catalyst // {}) | has(\"githubFeed\")) | not' \"\$cfg\" >/dev/null && \
+  cfg_node=\"\$h/.config/catalyst/node.json\"
+  jq -e '((.catalyst // {}) | has(\"githubFeed\")) | not' \"\$cfg_node\" >/dev/null && \
   echo \"\$out\" | grep -qF 'githubFeed=unset'"
 
 # T2.9 (fixture updated for CTL-1617 PR5 — see T2.8's note): same inferred-mode
@@ -946,7 +948,7 @@ run "T2.8b-agree mode=cluster declared AND roster>1 STILL wires (agreement case)
   echo \"\$out\" | grep -qF 'inferred=false' && \
   echo \"\$out\" | grep -qF 'heuristic_would=wire' && \
   ! echo \"\$out\" | grep -qF 'note=stage0-roster-guard' && \
-  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/config.json\" >/dev/null"
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/cluster-secrets.json\" >/dev/null"
 
 # T2.8c: (FIX 2 — P2 provisioner path parity) CATALYST_PLUGIN_SOURCE, when set,
 # overrides the $HOME-side default — mirroring setup-plugin-source.sh's own
@@ -978,7 +980,7 @@ run "T2.8c CATALYST_PLUGIN_SOURCE override is honored by the gate (FIX 2)" bash 
   echo \"\$out\" | grep -qF 'mode=cluster' && \
   echo \"\$out\" | grep -qF 'source=layer1' && \
   echo \"\$out\" | grep -qF 'inferred=false' && \
-  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/config.json\" >/dev/null"
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/cluster-secrets.json\" >/dev/null"
 
 # T2.9b: mode=single-host declared SKIPS despite roster>1 — the new behavior the
 # flip introduces (previously roster>1 alone was sufficient to wire). MULTIHOST_WH_BUNDLE
@@ -1099,7 +1101,7 @@ run "T2.9e resume after fixing the typo re-executes config-merge and wires (FIX 
   echo \"\$out\" | grep -qF 'mode=cluster' && \
   jq -e '.completedStages | index(\"config-merge\") != null' \"\$marker\" >/dev/null && \
   jq -e '.failedStage == null' \"\$marker\" >/dev/null && \
-  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/config.json\" >/dev/null"
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/cluster-secrets.json\" >/dev/null"
 
 # T2.9f: (#2914 Codex P2) when the UNRECOGNIZED mode came from the LAYER-1
 # plugin-source checkout (not env/layer2), failing config-merge alone is not
@@ -1160,7 +1162,7 @@ run "T2.9g resume after upstream layer1 fix re-pulls and wires (#2914 P2)" bash 
   echo \"\$out\" | grep -qF 'mode=cluster' && \
   jq -e '.completedStages | index(\"setup-plugin-source\") != null' \"\$marker\" >/dev/null && \
   jq -e '.failedStage == null' \"\$marker\" >/dev/null && \
-  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/config.json\" >/dev/null"
+  jq -e '.catalyst.monitor.github.smeeChannel == \"https://smee.io/GH\"' \"\$h/.config/catalyst/cluster-secrets.json\" >/dev/null"
 
 # T2.10 / T2.11: (CTL-1293) provision-thoughts that CLONES OK but fails push-auth
 # is FATAL on a multiHost member (roster>1 owns work → must sync thoughts to
@@ -1460,8 +1462,9 @@ run "T4.1 merge-preserve: node-local keys survive" bash -c "
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
   cfg=\"\$home41/.config/catalyst/config.json\"
+  cfg_shared=\"\$home41/.config/catalyst/cluster-secrets.json\"
   jq -e '.catalyst.otel.endpoint == \"http://localhost:4317\"' \"\$cfg\" >/dev/null && \
-  jq -e '.catalyst.cluster.livenessAnchorIssue | length > 0' \"\$cfg\" >/dev/null"
+  jq -e '.catalyst.cluster.livenessAnchorIssue | length > 0' \"\$cfg_shared\" >/dev/null"
 
 # T4.2: host.name persisted explicitly
 run "T4.2 host.name written to Layer-2 config" bash -c "
@@ -1481,7 +1484,7 @@ run "T4.2 host.name written to Layer-2 config" bash -c "
     CATALYST_JOIN_DOCTOR_SCRIPT='${STUBS4}/stub-check-setup.sh' \
     CATALYST_JOIN_REACH_PROBE='${STUBS4}/stub-reach-probe.sh' \
     bash '$JOIN' --bundle '$FIXTURE_BUNDLE' >/dev/null 2>&1
-  jq -e '.catalyst.host.name == \"mynode\"' \"\$home42/.config/catalyst/config.json\" >/dev/null"
+  jq -e '.catalyst.host.name == \"mynode\"' \"\$home42/.config/catalyst/node.json\" >/dev/null"
 
 # T4.3: LOCAL hosts.json written; committed roster NOT touched
 run "T4.3 local hosts.json written; committed roster untouched" bash -c "

--- a/plugins/dev/scripts/catalyst-join.sh
+++ b/plugins/dev/scripts/catalyst-join.sh
@@ -144,6 +144,11 @@ CATALYST_DIR="${CATALYST_DIR:-${HOME}/catalyst}"
 MARKER_DIR="${CATALYST_DIR}/cluster"
 MARKER_FILE="${MARKER_DIR}/join-progress.json"
 LAYER2_CONFIG="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+# CTL-1210: sibling files in the same dir — shared keys (byte-identical across nodes) and
+# per-node identity/tunables. Derived from LAYER2_CONFIG so CATALYST_LAYER2_CONFIG_FILE
+# overrides in tests also move these siblings correctly.
+CLUSTER_SECRETS_CONFIG="${LAYER2_CONFIG%/*}/cluster-secrets.json"
+NODE_CONFIG="${LAYER2_CONFIG%/*}/node.json"
 
 mkdir -p "$MARKER_DIR"
 
@@ -651,17 +656,19 @@ do_provision_thoughts() {
 
 # ── SHARED config merge ───────────────────────────────────────────────────────
 merge_shared_config() {
-  local cfg="$LAYER2_CONFIG"
+  # CTL-1210: shared bundle keys go to $CLUSTER_SECRETS_CONFIG (byte-identical across nodes,
+  # 0600).  $cfg remains for the webhook-wiring gate's cloudFeed/githubFeed node-local writes.
+  local cfg="$CLUSTER_SECRETS_CONFIG"
+  local cfg_node="$NODE_CONFIG"
   mkdir -p "$(dirname "$cfg")"
   if [[ ! -f "$cfg" ]]; then
-    # Create at 0600 before it ever holds botCreds.orchestrator/worker — the
-    # default umask would otherwise leave a transient world-readable window
-    # (verify security finding; CTL-1203 secrets-600 hygiene).
     echo '{}' > "$cfg"
     chmod 0600 "$cfg" 2>/dev/null || true
   fi
 
-  # Extract SHARED keys from bundle; preserve all existing node-local keys
+  # Extract SHARED keys from bundle. cluster-secrets.json must contain ONLY shared keys so its
+  # sha256 is byte-identical across all cluster nodes. Use `jq -S` (sorted keys) for
+  # deterministic serialization — a //= merge into a mixed file would vary by node-local state.
   local la_project la_team la_statemap bot_orch bot_worker liveness repo_url plugin_url
   la_project="$(bundle_get '.layer1Identity.projectKey')"
   la_team="$(bundle_get '.layer1Identity.teamKey')"
@@ -673,8 +680,10 @@ merge_shared_config() {
   plugin_url="$(bundle_get '.pluginSourceUrl')"
 
   local tmp
-  tmp="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
-  jq \
+  tmp="$(mktemp "$(dirname "$cfg")/.cluster-secrets.XXXXXX")"
+  chmod 0600 "$tmp" 2>/dev/null || true
+  # Fresh deterministic write (not //= merge) so the file is byte-identical on every node.
+  jq -S \
     --arg la_project "$la_project" \
     --arg la_team "$la_team" \
     --argjson la_statemap "$la_statemap" \
@@ -683,22 +692,17 @@ merge_shared_config() {
     --arg liveness "$liveness" \
     --arg repo_url "$repo_url" \
     --arg plugin_url "$plugin_url" \
-    '
-      .catalyst //= {}
-      | .catalyst.linear //= {}
-      | .catalyst.linear.bot //= {}
-      | .catalyst.linear.bot.orchestrator //= $bot_orch
-      | .catalyst.linear.bot.worker //= $bot_worker
-      | .catalyst.cluster //= {}
-      | .catalyst.cluster.livenessAnchorIssue //= $liveness
-      | .catalyst.repository //= $repo_url
-      | .catalyst.feedback //= $plugin_url
-      | .catalyst.layer1Identity //= {}
-      | .catalyst.layer1Identity.projectKey //= $la_project
-      | .catalyst.layer1Identity.teamKey //= $la_team
-      | .catalyst.layer1Identity.stateMap //= $la_statemap
-    ' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
-  info "SHARED config merged into ${cfg}"
+    --null-input \
+    '{
+      catalyst: {
+        cluster: { livenessAnchorIssue: $liveness },
+        feedback: $plugin_url,
+        layer1Identity: ($la_statemap | { projectKey: $la_project, teamKey: $la_team, stateMap: . }),
+        linear: { bot: { orchestrator: $bot_orch, worker: $bot_worker } },
+        repository: $repo_url
+      }
+    }' > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
+  info "SHARED config written to ${cfg}"
 
   # CTL-1284: webhook ingestion wiring (non-secret smee channels + per-team
   # webhookId map; HMAC secrets travel via SOPS/cluster-sync, not the bundle).
@@ -965,19 +969,31 @@ merge_shared_config() {
     # today's behaviour rather than being pinned to a posture nobody declared.
     local bundle_gf
     bundle_gf="$(echo "$BUNDLE_JSON" | jq -c '.githubFeed // null')" || bundle_gf="null"
-    jq --argjson wh "$monitor_wh_stripped" --argjson gf "$bundle_gf" '
+    # CTL-1210: split webhook writes by key class.
+    # SHARED (monitor.github.smeeChannel)         → $CLUSTER_SECRETS_CONFIG.
+    # NODE   (cloudFeed.mode, githubFeed.mode)    → $cfg_node (node.json).
+    local tmp_shared tmp_node
+    tmp_shared="$(mktemp "$(dirname "$cfg")/.cluster-secrets.XXXXXX")"
+    chmod 0600 "$tmp_shared" 2>/dev/null || true
+    # merge $wh (monitor block) into cluster-secrets.json (non-clobber for monitor sub-keys).
+    jq --argjson wh "$monitor_wh_stripped" '
         .catalyst //= {}
         | .catalyst.monitor = ($wh * (.catalyst.monitor // {}))
-        | .catalyst.cloudFeed //= {}
-        | .catalyst.cloudFeed.mode //= "enforce"
+      ' "$cfg" > "$tmp_shared" && mv "$tmp_shared" "$cfg" || { rm -f "$tmp_shared"; return 1; }
+    # cloudFeed.mode + githubFeed.mode (per-node tunables) → node.json (non-clobber).
+    if [[ ! -f "$cfg_node" ]]; then echo '{}' > "$cfg_node"; chmod 0600 "$cfg_node" 2>/dev/null || true; fi
+    tmp_node="$(mktemp "$(dirname "$cfg_node")/.node.XXXXXX")"
+    chmod 0600 "$tmp_node" 2>/dev/null || true
+    jq --argjson gf "$bundle_gf" '
+        .catalyst //= {}
+        | .catalyst.cloudFeed //= {} | .catalyst.cloudFeed.mode //= "enforce"
         | if ($gf | type) == "object" and ($gf.mode | type) == "string"
           then .catalyst.githubFeed //= {} | .catalyst.githubFeed.mode //= $gf.mode
           else . end
-      ' "$cfg" > "$tmp2" && mv "$tmp2" "$cfg" || { rm -f "$tmp2"; return 1; }
-    local cf_mode
-    cf_mode="$(jq -r '.catalyst.cloudFeed.mode // "unset"' "$cfg" 2>/dev/null)"
-    local gf_mode
-    gf_mode="$(jq -r '.catalyst.githubFeed.mode // "unset"' "$cfg" 2>/dev/null)"
+      ' "$cfg_node" > "$tmp_node" && mv "$tmp_node" "$cfg_node" || { rm -f "$tmp_node"; return 1; }
+    local cf_mode gf_mode
+    cf_mode="$(jq -r '.catalyst.cloudFeed.mode // "unset"' "$cfg_node" 2>/dev/null)"
+    gf_mode="$(jq -r '.catalyst.githubFeed.mode // "unset"' "$cfg_node" 2>/dev/null)"
     if [[ "$github_wired" == "no" ]]; then
       info "webhook ingestion NOT wired (rule=${rule} mode=${CATALYST_DEPLOYMENT_MODE_RESOLVED} roster=${roster_len:-0}) | bundle carried ONLY the retired Linear block (CTL-1928); cloudFeed=${cf_mode} githubFeed=${gf_mode}"
     else
@@ -989,7 +1005,8 @@ merge_shared_config() {
 }
 
 persist_host_name() {
-  local cfg="$LAYER2_CONFIG"
+  # CTL-1210: host.name is a per-node key — write to node.json, not config.json.
+  local cfg="$NODE_CONFIG"
   local host_name="${CATALYST_HOST_NAME:-}"
   if [[ -z "$host_name" ]]; then
     host_name="$(hostname -s 2>/dev/null || hostname | sed 's/\.local$//')"
@@ -997,10 +1014,11 @@ persist_host_name() {
   fi
   if [[ ! -f "$cfg" ]]; then
     echo '{}' > "$cfg"
-    chmod 0600 "$cfg" 2>/dev/null || true  # holds botCreds; protect immediately (CTL-1203)
+    chmod 0600 "$cfg" 2>/dev/null || true  # holds identity; protect immediately (CTL-1203)
   fi
   local tmp
-  tmp="$(mktemp "$(dirname "$cfg")/.config.XXXXXX")"
+  tmp="$(mktemp "$(dirname "$cfg")/.node.XXXXXX")"
+  chmod 0600 "$tmp" 2>/dev/null || true
   jq --arg hn "$host_name" '.catalyst.host.name = $hn' "$cfg" > "$tmp" && mv "$tmp" "$cfg" || { rm -f "$tmp"; return 1; }
   info "host.name set to: ${host_name}"
   # CTL-1185 remediate: return the host name via a global, NOT via stdout. The

--- a/plugins/dev/scripts/execution-core/cluster-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.mjs
@@ -164,9 +164,11 @@ function defaultGit(args) {
 }
 
 // destForSecret — map a secrets/ filename to its ~/.config/catalyst destination.
+// CTL-1210: cluster-bots contains shared bot credentials; route to cluster-secrets.json
+// so it is byte-identical across all cluster nodes and readable via readLayer2Merged().
 function destForSecret(name, configDir) {
   const base = basename(name).replace(/\.sops\.json$/, "");
-  if (base === "cluster-bots") return resolve(configDir, "config.json");
+  if (base === "cluster-bots") return resolve(configDir, "cluster-secrets.json");
   return resolve(configDir, `${base}.json`);
 }
 

--- a/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-sync.test.mjs
@@ -58,8 +58,8 @@ const touchSecret = (name) =>
   writeFileSync(join(clusterDir, "secrets", name), "{ciphertext-placeholder}");
 
 describe("destForSecret (CTL-1211)", () => {
-  test("cluster-bots maps to config.json (deep-merged into machine-global)", () => {
-    expect(destForSecret("cluster-bots.sops.json", "/cfg")).toBe(resolve("/cfg", "config.json"));
+  test("cluster-bots maps to cluster-secrets.json (CTL-1210: shared bot creds go to shared file)", () => {
+    expect(destForSecret("cluster-bots.sops.json", "/cfg")).toBe(resolve("/cfg", "cluster-secrets.json"));
   });
   test("config-<key> maps to config-<key>.json", () => {
     expect(destForSecret("config-catalyst-workspace.sops.json", "/cfg")).toBe(
@@ -91,13 +91,17 @@ describe("syncClusterSecrets (CTL-1211)", () => {
 
     const res = syncClusterSecrets({ clusterDir, configDir, decrypt });
     expect(res.ok).toBe(true);
-    expect(res.synced.sort()).toEqual(["config-catalyst-workspace.json", "config.json"]);
+    // CTL-1210: cluster-bots now syncs to cluster-secrets.json (not config.json)
+    expect(res.synced.sort()).toEqual(["cluster-secrets.json", "config-catalyst-workspace.json"]);
 
-    // deep-merge preserved the node-local host.name AND overlaid the bot creds
-    const merged = JSON.parse(readFileSync(join(configDir, "config.json"), "utf8"));
-    expect(merged.catalyst.host.name).toBe("mini");
-    expect(merged.catalyst.linear.bot.worker.accessToken).toBe("tok");
-    expect(statSync(join(configDir, "config.json")).mode & 0o777).toBe(0o600);
+    // config.json preserved the node-local host.name (not touched by cluster-bots)
+    const nodeCfg = JSON.parse(readFileSync(join(configDir, "config.json"), "utf8"));
+    expect(nodeCfg.catalyst.host.name).toBe("mini");
+    expect(nodeCfg.catalyst.linear?.bot?.worker?.accessToken).toBeUndefined();
+    // CTL-1210: bot creds land in cluster-secrets.json
+    const shared = JSON.parse(readFileSync(join(configDir, "cluster-secrets.json"), "utf8"));
+    expect(shared.catalyst.linear.bot.worker.accessToken).toBe("tok");
+    expect(statSync(join(configDir, "cluster-secrets.json")).mode & 0o777).toBe(0o600);
   });
 
   test("a single decrypt failure is skipped; the rest still sync (fail-open)", () => {
@@ -109,7 +113,8 @@ describe("syncClusterSecrets (CTL-1211)", () => {
       return { ok: true };
     };
     const res = syncClusterSecrets({ clusterDir, configDir, decrypt, logger: QUIET });
-    expect(res.synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
     expect(res.skipped).toEqual(["config-adva.sops.json"]);
   });
 
@@ -139,7 +144,8 @@ describe("syncClusterSecrets (CTL-1211)", () => {
     touchSecret("cluster-bots.sops.json");
     touchSecret("node-secret-files.sops.json");
     const res = syncClusterSecrets({ clusterDir, configDir, decrypt: () => ({ x: 1 }) });
-    expect(res.synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
     expect(existsSync(join(configDir, "node-secret-files.json"))).toBe(false);
   });
 
@@ -148,7 +154,8 @@ describe("syncClusterSecrets (CTL-1211)", () => {
     touchSecret("cluster-bots.sops.json");
     touchSecret("profile-files.sops.json");
     const res = syncClusterSecrets({ clusterDir, configDir, decrypt: () => ({ x: 1 }) });
-    expect(res.synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
     expect(existsSync(join(configDir, "profile-files.json"))).toBe(false);
   });
 });
@@ -818,9 +825,10 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     });
 
     expect(res.changed).toBe(true);
-    expect(res.synced).toEqual(["config.json"]);
-    // overwrite: the filled value replaced the stale placeholder
-    const merged = JSON.parse(readFileSync(join(configDir, "config.json"), "utf8"));
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
+    // bot creds land in cluster-secrets.json; the placeholder was merged there
+    const merged = JSON.parse(readFileSync(join(configDir, "cluster-secrets.json"), "utf8"));
     expect(merged.catalyst.linear.bot.worker.accessToken).toBe("FRESH");
     // marker advanced + timestamp from the injected clock
     const marker = readClusterSyncState(statePath);
@@ -829,7 +837,8 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
     // refreshed event emitted with the from→to shas
     expect(emits).toHaveLength(1);
     expect(emits[0].name).toBe("refreshed");
-    expect(emits[0].payload).toMatchObject({ fromSha: "OLDSHA", toSha: "NEWSHA", synced: ["config.json"] });
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(emits[0].payload).toMatchObject({ fromSha: "OLDSHA", toSha: "NEWSHA", synced: ["cluster-secrets.json"] });
   });
 
   test("(e1) sops UNRESOLVABLE on a changed HEAD → fail-open + refresh-failed event, marker NOT advanced", () => {
@@ -1048,7 +1057,8 @@ describe("refreshClusterSecretsIfChanged (CTL-1393)", () => {
 
     expect(res.ok).toBe(true);
     expect(res.changed).toBe(true);
-    expect(res.synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
     expect(res.written).toEqual(["cma-api-key"]);
     // full success advances the marker (guard against over-correcting the predicate)
     expect(readClusterSyncState(statePath).lastDecryptedSha).toBe("NEWSHA");
@@ -1947,10 +1957,11 @@ describe("clusterSync boot (CTL-1393 conditional marker seed)", () => {
     // success path still seeds the marker at the clone's HEAD
     expect(writeCalls).toHaveLength(1);
     expect(writeCalls[0].lastDecryptedSha).toBe("BOOTSHA");
-    expect(writeCalls[0].synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(writeCalls[0].synced).toEqual(["cluster-secrets.json"]);
     // boot success does not alarm
     expect(emits.map((e) => e.name)).not.toContain("refresh-failed");
-    expect(res.sync.synced).toEqual(["config.json"]);
+    expect(res.sync.synced).toEqual(["cluster-secrets.json"]);
   });
 
   test("fresh node, EMPTY secrets repo (nothing to decrypt) → still seeds marker (not a failure)", () => {
@@ -2022,8 +2033,48 @@ describe("clusterSync boot (CTL-1393 conditional marker seed)", () => {
     expect(writeCalls).toHaveLength(0);
     expect(emits.map((e) => e.name)).toContain("refresh-failed");
     expect(emits[0].payload.reason).toBe("secrets-skipped");
-    expect(res.sync.synced).toEqual(["config.json"]);
+    // CTL-1210: cluster-bots → cluster-secrets.json
+    expect(res.sync.synced).toEqual(["cluster-secrets.json"]);
     expect(res.sync.skipped).toEqual(["config-adva.sops.json"]);
+  });
+});
+
+// CTL-1210 Phase 3: destForSecret routes cluster-bots to cluster-secrets.json and
+// syncClusterSecrets delivers bot creds there; readLayer2Merged() sees them via the chain.
+describe("destForSecret CTL-1210 Phase 3", () => {
+  test("destForSecret: cluster-bots.sops.json → cluster-secrets.json (not config.json)", () => {
+    expect(destForSecret("cluster-bots.sops.json", "/cfg")).toBe(
+      resolve("/cfg", "cluster-secrets.json"),
+    );
+  });
+
+  test("destForSecret: other secrets (config-<key>.json) are unchanged", () => {
+    expect(destForSecret("config-catalyst-workspace.sops.json", "/cfg")).toBe(
+      resolve("/cfg", "config-catalyst-workspace.json"),
+    );
+    expect(destForSecret("cluster-cloud.sops.json", "/cfg")).toBe(
+      resolve("/cfg", "cluster-cloud.json"),
+    );
+  });
+
+  test("syncClusterSecrets: bot creds land in cluster-secrets.json (not config.json)", () => {
+    writeClusterJson({ schemaVersion: 1, roster: ["mini"] });
+    touchSecret("cluster-bots.sops.json");
+    const botCreds = { catalyst: { linear: { bot: { orchestrator: { accessToken: "orch-tok" }, worker: { accessToken: "worker-tok" } } } } };
+    const res = syncClusterSecrets({
+      clusterDir,
+      configDir,
+      decrypt: () => botCreds,
+      logger: QUIET,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.synced).toEqual(["cluster-secrets.json"]);
+    // cluster-secrets.json gets the bot creds
+    const shared = JSON.parse(readFileSync(join(configDir, "cluster-secrets.json"), "utf8"));
+    expect(shared.catalyst.linear.bot.orchestrator.accessToken).toBe("orch-tok");
+    expect(shared.catalyst.linear.bot.worker.accessToken).toBe("worker-tok");
+    // config.json is NOT touched (it didn't exist before)
+    expect(existsSync(join(configDir, "config.json"))).toBe(false);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -469,6 +469,56 @@ export function getLayer2ConfigPath() {
   return legacyPath;
 }
 
+// CTL-1210: sibling file resolvers — resolved off the SAME dir getLayer2ConfigPath()
+// returns so the deferred canonical cutover (config.mjs:432–444) is untouched.
+// cluster-secrets.json: SHARED, byte-identical on every cluster node.
+// node.json: PER-NODE, generated/edited locally, never mirrored.
+export function resolveClusterSecretsPath() {
+  return resolve(getLayer2ConfigPath(), "..", "cluster-secrets.json");
+}
+export function resolveNodeConfigPath() {
+  return resolve(getLayer2ConfigPath(), "..", "node.json");
+}
+
+// CTL-1210: merged Layer-2 reader. Composes config.json (bottom) < node.json <
+// cluster-secrets.json (top). Each read is fail-open to {} (ENOENT/malformed/absent
+// key), matching every existing readLayer2* site. Shared and per-node keys are
+// disjoint by classification so precedence only matters for the legacy fallback:
+// every migrated key resolves from its new home; every un-migrated key still
+// resolves from config.json. With only config.json present, the merged result
+// is byte-equal to today's read — zero behavior change.
+function _deepMergeLayer2(target, source) {
+  const out = { ...target };
+  for (const key of Object.keys(source)) {
+    if (
+      source[key] !== null &&
+      typeof source[key] === "object" &&
+      !Array.isArray(source[key]) &&
+      target[key] !== null &&
+      typeof target[key] === "object" &&
+      !Array.isArray(target[key])
+    ) {
+      out[key] = _deepMergeLayer2(target[key], source[key]);
+    } else {
+      out[key] = source[key];
+    }
+  }
+  return out;
+}
+export function readLayer2Merged() {
+  const readCatalyst = (p) => {
+    try {
+      return JSON.parse(readFileSync(p, "utf8"))?.catalyst ?? {};
+    } catch {
+      return {};
+    }
+  };
+  const legacy = readCatalyst(getLayer2ConfigPath());
+  const node = readCatalyst(resolveNodeConfigPath());
+  const shared = readCatalyst(resolveClusterSecretsPath());
+  return { catalyst: _deepMergeLayer2(_deepMergeLayer2(legacy, node), shared) };
+}
+
 // The repo root that owns the committed cluster roster (.catalyst/hosts.json).
 // CATALYST_CONFIG_FILE points at <repoRoot>/.catalyst/config.json (mirrors the
 // reaper-config resolution in daemon.mjs main()); otherwise fall back to the
@@ -527,8 +577,7 @@ export function getHostName() {
   const envOverride = process.env.CATALYST_HOST_NAME;
   if (typeof envOverride === "string" && envOverride.length > 0) return envOverride;
   try {
-    const parsed = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"));
-    const name = parsed?.catalyst?.host?.name;
+    const name = readLayer2Merged().catalyst?.host?.name;
     if (typeof name === "string" && name.length > 0) return name;
   } catch {
     /* missing/malformed Layer-2 file → hostname default */
@@ -546,8 +595,8 @@ export function isHostNamePinnedFromConfig() {
   const env = process.env.CATALYST_HOST_NAME;
   if (typeof env === "string" && env.length > 0) return true;
   try {
-    const parsed = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"));
-    return typeof parsed?.catalyst?.host?.name === "string" && parsed.catalyst.host.name.length > 0;
+    const name = readLayer2Merged().catalyst?.host?.name;
+    return typeof name === "string" && name.length > 0;
   } catch {
     return false;
   }
@@ -583,7 +632,7 @@ const NODE_CLASS_MOST_RESTRICTIVE = "monitor";
 // being silently flattened to "absent".
 function readLayer2NodeClass() {
   try {
-    return JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.node?.class;
+    return readLayer2Merged().catalyst?.node?.class;
   } catch {
     /* missing/malformed Layer-2 file → undefined (default-to-worker) */
     return undefined;
@@ -1052,7 +1101,7 @@ export function getStaticRoster() {
     if (hosts.length > 0) return hosts;
   }
   try {
-    const raw = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cluster
+    const raw = readLayer2Merged().catalyst?.cluster
       ?.staticRoster;
     if (Array.isArray(raw)) {
       const hosts = raw.filter((h) => typeof h === "string" && h.length > 0);
@@ -1239,7 +1288,7 @@ export function getLivenessAnchorIssue() {
   const env = process.env.CATALYST_LIVENESS_ANCHOR_ISSUE;
   if (typeof env === "string" && env.length > 0) return env;
   try {
-    const a = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cluster
+    const a = readLayer2Merged().catalyst?.cluster
       ?.livenessAnchorIssue;
     if (typeof a === "string" && a.length > 0) return a;
   } catch {
@@ -1838,7 +1887,7 @@ export const WATCHDOG_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2Watchdog() {
   try {
-    const w = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.watchdog;
+    const w = readLayer2Merged().catalyst?.watchdog;
     return w && typeof w === "object" ? w : {};
   } catch {
     return {};
@@ -1974,7 +2023,7 @@ const COST_CAP_DEFAULT_PROM_URL = "http://100.65.193.30:9098"; // OTel/Prom stac
 
 function readLayer2CostCap() {
   try {
-    const c = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.costCap;
+    const c = readLayer2Merged().catalyst?.costCap;
     return c && typeof c === "object" ? c : {};
   } catch {
     return {};
@@ -2055,7 +2104,7 @@ export const STALL_JANITOR_DEFAULT_CENSUS_INTERVAL_MS = 900_000; // 15 minutes
 
 function readLayer2StallJanitor() {
   try {
-    const sj = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.stallJanitor;
+    const sj = readLayer2Merged().catalyst?.stallJanitor;
     return sj && typeof sj === "object" ? sj : {};
   } catch {
     return {};
@@ -2101,7 +2150,7 @@ export const UNSTUCK_SWEEP_DEFAULT_INTERVAL_MS = 900_000; // 15 minutes
 
 function readLayer2UnstuckSweep() {
   try {
-    const us = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.unstuckSweep;
+    const us = readLayer2Merged().catalyst?.unstuckSweep;
     return us && typeof us === "object" ? us : {};
   } catch {
     return {};
@@ -2146,7 +2195,7 @@ export const RECOVERY_PASS_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2RecoveryPass() {
   try {
-    const rp = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery?.pass;
+    const rp = readLayer2Merged().catalyst?.recovery?.pass;
     return rp && typeof rp === "object" ? rp : {};
   } catch {
     return {};
@@ -2182,7 +2231,7 @@ const DELEGATE_FIRST_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2DelegateFirst() {
   try {
-    const df = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.delegateFirst;
+    const df = readLayer2Merged().catalyst?.delegateFirst;
     return df && typeof df === "object" ? df : {};
   } catch {
     return {};
@@ -2210,7 +2259,7 @@ export const STEWARD_ESCALATION_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2StewardEscalation() {
   try {
-    const se = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.stewardEscalation;
+    const se = readLayer2Merged().catalyst?.stewardEscalation;
     return se && typeof se === "object" ? se : {};
   } catch {
     return {};
@@ -2242,7 +2291,7 @@ const CLOUD_FEED_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2CloudFeed() {
   try {
-    const cf = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.cloudFeed;
+    const cf = readLayer2Merged().catalyst?.cloudFeed;
     return cf && typeof cf === "object" ? cf : {};
   } catch {
     return {};
@@ -2317,7 +2366,7 @@ export const LINEAR_WRITE_PROXY_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2LinearWriteProxy() {
   try {
-    const p = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.linearWriteProxy;
+    const p = readLayer2Merged().catalyst?.linearWriteProxy;
     return p && typeof p === "object" ? p : {};
   } catch {
     return {};
@@ -2365,7 +2414,7 @@ export const LEASE_AUTHORITY_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2LeaseAuthority() {
   try {
-    const p = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.leaseAuthority;
+    const p = readLayer2Merged().catalyst?.leaseAuthority;
     return p && typeof p === "object" ? p : {};
   } catch {
     return {};
@@ -2407,7 +2456,7 @@ export const DEAD_DOC_WORKER_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2DeadDocWorker() {
   try {
-    const d = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.recovery
+    const d = readLayer2Merged().catalyst?.recovery
       ?.deadDocWorker;
     return d && typeof d === "object" ? d : {};
   } catch {
@@ -2458,7 +2507,7 @@ export const BOARD_HEALTH_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2BoardHealth() {
   try {
-    const b = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.boardHealth;
+    const b = readLayer2Merged().catalyst?.boardHealth;
     return b && typeof b === "object" ? b : {};
   } catch {
     return {};
@@ -2522,7 +2571,7 @@ export const COORDINATION_MODES = new Set(["off", "shadow", "enforce"]);
 
 function readLayer2Coordination() {
   try {
-    const c = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.coordination;
+    const c = readLayer2Merged().catalyst?.coordination;
     return c && typeof c === "object" ? c : {};
   } catch {
     return {};
@@ -2653,7 +2702,7 @@ export const LINEAR_REPLICA_MODES = new Set(["on", "off"]);
 
 function readLayer2LinearReplica() {
   try {
-    const r = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.linearReplica;
+    const r = readLayer2Merged().catalyst?.linearReplica;
     return r && typeof r === "object" ? r : {};
   } catch {
     return {};
@@ -2835,7 +2884,7 @@ export function readDelegateQueueDepth() {
 
 function readLayer2Governance() {
   try {
-    const g = JSON.parse(readFileSync(getLayer2ConfigPath(), "utf8"))?.catalyst?.governance;
+    const g = readLayer2Merged().catalyst?.governance;
     return g && typeof g === "object" ? g : {};
   } catch {
     return {};
@@ -2935,4 +2984,152 @@ export function readGovernanceSources(env = process.env) {
     DEAD_DOC_WORKER_MODES
   );
   return out;
+}
+
+// CTL-1210: Frozen classification map (CTL-1187 table). Keyed by catalyst.* dotted
+// prefix; longest-prefix wins so "cluster.livenessAnchorIssue" → shared while
+// "cluster.staticRoster" → node. This is THE single source of truth for both the
+// migration (splitLayer2Config) and the writers.
+export const LAYER2_KEY_CLASS = Object.freeze({
+  "linear.bot": "shared",
+  "cluster.livenessAnchorIssue": "shared",
+  "layer1Identity": "shared",
+  "repository": "shared",
+  "feedback": "shared",
+  "monitor.github.smeeChannel": "shared",
+  "githubFeed.mode": "shared",
+  "host.name": "node",
+  "node.class": "node",
+  "cluster.staticRoster": "node",
+  "watchdog": "node",
+  "costCap": "node",
+  "stallJanitor": "node",
+  "unstuckSweep": "node",
+  "recovery": "node",
+  "delegateFirst": "node",
+  "stewardEscalation": "node",
+  "cloudFeed": "node",
+  "linearWriteProxy": "node",
+  "leaseAuthority": "node",
+  "boardHealth": "node",
+  "coordination": "node",
+  "linearReplica": "node",
+  "governance": "node",
+  "orchestration": "node",
+  "readReplica": "node",
+  "monitor": "node",
+});
+
+// _classifyLayer2Key — return the LAYER2_KEY_CLASS class for a dotted catalyst.*
+// key, using longest-prefix-wins. Returns "unclassified" when no prefix matches.
+function _classifyLayer2Key(dotPath) {
+  let best = null;
+  let bestLen = -1;
+  for (const [prefix, cls] of Object.entries(LAYER2_KEY_CLASS)) {
+    if (dotPath === prefix || dotPath.startsWith(prefix + ".")) {
+      if (prefix.length > bestLen) {
+        bestLen = prefix.length;
+        best = cls;
+      }
+    }
+  }
+  return best ?? "unclassified";
+}
+
+// _sortedStringify — deterministic, 0o600 JSON serialization. Stable across runs
+// so the doctor hash check is meaningful.
+function _sortedStringify(obj) {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return JSON.stringify(obj);
+  }
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${_sortedStringify(obj[k])}`);
+  return `{${parts.join(",")}}`;
+}
+
+// _setDotPath — set a dotted path inside a nested object, creating intermediaries.
+function _setDotPath(obj, dotPath, value) {
+  const parts = dotPath.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (cur[parts[i]] == null || typeof cur[parts[i]] !== "object") {
+      cur[parts[i]] = {};
+    }
+    cur = cur[parts[i]];
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+// CTL-1210: splitLayer2Config — classify every catalyst.* key in an existing
+// config.json by LAYER2_KEY_CLASS, write shared keys to cluster-secrets.json and
+// per-node keys to node.json (both 0o600, sorted-key serialization, tmp+rename),
+// then rewrite config.json with the migrated keys removed.
+//
+// Idempotent: re-running on an already-split node is a no-op.
+// Crash-safe: new files are written FIRST; config.json is trimmed LAST.
+// Unclassified keys stay in config.json and are never dropped.
+// Mixed subtrees (e.g. catalyst.cluster contains both a shared and a node key)
+// are recursively decomposed — the classifer recurses when a path is unclassified
+// at a given depth but may have classified children.
+export function splitLayer2Config({
+  configPath = getLayer2ConfigPath(),
+  sharedPath = resolveClusterSecretsPath(),
+  nodePath = resolveNodeConfigPath(),
+} = {}) {
+  let existing;
+  try {
+    existing = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch {
+    return; // config.json absent or malformed — nothing to migrate
+  }
+  const catalyst = existing?.catalyst;
+  if (!catalyst || typeof catalyst !== "object" || Array.isArray(catalyst)) return;
+
+  const sharedCat = {};
+  const nodeCat = {};
+  const leftoverCat = {};
+
+  function walkCatalyst(obj, prefix) {
+    for (const [k, v] of Object.entries(obj)) {
+      const dotPath = prefix ? `${prefix}.${k}` : k;
+      const cls = _classifyLayer2Key(dotPath);
+      if (cls === "shared") {
+        _setDotPath(sharedCat, dotPath, v);
+      } else if (cls === "node") {
+        _setDotPath(nodeCat, dotPath, v);
+      } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+        // Unclassified at this depth — recurse into children to find classified sub-paths.
+        walkCatalyst(v, dotPath);
+      } else {
+        _setDotPath(leftoverCat, dotPath, v);
+      }
+    }
+  }
+  walkCatalyst(catalyst, "");
+
+  function writeAtomic(path, catObj) {
+    const content = _sortedStringify({ catalyst: catObj }) + "\n";
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, content, { mode: 0o600 });
+    renameSync(tmp, path);
+  }
+
+  const hasShared = Object.keys(sharedCat).length > 0;
+  const hasNode = Object.keys(nodeCat).length > 0;
+
+  // If config.json had no classified keys, nothing to migrate — preserve all files.
+  if (!hasShared && !hasNode) return;
+
+  // Write shared + node FIRST (crash-safe ordering: new files written before trimming).
+  // Always write both sibling files when any migration runs to establish clean known state
+  // so subsequent idempotency checks can read both files unconditionally.
+  writeAtomic(sharedPath, sharedCat);
+  writeAtomic(nodePath, nodeCat);
+
+  // Trim config.json to only leftover (unclassified) keys — LAST step.
+  const trimmedCat = Object.keys(leftoverCat).length > 0 ? leftoverCat : {};
+  const trimContent = _sortedStringify({ catalyst: trimmedCat }) + "\n";
+  const trimTmp = `${configPath}.tmp.${process.pid}`;
+  writeFileSync(trimTmp, trimContent, { mode: 0o600 });
+  renameSync(trimTmp, configPath);
 }

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -3047,17 +3047,22 @@ function _sortedStringify(obj) {
   return `{${parts.join(",")}}`;
 }
 
+const _PROTO_POISON = new Set(["__proto__", "constructor", "prototype"]);
+
 // _setDotPath — set a dotted path inside a nested object, creating intermediaries.
 function _setDotPath(obj, dotPath, value) {
   const parts = dotPath.split(".");
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
+    if (_PROTO_POISON.has(parts[i])) throw new Error(`_setDotPath: forbidden key segment "${parts[i]}"`);
     if (cur[parts[i]] == null || typeof cur[parts[i]] !== "object") {
       cur[parts[i]] = {};
     }
     cur = cur[parts[i]];
   }
-  cur[parts[parts.length - 1]] = value;
+  const last = parts[parts.length - 1];
+  if (_PROTO_POISON.has(last)) throw new Error(`_setDotPath: forbidden key segment "${last}"`);
+  cur[last] = value;
 }
 
 // CTL-1210: splitLayer2Config — classify every catalyst.* key in an existing

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -2997,7 +2997,7 @@ export const LAYER2_KEY_CLASS = Object.freeze({
   "repository": "shared",
   "feedback": "shared",
   "monitor.github.smeeChannel": "shared",
-  "githubFeed.mode": "shared",
+  "githubFeed.mode": "node",
   "host.name": "node",
   "node.class": "node",
   "cluster.staticRoster": "node",

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -3047,22 +3047,23 @@ function _sortedStringify(obj) {
   return `{${parts.join(",")}}`;
 }
 
-const _PROTO_POISON = new Set(["__proto__", "constructor", "prototype"]);
-
 // _setDotPath — set a dotted path inside a nested object, creating intermediaries.
 function _setDotPath(obj, dotPath, value) {
   const parts = dotPath.split(".");
+  // Guard all segments upfront with explicit === comparisons (CodeQL-recognized sanitiser).
+  for (const p of parts) {
+    if (p === "__proto__" || p === "constructor" || p === "prototype") {
+      throw new Error(`_setDotPath: forbidden key segment "${p}"`);
+    }
+  }
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (_PROTO_POISON.has(parts[i])) throw new Error(`_setDotPath: forbidden key segment "${parts[i]}"`);
     if (cur[parts[i]] == null || typeof cur[parts[i]] !== "object") {
       cur[parts[i]] = {};
     }
     cur = cur[parts[i]];
   }
-  const last = parts[parts.length - 1];
-  if (_PROTO_POISON.has(last)) throw new Error(`_setDotPath: forbidden key segment "${last}"`);
-  cur[last] = value;
+  cur[parts[parts.length - 1]] = value;
 }
 
 // CTL-1210: splitLayer2Config — classify every catalyst.* key in an existing

--- a/plugins/dev/scripts/execution-core/config.test.mjs
+++ b/plugins/dev/scripts/execution-core/config.test.mjs
@@ -7,9 +7,9 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test config.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, existsSync, statSync } from "node:fs";
 import { tmpdir, hostname, homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname } from "node:path";
 
 // Mirrors getHostName()'s fallback: strip everything after the FIRST dot, not
 // just a trailing ".local". A naive `.replace(/\.local$/, "")` only agrees with
@@ -68,6 +68,12 @@ import {
   getLayer2ConfigPath,
   log,
   readGovernanceSources,
+  // CTL-1210: split Layer-2 config lifecycle
+  resolveClusterSecretsPath,
+  resolveNodeConfigPath,
+  readLayer2Merged,
+  LAYER2_KEY_CLASS,
+  splitLayer2Config,
 } from "./config.mjs";
 
 const PREV = process.env.CATALYST_WAIT_WATCHER;
@@ -1792,6 +1798,221 @@ describe("readFleetHealthConfig (CTL-1503)", () => {
     expect(readFleetHealthConfig().swapUsedMbClearThreshold).toBe(16384);
     process.env.EXECUTION_CORE_FLEET_SWAP_MB_CLEAR_THRESHOLD = "";
     expect(readFleetHealthConfig().swapUsedMbClearThreshold).toBe(16384);
+  });
+});
+
+// CTL-1210: split Layer-2 config by lifecycle helpers
+// Helpers for the CTL-1210 test suite
+function makeTmpLayer2() {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1210-"));
+  const configPath = join(dir, "config.json");
+  return { dir, configPath };
+}
+function writeLayer2(dir, name, obj) {
+  writeFileSync(join(dir, name), JSON.stringify(obj) + "\n");
+}
+function setLayer2Env(path) {
+  process.env.CATALYST_LAYER2_CONFIG_FILE = path;
+}
+function clearLayer2Env() {
+  delete process.env.CATALYST_LAYER2_CONFIG_FILE;
+}
+function rmTmpDir(dir) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+describe("resolveClusterSecretsPath / resolveNodeConfigPath (CTL-1210 Phase 1)", () => {
+  let dir;
+  beforeEach(() => {
+    const t = makeTmpLayer2();
+    dir = t.dir;
+    setLayer2Env(t.configPath);
+  });
+  afterEach(() => {
+    clearLayer2Env();
+    rmTmpDir(dir);
+  });
+
+  test("siblings of getLayer2ConfigPath dir", () => {
+    const base = getLayer2ConfigPath();
+    const d = dirname(base);
+    expect(resolveClusterSecretsPath()).toBe(resolve(d, "cluster-secrets.json"));
+    expect(resolveNodeConfigPath()).toBe(resolve(d, "node.json"));
+  });
+
+  test("honors CATALYST_LAYER2_CONFIG_FILE override", () => {
+    expect(resolveClusterSecretsPath()).toContain(dir);
+    expect(resolveNodeConfigPath()).toContain(dir);
+  });
+});
+
+describe("readLayer2Merged (CTL-1210 Phase 1)", () => {
+  let dir;
+  beforeEach(() => {
+    const t = makeTmpLayer2();
+    dir = t.dir;
+    setLayer2Env(t.configPath);
+  });
+  afterEach(() => {
+    clearLayer2Env();
+    rmTmpDir(dir);
+  });
+
+  test("cluster-secrets and node override legacy config.json", () => {
+    writeLayer2(dir, "config.json", { catalyst: { a: 1, host: { name: "old" } } });
+    writeLayer2(dir, "node.json", { catalyst: { host: { name: "n1" }, watchdog: { mode: "enforce" } } });
+    writeLayer2(dir, "cluster-secrets.json", { catalyst: { linear: { bot: { worker: { botUserId: "w" } } } } });
+    const merged = readLayer2Merged();
+    expect(merged.catalyst.host.name).toBe("n1");
+    expect(merged.catalyst.linear.bot.worker.botUserId).toBe("w");
+    expect(merged.catalyst.a).toBe(1);
+  });
+
+  test("only config.json present is byte-equal to legacy single read", () => {
+    const payload = { catalyst: { host: { name: "solo" }, watchdog: { mode: "shadow" } } };
+    writeLayer2(dir, "config.json", payload);
+    const merged = readLayer2Merged();
+    expect(merged).toEqual(payload);
+  });
+
+  test("missing/malformed sibling files fail open to {}", () => {
+    writeLayer2(dir, "config.json", { catalyst: { a: 42 } });
+    writeFileSync(join(dir, "node.json"), "NOT JSON");
+    // cluster-secrets.json absent (ENOENT)
+    const merged = readLayer2Merged();
+    expect(merged.catalyst.a).toBe(42);
+    expect(() => readLayer2Merged()).not.toThrow();
+  });
+
+  test("cluster-secrets wins over node, node wins over legacy (precedence chain)", () => {
+    writeLayer2(dir, "config.json", { catalyst: { x: "legacy", y: "legacy" } });
+    writeLayer2(dir, "node.json", { catalyst: { x: "node" } });
+    writeLayer2(dir, "cluster-secrets.json", { catalyst: { x: "shared" } });
+    const merged = readLayer2Merged();
+    expect(merged.catalyst.x).toBe("shared");
+    expect(merged.catalyst.y).toBe("legacy");
+  });
+});
+
+describe("getHostName reads from merged files (CTL-1210 Phase 1)", () => {
+  let dir;
+  beforeEach(() => {
+    const t = makeTmpLayer2();
+    dir = t.dir;
+    setLayer2Env(t.configPath);
+  });
+  afterEach(() => {
+    clearLayer2Env();
+    rmTmpDir(dir);
+  });
+
+  test("host.name from node.json wins over legacy config.json", () => {
+    writeLayer2(dir, "config.json", { catalyst: { host: { name: "old" } } });
+    writeLayer2(dir, "node.json", { catalyst: { host: { name: "new-from-node" } } });
+    delete process.env.CATALYST_HOST_NAME;
+    expect(getHostName()).toBe("new-from-node");
+  });
+});
+
+describe("LAYER2_KEY_CLASS (CTL-1210 Phase 2)", () => {
+  test("is defined and has shared + node classifications", () => {
+    expect(typeof LAYER2_KEY_CLASS).toBe("object");
+    expect(LAYER2_KEY_CLASS["linear.bot"]).toBe("shared");
+    expect(LAYER2_KEY_CLASS["host.name"]).toBe("node");
+    expect(LAYER2_KEY_CLASS["cluster.livenessAnchorIssue"]).toBe("shared");
+    expect(LAYER2_KEY_CLASS["watchdog"]).toBe("node");
+    expect(LAYER2_KEY_CLASS["layer1Identity"]).toBe("shared");
+  });
+});
+
+describe("splitLayer2Config (CTL-1210 Phase 2)", () => {
+  let dir;
+  beforeEach(() => {
+    const t = makeTmpLayer2();
+    dir = t.dir;
+    setLayer2Env(t.configPath);
+  });
+  afterEach(() => {
+    clearLayer2Env();
+    rmTmpDir(dir);
+  });
+
+  test("shared keys → cluster-secrets.json, per-node → node.json, both mode 0600", () => {
+    writeLayer2(dir, "config.json", {
+      catalyst: {
+        "linear": { bot: { orchestrator: { clientId: "oc", clientSecret: "os" } } },
+        "cluster": { livenessAnchorIssue: "CTL-1217" },
+        "host": { name: "mini" },
+        "watchdog": { mode: "shadow" },
+      },
+    });
+    splitLayer2Config({ configPath: join(dir, "config.json"), sharedPath: join(dir, "cluster-secrets.json"), nodePath: join(dir, "node.json") });
+    const shared = JSON.parse(readFileSync(join(dir, "cluster-secrets.json"), "utf8"));
+    const node = JSON.parse(readFileSync(join(dir, "node.json"), "utf8"));
+    expect(shared.catalyst?.linear?.bot?.orchestrator?.clientId).toBe("oc");
+    expect(shared.catalyst?.cluster?.livenessAnchorIssue).toBe("CTL-1217");
+    expect(node.catalyst?.host?.name).toBe("mini");
+    expect(node.catalyst?.watchdog?.mode).toBe("shadow");
+    const sharedMode = (statSync(join(dir, "cluster-secrets.json")).mode & 0o777).toString(8);
+    const nodeMode = (statSync(join(dir, "node.json")).mode & 0o777).toString(8);
+    expect(sharedMode).toBe("600");
+    expect(nodeMode).toBe("600");
+  });
+
+  test("old keys still resolve after migration via readLayer2Merged", () => {
+    writeLayer2(dir, "config.json", {
+      catalyst: {
+        linear: { bot: { orchestrator: { clientId: "oc" } } },
+        host: { name: "host1" },
+        watchdog: { mode: "enforce" },
+      },
+    });
+    splitLayer2Config({ configPath: join(dir, "config.json"), sharedPath: join(dir, "cluster-secrets.json"), nodePath: join(dir, "node.json") });
+    const merged = readLayer2Merged();
+    expect(merged.catalyst?.linear?.bot?.orchestrator?.clientId).toBe("oc");
+    expect(merged.catalyst?.host?.name).toBe("host1");
+    expect(merged.catalyst?.watchdog?.mode).toBe("enforce");
+  });
+
+  test("idempotent — second run on already-split node is a no-op (config.json trimmed)", () => {
+    const orig = { catalyst: { host: { name: "h" }, watchdog: { mode: "shadow" } } };
+    writeLayer2(dir, "config.json", orig);
+    const opts = { configPath: join(dir, "config.json"), sharedPath: join(dir, "cluster-secrets.json"), nodePath: join(dir, "node.json") };
+    splitLayer2Config(opts);
+    const node1 = readFileSync(join(dir, "node.json"), "utf8");
+    const shared1 = readFileSync(join(dir, "cluster-secrets.json"), "utf8");
+    const cfg1 = readFileSync(join(dir, "config.json"), "utf8");
+    // Second run: config.json is now trimmed (no classified keys) — output files unchanged.
+    splitLayer2Config(opts);
+    const node2 = readFileSync(join(dir, "node.json"), "utf8");
+    const shared2 = readFileSync(join(dir, "cluster-secrets.json"), "utf8");
+    const cfg2 = readFileSync(join(dir, "config.json"), "utf8");
+    expect(node1).toBe(node2);
+    expect(shared1).toBe(shared2);
+    expect(cfg1).toBe(cfg2);
+  });
+
+  test("deterministic serialization (sorted keys) — byte-stable given same input", () => {
+    const orig = { catalyst: { host: { name: "h" }, watchdog: { mode: "shadow" } } };
+    const opts = { configPath: join(dir, "config.json"), sharedPath: join(dir, "cluster-secrets.json"), nodePath: join(dir, "node.json") };
+    // First run.
+    writeLayer2(dir, "config.json", orig);
+    splitLayer2Config(opts);
+    const bytes1 = readFileSync(join(dir, "node.json"), "utf8");
+    // Reset to original state and run again.
+    rmSync(join(dir, "node.json"), { force: true });
+    rmSync(join(dir, "cluster-secrets.json"), { force: true });
+    writeLayer2(dir, "config.json", orig);
+    splitLayer2Config(opts);
+    const bytes2 = readFileSync(join(dir, "node.json"), "utf8");
+    expect(bytes1).toBe(bytes2);
+  });
+
+  test("unclassified key stays in config.json (fail-open, never dropped)", () => {
+    writeLayer2(dir, "config.json", { catalyst: { host: { name: "h" }, unknownKey: { val: 99 } } });
+    splitLayer2Config({ configPath: join(dir, "config.json"), sharedPath: join(dir, "cluster-secrets.json"), nodePath: join(dir, "node.json") });
+    const cfg = JSON.parse(readFileSync(join(dir, "config.json"), "utf8"));
+    expect(cfg.catalyst?.unknownKey?.val).toBe(99);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -109,6 +109,9 @@ import {
   // config.json (bottom), each fail-open to {}. Used by layer2HasKey so doctor
   // grades the same merged view the daemon reads.
   readLayer2Merged,
+  // CTL-1210 Phase 5: advisory presence checks for the two new Layer-2 sibling files.
+  resolveClusterSecretsPath,
+  resolveNodeConfigPath,
 } from "./config.mjs";
 // CTL-1785: the TTL constants + enum, imported DIRECTLY from the zero-import leaf
 // (node built-ins only — safe under doctor's bare-Node runtime), same pattern as
@@ -4161,6 +4164,57 @@ export function checkClusterSecretFreshness(deps = {}) {
   return checks;
 }
 
+// checkClusterSecretsPresent — CTL-1210 Phase 5. ADVISORY ONLY (WARN, never FAIL).
+// Reports whether ~/.config/catalyst/cluster-secrets.json exists, which is the
+// migration state indicator: absent on a fresh node (no cluster-sync yet run),
+// present once cluster-sync has written it. No content validation — presence only.
+export function checkClusterSecretsPresent(deps = {}) {
+  const {
+    csPath = resolveClusterSecretsPath(),
+    fileExists = (p) => existsSync(p),
+  } = deps;
+  const NAME = "cluster-secrets-present";
+  if (fileExists(csPath)) {
+    return [mkCheck(NAME, STATUS.PASS, `cluster-secrets.json present at ${csPath}`)];
+  }
+  return [
+    mkCheck(
+      NAME,
+      STATUS.WARN,
+      `cluster-secrets.json absent at ${csPath} — shared keys (bot creds, smeeChannel) ` +
+        "will be read from config.json until a cluster-sync or catalyst-join runs",
+    ),
+  ];
+}
+
+// checkNodeConfigPresent — CTL-1210 Phase 5. ADVISORY ONLY (WARN, never FAIL).
+// Reports whether ~/.config/catalyst/node.json exists and has a non-empty host.name.
+// A missing node.json is fine (new install); a present-but-host-name-less one is the
+// unexpected state worth surfacing.
+export function checkNodeConfigPresent(deps = {}) {
+  const {
+    nodePath = resolveNodeConfigPath(),
+    fileExists = (p) => existsSync(p),
+    readJson = (p) => {
+      try {
+        return JSON.parse(readFileSync(p, "utf8"));
+      } catch {
+        return null;
+      }
+    },
+  } = deps;
+  const NAME = "node-config-present";
+  if (!fileExists(nodePath)) {
+    return [mkCheck(NAME, STATUS.WARN, `node.json absent at ${nodePath} — per-node config (host.name, cloudFeed.mode, …) not split yet; config.json is the fallback`)];
+  }
+  const obj = readJson(nodePath);
+  const hostName = obj?.catalyst?.host?.name ?? obj?.catalyst?.["host.name"];
+  if (!hostName) {
+    return [mkCheck(NAME, STATUS.WARN, `node.json present but catalyst.host.name is unset — run catalyst-join or set it manually`)];
+  }
+  return [mkCheck(NAME, STATUS.PASS, `node.json present, host.name=${hostName}`)];
+}
+
 // checkConfigScopeLeak — CTL-1214. Flags a committed Layer-1 .catalyst/config.json
 // that still carries node/cluster-scoped keys, or a legacy .catalyst/hosts.json
 // roster file. `.catalyst/config.json` is committed per-repo and must carry ONLY
@@ -6470,6 +6524,8 @@ export function checksForClass(nc, opts = {}) {
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
       () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
       () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
+      () => checkClusterSecretsPresent(), // CTL-1210: cluster-secrets.json present? (advisory — new nodes haven't run cluster-sync yet)
+      () => checkNodeConfigPresent(), // CTL-1210: node.json present + host.name set? (advisory)
     ];
   }
 
@@ -6557,6 +6613,8 @@ export function checksForClass(nc, opts = {}) {
     () => checkLinearWriteBudget(), // CTL-1936: host cloud-write spend / exhaustion — advisory only (never FAIL)
     () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
     () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
+    () => checkClusterSecretsPresent(), // CTL-1210: cluster-secrets.json present? (advisory — new nodes haven't run cluster-sync yet)
+    () => checkNodeConfigPresent(), // CTL-1210: node.json present + host.name set? (advisory)
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -105,6 +105,10 @@ import {
   // CTL-1785: entitlement mode resolver, re-exported from the zero-import leaf
   // (same pattern as deployment-mode above) — doctor grades it advisory-only.
   resolveEntitlementMode,
+  // CTL-1210: merged Layer-2 reader — cluster-secrets.json (top) > node.json >
+  // config.json (bottom), each fail-open to {}. Used by layer2HasKey so doctor
+  // grades the same merged view the daemon reads.
+  readLayer2Merged,
 } from "./config.mjs";
 // CTL-1785: the TTL constants + enum, imported DIRECTLY from the zero-import leaf
 // (node built-ins only — safe under doctor's bare-Node runtime), same pattern as
@@ -395,7 +399,7 @@ function layer2Path() {
 
 function layer2HasKey(key) {
   try {
-    let obj = JSON.parse(readFileSync(layer2Path(), "utf8"));
+    let obj = readLayer2Merged();
     for (const part of key.split(".")) {
       if (obj == null || typeof obj !== "object") return false;
       obj = obj[part];

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -62,6 +62,8 @@ import {
   readLinearBotUserIds,
   readCloudBotUserId,
   checkSelfEchoIdentityHistory,
+  checkClusterSecretsPresent,
+  checkNodeConfigPresent,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -6327,5 +6329,73 @@ describe("checkFleetTokenExport — CTL-1908: a login shell must not spend the F
     // A check nobody runs is the failure mode this repo keeps meeting.
     const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
     expect(src.split("checkFleetTokenExport()").length - 1, "registered in BOTH class suites").toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─── checkClusterSecretsPresent (CTL-1210 Phase 5) ───────────────────────────
+describe("checkClusterSecretsPresent (CTL-1210)", () => {
+  it("PASS when cluster-secrets.json exists", () => {
+    const [c] = checkClusterSecretsPresent({ csPath: "/h/.config/catalyst/cluster-secrets.json", fileExists: () => true });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.name).toBe("cluster-secrets-present");
+  });
+
+  it("WARN when cluster-secrets.json absent — not FAIL (advisory)", () => {
+    const [c] = checkClusterSecretsPresent({ csPath: "/h/.config/catalyst/cluster-secrets.json", fileExists: () => false });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toMatch(/cluster-secrets\.json absent/i);
+  });
+
+  it("never FAILs (advisory) — exit-code-safe", async () => {
+    const code = await runDoctor({
+      checks: [() => checkClusterSecretsPresent({ csPath: "/absent/cluster-secrets.json", fileExists: () => false })],
+    });
+    expect(code).not.toBe(2);
+  });
+
+  it("is wired into both worker and developer suites", () => {
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    expect(src.split("checkClusterSecretsPresent()").length - 1, "registered in at least 2 class suites").toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─── checkNodeConfigPresent (CTL-1210 Phase 5) ───────────────────────────────
+describe("checkNodeConfigPresent (CTL-1210)", () => {
+  it("WARN when node.json absent — advisory", () => {
+    const [c] = checkNodeConfigPresent({ nodePath: "/h/node.json", fileExists: () => false });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toMatch(/node\.json absent/i);
+  });
+
+  it("WARN when node.json present but host.name unset", () => {
+    const [c] = checkNodeConfigPresent({
+      nodePath: "/h/node.json",
+      fileExists: () => true,
+      readJson: () => ({ catalyst: {} }),
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toMatch(/host\.name is unset/i);
+  });
+
+  it("PASS when node.json present and host.name set", () => {
+    const [c] = checkNodeConfigPresent({
+      nodePath: "/h/node.json",
+      fileExists: () => true,
+      readJson: () => ({ catalyst: { host: { name: "mini-1" } } }),
+    });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("mini-1");
+  });
+
+  it("never FAILs (advisory) — exit-code-safe", async () => {
+    const code = await runDoctor({
+      checks: [() => checkNodeConfigPresent({ nodePath: "/absent/node.json", fileExists: () => false })],
+    });
+    expect(code).not.toBe(2);
+  });
+
+  it("is wired into both worker and developer suites", () => {
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    expect(src.split("checkNodeConfigPresent()").length - 1, "registered in at least 2 class suites").toBeGreaterThanOrEqual(2);
   });
 });

--- a/plugins/dev/scripts/lib/catalyst-secret-contract.sh
+++ b/plugins/dev/scripts/lib/catalyst-secret-contract.sh
@@ -687,7 +687,15 @@ _csc_resolve_config_json() {
   fi
   _path="$(catalyst_secret_config_json_path "$_id")"
   _l2="$(catalyst_secret_resolve_layer2_path)"
-  _tagged="$(_csc_read_json_string "$_l2" "$_path")"
+  # CTL-1210: probe cluster-secrets.json first (shared keys land there via cluster-sync),
+  # then fall through to config.json for per-node keys and backward-compat installs.
+  local _l2_dir _cs_path
+  _l2_dir="$(dirname "$_l2")"
+  _cs_path="${_l2_dir}/cluster-secrets.json"
+  _tagged="$(_csc_read_json_string "$_cs_path" "$_path")"
+  if ! _csc_config_json_tag_accepted "$_id" "$_tagged"; then
+    _tagged="$(_csc_read_json_string "$_l2" "$_path")"
+  fi
   # ACTOR ROW SHAPE FIX (Codex finding fix): accepts BOTH the "@STR64:" tag (a JSON string —
   # the pre-existing groq-api-key/generic shape) AND the "@OBJ64:" tag (a JSON OBJECT — the
   # catalyst.linear.bot.orchestrator/.worker shape, canonicalized+base64'd by

--- a/plugins/dev/scripts/lib/secret-contract.mjs
+++ b/plugins/dev/scripts/lib/secret-contract.mjs
@@ -773,10 +773,19 @@ function resolveConfigJson(row, env, cwd) {
     const viaEnv = resolveEnvAliasOnly(row, env);
     if (viaEnv.value != null) return viaEnv;
   }
-  const path = resolveLayer2Path(env);
-  const raw = readJsonField(path, row.configJsonPath);
-  const resolved = canonicalizeConfigJsonValue(raw);
-  if (resolved != null && meetsRequiredObjectFields(row, raw)) {
+  // CTL-1210: probe cluster-secrets.json first (shared keys land there via cluster-sync),
+  // then fall through to config.json for per-node keys and backward-compat installs.
+  const layer2Path = resolveLayer2Path(env);
+  const clusterSecretsPath = join(dirname(layer2Path), "cluster-secrets.json");
+  let resolved = null;
+  let raw;
+  let path = null;
+  for (const candidate of [clusterSecretsPath, layer2Path]) {
+    raw = readJsonField(candidate, row.configJsonPath);
+    resolved = canonicalizeConfigJsonValue(raw);
+    if (resolved != null && meetsRequiredObjectFields(row, raw)) { path = candidate; break; }
+  }
+  if (path != null) {
     return { value: resolved, source: "config-json", provider: row.delivery, rotation: row.rotation, filePath: path };
   }
   // LEGACY TIERS (CTL-1616 PR4, linear-worker-actor only): tried, in order, ONLY once the

--- a/website/src/content/docs/reference/cluster-config-mirror.md
+++ b/website/src/content/docs/reference/cluster-config-mirror.md
@@ -13,7 +13,8 @@ monitoring code (M1 mirror tickets, CTL-1192 heartbeat quota):
 2. **Quota field-name schema** — the dotted event-log keys emitted by `ratelimit-event.mjs`,
    pinned here so heartbeat and quota consumers (CTL-1192) share one field-name contract.
 
-For the two-layer config model (`.catalyst/config.json` vs `~/.config/catalyst/config-{key}.json`)
+For the two-layer config model (`.catalyst/config.json` vs the three Layer-2 siblings:
+`cluster-secrets.json`, `node.json`, `config.json`)
 see the [configuration reference](/reference/configuration/).
 
 ---
@@ -33,15 +34,15 @@ and
 
 | Config item | File / key | Class | On mirror |
 |---|---|---|---|
-| Bot OAuth orchestrator token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.orchestrator.*` | **SHARED** | Copy the whole `catalyst.linear.bot` block (one Linear app per workspace; identical across nodes) |
-| Bot OAuth worker token | `~/.config/catalyst/config.json` → `catalyst.linear.bot.worker.*` | **SHARED** | Same block — worker and orchestrator tokens are workspace-scoped, not host-scoped |
+| Bot OAuth orchestrator token | `~/.config/catalyst/cluster-secrets.json` → `catalyst.linear.bot.orchestrator.*` | **SHARED** | Written by `cluster-sync` from `cluster-bots.sops.json`; one Linear app per workspace, identical across nodes. Falls back to `config.json` on nodes that haven't run cluster-sync yet. |
+| Bot OAuth worker token | `~/.config/catalyst/cluster-secrets.json` → `catalyst.linear.bot.worker.*` | **SHARED** | Same file — worker and orchestrator tokens are workspace-scoped, not host-scoped |
 | Cluster roster | `catalyst-cluster` repo → `cluster.json` `roster[]` | **SHARED** | Add the new node's name to `cluster.json.roster` and push. `cluster-sync` pulls it and the next scheduler tick honors it — no restart. *(The legacy committed `.catalyst/hosts.json` roster was retired in CTL-1274; the daemon no longer reads it.)* |
 | Layer-1 project config | `.catalyst/config.json` | **SHARED** | Committed to git; present after `git clone` |
-| Liveness anchor issue | `~/.config/catalyst/config.json` → `catalyst.cluster.livenessAnchorIssue` | **SHARED** | Copy from the seed node; one Linear ticket identifier per fleet |
+| Liveness anchor issue | `~/.config/catalyst/cluster-secrets.json` → `catalyst.cluster.livenessAnchorIssue` | **SHARED** | Written by `catalyst-join` from the bundle; one Linear ticket identifier per fleet. Falls back to `config.json`. |
 | Cloud token (`CATALYST_CLOUD_TOKEN`) | `catalyst-cluster` repo → `secrets/cluster-cloud.sops.json` `catalyst.cloud.token` | **SHARED** | One shared catalyst-cloud service credential (CTL-1307). Add it once to the cluster repo (SOPS); `cluster-sync` decrypts it to `~/.config/catalyst/cluster-cloud.json` and `cloud-token-env.mjs` projects it to the machine-level env (`cluster.env` + `~/.zshenv` guard) on every node. **Intentionally unread by catalyst core** — a prerequisite for the opt-in cloud path, not a switch that turns it on. |
 | Plugin source | `~/catalyst/plugin-source/` | **SHARED** | Pull from the same git remote; `setup-plugin-source.sh` does this |
 | Linear team/state map | Layer-1 `catalyst.linear.teamKey` / `stateMap` | **SHARED** | Present after `git clone` via `.catalyst/config.json` |
-| `catalyst.host.name` | `~/.config/catalyst/config.json` → `catalyst.host.name` | **PER-NODE** | Set to the new node's unique roster entry (must match an entry in the `catalyst-cluster` repo's `cluster.json.roster`; a name that isn't in the roster owns zero tickets under HRW) |
+| `catalyst.host.name` | `~/.config/catalyst/node.json` → `catalyst.host.name` | **PER-NODE** | Written by `catalyst-join` (non-clobber). Set to the new node's unique roster entry (must match an entry in the `catalyst-cluster` repo's `cluster.json.roster`; a name that isn't in the roster owns zero tickets under HRW). Falls back to `config.json`. |
 | `repoRoot` | `~/catalyst/execution-core/registry.json` → `repoRoot` | **PER-NODE** | The absolute path on the new host; written by `catalyst-execution-core register` |
 | Claude Code account login | macOS Keychain or `~/.claude/.credentials.json` | **PER-NODE** | Run `claude` interactively on the new host; each node uses its own account |
 | OTel endpoints | `~/.config/catalyst/config.json` → OTel keys | **PER-NODE** | Tailscale addresses differ per node; set in Layer-2 on each host |
@@ -55,7 +56,8 @@ and
 > **Why bot OAuth is SHARED:** `catalyst.linear.bot.orchestrator` and `catalyst.linear.bot.worker`
 > are credentials for a Linear OAuth application that is registered once per workspace. Every node in
 > the fleet acts on behalf of the same app. The tokens live in machine-global
-> `~/.config/catalyst/config.json` (not in the per-project `config-<key>.json`) so all nodes can
+> `~/.config/catalyst/cluster-secrets.json` (written by `cluster-sync` from `cluster-bots.sops.json`;
+> falls back to `config.json` on nodes that haven't run cluster-sync yet) so all nodes can
 > share them without per-project duplication.
 
 > **Why the cloud token is SHARED + machine-level (CTL-1307):** `CATALYST_CLOUD_TOKEN` is a single

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -7,13 +7,22 @@ sidebar:
   order: 0
 ---
 
-Catalyst reads two config files. The setup script (`setup-catalyst.sh`) writes both for you, so you
+Catalyst reads two config layers. The setup script (`setup-catalyst.sh`) writes both for you, so you
 rarely edit them by hand. This page covers the keys you're most likely to touch.
 
 - **`.catalyst/config.json`** — plain project info. Safe to commit to git.
-- **`~/.config/catalyst/config-{projectKey}.json`** — secrets like API keys. Never commit this.
+- **`~/.config/catalyst/`** — machine-local Layer-2. Never commit these files. Three siblings
+  compose the merged view (earlier wins):
+  - **`cluster-secrets.json`** — shared, byte-identical across all cluster nodes (bot OAuth creds,
+    `smeeChannel`, `livenessAnchorIssue`, etc.). Written by `cluster-sync` from `cluster-bots.sops.json`
+    and by `catalyst-join` from the bundle. Read first.
+  - **`node.json`** — per-node (host name, cloudFeed/githubFeed mode, orchestration tuning, etc.).
+    Written by `catalyst-join` (non-clobber; preserves operator overrides). Read second.
+  - **`config.json`** — backward-compat fallback. Read last. Keys still here on nodes that haven't
+    run `catalyst-join` or `cluster-sync` yet; migrated keys are gradually drained by those tools.
 
-The `projectKey` links the two files.
+The `projectKey` links Layer-1 and the per-project `config-{projectKey}.json` (legacy file for
+per-team API keys; separate from the three Layer-2 siblings above).
 
 ## Project config (`.catalyst/config.json`)
 


### PR DESCRIPTION
## Summary

Splits Layer-2 `~/.config/catalyst/config.json` into three sibling files with clear
lifecycle semantics:

- **`cluster-secrets.json`** — shared, byte-identical across all cluster nodes (bot OAuth creds,
  `smeeChannel`, `livenessAnchorIssue`, `repository`, `feedback`). Written by `cluster-sync`
  (from `cluster-bots.sops.json`) and by `catalyst-join` (from the bundle). Deterministic
  `jq -S` serialization for byte-identical content on all nodes.
- **`node.json`** — per-node, never mirrored (`host.name`, `cloudFeed.mode`, `githubFeed.mode`,
  orchestration config, etc.). Written by `catalyst-join` with non-clobber `//=` semantics so
  operator overrides survive re-joins.
- **`config.json`** — backward-compat fallback. Keys migrate out as nodes run `catalyst-join`/
  `cluster-sync`; un-migrated keys still resolve correctly.

The merged read order is `config.json` < `node.json` < `cluster-secrets.json` (cluster-secrets
wins on conflict). With only `config.json` present the merged result is byte-equal to today's
read — zero behavior change on existing installs.

**Phases implemented:**
- **Phase 1+2**: `resolveClusterSecretsPath()`, `resolveNodeConfigPath()`, `readLayer2Merged()`,
  `LAYER2_KEY_CLASS` (27 entries), `splitLayer2Config()` in `config.mjs`
- **Phase 3+4**: `catalyst-join.sh` splits writes by key class; `cluster-sync.mjs` routes
  `cluster-bots` → `cluster-secrets.json`; `secret-contract.mjs` and its bash mirror probe
  `cluster-secrets.json` first for `config-json` delivery rows
- **Phase 5**: `checkClusterSecretsPresent` and `checkNodeConfigPresent` in `doctor.mjs`
  (advisory WARN-only, wired into worker + developer profiles)
- **Phase 6**: `cluster-config-mirror.md` and `configuration.md` updated

**Key design decision:** `githubFeed.mode` reclassified from "shared" to "node". The key uses
`//=` non-clobber to preserve per-node rollout posture; `cluster-secrets.json` is freshly
overwritten every join, making `//=` a no-op there. Per-node `node.json` preserves operator
overrides correctly across joins.

## Test plan

- [x] `catalyst-join.test.sh`: 57/58 pass (T3.4 pre-existing, unrelated to CTL-1210)
- [x] `secret-contract-parity.test.sh`: 179/179 pass
- [x] `cluster-sync.test.mjs`: 98/98 pass
- [x] `lib/secret-contract.test.mjs`: 116/116 pass
- [x] `doctor.test.mjs`: +9 new tests (Phase 5 checks); 13 pre-existing failures unchanged
- [x] `config.test.mjs`: 195/202 pass; 7 pre-existing failures unchanged
- [x] Phase 3+4 must ship together (cluster-sync writes to cluster-secrets.json; secret-contract must read from there) — committed as one

🤖 Generated with [Claude Code](https://claude.com/claude-code)