### PR TITLE
feat(dev): CTL-2111 — triage re-dispatch cap re-arm + doctor visibility + durable park

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1410,6 +1410,7 @@ jobs:
             recovery-emit.test.mjs \
             sweep-stale-recovery-intents.test.mjs \
             triage-redispatch-guard.test.mjs \
+            triage-cap-event.test.mjs \
             recovery-evidence.test.mjs \
             unstuck-act-seams.test.mjs \
             unstuck-orphan-merge.test.mjs \

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -106,6 +106,8 @@ const INLINE_EVENT_NAMES = [
   "cloud-feed.would-dispatch",        // CTL-1847 cloud-feed-timer.mjs (shadow mode — would dispatch from the feed)
   "recovery.escalation.correlated",   // CAT-170 recovery-reasoning.mjs (enforced member pointer)
   "recovery.escalation.would-correlate", // CAT-170 recovery-reasoning.mjs (shadow group)
+  "triage.cap.rearmed.CTL-1",         // CTL-2111 triage-cap-event.mjs (INFO — cap re-armed on human re-queue)
+  "escalation.triage-cap-parked.CTL-1", // CTL-2111 triage-cap-event.mjs (WARN — durable park, budget-independent)
 ];
 
 // Build the flat list of all static exec-core event names.

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.mjs
@@ -560,3 +560,41 @@ export function bumpTriageAttemptCountSync(
     return { count: null };
   }
 }
+
+// resetTriageAttemptCountSync — spawn `node cluster-claim.mjs reset-triage-attempt
+// <ticket>` (CTL-2111). Used when a human re-queues a capped ticket: the fence
+// triage_attempt_count is reset to 0 so the next sweep re-dispatches triage.
+// Always invalidates the TTL cache for that ticket before the spawn (a reset
+// means the stored count is now stale — the next read must go live). Returns
+// `{ count: 0 }` on success, or `{ count: null }` on any failure (best-effort —
+// never throws).
+export function resetTriageAttemptCountSync(
+  { ticket },
+  {
+    spawn = spawnSync,
+    nodeBin = process.execPath,
+    cli = CLUSTER_CLAIM_CLI,
+    env = process.env,
+    timeout = CLAIM_TIMEOUT_MS,
+  } = {},
+) {
+  // Invalidate before the spawn: a reset means any cached count is now wrong,
+  // and the re-arm path is about to re-dispatch on the count having dropped.
+  triageAttemptCache.delete(ticket);
+  try {
+    const res = spawn(nodeBin, [cli, "reset-triage-attempt", ticket], {
+      encoding: "utf8",
+      env,
+      timeout,
+    });
+    if (!res || res.status !== 0 || typeof res.stdout !== "string") {
+      return { count: null };
+    }
+    const line = res.stdout.trim().split("\n").filter(Boolean).pop();
+    const parsed = JSON.parse(line);
+    const count = typeof parsed?.count === "number" ? parsed.count : null;
+    return { count };
+  } catch {
+    return { count: null };
+  }
+}

--- a/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim-sync.test.mjs
@@ -16,6 +16,7 @@ import {
   clearIssueIdCache,
   readTriageAttemptCountSync,
   bumpTriageAttemptCountSync,
+  resetTriageAttemptCountSync,
   clearTriageAttemptCacheSync,
 } from "./cluster-claim-sync.mjs";
 
@@ -718,5 +719,65 @@ describe("bumpTriageAttemptCountSync — argv + parsing (CTL-1649)", () => {
     now += 1_000;
     readTriageAttemptCountSync({ ticket: "CTL-1649" }, { spawn, env, now: () => now });
     expect(calls).toBe(2);
+  });
+});
+
+describe("resetTriageAttemptCountSync — argv + parsing (CTL-2111)", () => {
+  beforeEach(() => {
+    clearTriageAttemptCacheSync();
+  });
+
+  it("builds the right argv: node <cli> reset-triage-attempt <ticket>", () => {
+    let captured;
+    const spawn = (bin, args) => {
+      captured = { bin, args };
+      return { status: 0, stdout: JSON.stringify({ count: 0 }) + "\n" };
+    };
+    resetTriageAttemptCountSync(
+      { ticket: "CTL-2111" },
+      { spawn, nodeBin: "/usr/bin/node", cli: "/x/cluster-claim.mjs" },
+    );
+    expect(captured.bin).toBe("/usr/bin/node");
+    expect(captured.args).toEqual(["/x/cluster-claim.mjs", "reset-triage-attempt", "CTL-2111"]);
+  });
+
+  it("returns { count: 0 } on success", () => {
+    const spawn = () => ({ status: 0, stdout: JSON.stringify({ count: 0 }) + "\n" });
+    expect(resetTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn })).toEqual({ count: 0 });
+  });
+
+  it("non-zero exit → { count: null } (best-effort, never throws)", () => {
+    const spawn = () => ({ status: 1, stdout: "" });
+    expect(resetTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn })).toEqual({ count: null });
+  });
+
+  it("non-string stdout → { count: null }", () => {
+    const spawn = () => ({ status: 0, stdout: null });
+    expect(resetTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn })).toEqual({ count: null });
+  });
+
+  it("spawn throws → { count: null } (never propagates)", () => {
+    const spawn = () => { throw new Error("ETIMEDOUT"); };
+    expect(resetTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn })).toEqual({ count: null });
+  });
+
+  it("invalidates the cache for that ticket before the spawn (next read goes live)", () => {
+    let spawnCalls = 0;
+    const spawn = () => {
+      spawnCalls++;
+      return { status: 0, stdout: JSON.stringify({ count: 0 }) + "\n" };
+    };
+    const env = { CATALYST_TRIAGE_ATTEMPT_CACHE_MS: "30000" };
+    let now = 1_000_000;
+    // Populate cache
+    readTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn, env, now: () => now });
+    expect(spawnCalls).toBe(1);
+    // Reset invalidates cache
+    resetTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn, env });
+    expect(spawnCalls).toBe(2); // reset spawned
+    // Next read goes live (cache was invalidated)
+    now += 1_000;
+    readTriageAttemptCountSync({ ticket: "CTL-2111" }, { spawn, env, now: () => now });
+    expect(spawnCalls).toBe(3); // fresh spawn after invalidation
   });
 });

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -313,6 +313,32 @@ export async function bumpTriageAttemptCount(
   return newCount;
 }
 
+// resetTriageAttemptCount — reset the fleet-wide triage attempt count on the
+// fence attachment back to 0 (CTL-2111). Used when a human re-queues a ticket
+// that had tripped its host-local triage re-dispatch cap, so the next sweep
+// re-dispatches triage instead of refusing forever. Preserves owner_host,
+// catalyst_generation, phase, and claimed_at (does NOT bump the generation —
+// this is not a takeover — and does NOT re-stamp the staleness clock). Returns
+// 0 on success, or null when no fence exists (best-effort no-op, fail-open).
+export async function resetTriageAttemptCount(
+  ticket,
+  { post = defaultPost, transport = null, issueId = null } = {},
+) {
+  const current = await readClaim(ticket, { post, transport });
+  if (!current) return null; // no fence — no-op, fail-open
+  await writeClaim(
+    ticket,
+    {
+      owner_host: current.owner_host,
+      generation: current.generation,
+      phase: current.phase,
+      triage_attempt_count: 0,
+    },
+    { post, transport, issueId, preserveClaimedAt: current.claimed_at },
+  );
+  return 0;
+}
+
 // ─── soft-CAS claim ──────────────────────────────────────────────────────────
 
 // claimTicket — the soft compare-and-set that is the actual cross-host mutex.
@@ -702,10 +728,16 @@ export async function runCli(
       process.stdout.write(JSON.stringify({ count }) + "\n");
       return 0;
     }
+    case "reset-triage-attempt": {
+      const [ticket] = rest;
+      const count = await resetTriageAttemptCount(ticket, { post, transport: t });
+      process.stdout.write(JSON.stringify({ count }) + "\n");
+      return 0;
+    }
     default:
       process.stderr.write(
         `cluster-claim.mjs: unknown subcommand: ${cmd ?? "(none)"}\n` +
-          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> [issueId] | fence-check <ticket> <gen> | resolve-issue-id <ticket> | read-triage-attempt <ticket> | bump-triage-attempt <ticket>>\n",
+          "usage: cluster-claim.mjs <claim <ticket> <host> <phase> [issueId] | fence-check <ticket> <gen> | resolve-issue-id <ticket> | read-triage-attempt <ticket> | bump-triage-attempt <ticket> | reset-triage-attempt <ticket>>\n",
       );
       return 1;
   }

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -730,6 +730,32 @@ export async function runCli(
     }
     case "reset-triage-attempt": {
       const [ticket] = rest;
+      // CTL-2111 (Codex #3824 round-2 P1): under `enforce` the attachment counter is
+      // INAPPLICABLE, not merely absent. `claimViaLease` bypasses `writeClaim`, so no
+      // fence attachment is ever created and `resetTriageAttemptCount`'s `readClaim`
+      // returns null — reporting `{count:null}`, which is this CLI's word for "the
+      // reset did not happen". `rearmTriageCapOnRequeue` requires exactly 0 before it
+      // drops the host-local latch, so on a lease-enforced fleet a capped ticket could
+      // NEVER be re-armed by a human re-queue: every attempt returned
+      // `fence-reset-unconfirmed` forever.
+      //
+      // There is nothing to reset here, and that is a confirmed state rather than a
+      // failed write — the same counter is inert on the READ side too
+      // (`readTriageAttemptCount` finds no attachment, so `fleetTriageDispatchCount`
+      // fails open to the host-local count and the fence never gates anything under
+      // enforce). So report the reset as satisfied, with `inapplicable` naming WHY it
+      // was a no-op so the zero is never mistaken for a real attachment write.
+      //
+      // Deliberately NOT the `fence-check` treatment above: that throws because it
+      // would otherwise fabricate a STALE verdict that suppresses real writes — the
+      // fail-safe direction there is to decline. Here declining is what strands the
+      // ticket, and the honest answer ("no fleet counter exists to hold this cap") is
+      // available without inventing anything.
+      const mode = leaseMode ?? resolveLeaseAuthorityMode(env);
+      if (mode === "enforce") {
+        process.stdout.write(JSON.stringify({ count: 0, inapplicable: "lease-authority" }) + "\n");
+        return 0;
+      }
       const count = await resetTriageAttemptCount(ticket, { post, transport: t });
       process.stdout.write(JSON.stringify({ count }) + "\n");
       return 0;

--- a/plugins/dev/scripts/execution-core/cluster-claim.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.mjs
@@ -23,7 +23,7 @@ import {
   resolveAttachmentTransport,
 } from "./cluster-attachment-transport.mjs";
 import { createLinearWriteProxy } from "./linear-write-proxy.mjs";
-import { readLinearWriteProxyConfig, resolveLeaseAuthorityMode } from "./config.mjs";
+import { getHostName, readLinearWriteProxyConfig, resolveLeaseAuthorityMode } from "./config.mjs";
 // CTL-1786 — the lease-authority client half of CTC-410. The refusable claim path lives beside
 // the attachment soft-CAS here so `runCli`/`defaultTransport` can select it on the env gate with
 // ZERO change to any caller: it returns the same {won, generation} contract.
@@ -322,10 +322,42 @@ export async function bumpTriageAttemptCount(
 // 0 on success, or null when no fence exists (best-effort no-op, fail-open).
 export async function resetTriageAttemptCount(
   ticket,
-  { post = defaultPost, transport = null, issueId = null } = {},
+  { post = defaultPost, transport = null, issueId = null, hostName = null } = {},
 ) {
   const current = await readClaim(ticket, { post, transport });
   if (!current) return null; // no fence — no-op, fail-open
+  // CTL-2111 (Codex #3824 round-3 P1): this is a read-then-write with no CAS, so a
+  // human re-queue racing an ownership change could read generation G, let a
+  // concurrent `claimTicket` write G+1, then unconditionally restore G and the OLD
+  // owner_host — invalidating the real winner's fencing token and making a
+  // superseded worker current again. That is a fleet-safety failure, and a count
+  // reset must never be able to cause it.
+  //
+  // Two guards, both failing to `null` ("unconfirmed"), which the caller already
+  // treats as "retain the local latch and retry on the next re-queue" — never as a
+  // completed re-arm. The fail direction is a deferred re-arm, never a broken fence.
+  //
+  // Guard 1 — NEVER rewrite another host's claim. The re-arm runs on the host that
+  // holds the (host-local) cap record, so the claim it is refreshing should be its
+  // own. If the fence names a different owner, a takeover has already happened:
+  // decline outright rather than restoring ourselves over the winner. This alone
+  // removes the reported harm — the stale owner_host can no longer be written back
+  // — because the only claim we will now rewrite is one we already own.
+  const nonEmpty = (v) => typeof v === "string" && v !== "";
+  // A fence with no recorded owner, or a host we cannot name, is not evidence of a
+  // takeover — fall through to the read-back guard rather than declining outright,
+  // so an unowned/legacy fence record stays resettable.
+  let self = hostName;
+  if (!nonEmpty(self)) {
+    try {
+      self = getHostName();
+    } catch {
+      self = null;
+    }
+  }
+  if (nonEmpty(current.owner_host) && nonEmpty(self) && current.owner_host !== self) {
+    return null;
+  }
   await writeClaim(
     ticket,
     {
@@ -336,6 +368,20 @@ export async function resetTriageAttemptCount(
     },
     { post, transport, issueId, preserveClaimedAt: current.claimed_at },
   );
+  // Guard 2 — confirm by read-back, the same soft-CAS shape `claimTicket` uses. If
+  // anything other than exactly what we wrote is there, a concurrent writer landed
+  // after us and holds the fence: report unconfirmed rather than claiming a reset.
+  // A generation that MOVED is the takeover case; note it can only have moved
+  // FORWARD (generations are monotonic), so the winner's claim survives our write.
+  const readback = await readClaim(ticket, { post, transport });
+  if (
+    !readback ||
+    readback.owner_host !== current.owner_host ||
+    readback.generation !== current.generation ||
+    readback.triage_attempt_count !== 0
+  ) {
+    return null;
+  }
   return 0;
 }
 

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -6,6 +6,9 @@
 // metadata), so claimTicket's read→write→read-back soft-CAS exercises real
 // semantics.
 import { describe, it, expect, afterEach } from "bun:test";
+// CTL-2111 (round-3 P1): the owner guard in resetTriageAttemptCount compares against
+// this host, so the CLI-path test seeds the fence with the same resolver production uses.
+import { getHostName as cfgGetHostName } from "./config.mjs";
 
 import {
   fenceUrl,
@@ -862,7 +865,9 @@ describe("resetTriageAttemptCount (CTL-2111)", () => {
     const { post, store } = makeFakeLinear({
       seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 2, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 5 } },
     });
-    const result = await resetTriageAttemptCount("CTL-2111", { post });
+    // CTL-2111 (round-3 P1): the reset only ever rewrites THIS host's own claim,
+    // so the owning host is named explicitly rather than inherited from the box.
+    const result = await resetTriageAttemptCount("CTL-2111", { post, hostName: "mini" });
     expect(result).toBe(0);
     expect(store.get("CTL-2111").triage_attempt_count).toBe(0);
   });
@@ -871,11 +876,13 @@ describe("resetTriageAttemptCount (CTL-2111)", () => {
     const { post, store } = makeFakeLinear({
       seed: { "CTL-2111": { owner_host: "mac-studio", catalyst_generation: 5, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 3 } },
     });
-    await resetTriageAttemptCount("CTL-2111", { post });
+    const rc = await resetTriageAttemptCount("CTL-2111", { post, hostName: "mac-studio" });
+    expect(rc).toBe(0); // guards admitted it — without this the assertions below pass vacuously on a refusal
     const m = store.get("CTL-2111");
     expect(m.owner_host).toBe("mac-studio");
     expect(m.catalyst_generation).toBe(5);
     expect(m.phase).toBe("triage");
+    expect(m.triage_attempt_count).toBe(0);
   });
 
   it("preserves claimed_at (does not re-stamp the staleness clock)", async () => {
@@ -883,7 +890,7 @@ describe("resetTriageAttemptCount (CTL-2111)", () => {
     const { post, store } = makeFakeLinear({
       seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: original, triage_attempt_count: 4 } },
     });
-    await resetTriageAttemptCount("CTL-2111", { post });
+    expect(await resetTriageAttemptCount("CTL-2111", { post, hostName: "mini" })).toBe(0);
     expect(store.get("CTL-2111").claimed_at).toBe(original);
   });
 
@@ -892,13 +899,57 @@ describe("resetTriageAttemptCount (CTL-2111)", () => {
     expect(await resetTriageAttemptCount("CTL-2111", { post })).toBeNull();
   });
 
+  // ── CTL-2111 (Codex #3824 round-3 P1): a count reset must never invalidate a
+  // concurrent takeover's fencing token. This is a read-then-write with no CAS, so
+  // it could read generation G, let a racing claimTicket write G+1, and then restore
+  // G and the OLD owner — making a superseded worker current again. Both guards fail
+  // to `null` ("unconfirmed"), which the caller treats as "retain the latch, retry".
+  it("declines (null) when the fence is owned by ANOTHER host — never restores a stale owner", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "peer-host", catalyst_generation: 9, phase: "triage", claimed_at: "t", triage_attempt_count: 4 } },
+    });
+    expect(await resetTriageAttemptCount("CTL-2111", { post, hostName: "mini" })).toBeNull();
+    // The winner's record is untouched — owner, generation AND count.
+    const m = store.get("CTL-2111");
+    expect(m.owner_host).toBe("peer-host");
+    expect(m.catalyst_generation).toBe(9);
+    expect(m.triage_attempt_count).toBe(4);
+  });
+
+  it("declines (null) when a concurrent writer takes over between the read and the read-back", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 3, phase: "triage", claimed_at: "t", triage_attempt_count: 6 } },
+    });
+    // Simulate the race: a peer wins a new generation right after our write lands,
+    // so the read-back no longer matches what we wrote.
+    let writes = 0;
+    const racingPost = async (...args) => {
+      const res = await post(...args);
+      const body = typeof args[0] === "string" ? args[0] : JSON.stringify(args[0] ?? "");
+      if (/attachmentCreate|attachmentUpdate|attachmentLinkURL/i.test(body) && ++writes === 1) {
+        store.set("CTL-2111", {
+          owner_host: "peer-host",
+          catalyst_generation: 4,
+          phase: "triage",
+          claimed_at: "t",
+          triage_attempt_count: 6,
+        });
+      }
+      return res;
+    };
+    expect(await resetTriageAttemptCount("CTL-2111", { post: racingPost, hostName: "mini" })).toBeNull();
+    // The takeover survives — we reported unconfirmed instead of claiming a reset.
+    expect(store.get("CTL-2111").catalyst_generation).toBe(4);
+    expect(store.get("CTL-2111").owner_host).toBe("peer-host");
+  });
+
   it("a bump then a reset returns the count to 0", async () => {
     const { post } = makeFakeLinear({
       seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 0 } },
     });
     expect(await bumpTriageAttemptCount("CTL-2111", { post })).toBe(1);
     expect(await bumpTriageAttemptCount("CTL-2111", { post })).toBe(2);
-    expect(await resetTriageAttemptCount("CTL-2111", { post })).toBe(0);
+    expect(await resetTriageAttemptCount("CTL-2111", { post, hostName: "mini" })).toBe(0);
     expect(await readTriageAttemptCount("CTL-2111", { post })).toBe(0);
   });
 });
@@ -930,8 +981,12 @@ describe("runCli — read-triage-attempt / bump-triage-attempt (CTL-1649)", () =
   });
 
   it("reset-triage-attempt prints { count: 0 } and exits 0 on success (CTL-2111)", async () => {
+    // CTL-2111 (round-3 P1): the CLI has no --host flag, so resetTriageAttemptCount
+    // resolves the owner guard against this box's real hostname. Seed the fence as
+    // owned by that host — which is also the production shape, since the re-arm runs
+    // on the host holding the (host-local) cap record.
     const { post, store } = makeFakeLinear({
-      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 7 } },
+      seed: { "CTL-2111": { owner_host: cfgGetHostName(), catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 7 } },
     });
     const { code, out } = await captureStdout(() => runCli(["reset-triage-attempt", "CTL-2111"], { post }));
     expect(code).toBe(0);

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -946,6 +946,45 @@ describe("runCli — read-triage-attempt / bump-triage-attempt (CTL-1649)", () =
     expect(JSON.parse(out.trim())).toEqual({ count: null });
   });
 
+  // CTL-2111 (Codex #3824 round-2 P1): under lease-authority `enforce` no fence
+  // attachment is ever written (claimViaLease bypasses writeClaim), so the
+  // attachment reset is INAPPLICABLE rather than failed. Reporting `{count:null}`
+  // there made `rearmTriageCapOnRequeue` refuse the re-arm forever, so a ticket
+  // capped after enforcement was enabled could never be re-queued by a human.
+  it("reset-triage-attempt under leaseMode enforce → { count: 0, inapplicable } (CTL-2111 round-2 P1)", async () => {
+    const { post } = makeFakeLinear(); // no fence — the enforce-mode reality
+    const { code, out } = await captureStdout(() =>
+      runCli(["reset-triage-attempt", "CTL-2111"], { post, leaseMode: "enforce" }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: 0, inapplicable: "lease-authority" });
+  });
+
+  it("reset-triage-attempt under enforce does NOT touch the attachment transport (CTL-2111 round-2 P1)", async () => {
+    let calls = 0;
+    const post = async (...args) => {
+      calls += 1;
+      return makeFakeLinear().post(...args);
+    };
+    const { code } = await captureStdout(() =>
+      runCli(["reset-triage-attempt", "CTL-2111"], { post, leaseMode: "enforce" }),
+    );
+    expect(code).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  // Positive control for the pair above: the SAME no-fence store under a
+  // non-enforce mode still reports the honest `{count:null}`, so the new branch
+  // is proven to be mode-scoped rather than a blanket "always report success".
+  it("reset-triage-attempt under leaseMode off keeps the honest { count: null } (CTL-2111 round-2 P1 control)", async () => {
+    const { post } = makeFakeLinear();
+    const { code, out } = await captureStdout(() =>
+      runCli(["reset-triage-attempt", "CTL-2111"], { post, leaseMode: "off" }),
+    );
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: null });
+  });
+
   it("unknown subcommand still exits 1 with usage", async () => {
     const { post } = makeFakeLinear();
     const { code } = await captureStdout(() => runCli(["bogus-cmd"], { post }));

--- a/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
+++ b/plugins/dev/scripts/execution-core/cluster-claim.test.mjs
@@ -18,6 +18,7 @@ import {
   isFenceCurrent,
   readTriageAttemptCount,
   bumpTriageAttemptCount,
+  resetTriageAttemptCount,
   runCli,
 } from "./cluster-claim.mjs";
 
@@ -856,6 +857,52 @@ describe("bumpTriageAttemptCount (CTL-1649)", () => {
   });
 });
 
+describe("resetTriageAttemptCount (CTL-2111)", () => {
+  it("resets triage_attempt_count to 0 and returns 0 on success", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 2, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 5 } },
+    });
+    const result = await resetTriageAttemptCount("CTL-2111", { post });
+    expect(result).toBe(0);
+    expect(store.get("CTL-2111").triage_attempt_count).toBe(0);
+  });
+
+  it("preserves owner_host, catalyst_generation, phase (does NOT bump generation — not a takeover)", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mac-studio", catalyst_generation: 5, phase: "triage", claimed_at: "2026-08-01T00:00:00Z", triage_attempt_count: 3 } },
+    });
+    await resetTriageAttemptCount("CTL-2111", { post });
+    const m = store.get("CTL-2111");
+    expect(m.owner_host).toBe("mac-studio");
+    expect(m.catalyst_generation).toBe(5);
+    expect(m.phase).toBe("triage");
+  });
+
+  it("preserves claimed_at (does not re-stamp the staleness clock)", async () => {
+    const original = "2026-07-01T00:00:00Z";
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: original, triage_attempt_count: 4 } },
+    });
+    await resetTriageAttemptCount("CTL-2111", { post });
+    expect(store.get("CTL-2111").claimed_at).toBe(original);
+  });
+
+  it("returns null (no-op, fail-open) when no fence exists", async () => {
+    const { post } = makeFakeLinear();
+    expect(await resetTriageAttemptCount("CTL-2111", { post })).toBeNull();
+  });
+
+  it("a bump then a reset returns the count to 0", async () => {
+    const { post } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 0 } },
+    });
+    expect(await bumpTriageAttemptCount("CTL-2111", { post })).toBe(1);
+    expect(await bumpTriageAttemptCount("CTL-2111", { post })).toBe(2);
+    expect(await resetTriageAttemptCount("CTL-2111", { post })).toBe(0);
+    expect(await readTriageAttemptCount("CTL-2111", { post })).toBe(0);
+  });
+});
+
 describe("runCli — read-triage-attempt / bump-triage-attempt (CTL-1649)", () => {
   it("read-triage-attempt prints { count } and exits 0 when fence exists", async () => {
     const { post } = makeFakeLinear({
@@ -880,6 +927,23 @@ describe("runCli — read-triage-attempt / bump-triage-attempt (CTL-1649)", () =
     const { code, out } = await captureStdout(() => runCli(["bump-triage-attempt", "CTL-1649"], { post }));
     expect(code).toBe(0);
     expect(JSON.parse(out.trim())).toEqual({ count: 2 });
+  });
+
+  it("reset-triage-attempt prints { count: 0 } and exits 0 on success (CTL-2111)", async () => {
+    const { post, store } = makeFakeLinear({
+      seed: { "CTL-2111": { owner_host: "mini", catalyst_generation: 1, phase: "triage", claimed_at: "t", triage_attempt_count: 7 } },
+    });
+    const { code, out } = await captureStdout(() => runCli(["reset-triage-attempt", "CTL-2111"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: 0 });
+    expect(store.get("CTL-2111").triage_attempt_count).toBe(0);
+  });
+
+  it("reset-triage-attempt prints { count: null } and exits 0 when no fence (CTL-2111)", async () => {
+    const { post } = makeFakeLinear();
+    const { code, out } = await captureStdout(() => runCli(["reset-triage-attempt", "CTL-2111"], { post }));
+    expect(code).toBe(0);
+    expect(JSON.parse(out.trim())).toEqual({ count: null });
   });
 
   it("unknown subcommand still exits 1 with usage", async () => {

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -63,6 +63,7 @@ import {
   // shows the full topology). Entitlement is reported separately by
   // checkEntitlementConsistency. `off` mode: getExistenceHosts() === getClusterHosts().
   getExistenceHosts,
+  getEntitledHosts, // CTL-2111 round-3 P1: the ownership-gate roster class (CTL-1785)
   resolveClusterHosts,
   hostMembershipWarning,
   getLivenessAnchorIssue,
@@ -6717,7 +6718,12 @@ export function checkTriageCapParked(deps = {}) {
     listCapFiles = () => defaultListCapFiles(orchDir),
     readEligibleIdentifiers = defaultReadEligibleIdentifiers,
     isEligible = null, // optional direct seam; else derived from readEligibleIdentifiers
-    getRoster = getExistenceHosts,
+    // CTL-2111 (Codex #3824 round-3 P1): ENTITLEMENT, not existence. Per CTL-1785
+    // every dispatch / recovery / reclaim / HRW-ownership gate reads
+    // getEntitledHosts(); getExistenceHosts() is the topology/display roster. Using
+    // the existence roster here made doctor's ownership verdict disagree with the
+    // dispatcher's by construction whenever a peer was shed.
+    getRoster = getEntitledHosts,
     getHostName: _getHostName = getHostName,
     ownedBy: _ownedBy = ownedBy,
   } = deps;
@@ -6759,15 +6765,54 @@ export function checkTriageCapParked(deps = {}) {
       if (eligibleSet?.has(t)) return true;
       return eligibleUnreadable.length > 0 ? null : false;
     });
-  const roster = getRoster() ?? [];
-  const self = _getHostName();
+  // CTL-2111 (Codex #3824 round-3 P1): resolve the roster DEFENSIVELY. The
+  // entitlement roster is a richer read than the existence roster it replaced
+  // (provider + cluster hosts + self, with an emit hook), and any of those can
+  // throw or be unavailable in a degraded or bare-Node environment. A doctor check
+  // must never throw — and least of all THIS one, whose whole job is to surface a
+  // cap record: a throw here would hide the very blockage it exists to report.
+  // Degrade entitlement → existence → empty, and treat an unresolvable roster as
+  // single-host, which makes ownership a no-op and reports every record.
+  let roster;
+  try {
+    roster = getRoster() ?? [];
+  } catch {
+    try {
+      roster = getExistenceHosts() ?? [];
+    } catch {
+      roster = [];
+    }
+  }
+  if (!Array.isArray(roster)) roster = [];
+  let self;
+  try {
+    self = _getHostName();
+  } catch {
+    self = null;
+  }
   const multiHost = roster.length > 1;
 
   const checks = [];
   for (const { ticket, cappedAt, path } of capped) {
-    // Multi-host: only the HRW owner reports the ticket (the owning host is the
-    // one that must act). Single-host is always "owned".
-    if (multiHost && !_ownedBy(ticket, roster, self)) continue;
+    // CTL-2111 (Codex #3824 round-3 P1): ownership ANNOTATES, it no longer
+    // SUPPRESSES. Production triage hashes over the live DISPATCH roster
+    // (entitled → positive-liveness → restore-deflap, via resolveDispatchRoster),
+    // which this bare-Node check cannot compute: that resolver lives in
+    // scheduler.mjs and needs an async heartbeat read, and doctor's checks are
+    // sync and deliberately free of that dependency graph. So a `continue` here
+    // was a verdict this check is structurally unable to make correctly — when a
+    // peer is offline or entitlement-shed, the failed-over slice moves to THIS
+    // host while a static HRW pass still names the peer, and doctor then dropped
+    // the record and reported "no triage-capped tickets owned by this host" while
+    // this host's dispatcher was blocked by exactly that cap.
+    //
+    // Reporting instead of suppressing is also the right dedup trade: the cap
+    // record is HOST-LOCAL, written only by the host that actually refused to
+    // triage, so a peer without the file reports nothing regardless. The alarm
+    // fan-out the filter was protecting against is bounded by that already.
+    // Mirroring the dispatch roster would additionally re-introduce the very
+    // drift this finding is about, the next time either side changes.
+    const ownedHere = !multiHost || _ownedBy(ticket, roster, self);
     const elig = eligibleOf(ticket);
     const reArm =
       `delete ${path} to re-arm` +
@@ -6779,11 +6824,18 @@ export function checkTriageCapParked(deps = {}) {
     // states a negative ("not currently board-eligible") the reader was unable to
     // verify. Unknown is reported at WARN, naming the unreadable projections.
     const eligUnknown = elig === null || elig === undefined;
+    // A cap this host holds but that static HRW attributes to a peer is still
+    // reported — at INFO, and saying so — because the two rosters can legitimately
+    // disagree (see above). It is never dropped.
+    const ownerNote = ownedHere
+      ? ""
+      : ` [static HRW attributes this ticket to a peer; the live dispatch roster may differ —` +
+        ` the cap record is nevertheless on THIS host, so this host's dispatcher is the one it blocks]`;
     checks.push(
       mkCheck(
         "would-triage-capped",
-        eligUnknown || elig ? STATUS.WARN : STATUS.INFO,
-        `${ticket} tripped its triage re-dispatch cap (cappedAt=${cappedAt})` +
+        !ownedHere ? STATUS.INFO : eligUnknown || elig ? STATUS.WARN : STATUS.INFO,
+        `${ticket} tripped its triage re-dispatch cap (cappedAt=${cappedAt})` + ownerNote +
           (eligUnknown
             ? ` — board-eligibility INCONCLUSIVE (could not read ${eligibleUnreadable.length} eligible projection(s): ${eligibleUnreadable.join(", ")});` +
               ` this host may be refusing to triage a ready ticket`
@@ -6796,8 +6848,9 @@ export function checkTriageCapParked(deps = {}) {
   }
 
   if (checks.length === 0) {
-    // Tripped caps exist but all are owned by other hosts (they report them). An
-    // unreadable record could still have been THIS host's, so doubt outranks the pass.
+    // CTL-2111 (round-3 P1): with ownership no longer suppressing, this branch is
+    // reachable only when `capped` was empty of reportable records. An unreadable
+    // record could still have been a real cap, so doubt outranks the pass.
     if (unreadable.length > 0) return [inconclusiveCheck()];
     return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets owned by this host")];
   }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -6662,29 +6662,46 @@ function defaultListCapFiles(orchDir) {
 // defaultReadEligibleIdentifiers — the set of board-eligible ticket identifiers,
 // read straight off the on-disk eligible projections (<eligibleDir>/*.json, shape
 // { tickets: [{identifier, ...}] }). node:fs only — the projection is the
-// bare-node-safe eligible source (never bun:sqlite). Malformed files are skipped.
+// bare-node-safe eligible source (never bun:sqlite).
+//
+// CTL-2111 (Codex #3824 round-2 P1): THREE-VALUED, for the same reason
+// `defaultListCapFiles` above is. This read decides whether a tripped cap renders
+// as WARN ("board-eligible — this host will not triage it") or INFO ("not
+// currently board-eligible — parked"), so a silent read failure does not merely
+// lose a ticket from a list: it DOWNGRADES a real alarm into a reassuring INFO
+// that asserts the very thing the reader could not check. A readdir that fails on
+// EACCES/EIO, or a projection file that will not read or parse, is "could not
+// look" — carried out in `unreadable` so the caller can say INCONCLUSIVE.
+// A MISSING directory stays conclusive: no projections means nothing is eligible.
 function defaultReadEligibleIdentifiers() {
-  const set = new Set();
+  const identifiers = new Set();
+  const unreadable = [];
+  const dir = getEligibleDir();
   let files;
   try {
-    files = readdirSync(getEligibleDir());
-  } catch {
-    return set; // no dir → empty (nothing eligible)
+    files = readdirSync(dir);
+  } catch (err) {
+    // ENOENT is the only conclusive absence — nothing is projected as eligible.
+    if (err?.code === "ENOENT") return { identifiers, unreadable };
+    return { identifiers, unreadable: [`${dir} (${err?.code || "readdir failed"})`] };
   }
   for (const f of files) {
     if (!f.endsWith(".json")) continue;
     try {
-      const proj = JSON.parse(readFileSync(join(getEligibleDir(), f), "utf8"));
+      const proj = JSON.parse(readFileSync(join(dir, f), "utf8"));
       if (Array.isArray(proj?.tickets)) {
         for (const t of proj.tickets) {
-          if (t && typeof t.identifier === "string") set.add(t.identifier);
+          if (t && typeof t.identifier === "string") identifiers.add(t.identifier);
         }
+      } else {
+        // Readable but not the expected shape — its tickets are unknown, not absent.
+        unreadable.push(`${f} (no tickets array)`);
       }
-    } catch {
-      /* malformed/unreadable → skip */
+    } catch (err) {
+      unreadable.push(`${f} (${err?.code || "unparseable"})`);
     }
   }
-  return set;
+  return { identifiers, unreadable };
 }
 
 // checkTriageCapParked — report every tripped triage re-dispatch cap this host
@@ -6725,8 +6742,23 @@ export function checkTriageCapParked(deps = {}) {
     return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets on this host")];
   }
 
-  const eligibleSet = isEligible ? null : readEligibleIdentifiers();
-  const eligibleOf = isEligible ?? ((t) => eligibleSet.has(t));
+  // CTL-2111 (Codex #3824 round-2 P1): eligibility is THREE-VALUED — true /
+  // false / null ("could not look"). Accept both the structured
+  // {identifiers, unreadable} shape and a bare Set (an injected seam, which
+  // carries no doubt and so stays conclusive — unchanged behaviour).
+  const eligRaw = isEligible ? null : readEligibleIdentifiers();
+  const eligibleSet = eligRaw instanceof Set ? eligRaw : (eligRaw?.identifiers ?? null);
+  const eligibleUnreadable = eligRaw instanceof Set ? [] : (eligRaw?.unreadable ?? []);
+  const eligibleOf =
+    isEligible ??
+    ((t) => {
+      // PRESENCE is positive evidence regardless of any unreadable sibling file —
+      // the ticket was found. Only an ABSENCE is in doubt when part of the
+      // projection could not be read, because the missing file may be the one
+      // that listed it.
+      if (eligibleSet?.has(t)) return true;
+      return eligibleUnreadable.length > 0 ? null : false;
+    });
   const roster = getRoster() ?? [];
   const self = _getHostName();
   const multiHost = roster.length > 1;
@@ -6742,12 +6774,22 @@ export function checkTriageCapParked(deps = {}) {
       ` (also reset the fence via 'node cluster-claim.mjs reset-triage-attempt ${ticket}',` +
       ` and if the per-ticket Linear write budget is exhausted, clear the needs-human label` +
       ` + the linear-write-budget.json byTicket entry)`;
+    // CTL-2111 (Codex #3824 round-2 P1): `elig === null` is "could not determine
+    // eligibility", and it must NOT fall to the INFO/parked branch — that branch
+    // states a negative ("not currently board-eligible") the reader was unable to
+    // verify. Unknown is reported at WARN, naming the unreadable projections.
+    const eligUnknown = elig === null || elig === undefined;
     checks.push(
       mkCheck(
         "would-triage-capped",
-        elig ? STATUS.WARN : STATUS.INFO,
+        eligUnknown || elig ? STATUS.WARN : STATUS.INFO,
         `${ticket} tripped its triage re-dispatch cap (cappedAt=${cappedAt})` +
-          (elig ? " and is board-eligible — this host will not triage it" : " (not currently board-eligible — parked)") +
+          (eligUnknown
+            ? ` — board-eligibility INCONCLUSIVE (could not read ${eligibleUnreadable.length} eligible projection(s): ${eligibleUnreadable.join(", ")});` +
+              ` this host may be refusing to triage a ready ticket`
+            : elig
+              ? " and is board-eligible — this host will not triage it"
+              : " (not currently board-eligible — parked)") +
           ` — ${reArm}`,
       ),
     );

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -6620,17 +6620,28 @@ export function checkGithubFeedReaderConsistency(deps = {}) {
 // ─── CTL-2111: triage re-dispatch cap visibility ─────────────────────────────
 // defaultListCapFiles — enumerate <orchDir>/.triage-dispatch-counts/*.json and
 // return one {ticket, cappedAt, path} per file that carries a `cappedAt` (a
-// TRIPPED cap). node:fs only (bare-node-safe). Unreadable/malformed files are
-// skipped (fail-open) — a positive-control ticket in the same scan still reports.
+// TRIPPED cap). node:fs only (bare-node-safe).
+//
+// CTL-2111 (Codex #3824 P1): the result is THREE-VALUED, not a bare array. A
+// missing directory is a genuine absence ("no caps"), but a readdir that fails on
+// permissions/IO, or a record file that will not read or parse, is "COULD NOT
+// LOOK" — and a record we cannot parse may or may not carry `cappedAt`. Collapsing
+// either into the same empty array let `checkTriageCapParked` return PASS
+// ("no triage-capped tickets") certifying the exact negative it was unable to
+// inspect — the false-clean shape AGENTS.md forbids. Each doubt is carried out in
+// `unreadable` so the caller can report INCONCLUSIVE instead of a clean pass.
 function defaultListCapFiles(orchDir) {
   const dir = join(orchDir, ".triage-dispatch-counts");
   let entries;
   try {
     entries = readdirSync(dir);
-  } catch {
-    return []; // no dir → no capped tickets
+  } catch (err) {
+    // ENOENT is the only conclusive absence: no cap dir means no capped tickets.
+    if (err?.code === "ENOENT") return { entries: [], unreadable: [] };
+    return { entries: [], unreadable: [`${dir} (${err?.code || "readdir failed"})`] };
   }
   const out = [];
+  const unreadable = [];
   for (const f of entries) {
     if (!f.endsWith(".json")) continue;
     const path = join(dir, f);
@@ -6639,11 +6650,13 @@ function defaultListCapFiles(orchDir) {
       if (rec && typeof rec === "object" && rec.cappedAt) {
         out.push({ ticket: f.slice(0, -5), cappedAt: rec.cappedAt, path });
       }
-    } catch {
-      /* malformed/unreadable → skip (fail-open) */
+    } catch (err) {
+      // Unknown whether this record carries `cappedAt` — record the doubt rather
+      // than silently counting it as "not capped".
+      unreadable.push(`${f} (${err?.code || "unparseable"})`);
     }
   }
-  return out;
+  return { entries: out, unreadable };
 }
 
 // defaultReadEligibleIdentifiers — the set of board-eligible ticket identifiers,
@@ -6692,8 +6705,23 @@ export function checkTriageCapParked(deps = {}) {
     ownedBy: _ownedBy = ownedBy,
   } = deps;
 
-  const capped = listCapFiles();
+  // CTL-2111 (Codex #3824 P1): accept BOTH the structured {entries, unreadable}
+  // shape and a bare array (an injected seam, or any caller that only has a list).
+  // A bare array carries no doubt, so it stays conclusive — unchanged behaviour.
+  const capRaw = listCapFiles();
+  const capped = Array.isArray(capRaw) ? capRaw : (capRaw?.entries ?? []);
+  const unreadable = Array.isArray(capRaw) ? [] : (capRaw?.unreadable ?? []);
+  // "I could not look" must never render as "there is nothing there".
+  const inconclusiveCheck = () =>
+    mkCheck(
+      "triage-cap-parked",
+      STATUS.WARN,
+      `INCONCLUSIVE — could not read ${unreadable.length} triage-cap record(s): ${unreadable.join(", ")}` +
+        " — a tripped cap may be present but unreadable; fix permissions/IO or remove the malformed record, then re-run",
+    );
+
   if (capped.length === 0) {
+    if (unreadable.length > 0) return [inconclusiveCheck()];
     return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets on this host")];
   }
 
@@ -6726,9 +6754,13 @@ export function checkTriageCapParked(deps = {}) {
   }
 
   if (checks.length === 0) {
-    // Tripped caps exist but all are owned by other hosts (they report them).
+    // Tripped caps exist but all are owned by other hosts (they report them). An
+    // unreadable record could still have been THIS host's, so doubt outranks the pass.
+    if (unreadable.length > 0) return [inconclusiveCheck()];
     return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets owned by this host")];
   }
+  // Report the tripped caps AND any doubt — a partial scan must not read as complete.
+  if (unreadable.length > 0) checks.push(inconclusiveCheck());
   return checks;
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -113,6 +113,9 @@ import {
   // CTL-1210 Phase 5: advisory presence checks for the two new Layer-2 sibling files.
   resolveClusterSecretsPath,
   resolveNodeConfigPath,
+  // CTL-2111: the eligible-projection dir (node:fs, bare-node-safe) — cross-referenced
+  // by checkTriageCapParked to WARN only for a board-eligible tripped cap.
+  getEligibleDir,
 } from "./config.mjs";
 // CTL-1785: the TTL constants + enum, imported DIRECTLY from the zero-import leaf
 // (node built-ins only — safe under doctor's bare-Node runtime), same pattern as
@@ -6614,6 +6617,121 @@ export function checkGithubFeedReaderConsistency(deps = {}) {
   ];
 }
 
+// ─── CTL-2111: triage re-dispatch cap visibility ─────────────────────────────
+// defaultListCapFiles — enumerate <orchDir>/.triage-dispatch-counts/*.json and
+// return one {ticket, cappedAt, path} per file that carries a `cappedAt` (a
+// TRIPPED cap). node:fs only (bare-node-safe). Unreadable/malformed files are
+// skipped (fail-open) — a positive-control ticket in the same scan still reports.
+function defaultListCapFiles(orchDir) {
+  const dir = join(orchDir, ".triage-dispatch-counts");
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return []; // no dir → no capped tickets
+  }
+  const out = [];
+  for (const f of entries) {
+    if (!f.endsWith(".json")) continue;
+    const path = join(dir, f);
+    try {
+      const rec = JSON.parse(readFileSync(path, "utf8"));
+      if (rec && typeof rec === "object" && rec.cappedAt) {
+        out.push({ ticket: f.slice(0, -5), cappedAt: rec.cappedAt, path });
+      }
+    } catch {
+      /* malformed/unreadable → skip (fail-open) */
+    }
+  }
+  return out;
+}
+
+// defaultReadEligibleIdentifiers — the set of board-eligible ticket identifiers,
+// read straight off the on-disk eligible projections (<eligibleDir>/*.json, shape
+// { tickets: [{identifier, ...}] }). node:fs only — the projection is the
+// bare-node-safe eligible source (never bun:sqlite). Malformed files are skipped.
+function defaultReadEligibleIdentifiers() {
+  const set = new Set();
+  let files;
+  try {
+    files = readdirSync(getEligibleDir());
+  } catch {
+    return set; // no dir → empty (nothing eligible)
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const proj = JSON.parse(readFileSync(join(getEligibleDir(), f), "utf8"));
+      if (Array.isArray(proj?.tickets)) {
+        for (const t of proj.tickets) {
+          if (t && typeof t.identifier === "string") set.add(t.identifier);
+        }
+      }
+    } catch {
+      /* malformed/unreadable → skip */
+    }
+  }
+  return set;
+}
+
+// checkTriageCapParked — report every tripped triage re-dispatch cap this host
+// owns (CTL-2111, Tier 2). A board-eligible tripped cap is a WARN (the human
+// re-queued it or it's ready and this host refuses to triage it); a tripped cap
+// that is not currently eligible is an INFO (parked, possibly legitimate). In a
+// multi-host cluster only the HRW owner reports a ticket (avoids N duplicate
+// alarms). No tripped/owned files → a single PASS. Every read is fail-open and
+// bare-node-safe (node:fs + the eligible projection, never bun:sqlite).
+export function checkTriageCapParked(deps = {}) {
+  const {
+    orchDir = getExecutionCoreDir(),
+    listCapFiles = () => defaultListCapFiles(orchDir),
+    readEligibleIdentifiers = defaultReadEligibleIdentifiers,
+    isEligible = null, // optional direct seam; else derived from readEligibleIdentifiers
+    getRoster = getExistenceHosts,
+    getHostName: _getHostName = getHostName,
+    ownedBy: _ownedBy = ownedBy,
+  } = deps;
+
+  const capped = listCapFiles();
+  if (capped.length === 0) {
+    return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets on this host")];
+  }
+
+  const eligibleSet = isEligible ? null : readEligibleIdentifiers();
+  const eligibleOf = isEligible ?? ((t) => eligibleSet.has(t));
+  const roster = getRoster() ?? [];
+  const self = _getHostName();
+  const multiHost = roster.length > 1;
+
+  const checks = [];
+  for (const { ticket, cappedAt, path } of capped) {
+    // Multi-host: only the HRW owner reports the ticket (the owning host is the
+    // one that must act). Single-host is always "owned".
+    if (multiHost && !_ownedBy(ticket, roster, self)) continue;
+    const elig = eligibleOf(ticket);
+    const reArm =
+      `delete ${path} to re-arm` +
+      ` (also reset the fence via 'node cluster-claim.mjs reset-triage-attempt ${ticket}',` +
+      ` and if the per-ticket Linear write budget is exhausted, clear the needs-human label` +
+      ` + the linear-write-budget.json byTicket entry)`;
+    checks.push(
+      mkCheck(
+        "would-triage-capped",
+        elig ? STATUS.WARN : STATUS.INFO,
+        `${ticket} tripped its triage re-dispatch cap (cappedAt=${cappedAt})` +
+          (elig ? " and is board-eligible — this host will not triage it" : " (not currently board-eligible — parked)") +
+          ` — ${reArm}`,
+      ),
+    );
+  }
+
+  if (checks.length === 0) {
+    // Tripped caps exist but all are owned by other hosts (they report them).
+    return [mkCheck("triage-cap-parked", STATUS.PASS, "no triage-capped tickets owned by this host")];
+  }
+  return checks;
+}
+
 // ─── Suite selection ─────────────────────────────────────────────────────────
 
 // checksForClass — build the check-thunk suite for a resolved node class. This is
@@ -6876,6 +6994,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
     () => checkClusterSecretsPresent(), // CTL-1210: cluster-secrets.json present? (advisory — new nodes haven't run cluster-sync yet)
     () => checkNodeConfigPresent(), // CTL-1210: node.json present + host.name set? (advisory)
+    () => checkTriageCapParked(), // CTL-2111: this host holds a tripped triage re-dispatch cap for a board-eligible ticket? (advisory — WARN/INFO/PASS, never FAIL)
   ];
 }
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -315,6 +315,96 @@ describe("checkTriageCapParked (CTL-2111)", () => {
     expect(checks.some((c) => /INCONCLUSIVE/.test(c.detail))).toBe(true);
   });
 
+  // ── CTL-2111 (Codex #3824 round-2 P1): the ELIGIBILITY read must be three-valued
+  // too. It decides whether a tripped cap renders WARN ("board-eligible — this host
+  // will not triage it") or INFO ("not currently board-eligible — parked"), so a
+  // silent EACCES/EIO or an unparseable projection did not merely lose a ticket
+  // from a list: it DOWNGRADED a real alarm into a reassuring INFO asserting the
+  // very thing it could not check.
+  it("eligibility unreadable → WARN INCONCLUSIVE, never the reassuring 'not board-eligible' INFO", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      listCapFiles: () => ({
+        entries: [{ ticket: "CTL-2111", cappedAt: "2026-08-20T00:00:00Z", path: "/p/CTL-2111.json" }],
+        unreadable: [],
+      }),
+      // Present but unreadable — the ticket's absence from the set proves nothing.
+      readEligibleIdentifiers: () => ({
+        identifiers: new Set(),
+        unreadable: ["<eligibleDir> (EACCES)"],
+      }),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toMatch(/INCONCLUSIVE/);
+    expect(c.detail).toMatch(/EACCES/);
+    expect(c.detail).not.toMatch(/not currently board-eligible/);
+  });
+
+  // Presence is positive evidence: found is found, even beside an unreadable
+  // sibling. Only an ABSENCE is in doubt.
+  it("eligibility partially unreadable but the ticket IS listed → conclusive WARN (not inconclusive)", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      listCapFiles: () => ({
+        entries: [{ ticket: "CTL-2111", cappedAt: "2026-08-20T00:00:00Z", path: "/p/CTL-2111.json" }],
+        unreadable: [],
+      }),
+      readEligibleIdentifiers: () => ({
+        identifiers: new Set(["CTL-2111"]),
+        unreadable: ["other-team.json (unparseable)"],
+      }),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("is board-eligible");
+    expect(c.detail).not.toMatch(/INCONCLUSIVE/);
+  });
+
+  // Positive control for the pair above — a FULLY readable projection that simply
+  // does not list the ticket is a real negative and must still render INFO/parked,
+  // so those tests prove the distinction rather than that the check never INFOs.
+  it("eligibility fully readable and ticket absent → INFO parked (real negative, control)", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      listCapFiles: () => ({
+        entries: [{ ticket: "CTL-2111", cappedAt: "2026-08-20T00:00:00Z", path: "/p/CTL-2111.json" }],
+        unreadable: [],
+      }),
+      readEligibleIdentifiers: () => ({ identifiers: new Set(), unreadable: [] }),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c.status).toBe(STATUS.INFO);
+    expect(c.detail).toContain("not currently board-eligible");
+  });
+
+  // Back-compat: a seam returning a BARE Set carries no doubt and stays conclusive.
+  it("a bare Set from the eligibility seam stays conclusive (back-compat)", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      listCapFiles: () => ({
+        entries: [{ ticket: "CTL-2111", cappedAt: "2026-08-20T00:00:00Z", path: "/p/CTL-2111.json" }],
+        unreadable: [],
+      }),
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c.status).toBe(STATUS.INFO);
+    expect(c.detail).not.toMatch(/INCONCLUSIVE/);
+  });
+
   it("WARNs for a tripped cap that is board-eligible and owned by self, with path + re-arm command", () => {
     seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
     const checks = checkTriageCapParked({

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4,7 +4,7 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test doctor.test.mjs
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, mkdirSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 // CTL-1929: the consumed/suppressible name lists, from the zero-import leaf that
@@ -64,6 +64,7 @@ import {
   checkSelfEchoIdentityHistory,
   checkClusterSecretsPresent,
   checkNodeConfigPresent,
+  checkTriageCapParked,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -224,6 +225,130 @@ describe("checkHrwPartition", () => {
     expect(checks[0].name).toBe("hrw-partition");
     expect(checks[0].status).toBe(STATUS.WARN);
     expect(checks[0].detail).toContain("0/3");
+  });
+});
+
+// ─── CTL-2111: checkTriageCapParked ──────────────────────────────────────────
+
+describe("checkTriageCapParked (CTL-2111)", () => {
+  let capOrchDir;
+  beforeEach(() => {
+    capOrchDir = mkdtempSync(join(tmpdir(), "doctor-cap-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(capOrchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+  function seedCap(ticket, rec) {
+    const dir = join(capOrchDir, ".triage-dispatch-counts");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${ticket}.json`), JSON.stringify(rec));
+  }
+
+  it("WARNs for a tripped cap that is board-eligible and owned by self, with path + re-arm command", () => {
+    seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].name).toBe("would-triage-capped");
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toContain("CTL-2111");
+    expect(checks[0].detail).toContain(".triage-dispatch-counts");
+    expect(checks[0].detail).toContain("re-arm");
+  });
+
+  it("INFO for a tripped cap not currently board-eligible", () => {
+    seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.INFO);
+  });
+
+  it("omits a tripped cap NOT owned by this host (multi-host HRW)", () => {
+    seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini", "mac-studio"],
+      getHostName: () => "mini",
+      ownedBy: () => false, // owned by the other host
+    });
+    // no owned capped tickets → a single PASS
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("PASS when there are no tripped cap files", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toContain("no triage-capped");
+  });
+
+  it("a counter file WITHOUT cappedAt is not reported (only tripped caps count)", () => {
+    seedCap("CTL-2111", { count: 1, lastDispatchAt: "2026-08-20T00:00:00Z" });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.PASS);
+  });
+
+  it("malformed cap file is skipped (fail-open); a positive-control ticket in the same run still reports", () => {
+    const dir = join(capOrchDir, ".triage-dispatch-counts");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "CTL-BAD.json"), "not-json{");
+    seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    // CTL-BAD skipped, CTL-2111 still reported (positive control)
+    const names = checks.map((c) => c.detail);
+    expect(checks.some((c) => c.status === STATUS.WARN && c.detail.includes("CTL-2111"))).toBe(true);
+    expect(names.some((d) => d.includes("CTL-BAD"))).toBe(false);
+  });
+
+  it("checksForClass(worker) registers the check thunk", () => {
+    const thunks = checksForClass({ class: "worker", recognized: true });
+    // Every thunk is callable; at least one resolves to a would-triage-capped/triage-cap-parked row.
+    const names = new Set();
+    for (const t of thunks) {
+      try {
+        const rows = t();
+        if (Array.isArray(rows)) for (const r of rows) names.add(r?.name);
+      } catch {
+        /* network/env-dependent checks may throw in a bare test env — ignore */
+      }
+    }
+    expect(names.has("triage-cap-parked") || names.has("would-triage-capped")).toBe(true);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -435,18 +435,46 @@ describe("checkTriageCapParked (CTL-2111)", () => {
     expect(checks[0].status).toBe(STATUS.INFO);
   });
 
-  it("omits a tripped cap NOT owned by this host (multi-host HRW)", () => {
+  // CTL-2111 (Codex #3824 round-3 P1): a peer-ownership verdict now ANNOTATES
+  // rather than SUPPRESSES. Production triage hashes over the live dispatch roster
+  // (entitled → liveness → deflap), which this sync bare-Node check cannot compute;
+  // when a peer is offline or entitlement-shed, the failed-over slice belongs to
+  // THIS host while a static HRW pass still names the peer. Dropping the record
+  // there made doctor report "no triage-capped tickets owned by this host" while
+  // this host's dispatcher was blocked by exactly that cap.
+  it("REPORTS (does not omit) a tripped cap that static HRW attributes to a peer", () => {
     seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
     const checks = checkTriageCapParked({
       orchDir: capOrchDir,
       readEligibleIdentifiers: () => new Set(["CTL-2111"]),
       getRoster: () => ["mini", "mac-studio"],
       getHostName: () => "mini",
-      ownedBy: () => false, // owned by the other host
+      ownedBy: () => false, // static HRW says the other host owns it
     });
-    // no owned capped tickets → a single PASS
-    expect(checks).toHaveLength(1);
-    expect(checks[0].status).toBe(STATUS.PASS);
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c).toBeDefined();
+    expect(c.detail).toContain("CTL-2111");
+    expect(c.detail).toMatch(/attributes this ticket to a peer/);
+    // Reported at INFO — visible, but not the same alarm level as a cap this host
+    // definitively owns — and never a PASS that denies the record exists.
+    expect(c.status).toBe(STATUS.INFO);
+    expect(checks.some((x) => x.status === STATUS.PASS)).toBe(false);
+  });
+
+  // Positive control: an owned + eligible cap still WARNs and carries NO peer note,
+  // so the test above proves a distinction rather than that everything reads INFO.
+  it("an owned, board-eligible cap still WARNs with no peer annotation (control)", () => {
+    seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini", "mac-studio"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    const c = checks.find((x) => x.name === "would-triage-capped");
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).not.toMatch(/attributes this ticket to a peer/);
   });
 
   it("PASS when there are no tripped cap files", () => {

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -248,6 +248,73 @@ describe("checkTriageCapParked (CTL-2111)", () => {
     writeFileSync(join(dir, `${ticket}.json`), JSON.stringify(rec));
   }
 
+  // ── CTL-2111 (Codex #3824 P1): a scan that COULD NOT LOOK must never render as
+  // "there is nothing there". Previously an unreadable dir / unparseable record
+  // produced the same empty list as a genuinely empty one, and the check PASSed
+  // "no triage-capped tickets" — certifying the exact negative it could not inspect.
+  it("INCONCLUSIVE (not PASS) when the cap directory exists but cannot be read", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      // EACCES — "could not look", NOT ENOENT ("nothing there").
+      listCapFiles: () => ({ entries: [], unreadable: [".triage-dispatch-counts (EACCES)"] }),
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.WARN);
+    expect(checks[0].detail).toMatch(/INCONCLUSIVE/);
+    expect(checks[0].detail).not.toMatch(/no triage-capped tickets/);
+  });
+
+  it("INCONCLUSIVE when a cap record file is unparseable (may or may not be capped)", () => {
+    const dir = join(capOrchDir, ".triage-dispatch-counts");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "CTL-9999.json"), "{ not json");
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks.some((c) => /INCONCLUSIVE/.test(c.detail))).toBe(true);
+    expect(checks.some((c) => c.status === STATUS.PASS)).toBe(false);
+  });
+
+  // Positive control for BOTH assertions above: a genuinely absent directory is a
+  // real negative and must still PASS, so the two tests prove the distinction
+  // rather than merely proving the check never passes.
+  it("PASSes when the cap directory is genuinely absent (ENOENT — a real negative)", () => {
+    const checks = checkTriageCapParked({
+      orchDir: join(capOrchDir, "no-such-dir"),
+      readEligibleIdentifiers: () => new Set(),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks).toHaveLength(1);
+    expect(checks[0].status).toBe(STATUS.PASS);
+    expect(checks[0].detail).toMatch(/no triage-capped tickets/);
+  });
+
+  it("still reports a tripped cap AND the doubt when the scan is partially unreadable", () => {
+    const checks = checkTriageCapParked({
+      orchDir: capOrchDir,
+      listCapFiles: () => ({
+        entries: [{ ticket: "CTL-2111", cappedAt: "2026-08-20T00:00:00Z", path: "/p/CTL-2111.json" }],
+        unreadable: ["CTL-9999.json (unparseable)"],
+      }),
+      readEligibleIdentifiers: () => new Set(["CTL-2111"]),
+      getRoster: () => ["mini"],
+      getHostName: () => "mini",
+      ownedBy: () => true,
+    });
+    expect(checks.some((c) => c.name === "would-triage-capped")).toBe(true);
+    expect(checks.some((c) => /INCONCLUSIVE/.test(c.detail))).toBe(true);
+  });
+
   it("WARNs for a tripped cap that is board-eligible and owned by self, with path + re-arm command", () => {
     seedCap("CTL-2111", { count: 3, cappedAt: "2026-08-20T00:00:00Z", cap: 3 });
     const checks = checkTriageCapParked({
@@ -318,7 +385,7 @@ describe("checkTriageCapParked (CTL-2111)", () => {
     expect(checks[0].status).toBe(STATUS.PASS);
   });
 
-  it("malformed cap file is skipped (fail-open); a positive-control ticket in the same run still reports", () => {
+  it("malformed cap file is SURFACED as doubt (not silently skipped); a positive-control ticket in the same run still reports", () => {
     const dir = join(capOrchDir, ".triage-dispatch-counts");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "CTL-BAD.json"), "not-json{");
@@ -330,10 +397,15 @@ describe("checkTriageCapParked (CTL-2111)", () => {
       getHostName: () => "mini",
       ownedBy: () => true,
     });
-    // CTL-BAD skipped, CTL-2111 still reported (positive control)
-    const names = checks.map((c) => c.detail);
+    // CTL-2111 still reported (positive control — proves the scan ran at all).
     expect(checks.some((c) => c.status === STATUS.WARN && c.detail.includes("CTL-2111"))).toBe(true);
-    expect(names.some((d) => d.includes("CTL-BAD"))).toBe(false);
+    // CTL-2111 (Codex #3824 P1): CTL-BAD is no longer SILENTLY skipped. An
+    // unparseable record may or may not carry `cappedAt`, so the scan is partial and
+    // must say so — the old contract dropped it without a trace, which is how a
+    // "no capped tickets" pass could be certified over records nobody could read.
+    const details = checks.map((c) => c.detail);
+    expect(details.some((d) => d.includes("CTL-BAD"))).toBe(true);
+    expect(details.some((d) => /INCONCLUSIVE/.test(d))).toBe(true);
   });
 
   it("checksForClass(worker) registers the check thunk", () => {

--- a/plugins/dev/scripts/execution-core/event-name-fold.test.mjs
+++ b/plugins/dev/scripts/execution-core/event-name-fold.test.mjs
@@ -43,6 +43,18 @@ describe("monitor.mjs parse* resolve through the boundary (CTL-1834)", () => {
     expect(out).not.toBeNull();
     expect(out.identifier).toBe("CTL-9");
     expect(out.toState).toBe("In Progress");
+    // CTL-2111: the event ts is surfaced so the cap re-arm can prove a re-queue
+    // post-dates the park.
+    expect(out.ts).toBe("2026-08-07T00:00:00.000Z");
+  });
+
+  test("parseStateChangedEvent surfaces ts=null when the event has no ts (CTL-2111)", () => {
+    const out = parseStateChangedEvent({
+      name: "linear.issue.state_changed",
+      detail: { ticket: "CTL-9", teamKey: "CTL", toState: "Todo" },
+    });
+    expect(out).not.toBeNull();
+    expect(out.ts).toBeNull();
   });
 
   test("parseIssueUpdatedEvent reads a v3-shaped line", () => {

--- a/plugins/dev/scripts/execution-core/linear-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-event.mjs
@@ -106,6 +106,33 @@ const hasIds = (raw) => parseIds(raw).length > 0;
  * `docs`/the ticket's binding conditions. Two history rows must always produce two
  * events.
  */
+// isoFromFeedTimestamp — normalize a feed timestamp to an ISO-8601 string.
+//
+// CTL-2111 (Codex #3824 round-4 P1): `issue_history.created_at` is stored and
+// selected as an INTEGER of epoch milliseconds (see linear-feed-source.mjs, whose
+// cursor compares `created_at > $sinceMs`), not a string. Copying it verbatim made
+// the round-3 fix INERT in production: `parseStateChangedEvent` accepts
+// `transitionedAt` only when it is a string, so every real event fell straight back
+// to the delayed envelope `ts` and a pre-cap transition emitted later could still
+// clear a newer cap. Normalizing at the producer keeps the wire shape one type, so
+// no consumer has to know the storage representation.
+//
+// Accepts a number (epoch ms) or an already-ISO string; anything else, and any
+// value that does not round-trip through Date, yields null — the conservative
+// answer, since a null simply falls back to the envelope ts rather than asserting
+// a wrong time.
+export function isoFromFeedTimestamp(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  if (typeof value === "string" && value !== "") {
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+  }
+  return null;
+}
+
 export function historyEventId(history) {
   const id = history?.id;
   return typeof id === "string" && id !== "" ? id : null;
@@ -279,7 +306,7 @@ export function buildIssueEvent({ history, issue, actor, assignee, project, labe
         // compared against. The triage-cap re-arm gate is the first consumer that
         // needs the real edge time: judged on `ts`, a delayed PRE-cap transition can
         // look newer than a cap it actually preceded and wrongly clear it.
-        transitionedAt: history?.created_at ?? null,
+        transitionedAt: isoFromFeedTimestamp(history?.created_at),
       },
     },
     seams,

--- a/plugins/dev/scripts/execution-core/linear-feed-event.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-event.mjs
@@ -271,6 +271,15 @@ export function buildIssueEvent({ history, issue, actor, assignee, project, labe
         // line, and so an operator reading the log later can too.
         source: "cloud-feed",
         historyId: historyEventId(history),
+        // CTL-2111 (Codex #3824 round-3 P1): the SOURCE transition time, carried so
+        // consumers can order against when Linear actually recorded the change
+        // rather than when this feed emitted the envelope. `buildCanonicalEvent`
+        // stamps `ts` with now() AND truncates milliseconds, so the envelope time
+        // is both delayed (by sweep latency) and coarser than the timestamps it is
+        // compared against. The triage-cap re-arm gate is the first consumer that
+        // needs the real edge time: judged on `ts`, a delayed PRE-cap transition can
+        // look newer than a cap it actually preceded and wrongly clear it.
+        transitionedAt: history?.created_at ?? null,
       },
     },
     seams,

--- a/plugins/dev/scripts/execution-core/linear-feed-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-feed-event.test.mjs
@@ -404,3 +404,29 @@ describe("⭐ label changes are a named class, not 'nothing changed'", () => {
     expect(edgeDelta(h({ added_label_ids: "{not json" })).updatedFromKeys).not.toContain("labels");
   });
 });
+
+// ── CTL-2111 (Codex #3824 round-4 P1) ─────────────────────────────────────────
+describe("buildIssueEvent — transitionedAt normalization", () => {
+  const row = (createdAt) => ({
+    history: { id: "h1", issue_id: "i1", actor_id: "u1", created_at: createdAt, from_state: "Triage", to_state: "Todo" },
+    issue: { identifier: "CTL-2111", team_key: "CTL", id: "i1" },
+  });
+
+  test("an epoch-ms integer (the feed's storage type) is emitted as an ISO string", () => {
+    const ms = Date.parse("2026-08-21T09:59:00.000Z");
+    const ev = buildIssueEvent(row(ms));
+    expect(ev.body.payload.transitionedAt).toBe("2026-08-21T09:59:00.000Z");
+    expect(typeof ev.body.payload.transitionedAt).toBe("string");
+  });
+
+  test("an ISO string passes through", () => {
+    const ev = buildIssueEvent(row("2026-08-21T09:59:00.000Z"));
+    expect(ev.body.payload.transitionedAt).toBe("2026-08-21T09:59:00.000Z");
+  });
+
+  test("a missing or unusable created_at yields null (falls back to the envelope ts)", () => {
+    expect(buildIssueEvent(row(undefined)).body.payload.transitionedAt).toBeNull();
+    expect(buildIssueEvent(row("not-a-date")).body.payload.transitionedAt).toBeNull();
+    expect(buildIssueEvent(row(Number.NaN)).body.payload.transitionedAt).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -198,6 +198,22 @@ const DRAG_OUT_STATES = new Set(["Backlog", "Canceled", "Duplicate"]);
 // (attributes['event.name'] + body.payload) and the legacy flat shape
 // (event.event + event.detail). Returns null for anything that is not a
 // linear.issue.state_changed event with an extractable ticket identifier.
+// normalizeTransitionAt — coerce a source transition timestamp to an ISO string.
+// Accepts epoch milliseconds (the feed's storage type) or an ISO string; anything
+// unparseable yields null, which makes the caller fall back to the envelope ts
+// rather than assert a wrong ordering. See CTL-2111 round-4 P1.
+function normalizeTransitionAt(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  }
+  if (typeof value === "string" && value !== "") {
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? null : value;
+  }
+  return null;
+}
+
 export function parseStateChangedEvent(event) {
   const name = getEventName(event); // CTL-1834: the shared boundary
   if (name !== "linear.issue.state_changed") return null;
@@ -222,10 +238,12 @@ export function parseStateChangedEvent(event) {
     // Judged on `ts`, a delayed transition that genuinely PRE-dated a park could
     // appear newer and clear a cap that was created after it. Prefer the source
     // time; `ts` remains the fallback for any producer that does not carry one.
-    transitionAt:
-      typeof payload.transitionedAt === "string" && payload.transitionedAt
-        ? payload.transitionedAt
-        : null,
+    // CTL-2111 (Codex #3824 round-4 P1): accept a NUMBER (epoch ms) as well as an
+    // ISO string. The feed stores `issue_history.created_at` as an integer, and a
+    // string-only test silently discarded it and fell back to the envelope ts — the
+    // round-3 fix was inert in production. The producer now normalizes to ISO, and
+    // this stays tolerant of both so an older or third-party producer still works.
+    transitionAt: normalizeTransitionAt(payload.transitionedAt),
     // CTL triage-entry fix (Phase 0): carry the projection-fold fields so a
     // →status transition can be folded into the eligible set from the event
     // payload (no Linear poll), the same way handleIssueUpdatedEvent does.

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -213,6 +213,19 @@ export function parseStateChangedEvent(event) {
     // human re-queue is NEWER than the cap's cappedAt (only a re-queue that
     // post-dates the park re-arms). null when absent → conservative no-op.
     ts: typeof event?.ts === "string" ? event.ts : null,
+    // CTL-2111 (Codex #3824 round-3 P1): the SOURCE transition time — when Linear
+    // recorded the state change — as distinct from `ts`, the envelope EMISSION
+    // time. They are not interchangeable for an ordering comparison: the cloud
+    // feed (now the only ingestion leg, both webhook legs retired) stamps `ts`
+    // with `now()` at build time AND truncates milliseconds, so `ts` is late by
+    // the sweep latency and coarser than the `cappedAt` it is compared against.
+    // Judged on `ts`, a delayed transition that genuinely PRE-dated a park could
+    // appear newer and clear a cap that was created after it. Prefer the source
+    // time; `ts` remains the fallback for any producer that does not carry one.
+    transitionAt:
+      typeof payload.transitionedAt === "string" && payload.transitionedAt
+        ? payload.transitionedAt
+        : null,
     // CTL triage-entry fix (Phase 0): carry the projection-fold fields so a
     // →status transition can be folded into the eligible set from the event
     // payload (no Linear poll), the same way handleIssueUpdatedEvent does.
@@ -685,7 +698,8 @@ export function handleStateChangedEvent(
       // dispatch below stays gated.
       if (orchDir) {
         rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
-          eventTs: parsed.ts,
+          // Source transition time when the producer carries one; envelope ts otherwise.
+          eventTs: parsed.transitionAt ?? parsed.ts,
           multiHost: (hosts ?? getExistenceHosts()).length > 1,
         });
       }
@@ -753,7 +767,8 @@ export function handleStateChangedEvent(
       // the fold-only drain, which advances the cursor and never replays it.
       if (orchDir && parsed.toState === query.status) {
         rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
-          eventTs: parsed.ts,
+          // Source transition time when the producer carries one; envelope ts otherwise.
+          eventTs: parsed.transitionAt ?? parsed.ts,
           multiHost: (hosts ?? getExistenceHosts()).length > 1,
         });
       }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -659,18 +659,37 @@ export function handleStateChangedEvent(
       // →Triage — one-shot dispatch the triage phase agent. NOT the eligible
       // set: a Triage ticket is never scheduler-pulled. Idempotent downstream
       // (phase-agent-dispatch no-ops an existing signal file).
-      // CTL-731: skipped during the fold-only boot drain (no eligible fold here,
-      // so the entire branch is a no-op when foldOnly).
+      // CTL-731: the DISPATCH is skipped during the fold-only boot drain (there is
+      // no eligible fold in this branch). The cap re-arm below is not a dispatch and
+      // deliberately still runs — see the round-2 note on it.
+      // CTL-2111: a human re-queue newer than the cap's cappedAt re-arms the
+      // tripped triage cap BEFORE the dispatch below, so the sweep proceeds.
+      // Fail-open, never blocks the dispatch; single-host skips the fence reset.
+      //
+      // CTL-2111 (Codex #3824 round-2 P1): deliberately OUTSIDE the `!foldOnly`
+      // gate. Re-arming is a state RECONCILIATION — it drops a stale local latch,
+      // exactly like the `upsertTicket` eligibility fold in the sibling branch
+      // below — not a dispatch, so CTL-731's "boot drain folds only, no dispatch"
+      // rule does not cover it. Gated, the boot-gap re-queue was lost outright:
+      // a human re-queues a capped ticket while the daemon is down, the resumed
+      // `startMonitor` consumes that state_changed with `foldOnly:true` and
+      // ADVANCES THE DURABLE CURSOR past it, so the one event that could re-arm
+      // the cap is never replayed with side effects. The startup sweep then read
+      // the unchanged cap and re-parked the ticket, leaving it stuck until some
+      // later human transition happened to arrive while the daemon was up.
+      //
+      // Safe to run during the drain because the helper is self-limiting and
+      // idempotent: it no-ops unless a `cappedAt` is present AND the event
+      // post-dates it, and the re-arm itself drops `cappedAt` — so every replayed
+      // event after the first returns `not-capped`. It starts no worker; the
+      // dispatch below stays gated.
+      if (orchDir) {
+        rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
+          eventTs: parsed.ts,
+          multiHost: (hosts ?? getExistenceHosts()).length > 1,
+        });
+      }
       if (!foldOnly) {
-        // CTL-2111: a human re-queue newer than the cap's cappedAt re-arms the
-        // tripped triage cap BEFORE the dispatch below, so the sweep proceeds.
-        // Fail-open, never blocks the dispatch; single-host skips the fence reset.
-        if (orchDir) {
-          rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
-            eventTs: parsed.ts,
-            multiHost: (hosts ?? getExistenceHosts()).length > 1,
-          });
-        }
         dispatchTriage(parsed.identifier, {
           dispatch,
           orchDir,
@@ -729,7 +748,10 @@ export function handleStateChangedEvent(
       // so it re-arms even when a stale triage.json is present (the CTC-750 case:
       // the ticket had a triage.json but was capped and re-queued). Fail-open;
       // never blocks the dispatch below.
-      if (!foldOnly && orchDir && parsed.toState === query.status) {
+      // CTL-2111 (Codex #3824 round-2 P1): `!foldOnly` dropped here for the same
+      // reason as the →Triage branch above — a boot-gap re-queue is consumed by
+      // the fold-only drain, which advances the cursor and never replays it.
+      if (orchDir && parsed.toState === query.status) {
         rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
           eventTs: parsed.ts,
           multiHost: (hosts ?? getExistenceHosts()).length > 1,

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -1802,17 +1802,38 @@ export function rearmTriageCapOnRequeue(
   // a cappedAt we cannot parse, is a conservative no-op (cannot prove newer).
   if (!Number.isFinite(evMs) || !Number.isFinite(capMs) || evMs <= capMs)
     return { rearmed: false, reason: "not-newer" };
+  // CTL-2111 (Codex #3824 P1): on multi-host the FENCE reset must be CONFIRMED
+  // before the host-local latch is dropped. `resetTriageAttemptCountSync` reports
+  // ordinary write failures as `{count:null}` rather than throwing, and the old
+  // order cleared `cappedAt` first and then discarded that result. The next sweep
+  // therefore read the still-capped fleet fence (`fleetTriageDispatchCount` takes
+  // max(host-local, fence)) and re-parked the ticket, while every later
+  // state_changed saw no local `cappedAt` and returned "not-capped" — so the reset
+  // was never retried and the emitted event nevertheless claimed a re-arm. The
+  // host-local reset is NOT a fail-open here: on multi-host it un-gates nothing on
+  // its own. Retaining the latch keeps the re-arm retryable on the next re-queue
+  // and keeps the durable audit record honest.
+  if (multiHost) {
+    let fenceCount = null;
+    try {
+      fenceCount = resetFence({ ticket })?.count ?? null;
+    } catch {
+      // A throwing seam is indistinguishable from a failed reset — both are
+      // "unconfirmed", never "reset".
+      fenceCount = null;
+    }
+    if (fenceCount !== 0) {
+      log.warn(
+        { ticket, cappedAt: rec.cappedAt, eventTs },
+        "ctl-2111: triage cap re-arm DEFERRED — fence reset unconfirmed; local latch retained for retry"
+      );
+      return { rearmed: false, reason: "fence-reset-unconfirmed" };
+    }
+  }
   // Reset the host-local counter — drop `count` and `cappedAt` so the next sweep
   // re-dispatches triage (rewrite rather than unlink so a concurrent reader never
   // sees a transient absent file).
   writeTriageDispatchRecord(orchDir, ticket, { count: 0, lastDispatchAt: null });
-  if (multiHost) {
-    try {
-      resetFence({ ticket });
-    } catch {
-      /* fail-open — the host-local reset already un-gates the next sweep */
-    }
-  }
   try {
     clearLabel(orchDir, ticket);
   } catch {

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -115,6 +115,8 @@ import {
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
+// CTL-2111: durable, budget-independent triage-cap park event.
+import { appendTriageCapParkedEvent } from "./triage-cap-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import {
   readMaxParallel,
@@ -1133,6 +1135,10 @@ function dispatchTriage(
     // Single-host paths never call these.
     readFenceTriageAttempt = readTriageAttemptCountSync,
     bumpFenceTriageAttempt = bumpTriageAttemptCountSync,
+    // CTL-2111: durable, budget-independent park event emitted at the cap-park
+    // site regardless of the Linear needs-human label-write outcome. Injectable
+    // so tests assert the append without a real event-log write.
+    appendTriageCapParked = appendTriageCapParkedEvent,
   }
 ) {
   if (!orchDir) {
@@ -1229,6 +1235,27 @@ function dispatchTriage(
         { identifier, cap: TRIAGE_DISPATCH_CAP },
         "ctl-1441: triage re-dispatch cap reached — parked needs-human; delete .triage-dispatch-counts/<ticket>.json to re-arm"
       );
+      // CTL-2111 (Tier 3): surface the park DURABLY in the local event log,
+      // budget-independent. The needs-human label write above is subject to the
+      // per-ticket Linear write budget (CTC-750: an exhausted budget refused the
+      // label and the park was invisible everywhere). This append bypasses that
+      // budget entirely. Gated on markTriageCapped (the one-way first-park latch)
+      // so it fires exactly once per park episode, mirroring the WARN — a human
+      // re-queue clears cappedAt (re-arm), so a genuine re-park emits a fresh
+      // event. Fail-open: visibility must never wedge admission.
+      try {
+        appendTriageCapParked({
+          ticket: identifier,
+          orchId,
+          cap: TRIAGE_DISPATCH_CAP,
+          count: fleetTriageDispatchCount(orchDir, identifier, {
+            multiHost,
+            readFenceCount: readFenceTriageAttempt,
+          }),
+        });
+      } catch {
+        /* fail-open — visibility must never wedge admission */
+      }
     }
     // CTL-2090: this was the ONE remaining silent exit in triage admission — the
     // markTriageCapped WARN above fires once per park episode, and every later

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -80,7 +80,8 @@ import {
   isClaimFailure,
   readTriageAttemptCountSync,
   bumpTriageAttemptCountSync,
-} from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count
+  resetTriageAttemptCountSync,
+} from "./cluster-claim-sync.mjs"; // CTL-862: cross-host claim soft-CAS; CTL-1649: fleet-wide triage attempt count; CTL-2111: cap re-arm on human re-queue
 import { listProjects, getProjectConfig, resolveEligibleQuery } from "./registry.mjs";
 import {
   runEligibleQuery,
@@ -115,8 +116,12 @@ import {
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
-// CTL-2111: durable, budget-independent triage-cap park event.
-import { appendTriageCapParkedEvent } from "./triage-cap-event.mjs";
+// CTL-2111: durable, budget-independent triage-cap events (park + re-arm).
+import {
+  appendTriageCapParkedEvent,
+  appendTriageCapRearmedEvent,
+} from "./triage-cap-event.mjs";
+import { clearStalledLabel } from "./label-guard.mjs"; // CTL-2111: best-effort needs-human clear on re-arm
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
 import {
   readMaxParallel,
@@ -204,6 +209,10 @@ export function parseStateChangedEvent(event) {
     identifier,
     teamKey: payload.teamKey ?? null,
     toState: payload.toState ?? null,
+    // CTL-2111: surface the event timestamp so the re-arm helper can prove a
+    // human re-queue is NEWER than the cap's cappedAt (only a re-queue that
+    // post-dates the park re-arms). null when absent → conservative no-op.
+    ts: typeof event?.ts === "string" ? event.ts : null,
     // CTL triage-entry fix (Phase 0): carry the projection-fold fields so a
     // →status transition can be folded into the eligible set from the event
     // payload (no Linear poll), the same way handleIssueUpdatedEvent does.
@@ -653,6 +662,15 @@ export function handleStateChangedEvent(
       // CTL-731: skipped during the fold-only boot drain (no eligible fold here,
       // so the entire branch is a no-op when foldOnly).
       if (!foldOnly) {
+        // CTL-2111: a human re-queue newer than the cap's cappedAt re-arms the
+        // tripped triage cap BEFORE the dispatch below, so the sweep proceeds.
+        // Fail-open, never blocks the dispatch; single-host skips the fence reset.
+        if (orchDir) {
+          rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
+            eventTs: parsed.ts,
+            multiHost: (hosts ?? getExistenceHosts()).length > 1,
+          });
+        }
         dispatchTriage(parsed.identifier, {
           dispatch,
           orchDir,
@@ -704,6 +722,17 @@ export function handleStateChangedEvent(
           state: parsed.toState,
           priority: parsed.toPriority,
           project: parsed.toProject ?? null,
+        });
+      }
+      // CTL-2111: a human re-queue to Todo/Ready newer than the cap's cappedAt
+      // re-arms the tripped triage cap. Placed BEFORE the hasTriageArtifact gate
+      // so it re-arms even when a stale triage.json is present (the CTC-750 case:
+      // the ticket had a triage.json but was capped and re-queued). Fail-open;
+      // never blocks the dispatch below.
+      if (!foldOnly && orchDir && parsed.toState === query.status) {
+        rearmTriageCapOnRequeue(orchDir, parsed.identifier, {
+          eventTs: parsed.ts,
+          multiHost: (hosts ?? getExistenceHosts()).length > 1,
         });
       }
       if (
@@ -1732,6 +1761,73 @@ export function markTriageCapped(orchDir, ticket, { now = () => new Date().toISO
     cap: TRIAGE_DISPATCH_CAP,
   });
   return true;
+}
+
+// ── CTL-2111: re-arm the triage cap on a human re-queue ──────────────────────
+// defaultClearNeedsHumanLabel — a best-effort Linear write clearing the sticky
+// needs-human label AND its `.applied`/`.skipped` once-markers on a CONFIRMED
+// removal (via clearStalledLabel's onRemoved semantics). Subject to the same
+// write budget as any Linear write — re-arm correctness NEVER depends on it (the
+// counter/fence reset + durable event are the load-bearing parts).
+function defaultClearNeedsHumanLabel(orchDir, ticket) {
+  clearStalledLabel(orchDir, ticket, "needs-human", { removeLabel });
+}
+
+// rearmTriageCapOnRequeue — pure, fail-open helper that resets a tripped triage
+// re-dispatch cap when a human re-queues the ticket (CTL-2111, Tier 1). A
+// re-queue is a `state_changed` event NEWER than the record's `cappedAt`; the
+// webhook drops bot-authored issue events before the log, so any such event is
+// by construction not orchestrator-authored (we rely on that upstream, we do not
+// re-check an actor here). Resets the host-local counter (drops `count`+`cappedAt`),
+// resets the fence `triage_attempt_count` (multi-host only), best-effort clears
+// the needs-human label, and emits a durable `triage.cap.rearmed.<T>` event.
+// Every side-effecting seam is wrapped so a throw degrades to a no-op — the
+// helper never throws into the event-handling path. Returns {rearmed, reason?}.
+export function rearmTriageCapOnRequeue(
+  orchDir,
+  ticket,
+  {
+    eventTs,
+    multiHost = false,
+    resetFence = resetTriageAttemptCountSync,
+    clearLabel = defaultClearNeedsHumanLabel,
+    appendRearmEvent = appendTriageCapRearmedEvent,
+  } = {}
+) {
+  const rec = readTriageDispatchRecord(orchDir, ticket);
+  if (!rec?.cappedAt) return { rearmed: false, reason: "not-capped" };
+  const capMs = Date.parse(rec.cappedAt);
+  const evMs = eventTs ? Date.parse(eventTs) : NaN;
+  // Only a re-queue that POST-DATES the park re-arms. Missing/unparseable ts, or
+  // a cappedAt we cannot parse, is a conservative no-op (cannot prove newer).
+  if (!Number.isFinite(evMs) || !Number.isFinite(capMs) || evMs <= capMs)
+    return { rearmed: false, reason: "not-newer" };
+  // Reset the host-local counter — drop `count` and `cappedAt` so the next sweep
+  // re-dispatches triage (rewrite rather than unlink so a concurrent reader never
+  // sees a transient absent file).
+  writeTriageDispatchRecord(orchDir, ticket, { count: 0, lastDispatchAt: null });
+  if (multiHost) {
+    try {
+      resetFence({ ticket });
+    } catch {
+      /* fail-open — the host-local reset already un-gates the next sweep */
+    }
+  }
+  try {
+    clearLabel(orchDir, ticket);
+  } catch {
+    /* fail-open — label clear is best-effort, budget-subject, non-load-bearing */
+  }
+  try {
+    appendRearmEvent({ ticket, orchId: ticket, eventTs, cappedAt: rec.cappedAt });
+  } catch {
+    /* fail-open — the durable event is an audit tap, never load-bearing */
+  }
+  log.warn(
+    { ticket, cappedAt: rec.cappedAt, eventTs },
+    "ctl-2111: triage cap re-armed on human re-queue — counter/fence reset"
+  );
+  return { rearmed: true };
 }
 
 // fleetTriageDispatchCount — the CTL-1649 fleet-wide dispatch count for a ticket.

--- a/plugins/dev/scripts/execution-core/triage-cap-event.mjs
+++ b/plugins/dev/scripts/execution-core/triage-cap-event.mjs
@@ -1,0 +1,128 @@
+// triage-cap-event.mjs — durable triage re-dispatch-cap events (CTL-2111).
+//
+// Two budget-independent events that surface the triage-cap lifecycle in the
+// LOCAL event log, bypassing the per-ticket Linear write budget entirely (the
+// budget exhaustion was the root of the CTC-750 invisibility):
+//
+//   - triage.cap.rearmed.<TICKET>        (INFO) — a human re-queue reset the
+//                                         host-local counter + fence, so the next
+//                                         sweep re-dispatches triage.
+//   - escalation.triage-cap-parked.<T>   (WARN) — the ticket tripped its cap and
+//                                         was parked, emitted unconditionally at
+//                                         the park site regardless of whether the
+//                                         Linear `needs-human` label write landed.
+//
+// Modeled on triage-transition-event.mjs. Neither name is a
+// phase.*/filter.*/broker.daemon.* name, so no coordination stream_class stamp is
+// required (CTL-1488) — they route through shouldSkipEvent normally.
+import { randomBytes } from "node:crypto";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+// defaultAppend — writes a JSONL line to the canonical event log.
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+// buildTriageCapRearmedEvent — canonical JSONL line for the INFO
+// triage.cap.rearmed.<TICKET> event (host-local counter + fence reset on a human
+// re-queue newer than cappedAt).
+export function buildTriageCapRearmedEvent({
+  ticket,
+  orchId,
+  eventTs = null,
+  cappedAt = null,
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "INFO",
+      severityNumber: 9,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": `triage.cap.rearmed.${ticket}`,
+        "event.entity": "triage",
+        "event.action": "cap-rearmed",
+        "event.label": ticket,
+        "catalyst.orchestration": orchId ?? ticket,
+        "linear.issue.identifier": ticket,
+      },
+      body: {
+        payload: { ticket, eventTs, cappedAt },
+      },
+    }) + "\n"
+  );
+}
+
+// appendTriageCapRearmedEvent — append the re-arm event to the canonical log.
+// The `append` seam defaults to the real file write; inject a recorder in tests.
+// Returns true on success, false on any error (log.error + swallow) — this is an
+// audit tap and must never be load-bearing.
+export function appendTriageCapRearmedEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    const line = buildTriageCapRearmedEvent(fields);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error({ err: err.message }, "triage-cap-event: rearmed append failed");
+    return false;
+  }
+}
+
+// buildTriageCapParkedEvent — canonical JSONL line for the WARN
+// escalation.triage-cap-parked.<TICKET> event (the ticket tripped its cap and
+// was parked). Budget-independent by construction: emitted at the park site
+// whether or not the Linear needs-human label write succeeded.
+export function buildTriageCapParkedEvent({
+  ticket,
+  orchId,
+  cap = null,
+  count = null,
+} = {}) {
+  const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return (
+    JSON.stringify({
+      ts,
+      id: randomBytes(8).toString("hex"),
+      observedTs: ts,
+      severityText: "WARN",
+      severityNumber: 13,
+      traceId: randomBytes(16).toString("hex"),
+      spanId: randomBytes(8).toString("hex"),
+      resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+      attributes: {
+        "event.name": `escalation.triage-cap-parked.${ticket}`,
+        "event.entity": "escalation",
+        "event.action": "triage-cap-parked",
+        "event.label": ticket,
+        "catalyst.orchestration": orchId ?? ticket,
+        "linear.issue.identifier": ticket,
+      },
+      body: {
+        payload: { ticket, cap, count },
+      },
+    }) + "\n"
+  );
+}
+
+// appendTriageCapParkedEvent — append the park event to the canonical log.
+// Fail-open (returns false on any error) — visibility must never wedge admission.
+export function appendTriageCapParkedEvent({ append = defaultAppend, ...fields } = {}) {
+  try {
+    const line = buildTriageCapParkedEvent(fields);
+    append(line);
+    return true;
+  } catch (err) {
+    log.error({ err: err.message }, "triage-cap-event: parked append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/triage-cap-event.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-cap-event.test.mjs
@@ -1,0 +1,122 @@
+// triage-cap-event.test.mjs — CTL-2111: durable triage-cap re-arm / park events.
+// Run: cd plugins/dev/scripts/execution-core && bun test triage-cap-event.test.mjs
+import { describe, test, expect } from "bun:test";
+import {
+  buildTriageCapRearmedEvent,
+  appendTriageCapRearmedEvent,
+  buildTriageCapParkedEvent,
+  appendTriageCapParkedEvent,
+} from "./triage-cap-event.mjs";
+
+describe("buildTriageCapRearmedEvent", () => {
+  test("envelope shape — INFO, name, entity/action, payload", () => {
+    const line = buildTriageCapRearmedEvent({
+      ticket: "CTL-2111",
+      orchId: "CTL-2111",
+      eventTs: "2026-08-21T10:00:00Z",
+      cappedAt: "2026-08-20T00:00:00Z",
+    });
+    expect(typeof line).toBe("string");
+    expect(line.endsWith("\n")).toBe(true);
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("triage.cap.rearmed.CTL-2111");
+    expect(ev.attributes["event.entity"]).toBe("triage");
+    expect(ev.attributes["event.action"]).toBe("cap-rearmed");
+    expect(ev.attributes["event.label"]).toBe("CTL-2111");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-2111");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("INFO");
+    expect(ev.severityNumber).toBe(9);
+    expect(ev.body.payload).toMatchObject({
+      ticket: "CTL-2111",
+      eventTs: "2026-08-21T10:00:00Z",
+      cappedAt: "2026-08-20T00:00:00Z",
+    });
+    expect(ev.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  });
+
+  test("not a pipeline-lifecycle action (broker ignores it)", () => {
+    const ev = JSON.parse(buildTriageCapRearmedEvent({ ticket: "CTL-1" }));
+    expect(["complete", "failed", "turn-cap-exhausted", "skipped"]).not.toContain(
+      ev.attributes["event.action"],
+    );
+    // no coordination stamp — triage.* is not a coordination-published prefix
+    expect(ev.attributes["event.stream_class"]).toBeUndefined();
+  });
+});
+
+describe("appendTriageCapRearmedEvent", () => {
+  test("passes a canonical line to the injected append and returns true", () => {
+    let captured = null;
+    const ok = appendTriageCapRearmedEvent({
+      ticket: "CTL-2111",
+      orchId: "CTL-2111",
+      eventTs: "2026-08-21T10:00:00Z",
+      cappedAt: "2026-08-20T00:00:00Z",
+      append: (line) => { captured = line; },
+    });
+    expect(ok).toBe(true);
+    expect(JSON.parse(captured).attributes["event.name"]).toBe("triage.cap.rearmed.CTL-2111");
+  });
+
+  test("fail-open — swallows a throwing append and returns false", () => {
+    const ok = appendTriageCapRearmedEvent({
+      ticket: "CTL-2111",
+      append: () => { throw new Error("disk full"); },
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("buildTriageCapParkedEvent", () => {
+  test("envelope shape — WARN, name, entity/action, payload", () => {
+    const line = buildTriageCapParkedEvent({
+      ticket: "CTL-2111",
+      orchId: "CTL-2111",
+      cap: 3,
+      count: 3,
+    });
+    const ev = JSON.parse(line);
+    expect(ev.attributes["event.name"]).toBe("escalation.triage-cap-parked.CTL-2111");
+    expect(ev.attributes["event.entity"]).toBe("escalation");
+    expect(ev.attributes["event.action"]).toBe("triage-cap-parked");
+    expect(ev.attributes["event.label"]).toBe("CTL-2111");
+    expect(ev.attributes["linear.issue.identifier"]).toBe("CTL-2111");
+    expect(ev.resource["service.name"]).toBe("catalyst.execution-core");
+    expect(ev.severityText).toBe("WARN");
+    expect(ev.body.payload).toMatchObject({ ticket: "CTL-2111", cap: 3, count: 3 });
+  });
+
+  test("not a pipeline-lifecycle action, no coordination stamp", () => {
+    const ev = JSON.parse(buildTriageCapParkedEvent({ ticket: "CTL-1" }));
+    expect(["complete", "failed", "turn-cap-exhausted", "skipped"]).not.toContain(
+      ev.attributes["event.action"],
+    );
+    expect(ev.attributes["event.stream_class"]).toBeUndefined();
+  });
+});
+
+describe("appendTriageCapParkedEvent", () => {
+  test("passes a canonical line to the injected append and returns true", () => {
+    let captured = null;
+    const ok = appendTriageCapParkedEvent({
+      ticket: "CTL-2111",
+      orchId: "CTL-2111",
+      cap: 3,
+      count: 4,
+      append: (line) => { captured = line; },
+    });
+    expect(ok).toBe(true);
+    expect(JSON.parse(captured).attributes["event.name"]).toBe(
+      "escalation.triage-cap-parked.CTL-2111",
+    );
+  });
+
+  test("fail-open — swallows a throwing append and returns false", () => {
+    const ok = appendTriageCapParkedEvent({
+      ticket: "CTL-2111",
+      append: () => { throw new Error("disk full"); },
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -15,8 +15,11 @@ import {
   TRIAGE_DISPATCH_CAP,
   readTriageSignalStatus,
   readTriageDispatchCount,
+  readTriageDispatchRecord,
   bumpTriageDispatchCount,
   fleetTriageDispatchCount,
+  markTriageCapped,
+  rearmTriageCapOnRequeue,
 } from "./monitor.mjs";
 
 let orchDir;
@@ -166,5 +169,118 @@ describe("fleetTriageDispatchCount — fleet-wide cap (CTL-1649)", () => {
       readFenceCount: () => ({ count: TRIAGE_DISPATCH_CAP }),
     });
     expect(fleetCount).toBeGreaterThanOrEqual(TRIAGE_DISPATCH_CAP);
+  });
+});
+
+// ─── CTL-2111: rearmTriageCapOnRequeue ───────────────────────────────────────
+
+describe("rearmTriageCapOnRequeue — human re-queue re-arm (CTL-2111)", () => {
+  // Seed a capped record: bump to the cap, then mark it capped at a fixed time.
+  function seedCapped(ticket, cappedAt) {
+    bumpTriageDispatchCount(orchDir, ticket);
+    bumpTriageDispatchCount(orchDir, ticket);
+    bumpTriageDispatchCount(orchDir, ticket);
+    markTriageCapped(orchDir, ticket, { now: () => cappedAt });
+    const rec = readTriageDispatchRecord(orchDir, ticket);
+    expect(rec.cappedAt).toBe(cappedAt);
+    return rec;
+  }
+
+  function makeSpies() {
+    const calls = { resetFence: [], clearLabel: [], appendRearmEvent: [] };
+    return {
+      calls,
+      resetFence: (arg) => { calls.resetFence.push(arg); return { count: 0 }; },
+      clearLabel: (dir, t) => { calls.clearLabel.push({ dir, t }); },
+      appendRearmEvent: (arg) => { calls.appendRearmEvent.push(arg); return true; },
+    };
+  }
+
+  test("capped + eventTs NEWER than cappedAt → re-armed (multi-host): counter+fence reset, label cleared, event once", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z",
+      multiHost: true,
+      resetFence: s.resetFence,
+      clearLabel: s.clearLabel,
+      appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(true);
+    expect(s.calls.resetFence).toHaveLength(1);
+    expect(s.calls.resetFence[0]).toMatchObject({ ticket: "CTL-2111" });
+    expect(s.calls.clearLabel).toHaveLength(1);
+    expect(s.calls.appendRearmEvent).toHaveLength(1);
+    expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111").cappedAt).toBeUndefined();
+  });
+
+  test("capped + eventTs OLDER/equal to cappedAt → no-op, no spies", () => {
+    seedCapped("CTL-2111", "2026-08-21T00:00:00Z");
+    const s = makeSpies();
+    const older = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-20T00:00:00Z", multiHost: true,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(older.rearmed).toBe(false);
+    const equal = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(equal.rearmed).toBe(false);
+    expect(s.calls.resetFence).toHaveLength(0);
+    expect(s.calls.clearLabel).toHaveLength(0);
+    expect(s.calls.appendRearmEvent).toHaveLength(0);
+    // record untouched (still capped)
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111").cappedAt).toBe("2026-08-21T00:00:00Z");
+  });
+
+  test("NOT capped (no cappedAt) → no-op regardless of eventTs", () => {
+    bumpTriageDispatchCount(orchDir, "CTL-2111"); // count but never capped
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2030-01-01T00:00:00Z", multiHost: true,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(false);
+    expect(res.reason).toBe("not-capped");
+    expect(s.calls.resetFence).toHaveLength(0);
+  });
+
+  test("eventTs missing/unparseable → conservative no-op (cannot prove newer)", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    expect(rearmTriageCapOnRequeue(orchDir, "CTL-2111", { eventTs: null, multiHost: true,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent }).rearmed).toBe(false);
+    expect(rearmTriageCapOnRequeue(orchDir, "CTL-2111", { eventTs: "not-a-date", multiHost: true,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent }).rearmed).toBe(false);
+    expect(s.calls.resetFence).toHaveLength(0);
+  });
+
+  test("single-host → resetFence NOT called; host-local reset + event still happen", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: false,
+      resetFence: s.resetFence, clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(true);
+    expect(s.calls.resetFence).toHaveLength(0); // no fence write single-host
+    expect(s.calls.clearLabel).toHaveLength(1);
+    expect(s.calls.appendRearmEvent).toHaveLength(1);
+    expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
+  });
+
+  test("every seam throwing → still rearmed:true, never throws (fail-open)", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: () => { throw new Error("fence down"); },
+      clearLabel: () => { throw new Error("linear 500"); },
+      appendRearmEvent: () => { throw new Error("disk full"); },
+    });
+    expect(res.rearmed).toBe(true);
+    expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111").cappedAt).toBeUndefined();
   });
 });

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -479,3 +479,93 @@ describe("handleStateChangedEvent — cap re-arm during the fold-only boot drain
     expect(readCap(orchDir).cappedAt).toBeUndefined();
   });
 });
+
+// ── CTL-2111 (Codex #3824 round-3 P1): order on the SOURCE transition time ─────
+//
+// `buildCanonicalEvent` stamps the envelope `ts` with now() AND truncates
+// milliseconds, so `ts` is the feed's EMISSION time — late by the sweep latency
+// and coarser than the `cappedAt` it is compared against. Judged on `ts`, a
+// transition that genuinely PRE-dated a park can look newer and wrongly clear a
+// cap created after it. `buildIssueEvent` now carries `transitionedAt`
+// (history.created_at) and the re-arm prefers it.
+describe("handleStateChangedEvent — re-arm orders on the source transition time (CTL-2111 round-3 P1)", () => {
+  let dir;
+  let prevCatalystDir;
+  const TEAM = "CTL";
+  const TICKET = "CTL-2111";
+  const CAPPED_AT = "2026-08-21T10:00:00.000Z";
+
+  const writeCapped = (orchDir) => {
+    const d = pathJoin(orchDir, ".triage-dispatch-counts");
+    mkdirSync(d, { recursive: true });
+    writeFileSync(pathJoin(d, `${TICKET}.json`), JSON.stringify({ count: 3, cappedAt: CAPPED_AT }));
+  };
+  const capRec = (orchDir) =>
+    JSON.parse(readFileSync(pathJoin(orchDir, ".triage-dispatch-counts", `${TICKET}.json`), "utf8"));
+
+  const ev = ({ ts, transitionedAt }) => ({
+    ts,
+    name: "linear.issue.state_changed",
+    body: { payload: { ticket: TICKET, teamKey: TEAM, toState: "Todo", transitionedAt } },
+  });
+
+  beforeEach(() => {
+    dir = mkdtempSync(pathJoin(tmpdir(), "ctl2111-transition-"));
+    const orchDir = pathJoin(dir, "execution-core");
+    mkdirSync(orchDir, { recursive: true });
+    writeFileSync(
+      pathJoin(orchDir, "registry.json"),
+      JSON.stringify({
+        projects: [{ team: TEAM, repoRoot: dir, eligibleQuery: { status: "Todo", triageStatus: "Triage" } }],
+      }),
+    );
+    prevCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+  });
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const opts = (orchDir) => ({
+    orchDir,
+    dispatch: () => {},
+    applyTriageStatus: () => {},
+    appendEvent: () => {},
+    liveBackgroundCount: () => 0,
+    readMaxParallelFn: () => 4,
+    hosts: ["only-host"],
+    hostName: "only-host",
+    foldOnly: true, // fold path keeps the assertion about the re-arm alone
+  });
+
+  // THE DEFECT: a transition that happened BEFORE the cap, emitted after it.
+  test("a delayed pre-cap transition does NOT clear the cap, even though the envelope ts is newer", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    handleStateChangedEvent(
+      ev({ ts: "2026-08-21T10:05:00Z", transitionedAt: "2026-08-21T09:59:00.000Z" }),
+      opts(orchDir),
+    );
+    expect(capRec(orchDir).cappedAt).toBe(CAPPED_AT); // latch retained
+  });
+
+  test("a genuine post-cap transition DOES clear the cap (positive control)", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    handleStateChangedEvent(
+      ev({ ts: "2026-08-21T10:05:00Z", transitionedAt: "2026-08-21T10:01:00.000Z" }),
+      opts(orchDir),
+    );
+    expect(capRec(orchDir).cappedAt).toBeUndefined();
+  });
+
+  // Back-compat: a producer that carries no transitionedAt still falls back to ts.
+  test("no transitionedAt → falls back to the envelope ts (back-compat)", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    handleStateChangedEvent(ev({ ts: "2026-08-21T10:05:00Z", transitionedAt: undefined }), opts(orchDir));
+    expect(capRec(orchDir).cappedAt).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -561,6 +561,30 @@ describe("handleStateChangedEvent — re-arm orders on the source transition tim
     expect(capRec(orchDir).cappedAt).toBeUndefined();
   });
 
+  // CTL-2111 (Codex #3824 round-4 P1): the feed stores created_at as epoch
+  // MILLISECONDS, so a string-only accept made the round-3 fix inert in production
+  // — every real event fell back to the delayed envelope ts.
+  test("a NUMERIC (epoch ms) transitionedAt is honoured, not silently discarded", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    handleStateChangedEvent(
+      // 09:59 — genuinely BEFORE the 10:00 cap — as epoch ms, emitted at 10:05.
+      ev({ ts: "2026-08-21T10:05:00Z", transitionedAt: Date.parse("2026-08-21T09:59:00.000Z") }),
+      opts(orchDir),
+    );
+    expect(capRec(orchDir).cappedAt).toBe(CAPPED_AT); // latch retained
+  });
+
+  test("a NUMERIC post-cap transitionedAt still clears the cap (positive control)", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    handleStateChangedEvent(
+      ev({ ts: "2026-08-21T10:05:00Z", transitionedAt: Date.parse("2026-08-21T10:01:00.000Z") }),
+      opts(orchDir),
+    );
+    expect(capRec(orchDir).cappedAt).toBeUndefined();
+  });
+
   // Back-compat: a producer that carries no transitionedAt still falls back to ts.
   test("no transitionedAt → falls back to the envelope ts (back-compat)", () => {
     const orchDir = pathJoin(dir, "execution-core");

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -257,6 +257,59 @@ describe("rearmTriageCapOnRequeue — human re-queue re-arm (CTL-2111)", () => {
     expect(s.calls.resetFence).toHaveLength(0);
   });
 
+  // ── CTL-2111 (Codex #3824 P1): the fence reset must be CONFIRMED before the
+  // host-local latch is dropped. resetTriageAttemptCountSync signals failure with
+  // `{count:null}` and never throws, so an ignored result stranded the ticket:
+  // fleet fence still capped → re-parked, local cappedAt gone → never retried,
+  // and the durable event claimed a re-arm that did not happen.
+  test("multi-host + fence reset UNCONFIRMED ({count:null}) → latch retained, no event, not rearmed", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: () => ({ count: null }), // ordinary write failure — does NOT throw
+      clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(false);
+    expect(res.reason).toBe("fence-reset-unconfirmed");
+    // The durable event must not claim a re-arm that did not happen.
+    expect(s.calls.appendRearmEvent).toHaveLength(0);
+    // The latch survives, so a later re-queue can RETRY the reset (the old code
+    // cleared cappedAt here, after which every later event read "not-capped").
+    const rec = readTriageDispatchRecord(orchDir, "CTL-2111");
+    expect(rec?.cappedAt).toBe("2026-08-20T00:00:00Z");
+  });
+
+  test("multi-host + fence reset THROWS → treated as unconfirmed, latch retained", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: () => { throw new Error("spawn failed"); },
+      clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(false);
+    expect(res.reason).toBe("fence-reset-unconfirmed");
+    expect(s.calls.appendRearmEvent).toHaveLength(0);
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111")?.cappedAt).toBe("2026-08-20T00:00:00Z");
+  });
+
+  // Positive control: the SAME harness with a CONFIRMED reset must re-arm, so the
+  // two assertions above are evidence of the gate and not of a broken fixture.
+  test("multi-host + fence reset CONFIRMED ({count:0}) → latch cleared, event emitted", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const s = makeSpies();
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: () => ({ count: 0 }),
+      clearLabel: s.clearLabel, appendRearmEvent: s.appendRearmEvent,
+    });
+    expect(res.rearmed).toBe(true);
+    expect(s.calls.appendRearmEvent).toHaveLength(1);
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111")?.cappedAt).toBeFalsy();
+    expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
+  });
+
   test("single-host → resetFence NOT called; host-local reset + event still happen", () => {
     seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
     const s = makeSpies();
@@ -271,10 +324,28 @@ describe("rearmTriageCapOnRequeue — human re-queue re-arm (CTL-2111)", () => {
     expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
   });
 
-  test("every seam throwing → still rearmed:true, never throws (fail-open)", () => {
+  // CTL-2111 (Codex #3824 P1): the NON-load-bearing seams stay fail-open — but the
+  // multi-host fence reset does NOT, because on multi-host the host-local reset
+  // un-gates nothing by itself (fleetTriageDispatchCount takes max(local, fence)).
+  // This test therefore pairs a CONFIRMED fence reset with two throwing auxiliary
+  // seams; the throwing-fence case is asserted separately above.
+  test("auxiliary seams throwing → still rearmed:true, never throws (fail-open)", () => {
     seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
     const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
       eventTs: "2026-08-21T00:00:00Z", multiHost: true,
+      resetFence: () => ({ count: 0 }), // confirmed — the load-bearing seam succeeded
+      clearLabel: () => { throw new Error("linear 500"); },
+      appendRearmEvent: () => { throw new Error("disk full"); },
+    });
+    expect(res.rearmed).toBe(true);
+    expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
+    expect(readTriageDispatchRecord(orchDir, "CTL-2111").cappedAt).toBeUndefined();
+  });
+
+  test("single-host: every seam throwing → still rearmed:true, never throws (fail-open)", () => {
+    seedCapped("CTL-2111", "2026-08-20T00:00:00Z");
+    const res = rearmTriageCapOnRequeue(orchDir, "CTL-2111", {
+      eventTs: "2026-08-21T00:00:00Z", multiHost: false, // no fence involved at all
       resetFence: () => { throw new Error("fence down"); },
       clearLabel: () => { throw new Error("linear 500"); },
       appendRearmEvent: () => { throw new Error("disk full"); },

--- a/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/triage-redispatch-guard.test.mjs
@@ -20,6 +20,7 @@ import {
   fleetTriageDispatchCount,
   markTriageCapped,
   rearmTriageCapOnRequeue,
+  handleStateChangedEvent,
 } from "./monitor.mjs";
 
 let orchDir;
@@ -353,5 +354,128 @@ describe("rearmTriageCapOnRequeue — human re-queue re-arm (CTL-2111)", () => {
     expect(res.rearmed).toBe(true);
     expect(readTriageDispatchCount(orchDir, "CTL-2111")).toBe(0);
     expect(readTriageDispatchRecord(orchDir, "CTL-2111").cappedAt).toBeUndefined();
+  });
+});
+
+// ── CTL-2111 (Codex #3824 round-2 P1): boot-gap drain must still re-arm ────────
+//
+// The defect: a human re-queues a CAPPED ticket while the daemon is down. On
+// restart, `startMonitor` resumes from its durable cursor and consumes that
+// `state_changed` with `foldOnly:true`. The re-arm used to sit INSIDE the
+// `!foldOnly` gate, so it was skipped — while the cursor advanced past the event
+// regardless. The startup sweep then read the unchanged cap and re-parked the
+// ticket, and because the event is never replayed with side effects the re-arm
+// could never happen: the ticket stayed capped until some later human transition
+// happened to land while the daemon was up.
+//
+// These drive the REAL `handleStateChangedEvent` against a temp registry
+// (CATALYST_DIR), so they exercise the actual call-site gate rather than the
+// helper in isolation.
+describe("handleStateChangedEvent — cap re-arm during the fold-only boot drain (CTL-2111 round-2 P1)", () => {
+  let dir;
+  let prevCatalystDir;
+
+  const TEAM = "CTL";
+  const TICKET = "CTL-2111";
+  const CAPPED_AT = "2026-08-21T10:00:00.000Z";
+  const REQUEUE_TS = "2026-08-21T11:00:00.000Z"; // NEWER than cappedAt
+
+  // A tripped-cap record: count at the cap plus the `cappedAt` latch.
+  const writeCapped = (orchDir) => {
+    const d = pathJoin(orchDir, ".triage-dispatch-counts");
+    mkdirSync(d, { recursive: true });
+    writeFileSync(
+      pathJoin(d, `${TICKET}.json`),
+      JSON.stringify({ count: 3, cappedAt: CAPPED_AT, lastDispatchAt: CAPPED_AT }),
+    );
+  };
+  const readCap = (orchDir) =>
+    JSON.parse(readFileSync(pathJoin(orchDir, ".triage-dispatch-counts", `${TICKET}.json`), "utf8"));
+
+  const stateEvent = (toState) => ({
+    ts: REQUEUE_TS,
+    name: "linear.issue.state_changed",
+    body: { payload: { ticket: TICKET, teamKey: TEAM, toState } },
+  });
+
+  beforeEach(() => {
+    dir = mkdtempSync(pathJoin(tmpdir(), "ctl2111-folddrain-"));
+    const orchDir = pathJoin(dir, "execution-core");
+    mkdirSync(orchDir, { recursive: true });
+    writeFileSync(
+      pathJoin(orchDir, "registry.json"),
+      JSON.stringify({
+        projects: [
+          { team: TEAM, repoRoot: dir, eligibleQuery: { status: "Todo", triageStatus: "Triage" } },
+        ],
+      }),
+    );
+    prevCatalystDir = process.env.CATALYST_DIR;
+    process.env.CATALYST_DIR = dir;
+  });
+
+  afterEach(() => {
+    if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = prevCatalystDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The seams that would otherwise reach Linear / spawn a worker.
+  const inertOpts = (orchDir, dispatched) => ({
+    orchDir,
+    dispatch: (...a) => dispatched.push(a),
+    applyTriageStatus: () => {},
+    appendEvent: () => {},
+    liveBackgroundCount: () => 0,
+    readMaxParallelFn: () => 4,
+    hosts: ["only-host"], // single-host → the fence reset is skipped entirely
+    hostName: "only-host",
+  });
+
+  for (const toState of ["Todo", "Triage"]) {
+    test(`foldOnly:true still re-arms a capped ticket on a newer →${toState} re-queue`, () => {
+      const orchDir = pathJoin(dir, "execution-core");
+      writeCapped(orchDir);
+      const dispatched = [];
+
+      handleStateChangedEvent(stateEvent(toState), {
+        ...inertOpts(orchDir, dispatched),
+        foldOnly: true,
+      });
+
+      // The latch is gone → the next sweep re-dispatches triage.
+      const rec = readCap(orchDir);
+      expect(rec.cappedAt).toBeUndefined();
+      expect(rec.count).toBe(0);
+      // …and CTL-731 is preserved: the drain still dispatched nothing.
+      expect(dispatched).toEqual([]);
+    });
+  }
+
+  test("foldOnly:true does NOT re-arm when the re-queue PRE-dates the cap (guard intact)", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    const dispatched = [];
+    const stale = { ...stateEvent("Todo"), ts: "2026-08-21T09:00:00.000Z" }; // older
+
+    handleStateChangedEvent(stale, { ...inertOpts(orchDir, dispatched), foldOnly: true });
+
+    expect(readCap(orchDir).cappedAt).toBe(CAPPED_AT); // latch retained
+    expect(dispatched).toEqual([]);
+  });
+
+  // Positive control: the same event on the LIVE path re-arms too, proving the
+  // assertions above are reading a real re-arm and not an artifact of foldOnly.
+  test("foldOnly:false re-arms as before (control)", () => {
+    const orchDir = pathJoin(dir, "execution-core");
+    writeCapped(orchDir);
+    const dispatched = [];
+
+    handleStateChangedEvent(stateEvent("Todo"), {
+      ...inertOpts(orchDir, dispatched),
+      foldOnly: false,
+    });
+
+    expect(readCap(orchDir).cappedAt).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

When a human re-queues a ticket that has tripped its host-local triage re-dispatch cap (CTL-1441), the owning host previously refused to triage it **forever** (the CTC-750 incident). On top of PR #3787 this adds three pieces, all routed through **local event-log / local-file** seams that bypass the per-ticket Linear write budget (the root of the CTC-750 invisibility):

- **Tier 1 — re-arm on human re-queue** (`monitor.mjs`): a `state_changed` event newer than the cap's `cappedAt` resets the host-local counter + the fence `triage_attempt_count`, best-effort clears `needs-human`, and emits a durable `triage.cap.rearmed.<T>` event. Wired into both re-entry branches of `handleStateChangedEvent`, before the `hasTriageArtifact` gate.
- **Tier 2 — `catalyst doctor` visibility** (`doctor.mjs`): `checkTriageCapParked` WARNs per board-eligible tripped cap this host owns (INFO if not currently eligible), with the cap-record path + a copy-pasteable re-arm command. Bare-node-safe (node:fs + the eligible projection, never bun:sqlite), advisory-only.
- **Tier 3 — durable park event** (`monitor.mjs`): the cap-park emits `escalation.triage-cap-parked.<T>` to the local event log **unconditionally**, independent of the Linear label-write outcome.

Plus a fence-reset primitive (`resetTriageAttemptCount` + `reset-triage-attempt` CLI + `resetTriageAttemptCountSync`) and event-name registration.

## Test plan

- `bun test cluster-claim.test.mjs cluster-claim-sync.test.mjs triage-redispatch-guard.test.mjs triage-cap-event.test.mjs doctor.test.mjs event-name-fold.test.mjs` — 671 pass
- `bun test broker/namespace-parity.test.mjs` — 12 pass
- New `triage-cap-event.test.mjs` added to the `execution-core-tests.yml` allowlist

Plan: `thoughts/shared/plans/2026-08-21-ctl-2111.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)