### PR TITLE
feat(dev): CTL-1991 — Claude account tokens via cloud product (CTC-732)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -497,6 +497,23 @@ The same PR5 that unified the cloud-token name resolver did adjacent, unrelated 
 contract: none of those three call sites import `secret-contract.mjs`, and the registry's own
 `groq-api-key` row has no consumer today besides `checkSecretContract`'s shadow-only observation.
 
+**Claude account tokens via cloud materialize (CTL-1991).** The `claude-accounts.env` row in
+the secret registry is `delivery: "env-file"`, `rotation: "boot-only"` — presence-only. The token
+never flows through `resolveSecret()`; it flows through the launcher `source` and the live rearm
+hook. CTL-1991 adds a **cloud delivery path** beside the existing SOPS path: on a genuinely declared
+cloud node (`deployment.mode === "cloud"`, `inferred === false`, `recognized !== false`) the
+execution-core daemon's cluster-sync timer calls `syncClaudeAccountsFromCloud`
+(`execution-core/claude-accounts-cloud-fetch.mjs`) **before** `armSecret("claude-accounts.env")` on
+every tick. The function fetches `GET {CATALYST_CLOUD_BASE_URL}/me/secrets/claude-accounts.env`
+with a Bearer cloud-token, then materializes the body to disk via a symlink-safe 0o600 tmp+rename
+— identical to the `defaultWriteFile` pattern in `cluster-sync.mjs`. A no-churn idempotency
+check (byte-compare before write) avoids mtime churn and spurious rearm-hook triggers. Fetch
+failures in `enforce` mode leave the on-disk file untouched; a cluster outage at boot is
+fire-and-forget (`.catch()`) so the daemon always starts. Rollout is via tri-state
+`CATALYST_CLAUDE_ACCOUNTS_CLOUD ∈ off (default) | shadow | enforce`; default `off` means no live
+change on merge. See `website/src/content/docs/reference/configuration.md` → "Claude account tokens
+via cloud" for the full knob reference.
+
 **Secret-env hygiene rule**: the bash engine's `_csc_set_result` exports the non-secret
 `CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell's convenience but
 **never** exports the resolved value itself (`CATALYST_SECRET_LAST_VALUE` stays same-shell-only,

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -71,6 +71,12 @@ import { ESCALATION_EVENT_NEEDS_HUMAN } from "../execution-core/escalation-event
 // (not a re-typed literal). The `linear.label.` prefix is UNPROTECTED under the
 // namespace contract (a dedicated test below asserts it, alongside the salvage family).
 import { LABEL_RETRY_EXHAUSTED_EVENT } from "../execution-core/label-retry-event.mjs";
+// CTL-1991 — the cloud-delivery materialize pair (materialized / would_materialize),
+// imported from their owning module (not re-typed literals — CTL-1659 discipline).
+import {
+  CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT,
+  CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT,
+} from "../execution-core/claude-accounts-cloud-event.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -122,6 +128,8 @@ const EXEC_CORE_EVENT_NAMES = [
   ...ENTITLEMENT_EVENT_NAMES, // CTL-1785 entitlement-event.mjs — would-shed / shed / restored (v3 bare-name, host-suffixed)
   ESCALATION_EVENT_NEEDS_HUMAN, // CTL-2056 escalation-event.mjs — ticket.escalated (entity=ticket/action=escalated)
   LABEL_RETRY_EXHAUSTED_EVENT, // CTL-2052 label-retry-event.mjs — the "stopped after N and said so" escalation
+  CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT, // CTL-1991 — cloud delivery materialize: content written to disk
+  CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT, // CTL-1991 — shadow mode: would have materialized
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/execution-core/claude-accounts-cloud-daemon-wiring.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-cloud-daemon-wiring.test.mjs
@@ -1,0 +1,119 @@
+// claude-accounts-cloud-daemon-wiring.test.mjs — CTL-1991 Phase 2.
+// Verifies the daemon's cluster-sync timer ordering contract and event name
+// namespace safety. Does NOT start the live daemon — tests the contracts that
+// the injectable-fn pattern enforces (call order, fail-open) plus the event
+// name namespace checks.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-cloud-daemon-wiring.test.mjs
+
+import { describe, test, expect } from "bun:test";
+
+// ── timer call-order tests ─────────────────────────────────────────────────────
+
+describe("daemon cluster-sync timer call order (CTL-1991)", () => {
+  test("default-off: syncClaudeAccountsFromCloud returns skipped for cluster/off", async () => {
+    // Simulates syncClaudeAccountsFromCloud({mode:"off", ...}) — the function
+    // must return { skipped:true, reason:"disabled" } and leave disk untouched.
+    // The daemon imports this fn from the module; here we verify the module's
+    // real behavior directly.
+    const { syncClaudeAccountsFromCloud } = await import("./claude-accounts-cloud-fetch.mjs");
+    const result = await syncClaudeAccountsFromCloud({
+      env: {},
+      deploymentMode: { mode: "cluster", inferred: false, recognized: true },
+      mode: "off",
+      log: null,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud"); // cluster → not-cloud before even checking mode
+  });
+
+  test("non-cloud mode: not-cloud short-circuits before disabled check", async () => {
+    const { syncClaudeAccountsFromCloud } = await import("./claude-accounts-cloud-fetch.mjs");
+    // single-host should also be not-cloud
+    const result = await syncClaudeAccountsFromCloud({
+      env: { CATALYST_CLAUDE_ACCOUNTS_CLOUD: "enforce" },
+      deploymentMode: { mode: "single-host", inferred: false, recognized: true },
+      mode: "enforce",
+      log: null,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud");
+  });
+
+  test("inferred cloud: skipped as not-cloud (inferred=true never activates)", async () => {
+    const { syncClaudeAccountsFromCloud } = await import("./claude-accounts-cloud-fetch.mjs");
+    const result = await syncClaudeAccountsFromCloud({
+      env: { CATALYST_CLAUDE_ACCOUNTS_CLOUD: "enforce" },
+      deploymentMode: { mode: "cloud", inferred: true, recognized: true },
+      mode: "enforce",
+      log: null,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud");
+  });
+
+  test("enforce mode on genuine cloud: syncClaudeAccountsFromCloud is called before armSecret (ordering invariant)", () => {
+    // We verify the call order the daemon's timer tick enforces using a
+    // synthetic replay: cloud-sync is always first, then armSecret.
+    // This is a contract test — the daemon.mjs wiring puts syncClaudeAccountsFromCloudFn
+    // in a try/await block BEFORE armSecret("claude-accounts.env").
+    const callOrder = [];
+    const fakeCloudSync = async () => { callOrder.push("cloud-sync"); return { skipped: true, reason: "not-cloud" }; };
+    const fakeArmSecret = () => { callOrder.push("arm-secret"); };
+
+    // Simulate one timer tick (the try/catch wrapper in daemon.mjs)
+    return fakeCloudSync()
+      .catch(() => {})  // fail-open: swallow any throw
+      .then(() => { fakeArmSecret(); })
+      .then(() => {
+        expect(callOrder).toEqual(["cloud-sync", "arm-secret"]);
+      });
+  });
+
+  test("fail-open: a throw from syncClaudeAccountsFromCloud does not abort the tick", async () => {
+    const callOrder = [];
+    const throwingSync = async () => { throw new Error("cloud outage"); };
+    const fakeArmSecret = () => { callOrder.push("arm-secret"); };
+
+    // Mirrors the daemon's try/catch around syncClaudeAccountsFromCloudFn
+    try {
+      await throwingSync();
+    } catch {
+      // Swallowed — tick continues
+    }
+    fakeArmSecret();
+
+    expect(callOrder).toEqual(["arm-secret"]);
+  });
+
+  test("boot sync: fire-and-forget .catch() swallows throw (fail-open)", async () => {
+    // Boot path uses .catch() pattern (startDaemon is not async).
+    let caught = false;
+    const throwingSync = async () => { throw new Error("outage at boot"); };
+    await throwingSync().catch(() => { caught = true; });
+    // Process continues regardless
+    expect(caught).toBe(true);
+  });
+});
+
+// ── event emission tests ──────────────────────────────────────────────────────
+
+describe("event emission for cloud-accounts materialize (CTL-1991)", () => {
+  test("CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT is a valid non-broker-protected name", async () => {
+    const { CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT } = await import("./claude-accounts-cloud-event.mjs");
+    const { isBrokerProtectedName } = await import("../broker/namespace-contract.mjs");
+    expect(isBrokerProtectedName(CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT)).toBe(false);
+  });
+
+  test("CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT is a valid non-broker-protected name", async () => {
+    const { CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT } = await import("./claude-accounts-cloud-event.mjs");
+    const { isBrokerProtectedName } = await import("../broker/namespace-contract.mjs");
+    expect(isBrokerProtectedName(CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT)).toBe(false);
+  });
+
+  test("event name constants match the catalyst.claude-accounts.* prefix", async () => {
+    const { CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT, CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT } = await import("./claude-accounts-cloud-event.mjs");
+    expect(CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT).toMatch(/^catalyst\.claude-accounts\./);
+    expect(CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT).toMatch(/^catalyst\.claude-accounts\./);
+  });
+});

--- a/plugins/dev/scripts/execution-core/claude-accounts-cloud-event.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-cloud-event.mjs
@@ -1,0 +1,19 @@
+// claude-accounts-cloud-event.mjs — CTL-1991. Event-name constants for the
+// cloud-delivery materialize pair. Imported by namespace-parity.test.mjs (the
+// CTL-1659/CTL-1889 discipline — never re-type a literal when the constant
+// can be imported, so a rename cannot leave this contract asserting a name
+// nothing emits).
+//
+// The `catalyst.claude-accounts.*` prefix is UNPROTECTED under the CTL-1142
+// namespace contract (not filter.* / broker.daemon.* / session.heartbeat /
+// phase.<name>.<terminal>) and routes through shouldSkipEvent normally.
+//
+// Two names, not one name plus a flag: otel-forward strips body.payload
+// off-machine, so an alert on the materialized event must be able to select
+// it by attributes alone — a payload field is insufficient.
+
+export const CLAUDE_ACCOUNTS_CLOUD_MATERIALIZED_EVENT =
+  "catalyst.claude-accounts.cloud_materialized";
+
+export const CLAUDE_ACCOUNTS_CLOUD_WOULD_MATERIALIZE_EVENT =
+  "catalyst.claude-accounts.cloud_would_materialize";

--- a/plugins/dev/scripts/execution-core/claude-accounts-cloud-fetch.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-cloud-fetch.mjs
@@ -1,0 +1,312 @@
+// claude-accounts-cloud-fetch.mjs — CTL-1991. Cloud delivery of the
+// claude-accounts.env secret (Claude OAuth subscription tokens).
+//
+// WHAT THIS DOES. Fetches the active claude-accounts.env content from the
+// cloud product (CTC-732) and materializes it to ~/.config/catalyst/ so the
+// existing catalyst-execution-core launcher (which sources the file at boot)
+// and the live rearm hook (claude-accounts-rearm.mjs) keep working unchanged.
+// All three downstream consumers that read the whole file for all N token
+// slots (accounts-probe.mjs, ratelimit-accounts-probe.mjs, claude-accounts-
+// usage.mjs) also keep reading the same on-disk path unchanged.
+//
+// WHY MATERIALIZE INSTEAD OF RESOLVING VIA SECRET-CONTRACT. resolveSecret(
+// "claude-accounts.env") is presence-only (delivery: "env-file"). The token
+// never flowed through resolveSecret; it flows through the launcher `source`
+// and the rearm hook. Materializing to disk lets those paths continue working
+// without change, and a rollback to SOPS delivery is a single flag flip.
+//
+// MINTING IS NOT IN SCOPE. The cloud product delivers and switches subscription
+// OAuth tokens across hosts. Minting those tokens remains `claude login` on the
+// machine — this module does not issue credentials, only deliver existing ones.
+//
+// SDK HAS NO SECRETS API. @catalyst-cloud/sdk has no secrets/slot entity in
+// ENTITY_NAMES (verified on dist/node.d.ts + full dist/ grep for
+// "secret|slot|activate|/me/|oauth" — returned nothing). Host-side fetch is
+// a raw HTTP call, not an SDK method.
+//
+// ASSUMED CTC-732 ENDPOINT (must confirm before enabling "enforce" on a real
+// cloud host):
+//   GET {CATALYST_CLOUD_BASE_URL}/me/secrets/claude-accounts.env
+//   Headers: Authorization: Bearer <cloud-token>
+//   Body:    the active version's raw file content — full claude-accounts.env
+//            text (all slots + _catalyst_active_token selector line) so the
+//            probes that read all N slots keep working.
+// The path is configurable via CATALYST_CLAUDE_ACCOUNTS_CLOUD_PATH so only
+// that string changes if the real API differs.
+//
+// ROLLOUT. Tri-state CATALYST_CLAUDE_ACCOUNTS_CLOUD ∈ off (default) | shadow |
+// enforce. Default "off" means no live change on merge. Only a confirmed cloud
+// host should set "enforce". Shadow logs decisions without writing files.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-cloud-fetch.test.mjs
+
+import { writeFileSync, chmodSync, renameSync, rmSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { containsNul, isValidUtf8RoundTrip } from "../lib/secret-contract.mjs";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_BASE_URL = "https://api.catalyst-cloud.coalescelabs.ai/api/v1";
+const DEFAULT_ACCOUNT = "tenant-0";
+const DEFAULT_PATH = "/me/secrets/claude-accounts.env";
+
+// ── resolveClaudeAccountsCloudMode ───────────────────────────────────────────
+
+/**
+ * Resolve CATALYST_CLAUDE_ACCOUNTS_CLOUD env-var → "off" | "shadow" | "enforce".
+ * Unknown values degrade to "off" (matches resolveDepSkewMode pattern — never throws).
+ */
+export function resolveClaudeAccountsCloudMode(env) {
+  const val = env?.CATALYST_CLAUDE_ACCOUNTS_CLOUD ?? "";
+  if (val === "shadow") return "shadow";
+  if (val === "enforce") return "enforce";
+  return "off";
+}
+
+// ── fetchClaudeAccountsEnv ───────────────────────────────────────────────────
+
+/**
+ * fetchClaudeAccountsEnv — fetch the active claude-accounts.env content from
+ * the cloud. All I/O is injected for testability; never throws.
+ *
+ * Returns:
+ *   { ok:true, content } on success
+ *   { ok:false, reason } on any failure:
+ *     "no-cloud-token"  — token absent; no HTTP call made
+ *     "http-<status>"   — non-2xx HTTP response
+ *     "fetch-threw"     — fetchFn threw (network error, timeout, etc.)
+ *     "empty"           — 200 with whitespace-only body
+ *     "invalid-bytes"   — 200 but content contains NUL or fails UTF-8 round-trip
+ *
+ * @param {object} opts
+ * @param {object} [opts.env]           env vars (default: process.env)
+ * @param {function} [opts.fetchFn]     injectable fetch (default: globalThis.fetch)
+ * @param {function} [opts.resolveToken] injectable token resolver → string|null
+ * @param {object|null} [opts.log]      pino-style logger (null = silent)
+ */
+export async function fetchClaudeAccountsEnv({
+  env = process.env,
+  fetchFn = globalThis.fetch,
+  resolveToken,
+  log,
+} = {}) {
+  try {
+    const safeEnv = env ?? {};
+
+    // Resolve the bearer token first. Never make the HTTP call without one.
+    const token = resolveToken ? resolveToken(safeEnv) : null;
+    if (!token) {
+      return { ok: false, reason: "no-cloud-token" };
+    }
+
+    // Build the request URL.
+    const baseUrl = (safeEnv.CATALYST_CLOUD_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    const path = safeEnv.CATALYST_CLAUDE_ACCOUNTS_CLOUD_PATH ?? DEFAULT_PATH;
+    const url = `${baseUrl}${path}`;
+
+    // Perform the HTTP GET.
+    let response;
+    try {
+      response = await fetchFn(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    } catch (err) {
+      log?.warn?.({ err: err?.message }, "claude-accounts-cloud-fetch: fetch threw");
+      return { ok: false, reason: "fetch-threw" };
+    }
+
+    if (!response.ok) {
+      return { ok: false, reason: `http-${response.status}` };
+    }
+
+    const text = await response.text();
+
+    // Empty / whitespace-only body guard.
+    if (!text || !text.trim()) {
+      return { ok: false, reason: "empty" };
+    }
+
+    // Byte hygiene: NUL bytes and invalid-UTF-8 sequences are rejected (same
+    // guards as rearmClaudeAccountsFromFile / rearmGithubTokenFromFile).
+    const buf = Buffer.from(text, "utf8");
+    const decoded = buf.toString("utf8");
+    if (!isValidUtf8RoundTrip(buf, decoded) || containsNul(decoded)) {
+      return { ok: false, reason: "invalid-bytes" };
+    }
+
+    return { ok: true, content: text };
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "claude-accounts-cloud-fetch: unexpected error (continuing)");
+    return { ok: false, reason: "unexpected-error" };
+  }
+}
+
+// ── defaultWriteFile ──────────────────────────────────────────────────────────
+
+// Symlink-safe 0o600 tmp+rename writer — mirrors cluster-sync.mjs :267-282
+// (the `defaultWriteFile` function there). Writes to a sibling tmp file then
+// renameSync into place. rename replaces a symlink at `path` rather than
+// following it to its target — unlike writeFileSync (O_TRUNC follows symlinks).
+function defaultWriteFile(path, content) {
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`;
+  try {
+    writeFileSync(tmp, content, { mode: 0o600 });
+    chmodSync(tmp, 0o600); // defensively re-assert (umask can mask the create mode)
+    renameSync(tmp, path);
+  } catch (err) {
+    try { rmSync(tmp, { force: true }); } catch { /* ignore cleanup failure */ }
+    throw err;
+  }
+}
+
+// ── materializeClaudeAccountsEnv ─────────────────────────────────────────────
+
+/**
+ * materializeClaudeAccountsEnv — write `content` to `path` at 0o600 via
+ * tmp+rename. No-churn: if the on-disk content already equals `content`,
+ * returns { written:false, reason:"unchanged" } without writing.
+ *
+ * Injectable readFile / writeFile seams for tests; never throws.
+ *
+ * Returns:
+ *   { written:true }                   — file was written (content changed)
+ *   { written:false, reason:"unchanged" } — content identical, no write
+ *   { written:false, reason:"error" }  — write threw; no litter left
+ */
+export async function materializeClaudeAccountsEnv({
+  content,
+  path,
+  readFile = (p) => readFileSync(p, "utf8"),
+  writeFile = defaultWriteFile,
+  log,
+} = {}) {
+  try {
+    // No-churn idempotency: compare by exact bytes. Prevents mtime churn and
+    // stops the rearm hook (which watches for env changes) from firing every tick.
+    try {
+      const existing = readFile(path);
+      const existingStr = Buffer.isBuffer(existing) ? existing.toString("utf8") : String(existing);
+      if (existingStr === content) {
+        return { written: false, reason: "unchanged" };
+      }
+    } catch {
+      // ENOENT or unreadable — proceed with the write
+    }
+
+    try {
+      writeFile(path, content);
+      return { written: true };
+    } catch (err) {
+      log?.warn?.({ err: err?.message }, "claude-accounts-cloud-fetch: materialize write failed");
+      return { written: false, reason: "error" };
+    }
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "claude-accounts-cloud-fetch: materialize unexpected error");
+    return { written: false, reason: "error" };
+  }
+}
+
+// ── syncClaudeAccountsFromCloud ───────────────────────────────────────────────
+
+/**
+ * syncClaudeAccountsFromCloud — orchestration gate: deployment-mode guard +
+ * tri-state (off/shadow/enforce) dispatch. Composes fetchClaudeAccountsEnv and
+ * materializeClaudeAccountsEnv. Never throws.
+ *
+ * Returns one of:
+ *   { skipped:true, reason:"not-cloud" }  — deployment mode is not genuinely cloud
+ *   { skipped:true, reason:"disabled" }   — mode is "off"
+ *   { shadow:true, wouldWrite:<bool> }     — shadow mode (fetch but no write)
+ *   { written:<bool>, [reason] }           — enforce mode, materialize result
+ *   { ok:false, reason }                   — enforce mode, fetch failed (disk untouched)
+ *
+ * The "genuine cloud" predicate matches resolveSecret's (CTL-1617):
+ *   deploymentMode.mode === "cloud" && !deploymentMode.inferred && deploymentMode.recognized !== false
+ *
+ * @param {object} opts
+ * @param {object} [opts.env]              env vars (default: process.env)
+ * @param {object} [opts.deploymentMode]   result of resolveDeploymentMode()
+ * @param {string} [opts.mode]             "off" | "shadow" | "enforce" (default: resolves from env)
+ * @param {function} [opts.fetchFn]        injectable fetch
+ * @param {function} [opts.resolveToken]   injectable token resolver → string|null
+ * @param {string} [opts.path]             target file path (default: ~/.config/catalyst/claude-accounts.env)
+ * @param {object|null} [opts.log]         pino-style logger
+ */
+export async function syncClaudeAccountsFromCloud({
+  env = process.env,
+  deploymentMode,
+  mode,
+  fetchFn = globalThis.fetch,
+  resolveToken,
+  path,
+  log,
+} = {}) {
+  try {
+    const safeEnv = env ?? {};
+
+    // Resolve the target path the same way the launcher (catalyst-execution-core)
+    // and the rearm hook resolve it: env override or default config location.
+    const targetPath = path ??
+      safeEnv.CLAUDE_ACCOUNTS_ENV ??
+      join(homedir(), ".config", "catalyst", "claude-accounts.env");
+
+    // Deployment-mode gate: only activate on a genuinely declared cloud node.
+    // Never on inferred cloud (might be a laptop that just hasn't declared a mode),
+    // and never on an unrecognized/invalid value degraded to cloud.
+    const isGenuineCloud =
+      deploymentMode?.mode === "cloud" &&
+      deploymentMode?.inferred === false &&
+      deploymentMode?.recognized !== false;
+
+    if (!isGenuineCloud) {
+      return { skipped: true, reason: "not-cloud" };
+    }
+
+    // Tri-state mode gate.
+    const resolvedMode = mode ?? resolveClaudeAccountsCloudMode(safeEnv);
+    if (resolvedMode === "off" || !resolvedMode) {
+      return { skipped: true, reason: "disabled" };
+    }
+
+    // Fetch the content (shared by both shadow and enforce).
+    const fetchResult = await fetchClaudeAccountsEnv({ env: safeEnv, fetchFn, resolveToken, log });
+
+    if (resolvedMode === "shadow") {
+      if (!fetchResult.ok) {
+        return { shadow: true, wouldWrite: false, fetchReason: fetchResult.reason };
+      }
+      // Compute would-write by checking if on-disk content differs, without writing.
+      let wouldWrite = true;
+      try {
+        const existing = readFileSync(targetPath, "utf8");
+        wouldWrite = existing !== fetchResult.content;
+      } catch {
+        // File absent or unreadable — would write
+      }
+      log?.info?.({ wouldWrite, path: targetPath }, "claude-accounts-cloud-fetch: shadow — would materialize");
+      return { shadow: true, wouldWrite };
+    }
+
+    // enforce mode: materialize only on a successful fetch. A cloud outage must
+    // never blank the existing on-disk token — so a fetch failure returns the
+    // error result and leaves the file untouched.
+    if (!fetchResult.ok) {
+      log?.warn?.({ reason: fetchResult.reason }, "claude-accounts-cloud-fetch: enforce — fetch failed, disk untouched");
+      return { ok: false, reason: fetchResult.reason };
+    }
+
+    return await materializeClaudeAccountsEnv({
+      content: fetchResult.content,
+      path: targetPath,
+      log,
+    });
+  } catch (err) {
+    log?.warn?.({ err: err?.message }, "claude-accounts-cloud-fetch: sync unexpected error");
+    return { ok: false, reason: "unexpected-error" };
+  }
+}

--- a/plugins/dev/scripts/execution-core/claude-accounts-cloud-fetch.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-cloud-fetch.test.mjs
@@ -1,0 +1,424 @@
+// claude-accounts-cloud-fetch.test.mjs — CTL-1991. FULLY OFFLINE: every test
+// injects explicit env / fetchFn / resolveToken / readFile / writeFile stubs,
+// so no test ever reads real files (beyond a tmp dir), touches the network, or
+// modifies the host's ~/.config/catalyst.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-cloud-fetch.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, readFileSync, lstatSync, symlinkSync, readdirSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  fetchClaudeAccountsEnv,
+  materializeClaudeAccountsEnv,
+  syncClaudeAccountsFromCloud,
+  resolveClaudeAccountsCloudMode,
+} from "./claude-accounts-cloud-fetch.mjs";
+
+// Fake content — a realistic claude-accounts.env text (no real credentials)
+const FAKE_CONTENT =
+  "CLAUDE_TOKEN_acct1='sk-ant-oat01-FAKE-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'\n" +
+  "CLAUDE_TOKEN_acct2='sk-ant-oat01-FAKE-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'\n" +
+  "_catalyst_active_token=\"$CLAUDE_TOKEN_acct1\"\n" +
+  "export CLAUDE_CODE_OAUTH_TOKEN=\"$_catalyst_active_token\"\n";
+
+const FAKE_TOKEN = "ct-test-FAKE-CLOUD-TOKEN-1234567890";
+
+// resolveToken stubs
+const goodToken = () => FAKE_TOKEN;
+const noToken = () => null;
+
+// A 200-success fetch stub
+const successResponse = () => ({ ok: true, status: 200, text: async () => FAKE_CONTENT });
+
+// Silence log output in tests
+const noLog = null;
+
+// ── fetchClaudeAccountsEnv ───────────────────────────────────────────────────
+
+describe("fetchClaudeAccountsEnv", () => {
+  test("returns { ok:true, content } on 200 with non-empty body", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push({ url, init }); return successResponse(); };
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(true);
+    expect(result.content).toBe(FAKE_CONTENT);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("uses correct default URL containing the default base + path", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => { calls.push(url); return successResponse(); };
+    await fetchClaudeAccountsEnv({ env: {}, fetchFn, resolveToken: goodToken, log: noLog });
+    expect(calls[0]).toContain("https://api.catalyst-cloud.coalescelabs.ai");
+    expect(calls[0]).toContain("/me/secrets/claude-accounts.env");
+  });
+
+  test("overrides base URL from CATALYST_CLOUD_BASE_URL", async () => {
+    const calls = [];
+    const fetchFn = async (url) => { calls.push(url); return successResponse(); };
+    await fetchClaudeAccountsEnv({
+      env: { CATALYST_CLOUD_BASE_URL: "https://custom.example.com/api/v2" },
+      fetchFn, resolveToken: goodToken, log: noLog,
+    });
+    expect(calls[0]).toContain("https://custom.example.com/api/v2");
+  });
+
+  test("overrides path from CATALYST_CLAUDE_ACCOUNTS_CLOUD_PATH", async () => {
+    const calls = [];
+    const fetchFn = async (url) => { calls.push(url); return successResponse(); };
+    await fetchClaudeAccountsEnv({
+      env: { CATALYST_CLAUDE_ACCOUNTS_CLOUD_PATH: "/v2/secrets/accounts" },
+      fetchFn, resolveToken: goodToken, log: noLog,
+    });
+    expect(calls[0]).toContain("/v2/secrets/accounts");
+  });
+
+  test("sends Authorization: Bearer <token> header", async () => {
+    let capturedHeaders;
+    const fetchFn = async (url, init) => {
+      capturedHeaders = init?.headers ?? {};
+      return successResponse();
+    };
+    await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    const authHeader = capturedHeaders["Authorization"] ?? capturedHeaders["authorization"];
+    expect(authHeader).toBe(`Bearer ${FAKE_TOKEN}`);
+  });
+
+  test("returns { ok:false, reason:'no-cloud-token' } and makes NO HTTP call when token is null", async () => {
+    const calls = [];
+    const fetchFn = async (...args) => { calls.push(args); return successResponse(); };
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: noToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no-cloud-token");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("returns { ok:false, reason:'http-401' } on 401", async () => {
+    const fetchFn = async () => ({ ok: false, status: 401, text: async () => "Unauthorized" });
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("http-401");
+  });
+
+  test("returns { ok:false, reason:'http-503' } on 503", async () => {
+    const fetchFn = async () => ({ ok: false, status: 503, text: async () => "Service Unavailable" });
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("http-503");
+  });
+
+  test("returns { ok:false, reason:'fetch-threw' } when fetchFn throws", async () => {
+    const fetchFn = async () => { throw new Error("network error"); };
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("fetch-threw");
+  });
+
+  test("returns { ok:false, reason:'empty' } on 200 with empty body", async () => {
+    const fetchFn = async () => ({ ok: true, status: 200, text: async () => "" });
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("empty");
+  });
+
+  test("returns { ok:false, reason:'empty' } on 200 with whitespace-only body", async () => {
+    const fetchFn = async () => ({ ok: true, status: 200, text: async () => "   \n   " });
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("empty");
+  });
+
+  test("returns { ok:false, reason:'invalid-bytes' } when content contains NUL byte", async () => {
+    const contentWithNul = FAKE_CONTENT + "\u0000injected-nul";
+    const fetchFn = async () => ({ ok: true, status: 200, text: async () => contentWithNul });
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("invalid-bytes");
+  });
+
+  test("never throws on null env or missing optional fields", async () => {
+    const r1 = await fetchClaudeAccountsEnv({
+      env: null, fetchFn: async () => { throw new Error("x"); },
+      resolveToken: noToken, log: noLog,
+    });
+    expect(r1.ok).toBe(false);
+
+    // No resolveToken — should short-circuit cleanly
+    const r2 = await fetchClaudeAccountsEnv({ log: noLog });
+    expect(r2.ok).toBe(false);
+  });
+
+  // Positive control: the guard-passing tests above only prove guards. This test
+  // confirms the happy path (no-guard, token present, 200 response) returns ok:true.
+  test("positive control: happy path does fetch and return ok:true", async () => {
+    let fetched = false;
+    const fetchFn = async () => { fetched = true; return successResponse(); };
+    const result = await fetchClaudeAccountsEnv({ fetchFn, resolveToken: goodToken, log: noLog });
+    expect(fetched).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.content).toBe(FAKE_CONTENT);
+  });
+});
+
+// ── materializeClaudeAccountsEnv ─────────────────────────────────────────────
+
+describe("materializeClaudeAccountsEnv", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ctl-1991-mat-"));
+  });
+  afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  test("writes content at 0o600 and file is readable with correct content", async () => {
+    const targetPath = join(tmpDir, "claude-accounts.env");
+    const result = await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT, path: targetPath, log: noLog,
+    });
+    expect(result.written).toBe(true);
+    const stat = lstatSync(targetPath);
+    expect(stat.mode & 0o777).toBe(0o600);
+    expect(readFileSync(targetPath, "utf8")).toBe(FAKE_CONTENT);
+  });
+
+  test("leaves no .tmp. litter after successful write", async () => {
+    const targetPath = join(tmpDir, "claude-accounts.env");
+    await materializeClaudeAccountsEnv({ content: FAKE_CONTENT, path: targetPath, log: noLog });
+    const tmpFiles = readdirSync(tmpDir).filter(f => f.includes(".tmp."));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  test("returns { written:false, reason:'unchanged' } when on-disk content already equals content", async () => {
+    const targetPath = join(tmpDir, "claude-accounts.env");
+    writeFileSync(targetPath, FAKE_CONTENT, { mode: 0o600 });
+    const result = await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT, path: targetPath, log: noLog,
+    });
+    expect(result.written).toBe(false);
+    expect(result.reason).toBe("unchanged");
+  });
+
+  // Positive control: the unchanged guard above requires a "real change does write" test.
+  test("positive control: rewrites when content changes", async () => {
+    const targetPath = join(tmpDir, "claude-accounts.env");
+    writeFileSync(targetPath, "OLD CONTENT\n", { mode: 0o600 });
+    const result = await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT, path: targetPath, log: noLog,
+    });
+    expect(result.written).toBe(true);
+    expect(readFileSync(targetPath, "utf8")).toBe(FAKE_CONTENT);
+  });
+
+  test("replaces a symlink at the target path (does not follow it through)", async () => {
+    const realFile = join(tmpDir, "real.env");
+    const symlinkPath = join(tmpDir, "link.env");
+    writeFileSync(realFile, "REAL FILE CONTENT\n", { mode: 0o600 });
+    symlinkSync(realFile, symlinkPath);
+
+    await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT, path: symlinkPath, log: noLog,
+    });
+
+    // The symlink should have been replaced with a regular file
+    const stat = lstatSync(symlinkPath);
+    expect(stat.isSymbolicLink()).toBe(false);
+    expect(stat.isFile()).toBe(true);
+    expect(readFileSync(symlinkPath, "utf8")).toBe(FAKE_CONTENT);
+    // The original real file is untouched (symlink was not followed during write)
+    expect(readFileSync(realFile, "utf8")).toBe("REAL FILE CONTENT\n");
+  });
+
+  test("returns { written:false, reason:'error' } when injected writeFile throws", async () => {
+    const failWrite = () => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }); };
+    const result = await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT,
+      path: join(tmpDir, "target.env"),
+      writeFile: failWrite,
+      log: noLog,
+    });
+    expect(result.written).toBe(false);
+    expect(result.reason).toBe("error");
+  });
+
+  test("never throws for any input including bad path", async () => {
+    const result = await materializeClaudeAccountsEnv({
+      content: FAKE_CONTENT, path: "/definitely/does/not/exist/x.env", log: noLog,
+    });
+    expect(result.written).toBe(false);
+  });
+});
+
+// ── syncClaudeAccountsFromCloud ──────────────────────────────────────────────
+
+describe("syncClaudeAccountsFromCloud", () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ctl-1991-sync-"));
+  });
+  afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  const genuineCloud = { mode: "cloud", inferred: false, recognized: true };
+  const clusterMode = { mode: "cluster", inferred: false, recognized: true };
+  const inferredCloud = { mode: "cloud", inferred: true, recognized: true };
+  const recognizedFalse = { mode: "cloud", inferred: false, recognized: false };
+
+  const successFetch = async () => successResponse();
+
+  test("returns { skipped:true, reason:'not-cloud' } for cluster deployment mode", async () => {
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: clusterMode, mode: "enforce",
+      fetchFn: successFetch, resolveToken: goodToken, log: noLog,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud");
+  });
+
+  test("returns { skipped:true, reason:'not-cloud' } for inferred cloud (not genuine)", async () => {
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: inferredCloud, mode: "enforce",
+      fetchFn: successFetch, resolveToken: goodToken, log: noLog,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud");
+  });
+
+  test("returns { skipped:true, reason:'not-cloud' } for recognized:false (unrecognized explicit value)", async () => {
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: recognizedFalse, mode: "enforce",
+      fetchFn: successFetch, resolveToken: goodToken, log: noLog,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("not-cloud");
+  });
+
+  test("returns { skipped:true, reason:'disabled' } when mode is 'off' even on genuine cloud", async () => {
+    const calls = [];
+    const fetchFn = async (...args) => { calls.push(args); return successResponse(); };
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "off",
+      fetchFn, resolveToken: goodToken, log: noLog,
+    });
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe("disabled");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("shadow mode: returns { shadow:true, wouldWrite } without writing any file", async () => {
+    const targetPath = join(tmpDir, "shadow.env");
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "shadow",
+      fetchFn: successFetch, resolveToken: goodToken,
+      path: targetPath, log: noLog,
+    });
+    expect(result.shadow).toBe(true);
+    expect(typeof result.wouldWrite).toBe("boolean");
+    // No file created
+    let exists = false;
+    try { lstatSync(targetPath); exists = true; } catch { /* expected */ }
+    expect(exists).toBe(false);
+  });
+
+  test("shadow mode: wouldWrite:true when target file does not yet exist", async () => {
+    const targetPath = join(tmpDir, "new.env");
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "shadow",
+      fetchFn: successFetch, resolveToken: goodToken,
+      path: targetPath, log: noLog,
+    });
+    expect(result.shadow).toBe(true);
+    expect(result.wouldWrite).toBe(true);
+  });
+
+  test("shadow mode: wouldWrite:false when target already has the same content", async () => {
+    const targetPath = join(tmpDir, "same.env");
+    writeFileSync(targetPath, FAKE_CONTENT, { mode: 0o600 });
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "shadow",
+      fetchFn: successFetch, resolveToken: goodToken,
+      path: targetPath, log: noLog,
+    });
+    expect(result.shadow).toBe(true);
+    expect(result.wouldWrite).toBe(false);
+  });
+
+  // Positive control: shadow tests above are paired with an enforce-mode write test below.
+  test("enforce mode + genuine cloud + successful fetch: materializes the file", async () => {
+    const targetPath = join(tmpDir, "enforce.env");
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "enforce",
+      fetchFn: successFetch, resolveToken: goodToken,
+      path: targetPath, log: noLog,
+    });
+    expect(result.written).toBe(true);
+    expect(readFileSync(targetPath, "utf8")).toBe(FAKE_CONTENT);
+  });
+
+  test("enforce mode: HTTP failure does NOT touch existing on-disk file", async () => {
+    const targetPath = join(tmpDir, "existing.env");
+    const originalContent = "ORIGINAL CONTENT — must survive a cloud outage\n";
+    writeFileSync(targetPath, originalContent, { mode: 0o600 });
+    const failFetch = async () => ({ ok: false, status: 503, text: async () => "Unavailable" });
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "enforce",
+      fetchFn: failFetch, resolveToken: goodToken,
+      path: targetPath, log: noLog,
+    });
+    expect(result.ok).toBe(false);
+    // File untouched — a cloud outage must never blank a working token
+    expect(readFileSync(targetPath, "utf8")).toBe(originalContent);
+  });
+
+  test("enforce mode: fetchFn throw does NOT touch existing on-disk file", async () => {
+    const targetPath = join(tmpDir, "existing2.env");
+    const originalContent = "KEEP ME\n";
+    writeFileSync(targetPath, originalContent, { mode: 0o600 });
+    const result = await syncClaudeAccountsFromCloud({
+      deploymentMode: genuineCloud, mode: "enforce",
+      fetchFn: async () => { throw new Error("network down"); },
+      resolveToken: goodToken, path: targetPath, log: noLog,
+    });
+    expect(result.ok).toBe(false);
+    expect(readFileSync(targetPath, "utf8")).toBe(originalContent);
+  });
+
+  test("never throws for any input (no args, bad args, null mode)", async () => {
+    const r1 = await syncClaudeAccountsFromCloud({ log: noLog });
+    expect(r1).toBeDefined();
+    const r2 = await syncClaudeAccountsFromCloud({ deploymentMode: null, mode: null, log: noLog });
+    expect(r2).toBeDefined();
+  });
+});
+
+// ── resolveClaudeAccountsCloudMode ───────────────────────────────────────────
+
+describe("resolveClaudeAccountsCloudMode", () => {
+  test("returns 'off' when env var is unset (the default)", () => {
+    expect(resolveClaudeAccountsCloudMode({})).toBe("off");
+    expect(resolveClaudeAccountsCloudMode(null)).toBe("off");
+    expect(resolveClaudeAccountsCloudMode()).toBe("off");
+  });
+
+  test("returns 'off' when explicitly set to 'off'", () => {
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "off" })).toBe("off");
+  });
+
+  test("returns 'shadow' when set to 'shadow'", () => {
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "shadow" })).toBe("shadow");
+  });
+
+  test("returns 'enforce' when set to 'enforce'", () => {
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "enforce" })).toBe("enforce");
+  });
+
+  test("returns 'off' (degrade-safe) for unknown values including wrong case", () => {
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "ENFORCE" })).toBe("off");
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "yes" })).toBe("off");
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "1" })).toBe("off");
+    expect(resolveClaudeAccountsCloudMode({ CATALYST_CLAUDE_ACCOUNTS_CLOUD: "" })).toBe("off");
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -156,6 +156,8 @@ import {
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
 import { rearmClaudeAccountsFromFile } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook
+import { syncClaudeAccountsFromCloud, resolveClaudeAccountsCloudMode } from "./claude-accounts-cloud-fetch.mjs"; // CTL-1991: cloud delivery of claude-accounts.env (default off)
+import { getDeploymentMode } from "../lib/deployment-mode.mjs"; // CTL-1991: genuine-cloud gate for the cloud-token materialize path
 import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dependency-preflight.mjs";
 import { getReconcileHealth } from "./reconcile-health.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
@@ -1055,6 +1057,9 @@ export function startDaemon({
   refreshClusterSecrets = realRefreshClusterSecrets,
   clusterSyncIntervalMs = CLUSTER_SYNC_INTERVAL_MS,
   enableClusterSync = process.env.CATALYST_CLUSTER_SYNC !== "0",
+  // CTL-1991: injectable for tests; production default is the real module function.
+  // Resolved deployment mode + cloud mode knob are computed once at startup below.
+  syncClaudeAccountsFromCloud: syncClaudeAccountsFromCloudFn = syncClaudeAccountsFromCloud,
   // CTL-665: committed executionCore concurrency knobs resolved in main() from
   // .catalyst/config.json. Threaded into both the scheduler new-work pull and the
   // boot-resume ceiling. Empty {} (the test default) keeps the legacy state.json path.
@@ -1096,6 +1101,12 @@ export function startDaemon({
   const orchDir = getExecutionCoreDir();
   let bootDependencyState = { ok: true, missing: [], holdReason: null };
   ensureState(orchDir);
+  // CTL-1991: resolve deployment mode and the cloud-accounts knob once at startup.
+  // Both are passed into every syncClaudeAccountsFromCloud call so we don't re-read
+  // config on every timer tick. Default "off" means zero behavior change until an
+  // operator on a confirmed cloud host flips CATALYST_CLAUDE_ACCOUNTS_CLOUD.
+  const _claudeAccountsDeploymentMode = getDeploymentMode();
+  const _claudeAccountsCloudMode = resolveClaudeAccountsCloudMode(process.env);
   // CTL-862: write the resolved config path back into the env so downstream
   // callers (getClusterHosts → getCatalystRepoDir) resolve the right repo
   // regardless of the daemon's cwd. ||= preserves any launcher-provided value.
@@ -1352,6 +1363,19 @@ export function startDaemon({
         log.warn({ err: err?.message }, "execution-core daemon: boot cluster-sync threw (continuing)");
       }
     }
+    // CTL-1991: on cloud hosts, materialize claude-accounts.env from the cloud product
+    // (CTC-732) at boot, so dispatched workers see the cloud-current token from their
+    // first launch. Runs after clusterSync (which handles single-host/cluster delivery via
+    // SOPS) so the SOPS path is already on disk as a fallback. Default "off" = no-op.
+    // Fire-and-forget: startDaemon is not async; the cloud sync is best-effort and the
+    // SOPS-materialized file is already on disk if the cloud call loses the race.
+    syncClaudeAccountsFromCloudFn({
+      deploymentMode: _claudeAccountsDeploymentMode,
+      mode: _claudeAccountsCloudMode,
+      log,
+    }).catch((err) => {
+      log.warn({ err: err?.message }, "claude-accounts-cloud-fetch: boot sync threw (continuing)");
+    });
     // Re-arm ONLY (no probe) before anything dispatches: this is a cheap local file read,
     // and it is what stops a boot-resumed worker inheriting a credential the sync just
     // superseded. The probe is deliberately NOT here — it spawns `gh` with a 10s timeout,
@@ -2102,7 +2126,7 @@ export function startDaemon({
       // CTL-1612: the BOOT sync moved earlier (before the boot-resume dispatches, so
       // resumed workers never inherit a stale credential). Only the periodic refresh
       // is armed here, alongside the other timers.
-      _clusterSyncTimer = setInterval(() => {
+      _clusterSyncTimer = setInterval(async () => {
         try {
           refreshClusterSecrets();
         } catch (err) {
@@ -2138,6 +2162,18 @@ export function startDaemon({
         // via `log`. A wrapping try/catch here would only ever imply protection the callee
         // already provides.
         armSecret("github-token", { env: process.env });
+        // CTL-1991: on cloud hosts, refresh claude-accounts.env from the cloud product
+        // BEFORE re-arming, so the rearm hook (below) reads the cloud-current content.
+        // Default "off" makes this a no-op on cluster/single-host nodes.
+        try {
+          await syncClaudeAccountsFromCloudFn({
+            deploymentMode: _claudeAccountsDeploymentMode,
+            mode: _claudeAccountsCloudMode,
+            log,
+          });
+        } catch (err) {
+          log.warn({ err: err?.message }, "claude-accounts-cloud-fetch: timer sync threw (continuing)");
+        }
         // CTL-1984: re-arm the account-slot token on the same tick. armSecret never throws;
         // the hook closure (rearmClaudeAccountsFromFile) logs+swallows its own errors.
         armSecret("claude-accounts.env", { env: process.env });

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1468,6 +1468,71 @@ active deployment mode is declared `cloud` (recognized, not inferred) and the `c
 bootstrap row does not resolve — the one FAIL doctor cannot route around, per the cloud guard's
 bootstrap short-circuit above.
 
+## Claude account tokens via cloud (`CATALYST_CLAUDE_ACCOUNTS_CLOUD`, CTL-1991)
+
+On a declared-cloud host the execution-core daemon can pull the active
+`claude-accounts.env` content (Claude OAuth subscription tokens) from the cloud
+product (CTC-732) instead of reading a SOPS-materialized file from the git
+bundle. The file is written atomically at 0o600 via tmp+rename to
+`~/.config/catalyst/claude-accounts.env` (or the path in `CLAUDE_ACCOUNTS_ENV`).
+All downstream consumers — the launcher `source`, the live rearm hook
+(`claude-accounts-rearm.mjs`), the per-slot usage probes — read the same
+on-disk path and require no changes.
+
+**Tri-state knob** (`CATALYST_CLAUDE_ACCOUNTS_CLOUD ∈ off | shadow | enforce`,
+default **`off`**):
+
+| Mode      | Effect                                                                                                   |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| `off`     | **Default.** No cloud fetch; daemon reads whatever SOPS materialized (byte-identical to today).          |
+| `shadow`  | Fetches the cloud content and logs whether it would have written, but never writes to disk.              |
+| `enforce` | Fetches and materializes. A cloud fetch failure leaves the on-disk file **untouched** — fail-open.       |
+
+The knob is only meaningful on a **genuinely declared** cloud node
+(`catalyst.deployment.mode = cloud`, `inferred: false`, `recognized: true`). Any
+other deployment mode short-circuits to `skipped / not-cloud` before the knob is
+read — a cluster or single-host node is never contacted.
+
+**Resolution order:**
+
+| Precedence | Source                                                                        |
+| ---------- | ----------------------------------------------------------------------------- |
+| 1          | `mode` injected at call time (test / recovery seam)                          |
+| 2          | `CATALYST_CLAUDE_ACCOUNTS_CLOUD` env var on the daemon process               |
+| 3          | constant default `off`                                                        |
+
+Unknown values degrade to `off`.
+
+**Timing** (daemon cluster-sync timer, CTL-1991):
+
+The cloud sync runs inside the cluster-sync timer callback **before**
+`armSecret("claude-accounts.env")` on every tick, so the rearm hook reads a
+freshly materialized file on each cycle. At daemon boot the call is fire-and-forget
+(`.catch()`) — `startDaemon` is not async and boot fails open if the cloud is
+unavailable at startup. A no-churn idempotency check (byte-compare before write)
+prevents mtime-churn from spuriously triggering the rearm hook on every tick when
+the content is unchanged.
+
+**Path override** — the target path and the API path can each be overridden for
+testing or if the CTC-732 endpoint path changes:
+
+- `CLAUDE_ACCOUNTS_ENV` — override the local destination file path
+- `CATALYST_CLOUD_BASE_URL` — override the cloud API base URL
+- `CATALYST_CLAUDE_ACCOUNTS_CLOUD_PATH` — override the endpoint path (default `/me/secrets/claude-accounts.env`)
+
+**Minting is not in scope.** This feature delivers and refreshes tokens that were
+minted via `claude login`; it does not issue credentials. The cloud product owns
+switching subscription OAuth tokens across fleet hosts (CTC-732).
+
+**Events** (see `docs/architecture.md` → "Secret Contract"):
+
+| Event                                              | Emitted when                              |
+| -------------------------------------------------- | ----------------------------------------- |
+| `catalyst.claude-accounts.cloud_materialized`      | enforce mode wrote a new or changed file  |
+| `catalyst.claude-accounts.cloud_would_materialize` | shadow mode would have written            |
+
+Both names are unprotected under the CTL-1142 namespace contract.
+
 ## GitHub merge rules live in GitHub
 
 Catalyst can open PRs, fix CI, answer review bots, and merge. But GitHub decides what must pass


### PR DESCRIPTION
## Summary

- Adds `claude-accounts-cloud-fetch.mjs`: pure injectable module that fetches and materializes `claude-accounts.env` from the cloud product (CTC-732) — genuinely-declared cloud nodes only (`deployment.mode=cloud`, `inferred=false`), tri-state `CATALYST_CLAUDE_ACCOUNTS_CLOUD ∈ off|shadow|enforce`, default **off** (no live change on merge)
- Wires into `daemon.mjs` cluster-sync timer before `armSecret("claude-accounts.env")` on every tick (fire-and-forget at boot); symlink-safe 0o600 tmp+rename writer with no-churn idempotency
- Registers `catalyst.claude-accounts.cloud_materialized` / `catalyst.claude-accounts.cloud_would_materialize` event name constants in namespace-parity (CTL-1659 discipline)
- 46 tests (fetch suite + daemon wiring), 12 namespace-parity checks; all green

## Test plan

- [ ] `bun test plugins/dev/scripts/execution-core/claude-accounts-cloud-fetch.test.mjs` — 37 tests green
- [ ] `bun test plugins/dev/scripts/execution-core/claude-accounts-cloud-daemon-wiring.test.mjs` — 9 tests green
- [ ] `bun test plugins/dev/scripts/broker/namespace-parity.test.mjs` — 12 tests green
- [ ] `node --check plugins/dev/scripts/execution-core/daemon.mjs` — no syntax errors
- [ ] Default `off`: cluster host with no env var set → `syncClaudeAccountsFromCloud` returns `{skipped:true, reason:"not-cloud"}`, SOPS path unchanged
- [ ] Enforce on genuine cloud: `CATALYST_CLAUDE_ACCOUNTS_CLOUD=enforce` + declared cloud node → file materialized at 0o600 before `armSecret`
- [ ] Fetch failure in enforce → disk file untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)