### PR TITLE
fix(dev): CAT-139 — watchdog runner accepts an explicit --config path

### DIFF
--- a/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
+++ b/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
@@ -35,6 +35,24 @@ ok()   { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
 fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; }
 check() { if [[ "$1" == "yes" ]]; then ok "$2"; else fail "$2"; fi; }
 
+_wd_bounded() { # _wd_bounded <deadline_secs> <outfile> <cmd...>
+  local limit="$1" out="$2"; shift 2
+  local mark cpid wpid rc
+  mark="$(mktemp -u)"
+  "$@" > "$out" 2>&1 &
+  cpid=$!
+  ( sleep "$limit"; : > "$mark"; kill -9 "$cpid" 2>/dev/null ) >/dev/null 2>&1 &
+  wpid=$!
+  wait "$cpid"; rc=$?
+  kill -9 "$wpid" 2>/dev/null; wait "$wpid" 2>/dev/null
+  if [[ -e "$mark" ]]; then
+    rm -f "$mark"
+    echo "OVERRAN the ${limit}s deadline" >> "$out"
+    return 124
+  fi
+  return "$rc"
+}
+
 # ── 0. the pieces exist and parse ───────────────────────────────────────────
 [[ -f "$RUNNER" ]] && ok "standalone runner exists (daemon-watchdog-run.mjs)" \
                    || fail "standalone runner missing"
@@ -71,7 +89,7 @@ fi
 
 # ── 2. pid identity: a recycled pid must NOT be reported live ───────────────
 TMPDIR_T="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_T"' EXIT
+trap 'rm -rf "$TMPDIR_T" "${CFG_OFF:-}" "${CFG_DECOY:-}"' EXIT
 
 # An unrelated live process (stand-in for a recycled pid) written into both
 # pid files. Neither reader may claim it, and neither stop may signal it.
@@ -166,23 +184,65 @@ else
   fail "standalone runner ignores Layer-1 config (no configPath threaded)"
 fi
 
-# Functional: a Layer-1 `mode: "off"` must actually shut the runner down.
-CFG_HOME="$(mktemp -d)"
-mkdir -p "${CFG_HOME}/.catalyst"
-cat > "${CFG_HOME}/.catalyst/config.json" <<'JSON'
+# The explicit argv tier must beat the ambient environment tier. A separate
+# isolated check below covers the cwd fallback. CATALYST_DIR is a runtime-state
+# lever and deliberately does not participate in Layer-1 config resolution.
+CFG_OFF="$(mktemp -d)"
+mkdir -p "${CFG_OFF}/.catalyst"
+cat > "${CFG_OFF}/.catalyst/config.json" <<'JSON'
 {"catalyst":{"orchestration":{"daemonWatchdog":{"mode":"off"}}}}
 JSON
+CFG_DECOY="$(mktemp -d)"
+mkdir -p "${CFG_DECOY}/.catalyst"
+cat > "${CFG_DECOY}/.catalyst/config.json" <<'JSON'
+{"catalyst":{"orchestration":{"daemonWatchdog":{"mode":"shadow"}}}}
+JSON
 if command -v bun >/dev/null 2>&1; then
-  RUN_OUT="$(cd "$CFG_HOME" && CATALYST_DIR="$CFG_HOME" bun run "$RUNNER" 2>&1)"
-  if grep -q 'disabled by config' <<<"$RUN_OUT"; then
-    ok "Layer-1 daemonWatchdog.mode=off shuts the standalone runner down"
+  OUT="$(mktemp)"
+  if _wd_bounded 15 "$OUT" env CATALYST_CONFIG_FILE="${CFG_DECOY}/.catalyst/config.json" \
+       bun run "$RUNNER" --config "${CFG_OFF}/.catalyst/config.json" \
+     && grep -q 'disabled by config' "$OUT"; then
+    ok "--config outranks an ambient CATALYST_CONFIG_FILE"
   else
-    fail "Layer-1 mode=off ignored by the standalone runner: ${RUN_OUT}"
+    fail "--config did not win over the ambient env: $(cat "$OUT")"
   fi
+  grep -q '"configSource":"argv"\|configSource.*argv' "$OUT" \
+    && ok "runner reports which config tier won" \
+    || fail "no configSource in the runner's disabled-path log line"
+
+  if _wd_bounded 15 "$OUT" env CATALYST_CONFIG_FILE="${CFG_DECOY}/.catalyst/config.json" \
+       bun run "$RUNNER" --config "${CFG_OFF}/.catalyst/nope.json"; then
+    fail "an unreadable --config silently fell through to another tier"
+  else
+    rc=$?
+    [[ "$rc" == 2 ]] && grep -q 'config file not found' "$OUT" \
+      && ok "an unreadable --config exits 2 with a clear message" \
+      || fail "expected rc=2 + a clear message, got rc=${rc}: $(cat "$OUT")"
+  fi
+
+  if _wd_bounded 15 "$OUT" bun run "$RUNNER" --config; then
+    fail "--config without a value silently fell through"
+  else
+    rc=$?
+    [[ "$rc" == 2 ]] && grep -q -- '--config requires a path argument' "$OUT" \
+      && ok "--config without a value exits 2 with a clear message" \
+      || fail "expected rc=2 for valueless --config, got rc=${rc}: $(cat "$OUT")"
+  fi
+
+  # Functional: mode=off must shut down through the cwd tier too. The old form
+  # inherited host config and waited forever; this invocation isolates and bounds.
+  if _wd_bounded 15 "$OUT" \
+       env -u CATALYST_CONFIG_FILE -u CATALYST_CONFIG_PATH \
+         sh -c 'cd "$1" && exec bun run "$2"' _ "$CFG_OFF" "$RUNNER" \
+     && grep -q 'disabled by config' "$OUT"; then
+    ok "cwd fallback resolves Layer-1 when no env override is present"
+  else
+    fail "cwd fallback did not honor the fixture: $(cat "$OUT")"
+  fi
+  rm -f "$OUT"
 else
-  ok "SKIP: bun unavailable — Layer-1 functional check not run"
+  ok "SKIP: bun unavailable — Layer-1 functional checks not run"
 fi
-rm -rf "$CFG_HOME"
 
 # The runner's own <cwd>/.catalyst/config.json fallback is not enough under
 # launchd: the stack LaunchAgent sets neither WorkingDirectory nor

--- a/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
+++ b/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
@@ -248,6 +248,30 @@ if command -v bun >/dev/null 2>&1; then
       || fail "expected rc=2 for valueless --config, got rc=${rc}: $(cat "$OUT")"
   fi
 
+  # The GNU `--config=<path>` form must select the same tier as the space form.
+  # Before CAT-139 review it fell through to the ambient env tier and started a
+  # LIVE watchdog on the decoy config, so this asserts the WIN, not just an exit.
+  if _wd_bounded 15 "$OUT" env CATALYST_CONFIG_FILE="${CFG_DECOY}/.catalyst/config.json" \
+       bun run "$RUNNER" --config="${CFG_OFF}/.catalyst/config.json" \
+     && grep -q 'disabled by config' "$OUT" && grep -q 'argv' "$OUT"; then
+    ok "--config=<path> outranks an ambient CATALYST_CONFIG_FILE"
+  else
+    fail "--config=<path> did not win over the ambient env: $(cat "$OUT")"
+  fi
+
+  # A near-miss flag must NOT silently inherit the host config. This is the
+  # whole point of the explicit tier: fail loudly rather than watch the wrong
+  # daemon under the wrong mode.
+  if _wd_bounded 15 "$OUT" env CATALYST_CONFIG_FILE="${CFG_DECOY}/.catalyst/config.json" \
+       bun run "$RUNNER" --conifg "${CFG_OFF}/.catalyst/config.json"; then
+    fail "a typo'd flag silently fell through to the host config tier"
+  else
+    rc=$?
+    [[ "$rc" == 2 ]] && grep -q 'unrecognized argument' "$OUT" \
+      && ok "a typo'd flag exits 2 instead of inheriting host config" \
+      || fail "expected rc=2 for unknown argv, got rc=${rc}: $(cat "$OUT")"
+  fi
+
   # Functional: mode=off must shut down through the cwd tier too. The old form
   # inherited host config and waited forever; this invocation isolates and bounds.
   if _wd_bounded 15 "$OUT" \

--- a/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
+++ b/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
@@ -220,6 +220,25 @@ if command -v bun >/dev/null 2>&1; then
       || fail "expected rc=2 + a clear message, got rc=${rc}: $(cat "$OUT")"
   fi
 
+  printf '%s\n' '{not-json' > "${CFG_OFF}/.catalyst/malformed.json"
+  if _wd_bounded 15 "$OUT" bun run "$RUNNER" --config "${CFG_OFF}/.catalyst/malformed.json"; then
+    fail "a malformed explicit config silently degraded to defaults"
+  else
+    rc=$?
+    [[ "$rc" == 2 ]] && grep -q 'config file is not valid JSON' "$OUT" \
+      && ok "a malformed explicit config exits 2" \
+      || fail "expected rc=2 for malformed config, got rc=${rc}: $(cat "$OUT")"
+  fi
+
+  if _wd_bounded 15 "$OUT" bun run "$RUNNER" --config "${CFG_OFF}/.catalyst"; then
+    fail "a directory supplied as --config silently degraded to defaults"
+  else
+    rc=$?
+    [[ "$rc" == 2 ]] && grep -q 'config path is not a readable regular file' "$OUT" \
+      && ok "a directory supplied as --config exits 2" \
+      || fail "expected rc=2 for config directory, got rc=${rc}: $(cat "$OUT")"
+  fi
+
   if _wd_bounded 15 "$OUT" bun run "$RUNNER" --config; then
     fail "--config without a value silently fell through"
   else

--- a/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
+++ b/plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh
@@ -37,14 +37,42 @@ check() { if [[ "$1" == "yes" ]]; then ok "$2"; else fail "$2"; fi; }
 
 _wd_bounded() { # _wd_bounded <deadline_secs> <outfile> <cmd...>
   local limit="$1" out="$2"; shift 2
-  local mark cpid wpid rc
+  local mark donef cpid wpid rc
   mark="$(mktemp -u)"
+  donef="$(mktemp -u)"
   "$@" > "$out" 2>&1 &
   cpid=$!
-  ( sleep "$limit"; : > "$mark"; kill -9 "$cpid" 2>/dev/null ) >/dev/null 2>&1 &
+  # A SELF-LIMITING timer, deliberately NOT a kill-based watchdog.
+  #
+  # The obvious form — `( sleep "$limit"; kill "$cpid" ) &` reaped with a kill —
+  # leaks: `sleep` is a separate process from the subshell that spawned it, so a
+  # signal aimed at that subshell leaves the sleep reparented to PID 1, running
+  # to full term. One orphan per bounded call, eight call sites, and the suite
+  # still reports every check passed. Nor is it enough to signal more politely:
+  # TERM-plus-trap, a recorded-pid handshake, and a process-group kill were each
+  # measured leaking when the bounded command returns instantly, because they all
+  # race the timer's own fork — the signal can land before the handler exists.
+  #
+  # So the timer owns its deadline instead of being stopped from outside. It
+  # needs no signal, which is exactly why nothing can be orphaned, and it still
+  # terminates on its own even if every cleanup line below were broken (the
+  # AGENTS.md background-process rule). It SLEEPS rather than spinning — an
+  # empty-body deadline loop re-evaluates as fast as the CPU allows and burns a
+  # whole core. The parent's completion marker is a file, not a pid probe, so no
+  # branch here can be confused by a recycled pid.
+  ( i=0
+    while [ "$i" -lt "$limit" ]; do
+      [ -e "$donef" ] && exit 0        # command already finished — retire early
+      sleep 1
+      i=$((i + 1))
+    done
+    : > "$mark"
+    kill -9 "$cpid" 2>/dev/null ) >/dev/null 2>&1 &
   wpid=$!
   wait "$cpid"; rc=$?
-  kill -9 "$wpid" 2>/dev/null; wait "$wpid" 2>/dev/null
+  : > "$donef"                          # release the timer; never signal it
+  wait "$wpid" 2>/dev/null              # retires within ~1s, of its own accord
+  rm -f "$donef"
   if [[ -e "$mark" ]]; then
     rm -f "$mark"
     echo "OVERRAN the ${limit}s deadline" >> "$out"
@@ -177,8 +205,11 @@ fi
 # return {} unconditionally, silently ignoring every documented Layer-1 knob.
 # On a monitor node this runner is the ONLY watchdog host, so that would strand
 # its forwarder shadow-only while workers honored the same config file.
+# Matches the call PREFIX, not a fixed arity: configPath must be the first
+# argument, but the reader also accepts an optional pre-validated Layer-1
+# snapshot, so pinning the closing paren here would fail on an unrelated change.
 if grep -q 'CATALYST_CONFIG_FILE' "$RUNNER" \
-   && grep -q 'readDaemonWatchdogConfig(configPath)' "$RUNNER"; then
+   && grep -q 'readDaemonWatchdogConfig(configPath[,)]' "$RUNNER"; then
   ok "standalone runner resolves + passes a Layer-1 config path"
 else
   fail "standalone runner ignores Layer-1 config (no configPath threaded)"
@@ -249,7 +280,7 @@ if command -v bun >/dev/null 2>&1; then
   fi
 
   # The GNU `--config=<path>` form must select the same tier as the space form.
-  # Before CAT-139 review it fell through to the ambient env tier and started a
+  # Before the PROJ review it fell through to the ambient env tier and started a
   # LIVE watchdog on the decoy config, so this asserts the WIN, not just an exit.
   if _wd_bounded 15 "$OUT" env CATALYST_CONFIG_FILE="${CFG_DECOY}/.catalyst/config.json" \
        bun run "$RUNNER" --config="${CFG_OFF}/.catalyst/config.json" \

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1967,8 +1967,15 @@ export function readDaemonWatchdogConfigLayer1(configPath) {
   }
 }
 
-export function readDaemonWatchdogConfig(configPath) {
-  const l1 = readDaemonWatchdogConfigLayer1(configPath);
+// `layer1Override` lets a caller that has ALREADY read and validated the config
+// file hand in that exact snapshot instead of having it re-read here. Without it
+// a caller validates one read and this function consumes a second, so a file
+// replaced between the two is validated in one state and consumed in another —
+// and since readDaemonWatchdogConfigLayer1 swallows a parse failure and returns
+// {}, that divergence degrades silently to defaults. Omitted (undefined) keeps
+// the previous read-at-use behaviour for every existing caller.
+export function readDaemonWatchdogConfig(configPath, layer1Override) {
+  const l1 = layer1Override ?? readDaemonWatchdogConfigLayer1(configPath);
   // CATALYST_DAEMON_WATCHDOG=0 is the kill-switch → mode:off (mirrors
   // readWatchdogConfig's CATALYST_WATCHDOG=0). Otherwise env > Layer-1 > shadow.
   const mode =

--- a/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
+++ b/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
@@ -36,10 +36,31 @@ import { readDaemonWatchdogConfig, log } from "./config.mjs";
 // callers select a config without inheriting the host's live config. Mirrors
 // lib/deployment-mode.mjs resolveLayer1Path (explicit arg > env > cwd).
 // Production passes no args and continues to pin CATALYST_CONFIG_FILE.
+// Unknown argv is REJECTED rather than ignored. A near-miss invocation
+// (`--conifg <path>`) that fell through to the ambient tier would start a LIVE
+// watchdog on the host's own config — the exact silent leak this argument
+// exists to prevent — and would do so while looking like it had honored the
+// caller's file. Production passes no args, so nothing legitimate is rejected.
 function resolveConfigPath(argv, env) {
-  const i = argv.indexOf("--config");
-  if (i !== -1) {
-    const value = argv[i + 1];
+  let value;
+  let sawConfig = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--config") {
+      sawConfig = true;
+      value = argv[i + 1];
+      i += 1;
+      continue;
+    }
+    // GNU `--config=<path>`. Split on the FIRST `=` only: a path may contain one.
+    if (arg.startsWith("--config=")) {
+      sawConfig = true;
+      value = arg.slice("--config=".length);
+      continue;
+    }
+    return { error: `unrecognized argument: ${arg}` };
+  }
+  if (sawConfig) {
     if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
       return { error: "--config requires a path argument" };
     }
@@ -68,7 +89,7 @@ function resolveConfigPath(argv, env) {
 
 const resolved = resolveConfigPath(process.argv.slice(2), process.env);
 if (resolved.error) {
-  log.error({ err: resolved.error }, "daemon-watchdog-run: bad --config");
+  log.error({ err: resolved.error }, "daemon-watchdog-run: bad arguments");
   process.exit(2);
 }
 const { path: configPath, source: configSource } = resolved;

--- a/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
+++ b/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
@@ -19,7 +19,7 @@
 // Lifecycle: `catalyst-monitor watchdog-start|watchdog-stop|watchdog-status`
 // supervises this with a pid file, mirroring the forward-* commands.
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { startDaemonWatchdogProbe } from "./daemon-watchdog-probe.mjs";
 import { readDaemonWatchdogConfig, log } from "./config.mjs";
@@ -47,6 +47,17 @@ function resolveConfigPath(argv, env) {
     // An explicit path fails closed; falling through would recreate the host
     // config leak this argument exists to prevent.
     if (!existsSync(path)) return { error: `--config file not found: ${path}` };
+    try {
+      if (!statSync(path).isFile()) {
+        return { error: `--config path is not a readable regular file: ${path}` };
+      }
+      JSON.parse(readFileSync(path, "utf8"));
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        return { error: `--config file is not valid JSON: ${path}` };
+      }
+      return { error: `--config path is not a readable regular file: ${path}` };
+    }
     return { path, source: "argv" };
   }
   if (typeof env.CATALYST_CONFIG_FILE === "string" && env.CATALYST_CONFIG_FILE.length > 0) {

--- a/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
+++ b/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
@@ -32,7 +32,7 @@ import { readDaemonWatchdogConfig, log } from "./config.mjs";
 // silently ignored here. On a monitor node this is the ONLY watchdog host, so
 // that would strand its forwarder shadow-only while workers honored the very
 // same config file.
-// CAT-139: a third, explicit tier ahead of the two ambient ones lets direct
+// PROJ: a third, explicit tier ahead of the two ambient ones lets direct
 // callers select a config without inheriting the host's live config. Mirrors
 // lib/deployment-mode.mjs resolveLayer1Path (explicit arg > env > cwd).
 // Production passes no args and continues to pin CATALYST_CONFIG_FILE.
@@ -68,18 +68,23 @@ function resolveConfigPath(argv, env) {
     // An explicit path fails closed; falling through would recreate the host
     // config leak this argument exists to prevent.
     if (!existsSync(path)) return { error: `--config file not found: ${path}` };
+    let document;
     try {
       if (!statSync(path).isFile()) {
         return { error: `--config path is not a readable regular file: ${path}` };
       }
-      JSON.parse(readFileSync(path, "utf8"));
+      // KEEP this parsed snapshot — it is the one the caller consumes below.
+      // Re-reading the file at use time would let an atomic replace land between
+      // the two reads, so the contents validated here need not be the contents
+      // acted on (see the readDaemonWatchdogConfig `layer1Override` note).
+      document = JSON.parse(readFileSync(path, "utf8"));
     } catch (err) {
       if (err instanceof SyntaxError) {
         return { error: `--config file is not valid JSON: ${path}` };
       }
       return { error: `--config path is not a readable regular file: ${path}` };
     }
-    return { path, source: "argv" };
+    return { path, source: "argv", document };
   }
   if (typeof env.CATALYST_CONFIG_FILE === "string" && env.CATALYST_CONFIG_FILE.length > 0) {
     return { path: env.CATALYST_CONFIG_FILE, source: "env" };
@@ -94,7 +99,20 @@ if (resolved.error) {
 }
 const { path: configPath, source: configSource } = resolved;
 
-const config = readDaemonWatchdogConfig(configPath);
+// Consume the SAME snapshot resolveConfigPath validated. Only the explicit
+// --config tier carries one; the ambient env/cwd tiers are read at use time as
+// before (they are never validated up front, so there is no divergence to close).
+// Mirrors readDaemonWatchdogConfigLayer1's coercion: a non-object daemonWatchdog
+// key — or a document that is null / not an object at all — resolves to {}.
+const layer1FromSnapshot =
+  resolved.document === undefined
+    ? undefined
+    : (() => {
+        const dw = resolved.document?.catalyst?.orchestration?.daemonWatchdog;
+        return dw && typeof dw === "object" ? dw : {};
+      })();
+
+const config = readDaemonWatchdogConfig(configPath, layer1FromSnapshot);
 
 if (!config.enabled) {
   // Not an error: the knob is off for this node. Exit 0 so a supervisor treats

--- a/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
+++ b/plugins/dev/scripts/execution-core/daemon-watchdog-run.mjs
@@ -19,6 +19,7 @@
 // Lifecycle: `catalyst-monitor watchdog-start|watchdog-stop|watchdog-status`
 // supervises this with a pid file, mirroring the forward-* commands.
 
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { startDaemonWatchdogProbe } from "./daemon-watchdog-probe.mjs";
 import { readDaemonWatchdogConfig, log } from "./config.mjs";
@@ -31,20 +32,50 @@ import { readDaemonWatchdogConfig, log } from "./config.mjs";
 // silently ignored here. On a monitor node this is the ONLY watchdog host, so
 // that would strand its forwarder shadow-only while workers honored the very
 // same config file.
-const configPath =
-  process.env.CATALYST_CONFIG_FILE || resolve(process.cwd(), ".catalyst", "config.json");
+// CAT-139: a third, explicit tier ahead of the two ambient ones lets direct
+// callers select a config without inheriting the host's live config. Mirrors
+// lib/deployment-mode.mjs resolveLayer1Path (explicit arg > env > cwd).
+// Production passes no args and continues to pin CATALYST_CONFIG_FILE.
+function resolveConfigPath(argv, env) {
+  const i = argv.indexOf("--config");
+  if (i !== -1) {
+    const value = argv[i + 1];
+    if (typeof value !== "string" || value.length === 0 || value.startsWith("--")) {
+      return { error: "--config requires a path argument" };
+    }
+    const path = resolve(value);
+    // An explicit path fails closed; falling through would recreate the host
+    // config leak this argument exists to prevent.
+    if (!existsSync(path)) return { error: `--config file not found: ${path}` };
+    return { path, source: "argv" };
+  }
+  if (typeof env.CATALYST_CONFIG_FILE === "string" && env.CATALYST_CONFIG_FILE.length > 0) {
+    return { path: env.CATALYST_CONFIG_FILE, source: "env" };
+  }
+  return { path: resolve(process.cwd(), ".catalyst", "config.json"), source: "cwd" };
+}
+
+const resolved = resolveConfigPath(process.argv.slice(2), process.env);
+if (resolved.error) {
+  log.error({ err: resolved.error }, "daemon-watchdog-run: bad --config");
+  process.exit(2);
+}
+const { path: configPath, source: configSource } = resolved;
 
 const config = readDaemonWatchdogConfig(configPath);
 
 if (!config.enabled) {
   // Not an error: the knob is off for this node. Exit 0 so a supervisor treats
   // it as a clean no-op rather than a crash to restart forever.
-  log.info({ mode: config.mode }, "daemon-watchdog-run: disabled by config — exiting");
+  log.info(
+    { mode: config.mode, configPath, configSource },
+    "daemon-watchdog-run: disabled by config — exiting",
+  );
   process.exit(0);
 }
 
 log.info(
-  { mode: config.mode, intervalMs: config.intervalMs, configPath },
+  { mode: config.mode, intervalMs: config.intervalMs, configPath, configSource },
   "daemon-watchdog-run: standalone watchdog started (observation node)",
 );
 


### PR DESCRIPTION
## Summary

Adds an explicit configuration-path argument to the standalone daemon-watchdog runner (`daemon-watchdog-run.mjs`) so tests and direct callers can isolate themselves from a host's live Catalyst configuration. Today the runner only resolves configuration via `CATALYST_CONFIG_FILE` or the current working directory — no explicit override exists. The runner now resolves configuration in the order `--config` → `CATALYST_CONFIG_FILE` → current working directory, reports the winning source, and fails closed for invalid explicit arguments.

## Changes Made

### Watchdog runner
- Accept `--config <path>` and `--config=<path>` ahead of ambient configuration sources.
- Validate that an explicit path exists, is a readable regular file, and contains valid JSON.
- Reject missing values and unknown arguments with exit code 2 instead of silently falling through to host configuration (this is the load-bearing fix: a typo'd or malformed flag previously started a live watchdog against the host's own config).
- Include `configPath` and `configSource` in startup and disabled-mode logs.
- Preserve the production no-argument path, where `CATALYST_CONFIG_FILE` remains authoritative.
- `readDaemonWatchdogConfig` (config.mjs) gains an optional `layer1Override` parameter so a caller that already read and validated the config file (the `--config` tier) hands in that exact snapshot instead of triggering a second read — closing a validate/consume race on a file replaced between the two reads.
- Bounded-command timer in the test harness now owns its own deadline via a completion marker instead of being signalled, closing a process leak (one leaked `sleep` per bounded call) that review found in the original recovery pass.

### Regression coverage
- Exercise explicit-path precedence over a decoy environment configuration.
- Cover missing, malformed, directory, valueless, equals-form, and unknown-argument cases.
- Cover isolated current-working-directory fallback with ambient config variables removed.
- Bound direct runner invocations so a regression cannot hang the test suite indefinitely.

## How to Verify It

- [x] Syntax checks pass: `node --check` for `daemon-watchdog-run.mjs` and `config.mjs`, `bash -n` for the test script.
- [x] `plugins/dev/scripts/__tests__/daemon-watchdog-supervision.test.sh` — 30 passed, 0 failed (run 2026-08-21 against this branch).
- [x] `bun test plugins/dev/scripts/execution-core/daemon-watchdog-config.test.mjs` — 14 passed, 0 failed (run 2026-08-21 against this branch).

Regression risk is low — the change is additive (new optional argv tier + optional function parameter); the existing env/cwd resolution tiers keep their prior behavior unchanged.

## Reviewer Notes

The production launcher already supplies `CATALYST_CONFIG_FILE`; this change primarily isolates tests and direct invocations. The explicit argv tier intentionally fails closed, while the existing environment and working-directory tiers retain their prior unreadable-config behavior.

## Related Issues/PRs

- Original PR #3210 (thagale/catalyst), re-landed as a fresh branch after a clean cherry-pick — the fork branch was stale against current `main`.
- Fixes CAT-139
- Credits original author Tony Hagale (thagale)

Verified during the 2026-08-21 fork-PR verification sweep: `daemon-watchdog-run.mjs` on `main` still only resolves configuration via env/cwd with no `--config` override, confirming the premise still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
