### PR TITLE
fix(dev): CAT-251 — prevent HOME-restoration leaks in tests

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -927,7 +927,7 @@ jobs:
         # step documents). Measured green on origin/main (9 pass) and this branch
         # (10 pass), so it imports no pre-existing red like fence-held-fold would.
         working-directory: plugins/dev/scripts/broker
-        run: bun test worker-state-projection.test.mjs tailer-torn.test.mjs event-name-fold.test.mjs namespace-parity.test.mjs
+        run: bun test worker-state-projection.test.mjs tailer-torn.test.mjs event-name-fold.test.mjs namespace-parity.test.mjs event-leak-guard.test.mjs
 
       - name: plugin-refresh + lock-resolution-audit tests (CTL-1831)
         # `grep plugin-refresh .github/workflows/` returned only two COMMENTS
@@ -1277,6 +1277,7 @@ jobs:
             monitor-torn.test.mjs \
             event-log-window.test.mjs \
             event-log-read-guard.test.mjs \
+            env-restore-guard.test.mjs \
             event-name-fold.test.mjs \
             event-name-read-guard.test.mjs \
             event-envelope.test.mjs \

--- a/plugins/dev/scripts/broker/event-leak-guard.test.mjs
+++ b/plugins/dev/scripts/broker/event-leak-guard.test.mjs
@@ -37,7 +37,8 @@ describe("CTL-1086 sentinel write guard", () => {
       appendEvent({ name: "phase.plan.complete.CTL-100", orchestrator: "orch-test" });
       expect(existsSync(getEventLogPath())).toBe(false);
     } finally {
-      process.env.HOME = prevHome;
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
       const hermetic = process.env.CATALYST_HERMETIC_DIR;
       if (hermetic) {
         process.env.CATALYST_DIR = hermetic;
@@ -45,5 +46,6 @@ describe("CTL-1086 sentinel write guard", () => {
         process.env.CATALYST_DIR = prevDir;
       }
     }
+    expect(process.env.HOME).toBe(prevHome);
   });
 });

--- a/plugins/dev/scripts/execution-core/env-restore-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/env-restore-guard.test.mjs
@@ -1,0 +1,93 @@
+// env-restore-guard.test.mjs — CAT-251 HOME restoration regression guard.
+//
+// INVARIANT: deleting process.env.HOME is permitted only as the undefined arm
+// of a conditional restoration. A test that leaves HOME unset can make a later
+// `gh` invocation write `.local/state/gh/device-id` below cwd.
+//
+// This deliberately does not flag bare HOME assignments: a line-oriented rule
+// would match both the canonical `else process.env.HOME = savedHome` arm and
+// ordinary setters. Those shapes need targeted behavioral assertions instead.
+// Snapshot-set equality fails for both new offenders and stale exemptions.
+// This guard covers only the shapes its line-oriented detector can see. Named
+// blind spots are bracket notation, Reflect.deleteProperty, assignment of
+// undefined, a delete split across lines, and deletion through an env alias.
+
+import { expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPTS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SKIP_DIRS = new Set(["node_modules", ".git"]);
+const SOURCE_EXT = /\.(?:mjs|js|ts|tsx)$/;
+const OFFENDER = /delete\s+process\.env\.HOME/;
+const GUARDED = /if\s*\(\s*([A-Za-z_$][\w$]*)\s*===\s*undefined\s*\)\s*delete\s+process\.env\.HOME\s*;/;
+const BRACED_GUARD = /^\s*if\s*\(\s*([A-Za-z_$][\w$]*)\s*===\s*undefined\s*\)\s*\{\s*$/;
+const ALLOWLIST = [];
+
+function sourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) files.push(...sourceFiles(join(dir, entry.name)));
+    } else if (SOURCE_EXT.test(entry.name)) {
+      files.push(join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function classifyPair(lines, index) {
+  const inlineGuard = lines[index].match(GUARDED);
+  if (inlineGuard) {
+    return new RegExp(
+      `^\\s*else\\s+process\\.env\\.HOME\\s*=\\s*${inlineGuard[1]}\\s*;`,
+    ).test(lines[index + 1] ?? "");
+  }
+
+  const bracedGuard = (lines[index - 1] ?? "").match(BRACED_GUARD);
+  return Boolean(bracedGuard
+    && /^\s*delete\s+process\.env\.HOME\s*;\s*$/.test(lines[index])
+    && /^\s*}\s*else\s*{\s*$/.test(lines[index + 1] ?? "")
+    && new RegExp(
+      `^\\s*process\\.env\\.HOME\\s*=\\s*${bracedGuard[1]}\\s*;`,
+    ).test(lines[index + 2] ?? ""));
+}
+
+test("every process.env.HOME deletion is a conditional restoration", () => {
+  const files = sourceFiles(SCRIPTS_DIR);
+  const offenders = [];
+  expect(files.length).toBeGreaterThan(0);
+  expect(files).toContain(join(SCRIPTS_DIR, "broker", "watchdog-map-bounding.test.mjs"));
+  for (const file of files) {
+    const lines = readFileSync(file, "utf8").split("\n");
+    lines.forEach((line, index) => {
+      if (!OFFENDER.test(line)) return;
+      if (!classifyPair(lines, index)) {
+        offenders.push(`${relative(SCRIPTS_DIR, file)}:${index + 1}`);
+      }
+    });
+  }
+  expect(offenders.sort()).toEqual(ALLOWLIST.slice().sort());
+});
+
+test("the canonical-pair classifier rejects unrelated or incomplete guards", () => {
+  const deletion = ["delete", "process.env.HOME;"].join(" ");
+
+  expect(classifyPair([
+    `if (savedHome === undefined) ${deletion}`,
+    "else process.env.HOME = savedHome;",
+  ], 0)).toBe(true);
+  expect(classifyPair([
+    "if (savedHome === undefined) {",
+    deletion,
+    "} else {",
+    "  process.env.HOME = savedHome;",
+    "}",
+  ], 1)).toBe(true);
+  expect(classifyPair([
+    `if (unrelated === undefined) ${deletion}`,
+    "else process.env.HOME = savedHome;",
+  ], 0)).toBe(false);
+  expect(classifyPair([`if (savedHome === undefined) ${deletion}`], 0)).toBe(false);
+});

--- a/plugins/dev/scripts/execution-core/linear-estimation-method.test.mjs
+++ b/plugins/dev/scripts/execution-core/linear-estimation-method.test.mjs
@@ -1,6 +1,6 @@
 // linear-estimation-method.test.mjs — unit tests for CTL-954.
 // Run: cd plugins/dev/scripts/execution-core && bun test linear-estimation-method.test.mjs
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -16,7 +16,10 @@ import {
 // Isolate each test by redirecting HOME to a temp dir so cache files don't
 // collide with production state and don't persist between tests.
 let tmpHome;
+let savedHome;
+const HOME_AT_LOAD = process.env.HOME;
 beforeEach(() => {
+  savedHome = process.env.HOME;
   tmpHome = join(tmpdir(), `lem-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(join(tmpHome, "catalyst", "execution-core"), { recursive: true });
   process.env.HOME = tmpHome;
@@ -24,8 +27,12 @@ beforeEach(() => {
 });
 afterEach(() => {
   if (tmpHome && existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
-  delete process.env.HOME;
+  if (savedHome === undefined) delete process.env.HOME;
+  else process.env.HOME = savedHome;
   _resetMemoForTests();
+});
+afterAll(() => {
+  expect(process.env.HOME).toBe(HOME_AT_LOAD);
 });
 
 function cacheFilePath(teamId) {


### PR DESCRIPTION
## Summary
- Fixes `linear-estimation-method.test.mjs` and `event-leak-guard.test.mjs`, which unconditionally `delete process.env.HOME` in `afterEach`/`finally` instead of restoring the prior value — a leak that can strand `HOME` unset for the rest of the process, causing a later `gh` invocation to resolve `${XDG_STATE_HOME:-$HOME/.local/state}` to a relative path and write under cwd.
- Adds `env-restore-guard.test.mjs`, a repo-wide regression guard scanning `plugins/dev/scripts` for any `delete process.env.HOME` not paired with a conditional restoration.
- Wires the new guard and `event-leak-guard.test.mjs` into CI — neither test ran in this hand-enumerated workflow before.

Ported from stale fork PR #3274 (thagale/catalyst, CAT-251) as part of the 2026-08-21 verification sweep of stale fork PRs. The fork branch had diverged from main by 100+ unrelated commits; this PR rebases just the CAT-251 fix onto current main. Verified `watchdog-map-bounding.test.mjs` on current main already guards its HOME restoration correctly (unlike when the original PR was authored), so it needed no change here. Credit: Tony Hagale (original author).

## Test plan
- [x] `bun test linear-estimation-method.test.mjs env-restore-guard.test.mjs` (execution-core) — 47 pass / 0 fail
- [x] `bun test event-leak-guard.test.mjs` (broker) — 4 pass / 0 fail
- [x] `env-restore-guard.test.mjs` run against current main tree confirms no other unguarded `delete process.env.HOME` sites exist (empty allowlist holds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)