### PR TITLE
fix(dev): CAT-124 close deferred recovery-pass review findings

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1400,6 +1400,7 @@ jobs:
             recovery-reasoning.test.mjs \
             recovery-fix-backoff.test.mjs \
             recovery-orphan-stale-e2e.test.mjs \
+            recovery-seam-deps.test.mjs \
             pr-block-probe.test.mjs \
             recovery-emit.test.mjs \
             sweep-stale-recovery-intents.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -656,19 +656,21 @@ The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode 
 Pass 0r and Pass 0u share the same production act-seam dependencies. `runTick` constructs the
 PR-state resolver, background-job liveness probe, stall clearer, and status writer once; Pass 0u
 uses them to build its act registry, while Pass 0r receives both that registry and the raw bundle
-for capability-checked fallback construction. An injected partial registry therefore falls back to
-real dependencies instead of either using inert defaults or failing as unavailable.
+for capability-checked fallback construction. With no injected registry, a missing capability can
+therefore fall back to real dependencies instead of either using inert defaults or failing as
+unavailable.
 
-An operator-supplied `unstuckActByCategory` is a posture binding both passes. A partial registry or
-`{}` sets `seamFallbackSuppressed`, so Pass 0r reports suppression instead of rebuilding a live
-registry behind the override. With no operator registry, capability fallback remains active.
+An embedder- or test-supplied `unstuckActByCategory` is a posture binding both passes. A partial
+registry or `{}` sets `seamFallbackSuppressed`, so Pass 0r reports suppression instead of rebuilding
+a live registry behind the override. With no injected registry, capability fallback remains active.
 
 The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact
 `.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the
 liveness gate. Marker construction fails closed when phase is absent, preventing malformed
-`undefined` or `null` marker names. PR-state readers are synchronous; thenables are surfaced as
-`pr-state-async-unsupported` with an error-code identity rather than silently interpreted as missing
-evidence. A resolver error merely mentioning that text still fails closed to `pr-state-unknown`.
+`undefined` or `null` marker names. PR-state readers are synchronous. The act seam surfaces a
+thenable as `pr-state-async-unsupported` with an error-code identity; the Pass 0u census warns and
+returns `null`, which classifies as `pr-state-unknown`. A resolver error merely mentioning the
+unsupported code still fails closed to `pr-state-unknown`.
 `linearTerminal` is deliberately absent from Pass 0r candidates because both drivers pre-filter
 terminal tickets; sourcing a truthy value elsewhere would skip the merged-orphan cohort.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -659,20 +659,36 @@ uses them to build its act registry, while Pass 0r receives both that registry a
 for capability-checked fallback construction. An injected partial registry therefore falls back to
 real dependencies instead of either using inert defaults or failing as unavailable.
 
+An operator-supplied `unstuckActByCategory` is a posture binding both passes. A partial registry or
+`{}` sets `seamFallbackSuppressed`, so Pass 0r reports suppression instead of rebuilding a live
+registry behind the override. With no operator registry, capability fallback remains active.
+
 The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact
 `.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the
 liveness gate. Marker construction fails closed when phase is absent, preventing malformed
 `undefined` or `null` marker names. PR-state readers are synchronous; thenables are surfaced as
-`pr-state-async-unsupported` rather than silently interpreted as missing evidence.
+`pr-state-async-unsupported` with an error-code identity rather than silently interpreted as missing
+evidence. A resolver error merely mentioning that text still fails closed to `pr-state-unknown`.
+`linearTerminal` is deliberately absent from Pass 0r candidates because both drivers pre-filter
+terminal tickets; sourcing a truthy value elsewhere would skip the merged-orphan cohort.
+
+Synthetic completion is restricted by `ORPHAN_MERGE_PHASE_ALLOWLIST` to `monitor-merge` and
+`monitor-deploy`. The classifier applies that as its first gate, so both passes refuse an early phase
+with `phase-not-allowlisted` even when its PR is merged.
 
 Repeated identical fix failures are stored at
 `<orchDir>/.recovery-fix-failures/<ticket>-<fix_class>.json`, outside `workers/` because completed
 tickets may no longer have worker directories. This separate family is not erased by
-`recoveryForgetIntent`. After `RECOVERY_FIX_BACKOFF_THRESHOLD` identical failures (default 3),
-retries use exponential windows controlled by `RECOVERY_FIX_BACKOFF_BASE_MS` (default 30 minutes)
-and `RECOVERY_FIX_BACKOFF_MAX_MS` (default 24 hours). Audit-comment hashes are committed only after
+`recoveryForgetIntent`. After `CATALYST_RECOVERY_FIX_BACKOFF_THRESHOLD` identical failures (default
+3), retries use exponential windows controlled by `CATALYST_RECOVERY_FIX_BACKOFF_BASE_MS` (default 2
+hours, longer than the 30-minute intent cooldown) and `CATALYST_RECOVERY_FIX_BACKOFF_MAX_MS` (default
+24 hours). The threshold sits above the two-attempt ledger bound so this history guards only
+post-reset re-entry. Values are captured at module load and require a daemon restart; unprefixed
+CAT-47 names remain deprecated aliases. Audit-comment hashes are committed only after
 successful delivery, so an outage leaves the comment eligible for retry while delivered duplicate
-content is suppressed.
+content is suppressed. Manual hygiene can sweep files whose newest `lastTs`/`lastCommentTs` is older
+than 14 days with `sweep-stale-recovery-intents.mjs --family fix-failures`; that retention exceeds
+twice the maximum backoff window, and nothing depends on the sweep running.
 
 ### Delegate-first escalation + explanation chokepoint (CTL-1609)
 

--- a/plugins/dev/scripts/execution-core/reap-intent.test.mjs
+++ b/plugins/dev/scripts/execution-core/reap-intent.test.mjs
@@ -1,5 +1,5 @@
 // reap-intent.test.mjs — emitter unit tests (CTL-649 Phase 4).
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, readFileSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,6 +12,14 @@ beforeEach(() => {
   const yyyymm = new Date().toISOString().slice(0, 7);
   LOG_PATH = join(SCRATCH, "events", `${yyyymm}.jsonl`);
   process.env.CATALYST_DIR = SCRATCH;
+});
+
+afterEach(() => {
+  // The "unwritable event log" test below repoints CATALYST_DIR at a
+  // non-directory path and never gets a natural chance to undo it before the
+  // next test file runs in this same bun test process. Per test-setup.mjs's
+  // documented save/restore convention, always land back on the hermetic pin.
+  process.env.CATALYST_DIR = process.env.CATALYST_HERMETIC_DIR;
 });
 
 async function freshModule() {

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
@@ -5,19 +5,37 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-function envNum(name, fallback) {
-  const raw = process.env[name];
-  if (raw == null || raw === "") return fallback;
-  const value = Number(raw);
-  return Number.isFinite(value) && value >= 0 ? value : fallback;
+function envNum(names, fallback) {
+  for (const name of names) {
+    const raw = process.env[name];
+    if (raw == null || raw === "") continue;
+    const value = Number(raw);
+    return Number.isFinite(value) && value >= 0 ? value : fallback;
+  }
+  return fallback;
 }
 
-export const RECOVERY_FIX_BACKOFF_THRESHOLD = envNum("RECOVERY_FIX_BACKOFF_THRESHOLD", 3);
-export const RECOVERY_FIX_BACKOFF_BASE_MS = envNum("RECOVERY_FIX_BACKOFF_BASE_MS", 30 * 60 * 1000);
-export const RECOVERY_FIX_BACKOFF_MAX_MS = envNum("RECOVERY_FIX_BACKOFF_MAX_MS", 24 * 60 * 60 * 1000);
+// The attempts ledger owns the in-lifetime bound: threshold 3 deliberately exceeds its two
+// attempts, so this history engages only after forgetIntent resets that ledger. BASE_MS must
+// exceed the ledger's 30-minute cooldown or this layered guard never blocks. Values are captured
+// once at boot; CATALYST_-prefixed names are canonical and the CAT-47 names remain deprecated aliases.
+export const RECOVERY_FIX_BACKOFF_THRESHOLD = envNum(
+  ["CATALYST_RECOVERY_FIX_BACKOFF_THRESHOLD", "RECOVERY_FIX_BACKOFF_THRESHOLD"],
+  3
+);
+export const RECOVERY_FIX_BACKOFF_BASE_MS = envNum(
+  ["CATALYST_RECOVERY_FIX_BACKOFF_BASE_MS", "RECOVERY_FIX_BACKOFF_BASE_MS"],
+  2 * 60 * 60 * 1000
+);
+export const RECOVERY_FIX_BACKOFF_MAX_MS = envNum(
+  ["CATALYST_RECOVERY_FIX_BACKOFF_MAX_MS", "RECOVERY_FIX_BACKOFF_MAX_MS"],
+  24 * 60 * 60 * 1000
+);
+
+export const RECOVERY_FIX_FAILURES_DIR = ".recovery-fix-failures";
 
 export function fixFailurePath(orchDir, ticket, fixClass) {
-  return join(orchDir, ".recovery-fix-failures", `${ticket}-${fixClass}.json`);
+  return join(orchDir, RECOVERY_FIX_FAILURES_DIR, `${ticket}-${fixClass}.json`);
 }
 
 function readState(path) {

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
@@ -17,19 +17,46 @@ function envNum(names, fallback) {
 
 // The attempts ledger owns the in-lifetime bound: threshold 3 deliberately exceeds its two
 // attempts, so this history engages only after forgetIntent resets that ledger. BASE_MS must
-// exceed the ledger's 30-minute cooldown or this layered guard never blocks. Values are captured
+// exceed the ledger's cooldown or this layered guard never blocks. Values are captured
 // once at boot; CATALYST_-prefixed names are canonical and the CAT-47 names remain deprecated aliases.
 export const RECOVERY_FIX_BACKOFF_THRESHOLD = envNum(
   ["CATALYST_RECOVERY_FIX_BACKOFF_THRESHOLD", "RECOVERY_FIX_BACKOFF_THRESHOLD"],
   3
 );
-export const RECOVERY_FIX_BACKOFF_BASE_MS = envNum(
-  ["CATALYST_RECOVERY_FIX_BACKOFF_BASE_MS", "RECOVERY_FIX_BACKOFF_BASE_MS"],
-  2 * 60 * 60 * 1000
+
+// CAT-124 (Codex #3223 P2): the "BASE_MS exceeds the ledger cooldown" invariant above was
+// asserted against the cooldown's 30-MINUTE DEFAULT, not against its configured value. Raising
+// CATALYST_RECOVERY_COOLDOWN_MIN past 120 silently inverted it: defaultShouldSkipItem suppresses
+// the ticket for the whole cooldown and inFixBackoff is only consulted AFTER that skip check, so a
+// 2-hour base window had already expired by the time this guard was ever reached — the post-reset
+// guard became unreachable in a fully supported configuration. Derive the floor from the cooldown
+// that is actually configured instead of assuming its default.
+//
+// The cooldown formula is duplicated (not imported) on purpose: recovery-reasoning.mjs, which owns
+// RECOVERY_COOLDOWN_MS, already imports THIS module, so importing back would close a cycle. This
+// file is a zero-internal-import leaf and stays that way; the expression below is kept
+// character-for-character identical to recovery-reasoning.mjs's, including the `|| default` that
+// makes NaN and 0 fall through.
+const RECOVERY_COOLDOWN_MS_FOR_FLOOR =
+  Number(process.env.CATALYST_RECOVERY_COOLDOWN_MIN) * 60 * 1000 || 30 * 60 * 1000;
+
+// 2x mirrors the safety factor RECOVERY_FIX_FAILURE_TTL_MS already uses for its own
+// must-outlive relationship, rather than inventing a new margin. With the default cooldown
+// (30m → 1h floor) this is inert: the 2h default base already clears it, so default deployments
+// are byte-identical. A clamp only engages when the configured cooldown would otherwise render
+// the guard dead, and it always moves in the conservative direction (suppress a repeatedly
+// failing ticket for longer, never shorter).
+export const RECOVERY_FIX_BACKOFF_BASE_MS = Math.max(
+  envNum(["CATALYST_RECOVERY_FIX_BACKOFF_BASE_MS", "RECOVERY_FIX_BACKOFF_BASE_MS"], 2 * 60 * 60 * 1000),
+  2 * RECOVERY_COOLDOWN_MS_FOR_FLOOR
 );
-export const RECOVERY_FIX_BACKOFF_MAX_MS = envNum(
-  ["CATALYST_RECOVERY_FIX_BACKOFF_MAX_MS", "RECOVERY_FIX_BACKOFF_MAX_MS"],
-  24 * 60 * 60 * 1000
+
+// MAX is the ceiling the exponential windows saturate at, so it must not sit below the base it
+// bounds — otherwise a clamped base would be capped straight back under the cooldown, undoing the
+// floor above. RECOVERY_FIX_FAILURE_TTL_MS derives from this and so widens with it automatically.
+export const RECOVERY_FIX_BACKOFF_MAX_MS = Math.max(
+  envNum(["CATALYST_RECOVERY_FIX_BACKOFF_MAX_MS", "RECOVERY_FIX_BACKOFF_MAX_MS"], 24 * 60 * 60 * 1000),
+  RECOVERY_FIX_BACKOFF_BASE_MS
 );
 
 export const RECOVERY_FIX_FAILURES_DIR = ".recovery-fix-failures";

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.mjs
@@ -62,7 +62,10 @@ export function inFixBackoff(orchDir, ticket, fixClass, nowMs = Date.now()) {
     return { blocked: false, count, until: null, lastReason: state.lastReason ?? null };
   }
   const exponent = Math.max(0, count - RECOVERY_FIX_BACKOFF_THRESHOLD);
-  const windowMs = Math.min(RECOVERY_FIX_BACKOFF_BASE_MS * (2 ** exponent), RECOVERY_FIX_BACKOFF_MAX_MS);
+  const windowMs = Math.min(
+    RECOVERY_FIX_BACKOFF_BASE_MS * 2 ** exponent,
+    RECOVERY_FIX_BACKOFF_MAX_MS
+  );
   const until = state.lastTs + windowMs;
   return { blocked: nowMs < until, count, until, lastReason: state.lastReason ?? null };
 }
@@ -73,7 +76,7 @@ export function recordFixFailure(
   fixClass,
   failureReason,
   nowMs = Date.now(),
-  { log = console.warn } = {},
+  { log = console.warn } = {}
 ) {
   if (!orchDir) return null;
   const path = fixFailurePath(orchDir, ticket, fixClass);
@@ -94,9 +97,16 @@ export function clearFixFailures(orchDir, ticket, fixClass) {
   const path = fixFailurePath(orchDir, ticket, fixClass);
   const prior = readState(path);
   if (prior.lastCommentHash) {
-    try { writeState(path, { lastCommentHash: prior.lastCommentHash, lastCommentTs: prior.lastCommentTs }); } catch {}
+    try {
+      writeState(path, {
+        lastCommentHash: prior.lastCommentHash,
+        lastCommentTs: prior.lastCommentTs,
+      });
+    } catch {}
   } else {
-    try { unlinkSync(path); } catch {}
+    try {
+      unlinkSync(path);
+    } catch {}
   }
 }
 

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
@@ -112,4 +112,66 @@ describe("CAT-124 backoff invariants and env-name resolution", () => {
       delete process.env[legacy];
     }
   });
+
+  // CAT-124 Tier A item 1 asked for this explicitly: the CAT-47 coverage drove the
+  // backoff past a `shouldSkipItem: () => false` stub, which masked the very ordering
+  // question the ticket raised. This drives the REAL defaultRecordIntent /
+  // defaultShouldSkipItem / defaultForgetIntent so the documented posture — the
+  // attempts ledger owns the in-lifetime bound, this history guards post-reset
+  // re-entry — is demonstrated end to end rather than only asserted in prose.
+  test("the real attempts ledger latches first; the backoff guards post-reset re-entry", async () => {
+    const {
+      defaultRecordIntent,
+      defaultShouldSkipItem,
+      defaultForgetIntent,
+      RECOVERY_MAX_ATTEMPTS,
+      RECOVERY_COOLDOWN_MS,
+    } = await import("./recovery-reasoning.mjs");
+    const orchDir = fresh();
+    const ticket = "CAT-999";
+    const fixClass = "orphan_stale";
+    const reason = "same-failure";
+    // Step past BOTH the intent cooldown and the backoff window every pass, so the only
+    // thing that can stop the loop is the attempts latch itself.
+    const step = Math.max(RECOVERY_COOLDOWN_MS, RECOVERY_FIX_BACKOFF_BASE_MS) * 2 + 1;
+
+    let now = step;
+    let reached = 0;
+    // Run more passes than the ledger allows; the latch must stop us early.
+    for (let pass = 0; pass < RECOVERY_MAX_ATTEMPTS + 2; pass += 1, now += step) {
+      if (defaultShouldSkipItem(ticket, { orchDir, now: () => now })) continue;
+      reached += 1;
+      expect(inFixBackoff(orchDir, ticket, fixClass, now).blocked).toBe(false);
+      recordFixFailure(orchDir, ticket, fixClass, reason, now);
+      defaultRecordIntent(
+        ticket,
+        { decision: "fix", fix_class: fixClass },
+        { orchDir, now: () => now }
+      );
+    }
+
+    // Within one lifetime the ledger — not the backoff — is what bounds the retries.
+    expect(reached).toBe(RECOVERY_MAX_ATTEMPTS);
+    expect(defaultShouldSkipItem(ticket, { orchDir, now: () => now })).toBe(true);
+    // …and because the threshold sits above that bound, the backoff never armed.
+    const inLifetime = inFixBackoff(orchDir, ticket, fixClass, now);
+    expect(inLifetime.count).toBe(RECOVERY_MAX_ATTEMPTS);
+    expect(inLifetime.count).toBeLessThan(RECOVERY_FIX_BACKOFF_THRESHOLD);
+    expect(inLifetime.blocked).toBe(false);
+
+    // Resetting the ledger re-opens the item, but the fix-failure history survives it.
+    expect(defaultForgetIntent(ticket, { orchDir })).toBe(true);
+    now += step;
+    expect(defaultShouldSkipItem(ticket, { orchDir, now: () => now })).toBe(false);
+    expect(inFixBackoff(orchDir, ticket, fixClass, now).count).toBe(RECOVERY_MAX_ATTEMPTS);
+
+    // Identical failures on re-entry carry the count to the threshold and arm the block.
+    for (let i = RECOVERY_MAX_ATTEMPTS; i < RECOVERY_FIX_BACKOFF_THRESHOLD; i += 1) {
+      recordFixFailure(orchDir, ticket, fixClass, reason, now);
+    }
+    const armed = inFixBackoff(orchDir, ticket, fixClass, now);
+    expect(armed.count).toBe(RECOVERY_FIX_BACKOFF_THRESHOLD);
+    expect(armed.blocked).toBe(true);
+    expect(armed.until).toBe(now + RECOVERY_FIX_BACKOFF_BASE_MS);
+  });
 });

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
@@ -75,3 +75,32 @@ describe("comment dedup latch (CAT-47)", () => {
     expect(JSON.parse(readFileSync(join(root, ".recovery-fix-failures", "CAT-9-orphan_stale.json"), "utf8")).lastCommentHash).toBe(first);
   });
 });
+
+describe("CAT-124 backoff invariants and env-name resolution", () => {
+  test("the post-reset guard outlasts the recovery cooldown", async () => {
+    const { RECOVERY_COOLDOWN_MS } = await import("./recovery-reasoning.mjs");
+    expect(RECOVERY_FIX_BACKOFF_BASE_MS).toBeGreaterThan(RECOVERY_COOLDOWN_MS);
+  });
+
+  test("the canonical CATALYST_ name wins while the legacy alias remains supported", async () => {
+    const canonical = "CATALYST_RECOVERY_FIX_BACKOFF_THRESHOLD";
+    const legacy = "RECOVERY_FIX_BACKOFF_THRESHOLD";
+    try {
+      process.env[canonical] = "2";
+      process.env[legacy] = "5";
+      const preferred = await import("./recovery-fix-backoff.mjs?cat124=preferred");
+      expect(preferred.RECOVERY_FIX_BACKOFF_THRESHOLD).toBe(2);
+      const root = fresh();
+      preferred.recordFixFailure(root, "CAT-9", "orphan_stale", "same", 1000);
+      preferred.recordFixFailure(root, "CAT-9", "orphan_stale", "same", 1000);
+      expect(preferred.inFixBackoff(root, "CAT-9", "orphan_stale", 1000).blocked).toBe(true);
+
+      delete process.env[canonical];
+      const compatible = await import("./recovery-fix-backoff.mjs?cat124=legacy");
+      expect(compatible.RECOVERY_FIX_BACKOFF_THRESHOLD).toBe(5);
+    } finally {
+      delete process.env[canonical];
+      delete process.env[legacy];
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-fix-backoff.test.mjs
@@ -14,7 +14,10 @@ import {
 } from "./recovery-fix-backoff.mjs";
 
 let dir;
-afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = null;
+});
 const fresh = () => (dir = mkdtempSync(join(tmpdir(), "cat-47-backoff-")));
 
 describe("recovery-fix-backoff (CAT-47)", () => {
@@ -43,7 +46,9 @@ describe("recovery-fix-backoff (CAT-47)", () => {
     for (let i = 0; i < RECOVERY_FIX_BACKOFF_THRESHOLD; i += 1) {
       recordFixFailure(root, "CAT-9", "orphan_stale", "same", 1000);
     }
-    expect(inFixBackoff(root, "CAT-9", "orphan_stale", 1000 + RECOVERY_FIX_BACKOFF_BASE_MS).blocked).toBe(false);
+    expect(
+      inFixBackoff(root, "CAT-9", "orphan_stale", 1000 + RECOVERY_FIX_BACKOFF_BASE_MS).blocked
+    ).toBe(false);
   });
 
   test("state is outside workers and success clears failure fields", () => {
@@ -72,7 +77,11 @@ describe("comment dedup latch (CAT-47)", () => {
     commitFixCommentHash(root, "CAT-9", "orphan_stale", first, 1000);
     expect(shouldPostFixComment(root, "CAT-9", "orphan_stale", first, 1000)).toBe(false);
     expect(shouldPostFixComment(root, "CAT-9", "orphan_stale", second, 1000)).toBe(true);
-    expect(JSON.parse(readFileSync(join(root, ".recovery-fix-failures", "CAT-9-orphan_stale.json"), "utf8")).lastCommentHash).toBe(first);
+    expect(
+      JSON.parse(
+        readFileSync(join(root, ".recovery-fix-failures", "CAT-9-orphan_stale.json"), "utf8")
+      ).lastCommentHash
+    ).toBe(first);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
@@ -6,7 +6,10 @@ import { defaultInvokeSeam, reasoningRecoveryPass } from "./recovery-reasoning.m
 import { RECOVERY_FIX_BACKOFF_THRESHOLD } from "./recovery-fix-backoff.mjs";
 
 let dir;
-afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = null;
+});
 const fresh = () => (dir = mkdtempSync(join(tmpdir(), "cat-47-e2e-")));
 
 // Defect B is a CALL-SITE bug: attemptFix dropped item.phase/item.evidence.signal,
@@ -68,12 +71,20 @@ describe("defaultInvokeSeam registry selection (CAT-47 Defect A)", () => {
 
   test("an EMPTY injected registry falls back to one built from the injected deps", () => {
     let emits = 0;
-    const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
-      ...merged,
-      orchDir: fresh(),
-      actByCategory: {},
-      emitPhaseComplete: () => { emits += 1; return true; },
-    });
+    const result = defaultInvokeSeam(
+      "CAT-47",
+      "orphan-reconcile",
+      {},
+      {
+        ...merged,
+        orchDir: fresh(),
+        actByCategory: {},
+        emitPhaseComplete: () => {
+          emits += 1;
+          return true;
+        },
+      }
+    );
     expect(result.success).toBe(true);
     expect(emits).toBe(1);
   });
@@ -81,16 +92,21 @@ describe("defaultInvokeSeam registry selection (CAT-47 Defect A)", () => {
   test("an operator-suppressed registry never rebuilds a live fallback (CAT-124 F3)", () => {
     let emits = 0;
     const root = fresh();
-    const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
-      ...merged,
-      orchDir: root,
-      actByCategory: {},
-      seamFallbackSuppressed: true,
-      emitPhaseComplete: () => {
-        emits += 1;
-        return true;
-      },
-    });
+    const result = defaultInvokeSeam(
+      "CAT-47",
+      "orphan-reconcile",
+      {},
+      {
+        ...merged,
+        orchDir: root,
+        actByCategory: {},
+        seamFallbackSuppressed: true,
+        emitPhaseComplete: () => {
+          emits += 1;
+          return true;
+        },
+      }
+    );
     expect(result.success).toBe(false);
     expect(result.reason).toContain("suppressed by operator override");
     expect(result.details.suppressed).toBe(true);
@@ -98,23 +114,38 @@ describe("defaultInvokeSeam registry selection (CAT-47 Defect A)", () => {
   });
 
   test("a registry MISSING this category falls back rather than reporting unavailable", () => {
-    const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
-      ...merged,
-      orchDir: fresh(),
-      actByCategory: { "dirty-tree": () => {} },
-      emitPhaseComplete: () => true,
-    });
+    const result = defaultInvokeSeam(
+      "CAT-47",
+      "orphan-reconcile",
+      {},
+      {
+        ...merged,
+        orchDir: fresh(),
+        actByCategory: { "dirty-tree": () => {} },
+        emitPhaseComplete: () => true,
+      }
+    );
     expect(result.success).toBe(true);
     expect(result.reason ?? "").not.toContain("unavailable");
   });
 
   test("a registry that DOES provide the category is used verbatim (not rebuilt)", () => {
     let called = 0;
-    const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
-      orchDir: fresh(),
-      candidate: { phase: "monitor-merge", signal: null },
-      actByCategory: { "orphan-stale": (candidate) => { called += 1; expect(candidate.phase).toBe("monitor-merge"); } },
-    });
+    const result = defaultInvokeSeam(
+      "CAT-47",
+      "orphan-reconcile",
+      {},
+      {
+        orchDir: fresh(),
+        candidate: { phase: "monitor-merge", signal: null },
+        actByCategory: {
+          "orphan-stale": (candidate) => {
+            called += 1;
+            expect(candidate.phase).toBe("monitor-merge");
+          },
+        },
+      }
+    );
     expect(result.success).toBe(true);
     expect(called).toBe(1);
   });
@@ -128,7 +159,10 @@ describe("orphan-stale recovery end to end (CAT-47)", () => {
       orchDir: root,
       resolvePrState: () => "MERGED",
       jobLifecycle: () => false,
-      emitPhaseComplete: () => { emits += 1; return true; },
+      emitPhaseComplete: () => {
+        emits += 1;
+        return true;
+      },
       nowMs: () => Date.parse("2026-08-09T03:00:00Z"),
       candidate: {
         phase: "monitor-merge",
@@ -138,7 +172,9 @@ describe("orphan-stale recovery end to end (CAT-47)", () => {
     expect(defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, deps).success).toBe(true);
     expect(defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, deps).success).toBe(true);
     expect(emits).toBe(1);
-    expect(existsSync(join(root, "workers", "CAT-47", ".unstuck-orphan-merge-monitor-merge.applied"))).toBe(true);
+    expect(
+      existsSync(join(root, "workers", "CAT-47", ".unstuck-orphan-merge-monitor-merge.applied"))
+    ).toBe(true);
   });
 
   test("AC3: identical seam failures stop at the threshold and comment once", () => {
@@ -150,10 +186,19 @@ describe("orphan-stale recovery end to end (CAT-47)", () => {
       mode: "enforce",
       orchDir: root,
       shouldSkipItem: () => false,
-      classifyTicket: () => ({ decision: "fix", fix_class: "orphan_stale", details: { seam_id: "orphan-reconcile", reason: "stale" } }),
-      invokeSeam: () => { attempts += 1; throw new Error("same failure"); },
+      classifyTicket: () => ({
+        decision: "fix",
+        fix_class: "orphan_stale",
+        details: { seam_id: "orphan-reconcile", reason: "stale" },
+      }),
+      invokeSeam: () => {
+        attempts += 1;
+        throw new Error("same failure");
+      },
       recordIntent: () => {},
-      postComment: () => { comments += 1; },
+      postComment: () => {
+        comments += 1;
+      },
       emitEvent: () => {},
       log: () => {},
       nowMs: () => 1000,
@@ -169,10 +214,25 @@ describe("orphan-stale recovery end to end (CAT-47)", () => {
     const root = fresh();
     let comments = 0;
     const options = {
-      mode: "enforce", orchDir: root, shouldSkipItem: () => false,
-      classifyTicket: () => ({ decision: "fix", fix_class: "orphan_stale", details: { seam_id: "orphan-reconcile", reason: "stale" } }),
-      invokeSeam: () => { throw new Error("same failure"); }, recordIntent: () => {}, emitEvent: () => {}, log: () => {}, nowMs: () => 1000,
-      postComment: () => { comments += 1; throw new Error("Linear unavailable"); },
+      mode: "enforce",
+      orchDir: root,
+      shouldSkipItem: () => false,
+      classifyTicket: () => ({
+        decision: "fix",
+        fix_class: "orphan_stale",
+        details: { seam_id: "orphan-reconcile", reason: "stale" },
+      }),
+      invokeSeam: () => {
+        throw new Error("same failure");
+      },
+      recordIntent: () => {},
+      emitEvent: () => {},
+      log: () => {},
+      nowMs: () => 1000,
+      postComment: () => {
+        comments += 1;
+        throw new Error("Linear unavailable");
+      },
     };
     const item = { ticket: "CAT-47", phase: "monitor-merge", evidence: { signal: {} } };
     reasoningRecoveryPass([item], options);

--- a/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-orphan-stale-e2e.test.mjs
@@ -78,6 +78,25 @@ describe("defaultInvokeSeam registry selection (CAT-47 Defect A)", () => {
     expect(emits).toBe(1);
   });
 
+  test("an operator-suppressed registry never rebuilds a live fallback (CAT-124 F3)", () => {
+    let emits = 0;
+    const root = fresh();
+    const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
+      ...merged,
+      orchDir: root,
+      actByCategory: {},
+      seamFallbackSuppressed: true,
+      emitPhaseComplete: () => {
+        emits += 1;
+        return true;
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain("suppressed by operator override");
+    expect(result.details.suppressed).toBe(true);
+    expect(emits).toBe(0);
+  });
+
   test("a registry MISSING this category falls back rather than reporting unavailable", () => {
     const result = defaultInvokeSeam("CAT-47", "orphan-reconcile", {}, {
       ...merged,

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -377,6 +377,8 @@ export function reasoningRecoveryPass(items, opts = {}) {
     } else if (mode === "enforce") {
       // Enforce mode: actually invoke seams / remediate, record intent
       if (decision === "fix") {
+        // Deliberately after shouldSkipItem: the attempts ledger bounds failures within one
+        // lifetime. This history survives forgetIntent and guards identical post-reset re-entry.
         const backoff = inFixBackoffFn(orchDir, item.ticket, fix_class, nowMs());
         if (backoff.blocked) {
           actionLog.push(`fix backoff: ${fix_class} blocked (${backoff.count} identical failures)`);
@@ -1714,6 +1716,15 @@ export function defaultInvokeSeam(ticket, seamId, brief = {}, deps = {}) {
   // are deliberately inert, so callers with live evidence must inject them.
   let registry = deps.actByCategory;
   if (!registry || typeof registry[category] !== "function") {
+    // An explicit operator registry is a posture binding both passes. Do not rebuild a live
+    // fallback behind an empty or partial registry supplied to keep this category inert.
+    if (deps.seamFallbackSuppressed === true) {
+      return {
+        success: false,
+        reason: `registry seam '${category}' suppressed by operator override`,
+        details: { suppressed: true, category },
+      };
+    }
     try {
       registry = buildUnstuckActSeams({
         orchDir: deps.orchDir ?? resolveOrchDir(),

--- a/plugins/dev/scripts/execution-core/recovery-seam-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-seam-deps.test.mjs
@@ -1,0 +1,165 @@
+import { expect, test } from "bun:test";
+import { buildRecoverySeamDeps } from "./scheduler.mjs";
+import * as linearWrite from "./linear-write.mjs";
+
+// Every jobLifecycle test injects getAgents. The real getAgentsCached refreshes
+// by spawning `claude agents --json`, which a hermetic unit test must not do.
+const build = (opts = {}, seams = {}) =>
+  buildRecoverySeamDeps(opts, {
+    readSignals: () => [],
+    getAgents: () => ({ agents: [] }),
+    clearStallFactory: () => null,
+    ...seams,
+  });
+
+test("resolvePrState returns null without a PR adapter", () => {
+  const deps = build({}, { readSignals: () => expect.unreachable() });
+  expect(deps.resolvePrState("CAT-1")).toBeNull();
+});
+
+test("resolvePrState returns null when prView is not callable", () => {
+  for (const prAdapter of [{}, { prView: 42 }]) {
+    const deps = build({ prAdapter }, { readSignals: () => expect.unreachable() });
+    expect(deps.resolvePrState("CAT-1")).toBeNull();
+  }
+});
+
+test("resolvePrState returns null when no signal has a PR number", () => {
+  let calls = 0;
+  const deps = build(
+    { orchDir: "/orch", prAdapter: { prView: () => calls++ } },
+    { readSignals: () => [{ ticket: "CAT-1", raw: { pr: {} } }] }
+  );
+  expect(deps.resolvePrState("CAT-1")).toBeNull();
+  expect(calls).toBe(0);
+});
+
+test("resolvePrState selects the first numbered signal and prefers raw.pr", () => {
+  const calls = [];
+  const deps = build(
+    { orchDir: "/orch", prAdapter: { prView: (...args) => (calls.push(args), { state: "OPEN" }) } },
+    {
+      readSignals: (orchDir) => {
+        expect(orchDir).toBe("/orch");
+        return [
+          { ticket: "CAT-1", pr: {} },
+          { ticket: "CAT-1", raw: { pr: { number: 77 } }, pr: { number: 88 } },
+          { ticket: "CAT-1", pr: { number: 99 } },
+        ];
+      },
+    }
+  );
+  expect(deps.resolvePrState("CAT-1")).toBe("OPEN");
+  expect(calls).toEqual([["CAT-1", { number: 77 }]]);
+});
+
+test("resolvePrState normalizes merged state and mergedAt", () => {
+  for (const view of [{ state: "MERGED" }, { state: "OPEN", mergedAt: "now" }]) {
+    const deps = build(
+      { prAdapter: { prView: () => view } },
+      { readSignals: () => [{ ticket: "CAT-1", pr: { number: 1 } }] }
+    );
+    expect(deps.resolvePrState("CAT-1")).toBe("MERGED");
+  }
+});
+
+test("resolvePrState passes through state and nullifies absent state", () => {
+  for (const [view, expected] of [
+    [{ state: "OPEN" }, "OPEN"],
+    [null, null],
+    [{}, null],
+  ]) {
+    const deps = build(
+      { prAdapter: { prView: () => view } },
+      { readSignals: () => [{ ticket: "CAT-1", pr: { number: 1 } }] }
+    );
+    expect(deps.resolvePrState("CAT-1")).toBe(expected);
+  }
+});
+
+test("resolvePrState fails closed when prView throws", () => {
+  const deps = build(
+    {
+      prAdapter: {
+        prView: () => {
+          throw new Error("gh failed");
+        },
+      },
+    },
+    { readSignals: () => [{ ticket: "CAT-1", pr: { number: 1 } }] }
+  );
+  expect(deps.resolvePrState("CAT-1")).toBeNull();
+});
+
+test("jobLifecycle short-circuits without a liveness probe", () => {
+  const deps = build({}, { getAgents: () => expect.unreachable() });
+  expect(deps.jobLifecycle("job-1")).toBe(false);
+});
+
+test("jobLifecycle rejects falsy job ids without probing", () => {
+  let calls = 0;
+  const deps = build({ isBgJobAlive: () => calls++ });
+  for (const id of [null, "", undefined]) expect(deps.jobLifecycle(id)).toBe(false);
+  expect(calls).toBe(0);
+});
+
+test("jobLifecycle coerces probe results and threads the agents snapshot", () => {
+  const calls = [];
+  const agents = [{ id: "agent-1" }];
+  const deps = build(
+    { isBgJobAlive: (...args) => (calls.push(args), 1) },
+    { getAgents: () => ({ agents }) }
+  );
+  expect(deps.jobLifecycle("job-1")).toBe(true);
+  expect(calls).toEqual([["job-1", { agents }]]);
+});
+
+test("jobLifecycle fails closed when the probe throws", () => {
+  const deps = build({
+    isBgJobAlive: () => {
+      throw new Error("probe failed");
+    },
+  });
+  expect(deps.jobLifecycle("job-1")).toBe(false);
+});
+
+test("bundle defaults writeStatus and passes it with orchDir to clearStallFactory", () => {
+  for (const writeStatus of [undefined, { sentinel: true }]) {
+    const calls = [];
+    const clearStall = () => true;
+    const deps = build(
+      { orchDir: "/orch", writeStatus },
+      { clearStallFactory: (...args) => (calls.push(args), clearStall) }
+    );
+    const expected = writeStatus ?? linearWrite;
+    expect(deps.orchDir).toBe("/orch");
+    expect(deps.writeStatus).toBe(expected);
+    expect(deps.clearStall).toBe(clearStall);
+    expect(calls).toEqual([["/orch", expected]]);
+  }
+});
+
+test("closures lazily observe options assigned after construction", () => {
+  const opts = { orchDir: "/orch", prAdapter: undefined, isBgJobAlive: undefined };
+  const deps = build(opts, {
+    readSignals: () => [{ ticket: "CAT-1", pr: { number: 1 } }],
+    getAgents: () => ({ agents: ["warm"] }),
+  });
+  opts.prAdapter = { prView: () => ({ state: "OPEN" }) };
+  opts.isBgJobAlive = (_id, snapshot) => snapshot.agents[0] === "warm";
+  expect(deps.resolvePrState("CAT-1")).toBe("OPEN");
+  expect(deps.jobLifecycle("job-1")).toBe(true);
+});
+
+test("seam fallback suppression follows the effective operator registry override", () => {
+  const partial = { "dirty-tree": () => {} };
+  for (const [opts, expected] of [
+    [{ orchDir: "/orch" }, false],
+    [{ orchDir: "/orch", unstuckActByCategory: {} }, true],
+    [{ orchDir: "/orch", unstuckActByCategory: partial }, true],
+    [{ orchDir: "/orch", unstuckActByCategory: undefined }, false],
+    [{ orchDir: "/orch", unstuckSweep: { actByCategory: {} } }, true],
+  ]) {
+    expect(build(opts).seamFallbackSuppressed).toBe(expected);
+  }
+});

--- a/plugins/dev/scripts/execution-core/recovery-seam-deps.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-seam-deps.test.mjs
@@ -1,5 +1,13 @@
-import { expect, test } from "bun:test";
-import { buildRecoverySeamDeps } from "./scheduler.mjs";
+import { afterEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRecoverySeamDeps,
+  startScheduler,
+  __getRunningOpts,
+  __resetForTests,
+} from "./scheduler.mjs";
 import * as linearWrite from "./linear-write.mjs";
 
 // Every jobLifecycle test injects getAgents. The real getAgentsCached refreshes
@@ -162,4 +170,86 @@ test("seam fallback suppression follows the effective operator registry override
   ]) {
     expect(build(opts).seamFallbackSuppressed).toBe(expected);
   }
+});
+
+// ── CAT-124 (Codex #3223 P1): the override must survive the PRODUCTION entry point ──
+//
+// The suppression contract above is derived inside buildRecoverySeamDeps, which the
+// daemon calls as `buildRecoverySeamDeps(runningOpts)`. startScheduler originally
+// destructured none of the unstuck-* keys, so an operator's
+// `startScheduler({ unstuckActByCategory: {} })` never reached runningOpts: the
+// derivation saw `undefined`, seamFallbackSuppressed stayed false, and Pass 0r went
+// on rebuilding live seams behind a registry that was supposed to bind both passes.
+// Asserting only on a hand-built opts object cannot catch that — these tests go
+// through startScheduler so the wiring itself is pinned.
+// Temp orchDirs created per test, removed in afterEach. CATALYST_DIR itself is
+// already pinned to a hermetic temp dir by the bun [test].preload (test-setup.mjs),
+// so booting a real scheduler here cannot touch ~/catalyst or reach live Linear —
+// run this file from plugins/dev/scripts/execution-core so that preload applies.
+const bootDirs = [];
+function bootOrchDir() {
+  const dir = mkdtempSync(join(tmpdir(), "cat124-seam-wiring-"));
+  writeFileSync(join(dir, "state.json"), JSON.stringify({ maxParallel: 1 }));
+  bootDirs.push(dir);
+  return dir;
+}
+
+const bootOpts = (orchDir, extra) => ({
+  orchDir,
+  dispatch: () => ({ code: 0 }),
+  readEligible: () => [],
+  liveBackgroundCount: () => 0,
+  tickIntervalMs: 60_000,
+  debounceMs: 5,
+  ...extra,
+});
+
+afterEach(() => {
+  // __resetForTests stops the scheduler timer/watcher and clears runningOpts.
+  __resetForTests();
+  while (bootDirs.length) rmSync(bootDirs.pop(), { recursive: true, force: true });
+});
+
+test("startScheduler retains the unstuck override seams in runningOpts", () => {
+  const orchDir = bootOrchDir();
+  const unstuckActByCategory = {};
+  const unstuckSweep = { actByCategory: { "dirty-tree": () => {} } };
+  const unstuckEscalate = () => {};
+  const unstuckPostComment = () => {};
+
+  startScheduler(
+    bootOpts(orchDir, {
+      unstuckSweep,
+      unstuckActByCategory,
+      unstuckEscalate,
+      unstuckPostComment,
+    })
+  );
+
+  const opts = __getRunningOpts();
+  // Identity, not merely presence — runTick reads these off runningOpts directly.
+  expect(opts.unstuckActByCategory).toBe(unstuckActByCategory);
+  expect(opts.unstuckSweep).toBe(unstuckSweep);
+  expect(opts.unstuckEscalate).toBe(unstuckEscalate);
+  expect(opts.unstuckPostComment).toBe(unstuckPostComment);
+});
+
+test("an inert operator registry passed to startScheduler suppresses Pass 0r seam fallback", () => {
+  const orchDir = bootOrchDir();
+  // `{}` is the operator's "keep enforcement inert" posture — the exact shape the
+  // finding named. It must bind BOTH passes, not just Pass 0u.
+  startScheduler(bootOpts(orchDir, { unstuckActByCategory: {} }));
+
+  expect(build(__getRunningOpts()).seamFallbackSuppressed).toBe(true);
+});
+
+test("startScheduler without an override leaves capability fallback active", () => {
+  const orchDir = bootOrchDir();
+  startScheduler(bootOpts(orchDir));
+
+  const opts = __getRunningOpts();
+  expect(opts.unstuckActByCategory).toBeUndefined();
+  expect(opts.unstuckSweep).toBeUndefined();
+  // No injected registry → Pass 0r keeps its capability-checked fallback (unchanged).
+  expect(build(opts).seamFallbackSuppressed).toBe(false);
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -4755,6 +4755,58 @@ export function defaultClearStall(orchDir, writeStatus, { rmDir = rmSync } = {})
   };
 }
 
+export function buildRecoverySeamDeps(
+  opts = {},
+  {
+    readSignals = readWorkerSignals,
+    getAgents = getAgentsCached,
+    clearStallFactory = defaultClearStall,
+  } = {}
+) {
+  // CAT-124 F3: an operator-supplied act registry is an intentional posture
+  // that binds BOTH passes — `unstuckActByCategory: {}` means inert everywhere.
+  // `!= null` deliberately agrees with the `??` at the Pass 0u wiring below:
+  // undefined is absent. The ternary mirrors the wholesale unstuckSweep override,
+  // which replaces the default block including actByCategory. Keep them in lockstep.
+  const unstuckActOverride = opts.unstuckSweep
+    ? opts.unstuckSweep.actByCategory
+    : opts.unstuckActByCategory;
+  const seamFallbackSuppressed = unstuckActOverride != null;
+  return {
+    orchDir: opts.orchDir,
+    seamFallbackSuppressed,
+    clearStall: clearStallFactory(opts.orchDir, opts.writeStatus ?? linearWrite),
+    writeStatus: opts.writeStatus ?? linearWrite,
+    resolvePrState: (ticket) => {
+      const adapter = opts.prAdapter;
+      if (!adapter || typeof adapter.prView !== "function") return null;
+      let pr = null;
+      for (const sig of readSignals(opts.orchDir)) {
+        if (sig.ticket === ticket) {
+          pr = sig.raw?.pr ?? sig.pr ?? null;
+          if (pr?.number) break;
+        }
+      }
+      if (!pr?.number) return null;
+      try {
+        const view = adapter.prView(ticket, pr);
+        if (view && (view.state === "MERGED" || view.mergedAt != null)) return "MERGED";
+        return view?.state ?? null;
+      } catch {
+        return null; // fail-closed: a gh error is never treated as MERGED.
+      }
+    },
+    jobLifecycle: (bgJobId) => {
+      if (typeof opts.isBgJobAlive !== "function" || !bgJobId) return false;
+      try {
+        return Boolean(opts.isBgJobAlive(bgJobId, { agents: getAgents().agents }));
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
 // CTL-1290: board-health throttle state (host-local, mirrors the unstuck-sweep /
 // recovery-pass cadence vars). The single-LLM cadence floor lives in
 // BOARD_HEALTH_INTERVAL_MS; this holds the last run ms across ticks.
@@ -9841,38 +9893,7 @@ function runTick() {
     // re-deriving them. The bare call is replaced by const tickResult = ...
     // CAT-47: one production dependency bundle is shared by Pass 0u's registry
     // and Pass 0r's fallback registry construction.
-    const unstuckSeamDeps = {
-      orchDir: runningOpts.orchDir,
-      clearStall: defaultClearStall(runningOpts.orchDir, runningOpts.writeStatus ?? linearWrite),
-      writeStatus: runningOpts.writeStatus ?? linearWrite,
-      resolvePrState: (ticket) => {
-        const adapter = runningOpts.prAdapter;
-        if (!adapter || typeof adapter.prView !== "function") return null;
-        let pr = null;
-        for (const sig of readWorkerSignals(runningOpts.orchDir)) {
-          if (sig.ticket === ticket) {
-            pr = sig.raw?.pr ?? sig.pr ?? null;
-            if (pr?.number) break;
-          }
-        }
-        if (!pr?.number) return null;
-        try {
-          const view = adapter.prView(ticket, pr);
-          if (view && (view.state === "MERGED" || view.mergedAt != null)) return "MERGED";
-          return view?.state ?? null;
-        } catch {
-          return null;
-        }
-      },
-      jobLifecycle: (bgJobId) => {
-        if (typeof runningOpts.isBgJobAlive !== "function" || !bgJobId) return false;
-        try {
-          return Boolean(runningOpts.isBgJobAlive(bgJobId, { agents: getAgentsCached().agents }));
-        } catch {
-          return false;
-        }
-      },
-    };
+    const unstuckSeamDeps = buildRecoverySeamDeps(runningOpts);
 
     const tickResult = schedulerTick(runningOpts.orchDir, {
       recoverySeamDeps: unstuckSeamDeps,
@@ -10141,58 +10162,16 @@ function runTick() {
         // actByCategory[decision.category] solely on the enforce branch); the mode
         // gate (readUnstuckSweepConfig, default 'off') is UNTOUCHED, so production
         // stays inert until an operator opts in — enforce is an operator decision
-        // per ADR-023. Operators can still fully override via
-        // runningOpts.unstuckActByCategory (e.g. a partial registry during staged
-        // rollout, or {} to preserve the prior shadow-/escalate-only posture); the
-        // ?? precedence keeps every existing scheduler test that injects
-        // unstuckActByCategory:{} working unchanged. The seams are pure-cored +
-        // injectable; here we bind the production deps already in scope.
+        // per ADR-023. An operator override is a posture that binds BOTH passes:
+        // buildRecoverySeamDeps derives seamFallbackSuppressed from a partial
+        // registry or {}, preventing Pass 0r from rebuilding live seams behind it.
+        // The earlier claim that existing scheduler tests injected {} was wrong;
+        // no pre-existing test did. The seams are pure-cored + injectable; here we
+        // bind the production deps already in scope.
         actByCategory:
           runningOpts.unstuckActByCategory ??
           buildUnstuckActSeams({
-            orchDir: runningOpts.orchDir,
-            // re-arm seam: deletes the stalled signal so the phase re-dispatches.
-            clearStall: defaultClearStall(
-              runningOpts.orchDir,
-              runningOpts.writeStatus ?? linearWrite
-            ),
-            // label-removal seam for the stale-label category.
-            writeStatus: runningOpts.writeStatus ?? linearWrite,
-            // resolvePrState: normalize the live PR view ("MERGED" | other) for the
-            // orphan-stale gate. Reuses the SAME prAdapter the recovery short-circuit
-            // + reconcile backstop use (built once at boot, gh only fires inside
-            // prView). Inert when no prAdapter / PR number is wired.
-            resolvePrState: (ticket) => {
-              const adapter = runningOpts.prAdapter;
-              if (!adapter || typeof adapter.prView !== "function") return null;
-              let pr = null;
-              for (const sig of readWorkerSignals(runningOpts.orchDir)) {
-                if (sig.ticket === ticket) {
-                  pr = sig.raw?.pr ?? sig.pr ?? null;
-                  if (pr?.number) break;
-                }
-              }
-              if (!pr?.number) return null;
-              try {
-                const view = adapter.prView(ticket, pr);
-                if (view && (view.state === "MERGED" || view.mergedAt != null)) return "MERGED";
-                return view?.state ?? null;
-              } catch {
-                return null; // fail-closed: a gh error is never treated as MERGED.
-              }
-            },
-            // jobLifecycle: the same bg-liveness probe the reclaim sweep uses; bound
-            // to the warm agents snapshot. Inert (→ not-alive) without isBgJobAlive.
-            jobLifecycle: (bgJobId) => {
-              if (typeof runningOpts.isBgJobAlive !== "function" || !bgJobId) return false;
-              try {
-                return Boolean(
-                  runningOpts.isBgJobAlive(bgJobId, { agents: getAgentsCached().agents })
-                );
-              } catch {
-                return false;
-              }
-            },
+            ...unstuckSeamDeps,
             // runGit / fs primitives / emitPhaseComplete fall back to real defaults
             // inside unstuck-act-seams.mjs (git, node:fs, phase-agent-emit-complete).
           }),

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10727,6 +10727,21 @@ export function startScheduler({
   // schedulerTick's inline existsSync default applies. Tests that are not
   // exercising the triage gate inject () => true to unblock Pass 2 dispatch.
   hasTriageArtifact = undefined,
+  // CAT-124 (Codex #3223 P1): the unstuck-sweep operator/test override seams.
+  // runTick reads all five off runningOpts (`runningOpts.unstuckSweep`,
+  // `.unstuckActByCategory`, `.unstuckEscalate`, `.unstuckPostComment`) and
+  // buildRecoverySeamDeps reads `opts.unstuckSweep`/`opts.unstuckActByCategory`
+  // to derive `seamFallbackSuppressed` — but startScheduler never destructured
+  // any of them, so every override silently evaporated at the production entry
+  // point: `startScheduler({ unstuckActByCategory: {} })` left the flag false and
+  // Pass 0r kept rebuilding live seams behind an operator's inert-posture
+  // registry, contrary to the documented both-passes contract. Defaulting each to
+  // undefined keeps the `??` fallbacks (and `!= null`) byte-identical for every
+  // caller that supplies none.
+  unstuckSweep = undefined,
+  unstuckActByCategory = undefined,
+  unstuckEscalate = undefined,
+  unstuckPostComment = undefined,
   tickIntervalMs = TICK_INTERVAL_MS,
   debounceMs = TICK_DEBOUNCE_MS,
 } = {}) {
@@ -10762,6 +10777,13 @@ export function startScheduler({
     botWriteId, // CTL-781: orchestrator bot UUID to write as assignee on claim
     appendIntentEvent, // CTL-936: operator-event seam for intent.ineffective
     hasTriageArtifact, // CTL-1150: triage-artifact predicate for Pass 2
+    // CAT-124 (Codex #3223 P1): retain the unstuck override seams so runTick's
+    // `runningOpts.unstuck*` reads and buildRecoverySeamDeps(runningOpts)'s
+    // seamFallbackSuppressed derivation actually observe an operator's posture.
+    unstuckSweep,
+    unstuckActByCategory,
+    unstuckEscalate,
+    unstuckPostComment,
   };
 
   // CTL-585: warn once at startup if the Linear workspace lacks the labels

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
@@ -89,6 +89,28 @@ export const RECOVERY_FIX_FAILURE_TTL_MS = Math.max(
   2 * RECOVERY_FIX_BACKOFF_MAX_MS,
 );
 
+/**
+ * Read a fix-failure file's newest age anchor. Three outcomes are kept distinct
+ * because the scan and the pre-delete revalidation react to them differently:
+ *   { readable: false }            — absent or malformed
+ *   { readable: true, last: null } — parsed, but no finite lastTs/lastCommentTs
+ *   { readable: true, last: <n> }  — newest anchor
+ * Shared by both so they judge freshness by the identical rule.
+ *
+ * @param {string} path
+ * @returns {{ readable: boolean, last: number|null }}
+ */
+function readFixFailureAnchor(path) {
+  let data;
+  try {
+    data = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return { readable: false, last: null };
+  }
+  const anchors = [data?.lastTs, data?.lastCommentTs].filter(Number.isFinite);
+  return { readable: true, last: anchors.length === 0 ? null : Math.max(...anchors) };
+}
+
 export function selectStaleFixFailures({
   orchDir,
   now = () => Date.now(),
@@ -112,18 +134,12 @@ export function selectStaleFixFailures({
   for (const file of files) {
     if (!file.endsWith(".json")) continue;
     const path = join(dir, file);
-    let data;
-    try {
-      data = JSON.parse(readFileSync(path, "utf8"));
-    } catch {
-      continue;
-    }
-    const anchors = [data?.lastTs, data?.lastCommentTs].filter(Number.isFinite);
-    if (anchors.length === 0) {
+    const { readable, last } = readFixFailureAnchor(path);
+    if (!readable) continue; // malformed → skip (unchanged)
+    if (last === null) {
       unagable.push({ file });
       continue;
     }
-    const last = Math.max(...anchors);
     const ageMs = t - last;
     if (ageMs < ttlMs) continue;
     stale.push({ file, path, ageMs, last });
@@ -184,11 +200,30 @@ export function sweepStaleFixFailures({
   for (const { file } of unagable) {
     if (!quiet) console.log(`${file}: no lastTs/lastCommentTs — left in place`);
   }
-  for (const { file, path, ageMs } of stale) {
+  for (const { file, path, ageMs, last } of stale) {
     const ageDays = (ageMs / 864e5).toFixed(1);
     if (!execute) {
       if (!quiet) console.log(`[dry-run] would sweep ${file} (${ageDays}d old)`);
       swept.push(file);
+      continue;
+    }
+    // CAT-124 (Codex #3223 P2): revalidate immediately before deleting. This CLI
+    // can run concurrently with the recovery daemon, and both recordFixFailure and
+    // commitFixCommentHash publish via atomic rename onto this same path. Between
+    // the scan above and the unlink below, a freshly-timestamped file can land
+    // here; an unconditional unlink would then destroy live backoff state (letting
+    // a hot-looping ticket retry immediately) or live comment-dedup state (letting
+    // a duplicate audit comment post). Deleting only when the newest anchor is
+    // still the exact one the scan aged out makes the removal conditional on the
+    // version that was actually judged stale. Any other outcome — replaced,
+    // concurrently deleted, or now unreadable — is left in place; the next sweep
+    // re-scans it, so skipping is always safe and this fails closed.
+    const current = readFixFailureAnchor(path);
+    if (!current.readable || current.last !== last) {
+      if (!quiet) {
+        console.log(`${file}: changed since scan — left in place (re-run to sweep)`);
+      }
+      skipped.push(file);
       continue;
     }
     try {

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-// sweep-stale-recovery-intents.mjs — CTL-1431 one-time operator hygiene tool.
+// sweep-stale-recovery-intents.mjs — CTL-1431 / CAT-124 operator hygiene tool.
 //
 // Lists (and, with --execute, DELETES) escalated recovery-intent ledger entries
 // under <orchDir>/.recovery-intents/ that have aged past
@@ -10,21 +10,30 @@
 // non-terminal on the next scheduler tick — the ticket re-enters triage with the
 // stale `.recovery-intents/<ticket>.json` still on disk. This tool just clears
 // that leftover file so the ledger dir doesn't accumulate dead terminal markers;
-// nothing depends on it running.
+// nothing depends on it running. The second marker family lives under
+// .recovery-fix-failures/<ticket>-<fix_class>.json. Its newest lastTs or
+// lastCommentTs is aged, then the exact file path is unlinked (clearFixFailures
+// intentionally preserves comment hashes). The default TTL is at least twice
+// the maximum fix-backoff window, so swept files cannot carry a live backoff.
 //
 // Usage:
-//   bun sweep-stale-recovery-intents.mjs [--execute] [--orch-dir <path>] [--ttl-days <n>]
+//   bun sweep-stale-recovery-intents.mjs [--execute] [--orch-dir <path>]
+//     [--family intents|fix-failures|all] [--ttl-days <n>] [--fix-ttl-days <n>]
 //
 // Selector: entry.escalated === true AND (now - last) >= ttlMs, where
 //   last = typeof lastTs === "number" ? lastTs : ts   (mirrors defaultShouldSkipItem)
 
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync, readFileSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import {
   RECOVERY_TERMINAL_INTENT_TTL_MS,
   defaultForgetIntent,
 } from "./recovery-reasoning.mjs";
+import {
+  RECOVERY_FIX_BACKOFF_MAX_MS,
+  RECOVERY_FIX_FAILURES_DIR,
+} from "./recovery-fix-backoff.mjs";
 
 /**
  * Scan <orchDir>/.recovery-intents/ and return the escalated entries older than
@@ -75,6 +84,53 @@ export function selectStaleRecoveryIntents({
   return stale;
 }
 
+export const RECOVERY_FIX_FAILURE_TTL_MS = Math.max(
+  2 * RECOVERY_TERMINAL_INTENT_TTL_MS,
+  2 * RECOVERY_FIX_BACKOFF_MAX_MS,
+);
+
+export function selectStaleFixFailures({
+  orchDir,
+  now = () => Date.now(),
+  ttlMs = RECOVERY_FIX_FAILURE_TTL_MS,
+} = {}) {
+  if (!orchDir) return { stale: [], unagable: [] };
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new RangeError(`selectStaleFixFailures: ttlMs must be a positive finite number (got ${ttlMs})`);
+  }
+  const dir = join(orchDir, RECOVERY_FIX_FAILURES_DIR);
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return { stale: [], unagable: [] };
+  }
+
+  const stale = [];
+  const unagable = [];
+  const t = now();
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const path = join(dir, file);
+    let data;
+    try {
+      data = JSON.parse(readFileSync(path, "utf8"));
+    } catch {
+      continue;
+    }
+    const anchors = [data?.lastTs, data?.lastCommentTs].filter(Number.isFinite);
+    if (anchors.length === 0) {
+      unagable.push({ file });
+      continue;
+    }
+    const last = Math.max(...anchors);
+    const ageMs = t - last;
+    if (ageMs < ttlMs) continue;
+    stale.push({ file, path, ageMs, last });
+  }
+  return { stale, unagable };
+}
+
 /**
  * Dry-run (execute=false): return the stale intents without deleting.
  * Execute (execute=true): defaultForgetIntent each stale entry.
@@ -113,10 +169,50 @@ export function sweepStaleRecoveryIntents({
   return { swept, skipped, stale };
 }
 
+export function sweepStaleFixFailures({
+  orchDir,
+  now = () => Date.now(),
+  ttlMs = RECOVERY_FIX_FAILURE_TTL_MS,
+  execute = false,
+  unlink = (path) => { unlinkSync(path); },
+  quiet = false,
+} = {}) {
+  const { stale, unagable } = selectStaleFixFailures({ orchDir, now, ttlMs });
+  const swept = [];
+  const skipped = [];
+
+  for (const { file } of unagable) {
+    if (!quiet) console.log(`${file}: no lastTs/lastCommentTs — left in place`);
+  }
+  for (const { file, path, ageMs } of stale) {
+    const ageDays = (ageMs / 864e5).toFixed(1);
+    if (!execute) {
+      if (!quiet) console.log(`[dry-run] would sweep ${file} (${ageDays}d old)`);
+      swept.push(file);
+      continue;
+    }
+    try {
+      unlink(path);
+      if (!quiet) console.log(`swept ${file} (${ageDays}d old)`);
+      swept.push(file);
+    } catch {
+      if (!quiet) console.error(`failed to sweep ${file}`);
+      skipped.push(file);
+    }
+  }
+  return { swept, skipped, stale, unagable };
+}
+
 // CLI entrypoint when run directly.
 if (import.meta.main) {
   const args = process.argv.slice(2);
   const execute = args.includes("--execute");
+  const familyIdx = args.indexOf("--family");
+  const family = familyIdx !== -1 ? args[familyIdx + 1] : "all";
+  if (!["intents", "fix-failures", "all"].includes(family)) {
+    console.error(`error: --family must be intents, fix-failures, or all (got: ${family ?? "<missing>"})`);
+    process.exit(2);
+  }
   const orchIdx = args.indexOf("--orch-dir");
   const orchDir =
     orchIdx !== -1
@@ -134,16 +230,38 @@ if (import.meta.main) {
     }
     ttlMs = days * 864e5;
   }
+  const fixTtlIdx = args.indexOf("--fix-ttl-days");
+  let fixTtlMs = RECOVERY_FIX_FAILURE_TTL_MS;
+  if (fixTtlIdx !== -1) {
+    const days = Number(args[fixTtlIdx + 1]);
+    if (!Number.isFinite(days) || days <= 0) {
+      console.error(`error: --fix-ttl-days requires a positive number (got: ${args[fixTtlIdx + 1] ?? "<missing>"})`);
+      process.exit(2);
+    }
+    fixTtlMs = days * 864e5;
+  }
+  if ((family === "fix-failures" || family === "all") && fixTtlMs < RECOVERY_FIX_BACKOFF_MAX_MS) {
+    console.warn("warning: fix-failure TTL is shorter than the max backoff window — may delete a live backoff latch");
+  }
 
   console.log(`orch dir: ${orchDir}`);
-  console.log(`ttl: ${(ttlMs / 864e5).toFixed(1)}d`);
+  if (family === "intents" || family === "all") console.log(`intent ttl: ${(ttlMs / 864e5).toFixed(1)}d`);
+  if (family === "fix-failures" || family === "all") console.log(`fix-failure ttl: ${(fixTtlMs / 864e5).toFixed(1)}d`);
   console.log(execute ? "mode: EXECUTE" : "mode: dry-run (pass --execute to delete)");
   console.log("");
 
-  const { swept, skipped } = sweepStaleRecoveryIntents({ orchDir, ttlMs, execute });
-
-  console.log(`\nSummary: ${swept.length} ${execute ? "swept" : "would-sweep"}, ${skipped.length} skipped`);
-  if (!execute && swept.length > 0) {
-    console.log("Re-run with --execute to delete these stale terminal intents.");
+  let wouldSweep = 0;
+  if (family === "intents" || family === "all") {
+    const { swept, skipped } = sweepStaleRecoveryIntents({ orchDir, ttlMs, execute });
+    wouldSweep += swept.length;
+    console.log(`\nIntents: ${swept.length} ${execute ? "swept" : "would-sweep"}, ${skipped.length} skipped`);
+  }
+  if (family === "fix-failures" || family === "all") {
+    const { swept, skipped, unagable } = sweepStaleFixFailures({ orchDir, ttlMs: fixTtlMs, execute });
+    wouldSweep += swept.length;
+    console.log(`\nFix failures: ${swept.length} ${execute ? "swept" : "would-sweep"}, ${skipped.length} skipped, ${unagable.length} un-agable`);
+  }
+  if (!execute && wouldSweep > 0) {
+    console.log("Re-run with --execute to delete these stale recovery markers.");
   }
 }

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
@@ -5,17 +5,27 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test sweep-stale-recovery-intents.test.mjs
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import { tmpdir } from "node:os";
 import {
   selectStaleRecoveryIntents,
   sweepStaleRecoveryIntents,
+  selectStaleFixFailures,
+  sweepStaleFixFailures,
+  RECOVERY_FIX_FAILURE_TTL_MS,
 } from "./sweep-stale-recovery-intents.mjs";
 import {
   defaultRecordIntent,
   RECOVERY_TERMINAL_INTENT_TTL_MS,
 } from "./recovery-reasoning.mjs";
+import {
+  clearFixFailures,
+  commitFixCommentHash,
+  fixCommentHash,
+  recordFixFailure,
+  RECOVERY_FIX_BACKOFF_MAX_MS,
+} from "./recovery-fix-backoff.mjs";
 
 const intentPath = (orchDir, ticket) =>
   pathJoin(orchDir, ".recovery-intents", `${ticket}.json`);
@@ -117,5 +127,97 @@ describe("sweep-stale-recovery-intents (CTL-1431)", () => {
     expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: NaN, now: () => tNow })).toThrow();
     expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: 0, now: () => tNow })).toThrow();
     expect(() => selectStaleRecoveryIntents({ orchDir, ttlMs: -5, now: () => tNow })).toThrow();
+  });
+});
+
+describe("fix-failure marker hygiene (CAT-124)", () => {
+  let orchDir;
+  const t0 = 1_000_000_000_000;
+  const fixPath = (ticket) =>
+    pathJoin(orchDir, ".recovery-fix-failures", `${ticket}-orphan_stale.json`);
+
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "fix-failure-sweep-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  test("selects an aged failure and leaves a fresh failure", () => {
+    const tNow = t0 + RECOVERY_FIX_FAILURE_TTL_MS + 1;
+    recordFixFailure(orchDir, "OLD-1", "orphan_stale", "same", t0);
+    recordFixFailure(orchDir, "NEW-1", "orphan_stale", "same", tNow);
+
+    const result = selectStaleFixFailures({ orchDir, now: () => tNow });
+    expect(result.stale.map((entry) => entry.file)).toEqual(["OLD-1-orphan_stale.json"]);
+    expect(result.unagable).toEqual([]);
+  });
+
+  test("ages residual comment-hash-only files by lastCommentTs", () => {
+    commitFixCommentHash(orchDir, "RES-1", "orphan_stale", fixCommentHash("body"), t0);
+    clearFixFailures(orchDir, "RES-1", "orphan_stale");
+
+    expect(selectStaleFixFailures({ orchDir, now: () => t0 + RECOVERY_FIX_FAILURE_TTL_MS - 1 }).stale).toEqual([]);
+    expect(selectStaleFixFailures({ orchDir, now: () => t0 + RECOVERY_FIX_FAILURE_TTL_MS + 1 }).stale.map((entry) => entry.file)).toEqual(["RES-1-orphan_stale.json"]);
+  });
+
+  test("uses the newest timestamp as the age anchor", () => {
+    recordFixFailure(orchDir, "BOTH-1", "orphan_stale", "same", t0);
+    commitFixCommentHash(orchDir, "BOTH-1", "orphan_stale", fixCommentHash("body"), t0 + RECOVERY_FIX_FAILURE_TTL_MS);
+
+    expect(selectStaleFixFailures({ orchDir, now: () => t0 + RECOVERY_FIX_FAILURE_TTL_MS + 1 }).stale).toEqual([]);
+    expect(selectStaleFixFailures({ orchDir, now: () => t0 + 2 * RECOVERY_FIX_FAILURE_TTL_MS + 1 }).stale.map((entry) => entry.file)).toEqual(["BOTH-1-orphan_stale.json"]);
+  });
+
+  test("leaves timestamp-less files in place and reports them as un-agable", () => {
+    mkdirSync(pathJoin(orchDir, ".recovery-fix-failures"), { recursive: true });
+    writeFileSync(fixPath("NOTS-1"), '{"lastCommentHash":"x"}\n');
+
+    const selected = selectStaleFixFailures({ orchDir, now: () => t0 });
+    expect(selected.stale).toEqual([]);
+    expect(selected.unagable).toEqual([{ file: "NOTS-1-orphan_stale.json" }]);
+    sweepStaleFixFailures({ orchDir, now: () => t0, execute: true, quiet: true });
+    expect(existsSync(fixPath("NOTS-1"))).toBe(true);
+  });
+
+  test("rejects non-finite and non-positive TTLs", () => {
+    expect(() => selectStaleFixFailures({ orchDir, ttlMs: NaN })).toThrow();
+    expect(() => selectStaleFixFailures({ orchDir, ttlMs: 0 })).toThrow();
+    expect(() => selectStaleFixFailures({ orchDir, ttlMs: -5 })).toThrow();
+  });
+
+  test("default TTL outlives the maximum backoff and terminal intent windows", () => {
+    expect(RECOVERY_FIX_FAILURE_TTL_MS).toBeGreaterThanOrEqual(2 * RECOVERY_FIX_BACKOFF_MAX_MS);
+    expect(RECOVERY_FIX_FAILURE_TTL_MS).toBeGreaterThanOrEqual(RECOVERY_TERMINAL_INTENT_TTL_MS);
+  });
+
+  test("dry-run deletes nothing; execute unlinks only stale fix failures", () => {
+    const tNow = t0 + RECOVERY_FIX_FAILURE_TTL_MS + 1;
+    recordFixFailure(orchDir, "OLD-1", "orphan_stale", "same", t0);
+    recordFixFailure(orchDir, "NEW-1", "orphan_stale", "same", tNow);
+    defaultRecordIntent("INTENT-1", { decision: "escalate" }, { orchDir, now: () => t0 });
+    const intent = intentPath(orchDir, "INTENT-1");
+
+    sweepStaleFixFailures({ orchDir, now: () => tNow, execute: false, quiet: true });
+    expect(existsSync(fixPath("OLD-1"))).toBe(true);
+    expect(existsSync(fixPath("NEW-1"))).toBe(true);
+    expect(existsSync(intent)).toBe(true);
+
+    const unlinked = [];
+    const result = sweepStaleFixFailures({
+      orchDir,
+      now: () => tNow,
+      execute: true,
+      quiet: true,
+      unlink: (path) => {
+        unlinked.push(path);
+        rmSync(path);
+      },
+    });
+    expect(unlinked).toEqual([fixPath("OLD-1")]);
+    expect(result.swept).toEqual(["OLD-1-orphan_stale.json"]);
+    expect(existsSync(fixPath("OLD-1"))).toBe(false);
+    expect(existsSync(fixPath("NEW-1"))).toBe(true);
+    expect(existsSync(intent)).toBe(true);
   });
 });

--- a/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
+++ b/plugins/dev/scripts/execution-core/sweep-stale-recovery-intents.test.mjs
@@ -220,4 +220,87 @@ describe("fix-failure marker hygiene (CAT-124)", () => {
     expect(existsSync(fixPath("NEW-1"))).toBe(true);
     expect(existsSync(intent)).toBe(true);
   });
+
+  // CAT-124 (Codex #3223 P2): --execute races the recovery daemon, which publishes
+  // both backoff state (recordFixFailure) and comment-dedup state
+  // (commitFixCommentHash) by atomic rename onto the very path being swept. The
+  // scan/unlink window is real, so the delete must be conditional on the version
+  // that was scanned — otherwise live state is destroyed and the ticket retries
+  // immediately / re-posts a duplicate audit comment.
+  describe("pre-delete revalidation (scan→unlink race)", () => {
+    const tNow = () => t0 + RECOVERY_FIX_FAILURE_TTL_MS + 1;
+    const TICKETS = ["RACEA-1", "RACEZ-1"];
+
+    // The scan→unlink window only exists INSIDE sweepStaleFixFailures, so the race
+    // has to be driven from a seam that fires there. Two equally-stale markers are
+    // seeded; when the sweep unlinks whichever it reaches first, `duringSweep` runs
+    // against the OTHER one — i.e. the daemon lands state mid-loop, exactly the
+    // interleaving the finding describes. Written order-independently because
+    // readdirSync order is not guaranteed.
+    const sweepRacing = (duringSweep) => {
+      for (const ticket of TICKETS) recordFixFailure(orchDir, ticket, "orphan_stale", "same", t0);
+      expect(selectStaleFixFailures({ orchDir, now: tNow }).stale).toHaveLength(2);
+
+      const unlinked = [];
+      const result = sweepStaleFixFailures({
+        orchDir,
+        now: tNow,
+        execute: true,
+        quiet: true,
+        unlink: (path) => {
+          unlinked.push(path);
+          rmSync(path);
+          if (unlinked.length === 1) {
+            duringSweep(TICKETS.find((t) => !path.includes(t.split("-")[0])));
+          }
+        },
+      });
+      const victim = TICKETS.find((t) => unlinked[0]?.includes(t.split("-")[0]));
+      const raced = TICKETS.find((t) => t !== victim);
+      return { unlinked, result, victim, raced };
+    };
+
+    test("keeps a marker whose backoff state was refreshed after the scan", () => {
+      const { unlinked, result, victim, raced } = sweepRacing((ticket) =>
+        recordFixFailure(orchDir, ticket, "orphan_stale", "same", tNow())
+      );
+
+      // The untouched marker is still swept; the refreshed one survives.
+      expect(unlinked).toHaveLength(1);
+      expect(result.swept).toEqual([`${victim}-orphan_stale.json`]);
+      expect(result.skipped).toEqual([`${raced}-orphan_stale.json`]);
+      expect(existsSync(fixPath(victim))).toBe(false);
+      expect(existsSync(fixPath(raced))).toBe(true);
+    });
+
+    test("keeps a marker whose comment-dedup state was committed after the scan", () => {
+      const { result, victim, raced } = sweepRacing((ticket) =>
+        commitFixCommentHash(orchDir, ticket, "orphan_stale", fixCommentHash("body"), tNow())
+      );
+
+      expect(result.swept).toEqual([`${victim}-orphan_stale.json`]);
+      expect(result.skipped).toEqual([`${raced}-orphan_stale.json`]);
+      expect(existsSync(fixPath(raced))).toBe(true);
+    });
+
+    test("tolerates a marker deleted by someone else between scan and unlink", () => {
+      const { unlinked, result, victim, raced } = sweepRacing((ticket) =>
+        rmSync(fixPath(ticket))
+      );
+
+      // Only the first unlink runs — the vanished one is reported skipped, not thrown.
+      expect(unlinked).toHaveLength(1);
+      expect(result.swept).toEqual([`${victim}-orphan_stale.json`]);
+      expect(result.skipped).toEqual([`${raced}-orphan_stale.json`]);
+    });
+
+    test("sweeps both when nothing races (revalidation is not a blanket refusal)", () => {
+      const { unlinked, result } = sweepRacing(() => {});
+
+      expect(unlinked).toHaveLength(2);
+      expect(result.swept).toHaveLength(2);
+      expect(result.skipped).toEqual([]);
+      for (const ticket of TICKETS) expect(existsSync(fixPath(ticket))).toBe(false);
+    });
+  });
 });

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
@@ -34,7 +34,10 @@ import { fileURLToPath } from "node:url";
 import { log as defaultLog } from "./config.mjs";
 import { filterMachineLocalDirt, isNodeModulesDeletion } from "./dirty-tree-classifier.mjs";
 import { classifyCleanRebaseForcePush } from "./catB-force-with-lease.mjs";
-import { classifyOrphanMergedReconcile } from "./unstuck-orphan-merge.mjs";
+import {
+  classifyOrphanMergedReconcile,
+  isOrphanMergePhaseAllowed,
+} from "./unstuck-orphan-merge.mjs";
 import { clearStalledLabel, inRemovalBackoff } from "./label-guard.mjs";
 
 // phase-agent-emit-complete sits two directories up from execution-core/
@@ -290,8 +293,24 @@ export function buildOrphanStaleActSeam(deps = {}) {
   return function orphanStaleActSeam(candidate, _decision) {
     const { ticket, phase, signal } = candidate;
 
+    // markerPath validates the phase's SHAPE and throws `missing-phase` on a
+    // malformed one (CAT-47) — a stricter, more specific verdict than the
+    // allowlist below, so it deliberately stays first.
     const marker = markerPath(orchDir, ticket, phase, "orphan-merge");
     if (markerExists(marker)) return; // idempotent — already emitted this lifetime.
+
+    // CAT-124 (Codex #3223 P2): refuse a non-allowlisted phase HERE, before any
+    // evidence resolution. Everything below — the terminal-done probe and above all
+    // resolvePrState — is wasted or actively misleading work for a phase that can
+    // never be advanced: a synchronous production resolver burned a real GitHub
+    // query before the refusal, and a thenable resolver threw
+    // `pr-state-async-unsupported` first, recording a seam failure + backoff in
+    // place of the intended `phase-not-allowlisted` refusal. The classifier keeps
+    // its own FIRST-gate check (both drivers reach it by other paths); this raises
+    // the same verdict earlier rather than relocating it.
+    if (!isOrphanMergePhaseAllowed(phase)) {
+      throw new Error(`orphan-stale: phase-not-allowlisted (${ticket})`);
+    }
 
     const terminalDoneApplied = markerExists(
       join(orchDir ?? ".", "workers", ticket, ".terminal-done.applied")

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
@@ -100,6 +100,13 @@ function markerPath(orchDir, ticket, phase, name) {
   return join(orchDir ?? ".", "workers", ticket, `.unstuck-${name}-${phase}.applied`);
 }
 
+// CAT-124 F5: Pass 0u sets this flag in BOTH slots from one lookup
+// (unstuck-sweep.mjs:189,198,206); Pass 0r's { ticket, phase, signal } candidate
+// (recovery-reasoning.mjs:1182-1186) sets neither, so it resolves false there deliberately.
+function readLinearTerminal(candidate) {
+  return Boolean(candidate?.linearTerminal ?? candidate?.evidence?.linearTerminal ?? false);
+}
+
 // ─── Phase 1: dirty-tree act seam ─────────────────────────────────────────────
 //
 // Clears machine-local rebase noise (REBASE_NOISE_PATHS + deleted node_modules)
@@ -232,7 +239,7 @@ export function buildSourceConflictActSeam(deps = {}) {
       commitSubjects,
       headIsDescendant,
       liveSessionInWorktree: false,
-      linearTerminal: candidate.evidence?.linearTerminal ?? false,
+      linearTerminal: readLinearTerminal(candidate),
       alreadyPushed: false,
     });
     if (decision.action !== "force-push") {
@@ -291,17 +298,23 @@ export function buildOrphanStaleActSeam(deps = {}) {
     );
 
     // Resolve LIVE evidence the way defaultCollectOrphanMergedCandidates does.
-    let prState = null;
+    let raw = null;
     try {
-      const r = resolvePrState(ticket);
-      if (r && typeof r.then === "function") {
-        throw new Error(`orphan-stale: pr-state-async-unsupported (${ticket})`);
-      }
-      prState = r;
-    } catch (err) {
-      if (err?.message?.includes("pr-state-async-unsupported")) throw err;
-      prState = null;
+      raw = resolvePrState(ticket);
+    } catch {
+      raw = null; // fail closed → classifier skip/pr-state-unknown
     }
+    // CAT-124 F6: checked OUTSIDE the try, and tagged by identity. Keying the rethrow on message
+    // text rethrew any injected reader whose own error merely MENTIONED the marker, instead of
+    // failing closed. We deliberately do NOT converge on the census's warn-and-null shape
+    // (unstuck-orphan-merge.mjs:91-99): that path still throws one line later as the generic
+    // pr-state-unknown, which erases the diagnostic while leaving the fail-loud contract identical.
+    if (raw && typeof raw.then === "function") {
+      const err = new Error(`orphan-stale: pr-state-async-unsupported (${ticket})`);
+      err.code = "pr-state-async-unsupported";
+      throw err;
+    }
+    const prState = raw;
 
     const bgJobId = signal?.bg_job_id ?? null;
     let bgJobAlive = false;
@@ -327,7 +340,11 @@ export function buildOrphanStaleActSeam(deps = {}) {
       nowMs: nowMs(),
       alreadyEmitted: false, // marker already gated above
       terminalDoneApplied,
-      linearTerminal: candidate.linearTerminal ?? false,
+      // Defense-in-depth: both live drivers make this gate unreachable. Pass 0u pre-skips terminal
+      // tickets before acting; Pass 0r's census and reasoning pass exclude them and never forward
+      // this field. Forwarding the CAT-47 plan's proposed value is therefore a no-op, while sourcing
+      // a truthy value elsewhere would skip the merged-orphan cohort this seam exists to reconcile.
+      linearTerminal: readLinearTerminal(candidate),
     });
     if (decision.action !== "emit-complete") {
       throw new Error(`orphan-stale: ${decision.reason ?? "gate-failed"} (${ticket})`);

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
@@ -692,3 +692,131 @@ describe("buildUnstuckActSeams — registry factory (CTL-1219)", () => {
     expect(Object.isFrozen(seams)).toBe(true);
   });
 });
+
+describe("CAT-124: pr-state async contract + linearTerminal shape", () => {
+  test("a non-allowlisted phase fails closed before emitting or writing a marker", () => {
+    const emits = [];
+    const markers = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        emitPhaseComplete: (value) => {
+          emits.push(value);
+          return true;
+        },
+        writeMarker: (value) => {
+          markers.push(value);
+        },
+        nowMs: () => new Date("2025-01-01T00:00:00Z").getTime(),
+      })
+    );
+
+    expect(() =>
+      seam(
+        orphanStaleCandidate({
+          phase: "implement",
+          signal: {
+            phase: "implement",
+            status: "failed",
+            failureReason: "orphan-sweep-stale",
+            bg_job_id: "dead",
+            updatedAt: "2020-01-01T00:00:00Z",
+          },
+        }),
+        {}
+      )
+    ).toThrow(/phase-not-allowlisted/);
+    expect(emits).toHaveLength(0);
+    expect(markers).toHaveLength(0);
+  });
+
+  test("a resolver error mentioning the async marker fails closed", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        resolvePrState: () => {
+          throw new Error("gh: pr-state-async-unsupported adapter crashed");
+        },
+        emitPhaseComplete: (value) => {
+          emits.push(value);
+          return true;
+        },
+      })
+    );
+
+    expect(() => seam(orphanStaleCandidate(), {})).toThrow(
+      /orphan-stale: pr-state-unknown/
+    );
+    expect(emits).toHaveLength(0);
+  });
+
+  test("a thenable resolver fails loud with an identity-tagged sentinel", () => {
+    const emits = [];
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        resolvePrState: () => Promise.resolve("MERGED"),
+        emitPhaseComplete: (value) => {
+          emits.push(value);
+          return true;
+        },
+      })
+    );
+
+    let caught;
+    try {
+      seam(orphanStaleCandidate(), {});
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught?.code).toBe("pr-state-async-unsupported");
+    expect(caught?.message).toMatch(/orphan-stale: pr-state-async-unsupported \(CTL-3\)/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("orphan-stale honors evidence.linearTerminal when the top-level key is absent", () => {
+    const emits = [];
+    const { linearTerminal: _drop, ...candidate } = orphanStaleCandidate({
+      evidence: {
+        reason: "orphan-sweep-stale",
+        ticket: "CTL-3",
+        phase: "monitor-merge",
+        linearTerminal: true,
+      },
+    });
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        nowMs: () => new Date("2025-01-01T00:00:00Z").getTime(),
+        emitPhaseComplete: (value) => {
+          emits.push(value);
+          return true;
+        },
+      })
+    );
+
+    expect(() => seam(candidate, {})).toThrow(/linear-terminal/);
+    expect(emits).toHaveLength(0);
+  });
+
+  test("the Pass 0r candidate shape deliberately classifies with linearTerminal false", () => {
+    const emits = [];
+    const candidate = {
+      ticket: "CAT-901",
+      phase: "monitor-merge",
+      signal: {
+        bg_job_id: "dead",
+        updatedAt: "2020-01-01T00:00:00Z",
+      },
+    };
+    const seam = buildOrphanStaleActSeam(
+      makeStubDeps({
+        nowMs: () => new Date("2025-01-01T00:00:00Z").getTime(),
+        emitPhaseComplete: (value) => {
+          emits.push(value);
+          return true;
+        },
+      })
+    );
+
+    expect(() => seam(candidate, {})).not.toThrow();
+    expect(emits).toEqual([{ ticket: "CAT-901", phase: "monitor-merge" }]);
+  });
+});

--- a/plugins/dev/scripts/execution-core/unstuck-orphan-merge.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-orphan-merge.mjs
@@ -13,6 +13,14 @@
 // and may still have a live worker even if bg_job_id appears dead. 300 seconds.
 export const STALE_WORKER_CUTOFF_MS = 300_000;
 
+// CAT-124 F2: this reconciler advances the pipeline, so only late phases where a
+// merged PR is the completion signal are eligible. Legacy/non-string phases fail closed.
+export const ORPHAN_MERGE_PHASE_ALLOWLIST = Object.freeze(["monitor-merge", "monitor-deploy"]);
+
+export function isOrphanMergePhaseAllowed(phase) {
+  return typeof phase === "string" && ORPHAN_MERGE_PHASE_ALLOWLIST.includes(phase);
+}
+
 // classifyOrphanMergedReconcile — PURE classifier. No IO.
 // evidence shape:
 //   ticket               string
@@ -28,6 +36,7 @@ export const STALE_WORKER_CUTOFF_MS = 300_000;
 // Returns { action: 'emit-complete' } or { action: 'skip', reason }
 export function classifyOrphanMergedReconcile(evidence = {}) {
   const {
+    phase,
     prState,
     bgJobAlive,
     signalUpdatedAt,
@@ -36,6 +45,11 @@ export function classifyOrphanMergedReconcile(evidence = {}) {
     terminalDoneApplied,
     linearTerminal,
   } = evidence;
+
+  // FIRST gate deliberately: refusal to advance an early phase must not be masked.
+  if (!isOrphanMergePhaseAllowed(phase)) {
+    return { action: "skip", reason: "phase-not-allowlisted" };
+  }
 
   // .terminal-done.applied present → teardown already owns this ticket; skip.
   if (terminalDoneApplied) return { action: "skip", reason: "terminal-done-owns-it" };
@@ -76,7 +90,7 @@ export function defaultCollectOrphanMergedCandidates({
   jobLifecycle = null,   // (bgJobId) → bool (is the bg job alive)
   log = null,
   nowMs = Date.now(),
-  phaseAllowlist = ["monitor-merge", "monitor-deploy"],
+  phaseAllowlist = ORPHAN_MERGE_PHASE_ALLOWLIST,
 } = {}) {
   const out = [];
   for (const c of candidates) {

--- a/plugins/dev/scripts/execution-core/unstuck-orphan-merge.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-orphan-merge.test.mjs
@@ -4,6 +4,7 @@ import { describe, test, expect } from "bun:test";
 import {
   classifyOrphanMergedReconcile,
   defaultCollectOrphanMergedCandidates,
+  ORPHAN_MERGE_PHASE_ALLOWLIST,
   STALE_WORKER_CUTOFF_MS,
 } from "./unstuck-orphan-merge.mjs";
 
@@ -43,6 +44,34 @@ test("a thenable PR-state reader is reported and remains fail-closed (CAT-47)", 
 // classifyOrphanMergedReconcile — pure classifier
 // ---------------------------------------------------------------------------
 describe("classifyOrphanMergedReconcile — pure classifier (CTL-1064 catC)", () => {
+  test("non-allowlisted phases fail closed before every evidence gate (CAT-124 F2)", () => {
+    expect(classifyOrphanMergedReconcile({ ...BASE, phase: "implement" })).toEqual({
+      action: "skip",
+      reason: "phase-not-allowlisted",
+    });
+    expect(
+      classifyOrphanMergedReconcile({
+        ...BASE,
+        phase: "triage",
+        terminalDoneApplied: true,
+        linearTerminal: true,
+        prState: null,
+      }).reason
+    ).toBe("phase-not-allowlisted");
+    for (const phase of [null, undefined, "", 5, {}]) {
+      expect(classifyOrphanMergedReconcile({ ...BASE, phase })).toEqual({
+        action: "skip",
+        reason: "phase-not-allowlisted",
+      });
+    }
+  });
+
+  test("the shared allowlist preserves both late phases (CAT-124 F2)", () => {
+    expect(ORPHAN_MERGE_PHASE_ALLOWLIST).toEqual(["monitor-merge", "monitor-deploy"]);
+    for (const phase of ORPHAN_MERGE_PHASE_ALLOWLIST) {
+      expect(classifyOrphanMergedReconcile({ ...BASE, phase }).action).toBe("emit-complete");
+    }
+  });
   test("PR MERGED + bg dead + not already emitted + no .terminal-done → emit-complete", () => {
     expect(classifyOrphanMergedReconcile(BASE).action).toBe("emit-complete");
   });


### PR DESCRIPTION
## Summary

Closes the deferred CAT-124 recovery-pass review findings by making fix-backoff behavior, orphan-stale safety gates, and recovery seam dependency handling match their documented contracts. `recovery-fix-backoff.mjs` on `main` was still the plain CAT-47 base without the identical-failure latch this PR adds. Also expands regression coverage around real intent-ledger ordering, stale recovery marker cleanup, injected seam behavior, and orphan-merge classification.

## Changes Made

- Retuned and hardened recovery fix-backoff bookkeeping, including the relationship between the attempts ledger and the longer-lived identical-failure latch — and derives the fix-backoff floor from the configured cooldown rather than a hardcoded value.
- Added phase allowlisting and fail-closed PR-state handling for orphan-stale/orphan-merge recovery paths.
- Extracted and tested recovery seam dependency construction (`recovery-seam-deps.test.mjs`, new), including suppression behavior for partial injected registries.
- Expanded stale recovery-intent sweeping to cover fix-failure markers with family-specific retention and reporting.
- Added focused unit and end-to-end tests for backoff ordering (against the real intent ledger, not a stub), seam defaults, stale marker cleanup, thenable/error handling, and orphan recovery gates.
- Updated the execution-core CI test list and architecture documentation to reflect the implemented behavior.

## How to Verify It

- [x] `node --check` passes on all six touched non-test `.mjs` files.
- [x] All touched/added test files pass: `recovery-fix-backoff.test.mjs`, `recovery-orphan-stale-e2e.test.mjs`, `recovery-seam-deps.test.mjs` (new), `sweep-stale-recovery-intents.test.mjs`, `unstuck-act-seams.test.mjs`, `unstuck-orphan-merge.test.mjs` — 113 tests, 284 `expect()` calls, run 2026-08-21 against this branch.
  - One test (`startScheduler retains the unstuck override seams in runningOpts`) initially reported a timeout under bun's default 5s limit; it calls the real `startScheduler` entrypoint, whose first tick does a bounded heartbeat-tail scan against this host's live (~4.3GB) event log and took ~10s under this shared dev laptop's load average of ~57 at the time. Rerun with `--timeout 30000` in isolation: 1 passed, 0 failed, 4 `expect()` calls satisfied — confirms this is host-load timing noise, not a defect from the cherry-pick.
- All five original commits cherry-picked cleanly onto current `main` (git's three-way merge auto-resolved `scheduler.mjs`/`docs/architecture.md`/the CI workflow YAML against the several unrelated commits that landed on those files since the fork point) — no conflict markers, verified by grep.

## Risk

Original PR's own verify phase found no production defect and retained four low-priority coverage/safety observations for later consideration; all required typecheck, test, lint, security, review, coverage, silent-failure, and documentation gates passed in the original PR.

## Related Issues/PRs

- Original PR #3223 (thagale/catalyst), re-landed as a fresh branch — the fork branch was stale against current `main`. Cherry-picked all 5 content commits cleanly.
- Fixes CAT-124
- Related to #3169
- Credits original author Tony Hagale (thagale)

Verified during the 2026-08-21 fork-PR verification sweep: `recovery-fix-backoff.mjs` on `main` was confirmed to still be the plain CAT-47 base without the identical-failure latch, confirming the premise still holds.

## Reviewer Notes

The five commits are: the original recovery-seam remediation, a formatting cleanup, verify-phase remediation, a real-ledger regression test proving the backoff threshold stays ordered above the attempts-ledger bound, and the final fix deriving the backoff floor from the configured cooldown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
