### PR TITLE
feat(dev): CAT-60 — publish capability preflight

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1122,6 +1122,18 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/merge-delete-branch-worktree-guard.test.sh
 
+      - name: CAT-60 config documentation coverage
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/config-docs-coverage.test.sh
+
+      - name: CAT-60 phase-pr return-code mapping
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/phase-pr-rc-map.test.sh
+
+      - name: CAT-60 draft PR push-remote and permission contract
+        working-directory: plugins/dev/scripts
+        run: bash __tests__/draft-pr-lib.test.sh
+
       - name: Run stable unit tests
         # CTL-1789 round-1 P2 (Codex): assertion-evidence.test.mjs and
         # assertion-evidence-parity.test.mjs are added below. The parity
@@ -1271,6 +1283,7 @@ jobs:
             __tests__/replica-health.test.mjs \
             __tests__/replica-health-event.test.mjs \
             __tests__/linear-query-triage-source.test.mjs \
+            doctor-publish-preflight.test.mjs \
             eligible-set.test.mjs \
             event-cursor.test.mjs \
             event-scan.test.mjs \
@@ -1432,6 +1445,8 @@ jobs:
             service-manifest.test.mjs \
             github-auth-preflight.test.mjs \
             claude-accounts-rearm.test.mjs \
+            publish-preflight.test.mjs \
+            publish-preflight-config.test.mjs \
             github-token-candidates-legacy-parity.test.mjs \
             github-quota.test.mjs \
             github-quota-timer.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -601,6 +601,24 @@ via `orchestrate-phase-advance`, and dispatches the next `--bg` job. Dispatcher:
 `plugins/dev/scripts/phase-agent-dispatch` (CTL-448). `oneshot-legacy` (single long-lived
 job/ticket) is the runtime fallback when the key is missing.
 
+### Publish-capability preflight and the push remote (CAT-60)
+
+GitHub access is asymmetric: cloning, fetching, and reading a repository can succeed for an identity
+that cannot publish a branch there. Catalyst resolves the write target separately and checks its
+push capability inside `dispatchAndVerify`, immediately before launching a phase worker.
+
+Historically three surfaces assumed `origin`: the rebase/diff base, the push target, and remote-branch
+discovery during resume. CAT-60 makes the push target and resume discovery use the resolved push
+remote. The rebase/diff base deliberately remains `origin/<base>`; publication routing cannot
+change the canonical integration base.
+
+The probe returns `allowed`, `denied`, or `unknown` under an `off` / `shadow` / `enforce` rollout
+flag (`CATALYST_PUBLISH_PREFLIGHT` over Layer-2 configuration, default `shadow`). Shadow emits
+`publish.preflight.would-block` and continues. Enforce blocks only a definitive denial and emits
+`publish.preflight.blocked`; unknown always proceeds. A bounded identity-aware cache conserves
+GitHub quota. The worker-only doctor check reports PASS when allowed, WARN for shadow denial, FAIL
+for enforce denial, and INFO when inconclusive.
+
 ### Dispatch-time rebase (front-load conflict surfacing, CTL-667 + CTL-707 + CAT-31)
 
 On a **fresh** dispatch of a **build** phase (`research`,`plan`,`implement`,`verify`,`review`),

--- a/plugins/dev/scripts/__tests__/config-docs-coverage.test.sh
+++ b/plugins/dev/scripts/__tests__/config-docs-coverage.test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# CAT-60: keep the two publish-routing knobs discoverable in the canonical
+# configuration reference.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+REFERENCE="$REPO_ROOT/website/src/content/docs/reference/configuration.md"
+
+failures=0
+for key in 'catalyst.pr.pushRemote' 'catalyst.orchestration.publishPreflight.mode'; do
+	if grep -Fq "$key" "$REFERENCE"; then
+		echo "PASS: configuration reference documents $key"
+	else
+		echo "FAIL: configuration reference does not document $key"
+		failures=$((failures + 1))
+	fi
+done
+
+[[ $failures -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/phase-pr-rc-map.test.sh
+++ b/plugins/dev/scripts/__tests__/phase-pr-rc-map.test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SKILL="${ROOT}/skills/phase-pr/SKILL.md"
+
+count="$(grep -c 'PUSH_VERIFY_RC" -eq 5' "$SKILL" || true)"
+reasons="$(grep -c -- '--reason "push_denied_no_permission"' "$SKILL" || true)"
+
+[[ "$count" -eq 2 ]] || { echo "FAIL: expected rc=5 in both phase-pr paths, got $count"; exit 1; }
+[[ "$reasons" -eq 2 ]] || { echo "FAIL: expected permission reason in both paths, got $reasons"; exit 1; }
+echo "PASS: phase-pr maps rc=5 to push_denied_no_permission on both paths"

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -78,6 +78,12 @@ import {
   EVENT_READERS_DIVERGED,
   EVENT_READERS_CONVERGED,
 } from "../execution-core/github-feed-timer.mjs";
+// CAT-60 — the publish-capability preflight blocked/would-block pair, imported from its
+// owning module so a rename cannot leave a re-typed literal behind that still passes.
+import {
+  PUBLISH_PREFLIGHT_BLOCKED,
+  PUBLISH_PREFLIGHT_WOULD_BLOCK,
+} from "../execution-core/publish-preflight-event.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -134,6 +140,8 @@ const EXEC_CORE_EVENT_NAMES = [
   FENCE_STANDOFF_EVENT, // CAT-173 fence-standoff.mjs — mutual fence standoff escalation
   EVENT_READERS_DIVERGED, // CTL-2011 github-feed-timer.mjs — exec-core env-pin diverges from broker/orch-monitor view
   EVENT_READERS_CONVERGED, // CTL-2011 github-feed-timer.mjs — readers converged after a prior split
+  PUBLISH_PREFLIGHT_BLOCKED, // CAT-60 publish-preflight-event.mjs — denied push capability
+  PUBLISH_PREFLIGHT_WOULD_BLOCK, // CAT-60 publish-preflight-event.mjs — shadow mode would-block
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/create-worktree.sh
+++ b/plugins/dev/scripts/create-worktree.sh
@@ -133,6 +133,15 @@ BASE_BRANCH="${POSITIONAL[1]:-$(git branch --show-current)}"
 # Get repository information
 REPO_ROOT=$(git rev-parse --show-toplevel)
 REPO_NAME=$(basename "$REPO_ROOT")
+_CW_DRAFT_PR_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/draft-pr.sh"
+if [ -r "$_CW_DRAFT_PR_LIB" ]; then
+	# shellcheck source=/dev/null
+	source "$_CW_DRAFT_PR_LIB"
+fi
+PUSH_REMOTE="origin"
+if type _draft_pr_push_remote >/dev/null 2>&1; then
+	PUSH_REMOTE="$(_draft_pr_push_remote)"
+fi
 
 # Try to detect GitHub org from remote URL
 GIT_REMOTE=$(git config --get remote.origin.url 2>/dev/null || echo "")
@@ -309,11 +318,11 @@ else
 	# between the snapshot and the fetch could be missed), and a missing ticket ref simply
 	# makes the fetch exit non-zero so we fall through to seeding from base.
 	if [ "$SKIP_FETCH" = false ] && [ "$FROM_REMOTE" = true ] \
-		&& git fetch --quiet origin \
-			"+refs/heads/${WORKTREE_NAME}:refs/remotes/origin/${WORKTREE_NAME}" 2>/dev/null; then
-		START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
+		&& git fetch --quiet "$PUSH_REMOTE" \
+			"+refs/heads/${WORKTREE_NAME}:refs/remotes/${PUSH_REMOTE}/${WORKTREE_NAME}" 2>/dev/null; then
+		START_POINT="refs/remotes/${PUSH_REMOTE}/${WORKTREE_NAME}"
 		SEEDED_FROM_REMOTE=true
-		echo "🌱 Resuming from origin/${WORKTREE_NAME}; seeding worktree from its pushed tip (CTL-1640)"
+		echo "🌱 Resuming from ${PUSH_REMOTE}/${WORKTREE_NAME}; seeding worktree from its pushed tip (CTL-1640)"
 	fi
 	if [ "$SEEDED_FROM_REMOTE" = false ] && [ "$SKIP_FETCH" = false ]; then
 		if git fetch --quiet origin "$BASE_BRANCH" 2>/dev/null; then
@@ -331,11 +340,11 @@ else
 		# the add. It does NOT fully close the race — the durable fix is a cluster-fence guard
 		# on the producer's early-draft push — but it converts the common case back to a resume.
 		if [ "$FROM_REMOTE" = true ] \
-			&& git fetch --quiet origin \
-				"+refs/heads/${WORKTREE_NAME}:refs/remotes/origin/${WORKTREE_NAME}" 2>/dev/null; then
-			START_POINT="refs/remotes/origin/${WORKTREE_NAME}"
+			&& git fetch --quiet "$PUSH_REMOTE" \
+				"+refs/heads/${WORKTREE_NAME}:refs/remotes/${PUSH_REMOTE}/${WORKTREE_NAME}" 2>/dev/null; then
+			START_POINT="refs/remotes/${PUSH_REMOTE}/${WORKTREE_NAME}"
 			SEEDED_FROM_REMOTE=true
-			echo "🌱 origin/${WORKTREE_NAME} appeared during provisioning; resuming from its pushed tip (CTL-1640)"
+			echo "🌱 ${PUSH_REMOTE}/${WORKTREE_NAME} appeared during provisioning; resuming from its pushed tip (CTL-1640)"
 		fi
 	fi
 	git worktree add -b "$WORKTREE_NAME" "$WORKTREE_PATH" "$START_POINT"

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -74,6 +74,21 @@ try {
 }
 export { log };
 
+export const PUBLISH_PREFLIGHT_MODES = ["off", "shadow", "enforce"];
+
+export function resolvePublishPreflightMode({ env = process.env, configPath = null, logger = log } = {}) {
+  let raw = env?.CATALYST_PUBLISH_PREFLIGHT;
+  if (raw == null && configPath) {
+    try {
+      raw = JSON.parse(readFileSync(configPath, "utf8"))?.catalyst?.orchestration?.publishPreflight?.mode;
+    } catch { /* missing/malformed config uses shipped default */ }
+  }
+  const mode = typeof raw === "string" ? raw.trim().toLowerCase() : "shadow";
+  if (PUBLISH_PREFLIGHT_MODES.includes(mode)) return mode;
+  logger?.warn?.({ value: raw }, "publish-preflight: invalid mode; using shadow");
+  return "shadow";
+}
+
 // CTL-1617: the canonical deployment-mode resolver is a zero-import leaf
 // (../lib/deployment-mode.mjs) shared verbatim by execution-core (this
 // re-export) and orch-monitor (direct cross-directory import) — never

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -67,6 +67,7 @@ import {
   codexConfig, // CTL-1457: codex-exec runtime settings (codexHome/bin/…) for the boot-eligibility gate
   readGovernanceConfig, // CTL-1552: boot governance-mode + source self-report
   readGovernanceSources, // CTL-1552: which config layer each governance mode resolved from
+  resolvePublishPreflightMode,
 } from "./config.mjs";
 import { resolveBootIdentity } from "./host-boot-identity.mjs"; // CTL-1093
 import { readStickyIdentity, writeStickyIdentity } from "./host-sticky.mjs"; // CTL-1093
@@ -159,6 +160,7 @@ import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-p
 import { rearmClaudeAccountsFromFile } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook
 import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dependency-preflight.mjs";
 import { getReconcileHealth } from "./reconcile-health.mjs";
+import { probePublishCapability as realProbePublishCapability } from "./publish-preflight.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn, setAgentSessionNarrator } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
@@ -1920,6 +1922,18 @@ export function startDaemon({
       // terminal-ness from the local Catalyst-Cloud replica. undefined → inert.
       replica: replicaReader,
       isBgJobAlive,
+      // CAT-60: production arms the otherwise-hermetic scheduler seam. Resolve
+      // the project repo from the ticket prefix and cache per remote slug.
+      publishPreflightMode: resolvePublishPreflightMode({ configPath }),
+      probePublishCapability: ({ ticket }) => {
+        const team = String(ticket || "").split("-")[0];
+        const project = realListProjects().find((p) => p.team === team);
+        return realProbePublishCapability({
+          repoRoot: project?.repoRoot,
+          pushRemote: process.env.CATALYST_PUSH_REMOTE || "origin",
+          cacheDir: join(orchDir, ".publish-preflight"),
+        });
+      },
       // CTL-1044: provide the production operator-event appender for the
       // scheduler's `appendIntentEvent` seam (scheduler.mjs:4300). Without this
       // the seam is null and the advance-shadow comparator's disagree/tick

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -160,7 +160,7 @@ import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-p
 import { rearmClaudeAccountsFromFile } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook
 import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dependency-preflight.mjs";
 import { getReconcileHealth } from "./reconcile-health.mjs";
-import { probePublishCapability as realProbePublishCapability } from "./publish-preflight.mjs";
+import { probePublishCapability as realProbePublishCapability, resolvePushRemote } from "./publish-preflight.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
 import { startAutoTuner } from "./autotune.mjs"; // CTL-684: side-car maxParallel auto-tuner
 import { dispatchTicket, makeCommentWakeDispatch, makePhaseAwareDispatchFn, setAgentSessionNarrator } from "./dispatch.mjs"; // CTL-549: comment-wake re-dispatch; CTL-1365a/b: executor→dispatch selection at the launch seam + comment-wake executor binding; CTL-1457: per-phase-aware dispatchFn factory (owns the executor→dispatch selection internally)
@@ -1930,7 +1930,7 @@ export function startDaemon({
         const project = realListProjects().find((p) => p.team === team);
         return realProbePublishCapability({
           repoRoot: project?.repoRoot,
-          pushRemote: process.env.CATALYST_PUSH_REMOTE || "origin",
+          pushRemote: resolvePushRemote({ repoRoot: project?.repoRoot, layer1Path: configPath, layer2Path }),
           cacheDir: join(orchDir, ".publish-preflight"),
         });
       },

--- a/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkRepoPushPermission, runDoctor } from "./doctor.mjs";
+
+const verdict = (state, extra = {}) => ({
+  state, slug: "coalesce-labs/catalyst", login: "octocat", detail: state, cached: false, ...extra,
+});
+const check = (state, mode = "shadow", extra = {}) => checkRepoPushPermission({
+  repoRoot: "/repo", pushRemote: "fork", resolveMode: () => mode,
+  probe: () => verdict(state, extra),
+})[0];
+
+describe("checkRepoPushPermission (CAT-60)", () => {
+  test("allowed is PASS and names slug and resolved remote", () => {
+    const got = check("allowed");
+    expect(got.status).toBe("pass");
+    expect(got.detail).toContain("coalesce-labs/catalyst");
+    expect(got.detail).toContain("fork");
+  });
+
+  test("denied in shadow is WARN and does not affect runDoctor exit code", async () => {
+    const fn = () => checkRepoPushPermission({ resolveMode: () => "shadow", probe: () => verdict("denied") });
+    expect((await fn())[0].status).toBe("warn");
+    expect(await runDoctor({ checks: [fn], log: () => {}, resolveClass: () => ({ recognized: true, class: "worker" }) })).toBe(0);
+  });
+
+  test("denied in enforce is FAIL", () => expect(check("denied", "enforce").status).toBe("fail"));
+  test("unknown is INFO and never FAIL", () => expect(check("unknown", "enforce").status).toBe("info"));
+
+  test("fresh probe cache is reused without a gh call", () => {
+    const cacheDir = mkdtempSync(join(tmpdir(), "doctor-publish-"));
+    let ghCalls = 0;
+    const spawn = (cmd) => {
+      if (cmd === "git") return { status: 0, stdout: "git@github.com:coalesce-labs/catalyst.git\n" };
+      ghCalls += 1;
+      return { status: 0, stdout: '{"push":true,"login":"octocat"}' };
+    };
+    const deps = { repoRoot: "/repo", cacheDir, spawn, now: () => 1000, resolveMode: () => "shadow" };
+    expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
+    expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
+    expect(ghCalls).toBe(1);
+  });
+
+  test("all messages qualify permission as push/publish", () => {
+    for (const state of ["allowed", "denied", "unknown"])
+      expect(check(state).detail).toMatch(/push permission|publish/i);
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkRepoPushPermission, runDoctor } from "./doctor.mjs";
@@ -41,6 +41,41 @@ describe("checkRepoPushPermission (CAT-60)", () => {
     expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
     expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
     expect(ghCalls).toBe(3); // identity is refreshed before selecting its cache key
+  });
+
+  // Regression: every other case here injects `resolveMode`, so the real
+  // resolver was never exercised — and checkRepoPushPermission was calling it
+  // as resolveMode({ env }) without the configPath it had already destructured
+  // for resolvePushRemote. A Layer-1 enforce was therefore invisible to doctor
+  // and a denied verdict graded WARN instead of the documented FAIL. Drive the
+  // mode from a config FILE (no stub, no env) so that omission cannot return.
+  test("Layer-1 config enforce reaches the real resolver and makes denied a FAIL", () => {
+    const dir = mkdtempSync(join(tmpdir(), "doctor-preflight-cfg-"));
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: { orchestration: { publishPreflight: { mode: "enforce" } } },
+    }));
+    const got = checkRepoPushPermission({
+      repoRoot: "/repo", pushRemote: "fork", configPath, env: {},
+      probe: () => verdict("denied"),
+    })[0];
+    expect(got.status).toBe("fail");
+    expect(got.detail).toContain("(enforce)");
+  });
+
+  test("env still overrides a Layer-1 config mode", () => {
+    const dir = mkdtempSync(join(tmpdir(), "doctor-preflight-cfg-"));
+    const configPath = join(dir, "config.json");
+    writeFileSync(configPath, JSON.stringify({
+      catalyst: { orchestration: { publishPreflight: { mode: "enforce" } } },
+    }));
+    const got = checkRepoPushPermission({
+      repoRoot: "/repo", pushRemote: "fork", configPath,
+      env: { CATALYST_PUBLISH_PREFLIGHT: "shadow" },
+      probe: () => verdict("denied"),
+    })[0];
+    expect(got.status).toBe("warn");
+    expect(got.detail).toContain("(shadow)");
   });
 
   test("all messages qualify permission as push/publish", () => {

--- a/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-publish-preflight.test.mjs
@@ -32,15 +32,15 @@ describe("checkRepoPushPermission (CAT-60)", () => {
   test("fresh probe cache is reused without a gh call", () => {
     const cacheDir = mkdtempSync(join(tmpdir(), "doctor-publish-"));
     let ghCalls = 0;
-    const spawn = (cmd) => {
+    const spawn = (cmd, args) => {
       if (cmd === "git") return { status: 0, stdout: "git@github.com:coalesce-labs/catalyst.git\n" };
       ghCalls += 1;
-      return { status: 0, stdout: '{"push":true,"login":"octocat"}' };
+      return args[1] === "user" ? { status: 0, stdout: "octocat\n" } : { status: 0, stdout: '{"push":true,"owner":"coalesce-labs"}' };
     };
     const deps = { repoRoot: "/repo", cacheDir, spawn, now: () => 1000, resolveMode: () => "shadow" };
     expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
     expect(checkRepoPushPermission(deps)[0].status).toBe("pass");
-    expect(ghCalls).toBe(1);
+    expect(ghCalls).toBe(3); // identity is refreshed before selecting its cache key
   });
 
   test("all messages qualify permission as push/publish", () => {

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -177,6 +177,8 @@ import { listProjects } from "./registry.mjs";
 // is no bun: protocol anywhere in its graph (asserted in config-dump.test.mjs).
 // Read-only and advisory: nothing in this module can change a grade to FAIL.
 import { collectConfigDump } from "./config-dump.mjs";
+import { probePublishCapability } from "./publish-preflight.mjs"; // CAT-60: worker write-capability gate
+import { resolvePublishPreflightMode } from "./config.mjs";
 
 // readLinearBotUserIds — inlined from daemon.mjs to avoid pulling in the full
 // daemon dependency chain (which includes bun: protocol imports incompatible
@@ -250,6 +252,43 @@ export { checkLinearWriteBudget };
 export { checkAgentToolsWritePath };
 export { checkExecutionCoreEnvDrift };
 export { checkIndexServingRoot };
+
+// checkRepoPushPermission — CAT-60. Grade the worker's ability to publish to
+// its resolved write remote independently of scheduler dispatch. Only a
+// definitive denial can fail; operational uncertainty is always informational.
+export function checkRepoPushPermission(deps = {}) {
+  const {
+    repoRoot = process.cwd(),
+    pushRemote = process.env.CATALYST_PUSH_REMOTE || "origin",
+    env = process.env,
+    cacheDir = resolve(getExecutionCoreDir(), ".publish-preflight"),
+    probe = probePublishCapability,
+    resolveMode = resolvePublishPreflightMode,
+    now,
+    spawn,
+  } = deps;
+  let mode;
+  try { mode = resolveMode({ env }); } catch { mode = "shadow"; }
+  if (mode === "off") {
+    return [mkCheck("repo-push-permission", STATUS.INFO, "publish preflight is off — push permission not checked")];
+  }
+  let verdict;
+  try { verdict = probe({ repoRoot, pushRemote, env, cacheDir, now, spawn }); }
+  catch (err) {
+    verdict = { state: "unknown", detail: err?.message ?? "publish probe threw" };
+  }
+  const target = `${verdict?.slug ?? "the configured repository"} via ${pushRemote}`;
+  const identity = verdict?.login ? ` for ${verdict.login}` : "";
+  const cached = verdict?.cached ? " (cached)" : "";
+  if (verdict?.state === "allowed") {
+    return [mkCheck("repo-push-permission", STATUS.PASS, `publish push permission allowed on ${target}${identity}${cached}`)];
+  }
+  if (verdict?.state === "denied") {
+    const status = mode === "enforce" ? STATUS.FAIL : STATUS.WARN;
+    return [mkCheck("repo-push-permission", status, `publish push permission denied on ${target}${identity} (${mode})${cached}`)];
+  }
+  return [mkCheck("repo-push-permission", STATUS.INFO, `publish push permission could not be determined for ${target}: ${verdict?.detail ?? "unknown"}${cached}`)];
+}
 
 // ─── CTL-1616 PR2/PR3: secret-contract observability (zero grade change) ─────
 //
@@ -6643,6 +6682,13 @@ export function checksForClass(nc, opts = {}) {
     hasStackAgent,
     hasUpdaterAgent,
     pluginPullOwner,
+    repoRoot,
+    pushRemote,
+    publishProbe,
+    publishPreflightMode,
+    publishCacheDir,
+    publishNow,
+    publishSpawn,
     // CTL-1473: pre-install flag downgrades install-remediable checks (shipper, agents-for-class)
     // from FAIL to WARN when the join gate runs BEFORE install-services (which creates the services).
     preinstall = !!process.env.CATALYST_DOCTOR_PREINSTALL,
@@ -6865,6 +6911,15 @@ export function checksForClass(nc, opts = {}) {
     () => checkSdkDaemonEnv(), // CTL-1396 item A: under executor=sdk, the RUNNING daemon's process env must carry CLAUDE_CODE_OAUTH_TOKEN (not just the operator shell) + surface recent silent sdk→bg degrades
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
     () => checkRepoIconTokenScope(), // CTL-1375: monitor daemon's gh token can read configured private repos' contents (else favicons fall back to the org avatar) — advisory (never FAIL)
+    () => checkRepoPushPermission({
+      repoRoot,
+      pushRemote,
+      probe: publishProbe,
+      resolveMode: publishPreflightMode ? () => publishPreflightMode : undefined,
+      cacheDir: publishCacheDir,
+      now: publishNow,
+      spawn: publishSpawn,
+    }), // CAT-60: workers must be able to publish to the resolved write remote
     () => checkMonitorProductionBuild(), // CTL-1372: warn if the local monitor serves a dev-build React bundle (leaks via performance.measure) — advisory (never FAIL)
     () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
     () => checkDrainDisabled(), // CTL-1678: surface the per-node drain override + the draining-but-ignored third state — advisory only (never FAIL)

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -271,7 +271,7 @@ export function checkRepoPushPermission(deps = {}) {
   } = deps;
   const resolvedPushRemote = pushRemote ?? resolvePushRemote({ repoRoot, env, layer1Path: configPath, layer2Path: layer2ConfigPath, spawn });
   let mode;
-  try { mode = resolveMode({ env }); } catch { mode = "shadow"; }
+  try { mode = resolveMode({ env, configPath }); } catch { mode = "shadow"; }
   if (mode === "off") {
     return [mkCheck("repo-push-permission", STATUS.INFO, "publish preflight is off — push permission not checked")];
   }

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -177,7 +177,7 @@ import { listProjects } from "./registry.mjs";
 // is no bun: protocol anywhere in its graph (asserted in config-dump.test.mjs).
 // Read-only and advisory: nothing in this module can change a grade to FAIL.
 import { collectConfigDump } from "./config-dump.mjs";
-import { probePublishCapability } from "./publish-preflight.mjs"; // CAT-60: worker write-capability gate
+import { probePublishCapability, resolvePushRemote } from "./publish-preflight.mjs"; // CAT-60: worker write-capability gate
 import { resolvePublishPreflightMode } from "./config.mjs";
 
 // readLinearBotUserIds — inlined from daemon.mjs to avoid pulling in the full
@@ -259,7 +259,9 @@ export { checkIndexServingRoot };
 export function checkRepoPushPermission(deps = {}) {
   const {
     repoRoot = process.cwd(),
-    pushRemote = process.env.CATALYST_PUSH_REMOTE || "origin",
+    pushRemote,
+    configPath = process.env.CATALYST_CONFIG_FILE || layer1Path(),
+    layer2ConfigPath = layer2Path(),
     env = process.env,
     cacheDir = resolve(getExecutionCoreDir(), ".publish-preflight"),
     probe = probePublishCapability,
@@ -267,17 +269,18 @@ export function checkRepoPushPermission(deps = {}) {
     now,
     spawn,
   } = deps;
+  const resolvedPushRemote = pushRemote ?? resolvePushRemote({ repoRoot, env, layer1Path: configPath, layer2Path: layer2ConfigPath, spawn });
   let mode;
   try { mode = resolveMode({ env }); } catch { mode = "shadow"; }
   if (mode === "off") {
     return [mkCheck("repo-push-permission", STATUS.INFO, "publish preflight is off — push permission not checked")];
   }
   let verdict;
-  try { verdict = probe({ repoRoot, pushRemote, env, cacheDir, now, spawn }); }
+  try { verdict = probe({ repoRoot, pushRemote: resolvedPushRemote, env, cacheDir, now, spawn }); }
   catch (err) {
     verdict = { state: "unknown", detail: err?.message ?? "publish probe threw" };
   }
-  const target = `${verdict?.slug ?? "the configured repository"} via ${pushRemote}`;
+  const target = `${verdict?.slug ?? "the configured repository"} via ${resolvedPushRemote}`;
   const identity = verdict?.login ? ` for ${verdict.login}` : "";
   const cached = verdict?.cached ? " (cached)" : "";
   if (verdict?.state === "allowed") {

--- a/plugins/dev/scripts/execution-core/publish-preflight-config.test.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight-config.test.mjs
@@ -1,0 +1,23 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolvePublishPreflightMode } from "./config.mjs";
+
+test("publish preflight defaults to shadow", () => {
+  expect(resolvePublishPreflightMode({ env: {}, logger: null })).toBe("shadow");
+});
+
+test("environment wins over Layer-1 mode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "publish-mode-"));
+  const file = join(dir, "config.json");
+  writeFileSync(file, JSON.stringify({ catalyst: { orchestration: { publishPreflight: { mode: "enforce" } } } }));
+  expect(resolvePublishPreflightMode({ env: { CATALYST_PUBLISH_PREFLIGHT: "off" }, configPath: file, logger: null })).toBe("off");
+  expect(resolvePublishPreflightMode({ env: {}, configPath: file, logger: null })).toBe("enforce");
+});
+
+test("invalid mode degrades to shadow and warns", () => {
+  const warnings = [];
+  expect(resolvePublishPreflightMode({ env: { CATALYST_PUBLISH_PREFLIGHT: "maybe" }, logger: { warn: (...args) => warnings.push(args) } })).toBe("shadow");
+  expect(warnings).toHaveLength(1);
+});

--- a/plugins/dev/scripts/execution-core/publish-preflight-event.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight-event.mjs
@@ -1,0 +1,38 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getEventLogPath, getHostName, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const PUBLISH_PREFLIGHT_WOULD_BLOCK = "publish.preflight.would-block";
+export const PUBLISH_PREFLIGHT_BLOCKED = "publish.preflight.blocked";
+
+export function buildPublishPreflightEnvelope({ action, ticket, phase, verdict, now } = {}) {
+  const ts = now ? now() : new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return {
+    ts, id: randomBytes(8).toString("hex"), observedTs: ts,
+    severityText: action === "blocked" ? "WARN" : "INFO",
+    severityNumber: action === "blocked" ? 13 : 9,
+    traceId: null, spanId: null,
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": action === "blocked" ? PUBLISH_PREFLIGHT_BLOCKED : PUBLISH_PREFLIGHT_WOULD_BLOCK,
+      "event.entity": "repository", "event.action": action, "event.label": verdict?.slug ?? ticket,
+    },
+    body: { payload: { ticket, phase, host: getHostName(), ...verdict } },
+  };
+}
+
+export function appendPublishPreflightEvent({ logPath = getEventLogPath(), ...fields } = {}) {
+  try {
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(buildPublishPreflightEnvelope(fields))}\n`);
+    return true;
+  } catch (err) {
+    log.warn({ err: err?.message }, "publish-preflight: event append failed");
+    return false;
+  }
+}
+
+export const appendPublishPreflightBlockedEvent = (fields) => appendPublishPreflightEvent({ ...fields, action: "blocked" });
+export const appendPublishPreflightWouldBlockEvent = (fields) => appendPublishPreflightEvent({ ...fields, action: "would-block" });

--- a/plugins/dev/scripts/execution-core/publish-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight.mjs
@@ -1,0 +1,85 @@
+// publish-preflight.mjs — CAT-60. Three-state, cached repository push-permission probe.
+// Only a definitive permissions.push=false is "denied"; every operational or
+// parsing failure is "unknown" so a transient GitHub failure cannot stop work.
+
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const PUBLISH_PROBE_TIMEOUT_MS = 10_000;
+export const PUBLISH_VERDICT_TTL_MS = 60 * 60 * 1000;
+
+export function parseGithubSlug(remoteUrl) {
+  if (typeof remoteUrl !== "string") return null;
+  const value = remoteUrl.trim().replace(/\.git$/, "");
+  const match = value.match(/github\.com[/:]([^/]+)\/([^/]+)$/i);
+  return match ? `${match[1]}/${match[2]}` : null;
+}
+
+function run(spawn, command, args, options) {
+  const result = spawn(command, args, options);
+  return result && typeof result === "object" ? result : {};
+}
+
+function cachePath(cacheDir, slug) {
+  return join(cacheDir, `${slug.replace(/[^A-Za-z0-9._-]/g, "_")}.json`);
+}
+
+export function probePublishCapability({
+  repoRoot,
+  pushRemote = "origin",
+  cacheDir,
+  env = process.env,
+  now = Date.now,
+  spawn = nodeSpawnSync,
+  timeoutMs = PUBLISH_PROBE_TIMEOUT_MS,
+  ttlMs = PUBLISH_VERDICT_TTL_MS,
+} = {}) {
+  try {
+    if (!repoRoot) return { state: "unknown", slug: null, login: null, detail: "repo root unavailable", cached: false };
+    const remote = run(spawn, "git", ["-C", repoRoot, "remote", "get-url", pushRemote], {
+      env, encoding: "utf8", timeout: timeoutMs,
+    });
+    const slug = remote.status === 0 ? parseGithubSlug(remote.stdout) : null;
+    if (!slug) return { state: "unknown", slug: null, login: null, detail: "push remote slug unavailable", cached: false };
+
+    const file = cacheDir ? cachePath(cacheDir, slug) : null;
+    if (file) {
+      try {
+        const cached = JSON.parse(readFileSync(file, "utf8"));
+        const age = Number(now()) - Number(cached.ts);
+        if (["allowed", "denied"].includes(cached.state) && age >= 0 && age < ttlMs) {
+          return { ...cached, cached: true };
+        }
+      } catch { /* corrupt/missing cache => live probe */ }
+    }
+
+    const result = run(spawn, "gh", ["api", `repos/${slug}`, "--jq", "{push:.permissions.push,login:.owner.login}"], {
+      env, encoding: "utf8", timeout: timeoutMs,
+    });
+    if (result.error || result.status !== 0) {
+      return { state: "unknown", slug, login: null, detail: result.error?.message || String(result.stderr || "probe failed").trim(), cached: false };
+    }
+    let body;
+    try { body = JSON.parse(String(result.stdout || "")); } catch { return { state: "unknown", slug, login: null, detail: "unparseable GitHub response", cached: false }; }
+    if (typeof body?.push !== "boolean") return { state: "unknown", slug, login: body?.login ?? null, detail: "GitHub response omitted permissions.push", cached: false };
+    const verdict = {
+      state: body.push ? "allowed" : "denied",
+      slug,
+      login: body.login ?? null,
+      detail: body.push ? `push allowed on ${slug}` : `push denied on ${slug} for ${body.login ?? "unknown identity"}`,
+      ts: Number(now()),
+    };
+    if (file) {
+      try {
+        mkdirSync(cacheDir, { recursive: true });
+        const tmp = `${file}.${process.pid}.tmp`;
+        writeFileSync(tmp, JSON.stringify(verdict));
+        renameSync(tmp, file);
+      } catch { /* cache is an optimization */ }
+    }
+    return { ...verdict, cached: false };
+  } catch (err) {
+    return { state: "unknown", slug: null, login: null, detail: err?.message ?? "probe threw", cached: false };
+  }
+}

--- a/plugins/dev/scripts/execution-core/publish-preflight.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight.mjs
@@ -8,6 +8,7 @@ import { join } from "node:path";
 
 export const PUBLISH_PROBE_TIMEOUT_MS = 10_000;
 export const PUBLISH_VERDICT_TTL_MS = 60 * 60 * 1000;
+export const PUBLISH_UNKNOWN_TTL_MS = 60 * 1000;
 
 export function parseGithubSlug(remoteUrl) {
   if (typeof remoteUrl !== "string") return null;
@@ -21,8 +22,30 @@ function run(spawn, command, args, options) {
   return result && typeof result === "object" ? result : {};
 }
 
-function cachePath(cacheDir, slug) {
-  return join(cacheDir, `${slug.replace(/[^A-Za-z0-9._-]/g, "_")}.json`);
+function cachePath(cacheDir, slug, pushRemote, login) {
+  const key = `${slug}__${pushRemote}__${login ?? "unknown"}`;
+  return join(cacheDir, `${key.replace(/[^A-Za-z0-9._-]/g, "_")}.json`);
+}
+
+function configString(path, selector) {
+  if (!path) return null;
+  try {
+    const value = selector(JSON.parse(readFileSync(path, "utf8")));
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  } catch { return null; }
+}
+
+export function resolvePushRemote({ repoRoot, env = process.env, layer1Path, layer2Path, spawn = nodeSpawnSync } = {}) {
+  let candidate = env?.CATALYST_PUSH_REMOTE
+    || configString(layer2Path, (c) => c?.catalyst?.pr?.pushRemote)
+    || configString(layer1Path, (c) => c?.catalyst?.pr?.pushRemote);
+  if (!candidate && repoRoot) {
+    const upstream = run(spawn, "git", ["-C", repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], { env, encoding: "utf8" });
+    if (upstream.status === 0) candidate = String(upstream.stdout || "").trim().split("/")[0];
+  }
+  if (!candidate || /[^A-Za-z0-9._/-]/.test(candidate)) return "origin";
+  const exists = run(spawn, "git", ["-C", repoRoot, "remote", "get-url", candidate], { env, encoding: "utf8" });
+  return exists.status === 0 ? candidate : "origin";
 }
 
 export function probePublishCapability({
@@ -34,6 +57,7 @@ export function probePublishCapability({
   spawn = nodeSpawnSync,
   timeoutMs = PUBLISH_PROBE_TIMEOUT_MS,
   ttlMs = PUBLISH_VERDICT_TTL_MS,
+  unknownTtlMs = PUBLISH_UNKNOWN_TTL_MS,
 } = {}) {
   try {
     if (!repoRoot) return { state: "unknown", slug: null, login: null, detail: "repo root unavailable", cached: false };
@@ -43,31 +67,37 @@ export function probePublishCapability({
     const slug = remote.status === 0 ? parseGithubSlug(remote.stdout) : null;
     if (!slug) return { state: "unknown", slug: null, login: null, detail: "push remote slug unavailable", cached: false };
 
-    const file = cacheDir ? cachePath(cacheDir, slug) : null;
+    const identity = run(spawn, "gh", ["api", "user", "--jq", ".login"], { env, encoding: "utf8", timeout: timeoutMs });
+    const login = identity.status === 0 ? String(identity.stdout || "").trim() || null : null;
+    const file = cacheDir ? cachePath(cacheDir, slug, pushRemote, login) : null;
     if (file) {
       try {
         const cached = JSON.parse(readFileSync(file, "utf8"));
         const age = Number(now()) - Number(cached.ts);
-        if (["allowed", "denied"].includes(cached.state) && age >= 0 && age < ttlMs) {
+        const cacheTtl = cached.state === "unknown" ? unknownTtlMs : ttlMs;
+        if (["allowed", "denied", "unknown"].includes(cached.state) && age >= 0 && age < cacheTtl) {
           return { ...cached, cached: true };
         }
       } catch { /* corrupt/missing cache => live probe */ }
     }
 
-    const result = run(spawn, "gh", ["api", `repos/${slug}`, "--jq", "{push:.permissions.push,login:.owner.login}"], {
+    const result = run(spawn, "gh", ["api", `repos/${slug}`, "--jq", "{push:.permissions.push,owner:.owner.login}"], {
       env, encoding: "utf8", timeout: timeoutMs,
     });
     if (result.error || result.status !== 0) {
-      return { state: "unknown", slug, login: null, detail: result.error?.message || String(result.stderr || "probe failed").trim(), cached: false };
+      const verdict = { state: "unknown", slug, login, detail: result.error?.message || String(result.stderr || "probe failed").trim(), ts: Number(now()) };
+      if (file) try { mkdirSync(cacheDir, { recursive: true }); writeFileSync(file, JSON.stringify(verdict)); } catch { /* optimization */ }
+      return { ...verdict, cached: false };
     }
     let body;
     try { body = JSON.parse(String(result.stdout || "")); } catch { return { state: "unknown", slug, login: null, detail: "unparseable GitHub response", cached: false }; }
-    if (typeof body?.push !== "boolean") return { state: "unknown", slug, login: body?.login ?? null, detail: "GitHub response omitted permissions.push", cached: false };
+    if (typeof body?.push !== "boolean") return { state: "unknown", slug, login, detail: "GitHub response omitted permissions.push", cached: false };
     const verdict = {
       state: body.push ? "allowed" : "denied",
       slug,
-      login: body.login ?? null,
-      detail: body.push ? `push allowed on ${slug}` : `push denied on ${slug} for ${body.login ?? "unknown identity"}`,
+      login,
+      owner: body.owner ?? null,
+      detail: body.push ? `push allowed on ${slug}` : `push denied on ${slug} for ${login ?? "unknown identity"}`,
       ts: Number(now()),
     };
     if (file) {

--- a/plugins/dev/scripts/execution-core/publish-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight.test.mjs
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { probePublishCapability, parseGithubSlug } from "./publish-preflight.mjs";
+
+const root = mkdtempSync(join(tmpdir(), "publish-preflight-"));
+const remote = { status: 0, stdout: "git@github.com:acme/widgets.git\n" };
+
+test("parses SSH and HTTPS GitHub remotes", () => {
+  expect(parseGithubSlug("git@github.com:acme/widgets.git")).toBe("acme/widgets");
+  expect(parseGithubSlug("https://github.com/acme/widgets.git")).toBe("acme/widgets");
+});
+
+test("push true is allowed and push false is denied with detail", () => {
+  for (const [push, state] of [[true, "allowed"], [false, "denied"]]) {
+    const spawn = (_cmd, args) => args[0] === "-C" ? remote : { status: 0, stdout: JSON.stringify({ push, login: "robot" }) };
+    const got = probePublishCapability({ repoRoot: root, spawn, cacheDir: null });
+    expect(got.state).toBe(state);
+    expect(got.slug).toBe("acme/widgets");
+    expect(got.detail).toContain("acme/widgets");
+  }
+});
+
+test("missing gh, timeout, 404, and malformed JSON are unknown", () => {
+  const cases = [
+    { error: Object.assign(new Error("missing"), { code: "ENOENT" }) },
+    { error: Object.assign(new Error("timeout"), { code: "ETIMEDOUT" }) },
+    { status: 1, stderr: "HTTP 404" },
+    { status: 0, stdout: "not json" },
+  ];
+  for (const response of cases) {
+    const got = probePublishCapability({ repoRoot: root, cacheDir: null, spawn: (_cmd, args) => args[0] === "-C" ? remote : response });
+    expect(got.state).toBe("unknown");
+  }
+});
+
+test("fresh definitive verdict is cached; unknown is not", () => {
+  let calls = 0;
+  const cacheDir = join(root, "cache");
+  const spawn = (_cmd, args) => {
+    if (args[0] === "-C") return remote;
+    calls++;
+    return { status: 0, stdout: '{"push":false,"login":"robot"}' };
+  };
+  expect(probePublishCapability({ repoRoot: root, cacheDir, spawn, now: () => 100 }).cached).toBe(false);
+  expect(probePublishCapability({ repoRoot: root, cacheDir, spawn, now: () => 101 }).cached).toBe(true);
+  expect(calls).toBe(1);
+  expect(readFileSync(join(cacheDir, "acme_widgets.json"), "utf8")).toContain("denied");
+
+  let unknownCalls = 0;
+  const noCache = join(root, "unknown-cache");
+  const badSpawn = (_cmd, args) => {
+    if (args[0] === "-C") return remote;
+    unknownCalls++;
+    return { status: 1, stderr: "network" };
+  };
+  probePublishCapability({ repoRoot: root, cacheDir: noCache, spawn: badSpawn });
+  probePublishCapability({ repoRoot: root, cacheDir: noCache, spawn: badSpawn });
+  expect(unknownCalls).toBe(2);
+});

--- a/plugins/dev/scripts/execution-core/publish-preflight.test.mjs
+++ b/plugins/dev/scripts/execution-core/publish-preflight.test.mjs
@@ -2,7 +2,7 @@ import { test, expect } from "bun:test";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { probePublishCapability, parseGithubSlug } from "./publish-preflight.mjs";
+import { probePublishCapability, parseGithubSlug, resolvePushRemote } from "./publish-preflight.mjs";
 
 const root = mkdtempSync(join(tmpdir(), "publish-preflight-"));
 const remote = { status: 0, stdout: "git@github.com:acme/widgets.git\n" };
@@ -14,7 +14,9 @@ test("parses SSH and HTTPS GitHub remotes", () => {
 
 test("push true is allowed and push false is denied with detail", () => {
   for (const [push, state] of [[true, "allowed"], [false, "denied"]]) {
-    const spawn = (_cmd, args) => args[0] === "-C" ? remote : { status: 0, stdout: JSON.stringify({ push, login: "robot" }) };
+    const spawn = (_cmd, args) => args[0] === "-C" ? remote
+      : args[1] === "user" ? { status: 0, stdout: "robot\n" }
+      : { status: 0, stdout: JSON.stringify({ push, owner: "acme" }) };
     const got = probePublishCapability({ repoRoot: root, spawn, cacheDir: null });
     expect(got.state).toBe(state);
     expect(got.slug).toBe("acme/widgets");
@@ -41,12 +43,12 @@ test("fresh definitive verdict is cached; unknown is not", () => {
   const spawn = (_cmd, args) => {
     if (args[0] === "-C") return remote;
     calls++;
-    return { status: 0, stdout: '{"push":false,"login":"robot"}' };
+    return args[1] === "user" ? { status: 0, stdout: "robot\n" } : { status: 0, stdout: '{"push":false,"owner":"acme"}' };
   };
   expect(probePublishCapability({ repoRoot: root, cacheDir, spawn, now: () => 100 }).cached).toBe(false);
   expect(probePublishCapability({ repoRoot: root, cacheDir, spawn, now: () => 101 }).cached).toBe(true);
-  expect(calls).toBe(1);
-  expect(readFileSync(join(cacheDir, "acme_widgets.json"), "utf8")).toContain("denied");
+  expect(calls).toBe(3); // identity is refreshed before selecting its cache key
+  expect(readFileSync(join(cacheDir, "acme_widgets__origin__robot.json"), "utf8")).toContain("denied");
 
   let unknownCalls = 0;
   const noCache = join(root, "unknown-cache");
@@ -57,5 +59,14 @@ test("fresh definitive verdict is cached; unknown is not", () => {
   };
   probePublishCapability({ repoRoot: root, cacheDir: noCache, spawn: badSpawn });
   probePublishCapability({ repoRoot: root, cacheDir: noCache, spawn: badSpawn });
-  expect(unknownCalls).toBe(2);
+  expect(unknownCalls).toBe(3); // second call refreshes identity, then uses short unknown cache
+});
+
+test("push remote resolution follows env, Layer-2, Layer-1, upstream, origin", () => {
+  const spawn = (_cmd, args) => {
+    if (args.includes("@{u}")) return { status: 0, stdout: "fork/topic\n" };
+    return { status: 0, stdout: "git@github.com:acme/widgets.git\n" };
+  };
+  expect(resolvePushRemote({ repoRoot: root, env: { CATALYST_PUSH_REMOTE: "envfork" }, spawn })).toBe("envfork");
+  expect(resolvePushRemote({ repoRoot: root, env: {}, spawn })).toBe("fork");
 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1029,6 +1029,19 @@ export function defaultClassifyTicket(evidence, opts = {}) {
         };
       }
     }
+    // CAT-60 — deterministic checks that already carry an explicit escalate
+    // verdict (e.g. push_denied_no_permission) short-circuit straight to
+    // escalate rather than falling through to the generic "fix" return below.
+    if (deterministic.escalate) {
+      return {
+        decision: "escalate",
+        fix_class: deterministic.fix_class,
+        details: {
+          reason: deterministic.reason,
+          explanation: deterministic.explanation,
+        },
+      };
+    }
     return {
       decision: "fix",
       fix_class: deterministic.fix_class,
@@ -1148,6 +1161,23 @@ export function checkDeterministicErrors(logsOutput, failureReason, signal = nul
       fix_class: "push_rejected_no_workflow_scope",
       seam_id: "workflow-token-redispatch",
       reason: "Push rejected (no workflow scope); re-arm phase-pr to re-run with the scoped token",
+    };
+  }
+  if (failureReason === "push_denied_no_permission") {
+    return {
+      fix_class: "push_denied_no_permission",
+      seam_id: null,
+      escalate: true,
+      reason:
+        "Cannot publish to the repository: the automation's GitHub identity lacks push " +
+        "permission on the configured push remote. Reviewed commits exist only on this " +
+        "host until the push target or the identity's permission changes.",
+      explanation: {
+        problem:
+          "The configured push remote rejected the automation identity because it lacks repository push permission.",
+        call_to_action:
+          "Grant the automation identity push permission on that repository, or set catalyst.pr.pushRemote to a writable remote.",
+      },
     };
   }
   // Merge-conflict and rebase-failed via failureReason → bounded-LLM, not a seam stub.

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5299,7 +5299,10 @@ export function schedulerTick(
     publishPreflightMode = "off",
     appendPublishPreflightBlockedEvent = defaultAppendPublishPreflightBlockedEvent,
     appendPublishPreflightWouldBlockEvent = defaultAppendPublishPreflightWouldBlockEvent,
-    escalatePublishDenied = () => {},
+    escalatePublishDenied = ({ orchDir: dir, ticket, explanation }) =>
+      labelNeedsHumanUnlessBeliefOwner(dir, ticket, writeStatus, {
+        env: process.env, site: "publish-preflight", explanation,
+      }),
     // CTL-1410 Phase B: in-process SDK-worker probe for the sweep. The REAL
     // registry read is the safe default here — it is a local Map lookup in this
     // same process (never shells out), and an empty registry (bare unit tick)
@@ -5804,14 +5807,20 @@ export function schedulerTick(
     // CAT-60: one choke-point covers advancement, parked resume, and new work.
     // Definitive denials gate only in enforce; unknown always proceeds.
     let pub = { state: "unknown" };
-    try {
-      pub = probePublishCapability({ orchDir, ticket, phase }) ?? pub;
-    } catch (err) {
-      log.warn({ ticket, phase, err: err?.message }, "publish-preflight: probe threw; dispatch proceeding");
+    if (publishPreflightMode !== "off") {
+      try {
+        pub = probePublishCapability({ orchDir, ticket, phase }) ?? pub;
+      } catch (err) {
+        log.warn({ ticket, phase, err: err?.message }, "publish-preflight: probe threw; dispatch proceeding");
+      }
     }
     if (pub.state === "denied" && publishPreflightMode !== "off") {
       if (publishPreflightMode === "enforce") {
-        safeEmit(appendPublishPreflightBlockedEvent, { ticket, phase, verdict: pub }, { ticket, phase });
+        const repoKey = pub.slug ?? ticket;
+        if (!publishWouldBlockSeen.has(repoKey)) {
+          publishWouldBlockSeen.add(repoKey);
+          safeEmit(appendPublishPreflightBlockedEvent, { ticket, phase, verdict: pub }, { ticket, phase });
+        }
         try {
           escalatePublishDenied({ orchDir, ticket, phase, verdict: pub,
             explanation: {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -113,6 +113,10 @@ import {
 } from "./linear-query.mjs";
 import { gatewayLabelsHit, descriptorAgeMs } from "./gateway-read.mjs"; // CTL-1079 / CTL-1570
 import { getProjectConfig, listProjects, ownerRepoFromRepoRoot, resolveEligibleQuery } from "./registry.mjs"; // CTL-1157: ownerRepoFromRepoRoot reconciles registry repoRoot → GitHub owner/repo for board-health's composite (repo,number) PR-status lookup; resolveEligibleQuery (CTL-1783) — the reopen-to-eligible-status check
+import {
+  appendPublishPreflightBlockedEvent as defaultAppendPublishPreflightBlockedEvent,
+  appendPublishPreflightWouldBlockEvent as defaultAppendPublishPreflightWouldBlockEvent,
+} from "./publish-preflight-event.mjs";
 // CTL-703: worktree teardown is now handled by the dedicated phase-teardown
 // phase agent (the 10th pipeline phase), not the scheduler's terminal sweep.
 // The gatedTeardownWorktree import is removed; the teardown phase agent
@@ -5290,6 +5294,12 @@ export function schedulerTick(
     // production; sweep-specific tests inject their own stubs.
     classifyResolution = () => "unknown",
     isBgJobAlive = () => true,
+    // CAT-60: safe no-op defaults keep direct schedulerTick calls hermetic.
+    probePublishCapability = () => ({ state: "unknown" }),
+    publishPreflightMode = "off",
+    appendPublishPreflightBlockedEvent = defaultAppendPublishPreflightBlockedEvent,
+    appendPublishPreflightWouldBlockEvent = defaultAppendPublishPreflightWouldBlockEvent,
+    escalatePublishDenied = () => {},
     // CTL-1410 Phase B: in-process SDK-worker probe for the sweep. The REAL
     // registry read is the safe default here — it is a local Map lookup in this
     // same process (never shells out), and an empty registry (bare unit tick)
@@ -5742,6 +5752,8 @@ export function schedulerTick(
   //
   // Returns: { ok, code, reason, signal } on a real dispatch attempt, or
   // { aborted: true } when preDispatch vetoed the iteration (caller `continue`s).
+  // Dedup shadow observations within this tick: permission is repo-scoped, not ticket-scoped.
+  const publishWouldBlockSeen = new Set();
   function dispatchAndVerify(
     orchDir,
     ticket,
@@ -5786,6 +5798,36 @@ export function schedulerTick(
           "ctl-2068: skipping dispatch — a lane holds this ticket"
         );
         return { aborted: true, laneClaimed: true };
+      }
+    }
+
+    // CAT-60: one choke-point covers advancement, parked resume, and new work.
+    // Definitive denials gate only in enforce; unknown always proceeds.
+    let pub = { state: "unknown" };
+    try {
+      pub = probePublishCapability({ orchDir, ticket, phase }) ?? pub;
+    } catch (err) {
+      log.warn({ ticket, phase, err: err?.message }, "publish-preflight: probe threw; dispatch proceeding");
+    }
+    if (pub.state === "denied" && publishPreflightMode !== "off") {
+      if (publishPreflightMode === "enforce") {
+        safeEmit(appendPublishPreflightBlockedEvent, { ticket, phase, verdict: pub }, { ticket, phase });
+        try {
+          escalatePublishDenied({ orchDir, ticket, phase, verdict: pub,
+            explanation: {
+              problem: `Cannot publish to ${pub.slug ?? "the configured repository"}: the automation identity lacks push permission.`,
+              call_to_action: `Grant push permission${pub.login ? ` to ${pub.login}` : ""} on ${pub.slug ?? "the configured push remote"}, or configure catalyst.pr.pushRemote to a writable remote.`,
+            },
+          });
+        } catch (err) {
+          log.warn({ ticket, err: err?.message }, "publish-preflight: escalation failed; dispatch remains blocked");
+        }
+        return { aborted: true };
+      }
+      const repoKey = pub.slug ?? ticket;
+      if (!publishWouldBlockSeen.has(repoKey)) {
+        publishWouldBlockSeen.add(repoKey);
+        safeEmit(appendPublishPreflightWouldBlockEvent, { ticket, phase, verdict: pub }, { ticket, phase });
       }
     }
 
@@ -10204,6 +10246,11 @@ function runTick() {
       // + the standalone main() pass the real impls to arm the sweep.
       classifyResolution: runningOpts.classifyResolution,
       isBgJobAlive: runningOpts.isBgJobAlive,
+      probePublishCapability: runningOpts.probePublishCapability,
+      publishPreflightMode: runningOpts.publishPreflightMode,
+      appendPublishPreflightBlockedEvent: runningOpts.appendPublishPreflightBlockedEvent,
+      appendPublishPreflightWouldBlockEvent: runningOpts.appendPublishPreflightWouldBlockEvent,
+      escalatePublishDenied: runningOpts.escalatePublishDenied,
       // CTL-781: respect-assignment + self-assign seams (undefined = gate off).
       botUserIds: runningOpts.botUserIds,
       botWriteId: runningOpts.botWriteId,
@@ -10960,6 +11007,11 @@ export function startScheduler({
   // real daemon (startDaemon) and the standalone main() pass the real impls.
   classifyResolution,
   isBgJobAlive,
+  probePublishCapability,
+  publishPreflightMode = "off",
+  appendPublishPreflightBlockedEvent,
+  appendPublishPreflightWouldBlockEvent,
+  escalatePublishDenied,
   // CTL-781: respect-assignment + self-assign. Undefined → gate off (fail-open).
   botUserIds,
   botWriteId,
@@ -11017,6 +11069,11 @@ export function startScheduler({
     checkOpenPrs, // CTL-1157: optional terminal-sweep open-PR gate override (runTick arms the real one)
     classifyResolution, // CTL-671: optional phantom-sweep Linear-probe seam
     isBgJobAlive, // CTL-671: optional phantom-sweep bg-liveness seam
+    probePublishCapability,
+    publishPreflightMode,
+    appendPublishPreflightBlockedEvent,
+    appendPublishPreflightWouldBlockEvent,
+    escalatePublishDenied,
     botUserIds, // CTL-781: respect-assignment predicate membership set
     botWriteId, // CTL-781: orchestrator bot UUID to write as assignee on claim
     appendIntentEvent, // CTL-936: operator-event seam for intent.ineffective

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.mjs
@@ -43,6 +43,7 @@ import { clearStalledLabel, inRemovalBackoff } from "./label-guard.mjs";
 // phase-agent-emit-complete sits two directories up from execution-core/
 // (mirrors recovery.mjs:86 — the canonical synthetic-complete emitter).
 const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", import.meta.url));
+const DRAFT_PR_LIB = fileURLToPath(new URL("../lib/draft-pr.sh", import.meta.url));
 
 // ─── default IO seams ───────────────────────────────────────────────────────
 // Each is overridable via deps; the production defaults shell to real git / fs /
@@ -51,6 +52,16 @@ const EMIT_COMPLETE_BIN = fileURLToPath(new URL("../phase-agent-emit-complete", 
 
 function defaultRunGit(args) {
   return spawnSync("git", args, { encoding: "utf8" });
+}
+
+function defaultResolvePushRemote(worktreePath) {
+  const script = `source "$1"; _draft_pr_push_remote`;
+  const res = spawnSync("bash", ["-c", script, "bash", DRAFT_PR_LIB], {
+    cwd: worktreePath,
+    encoding: "utf8",
+  });
+  if (res?.error || (res?.status ?? 1) !== 0) return "origin";
+  return String(res.stdout ?? "").trim() || "origin";
 }
 
 function defaultReadPorcelain(worktreePath, runGit) {
@@ -203,6 +214,7 @@ export function buildSourceConflictActSeam(deps = {}) {
     runGit = defaultRunGit,
     writeMarker = defaultWriteMarker,
     markerExists = defaultMarkerExists,
+    resolvePushRemote = defaultResolvePushRemote,
     orchDir = null,
   } = deps;
 
@@ -249,6 +261,8 @@ export function buildSourceConflictActSeam(deps = {}) {
       throw new Error(`source-conflict: ${decision.reason ?? "gate-failed"} (${ticket})`);
     }
 
+    const pushRemote = resolvePushRemote(worktreePath);
+
     // Disable hooks for the push (mechanical action; no local hook side-effects).
     const push = runGit([
       "-C",
@@ -258,7 +272,7 @@ export function buildSourceConflictActSeam(deps = {}) {
       "push",
       "--force-with-lease",
       "-u",
-      "origin",
+      pushRemote,
       "HEAD",
     ]);
     if (push?.error || (push?.status ?? 1) !== 0) {

--- a/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
+++ b/plugins/dev/scripts/execution-core/unstuck-act-seams.test.mjs
@@ -255,6 +255,23 @@ describe("buildSourceConflictActSeam (CTL-1219)", () => {
     expect(pushCall).toContain("--force-with-lease");
   });
 
+  test("force-push seam targets the resolved push remote", () => {
+    const gitCalls = [];
+    const seam = buildSourceConflictActSeam(
+      makeStubDeps({
+        resolvePushRemote: () => "fork",
+        runGit: (args) => {
+          gitCalls.push(args);
+          return cleanBranchGit()(args);
+        },
+      })
+    );
+    seam(sourceConflictCandidate(), { category: "source-conflict", action: "force-push-if-clean" });
+    const pushCall = gitCalls.find((a) => a.includes("push"));
+    expect(pushCall).toContain("fork");
+    expect(pushCall).not.toContain("origin");
+  });
+
   test("throws (no push) when the worktree is dirty with real work", () => {
     const gitCalls = [];
     const seam = buildSourceConflictActSeam(

--- a/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
+++ b/plugins/dev/scripts/lib/__tests__/draft-pr.test.sh
@@ -1374,6 +1374,19 @@ new_fixture safety-blast-offset
 assert_eq "0" "$(cat "${SCRATCH}/safety-blast-offset.exit" 2>/dev/null)" "11c: offsetting insertion does not trip the gate"
 assert_eq "$(cat "${SCRATCH}/safety-blast-offset.local")" "$(cat "${SCRATCH}/safety-blast-offset.remote")" "11c: origin/feature advanced to HEAD (push succeeded)"
 
+echo ""
+echo "Suite 12: configurable push remote + permission classifier (CAT-60)"
+new_fixture push-remote
+FORK="${SCRATCH}/push-remote/fork.git"
+git init --quiet --bare -b main "$FORK"
+git -C "$WORK" remote add fork "$FORK"
+assert_eq "origin" "$(cd "$WORK" && source "$DRAFT_PR_LIB" && _draft_pr_push_remote)" "12a: push remote defaults to origin"
+assert_eq "fork" "$(cd "$WORK" && CATALYST_PUSH_REMOTE=fork; export CATALYST_PUSH_REMOTE; source "$DRAFT_PR_LIB"; _draft_pr_push_remote)" "12b: env selects configured remote"
+printf '%s\n' 'remote: Permission to owner/repo.git denied to user.' > "${SCRATCH}/permission.err"
+if (source "$DRAFT_PR_LIB"; _draft_pr_is_permission_error "${SCRATCH}/permission.err"); then pass "12c: repository permission rejection detected"; else fail "12c: repository permission rejection detected"; fi
+printf '%s\n' 'refusing to allow an OAuth App to create or update workflow' > "${SCRATCH}/workflow.err"
+if (source "$DRAFT_PR_LIB"; _draft_pr_is_permission_error "${SCRATCH}/workflow.err"); then fail "12d: workflow-scope rejection excluded"; else pass "12d: workflow-scope rejection excluded"; fi
+
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────────────"

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -4,8 +4,9 @@
 # POSIX/zsh-safe: no ${VAR,,}, no shopt, no ${BASH_SOURCE[0]} at top-level.
 #
 # Exported functions:
-#   draft_pr_push                 — push current branch to origin (idempotent, fail-open)
-#   draft_pr_push_verify          — push + prove origin==HEAD; fail-closed; rc=3 when
+#   _draft_pr_push_remote         — resolve the configured automated push remote
+#   draft_pr_push                 — push current branch to the resolved remote (fail-open)
+#   draft_pr_push_verify          — push + prove remote==HEAD; fail-closed; rc=3 when
 #                                   the push is rejected for missing 'workflow' OAuth scope
 #                                   and no CATALYST_WORKFLOW_GITHUB_TOKEN is configured
 #   draft_pr_push_token TOKEN ... — push using an explicit PAT, bypassing GITHUB_TOKEN
@@ -22,6 +23,8 @@
 #   4 — draft_pr_push / draft_pr_push_verify: the pre-push safety gate refused the
 #       push (placeholder-identity commit or anomalous tree-wide deletion). Callers
 #       translate this into a push_safety_gate_blocked escalation.
+#   5 — draft_pr_push_verify: repository permission denied. Callers translate this
+#       into a push_denied_no_permission escalation.
 
 _draft_pr_warn() {
   printf 'draft-pr: %s\n' "$*" >&2
@@ -37,6 +40,59 @@ _DRAFT_PR_WORKFLOW_SCOPE_RC=3
 # tree, commit as "fixture") directly against its real cwd instead of the
 # test's isolated mkdtemp sandbox, and pushed the result to a real branch.
 _DRAFT_PR_SAFETY_GATE_RC=4
+_DRAFT_PR_PERMISSION_RC=5
+
+_draft_pr_config_str() {
+  local file="$1" path="$2" raw
+  [[ -f "$file" ]] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  raw="$(jq -r "$path" "$file" 2>/dev/null || true)"
+  [[ -z "$raw" || "$raw" == "null" ]] && return 1
+  printf '%s\n' "$raw"
+}
+
+_draft_pr_layer2_config_path() {
+  local common root project_key contract base
+  common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  [[ -n "$common" ]] || return 1
+  root="$(cd "$(dirname "$common")" 2>/dev/null && pwd || true)"
+  [[ -n "$root" ]] || return 1
+  project_key="$(_draft_pr_config_str "${root}/.catalyst/config.json" '.catalyst.projectKey // .projectKey' || true)"
+  [[ -n "$project_key" ]] || return 1
+  contract="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/catalyst-secret-contract.sh"
+  [[ -r "$contract" ]] || return 1
+  # shellcheck source=/dev/null
+  source "$contract"
+  base="$(catalyst_secret_resolve_layer2_path 2>/dev/null || true)"
+  [[ -n "$base" ]] || return 1
+  printf '%s/config-%s.json\n' "$(dirname "$base")" "$project_key"
+}
+
+_draft_pr_push_remote() {
+  local candidate="" l2 common root
+  [[ -n "${CATALYST_PUSH_REMOTE:-}" ]] && candidate="$CATALYST_PUSH_REMOTE"
+  if [[ -z "$candidate" ]]; then
+    l2="$(_draft_pr_layer2_config_path 2>/dev/null || true)"
+    [[ -n "$l2" ]] && candidate="$(_draft_pr_config_str "$l2" '.catalyst.pr.pushRemote' || true)"
+  fi
+  if [[ -z "$candidate" ]]; then
+    common="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+    if [[ -n "$common" ]]; then
+      root="$(cd "$(dirname "$common")" 2>/dev/null && pwd || true)"
+      [[ -n "$root" ]] && candidate="$(_draft_pr_config_str "${root}/.catalyst/config.json" '.catalyst.pr.pushRemote' || true)"
+    fi
+  fi
+  [[ -z "$candidate" ]] && candidate="$(_draft_pr_config_str "${CATALYST_CONFIG_PATH:-.catalyst/config.json}" '.catalyst.pr.pushRemote' || true)"
+  [[ -z "$candidate" ]] && { printf 'origin\n'; return 0; }
+  case "$candidate" in
+    *[!A-Za-z0-9._/-]*) _draft_pr_warn "ignoring unsafe pushRemote '${candidate}'; using origin"; printf 'origin\n'; return 0 ;;
+  esac
+  if ! git remote get-url "$candidate" >/dev/null 2>&1; then
+    _draft_pr_warn "pushRemote '${candidate}' is not a configured remote; using origin"
+    printf 'origin\n'; return 0
+  fi
+  printf '%s\n' "$candidate"
+}
 
 # _draft_pr_pending_range — the commit range about to be pushed: unpushed
 # local commits ahead of the upstream tracking branch, or ahead of
@@ -145,6 +201,20 @@ _draft_pr_is_workflow_scope_error() {
   grep -qi 'refusing to allow' "$errfile" && grep -qi 'workflow' "$errfile"
 }
 
+_draft_pr_is_permission_error() {
+  local errfile="$1"
+  [[ -f "$errfile" ]] || return 1
+  _draft_pr_is_workflow_scope_error "$errfile" && return 1
+  grep -qiE 'permission to .* denied|returned error: 403|HTTP 403' "$errfile"
+}
+
+_draft_pr_permission_context() {
+  local remote="$1" slug identity
+  slug="$(git remote get-url "$remote" 2>/dev/null || printf '<unknown>')"
+  identity="$(gh api user -q .login 2>/dev/null || printf '<unknown>')"
+  printf 'remote=%s repo=%s identity=%s' "$remote" "$slug" "$identity"
+}
+
 # draft_pr_diff_touches_workflows BASE — returns 0 iff the diff from
 # origin/<BASE> to HEAD adds or modifies a .github/workflows/ file.
 # Falls back to comparing HEAD only when origin/<BASE> is not resolvable.
@@ -199,26 +269,18 @@ _draft_pr_default_base() {
 draft_pr_push() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
   _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
-  local errf
+  local remote errf
+  remote="$(_draft_pr_push_remote)"
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-$$")"
-  if git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    if ! git -c core.hooksPath=/dev/null push 2>"$errf"; then
-      if _draft_pr_is_workflow_scope_error "$errf"; then
-        _draft_pr_warn "git push failed: missing 'workflow' OAuth scope (continuing)"
-      else
-        _draft_pr_warn "git push failed (continuing)"
-      fi
-      rm -f "$errf"; return 1
+  if ! git -c core.hooksPath=/dev/null push -u "$remote" HEAD 2>"$errf"; then
+    if _draft_pr_is_workflow_scope_error "$errf"; then
+      _draft_pr_warn "git push -u ${remote} failed: missing 'workflow' OAuth scope (continuing)"
+    elif _draft_pr_is_permission_error "$errf"; then
+      _draft_pr_warn "git push denied: $(_draft_pr_permission_context "$remote") missing=push (continuing)"
+    else
+      _draft_pr_warn "git push -u ${remote} failed (continuing)"
     fi
-  else
-    if ! git -c core.hooksPath=/dev/null push -u origin HEAD 2>"$errf"; then
-      if _draft_pr_is_workflow_scope_error "$errf"; then
-        _draft_pr_warn "git push -u failed: missing 'workflow' OAuth scope (continuing)"
-      else
-        _draft_pr_warn "git push -u failed (continuing)"
-      fi
-      rm -f "$errf"; return 1
-    fi
+    rm -f "$errf"; return 1
   fi
   rm -f "$errf"
 }
@@ -339,11 +401,12 @@ draft_pr_promote() {
 draft_pr_push_verify() {
   command -v git >/dev/null 2>&1 || { _draft_pr_warn "git unavailable"; return 1; }
   _draft_pr_safety_gate || return "$_DRAFT_PR_SAFETY_GATE_RC"
-  local branch local_sha remote_sha errf
+  local branch local_sha remote remote_sha errf
   branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
   [[ -z "$branch" || "$branch" == "HEAD" ]] && { _draft_pr_warn "detached HEAD; cannot push-verify"; return 1; }
   local_sha="$(git rev-parse HEAD 2>/dev/null || true)"
   [[ -z "$local_sha" ]] && { _draft_pr_warn "cannot resolve local HEAD"; return 1; }
+  remote="$(_draft_pr_push_remote)"
 
   errf="$(mktemp -t draft-pr-push-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-push-verify-$$")"
 
@@ -352,14 +415,14 @@ draft_pr_push_verify() {
   # scoped credential instead of attempting the plain push that will be rejected.
   if [[ -n "${CATALYST_WORKFLOW_GITHUB_TOKEN:-}" ]] && draft_pr_diff_touches_workflows; then
     _draft_pr_warn "workflow files + CATALYST_WORKFLOW_GITHUB_TOKEN set — routing through scoped token proactively"
-    if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u origin HEAD >/dev/null 2>&1; then
+    if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u "$remote" HEAD >/dev/null 2>&1; then
       rm -f "$errf"
-      git fetch --quiet origin "$branch" 2>/dev/null || true
-      remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+      git fetch --quiet "$remote" "$branch" 2>/dev/null || true
+      remote_sha="$(git rev-parse "${remote}/${branch}" 2>/dev/null || true)"
       if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
         printf '%s\n' "$local_sha"; return 0
       fi
-      _draft_pr_warn "post-push verify mismatch (proactive route): local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+      _draft_pr_warn "post-push verify mismatch (proactive route): local=${local_sha} ${remote}/${branch}=${remote_sha:-<none>}"
       return 1
     fi
     _draft_pr_warn "proactive scoped-token push failed"
@@ -367,7 +430,7 @@ draft_pr_push_verify() {
     return "$_DRAFT_PR_WORKFLOW_SCOPE_RC"
   fi
 
-  if ! git -c core.hooksPath=/dev/null push -u origin HEAD >/dev/null 2>"$errf"; then
+  if ! git -c core.hooksPath=/dev/null push -u "$remote" HEAD >/dev/null 2>"$errf"; then
     if _draft_pr_is_workflow_scope_error "$errf"; then
       _draft_pr_warn "push rejected: missing 'workflow' OAuth scope"
       rm -f "$errf"
@@ -376,7 +439,7 @@ draft_pr_push_verify() {
         _draft_pr_warn "retrying push with CATALYST_WORKFLOW_GITHUB_TOKEN"
         local tok_errf
         tok_errf="$(mktemp -t draft-pr-tok-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-tok-$$")"
-        if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u origin HEAD >/dev/null 2>"$tok_errf"; then
+        if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" -u "$remote" HEAD >/dev/null 2>"$tok_errf"; then
           rm -f "$tok_errf"
         else
           _draft_pr_warn "token-routed push also failed"
@@ -386,9 +449,13 @@ draft_pr_push_verify() {
       else
         return "$_DRAFT_PR_WORKFLOW_SCOPE_RC"
       fi
+    elif _draft_pr_is_permission_error "$errf"; then
+      _draft_pr_warn "push denied: $(_draft_pr_permission_context "$remote") missing=push"
+      rm -f "$errf"
+      return "$_DRAFT_PR_PERMISSION_RC"
     else
       _draft_pr_warn "fast-forward push failed; retrying with --force-with-lease"
-      if ! git -c core.hooksPath=/dev/null push --force-with-lease -u origin HEAD >/dev/null 2>"$errf"; then
+      if ! git -c core.hooksPath=/dev/null push --force-with-lease -u "$remote" HEAD >/dev/null 2>"$errf"; then
         if _draft_pr_is_workflow_scope_error "$errf"; then
           _draft_pr_warn "force-with-lease push rejected: missing 'workflow' OAuth scope"
           rm -f "$errf"
@@ -396,7 +463,7 @@ draft_pr_push_verify() {
             _draft_pr_warn "retrying force-with-lease with CATALYST_WORKFLOW_GITHUB_TOKEN"
             local tok_errf2
             tok_errf2="$(mktemp -t draft-pr-tok-XXXXXX 2>/dev/null || echo "/tmp/draft-pr-tok2-$$")"
-            if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" --force-with-lease -u origin HEAD >/dev/null 2>"$tok_errf2"; then
+            if draft_pr_push_token "$CATALYST_WORKFLOW_GITHUB_TOKEN" --force-with-lease -u "$remote" HEAD >/dev/null 2>"$tok_errf2"; then
               rm -f "$tok_errf2"
             else
               rm -f "$tok_errf2"
@@ -405,6 +472,10 @@ draft_pr_push_verify() {
           else
             return "$_DRAFT_PR_WORKFLOW_SCOPE_RC"
           fi
+        elif _draft_pr_is_permission_error "$errf"; then
+          _draft_pr_warn "force push denied: $(_draft_pr_permission_context "$remote") missing=push"
+          rm -f "$errf"
+          return "$_DRAFT_PR_PERMISSION_RC"
         else
           _draft_pr_warn "force-with-lease push failed"
           rm -f "$errf"
@@ -418,13 +489,13 @@ draft_pr_push_verify() {
     rm -f "$errf"
   fi
 
-  git fetch --quiet origin "$branch" 2>/dev/null || true
-  remote_sha="$(git rev-parse "origin/${branch}" 2>/dev/null || true)"
+  git fetch --quiet "$remote" "$branch" 2>/dev/null || true
+  remote_sha="$(git rev-parse "${remote}/${branch}" 2>/dev/null || true)"
   if [[ -n "$remote_sha" && "$remote_sha" == "$local_sha" ]]; then
     printf '%s\n' "$local_sha"
     return 0
   fi
-  _draft_pr_warn "post-push verify mismatch: local=${local_sha} origin/${branch}=${remote_sha:-<none>}"
+  _draft_pr_warn "post-push verify mismatch: local=${local_sha} ${remote}/${branch}=${remote_sha:-<none>}"
   return 1
 }
 
@@ -444,9 +515,9 @@ draft_pr_head_oid() {
 # falsy, so `false // true` → `true`. Read the raw string and test it directly.
 draft_pr_enabled() {
   local config_path="${CATALYST_CONFIG_PATH:-.catalyst/config.json}"
-  if [[ -f "$config_path" ]] && command -v jq >/dev/null 2>&1; then
-    local raw
-    raw="$(jq -r '.catalyst.orchestration.draftPr.enabled' "$config_path" 2>/dev/null || echo 'null')"
+  local raw
+  raw="$(_draft_pr_config_str "$config_path" '.catalyst.orchestration.draftPr.enabled' || true)"
+  if [[ -n "$raw" ]]; then
     if [[ "$raw" == "false" ]]; then
       printf 'false\n'
     else

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -59,7 +59,13 @@ _draft_pr_layer2_config_path() {
   [[ -n "$root" ]] || return 1
   project_key="$(_draft_pr_config_str "${root}/.catalyst/config.json" '.catalyst.projectKey // .projectKey' || true)"
   [[ -n "$project_key" ]] || return 1
-  contract="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)/catalyst-secret-contract.sh"
+  local source_path
+  if [[ -n "${ZSH_VERSION:-}" ]]; then
+    source_path="${(%):-%x}"
+  else
+    source_path="${BASH_SOURCE[0]:-$0}"
+  fi
+  contract="$(cd "$(dirname "$source_path")" 2>/dev/null && pwd)/catalyst-secret-contract.sh"
   [[ -r "$contract" ]] || return 1
   # shellcheck source=/dev/null
   source "$contract"
@@ -83,6 +89,11 @@ _draft_pr_push_remote() {
     fi
   fi
   [[ -z "$candidate" ]] && candidate="$(_draft_pr_config_str "${CATALYST_CONFIG_PATH:-.catalyst/config.json}" '.catalyst.pr.pushRemote' || true)"
+  if [[ -z "$candidate" ]]; then
+    local upstream
+    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    [[ -n "$upstream" ]] && candidate="${upstream%%/*}"
+  fi
   [[ -z "$candidate" ]] && { printf 'origin\n'; return 0; }
   case "$candidate" in
     *[!A-Za-z0-9._/-]*) _draft_pr_warn "ignoring unsafe pushRemote '${candidate}'; using origin"; printf 'origin\n'; return 0 ;;

--- a/plugins/dev/scripts/lib/draft-pr.sh
+++ b/plugins/dev/scripts/lib/draft-pr.sh
@@ -43,10 +43,10 @@ _DRAFT_PR_SAFETY_GATE_RC=4
 _DRAFT_PR_PERMISSION_RC=5
 
 _draft_pr_config_str() {
-  local file="$1" path="$2" raw
+  local file="$1" selector="$2" raw
   [[ -f "$file" ]] || return 1
   command -v jq >/dev/null 2>&1 || return 1
-  raw="$(jq -r "$path" "$file" 2>/dev/null || true)"
+  raw="$(jq -r "$selector" "$file" 2>/dev/null || true)"
   [[ -z "$raw" || "$raw" == "null" ]] && return 1
   printf '%s\n' "$raw"
 }
@@ -61,6 +61,8 @@ _draft_pr_layer2_config_path() {
   [[ -n "$project_key" ]] || return 1
   local source_path
   if [[ -n "${ZSH_VERSION:-}" ]]; then
+    # This is zsh's current sourced-file expansion.
+    # shellcheck disable=SC2296
     source_path="${(%):-%x}"
   else
     source_path="${BASH_SOURCE[0]:-$0}"

--- a/plugins/dev/skills/phase-pr/SKILL.md
+++ b/plugins/dev/skills/phase-pr/SKILL.md
@@ -232,6 +232,12 @@ if [[ -n "$EXISTING_PR_NUMBER" ]]; then
       --phase "$PHASE" --ticket "$TICKET" --status failed \
       --reason "push_safety_gate_blocked"
     exit 1
+  elif [[ "$PUSH_VERIFY_RC" -eq 5 ]]; then
+    echo "phase-pr: push denied — configured remote does not grant push permission" >&2
+    "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+      --phase "$PHASE" --ticket "$TICKET" --status failed \
+      --reason "push_denied_no_permission"
+    exit 1
   elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
     echo "phase-pr: push-verify failed for #${EXISTING_PR_NUMBER} (stale ref)" >&2
     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
@@ -329,6 +335,12 @@ itself.
      "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
        --phase "$PHASE" --ticket "$TICKET" --status failed \
        --reason "push_safety_gate_blocked"
+     exit 1
+   elif [[ "$PUSH_VERIFY_RC" -eq 5 ]]; then
+     echo "phase-pr: push denied — configured remote does not grant push permission" >&2
+     "${PLUGIN_ROOT}/scripts/phase-agent-emit-complete" \
+       --phase "$PHASE" --ticket "$TICKET" --status failed \
+       --reason "push_denied_no_permission"
      exit 1
    elif [[ "$PUSH_VERIFY_RC" -ne 0 ]]; then
      echo "phase-pr: post-create-pr push-verify failed (stale ref)" >&2

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -128,9 +128,42 @@ The `orchestration.dispatchMode` key picks how Catalyst runs each ticket:
 }
 ```
 
+### Push remote (`catalyst.pr.pushRemote`, CAT-60)
+
+The push remote is machine-local routing, so its canonical home is Layer 2 at
+`~/.config/catalyst/config.json`, not the repository's committed Layer-1 file. Keeping it outside
+the git tree means a rebase cannot rewrite the setting that selects where the branch is published.
+
+Resolution is `CATALYST_PUSH_REMOTE` → `catalyst.pr.pushRemote` → the branch's configured upstream
+remote → `origin`. The value must name an existing, safe git remote. It controls branch publication
+and remote-branch discovery when a worker resumes. It does **not** change the rebase or diff base:
+those continue to use `origin/<base>`. The operator-facing branch listing in `cli/branches.mjs` is
+still an `origin`-only surface and does not determine dispatch or publication behavior.
+
+```json
+{ "catalyst": { "pr": { "pushRemote": "fork" } } }
+```
+
+### Publish-capability preflight (`catalyst.orchestration.publishPreflight.mode`, CAT-60)
+
+Before dispatch, execution-core asks GitHub whether the active identity has push permission for the
+repository behind the resolved push remote. `CATALYST_PUBLISH_PREFLIGHT` overrides the Layer-2
+`catalyst.orchestration.publishPreflight.mode`; the default is `shadow`:
+
+- `off` does not probe.
+- `shadow` emits `publish.preflight.would-block` for denial but still dispatches.
+- `enforce` emits `publish.preflight.blocked` and stops that dispatch on definitive denial.
+
+Verdicts are `allowed`, `denied`, or `unknown`. An inconclusive `unknown` (missing `gh`, timeout,
+transient API failure, or unparseable remote) never blocks. Results are cached per repository,
+remote, and GitHub identity for a bounded TTL so scheduler ticks conserve GitHub API quota.
+`catalyst doctor` reports the same capability independently: denied is advisory in `shadow` and a
+failure in `enforce`.
+
 | Key                                                           | Default                      | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | ------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `orchestration.dispatchMode`                                  | `oneshot-legacy`             | Which run mode to use (above)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `catalyst.orchestration.publishPreflight.mode` _(Layer-2)_    | `shadow`                     | Before dispatch, verify that the resolved GitHub identity can push to the configured push remote. `off` skips the probe; `shadow` reports denied capability but still dispatches; `enforce` blocks dispatch only on a definitive denied verdict. `CATALYST_PUBLISH_PREFLIGHT` overrides this value. Unknown values fall back to `shadow`. |
 | `orchestration.executor`                                      | `bg`                         | Which substrate runs a phase worker: `bg` (a `claude --bg` background job, today's behavior), `oneshot-legacy`, or `sdk` (the in-process Claude Agent SDK — **not yet implemented; falls back to `bg`**, CTL-1365b). Resolution: `CATALYST_EXECUTOR` env → this key → node-class default (all classes → `bg` today). Distinct from `dispatchMode`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `orchestration.maxParallel`                                   | `3`                          | How many tickets run at once                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `orchestration.worktreeDir`                                   | `~/catalyst/wt/<projectKey>` | Where worktrees are created                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |


### PR DESCRIPTION
## Summary
- Adds `publish-preflight.mjs`: a probe run inside `dispatchAndVerify`, immediately before launching a phase worker, that checks whether the resolved push remote's identity can actually publish a branch — GitHub read access and write access are separate grants, and cloning/fetching succeeding says nothing about push capability.
- Three surfaces (`push` target, resume remote-branch discovery, `draft-pr.sh`) previously assumed `origin`; this makes them use the resolved push remote instead (the rebase/diff base deliberately stays `origin/<base>` — publication routing must not change the canonical integration base).
- Rollout flag `CATALYST_PUBLISH_PREFLIGHT` (`off` / `shadow` / `enforce`, default `shadow`) over Layer-2 config (`catalyst.orchestration.publishPreflight.mode`). Shadow emits `publish.preflight.would-block` and continues; enforce blocks only a definitive `denied` verdict and emits `publish.preflight.blocked` with an escalation; `unknown` always proceeds. A bounded identity-aware cache conserves GitHub quota.
- `doctor.mjs` gets a worker-only check: PASS (allowed) / WARN (shadow denial) / FAIL (enforce denial) / INFO (inconclusive).
- Wires the new suites, `config-docs-coverage.test.sh`, `phase-pr-rc-map.test.sh`, and `draft-pr-lib.test.sh` into CI — none ran in this hand-enumerated workflow before.

Ported from stale fork PR #3147 (thagale/catalyst, CAT-60) as part of the 2026-08-21 verification sweep of stale fork PRs. All 7 original commits cherry-picked cleanly onto current main with a handful of additive-only conflicts (new imports/constants/CI steps alongside code added to `main` since the fork diverged — e.g. the CTL-2068 lane-claim dispatch veto in `scheduler.mjs`, which now runs before this preflight check as a second, independent choke point). No logic from either side was dropped. Credit: Tony Hagale (original author).

## Test plan
All touched/added test files, run individually (never the full suite):
- [x] `bun test doctor-publish-preflight.test.mjs` — 8 pass
- [x] `bun test publish-preflight-config.test.mjs` — 3 pass
- [x] `bun test publish-preflight.test.mjs` — 13 pass
- [x] `bun test unstuck-act-seams.test.mjs` — 36 pass
- [x] `bun test namespace-parity.test.mjs` (broker) — 12 pass
- [x] `bash __tests__/config-docs-coverage.test.sh` — pass
- [x] `bash __tests__/phase-pr-rc-map.test.sh` — pass
- [x] `bash lib/__tests__/draft-pr.test.sh` — 89 pass (incl. the new CAT-60 push-remote/permission-classifier cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)