### PR TITLE
fix(dev): CAT-116 — validate registry identity at dispatch revision

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,9 +251,10 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
   enrollment under `execution-core/projects/` and the `/orchestrate` enroll step were retired in
   CTL-582. Access flows through `registry.mjs` `list-projects`/`get-project-config` — the D9 cloud
   seam (swappable to a hosted table without touching callers). Each entry's `team` must match its
-  `repoRoot`'s Layer-1 `catalyst.linear.teamKey`; `listProjects()` warns on a mismatch and
-  `catalyst doctor` grades it with the advisory `registry-team-identity` check. Catalyst's own CAT
-  registration is recorded in ADR-028.
+  `repoRoot`'s Layer-1 `catalyst.linear.teamKey`. The hot-path `listProjects()` check reads the
+  working tree and warns on mismatch; the opt-in `catalyst doctor` arm reads the dispatch revision
+  from local refs only and grades working-tree/revision drift as WARN. Both remain advisory under
+  `registry-team-identity`. Catalyst's own CAT registration is recorded in ADR-028.
 - **Heartbeat** — orchestrators write `lastHeartbeat` every 2–3 min; entries stale >10 min are GC'd
   as `abandoned`.
 

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-registry-team-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-registry-team-identity.test.mjs
@@ -132,6 +132,52 @@ describe("checkRegistryTeamIdentity", () => {
     expect(rec.detail).not.toContain("checkout that declares a DIFFERENT");
   });
 
+  // Codex #3232 P2: category precedence is per ENTRY. It must never hide a
+  // DIFFERENT entry's defect — one doctor run has to name every affected
+  // registration, not just the strongest category's.
+  test("reports every affected entry across all three categories at once", () => {
+    const rec = checkRegistryTeamIdentity(deps([
+      {
+        team: "CAT", repoRoot: "/rev",
+        identity: { declared: "CAT", matches: true },
+        dispatchIdentity: { declared: "CTL", matches: false, rev: "refs/heads/main" },
+      },
+      {
+        team: "PAN", repoRoot: "/drift",
+        identity: { declared: "OLD", matches: false },
+        dispatchIdentity: { declared: "PAN", matches: true, rev: "refs/remotes/origin/main" },
+      },
+      {
+        team: "ADV", repoRoot: "/checkout",
+        identity: { declared: "WRONG", matches: false },
+        dispatchIdentity: { declared: null, matches: null, rev: null },
+      },
+    ]));
+    expect(rec.status).toBe(STATUS.WARN);
+    // entry 1 — dispatch-revision mismatch
+    expect(rec.detail).toContain("/rev");
+    expect(rec.detail).toContain("would receive a DIFFERENT Linear team");
+    // entry 2 — checkout ↔ dispatch drift, NOT suppressed by entry 1
+    expect(rec.detail).toContain("/drift");
+    expect(rec.detail).toContain("drift");
+    // entry 3 — plain checkout mismatch, NOT suppressed by entries 1-2
+    expect(rec.detail).toContain("/checkout");
+    expect(rec.detail).toContain("WRONG");
+    expect(rec.detail).toContain("CAT-52");
+  });
+
+  test("an entry counted as a revision mismatch is not double-reported", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT", repoRoot: "/r",
+      identity: { declared: "OLD", matches: false },
+      dispatchIdentity: { declared: "CTL", matches: false, rev: "refs/heads/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.WARN);
+    expect(rec.detail).toContain("1 registry entry would receive a DIFFERENT");
+    expect(rec.detail).not.toContain("checkout that declares a DIFFERENT");
+    expect(rec.detail).not.toContain("drift");
+  });
+
   test("still never FAILs when every entry mismatches on both arms", () => {
     const rec = checkRegistryTeamIdentity(deps([{
       team: "A", repoRoot: "/a",

--- a/plugins/dev/scripts/execution-core/__tests__/doctor-registry-team-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/doctor-registry-team-identity.test.mjs
@@ -2,7 +2,7 @@
 // injected; the never-FAIL and never-throw invariants are load-bearing.
 
 import { describe, test, expect } from "bun:test";
-import { checkRegistryTeamIdentity } from "../doctor.mjs";
+import { checkRegistryTeamIdentity, STATUS } from "../doctor.mjs";
 
 const deps = (projects) => ({ listProjects: () => projects });
 
@@ -92,5 +92,93 @@ describe("checkRegistryTeamIdentity", () => {
     }).not.toThrow();
     expect(rec.status).toBe("info");
     expect(rec.status).not.toBe("fail");
+  });
+
+  test("WARNs when the dispatch revision declares a different team than the registry", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT",
+      repoRoot: "/r",
+      identity: { declared: "CAT", matches: true },
+      dispatchIdentity: { declared: "CTL", matches: false, rev: "refs/remotes/origin/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.WARN);
+    expect(rec.detail).toContain("CTL");
+    expect(rec.detail).toContain("refs/remotes/origin/main");
+    expect(rec.detail).toContain("CAT-116");
+  });
+
+  test("WARNs on drift even when the dispatch revision matches the registry", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT",
+      repoRoot: "/r",
+      identity: { declared: "CTL", matches: false },
+      dispatchIdentity: { declared: "CAT", matches: true, rev: "refs/remotes/origin/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.WARN);
+    expect(rec.detail).toContain("checkout declares \"CTL\"");
+    expect(rec.detail).toContain("fresh worktree follows \"CAT\"");
+  });
+
+  test("dispatch-revision mismatch outranks a working-tree mismatch", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT",
+      repoRoot: "/r",
+      identity: { declared: "OLD", matches: false },
+      dispatchIdentity: { declared: "CTL", matches: false, rev: "refs/heads/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.WARN);
+    expect(rec.detail).toContain("dispatch revision");
+    expect(rec.detail).toContain("CTL");
+    expect(rec.detail).not.toContain("checkout that declares a DIFFERENT");
+  });
+
+  test("still never FAILs when every entry mismatches on both arms", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "A", repoRoot: "/a",
+      identity: { declared: "X", matches: false },
+      dispatchIdentity: { declared: "Y", matches: false, rev: "refs/heads/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.WARN);
+    expect(rec.status).not.toBe(STATUS.FAIL);
+  });
+
+  test("an unknown dispatch identity is INFO-unverified, never PASS", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT", repoRoot: "/r",
+      identity: { declared: "CAT", matches: true },
+      dispatchIdentity: { declared: null, matches: null, rev: null },
+    }]));
+    expect(rec.status).toBe(STATUS.INFO);
+    expect(rec.detail).toContain("dispatch revision");
+    expect(rec.detail).toContain("0/1");
+  });
+
+  test("absent dispatchIdentity grades exactly as before CAT-116", () => {
+    const pass = checkRegistryTeamIdentity(deps([
+      { team: "CAT", identity: { declared: "CAT", matches: true } },
+    ]));
+    expect(pass.status).toBe(STATUS.PASS);
+    expect(pass.detail).toContain("1/1");
+  });
+
+  test("PASS requires both identity arms verified and agreeing", () => {
+    const rec = checkRegistryTeamIdentity(deps([{
+      team: "CAT", repoRoot: "/r",
+      identity: { declared: "CAT", matches: true },
+      dispatchIdentity: { declared: "CAT", matches: true, rev: "refs/remotes/origin/main" },
+    }]));
+    expect(rec.status).toBe(STATUS.PASS);
+    expect(rec.detail).toContain("both checkout and dispatch revision");
+  });
+
+  test("production reader opts into dispatch identity", () => {
+    let options;
+    checkRegistryTeamIdentity({
+      listProjects: (received) => {
+        options = received;
+        return [];
+      },
+    });
+    expect(options).toEqual({ withDispatchIdentity: true });
   });
 });

--- a/plugins/dev/scripts/execution-core/__tests__/registry-dispatch-revision-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/registry-dispatch-revision-identity.test.mjs
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  dispatchRevisionIdentityOf,
+  listProjects,
+  upsertProjectEntry,
+} from "../registry.mjs";
+
+function gitFake(map) {
+  return (_repoRoot, rev) =>
+    rev in map ? { ok: true, stdout: map[rev] } : { ok: false, stdout: "" };
+}
+
+const cfg = (team) => JSON.stringify({ catalyst: { linear: { teamKey: team } } });
+
+describe("dispatchRevisionIdentityOf", () => {
+  test("prefers refs/remotes/origin/main and records the ref that answered", () => {
+    expect(
+      dispatchRevisionIdentityOf(
+        { team: "CAT", repoRoot: "/repo" },
+        { showAtRev: gitFake({ "refs/remotes/origin/main": cfg("CAT"), "refs/heads/main": cfg("CTL") }) },
+      ),
+    ).toEqual({ declared: "CAT", matches: true, rev: "refs/remotes/origin/main" });
+  });
+
+  test("falls back to refs/heads/main when origin/main is absent", () => {
+    expect(
+      dispatchRevisionIdentityOf(
+        { team: "CAT", repoRoot: "/repo" },
+        { showAtRev: gitFake({ "refs/heads/main": cfg("CAT") }) },
+      ),
+    ).toEqual({ declared: "CAT", matches: true, rev: "refs/heads/main" });
+  });
+
+  test("detects a mismatch at the dispatch revision", () => {
+    expect(
+      dispatchRevisionIdentityOf(
+        { team: "CAT", repoRoot: "/repo" },
+        { showAtRev: gitFake({ "refs/remotes/origin/main": cfg("CTL") }) },
+      ),
+    ).toEqual({ declared: "CTL", matches: false, rev: "refs/remotes/origin/main" });
+  });
+
+  test("accepts the bare config shape", () => {
+    const showAtRev = gitFake({ "refs/remotes/origin/main": JSON.stringify({ linear: { teamKey: "CAT" } }) });
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev }).matches).toBe(true);
+  });
+
+  test("no resolvable ref is unknown with rev null", () => {
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev: gitFake({}) })).toEqual({
+      declared: null,
+      matches: null,
+      rev: null,
+    });
+  });
+
+  test("malformed JSON at the revision is unknown and never throws", () => {
+    const showAtRev = gitFake({ "refs/remotes/origin/main": "{oops" });
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev })).toEqual({
+      declared: null,
+      matches: null,
+      rev: "refs/remotes/origin/main",
+    });
+  });
+
+  test.each([undefined, "", "   ", 42])("missing, blank, or non-string teamKey %p is unknown", (teamKey) => {
+    const showAtRev = gitFake({
+      "refs/remotes/origin/main": JSON.stringify({ catalyst: { linear: { teamKey } } }),
+    });
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev }).matches).toBeNull();
+  });
+
+  test("a throwing git reader is unknown and never throws", () => {
+    const showAtRev = () => {
+      throw new Error("boom");
+    };
+    expect(() => dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev })).not.toThrow();
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev }).rev).toBeNull();
+  });
+
+  test("comparison is exact", () => {
+    const showAtRev = gitFake({ "refs/remotes/origin/main": cfg("cat") });
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev }).matches).toBe(false);
+  });
+
+  test("does not fall through when a resolved ref contains malformed config", () => {
+    const showAtRev = gitFake({
+      "refs/remotes/origin/main": "{oops",
+      "refs/heads/main": cfg("CAT"),
+    });
+    expect(dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { showAtRev })).toEqual({
+      declared: null,
+      matches: null,
+      rev: "refs/remotes/origin/main",
+    });
+  });
+
+  test("the default showAtRev never invokes a network git subcommand", () => {
+    const calls = [];
+    const spawn = (bin, argv) => {
+      calls.push([bin, ...argv].join(" "));
+      return { status: 128, stdout: "", stderr: "" };
+    };
+    dispatchRevisionIdentityOf({ team: "CAT", repoRoot: "/repo" }, { spawn });
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) {
+      expect(call).toMatch(/^git show /);
+      expect(call).not.toMatch(/fetch|ls-remote|pull|clone/);
+    }
+  });
+});
+
+describe("listProjects dispatch-revision opt-in", () => {
+  const registryJson = JSON.stringify({ projects: [{ team: "CAT", repoRoot: "/repo" }] });
+  const baseDeps = {
+    readRegistry: () => registryJson,
+    exists: () => true,
+    readLayer1: () => cfg("CAT"),
+    warn: () => {},
+  };
+
+  test("default call spawns no git and attaches no dispatchIdentity", () => {
+    let spawned = 0;
+    const projects = listProjects({
+      ...baseDeps,
+      spawn: () => {
+        spawned++;
+        return { status: 0, stdout: "" };
+      },
+    });
+    expect(spawned).toBe(0);
+    expect(projects[0].dispatchIdentity).toBeUndefined();
+    expect(projects[0].identity).toEqual({ declared: "CAT", matches: true });
+  });
+
+  test("withDispatchIdentity attaches the revision answer per entry", () => {
+    const projects = listProjects({
+      ...baseDeps,
+      withDispatchIdentity: true,
+      showAtRev: gitFake({ "refs/remotes/origin/main": cfg("CAT") }),
+    });
+    expect(projects[0].dispatchIdentity).toEqual({
+      declared: "CAT",
+      matches: true,
+      rev: "refs/remotes/origin/main",
+    });
+  });
+
+  test("withDispatchIdentity does not change arm-A warn behavior", () => {
+    const run = (withDispatchIdentity) => {
+      const warnings = [];
+      listProjects({
+        ...baseDeps,
+        readLayer1: () => cfg("CTL"),
+        withDispatchIdentity,
+        showAtRev: gitFake({ "refs/remotes/origin/main": cfg("CAT") }),
+        warn: (obj, message) => warnings.push({ obj, message }),
+      });
+      return warnings;
+    };
+    expect(run(true)).toEqual(run(false));
+    expect(run(true)).toHaveLength(1);
+  });
+
+  test("a nonexistent repoRoot skips the revision read", () => {
+    let reads = 0;
+    const projects = listProjects({
+      ...baseDeps,
+      exists: () => false,
+      withDispatchIdentity: true,
+      showAtRev: () => {
+        reads++;
+        return { ok: true, stdout: cfg("CAT") };
+      },
+    });
+    expect(reads).toBe(0);
+    expect(projects[0].dispatchIdentity).toEqual({ declared: null, matches: null, rev: null });
+  });
+});
+
+describe("upsertProjectEntry runtime fields", () => {
+  let dir;
+  let previousCatalystDir;
+
+  afterEach(() => {
+    if (previousCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = previousCatalystDir;
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  test("strips dispatchIdentity as well as identity from retained entries", () => {
+    previousCatalystDir = process.env.CATALYST_DIR;
+    dir = mkdtempSync(join(tmpdir(), "cat-116-registry-"));
+    process.env.CATALYST_DIR = dir;
+    mkdirSync(join(dir, "execution-core"), { recursive: true });
+    writeFileSync(
+      join(dir, "execution-core", "registry.json"),
+      JSON.stringify({
+        projects: [{
+          team: "PAN",
+          repoRoot: "/missing",
+          eligibleQuery: null,
+          identity: { declared: "PAN", matches: true },
+          dispatchIdentity: { declared: "PAN", matches: true, rev: "refs/heads/main" },
+        }],
+      }),
+    );
+    upsertProjectEntry({ team: "CAT", repoRoot: "/cat" });
+    const saved = JSON.parse(readFileSync(join(dir, "execution-core", "registry.json"), "utf8"));
+    expect(saved.projects[0].identity).toBeUndefined();
+    expect(saved.projects[0].dispatchIdentity).toBeUndefined();
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/registry-team-identity.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/registry-team-identity.test.mjs
@@ -32,7 +32,9 @@ describe("teamIdentityOf", () => {
     expect(result.matches).toBe(true);
   });
 
-  test("detects the live CAT to CTL mismatch", () => {
+  // The real CAT -> CTL dispatch-revision case belongs to
+  // registry-dispatch-revision-identity.test.mjs; this suite covers Arm A.
+  test("detects a mismatch between the registry team and the declared teamKey", () => {
     const result = teamIdentityOf(
       { team: "CAT", repoRoot: "/clone" },
       reader({ "/clone/.catalyst/config.json": JSON.stringify({ catalyst: { linear: { teamKey: "CTL" } } }) }),

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4608,11 +4608,32 @@ export function checkRegistryTeamIdentity(deps = {}) {
     );
   }
 
-  // What dispatch installs outranks checkout state: create-worktree.sh restores
-  // tracked .catalyst paths from its start revision after copying the checkout.
-  const revisionMismatches = projects.filter(
-    (project) => project?.dispatchIdentity?.matches === false,
+  // Every defect category is classified in ONE pass and reported TOGETHER
+  // (Codex #3232 P2). Precedence is per ENTRY, not per report: an entry whose
+  // dispatch revision mismatches is described only by that (strongest) category,
+  // because what dispatch installs outranks checkout state — create-worktree.sh
+  // restores tracked .catalyst paths from its start revision after copying the
+  // checkout. But precedence must never SUPPRESS a different entry's defect:
+  // returning on the first non-empty category let a multi-project run name one
+  // project while leaving another project's known mismatch undisclosed until the
+  // first was repaired and doctor rerun.
+  const classified = new Set();
+  const claim = (list) => {
+    list.forEach((project) => classified.add(project));
+    return list;
+  };
+  const revisionMismatches = claim(
+    projects.filter((project) => project?.dispatchIdentity?.matches === false),
   );
+  const drifted = claim(projects.filter((project) =>
+    !classified.has(project) &&
+    typeof project?.identity?.declared === "string" &&
+    typeof project?.dispatchIdentity?.declared === "string" &&
+    project.identity.declared !== project.dispatchIdentity.declared));
+  const mismatches = claim(projects.filter((project) =>
+    !classified.has(project) && project?.identity?.matches === false));
+
+  const findings = [];
   if (revisionMismatches.length) {
     const details = revisionMismatches
       .map((project) =>
@@ -4620,19 +4641,12 @@ export function checkRegistryTeamIdentity(deps = {}) {
         `${project.dispatchIdentity.rev ?? "unknown"} declares ` +
         `"${project.dispatchIdentity.declared}")`)
       .join("; ");
-    return mkCheck(
-      "registry-team-identity",
-      STATUS.WARN,
+    findings.push(
       `${revisionMismatches.length} registry entr${revisionMismatches.length === 1 ? "y" : "ies"} ` +
         "would receive a DIFFERENT Linear team from the dispatch revision: " +
         `${details} — a fresh worktree follows that revision (CAT-116)`,
     );
   }
-
-  const drifted = projects.filter((project) =>
-    typeof project?.identity?.declared === "string" &&
-    typeof project?.dispatchIdentity?.declared === "string" &&
-    project.identity.declared !== project.dispatchIdentity.declared);
   if (drifted.length) {
     const details = drifted
       .map((project) =>
@@ -4641,27 +4655,24 @@ export function checkRegistryTeamIdentity(deps = {}) {
         `"${project.dispatchIdentity.declared}" at ` +
         `${project.dispatchIdentity.rev ?? "unknown"})`)
       .join("; ");
-    return mkCheck(
-      "registry-team-identity",
-      STATUS.WARN,
+    findings.push(
       `${drifted.length} registry entr${drifted.length === 1 ? "y has" : "ies have"} ` +
         `checkout ↔ dispatch-revision team identity drift: ${details} (CAT-116)`,
     );
   }
-
-  const mismatches = projects.filter((project) => project?.identity?.matches === false);
   if (mismatches.length) {
     const details = mismatches
       .map((project) =>
         `${project.team} → ${project.repoRoot} (declares "${project.identity.declared}")`)
       .join("; ");
-    return mkCheck(
-      "registry-team-identity",
-      STATUS.WARN,
+    findings.push(
       `${mismatches.length} registry entr${mismatches.length === 1 ? "y" : "ies"} point at a ` +
         "checkout that declares a DIFFERENT Linear team — worktrees cut from it inherit that " +
         `checkout's Layer-1 catalyst.linear config and ticket prefix: ${details} (CAT-52)`,
     );
+  }
+  if (findings.length) {
+    return mkCheck("registry-team-identity", STATUS.WARN, findings.join(" | "));
   }
   // Preserve the pre-CAT-116 injectable project shape: when no entry carries
   // dispatchIdentity, grade checkout identity exactly as before. Once any

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4589,7 +4589,10 @@ export function checkRegistryTeamIdentity(deps = {}) {
   const { listProjects: readProjects = listProjects } = deps;
   let projects;
   try {
-    projects = readProjects();
+    // CAT-116: revision inspection is deliberately opt-in so listProjects()'s
+    // scheduler/daemon hot path remains free of git subprocesses. Doctor is a
+    // one-shot caller and grades the revision a fresh dispatch would install.
+    projects = readProjects({ withDispatchIdentity: true });
   } catch (err) {
     return mkCheck(
       "registry-team-identity",
@@ -4604,6 +4607,48 @@ export function checkRegistryTeamIdentity(deps = {}) {
       "registry has no projects — nothing to check (the zero-project warning is the daemon's, CTL-854)",
     );
   }
+
+  // What dispatch installs outranks checkout state: create-worktree.sh restores
+  // tracked .catalyst paths from its start revision after copying the checkout.
+  const revisionMismatches = projects.filter(
+    (project) => project?.dispatchIdentity?.matches === false,
+  );
+  if (revisionMismatches.length) {
+    const details = revisionMismatches
+      .map((project) =>
+        `${project.team} → ${project.repoRoot} (dispatch revision ` +
+        `${project.dispatchIdentity.rev ?? "unknown"} declares ` +
+        `"${project.dispatchIdentity.declared}")`)
+      .join("; ");
+    return mkCheck(
+      "registry-team-identity",
+      STATUS.WARN,
+      `${revisionMismatches.length} registry entr${revisionMismatches.length === 1 ? "y" : "ies"} ` +
+        "would receive a DIFFERENT Linear team from the dispatch revision: " +
+        `${details} — a fresh worktree follows that revision (CAT-116)`,
+    );
+  }
+
+  const drifted = projects.filter((project) =>
+    typeof project?.identity?.declared === "string" &&
+    typeof project?.dispatchIdentity?.declared === "string" &&
+    project.identity.declared !== project.dispatchIdentity.declared);
+  if (drifted.length) {
+    const details = drifted
+      .map((project) =>
+        `${project.team} → ${project.repoRoot} (checkout declares ` +
+        `"${project.identity.declared}"; fresh worktree follows ` +
+        `"${project.dispatchIdentity.declared}" at ` +
+        `${project.dispatchIdentity.rev ?? "unknown"})`)
+      .join("; ");
+    return mkCheck(
+      "registry-team-identity",
+      STATUS.WARN,
+      `${drifted.length} registry entr${drifted.length === 1 ? "y has" : "ies have"} ` +
+        `checkout ↔ dispatch-revision team identity drift: ${details} (CAT-116)`,
+    );
+  }
+
   const mismatches = projects.filter((project) => project?.identity?.matches === false);
   if (mismatches.length) {
     const details = mismatches
@@ -4616,6 +4661,33 @@ export function checkRegistryTeamIdentity(deps = {}) {
       `${mismatches.length} registry entr${mismatches.length === 1 ? "y" : "ies"} point at a ` +
         "checkout that declares a DIFFERENT Linear team — worktrees cut from it inherit that " +
         `checkout's Layer-1 catalyst.linear config and ticket prefix: ${details} (CAT-52)`,
+    );
+  }
+  // Preserve the pre-CAT-116 injectable project shape: when no entry carries
+  // dispatchIdentity, grade checkout identity exactly as before. Once any
+  // entry opts into the new arm, every entry must verify both arms for PASS.
+  const hasDispatchArm = projects.some((project) =>
+    Object.prototype.hasOwnProperty.call(project ?? {}, "dispatchIdentity"));
+  if (hasDispatchArm) {
+    const knownBoth = projects.filter((project) =>
+      project?.identity?.matches === true &&
+      project?.dispatchIdentity?.matches === true &&
+      project.identity.declared === project.dispatchIdentity.declared).length;
+    if (knownBoth < projects.length) {
+      const unverified = projects.length - knownBoth;
+      return mkCheck(
+        "registry-team-identity",
+        STATUS.INFO,
+        `${knownBoth}/${projects.length} registry entries verified against both checkout and ` +
+          `dispatch revision; ${unverified} could not be checked on both arms — no mismatch ` +
+          "found, but the dispatch revision contract is unverified (CAT-116)",
+      );
+    }
+    return mkCheck(
+      "registry-team-identity",
+      STATUS.PASS,
+      `${knownBoth}/${projects.length} registry entries verified against both checkout and ` +
+        "dispatch revision; no mismatches or drift (CAT-116)",
     );
   }
   const known = projects.filter((project) => project?.identity?.matches === true).length;

--- a/plugins/dev/scripts/execution-core/registry.mjs
+++ b/plugins/dev/scripts/execution-core/registry.mjs
@@ -20,11 +20,29 @@ import {
   mkdirSync,
   existsSync,
 } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getRegistryPath, log } from "./config.mjs";
 
 const defaultReadLayer1 = (path) => readFileSync(path, "utf8");
+
+const DISPATCH_REV_LADDER = ["refs/remotes/origin/main", "refs/heads/main"];
+
+const defaultShowAtRev = (repoRoot, rev, path, spawn = spawnSync) => {
+  const result = spawn("git", ["show", `${rev}:${path}`], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result?.error || (result?.status ?? 1) !== 0) return { ok: false, stdout: "" };
+  return { ok: true, stdout: result.stdout ?? "" };
+};
+
+function declaredTeamOf(raw) {
+  const parsed = JSON.parse(raw);
+  const declared = (parsed?.catalyst ?? parsed)?.linear?.teamKey;
+  return typeof declared === "string" && declared.trim() !== "" ? declared : null;
+}
 
 // Compare the registry's team with the team declared by the checkout's Layer-1
 // config. Unknown is deliberately distinct from mismatch: an absent, unreadable,
@@ -42,9 +60,8 @@ export function teamIdentityOf(entry, readLayer1 = defaultReadLayer1) {
   const unknown = { declared: null, matches: null };
   try {
     const raw = readLayer1(join(entry.repoRoot, ".catalyst", "config.json"));
-    const parsed = JSON.parse(raw);
-    const declared = (parsed?.catalyst ?? parsed)?.linear?.teamKey;
-    if (typeof declared !== "string" || declared.trim() === "") return unknown;
+    const declared = declaredTeamOf(raw);
+    if (declared === null) return unknown;
     return {
       declared,
       matches: declared === entry.team,
@@ -52,6 +69,36 @@ export function teamIdentityOf(entry, readLayer1 = defaultReadLayer1) {
   } catch {
     return unknown;
   }
+}
+
+// Resolve the Layer-1 identity a fresh dispatch receives from already-present
+// local refs. This is opt-in because git subprocesses do not belong on the
+// registry's daemon hot path. A resolved ref is authoritative even when its
+// config is malformed; falling through would describe a revision dispatch
+// would not use.
+export function dispatchRevisionIdentityOf(entry, deps = {}) {
+  const {
+    spawn = spawnSync,
+    showAtRev = (root, rev, path) => defaultShowAtRev(root, rev, path, spawn),
+  } = deps;
+  const unknown = { declared: null, matches: null, rev: null };
+  for (const rev of DISPATCH_REV_LADDER) {
+    let result;
+    try {
+      result = showAtRev(entry.repoRoot, rev, ".catalyst/config.json");
+    } catch {
+      return unknown;
+    }
+    if (!result?.ok) continue;
+    try {
+      const declared = declaredTeamOf(result.stdout);
+      if (declared === null) return { ...unknown, rev };
+      return { declared, matches: declared === entry.team, rev };
+    } catch {
+      return { ...unknown, rev };
+    }
+  }
+  return unknown;
 }
 
 // listProjects() — every well-formed entry in the registry. Missing file → [].
@@ -64,6 +111,9 @@ export function listProjects(deps = {}) {
     exists = existsSync,
     readLayer1 = defaultReadLayer1,
     warn = (obj, message) => log.warn(obj, message),
+    withDispatchIdentity = false,
+    spawn = spawnSync,
+    showAtRev,
   } = deps;
   const file = getRegistryPath();
   let parsed;
@@ -83,6 +133,7 @@ export function listProjects(deps = {}) {
       continue;
     }
     let identity = { declared: null, matches: null };
+    let dispatchIdentity = { declared: null, matches: null, rev: null };
     if (!exists(entry.repoRoot)) {
       // CTL-854: a copied/stale registry can carry a repoRoot absent on this host.
       // Keep the entry (behavior unchanged) but flag the misconfiguration so it is
@@ -106,13 +157,18 @@ export function listProjects(deps = {}) {
             "ticket prefix (CAT-52)",
         );
       }
+      if (withDispatchIdentity) {
+        dispatchIdentity = dispatchRevisionIdentityOf(entry, { spawn, showAtRev });
+      }
     }
-    projects.push({
+    const project = {
       team: entry.team,
       repoRoot: entry.repoRoot,
       eligibleQuery: entry.eligibleQuery ?? null,
       identity,
-    });
+    };
+    if (withDispatchIdentity) project.dispatchIdentity = dispatchIdentity;
+    projects.push(project);
   }
   return projects;
 }


### PR DESCRIPTION
## Summary
- `registry.mjs` gains a dispatch-revision identity axis alongside the existing `teamIdentityOf`: it validates the registry's recorded team identity against the identity a dispatch would actually see at the revision it's about to dispatch against, catching drift that the plain checkout-time identity check misses.
- `doctor.mjs` grades the new drift category (dispatch-revision mismatch) alongside the two pre-existing ones (checkout <-> dispatch drift, checkout mismatch).
- A doctor run previously returned early on the first non-empty category, so a multi-project run could silently omit a second project's known defect until the first was fixed and the command re-run. Doctor now classifies every entry in one pass (precedence still resolved per entry — an entry with a dispatch-revision mismatch is described only by that category) and emits a single WARN aggregating all non-empty categories.
- Docs updated to explain the identity checks.

Ported from stale fork PR #3232 (thagale/catalyst, CAT-116) as part of the 2026-08-21 verification sweep of stale fork PRs. All 4 original commits cherry-picked cleanly onto current main with zero conflicts. Credit: Tony Hagale (original author).

## Test plan
All touched/added test files, run individually (never the full suite):
- [x] `bun test __tests__/registry-team-identity.test.mjs __tests__/doctor-registry-team-identity.test.mjs __tests__/registry-dispatch-revision-identity.test.mjs` (execution-core) — 50 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)