### PR TITLE
feat(dev): CAT-173 surface mutual fence standoffs (lands #3241)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1311,6 +1311,7 @@ jobs:
             lib/canonical-event.test.mjs \
             lib/dual-envelope.test.mjs \
             fence-guard.test.mjs \
+            fence-standoff.test.mjs \
             fence-guard-integration.test.mjs \
             terminal-done-cooldown.test.mjs \
             fleet-health-event.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,6 +321,16 @@ advisory `entitlement-*` checks report the resolved mode, the provider (local vs
 whether the ordering constraint holds — INFO/WARN only, never FAIL. The `entitlement.*` event prefix
 is **unprotected** under the CTL-1142 namespace contract.
 
+**Fence-standoff bound (CAT-173).** Two live hosts can each hold evidence that the other owns a
+ticket, causing every fence-guarded human escalation to be suppressed. Each escalation site records
+that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both
+the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an
+unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`; the
+board renders that record as `needs-human` and the notification bridge can surface it without a
+Linear write. The post-bound retry cooldown defaults to 6 hours. This changes no `fenceGuard`
+decision: every write suppressed before CAT-173 remains suppressed; only the out-of-band human
+signal is bounded.
+
 **Board-health ownership scope (CAT-57).** Board-health uses the same dispatch roster as the
 scheduler's new-work gate when assigning eligible tickets, rather than hashing over the raw roster.
 Its `dispatchLiveness` invariant judges only this host's owned queue, while preserving the raw and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -326,12 +326,26 @@ ticket, causing every fence-guarded human escalation to be suppressed. Each esca
 that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both
 the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an
 unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the
-notification bridge can surface the ticket without a Linear write. The record is GC-surviving and
-renders as a `needs-human` board card **only when the ticket has no card already** —
-`synthesizeDurableEscalations` dedupes by ticket id — so for a terminal-sweep standoff (which by
-construction has a live `failed`/`stalled` signal, hence a card, hence `deriveAttention`'s
-`phaseFailed` → `needs-human`) the operator sees the attention state but not the record's
-standoff-specific reason.
+notification bridge can surface the ticket without a Linear write.
+
+Only a MUTUAL standoff counts. A `foreign-owner` verdict is positive, confirmed evidence that a
+specific other host holds the claim — the correct outcome on the superseded host after a healthy
+takeover, where `fenceGuard` deliberately leaves the escalation to the current owner (whose own
+fence passes). Counting it would let a lingering worker directory on the old host cross the bound
+and page an operator about a ticket the new owner is actively processing, so `foreign-owner` is
+excluded from accounting and additionally CLEARS the ledger, letting a later genuine standoff start
+a fresh episode instead of inheriting a stale count and age.
+
+The record is GC-surviving and reaches the board two ways. When the ticket has **no** card,
+`synthesizeDurableEscalations` mints one. When it already has a card, that function's id dedupe
+drops the record, so `mergeDurableEscalationsIntoCards` runs first and stamps the escalation's
+reason onto the existing card — but only when that card carries no `attention` yet, so a live
+reason always wins. Both halves are needed: a terminal-sweep standoff has a live `failed`/`stalled`
+signal (hence a card, hence `deriveAttention`'s `phaseFailed` → `needs-human`) and only wanted the
+standoff-specific reason, whereas a stale-PR standoff on a `BEHIND` PR has a card with **no**
+attention at all — `BEHIND` is excluded from `PR_BLOCKER_STATES` as auto-rebasable and the fence
+suppressed the label — so before the merge pass its break-glass reached no operator surface,
+including the push bridge, which projects only board tickets.
 
 This changes no `fenceGuard` decision: every write suppressed before CAT-173 remains suppressed.
 It does change the **retry cadence** of those suppressed writes. Crossing the bound stamps a
@@ -340,7 +354,10 @@ It does change the **retry cadence** of those suppressed writes. Crossing the bo
 label write — and the terminal-clear branch that retracts it on a late Done — is retried every 6 h
 rather than every 15 min. A break-glass whose delivery FAILS drops the 15-minute marker to retry on
 the next tick, bounded by `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` (default 5) so a persistently
-unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn.
+unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn. That bound is only enforceable
+while the attempt counter survives the tick, so a failed-delivery increment that cannot be persisted
+(full disk, read-only mount) fails CLOSED — reported as not-retryable rather than retryable-forever,
+since an unpersisted counter can never grow past the max.
 
 **Board-health ownership scope (CAT-57).** Board-health uses the same dispatch roster as the
 scheduler's new-work gate when assigning eligible tickets, rather than hashing over the raw roster.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,11 +325,22 @@ is **unprotected** under the CTL-1142 namespace contract.
 ticket, causing every fence-guarded human escalation to be suppressed. Each escalation site records
 that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both
 the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an
-unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`; the
-board renders that record as `needs-human` and the notification bridge can surface it without a
-Linear write. The post-bound retry cooldown defaults to 6 hours. This changes no `fenceGuard`
-decision: every write suppressed before CAT-173 remains suppressed; only the out-of-band human
-signal is bounded.
+unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the
+notification bridge can surface the ticket without a Linear write. The record is GC-surviving and
+renders as a `needs-human` board card **only when the ticket has no card already** —
+`synthesizeDurableEscalations` dedupes by ticket id — so for a terminal-sweep standoff (which by
+construction has a live `failed`/`stalled` signal, hence a card, hence `deriveAttention`'s
+`phaseFailed` → `needs-human`) the operator sees the attention state but not the record's
+standoff-specific reason.
+
+This changes no `fenceGuard` decision: every write suppressed before CAT-173 remains suppressed.
+It does change the **retry cadence** of those suppressed writes. Crossing the bound stamps a
+`.fence-standoff-cooldown` (default 6 h) that gates the same terminal-sweep probe+write block
+`.fence-suppressed` (15 min) already gated, so after a break-glass a healed standoff's `needs-human`
+label write — and the terminal-clear branch that retracts it on a late Done — is retried every 6 h
+rather than every 15 min. A break-glass whose delivery FAILS drops the 15-minute marker to retry on
+the next tick, bounded by `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` (default 5) so a persistently
+unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn.
 
 **Board-health ownership scope (CAT-57).** Board-health uses the same dispatch roster as the
 scheduler's new-work gate when assigning eligible tickets, rather than hashing over the raw roster.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,12 +328,20 @@ the configured count (default 4) and age (default 45 minutes) are reached, Catal
 unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the
 notification bridge can surface the ticket without a Linear write.
 
-Only a MUTUAL standoff counts. A `foreign-owner` verdict is positive, confirmed evidence that a
-specific other host holds the claim — the correct outcome on the superseded host after a healthy
-takeover, where `fenceGuard` deliberately leaves the escalation to the current owner (whose own
-fence passes). Counting it would let a lingering worker directory on the old host cross the bound
-and page an operator about a ticket the new owner is actively processing, so `foreign-owner` is
-excluded from accounting and additionally CLEARS the ledger, letting a later genuine standoff start
+Only a MUTUAL standoff counts, and a standoff is by definition AMBIGUOUS — nobody can tell who owns
+the ticket. Just two `fenceGuard` verdicts are ambiguous in that sense and so accumulate toward the
+bound: `unverifiable` (the authoritative read neither confirmed nor refuted this host's generation)
+and `threw` (fail-closed on an error), alongside a non-fail-open `missing-generation`.
+
+The CONFIRMED-TAKEOVER verdicts are the opposite — positive evidence that a specific other host holds
+the claim, which is the correct outcome on the superseded host after a healthy takeover, where
+`fenceGuard` deliberately leaves the escalation to the current owner (whose own fence passes).
+There are TWO of them and BOTH are excluded: `foreign-owner` (the projection names a different owner
+host) and `superseded` (the authoritative read returned `stale: true`, i.e. a newer generation
+exists — the shape an ordinary healthy takeover takes on the old host, discovered via generation
+rather than owner identity). Counting either would let a lingering worker directory on the old host
+cross the bound and page an operator about a ticket the new owner is actively processing, so both are
+excluded from accounting and additionally CLEAR the ledger, letting a later genuine standoff start
 a fresh episode instead of inheriting a stale count and age.
 
 The record is GC-surviving and reaches the board two ways. When the ticket has **no** card,

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -71,6 +71,7 @@ import { ESCALATION_EVENT_NEEDS_HUMAN } from "../execution-core/escalation-event
 // (not a re-typed literal). The `linear.label.` prefix is UNPROTECTED under the
 // namespace contract (a dedicated test below asserts it, alongside the salvage family).
 import { LABEL_RETRY_EXHAUSTED_EVENT } from "../execution-core/label-retry-event.mjs";
+import { FENCE_STANDOFF_EVENT } from "../execution-core/fence-standoff.mjs"; // CAT-173
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -122,6 +123,7 @@ const EXEC_CORE_EVENT_NAMES = [
   ...ENTITLEMENT_EVENT_NAMES, // CTL-1785 entitlement-event.mjs — would-shed / shed / restored (v3 bare-name, host-suffixed)
   ESCALATION_EVENT_NEEDS_HUMAN, // CTL-2056 escalation-event.mjs — ticket.escalated (entity=ticket/action=escalated)
   LABEL_RETRY_EXHAUSTED_EVENT, // CTL-2052 label-retry-event.mjs — the "stopped after N and said so" escalation
+  FENCE_STANDOFF_EVENT, // CAT-173 fence-standoff.mjs — mutual fence standoff escalation
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/execution-core/fence-guard.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.mjs
@@ -349,8 +349,11 @@ export function fenceGuard(
     if (effectiveReadSource === "projection-first" && gateway) {
       const f = readFence(ticket);
       if (f && isFresh(f, env)) {
-        if (f.ownerHost !== self) return false; // foreign owner (incl. released→null) → suppress
-        return f.generation === generation; // higher/other gen → suppress
+        if (f.ownerHost !== self) {
+          return suppress(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER, f.generation ?? null);
+        }
+        if (f.generation === generation) return true;
+        return suppress(FENCE_SUPPRESS_REASONS.SUPERSEDED, generation);
       }
       // stale/absent projection → fall through to the authoritative read.
     }

--- a/plugins/dev/scripts/execution-core/fence-guard.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.mjs
@@ -54,6 +54,17 @@ import { log } from "./config.mjs";
 // CATALYST_FENCE_FRESH_MS for tuning.
 const FENCE_FRESH_MS_DEFAULT = 240_000;
 
+// CAT-173: report why a guarded write was suppressed without changing the
+// guard's boolean decision. In particular, preserve the authoritative read's
+// distinction between a confirmed takeover and an unavailable read.
+export const FENCE_SUPPRESS_REASONS = Object.freeze({
+  FOREIGN_OWNER: "foreign-owner",
+  MISSING_GENERATION: "missing-generation",
+  SUPERSEDED: "superseded",
+  UNVERIFIABLE: "unverifiable",
+  THREW: "threw",
+});
+
 function resolveFenceFreshMs(env) {
   const raw = Number(env?.CATALYST_FENCE_FRESH_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : FENCE_FRESH_MS_DEFAULT;
@@ -206,8 +217,26 @@ export function fenceGuard(
     // the terminal-probe path. Optional; default no-op so existing callers are
     // unaffected.
     onMissingGeneration = null,
+    // CAT-173: optional observation hook for false verdicts. Like
+    // onMissingGeneration, hook failures are swallowed and cannot affect the
+    // already-decided guard result.
+    onSuppress = null,
   } = {},
 ) {
+  const suppress = (reason, generation = null) => {
+    if (typeof onSuppress === "function") {
+      try {
+        onSuppress({ ticket, reason, generation });
+      } catch (err) {
+        logger?.debug?.(
+          { ticket, err: err?.message },
+          "fenceGuard: onSuppress hook threw — continuing",
+        );
+      }
+    }
+    return false;
+  };
+
   // N=1 single-host gate: provably no peer → trust local unconditionally.
   if (!multiHost) return true;
 
@@ -290,7 +319,7 @@ export function fenceGuard(
             "SUPPRESSING the guarded write (fail-closed) even at an escalation site; " +
             "the current owner escalates this ticket itself.",
         );
-        return false;
+        return suppress(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
       }
       if (typeof onMissingGeneration === "function") {
         try {
@@ -311,7 +340,7 @@ export function fenceGuard(
         );
         return true;
       }
-      return false; // missing/null/NaN → fail-closed (mutating write sites)
+      return suppress(FENCE_SUPPRESS_REASONS.MISSING_GENERATION);
     }
 
     // Stage 1 opt-in: trust a FRESH cross-host-reconciled projection row.
@@ -327,8 +356,15 @@ export function fenceGuard(
     }
 
     // Stage 0 default (and Stage 1 stale/absent fallback): authoritative read.
-    return escalate({ ticket, generation }).current === true;
+    const verdict = escalate({ ticket, generation });
+    if (verdict?.current === true) return true;
+    return suppress(
+      verdict?.stale === true
+        ? FENCE_SUPPRESS_REASONS.SUPERSEDED
+        : FENCE_SUPPRESS_REASONS.UNVERIFIABLE,
+      generation,
+    );
   } catch {
-    return false; // any error → fail-closed
+    return suppress(FENCE_SUPPRESS_REASONS.THREW); // any error → fail-closed
   }
 }

--- a/plugins/dev/scripts/execution-core/fence-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.test.mjs
@@ -7,7 +7,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { fenceGuard, readClusterGeneration, readSignalGeneration } from "./fence-guard.mjs";
+import {
+  fenceGuard,
+  FENCE_SUPPRESS_REASONS,
+  readClusterGeneration,
+  readSignalGeneration,
+} from "./fence-guard.mjs";
 
 // A helper to build a `readFence` seam that returns a fixed projection row.
 const fenceRow = (over = {}) => ({
@@ -16,6 +21,99 @@ const fenceRow = (over = {}) => ({
   phase: "implement",
   claimedAt: new Date().toISOString(),
   ...over,
+});
+
+describe("fenceGuard — discriminated suppression verdict (CAT-173)", () => {
+  const base = { ticket: "CTL-1", orchDir: "/tmp/x", multiHost: true, self: "hostA" };
+  const silent = { warn() {}, debug() {} };
+
+  test("confirmed-stale authoritative read reports SUPERSEDED", () => {
+    const seen = [];
+    const ok = fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: false, stale: true }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(ok).toBe(false);
+    expect(seen).toEqual([
+      { ticket: "CTL-1", reason: FENCE_SUPPRESS_REASONS.SUPERSEDED, generation: 7 },
+    ]);
+  });
+
+  test("indeterminate authoritative read reports UNVERIFIABLE — distinct from SUPERSEDED", () => {
+    const seen = [];
+    fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: false, stale: false }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.UNVERIFIABLE);
+    expect(FENCE_SUPPRESS_REASONS.UNVERIFIABLE).not.toBe(FENCE_SUPPRESS_REASONS.SUPERSEDED);
+  });
+
+  test("known-foreign owner reports FOREIGN_OWNER", () => {
+    const seen = [];
+    fenceGuard({ ...base, gateway: {} }, {
+      readGen: () => null,
+      readFence: () => ({ ownerHost: "hostB", generation: 3 }),
+      proceedOnMissingGeneration: true,
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
+  });
+
+  test("missing generation at a MUTATING site reports MISSING_GENERATION", () => {
+    const seen = [];
+    fenceGuard(base, { readGen: () => null, onSuppress: (v) => seen.push(v), logger: silent });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.MISSING_GENERATION);
+  });
+
+  test("a throwing escalate reports THREW", () => {
+    const seen = [];
+    fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => { throw new Error("boom"); },
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    });
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.THREW);
+  });
+
+  test("onSuppress NEVER fires on a PASS, and a throwing hook cannot flip the verdict", () => {
+    const seen = [];
+    expect(fenceGuard(base, {
+      readGen: () => 7,
+      escalate: () => ({ current: true, stale: false }),
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    })).toBe(true);
+    expect(seen).toEqual([]);
+
+    expect(fenceGuard(base, {
+      readGen: () => null,
+      proceedOnMissingGeneration: true,
+      onSuppress: () => { throw new Error("hook exploded"); },
+      logger: silent,
+    })).toBe(true);
+  });
+
+  test("single-host (multiHost:false) never fires the hook", () => {
+    const seen = [];
+    expect(fenceGuard({ ...base, multiHost: false }, {
+      readGen: () => 1,
+      onSuppress: (v) => seen.push(v),
+      logger: silent,
+    })).toBe(true);
+    expect(seen).toEqual([]);
+  });
+
+  test("omitting onSuppress leaves every path byte-identical (default no-op)", () => {
+    expect(fenceGuard(base, { readGen: () => 7, escalate: () => ({ current: false, stale: true }), logger: silent })).toBe(false);
+    expect(fenceGuard(base, { readGen: () => 7, escalate: () => ({ current: true }), logger: silent })).toBe(true);
+  });
 });
 
 describe("fenceGuard — N=1 single-host gate (spec §C1)", () => {

--- a/plugins/dev/scripts/execution-core/fence-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.test.mjs
@@ -24,7 +24,7 @@ const fenceRow = (over = {}) => ({
 });
 
 describe("fenceGuard — discriminated suppression verdict (CAT-173)", () => {
-  const base = { ticket: "CTL-1", orchDir: "/tmp/x", multiHost: true, self: "hostA" };
+  const base = { ticket: "PROJ-1", orchDir: "/tmp/x", multiHost: true, self: "hostA" };
   const silent = { warn() {}, debug() {} };
 
   test("confirmed-stale authoritative read reports SUPERSEDED", () => {
@@ -37,7 +37,7 @@ describe("fenceGuard — discriminated suppression verdict (CAT-173)", () => {
     });
     expect(ok).toBe(false);
     expect(seen).toEqual([
-      { ticket: "CTL-1", reason: FENCE_SUPPRESS_REASONS.SUPERSEDED, generation: 7 },
+      { ticket: "PROJ-1", reason: FENCE_SUPPRESS_REASONS.SUPERSEDED, generation: 7 },
     ]);
   });
 
@@ -121,7 +121,7 @@ describe("fenceGuard — N=1 single-host gate (spec §C1)", () => {
     let escalated = false;
     let fenceRead = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: false, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: false, gateway: {}, self: "mini" },
       {
         escalate: () => { escalated = true; return { current: true }; },
         readFence: () => { fenceRead = true; return null; },
@@ -136,7 +136,7 @@ describe("fenceGuard — N=1 single-host gate (spec §C1)", () => {
 describe("fenceGuard — multi-host default (Stage 0, readSource=linear → escalate)", () => {
   test("current generation via authoritative read → passes", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 5, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(true);
@@ -144,7 +144,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("stale generation via authoritative read → blocks", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 5, escalate: () => ({ current: false }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -152,7 +152,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("missing generation (null) → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => null, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -160,7 +160,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("NaN generation → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => NaN, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -168,7 +168,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("escalate throws → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 3, escalate: () => { throw new Error("spawn failed"); }, readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -176,7 +176,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 
   test("readGen throws → fail-closed", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => { throw new Error("ENOENT"); }, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -185,10 +185,10 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
   test("passes the correct ticket+generation to the authoritative read", () => {
     let captured = null;
     fenceGuard(
-      { ticket: "CTL-999", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-999", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => 42, escalate: (args) => { captured = args; return { current: true }; }, readSource: "linear" },
     );
-    expect(captured).toEqual({ ticket: "CTL-999", generation: 42 });
+    expect(captured).toEqual({ ticket: "PROJ-999", generation: 42 });
   });
 
   test("Stage-0 default NEVER trusts the local projection — a fresh self-owned row still escalates", () => {
@@ -198,7 +198,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
     let escalated = false;
     let fenceRead = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => 5,
         readFence: () => { fenceRead = true; return fenceRow(); },
@@ -213,7 +213,7 @@ describe("fenceGuard — multi-host default (Stage 0, readSource=linear → esca
 });
 
 describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gated)", () => {
-  const base = { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" };
+  const base = { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" };
   // The N>1 guardrail hard-refuses projection-first on a multi-host roster unless
   // the Stage-1 capability marker is present; these tests exercise the Stage-1
   // projection LOGIC, so they arm the marker.
@@ -364,7 +364,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
   test("proceedOnMissingGeneration:true + null generation → PROCEED (write) + loud warn, never a silent drop", () => {
     const warns = [];
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       {
         readGen: () => null,
         escalate: () => ({ current: false }),
@@ -379,7 +379,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
 
   test("default (proceedOnMissingGeneration:false) + null generation → fail-closed (mutating write sites unchanged)", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       { readGen: () => null, escalate: () => ({ current: true }), readSource: "linear" },
     );
     expect(result).toBe(false);
@@ -387,7 +387,7 @@ describe("fenceGuard — escalation-site fail-open on missing generation (watch 
 
   test("proceedOnMissingGeneration does NOT loosen a readable-but-superseded generation (still suppresses)", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, self: "mini" },
       {
         readGen: () => 5, // generation IS readable
         escalate: () => ({ current: false }), // authoritative says superseded
@@ -409,7 +409,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
     let escalated = false;
     const warns = [];
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null, // this host's cluster-generation.json is gone
         readFence: () => fenceRow({ ownerHost: "mini-2", generation: 9 }), // a peer owns it NOW
@@ -427,7 +427,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
   test("a foreign owner suppresses BEFORE onMissingGeneration fires (the call site's own fail-closed path arms its cooldown)", () => {
     let hookFired = false;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => fenceRow({ ownerHost: "mini-2", generation: 9 }),
@@ -446,7 +446,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
     for (const row of [null, fenceRow({ ownerHost: null }), fenceRow({ ownerHost: "" })]) {
       let hookFired = false;
       const result = fenceGuard(
-        { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+        { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
         {
           readGen: () => null,
           readFence: () => row,
@@ -463,7 +463,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
 
   test("a throwing projection read is UNKNOWN, not foreign → still fails open at an escalation site", () => {
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => { throw new Error("sqlite is down"); },
@@ -478,7 +478,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
   test("SELF-owned projection is unaffected — still borrows the generation and escalates", () => {
     let captured = null;
     const result = fenceGuard(
-      { ticket: "CTL-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
+      { ticket: "PROJ-1", orchDir: "/o", multiHost: true, gateway: {}, self: "mini" },
       {
         readGen: () => null,
         readFence: () => fenceRow({ ownerHost: "mini", generation: 9 }),
@@ -487,7 +487,7 @@ describe("fenceGuard — escalation sites stay fail-CLOSED on a KNOWN-foreign ow
         proceedOnMissingGeneration: true,
       },
     );
-    expect(captured).toEqual({ ticket: "CTL-1", generation: 9 });
+    expect(captured).toEqual({ ticket: "PROJ-1", generation: 9 });
     expect(result).toBe(true);
   });
 });
@@ -513,7 +513,7 @@ describe("fenceGuard — generation SOURCE wiring (CTL-1157 A1 regression)", () 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "fence-src-"));
     orchDir = dir;
-    ticket = "CTL-1423";
+    ticket = "PROJ-1423";
     wdir = join(orchDir, "workers", ticket);
     mkdirSync(wdir, { recursive: true });
   });

--- a/plugins/dev/scripts/execution-core/fence-guard.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-guard.test.mjs
@@ -234,6 +234,7 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
   });
 
   test("fresh row showing a FOREIGN owner → suppress (the partitioned-zombie catch)", () => {
+    const seen = [];
     const result = fenceGuard(base, {
       readGen: () => 5,
       readFence: () => fenceRow({ ownerHost: "laptop", generation: 6 }), // peer took over
@@ -241,11 +242,14 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
       escalate: () => ({ current: true }), // even if Linear lied, we must not reach it
       readSource: "projection-first",
       env: STAGE1,
+      onSuppress: (verdict) => seen.push(verdict),
     });
     expect(result).toBe(false);
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.FOREIGN_OWNER);
   });
 
   test("fresh self-owned row at a HIGHER generation → suppress", () => {
+    const seen = [];
     const result = fenceGuard(base, {
       readGen: () => 5,
       readFence: () => fenceRow({ ownerHost: "mini", generation: 6 }),
@@ -253,8 +257,10 @@ describe("fenceGuard — multi-host projection-first (Stage 1 opt-in, marker-gat
       escalate: () => ({ current: true }),
       readSource: "projection-first",
       env: STAGE1,
+      onSuppress: (verdict) => seen.push(verdict),
     });
     expect(result).toBe(false);
+    expect(seen[0].reason).toBe(FENCE_SUPPRESS_REASONS.SUPERSEDED);
   });
 
   test("STALE self-owned row → escalates (does NOT trust local; regression guard for findings 1/2/7)", () => {

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -1,0 +1,159 @@
+// fence-standoff.mjs — bounded escape from a mutual multi-host fencing standoff (CAT-173).
+//
+// This module changes no fence decision. It records repeated suppressions so a
+// caller can eventually surface the condition out-of-band, without a Linear
+// write or a fence dependency. Every I/O helper is fail-open and never throws.
+
+import { randomBytes } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getEventLogPath, log } from "./config.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+
+export const FENCE_STANDOFF_CAP_DEFAULT = 4;
+export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;
+export const FENCE_STANDOFF_COOLDOWN_MS_DEFAULT = 6 * 60 * 60_000;
+export const FENCE_STANDOFF_EVENT = "escalation.fence-standoff.CTL-1";
+
+function positiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function resolveStandoffCap(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_CAP, FENCE_STANDOFF_CAP_DEFAULT);
+}
+
+export function resolveStandoffMinAgeMs(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_MIN_AGE_MS, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT);
+}
+
+export function resolveStandoffCooldownMs(env = process.env) {
+  return positiveNumber(env?.CATALYST_FENCE_STANDOFF_COOLDOWN_MS, FENCE_STANDOFF_COOLDOWN_MS_DEFAULT);
+}
+
+function standoffDir(orchDir) {
+  return join(orchDir, ".fence-standoff");
+}
+
+function standoffPath(orchDir, ticket) {
+  return join(standoffDir(orchDir), `${ticket}.json`);
+}
+
+export function readFenceStandoff(orchDir, ticket) {
+  try {
+    const path = standoffPath(orchDir, ticket);
+    if (!existsSync(path)) return null;
+    const rec = JSON.parse(readFileSync(path, "utf8"));
+    return rec && typeof rec === "object" ? rec : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeRecord(orchDir, ticket, rec) {
+  const dir = standoffDir(orchDir);
+  mkdirSync(dir, { recursive: true });
+  const path = standoffPath(orchDir, ticket);
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmp, JSON.stringify(rec, null, 2));
+  renameSync(tmp, path);
+  return rec;
+}
+
+export function recordFenceSuppression({ orchDir, ticket, site, reason, now }) {
+  const prior = readFenceStandoff(orchDir, ticket);
+  const rec = {
+    ticket,
+    site,
+    reason,
+    firstSuppressedAt: Number.isFinite(prior?.firstSuppressedAt) ? prior.firstSuppressedAt : now,
+    lastSuppressedAt: now,
+    count: Number.isFinite(prior?.count) ? prior.count + 1 : 1,
+    breakGlassAt: Number.isFinite(prior?.breakGlassAt) ? prior.breakGlassAt : null,
+  };
+  try {
+    return writeRecord(orchDir, ticket, rec);
+  } catch {
+    return rec;
+  }
+}
+
+export function markBreakGlass({ orchDir, ticket, now }) {
+  const prior = readFenceStandoff(orchDir, ticket);
+  if (!prior) return null;
+  const rec = {
+    ...prior,
+    breakGlassAt: Number.isFinite(prior.breakGlassAt) ? prior.breakGlassAt : now,
+  };
+  try {
+    return writeRecord(orchDir, ticket, rec);
+  } catch {
+    return rec;
+  }
+}
+
+export function clearFenceStandoff(orchDir, ticket) {
+  try {
+    const path = standoffPath(orchDir, ticket);
+    if (existsSync(path)) unlinkSync(path);
+  } catch {
+    // Fail open: bookkeeping must never interrupt a scheduler tick.
+  }
+}
+
+export function evaluateStandoff(rec, { now, cap, minAgeMs }) {
+  if (!rec || !Number.isFinite(rec.count) || !Number.isFinite(rec.firstSuppressedAt)) {
+    return { breakGlass: false, firstBreakGlass: false, ageMs: 0 };
+  }
+  const ageMs = now - rec.firstSuppressedAt;
+  const breakGlass = rec.count >= cap && ageMs >= minAgeMs;
+  return { breakGlass, firstBreakGlass: breakGlass && !Number.isFinite(rec.breakGlassAt), ageMs };
+}
+
+function defaultAppend(line) {
+  const logPath = getEventLogPath();
+  mkdirSync(dirname(logPath), { recursive: true });
+  appendFileSync(logPath, line);
+}
+
+export function buildFenceStandoffEvent(
+  { ticket, site, reason, count, ageMs } = {},
+  {
+    now = () => new Date(),
+    newId = () => randomBytes(8).toString("hex"),
+    newTrace = () => randomBytes(16).toString("hex"),
+    newSpan = () => randomBytes(8).toString("hex"),
+  } = {},
+) {
+  if (!ticket) throw new Error("buildFenceStandoffEvent: ticket is required");
+  const ts = now().toISOString().replace(/\.\d{3}Z$/, "Z");
+  return JSON.stringify({
+    ts,
+    id: newId(),
+    observedTs: ts,
+    severityText: "WARN",
+    severityNumber: 13,
+    traceId: newTrace(),
+    spanId: newSpan(),
+    resource: buildCatalystResource({ serviceName: "catalyst.execution-core" }),
+    attributes: {
+      "event.name": `escalation.fence-standoff.${ticket}`,
+      "event.entity": "escalation",
+      "event.action": "fence-standoff",
+      "event.label": ticket,
+      "linear.issue.identifier": ticket,
+    },
+    body: { payload: { ticket, site, reason, count, ageMs } },
+  }) + "\n";
+}
+
+export function appendFenceStandoffEvent(payload, { append = defaultAppend, build = buildFenceStandoffEvent } = {}) {
+  try {
+    append(build(payload));
+    return true;
+  } catch (err) {
+    log.error({ err: err?.message, ticket: payload?.ticket }, "fence-standoff: append failed");
+    return false;
+  }
+}

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -14,6 +14,11 @@ import { recordDurableEscalation } from "./durable-escalation.mjs";
 export const FENCE_STANDOFF_CAP_DEFAULT = 4;
 export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;
 export const FENCE_STANDOFF_COOLDOWN_MS_DEFAULT = 6 * 60 * 60_000;
+// How many consecutive FAILED deliveries may bypass the caller's ordinary
+// suppression cooldown before the retry falls back to that cooldown's cadence.
+// A transient disk/event blip is retried immediately; a PERSISTENT one must not
+// re-run the caller's per-tick probe forever (the CTL-1329 quota burn).
+export const FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT = 5;
 export const FENCE_STANDOFF_EVENT = "escalation.fence-standoff.CTL-1";
 
 function positiveNumber(value, fallback) {
@@ -31,6 +36,13 @@ export function resolveStandoffMinAgeMs(env = process.env) {
 
 export function resolveStandoffCooldownMs(env = process.env) {
   return positiveNumber(env?.CATALYST_FENCE_STANDOFF_COOLDOWN_MS, FENCE_STANDOFF_COOLDOWN_MS_DEFAULT);
+}
+
+export function resolveStandoffDeliveryRetryMax(env = process.env) {
+  return positiveNumber(
+    env?.CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX,
+    FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT,
+  );
 }
 
 function standoffDir(orchDir) {
@@ -75,6 +87,10 @@ export function recordFenceSuppression({ orchDir, ticket, site, reason, now }) {
     lastSuppressedAt: now,
     count: Number.isFinite(prior?.count) ? prior.count + 1 : 1,
     breakGlassAt: Number.isFinite(prior?.breakGlassAt) ? prior.breakGlassAt : null,
+    // Consecutive failed break-glass deliveries. Preserved across suppression
+    // ticks so a persistent failure can be bounded; reset only by
+    // clearFenceStandoff (the episode ending).
+    deliveryAttempts: Number.isFinite(prior?.deliveryAttempts) ? prior.deliveryAttempts : 0,
   };
   try {
     return writeRecord(orchDir, ticket, rec);
@@ -95,6 +111,20 @@ export function markBreakGlass({ orchDir, ticket, now }) {
   } catch {
     return rec;
   }
+}
+
+// markDeliveryAttempt — count one FAILED break-glass delivery and return the new
+// running total. Fail-open: an unwritable record still reports the incremented
+// count so the caller's bound is applied to this tick rather than skipped.
+export function markDeliveryAttempt({ orchDir, ticket, record }) {
+  const prior = Number.isFinite(record?.deliveryAttempts) ? record.deliveryAttempts : 0;
+  const attempts = prior + 1;
+  try {
+    writeRecord(orchDir, ticket, { ...record, deliveryAttempts: attempts });
+  } catch {
+    // Fail open: bookkeeping must never interrupt a scheduler tick.
+  }
+  return attempts;
 }
 
 export function clearFenceStandoff(orchDir, ticket) {
@@ -229,7 +259,22 @@ export function maybeBreakGlass({
       if (durableConfirmed && eventConfirmed === true) {
         markBreakGlass({ orchDir, ticket, now });
       } else {
-        return { ...evaluation, firstBreakGlass: true, record: rec, deliveryPending: true };
+        // Delivery failed. Report it as retryable ONLY while the consecutive-failure
+        // count is under the bound: the caller drops its own suppression cooldown to
+        // retry next tick, and an unbounded version of that re-runs the caller's
+        // per-tick terminal probe + fence check forever on a PERSISTENTLY failing
+        // sink — the CTL-1329 burn that froze fleet dispatch. Past the bound the
+        // caller keeps its ordinary cooldown, so delivery still retries, just on the
+        // ordinary cadence instead of every tick.
+        const deliveryAttempts = markDeliveryAttempt({ orchDir, ticket, record: rec });
+        return {
+          ...evaluation,
+          firstBreakGlass: true,
+          record: rec,
+          deliveryPending: true,
+          deliveryAttempts,
+          deliveryRetryable: deliveryAttempts <= resolveStandoffDeliveryRetryMax(env),
+        };
       }
       logger?.warn?.(
         { ticket, site, reason: rec.reason, count: rec.count, ageMs: evaluation.ageMs },

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -9,6 +9,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlink
 import { dirname, join } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 
 export const FENCE_STANDOFF_CAP_DEFAULT = 4;
 export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;
@@ -155,5 +156,70 @@ export function appendFenceStandoffEvent(payload, { append = defaultAppend, buil
   } catch (err) {
     log.error({ err: err?.message, ticket: payload?.ticket }, "fence-standoff: append failed");
     return false;
+  }
+}
+
+// maybeBreakGlass — shared best-effort suppression accounting for every
+// escalation site. The caller still owns its fence decision; this helper only
+// records a durable, out-of-band human signal once the count+age bound is met.
+export function maybeBreakGlass({
+  orchDir,
+  ticket,
+  site,
+  verdict,
+  phase = site,
+  now,
+  env = process.env,
+  appendEvent = appendFenceStandoffEvent,
+  recordEscalation = recordDurableEscalation,
+  logger = log,
+  detail = "",
+}) {
+  try {
+    const rec = recordFenceSuppression({
+      orchDir,
+      ticket,
+      site,
+      reason: verdict?.reason ?? "unknown",
+      now,
+    });
+    const evaluation = evaluateStandoff(rec, {
+      now,
+      cap: resolveStandoffCap(env),
+      minAgeMs: resolveStandoffMinAgeMs(env),
+    });
+    if (evaluation.firstBreakGlass) {
+      markBreakGlass({ orchDir, ticket, now });
+      recordEscalation({
+        orchDir,
+        ticket,
+        phase,
+        reason:
+          `fence-standoff (${rec.reason}) at ${site}: ${ticket} is stuck but the ` +
+          `fence suppressed every needs-human write${detail ? `; ${detail}` : ""}. ` +
+          "Check cluster-generation.json divergence across hosts.",
+        labelConfirmed: false,
+        source: "fence-standoff",
+        now,
+      });
+      appendEvent({
+        ticket,
+        site,
+        reason: rec.reason,
+        count: rec.count,
+        ageMs: evaluation.ageMs,
+      });
+      logger?.warn?.(
+        { ticket, site, reason: rec.reason, count: rec.count, ageMs: evaluation.ageMs },
+        "cat-173: FENCE STANDOFF — wrote a durable escalation without a Linear label",
+      );
+    }
+    return { ...evaluation, record: rec };
+  } catch (err) {
+    logger?.warn?.(
+      { ticket, site, err: err?.message },
+      "cat-173: standoff bookkeeping failed — continuing",
+    );
+    return { breakGlass: false, firstBreakGlass: false, ageMs: 0, record: null };
   }
 }

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -203,11 +203,20 @@ export function maybeBreakGlass({
           "Check cluster-generation.json divergence across hosts.",
         labelConfirmed: false,
         source: "fence-standoff",
-        now,
+        now: new Date(now).toISOString(),
       });
-      const durableConfirmed = durableResult?.confirmed === true || existsSync(
-        join(orchDir, ".escalations", `${ticket}.json`),
-      );
+      let persistedDurable = null;
+      try {
+        persistedDurable = JSON.parse(readFileSync(
+          join(orchDir, ".escalations", `${ticket}.json`),
+          "utf8",
+        ));
+      } catch {
+        persistedDurable = null;
+      }
+      const durableConfirmed = durableResult?.source === "fence-standoff"
+        && persistedDurable?.source === "fence-standoff"
+        && persistedDurable?.lastTs === new Date(now).toISOString();
       const eventConfirmed = durableConfirmed && appendEvent({
         ticket,
         site,

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -13,17 +13,32 @@ import { recordDurableEscalation } from "./durable-escalation.mjs";
 import { FENCE_SUPPRESS_REASONS } from "./fence-guard.mjs";
 
 // A STANDOFF is mutual: every live host believes some OTHER host owns the ticket,
-// so nobody writes the escalation. `foreign-owner` is not that — it is positive,
-// confirmed evidence that a specific other host holds the claim, which is the
-// CORRECT outcome on the old host after a healthy takeover. fenceGuard
-// deliberately leaves the escalation to the current owner there, and that owner's
-// own fence passes, so it escalates normally.
+// so nobody writes the escalation. That is the AMBIGUOUS class of verdict —
+// `unverifiable` (the authoritative read could neither confirm nor refute this
+// host's generation) and `threw` (fail-closed on an error). Only those can be a
+// standoff, because only there is it genuinely unknown who owns the ticket.
 //
-// Counting those suppressions would let a lingering failed / stale-PR worker
-// directory on the superseded host accumulate the bound over 45 minutes and page
-// an operator about a ticket the NEW owner is actively processing — turning
-// correct zombie fencing into a false page. Excluded from accounting entirely.
-const NON_STANDOFF_SUPPRESS_REASONS = new Set([FENCE_SUPPRESS_REASONS.FOREIGN_OWNER]);
+// The CONFIRMED-TAKEOVER verdicts are the opposite: positive evidence that a
+// specific other host holds the claim, which is the CORRECT outcome on the old
+// host after a healthy takeover. fenceGuard deliberately leaves the escalation to
+// the current owner there, and that owner's own fence passes, so it escalates
+// normally. There are TWO such verdicts, and both must be excluded:
+//   * `foreign-owner` — the projection names a different owner host outright.
+//   * `superseded`    — the authoritative read returned stale:true, i.e. a NEWER
+//                       generation exists. A healthy takeover bumps the generation,
+//                       so this is the shape an ordinary supersession takes on the
+//                       old host; it is confirmed takeover evidence just like
+//                       `foreign-owner`, only discovered via generation rather than
+//                       owner identity.
+//
+// Counting either would let a lingering failed / stale-PR worker directory on the
+// superseded host accumulate the bound over 45 minutes and page an operator about a
+// ticket the NEW owner is actively processing — turning correct zombie fencing into
+// a false page. Excluded from accounting entirely.
+const NON_STANDOFF_SUPPRESS_REASONS = new Set([
+  FENCE_SUPPRESS_REASONS.FOREIGN_OWNER,
+  FENCE_SUPPRESS_REASONS.SUPERSEDED,
+]);
 
 export const FENCE_STANDOFF_CAP_DEFAULT = 4;
 export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -10,6 +10,20 @@ import { dirname, join } from "node:path";
 import { getEventLogPath, log } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { recordDurableEscalation } from "./durable-escalation.mjs";
+import { FENCE_SUPPRESS_REASONS } from "./fence-guard.mjs";
+
+// A STANDOFF is mutual: every live host believes some OTHER host owns the ticket,
+// so nobody writes the escalation. `foreign-owner` is not that — it is positive,
+// confirmed evidence that a specific other host holds the claim, which is the
+// CORRECT outcome on the old host after a healthy takeover. fenceGuard
+// deliberately leaves the escalation to the current owner there, and that owner's
+// own fence passes, so it escalates normally.
+//
+// Counting those suppressions would let a lingering failed / stale-PR worker
+// directory on the superseded host accumulate the bound over 45 minutes and page
+// an operator about a ticket the NEW owner is actively processing — turning
+// correct zombie fencing into a false page. Excluded from accounting entirely.
+const NON_STANDOFF_SUPPRESS_REASONS = new Set([FENCE_SUPPRESS_REASONS.FOREIGN_OWNER]);
 
 export const FENCE_STANDOFF_CAP_DEFAULT = 4;
 export const FENCE_STANDOFF_MIN_AGE_MS_DEFAULT = 45 * 60_000;
@@ -19,7 +33,10 @@ export const FENCE_STANDOFF_COOLDOWN_MS_DEFAULT = 6 * 60 * 60_000;
 // A transient disk/event blip is retried immediately; a PERSISTENT one must not
 // re-run the caller's per-tick probe forever (the CTL-1329 quota burn).
 export const FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT = 5;
-export const FENCE_STANDOFF_EVENT = "escalation.fence-standoff.CTL-1";
+// Namespace specimen only — the `<ticket>` slot is filled per-emit by
+// buildFenceStandoffEvent. Uses the repo-neutral `PROJ` prefix so this
+// distributed plugin encodes no project-specific ticket namespace.
+export const FENCE_STANDOFF_EVENT = "escalation.fence-standoff.PROJ-1";
 
 function positiveNumber(value, fallback) {
   const parsed = Number(value);
@@ -113,18 +130,29 @@ export function markBreakGlass({ orchDir, ticket, now }) {
   }
 }
 
-// markDeliveryAttempt — count one FAILED break-glass delivery and return the new
-// running total. Fail-open: an unwritable record still reports the incremented
-// count so the caller's bound is applied to this tick rather than skipped.
+// markDeliveryAttempt — count one FAILED break-glass delivery and report both the
+// new running total AND whether that total actually reached disk.
+//
+// The `persisted` half is load-bearing, not diagnostic. The retry bound is only
+// enforceable if the count SURVIVES the tick: when the ledger is unwritable the
+// next tick re-reads the OLD `deliveryAttempts`, recomputes the same total, and
+// would report "still under the bound" forever — so an unbounded caller re-runs
+// its terminal probe + fence check + delivery on EVERY tick against a full disk
+// or read-only mount. That is precisely the CTL-1329 per-tick burn this bound
+// exists to prevent, so a non-persisted attempt must fail CLOSED (see the
+// `deliveryRetryable` computation in maybeBreakGlass): delivery still retries,
+// on the caller's ordinary cooldown cadence instead of every tick.
+//
+// Never throws — bookkeeping must not interrupt a scheduler tick.
 export function markDeliveryAttempt({ orchDir, ticket, record }) {
   const prior = Number.isFinite(record?.deliveryAttempts) ? record.deliveryAttempts : 0;
   const attempts = prior + 1;
   try {
     writeRecord(orchDir, ticket, { ...record, deliveryAttempts: attempts });
+    return { attempts, persisted: true };
   } catch {
-    // Fail open: bookkeeping must never interrupt a scheduler tick.
+    return { attempts, persisted: false };
   }
-  return attempts;
 }
 
 export function clearFenceStandoff(orchDir, ticket) {
@@ -210,6 +238,19 @@ export function maybeBreakGlass({
 }) {
   try {
     standoffPath(orchDir, ticket); // validate containment before any sink path is built
+    // A confirmed takeover is not a standoff — the new owner escalates. Clear any
+    // ledger this host built up BEFORE the takeover so a later genuine standoff
+    // starts a fresh episode rather than inheriting a stale count/age.
+    if (NON_STANDOFF_SUPPRESS_REASONS.has(verdict?.reason)) {
+      clearFenceStandoff(orchDir, ticket);
+      return {
+        breakGlass: false,
+        firstBreakGlass: false,
+        ageMs: 0,
+        record: null,
+        skipped: verdict.reason,
+      };
+    }
     const rec = recordFenceSuppression({
       orchDir,
       ticket,
@@ -266,14 +307,22 @@ export function maybeBreakGlass({
         // sink — the CTL-1329 burn that froze fleet dispatch. Past the bound the
         // caller keeps its ordinary cooldown, so delivery still retries, just on the
         // ordinary cadence instead of every tick.
-        const deliveryAttempts = markDeliveryAttempt({ orchDir, ticket, record: rec });
+        const { attempts: deliveryAttempts, persisted } = markDeliveryAttempt({
+          orchDir,
+          ticket,
+          record: rec,
+        });
         return {
           ...evaluation,
           firstBreakGlass: true,
           record: rec,
           deliveryPending: true,
           deliveryAttempts,
-          deliveryRetryable: deliveryAttempts <= resolveStandoffDeliveryRetryMax(env),
+          // Fail CLOSED when the incremented count did not reach disk: an
+          // unpersisted counter can never grow, so treating it as retryable
+          // would drop the caller's cooldown on every tick forever.
+          deliveryRetryable:
+            persisted && deliveryAttempts <= resolveStandoffDeliveryRetryMax(env),
         };
       }
       logger?.warn?.(

--- a/plugins/dev/scripts/execution-core/fence-standoff.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.mjs
@@ -38,6 +38,9 @@ function standoffDir(orchDir) {
 }
 
 function standoffPath(orchDir, ticket) {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(String(ticket ?? ""))) {
+    throw new Error("fence-standoff: invalid ticket identifier");
+  }
   return join(standoffDir(orchDir), `${ticket}.json`);
 }
 
@@ -176,6 +179,7 @@ export function maybeBreakGlass({
   detail = "",
 }) {
   try {
+    standoffPath(orchDir, ticket); // validate containment before any sink path is built
     const rec = recordFenceSuppression({
       orchDir,
       ticket,
@@ -189,8 +193,7 @@ export function maybeBreakGlass({
       minAgeMs: resolveStandoffMinAgeMs(env),
     });
     if (evaluation.firstBreakGlass) {
-      markBreakGlass({ orchDir, ticket, now });
-      recordEscalation({
+      const durableResult = recordEscalation({
         orchDir,
         ticket,
         phase,
@@ -202,13 +205,23 @@ export function maybeBreakGlass({
         source: "fence-standoff",
         now,
       });
-      appendEvent({
+      const durableConfirmed = durableResult?.confirmed === true || existsSync(
+        join(orchDir, ".escalations", `${ticket}.json`),
+      );
+      const eventConfirmed = durableConfirmed && appendEvent({
         ticket,
         site,
         reason: rec.reason,
         count: rec.count,
         ageMs: evaluation.ageMs,
       });
+      // Persist the once-per-episode latch only after BOTH human-facing outputs
+      // confirm. A transient disk/event failure stays retryable next tick.
+      if (durableConfirmed && eventConfirmed === true) {
+        markBreakGlass({ orchDir, ticket, now });
+      } else {
+        return { ...evaluation, firstBreakGlass: true, record: rec, deliveryPending: true };
+      }
       logger?.warn?.(
         { ticket, site, reason: rec.reason, count: rec.count, ageMs: evaluation.ageMs },
         "cat-173: FENCE STANDOFF — wrote a durable escalation without a Linear label",

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -17,15 +17,15 @@ describe("fence-standoff ledger (CAT-173)", () => {
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   test("first suppression seeds count:1 and anchors firstSuppressedAt", () => {
-    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 1000 });
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 1000 });
     expect(r.count).toBe(1);
     expect(r.firstSuppressedAt).toBe(1000);
     expect(r.lastSuppressedAt).toBe(1000);
   });
 
   test("repeat suppressions increment count and PRESERVE firstSuppressedAt (the age anchor)", () => {
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 1000 });
-    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "unverifiable", now: 5000 });
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 1000 });
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 5000 });
     expect(r.count).toBe(2);
     expect(r.firstSuppressedAt).toBe(1000);
     expect(r.lastSuppressedAt).toBe(5000);
@@ -34,40 +34,40 @@ describe("fence-standoff ledger (CAT-173)", () => {
 
   test("clearFenceStandoff is idempotent and safe on an absent record", () => {
     clearFenceStandoff(dir, "NOPE");
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 1 });
-    clearFenceStandoff(dir, "CAT-53");
-    clearFenceStandoff(dir, "CAT-53");
-    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 1 });
+    clearFenceStandoff(dir, "PROJ-53");
+    clearFenceStandoff(dir, "PROJ-53");
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
   });
 
   test("a malformed record file degrades to null, never throws", () => {
     mkdirSync(join(dir, ".fence-standoff"), { recursive: true });
-    writeFileSync(join(dir, ".fence-standoff", "CAT-53.json"), "{not json");
-    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
-    expect(recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 9 }).count).toBe(1);
+    writeFileSync(join(dir, ".fence-standoff", "PROJ-53.json"), "{not json");
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
+    expect(recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 9 }).count).toBe(1);
   });
 
   test("an unwritable orchDir fails open — returns a synthetic record, never throws", () => {
-    const r = recordFenceSuppression({ orchDir: "/proc/nonexistent-cat173", ticket: "CAT-53", site: "s", reason: "superseded", now: 3 });
+    const r = recordFenceSuppression({ orchDir: "/proc/nonexistent-cat173", ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 3 });
     expect(r.count).toBe(1);
-    expect(r.ticket).toBe("CAT-53");
+    expect(r.ticket).toBe("PROJ-53");
   });
 
   test("ticket identifiers cannot escape the ledger directory", () => {
-    recordFenceSuppression({ orchDir: dir, ticket: "../../escaped", site: "s", reason: "superseded", now: 3 });
+    recordFenceSuppression({ orchDir: dir, ticket: "../../escaped", site: "s", reason: "unverifiable", now: 3 });
     clearFenceStandoff(dir, "../../escaped");
     expect(existsSync(join(dir, "..", "..", "escaped.json"))).toBe(false);
   });
 
   test("markBreakGlass preserves the first break-glass timestamp", () => {
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 1 });
-    expect(markBreakGlass({ orchDir: dir, ticket: "CAT-53", now: 9 }).breakGlassAt).toBe(9);
-    expect(markBreakGlass({ orchDir: dir, ticket: "CAT-53", now: 12 }).breakGlassAt).toBe(9);
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "s", reason: "unverifiable", now: 1 });
+    expect(markBreakGlass({ orchDir: dir, ticket: "PROJ-53", now: 9 }).breakGlassAt).toBe(9);
+    expect(markBreakGlass({ orchDir: dir, ticket: "PROJ-53", now: 12 }).breakGlassAt).toBe(9);
   });
 });
 
 describe("evaluateStandoff — pure break-glass predicate (CAT-173)", () => {
-  const rec = (count, firstSuppressedAt, breakGlassAt = null) => ({ ticket: "CAT-53", count, firstSuppressedAt, breakGlassAt });
+  const rec = (count, firstSuppressedAt, breakGlassAt = null) => ({ ticket: "PROJ-53", count, firstSuppressedAt, breakGlassAt });
   const opts = { cap: 4, minAgeMs: 45 * 60_000 };
 
   test("count reached but episode TOO YOUNG → no break-glass (a fast tick loop cannot trip it)", () => {
@@ -96,9 +96,9 @@ describe("evaluateStandoff — pure break-glass predicate (CAT-173)", () => {
 
 describe("buildFenceStandoffEvent (CAT-173)", () => {
   test("event name is the per-ticket canonical form", () => {
-    const ev = JSON.parse(buildFenceStandoffEvent({ ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", count: 4, ageMs: 2_700_000 }, { now: () => new Date("2026-08-11T00:00:00Z") }));
-    expect(ev.attributes["event.name"]).toBe("escalation.fence-standoff.CAT-53");
-    expect(ev.body.payload).toMatchObject({ ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", count: 4 });
+    const ev = JSON.parse(buildFenceStandoffEvent({ ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", count: 4, ageMs: 2_700_000 }, { now: () => new Date("2026-08-11T00:00:00Z") }));
+    expect(ev.attributes["event.name"]).toBe("escalation.fence-standoff.PROJ-53");
+    expect(ev.body.payload).toMatchObject({ ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", count: 4 });
   });
   test("FENCE_STANDOFF_EVENT is the registrable prefix form", () => {
     expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.PROJ-1");
@@ -117,9 +117,9 @@ test("maybeBreakGlass emits and records exactly once after the bound", () => {
   try {
     const opts = {
       orchDir: dir,
-      ticket: "CAT-53",
+      ticket: "PROJ-53",
       site: "terminal-sweep",
-      verdict: { reason: "superseded" },
+      verdict: { reason: "unverifiable" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "2", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
       appendEvent: (event) => { events.push(event); return true; },
       recordEscalation: (record) => { escalations.push(record); return recordDurableEscalation(record); },
@@ -143,18 +143,18 @@ test("maybeBreakGlass retries delivery before latching the episode", () => {
   try {
     const opts = {
       orchDir: dir,
-      ticket: "CAT-53",
+      ticket: "PROJ-53",
       site: "terminal-sweep",
-      verdict: { reason: "superseded" },
+      verdict: { reason: "unverifiable" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
       appendEvent: () => { eventAttempts += 1; return eventAttempts > 1; },
       logger: { warn() {} },
     };
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
     expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryPending).toBe(true);
-    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBeNull();
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBeNull();
     expect(maybeBreakGlass({ ...opts, now: 2 }).deliveryPending).toBeUndefined();
-    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBe(2);
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBe(2);
     expect(eventAttempts).toBe(2);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -169,9 +169,9 @@ test("maybeBreakGlass stops reporting a persistently failing delivery as retryab
   try {
     const opts = {
       orchDir: dir,
-      ticket: "CAT-53",
+      ticket: "PROJ-53",
       site: "terminal-sweep",
-      verdict: { reason: "superseded" },
+      verdict: { reason: "unverifiable" },
       env: {
         CATALYST_FENCE_STANDOFF_CAP: "1",
         CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
@@ -180,14 +180,14 @@ test("maybeBreakGlass stops reporting a persistently failing delivery as retryab
       appendEvent: () => false, // never succeeds
       logger: { warn() {} },
     };
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
     const verdicts = [1, 2, 3, 4, 5].map((now) => maybeBreakGlass({ ...opts, now }));
     expect(verdicts.map((v) => v.deliveryPending)).toEqual([true, true, true, true, true]);
     expect(verdicts.map((v) => v.deliveryAttempts)).toEqual([1, 2, 3, 4, 5]);
     expect(verdicts.map((v) => v.deliveryRetryable)).toEqual([true, true, true, false, false]);
     // The episode is still unlatched, so delivery keeps being ATTEMPTED — only the
     // caller's cooldown bypass is withdrawn.
-    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBeNull();
+    expect(readFenceStandoff(dir, "PROJ-53").breakGlassAt).toBeNull();
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -199,19 +199,19 @@ test("the delivery-retry bound defaults to 5 and survives across suppression tic
     expect(FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT).toBe(5);
     const opts = {
       orchDir: dir,
-      ticket: "CAT-53",
+      ticket: "PROJ-53",
       site: "terminal-sweep",
-      verdict: { reason: "superseded" },
+      verdict: { reason: "unverifiable" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
       appendEvent: () => false,
       logger: { warn() {} },
     };
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
     for (let i = 1; i <= 5; i++) expect(maybeBreakGlass({ ...opts, now: i }).deliveryRetryable).toBe(true);
     expect(maybeBreakGlass({ ...opts, now: 6 }).deliveryRetryable).toBe(false);
     // Ending the episode resets the counter — a later recurrence retries promptly again.
-    clearFenceStandoff(dir, "CAT-53");
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 100 });
+    clearFenceStandoff(dir, "PROJ-53");
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 100 });
     expect(maybeBreakGlass({ ...opts, now: 101 }).deliveryRetryable).toBe(true);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -220,16 +220,24 @@ test("the delivery-retry bound defaults to 5 and survives across suppression tic
 
 // ─── Codex #3241 round-1 P1 remediations ────────────────────────────────────
 
-describe("foreign-owner is not a standoff (CAT-173, Codex #3241 P1)", () => {
+// A CONFIRMED TAKEOVER is not a standoff. There are two verdicts that carry that
+// evidence and BOTH must be excluded from accounting: `foreign-owner` (the
+// projection names another owner host) and `superseded` (the authoritative read
+// returned stale:true — a newer generation exists, which is precisely the shape an
+// ordinary healthy takeover takes on the old host). Counting either would page an
+// operator about a ticket the NEW owner is actively working.
+describe.each(["foreign-owner", "superseded"])(
+  "%s is a confirmed takeover, not a standoff (CAT-173, Codex #3241 P1)",
+  (takeoverReason) => {
   let dir;
   beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "fs-foreign-")); });
   afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
 
   const opts = (now) => ({
     orchDir: dir,
-    ticket: "CAT-53",
+    ticket: "PROJ-53",
     site: "terminal-sweep",
-    verdict: { reason: "foreign-owner" },
+    verdict: { reason: takeoverReason },
     now,
     env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "0" },
     appendEvent: () => true,
@@ -242,34 +250,36 @@ describe("foreign-owner is not a standoff (CAT-173, Codex #3241 P1)", () => {
     for (let i = 1; i <= 10; i++) {
       const r = maybeBreakGlass({ ...opts(i * 1000), appendEvent: (p) => { events.push(p); return true; } });
       expect(r.breakGlass).toBe(false);
-      expect(r.skipped).toBe("foreign-owner");
+      expect(r.skipped).toBe(takeoverReason);
     }
     expect(events).toEqual([]);
-    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
   });
 
   test("a takeover CLEARS a prior episode so a later standoff starts fresh", () => {
     // Three genuine standoff suppressions accumulate...
     for (let i = 1; i <= 3; i++) {
-      recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: i });
+      recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: i });
     }
-    expect(readFenceStandoff(dir, "CAT-53").count).toBe(3);
+    expect(readFenceStandoff(dir, "PROJ-53").count).toBe(3);
     // ...then the ticket is legitimately taken over.
     maybeBreakGlass(opts(4));
-    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+    expect(readFenceStandoff(dir, "PROJ-53")).toBeNull();
     // A later genuine standoff must re-earn the bound from count 1, not inherit 3.
-    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 5 });
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 5 });
     expect(r.count).toBe(1);
     expect(r.firstSuppressedAt).toBe(5);
   });
 
   test("genuine standoff reasons are still counted (negative control)", () => {
-    for (const reason of ["superseded", "unverifiable", "missing-generation", "threw"]) {
+    // Only the AMBIGUOUS verdicts — where it is genuinely unknown who owns the
+    // ticket — may accumulate toward a break-glass.
+    for (const reason of ["unverifiable", "missing-generation", "threw"]) {
       const d = mkdtempSync(join(tmpdir(), "fs-ctl-"));
       try {
         const r = maybeBreakGlass({ ...opts(1000), orchDir: d, verdict: { reason } });
         expect(r.skipped).toBeUndefined();
-        expect(readFenceStandoff(d, "CAT-53")?.count).toBe(1);
+        expect(readFenceStandoff(d, "PROJ-53")?.count).toBe(1);
       } finally {
         rmSync(d, { recursive: true, force: true });
       }
@@ -282,14 +292,14 @@ test("an UNPERSISTABLE delivery count fails closed, not retryable-forever (Codex
   try {
     const opts = {
       orchDir: dir,
-      ticket: "CAT-53",
+      ticket: "PROJ-53",
       site: "terminal-sweep",
-      verdict: { reason: "superseded" },
+      verdict: { reason: "unverifiable" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
       appendEvent: () => false, // delivery keeps failing
       logger: { warn() {} },
     };
-    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    recordFenceSuppression({ orchDir: dir, ticket: "PROJ-53", site: "terminal-sweep", reason: "unverifiable", now: 0 });
     // Baseline: a writable ledger reports the attempt as retryable.
     expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryRetryable).toBe(true);
 

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { recordDurableEscalation } from "./durable-escalation.mjs";
@@ -101,7 +101,12 @@ describe("buildFenceStandoffEvent (CAT-173)", () => {
     expect(ev.body.payload).toMatchObject({ ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", count: 4 });
   });
   test("FENCE_STANDOFF_EVENT is the registrable prefix form", () => {
-    expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.CTL-1");
+    expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.PROJ-1");
+  });
+  // AGENTS.md → Version Control: this plugin ships to other projects, so the
+  // shipped module must not encode a specific ticket prefix in its specimen.
+  test("FENCE_STANDOFF_EVENT carries no project-specific ticket prefix", () => {
+    expect(FENCE_STANDOFF_EVENT).not.toMatch(/\.(CTL|CAT)-\d+$/);
   });
 });
 
@@ -208,6 +213,99 @@ test("the delivery-retry bound defaults to 5 and survives across suppression tic
     clearFenceStandoff(dir, "CAT-53");
     recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 100 });
     expect(maybeBreakGlass({ ...opts, now: 101 }).deliveryRetryable).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── Codex #3241 round-1 P1 remediations ────────────────────────────────────
+
+describe("foreign-owner is not a standoff (CAT-173, Codex #3241 P1)", () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "fs-foreign-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const opts = (now) => ({
+    orchDir: dir,
+    ticket: "CAT-53",
+    site: "terminal-sweep",
+    verdict: { reason: "foreign-owner" },
+    now,
+    env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "0" },
+    appendEvent: () => true,
+    logger: { warn() {} },
+  });
+
+  test("a confirmed takeover is never counted, so it can never break glass", () => {
+    const events = [];
+    // Well past the cap+age bound: a counted reason would have paged several times.
+    for (let i = 1; i <= 10; i++) {
+      const r = maybeBreakGlass({ ...opts(i * 1000), appendEvent: (p) => { events.push(p); return true; } });
+      expect(r.breakGlass).toBe(false);
+      expect(r.skipped).toBe("foreign-owner");
+    }
+    expect(events).toEqual([]);
+    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+  });
+
+  test("a takeover CLEARS a prior episode so a later standoff starts fresh", () => {
+    // Three genuine standoff suppressions accumulate...
+    for (let i = 1; i <= 3; i++) {
+      recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: i });
+    }
+    expect(readFenceStandoff(dir, "CAT-53").count).toBe(3);
+    // ...then the ticket is legitimately taken over.
+    maybeBreakGlass(opts(4));
+    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+    // A later genuine standoff must re-earn the bound from count 1, not inherit 3.
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 5 });
+    expect(r.count).toBe(1);
+    expect(r.firstSuppressedAt).toBe(5);
+  });
+
+  test("genuine standoff reasons are still counted (negative control)", () => {
+    for (const reason of ["superseded", "unverifiable", "missing-generation", "threw"]) {
+      const d = mkdtempSync(join(tmpdir(), "fs-ctl-"));
+      try {
+        const r = maybeBreakGlass({ ...opts(1000), orchDir: d, verdict: { reason } });
+        expect(r.skipped).toBeUndefined();
+        expect(readFenceStandoff(d, "CAT-53")?.count).toBe(1);
+      } finally {
+        rmSync(d, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+test("an UNPERSISTABLE delivery count fails closed, not retryable-forever (Codex #3241 P1)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-unwritable-"));
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "CAT-53",
+      site: "terminal-sweep",
+      verdict: { reason: "superseded" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: () => false, // delivery keeps failing
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    // Baseline: a writable ledger reports the attempt as retryable.
+    expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryRetryable).toBe(true);
+
+    // Now make the ledger directory unwritable so the incremented count cannot
+    // reach disk. Without the fix the count silently resets every tick and
+    // deliveryRetryable stays true forever — the CTL-1329 per-tick burn.
+    const ledgerDir = join(dir, ".fence-standoff");
+    const mode = 0o500;
+    chmodSync(ledgerDir, mode);
+    try {
+      const r = maybeBreakGlass({ ...opts, now: 2 });
+      expect(r.deliveryPending).toBe(true);
+      expect(r.deliveryRetryable).toBe(false);
+    } finally {
+      chmodSync(ledgerDir, 0o700);
+    }
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  recordFenceSuppression, readFenceStandoff, clearFenceStandoff,
+  evaluateStandoff, markBreakGlass, buildFenceStandoffEvent,
+  FENCE_STANDOFF_EVENT, FENCE_STANDOFF_CAP_DEFAULT, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT,
+} from "./fence-standoff.mjs";
+
+describe("fence-standoff ledger (CAT-173)", () => {
+  let dir;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "fs-")); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  test("first suppression seeds count:1 and anchors firstSuppressedAt", () => {
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 1000 });
+    expect(r.count).toBe(1);
+    expect(r.firstSuppressedAt).toBe(1000);
+    expect(r.lastSuppressedAt).toBe(1000);
+  });
+
+  test("repeat suppressions increment count and PRESERVE firstSuppressedAt (the age anchor)", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 1000 });
+    const r = recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "unverifiable", now: 5000 });
+    expect(r.count).toBe(2);
+    expect(r.firstSuppressedAt).toBe(1000);
+    expect(r.lastSuppressedAt).toBe(5000);
+    expect(r.reason).toBe("unverifiable");
+  });
+
+  test("clearFenceStandoff is idempotent and safe on an absent record", () => {
+    clearFenceStandoff(dir, "NOPE");
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 1 });
+    clearFenceStandoff(dir, "CAT-53");
+    clearFenceStandoff(dir, "CAT-53");
+    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+  });
+
+  test("a malformed record file degrades to null, never throws", () => {
+    mkdirSync(join(dir, ".fence-standoff"), { recursive: true });
+    writeFileSync(join(dir, ".fence-standoff", "CAT-53.json"), "{not json");
+    expect(readFenceStandoff(dir, "CAT-53")).toBeNull();
+    expect(recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 9 }).count).toBe(1);
+  });
+
+  test("an unwritable orchDir fails open — returns a synthetic record, never throws", () => {
+    const r = recordFenceSuppression({ orchDir: "/proc/nonexistent-cat173", ticket: "CAT-53", site: "s", reason: "superseded", now: 3 });
+    expect(r.count).toBe(1);
+    expect(r.ticket).toBe("CAT-53");
+  });
+
+  test("markBreakGlass preserves the first break-glass timestamp", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "s", reason: "superseded", now: 1 });
+    expect(markBreakGlass({ orchDir: dir, ticket: "CAT-53", now: 9 }).breakGlassAt).toBe(9);
+    expect(markBreakGlass({ orchDir: dir, ticket: "CAT-53", now: 12 }).breakGlassAt).toBe(9);
+  });
+});
+
+describe("evaluateStandoff — pure break-glass predicate (CAT-173)", () => {
+  const rec = (count, firstSuppressedAt, breakGlassAt = null) => ({ ticket: "CAT-53", count, firstSuppressedAt, breakGlassAt });
+  const opts = { cap: 4, minAgeMs: 45 * 60_000 };
+
+  test("count reached but episode TOO YOUNG → no break-glass (a fast tick loop cannot trip it)", () => {
+    expect(evaluateStandoff(rec(9, 0), { now: 60_000, ...opts }).breakGlass).toBe(false);
+  });
+  test("old enough but UNDER the cap → no break-glass (one blip is not a standoff)", () => {
+    expect(evaluateStandoff(rec(2, 0), { now: 3 * 60 * 60_000, ...opts }).breakGlass).toBe(false);
+  });
+  test("cap AND age both satisfied → break-glass, flagged as the FIRST for this episode", () => {
+    expect(evaluateStandoff(rec(4, 0), { now: 46 * 60_000, ...opts })).toEqual({ breakGlass: true, firstBreakGlass: true, ageMs: 46 * 60_000 });
+  });
+  test("already broken glass this episode → still breakGlass, but firstBreakGlass:false (fires ONCE)", () => {
+    const v = evaluateStandoff(rec(50, 0, 46 * 60_000), { now: 99 * 60_000, ...opts });
+    expect(v.breakGlass).toBe(true);
+    expect(v.firstBreakGlass).toBe(false);
+  });
+  test("a null/garbage record is not a standoff", () => {
+    expect(evaluateStandoff(null, { now: 1e12, ...opts }).breakGlass).toBe(false);
+    expect(evaluateStandoff({}, { now: 1e12, ...opts }).breakGlass).toBe(false);
+  });
+  test("defaults are the documented bound: cap 4, min age 45m (3x the 15m fence cooldown)", () => {
+    expect(FENCE_STANDOFF_CAP_DEFAULT).toBe(4);
+    expect(FENCE_STANDOFF_MIN_AGE_MS_DEFAULT).toBe(45 * 60_000);
+  });
+});
+
+describe("buildFenceStandoffEvent (CAT-173)", () => {
+  test("event name is the per-ticket canonical form", () => {
+    const ev = JSON.parse(buildFenceStandoffEvent({ ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", count: 4, ageMs: 2_700_000 }, { now: () => new Date("2026-08-11T00:00:00Z") }));
+    expect(ev.attributes["event.name"]).toBe("escalation.fence-standoff.CAT-53");
+    expect(ev.body.payload).toMatchObject({ ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", count: 4 });
+  });
+  test("FENCE_STANDOFF_EVENT is the registrable prefix form", () => {
+    expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.CTL-1");
+  });
+});

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -49,6 +49,12 @@ describe("fence-standoff ledger (CAT-173)", () => {
     const r = recordFenceSuppression({ orchDir: "/proc/nonexistent-cat173", ticket: "CAT-53", site: "s", reason: "superseded", now: 3 });
     expect(r.count).toBe(1);
     expect(r.ticket).toBe("CAT-53");
+  });
+
+  test("ticket identifiers cannot escape the ledger directory", () => {
+    recordFenceSuppression({ orchDir: dir, ticket: "../../escaped", site: "s", reason: "superseded", now: 3 });
+    clearFenceStandoff(dir, "../../escaped");
+    expect(existsSync(join(dir, "..", "..", "escaped.json"))).toBe(false);
   });
 
   test("markBreakGlass preserves the first break-glass timestamp", () => {
@@ -108,8 +114,8 @@ test("maybeBreakGlass emits and records exactly once after the bound", () => {
       site: "terminal-sweep",
       verdict: { reason: "superseded" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "2", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
-      appendEvent: (event) => events.push(event),
-      recordEscalation: (record) => escalations.push(record),
+      appendEvent: (event) => { events.push(event); return true; },
+      recordEscalation: (record) => { escalations.push(record); return { confirmed: true }; },
       logger: { warn() {} },
     };
     maybeBreakGlass({ ...opts, now: 1 });
@@ -118,6 +124,31 @@ test("maybeBreakGlass emits and records exactly once after the bound", () => {
     expect(events).toHaveLength(1);
     expect(escalations).toHaveLength(1);
     expect(escalations[0]).toMatchObject({ labelConfirmed: false, source: "fence-standoff" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("maybeBreakGlass retries delivery before latching the episode", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-"));
+  let eventAttempts = 0;
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "CAT-53",
+      site: "terminal-sweep",
+      verdict: { reason: "superseded" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      recordEscalation: () => ({ confirmed: true }),
+      appendEvent: () => { eventAttempts += 1; return eventAttempts > 1; },
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    expect(maybeBreakGlass({ ...opts, now: 1 }).deliveryPending).toBe(true);
+    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBeNull();
+    expect(maybeBreakGlass({ ...opts, now: 2 }).deliveryPending).toBeUndefined();
+    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBe(2);
+    expect(eventAttempts).toBe(2);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -8,6 +8,7 @@ import {
   evaluateStandoff, markBreakGlass, buildFenceStandoffEvent,
   maybeBreakGlass,
   FENCE_STANDOFF_EVENT, FENCE_STANDOFF_CAP_DEFAULT, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT,
+  FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT,
 } from "./fence-standoff.mjs";
 
 describe("fence-standoff ledger (CAT-173)", () => {
@@ -150,6 +151,63 @@ test("maybeBreakGlass retries delivery before latching the episode", () => {
     expect(maybeBreakGlass({ ...opts, now: 2 }).deliveryPending).toBeUndefined();
     expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBe(2);
     expect(eventAttempts).toBe(2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// CAT-173 review: the retry above lets the caller drop its own suppression cooldown
+// to re-try next tick. A PERSISTENTLY failing sink must stop earning that bypass, or
+// the caller's per-tick probe runs forever (the CTL-1329 quota burn).
+test("maybeBreakGlass stops reporting a persistently failing delivery as retryable", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-bound-"));
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "CAT-53",
+      site: "terminal-sweep",
+      verdict: { reason: "superseded" },
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX: "3",
+      },
+      appendEvent: () => false, // never succeeds
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    const verdicts = [1, 2, 3, 4, 5].map((now) => maybeBreakGlass({ ...opts, now }));
+    expect(verdicts.map((v) => v.deliveryPending)).toEqual([true, true, true, true, true]);
+    expect(verdicts.map((v) => v.deliveryAttempts)).toEqual([1, 2, 3, 4, 5]);
+    expect(verdicts.map((v) => v.deliveryRetryable)).toEqual([true, true, true, false, false]);
+    // The episode is still unlatched, so delivery keeps being ATTEMPTED — only the
+    // caller's cooldown bypass is withdrawn.
+    expect(readFenceStandoff(dir, "CAT-53").breakGlassAt).toBeNull();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the delivery-retry bound defaults to 5 and survives across suppression ticks", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-retry-default-"));
+  try {
+    expect(FENCE_STANDOFF_DELIVERY_RETRY_MAX_DEFAULT).toBe(5);
+    const opts = {
+      orchDir: dir,
+      ticket: "CAT-53",
+      site: "terminal-sweep",
+      verdict: { reason: "superseded" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: () => false,
+      logger: { warn() {} },
+    };
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 0 });
+    for (let i = 1; i <= 5; i++) expect(maybeBreakGlass({ ...opts, now: i }).deliveryRetryable).toBe(true);
+    expect(maybeBreakGlass({ ...opts, now: 6 }).deliveryRetryable).toBe(false);
+    // Ending the episode resets the counter — a later recurrence retries promptly again.
+    clearFenceStandoff(dir, "CAT-53");
+    recordFenceSuppression({ orchDir: dir, ticket: "CAT-53", site: "terminal-sweep", reason: "superseded", now: 100 });
+    expect(maybeBreakGlass({ ...opts, now: 101 }).deliveryRetryable).toBe(true);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 import {
   recordFenceSuppression, readFenceStandoff, clearFenceStandoff,
   evaluateStandoff, markBreakGlass, buildFenceStandoffEvent,
@@ -115,7 +116,7 @@ test("maybeBreakGlass emits and records exactly once after the bound", () => {
       verdict: { reason: "superseded" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "2", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
       appendEvent: (event) => { events.push(event); return true; },
-      recordEscalation: (record) => { escalations.push(record); return { confirmed: true }; },
+      recordEscalation: (record) => { escalations.push(record); return recordDurableEscalation(record); },
       logger: { warn() {} },
     };
     maybeBreakGlass({ ...opts, now: 1 });
@@ -124,6 +125,7 @@ test("maybeBreakGlass emits and records exactly once after the bound", () => {
     expect(events).toHaveLength(1);
     expect(escalations).toHaveLength(1);
     expect(escalations[0]).toMatchObject({ labelConfirmed: false, source: "fence-standoff" });
+    expect(escalations[0].now).toBe("1970-01-01T00:00:00.002Z");
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -139,7 +141,6 @@ test("maybeBreakGlass retries delivery before latching the episode", () => {
       site: "terminal-sweep",
       verdict: { reason: "superseded" },
       env: { CATALYST_FENCE_STANDOFF_CAP: "1", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
-      recordEscalation: () => ({ confirmed: true }),
       appendEvent: () => { eventAttempts += 1; return eventAttempts > 1; },
       logger: { warn() {} },
     };

--- a/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
+++ b/plugins/dev/scripts/execution-core/fence-standoff.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import {
   recordFenceSuppression, readFenceStandoff, clearFenceStandoff,
   evaluateStandoff, markBreakGlass, buildFenceStandoffEvent,
+  maybeBreakGlass,
   FENCE_STANDOFF_EVENT, FENCE_STANDOFF_CAP_DEFAULT, FENCE_STANDOFF_MIN_AGE_MS_DEFAULT,
 } from "./fence-standoff.mjs";
 
@@ -94,4 +95,30 @@ describe("buildFenceStandoffEvent (CAT-173)", () => {
   test("FENCE_STANDOFF_EVENT is the registrable prefix form", () => {
     expect(FENCE_STANDOFF_EVENT).toBe("escalation.fence-standoff.CTL-1");
   });
+});
+
+test("maybeBreakGlass emits and records exactly once after the bound", () => {
+  const dir = mkdtempSync(join(tmpdir(), "fs-break-"));
+  const events = [];
+  const escalations = [];
+  try {
+    const opts = {
+      orchDir: dir,
+      ticket: "CAT-53",
+      site: "terminal-sweep",
+      verdict: { reason: "superseded" },
+      env: { CATALYST_FENCE_STANDOFF_CAP: "2", CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1" },
+      appendEvent: (event) => events.push(event),
+      recordEscalation: (record) => escalations.push(record),
+      logger: { warn() {} },
+    };
+    maybeBreakGlass({ ...opts, now: 1 });
+    maybeBreakGlass({ ...opts, now: 2 });
+    maybeBreakGlass({ ...opts, now: 3 });
+    expect(events).toHaveLength(1);
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0]).toMatchObject({ labelConfirmed: false, source: "fence-standoff" });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -140,6 +140,12 @@ import {
 import { collectBeliefsTick, getBeliefsDb, getEscalateHumanBelief } from "./beliefs/collector.mjs";
 import { buildRecoveryItems } from "./recovery-evidence.mjs";
 import { forgetDurableEscalation } from "./durable-escalation.mjs"; // CTL-1643: clear durable record on operator re-arm
+import {
+  appendFenceStandoffEvent as defaultAppendFenceStandoffEvent,
+  clearFenceStandoff,
+  maybeBreakGlass,
+  resolveStandoffCooldownMs,
+} from "./fence-standoff.mjs"; // CAT-173: bounded out-of-band surfacing for fence standoffs
 // CTL-1045 Bug 1: kill-storm suppression guard for defaultJanitorKillIntentRecorder.
 import {
   isIntentEffective,
@@ -5047,6 +5053,7 @@ export function schedulerTick(
     // CTL-868 — orphan-detected emitter (route B observability). Injectable; tests
     // pass a spy, production uses the canonical unified-event-log appender.
     appendOrphanDetectedEvent = defaultAppendOrphanDetectedEvent,
+    appendFenceStandoffEvent = defaultAppendFenceStandoffEvent,
     // CTL-537: sequencing seam. Default undefined → the new-work gate is skipped
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
@@ -7371,12 +7378,17 @@ export function schedulerTick(
         for (const member of anomaly.members) {
           if (triagedWaiting.includes(member)) {
             cycleMembers.add(member);
+            let cycleFenceVerdict = null;
             if (
               fenceGuard(
                 { ticket: member, orchDir, multiHost, gateway, self },
-                { proceedOnMissingGeneration: true }
+                {
+                  proceedOnMissingGeneration: true,
+                  onSuppress: (verdict) => { cycleFenceVerdict = verdict; },
+                }
               )
             ) {
+              clearFenceStandoff(orchDir, member);
               const dcResult = routeStuckTicketToDelegate(orchDir, member, {
                 site: "dependency-cycle",
                 reason: "dependency-cycle",
@@ -7423,9 +7435,21 @@ export function schedulerTick(
               }
             } else {
               log.warn(
-                { ticket: member },
+                { ticket: member, reason: cycleFenceVerdict?.reason ?? null },
                 "ctl-863: stale fence — suppressing labelOnce(needs-human/cycle) write (zombie guard)"
               );
+              maybeBreakGlass({
+                orchDir,
+                ticket: member,
+                site: "triaged-waiting-cycle",
+                verdict: cycleFenceVerdict,
+                phase: "dependency-cycle",
+                now: now(),
+                env,
+                appendEvent: appendFenceStandoffEvent,
+                logger: log,
+                detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
+              });
             }
           }
         }
@@ -8425,12 +8449,17 @@ export function schedulerTick(
           );
           // CTL-863 fence: external Linear write — a zombie host that lost its
           // claim must not label after takeover (mirrors the A.5 cycle site).
+          let c925FenceVerdict = null;
           if (
             fenceGuard(
               { ticket: member, orchDir, multiHost, gateway, self },
-              { proceedOnMissingGeneration: true }
+              {
+                proceedOnMissingGeneration: true,
+                onSuppress: (verdict) => { c925FenceVerdict = verdict; },
+              }
             )
           ) {
+            clearFenceStandoff(orchDir, member);
             const c925Result = routeStuckTicketToDelegate(orchDir, member, {
               site: "ctl-925-cycle",
               reason: "dependency-cycle",
@@ -8463,6 +8492,23 @@ export function schedulerTick(
                 source: "ctl-925-cycle",
               });
             }
+          } else {
+            log.warn(
+              { ticket: member, reason: c925FenceVerdict?.reason ?? null },
+              "cat-173: fence suppressed eligible dependency-cycle escalation",
+            );
+            maybeBreakGlass({
+              orchDir,
+              ticket: member,
+              site: "ctl-925-cycle",
+              verdict: c925FenceVerdict,
+              phase: "dependency-cycle",
+              now: now(),
+              env,
+              appendEvent: appendFenceStandoffEvent,
+              logger: log,
+              detail: `dependency-cycle members: ${anomaly.members.join(" → ")}`,
+            });
           }
         }
       }
@@ -9127,9 +9173,11 @@ export function schedulerTick(
           // latch so a finished ticket's escalated/cooldown ledger entry doesn't
           // linger (hygiene — the recovery router already drops terminal tickets).
           recoveryForgetIntent(ticket, { orchDir });
+          clearFenceStandoff(orchDir, ticket);
         } else {
           // Non-terminal stalled/failed ticket → apply the belief-aware needs-human
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
+          let fenceVerdict = null;
           if (
             fenceGuard(
               { ticket, orchDir, multiHost, gateway, self },
@@ -9144,9 +9192,13 @@ export function schedulerTick(
                 // that one here would hold a genuinely-completed pipeline non-terminal
                 // for a whole cooldown window when recovery finishes teardown.
                 onMissingGeneration: () => stampEscalationProbeCooldown(orchDir, ticket, now()),
+                onSuppress: (verdict) => {
+                  fenceVerdict = verdict;
+                },
               }
             )
           ) {
+            clearFenceStandoff(orchDir, ticket);
             const stalledSig = signalByTicket.get(ticket);
             // CTL-1754: resolve the reason across every key the pipeline
             // actually writes. This line used to read `stalledSig?.stalledReason`
@@ -9178,12 +9230,29 @@ export function schedulerTick(
             }
           } else {
             log.warn(
-              { ticket },
+              { ticket, reason: fenceVerdict?.reason ?? null },
               "ctl-863: stale fence — suppressing labelOnce(needs-human/failed-or-stalled) write (zombie guard)"
             );
             // CTL-1329: arm the cooldown so the next ticks skip this dir's probe+fence
             // instead of re-burning Linear quota every tick until the dir is reaped.
             stampFenceSuppress(orchDir, ticket, now());
+            const standoff = maybeBreakGlass({
+              orchDir,
+              ticket,
+              site: "terminal-sweep",
+              verdict: fenceVerdict,
+              phase: signalByTicket.get(ticket)?.phase ?? "terminal-sweep",
+              now: now(),
+              env,
+              appendEvent: appendFenceStandoffEvent,
+              logger: log,
+            });
+            if (standoff.breakGlass) {
+              stampCooldownMarker(
+                fenceSuppressMarkerPath(orchDir, ticket),
+                now() + resolveStandoffCooldownMs(env) - FENCE_SUPPRESS_COOLDOWN_MS
+              );
+            }
           }
           // CTL-868 route (B): emit a canonical orphan-detected event (once) so a
           // non-terminal stalled/failed-no-recovery ticket is visible on the dashboard
@@ -9919,6 +9988,8 @@ function runTick() {
       // CTL-1789: same shape — undefined keeps schedulerTick's default-on
       // defaultAppendPhaseAdvanceAppliedEvent; a test injects a spy.
       appendPhaseAdvanceAppliedEvent: runningOpts.appendPhaseAdvanceAppliedEvent,
+      appendFenceStandoffEvent:
+        runningOpts.appendFenceStandoffEvent ?? defaultAppendFenceStandoffEvent,
       // CTL-1605: arm the guarded fast-path eviction seam for the STEP A terminal
       // short-circuit. Reuses the SAME warm agents snapshot + freshness + worktree
       // resolver the J4 census uses (never removes a dir whose worktree hosts a live

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -9287,10 +9287,18 @@ export function schedulerTick(
             });
             if (standoff.breakGlass && !standoff.deliveryPending) {
               stampFenceStandoffCooldown(orchDir, ticket, now(), env);
-            } else if (standoff.deliveryPending) {
+            } else if (standoff.deliveryPending && standoff.deliveryRetryable === true) {
               // Delivery is intentionally retryable on the next tick. The ordinary
               // 15-minute suppression marker was stamped immediately above; remove
               // it so it cannot accidentally become a delivery-retry latch.
+              //
+              // BOUNDED (CAT-173 review): only while maybeBreakGlass still reports the
+              // failure as retryable. Dropping the marker every tick on a PERSISTENTLY
+              // failing sink (unwritable `.escalations`, full disk) re-runs this block's
+              // terminal Linear probe + fence-check subprocess ~2x/sec forever — exactly
+              // the CTL-1329 burn that drained the OAuth bucket and froze fleet dispatch.
+              // Past the bound we leave the marker, so delivery still retries — once per
+              // 15-minute cooldown instead of every tick. Fail-closed on an absent flag.
               try {
                 unlinkSync(fenceSuppressMarkerPath(orchDir, ticket));
               } catch {

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -3875,6 +3875,35 @@ function escalationProbeCooldownPath(orchDir, ticket) {
   return join(orchDir, "workers", ticket, ".escalation-probe-cooldown");
 }
 
+// CAT-173: successful fence-standoff delivery has its own long cooldown. Keep it
+// separate from `.fence-suppressed`: terminalDoneOnce consumes that marker and
+// must remain free to write Done while standoff re-escalation is rate-bounded.
+function fenceStandoffCooldownPath(orchDir, ticket) {
+  return join(orchDir, "workers", ticket, ".fence-standoff-cooldown");
+}
+
+function stampFenceStandoffCooldown(orchDir, ticket, nowMs, env = process.env) {
+  try {
+    writeFileSync(
+      fenceStandoffCooldownPath(orchDir, ticket),
+      JSON.stringify({ expiresAt: nowMs + resolveStandoffCooldownMs(env) }),
+    );
+  } catch {
+    /* best-effort — re-probe next tick */
+  }
+}
+
+function isFenceStandoffCooldownFresh(orchDir, ticket, nowMs) {
+  try {
+    const { expiresAt } = JSON.parse(
+      readFileSync(fenceStandoffCooldownPath(orchDir, ticket), "utf8"),
+    );
+    return Number.isFinite(expiresAt) && nowMs < expiresAt;
+  } catch {
+    return false;
+  }
+}
+
 // Best-effort: a failed write just means we re-probe next tick (no worse than before).
 function stampCooldownMarker(path, nowMs) {
   try {
@@ -5054,6 +5083,8 @@ export function schedulerTick(
     // pass a spy, production uses the canonical unified-event-log appender.
     appendOrphanDetectedEvent = defaultAppendOrphanDetectedEvent,
     appendFenceStandoffEvent = defaultAppendFenceStandoffEvent,
+    // CAT-173: injectable terminal-sweep fence seam for scheduler integration tests.
+    terminalFenceGuard = fenceGuard,
     // CTL-537: sequencing seam. Default undefined → the new-work gate is skipped
     // entirely (byte-for-byte legacy dispatch for every test that doesn't inject
     // it). Production wires defaultCheckSequencing via runTick/startScheduler.
@@ -9130,7 +9161,8 @@ export function schedulerTick(
       // fence-check runs before we've proven a write is needed.
       if (
         isFenceSuppressFresh(orchDir, ticket, now()) ||
-        isEscalationProbeCooldownFresh(orchDir, ticket, now())
+        isEscalationProbeCooldownFresh(orchDir, ticket, now()) ||
+        isFenceStandoffCooldownFresh(orchDir, ticket, now())
       ) {
         // Still surface the orphan once for the dashboard (the probe/write is what we
         // skip, not the visibility signal).
@@ -9179,7 +9211,7 @@ export function schedulerTick(
           // label (CTL-1241: skipped when the belief engine owns the reclaim).
           let fenceVerdict = null;
           if (
-            fenceGuard(
+            terminalFenceGuard(
               { ticket, orchDir, multiHost, gateway, self },
               {
                 proceedOnMissingGeneration: true,
@@ -9244,14 +9276,26 @@ export function schedulerTick(
               phase: signalByTicket.get(ticket)?.phase ?? "terminal-sweep",
               now: now(),
               env,
-              appendEvent: appendFenceStandoffEvent,
+              appendEvent: (payload) => {
+                try {
+                  return appendFenceStandoffEvent(payload);
+                } catch {
+                  return false;
+                }
+              },
               logger: log,
             });
-            if (standoff.breakGlass) {
-              stampCooldownMarker(
-                fenceSuppressMarkerPath(orchDir, ticket),
-                now() + resolveStandoffCooldownMs(env) - FENCE_SUPPRESS_COOLDOWN_MS
-              );
+            if (standoff.breakGlass && !standoff.deliveryPending) {
+              stampFenceStandoffCooldown(orchDir, ticket, now(), env);
+            } else if (standoff.deliveryPending) {
+              // Delivery is intentionally retryable on the next tick. The ordinary
+              // 15-minute suppression marker was stamped immediately above; remove
+              // it so it cannot accidentally become a delivery-retry latch.
+              try {
+                unlinkSync(fenceSuppressMarkerPath(orchDir, ticket));
+              } catch {
+                /* best-effort — a missing marker already permits retry */
+              }
             }
           }
           // CTL-868 route (B): emit a canonical orphan-detected event (once) so a

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5342,6 +5342,68 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
   });
 });
 
+describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
+  test("delivery failure does not extend fence suppression and retries next tick", () => {
+    const ticket = "CAT-173-RETRY";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "foreign-owner",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "foreign-owner" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        throw new Error("injected append failure");
+      },
+    };
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-suppressed"))).toBe(false);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-standoff-cooldown"))).toBe(false);
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(2);
+  });
+});
+
 // ── CTL-1079: retraction sweep reads from broker cache instead of live API ──
 // These tests use an exec spy + the real removeLabel (from linear-write.mjs)
 // to verify that gateway cache hits suppress the live `linearis issues read`

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5344,7 +5344,7 @@ describe("schedulerTick — terminal-sweep needs-human clear (CTL-1242)", () => 
 
 describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
   test("delivery failure does not extend fence suppression and retries next tick", () => {
-    const ticket = "CAT-173-RETRY";
+    const ticket = "PROJ-173-RETRY";
     const nowMs = Date.now();
     writeSignal(ticket, "implement", "failed");
     mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
@@ -5353,7 +5353,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "superseded",
+        reason: "unverifiable",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5386,7 +5386,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "superseded" });
+        hooks.onSuppress?.({ reason: "unverifiable" });
         return false;
       },
       appendFenceStandoffEvent: () => {
@@ -5407,7 +5407,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
   // terminal Linear probe + fence-check every tick on a persistently failing sink —
   // the CTL-1329 burn. Past the bound the ordinary 15-minute marker is retained.
   test("a persistently failing delivery stops bypassing the 15-minute cooldown", () => {
-    const ticket = "CAT-173-RETRY-BOUND";
+    const ticket = "PROJ-173-RETRY-BOUND";
     const nowMs = Date.now();
     writeSignal(ticket, "implement", "failed");
     mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
@@ -5416,7 +5416,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "superseded",
+        reason: "unverifiable",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5450,7 +5450,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "superseded" });
+        hooks.onSuppress?.({ reason: "unverifiable" });
         return false;
       },
       appendFenceStandoffEvent: () => {
@@ -5470,7 +5470,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
   // that a successful break-glass stamps the cooldown, nor that the cooldown then
   // short-circuits the next tick's probe+write block.
   test("a successful break-glass stamps the cooldown and short-circuits the next tick", () => {
-    const ticket = "CAT-173-COOLDOWN";
+    const ticket = "PROJ-173-COOLDOWN";
     const nowMs = Date.now();
     writeSignal(ticket, "implement", "failed");
     mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
@@ -5479,7 +5479,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "superseded",
+        reason: "unverifiable",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5513,7 +5513,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "superseded" });
+        hooks.onSuppress?.({ reason: "unverifiable" });
         return false;
       },
       appendFenceStandoffEvent: () => {

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5402,6 +5402,144 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
     schedulerTick(orchDir, opts);
     expect(fenceCalls).toBe(2);
   });
+
+  // CAT-173 review: the retry above must be BOUNDED. An unbounded one re-runs the
+  // terminal Linear probe + fence-check every tick on a persistently failing sink —
+  // the CTL-1329 burn. Past the bound the ordinary 15-minute marker is retained.
+  test("a persistently failing delivery stops bypassing the 15-minute cooldown", () => {
+    const ticket = "CAT-173-RETRY-BOUND";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "foreign-owner",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+        CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX: "3",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "foreign-owner" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        throw new Error("injected persistent append failure");
+      },
+    };
+
+    for (let i = 0; i < 12; i++) schedulerTick(orchDir, opts);
+    // 4 probes: the first three failures are under the bound and drop the marker;
+    // the fourth retains it, so every later tick short-circuits before the fence.
+    expect(fenceCalls).toBe(4);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-suppressed"))).toBe(true);
+    expect(existsSync(join(orchDir, "workers", ticket, ".fence-standoff-cooldown"))).toBe(false);
+  });
+
+  // CAT-173 verify finding #3: the POSITIVE path was unpinned — nothing asserted
+  // that a successful break-glass stamps the cooldown, nor that the cooldown then
+  // short-circuits the next tick's probe+write block.
+  test("a successful break-glass stamps the cooldown and short-circuits the next tick", () => {
+    const ticket = "CAT-173-COOLDOWN";
+    const nowMs = Date.now();
+    writeSignal(ticket, "implement", "failed");
+    mkdirSync(join(orchDir, ".fence-standoff"), { recursive: true });
+    writeFileSync(
+      join(orchDir, ".fence-standoff", `${ticket}.json`),
+      JSON.stringify({
+        ticket,
+        site: "terminal-sweep",
+        reason: "foreign-owner",
+        firstSuppressedAt: nowMs - 2,
+        lastSuppressedAt: nowMs - 2,
+        count: 0,
+        breakGlassAt: null,
+      }),
+    );
+
+    let fenceCalls = 0;
+    let appendCalls = 0;
+    const opts = {
+      readEligible: () => [],
+      dispatch: fakeDispatch(),
+      now: () => nowMs,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+        CATALYST_FENCE_STANDOFF_COOLDOWN_MS: "21600000",
+      },
+      gateway: {
+        getDescriptor: () => ({
+          state: "In Progress",
+          removed: false,
+          updatedAt: new Date(nowMs).toISOString(),
+        }),
+      },
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: true }),
+      },
+      terminalFenceGuard: (_subject, hooks) => {
+        fenceCalls += 1;
+        hooks.onSuppress?.({ reason: "foreign-owner" });
+        return false;
+      },
+      appendFenceStandoffEvent: () => {
+        appendCalls += 1;
+        return true;
+      },
+    };
+
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(appendCalls).toBe(1);
+    const cooldownPath = join(orchDir, "workers", ticket, ".fence-standoff-cooldown");
+    expect(existsSync(cooldownPath)).toBe(true);
+    expect(JSON.parse(readFileSync(cooldownPath, "utf8")).expiresAt).toBe(nowMs + 21600000);
+    // The durable, unfenced human signal was written without a Linear label.
+    const durable = JSON.parse(
+      readFileSync(join(orchDir, ".escalations", `${ticket}.json`), "utf8"),
+    );
+    expect(durable.source).toBe("fence-standoff");
+    expect(durable.labelConfirmed).toBe(false);
+
+    // Second tick inside the window: zero fence calls, zero further escalations.
+    schedulerTick(orchDir, opts);
+    expect(fenceCalls).toBe(1);
+    expect(appendCalls).toBe(1);
+  });
 });
 
 // ── CTL-1079: retraction sweep reads from broker cache instead of live API ──

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -5353,7 +5353,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "foreign-owner",
+        reason: "superseded",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5386,7 +5386,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "foreign-owner" });
+        hooks.onSuppress?.({ reason: "superseded" });
         return false;
       },
       appendFenceStandoffEvent: () => {
@@ -5416,7 +5416,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "foreign-owner",
+        reason: "superseded",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5450,7 +5450,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "foreign-owner" });
+        hooks.onSuppress?.({ reason: "superseded" });
         return false;
       },
       appendFenceStandoffEvent: () => {
@@ -5479,7 +5479,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       JSON.stringify({
         ticket,
         site: "terminal-sweep",
-        reason: "foreign-owner",
+        reason: "superseded",
         firstSuppressedAt: nowMs - 2,
         lastSuppressedAt: nowMs - 2,
         count: 0,
@@ -5513,7 +5513,7 @@ describe("CAT-173: terminal-sweep fence-standoff cooldown", () => {
       },
       terminalFenceGuard: (_subject, hooks) => {
         fenceCalls += 1;
-        hooks.onSuppress?.({ reason: "foreign-owner" });
+        hooks.onSuppress?.({ reason: "superseded" });
         return false;
       },
       appendFenceStandoffEvent: () => {

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -815,7 +815,10 @@ async function processTicket({
     }
     const stalledOutcome = escalate(
       ticket,
-      { reason: "rescue_worker_stalled", ...rescueState },
+      // CAT-173: thread the known PR number — rescueState carries attempt/behind/
+      // conflict fields but never prNumber, so the standoff detail rendered
+      // "stale PR #?" and dropped the primary actionable identifier.
+      { reason: "rescue_worker_stalled", prNumber: prInfo.number, ...rescueState },
       { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel, now: () => nowMs }
     );
     // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
@@ -952,7 +955,9 @@ async function processTicket({
     }
 
     case "escalate": {
-      const outcome = escalate(ticket, decision.detail ?? {}, {
+      // CAT-173: decideRescue's detail supplies attempt/behind/conflict only —
+      // thread prNumber so the standoff/escalation reason names the actual PR.
+      const outcome = escalate(ticket, { prNumber: prInfo.number, ...(decision.detail ?? {}) }, {
         orchDir,
         orchId: effectiveOrchId,
         linearWrite,

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -420,6 +420,7 @@ export function defaultEscalate(
     postConciergePage = defaultPostConciergePage,
     now = () => Date.now(),
     fenceGuardFn = fenceGuard,
+    recordDurableEscalationFn = recordDurableEscalation,
     appendStandoffEvent = appendFenceStandoffEvent,
   } = {}
 ) {
@@ -530,8 +531,7 @@ export function defaultEscalate(
           minAgeMs: resolveStandoffMinAgeMs(env),
         });
         if (verdict.firstBreakGlass) {
-          markBreakGlass({ orchDir, ticket, now: nowMs });
-          recordDurableEscalation({
+          const durableResult = recordDurableEscalationFn({
             orchDir,
             ticket,
             phase: "pr",
@@ -542,17 +542,28 @@ export function defaultEscalate(
             source: "fence-standoff",
             now: new Date(nowMs).toISOString(),
           });
-          appendStandoffEvent({
+          const durableWritten = durableResult === true || (
+            durableResult !== false && existsSync(join(orchDir, ".escalations", `${ticket}.json`))
+          );
+          const eventWritten = durableWritten && appendStandoffEvent({
             ticket,
             site: "stale-pr-rescue",
             reason: rec.reason,
             count: rec.count,
             ageMs: verdict.ageMs,
-          });
-          log.warn(
-            { ticket, prNumber: detail?.prNumber, reason: rec.reason, count: rec.count, ageMs: verdict.ageMs },
-            "cat-173: FENCE STANDOFF — wrote a durable stale-PR escalation without a Linear label",
-          );
+          }) === true;
+          if (durableWritten && eventWritten) {
+            markBreakGlass({ orchDir, ticket, now: nowMs });
+            log.warn(
+              { ticket, prNumber: detail?.prNumber, reason: rec.reason, count: rec.count, ageMs: verdict.ageMs },
+              "cat-173: FENCE STANDOFF — wrote a durable stale-PR escalation without a Linear label",
+            );
+          } else {
+            log.warn(
+              { ticket, durableWritten, eventWritten },
+              "cat-173: fence-standoff surfacing incomplete — leaving break-glass unlatched for retry",
+            );
+          }
         }
       } catch (err) {
         log.warn({ ticket, err: err?.message }, "cat-173: stale-pr-rescue standoff bookkeeping failed — continuing");

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -26,11 +26,7 @@ import { fenceGuard } from "./fence-guard.mjs";
 import {
   appendFenceStandoffEvent,
   clearFenceStandoff,
-  evaluateStandoff,
-  markBreakGlass,
-  recordFenceSuppression,
-  resolveStandoffCap,
-  resolveStandoffMinAgeMs,
+  maybeBreakGlass,
 } from "./fence-standoff.mjs";
 import { recordDurableEscalation } from "./durable-escalation.mjs";
 import { appendFileSync } from "node:fs";
@@ -516,58 +512,18 @@ export function defaultEscalate(
         { ticket, reason: fenceVerdict?.reason ?? null },
         "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)"
       );
-      try {
-        const nowMs = now();
-        const rec = recordFenceSuppression({
-          orchDir,
-          ticket,
-          site: "stale-pr-rescue",
-          reason: fenceVerdict?.reason ?? "unknown",
-          now: nowMs,
-        });
-        const verdict = evaluateStandoff(rec, {
-          now: nowMs,
-          cap: resolveStandoffCap(env),
-          minAgeMs: resolveStandoffMinAgeMs(env),
-        });
-        if (verdict.firstBreakGlass) {
-          const durableResult = recordDurableEscalationFn({
-            orchDir,
-            ticket,
-            phase: "pr",
-            reason:
-              `fence-standoff (${rec.reason}): stale PR #${detail?.prNumber ?? "?"} for ${ticket} ` +
-              "needs human attention, but the fence suppressed the Linear label write.",
-            labelConfirmed: false,
-            source: "fence-standoff",
-            now: new Date(nowMs).toISOString(),
-          });
-          const durableWritten = durableResult === true || (
-            durableResult !== false && existsSync(join(orchDir, ".escalations", `${ticket}.json`))
-          );
-          const eventWritten = durableWritten && appendStandoffEvent({
-            ticket,
-            site: "stale-pr-rescue",
-            reason: rec.reason,
-            count: rec.count,
-            ageMs: verdict.ageMs,
-          }) === true;
-          if (durableWritten && eventWritten) {
-            markBreakGlass({ orchDir, ticket, now: nowMs });
-            log.warn(
-              { ticket, prNumber: detail?.prNumber, reason: rec.reason, count: rec.count, ageMs: verdict.ageMs },
-              "cat-173: FENCE STANDOFF — wrote a durable stale-PR escalation without a Linear label",
-            );
-          } else {
-            log.warn(
-              { ticket, durableWritten, eventWritten },
-              "cat-173: fence-standoff surfacing incomplete — leaving break-glass unlatched for retry",
-            );
-          }
-        }
-      } catch (err) {
-        log.warn({ ticket, err: err?.message }, "cat-173: stale-pr-rescue standoff bookkeeping failed — continuing");
-      }
+      maybeBreakGlass({
+        orchDir,
+        ticket,
+        site: "stale-pr-rescue",
+        verdict: fenceVerdict,
+        phase: "pr",
+        now: now(),
+        env,
+        appendEvent: appendStandoffEvent,
+        recordEscalation: recordDurableEscalationFn,
+        detail: `stale PR #${detail?.prNumber ?? "?"}`,
+      });
     }
   } else {
     log.warn(

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs
@@ -23,6 +23,16 @@ import { jobLifecycle } from "./recovery.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { fenceGuard } from "./fence-guard.mjs";
+import {
+  appendFenceStandoffEvent,
+  clearFenceStandoff,
+  evaluateStandoff,
+  markBreakGlass,
+  recordFenceSuppression,
+  resolveStandoffCap,
+  resolveStandoffMinAgeMs,
+} from "./fence-standoff.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 import { appendFileSync } from "node:fs";
 // CTL-1785: `tickMultiHost` below is a TOPOLOGY fact that arms the fence
 // zombie-guard — the fenceGuard `!multiHost` disarm must stay EXISTENCE-derived so
@@ -408,6 +418,9 @@ export function defaultEscalate(
     // of applying needs-human. off is byte-identical to shadow minus the log.
     resolveSteward = defaultResolveSteward,
     postConciergePage = defaultPostConciergePage,
+    now = () => Date.now(),
+    fenceGuardFn = fenceGuard,
+    appendStandoffEvent = appendFenceStandoffEvent,
   } = {}
 ) {
   const stewardMode = readStewardEscalationConfig(env).mode; // off | shadow | enforce (default shadow)
@@ -466,12 +479,15 @@ export function defaultEscalate(
     // generation must LOUDLY proceed with the label rather than silently drop a
     // human escalation. A genuine supersession (readable generation, fresh
     // foreign owner / authoritative read says not-current) still suppresses.
-    if (
-      fenceGuard(
-        { ticket, orchDir, multiHost, gateway, self },
-        { proceedOnMissingGeneration: true }
-      )
-    ) {
+    let fenceVerdict = null;
+    if (fenceGuardFn(
+      { ticket, orchDir, multiHost, gateway, self },
+      {
+        proceedOnMissingGeneration: true,
+        onSuppress: (verdict) => { fenceVerdict = verdict; },
+      },
+    )) {
+      clearFenceStandoff(orchDir, ticket);
       const r = routeStuckTicketToDelegate(orchDir, ticket, {
         site: "stale-pr-rescue",
         reason: detail?.reason ?? "unresolvable-conflict",
@@ -496,9 +512,51 @@ export function defaultEscalate(
     } else {
       outcomeReason = "fence-suppressed";
       log.warn(
-        { ticket },
+        { ticket, reason: fenceVerdict?.reason ?? null },
         "ctl-863: stale fence — suppressing stale-pr-rescue labelOnce write (zombie guard)"
       );
+      try {
+        const nowMs = now();
+        const rec = recordFenceSuppression({
+          orchDir,
+          ticket,
+          site: "stale-pr-rescue",
+          reason: fenceVerdict?.reason ?? "unknown",
+          now: nowMs,
+        });
+        const verdict = evaluateStandoff(rec, {
+          now: nowMs,
+          cap: resolveStandoffCap(env),
+          minAgeMs: resolveStandoffMinAgeMs(env),
+        });
+        if (verdict.firstBreakGlass) {
+          markBreakGlass({ orchDir, ticket, now: nowMs });
+          recordDurableEscalation({
+            orchDir,
+            ticket,
+            phase: "pr",
+            reason:
+              `fence-standoff (${rec.reason}): stale PR #${detail?.prNumber ?? "?"} for ${ticket} ` +
+              "needs human attention, but the fence suppressed the Linear label write.",
+            labelConfirmed: false,
+            source: "fence-standoff",
+            now: new Date(nowMs).toISOString(),
+          });
+          appendStandoffEvent({
+            ticket,
+            site: "stale-pr-rescue",
+            reason: rec.reason,
+            count: rec.count,
+            ageMs: verdict.ageMs,
+          });
+          log.warn(
+            { ticket, prNumber: detail?.prNumber, reason: rec.reason, count: rec.count, ageMs: verdict.ageMs },
+            "cat-173: FENCE STANDOFF — wrote a durable stale-PR escalation without a Linear label",
+          );
+        }
+      } catch (err) {
+        log.warn({ ticket, err: err?.message }, "cat-173: stale-pr-rescue standoff bookkeeping failed — continuing");
+      }
     }
   } else {
     log.warn(
@@ -791,7 +849,7 @@ async function processTicket({
     const stalledOutcome = escalate(
       ticket,
       { reason: "rescue_worker_stalled", ...rescueState },
-      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel }
+      { orchDir, orchId: effectiveOrchId, linearWrite, multiHost, maxParallel, now: () => nowMs }
     );
     // CTL-1609 (Codex P1): latch escalatedAt ONLY on a confirmed label write.
     // decideRescue skips forever once escalatedAt exists, so latching on an
@@ -933,6 +991,7 @@ async function processTicket({
         linearWrite,
         multiHost,
         maxParallel,
+        now: () => nowMs,
       });
       // CTL-1609 (Codex P1): see recordEscalationOutcome — escalatedAt is a
       // permanent skip in decideRescue, so it is written only when the needs-human

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -647,7 +647,10 @@ describe("escalation default seam", () => {
       },
       now: () => now,
       fenceGuardFn,
-      appendStandoffEvent: (payload) => events.push(payload),
+      appendStandoffEvent: (payload) => {
+        events.push(payload);
+        return true;
+      },
     };
 
     const first = defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
@@ -667,6 +670,59 @@ describe("escalation default seam", () => {
     now += 2;
     defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
     expect(events).toHaveLength(1);
+  });
+
+  it("retries break-glass until both the durable record and event append succeed (CAT-173 P1)", () => {
+    const orchDir = mkOrchDir();
+    let now = 2_000;
+    let durableAttempts = 0;
+    let eventAttempts = 0;
+    const deps = {
+      orchDir,
+      linearWrite: {},
+      multiHost: true,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "1",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+      },
+      now: () => now,
+      fenceGuardFn: (_ctx, opts) => {
+        opts.onSuppress?.({ ticket: "CAT-174", reason: "superseded", generation: 8 });
+        return false;
+      },
+      recordDurableEscalationFn: () => {
+        durableAttempts += 1;
+        return durableAttempts > 1;
+      },
+      appendStandoffEvent: () => {
+        eventAttempts += 1;
+        return eventAttempts > 1;
+      },
+    };
+
+    now += 2;
+    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(0);
+
+    now += 2;
+    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(0);
+
+    now += 2;
+    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    expect(eventAttempts).toBe(1);
+
+    now += 2;
+    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBe(now);
+    expect(eventAttempts).toBe(2);
+
+    now += 2;
+    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    expect(eventAttempts).toBe(2);
   });
 });
 

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -635,7 +635,7 @@ describe("escalation default seam", () => {
     const events = [];
     let now = 1_000;
     const fenceGuardFn = (_ctx, opts) => {
-      opts.onSuppress?.({ ticket: "CAT-173", reason: "superseded", generation: 7 });
+      opts.onSuppress?.({ ticket: "PROJ-173", reason: "unverifiable", generation: 7 });
       return false;
     };
     const deps = {
@@ -654,22 +654,22 @@ describe("escalation default seam", () => {
       },
     };
 
-    const first = defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    const first = defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
     expect(first.reason).toBe("fence-suppressed");
-    expect(readFenceStandoff(orchDir, "CAT-173")?.count).toBe(1);
-    expect(existsSync(join(orchDir, ".escalations", "CAT-173.json"))).toBe(false);
+    expect(readFenceStandoff(orchDir, "PROJ-173")?.count).toBe(1);
+    expect(existsSync(join(orchDir, ".escalations", "PROJ-173.json"))).toBe(false);
 
     now += 2;
-    const second = defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    const second = defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
     expect(second.reason).toBe("fence-suppressed");
-    const durable = JSON.parse(readFileSync(join(orchDir, ".escalations", "CAT-173.json"), "utf8"));
+    const durable = JSON.parse(readFileSync(join(orchDir, ".escalations", "PROJ-173.json"), "utf8"));
     expect(durable.source).toBe("fence-standoff");
     expect(durable.reason).toMatch(/fence-standoff.*PR #173/);
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ ticket: "CAT-173", site: "stale-pr-rescue", count: 2 });
+    expect(events[0]).toMatchObject({ ticket: "PROJ-173", site: "stale-pr-rescue", count: 2 });
 
     now += 2;
-    defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    defaultEscalate("PROJ-173", { prNumber: 173, reason: "conflicting" }, deps);
     expect(events).toHaveLength(1);
   });
 
@@ -688,7 +688,7 @@ describe("escalation default seam", () => {
       },
       now: () => now,
       fenceGuardFn: (_ctx, opts) => {
-        opts.onSuppress?.({ ticket: "CAT-174", reason: "superseded", generation: 8 });
+        opts.onSuppress?.({ ticket: "PROJ-174", reason: "unverifiable", generation: 8 });
         return false;
       },
       recordDurableEscalationFn: (record) => {
@@ -702,27 +702,27 @@ describe("escalation default seam", () => {
     };
 
     now += 2;
-    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
-    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
     expect(eventAttempts).toBe(0);
 
     now += 2;
-    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
-    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
     expect(eventAttempts).toBe(0);
 
     now += 2;
-    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
-    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBeNull();
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBeNull();
     expect(eventAttempts).toBe(1);
 
     now += 2;
-    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
-    expect(readFenceStandoff(orchDir, "CAT-174")?.breakGlassAt).toBe(now);
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
+    expect(readFenceStandoff(orchDir, "PROJ-174")?.breakGlassAt).toBe(now);
     expect(eventAttempts).toBe(2);
 
     now += 2;
-    defaultEscalate("CAT-174", { prNumber: 174 }, deps);
+    defaultEscalate("PROJ-174", { prNumber: 174 }, deps);
     expect(eventAttempts).toBe(2);
   });
 });

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -14,6 +14,7 @@ import {
   defaultEscalate,
 } from "./stale-pr-rescue-timer.mjs";
 import { readFenceStandoff } from "./fence-standoff.mjs";
+import { recordDurableEscalation } from "./durable-escalation.mjs";
 import * as linearWriteModule from "./linear-write.mjs";
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
@@ -690,9 +691,9 @@ describe("escalation default seam", () => {
         opts.onSuppress?.({ ticket: "CAT-174", reason: "superseded", generation: 8 });
         return false;
       },
-      recordDurableEscalationFn: () => {
+      recordDurableEscalationFn: (record) => {
         durableAttempts += 1;
-        return durableAttempts > 1;
+        return durableAttempts > 1 ? recordDurableEscalation(record) : null;
       },
       appendStandoffEvent: () => {
         eventAttempts += 1;

--- a/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/stale-pr-rescue-timer.test.mjs
@@ -11,7 +11,9 @@ import {
   buildRescueDispatchArgs,
   defaultMergeTree,
   defaultLinearWrite,
+  defaultEscalate,
 } from "./stale-pr-rescue-timer.mjs";
+import { readFenceStandoff } from "./fence-standoff.mjs";
 import * as linearWriteModule from "./linear-write.mjs";
 import { spawnSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
@@ -625,6 +627,46 @@ describe("escalation default seam", () => {
 
     expect(labels).toEqual([{ ticket: "CTL-31", label: "needs-human" }]);
     expect(existsSync(join(orchDir, "workers", "CTL-31", ".linear-label-needs-human.applied"))).toBe(true);
+  });
+
+  it("fence-suppressed rescue records the episode and writes one durable escalation past the bound (CAT-173)", () => {
+    const orchDir = mkOrchDir();
+    const events = [];
+    let now = 1_000;
+    const fenceGuardFn = (_ctx, opts) => {
+      opts.onSuppress?.({ ticket: "CAT-173", reason: "superseded", generation: 7 });
+      return false;
+    };
+    const deps = {
+      orchDir,
+      linearWrite: {},
+      multiHost: true,
+      env: {
+        CATALYST_FENCE_STANDOFF_CAP: "2",
+        CATALYST_FENCE_STANDOFF_MIN_AGE_MS: "1",
+      },
+      now: () => now,
+      fenceGuardFn,
+      appendStandoffEvent: (payload) => events.push(payload),
+    };
+
+    const first = defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(first.reason).toBe("fence-suppressed");
+    expect(readFenceStandoff(orchDir, "CAT-173")?.count).toBe(1);
+    expect(existsSync(join(orchDir, ".escalations", "CAT-173.json"))).toBe(false);
+
+    now += 2;
+    const second = defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(second.reason).toBe("fence-suppressed");
+    const durable = JSON.parse(readFileSync(join(orchDir, ".escalations", "CAT-173.json"), "utf8"));
+    expect(durable.source).toBe("fence-standoff");
+    expect(durable.reason).toMatch(/fence-standoff.*PR #173/);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ ticket: "CAT-173", site: "stale-pr-rescue", count: 2 });
+
+    now += 2;
+    defaultEscalate("CAT-173", { prNumber: 173, reason: "conflicting" }, deps);
+    expect(events).toHaveLength(1);
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
@@ -241,3 +241,80 @@ describe("assembleBoard wiring — durable escalation cards", () => {
     expect(boardDataSrc).toContain("...durableTickets");
   });
 });
+
+// ─── CAT-173 (Codex #3241 round-1 P1) ───────────────────────────────────────
+// The id dedupe in synthesizeDurableEscalations DROPS a record whose ticket
+// already has a card. Correct for terminal-sweep (that card already renders
+// needs-human via deriveAttention's phaseFailed path), but it silently swallowed
+// a fence-standoff break-glass on a BEHIND PR: the rescue timer only reaches
+// break-glass through an existing worker dir (so a card always exists), BEHIND is
+// excluded from PR_BLOCKER_STATES, and the fence suppressed the needs-human
+// label — leaving the escalation on no operator surface at all.
+const mergeDurableEscalationsIntoCards = (boardMod as Record<string, unknown>)
+  .mergeDurableEscalationsIntoCards as (
+  tickets: unknown,
+  records: unknown,
+  linfo?: unknown,
+  terminalIds?: unknown,
+) => BoardTicket[];
+
+describe("mergeDurableEscalationsIntoCards — CAT-173 standoff visibility", () => {
+  const card = (over: Record<string, unknown> = {}): BoardTicket =>
+    ({
+      id: "CTL-9",
+      title: "a behind PR",
+      attention: null,
+      attentionSince: null,
+      humanQuestion: null,
+      ...over,
+    }) as unknown as BoardTicket;
+
+  it("fills attention on an existing attention-less card (the BEHIND-PR hole)", () => {
+    const tickets = [card()];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec({ source: "fence-standoff" })]);
+    expect(tickets[0].attention).toBe("needs-human");
+    expect(tickets[0].humanQuestion).toBe("Worker stuck > 24h, no progress");
+    // Anchored to the ORIGINAL escalation, not this tick.
+    expect(tickets[0].attentionSince).toBe(new Date(100_000).toISOString());
+  });
+
+  it("never overwrites an attention that is already set (live reason wins)", () => {
+    const tickets = [
+      card({ attention: "waiting-on-you", humanQuestion: "answer my question", attentionSince: "X" }),
+    ];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec()]);
+    expect(tickets[0].attention).toBe("waiting-on-you");
+    expect(tickets[0].humanQuestion).toBe("answer my question");
+    expect(tickets[0].attentionSince).toBe("X");
+  });
+
+  it("never pages on a terminal ticket", () => {
+    const bySet = [card()];
+    mergeDurableEscalationsIntoCards(bySet, [durableRec()], {}, new Set(["CTL-9"]));
+    expect(bySet[0].attention).toBeNull();
+
+    const byLinfo = [card()];
+    mergeDurableEscalationsIntoCards(byLinfo, [durableRec()], { "CTL-9": { linearState: "Done" } });
+    expect(byLinfo[0].attention).toBeNull();
+  });
+
+  it("ignores records with no matching card — synthesis owns those", () => {
+    const tickets = [card({ id: "CTL-OTHER" })];
+    mergeDurableEscalationsIntoCards(tickets, [durableRec()]);
+    expect(tickets[0].attention).toBeNull();
+    expect(tickets).toHaveLength(1);
+  });
+
+  it("is total on junk input and never throws", () => {
+    expect(() => mergeDurableEscalationsIntoCards(null, null)).not.toThrow();
+    expect(() => mergeDurableEscalationsIntoCards([card()], [null, {}, { ticket: "" }])).not.toThrow();
+  });
+
+  it("leaves the dedupe path intact: a merged card still yields no second card", () => {
+    const tickets = [card()];
+    const recs = [durableRec({ source: "fence-standoff" })];
+    mergeDurableEscalationsIntoCards(tickets, recs);
+    const extra = synthesizeDurableEscalations(recs, new Set(tickets.map((t) => t.id)), 600_000);
+    expect(extra).toHaveLength(0);
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
@@ -36,7 +36,7 @@ const synthesizeDurableEscalations = (boardMod as Record<string, unknown>)
 
 // Minimal durable record as recordDurableEscalation writes it.
 const durableRec = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
-  ticket: "CTL-9",
+  ticket: "PROJ-9",
   phase: "implement",
   reason: "Worker stuck > 24h, no progress",
   escalatedAt: new Date(100_000).toISOString(),
@@ -63,7 +63,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
   it("a fence-standoff durable record round-trips as needs-human attention (CAT-173)", () => {
     const cards = synthesizeDurableEscalations(
       [durableRec({
-        ticket: "CAT-53",
+        ticket: "PROJ-53",
         reason: "fence-standoff: superseded on 2 hosts",
         escalatedAt: "2026-08-11T00:00:00Z",
         source: "fence-standoff",
@@ -79,7 +79,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
   it("(a) a durable record with labelConfirmed:false and no existing card → attention card (Hole 1)", () => {
     const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
     expect(cards).toHaveLength(1);
-    expect(cards[0].id).toBe("CTL-9");
+    expect(cards[0].id).toBe("PROJ-9");
     expect(cards[0].attention).toBe("needs-human");
     // attentionSince anchored to the original escalatedAt (not lastTs / now).
     expect(cards[0].attentionSince).toBe(new Date(100_000).toISOString());
@@ -90,7 +90,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
     const model = deriveInbox(mkPayload(cards));
     expect(model.counts.attention).toBe(1);
     expect(model.counts.needsYou).toBe(1);
-    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("CTL-9");
+    expect(model.sections.find((s) => s.kind === "attention")?.rows[0].id).toBe("PROJ-9");
   });
 
   it("(b) a durable record with labelConfirmed:true surfaces identically to labelConfirmed:false", () => {
@@ -108,7 +108,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
   it("(c) a ticket already carded (worker-dir / parked / queued) is NOT duplicated", () => {
     const cards = synthesizeDurableEscalations(
       [durableRec()],
-      new Set(["CTL-9"]),
+      new Set(["PROJ-9"]),
       600_000,
     );
     expect(cards).toHaveLength(0);
@@ -125,7 +125,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
 
   it("(d) terminal-aware: linfo carries Done linearState → NO card", () => {
     const linfo: Record<string, { linearState?: string }> = {
-      "CTL-9": { linearState: "Done" },
+      "PROJ-9": { linearState: "Done" },
     };
     const cards = synthesizeDurableEscalations(
       [durableRec()],
@@ -144,7 +144,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       600_000,
       {},
       {},
-      new Set(["CTL-9"]),
+      new Set(["PROJ-9"]),
     );
     expect(cards).toHaveLength(0);
   });
@@ -155,7 +155,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { linearState: "Canceled" } },
+      { "PROJ-9": { linearState: "Canceled" } },
     );
     expect(cards).toHaveLength(0);
   });
@@ -166,7 +166,7 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { linearState: "Implement" } },
+      { "PROJ-9": { linearState: "Implement" } },
     );
     expect(cards).toHaveLength(1);
   });
@@ -176,8 +176,8 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       [durableRec()],
       new Set<string>(),
       600_000,
-      { "CTL-9": "Replica title" },
-      { "CTL-9": { title: "Linfo title" } },
+      { "PROJ-9": "Replica title" },
+      { "PROJ-9": { title: "Linfo title" } },
     );
     expect(replica[0].title).toBe("Replica title");
 
@@ -186,23 +186,23 @@ describe("synthesizeDurableEscalations — the pure card builder", () => {
       new Set<string>(),
       600_000,
       {},
-      { "CTL-9": { title: "Linfo title" } },
+      { "PROJ-9": { title: "Linfo title" } },
     );
     expect(linfoOnly[0].title).toBe("Linfo title");
 
     const bareId = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
-    expect(bareId[0].title).toBe("CTL-9");
+    expect(bareId[0].title).toBe("PROJ-9");
   });
 
   it("card has the correct type, team, and repo fields", () => {
     const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
     expect(cards[0].type).toBe("durable-escalation");
-    expect(cards[0].team).toBe("CTL");
+    expect(cards[0].team).toBe("PROJ");
     expect(classifyTicket(cards[0])).not.toBe("done");
   });
 
   it("existingIds may arrive as a plain array (also deduped)", () => {
-    const cards = synthesizeDurableEscalations([durableRec()], ["CTL-9"], 600_000);
+    const cards = synthesizeDurableEscalations([durableRec()], ["PROJ-9"], 600_000);
     expect(cards).toHaveLength(0);
   });
 
@@ -261,7 +261,7 @@ const mergeDurableEscalationsIntoCards = (boardMod as Record<string, unknown>)
 describe("mergeDurableEscalationsIntoCards — CAT-173 standoff visibility", () => {
   const card = (over: Record<string, unknown> = {}): BoardTicket =>
     ({
-      id: "CTL-9",
+      id: "PROJ-9",
       title: "a behind PR",
       attention: null,
       attentionSince: null,
@@ -290,16 +290,16 @@ describe("mergeDurableEscalationsIntoCards — CAT-173 standoff visibility", () 
 
   it("never pages on a terminal ticket", () => {
     const bySet = [card()];
-    mergeDurableEscalationsIntoCards(bySet, [durableRec()], {}, new Set(["CTL-9"]));
+    mergeDurableEscalationsIntoCards(bySet, [durableRec()], {}, new Set(["PROJ-9"]));
     expect(bySet[0].attention).toBeNull();
 
     const byLinfo = [card()];
-    mergeDurableEscalationsIntoCards(byLinfo, [durableRec()], { "CTL-9": { linearState: "Done" } });
+    mergeDurableEscalationsIntoCards(byLinfo, [durableRec()], { "PROJ-9": { linearState: "Done" } });
     expect(byLinfo[0].attention).toBeNull();
   });
 
   it("ignores records with no matching card — synthesis owns those", () => {
-    const tickets = [card({ id: "CTL-OTHER" })];
+    const tickets = [card({ id: "PROJ-OTHER" })];
     mergeDurableEscalationsIntoCards(tickets, [durableRec()]);
     expect(tickets[0].attention).toBeNull();
     expect(tickets).toHaveLength(1);

--- a/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/board-durable-escalations.test.ts
@@ -60,6 +60,22 @@ function mkPayload(tickets: BoardTicket[]): BoardPayload {
 }
 
 describe("synthesizeDurableEscalations — the pure card builder", () => {
+  it("a fence-standoff durable record round-trips as needs-human attention (CAT-173)", () => {
+    const cards = synthesizeDurableEscalations(
+      [durableRec({
+        ticket: "CAT-53",
+        reason: "fence-standoff: superseded on 2 hosts",
+        escalatedAt: "2026-08-11T00:00:00Z",
+        source: "fence-standoff",
+      })],
+      new Set<string>(),
+      Date.now(),
+    );
+    expect(cards[0].attention).toBe("needs-human");
+    expect(cards[0].humanQuestion).toMatch(/fence-standoff/);
+    expect(cards[0].attentionSince).toBe("2026-08-11T00:00:00Z");
+  });
+
   it("(a) a durable record with labelConfirmed:false and no existing card → attention card (Hole 1)", () => {
     const cards = synthesizeDurableEscalations([durableRec()], new Set<string>(), 600_000);
     expect(cards).toHaveLength(1);

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -1524,6 +1524,53 @@ export function synthesizeParkedNeedsHumanTickets(
   return cards;
 }
 
+// mergeDurableEscalationsIntoCards — CAT-173: the complement of
+// synthesizeDurableEscalations, which by design DROPS a durable record whose ticket
+// already has a card (id dedupe). That dedupe is right for the terminal-sweep case:
+// such a ticket has a live failed/stalled signal, so deriveAttention's phaseFailed
+// path already renders it needs-human and a second card would double-list it.
+//
+// It is WRONG for a record whose existing card carries no attention at all. The
+// concrete hole: a fence-suppressed break-glass on a BEHIND PR whose rescue budget
+// is exhausted. The rescue timer only reaches that point via an existing worker
+// directory, so the ticket always has a card; BEHIND is deliberately excluded from
+// PR_BLOCKER_STATES (the pipeline may auto-rebase it); and the fence suppressed the
+// needs-human label, so nothing else marks it. The record was then deduped away —
+// leaving the break-glass on no operator surface at all, including the push bridge,
+// which projects only board tickets.
+//
+// So: fill the EXISTING card's attention instead of dropping the record. Never
+// overwrite an attention that is already set — a live reason is always better than
+// a durable record's replay of it.
+export function mergeDurableEscalationsIntoCards(
+  tickets,
+  records,
+  linfo = {},
+  terminalIds = new Set(),
+) {
+  if (!Array.isArray(tickets) || !Array.isArray(records)) return tickets;
+  const terminal = terminalIds instanceof Set ? terminalIds : new Set();
+  const byId = new Map();
+  for (const t of tickets) {
+    if (t && t.id != null && !byId.has(t.id)) byId.set(t.id, t);
+  }
+  for (const rec of records) {
+    if (!rec || !rec.ticket) continue;
+    const card = byId.get(rec.ticket);
+    if (!card) continue; // no existing card → synthesizeDurableEscalations owns it
+    // Terminal-aware, matching the synthesis path: never page on a Done/Canceled ticket.
+    if (terminal.has(rec.ticket) || isLinearTerminal(linfo?.[rec.ticket]?.linearState)) continue;
+    if (card.attention) continue; // already surfaced — keep the live reason
+    card.attention = "needs-human";
+    card.attentionSince = rec.escalatedAt ?? card.attentionSince ?? null;
+    card.humanQuestion =
+      typeof rec.reason === "string" && rec.reason.length > 0
+        ? rec.reason
+        : "Escalated for a human.";
+  }
+  return tickets;
+}
+
 // synthesizeDurableEscalations — CTL-1643: surface durable escalation records on
 // the board even when the worker dir has been GC'd (Hole 2) and even when the
 // needs-human label never confirmed in Linear (Hole 1). Mirrors the parked-synthesis
@@ -2362,6 +2409,15 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
     Object.keys(linfo).filter((id) => isLinearTerminal(linfo[id]?.linearState))
   );
   const durableEscalationRecords = readDurableEscalations(EC);
+  // CAT-173: fill attention on cards that already exist BEFORE the id dedupe below
+  // drops their records, so a fence-standoff break-glass on an otherwise
+  // attention-less card (e.g. a BEHIND PR) still reaches the board and push bridge.
+  tickets = mergeDurableEscalationsIntoCards(
+    tickets,
+    durableEscalationRecords,
+    linfo,
+    terminalLinearIds,
+  );
   const durableCardIds = new Set(tickets.map((t) => t.id));
   const durableTickets = synthesizeDurableEscalations(
     durableEscalationRecords,

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1527,6 +1527,21 @@ write-budget unit). These env vars on the `catalyst-execution-core` process boun
   since-resolved conflict can still land (the label is never permanently abandoned — COORD-236); a
   successful apply resets the counter.
 
+### Fence-standoff human-surfacing bound (CAT-173)
+
+These execution-core environment variables bound how long repeated fence suppression can remain
+invisible to a human. The count and age must both be reached; the 45-minute floor spans three
+15-minute fence cooldowns, preventing a fast tick loop from paging on a transient blip.
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `CATALYST_FENCE_STANDOFF_CAP` | `4` | Consecutive suppressions required before out-of-band escalation. |
+| `CATALYST_FENCE_STANDOFF_MIN_AGE_MS` | `2700000` (45 min) | Minimum episode age before out-of-band escalation. |
+| `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` | `21600000` (6 h) | Retry cooldown after the bound is crossed; rate-bounded, never a permanent stop. |
+
+Crossing the bound writes a durable board/push escalation and does not loosen the fence or perform
+a Linear write.
+
 ### Broker watchdog session eviction (CTL-1516)
 
 The broker's watchdog tick keeps per-session bookkeeping (`lastHeartbeat`, `workerToOrchestrator`)

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1537,10 +1537,25 @@ invisible to a human. The count and age must both be reached; the 45-minute floo
 | --- | ---: | --- |
 | `CATALYST_FENCE_STANDOFF_CAP` | `4` | Consecutive suppressions required before out-of-band escalation. |
 | `CATALYST_FENCE_STANDOFF_MIN_AGE_MS` | `2700000` (45 min) | Minimum episode age before out-of-band escalation. |
-| `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` | `21600000` (6 h) | Retry cooldown after the bound is crossed; rate-bounded, never a permanent stop. |
+| `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` | `21600000` (6 h) | After a delivered break-glass, how long the terminal sweep skips this ticket's probe + fence check + `needs-human` write. |
+| `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` | `5` | Consecutive FAILED break-glass deliveries that may bypass the ordinary 15-minute suppression cooldown to retry on the very next tick. |
 
 Crossing the bound writes a durable board/push escalation and does not loosen the fence or perform
-a Linear write.
+a Linear write. Two cadence caveats:
+
+- The out-of-band escalation fires **once per episode**. `breakGlassAt` latches on the first
+  delivered break-glass and is reset only by `clearFenceStandoff` (a later fence PASS, or the
+  terminal branch of the sweep), so `CATALYST_FENCE_STANDOFF_COOLDOWN_MS` paces the ticket's
+  *fence re-probe*, not a repeat page.
+- Because that cooldown gates the whole terminal-sweep probe+write block, a standoff that heals
+  after a break-glass has its `needs-human` Linear write — and the terminal-clear retraction on a
+  late Done — deferred by up to one cooldown window (6 h by default, versus the 15 min the
+  pre-existing `.fence-suppressed` marker imposed).
+- A break-glass whose durable-record or event write fails drops the 15-minute marker so delivery
+  retries next tick. `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` bounds that bypass: past it the
+  ordinary cooldown is retained, so a persistently unwritable sink degrades to a 15-minute retry
+  cadence instead of re-running the per-tick Linear probe + fence-check subprocess forever
+  (the CTL-1329 quota burn).
 
 ### Broker watchdog session eviction (CTL-1516)
 


### PR DESCRIPTION
## Summary

Lands #3241 (CAT-173, originally by @thagale) as a fresh PR against current `main`. Surfaces mutual multi-host fencing standoffs instead of allowing both hosts to suppress the same needs-human escalation indefinitely. Fence ownership decisions remain fail-closed; repeated suppression is observed through a durable, bounded standoff ledger and escalated out of band once the configured threshold is crossed.

## Provenance

- Credits the original work to #3241 by **@thagale**.
- CAT-173.
- Verified still-unsolved on `main` during the 2026-08-21 backlog sweep (Ryan-directed).
- The original fork branch had accumulated ~100 unrelated commits from other in-flight fork work and upstream syncs (GitHub's PR-diff API refused to even generate a diff — "exceeded the maximum number of files (300)"). This PR cherry-picks only the 12 commits that are actually CAT-173 (fence-standoff) content, identified by diffing each candidate commit against its own diff, filtered by message/content, and applied in true topological order onto current `main`.

## Conflict-resolution decisions

- `plugins/dev/scripts/broker/namespace-parity.test.mjs`: purely additive — kept every event-name registration `main` has picked up since this PR forked, and appended the PR's new `FENCE_STANDOFF_EVENT` import/entry alongside them.
- `website/src/content/docs/reference/configuration.md`: two unrelated doc sections (CTL-2052 label-retry-cap, already on `main`, and this PR's CAT-173 fence-standoff-bound section) landed at the same anchor point — kept both, concatenated.
- `plugins/dev/scripts/execution-core/stale-pr-rescue-timer.mjs` and `scheduler.mjs` (terminal-sweep site, several rounds): the fork branch's tree had **also** picked up an unrelated `resolve-conflict-sweep` feature (the `RESOLVED_MARKER_REASON` exemption wrapper) from other fork commits that are **not** part of this PR and **not** on `main`. Confirmed via `git show origin/main:...scheduler.mjs | grep RESOLVED_MARKER_REASON` (no hits) that this wrapper does not exist upstream. Resolution applies only the genuine CAT-173 fence-standoff delta (verdict tracking, `clearFenceStandoff`, `maybeBreakGlass`/cooldown escalation) onto `main`'s actual (non-wrapped) terminal-sweep structure, and discards the contaminating wrapper and its duplicate/dead-code branches.
- All other conflicts (scheduler.mjs seam-parameter additions, dependency-cycle and ctl-925-cycle sites) auto-merged cleanly.

## Verification

- `bun test` on every test file this PR touches or adds: `namespace-parity.test.mjs`, `fence-guard.test.mjs`, `fence-standoff.test.mjs`, `scheduler.test.mjs`, `stale-pr-rescue-timer.test.mjs`, `board-durable-escalations.test.ts` — **801 pass, 6 fail** (807 total across the execution-core files) plus 23/23 pass on the board test.
- The 6 failures were confirmed **pre-existing on a clean `origin/main` checkout** (same 6 test names fail identically there, unrelated to this PR's fence-standoff changes — CTL-868 orphan-detected tests, a CTL-653 verify⇄remediate cycle test, a CTL-663 partial-commit lock test, and a CTL-764 worker.transition test).
- `node --check` passes on every hand-resolved file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
