### PR TITLE
fix(dev): CTL-2108 — emit entitlement.restored.<host> when a shed host regains entitlement

### DIFF
--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -1236,6 +1236,14 @@ function defaultEntitlementEmit(name, payload) {
   }
 }
 
+// Inter-tick shed-state accumulation for entitlement.restored.* (CTL-2108).
+// Module-level so the primary scheduler tick can accumulate across calls without
+// threading the Set through the scheduler's large closure. Opt-in via trackShedState;
+// only the primary per-tick call (scheduler.mjs:5354) enables it.
+let _entitlementShedState = new Set();
+/** @internal test-only — reset inter-tick shed accumulation between test cases */
+export function __resetEntitlementShedState() { _entitlementShedState = new Set(); }
+
 // getEntitledHosts — "may this host take work?" The roster dispatch/recovery hash
 // HRW ownership over. In `off` mode this is byte-identical to getClusterHosts(); in
 // shadow/enforce it consults the injectable provider via resolveEntitledRoster.
@@ -1248,9 +1256,16 @@ export function getEntitledHosts({
   hosts = getClusterHosts(),
   self = getHostName(),
   emit = defaultEntitlementEmit,
+  trackShedState = false,
 } = {}) {
   if (mode === "off") return hosts;
-  return resolveEntitledRoster({ mode, provider, hosts, self, emit });
+  const previouslyShedHosts = trackShedState ? _entitlementShedState : undefined;
+  const roster = resolveEntitledRoster({ mode, provider, hosts, self, emit, previouslyShedHosts });
+  if (trackShedState && mode === "enforce" && Array.isArray(hosts) && Array.isArray(roster)) {
+    // newShed = hosts \ roster, excluding self (self is always kept, never shed).
+    _entitlementShedState = new Set(hosts.filter((h) => h !== self && !roster.includes(h)));
+  }
+  return roster;
 }
 
 // getCatalystRepoDirHostsPath — absolute path to the committed cluster roster.

--- a/plugins/dev/scripts/execution-core/entitlement-enforce.test.mjs
+++ b/plugins/dev/scripts/execution-core/entitlement-enforce.test.mjs
@@ -3,13 +3,13 @@
 // roster), the ordering constraint holds (and its assertion fires on an inverted
 // fixture), and losing self-entitlement revokes held work leases via the
 // now-wired emitFenceReleased.
-import { test, expect } from "bun:test";
+import { test, expect, beforeEach } from "bun:test";
 import {
   ENTITLEMENT_TTL_MS,
   WORK_LEASE_TTL_MS,
   assertEntitlementOrdering,
 } from "../lib/entitlement.mjs";
-import { getEntitledHosts } from "./config.mjs";
+import { getEntitledHosts, __resetEntitlementShedState } from "./config.mjs";
 import { resolveEntitledRoster } from "./entitlement-roster.mjs";
 import { revokeLeasesOnEntitlementLoss } from "./entitlement-revoke.mjs";
 
@@ -200,4 +200,224 @@ test("a throwing self-check fails open: never revokes on an unanswerable authori
   });
   expect(released).toEqual([]);
   expect(r.reason).toBe("self-still-entitled");
+});
+
+// --- enforce restores --- (CTL-2108)
+
+test("restore is emitted when a previously-shed host returns to the kept roster", () => {
+  const provider = {
+    ttlMs: 1,
+    check: () => ({ verdict: "entitled" }),
+  };
+  const calls = [];
+  const result = resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(["dead"]),
+  });
+  expect(result).toEqual(["mini", "dead"]);
+  expect(calls.map((c) => c.name)).toEqual(["entitlement.restored.dead"]);
+  expect(calls[0].payload).toMatchObject({ host: "dead", self: "mini", mode: "enforce" });
+});
+
+test("no restore when the host was never shed", () => {
+  const provider = { ttlMs: 1, check: () => ({ verdict: "entitled" }) };
+  const calls = [];
+  resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(),
+  });
+  expect(calls.length).toBe(0);
+});
+
+test("no restore when the host is still unentitled (re-shed instead)", () => {
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => ({ verdict: host === "dead" ? "unentitled" : "entitled" }),
+  };
+  const calls = [];
+  const result = resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(["dead"]),
+  });
+  expect(result).toEqual(["mini"]);
+  expect(calls.map((c) => c.name)).toEqual(["entitlement.shed.dead"]);
+  expect(calls.map((c) => c.name)).not.toContain("entitlement.restored.dead");
+});
+
+test("self is never restored even if in previouslyShedHosts", () => {
+  const provider = { ttlMs: 1, check: () => ({ verdict: "unentitled" }) };
+  const calls = [];
+  resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(["mini"]),
+  });
+  const names = calls.map((c) => c.name);
+  expect(names).not.toContain("entitlement.restored.mini");
+});
+
+test("no restore on the total-outage degrade (self absent)", () => {
+  const provider = { ttlMs: 1, check: () => ({ verdict: "unentitled" }) };
+  const calls = [];
+  const result = resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["a", "b"],
+    self: "c",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(["a"]),
+  });
+  expect(result).toEqual(["a", "b"]);
+  expect(calls.length).toBe(0);
+});
+
+test("fail-open keep of a previously-shed host emits restore", () => {
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => {
+      if (host === "flaky") throw new Error("authority unreachable");
+      return { verdict: "entitled" };
+    },
+  };
+  const calls = [];
+  const result = resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "flaky"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    previouslyShedHosts: new Set(["flaky"]),
+  });
+  expect(result).toEqual(["mini", "flaky"]);
+  expect(calls.map((c) => c.name)).toContain("entitlement.restored.flaky");
+});
+
+test("previouslyShedHosts defaults to empty (no restore emits without opt-in)", () => {
+  const provider = { ttlMs: 1, check: () => ({ verdict: "entitled" }) };
+  const calls = [];
+  resolveEntitledRoster({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls.push({ name, payload }),
+    // no previouslyShedHosts
+  });
+  expect(calls.length).toBe(0);
+});
+
+// --- getEntitledHosts shed-state tracking --- (CTL-2108)
+
+beforeEach(() => {
+  __resetEntitlementShedState();
+});
+
+test("two-tick restore: provider verdict flips → shed on tick 1, restored on tick 2", () => {
+  let callCount = 0;
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => {
+      if (host !== "dead") return { verdict: "entitled" };
+      return { verdict: callCount === 0 ? "unentitled" : "entitled" };
+    },
+  };
+  const calls1 = [];
+  callCount = 0;
+  getEntitledHosts({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls1.push({ name, payload }),
+    trackShedState: true,
+  });
+  callCount = 1;
+  const calls2 = [];
+  getEntitledHosts({
+    mode: "enforce",
+    provider,
+    hosts: ["mini", "dead"],
+    self: "mini",
+    emit: (name, payload) => calls2.push({ name, payload }),
+    trackShedState: true,
+  });
+  expect(calls1.map((c) => c.name)).toContain("entitlement.shed.dead");
+  expect(calls2.map((c) => c.name)).toContain("entitlement.restored.dead");
+});
+
+test("still-shed host is not re-restored across ticks", () => {
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => ({ verdict: host === "dead" ? "unentitled" : "entitled" }),
+  };
+  const calls = [];
+  const emit = (name, payload) => calls.push({ name, payload });
+  getEntitledHosts({ mode: "enforce", provider, hosts: ["mini", "dead"], self: "mini", emit, trackShedState: true });
+  getEntitledHosts({ mode: "enforce", provider, hosts: ["mini", "dead"], self: "mini", emit, trackShedState: true });
+  const names = calls.map((c) => c.name);
+  expect(names).not.toContain("entitlement.restored.dead");
+});
+
+test("trackShedState defaults off: no restore emitted without opt-in", () => {
+  let callCount = 0;
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => {
+      if (host !== "dead") return { verdict: "entitled" };
+      return { verdict: callCount === 0 ? "unentitled" : "entitled" };
+    },
+  };
+  const calls = [];
+  const emit = (name, payload) => calls.push({ name, payload });
+  callCount = 0;
+  getEntitledHosts({ mode: "enforce", provider, hosts: ["mini", "dead"], self: "mini", emit });
+  callCount = 1;
+  getEntitledHosts({ mode: "enforce", provider, hosts: ["mini", "dead"], self: "mini", emit });
+  expect(calls.map((c) => c.name)).not.toContain("entitlement.restored.dead");
+});
+
+test("shadow mode never accumulates shed state (no restore even with trackShedState)", () => {
+  let callCount = 0;
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => {
+      if (host !== "dead") return { verdict: "entitled" };
+      return { verdict: callCount === 0 ? "unentitled" : "entitled" };
+    },
+  };
+  const calls = [];
+  const emit = (name, payload) => calls.push({ name, payload });
+  callCount = 0;
+  getEntitledHosts({ mode: "shadow", provider, hosts: ["mini", "dead"], self: "mini", emit, trackShedState: true });
+  callCount = 1;
+  getEntitledHosts({ mode: "shadow", provider, hosts: ["mini", "dead"], self: "mini", emit, trackShedState: true });
+  expect(calls.map((c) => c.name)).not.toContain("entitlement.restored.dead");
+});
+
+test("__resetEntitlementShedState clears accumulated state", () => {
+  const provider = {
+    ttlMs: 1,
+    check: ({ host }) => ({ verdict: host === "dead" ? "unentitled" : "entitled" }),
+  };
+  getEntitledHosts({ mode: "enforce", provider, hosts: ["mini", "dead"], self: "mini", emit: () => {}, trackShedState: true });
+  __resetEntitlementShedState();
+  const provider2 = { ttlMs: 1, check: () => ({ verdict: "entitled" }) };
+  const calls = [];
+  getEntitledHosts({ mode: "enforce", provider: provider2, hosts: ["mini", "dead"], self: "mini", emit: (name, payload) => calls.push({ name, payload }), trackShedState: true });
+  expect(calls.map((c) => c.name)).not.toContain("entitlement.restored.dead");
 });

--- a/plugins/dev/scripts/execution-core/entitlement-roster.mjs
+++ b/plugins/dev/scripts/execution-core/entitlement-roster.mjs
@@ -13,9 +13,11 @@
 //                   unentitled rostered host but STILL returns the full roster.
 //   Phase 4: enforce branch actually sheds unentitled hosts (self always admitted;
 //            total-outage degrades to the full roster) and emits `entitlement.shed.*`.
+//   CTL-2108: enforce branch also emits `entitlement.restored.<host>` when a
+//             previously-shed host returns to the kept roster.
 
 import { VERDICT } from "../lib/entitlement.mjs";
-import { ENTITLEMENT_WOULD_SHED, ENTITLEMENT_SHED } from "./entitlement-event.mjs";
+import { ENTITLEMENT_WOULD_SHED, ENTITLEMENT_SHED, ENTITLEMENT_RESTORED } from "./entitlement-event.mjs";
 
 // safeCheck — provider.check is contractually total (fail direction ENTITLED), but
 // an INJECTED provider (W12's authority, a test double) may throw. A throw here
@@ -42,9 +44,12 @@ function safeCheck(provider, arg) {
  * @param {string[]} args.hosts   the raw existence roster
  * @param {string} args.self      this host's name
  * @param {(name:string, payload:object)=>void} [args.emit]  event-append seam
+ * @param {Set<string>|string[]} [args.previouslyShedHosts]  hosts shed on a prior tick;
+ *   when a kept non-self host is in this set an `entitlement.restored.<host>` event is
+ *   emitted. Defaults to empty (backward-compatible — no restore emits without opt-in).
  * @returns {string[]}
  */
-export function resolveEntitledRoster({ mode, provider, hosts, self, emit } = {}) {
+export function resolveEntitledRoster({ mode, provider, hosts, self, emit, previouslyShedHosts } = {}) {
   // Fail-open guard: a malformed roster preserves whatever was passed.
   if (!Array.isArray(hosts)) return hosts;
 
@@ -98,6 +103,17 @@ export function resolveEntitledRoster({ mode, provider, hosts, self, emit } = {}
     if (shedHosts.length > 0 && typeof emit === "function") {
       for (const host of shedHosts) {
         emit(`${ENTITLEMENT_SHED}.${host}`, { host, self, mode, roster_size: hosts.length });
+      }
+    }
+    const prevShed = previouslyShedHosts instanceof Set
+      ? previouslyShedHosts
+      : new Set(previouslyShedHosts ?? []);
+    if (prevShed.size > 0 && typeof emit === "function") {
+      for (const host of kept) {
+        if (host === self) continue;
+        if (prevShed.has(host)) {
+          emit(`${ENTITLEMENT_RESTORED}.${host}`, { host, self, mode, roster_size: hosts.length });
+        }
       }
     }
     return kept;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -5351,7 +5351,9 @@ export function schedulerTick(
   // daemon restart). multiHost gates the Linear-touching claim: a single-host
   // roster makes the HRW filter an identity AND skips the claim entirely, so the
   // coordination wiring is an exact no-op until a 2nd host joins the roster.
-  const roster = hosts ?? getEntitledHosts();
+  // trackShedState: true — this is the single accumulation point for entitlement.restored.*
+  // events (CTL-2108). The diagnostician call at line ~9746 stays bare (no accumulation).
+  const roster = hosts ?? getEntitledHosts({ trackShedState: true });
   const self = hostName ?? getHostName();
   // CTL-1785: multiHost (the fenceGuard `!multiHost` disarm + the Linear-touching
   // claim gate) stays EXISTENCE-derived so entitlement shedding can never re-enable


### PR DESCRIPTION
## Changes

8629bbba fix(dev): CTL-2108 — emit entitlement.restored.<host> when a shed host regains entitlement

Refs: CTL-2108