### PR TITLE
feat(dev): CAT-170 correlated recovery-pass retry-cap alerts (lands #3209)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -651,6 +651,22 @@ as a recovery item. Previously the classifier blindly escalated it to a human. W
 The behavior is gated by `CATALYST_RECOVERY_PASS` (off by default); shadow mode logs a
 `recovery.would-fix` event without dispatching; enforce dispatches the recovery-pass worker.
 
+### Correlated retry-cap escalation (CAT-170)
+
+Retry-cap escalation records a normalized failure signature at attempt time in the host-local
+`.recovery-intents/<TICKET>.json` ledger. The exhausted-intent sweep then follows a
+**collect → group → act** flow: candidates sharing a signature inside the configured window are
+represented by one deterministic anchor escalation, while each other ticket receives a member
+pointer to that anchor. Every affected ticket retains its `needs-human` label, but the pointer
+briefs do not represent separate operator decisions.
+
+`CATALYST_RECOVERY_CORRELATION` controls rollout: `off` keeps independent escalations, `shadow`
+(the default) computes groups and emits `recovery.escalation.would-correlate` without changing the
+operator-visible path, and `enforce` emits one anchor plus `recovery.escalation.correlated` member
+events. Correlation is intentionally per-host because the intent ledger is host-local; cross-host
+correlation remains separate work. A missing/null signature always forms a singleton and can never
+correlate with another missing signature.
+
 ### Orphan-stale merged-PR reconciliation (CAT-47)
 
 Pass 0r and Pass 0u share the same production act-seam dependencies. `runTick` constructs the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -660,12 +660,34 @@ represented by one deterministic anchor escalation, while each other ticket rece
 pointer to that anchor. Every affected ticket retains its `needs-human` label, but the pointer
 briefs do not represent separate operator decisions.
 
+Signatures are read from the evidence the collector actually produced, not from item-level fields
+the production `buildRecoveryItems` shape never populates, and a board-health attempt is signed with
+the invariant that flagged **that** candidate rather than the gate's count summary — two tickets
+stuck for unrelated reasons must not share a signature. Signature normalization strips ticket ids
+and occurrence timestamps but preserves stable numeric identifiers (account, customer, and build
+numbers), so distinct causes cannot collapse into one incident.
+
 `CATALYST_RECOVERY_CORRELATION` controls rollout: `off` keeps independent escalations, `shadow`
 (the default) computes groups and emits `recovery.escalation.would-correlate` without changing the
 operator-visible path, and `enforce` emits one anchor plus `recovery.escalation.correlated` member
-events. Correlation is intentionally per-host because the intent ledger is host-local; cross-host
-correlation remains separate work. A missing/null signature always forms a singleton and can never
-correlate with another missing signature.
+events. An unrecognized value degrades to `shadow`, never to silence, and the window/group-size
+tunables accept only a finite positive window and an integer group size of at least two.
+Correlation identifiers ride the event envelope as both attributes and body payload, so a shadow
+event can identify the group it proposed. Correlation is intentionally per-host because the intent
+ledger is host-local; cross-host correlation remains separate work. A missing/null signature always
+forms a singleton and can never correlate with another missing signature.
+
+Group membership survives a partial act. Within a tick, a candidate tried as a provisional anchor is
+never acted on a second time in the member loop — that double-act burned the bounded escalation-
+deferral budget at twice the rate. Across ticks, a member whose label write fails records a durable
+pointer at its anchor under `.escalation-correlation/<TICKET>.json`; because the anchor's ledger is
+already latched `escalated:true` it is no longer a candidate and no group can re-form, so without
+that pointer the member would regroup as a singleton and raise a second full operator decision for a
+cause the anchor already covers. The pointer is windowed by the same correlation window, so a
+long-closed incident expires back to normal handling. For a correlated member the escalation signal
+carries a first-class `correlation` block (id, role, anchor, tickets) — the curated explanation
+projection drops the audit `observed` field, so that block is what a board consumer groups or
+suppresses on.
 
 ### Orphan-stale merged-PR reconciliation (CAT-47)
 

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -97,6 +97,8 @@ const INLINE_EVENT_NAMES = [
   "delegate.route-fallback",          // CTL-1609 delegate-first.mjs (enforce mode — queue full / failed)
   "catalyst.replica.writer_idle",     // CAT-21 cloud-sync.mjs (tokenless writer provisioning gap)
   "cloud-feed.would-dispatch",        // CTL-1847 cloud-feed-timer.mjs (shadow mode — would dispatch from the feed)
+  "recovery.escalation.correlated",   // CAT-170 recovery-reasoning.mjs (enforced member pointer)
+  "recovery.escalation.would-correlate", // CAT-170 recovery-reasoning.mjs (shadow group)
 ];
 
 // Build the flat list of all static exec-core event names.
@@ -162,6 +164,27 @@ describe("exec-core static event names", () => {
       // Not a phase-lifecycle event: no phase slot, so the broker never routes it
       // as a terminal phase transition.
       expect(phaseSlotOf(`${base}.mini-2`)).toBe(null);
+    }
+  });
+});
+
+describe("CAT-170 recovery escalation correlation event names", () => {
+  const CORRELATION_EVENT_NAMES = [
+    "recovery.escalation.correlated",
+    "recovery.escalation.would-correlate",
+  ];
+
+  test("both names are registered and outside protected namespaces", () => {
+    expect(
+      INLINE_EVENT_NAMES.filter((name) => CORRELATION_EVENT_NAMES.includes(name))
+    ).toEqual(CORRELATION_EVENT_NAMES);
+
+    for (const name of CORRELATION_EVENT_NAMES) {
+      expect(name.startsWith("filter.")).toBe(false);
+      expect(name.startsWith("broker.daemon")).toBe(false);
+      expect(name).not.toBe("session.heartbeat");
+      expect(isBrokerProtectedName(name)).toBe(false);
+      expect(phaseSlotOf(name)).toBeNull();
     }
   });
 });

--- a/plugins/dev/scripts/execution-core/escalation-correlation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-correlation.mjs
@@ -1,16 +1,50 @@
 import { createHash } from "node:crypto";
 
-export const RECOVERY_CORRELATION_WINDOW_MS =
-  Number(process.env.CATALYST_RECOVERY_CORRELATION_WINDOW_MIN) * 60 * 1000 || 60 * 60 * 1000;
-export const RECOVERY_CORRELATION_MIN_GROUP =
-  Number(process.env.CATALYST_RECOVERY_CORRELATION_MIN_GROUP) || 2;
+export const DEFAULT_CORRELATION_WINDOW_MS = 60 * 60 * 1000;
+export const DEFAULT_CORRELATION_MIN_GROUP = 2;
+
+// CAT-170 (Codex #3209 P2): `Number(value) || default` accepts a NEGATIVE or
+// non-finite setting instead of falling back — a negative window prevents matching
+// tickets from ever grouping, `Infinity` removes the age bound entirely, and
+// MIN_GROUP=-1 marks a single signed ticket as a correlated "incident". Both
+// tunables are validated at their declared domain: a finite positive window, and an
+// integer group size of at least two (a group of one is a singleton by definition).
+export function resolveCorrelationWindowMs(raw, fallback = DEFAULT_CORRELATION_WINDOW_MS) {
+  const minutes = Number(raw);
+  if (!Number.isFinite(minutes) || minutes <= 0) return fallback;
+  return minutes * 60 * 1000;
+}
+
+export function resolveCorrelationMinGroup(raw, fallback = DEFAULT_CORRELATION_MIN_GROUP) {
+  const size = Number(raw);
+  if (!Number.isInteger(size) || size < 2) return fallback;
+  return size;
+}
+
+export const RECOVERY_CORRELATION_WINDOW_MS = resolveCorrelationWindowMs(
+  process.env.CATALYST_RECOVERY_CORRELATION_WINDOW_MIN,
+);
+export const RECOVERY_CORRELATION_MIN_GROUP = resolveCorrelationMinGroup(
+  process.env.CATALYST_RECOVERY_CORRELATION_MIN_GROUP,
+);
 
 // Ticket ids vary per ledger entry even when the underlying failure is shared.
 const TICKET_ID_NOISE = /\b[A-Z]{2,5}-\d+\b/gi;
 // Absolute timestamps describe when a failure occurred, not what caused it.
 const ISO_TIMESTAMP_NOISE = /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\b/gi;
-// Epoch-millisecond values are occurrence-specific and safe to omit from a cause signature.
-const EPOCH_MS_NOISE = /\b\d{12,}\b/g;
+// Epoch-millisecond values are occurrence-specific and safe to omit from a cause
+// signature.
+//
+// CAT-170 (Codex #3209 P2): the old `\b\d{12,}\b` erased EVERY long digit run, not
+// just occurrence timestamps — a 12-digit AWS account id, a customer id, or a build
+// number was normalized away, so `AccessDenied for account 123456789012` and
+// `AccessDenied for account 999999999999` collapsed into ONE operator incident even
+// though they are distinct causes. Epoch-millisecond values have a known shape:
+// exactly 13 digits beginning with 1 (2001-09-09 → 2286-11-20), which covers every
+// timestamp this fleet can observe while leaving stable identifiers of any other
+// length or leading digit intact. Narrowing here can only ever SPLIT signatures that
+// used to collapse — never merge two that previously stayed apart.
+const EPOCH_MS_NOISE = /\b1\d{12}\b/g;
 const MAX_SIGNATURE_LENGTH = 96;
 
 function shortHash(value, length) {
@@ -84,8 +118,14 @@ export function groupCandidates(
     buckets.set(candidate.signature, bucket);
   }
 
-  const effectiveWindowMs = Number(windowMs) || RECOVERY_CORRELATION_WINDOW_MS;
-  const effectiveMinGroup = Number(minGroup) || RECOVERY_CORRELATION_MIN_GROUP;
+  // CAT-170 (Codex #3209 P2): validate the per-call overrides at the same domain as
+  // the env-derived defaults — an injected negative/non-finite value must not slip
+  // past `Number(x) || default` the way it did before.
+  const effectiveWindowMs = resolveCorrelationWindowMs(
+    Number(windowMs) / 60000,
+    RECOVERY_CORRELATION_WINDOW_MS,
+  );
+  const effectiveMinGroup = resolveCorrelationMinGroup(minGroup, RECOVERY_CORRELATION_MIN_GROUP);
   for (const [signature, bucket] of buckets) {
     const ordered = bucket.sort(compareCandidates);
     let cluster = [];

--- a/plugins/dev/scripts/execution-core/escalation-correlation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-correlation.mjs
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+
+export const RECOVERY_CORRELATION_WINDOW_MS =
+  Number(process.env.CATALYST_RECOVERY_CORRELATION_WINDOW_MIN) * 60 * 1000 || 60 * 60 * 1000;
+export const RECOVERY_CORRELATION_MIN_GROUP =
+  Number(process.env.CATALYST_RECOVERY_CORRELATION_MIN_GROUP) || 2;
+
+// Ticket ids vary per ledger entry even when the underlying failure is shared.
+const TICKET_ID_NOISE = /\b[A-Z]{2,5}-\d+\b/gi;
+// Absolute timestamps describe when a failure occurred, not what caused it.
+const ISO_TIMESTAMP_NOISE = /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\b/gi;
+// Epoch-millisecond values are occurrence-specific and safe to omit from a cause signature.
+const EPOCH_MS_NOISE = /\b\d{12,}\b/g;
+const MAX_SIGNATURE_LENGTH = 96;
+
+function shortHash(value, length) {
+  return createHash("sha256").update(value).digest("hex").slice(0, length);
+}
+
+export function normalizeSignature(raw) {
+  if (raw == null) return null;
+  const signature = String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(TICKET_ID_NOISE, "")
+    .replace(ISO_TIMESTAMP_NOISE, "")
+    .replace(EPOCH_MS_NOISE, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!signature) return null;
+  if (signature.length > MAX_SIGNATURE_LENGTH) {
+    return `sha256:${shortHash(signature, 16)}`;
+  }
+  return signature;
+}
+
+export function correlationId(signature, anchorTicket) {
+  return `corr-${shortHash(`${signature}|${anchorTicket}`, 12)}`;
+}
+
+function timestamp(candidate) {
+  const value = Number(candidate.lastTs);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function compareCandidates(left, right) {
+  return timestamp(left) - timestamp(right) || left.ticket.localeCompare(right.ticket);
+}
+
+function makeGroup(candidates, signature, correlated) {
+  const ordered = [...candidates].sort(compareCandidates);
+  const anchor = ordered[0].ticket;
+  const members = ordered.slice(1).map(({ ticket }) => ticket).sort((a, b) => a.localeCompare(b));
+  return {
+    signature,
+    anchor,
+    members,
+    tickets: [anchor, ...members],
+    correlated,
+    _anchorTs: timestamp(ordered[0]),
+  };
+}
+
+export function groupCandidates(
+  candidates,
+  {
+    windowMs = RECOVERY_CORRELATION_WINDOW_MS,
+    minGroup = RECOVERY_CORRELATION_MIN_GROUP,
+    now: _now = Date.now(),
+  } = {},
+) {
+  if (!Array.isArray(candidates) || candidates.length === 0) return [];
+
+  const buckets = new Map();
+  const groups = [];
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate.ticket !== "string" || !candidate.ticket) continue;
+    if (candidate.signature == null) {
+      groups.push(makeGroup([candidate], null, false));
+      continue;
+    }
+    const bucket = buckets.get(candidate.signature) ?? [];
+    bucket.push(candidate);
+    buckets.set(candidate.signature, bucket);
+  }
+
+  const effectiveWindowMs = Number(windowMs) || RECOVERY_CORRELATION_WINDOW_MS;
+  const effectiveMinGroup = Number(minGroup) || RECOVERY_CORRELATION_MIN_GROUP;
+  for (const [signature, bucket] of buckets) {
+    const ordered = bucket.sort(compareCandidates);
+    let cluster = [];
+    for (const candidate of ordered) {
+      if (cluster.length > 0 && timestamp(candidate) - timestamp(cluster[0]) > effectiveWindowMs) {
+        appendCluster(groups, cluster, signature, effectiveMinGroup);
+        cluster = [];
+      }
+      cluster.push(candidate);
+    }
+    appendCluster(groups, cluster, signature, effectiveMinGroup);
+  }
+
+  return groups
+    .sort((left, right) => left._anchorTs - right._anchorTs || left.anchor.localeCompare(right.anchor))
+    .map(({ _anchorTs, ...group }) => group);
+}
+
+function appendCluster(groups, cluster, signature, minGroup) {
+  if (cluster.length >= minGroup) {
+    groups.push(makeGroup(cluster, signature, true));
+    return;
+  }
+  for (const candidate of cluster) {
+    groups.push(makeGroup([candidate], signature, false));
+  }
+}

--- a/plugins/dev/scripts/execution-core/escalation-correlation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-correlation.test.mjs
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_CORRELATION_MIN_GROUP,
+  DEFAULT_CORRELATION_WINDOW_MS,
   RECOVERY_CORRELATION_MIN_GROUP,
   RECOVERY_CORRELATION_WINDOW_MS,
   correlationId,
   groupCandidates,
   normalizeSignature,
+  resolveCorrelationMinGroup,
+  resolveCorrelationWindowMs,
 } from "./escalation-correlation.mjs";
 
 describe("normalizeSignature (CAT-170)", () => {
@@ -145,5 +149,70 @@ describe("correlation tunables (CAT-170)", () => {
       expect(result.exitCode).toBe(0);
       expect(JSON.parse(result.stdout.toString())).toEqual([60 * 60 * 1000, 2]);
     }
+  });
+});
+
+// ─── CAT-170 (Codex #3209 review remediations) ──────────────────────────────
+describe("correlation tunable validation (Codex #3209 P2)", () => {
+  test("negative, zero, and non-finite values fall back to the documented default", () => {
+    for (const bad of [-1, 0, Number.NaN, Number.POSITIVE_INFINITY, "abc", null, undefined]) {
+      expect(resolveCorrelationWindowMs(bad)).toBe(DEFAULT_CORRELATION_WINDOW_MS);
+      expect(resolveCorrelationMinGroup(bad)).toBe(DEFAULT_CORRELATION_MIN_GROUP);
+    }
+  });
+
+  test("a group size below two is rejected — a group of one is a singleton", () => {
+    expect(resolveCorrelationMinGroup(1)).toBe(DEFAULT_CORRELATION_MIN_GROUP);
+    expect(resolveCorrelationMinGroup(2)).toBe(2);
+    expect(resolveCorrelationMinGroup(5)).toBe(5);
+    // non-integers are not a valid group size
+    expect(resolveCorrelationMinGroup(2.5)).toBe(DEFAULT_CORRELATION_MIN_GROUP);
+  });
+
+  test("a valid positive window is honoured", () => {
+    expect(resolveCorrelationWindowMs(30)).toBe(30 * 60 * 1000);
+  });
+
+  test("MIN_GROUP=-1 can no longer mark a lone signed ticket as an incident", () => {
+    const groups = groupCandidates([{ ticket: "CTL-1", signature: "boom", lastTs: 1000 }], {
+      minGroup: -1,
+      windowMs: 60 * 60 * 1000,
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].correlated).toBe(false);
+  });
+
+  test("a negative window no longer prevents matching tickets from grouping", () => {
+    const groups = groupCandidates(
+      [
+        { ticket: "CTL-1", signature: "boom", lastTs: 1000 },
+        { ticket: "CTL-2", signature: "boom", lastTs: 2000 },
+      ],
+      { windowMs: -1 },
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].correlated).toBe(true);
+    expect(groups[0].tickets).toEqual(["CTL-1", "CTL-2"]);
+  });
+});
+
+describe("normalizeSignature — stable numeric identifiers (Codex #3209 P2)", () => {
+  test("distinct 12-digit account ids stay distinct", () => {
+    const a = normalizeSignature("AccessDenied for account 123456789012");
+    const b = normalizeSignature("AccessDenied for account 999999999999");
+    expect(a).not.toBe(b);
+    expect(a).toContain("123456789012");
+  });
+
+  test("epoch-millisecond timestamps are still erased", () => {
+    // 13 digits starting with 1 — the real epoch-ms shape.
+    const a = normalizeSignature("worker died at 1786451344871");
+    const b = normalizeSignature("worker died at 1786451399999");
+    expect(a).toBe(b);
+    expect(a).not.toMatch(/\d{13}/);
+  });
+
+  test("a long non-timestamp build number is preserved", () => {
+    expect(normalizeSignature("build 999999999999999 failed")).toContain("999999999999999");
   });
 });

--- a/plugins/dev/scripts/execution-core/escalation-correlation.test.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-correlation.test.mjs
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import {
+  RECOVERY_CORRELATION_MIN_GROUP,
+  RECOVERY_CORRELATION_WINDOW_MS,
+  correlationId,
+  groupCandidates,
+  normalizeSignature,
+} from "./escalation-correlation.mjs";
+
+describe("normalizeSignature (CAT-170)", () => {
+  test("missing and blank reasons never correlate", () => {
+    for (const value of [null, undefined, "", " \n\t "]) {
+      expect(normalizeSignature(value)).toBeNull();
+    }
+  });
+
+  test("normalizes case and whitespace", () => {
+    expect(normalizeSignature("Hit your session limit")).toBe(
+      normalizeSignature("hit your   session   limit"),
+    );
+  });
+
+  test("removes ticket-specific identifiers", () => {
+    expect(normalizeSignature("CAT-47 stalled: usage limit")).toBe(
+      normalizeSignature("CAT-135 stalled: usage limit"),
+    );
+  });
+
+  test("removes absolute timestamps and epoch-millisecond runs", () => {
+    expect(normalizeSignature("failed at 2026-08-09T15:42:31.123Z after 1723218151123 ms")).toBe(
+      normalizeSignature("failed at 2026-08-10T03:01:02Z after 1723258862000 ms"),
+    );
+  });
+
+  test("is stable and bounds long reasons with distinct hashes", () => {
+    const first = `failure ${"a".repeat(200)}`;
+    const second = `failure ${"b".repeat(200)}`;
+    const signature = normalizeSignature(first);
+    expect(signature).toBe(normalizeSignature(first));
+    expect(signature).toMatch(/^sha256:[0-9a-f]{16}$/);
+    expect(signature.length).toBeLessThanOrEqual(96);
+    expect(normalizeSignature(second)).not.toBe(signature);
+  });
+
+  test("correlation ids are short and stable per signature and anchor", () => {
+    expect(correlationId("usage limit", "CAT-1")).toBe(correlationId("usage limit", "CAT-1"));
+    expect(correlationId("usage limit", "CAT-1")).toMatch(/^corr-[0-9a-f]{12}$/);
+    expect(correlationId("usage limit", "CAT-2")).not.toBe(correlationId("usage limit", "CAT-1"));
+  });
+});
+
+describe("groupCandidates (CAT-170)", () => {
+  const opts = { windowMs: 60_000, minGroup: 2, now: 1_000_000 };
+
+  test("groups three matching candidates inside the window", () => {
+    expect(groupCandidates([
+      { ticket: "CAT-3", signature: "limit", lastTs: 30_000 },
+      { ticket: "CAT-1", signature: "limit", lastTs: 10_000 },
+      { ticket: "CAT-2", signature: "limit", lastTs: 20_000 },
+    ], opts)).toEqual([{
+      signature: "limit",
+      anchor: "CAT-1",
+      members: ["CAT-2", "CAT-3"],
+      tickets: ["CAT-1", "CAT-2", "CAT-3"],
+      correlated: true,
+    }]);
+  });
+
+  test("different signatures remain uncorrelated singletons", () => {
+    expect(groupCandidates([
+      { ticket: "CAT-1", signature: "one", lastTs: 10 },
+      { ticket: "CAT-2", signature: "two", lastTs: 20 },
+    ], opts)).toEqual([
+      { signature: "one", anchor: "CAT-1", members: [], tickets: ["CAT-1"], correlated: false },
+      { signature: "two", anchor: "CAT-2", members: [], tickets: ["CAT-2"], correlated: false },
+    ]);
+  });
+
+  test("null signatures never group with each other", () => {
+    const groups = groupCandidates([
+      { ticket: "CAT-3", signature: null, lastTs: 30 },
+      { ticket: "CAT-1", signature: null, lastTs: 10 },
+      { ticket: "CAT-2", signature: null, lastTs: 20 },
+    ], opts);
+    expect(groups).toHaveLength(3);
+    expect(groups.every((group) => !group.correlated && group.tickets.length === 1)).toBe(true);
+  });
+
+  test("splits a candidate outside the newest member's window", () => {
+    const groups = groupCandidates([
+      { ticket: "CAT-1", signature: "limit", lastTs: 0 },
+      { ticket: "CAT-2", signature: "limit", lastTs: 59_000 },
+      { ticket: "CAT-3", signature: "limit", lastTs: 60_001 },
+    ], opts);
+    expect(groups.map((group) => group.tickets)).toEqual([["CAT-1", "CAT-2"], ["CAT-3"]]);
+  });
+
+  test("groups below minGroup are emitted as singletons", () => {
+    const groups = groupCandidates([
+      { ticket: "CAT-1", signature: "limit", lastTs: 10 },
+      { ticket: "CAT-2", signature: "limit", lastTs: 20 },
+    ], { ...opts, minGroup: 3 });
+    expect(groups.map((group) => group.tickets)).toEqual([["CAT-1"], ["CAT-2"]]);
+    expect(groups.every((group) => !group.correlated)).toBe(true);
+  });
+
+  test("anchor is earliest, tie-broken by ticket, regardless of input order", () => {
+    const candidates = [
+      { ticket: "CAT-9", signature: "limit", lastTs: 10 },
+      { ticket: "CAT-2", signature: "limit", lastTs: 10 },
+      { ticket: "CAT-5", signature: "limit", lastTs: 20 },
+    ];
+    const forward = groupCandidates(candidates, opts)[0];
+    const shuffled = groupCandidates([candidates[2], candidates[0], candidates[1]], opts)[0];
+    expect(forward.anchor).toBe("CAT-2");
+    expect(shuffled.anchor).toBe("CAT-2");
+    expect(forward.members).toEqual(["CAT-5", "CAT-9"]);
+    expect(shuffled).toEqual(forward);
+  });
+
+  test("empty input is empty and malformed candidates are dropped", () => {
+    expect(groupCandidates([], opts)).toEqual([]);
+    expect(() => groupCandidates([null, {}, { signature: "limit", lastTs: 1 }], opts)).not.toThrow();
+    expect(groupCandidates([null, {}, { signature: "limit", lastTs: 1 }], opts)).toEqual([]);
+  });
+});
+
+describe("correlation tunables (CAT-170)", () => {
+  test("use documented defaults", () => {
+    expect(RECOVERY_CORRELATION_WINDOW_MS).toBe(60 * 60 * 1000);
+    expect(RECOVERY_CORRELATION_MIN_GROUP).toBe(2);
+  });
+
+  test("NaN and zero environment values fall through to defaults", () => {
+    const moduleUrl = new URL("./escalation-correlation.mjs", import.meta.url).href;
+    for (const value of ["not-a-number", "0"]) {
+      const result = Bun.spawnSync({
+        cmd: [process.execPath, "-e", `import(${JSON.stringify(moduleUrl)}).then(m => console.log(JSON.stringify([m.RECOVERY_CORRELATION_WINDOW_MS, m.RECOVERY_CORRELATION_MIN_GROUP])))`],
+        env: {
+          ...process.env,
+          CATALYST_RECOVERY_CORRELATION_WINDOW_MIN: value,
+          CATALYST_RECOVERY_CORRELATION_MIN_GROUP: value,
+        },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout.toString())).toEqual([60 * 60 * 1000, 2]);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1344,9 +1344,14 @@ export function synthesizeEscalationExplanation(escalationPayload = {}) {
 // real Needs-You brief for a router-originated escalation. Read-modify-write
 // (preserve a prior needsHumanSince) + atomic tmp+rename (mkdir -p the worker
 // dir). Best-effort: catches all, logs via opts.log, NEVER throws.
+// CAT-170 (Codex #3209 round-2 P1): reports SUCCESS as a boolean. It still never
+// throws, but a silent catch-and-log gave the caller no way to tell a persisted
+// signal from a lost one — and for a correlated member the `correlation` block
+// written here is the ONLY durable carrier of its member role. The escalate path
+// below needs that answer to decide whether the act may latch.
 function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
   const log = opts.log ?? defaultLogFn;
-  if (!orchDir || !ticket) return;
+  if (!orchDir || !ticket) return false;
   try {
     const p = join(orchDir, "workers", ticket, "phase-recovery-pass.json");
     const explanation = synthesizeEscalationExplanation(escalationPayload);
@@ -1396,12 +1401,14 @@ function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
     const tmp = `${p}.tmp.${process.pid}`;
     writeFileSync(tmp, JSON.stringify(signal, null, 2));
     renameSync(tmp, p); // atomic
+    return true;
   } catch (err) {
     try {
       log(`recovery-reasoning: ${ticket} escalation signal write failed: ${err.message}`);
     } catch {
       /* logging must never break the escalate path */
     }
+    return false;
   }
 }
 
@@ -1409,8 +1416,10 @@ function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
 // tick's orchDir. Resolves orchDir from opts/env (a no-op when unset).
 export function defaultWriteEscalationSignal(ticket, escalationPayload, opts = {}) {
   const orchDir = opts.orchDir ?? resolveOrchDir();
-  if (!orchDir) return;
-  writeEscalationSignal(orchDir, ticket, escalationPayload, opts);
+  // CAT-170 (Codex #3209 round-2 P1): propagate the boolean. With no orchDir there
+  // is nowhere to persist the member role, which is a failed write, not a success.
+  if (!orchDir) return false;
+  return writeEscalationSignal(orchDir, ticket, escalationPayload, opts);
 }
 
 // buildEscalationPayload — the composer-ready EscalationPayload for the router's
@@ -2997,6 +3006,52 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     // The label landed (or its owner has it) — this escalation can now complete.
     clearEscalationDeferrals(orchDir, ticket);
 
+    // CAT-170 (Codex #3209 round-2 P1): persist the escalation signal BEFORE the
+    // ledger latch, and treat a failed write as a failed act. The `correlation`
+    // block on this signal is the ONLY durable carrier of a member's role, and the
+    // latch below is IRREVERSIBLE: `escalated:true` drops the ticket from every
+    // later candidate sweep, so its pointer is never re-read and the role can never
+    // be retried. Latching first turned one lost write into a PERMANENTLY
+    // uncorrelated member — both notification projectors then treat it as
+    // independent and emit exactly the duplicate operator alert this feature exists
+    // to suppress. Writing first keeps that failure recoverable: no latch, pointer
+    // retained, so the next sweep re-acts it as a member. Ordering is safe because
+    // this write is an idempotent atomic tmp+rename keyed by ticket — a retry
+    // rewrites one file rather than re-posting anything operator-visible. The
+    // comment/event below stay gated behind the VERIFIED latch, exactly as before,
+    // so the at-most-once discipline for those surfaces is unchanged.
+    let signalWritten = true;
+    try {
+      // `!== false` so an injected double returning undefined still reads as success.
+      signalWritten = writeSignal(ticket, escalation) !== false;
+    } catch (err) {
+      log(`recovery-reasoning: ${ticket} exhausted-escalate signal write failed: ${err.message}`);
+      signalWritten = false;
+    }
+    if (!signalWritten) {
+      // Same reasoning as the label-failure branch above: this act failed for a
+      // ticket whose anchor may have already latched this tick, so the group cannot
+      // re-form next tick. Record (or refresh) the pointer or the member regroups as
+      // a singleton and raises the duplicate escalation anyway.
+      if (group?.correlated && anchor && anchor !== ticket) {
+        writeCorrelationPointer(
+          orchDir,
+          ticket,
+          {
+            anchor,
+            correlation_id: corrId,
+            signature: group.signature,
+            tickets: correlatedTickets,
+          },
+          now(),
+        );
+      }
+      log(
+        `recovery-reasoning: ${ticket} exhausted-escalate signal did not persist — retrying next tick (correlation pointer retained)`,
+      );
+      return false; // unlatched → still a candidate, pointer intact → retried as a member
+    }
+
     try {
       recordIntent(ticket, {
         type: "recovery-pass",
@@ -3034,12 +3089,10 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     // this correlation work exists to prevent. Retaining the pointer until the
     // latch is proven costs at most a stale pointer on a permanently-failing host,
     // which the correlation window expires anyway.
+    // The signal (and with it the member's correlation role) is already durable —
+    // written and confirmed above, before the latch — so dropping the pointer here
+    // can no longer lose the role.
     clearCorrelationPointer(orchDir, ticket);
-    try {
-      writeSignal(ticket, escalation);
-    } catch (err) {
-      log(`recovery-reasoning: ${ticket} exhausted-escalate signal write failed: ${err.message}`);
-    }
     emitEvent({
       type: role === "member" ? "recovery.escalation.correlated" : "recovery.escalated",
       ticket,

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -2864,6 +2864,10 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
           correlated: false,
         }));
   const escalatedTickets = [];
+  // A provisional anchor whose signal persisted is already operator-visible even
+  // when its ledger latch later fails. Do not fail over to a second anchor in the
+  // same tick: that would leave two durable `role: "anchor"` signals until retry.
+  const durableAnchorSignals = new Set();
 
   const actOnTicket = (candidate, { role = "singleton", group = null, anchor = null } = {}) => {
     const { ticket, data, file: f } = candidate;
@@ -3051,6 +3055,7 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
       );
       return false; // unlatched → still a candidate, pointer intact → retried as a member
     }
+    if (role === "anchor") durableAnchorSignals.add(ticket);
 
     try {
       recordIntent(ticket, {
@@ -3139,6 +3144,7 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
         anchorCandidate = candidate;
         break;
       }
+      if (durableAnchorSignals.has(candidate.ticket)) break;
     }
     if (!anchorCandidate) {
       // Every candidate was already attempted above (the loop only breaks on a

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -1397,6 +1397,17 @@ function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
       // uncorrelated escalation, so an existing single-ticket signal is unchanged.
       ...(escalationPayload?.correlation ? { correlation: escalationPayload.correlation } : {}),
     };
+    // CAT-170 (phase-review): this writer is a read-modify-write over `prior`, so an
+    // omitted `correlation` block does NOT clear the one a previous escalation left
+    // behind — it inherits it. A ticket that once escalated as a correlated MEMBER
+    // would keep `correlation.role === "member"` forever, and a later INDEPENDENT
+    // escalation on that ticket (fresh exhaustion after the 7-day latch TTL) would be
+    // suppressed by every notification path that keys on the role — board projector
+    // and desktop bridge alike — so the operator gets no alert at all. Silent
+    // suppression of a genuine escalation is the exact failure this feature exists to
+    // prevent, inverted. The block is per-incident state, not accumulating history:
+    // an uncorrelated payload must ERASE it, not merely decline to replace it.
+    if (!escalationPayload?.correlation) delete signal.correlation;
     mkdirSync(dirname(p), { recursive: true });
     const tmp = `${p}.tmp.${process.pid}`;
     writeFileSync(tmp, JSON.stringify(signal, null, 2));

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -2836,7 +2836,13 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
       }
     }
     if (!anchorCandidate) {
-      for (const candidate of ordered) actOnTicket(candidate);
+      // Every candidate was already attempted above (the loop only breaks on a
+      // success), and a FAILED anchor attempt produces exactly the singleton
+      // path's side effects — the label gate fails before any correlated
+      // escalation is written. Re-running them here would bump each ticket's
+      // escalation-deferral counter twice in one tick, burning the
+      // RECOVERY_MAX_ESCALATION_DEFERRALS budget at 2x rate and double-emitting
+      // recovery.escalation.deferred. Nothing left to do for this group.
       continue;
     }
     for (const candidate of ordered) {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -2996,10 +2996,6 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     }
     // The label landed (or its owner has it) — this escalation can now complete.
     clearEscalationDeferrals(orchDir, ticket);
-    // CAT-170: this ticket's escalation is proceeding under its own steam, so any
-    // pending member pointer has served its purpose. Cleared BEFORE the ledger latch
-    // so a later failure path cannot leave a stale pointer behind.
-    clearCorrelationPointer(orchDir, ticket);
 
     try {
       recordIntent(ticket, {
@@ -3029,6 +3025,16 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
       log(`recovery-reasoning: ${ticket} exhausted-escalate latch did not persist — deferring side effects to the next tick`);
       return false;
     }
+    // CAT-170 (Codex #3209 P2): clear the member pointer ONLY once the latch is
+    // verified. It used to be cleared before recordIntent, which meant a throwing
+    // ledger write or a latch that did not persist dropped the durable anchor
+    // pointer while the escalation itself returned for retry. The next sweep then
+    // saw an unlatched ticket with no pointer, regrouped it as a singleton, and
+    // raised a SECOND full operator escalation — the exact duplicate-alert failure
+    // this correlation work exists to prevent. Retaining the pointer until the
+    // latch is proven costs at most a stale pointer on a permanently-failing host,
+    // which the correlation window expires anyway.
+    clearCorrelationPointer(orchDir, ticket);
     try {
       writeSignal(ticket, escalation);
     } catch (err) {

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -97,6 +97,37 @@ const EMIT_COMPLETE_BIN = fileURLToPath(
   new URL("../phase-agent-emit-complete", import.meta.url),
 );
 
+// deriveFailureSignature — CAT-170 (Codex #3209 P1). PURE. The raw failure text a
+// recovery attempt is signed with, read from wherever the caller actually put it.
+//
+// The original read `item.reason ?? item.signal?.stalledReason ??
+// item.signal?.failureReason` — but the PRODUCTION caller is the scheduler, whose
+// buildRecoveryItems (recovery-evidence.mjs) returns `{ticket, phase, bgJobId,
+// evidence}` and populates NEITHER `item.reason` NOR `item.signal`: the raw signal
+// fields are spread onto `item.evidence`, with the whole signal also nested at
+// `evidence.signal`. So every normal per-item fix attempt persisted a NULL
+// signature, its exhausted intent could never participate in correlation, and the
+// correlation feature was structurally dead on the path that produces the most
+// candidates. (The same gap CTL-1299 closed for the classifier, one field over.)
+//
+// Reads the item-level fields FIRST so a caller that does supply them (the tests'
+// hand-built items, and any future caller with a richer shape) keeps its meaning,
+// then falls back to the evidence object the scheduler really sends. `stalledReason`
+// outranks `failureReason` at both altitudes, preserving the original precedence.
+export function deriveFailureSignature(item = {}, evidence = null) {
+  const ev = evidence ?? item.evidence ?? {};
+  return (
+    item.reason ??
+    item.signal?.stalledReason ??
+    item.signal?.failureReason ??
+    ev.stalledReason ??
+    ev.failureReason ??
+    ev.signal?.stalledReason ??
+    ev.signal?.failureReason ??
+    null
+  );
+}
+
 // ─── Main entry point ──────────────────────────────────────────────────────
 
 export function reasoningRecoveryPass(items, opts = {}) {
@@ -453,8 +484,9 @@ export function reasoningRecoveryPass(items, opts = {}) {
             fix_class,
             outcome: fixOutcome.success,
             details: fixOutcome.details,
-            signature:
-              item.reason ?? item.signal?.stalledReason ?? item.signal?.failureReason ?? null,
+            // CAT-170 (Codex #3209 P1): read the signature from the COLLECTED
+            // evidence — the production item shape carries no `.reason`/`.signal`.
+            signature: deriveFailureSignature(item, evidence),
           });
           actionLog.push("recorded recovery-pass intent");
         } catch (err) {
@@ -1347,6 +1379,18 @@ function writeEscalationSignal(orchDir, ticket, escalationPayload, opts = {}) {
       updatedAt: nowIso,
       phase: RECOVERY_PASS_PHASE,
       explanation,
+      // CAT-170 (Codex #3209 P1): persist the correlation identity as a FIRST-CLASS
+      // signal field. It used to ride only inside `escalation.observed`, and
+      // synthesizeEscalationExplanation (called just above) projects the payload down
+      // to its six render fields — dropping `observed` entirely. The board therefore
+      // saw an ordinary `needs-human` authorization for every correlated member and
+      // its notification projector, which keys on ticket id, emitted a separate
+      // "<member> needs your decision" push for each one — precisely the per-ticket
+      // operator spam this correlation work exists to collapse. Written top-level so
+      // a consumer can group by `correlation.id` or suppress `correlation.role ===
+      // "member"` without reaching into the explanation. Omitted entirely for an
+      // uncorrelated escalation, so an existing single-ticket signal is unchanged.
+      ...(escalationPayload?.correlation ? { correlation: escalationPayload.correlation } : {}),
     };
     mkdirSync(dirname(p), { recursive: true });
     const tmp = `${p}.tmp.${process.pid}`;
@@ -1559,6 +1603,16 @@ export function buildRecoveryEnvelope(event, { now } = {}) {
     escalation = null,
     site = null,
     deferrals = null,
+    // CAT-170 (Codex #3209 P2): the correlation identifiers were passed by both the
+    // shadow (`recovery.escalation.would-correlate`) and enforce
+    // (`recovery.escalation.correlated`) emitters and silently DROPPED here, so a
+    // shadow event carried nothing but its own name and a null ticket — it could not
+    // identify the proposed group at all, which is the entire point of shadow mode.
+    // (The unit tests missed it because they inspect the raw pre-envelope object.)
+    correlation_id = null,
+    signature = null,
+    anchor = null,
+    tickets = null,
   } = event;
   // Escalations carry WARN severity; fixes/triage carry INFO.
   //
@@ -1594,11 +1648,33 @@ export function buildRecoveryEnvelope(event, { now } = {}) {
       // one-off transient from a ticket wedged against a permanently failing label.
       ...(site != null ? { "recovery.site": String(site) } : {}),
       ...(deferrals != null ? { "recovery.deferrals": Number(deferrals) } : {}),
+      // CAT-170: correlation dimensions promoted to attributes so a dashboard can
+      // group an incident by id/anchor without parsing the body. `tickets` stays
+      // body-only — an unbounded list has no place in an attribute set.
+      ...(correlation_id != null ? { "recovery.correlation_id": String(correlation_id) } : {}),
+      ...(signature != null ? { "recovery.signature": String(signature) } : {}),
+      ...(anchor != null ? { "recovery.anchor": String(anchor) } : {}),
+      ...(Array.isArray(tickets) ? { "recovery.correlated_count": tickets.length } : {}),
       // CTL-1291: bounded numerics/enums promoted so the numbers are chartable.
       ...promoteNumericAttrs(type, details),
     },
     // human-readable mirror; also the reader's fallback ticket-key source.
-    body: { payload: { ticket, type, fix_class, reason, details, escalation, site, deferrals } },
+    body: {
+      payload: {
+        ticket,
+        type,
+        fix_class,
+        reason,
+        details,
+        escalation,
+        site,
+        deferrals,
+        ...(correlation_id != null ? { correlation_id } : {}),
+        ...(signature != null ? { signature } : {}),
+        ...(anchor != null ? { anchor } : {}),
+        ...(Array.isArray(tickets) ? { tickets } : {}),
+      },
+    },
   };
 }
 
@@ -2538,6 +2614,85 @@ export function clearEscalationDeferrals(orchDir, ticket) {
   }
 }
 
+// ─── CAT-170: pending member→anchor pointer ─────────────────────────────────
+// Codex #3209 P1. A correlated group escalates in two steps: the anchor is acted on
+// first, then each member gets a pointer brief. When the anchor SUCCEEDS but a
+// member's label write transiently fails, that member is left unlatched — and the
+// anchor's ledger is now `escalated:true`, which excludes it from the next sweep's
+// candidate scan. So on the following tick the member regroups ALONE, classifies as
+// a singleton, and receives its own full `recovery.escalated` decision — a second
+// operator incident for a cause the anchor already advertised as covering it.
+//
+// This marker is what survives that gap: it records which anchor the member belongs
+// to, so its retry stays a POINTER instead of becoming a new decision. Stored beside
+// the deferral counter (never in the recovery-intent ledger, for the same reason:
+// any write carrying decision:"escalate" trips the sticky `escalated` latch and the
+// sweep would skip the very ticket we still need to retry).
+//
+// The pointer is deliberately WINDOWED by the same correlation window the grouping
+// uses — an anchor from days ago is no longer a live incident, so a stale pointer
+// expires into normal singleton handling rather than pointing a human at an
+// escalation they have long since closed.
+function correlationPointerPath(orchDir, ticket) {
+  return join(orchDir, ".escalation-correlation", `${ticket}.json`);
+}
+
+// readCorrelationPointer — this ticket's pending member pointer, or null when absent,
+// malformed, or older than `windowMs`. Never throws.
+export function readCorrelationPointer(orchDir, ticket, { windowMs, now } = {}) {
+  let prior;
+  try {
+    prior = JSON.parse(readFileSync(correlationPointerPath(orchDir, ticket), "utf8"));
+  } catch {
+    return null; // absent or malformed → no pointer
+  }
+  if (!prior || typeof prior.anchor !== "string" || !prior.anchor) return null;
+  // A pointer at its own anchor is meaningless (and would make the member loop skip
+  // the anchor act entirely) — treat it as absent.
+  if (prior.anchor === ticket) return null;
+  if (typeof windowMs === "number" && Number.isFinite(windowMs)) {
+    const at = Number(prior.at);
+    const ts = typeof now === "number" ? now : Date.now();
+    if (!Number.isFinite(at) || ts - at > windowMs) return null; // stale → expired
+  }
+  return prior;
+}
+
+// writeCorrelationPointer — record that `ticket` is a deferred member of `anchor`.
+// Best-effort: a write failure just means the next tick treats it as a singleton
+// (the pre-CAT-170 behaviour), never a thrown error. Returns true when persisted.
+export function writeCorrelationPointer(orchDir, ticket, pointer, now) {
+  const p = correlationPointerPath(orchDir, ticket);
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(
+      p,
+      JSON.stringify({
+        ticket,
+        anchor: pointer.anchor,
+        correlation_id: pointer.correlation_id ?? null,
+        signature: pointer.signature ?? null,
+        tickets: Array.isArray(pointer.tickets) ? pointer.tickets : [ticket],
+        at: now,
+      }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// clearCorrelationPointer — drop the pointer once the member's escalation completes
+// (or once it is no longer a member). Idempotent; never throws.
+export function clearCorrelationPointer(orchDir, ticket) {
+  try {
+    unlinkSync(correlationPointerPath(orchDir, ticket));
+    return true;
+  } catch {
+    return false; // absent is the common case
+  }
+}
+
 // escalateExhaustedIntents — CTL-1440 (P0b): the terminal-state policy sweep.
 // An intent whose fix attempts are exhausted (attempts >= max) WITHOUT a verdict
 // must escalate LOUDLY — ledger escalated:true (B1's 7-day TTL then ages it out
@@ -2550,8 +2705,22 @@ export function clearEscalationDeferrals(orchDir, ticket) {
 // no-verdict decisions ("dispatched" dispatch markers and "fix" classifier
 // writes) are swept — leave-alone / escalate / defer / fixed carry their own
 // terminal policies. Never throws; returns the tickets it escalated.
+// CAT-170 (Codex #3209 P2): only three modes are recognized downstream (`off`,
+// `shadow`, `enforce`). The raw env value used to pass through unvalidated, so an
+// empty string, a typo, or `Shadow` fell through every branch and behaved like
+// `off` — silently suppressing even the default-shadow telemetry an operator relies
+// on to see what correlation WOULD do. Normalize case/whitespace and fall an
+// unrecognized value back to the DECLARED default (`shadow`), never to `off`:
+// degrading toward observe-only is safe, degrading toward silence is not.
+export const RECOVERY_CORRELATION_MODES = Object.freeze(["off", "shadow", "enforce"]);
+
+export function resolveCorrelationMode(raw, fallback = "shadow") {
+  const mode = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  return RECOVERY_CORRELATION_MODES.includes(mode) ? mode : fallback;
+}
+
 export const RECOVERY_CORRELATION_MODE = () =>
-  process.env.CATALYST_RECOVERY_CORRELATION ?? "shadow";
+  resolveCorrelationMode(process.env.CATALYST_RECOVERY_CORRELATION);
 
 export function escalateExhaustedIntents(orchDir, opts = {}) {
   const {
@@ -2581,10 +2750,13 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     // cached terminal/merged check; default keeps the function pure/hermetic.
     isActive = () => true,
     log = defaultLogFn,
-    correlationMode = RECOVERY_CORRELATION_MODE(),
+    correlationMode: correlationModeOpt = RECOVERY_CORRELATION_MODE(),
     correlationWindowMs = RECOVERY_CORRELATION_WINDOW_MS,
     correlationMinGroup = RECOVERY_CORRELATION_MIN_GROUP,
   } = opts;
+  // CAT-170 (Codex #3209 P2): an INJECTED mode gets the same validation as the env
+  // one, so a caller cannot smuggle an unrecognized value past the branches below.
+  const correlationMode = resolveCorrelationMode(correlationModeOpt);
   if (!orchDir) return [];
   let files;
   try {
@@ -2625,12 +2797,38 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     });
   }
 
-  const computedGroups = groupCandidates(candidates, {
+  // CAT-170 (Codex #3209 P1): pull out candidates carrying a PENDING member pointer
+  // BEFORE grouping. A member whose act failed after its anchor already latched is
+  // still part of that incident — but the anchor's ledger now reads `escalated:true`,
+  // so it is no longer a candidate and cannot re-form the group. Left to normal
+  // grouping the member would classify as a singleton and emit a second full
+  // `recovery.escalated` for a cause the anchor already advertised as covering it.
+  // Routing it through the pointer pass keeps its retry a POINTER at the original
+  // anchor. Only `enforce` produces members; a pointer older than the correlation
+  // window expires inside readCorrelationPointer and the ticket falls back to normal
+  // grouping (a long-closed incident must not keep pointing a human at it).
+  const pendingPointers = new Map();
+  if (correlationMode === "enforce") {
+    for (const candidate of candidates) {
+      const pointer = readCorrelationPointer(orchDir, candidate.ticket, {
+        windowMs: correlationWindowMs,
+        now: now(),
+      });
+      if (pointer) pendingPointers.set(candidate.ticket, pointer);
+    }
+  }
+  const groupableCandidates = pendingPointers.size
+    ? candidates.filter((candidate) => !pendingPointers.has(candidate.ticket))
+    : candidates;
+
+  const computedGroups = groupCandidates(groupableCandidates, {
     windowMs: correlationWindowMs,
     minGroup: correlationMinGroup,
     now: now(),
   });
-  const candidateByTicket = new Map(candidates.map((candidate) => [candidate.ticket, candidate]));
+  const candidateByTicket = new Map(
+    groupableCandidates.map((candidate) => [candidate.ticket, candidate]),
+  );
   if (correlationMode === "shadow") {
     for (const group of computedGroups.filter((g) => g.correlated)) {
       emitEvent({
@@ -2661,7 +2859,12 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
   const actOnTicket = (candidate, { role = "singleton", group = null, anchor = null } = {}) => {
     const { ticket, data, file: f } = candidate;
     const reason = `self-heal attempts exhausted (${data.attempts} dispatches without a recorded verdict)`;
-    const corrId = group?.correlated ? correlationId(group.signature, anchor ?? ticket) : null;
+    // CAT-170: a resumed member carries the correlation id its anchor was escalated
+    // under, so prefer the recorded value over a recompute — the id a human already
+    // saw must stay stable even if the signature text is normalized differently later.
+    const corrId = group?.correlated
+      ? (group.correlationId ?? correlationId(group.signature, anchor ?? ticket))
+      : null;
     const correlatedTickets = group?.tickets ?? [ticket];
     const escalation = role === "singleton" ? {
       escalation_type: "authorization",
@@ -2697,6 +2900,18 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
         signature: group.signature,
         correlated_tickets: correlatedTickets,
         correlated_count: correlatedTickets.length,
+      },
+      // CAT-170 (Codex #3209 P1): the same identity ALSO as a first-class payload
+      // key. `observed` is audit passthrough that synthesizeEscalationExplanation
+      // discards, so it cannot be what a board consumer groups or suppresses on —
+      // writeEscalationSignal persists THIS key onto the signal instead.
+      correlation: {
+        id: corrId,
+        role,
+        anchor: anchor ?? ticket,
+        signature: group.signature,
+        tickets: correlatedTickets,
+        count: correlatedTickets.length,
       },
       attempts: [],
     };
@@ -2759,10 +2974,32 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
             `after ${deferrals} attempts; escalation cannot complete from this host`,
         );
       }
+      // CAT-170 (Codex #3209 P1): the act failed for a ticket that IS part of a
+      // correlated incident whose anchor has already latched. Record which anchor it
+      // belongs to so the next tick retries it as a POINTER rather than regrouping it
+      // into a fresh standalone escalation. Best-effort — a failed pointer write just
+      // restores the previous singleton behaviour.
+      if (group?.correlated && anchor && anchor !== ticket) {
+        writeCorrelationPointer(
+          orchDir,
+          ticket,
+          {
+            anchor,
+            correlation_id: corrId,
+            signature: group.signature,
+            tickets: correlatedTickets,
+          },
+          now(),
+        );
+      }
       return false; // the act did not complete — not counted as escalated
     }
     // The label landed (or its owner has it) — this escalation can now complete.
     clearEscalationDeferrals(orchDir, ticket);
+    // CAT-170: this ticket's escalation is proceeding under its own steam, so any
+    // pending member pointer has served its purpose. Cleared BEFORE the ledger latch
+    // so a later failure path cannot leave a stale pointer behind.
+    clearCorrelationPointer(orchDir, ticket);
 
     try {
       recordIntent(ticket, {
@@ -2829,7 +3066,16 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     }
     const ordered = [group.anchor, ...group.members];
     let anchorCandidate = null;
+    // CAT-170 (Codex #3209 P2): remember which candidates the anchor-selection loop
+    // already spent an act on. It breaks on the FIRST success, so every candidate up
+    // to and including the winner has been attempted; the member loop below must not
+    // act on any of them a second time. A persistently label-failing ticket that was
+    // tried as a provisional anchor and then re-tried as a member performed two label
+    // writes, emitted two recovery.escalation.deferred events, and burned its bounded
+    // RECOVERY_MAX_ESCALATION_DEFERRALS budget at 2x rate in a single tick.
+    const attempted = new Set();
     for (const candidate of ordered) {
+      attempted.add(candidate.ticket);
       if (actOnTicket(candidate, { role: "anchor", group, anchor: candidate.ticket })) {
         anchorCandidate = candidate;
         break;
@@ -2847,12 +3093,51 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     }
     for (const candidate of ordered) {
       if (candidate.ticket === anchorCandidate.ticket) continue;
+      if (attempted.has(candidate.ticket)) {
+        // Already acted on this tick as a provisional anchor, and it failed. Do not
+        // spend a second act — but DO record the pointer, so its retry next tick is a
+        // member of the anchor that actually won rather than a fresh singleton
+        // escalation (the same P1 correlation loss the deferred-member path fixes).
+        writeCorrelationPointer(
+          orchDir,
+          candidate.ticket,
+          {
+            anchor: anchorCandidate.ticket,
+            correlation_id: correlationId(group.signature, anchorCandidate.ticket),
+            signature: group.signature,
+            tickets: group.tickets,
+          },
+          now(),
+        );
+        continue;
+      }
       actOnTicket(candidate, {
         role: "member",
         group,
         anchor: anchorCandidate.ticket,
       });
     }
+  }
+
+  // CAT-170 (Codex #3209 P1): the pointer pass — deferred members retrying against an
+  // anchor that has already latched (and is therefore no longer a candidate, so no
+  // group can re-form around it). Each is acted on as a MEMBER of its recorded
+  // anchor, so it stays a pointer brief instead of becoming a second standalone
+  // operator decision. A synthetic group carries the pointer's own recorded identity;
+  // `correlated: true` is what makes actOnTicket take the member branch.
+  for (const [ticket, pointer] of pendingPointers) {
+    const candidate = candidates.find((c) => c.ticket === ticket);
+    if (!candidate) continue;
+    actOnTicket(candidate, {
+      role: "member",
+      group: {
+        signature: pointer.signature ?? null,
+        correlationId: pointer.correlation_id ?? null,
+        tickets: Array.isArray(pointer.tickets) ? pointer.tickets : [ticket],
+        correlated: true,
+      },
+      anchor: pointer.anchor,
+    });
   }
   return escalatedTickets;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -68,6 +68,13 @@ import {
   recordFixFailure,
   shouldPostFixComment,
 } from "./recovery-fix-backoff.mjs";
+import {
+  correlationId,
+  groupCandidates,
+  normalizeSignature,
+  RECOVERY_CORRELATION_MIN_GROUP,
+  RECOVERY_CORRELATION_WINDOW_MS,
+} from "./escalation-correlation.mjs";
 
 // Wrap defaultLog to ensure it's a function (config.mjs may export an object)
 const defaultLogFn = typeof defaultLog === "function" ? defaultLog : (msg) => {
@@ -446,6 +453,8 @@ export function reasoningRecoveryPass(items, opts = {}) {
             fix_class,
             outcome: fixOutcome.success,
             details: fixOutcome.details,
+            signature:
+              item.reason ?? item.signal?.stalledReason ?? item.signal?.failureReason ?? null,
           });
           actionLog.push("recorded recovery-pass intent");
         } catch (err) {
@@ -2286,6 +2295,11 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
   // surface — the verdict fields must never contradict the decision).
   const hasVerdict = typeof intent.verdict === "string";
   const isMarkerWrite = intent.decision === "dispatched" || intent.decision === "defer";
+  // CAT-170: best-effort typed failure signature, written on attempt/marker
+  // writes. Absence means no typed signature; terminal writes clear stale data.
+  const signature =
+    normalizeSignature(intent.signature) ??
+    (isMarkerWrite ? normalizeSignature(prior.signature) : null);
   const entry = {
     ticket,
     ts: typeof prior.ts === "number" ? prior.ts : ts, // first-action timestamp
@@ -2307,6 +2321,7 @@ export function defaultRecordIntent(ticket, intent, opts = {}) {
             verdictTs: prior.verdictTs ?? null,
           }
         : {}),
+    ...(signature ? { signature } : {}),
   };
 
   try {
@@ -2535,6 +2550,9 @@ export function clearEscalationDeferrals(orchDir, ticket) {
 // no-verdict decisions ("dispatched" dispatch markers and "fix" classifier
 // writes) are swept — leave-alone / escalate / defer / fixed carry their own
 // terminal policies. Never throws; returns the tickets it escalated.
+export const RECOVERY_CORRELATION_MODE = () =>
+  process.env.CATALYST_RECOVERY_CORRELATION ?? "shadow";
+
 export function escalateExhaustedIntents(orchDir, opts = {}) {
   const {
     now = () => Date.now(),
@@ -2563,6 +2581,9 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     // cached terminal/merged check; default keeps the function pure/hermetic.
     isActive = () => true,
     log = defaultLogFn,
+    correlationMode = RECOVERY_CORRELATION_MODE(),
+    correlationWindowMs = RECOVERY_CORRELATION_WINDOW_MS,
+    correlationMinGroup = RECOVERY_CORRELATION_MIN_GROUP,
   } = opts;
   if (!orchDir) return [];
   let files;
@@ -2571,7 +2592,7 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
   } catch {
     return [];
   }
-  const escalatedTickets = [];
+  const candidates = [];
   for (const f of files) {
     if (!f.endsWith(".json")) continue;
     let data;
@@ -2594,8 +2615,55 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
       active = true;
     }
     if (!active) continue;
+    if (readEscalationDeferrals(orchDir, ticket) >= maxDeferrals) continue;
+    candidates.push({
+      ticket,
+      file: f,
+      data,
+      signature: data.signature ?? null,
+      lastTs: data.lastTs ?? data.ts,
+    });
+  }
+
+  const computedGroups = groupCandidates(candidates, {
+    windowMs: correlationWindowMs,
+    minGroup: correlationMinGroup,
+    now: now(),
+  });
+  const candidateByTicket = new Map(candidates.map((candidate) => [candidate.ticket, candidate]));
+  if (correlationMode === "shadow") {
+    for (const group of computedGroups.filter((g) => g.correlated)) {
+      emitEvent({
+        type: "recovery.escalation.would-correlate",
+        correlation_id: correlationId(group.signature, group.anchor),
+        signature: group.signature,
+        anchor: group.anchor,
+        tickets: group.tickets,
+      });
+    }
+  }
+  const groups =
+    correlationMode === "enforce"
+      ? computedGroups.map((group) => ({
+          ...group,
+          anchor: candidateByTicket.get(group.anchor),
+          members: group.members.map((ticket) => candidateByTicket.get(ticket)).filter(Boolean),
+        }))
+      : candidates.map((candidate) => ({
+          signature: candidate.signature,
+          anchor: candidate,
+          members: [],
+          tickets: [candidate.ticket],
+          correlated: false,
+        }));
+  const escalatedTickets = [];
+
+  const actOnTicket = (candidate, { role = "singleton", group = null, anchor = null } = {}) => {
+    const { ticket, data, file: f } = candidate;
     const reason = `self-heal attempts exhausted (${data.attempts} dispatches without a recorded verdict)`;
-    const escalation = {
+    const corrId = group?.correlated ? correlationId(group.signature, anchor ?? ticket) : null;
+    const correlatedTickets = group?.tickets ?? [ticket];
+    const escalation = role === "singleton" ? {
       escalation_type: "authorization",
       problem: `${ticket} consumed ${data.attempts} recovery attempts (last decision "${data.decision}") without any recorded verdict — the self-heal loop is not resolving it.`,
       call_to_action: `look at ${ticket}: authorize another recovery cycle (clear its ledger latch), or take it over?`,
@@ -2606,6 +2674,29 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
         attempts: data.attempts,
         decision: data.decision ?? null,
         fix_class: data.fix_class ?? null,
+      },
+      attempts: [],
+    } : {
+      escalation_type: "authorization",
+      problem:
+        role === "anchor"
+          ? `${correlatedTickets.join(", ")} exhausted recovery attempts for the shared cause "${group.signature}".`
+          : `${ticket} is part of correlated incident ${corrId} — ${correlatedTickets.length} tickets share this cause; the decision is on ${anchor}.`,
+      call_to_action:
+        role === "anchor"
+          ? `look at ${correlatedTickets.join(", ")}: authorize one recovery cycle for this shared cause, or take the incident over?`
+          : `see the escalation on ${anchor}`,
+      recommendation: `inspect the correlated recovery-pass failures on ${anchor ?? ticket}`,
+      risk: `left latched the affected tickets rot silently`,
+      why_asking: reason,
+      observed: {
+        attempts: data.attempts,
+        decision: data.decision ?? null,
+        fix_class: data.fix_class ?? null,
+        correlation_id: corrId,
+        signature: group.signature,
+        correlated_tickets: correlatedTickets,
+        correlated_count: correlatedTickets.length,
       },
       attempts: [],
     };
@@ -2627,8 +2718,6 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     // has already fired and only a human can resolve it, so stop spending a Linear
     // label write on it every tick. This ceiling is what keeps the pre-latch attempt
     // from re-firing forever on a persistently-failing host.
-    if (readEscalationDeferrals(orchDir, ticket) >= maxDeferrals) continue;
-
     let labelled = false;
     try {
       labelled = labelNeedsHuman?.(orchDir, ticket) === true;
@@ -2670,7 +2759,7 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
             `after ${deferrals} attempts; escalation cannot complete from this host`,
         );
       }
-      continue; // the act did not complete — not counted as escalated
+      return false; // the act did not complete — not counted as escalated
     }
     // The label landed (or its owner has it) — this escalation can now complete.
     clearEscalationDeferrals(orchDir, ticket);
@@ -2686,7 +2775,7 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
       });
     } catch (err) {
       log(`recovery-reasoning: ${ticket} exhausted-escalate ledger write failed: ${err.message}`);
-      continue; // without the latch the sweep would re-fire every tick — try again next tick
+      return false; // without the latch the sweep would re-fire every tick — try again next tick
     }
     // Codex R1: defaultRecordIntent swallows write failures (best-effort by
     // design) — VERIFY the latch actually landed before any human-facing side
@@ -2701,27 +2790,63 @@ export function escalateExhaustedIntents(orchDir, opts = {}) {
     }
     if (!latched) {
       log(`recovery-reasoning: ${ticket} exhausted-escalate latch did not persist — deferring side effects to the next tick`);
-      continue;
+      return false;
     }
     try {
       writeSignal(ticket, escalation);
     } catch (err) {
       log(`recovery-reasoning: ${ticket} exhausted-escalate signal write failed: ${err.message}`);
     }
-    emitEvent({ type: "recovery.escalated", ticket, reason, escalation });
+    emitEvent({
+      type: role === "member" ? "recovery.escalation.correlated" : "recovery.escalated",
+      ticket,
+      reason,
+      escalation,
+      ...(corrId ? { correlation_id: corrId, anchor: anchor ?? ticket } : {}),
+    });
     try {
       postComment(
         ticket,
-        `🔼 **recovery-pass** self-heal attempts exhausted on this ticket — escalated to the operator. ${reason}. (See your inbox.)`,
+        role === "member"
+          ? `Part of correlated recovery incident ${corrId}; see the operator escalation on ${anchor}.`
+          : `🔼 **recovery-pass** self-heal attempts exhausted on this ticket — escalated to the operator. ${reason}. (See your inbox.)`,
       );
     } catch {
       /* comment is best-effort; the signal + event are the durable surfaces */
     }
-    escalatedTickets.push(ticket);
+    if (role !== "member") escalatedTickets.push(ticket);
     log(
       `recovery-reasoning: ${ticket} attempts-exhausted → escalated loudly (CTL-1440)` +
         (ownedByBelief ? " [label owned by belief engine — CTL-1568 transfer]" : ""),
     );
+    return true;
+  };
+
+  for (const group of groups) {
+    if (!group.correlated) {
+      actOnTicket(group.anchor);
+      continue;
+    }
+    const ordered = [group.anchor, ...group.members];
+    let anchorCandidate = null;
+    for (const candidate of ordered) {
+      if (actOnTicket(candidate, { role: "anchor", group, anchor: candidate.ticket })) {
+        anchorCandidate = candidate;
+        break;
+      }
+    }
+    if (!anchorCandidate) {
+      for (const candidate of ordered) actOnTicket(candidate);
+      continue;
+    }
+    for (const candidate of ordered) {
+      if (candidate.ticket === anchorCandidate.ticket) continue;
+      actOnTicket(candidate, {
+        role: "member",
+        group,
+        anchor: anchorCandidate.ticket,
+      });
+    }
   }
   return escalatedTickets;
 }

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2609,6 +2609,28 @@ describe("escalateExhaustedIntents correlation (CAT-170)", () => {
     expect(run().events).toEqual([]);
   });
 
+  // Regression (phase-review, CAT-170): when NO candidate in a correlated group
+  // can carry the anchor (every label write fails), each ticket must still be
+  // attempted exactly ONCE per tick. The pre-fix fallback re-ran every already-
+  // attempted candidate as a singleton, bumping each escalation-deferral counter
+  // twice and burning the RECOVERY_MAX_ESCALATION_DEFERRALS budget at 2x rate.
+  test("a correlated group whose anchor never lands bumps each deferral counter once per tick", () => {
+    seed("CAT-220", "account-rate-limited", t0);
+    seed("CAT-221", "account-rate-limited", t0 + 1);
+
+    const out = run({ labelNeedsHuman: () => false });
+
+    expect(out.result).toEqual([]);
+    expect(out.events.filter((e) => e.type === "recovery.escalated")).toHaveLength(0);
+    expect(out.events.filter((e) => e.type === "recovery.escalation.correlated")).toHaveLength(0);
+    const deferred = out.events.filter((e) => e.type === "recovery.escalation.deferred");
+    expect(deferred).toHaveLength(2);
+    expect(deferred.map((e) => e.ticket).sort()).toEqual(["CAT-220", "CAT-221"]);
+    for (const ticket of ["CAT-220", "CAT-221"]) {
+      expect(readEscalationDeferrals(orchDir, ticket)).toBe(1);
+    }
+  });
+
   test("different or absent signatures retain independent escalation behavior", () => {
     seed("CAT-180", "account-rate-limited");
     seed("CAT-181", "source-conflict");

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -1126,6 +1126,64 @@ describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
     expect(second.attempts).toBe(2);
   });
 
+  // CAT-170 Phase 2: the attempt-time failure signature is durable, but marker
+  // writes must not accidentally erase it before the exhausted-intent sweep.
+  test("failure signature is normalized and preserved across marker writes", () => {
+    const t0 = 1_000_000_000_000;
+    const first = defaultRecordIntent(
+      "CAT-170",
+      { decision: "dispatched", signature: "  Hit your   SESSION limit  " },
+      { orchDir, now: () => t0 },
+    );
+    expect(first.signature).toBe("hit your session limit");
+    expect(first.escalated).toBe(false);
+
+    const marker = defaultRecordIntent(
+      "CAT-170",
+      { decision: "defer", attempts: 0 },
+      { orchDir, now: () => t0 + 1 },
+    );
+    expect(marker.signature).toBe("hit your session limit");
+    expect(marker.escalated).toBe(false);
+  });
+
+  test("classifier writes clear stale signatures and explicit signatures replace them", () => {
+    const t0 = 1_000_000_000_000;
+    defaultRecordIntent(
+      "CAT-171",
+      { decision: "dispatched", signature: "old failure" },
+      { orchDir, now: () => t0 },
+    );
+    const replaced = defaultRecordIntent(
+      "CAT-171",
+      { decision: "dispatched", signature: "new failure" },
+      { orchDir, now: () => t0 + 1 },
+    );
+    expect(replaced.signature).toBe("new failure");
+
+    const classified = defaultRecordIntent(
+      "CAT-171",
+      { decision: "fix", fix_class: "bounded-llm" },
+      { orchDir, now: () => t0 + 2 },
+    );
+    expect("signature" in classified).toBe(false);
+  });
+
+  test("missing and whitespace-only signatures do not alter the legacy ledger shape", () => {
+    const absent = defaultRecordIntent(
+      "CAT-172",
+      { decision: "dispatched" },
+      { orchDir, now: () => 1 },
+    );
+    const blank = defaultRecordIntent(
+      "CAT-173",
+      { decision: "dispatched", signature: " \n\t " },
+      { orchDir, now: () => 1 },
+    );
+    expect("signature" in absent).toBe(false);
+    expect("signature" in blank).toBe(false);
+  });
+
   test("fail-open: no ledger → shouldSkip returns false", () => {
     expect(defaultShouldSkipItem("CTL-999", { orchDir, now: () => Date.now() })).toBe(false);
   });
@@ -2459,6 +2517,150 @@ describe("defaultSkipReason + escalateExhaustedIntents (CTL-1440 P0b)", () => {
     expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 })).toBe("escalated");
     // …and B1's terminal TTL ages it back into triage.
     expect(defaultSkipReason("CTL-Y", { orchDir, now: () => t0 + 2 + RECOVERY_TERMINAL_INTENT_TTL_MS })).toBeNull();
+  });
+});
+
+// ─── CAT-170 Phase 3: correlate retry-cap escalations by failure signature ──
+describe("escalateExhaustedIntents correlation (CAT-170)", () => {
+  let orchDir;
+  const t0 = 1_000_000_000_000;
+
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-correlation-"));
+    mkdirSync(pathJoin(orchDir, ".recovery-intents"), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  const seed = (ticket, signature, lastTs = t0) => {
+    const entry = {
+      ticket,
+      ts: lastTs,
+      lastTs,
+      decision: "dispatched",
+      fix_class: "board-health",
+      attempts: RECOVERY_MAX_ATTEMPTS,
+      escalated: false,
+      ...(signature ? { signature } : {}),
+    };
+    writeFileSync(
+      pathJoin(orchDir, ".recovery-intents", `${ticket}.json`),
+      JSON.stringify(entry),
+    );
+  };
+
+  const run = (overrides = {}) => {
+    const events = [];
+    const comments = [];
+    const labels = [];
+    const signals = [];
+    const result = escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 100,
+      correlationMode: "enforce",
+      correlationWindowMs: 60 * 60_000,
+      correlationMinGroup: 2,
+      emitEvent: (event) => events.push(event),
+      postComment: (ticket, body) => comments.push({ ticket, body }),
+      labelNeedsHuman: (_dir, ticket) => { labels.push(ticket); return true; },
+      beliefOwnsLabel: () => false,
+      writeSignal: (ticket, payload) => signals.push({ ticket, payload }),
+      ...overrides,
+    });
+    return { result, events, comments, labels, signals };
+  };
+
+  test("enforce emits one anchored escalation and pointer events for matching signatures", () => {
+    seed("CAT-172", "account-rate-limited", t0 + 2);
+    seed("CAT-170", "account-rate-limited", t0);
+    seed("CAT-171", "account-rate-limited", t0 + 1);
+
+    const out = run();
+    const escalations = out.events.filter((e) => e.type === "recovery.escalated");
+    const pointers = out.events.filter((e) => e.type === "recovery.escalation.correlated");
+    expect(out.result).toEqual(["CAT-170"]);
+    expect(escalations).toHaveLength(1);
+    expect(escalations[0].ticket).toBe("CAT-170");
+    expect(escalations[0].escalation.observed.correlated_tickets).toEqual([
+      "CAT-170", "CAT-171", "CAT-172",
+    ]);
+    expect(escalations[0].escalation.observed.signature).toBe("account-rate-limited");
+    expect(escalations[0].escalation.observed.correlation_id).toMatch(/^corr-/);
+    for (const ticket of ["CAT-170", "CAT-171", "CAT-172"]) {
+      expect(escalations[0].escalation.problem).toContain(ticket);
+      expect(escalations[0].escalation.call_to_action).toContain(ticket);
+    }
+    expect(pointers).toHaveLength(2);
+    expect(new Set(pointers.map((e) => e.correlation_id))).toEqual(
+      new Set([escalations[0].escalation.observed.correlation_id]),
+    );
+    expect(pointers.every((e) => e.anchor === "CAT-170")).toBe(true);
+    expect(out.labels.sort()).toEqual(["CAT-170", "CAT-171", "CAT-172"]);
+    expect(out.comments).toHaveLength(3);
+    const memberComments = out.comments.filter((c) => c.ticket !== "CAT-170");
+    expect(memberComments.every((c) => c.body.includes("CAT-170"))).toBe(true);
+    expect(memberComments.every((c) => !c.body.includes("authorize another recovery cycle"))).toBe(true);
+
+    // Every member is latched, while only the incident anchor is returned.
+    for (const ticket of ["CAT-170", "CAT-171", "CAT-172"]) {
+      const ledger = JSON.parse(readFileSync(pathJoin(orchDir, ".recovery-intents", `${ticket}.json`), "utf8"));
+      expect(ledger.escalated).toBe(true);
+    }
+    expect(run().events).toEqual([]);
+  });
+
+  test("different or absent signatures retain independent escalation behavior", () => {
+    seed("CAT-180", "account-rate-limited");
+    seed("CAT-181", "source-conflict");
+    seed("CAT-182", null);
+    const out = run();
+    expect(out.events.filter((e) => e.type === "recovery.escalated")).toHaveLength(3);
+    expect(out.events.filter((e) => e.type === "recovery.escalation.correlated")).toHaveLength(0);
+    for (const event of out.events.filter((e) => e.type === "recovery.escalated")) {
+      const otherTickets = ["CAT-180", "CAT-181", "CAT-182"].filter((t) => t !== event.ticket);
+      expect(otherTickets.some((t) => JSON.stringify(event.escalation).includes(t))).toBe(false);
+    }
+  });
+
+  test("shadow reports the would-be group but preserves one escalation per ticket", () => {
+    seed("CAT-190", "account-rate-limited", t0);
+    seed("CAT-191", "account-rate-limited", t0 + 1);
+    seed("CAT-192", "account-rate-limited", t0 + 2);
+    const out = run({ correlationMode: "shadow" });
+    expect(out.events.filter((e) => e.type === "recovery.escalated")).toHaveLength(3);
+    expect(out.events.filter((e) => e.type === "recovery.escalation.correlated")).toHaveLength(0);
+    const shadow = out.events.filter((e) => e.type === "recovery.escalation.would-correlate");
+    expect(shadow).toHaveLength(1);
+    expect(shadow[0]).toMatchObject({
+      signature: "account-rate-limited",
+      anchor: "CAT-190",
+      tickets: ["CAT-190", "CAT-191", "CAT-192"],
+    });
+  });
+
+  test("off emits no correlation events and preserves the pre-change brief exactly", () => {
+    seed("CAT-200", "account-rate-limited");
+    seed("CAT-201", "account-rate-limited", t0 + 1);
+    const out = run({ correlationMode: "off" });
+    expect(out.events.map((e) => e.type)).toEqual(["recovery.escalated", "recovery.escalated"]);
+    const event = out.events.find((e) => e.ticket === "CAT-200");
+    expect(event.escalation.problem).toBe(
+      'CAT-200 consumed 2 recovery attempts (last decision "dispatched") without any recorded verdict — the self-heal loop is not resolving it.',
+    );
+    expect(event.escalation.call_to_action).toBe(
+      "look at CAT-200: authorize another recovery cycle (clear its ledger latch), or take it over?",
+    );
+  });
+
+  test("inactive tickets are removed before grouping and cannot appear in anchor text", () => {
+    seed("CAT-210", "same-cause", t0);
+    seed("CAT-211", "same-cause", t0 + 1);
+    seed("CAT-212", "same-cause", t0 + 2);
+    const out = run({ isActive: (ticket) => ticket !== "CAT-210" });
+    const anchor = out.events.find((e) => e.type === "recovery.escalated");
+    expect(anchor.ticket).toBe("CAT-211");
+    expect(JSON.stringify(anchor.escalation)).not.toContain("CAT-210");
+    expect(out.labels).not.toContain("CAT-210");
   });
 });
 

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -35,6 +35,10 @@ import {
   defaultClearIntentCooldown,
   defaultLatchHasNoClock,
   restampNoClockEscalations,
+  deriveFailureSignature, // CAT-170
+  resolveCorrelationMode, // CAT-170
+  readCorrelationPointer, // CAT-170
+  writeCorrelationPointer, // CAT-170
 } from "./recovery-reasoning.mjs";
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
@@ -3392,5 +3396,214 @@ describe("prNumberFromWorkerDir / resolvePrNumberForRecovery (CTL-1680)", () => 
     expect(
       resolvePrNumberForRecovery({ signal: { failureReason: "stalled" }, signalPath: signalPath() }),
     ).toBe(77);
+  });
+});
+
+// ─── CAT-170 (Codex #3209 review remediations) ──────────────────────────────
+
+describe("deriveFailureSignature (Codex #3209 P1)", () => {
+  test("reads the production item shape — fields live under .evidence, not .reason/.signal", () => {
+    // Exactly what buildRecoveryItems (recovery-evidence.mjs) emits.
+    const item = {
+      ticket: "CTL-1",
+      phase: "implement",
+      bgJobId: null,
+      evidence: { failureReason: "hit your session limit", signal: { failureReason: "hit your session limit" } },
+    };
+    expect(deriveFailureSignature(item)).toBe("hit your session limit");
+  });
+
+  test("stalledReason outranks failureReason at both altitudes", () => {
+    expect(
+      deriveFailureSignature({ evidence: { stalledReason: "phantom-ticket", failureReason: "other" } }),
+    ).toBe("phantom-ticket");
+    expect(
+      deriveFailureSignature({ evidence: { signal: { stalledReason: "nested", failureReason: "other" } } }),
+    ).toBe("nested");
+  });
+
+  test("an explicitly-supplied item-level field still wins", () => {
+    expect(
+      deriveFailureSignature({ reason: "explicit", evidence: { failureReason: "evidence" } }),
+    ).toBe("explicit");
+  });
+
+  test("nothing anywhere → null (a missing signature never correlates)", () => {
+    expect(deriveFailureSignature({})).toBeNull();
+    expect(deriveFailureSignature({ evidence: {} })).toBeNull();
+  });
+
+  test("an explicit evidence argument overrides item.evidence", () => {
+    expect(
+      deriveFailureSignature({ evidence: { failureReason: "stale" } }, { failureReason: "fresh" }),
+    ).toBe("fresh");
+  });
+});
+
+describe("resolveCorrelationMode (Codex #3209 P2)", () => {
+  test("the three supported modes pass through", () => {
+    for (const m of ["off", "shadow", "enforce"]) expect(resolveCorrelationMode(m)).toBe(m);
+  });
+
+  test("case and surrounding whitespace are normalized", () => {
+    expect(resolveCorrelationMode("  Enforce ")).toBe("enforce");
+    expect(resolveCorrelationMode("SHADOW")).toBe("shadow");
+  });
+
+  test("empty/misspelled/non-string values fall back to shadow, never silently to off", () => {
+    for (const bad of ["", "   ", "shdow", "on", null, undefined, 7, {}]) {
+      expect(resolveCorrelationMode(bad)).toBe("shadow");
+    }
+  });
+});
+
+describe("buildRecoveryEnvelope — correlation identifiers (Codex #3209 P2)", () => {
+  test("a shadow would-correlate event can identify its proposed group", () => {
+    const env = buildRecoveryEnvelope({
+      type: "recovery.escalation.would-correlate",
+      correlation_id: "corr-abc123",
+      signature: "hit your session limit",
+      anchor: "CTL-1",
+      tickets: ["CTL-1", "CTL-2", "CTL-3"],
+    });
+    expect(env.attributes["recovery.correlation_id"]).toBe("corr-abc123");
+    expect(env.attributes["recovery.signature"]).toBe("hit your session limit");
+    expect(env.attributes["recovery.anchor"]).toBe("CTL-1");
+    expect(env.attributes["recovery.correlated_count"]).toBe(3);
+    expect(env.body.payload.tickets).toEqual(["CTL-1", "CTL-2", "CTL-3"]);
+    expect(env.body.payload.correlation_id).toBe("corr-abc123");
+  });
+
+  test("an uncorrelated event is unchanged — no correlation keys are fabricated", () => {
+    const env = buildRecoveryEnvelope({ type: "recovery.escalated", ticket: "CTL-9" });
+    expect(env.attributes["recovery.correlation_id"]).toBeUndefined();
+    expect(env.attributes["recovery.anchor"]).toBeUndefined();
+    expect(env.body.payload).not.toHaveProperty("correlation_id");
+    expect(env.body.payload).not.toHaveProperty("tickets");
+  });
+});
+
+describe("escalateExhaustedIntents — correlation remediations (CAT-170 / Codex #3209)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-corr-"));
+  });
+  afterEach(() => {
+    try {
+      rmSync(orchDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  const t0 = 1_000_000_000_000;
+  const seed = (ticket, signature, at = t0) =>
+    defaultRecordIntent(
+      ticket,
+      { decision: "dispatched", fix_class: "board-health", attempts: RECOVERY_MAX_ATTEMPTS, signature },
+      { orchDir, now: () => at },
+    );
+  const inert = { postComment: () => {}, writeSignal: () => {} };
+
+  test("P1 — a member whose label write fails is retried as a POINTER, not a new escalation", () => {
+    seed("CTL-1", "hit your session limit");
+    seed("CTL-2", "hit your session limit", t0 + 1000);
+
+    // Tick 1: the anchor (CTL-1, oldest) succeeds; the member's label write fails.
+    const events1 = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 2000,
+      correlationMode: "enforce",
+      emitEvent: (e) => events1.push(e),
+      labelNeedsHuman: (_d, t) => t === "CTL-1",
+      beliefOwnsLabel: () => false,
+      ...inert,
+    });
+    expect(events1.filter((e) => e.type === "recovery.escalated").map((e) => e.ticket)).toEqual(["CTL-1"]);
+    // CTL-2 did not complete — it deferred, and left a pointer at its anchor.
+    const pointer = readCorrelationPointer(orchDir, "CTL-2", { windowMs: 60 * 60 * 1000, now: t0 + 2000 });
+    expect(pointer).not.toBeNull();
+    expect(pointer.anchor).toBe("CTL-1");
+
+    // Tick 2: CTL-1 is now escalated:true, so it is NOT a candidate and no group can
+    // re-form. Pre-fix, CTL-2 regrouped as a singleton and got its own full
+    // recovery.escalated. It must stay a MEMBER pointer at CTL-1.
+    const events2 = [];
+    const signals2 = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 3000,
+      correlationMode: "enforce",
+      emitEvent: (e) => events2.push(e),
+      labelNeedsHuman: () => true,
+      beliefOwnsLabel: () => false,
+      postComment: () => {},
+      writeSignal: (t, payload) => signals2.push({ t, payload }),
+    });
+    expect(events2.filter((e) => e.type === "recovery.escalated")).toHaveLength(0);
+    const correlated = events2.filter((e) => e.type === "recovery.escalation.correlated");
+    expect(correlated).toHaveLength(1);
+    expect(correlated[0].ticket).toBe("CTL-2");
+    expect(correlated[0].anchor).toBe("CTL-1");
+    // and the pointer is cleared once the member completes
+    expect(readCorrelationPointer(orchDir, "CTL-2", {})).toBeNull();
+    // P1 — the correlation identity is board-readable on the written signal
+    expect(signals2[0].payload.correlation.role).toBe("member");
+    expect(signals2[0].payload.correlation.anchor).toBe("CTL-1");
+    expect(signals2[0].payload.correlation.id).toBe(correlated[0].correlation_id);
+  });
+
+  test("P2 — a candidate tried as a provisional anchor is not acted on twice in one tick", () => {
+    seed("CTL-1", "hit your session limit");
+    seed("CTL-2", "hit your session limit", t0 + 1000);
+
+    const deferred = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 2000,
+      correlationMode: "enforce",
+      emitEvent: (e) => {
+        if (e.type === "recovery.escalation.deferred") deferred.push(e.ticket);
+      },
+      // CTL-1 (the provisional anchor) always fails; CTL-2 succeeds as anchor.
+      labelNeedsHuman: (_d, t) => t === "CTL-2",
+      beliefOwnsLabel: () => false,
+      ...inert,
+    });
+    // Pre-fix CTL-1 was acted on twice (anchor attempt + member loop), bumping its
+    // bounded deferral counter twice and double-emitting the deferred event.
+    expect(deferred.filter((t) => t === "CTL-1")).toHaveLength(1);
+    expect(readEscalationDeferrals(orchDir, "CTL-1")).toBe(1);
+    // and it still carries a pointer at the anchor that actually won
+    expect(readCorrelationPointer(orchDir, "CTL-1", {}).anchor).toBe("CTL-2");
+  });
+
+  test("a stale pointer past the correlation window expires back to normal handling", () => {
+    seed("CTL-2", "hit your session limit");
+    writeCorrelationPointer(orchDir, "CTL-2", { anchor: "CTL-1", correlation_id: "corr-x" }, t0);
+    expect(readCorrelationPointer(orchDir, "CTL-2", { windowMs: 1000, now: t0 + 999 })).not.toBeNull();
+    expect(readCorrelationPointer(orchDir, "CTL-2", { windowMs: 1000, now: t0 + 5000 })).toBeNull();
+  });
+
+  test("a pointer at the ticket's own id is ignored (never self-anchors)", () => {
+    writeCorrelationPointer(orchDir, "CTL-2", { anchor: "CTL-2" }, t0);
+    expect(readCorrelationPointer(orchDir, "CTL-2", {})).toBeNull();
+  });
+
+  test("off/shadow modes ignore pointers entirely and stay independent escalations", () => {
+    seed("CTL-1", "hit your session limit");
+    seed("CTL-2", "hit your session limit", t0 + 1000);
+    writeCorrelationPointer(orchDir, "CTL-2", { anchor: "CTL-1", correlation_id: "corr-x" }, t0 + 1000);
+    const events = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 2000,
+      correlationMode: "off",
+      emitEvent: (e) => events.push(e),
+      labelNeedsHuman: () => true,
+      beliefOwnsLabel: () => false,
+      ...inert,
+    });
+    expect(events.filter((e) => e.type === "recovery.escalated").map((e) => e.ticket).sort()).toEqual([
+      "CTL-1",
+      "CTL-2",
+    ]);
   });
 });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2,7 +2,7 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test recovery-reasoning.test.mjs
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import {
   reasoningRecoveryPass,
   defaultClassifyTicket,
@@ -43,6 +43,31 @@ import {
 import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { join as pathJoin } from "node:path";
 import { tmpdir } from "node:os";
+
+// CAT-170: this suite exercises defaultRecordIntent / defaultShouldSkipItem, whose orchDir
+// resolves `opts.orchDir ?? resolveOrchDir()` (recovery-reasoning.mjs:1479-1481, :2307).
+// `??` does not honor an explicit null, so an inherited CATALYST_ORCHESTRATOR_DIR — which every
+// phase agent exports — both flips 17 assertions to red AND writes fixture tickets into the
+// operator's live ~/catalyst/execution-core/.recovery-intents/. Delete it for the suite.
+const SAVED_ORCH_DIR = process.env.CATALYST_ORCHESTRATOR_DIR;
+beforeAll(() => {
+  delete process.env.CATALYST_ORCHESTRATOR_DIR;
+});
+afterAll(() => {
+  if (SAVED_ORCH_DIR === undefined) delete process.env.CATALYST_ORCHESTRATOR_DIR;
+  else process.env.CATALYST_ORCHESTRATOR_DIR = SAVED_ORCH_DIR;
+});
+
+describe("suite hermeticity (CAT-170)", () => {
+  test("the ledger never resolves to an ambient orchestrator dir", () => {
+    // Reproduces the phase-agent environment: a real orch dir exported by the caller.
+    // Before the beforeAll/afterAll isolation below, this test FAILS — defaultRecordIntent
+    // resolves `opts.orchDir ?? resolveOrchDir()`, so an explicit null falls through to the
+    // env and the call writes into the operator's live .recovery-intents/.
+    expect(process.env.CATALYST_ORCHESTRATOR_DIR).toBeUndefined();
+    expect(defaultRecordIntent("CTL-998", { decision: "fix" }, { orchDir: null })).toBeNull();
+  });
+});
 
 describe("checkDeterministicErrors", () => {
   test("detects push_rejected_no_workflow_scope", () => {
@@ -1193,8 +1218,8 @@ describe("recovery-intent ledger (cooldown + max-attempts + escalated)", () => {
   });
 
   test("no orchDir → record no-ops, shouldSkip fail-open false", () => {
-    // resolveOrchDir() returns null when CATALYST_ORCHESTRATOR_DIR is unset and
-    // none is injected. Force that by passing orchDir: null explicitly.
+    // The suite-level environment isolation makes resolveOrchDir() return null when
+    // no directory is injected; explicit null alone would fall through via `??`.
     expect(defaultRecordIntent("CTL-998", { decision: "fix" }, { orchDir: null })).toBeNull();
     expect(defaultShouldSkipItem("CTL-998", { orchDir: null })).toBe(false);
   });

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -3706,3 +3706,74 @@ describe("escalateExhaustedIntents — correlation remediations (CAT-170 / Codex
     ]);
   });
 });
+
+// ─── CAT-170 phase-review: stale correlation block must not survive ──────────
+describe("defaultWriteEscalationSignal — stale correlation clearing (CAT-170)", () => {
+  let orchDir;
+  beforeEach(() => {
+    orchDir = mkdtempSync(pathJoin(tmpdir(), "rec-stale-corr-"));
+  });
+  afterEach(() => {
+    rmSync(orchDir, { recursive: true, force: true });
+  });
+
+  const signalPath = (ticket) =>
+    pathJoin(orchDir, "workers", ticket, "phase-recovery-pass.json");
+  const readSignal = (ticket) => JSON.parse(readFileSync(signalPath(ticket), "utf8"));
+
+  test("a later UNCORRELATED escalation erases the prior member correlation block", () => {
+    // 1. escalate as a correlated member — the role is persisted first-class.
+    expect(
+      defaultWriteEscalationSignal(
+        "CTL-2",
+        { reason: "attempts exhausted", correlation: { id: "corr-a", role: "member", anchor: "CTL-1" } },
+        { orchDir },
+      ),
+    ).toBe(true);
+    expect(readSignal("CTL-2").correlation.role).toBe("member");
+
+    // 2. weeks later the same ticket exhausts again, this time on its own. The
+    // writer is a read-modify-write over the prior signal, so without an explicit
+    // delete the stale "member" role rides forward and every notification path
+    // suppresses a genuinely independent operator escalation.
+    expect(
+      defaultWriteEscalationSignal("CTL-2", { reason: "attempts exhausted" }, { orchDir }),
+    ).toBe(true);
+    expect(readSignal("CTL-2")).not.toHaveProperty("correlation");
+  });
+
+  test("an unrelated field on the prior signal is still preserved", () => {
+    defaultWriteEscalationSignal(
+      "CTL-3",
+      { reason: "attempts exhausted", correlation: { id: "corr-b", role: "anchor", anchor: "CTL-3" } },
+      { orchDir },
+    );
+    const first = readSignal("CTL-3");
+    expect(first.needsHumanSince).toBeTruthy();
+
+    defaultWriteEscalationSignal("CTL-3", { reason: "attempts exhausted" }, { orchDir });
+    const second = readSignal("CTL-3");
+    expect(second).not.toHaveProperty("correlation");
+    // the read-modify-write is otherwise intact — needsHumanSince still carries the
+    // FIRST escalation's timestamp rather than being reset.
+    expect(second.needsHumanSince).toBe(first.needsHumanSince);
+  });
+
+  test("a correlated payload still replaces a prior correlation block", () => {
+    defaultWriteEscalationSignal(
+      "CTL-4",
+      { reason: "r", correlation: { id: "corr-old", role: "member", anchor: "CTL-1" } },
+      { orchDir },
+    );
+    defaultWriteEscalationSignal(
+      "CTL-4",
+      { reason: "r", correlation: { id: "corr-new", role: "anchor", anchor: "CTL-4" } },
+      { orchDir },
+    );
+    expect(readSignal("CTL-4").correlation).toEqual({
+      id: "corr-new",
+      role: "anchor",
+      anchor: "CTL-4",
+    });
+  });
+});

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -3552,6 +3552,66 @@ describe("escalateExhaustedIntents — correlation remediations (CAT-170 / Codex
     expect(signals2[0].payload.correlation.id).toBe(correlated[0].correlation_id);
   });
 
+  test("P1 (round 2) — a member whose SIGNAL write fails keeps its pointer and retries as a member", () => {
+    seed("CTL-1", "hit your session limit");
+    seed("CTL-2", "hit your session limit", t0 + 1000);
+
+    // Tick 1: the anchor completes; the MEMBER's signal write fails. The signal is
+    // the only durable carrier of correlation.role, so this act must not latch.
+    const events1 = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 2000,
+      correlationMode: "enforce",
+      emitEvent: (e) => events1.push(e),
+      labelNeedsHuman: () => true,
+      beliefOwnsLabel: () => false,
+      postComment: () => {},
+      writeSignal: (t) => t !== "CTL-2",
+    });
+    expect(events1.filter((e) => e.type === "recovery.escalated").map((e) => e.ticket)).toEqual([
+      "CTL-1",
+    ]);
+    // The member did NOT complete — no correlated event, and no comment/event fired.
+    expect(events1.filter((e) => e.type === "recovery.escalation.correlated")).toHaveLength(0);
+    // Its pointer survives, so the next tick still knows which incident it belongs to.
+    const pointer = readCorrelationPointer(orchDir, "CTL-2", {
+      windowMs: 60 * 60 * 1000,
+      now: t0 + 2000,
+    });
+    expect(pointer).not.toBeNull();
+    expect(pointer.anchor).toBe("CTL-1");
+
+    // Tick 2: the write succeeds. Pre-fix the member had ALREADY latched
+    // escalated:true (the latch ran before the write) with its pointer cleared, so it
+    // was never a candidate again and its member role was lost permanently — the
+    // board then treated it as independent and sent the duplicate operator alert this
+    // feature exists to suppress. It must now land as a member of the same anchor.
+    const events2 = [];
+    const signals2 = [];
+    escalateExhaustedIntents(orchDir, {
+      now: () => t0 + 3000,
+      correlationMode: "enforce",
+      emitEvent: (e) => events2.push(e),
+      labelNeedsHuman: () => true,
+      beliefOwnsLabel: () => false,
+      postComment: () => {},
+      writeSignal: (t, payload) => {
+        signals2.push({ t, payload });
+        return true;
+      },
+    });
+    expect(events2.filter((e) => e.type === "recovery.escalated")).toHaveLength(0);
+    const correlated = events2.filter((e) => e.type === "recovery.escalation.correlated");
+    expect(correlated).toHaveLength(1);
+    expect(correlated[0].ticket).toBe("CTL-2");
+    expect(correlated[0].anchor).toBe("CTL-1");
+    // and the role is board-readable on the signal that finally persisted
+    const memberSignal = signals2.find((s) => s.t === "CTL-2");
+    expect(memberSignal.payload.correlation.role).toBe("member");
+    expect(memberSignal.payload.correlation.anchor).toBe("CTL-1");
+    expect(readCorrelationPointer(orchDir, "CTL-2", {})).toBeNull();
+  });
+
   test("P2 — a candidate tried as a provisional anchor is not acted on twice in one tick", () => {
     seed("CTL-1", "hit your session limit");
     seed("CTL-2", "hit your session limit", t0 + 1000);

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.test.mjs
@@ -2660,6 +2660,20 @@ describe("escalateExhaustedIntents correlation (CAT-170)", () => {
     }
   });
 
+  test("a durable provisional-anchor signal blocks failover when its ledger latch does not land", () => {
+    seed("CAT-222", "account-rate-limited", t0);
+    seed("CAT-223", "account-rate-limited", t0 + 1);
+
+    const out = run({ recordIntent: () => null });
+
+    expect(out.result).toEqual([]);
+    expect(out.events).toEqual([]);
+    expect(out.signals).toHaveLength(1);
+    expect(out.signals[0].ticket).toBe("CAT-222");
+    expect(out.signals[0].payload.correlation.role).toBe("anchor");
+    expect(out.labels).toEqual(["CAT-222"]);
+  });
+
   test("different or absent signatures retain independent escalation behavior", () => {
     seed("CAT-180", "account-rate-limited");
     seed("CAT-181", "source-conflict");

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10581,6 +10581,30 @@ export function holisticBoardHealthAct(
   } = {}
 ) {
   const ordered = candidates.length ? candidates : anchor ? [anchor] : [];
+  // CAT-170 (Codex #3209 P1): sign each dispatch with the invariant that actually
+  // flagged THIS candidate, not the gate's count summary. `decision.gate.reason` on a
+  // proceeding scan is "N invariant(s) flagged" — identical for every ticket in the
+  // scan and identical across unrelated scans that happened to flag the same NUMBER
+  // of invariants, so two tickets stuck for completely different reasons received the
+  // same signature and the correlation sweep could collapse them into one operator
+  // incident. proposeMoves already records the per-ticket cause as the move name
+  // (kick-dispatch / judge-done-or-reopen / recover-unowned-in-flight / …), so the
+  // ticket→move map is the invariant evidence, keyed per candidate.
+  const moveByTicket = new Map();
+  for (const tier of ["tier1", "tier2", "tier3"]) {
+    for (const m of decision?.moves?.[tier] ?? []) {
+      // First writer wins: tier1 outranks tier2 outranks tier3, matching
+      // selectAnchorCandidates' own ordering.
+      if (m?.ticket && !moveByTicket.has(m.ticket)) moveByTicket.set(m.ticket, m.move ?? null);
+    }
+  }
+  // A candidate with no proposed move (a deferred-intent anchor, or the
+  // eligible-queue fallback) has no per-ticket invariant to name — fall back to the
+  // gate reason, which is at least truthful about why the scan proceeded.
+  const signatureFor = (cand) => {
+    const move = moveByTicket.get(cand);
+    return move ? `board-health: ${move}` : (decision?.gate?.reason ?? null);
+  };
   // CTL-1440 (P0b): track WHY candidates were ledger-skipped so the no-dispatch
   // return distinguishes "everything is terminally attempts-exhausted" (a
   // truthful non-wedge — the exhaustion sweep has escalated them to a human)
@@ -10620,7 +10644,7 @@ export function holisticBoardHealthAct(
         type: "recovery-pass",
         decision: "dispatched",
         fix_class: "board-health",
-        signature: decision?.gate?.reason ?? null,
+        signature: signatureFor(cand),
         outcome: !!r?.dispatched,
         source: "board-health",
       });

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10591,19 +10591,39 @@ export function holisticBoardHealthAct(
   // (kick-dispatch / judge-done-or-reopen / recover-unowned-in-flight / …), so the
   // ticket→move map is the invariant evidence, keyed per candidate.
   const moveByTicket = new Map();
+  // CAT-170 (Codex #3209 round-3 P1): GLOBAL moves carry no ticket. proposeMoves
+  // emits `kick-dispatch` (dispatch-liveness) and `note-cache-drift`
+  // (cache-coherence) as scan-wide findings, while selectAnchorCandidates still
+  // services those scans by picking an eligible ticket — so moveByTicket cannot
+  // name their cause and every such candidate fell through to the gate reason
+  // ("N invariant(s) flagged"). That string is identical across UNRELATED scans
+  // flagging the same count, so a dispatch-liveness scan and a cache-coherence
+  // scan signed identically and the correlation sweep collapsed two unrelated
+  // causes into one operator incident — the precise failure the per-candidate
+  // signature exists to prevent. Collect the ticketless moves in tier order and
+  // sign with them instead.
+  const globalMoves = [];
   for (const tier of ["tier1", "tier2", "tier3"]) {
     for (const m of decision?.moves?.[tier] ?? []) {
       // First writer wins: tier1 outranks tier2 outranks tier3, matching
       // selectAnchorCandidates' own ordering.
       if (m?.ticket && !moveByTicket.has(m.ticket)) moveByTicket.set(m.ticket, m.move ?? null);
+      else if (!m?.ticket && m?.move && !globalMoves.includes(m.move)) globalMoves.push(m.move);
     }
   }
+  // Deterministic regardless of proposal order, so the same pair of global moves
+  // always yields the same signature (and two different pairs never coincide).
+  const globalSignature = globalMoves.length
+    ? `board-health: ${[...globalMoves].sort().join("+")}`
+    : null;
   // A candidate with no proposed move (a deferred-intent anchor, or the
-  // eligible-queue fallback) has no per-ticket invariant to name — fall back to the
-  // gate reason, which is at least truthful about why the scan proceeded.
+  // eligible-queue fallback) has no per-ticket invariant to name — prefer the
+  // scan's global moves, and only then the gate reason, which is at least
+  // truthful about why the scan proceeded.
   const signatureFor = (cand) => {
     const move = moveByTicket.get(cand);
-    return move ? `board-health: ${move}` : (decision?.gate?.reason ?? null);
+    if (move) return `board-health: ${move}`;
+    return globalSignature ?? decision?.gate?.reason ?? null;
   };
   // CTL-1440 (P0b): track WHY candidates were ledger-skipped so the no-dispatch
   // return distinguishes "everything is terminally attempts-exhausted" (a

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10602,28 +10602,38 @@ export function holisticBoardHealthAct(
   // causes into one operator incident — the precise failure the per-candidate
   // signature exists to prevent. Collect the ticketless moves in tier order and
   // sign with them instead.
-  const globalMoves = [];
+  // CAT-170 (Codex #3209 round-4 P1): the scan-level fallback names the moves that
+  // actually TRIGGERED this scan — ticketed and ticketless alike. Round 3 covered
+  // only ticketless global moves, which left the other half of the same hole open:
+  // when every ticket-specific candidate is cooldown/terminal-skipped,
+  // selectAnchorCandidates dispatches an eligible-queue FALLBACK ticket that has no
+  // entry in moveByTicket, so a scan whose moves are all ticketed still fell through
+  // to the gate reason. Two scans triggered by unrelated causes (e.g. `nudge` vs
+  // `finish-or-close-pr`) then persisted the same "N invariant(s) flagged" signature
+  // and their exhausted tickets could collapse into one operator incident.
+  const scanMoves = new Set();
   for (const tier of ["tier1", "tier2", "tier3"]) {
     for (const m of decision?.moves?.[tier] ?? []) {
       // First writer wins: tier1 outranks tier2 outranks tier3, matching
       // selectAnchorCandidates' own ordering.
       if (m?.ticket && !moveByTicket.has(m.ticket)) moveByTicket.set(m.ticket, m.move ?? null);
-      else if (!m?.ticket && m?.move && !globalMoves.includes(m.move)) globalMoves.push(m.move);
+      if (m?.move) scanMoves.add(m.move);
     }
   }
-  // Deterministic regardless of proposal order, so the same pair of global moves
-  // always yields the same signature (and two different pairs never coincide).
-  const globalSignature = globalMoves.length
-    ? `board-health: ${[...globalMoves].sort().join("+")}`
+  // Sorted, so the signature depends on the SET of causes and not on proposal
+  // order — two scans with the same causes always agree, two with different
+  // causes never coincide.
+  const scanSignature = scanMoves.size
+    ? `board-health: ${[...scanMoves].sort().join("+")}`
     : null;
-  // A candidate with no proposed move (a deferred-intent anchor, or the
-  // eligible-queue fallback) has no per-ticket invariant to name — prefer the
-  // scan's global moves, and only then the gate reason, which is at least
-  // truthful about why the scan proceeded.
+  // A candidate with no proposed move of its own (a deferred-intent anchor, or the
+  // eligible-queue fallback) has no per-ticket invariant to name — fall back to the
+  // scan's triggering moves, and only then to the gate reason, which is at least
+  // truthful about why the scan proceeded even though it cannot distinguish causes.
   const signatureFor = (cand) => {
     const move = moveByTicket.get(cand);
     if (move) return `board-health: ${move}`;
-    return globalSignature ?? decision?.gate?.reason ?? null;
+    return scanSignature ?? decision?.gate?.reason ?? null;
   };
   // CTL-1440 (P0b): track WHY candidates were ledger-skipped so the no-dispatch
   // return distinguishes "everything is terminally attempts-exhausted" (a

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -10620,6 +10620,7 @@ export function holisticBoardHealthAct(
         type: "recovery-pass",
         decision: "dispatched",
         fix_class: "board-health",
+        signature: decision?.gate?.reason ?? null,
         outcome: !!r?.dispatched,
         source: "board-health",
       });

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13451,6 +13451,25 @@ describe("holisticBoardHealthAct — global moves sign their own cause (CAT-170)
     expect(a).toBe(b);
   });
 
+  test("(CAT-170 round 4) an eligible-queue FALLBACK candidate is signed with the scan's triggering move", () => {
+    // Every ticket-specific candidate was cooldown/terminal-skipped, so the
+    // dispatching candidate (CTL-1) is the eligible-queue fallback and has no entry
+    // in moveByTicket. Round 3 only rescued ticketless moves, so an all-ticketed
+    // scan like this still fell through to the gate count.
+    const nudgeScan = runWith({
+      gate: { reason: "1 invariant(s) flagged" },
+      moves: { tier1: [{ ticket: "OTHER-1", move: "nudge" }] },
+    });
+    const prScan = runWith({
+      gate: { reason: "1 invariant(s) flagged" },
+      moves: { tier1: [{ ticket: "OTHER-2", move: "finish-or-close-pr" }] },
+    });
+    expect(nudgeScan).toBe("board-health: nudge");
+    expect(prScan).toBe("board-health: finish-or-close-pr");
+    // Pre-fix both were "1 invariant(s) flagged" and correlated into one incident.
+    expect(nudgeScan).not.toBe(prScan);
+  });
+
   test("(CAT-170) with no moves at all the gate reason is still the fallback", () => {
     expect(runWith({ gate: { reason: "3 invariant(s) flagged" }, moves: {} })).toBe(
       "3 invariant(s) flagged",

--- a/plugins/dev/scripts/execution-core/scheduler.test.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.test.mjs
@@ -13392,6 +13392,72 @@ describe("Pass 0a live-probe bounding for non-phantom dirs (CTL-1580)", () => {
   });
 });
 
+// ─── CAT-170 (Codex #3209 round-3 P1): global-move signatures ────────────────
+describe("holisticBoardHealthAct — global moves sign their own cause (CAT-170)", () => {
+  const runWith = (decision) => {
+    const intents = [];
+    holisticBoardHealthAct(
+      { candidates: ["CTL-1"], boardContext: {}, decision },
+      {
+        shouldSkipItem: () => false,
+        invokeRecoveryPass: () => ({ dispatched: true }),
+        recordIntent: (ticket, entry) => intents.push({ ticket, ...entry }),
+      },
+    );
+    return intents[0]?.signature ?? null;
+  };
+
+  test("(CAT-170) a ticketless global move names itself, not the gate count summary", () => {
+    // kick-dispatch / note-cache-drift carry no ticket, so moveByTicket cannot
+    // recover their cause and the candidate used to fall through to gate.reason.
+    const sig = runWith({
+      gate: { reason: "1 invariant(s) flagged" },
+      moves: { tier1: [{ move: "kick-dispatch", rationale: "dispatch liveness" }] },
+    });
+    expect(sig).toBe("board-health: kick-dispatch");
+    expect(sig).not.toBe("1 invariant(s) flagged");
+  });
+
+  test("(CAT-170) two unrelated global-move scans do NOT collapse into one incident", () => {
+    const dispatchScan = runWith({
+      gate: { reason: "1 invariant(s) flagged" },
+      moves: { tier1: [{ move: "kick-dispatch" }] },
+    });
+    const cacheScan = runWith({
+      gate: { reason: "1 invariant(s) flagged" },
+      moves: { tier1: [{ move: "note-cache-drift" }] },
+    });
+    // Pre-fix both signed "1 invariant(s) flagged" and correlated together.
+    expect(dispatchScan).not.toBe(cacheScan);
+  });
+
+  test("(CAT-170) a per-ticket move still outranks the scan's global moves", () => {
+    const sig = runWith({
+      gate: { reason: "2 invariant(s) flagged" },
+      moves: {
+        tier1: [{ move: "kick-dispatch" }, { ticket: "CTL-1", move: "nudge" }],
+      },
+    });
+    expect(sig).toBe("board-health: nudge");
+  });
+
+  test("(CAT-170) the global signature is order-independent", () => {
+    const a = runWith({
+      moves: { tier1: [{ move: "kick-dispatch" }, { move: "note-cache-drift" }] },
+    });
+    const b = runWith({
+      moves: { tier1: [{ move: "note-cache-drift" }, { move: "kick-dispatch" }] },
+    });
+    expect(a).toBe(b);
+  });
+
+  test("(CAT-170) with no moves at all the gate reason is still the fallback", () => {
+    expect(runWith({ gate: { reason: "3 invariant(s) flagged" }, moves: {} })).toBe(
+      "3 invariant(s) flagged",
+    );
+  });
+});
+
 // ─── CTL-1610 (Phase 2): holisticBoardHealthAct latchedNoClock ───────────────
 describe("holisticBoardHealthAct — latchedNoClock (CTL-1610)", () => {
   test("(CTL-1610) all-candidates-exhausted with a no-clock latch → latchedNoClock:true", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-signal.test.ts
@@ -49,6 +49,7 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     currentPhaseSince: null,
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     host: null,
     generation: null,
     ...overrides,

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view-capacity.test.ts
@@ -39,6 +39,7 @@ function ticket(id: string): BoardTicket {
     currentPhaseSince: null,
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     host: null,
     generation: null,
   };

--- a/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/cluster-view.test.ts
@@ -51,6 +51,7 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     currentPhaseSince: null,
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     // BFF10 stamps host:{name,id} + generation on every BoardTicket. The cluster
     // view groups off ownerHostById (the durable fence projection), not this per-
     // entity host, so these default null (single-host identity no-op) and tests

--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-needs-human.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal-needs-human.test.ts
@@ -38,6 +38,7 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     blockers: [],
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     host: null,
     generation: null,
     failureReason: null,

--- a/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/nav-signal.test.ts
@@ -70,6 +70,7 @@ function ticket(id: string, overrides: Partial<BoardTicket> = {}): BoardTicket {
     currentPhaseSince: null,
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     blockers: [],
     host: null,
     generation: null,

--- a/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import {
   shouldNotify,
   createNotificationProjector,
@@ -170,6 +172,21 @@ describe("createNotificationProjector (edge detection + dedup)", () => {
       }),
     );
     expect(out.map((n) => n.title)).toEqual(["CTL-1 needs your decision"]);
+  });
+
+  // CAT-170 (Codex #3209 round-3 P1): the suppression above only works if the role
+  // actually REACHES the projector. server.ts's `toProjectorBoard` rebuilds each
+  // ticket field-by-field, and both server notification paths (SSE + web push) go
+  // through it — so an omitted `correlationRole` there silently re-broke the feature
+  // one layer below these tests, which construct ProjectorBoard tickets directly and
+  // therefore cannot catch it. Pin the adapter's forwarding at the source level
+  // (same technique as the broker namespace-parity source-scan).
+  it("server.ts's toProjectorBoard forwards correlationRole to the projector", () => {
+    const src = readFileSync(join(import.meta.dir, "..", "server.ts"), "utf8");
+    const start = src.indexOf("const toProjectorBoard");
+    expect(start).toBeGreaterThan(-1);
+    const mapping = src.slice(start, src.indexOf("daemon: nav.daemon", start));
+    expect(mapping).toContain("correlationRole");
   });
 
   it("a suppressed member still notifies later if it becomes its own anchor", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/notification-filter.test.ts
@@ -56,6 +56,52 @@ describe("shouldNotify (template parity with lib.rs)", () => {
     ).toBeNull();
   });
 
+  // CAT-170: one correlated incident → ONE alert. Members are labeled/rendered
+  // normally; only their push is suppressed so the anchor speaks for the group.
+  it("correlated MEMBER ticket → suppressed (the anchor carries the alert)", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-11",
+        attention: "needs-human",
+        humanQuestion: "Approve plan?",
+        correlationRole: "member",
+      }),
+    ).toBeNull();
+  });
+
+  it("correlated ANCHOR ticket → still notifies", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-10",
+        attention: "needs-human",
+        humanQuestion: "Approve plan?",
+        correlationRole: "anchor",
+      }),
+    ).toEqual({
+      title: "CTL-10 needs your decision",
+      body: "Approve plan?",
+      deepLink: "/?ticket=CTL-10",
+    });
+  });
+
+  it("uncorrelated singleton (no role) → notifies as before", () => {
+    expect(
+      shouldNotify({
+        kind: "ticket",
+        id: "CTL-12",
+        attention: "needs-human",
+        humanQuestion: "Approve plan?",
+        correlationRole: null,
+      }),
+    ).toEqual({
+      title: "CTL-12 needs your decision",
+      body: "Approve plan?",
+      deepLink: "/?ticket=CTL-12",
+    });
+  });
+
   it("daemon → healthy → 'Catalyst — daemon recovered'", () => {
     expect(shouldNotify({ kind: "daemon", to: "healthy" })).toEqual({
       title: "Catalyst — daemon recovered",
@@ -89,6 +135,7 @@ describe("createNotificationProjector (edge detection + dedup)", () => {
       attentionSince?: string | null;
       humanQuestion?: string;
       title?: string;
+      correlationRole?: string | null;
     }>,
     daemon: "healthy" as "healthy" | "degraded" | "offline",
     anomaly: false,
@@ -106,6 +153,44 @@ describe("createNotificationProjector (edge detection + dedup)", () => {
       }),
     );
     expect(out.map((n) => n.title)).toEqual(["CTL-1 needs your decision"]);
+  });
+
+  // CAT-170 regression pin: THE bug this ticket exists to fix. A three-ticket
+  // correlated incident used to produce three separate operator pushes because the
+  // projector keys purely on ticket id. Exactly one alert — the anchor's — now escapes.
+  it("a 3-ticket correlated incident emits exactly ONE alert (the anchor's)", () => {
+    const p = createNotificationProjector();
+    const out = p.project(
+      board({
+        tickets: [
+          { id: "CTL-1", attention: "needs-human", attentionSince: "s1", correlationRole: "anchor" },
+          { id: "CTL-2", attention: "needs-human", attentionSince: "s1", correlationRole: "member" },
+          { id: "CTL-3", attention: "needs-human", attentionSince: "s1", correlationRole: "member" },
+        ],
+      }),
+    );
+    expect(out.map((n) => n.title)).toEqual(["CTL-1 needs your decision"]);
+  });
+
+  it("a suppressed member still notifies later if it becomes its own anchor", () => {
+    const p = createNotificationProjector();
+    p.project(
+      board({
+        tickets: [
+          { id: "CTL-2", attention: "needs-human", attentionSince: "s1", correlationRole: "member" },
+        ],
+      }),
+    );
+    // Same episode, now promoted to anchor: suppression must not have latched the
+    // dedup key (fired.add only runs on a real emit), so the alert still lands.
+    const out = p.project(
+      board({
+        tickets: [
+          { id: "CTL-2", attention: "needs-human", attentionSince: "s1", correlationRole: "anchor" },
+        ],
+      }),
+    );
+    expect(out.map((n) => n.title)).toEqual(["CTL-2 needs your decision"]);
   });
 
   it("does not re-fire the same ticket attention episode", () => {

--- a/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/read-model.test.ts
@@ -76,6 +76,7 @@ function ticket(id: string): BoardTicket {
     currentPhaseSince: null,
     attention: null,
     attentionSince: null,
+    correlationRole: null, // CAT-170
     host: null,
     generation: null,
   };

--- a/plugins/dev/scripts/orch-monitor/desktop/src-tauri/src/lib.rs
+++ b/plugins/dev/scripts/orch-monitor/desktop/src-tauri/src/lib.rs
@@ -76,7 +76,8 @@ async fn attention_bridge(app: tauri::AppHandle) {
                     notify(&app, "Catalyst", &format!("Connected — watching {base}"));
                     announced = true;
                 }
-                let mut current: Vec<(String, String, String)> = Vec::new();
+                // (id, attention, body, is_correlated_member)
+                let mut current: Vec<(String, String, String, bool)> = Vec::new();
                 if let Some(tickets) = board.get("tickets").and_then(|t| t.as_array()) {
                     for t in tickets {
                         let Some(att) = t.get("attention").and_then(serde_json::Value::as_str) else {
@@ -94,7 +95,14 @@ async fn attention_bridge(app: tauri::AppHandle) {
                             .or_else(|| t.get("title").and_then(serde_json::Value::as_str))
                             .unwrap_or("needs your attention")
                             .to_string();
-                        current.push((id, att.to_string(), body));
+                        // CAT-170: a correlated MEMBER still counts toward the badge and
+                        // still renders in the list, but must not raise its own toast —
+                        // the anchor carries the single alert for the whole incident.
+                        let member = t
+                            .get("correlationRole")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|r| r == "member");
+                        current.push((id, att.to_string(), body, member));
                     }
                 }
 
@@ -104,8 +112,8 @@ async fn attention_bridge(app: tauri::AppHandle) {
                 }
 
                 if !first_poll {
-                    for (id, att, body) in &current {
-                        if !known.contains(id) {
+                    for (id, att, body, member) in &current {
+                        if !known.contains(id) && !*member {
                             let label = if att == "needs-human" {
                                 "needs your decision"
                             } else {
@@ -116,7 +124,7 @@ async fn attention_bridge(app: tauri::AppHandle) {
                     }
                 }
 
-                known = current.into_iter().map(|(id, _, _)| id).collect();
+                known = current.into_iter().map(|(id, _, _, _)| id).collect();
                 first_poll = false;
             }
         }

--- a/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data-attention.test.mjs
@@ -5,7 +5,7 @@
 //   cd plugins/dev/scripts/orch-monitor && bun test lib/board-data-attention.test.mjs
 
 import { describe, it, expect } from "bun:test";
-import { deriveNeedsHumanSince, deriveAttention } from "./board-data.mjs";
+import { deriveNeedsHumanSince, deriveAttention, deriveCorrelationRole } from "./board-data.mjs";
 
 describe("CTL-1131: deriveNeedsHumanSince", () => {
   it("returns needsHumanSince from the newest signal carrying it", () => {
@@ -56,12 +56,71 @@ describe("CTL-1131: deriveAttention projects needsHumanSince → attentionSince"
       needsHumanMarker: true,
       needsHumanSince: "2026-06-14T16:00:00Z",
     });
-    expect(r).toEqual({ attention: "needs-human", attentionSince: "2026-06-14T16:00:00Z", escalationType: null });
+    expect(r).toEqual({
+      attention: "needs-human",
+      attentionSince: "2026-06-14T16:00:00Z",
+      escalationType: null,
+      correlationRole: null,
+    });
   });
 
   it("attentionSince is null when needs-human wins but no stamp provided", () => {
     const r = deriveAttention({ needsHumanMarker: true, needsHumanSince: null });
-    expect(r).toEqual({ attention: "needs-human", attentionSince: null, escalationType: null });
+    expect(r).toEqual({
+      attention: "needs-human",
+      attentionSince: null,
+      escalationType: null,
+      correlationRole: null,
+    });
+  });
+});
+
+// ─── CAT-170: correlation role projection (the notification-suppression seam) ──
+//
+// The producer writes a top-level `correlation` field on the escalation signal;
+// deriveCorrelationRole projects it and deriveAttention passes it through on the
+// needs-human branch ONLY. Without this projection every correlated member looked
+// like an ordinary needs-human authorization and the notification path — which
+// keys on ticket id — emitted one push per member.
+describe("CAT-170: deriveCorrelationRole", () => {
+  it("returns the role from the newest signal carrying a correlation", () => {
+    const sigs = [
+      { status: "stalled", correlation: { id: "c1", role: "anchor", anchor: "CAT-1" } },
+      { status: "stalled", correlation: { id: "c1", role: "member", anchor: "CAT-1" } },
+    ];
+    expect(deriveCorrelationRole(sigs)).toBe("member");
+  });
+
+  it("skips signals without a correlation and returns null when none carry one", () => {
+    expect(deriveCorrelationRole([{ status: "running" }, { status: "stalled" }])).toBeNull();
+  });
+
+  it("ignores a malformed correlation (no string role)", () => {
+    expect(deriveCorrelationRole([{ correlation: { id: "c1" } }, { correlation: null }])).toBeNull();
+  });
+});
+
+describe("CAT-170: deriveAttention passes the correlation role through", () => {
+  it("surfaces the role on the needs-human branch", () => {
+    const r = deriveAttention({ needsHumanMarker: true, correlationRole: "member" });
+    expect(r.attention).toBe("needs-human");
+    expect(r.correlationRole).toBe("member");
+  });
+
+  it("does not surface a role on the waiting-on-you branch", () => {
+    const r = deriveAttention({ waitingOnUser: true, correlationRole: "member" });
+    expect(r.attention).toBe("waiting-on-you");
+    expect(r.correlationRole).toBeNull();
+  });
+
+  it("does not surface a role when the ticket is Linear-terminal", () => {
+    const r = deriveAttention({
+      needsHumanMarker: true,
+      correlationRole: "member",
+      linearTerminal: true,
+    });
+    expect(r.attention).toBeNull();
+    expect(r.correlationRole).toBeNull();
   });
 });
 

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.d.mts
@@ -170,6 +170,10 @@ export interface BoardTicket {
    *  stamp is projected). The Inbox row anchors its duration to attentionSince ??
    *  heldSince; null is rendered unavailable, never fabricated. */
   attentionSince: string | null;
+  /** CAT-170: "anchor" | "member" | null — the escalation-correlation role for a
+   *  multi-ticket incident. Members render normally but are suppressed by the
+   *  notification projectors so one incident yields ONE operator alert. */
+  correlationRole: string | null;
   /** CTL-922 (BFF10): the node owning this ticket, from the phase signals
    *  host:{name,id} (CTL-852) or the durable fence projection owner_host (BFF11).
    *  null when no host is named (single-host resolves to the one node). */
@@ -343,7 +347,20 @@ export function deriveAttention(opts?: {
    *  Short-circuits all attention reasons to null — a shipped/canceled ticket must
    *  never surface as needs-human / waiting-on-you from a stale phase signal. */
   linearTerminal?: boolean;
-}): { attention: BoardAttention; attentionSince: string | null; escalationType: string | null };
+  /** CAT-170: the escalation-correlation role ("anchor" | "member") from
+   *  deriveCorrelationRole. Surfaced only on the needs-human branch — it is the
+   *  projection the notification path uses to suppress a member's duplicate push. */
+  correlationRole?: string | null;
+}): {
+  attention: BoardAttention;
+  attentionSince: string | null;
+  escalationType: string | null;
+  correlationRole: string | null;
+};
+
+/** CAT-170: extract the top-level `correlation.role` from the most-recent phase
+ *  signal carrying one. Returns "anchor" | "member" | null. */
+export function deriveCorrelationRole(phaseSigs: unknown[]): string | null;
 
 /** CTL-1239: true when a dead bg-job corpse sits on a Linear-terminal ticket
  *  (Done/Canceled) — leftover state on a shipped/canceled ticket, not a real dead

--- a/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/board-data.mjs
@@ -251,12 +251,13 @@ export function deriveAttention({
   phaseFailed = false, // CTL-1180: a terminal failed/stalled phase, ticket NOT pipeline-done
   escalationType = null, // CTL-1180: passthrough of explanation.escalation_type (forensic/render)
   linearTerminal = false, // CTL-1239: live Linear state is Done/Canceled
+  correlationRole = null, // CAT-170: passthrough of correlation.role ("anchor"|"member")
 } = {}) {
   // CTL-1239: a ticket terminal in Linear (Done/Canceled) is finished regardless of
   // any stale failed/stalled phase-*.json left on disk. Short-circuit BEFORE the
   // needs-human/waiting computation so a stale signal can never re-raise attention.
   if (linearTerminal === true) {
-    return { attention: null, attentionSince: null, escalationType: null };
+    return { attention: null, attentionSince: null, escalationType: null, correlationRole: null };
   }
   const set = new Set(Array.isArray(labels) ? labels : []);
   const labelNeedsHuman =
@@ -271,6 +272,10 @@ export function deriveAttention({
       attention: "needs-human",
       attentionSince: needsHumanSince ?? (prStuck ? prStuckSince : null),
       escalationType: escalationType ?? null, // CTL-1180 passthrough; null when not a failed-phase source
+      // CAT-170: only the needs-human branch carries the correlation role — that is
+      // the one branch the notification projector acts on, so a member's alert can
+      // be suppressed in favour of its anchor's single correlated alert.
+      correlationRole: correlationRole ?? null,
     };
   }
   if (waitingOnUser === true) {
@@ -278,9 +283,10 @@ export function deriveAttention({
       attention: "waiting-on-you",
       attentionSince: waitingSince ?? null,
       escalationType: null,
+      correlationRole: null,
     };
   }
-  return { attention: null, attentionSince: null, escalationType: null };
+  return { attention: null, attentionSince: null, escalationType: null, correlationRole: null };
 }
 
 // phase → Linear workflow state (board columns for the Tickets/Linear lens).
@@ -1034,6 +1040,29 @@ export function deriveEscalationType(phaseSigs) {
     const expl = sig.explanation;
     if (expl && typeof expl === "object" && typeof expl.escalation_type === "string") {
       return expl.escalation_type;
+    }
+  }
+  return null;
+}
+
+/** CAT-170: extract the escalation-correlation role from the most-recent phase
+ *  signal that carries one. Mirrors deriveEscalationType's newest-phase-first
+ *  scan, but reads the TOP-LEVEL `correlation` field (a sibling of
+ *  `explanation`, not a member of it — synthesizeEscalationExplanation projects
+ *  the payload down to its six render fields and drops `observed`, which is why
+ *  the correlation identity is persisted top-level in the first place).
+ *
+ *  Returns "anchor" | "member" | null. This is the projection the notification
+ *  path needs to collapse a multi-ticket incident into ONE operator alert: every
+ *  correlated member still earns its own needs-human label and signal (the
+ *  operator can open any of them), but only the anchor is allowed to notify. */
+export function deriveCorrelationRole(phaseSigs) {
+  for (let i = phaseSigs.length - 1; i >= 0; i--) {
+    const sig = phaseSigs[i];
+    if (!sig || typeof sig !== "object") continue;
+    const corr = sig.correlation;
+    if (corr && typeof corr === "object" && typeof corr.role === "string") {
+      return corr.role;
     }
   }
   return null;
@@ -2193,6 +2222,10 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
         // surfaces this in the needs-human branch, so it stays null elsewhere.
         escalationType: escalationType ?? failedEscalationType,
         linearTerminal, // CTL-1239
+        // CAT-170: the correlation role rides the same explSigs scan (canonical +
+        // ancillary) so a recovery-pass escalation signal — which is where the
+        // correlation identity is written — is seen here.
+        correlationRole: deriveCorrelationRole(explSigs),
       });
       return {
         id,
@@ -2271,6 +2304,12 @@ export async function assembleBoard({ getPrStatus = null, ring = null } = {}) {
         // yellow board accent + the Inbox "Needs you" section. needs-human wins.
         attention: attn.attention,
         attentionSince: attn.attentionSince,
+        // CAT-170: "anchor" | "member" | null. The notification projectors (web
+        // push/SSE via shouldNotify, and the desktop poller) suppress a "member"
+        // so a three-ticket correlated incident produces ONE operator alert
+        // instead of three. Rendering is unaffected — every member still shows in
+        // the Needs-you list with its own card.
+        correlationRole: attn.correlationRole ?? null,
         // CTL-1220: recovery-sweep outcome flags, read from the unified event
         // log. id is the CTL key — exactly what attributes["event.label"] carries.
         autoFixed: recoveryByTicket.get(id)?.autoFixed ?? false,

--- a/plugins/dev/scripts/orch-monitor/lib/notification-filter.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/notification-filter.ts
@@ -7,6 +7,9 @@ export type NotificationEvent =
       attention: BoardAttention;
       humanQuestion?: string;
       title?: string;
+      /** CAT-170: "anchor" | "member" | null. A correlated incident labels every
+       *  member needs-human, but only the anchor may notify — see shouldNotify. */
+      correlationRole?: string | null;
     }
   | { kind: "daemon"; to: "healthy" | "degraded" | "offline" }
   | { kind: "anomaly" };
@@ -33,6 +36,12 @@ const TMPL = {
 export function shouldNotify(ev: NotificationEvent): PushNotification | null {
   if (ev.kind === "ticket") {
     if (ev.attention === null) return null;
+    // CAT-170: collapse a correlated incident to ONE alert. Every correlated
+    // ticket still carries its own needs-human label, signal and board card —
+    // only the PUSH is suppressed for members, so the operator gets a single
+    // "<anchor> needs your decision" instead of one notification per member.
+    // Unknown/absent role (the uncorrelated singleton case) notifies as before.
+    if (ev.correlationRole === "member") return null;
     const label =
       ev.attention === "needs-human"
         ? TMPL.TICKET_NEEDS_DECISION
@@ -75,6 +84,8 @@ export interface ProjectorBoard {
     attentionSince?: string | null;
     humanQuestion?: string;
     title?: string;
+    /** CAT-170: correlation role projected by board-data's deriveAttention. */
+    correlationRole?: string | null;
   }>;
   daemon?: "healthy" | "degraded" | "offline";
   anomaly?: boolean;
@@ -187,6 +198,7 @@ export function createNotificationProjector(
           attention: t.attention,
           humanQuestion: t.humanQuestion,
           title: t.title,
+          correlationRole: t.correlationRole, // CAT-170
         });
         if (n) {
           out.push(n);

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -1879,6 +1879,15 @@ export function createServer(opts: CreateServerOptions): BunServer {
         // humanQuestion lives in explanation.call_to_action (CTL-1130).
         humanQuestion: t.explanation?.call_to_action ?? undefined,
         title: t.title,
+        // CAT-170 (Codex #3209 round-3 P1): forward the correlation role. This
+        // adapter rebuilds each ticket field-by-field, so omitting it silently
+        // stripped the role board-data had just projected — and BOTH server
+        // notification paths (the SSE stream and the web-push bridge) reach the
+        // projector only through here. Without it `shouldNotify` never sees
+        // role === "member", so every member of a correlated incident still
+        // emitted its own push: the exact per-ticket operator spam this ticket
+        // exists to collapse, reintroduced one layer below the fix.
+        correlationRole: t.correlationRole,
       })),
       daemon: nav.daemon,
       anomaly: nav.anomaly,

--- a/plugins/dev/skills/recovery-pass/SKILL.md
+++ b/plugins/dev/skills/recovery-pass/SKILL.md
@@ -74,6 +74,9 @@ move genuinely requires the operator, author a clear executive briefing and hand
    degrades-other-functionality / real-cost-benefit / serious-architecture / ADR
    cases (the Step-3 checklist). A mere conflict or failed check is never one.
 
+An escalation may be the anchor for a correlated retry-cap incident covering several tickets;
+member pointer briefs refer to that anchor and are not separate decisions for the operator.
+
 ## Two invocation modes
 
 1. **Router-dispatched (the bounded-LLM recovery path).** The scheduler's recovery

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1576,6 +1576,23 @@ immediately before its terminal `phase-agent-emit-complete` call.
 }
 ```
 
+### Retry-cap escalation correlation (CAT-170)
+
+The exhausted recovery-intent sweep can correlate tickets that reached the retry cap for the same
+normalized failure signature. Signatures are recorded at attempt time in the host-local intent
+ledger, so grouping is per host; legacy or null-signature entries continue to escalate
+individually. In enforce mode, one deterministic anchor carries the operator decision and the other
+tickets receive pointer briefs rather than separate decisions.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `CATALYST_RECOVERY_CORRELATION` | `shadow` | `off` preserves independent escalation and emits no correlation events; `shadow` computes candidate groups and emits `recovery.escalation.would-correlate` without changing operator-visible behavior; `enforce` raises one anchored escalation per group and emits `recovery.escalation.correlated` for each member. |
+| `CATALYST_RECOVERY_CORRELATION_WINDOW_MIN` | `60` | Maximum span, in minutes, for matching signatures to belong to one correlated group. `0` or a non-number falls back to the default. |
+| `CATALYST_RECOVERY_CORRELATION_MIN_GROUP` | `2` | Minimum number of matching candidates required for correlation. `0` or a non-number falls back to the default. |
+
+A missing or null signature never correlates with another missing signature. Changing the mode to
+`off` restores the independent escalation path; there is no on-disk migration to reverse.
+
 ### Board-health delegate (CTL-1290)
 
 On a low-frequency cadence the scheduler runs a **whole-board health scan**: a read-only pass that

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -1586,12 +1586,20 @@ tickets receive pointer briefs rather than separate decisions.
 
 | Key | Default | Notes |
 | --- | --- | --- |
-| `CATALYST_RECOVERY_CORRELATION` | `shadow` | `off` preserves independent escalation and emits no correlation events; `shadow` computes candidate groups and emits `recovery.escalation.would-correlate` without changing operator-visible behavior; `enforce` raises one anchored escalation per group and emits `recovery.escalation.correlated` for each member. |
-| `CATALYST_RECOVERY_CORRELATION_WINDOW_MIN` | `60` | Maximum span, in minutes, for matching signatures to belong to one correlated group. `0` or a non-number falls back to the default. |
-| `CATALYST_RECOVERY_CORRELATION_MIN_GROUP` | `2` | Minimum number of matching candidates required for correlation. `0` or a non-number falls back to the default. |
+| `CATALYST_RECOVERY_CORRELATION` | `shadow` | `off` preserves independent escalation and emits no correlation events; `shadow` computes candidate groups and emits `recovery.escalation.would-correlate` without changing operator-visible behavior; `enforce` raises one anchored escalation per group and emits `recovery.escalation.correlated` for each member. Matching is case-insensitive and trims surrounding whitespace. Any unrecognized value (empty, misspelled) falls back to `shadow` — never to `off`, so a typo degrades to observe-only rather than silently disabling the telemetry. |
+| `CATALYST_RECOVERY_CORRELATION_WINDOW_MIN` | `60` | Maximum span, in minutes, for matching signatures to belong to one correlated group. Must be a **finite positive** number; `0`, a negative value, `Infinity`, or a non-number falls back to the default. |
+| `CATALYST_RECOVERY_CORRELATION_MIN_GROUP` | `2` | Minimum number of matching candidates required for correlation. Must be an **integer of at least 2** (a group of one is a singleton by definition); anything smaller, non-integer, or non-numeric falls back to the default. |
+
+Both tunables are read once at module load, so a window or group-size change needs a daemon
+restart; the mode is re-read per call and takes effect without one.
 
 A missing or null signature never correlates with another missing signature. Changing the mode to
 `off` restores the independent escalation path; there is no on-disk migration to reverse.
+
+In `enforce` mode a member whose escalation cannot complete (for example a failed `needs-human`
+label write) records a pointer at its anchor under `<orchDir>/.escalation-correlation/<TICKET>.json`,
+so its retry on a later tick stays a pointer instead of becoming a second operator decision. The
+pointer expires with `CATALYST_RECOVERY_CORRELATION_WINDOW_MIN`.
 
 ### Board-health delegate (CTL-1290)
 


### PR DESCRIPTION
## Summary

Lands #3209 (CAT-170, originally by @thagale) as a fresh PR against current `main`. Correlates recovery-pass retry-cap escalations that share a normalized failure signature within a configured time window. In enforce mode, one deterministic anchor carries the operator decision while related tickets receive pointer events and comments; shadow and off modes preserve existing operator-visible behavior. Rollout is gated by `CATALYST_RECOVERY_CORRELATION` (`off` / `shadow` / `enforce`).

## Provenance

- Credits the original work to #3209 by **@thagale**.
- CAT-170.
- Verified still-unsolved on `main` during the 2026-08-21 backlog sweep (Ryan-directed).
- The fork branch's history for this PR was clean (14 real commits + 2 sync/merge commits), so all 14 non-merge commits were cherry-picked in topological order onto current `main`.

## Conflict-resolution decisions

- `plugins/dev/scripts/broker/namespace-parity.test.mjs`: purely additive — kept every event-name registration `main` has picked up since this PR forked, and appended this PR's new `recovery.escalation.correlated` / `recovery.escalation.would-correlate` inline names alongside them.
- Every other conflict across the 14 commits auto-merged cleanly.

## Verification

- `bun test` on every test file this PR touches or adds: `namespace-parity.test.mjs`, `escalation-correlation.test.mjs`, `recovery-reasoning.test.mjs`, `scheduler.test.mjs`, plus the `orch-monitor` board/nav/cluster test files this PR's server-adapter and board-projection commits touch (`cluster-signal`, `cluster-view-capacity`, `cluster-view`, `nav-signal-needs-human`, `nav-signal`, `notification-filter`, `read-model`, `board-data-attention`).
- Running all 12 files together showed 1082 pass / 7 fail; 6 of those 7 are pre-existing `scheduler.test.mjs` failures confirmed identical on a clean `origin/main` checkout (unrelated to this PR — CTL-868 orphan-detected tests, a CTL-653 verify⇄remediate cycle test, a CTL-663 partial-commit lock test, a CTL-764 worker.transition test). The 7th (a CTL-826 dispatchAndVerify timing test) passed cleanly both filtered in isolation and on a full solo rerun of `scheduler.test.mjs` (683 pass / 6 fail, matching the known baseline exactly) — it was shared-host load flakiness from running all 12 files concurrently, not a regression.
- `node --check` passes on every hand-resolved/touched `.mjs` file.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
