### PR TITLE
fix(dev): CTL-2137 — exclude listing-`blocked` bg sessions from the admission count

### DIFF
--- a/plugins/dev/scripts/execution-core/claude-agents.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.mjs
@@ -514,6 +514,12 @@ export function defaultStatJobState(shortId) {
 // and dir-gone sessions are excluded so they cannot starve the admission gate.
 // The `statJob` seam (defaulting to defaultStatJobState) is injectable for tests.
 //
+// CTL-2137: `isBgJobDead`/`statJob` read the DURABLE state.json only; a session
+// whose live LISTING .state is "blocked" (the wedged-never-started signature,
+// CTL-932) can still read durable "working" and would otherwise be counted. The
+// filter excludes listing-`blocked` sessions directly off the in-hand agent's
+// verbatim .state (zero-I/O), matching the durable-blocked / parked exclusion.
+//
 // CTL-1165 (D1): exclude the daemon's OWN controlling background session from the
 // admission count. The scheduler's in-flight count IS this live `claude agents`
 // background count (scheduler.mjs:4247), so counting the daemon's own session
@@ -537,6 +543,15 @@ export function countBackgroundAgents({
     // so the daemon's own background session never occupies an admission slot.
     if (excludeSelf && a?.sessionId && isSelf(a.sessionId, env)) return false;
     if (a?.kind !== "background") return false; // unchanged: interactive/unknown excluded
+    // CTL-2137: the durable state.json and the live `claude agents --json`
+    // listing .state can disagree (recovery.mjs:294-299 — durable "working"
+    // while the listing shows "blocked"). A listing state:"blocked" is the
+    // wedged-never-started / dead-on-launch signature (CTL-932) and holds no
+    // real slot, so it must NOT count against maxParallel even when the durable
+    // state.json still reads a non-terminal value. Zero-I/O (the agent carries
+    // the verbatim listing .state) and same capacity semantics / fail direction
+    // as the durable-blocked exclusion (CTL-768: parked ⇒ out of capacity).
+    if (a.state === "blocked") return false;
     // CTL-1055: count only if the bg job is alive.
     let shortId;
     try {

--- a/plugins/dev/scripts/execution-core/claude-agents.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-agents.test.mjs
@@ -333,7 +333,13 @@ describe("countBackgroundAgents", () => {
 
   // --- CTL-1055: dead-session exclusion ---
   // shortIdFromSessionId requires a hex-prefixed UUID (/^[0-9a-f]{8}-/).
-  const bg = (id) => ({ sessionId: `${id}-0000-0000-0000-000000000000`, kind: "background" });
+  // CTL-2137: accepts an optional `extra` so a test can set a verbatim listing
+  // field (e.g. the live `claude agents --json` `.state`) on the agent object.
+  const bg = (id, extra = {}) => ({
+    sessionId: `${id}-0000-0000-0000-000000000000`,
+    kind: "background",
+    ...extra,
+  });
 
   test("excludes a terminal (done) background session", () => {
     const statJob = (shortId) =>
@@ -374,6 +380,32 @@ describe("countBackgroundAgents", () => {
         ? { state: "working", firstTerminalAt: null }
         : { state: "done", firstTerminalAt: null };
     expect(countBackgroundAgents({ agents: [...live, ...ghosts], statJob })).toBe(3);
+  });
+
+  // --- CTL-2137: listing-`blocked` exclusion (durable/listing .state split) ---
+  // The durable state.json and the live `claude agents --json` listing .state can
+  // disagree (recovery.mjs:294-299). A listing state:"blocked" session is the
+  // wedged-never-started / dead-on-launch signature (CTL-932) and holds no real
+  // slot even when its durable state.json still reads "working".
+  test("excludes a background agent whose LISTING state is 'blocked' even when durable is alive (CTL-2137)", () => {
+    const durableAlive = () => ({ state: "working", firstTerminalAt: null });
+    const agents = [bg("a1111111", { state: "blocked" })];
+    expect(countBackgroundAgents({ agents, statJob: durableAlive })).toBe(0); // FAILS before the fix (counts 1)
+  });
+
+  test("counts a background agent whose LISTING state is 'active' and durable is alive (positive control)", () => {
+    const durableAlive = () => ({ state: "working", firstTerminalAt: null });
+    const agents = [bg("a1111111", { state: "active" })];
+    expect(countBackgroundAgents({ agents, statJob: durableAlive })).toBe(1);
+  });
+
+  test("live repro: 3 working (active listing) + 4 listing-'blocked' auth-fail ghosts → 3 (CTL-2137)", () => {
+    const durableAlive = () => ({ state: "working", firstTerminalAt: null }); // durable says alive for ALL
+    const live = ["a1111111", "a2222222", "a3333333"].map((id) => bg(id, { state: "active" }));
+    const ghosts = ["b1111111", "b2222222", "b3333333", "b4444444"].map((id) =>
+      bg(id, { state: "blocked" }),
+    );
+    expect(countBackgroundAgents({ agents: [...live, ...ghosts], statJob: durableAlive })).toBe(3);
   });
 });
 


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-21T14:04:56Z -->
<!-- Last updated: 2026-08-21T14:04:56Z -->
<!-- PR: #3846 -->
<!-- Previous commits: aca0c0f1f78d93c2981dc4fb12735c519d1d4247 -->

## Summary

A background job wedged `blocked` since launch (dead-on-launch, typically expired auth) was being
counted as an occupied dispatch slot. Its durable `state.json` still reads a non-terminal value
(e.g. `working`), so the existing `isBgJobDead`/`statJob` admission filter — which reads the
durable state only — let it through and charged it against `maxParallel`. The live
`claude agents --json` listing, however, reports `.state = "blocked"`, the wedged-never-started
signature. The result: `free_slots` accounting diverged from `ps` reality (RELWATCH-46: mini-2
reported `free_slots:1 / eligible:6` while only one SDK process was actually running), starving
dispatch and tripping the CAT-36 dispatch-starvation alarm.

This adds a zero-I/O guard in `countBackgroundAgents` that excludes any background agent whose
verbatim listing `.state` is `"blocked"`, so a dead-on-launch ghost no longer occupies a slot.

## Changes Made

- `plugins/dev/scripts/execution-core/claude-agents.mjs` (+15): in `countBackgroundAgents`, after
  the existing `kind === "background"` gate, skip any agent with `a.state === "blocked"`. The agent
  object already carries the verbatim listing `.state`, so the check is zero additional I/O. Same
  capacity semantics and fail direction as the existing durable-blocked / parked exclusion (a parked
  or wedged worker is out of capacity), fenced by the existing generation guard.
- `plugins/dev/scripts/execution-core/claude-agents.test.mjs` (+33/-1): the `bg()` test helper now
  accepts an optional `extra` so a test can set a verbatim listing field. Three new tests:
  - excludes a listing-`blocked` agent even when its durable state reads alive (fails before the fix);
  - **positive control** — counts a listing-`active` agent whose durable state is alive (proves the
    guard is specific to `blocked`, not a blanket exclusion);
  - live repro — 3 active + 4 listing-`blocked` auth-fail ghosts (all durable-alive) count as 3.

## How to Verify It

- [x] Unit tests pass: `bun test plugins/dev/scripts/execution-core/claude-agents.test.mjs`
- [x] Verify phase gates clean (regression_risk 0/10; tests, typecheck, lint, security,
      reward-hacking, silent-failure all green)
- [x] Review phase passed (2 low-severity notes, one adversarially refuted; no changes required)

## Why the durable/listing split is real

`recovery.mjs` (≈294-299) documents that the durable `state.json` and the live listing `.state` can
disagree: durable `working` while the listing shows `blocked`. The prior admission filter read only
the durable side, so this class of ghost was invisible to it. This guard closes that gap at the one
place capacity is counted.

Refs: CTL-2137

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CAT-36
skip RELWATCH-46
