### PR TITLE
fix(dev): CTL-1647 — transient provider overload retries instead of parking tickets for a human

### DIFF
--- a/plugins/dev/scripts/execution-core/__tests__/ctl-1647-scheduler-transient-gate.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/ctl-1647-scheduler-transient-gate.test.mjs
@@ -1,0 +1,307 @@
+// ctl-1647-scheduler-transient-gate.test.mjs — CTL-1647.
+//
+// The LOAD-BEARING half of the fix: the terminal sweep must NOT apply
+// `needs-human` to a ticket whose phase signal is a transient, retry-safe
+// provider-capacity park — it must back off and re-arm the phase instead.
+//
+// This drives the REAL `schedulerTick`, not the classifier in isolation. The
+// first round of this work only unit-tested `classifyTransientSignal`, and a
+// reviewer's mutation (`if (false && …)` on the sweep gate) passed the entire
+// 11k-test execution-core suite: the one line that actually stops the label had
+// ZERO coverage. Every test below fails if that gate is removed.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test __tests__/ctl-1647-scheduler-transient-gate.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  schedulerTick,
+  maybeRearmTransientSignal,
+  __resetForTests,
+  transientRearmMarkerPath,
+  TRANSIENT_REARM_DELAY_MS,
+  TRANSIENT_MAX_REARMS,
+} from "../scheduler.mjs";
+
+const TICKET = "CTL-1647T";
+const PHASE = "implement";
+
+let orchDir;
+let catalystDir;
+let prevCatalystDir;
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1647-sched-"));
+  prevCatalystDir = process.env.CATALYST_DIR;
+  catalystDir = mkdtempSync(join(tmpdir(), "ctl1647-cat-"));
+  process.env.CATALYST_DIR = catalystDir;
+  writeFileSync(join(orchDir, "state.json"), JSON.stringify({ maxParallel: 2 }));
+  // Clear the module-level worker.transition dedup, or an earlier test's
+  // needs-human emit suppresses a later test's (order-coupled false green).
+  __resetForTests();
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+  rmSync(catalystDir, { recursive: true, force: true });
+  if (prevCatalystDir === undefined) delete process.env.CATALYST_DIR;
+  else process.env.CATALYST_DIR = prevCatalystDir;
+});
+
+function signalPath(phase = PHASE) {
+  return join(orchDir, "workers", TICKET, `phase-${phase}.json`);
+}
+
+function writeSignal(phase, obj) {
+  mkdirSync(join(orchDir, "workers", TICKET), { recursive: true });
+  writeFileSync(signalPath(phase), JSON.stringify({ ticket: TICKET, phase, ...obj }));
+}
+
+function readSignal(phase = PHASE) {
+  return JSON.parse(readFileSync(signalPath(phase), "utf8"));
+}
+
+/** The stalled overload signal the SDK backstop leaves on disk. */
+function writeOverloadPark(over = {}) {
+  // The whole prefix must be `done` — deleting the parked signal re-derives the
+  // next phase from the latest DONE one, so the ticket resumes at PHASE and does
+  // not walk backwards.
+  writeSignal("triage", { status: "done" });
+  writeSignal("research", { status: "done" });
+  writeSignal("plan", { status: "done" });
+  writeSignal(PHASE, {
+    status: "stalled",
+    generation: 1,
+    attentionReason: "sdk-overloaded-exhausted",
+    retrySafe: true,
+    assertedBy: "sdk-backstop",
+    updatedAt: new Date().toISOString(),
+    ...over,
+  });
+}
+
+/** Run one schedulerTick with every outbound write captured. */
+function tick() {
+  const labels = [];
+  const transitions = [];
+  schedulerTick(orchDir, {
+    readEligible: () => [],
+    dispatch: () => ({ code: 0, stdout: "", stderr: "" }),
+    verifyDispatched: () => ({ ok: true }),
+    writeStatus: {
+      applyPhaseStatus() {},
+      applyTerminalDone() {},
+      applyLabel: (arg) => {
+        labels.push(arg);
+        return { applied: true, label: arg?.label };
+      },
+      removeLabel: () => ({ removed: false }),
+    },
+    appendWorkerTransitionEvent: (ev) => transitions.push(ev),
+    env: {},
+  });
+  return {
+    labels,
+    transitions,
+    needsHuman: labels.filter((l) => l?.label === "needs-human"),
+    needsHumanTransitions: transitions.filter((e) => e.toDisposition === "needs-human"),
+  };
+}
+
+describe("CTL-1647 — schedulerTick does NOT park a transient provider outage", () => {
+  test("a fresh retry-safe overload park applies NO needs-human label and records NO transition", () => {
+    writeOverloadPark();
+    const r = tick();
+    expect(r.needsHuman).toEqual([]);
+    expect(r.needsHumanTransitions).toEqual([]);
+    // The marker file the label path writes must be absent too.
+    expect(existsSync(join(orchDir, "workers", TICKET, ".linear-label-needs-human.applied"))).toBe(
+      false,
+    );
+  });
+
+  // POSITIVE CONTROL 1 — a GENUINE failure on the SAME code path still parks.
+  // Without this the test above could pass because the sweep never ran at all.
+  test("POSITIVE CONTROL: a genuine (non-transient) stall STILL applies needs-human", () => {
+    writeSignal("research", { status: "done" });
+    writeSignal(PHASE, {
+      status: "failed",
+      generation: 1,
+      failureReason: "ended-without-declaration",
+      updatedAt: new Date().toISOString(),
+    });
+    const r = tick();
+    expect(r.needsHuman.length).toBeGreaterThan(0);
+    expect(r.needsHumanTransitions.length).toBeGreaterThan(0);
+  });
+
+  // POSITIVE CONTROL 2 — a transient reason with NO retrySafe stamp has no route
+  // that would re-dispatch it, so suppressing it would be a silent stall. It parks.
+  test("POSITIVE CONTROL: a transient reason WITHOUT retrySafe still parks", () => {
+    writeOverloadPark({ retrySafe: undefined });
+    const r = tick();
+    expect(r.needsHuman.length).toBeGreaterThan(0);
+  });
+
+  // POSITIVE CONTROL 3 — the suppression is BOUNDED. Once the phase has re-armed
+  // itself TRANSIENT_MAX_REARMS times the sweep escalates, because a silently
+  // stranded ticket is strictly worse than a false page.
+  test("POSITIVE CONTROL: past the re-arm budget the sweep DOES park it", () => {
+    writeOverloadPark({ updatedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString() });
+    writeFileSync(
+      transientRearmMarkerPath(orchDir, TICKET, PHASE),
+      JSON.stringify({ count: TRANSIENT_MAX_REARMS }),
+    );
+    const r = tick();
+    expect(r.needsHuman.length).toBeGreaterThan(0);
+  });
+
+  test("an aged transient park is RE-ARMED (signal dropped) instead of parked", () => {
+    writeOverloadPark({
+      updatedAt: new Date(Date.now() - TRANSIENT_REARM_DELAY_MS - 60_000).toISOString(),
+    });
+    const r = tick();
+    expect(r.needsHuman).toEqual([]);
+    // ⚠️ The terminal signal is DELETED, not rewritten to "pending":
+    // deriveAdvancement advances only when the latest LIVE phase is `done`, so a
+    // pending signal would make this phase latest and the ticket would sit
+    // forever. Dropping it makes `research: done` latest again → implement is
+    // re-derived and dispatched.
+    expect(existsSync(signalPath())).toBe(false);
+    const marker = JSON.parse(readFileSync(transientRearmMarkerPath(orchDir, TICKET, PHASE), "utf8"));
+    expect(marker.count).toBe(1);
+  });
+
+  // The re-arm must actually produce a DISPATCH — a reset that no phase picks up
+  // is a silent stall wearing a fix's clothes.
+  test("after the re-arm the next tick DISPATCHES the phase again", () => {
+    writeOverloadPark({
+      updatedAt: new Date(Date.now() - TRANSIENT_REARM_DELAY_MS - 60_000).toISOString(),
+    });
+    tick(); // re-arm
+    const dispatched = [];
+    schedulerTick(orchDir, {
+      readEligible: () => [],
+      dispatch: (args) => {
+        dispatched.push(args);
+        return { code: 0, stdout: "", stderr: "" };
+      },
+      verifyDispatched: () => ({ ok: true }),
+      writeStatus: {
+        applyPhaseStatus() {},
+        applyTerminalDone() {},
+        applyLabel: () => ({ applied: true }),
+        removeLabel: () => ({ removed: false }),
+      },
+      env: {},
+    });
+    expect(dispatched.some((d) => d?.ticket === TICKET && d?.phase === PHASE)).toBe(true);
+  });
+
+  test("a park younger than the back-off delay is left alone (real wall-clock back-off)", () => {
+    writeOverloadPark();
+    const r = tick();
+    expect(r.needsHuman).toEqual([]);
+    // NOT re-armed yet — the whole point is to wait for capacity to return rather
+    // than re-fire on the next tick into a provider that is still returning 529.
+    expect(readSignal().status).toBe("stalled");
+  });
+});
+
+describe("CTL-1647 — maybeRearmTransientSignal (the back-off actuator)", () => {
+  const projection = (raw) => ({
+    ticket: TICKET,
+    phase: raw.phase,
+    status: raw.status,
+    updatedAt: raw.updatedAt,
+    signalPath: signalPath(raw.phase),
+    raw,
+  });
+
+  function park(over = {}) {
+    writeOverloadPark(over);
+    return projection(readSignal());
+  }
+
+  test("waits while fresh, re-arms once aged, and gives up after the budget", () => {
+    const now = Date.now();
+    // fresh → waiting
+    let sig = park({ updatedAt: new Date(now).toISOString() });
+    expect(maybeRearmTransientSignal(orchDir, TICKET, sig, { now })).toMatchObject({
+      handled: true,
+      action: "waiting",
+    });
+    expect(readSignal().status).toBe("stalled");
+
+    // aged → rearmed
+    sig = park({ updatedAt: new Date(now - TRANSIENT_REARM_DELAY_MS - 1).toISOString() });
+    expect(maybeRearmTransientSignal(orchDir, TICKET, sig, { now })).toMatchObject({
+      handled: true,
+      action: "rearmed",
+      attempts: 1,
+    });
+    expect(existsSync(signalPath())).toBe(false);
+
+    // budget spent → NOT handled, the sweep escalates
+    sig = park({ updatedAt: new Date(now - TRANSIENT_REARM_DELAY_MS - 1).toISOString() });
+    writeFileSync(
+      transientRearmMarkerPath(orchDir, TICKET, PHASE),
+      JSON.stringify({ count: TRANSIENT_MAX_REARMS }),
+    );
+    expect(maybeRearmTransientSignal(orchDir, TICKET, sig, { now })).toMatchObject({
+      handled: false,
+      action: "exhausted",
+    });
+    expect(existsSync(signalPath())).toBe(true);
+  });
+
+  // The counter must OUTLIVE the signal it deletes, or the bound is fictional.
+  test("the re-arm budget is cause-scoped and survives the deleted signal", () => {
+    const now = Date.now();
+    const aged = () => new Date(now - TRANSIENT_REARM_DELAY_MS - 1).toISOString();
+    for (let i = 1; i <= TRANSIENT_MAX_REARMS; i++) {
+      const sig = park({ updatedAt: aged() });
+      expect(maybeRearmTransientSignal(orchDir, TICKET, sig, { now })).toMatchObject({
+        action: "rearmed",
+        attempts: i,
+      });
+    }
+    const sig = park({ updatedAt: aged() });
+    expect(maybeRearmTransientSignal(orchDir, TICKET, sig, { now })).toMatchObject({
+      handled: false,
+      action: "exhausted",
+    });
+  });
+
+  test("an unreadable timestamp re-arms (bounded) rather than waiting forever", () => {
+    const sig = park({ updatedAt: "not-a-date" });
+    const out = maybeRearmTransientSignal(orchDir, TICKET, sig, { now: Date.now() });
+    expect(out).toMatchObject({ handled: true, action: "rearmed", attempts: 1 });
+  });
+
+  test("the stale claim tombstone and the dispatch cooldown are cleared", () => {
+    const claim = join(orchDir, "workers", TICKET, `phase-${PHASE}.claim.1`);
+    const cooldown = join(orchDir, ".dispatch-cooldowns", `${TICKET}-${PHASE}.json`);
+    const sig = park({ updatedAt: new Date(Date.now() - TRANSIENT_REARM_DELAY_MS - 1).toISOString() });
+    mkdirSync(join(orchDir, ".dispatch-cooldowns"), { recursive: true });
+    writeFileSync(claim, "");
+    writeFileSync(cooldown, "{}");
+    maybeRearmTransientSignal(orchDir, TICKET, sig, { now: Date.now() });
+    // A leftover tombstone collides on the next O_EXCL claim create → silent stall.
+    expect(existsSync(claim)).toBe(false);
+    // A live cooldown would suppress the very re-dispatch we just armed.
+    expect(existsSync(cooldown)).toBe(false);
+  });
+
+  test("a missing signal file is not handled — the sweep falls through to escalate", () => {
+    const out = maybeRearmTransientSignal(
+      orchDir,
+      TICKET,
+      { signalPath: join(orchDir, "workers", TICKET, "phase-nope.json"), raw: {} },
+      { now: Date.now() },
+    );
+    expect(out.handled).toBe(false);
+  });
+});

--- a/plugins/dev/scripts/execution-core/__tests__/ctl-1647-transient-overload-not-human.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/ctl-1647-transient-overload-not-human.test.mjs
@@ -1,0 +1,460 @@
+// ctl-1647-transient-overload-not-human.test.mjs — CTL-1647.
+//
+// GUARD: a transient provider-capacity failure (429/529 overload, codex rate
+// park) must NEVER be recorded as a plain terminal failure and must NEVER
+// produce a per-ticket human-decision escalation. It must take the existing
+// retry-safe path (CTL-1679) so the ticket resumes by itself.
+//
+// Measured 2026-08-21: 41 of 79 tickets parked as "a human must decide" died on
+// this exact path — the SDK backstop wrote a terminal signal with no retry-safe
+// marker, the scheduler's terminal sweep escalated it, and coerceExplanation
+// fabricated "decide whether to retry, hand off, or cancel".
+//
+// EVERY assertion here is paired with a POSITIVE CONTROL that reproduces the
+// PRE-FIX shape and proves the assertion fails on it — a guard test that cannot
+// fail is worthless.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test __tests__/ctl-1647-transient-overload-not-human.test.mjs
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { defaultEmitBackstop } from "../sdk-run-phase-agent.mjs";
+import { buildRecoveryItems } from "../recovery-evidence.mjs";
+import { defaultClassifyTicket, buildRetrySafeExhaustionExplanation } from "../recovery-reasoning.mjs";
+import {
+  buildTransientExhaustedExplanation,
+  classifyTransientSignal,
+  coerceExplanation,
+  isTransientInfraReason,
+  validateExplanation,
+  TRANSIENT_ESCALATION_BACKOFF_MS,
+} from "../escalation-explanation.mjs";
+
+const TICKET = "CTL-9647";
+const PHASE = "implement";
+
+let orchDir;
+let spawnCalls;
+const spawnStub = (bin, args) => {
+  spawnCalls.push({ bin, args });
+  return { status: 0, stdout: "", stderr: "", signal: null };
+};
+
+function signalPath() {
+  return join(orchDir, "workers", TICKET, `phase-${PHASE}.json`);
+}
+
+/** Write the in-flight signal the pre-launch leaves on disk. */
+function writeInFlightSignal() {
+  mkdirSync(join(orchDir, "workers", TICKET), { recursive: true });
+  writeFileSync(
+    signalPath(),
+    JSON.stringify({
+      ticket: TICKET,
+      phase: PHASE,
+      status: "running",
+      generation: 1,
+      bg_job_id: "bg-1",
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+}
+
+function readSignal() {
+  return JSON.parse(readFileSync(signalPath(), "utf8"));
+}
+
+/** The reader projection the scheduler/recovery see: on-disk JSON nested under `.raw`. */
+function projection(raw) {
+  return {
+    ticket: raw.ticket,
+    phase: raw.phase,
+    status: raw.status,
+    updatedAt: raw.updatedAt,
+    signalPath: signalPath(),
+    raw,
+  };
+}
+
+/** Run the recovery classifier over a signal exactly as the daemon does. */
+function classify(raw) {
+  const items = buildRecoveryItems([projection(raw)]);
+  return defaultClassifyTicket(items[0].evidence, {
+    ticket: TICKET,
+    readIntentAttempts: () => 0, // hermetic: fresh retry budget
+    log: () => {},
+  });
+}
+
+beforeEach(() => {
+  orchDir = mkdtempSync(join(tmpdir(), "ctl1647-"));
+  spawnCalls = [];
+});
+afterEach(() => {
+  rmSync(orchDir, { recursive: true, force: true });
+});
+
+describe("CTL-1647 — step 1: the overload backstop records a RETRY-SAFE terminal", () => {
+  test("sdk-overloaded-exhausted → signal.retrySafe:true + retry_safe on the emitted event", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "sdk-overloaded-exhausted",
+        orchDir,
+        signalFile: signalPath(),
+        retrySafe: true,
+      },
+      { spawn: spawnStub },
+    );
+
+    const sig = readSignal();
+    // The terminal write itself is PRESERVED (CTL-1367 item 4 — an in-flight
+    // signal strands the worker forever); what changes is the retry-safe marker.
+    expect(sig.status).toBe("stalled");
+    expect(sig.attentionReason).toBe("sdk-overloaded-exhausted");
+    expect(sig.retrySafe).toBe(true);
+
+    // Signal and EVENT must carry the same flag or the two records desync.
+    const args = spawnCalls[0].args;
+    expect(args).toContain("--payload-json");
+    expect(args[args.indexOf("--payload-json") + 1]).toBe('{"retry_safe":true}');
+  });
+
+  // POSITIVE CONTROL — the PRE-FIX shape. A genuine (non-transient) backstop
+  // still writes a bare terminal with NO retrySafe and NO retry_safe payload.
+  // If the production call site ever loses `retrySafe: true`, the test above
+  // produces exactly this shape and fails.
+  test("POSITIVE CONTROL: a non-transient backstop writes NO retrySafe (pre-fix shape)", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "sdk-threw",
+        orchDir,
+        signalFile: signalPath(),
+      },
+      { spawn: spawnStub },
+    );
+    const sig = readSignal();
+    expect(sig.status).toBe("stalled");
+    expect(sig.retrySafe).toBeUndefined();
+    expect(spawnCalls[0].args).not.toContain("--payload-json");
+  });
+});
+
+describe("CTL-1647 — step 2: recovery re-dispatches it instead of escalating", () => {
+  test("the on-disk overload signal classifies as fix / retry_safe_redispatch", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "sdk-overloaded-exhausted",
+        orchDir,
+        signalFile: signalPath(),
+        retrySafe: true,
+      },
+      { spawn: spawnStub },
+    );
+
+    const decision = classify(readSignal());
+    expect(decision.decision).toBe("fix");
+    expect(decision.fix_class).toBe("retry_safe_redispatch");
+    expect(decision.details.seam_id).toBe("fence-stale-redispatch");
+    // The cause is NAMED, not the anonymous "unrecognized-retry-safe".
+    expect(decision.details.reason).toContain("sdk-overloaded-exhausted");
+    // And it is emphatically NOT a human escalation.
+    expect(decision.fix_class).not.toBe("human");
+  });
+
+  // POSITIVE CONTROL — the exact pre-fix signal (identical in every way except
+  // the missing retrySafe marker) must NOT classify as a retry. This is the
+  // regression detector: revert the producer change and the test above lands here.
+  test("POSITIVE CONTROL: the same signal WITHOUT retrySafe does NOT auto-retry", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "sdk-overloaded-exhausted",
+        orchDir,
+        signalFile: signalPath(),
+        // retrySafe omitted — the pre-CTL-1647 production call
+      },
+      { spawn: spawnStub },
+    );
+    const raw = readSignal();
+    expect(raw.retrySafe).toBeUndefined(); // control is really the pre-fix shape
+    const decision = classify(raw);
+    expect(decision.fix_class).not.toBe("retry_safe_redispatch");
+  });
+
+  test("codex-rate-park-exhausted takes the same retry-safe path", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "codex-rate-park-exhausted",
+        orchDir,
+        signalFile: signalPath(),
+        retrySafe: true,
+      },
+      { spawn: spawnStub },
+    );
+    const decision = classify(readSignal());
+    expect(decision.decision).toBe("fix");
+    expect(decision.fix_class).toBe("retry_safe_redispatch");
+  });
+});
+
+describe("CTL-1647 — step 3: the classifier is a CLOSED SET, not a prose match", () => {
+  const overloadRaw = (over = {}) => ({
+    ticket: TICKET,
+    phase: PHASE,
+    status: "stalled",
+    attentionReason: "sdk-overloaded-exhausted",
+    retrySafe: true,
+    updatedAt: new Date().toISOString(),
+    ...over,
+  });
+
+  test("a fresh retry-safe transient signal is inside the back-off window", () => {
+    const v = classifyTransientSignal(projection(overloadRaw()));
+    expect(v.transient).toBe(true);
+    expect(v.retrySafe).toBe(true);
+    expect(v.withinBackoff).toBe(true);
+  });
+
+  // POSITIVE CONTROL 1 — a GENUINE failure must still escalate.
+  test("POSITIVE CONTROL: a genuine failure is NOT transient → still escalates", () => {
+    const v = classifyTransientSignal(
+      projection({
+        ticket: TICKET,
+        phase: PHASE,
+        status: "failed",
+        failureReason: "ended-without-declaration",
+        updatedAt: new Date().toISOString(),
+      }),
+    );
+    expect(v.transient).toBe(false);
+    expect(v.withinBackoff).toBe(false);
+  });
+
+  // POSITIVE CONTROL 2 — the skip is BOUNDED.
+  test("POSITIVE CONTROL: past the backoff window the transient skip expires", () => {
+    const stale = overloadRaw({
+      updatedAt: new Date(Date.now() - TRANSIENT_ESCALATION_BACKOFF_MS - 60_000).toISOString(),
+    });
+    const v = classifyTransientSignal(projection(stale));
+    expect(v.transient).toBe(true);
+    expect(v.withinBackoff).toBe(false);
+  });
+
+  // Codex R1: a transient-looking reason with NO retrySafe stamp has no route
+  // that re-dispatches it, so suppressing its escalation would be a pure silent
+  // stall. It must fall OUT of the window.
+  test("a transient reason WITHOUT retrySafe is never inside the window", () => {
+    const v = classifyTransientSignal(projection(overloadRaw({ retrySafe: undefined })));
+    expect(v.transient).toBe(true);
+    expect(v.retrySafe).toBe(false);
+    expect(v.withinBackoff).toBe(false);
+  });
+
+  // Codex R2 P3: an unreadable/absent timestamp can never age. Treating it as
+  // "fresh" would suppress the escalation on EVERY tick, forever.
+  test("an unreadable updatedAt does NOT buy an unbounded suppression", () => {
+    for (const stamp of [undefined, null, "not-a-date"]) {
+      const v = classifyTransientSignal(projection(overloadRaw({ updatedAt: stamp })));
+      expect(v.transient).toBe(true);
+      expect(v.ageMs).toBeNull();
+      expect(v.withinBackoff).toBe(false);
+    }
+  });
+
+  test("the reason classifier accepts ONLY the producer literals", () => {
+    for (const r of ["sdk-overloaded-exhausted", "codex-rate-park-exhausted"]) {
+      expect(isTransientInfraReason(r)).toBe(true);
+    }
+    for (const r of [
+      "ended-without-declaration",
+      "cluster_fence_stale",
+      "pr_not_merged",
+      "tests failed",
+      null,
+      undefined,
+      "",
+    ]) {
+      expect(isTransientInfraReason(r)).toBe(false);
+    }
+  });
+
+  // POSITIVE CONTROL — the anti-over-match guard. Agent-authored prose reaches
+  // this predicate through escalation-explain.mjs / label-guard.mjs, so a
+  // GENUINE human escalation that merely MENTIONS a rate limit must not match.
+  // The pre-review draft used a substring regex and silently swallowed these.
+  test("POSITIVE CONTROL: prose that merely MENTIONS overload/429 is NOT transient", () => {
+    for (const r of [
+      "the API client we're building has no rate limit handling",
+      "provider returned 529 overloaded",
+      "HTTP 429 rate limit",
+      "the test run overloaded the box",
+      "CTL-9 has a stalled phase signal (sdk-overloaded-exhausted) and is not terminal",
+      "service unavailable",
+    ]) {
+      expect(isTransientInfraReason(r)).toBe(false);
+    }
+  });
+});
+
+describe("CTL-1647 — step 4: the template refuses to fabricate a human decision", () => {
+  test("a STRUCTURED transient reason yields NO fabricated options / why_you / decision", () => {
+    const e = coerceExplanation(
+      {
+        problem: `${TICKET} has a stalled phase signal (sdk-overloaded-exhausted) and is not terminal`,
+        call_to_action: `decide whether to retry ${TICKET} or close it`,
+        reason: "sdk-overloaded-exhausted",
+      },
+      { ticket: TICKET, canExecute: false },
+    );
+    expect(e.escalation_type).not.toBe("decision");
+    expect(e.transient).toBe(true);
+    expect(e.options).toBeUndefined();
+    expect(e.why_you).toBeUndefined();
+    expect(e.call_to_action).not.toContain("decide whether to retry, hand off, or cancel");
+    expect(JSON.stringify(e)).not.toContain("priority call the agent cannot make unilaterally");
+  });
+
+  // Codex R2 P2 (demonstrated defect in the pre-review draft): the card must NOT
+  // claim "no decision is required / it will re-dispatch itself". Every site that
+  // reaches an explanation has ALREADY spent its automatic window, so that text
+  // is a false all-clear on a still-parked ticket.
+  test("the transient card never claims the ticket needs nothing", () => {
+    const e = buildTransientExhaustedExplanation(TICKET, "sdk-overloaded-exhausted", 3);
+    const text = JSON.stringify(e).toLowerCase();
+    expect(text).not.toContain("no decision is required");
+    expect(text).not.toContain("do not retry");
+    expect(text).toContain("re-dispatch");
+    expect(e.call_to_action.toLowerCase()).toContain("already passed");
+    // It is a VALID manual escalation (act-then-confirm), which is what it now is.
+    expect(validateExplanation(e, { canExecute: false })).toMatchObject({ valid: true });
+  });
+
+  // It must survive coerceExplanation untouched (valid → early return), so the
+  // terminal sweep's truthful card is not re-degraded into the decision template.
+  test("the transient card passes coerceExplanation unchanged", () => {
+    const e = buildTransientExhaustedExplanation(TICKET, "sdk-overloaded-exhausted", 3);
+    const c = coerceExplanation(e, { ticket: TICKET, canExecute: false });
+    expect(c.escalation_type).toBe("manual");
+    expect(c.degraded).toBeUndefined();
+    expect(c.call_to_action).toBe(e.call_to_action);
+  });
+
+  // POSITIVE CONTROL — the template's LEGITIMATE use is untouched.
+  test("POSITIVE CONTROL: a genuine unexplained failure STILL gets the decision template", () => {
+    const e = coerceExplanation(
+      {
+        problem: `${TICKET} has a failed phase signal (ended-without-declaration) and is not terminal`,
+        call_to_action: `decide whether to retry ${TICKET} or close it`,
+      },
+      { ticket: TICKET, canExecute: false },
+    );
+    expect(e.escalation_type).toBe("decision");
+    expect(Array.isArray(e.options)).toBe(true);
+    expect(e.why_you).toContain("priority call the agent cannot make unilaterally");
+  });
+
+  // POSITIVE CONTROL — an agent-authored escalation whose PROSE mentions a rate
+  // limit still gets its human decision card. This is the over-match regression
+  // detector: gate the arm on prose again and this fails.
+  test("POSITIVE CONTROL: prose mentioning a rate limit still gets the decision card", () => {
+    const e = coerceExplanation(
+      { problem: "the API client we're building has no rate limit handling and 429s" },
+      { ticket: TICKET, canExecute: false },
+    );
+    expect(e.escalation_type).toBe("decision");
+    expect(e.transient).toBeUndefined();
+    expect(e.call_to_action).toContain("decide whether to retry, hand off, or cancel");
+  });
+
+  // POSITIVE CONTROL — the coverage-gap ask CTL-1679 raises after its budget is
+  // spent must not be swallowed by the transient arm.
+  test("POSITIVE CONTROL: the retry-safe exhaustion ask is not rewritten as transient", () => {
+    const e = coerceExplanation(
+      buildRetrySafeExhaustionExplanation(TICKET, "sdk-overloaded-exhausted", 2),
+      { ticket: TICKET, canExecute: false },
+    );
+    expect(e.transient).toBeUndefined();
+  });
+});
+
+describe("CTL-1647 — step 5: recovery never escalates a transient cause", () => {
+  const overload = () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "sdk-overloaded-exhausted",
+        orchDir,
+        signalFile: signalPath(),
+        retrySafe: true,
+      },
+      { spawn: spawnStub },
+    );
+    return readSignal();
+  };
+
+  function classifyWithAttempts(raw, attempts) {
+    const items = buildRecoveryItems([projection(raw)]);
+    return defaultClassifyTicket(items[0].evidence, {
+      ticket: TICKET,
+      readIntentAttempts: () => attempts,
+      log: () => {},
+    });
+  }
+
+  // ROUTE A / A': RECOVERY_MAX_ATTEMPTS defaults to 2 and the counter is the
+  // ticket's GENERIC recovery-intent counter — a ticket that already took two
+  // unrelated recovery fixes got ZERO retries and escalated on the FIRST overload.
+  test("an EXHAUSTED retry budget defers a transient cause — it never escalates", () => {
+    const d = classifyWithAttempts(overload(), 99);
+    expect(d.decision).toBe("defer");
+    expect(d.fix_class).not.toBe("human");
+    expect(d.details.reason).toContain("transient");
+  });
+
+  // POSITIVE CONTROL — a NON-transient retry-safe failure with the same exhausted
+  // budget still escalates with the CTL-1679 coverage-gap ask. Widen the gate and
+  // this fails.
+  test("POSITIVE CONTROL: a non-transient retry-safe failure still escalates at budget end", () => {
+    writeInFlightSignal();
+    defaultEmitBackstop(
+      {
+        phase: PHASE,
+        ticket: TICKET,
+        status: "failed",
+        reason: "cluster_fence_stale_unrecognized",
+        orchDir,
+        signalFile: signalPath(),
+        retrySafe: true,
+      },
+      { spawn: spawnStub },
+    );
+    const d = classifyWithAttempts(readSignal(), 99);
+    expect(d.decision).toBe("escalate");
+    expect(d.fix_class).toBe("human");
+  });
+});

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.mjs
@@ -127,10 +127,10 @@ function defaultSpawnChild(bin, args, opts) {
 // signal to a terminal status AND emit the canonical terminal phase event, exactly
 // like the sdk path's defaultEmitBackstop. Best-effort; never throws.
 function defaultMarkLaunchFailed(
-  { phase, ticket, status = "failed", reason, orchDir, signalFile },
+  { phase, ticket, status = "failed", reason, orchDir, signalFile, retrySafe = false },
   { spawn = spawnSync } = {},
 ) {
-  defaultEmitBackstop({ phase, ticket, status, reason, orchDir, signalFile }, { spawn });
+  defaultEmitBackstop({ phase, ticket, status, reason, orchDir, signalFile, retrySafe }, { spawn });
 }
 
 // ── Auth guard ──────────────────────────────────────────────────────────────
@@ -1764,8 +1764,13 @@ export async function codexRunPhaseAgent(
         // which is the TRANSIENT behavior rate-park intends. Classification stays
         // "rate-park" for any caller that inspects it.
         if (!_staleGeneration) {
+          // CTL-1647: same defect as the sdk overloaded-exhausted backstop — the
+          // comment above always claimed this was the TRANSIENT path, but the
+          // terminal it writes lands on stalled and the terminal sweep parks the
+          // ticket for a human. `retrySafe` is what actually makes it transient:
+          // recovery's bounded retry_safe_redispatch owns it from here.
           markLaunchFailed(
-            { phase, ticket, status: "failed", reason: "codex-rate-park-exhausted", orchDir, signalFile },
+            { phase, ticket, status: "failed", reason: "codex-rate-park-exhausted", orchDir, signalFile, retrySafe: true },
             { spawn },
           );
         }

--- a/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/codex-run-phase-agent.test.mjs
@@ -1633,6 +1633,61 @@ describe("codexRunPhaseAgent — failure classification", () => {
     expect(stalled.length).toBe(0); // NOT the sticky auth-park stalled path
   });
 
+  // CTL-1647: the rate-park EXHAUSTION backstop must declare itself RETRY-SAFE.
+  // Without the flag the terminal it writes is indistinguishable from a genuine
+  // dead end and the terminal sweep parks the ticket for a human — the same
+  // defect as the sdk overloaded-exhausted backstop (41 of 79 false escalations
+  // measured 2026-08-21). This drives the PRODUCTION call site: deleting
+  // `retrySafe: true` from codex-run-phase-agent.mjs's rate-park branch fails here.
+  test("CTL-1647: rate-park exhaustion marks the backstop retrySafe (production call site)", async () => {
+    const marks = [];
+    const { opts } = runnerOpts({
+      over: {
+        spawnChild: () => autoChild([RATE_ERR], 1),
+        markLaunchFailed: (arg) => marks.push(arg),
+        maxRateRetries: 1,
+      },
+    });
+    const r = await codexRunPhaseAgent(ARGS, opts);
+    expect(r.classification).toBe("rate-park");
+    expect(marks).toHaveLength(1);
+    expect(marks[0].reason).toBe("codex-rate-park-exhausted");
+    expect(marks[0].retrySafe).toBe(true);
+  });
+
+  // POSITIVE CONTROL for the test above, driven through the SAME production
+  // function: a genuine `codex-failed` terminal must NOT be retry-safe, so the
+  // assertion above discriminates rather than passing vacuously. Needs a real
+  // signal file because the failed branch gates on readSignalStatus (not injectable).
+  test("CTL-1647 POSITIVE CONTROL: a genuine codex failure is NOT retrySafe", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1647-codex-"));
+    try {
+      mkdirSync(join(dir, "workers", "CTL-100"), { recursive: true });
+      writeFileSync(
+        join(dir, "workers", "CTL-100", "phase-implement.json"),
+        JSON.stringify({ ticket: "CTL-100", phase: "implement", status: "running" }),
+      );
+      const marks = [];
+      const { opts } = runnerOpts({
+        // the signal path lives on the prelaunch SPEC, not on ARGS.orchDir
+        spec: makeCodexSpec({ signalFile: join(dir, "workers", "CTL-100", "phase-implement.json") }),
+        over: {
+          // exitCode 1 with no rate/auth marker → classification "failed"
+          spawnChild: () => autoChild(['{"type":"error","message":"compiler exploded"}'], 1),
+          markLaunchFailed: (arg) => marks.push(arg),
+        },
+      });
+      const r = await codexRunPhaseAgent({ ...ARGS, orchDir: dir }, opts);
+      expect(r.classification).toBe("failed");
+      expect(marks).toHaveLength(1);
+      expect(marks[0].reason).toBe("codex-failed");
+      // The pre-fix shape: no retry-safe marker at all.
+      expect(marks[0].retrySafe).toBeUndefined();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   // D5: park is the stalled-signal + classification consumed by the daemon's
   // existing cool-down / needs-human machinery — there is NO `phase.<phase>.park`
   // canonical event. Assert neither the auth-park nor rate-park path emits one.

--- a/plugins/dev/scripts/execution-core/escalation-explanation.mjs
+++ b/plugins/dev/scripts/execution-core/escalation-explanation.mjs
@@ -194,6 +194,36 @@ export function coerceExplanation(fields, ctx = {}) {
     (TAUTOLOGY_RE.test(ctaNorm) || VAGUE_RE.test(ctaNorm) || DEFER_RE.test(ctaNorm));
   const ctaIsSameProblem = ctaNorm != null && ctaNorm === norm(rawProblem);
 
+  // CTL-1647: REFUSE to fabricate a human decision for a transient
+  // infrastructure cause. The degrade branches below invent options, a
+  // recommendation and a "priority call the agent cannot make unilaterally"
+  // rationale for ANY failure that arrives without a real explanation — but a
+  // provider 429/529 is not a priority call, it is capacity that comes back on
+  // its own. The primary fix is upstream (the terminal sweep backs off and
+  // re-arms the phase instead of parking it); this is the backstop for a
+  // transient park that still reaches the template, and it tells the human the
+  // TRUTH: the automatic window is spent, confirm it or re-dispatch it.
+  //
+  // ⚠️ Gated on the STRUCTURED reason field only — never on `problem` prose.
+  // escalation-explain.mjs and label-guard.mjs route agent-authored explanation
+  // text through here, so matching prose would silently rewrite a genuine human
+  // escalation that merely mentions "rate limit" into an all-clear.
+  //
+  // Scoped to the DECISION arm (ctx.canExecute !== true) on purpose: that is the
+  // arm label-guard hardcodes and the one the 41 tickets took, and `manual` is
+  // invalid under the anti-delegation guard when canExecute is true.
+  const transientReason =
+    type === "decision"
+      ? ([ctx.reason, fields.reason].find((c) => isTransientInfraReason(c)) ?? null)
+      : null;
+  if (transientReason !== null) {
+    return buildTransientExhaustedExplanation(
+      ticket,
+      transientReason,
+      typeof ctx.transientAttempts === "number" ? ctx.transientAttempts : 0,
+    );
+  }
+
   const degraded = { escalation_type: type, problem: rawProblem };
 
   if (type === "authorization") {
@@ -451,4 +481,139 @@ export function describeSignalReason(signal) {
   const r = resolveSignalReason(signal);
   if (r.status === "named") return r.reason;
   return r.status === "unreadable" ? "signal unreadable" : "no reason recorded";
+}
+
+// ── CTL-1647: transient infrastructure causes are NOT human decisions ────────
+//
+// A provider that returns 429/529 (overloaded / out of capacity / rate limited)
+// is a SYSTEM-level condition: it resolves by itself when capacity returns, and
+// the correct response is ONE fleet alert plus a bounded retry — never N
+// per-ticket human blocks. 41 of 79 tickets measured parked as "a human must
+// decide" on 2026-08-21 died exactly this way.
+//
+// This is a CLASSIFIER over the reason string only. The retry MECHANISM is the
+// existing one: the producer stamps `retrySafe: true` on the phase signal
+// (CTL-1679), recovery-reasoning's retry_safe_redispatch rule re-dispatches it
+// within the shared bounded budget, and an exhausted budget escalates with a
+// real coverage-gap explanation. Nothing new is invented here.
+
+/**
+ * The CLOSED SET of producer reason literals that name a transient
+ * provider/infrastructure condition. EXACT match only — deliberately NOT a
+ * substring/prose regex.
+ *
+ * ⚠️ This predicate feeds paths that SUPPRESS a human escalation, so a false
+ * positive is the same defect class this ticket fixes, pointed the other way: a
+ * genuine human escalation whose prose merely mentions "rate limit", "429" or
+ * "overloaded" (e.g. "the API client we're building has no rate limit handling")
+ * must NEVER be silently rewritten into "nothing is required". Agent-authored
+ * prose reaches `coerceExplanation` via escalation-explain.mjs and
+ * label-guard.mjs, so free-text matching here is unsafe by construction.
+ *
+ * Add a literal here only when a PRODUCER writes it as a signal reason.
+ */
+export const TRANSIENT_INFRA_REASONS = Object.freeze([
+  "sdk-overloaded-exhausted", // sdk-run-phase-agent.mjs 429/529 ladder exhausted
+  "codex-rate-park-exhausted", // codex-run-phase-agent.mjs rate-park exhausted
+]);
+const TRANSIENT_INFRA_SET = new Set(TRANSIENT_INFRA_REASONS);
+
+/**
+ * Is this failure/stall reason a transient infrastructure condition?
+ * Pure string predicate over the closed set above — never throws, false for
+ * anything that is not one of those exact literals.
+ */
+export function isTransientInfraReason(reason) {
+  if (typeof reason !== "string") return false;
+  return TRANSIENT_INFRA_SET.has(reason.trim().toLowerCase());
+}
+
+/**
+ * How long a transient signal is left alone before the normal escalation path
+ * is allowed to run. The suppression MUST be bounded: an unbounded skip turns a
+ * false page into a silently stranded ticket, which is strictly worse.
+ */
+export const TRANSIENT_ESCALATION_BACKOFF_MS = 30 * 60 * 1000; // 30 min
+
+/**
+ * Classify a phase signal as a transient-infrastructure park.
+ *
+ * @returns {{transient: boolean, reason: string|null, retrySafe: boolean,
+ *            withinBackoff: boolean, ageMs: number|null}}
+ *   `transient`     the reason is one of TRANSIENT_INFRA_REASONS
+ *   `retrySafe`     the producer stamped retrySafe:true (CTL-1679)
+ *   `withinBackoff` the signal is retry-safe AND recent enough that the bounded
+ *                   retry has not had its window yet — escalation may be SKIPPED
+ * Reads both the top level and `.raw` (the scheduler's projection nests the
+ * on-disk fields under `.raw` — the CTL-1754 trap).
+ *
+ * ⚠️ `withinBackoff` requires BOTH `retrySafe` and a READABLE timestamp:
+ *   - no `retrySafe` stamp → there is no route that re-dispatches the phase, so
+ *     suppressing the escalation would be a pure silent stall (Codex R1);
+ *   - an unreadable/absent `updatedAt` → the age can never advance, so treating
+ *     it as "fresh" would suppress the escalation on EVERY tick, forever
+ *     (Codex R2 P3). Both fall OUT of the window and escalate normally.
+ */
+export function classifyTransientSignal(
+  signal,
+  { now = Date.now(), backoffMs = TRANSIENT_ESCALATION_BACKOFF_MS } = {},
+) {
+  const absent = { transient: false, reason: null, retrySafe: false, withinBackoff: false, ageMs: null };
+  if (signal === null || signal === undefined || typeof signal !== "object") return absent;
+  const raw = signal.raw !== null && typeof signal.raw === "object" ? signal.raw : null;
+  const retrySafe = signal.retrySafe === true || raw?.retrySafe === true;
+  const { reason } = resolveSignalReason(signal);
+  const transient = isTransientInfraReason(reason);
+  if (!transient) return { ...absent, reason, retrySafe };
+
+  const stamp = signal.updatedAt ?? raw?.updatedAt ?? null;
+  const at = stamp ? Date.parse(stamp) : NaN;
+  const ageMs = Number.isFinite(at) ? Math.max(0, now - at) : null;
+  const withinBackoff = retrySafe && ageMs !== null && ageMs < backoffMs;
+  return { transient: true, reason, retrySafe, withinBackoff, ageMs };
+}
+
+/**
+ * CTL-1647: the explanation for a transient park that has ALREADY spent its
+ * automatic retry window. This is the ONLY transient wording, on purpose.
+ *
+ * The earlier draft of this fix emitted "No decision is required — it will
+ * re-dispatch itself", but every site that reaches an explanation has by then
+ * exhausted the bounded back-off (the terminal sweep re-arms up to N times
+ * before it escalates; recovery only escalates past its budget). Telling the
+ * human "nothing is required" on a ticket that demonstrably did NOT recover is
+ * a false all-clear — strictly worse than the false decision card it replaced.
+ *
+ * `manual` + blocked_capability + instructions is exactly the shape the operator
+ * inbox renders as ACT-THEN-CONFIRM (inbox-ask.mjs isValidatedManualEscalation),
+ * which is what this now genuinely is: check it, re-dispatch by hand if it is
+ * still parked. It still asks for NO priority/scope decision, and it names the
+ * fleet-level framing so N of these read as ONE incident.
+ */
+export function buildTransientExhaustedExplanation(ticket, reason, attempts = 0) {
+  const t = ticket ?? "this ticket";
+  const r = reason ?? "a transient provider-capacity condition";
+  return Object.freeze({
+    escalation_type: "manual",
+    transient: true,
+    problem:
+      `${t} stalled on a transient provider/infrastructure condition ("${r}") and its automatic ` +
+      `back-off window is spent (${attempts} automatic re-arm(s)). The provider being over capacity ` +
+      `says nothing about this ticket's work.`,
+    call_to_action:
+      `Check whether ${t} resumed once provider capacity returned; if it is still parked, re-dispatch it — ` +
+      `the automatic retry window has already passed.`,
+    blocked_capability:
+      `automatic recovery of ${t} from the provider-capacity condition "${r}" — the bounded back-off is spent`,
+    instructions: [
+      `Confirm whether ${t} re-dispatched on its own; if it is still parked, re-dispatch the failed phase`,
+      `If many tickets carry "${r}", treat it as ONE fleet provider-capacity incident — do NOT decide them one by one`,
+    ],
+    remediation_then_retry:
+      `wait for provider capacity to return, then re-dispatch ${t}'s failed phase`,
+    why_not_auto:
+      `the bounded automatic back-off for "${r}" ran ${attempts} time(s) without clearing ${t}, ` +
+      `so nothing re-dispatches it automatically any more`,
+    attempts: [{ reason: r, count: attempts }],
+  });
 }

--- a/plugins/dev/scripts/execution-core/monitor.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.mjs
@@ -113,6 +113,7 @@ import {
   removeLabel, // CTL-1481: worker:<host> swap (remove-before-add)
 } from "./linear-write.mjs";
 import { routeStuckTicketToDelegate } from "./delegate-first.mjs"; // CTL-1609
+import { classifyTransientSignal } from "./escalation-explanation.mjs"; // CTL-1647 (pure leaf)
 import { appendDelegateEvent as defaultAppendDelegateEvent } from "./delegate-event.mjs"; // CTL-1774
 import { appendTriageTransitionEvent as defaultAppendEvent } from "./triage-transition-event.mjs";
 import { countBackgroundAgents, resetLivenessCache } from "./claude-agents.mjs";
@@ -1211,6 +1212,25 @@ function dispatchTriage(
       noteTriageSkip(identifier, "triage-worker-in-flight"); // CTL-879
       return false;
     }
+    // CTL-1647 ROUTE C: repeated provider 429/529 overloads during triage burn the
+    // dispatch counter, and this site then parks the ticket with reason
+    // "triage-redispatch-cap" — a per-ticket human block for a fleet-level
+    // condition (45 live escalations in Aug 2026). While the triage signal is a
+    // FRESH, retry-safe transient park, defer instead. Bounded by the same
+    // TRANSIENT_ESCALATION_BACKOFF_MS window as the terminal sweep: once it
+    // expires (or the phase re-arms and fails for a real reason) the cap parks
+    // exactly as before.
+    const triageTransient = classifyTransientSignal(readTriageSignalRaw(orchDir, identifier));
+    if (triageTransient.transient && triageTransient.withinBackoff) {
+      log.warn(
+        { identifier, reason: triageTransient.reason, ageMs: triageTransient.ageMs },
+        "ctl-1647: triage cap reached on a TRANSIENT provider-capacity park — deferring the needs-human park"
+      );
+      noteTriageSkip(identifier, "triage-transient-provider-capacity", {
+        reason: triageTransient.reason,
+      });
+      return false;
+    }
     try {
       labelNeedsHuman(orchDir, identifier);
     } catch (err) {
@@ -1591,6 +1611,19 @@ function hasTriageArtifact(orchDir, ticket) {
 //       dying on a bad repoRoot). Re-arm by deleting
 //       workers/<t>/.triage-redispatch-capped + .triage-dispatch-count.json.
 export const TRIAGE_DISPATCH_CAP = Number(process.env.CATALYST_TRIAGE_DISPATCH_CAP) || 3;
+
+// CTL-1647: the RAW triage signal (not just its status) so the cap-park gate can
+// see a transient provider-capacity park. Absent/malformed → null (fail-open).
+export function readTriageSignalRaw(orchDir, ticket) {
+  try {
+    const sig = JSON.parse(
+      readFileSync(join(orchDir, "workers", ticket, "phase-triage.json"), "utf8")
+    );
+    return sig && typeof sig === "object" ? sig : null;
+  } catch {
+    return null;
+  }
+}
 
 export function readTriageSignalStatus(orchDir, ticket) {
   try {

--- a/plugins/dev/scripts/execution-core/monitor.test.mjs
+++ b/plugins/dev/scripts/execution-core/monitor.test.mjs
@@ -2024,6 +2024,66 @@ describe("triage re-dispatch guard (CTL-1441)", () => {
     expect(JSON.parse(readFileSync(join(realOrchDir, ".triage-dispatch-counts", "ENG-9.json"), "utf8")).cappedAt).toBeTruthy();
   });
 
+  // CTL-1647 ROUTE C: repeated provider 429/529 overloads during triage burn the
+  // dispatch counter, and this site then parked the ticket with reason
+  // "triage-redispatch-cap" — a per-ticket human block for a fleet-level
+  // condition (45 live escalations in Aug 2026, none of them a human decision).
+  const capWithTriageSignal = (realOrchDir, sig) => {
+    const dir = join(realOrchDir, "workers", "ENG-9");
+    mkdirSync(dir, { recursive: true });
+    mkdirSync(join(realOrchDir, ".triage-dispatch-counts"), { recursive: true });
+    writeFileSync(join(realOrchDir, ".triage-dispatch-counts", "ENG-9.json"), JSON.stringify({ count: 3 }));
+    writeFileSync(join(dir, "phase-triage.json"), JSON.stringify(sig));
+    reconcileAll({ exec: execReturning({ ENG: [node("ENG-9")] }) });
+  };
+
+  test("CTL-1647: a capped ticket parked on a TRANSIENT provider overload is NOT labelled needs-human", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    capWithTriageSignal(realOrchDir, {
+      status: "stalled",
+      attentionReason: "sdk-overloaded-exhausted",
+      retrySafe: true,
+      updatedAt: new Date().toISOString(),
+    });
+    const dispatch = mock(() => ({ code: 0 }));
+    const labelNeedsHuman = mock(() => {});
+    sweepMissingTriage(sweepOpts(realOrchDir, dispatch, labelNeedsHuman));
+    expect(labelNeedsHuman).not.toHaveBeenCalled();
+    expect(readFileSync(join(realOrchDir, ".triage-dispatch-counts", "ENG-9.json"), "utf8")).not.toContain("cappedAt");
+  });
+
+  // POSITIVE CONTROL 1 — a GENUINE settled failure at the cap still parks.
+  test("CTL-1647 POSITIVE CONTROL: a genuine failure at the cap STILL parks", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    capWithTriageSignal(realOrchDir, {
+      status: "failed",
+      failureReason: "ended-without-declaration",
+      updatedAt: new Date().toISOString(),
+    });
+    const dispatch = mock(() => ({ code: 0 }));
+    const labelNeedsHuman = mock(() => {});
+    sweepMissingTriage(sweepOpts(realOrchDir, dispatch, labelNeedsHuman));
+    expect(labelNeedsHuman).toHaveBeenCalledTimes(1);
+  });
+
+  // POSITIVE CONTROL 2 — the deferral is BOUNDED: an aged transient park still parks.
+  test("CTL-1647 POSITIVE CONTROL: an AGED transient park at the cap parks normally", () => {
+    enroll("ENG", { status: "Ready" });
+    const realOrchDir = join(catalystDir, "execution-core");
+    capWithTriageSignal(realOrchDir, {
+      status: "stalled",
+      attentionReason: "sdk-overloaded-exhausted",
+      retrySafe: true,
+      updatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    });
+    const dispatch = mock(() => ({ code: 0 }));
+    const labelNeedsHuman = mock(() => {});
+    sweepMissingTriage(sweepOpts(realOrchDir, dispatch, labelNeedsHuman));
+    expect(labelNeedsHuman).toHaveBeenCalledTimes(1);
+  });
+
   test("(R4) a SATURATED fleet still parks a capped ticket (park is capacity-independent)", () => {
     enroll("ENG", { status: "Ready" });
     const realOrchDir = join(catalystDir, "execution-core");

--- a/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
+++ b/plugins/dev/scripts/execution-core/recovery-reasoning.mjs
@@ -91,6 +91,7 @@ const LINEAR_COMMENT_POST_BIN = fileURLToPath(
   new URL("../lib/linear-comment-post.sh", import.meta.url),
 );
 import { postLinearCommentAsSpawnResult } from "./linear-comment-write.mjs"; // CTL-1889 inc 2
+import { isTransientInfraReason } from "./escalation-explanation.mjs"; // CTL-1647 (pure leaf — no cycle)
 
 // phase-agent-emit-complete — the canonical wake/synthetic-complete emitter, used
 // by the CTL-1186 phase-pr re-dispatch to nudge the scheduler after re-arming.
@@ -1062,7 +1063,16 @@ export function defaultClassifyTicket(evidence, opts = {}) {
   // unrecognized coverage gap. An unrecognized UNSAFE failure (no retrySafe) skips
   // this rule entirely and falls through to Rule 3's immediate escalate (unchanged).
   if (evidence.retrySafe === true) {
-    const reason = effectiveFailureReason ?? "unrecognized-retry-safe";
+    // CTL-1647: the SDK/codex overload backstop records its cause as
+    // `attentionReason` (a `failureReason` trips revive Loop 2's escalate branch),
+    // so read it as a LAST fallback here — otherwise every transient-capacity
+    // redispatch is logged as the anonymous "unrecognized-retry-safe". Naming only:
+    // the routing below is unchanged.
+    const reason =
+      effectiveFailureReason ??
+      signal?.attentionReason ??
+      evidence.attentionReason ??
+      "unrecognized-retry-safe";
     const phase = signal?.phase;
     const budget = retrySafeBudgetDecision(ticket, { readIntentAttempts });
     if (budget.retry) {
@@ -1073,6 +1083,31 @@ export function defaultClassifyTicket(evidence, opts = {}) {
           reason: `retry-safe failure "${reason}" (attempt ${budget.attempts + 1}/${RECOVERY_MAX_ATTEMPTS}); re-dispatching`,
           seam_id: "fence-stale-redispatch",
           ...(phase !== undefined ? { phase } : {}),
+        },
+      };
+    }
+    // CTL-1647 ROUTE A / A': a TRANSIENT provider-capacity cause must never reach
+    // this escalate. Two independent ways it did:
+    //   A  — RECOVERY_MAX_ATTEMPTS defaults to 2 and the redispatch fires on the
+    //        next tick with NO delay, so a real 429/529 storm burned both attempts
+    //        inside ~3 minutes and parked the ticket while the provider was still
+    //        down. The whole 41-ticket scenario reproduced, just 3 minutes later.
+    //   A' — `attempts` is the ticket's GENERIC recovery-intent counter, bumped by
+    //        every unrelated prior fix (bounded-llm, orphan_stale, …). A ticket
+    //        already at attempts>=2 got ZERO retries: the FIRST overload classified
+    //        straight to escalate → needs-human.
+    // The bounded back-off + re-arm for this cause is owned by the scheduler's
+    // terminal sweep (maybeRearmTransientSignal), which is wall-clock spaced,
+    // cause-scoped, and — unlike this pass — not behind the recovery-pass
+    // feature flag. Defer (cooldown-only, NO escalated latch, no needs-human).
+    if (isTransientInfraReason(reason)) {
+      return {
+        decision: "defer",
+        fix_class: "board-health",
+        details: {
+          reason:
+            `transient provider-capacity failure "${reason}" — a system-level condition, not a ` +
+            `per-ticket human decision; the terminal sweep owns its bounded back-off (CTL-1647)`,
         },
       };
     }
@@ -2058,6 +2093,12 @@ export function defaultInvokeSeam(ticket, seamId, brief = {}, deps = {}) {
       sig.status = "pending";
       delete sig.failureReason;
       delete sig.retrySafe;
+      // CTL-1647 (Codex R2/R3): ALSO clear attentionReason. It is the third key
+      // resolveSignalReason reads, and it is where the overload backstop stores its
+      // cause — a later writer that stamps `status:"stalled"` without its own reason
+      // would let this stale "sdk-overloaded-exhausted" resolve on a FRESH updatedAt
+      // and buy an unrelated failure another transient back-off window.
+      delete sig.attentionReason;
       const tmp = `${signalPath}.tmp.${process.pid}`;
       writeFileSync(tmp, JSON.stringify(sig, null, 2));
       renameSync(tmp, signalPath);

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -466,7 +466,140 @@ import {
   coerceExplanation,
   describeSignalReason,
   resolveSignalReason,
-} from "./escalation-explanation.mjs"; // CTL-1130, CTL-1754
+  classifyTransientSignal,
+  buildTransientExhaustedExplanation,
+} from "./escalation-explanation.mjs"; // CTL-1130, CTL-1754, CTL-1647
+
+// ── CTL-1647: bounded back-off + self re-arm for a transient provider park ───
+//
+// A provider 429/529 is a SYSTEM-level condition. The correct response is ONE
+// fleet alert plus a delayed retry — never N per-ticket human blocks.
+//
+// This lives HERE, in the terminal sweep, and not only in the recovery pass, for
+// three measured reasons:
+//   1. The recovery pass is behind `catalyst.recoveryPass.mode`, which defaults
+//      to "off" and runs in "shadow" on part of the live fleet. On those hosts a
+//      recovery-only fix is a delay, not a fix — the sweep still parks the ticket.
+//   2. The recovery budget (RECOVERY_MAX_ATTEMPTS, default 2) is the ticket's
+//      GENERIC attempt counter and can already be spent by unrelated prior fixes,
+//      giving a transient cause ZERO retries.
+//   3. Nothing on the recovery path DELAYS the redispatch — it re-fires on the
+//      next tick into a provider that is still returning 529, so both attempts
+//      are consumed against the same outage. The re-arm below is wall-clock
+//      spaced, and the counter is stored ON THE SIGNAL, so it is cause-scoped.
+//
+// Bounded on purpose: after TRANSIENT_MAX_REARMS re-arms the sweep escalates with
+// buildTransientExhaustedExplanation — a truthful "the automatic window is spent"
+// card, not a silent stall (which would be strictly worse than a false page).
+
+/** Wall-clock delay between transient re-arms. Env-overridable (NaN/0 → default). */
+export const TRANSIENT_REARM_DELAY_MS =
+  Number(process.env.CATALYST_TRANSIENT_REARM_DELAY_MIN) * 60 * 1000 || 5 * 60 * 1000;
+
+/** How many times a single transient park may re-arm itself before escalating. */
+export const TRANSIENT_MAX_REARMS = Number(process.env.CATALYST_TRANSIENT_MAX_REARMS) || 3;
+
+/** Where the cause-scoped re-arm counter lives (it must OUTLIVE the signal file). */
+export function transientRearmMarkerPath(orchDir, ticket, phase) {
+  return join(orchDir, "workers", ticket, `.transient-rearms-${phase}.json`);
+}
+
+/**
+ * maybeRearmTransientSignal — back off, then RE-ARM a transient-parked phase so
+ * the normal dispatch path launches it again.
+ *
+ * ⚠️ Re-arming means DELETING the terminal signal, not rewriting it to
+ * `pending`. `deriveAdvancement` advances only when the latest LIVE phase is
+ * `done`; a `pending` implement signal makes implement the latest live phase and
+ * returns null — the ticket would sit pending forever, a silent stall. Dropping
+ * the signal makes the previous `done` phase latest again, so the FSM re-derives
+ * this phase as next and dispatches it. This is the same reset the
+ * verify⇄remediate cycle uses (REMEDIATE_CYCLE_FILES).
+ *
+ * Because the signal goes away, the attempt counter lives in its own marker file
+ * next to it — cause-scoped (per ticket+phase), unlike the recovery-intent
+ * ledger's ticket-wide counter, which unrelated prior fixes can pre-exhaust.
+ *
+ * @returns {{handled: boolean, action: string, attempts: number, ageMs: number|null}}
+ *   handled:true  → the sweep must NOT escalate this tick ("waiting" | "rearmed")
+ *   handled:false → fall through to the normal escalation ("exhausted" | …)
+ */
+export function maybeRearmTransientSignal(
+  orchDir,
+  ticket,
+  signal,
+  {
+    now = Date.now(),
+    delayMs = TRANSIENT_REARM_DELAY_MS,
+    maxRearms = TRANSIENT_MAX_REARMS,
+    log: logArg = null,
+  } = {},
+) {
+  const raw =
+    signal?.raw !== null && typeof signal?.raw === "object" ? signal.raw : (signal ?? {});
+  const phase = raw.phase ?? signal?.phase ?? null;
+  const stamp = signal?.updatedAt ?? raw.updatedAt ?? null;
+  const at = stamp ? Date.parse(stamp) : NaN;
+  const ageMs = Number.isFinite(at) ? Math.max(0, now - at) : null;
+  if (phase === null) return { handled: false, action: "no-phase", attempts: 0, ageMs };
+
+  const markerPath = transientRearmMarkerPath(orchDir, ticket, phase);
+  let attempts = 0;
+  try {
+    const m = JSON.parse(readFileSync(markerPath, "utf8"));
+    if (Number.isFinite(m?.count)) attempts = m.count;
+  } catch {
+    attempts = 0; // absent/malformed → never re-armed
+  }
+
+  if (attempts >= maxRearms) return { handled: false, action: "exhausted", attempts, ageMs };
+  const signalPath = signal?.signalPath ?? null;
+  if (!signalPath || !existsSync(signalPath)) {
+    return { handled: false, action: "no-signal-file", attempts, ageMs };
+  }
+  // An unreadable/absent timestamp cannot age, so it must NOT hold the ticket in
+  // "waiting" forever — fall straight through to the (bounded) re-arm.
+  if (ageMs !== null && ageMs < delayMs) {
+    return { handled: true, action: "waiting", attempts, ageMs };
+  }
+  try {
+    // (1) bump the counter FIRST. If anything below throws we have still spent an
+    // attempt — the bound must never be able to leak into an unbounded retry loop.
+    const tmpMarker = `${markerPath}.tmp.${process.pid}`;
+    writeFileSync(
+      tmpMarker,
+      JSON.stringify({ count: attempts + 1, lastAt: new Date(now).toISOString(), phase }),
+    );
+    renameSync(tmpMarker, markerPath);
+    // (2) drop the stale claim tombstone — a leftover collides on the next O_EXCL
+    // claim create and silently stalls the re-dispatch ("claim-lost").
+    let gen = null;
+    try {
+      gen = JSON.parse(readFileSync(signalPath, "utf8"))?.generation ?? null;
+    } catch {
+      gen = null;
+    }
+    if (gen !== null && gen !== undefined) {
+      try {
+        rmSync(join(orchDir, "workers", ticket, `phase-${phase}.claim.${gen}`), { force: true });
+      } catch {
+        /* best-effort — a leftover tombstone is the very thing we're clearing */
+      }
+    }
+    // (3) drop the terminal signal so deriveAdvancement re-derives this phase.
+    rmSync(signalPath, { force: true });
+    // (4) clear the dispatch cooldown so a 30-min window doesn't suppress the retry.
+    try {
+      rmSync(join(orchDir, ".dispatch-cooldowns", `${ticket}-${phase}.json`), { force: true });
+    } catch {
+      /* best-effort — a stale marker just suppresses one re-dispatch */
+    }
+    return { handled: true, action: "rearmed", attempts: attempts + 1, ageMs };
+  } catch (err) {
+    logArg?.warn?.({ ticket, err: err?.message }, "ctl-1647: transient re-arm failed");
+    return { handled: false, action: "rearm-failed", attempts, ageMs };
+  }
+}
 
 // The last pipeline phase — its `done` signal means the whole pipeline
 // finished. `done` is otherwise phase-dependent: a `triage: done` signal still
@@ -9291,29 +9424,71 @@ export function schedulerTick(
             // alone — a key present on 0 of 44 live failed/stalled signals — so
             // every card said "(no reason)" while the reason sat in the same file.
             const stalledReason = resolveSignalReason(stalledSig);
-            const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
-              site: "terminal-sweep",
-              reason: stalledReason.reason ?? "stalled",
-              boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
-              applyLabel: writeStatus,
-              env,
-              log,
-              appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
-              explanation: {
-                problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${describeSignalReason(stalledSig)}) and is not terminal`,
-                call_to_action: `decide whether to retry ${ticket} or close it`,
-              },
-              // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
-              // terminal-sweep cohort cannot enqueue past maxParallel.
-              deps: { orchDir, maxParallel },
-            });
-            // CTL-764 finding 8: emit worker.transition ONLY when the label write
-            // actually occurred. A persisted .linear-label-needs-human marker after a
-            // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
-            // label — recording a fresh needs-human transition there is a false escalation.
-            if (tsResult.labelled === true) {
-              recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
-            }
+            // CTL-1647: a TRANSIENT provider condition (429/529 overload, rate
+            // park) is a system-level fact, not a per-ticket human decision. The
+            // producer stamps `retrySafe`; instead of parking the ticket we back
+            // off and re-arm the phase HERE — the one path that runs regardless of
+            // the recovery-pass feature flag, with a wall-clock delay and a
+            // cause-scoped attempt counter (see maybeRearmTransientSignal).
+            //
+            // BOUNDED: past TRANSIENT_MAX_REARMS we DO escalate — with a truthful
+            // "the automatic window is spent, confirm or re-dispatch" card instead
+            // of the fabricated "decide whether to retry, hand off, or cancel".
+            // An unbounded skip turns a false page into a silently stranded ticket,
+            // which is strictly worse.
+            const transient = classifyTransientSignal(stalledSig, { now: now() });
+            const rearm =
+              transient.transient && transient.retrySafe
+                ? maybeRearmTransientSignal(orchDir, ticket, stalledSig, { now: now(), log })
+                : null;
+            if (rearm?.handled === true) {
+              // ONE fleet-level line, not a per-ticket human block. The producer
+              // already emitted execution-core.sdk.overloaded — that is the fleet
+              // alert; this records the per-ticket back-off decision only.
+              log.warn(
+                {
+                  ticket,
+                  reason: transient.reason,
+                  action: rearm.action,
+                  attempts: rearm.attempts,
+                  ageMs: rearm.ageMs,
+                },
+                "ctl-1647: transient provider-capacity park — backing off / re-arming, NOT parking needs-human",
+              );
+            } else {
+              const tsResult = routeStuckTicketToDelegate(orchDir, ticket, {
+                site: "terminal-sweep",
+                reason: stalledReason.reason ?? "stalled",
+                boardContext: { status: stalledSig?.status, phase: stalledSig?.phase },
+                applyLabel: writeStatus,
+                env,
+                log,
+                appendEvent: (evt) => appendDelegateEvent({ ...evt, orchId: ticket }), // CTL-1774
+                explanation: transient.transient
+                  ? // CTL-1647: the transient park DID exhaust its automatic window.
+                    // Say exactly that — never "no decision is required", which on a
+                    // still-parked ticket is a false all-clear.
+                    buildTransientExhaustedExplanation(
+                      ticket,
+                      transient.reason,
+                      rearm?.attempts ?? 0,
+                    )
+                  : {
+                      problem: `${ticket} has a ${stalledSig?.status ?? "stalled"} phase signal (${describeSignalReason(stalledSig)}) and is not terminal`,
+                      call_to_action: `decide whether to retry ${ticket} or close it`,
+                    },
+                // CTL-1609 (Codex P1): thread the tick's resolved ceiling so a large
+                // terminal-sweep cohort cannot enqueue past maxParallel.
+                deps: { orchDir, maxParallel },
+              });
+              // CTL-764 finding 8: emit worker.transition ONLY when the label write
+              // actually occurred. A persisted .linear-label-needs-human marker after a
+              // daemon restart (labelOnce no-ops) or a belief-owner deferral changes no
+              // label — recording a fresh needs-human transition there is a false escalation.
+              if (tsResult.labelled === true) {
+                recordTransition({ ticket, toDisposition: "needs-human", source: "terminal-sweep" });
+              }
+            } // CTL-1647: end of the non-transient escalation branch
           } else {
             log.warn(
               { ticket, reason: fenceVerdict?.reason ?? null },

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.mjs
@@ -305,7 +305,7 @@ function defaultEmitEvent(name, payload) {
 // --no-signal-update so the skill/pre-launch keeps ownership of the signal file).
 // Best-effort; never throws.
 export function defaultEmitBackstop(
-  { phase, ticket, status, reason, orchDir, signalFile, orchestrator },
+  { phase, ticket, status, reason, orchDir, signalFile, orchestrator, retrySafe = false },
   {
     spawn = spawnSync,
     writeSignalStalled = defaultWriteSignalStalled,
@@ -325,11 +325,23 @@ export function defaultEmitBackstop(
   // write here would mislabel a max-turns outcome as operator-stalled even though
   // the event stream says turn-cap-exhausted. Every other abnormal backstop
   // (failed / overloaded-exhausted) still writes "stalled".
+  //
+  // CTL-1647: `retrySafe` rides onto BOTH writes below. A transient provider
+  // condition (429/529 overload) is still written terminal — leaving the signal
+  // in-flight is the CTL-1367 item-4 regression — but it is written as a
+  // RETRY-SAFE terminal, which is the existing CTL-1679 vocabulary: recovery
+  // reasoning's retry_safe_redispatch rule re-dispatches it inside the shared
+  // bounded budget instead of parking it for a human. Signal and event must
+  // carry the same flag or the two records desync (the P2-F trap above).
   if (signalFile) {
     if (status === "turn-cap-exhausted") {
-      writeSignalTerminal(signalFile, "turn-cap-exhausted", reason);
+      // CTL-1647 (Codex R2 note): a turn-cap exhaustion is NEVER retry-safe — the
+      // agent burned its whole turn budget, which is a verdict about the WORK, not
+      // an infrastructure condition. Hard-coded false so no future caller can
+      // declare it transient by threading the flag through this shared backstop.
+      writeSignalTerminal(signalFile, "turn-cap-exhausted", reason, { retrySafe: false });
     } else {
-      writeSignalStalled(signalFile, reason);
+      writeSignalStalled(signalFile, reason, { retrySafe });
     }
   }
 
@@ -359,6 +371,9 @@ export function defaultEmitBackstop(
     "--no-signal-update",
   ];
   if (reason) args.push("--reason", reason);
+  // CTL-1647 / CTL-1679: the same retry_safe payload the fence guard stamps, so
+  // the emitted event matches the signal the writer above left on disk.
+  if (retrySafe) args.push("--payload-json", '{"retry_safe":true}');
   let res;
   try {
     res = spawn(EMIT_COMPLETE_BIN, args, { encoding: "utf8" });
@@ -452,7 +467,13 @@ const SIGNAL_TERMINAL_STATUSES = new Set([
 // terminal event (a turn-cap-exhausted backstop must leave "turn-cap-exhausted", not
 // "stalled"; the terminal sweep applies needs-human only to stalled/failed). The P3
 // terminal-clobber guard and the atomic tmp+rename are shared by every status.
-function defaultWriteSignalTerminal(signalFile, status, reason) {
+// CTL-1647: `opts.retrySafe` stamps the CTL-1679 `retrySafe:true` flag onto the
+// terminal signal. It is the ONE existing marker that says "this terminal is an
+// infrastructure condition, not a verdict about the work" — recovery-reasoning's
+// retry_safe_redispatch rule re-dispatches such a signal inside the shared
+// bounded budget (and the redispatch seam clears the flag again), so a provider
+// 429/529 backs off and resumes by itself instead of parking for a human.
+function defaultWriteSignalTerminal(signalFile, status, reason, { retrySafe = false } = {}) {
   try {
     let sig;
     try {
@@ -468,6 +489,9 @@ function defaultWriteSignalTerminal(signalFile, status, reason) {
     sig.attentionReason = reason || "sdk-backstop";
     // CTL-1789: record WHO asserted this terminal. Infrastructure, not the agent.
     sig.assertedBy = ASSERTED_BY.SDK_BACKSTOP;
+    // CTL-1647: only ever SET the flag — never delete an existing one, so this
+    // writer cannot downgrade a retry-safe terminal another producer stamped.
+    if (retrySafe) sig.retrySafe = true;
     sig.updatedAt = ts;
     sig.phaseTimestamps = { ...(sig.phaseTimestamps ?? {}), [status]: ts };
     // ⚠️ CTL-1854: strip the yield anchors on ANY non-yield terminal. This writer
@@ -502,8 +526,8 @@ function defaultWriteSignalTerminal(signalFile, status, reason) {
 // stalled" writer instead of duplicating the atomic tmp+rename + P3
 // terminal-clobber guard. Its closure deps (defaultWriteSignalTerminal,
 // SIGNAL_TERMINAL_STATUSES) travel with it.
-export function defaultWriteSignalStalled(signalFile, reason) {
-  return defaultWriteSignalTerminal(signalFile, "stalled", reason);
+export function defaultWriteSignalStalled(signalFile, reason, opts = {}) {
+  return defaultWriteSignalTerminal(signalFile, "stalled", reason, opts);
 }
 
 // CTL-1410 Phase A: the SDK success-branch signal flip. When query() resolves
@@ -1328,7 +1352,13 @@ export async function sdkRunPhaseAgent(
         emitEvent("execution-core.sdk.overloaded", {
           ticket, phase, attempt: i, exhausted: true, status: statusOf(lastOverload),
         });
-        emitBackstop({ phase, ticket, status: "failed", reason: "sdk-overloaded-exhausted", orchDir, signalFile }, { spawn });
+        // CTL-1647: RETRY-SAFE terminal, not a human block. The provider being at
+        // capacity says nothing about this ticket — 41 of 79 tickets parked as "a
+        // human must decide" on 2026-08-21 died exactly here. The terminal write
+        // stays (CTL-1367 item 4: an in-flight signal strands the worker forever),
+        // but `retrySafe` routes it to the CTL-1679 bounded redispatch instead of
+        // the terminal sweep's needs-human label.
+        emitBackstop({ phase, ticket, status: "failed", reason: "sdk-overloaded-exhausted", orchDir, signalFile, retrySafe: true }, { spawn });
         return {
           code: 1,
           stdout: "",

--- a/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
+++ b/plugins/dev/scripts/execution-core/sdk-run-phase-agent.test.mjs
@@ -821,6 +821,44 @@ describe("sdkRunPhaseAgent — 429/529 backoff", () => {
     expect(backstops[0].reason).toBe("sdk-overloaded-exhausted");
   });
 
+  // CTL-1647: the exhaustion backstop must declare itself RETRY-SAFE. Without
+  // this the terminal it writes is indistinguishable from a genuine dead end and
+  // the terminal sweep parks the ticket for a human (41 of 79 false escalations
+  // measured 2026-08-21). This asserts the PRODUCTION CALL SITE, not just the
+  // plumbing — deleting `retrySafe: true` at sdk-run-phase-agent.mjs's overload
+  // branch fails here.
+  test("CTL-1647: backoff exhaustion marks the backstop retrySafe (transient, not terminal-failure)", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const runQuery = () =>
+      (async function* () { yield resultMsg({ subtype: "error", is_error: true, api_error_status: 429 }); })();
+    await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      sleep: () => Promise.resolve(),
+      maxRetries: 1,
+      backoff: { baseMs: 1, capMs: 2 },
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(backstops[0].reason).toBe("sdk-overloaded-exhausted");
+    expect(backstops[0].retrySafe).toBe(true);
+  });
+
+  // POSITIVE CONTROL for the test above: a GENUINE failure backstop must NOT be
+  // retry-safe, so the assertion above is discriminating rather than vacuous.
+  test("CTL-1647 POSITIVE CONTROL: a thrown (non-transient) failure is NOT retrySafe", async () => {
+    const { spawn } = spawnReturningSpec();
+    const backstops = [];
+    const runQuery = () =>
+      (async function* () { throw new Error("boom"); })();
+    await sdkRunPhaseAgent(ARGS, {
+      ...GOOD_AUTH, spawn, runQuery,
+      sleep: () => Promise.resolve(),
+      emitBackstop: (e) => backstops.push(e),
+    });
+    expect(backstops[0].reason).toBe("sdk-threw");
+    expect(backstops[0].retrySafe).toBeUndefined();
+  });
+
   test("a 200 success does NOT retry", async () => {
     const { spawn } = spawnReturningSpec();
     let attempt = 0;


### PR DESCRIPTION
Fixes CTL-1647.

## The bug, in plain English

When the AI provider is overloaded it returns 429/529. The worker retries a
few times, gives up, and — this is the defect — records "the provider was
busy" as a **terminal failure of the ticket**. A terminal failure escalates,
so the ticket gets labelled `needs-human` and a human is asked to "decide
whether to retry, hand off, or cancel."

But there is nothing to decide. The provider being at capacity says nothing
about that ticket's work, and capacity comes back on its own. A system-level
problem (provider down, out of capacity, rate limited) should be **one fleet
alert**, never N per-ticket human blocks.

Worse, the escalation text was **fabricated**. `coerceExplanation`'s degrade
branch invents a decision card — canned options, a recommendation, and "a
priority call the agent cannot make unilaterally" — for any failure that
arrives without a real explanation. So a human opened a ticket that claimed
to need their judgment, about a decision that never existed.

## Measured impact

**2026-08-21: 79 tickets across two fleet hosts were parked as "a human must
decide" when nothing needed a human. 41 of those 79 — over half — died
exactly this way.**

## What changed

Five seams, all in `plugins/dev/scripts/execution-core/`.

**1. The producers (`sdk-run-phase-agent.mjs`, `codex-run-phase-agent.mjs`)** —
the 429/529 backstops still write a *terminal* signal, because leaving it
in-flight strands the worker forever (the CTL-1367 item-4 regression), but
they now write a **retry-safe** terminal: `retrySafe: true` on the signal
**and** `--payload-json '{"retry_safe":true}'` on the emitted event, so the
two records cannot desync. `retrySafe` is not a new mechanism — it is the
existing CTL-1679 vocabulary; this adds two producers to it.
`turn-cap-exhausted` is hard-coded **not** retry-safe: burning a turn budget
is a verdict about the work, not an infrastructure condition.

**2. The terminal sweep (`scheduler.mjs`)** — the sweep now owns the back-off
itself. `maybeRearmTransientSignal()` waits a wall-clock delay (5 min), then
drops the claim tombstone, the terminal signal and the dispatch cooldown so
`deriveAdvancement` re-derives the phase and dispatches it again. Bounded at
3 re-arms by a **cause-scoped** counter in
`workers/<T>/.transient-rearms-<phase>.json`, which outlives the signal.

This lives in the sweep, not only in the recovery pass, for three measured
reasons: the recovery pass is behind `catalyst.recoveryPass.mode` (defaults
`"off"`, and part of the live fleet runs `"shadow"`), so a recovery-only fix
would be a delay rather than a fix on those hosts; its budget is the
ticket's **generic** attempt counter, which unrelated prior fixes can
pre-exhaust, giving a transient cause zero retries; and nothing on that path
**delays** the redispatch, so both attempts burn against the same outage.

> ⚠️ Re-arming **deletes** the signal rather than rewriting it to `pending`.
> `deriveAdvancement` advances only when the latest live phase is `done`, so
> a pending signal makes that phase latest and returns `null` — a silent
> stall. This was proven with a direct `schedulerTick` probe and there is a
> test for it.

**3. The explanation (`escalation-explanation.mjs`)** — `coerceExplanation`'s
degrade branch refuses to fabricate a decision for a transient cause. Past
the budget it emits `buildTransientExhaustedExplanation`: a truthful "the
automatic window is spent — confirm it resumed, otherwise re-dispatch",
which is a genuine act-then-confirm and renders as one. The classifier is an
**exact-match closed set** of the two producer literals, keyed off the
structured reason field only — **never `problem` prose**. Matching prose
would rewrite a genuine escalation that merely mentions "rate limit" into an
all-clear, which is this same defect pointed the other way.

**4. `monitor.mjs`** — the `triage-redispatch-cap` park (45 live escalations
in August) defers while the triage signal is a fresh retry-safe transient
park, bounded by the same window.

**5. `recovery-reasoning.mjs`** — a transient cause at budget end returns
`defer` (cooldown only, no latch) instead of `escalate`/`human`;
`fence-stale-redispatch` also clears `attentionReason` on reset so a stale
cause cannot buy an unrelated failure another window.

## Test evidence

**39 new tests** across two `__tests__` files plus the sdk / codex / monitor
suites, covering all four steps of the chain.

**Positive controls** — every assertion is paired with one asserting the
**pre-fix** shape, so the suite proves the change is discriminating and not
just permissive:

- a non-transient backstop writes **no** `retrySafe`
- a genuine `ended-without-declaration` failure is not transient and **still
  escalates**
- a transient park **without** the `retrySafe` stamp still parks (no route
  to redispatch ⇒ no suppression)
- an aged / budget-spent transient park **still escalates**
- agent prose mentioning "rate limit" / "429" / "overloaded" **still gets the
  decision card**
- the CTL-1679 coverage-gap ask is **not** rewritten

**Mutation testing** — every load-bearing line was reverted in place and the
suite re-run; each mutation turned tests red, and all were restored:

| mutation | result |
|---|---|
| sweep gate → `if (false && …)` | 3–4 fail in `ctl-1647-scheduler-transient-gate` |
| back-off delay → `if (false)` | 2 fail (incl. the actuator ladder test) |
| codex `retrySafe: true` removed | 1 fail in `codex-run-phase-agent.test.mjs` |
| recovery transient defer → `if (false && …)` | 1 fail in `ctl-1647-transient-overload-not-human` |
| monitor cap gate → `if (false && …)` | 1 fail in `monitor.test.mjs` |

**Regression check** — the full `execution-core` suite was run twice, once
with the change and once against a `git stash` baseline of clean
`origin/main`:

- **after:** 11473 tests, 11402 pass, 70 fail
- **before (baseline):** 11434 tests, 11363 pass, 70 fail

The failing-test **name sets are byte-identical** (`comm` diff on both sides
is empty), so all 70 failures are pre-existing on `main` and **zero were
introduced**. The 39 added tests all pass. Bash
`phase-agent-emit-complete.test.sh`: 111/111. `node --check` clean on all
five modified production files.

## Deliberately out of scope

- **A dedicated provider-capacity alert kind.**
  `execution-core.sdk.overloaded {exhausted:true}` is already emitted at the
  exhaustion point and `dispatch-alert.mjs` already throttles per-kind at
  60s, which is the "one alert, not N" behaviour. Wiring a new
  `ALERT_KIND_*` needs a consumer decision and would pull an alert
  dependency into the worker process.
- **`coerceExplanation`'s authorization arm.** The refusal is scoped to the
  `decision` arm, which is the arm `label-guard.mjs` hardcodes and the one
  all 41 tickets took; `manual` is invalid under the anti-delegation guard
  when `canExecute` is true.
- **`label-guard.mjs`'s ordering.** It applies the Linear label *before*
  coercing the explanation, so nothing in the template could ever have
  un-parked a ticket. The fix is upstream.
- **The 79 already-parked tickets.** This is the code fix only — no backfill
  or label retraction.

**One accepted residual:** the re-arm counter is never reset on a later
success, so a phase hit by three *separate* provider outages across its life
escalates on the fourth. That errs toward paging rather than stranding,
which is the direction the bounded-window argument wants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
