### PR TITLE
docs(dev): CTL-2147 — correct stale armSecret claim, wire new tests into CI

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -322,6 +322,29 @@ jobs:
         working-directory: .
         run: bash plugins/dev/scripts/__tests__/catalyst-account-usage-page.test.sh
 
+      - name: claude-account switch/sync + --soft rotation test (CTL-1650 / CTL-2147)
+        # ⛔ PINNED DELIBERATELY (same reason as the suites around it): CI runs an EXPLICIT list of
+        # shell suites, not a glob runner, so an unpinned suite runs only in the local full gate.
+        # This one is entirely hermetic — no real sops/git/network/daemon — see the file's own
+        # header comment.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
+
+      - name: execution-core CLI noun/verb routing test (CTL-649 / CTL-2147)
+        # Backcompat daemon aliases, the `daemon` noun, the `sessions`/`worktrees`/`branches` audit
+        # routes, and (CTL-2147) the `rearm` verb — including its success path against a fake
+        # SIGHUP-trapping process, not just its "daemon not running" failure path.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/execution-core-cli-routing.test.sh
+
+      - name: architecture.md armSecret-claim guard (CTL-2147)
+        # docs/architecture.md is @-imported in full at every agent session start, so a stale claim
+        # there actively misleads the next agent. Grep guard + positive control (daemon.mjs really
+        # does still call armSecret 3+ times) so this fails loudly if the callers are ever removed
+        # rather than silently blessing a doc that would then be correct again.
+        working-directory: .
+        run: bash plugins/dev/scripts/__tests__/architecture-armsecret-claim.test.sh
+
       - name: archive + uninstall test (CTL-1975)
         # ⛔ PINNED DELIBERATELY, and the reason is the PR that added it. CI runs an EXPLICIT list
         # of shell suites — there is no glob runner and no run-tests.sh here — so a suite that is
@@ -1429,6 +1452,7 @@ jobs:
             service-manifest.test.mjs \
             github-auth-preflight.test.mjs \
             claude-accounts-rearm.test.mjs \
+            daemon-signals.test.mjs \
             github-token-candidates-legacy-parity.test.mjs \
             github-quota.test.mjs \
             github-quota-timer.test.mjs \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -512,9 +512,23 @@ than one that structurally can't) reports it when a caller invokes `armSecret` a
 value has changed since the PROCESS's last `armSecret` observation for that id (`_lastArmedValue` is
 module-level, one baseline per secret id shared by every caller in the process — caller B observing
 a rotation resets what caller A sees) — a caller-invoked report, not an automatic one fired the
-moment the value changes. No production call site invokes `armSecret` today (a repo-wide search
-outside tests finds only the definition and a comment reference in `linear-remint.mjs`), so this
-reporting is not yet wired to any running daemon.
+moment the value changes. `armSecret` has three live production call sites, all in
+`execution-core/daemon.mjs`: a boot-time arm of `github-token` (`:1363`), and two calls on the
+periodic `_clusterSyncTimer` tick (`:2140` `github-token`, `:2143` `claude-accounts.env`). The
+`claude-accounts.env` row is `re-armable`/`timer` with **no boot-time arm** — its only historical
+trigger was that 5-minute timer, until CTL-2147 added `SIGHUP` as an on-demand trigger for the same
+row (see "Phase-Agent Communication" → `catalyst-stack claude-account switch/sync --soft` below).
+
+**Soft claude-account rotation (CTL-2147).** `catalyst-stack claude-account switch <handle> --soft`
+and `claude-account sync --soft` flip the selector exactly as the default (restart-based) path, but
+skip `cmd_restart` entirely: they `kill -HUP` the execution-core daemon (`catalyst-execution-core
+rearm`) to trigger the `claude-accounts.env` rearm above immediately, then verify against the
+daemon's own emitted `account.rearm.applied` event — never a re-read of the local file, which would
+report success identically against a daemon that never re-armed. Correct only under `executor=sdk`
+(the SDK executor binds `CLAUDE_CODE_OAUTH_TOKEN` from the daemon's live `process.env` on every
+dispatch — `sdk-run-phase-agent.mjs:1152-1157`/`:950`), so `--soft` refuses on any other executor.
+Because it never restarts, `--soft` removes account rotation as a trigger of the CTL-2133
+boot-resume pen — the restart-based path stays the default rotation mechanism.
 
 **Consumers folded onto the contract so far**: the 10-file/12-site Linear-token read
 (`linear-query.mjs` — 3 sites, `cluster-heartbeat.mjs`, `cluster-claim.mjs`,

--- a/plugins/dev/scripts/__tests__/architecture-armsecret-claim.test.sh
+++ b/plugins/dev/scripts/__tests__/architecture-armsecret-claim.test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# architecture-armsecret-claim.test.sh — CTL-2147. docs/architecture.md used to state
+# "No production call site invokes armSecret today", which was already false (daemon.mjs
+# calls it live at three sites) and is the exact premise CTL-2147 builds on (SIGHUP triggers
+# one of those calls on demand). This is always-loaded context (@docs/architecture.md), so a
+# stale claim there actively misleads the next agent — guard it with a grep assertion.
+#
+# Run: bash plugins/dev/scripts/__tests__/architecture-armsecret-claim.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+DOC="${REPO_ROOT}/docs/architecture.md"
+DAEMON="${REPO_ROOT}/plugins/dev/scripts/execution-core/daemon.mjs"
+
+FAILURES=0
+PASSES=0
+ok() { PASSES=$((PASSES + 1)); echo "  PASS: $1"; }
+fail_t() { FAILURES=$((FAILURES + 1)); echo "  FAIL: $1"; }
+check() {
+  local name="$1"; shift
+  if "$@"; then ok "$name"; else fail_t "$name"; fi
+}
+
+echo "architecture.md armSecret claim (CTL-2147) tests"
+
+t_no_stale_armsecret_claim() {
+  ! /usr/bin/grep -q "No production call site invokes .armSecret. today" "$DOC"
+}
+check "architecture.md no longer claims armSecret has no production caller" t_no_stale_armsecret_claim
+
+t_armsecret_callers_are_real() {
+  # Positive control: the claim was false because these callers exist. Assert they do, so
+  # this test fails loudly if the callers are ever removed rather than silently blessing a
+  # doc that would then be correct again.
+  [[ "$(/usr/bin/grep -c 'armSecret(' "$DAEMON")" -ge 3 ]]
+}
+check "daemon.mjs retains its armSecret call sites (positive control)" t_armsecret_callers_are_real
+
+t_doc_mentions_soft_rotation() {
+  /usr/bin/grep -q -- "--soft" "$DOC"
+}
+check "architecture.md documents claude-account switch/sync --soft" t_doc_mentions_soft_rotation
+
+echo ""
+TOTAL=$((PASSES + FAILURES))
+echo "architecture-armsecret-claim: $PASSES/$TOTAL passed, $FAILURES failed"
+exit "$FAILURES"

--- a/plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-stack-claude-account.test.sh
@@ -506,6 +506,153 @@ t_daemon_default_matches_writer_default() {
 }
 check "execution-core daemon default matches CA_ACCOUNTS_ENV_DEFAULT" t_daemon_default_matches_writer_default
 
+# ── N. --soft flag parsing (CTL-2147) ────────────────────────────────────────
+t_soft_flag_recognized_switch() {
+  # _ca_parse_mode is the extracted pure helper both commands share.
+  [[ "$(_ca_parse_mode --soft)" == "soft" ]]
+}
+check "switch/sync accept --soft" t_soft_flag_recognized_switch
+
+t_default_mode_is_restart() {
+  [[ "$(_ca_parse_mode)" == "restart" ]]
+}
+check "default (no flag) stays restart — opt-in, not a behavior flip" t_default_mode_is_restart
+
+t_soft_and_yes_compose() {
+  [[ "$(_ca_parse_mode --soft --yes)" == "soft" ]]
+}
+check "--soft composes with --yes" t_soft_and_yes_compose
+
+t_unknown_flag_still_rejected() {
+  ! _ca_parse_mode --sofT >/dev/null 2>&1
+}
+check "a near-miss flag is rejected, not silently treated as restart" t_unknown_flag_still_rejected
+
+# ── N+1. soft verification must NOT be the file-sourced check (CTL-2147) ─────
+t_soft_verify_is_distinct_fn() {
+  # Guards the false-green trap: _ca_verify_active proves the FILE, not the daemon.
+  declare -f _ca_verify_soft_rearm >/dev/null 2>&1 &&
+    ! declare -f _ca_verify_soft_rearm | grep -q '_ca_verify_active'
+}
+check "soft mode has its own daemon-observing verification" t_soft_verify_is_distinct_fn
+
+t_soft_verify_fails_when_no_event() {
+  # Point the event-log resolver at an empty scratch log: absence must FAIL, not pass.
+  : > "${SCRATCH}/empty.jsonl"
+  ! CATALYST_EVENT_LOG="${SCRATCH}/empty.jsonl" _ca_verify_soft_rearm acct2 1 >/dev/null 2>&1
+}
+check "soft verify FAILS on no rearm event (fail-closed, never a silent pass)" t_soft_verify_fails_when_no_event
+
+t_soft_verify_rejects_wrong_handle() {
+  printf '%s\n' '{"ts":"2026-08-21T23:00:00Z","attributes":{"event.name":"account.rearm.applied","account.handle":"acct1"}}' > "${SCRATCH}/wrong.jsonl"
+  ! CATALYST_EVENT_LOG="${SCRATCH}/wrong.jsonl" _ca_verify_soft_rearm acct2 1 >/dev/null 2>&1
+}
+check "soft verify rejects a rearm event naming a DIFFERENT handle" t_soft_verify_rejects_wrong_handle
+
+t_soft_verify_accepts_matching_handle() {
+  printf '%s\n' '{"ts":"2026-08-21T23:00:00Z","attributes":{"event.name":"account.rearm.applied","account.handle":"acct2"}}' > "${SCRATCH}/right.jsonl"
+  CATALYST_EVENT_LOG="${SCRATCH}/right.jsonl" _ca_verify_soft_rearm acct2 1 >/dev/null 2>&1
+}
+check "soft verify passes on a matching-handle rearm event" t_soft_verify_accepts_matching_handle
+
+# ── N+2. freshness fencepost (CTL-2147, security-review follow-up) ──────────
+# A small handle pool + fleets legitimately revisiting the same handle within a
+# month means an unbounded scan would accept a STALE same-handle event as proof
+# that THIS rearm request landed. SINCE_TS (3rd arg) closes that gap.
+t_soft_verify_since_ts_rejects_stale_event() {
+  printf '%s\n' '{"ts":"2020-01-01T00:00:00Z","attributes":{"event.name":"account.rearm.applied","account.handle":"acct2"}}' > "${SCRATCH}/stale.jsonl"
+  ! CATALYST_EVENT_LOG="${SCRATCH}/stale.jsonl" _ca_verify_soft_rearm acct2 1 "2026-08-21T23:00:00Z" >/dev/null 2>&1
+}
+check "SINCE_TS rejects an event older than the fencepost" t_soft_verify_since_ts_rejects_stale_event
+
+t_soft_verify_since_ts_accepts_fresh_event() {
+  printf '%s\n' '{"ts":"2026-08-21T23:59:00Z","attributes":{"event.name":"account.rearm.applied","account.handle":"acct2"}}' > "${SCRATCH}/fresh.jsonl"
+  CATALYST_EVENT_LOG="${SCRATCH}/fresh.jsonl" _ca_verify_soft_rearm acct2 1 "2026-08-21T23:00:00Z" >/dev/null 2>&1
+}
+check "SINCE_TS accepts an event at/after the fencepost" t_soft_verify_since_ts_accepts_fresh_event
+
+t_soft_verify_no_since_ts_still_matches_any_age() {
+  # Omitting SINCE_TS (the shell-test callers above) must stay backward compatible.
+  printf '%s\n' '{"ts":"2020-01-01T00:00:00Z","attributes":{"event.name":"account.rearm.applied","account.handle":"acct2"}}' > "${SCRATCH}/nofence.jsonl"
+  CATALYST_EVENT_LOG="${SCRATCH}/nofence.jsonl" _ca_verify_soft_rearm acct2 1 >/dev/null 2>&1
+}
+check "omitting SINCE_TS matches an event of any age (back-compat default)" t_soft_verify_no_since_ts_still_matches_any_age
+
+# ── N+3. executor guard (CTL-2147) ───────────────────────────────────────────
+t_soft_refuses_non_sdk_executor() {
+  ! CATALYST_EXECUTOR=bg _ca_soft_supported >/dev/null 2>&1
+}
+check "--soft refuses under executor=bg (rearm does not cross the claude --bg RPC)" t_soft_refuses_non_sdk_executor
+
+t_soft_allowed_under_sdk() {
+  CATALYST_EXECUTOR=sdk _ca_soft_supported >/dev/null 2>&1
+}
+check "--soft allowed under executor=sdk" t_soft_allowed_under_sdk
+
+# ── N+4. _ca_apply_rotation dispatches to the correct tail (CTL-2147, ─────────
+# test-coverage-review follow-up). Neither cmd_claude_account_switch nor
+# cmd_claude_account_sync is otherwise driven past their early guards anywhere in
+# this suite (both real flows need a working sops/git/probe chain), so without this
+# section the mode branch itself — the actual "does --soft skip the restart" logic
+# — was untested: an inverted `if`, a typo'd mode string, or a dropped
+# _ca_soft_supported call could pass every other check here. Stubs cmd_restart /
+# catalyst-execution-core / _ca_verify_soft_rearm / _ca_verify_active as plain shell
+# functions (bash resolves a defined function before a same-named PATH command) so
+# the dispatch is observed directly, without needing a real daemon/sops/git. Every
+# invocation runs inside `$(...)` — _ca_apply_rotation calls `fail`, which `exit`s,
+# and this test file sources $STACK directly into the CURRENT shell (not a
+# subprocess), so an uncontained `exit` here would kill the whole test run.
+_ROT_CALLS="${SCRATCH}/rotation-calls.log"
+_rot_verify_soft_rc=0
+_rot_verify_active_rc=0
+cmd_restart() { printf 'cmd_restart %s\n' "$*" >> "$_ROT_CALLS"; }
+catalyst-execution-core() { printf 'catalyst-execution-core %s\n' "$*" >> "$_ROT_CALLS"; return 0; }
+_ca_verify_soft_rearm() { printf '_ca_verify_soft_rearm %s\n' "$*" >> "$_ROT_CALLS"; return "$_rot_verify_soft_rc"; }
+_ca_verify_active() { printf '_ca_verify_active %s\n' "$*" >> "$_ROT_CALLS"; return "$_rot_verify_active_rc"; }
+
+t_apply_rotation_soft_signals_daemon_not_restart() {
+  : > "$_ROT_CALLS"; _rot_verify_soft_rc=0; _rot_verify_active_rc=0
+  local rc; ( _ca_apply_rotation soft acct2 no switch >/dev/null 2>&1 ); rc=$?
+  [[ $rc -eq 0 ]] &&
+    grep -q '^catalyst-execution-core rearm$' "$_ROT_CALLS" &&
+    grep -q '^_ca_verify_soft_rearm acct2 ' "$_ROT_CALLS" &&
+    grep -q '^_ca_verify_active acct2$' "$_ROT_CALLS" &&
+    ! grep -q '^cmd_restart' "$_ROT_CALLS"
+}
+check "--soft mode signals the daemon and verifies, never calling cmd_restart" t_apply_rotation_soft_signals_daemon_not_restart
+
+t_apply_rotation_restart_calls_cmd_restart_not_soft_path() {
+  : > "$_ROT_CALLS"; _rot_verify_soft_rc=0; _rot_verify_active_rc=0
+  local rc; ( _ca_apply_rotation restart acct2 no switch >/dev/null 2>&1 ); rc=$?
+  [[ $rc -eq 0 ]] &&
+    grep -q '^cmd_restart[[:space:]]*$' "$_ROT_CALLS" &&
+    grep -q '^_ca_verify_active acct2$' "$_ROT_CALLS" &&
+    ! grep -q '^catalyst-execution-core' "$_ROT_CALLS" &&
+    ! grep -q '^_ca_verify_soft_rearm' "$_ROT_CALLS"
+}
+check "default (restart) mode calls cmd_restart, never signals the daemon (regression coverage)" t_apply_rotation_restart_calls_cmd_restart_not_soft_path
+
+t_apply_rotation_restart_yes_passes_through() {
+  : > "$_ROT_CALLS"; _rot_verify_soft_rc=0; _rot_verify_active_rc=0
+  ( _ca_apply_rotation restart acct2 yes switch >/dev/null 2>&1 )
+  grep -q '^cmd_restart --yes$' "$_ROT_CALLS"
+}
+check "restart mode with assume_yes=yes calls cmd_restart --yes" t_apply_rotation_restart_yes_passes_through
+
+t_apply_rotation_soft_fails_closed_when_daemon_never_rearms() {
+  : > "$_ROT_CALLS"; _rot_verify_soft_rc=1; _rot_verify_active_rc=0
+  local rc; ( _ca_apply_rotation soft acct2 no switch >/dev/null 2>&1 ); rc=$?
+  [[ $rc -ne 0 ]]
+}
+check "--soft mode fails closed when the daemon never reports re-arming" t_apply_rotation_soft_fails_closed_when_daemon_never_rearms
+
+t_apply_rotation_soft_fails_closed_when_file_verify_fails() {
+  : > "$_ROT_CALLS"; _rot_verify_soft_rc=0; _rot_verify_active_rc=1
+  local rc; ( _ca_apply_rotation soft acct2 no switch >/dev/null 2>&1 ); rc=$?
+  [[ $rc -ne 0 ]]
+}
+check "--soft mode fails closed when the post-switch file check fails too" t_apply_rotation_soft_fails_closed_when_file_verify_fails
+
 echo ""
 TOTAL=$((PASSES + FAILURES))
 echo "catalyst-stack-claude-account: $PASSES/$TOTAL passed, $FAILURES failed"

--- a/plugins/dev/scripts/__tests__/execution-core-cli-routing.test.sh
+++ b/plugins/dev/scripts/__tests__/execution-core-cli-routing.test.sh
@@ -73,6 +73,67 @@ else
 	pass "daemon probe routes correctly"
 fi
 
+echo "test 4b (CTL-2147): backcompat 'rearm' routes to daemon rearm (no daemon → nonzero)"
+OUT="$("$SCRIPT" rearm 2>&1)"
+RC=$?
+if [ "$RC" != "0" ] && echo "$OUT" | grep -qi "not running"; then
+	pass "backcompat rearm routes to daemon rearm"
+else
+	fail "backcompat rearm routes to daemon rearm" "rc=$RC out=$OUT"
+fi
+
+echo "test 4c (CTL-2147): 'daemon rearm' is the canonical form"
+OUT="$("$SCRIPT" daemon rearm 2>&1)"
+RC=$?
+if [ "$RC" != "0" ] && echo "$OUT" | grep -qi "not running"; then
+	pass "daemon rearm routes correctly"
+else
+	fail "daemon rearm routes correctly" "rc=$RC out=$OUT"
+fi
+
+echo "test 4d (CTL-2147): 'rearm' success path — a live pid actually gets SIGHUP"
+# Tests 4b/4c above only cover the "daemon not running" failure path. This exercises
+# the success path with a real (fake) process: a tiny script that traps SIGHUP and
+# writes a marker file, backgrounded and pointed to via EXECUTION_CORE_PID_FILE.
+# AGENTS.md "Spawning a background process": the loop is self-limiting via its own
+# SECONDS deadline (30s) so it exits on its own even if this test's cleanup below
+# never runs — never an unbounded `while :; do :; done`.
+REARM_MARKER="$SCRATCH/sighup-received"
+FAKE_DAEMON="$SCRATCH/fake-daemon.sh"
+cat >"$FAKE_DAEMON" <<'EOF'
+#!/usr/bin/env bash
+marker="$1"
+trap 'touch "$marker"; exit 0' HUP
+end=$((SECONDS + 30))
+while [ "$SECONDS" -lt "$end" ]; do sleep 1; done
+EOF
+chmod +x "$FAKE_DAEMON"
+rm -f "$REARM_MARKER"
+"$FAKE_DAEMON" "$REARM_MARKER" &
+FAKE_PID=$!
+FAKE_PID_FILE="$SCRATCH/fake-daemon.pid"
+echo "$FAKE_PID" > "$FAKE_PID_FILE"
+# Give the backgrounded interpreter time to actually install the HUP trap before
+# signalling it — without this, SIGHUP can arrive before `trap` runs and the
+# process dies to the DEFAULT SIGHUP action instead (observed: "Hangup: 1").
+sleep 0.3
+
+OUT="$(EXECUTION_CORE_PID_FILE="$FAKE_PID_FILE" "$SCRIPT" rearm 2>&1)"
+RC=$?
+
+# Bounded wait for the trap to fire (never an unbounded poll — AGENTS.md).
+end=$((SECONDS + 10))
+while [ ! -e "$REARM_MARKER" ] && [ "$SECONDS" -lt "$end" ]; do sleep 0.2; done
+
+if [ "$RC" = "0" ] && echo "$OUT" | grep -qi "SIGHUP sent" && [ -e "$REARM_MARKER" ]; then
+	pass "rearm success path: SIGHUP delivered to a live pid, exit 0"
+else
+	fail "rearm success path: SIGHUP delivered to a live pid, exit 0" "rc=$RC out=$OUT marker_exists=$([ -e "$REARM_MARKER" ] && echo yes || echo no)"
+fi
+
+kill "$FAKE_PID" 2>/dev/null || true
+rm -f "$FAKE_PID_FILE" "$REARM_MARKER" "$FAKE_DAEMON"
+
 echo "test 5 (CTL-649): 'sessions list --json' routes to the sessions module"
 OUT="$("$SCRIPT" sessions list --json 2>/dev/null)"
 RC=$?

--- a/plugins/dev/scripts/broker/namespace-parity.test.mjs
+++ b/plugins/dev/scripts/broker/namespace-parity.test.mjs
@@ -72,6 +72,9 @@ import { ESCALATION_EVENT_NEEDS_HUMAN } from "../execution-core/escalation-event
 // namespace contract (a dedicated test below asserts it, alongside the salvage family).
 import { LABEL_RETRY_EXHAUSTED_EVENT } from "../execution-core/label-retry-event.mjs";
 import { FENCE_STANDOFF_EVENT } from "../execution-core/fence-standoff.mjs"; // CAT-173
+// CTL-2147 — the claude-accounts soft-rearm observability event, imported from its
+// owning module rather than re-typed as a literal (same precedent as CTL-1659/CTL-1889).
+import { ACCOUNT_REARM_APPLIED_EVENT } from "../execution-core/claude-accounts-rearm.mjs";
 
 // Inline names that don't have a dedicated exported constant; verified against
 // the source file they appear in.
@@ -126,6 +129,7 @@ const EXEC_CORE_EVENT_NAMES = [
   ESCALATION_EVENT_NEEDS_HUMAN, // CTL-2056 escalation-event.mjs — ticket.escalated (entity=ticket/action=escalated)
   LABEL_RETRY_EXHAUSTED_EVENT, // CTL-2052 label-retry-event.mjs — the "stopped after N and said so" escalation
   FENCE_STANDOFF_EVENT, // CAT-173 fence-standoff.mjs — mutual fence standoff escalation
+  ACCOUNT_REARM_APPLIED_EVENT, // CTL-2147 claude-accounts-rearm.mjs — soft-rearm observability
   ...INLINE_EVENT_NAMES,
 ];
 

--- a/plugins/dev/scripts/catalyst-execution-core
+++ b/plugins/dev/scripts/catalyst-execution-core
@@ -16,6 +16,9 @@
 #   restart    Stop then start
 #   probe      Exit 0 if the daemon is running, non-zero otherwise (silent)
 #   status     Print running/stopped + pid
+#   rearm      SIGHUP the daemon — re-arm claude-accounts.env now (CTL-2147),
+#              instead of waiting out the 5-minute cluster-sync tick. Exits
+#              non-zero when the daemon is not running.
 
 set -uo pipefail
 
@@ -404,6 +407,25 @@ cmd_probe() {
 	read_pid >/dev/null 2>&1
 }
 
+# cmd_rearm — CTL-2147. Send SIGHUP to the running daemon, which triggers the
+# CTL-1984 claude-accounts.env rearm immediately instead of waiting out the
+# 5-minute cluster-sync tick. This is the on-demand trigger `catalyst-stack
+# claude-account switch/sync --soft` signals before verifying the rotation.
+# Exits non-zero when the daemon is not running, so a soft switch can
+# distinguish "signalled" from "nothing to signal" rather than failing open.
+cmd_rearm() {
+	local pid
+	if ! pid=$(read_pid); then
+		echo "catalyst-execution-core not running — nothing to rearm" >&2
+		return 1
+	fi
+	kill -HUP "$pid" 2>/dev/null || {
+		echo "catalyst-execution-core: failed to signal pid ${pid}" >&2
+		return 1
+	}
+	echo "catalyst-execution-core: SIGHUP sent (pid ${pid}) — requesting claude-accounts rearm"
+}
+
 cmd_status() {
 	# CTL-649 devex finding #5: `daemon status --json` (and the top-level `status`
 	# alias) emit a machine-readable object so a headless agent can branch on
@@ -557,8 +579,9 @@ dispatch_daemon() {
 	restart) cmd_restart ;;
 	probe) cmd_probe ;;
 	status) cmd_status "$@" ;;
+	rearm) cmd_rearm ;;
 	*)
-		echo "Usage: catalyst-execution-core daemon {start|stop|restart|probe|status}" >&2
+		echo "Usage: catalyst-execution-core daemon {start|stop|restart|probe|status|rearm}" >&2
 		exit 1
 		;;
 	esac
@@ -625,7 +648,10 @@ catalyst-execution-core — manage the execution-core daemon and audit/clean its
 Usage: catalyst-execution-core <command> [args]
 
 Commands:
-  daemon      manage the long-lived execution-core daemon (start|stop|restart|probe|status)
+  daemon      manage the long-lived execution-core daemon (start|stop|restart|probe|status|rearm)
+              rearm signals the running daemon (SIGHUP) to re-arm claude-accounts.env
+              immediately instead of waiting out the 5-minute cluster-sync tick.
+              Backcompat top-level alias: `catalyst-execution-core rearm`.
   register    enroll a project in the execution-core registry
               Usage: catalyst-execution-core register --team <TEAM> [--repo-root <path>] [--eligible-query JSON]
               Resolves repo root from --repo-root, $CATALYST_REPO_ROOT, or git rev-parse --show-toplevel.
@@ -674,7 +700,7 @@ if ! (return 0 2>/dev/null); then
 		;;
 	# Backcompat aliases — operator muscle memory for the daemon verbs. Trailing
 	# flags (e.g. top-level `status --json`) pass through to the daemon handler.
-	start | stop | restart | probe | status) dispatch_daemon "$@" ;;
+	start | stop | restart | probe | status | rearm) dispatch_daemon "$@" ;;
 	daemon)
 		shift
 		dispatch_daemon "$@"

--- a/plugins/dev/scripts/catalyst-stack
+++ b/plugins/dev/scripts/catalyst-stack
@@ -29,8 +29,8 @@
 #   catalyst-stack verify-node [--json]
 #   catalyst-stack sync-cloud-env
 #   catalyst-stack claude-account status
-#   catalyst-stack claude-account switch <handle> [--yes]
-#   catalyst-stack claude-account sync [--yes]
+#   catalyst-stack claude-account switch <handle> [--soft] [--yes]
+#   catalyst-stack claude-account sync [--soft] [--yes]
 #
 # claude-account (CTL-1650):
 #   Fleet-wide Claude OAuth-account control, one command.
@@ -49,6 +49,16 @@
 #   sync            — for a second node after a switch was pushed elsewhere: git pull
 #                    the cluster repo, re-materialize claude-accounts.env, restart,
 #                    and verify.
+#   --soft (CTL-2147) — on either command, skip the stack restart: signal the running
+#                    execution-core daemon (SIGHUP) to re-arm claude-accounts.env
+#                    immediately (CTL-1984's already-shipped in-process rearm hook),
+#                    then verify against the daemon's OWN account.rearm.applied event
+#                    — never a re-read of the file, which would pass identically
+#                    against a daemon that never re-armed. Requires executor=sdk
+#                    (refuses otherwise); does NOT touch already-running workers
+#                    (they keep their launch-time account by design); does NOT
+#                    refill the CTL-2133 boot-resume pen the way a restart does.
+#                    Opt-in — the restart stays the default rotation path.
 #   Token values are never echoed, logged, or written anywhere but the 0600
 #   ~/.config/catalyst/claude-accounts.env target file.
 #
@@ -4076,6 +4086,9 @@ CA_ACCOUNTS_ENV_DEFAULT="${HOME}/.config/catalyst/claude-accounts.env"
 # posture as execution-core/cluster-sync.mjs's SOPS_CANDIDATES (CTL-1393: a restricted
 # daemon/shell PATH frequently omits /opt/homebrew/bin), plus ~/.local/bin (CTL-1650).
 CA_SOPS_CANDIDATES=("/opt/homebrew/bin/sops" "/usr/local/bin/sops" "/usr/bin/sops" "${HOME}/.local/bin/sops")
+# CTL-2147: how long --soft waits for the daemon's account.rearm.applied event
+# before giving up. Overridable for a slow/loaded node.
+CA_SOFT_VERIFY_TIMEOUT="${CA_SOFT_VERIFY_TIMEOUT:-60}"
 
 _ca_age_key_file()    { echo "${CATALYST_AGE_KEY_FILE:-$CA_AGE_KEY_FILE_DEFAULT}"; }
 # CTL-1650 Codex fix: mirror execution-core/config.mjs's getClusterRepoDir() exactly —
@@ -4246,6 +4259,98 @@ _ca_probe_handle_ok() {
   [[ -z "$rejected" ]]
 }
 
+# _ca_parse_mode [ARGS...] — CTL-2147. Pure, testable flag parser shared by both
+# switch and sync: prints "soft" when --soft is among ARGS, else "restart" (the
+# opt-in default — the restart stays the default rotation path). Any other flag
+# (typo'd or unknown) is a hard failure so a mistake is never silently treated
+# as "restart" — the caller's own `*) fail "unknown ... arg"` catch-all covers
+# real dispatch, but this pure helper must fail the same way when called directly.
+_ca_parse_mode() {
+  local mode="restart" a
+  for a in "$@"; do
+    case "$a" in
+      --soft) mode="soft" ;;
+      --yes) : ;;
+      *) return 1 ;;
+    esac
+  done
+  printf '%s\n' "$mode"
+}
+
+# _ca_soft_supported — CTL-2147. --soft is only correct where a dispatch binds the
+# token from the daemon's live process.env at call time. That is executor=sdk
+# (sdk-run-phase-agent.mjs:1152-1157 + :950). Under executor=bg the worker session
+# sits behind the claude --bg RPC boundary, which carries neither DISPATCH_ENV nor
+# CLAUDE_CODE_OAUTH_TOKEN in --settings — a soft switch there would report success
+# while every bg worker kept the old account. Refuse rather than under-deliver.
+_ca_soft_supported() {
+  local ex="${CATALYST_EXECUTOR:-sdk}"
+  [[ "$ex" == "sdk" ]] || { warn "--soft requires executor=sdk (this node reports '${ex}') — rerun without --soft"; return 1; }
+}
+
+# _ca_event_log_path — resolves the unified event log this node's daemon appends
+# to. CATALYST_EVENT_LOG is a full-path override (tests only); otherwise mirrors
+# execution-core/config.mjs's getEventLogPath(): <CATALYST_DIR>/events/YYYY-MM.jsonl.
+_ca_event_log_path() {
+  if [[ -n "${CATALYST_EVENT_LOG:-}" ]]; then
+    printf '%s' "$CATALYST_EVENT_LOG"
+    return 0
+  fi
+  printf '%s/events/%s.jsonl' "${CATALYST_DIR:-$HOME/catalyst}" "$(date -u +%Y-%m)"
+}
+
+# _ca_verify_soft_rearm HANDLE [TIMEOUT_SECONDS] [SINCE_TS] — CTL-2147. THE point
+# of this function is that it does NOT re-read claude-accounts.env.
+# _ca_verify_active sources that file in a subshell, so under --soft (no
+# restart) it proves only that WE wrote the file — it would pass identically
+# against a daemon that never re-armed and is still dispatching on the walled
+# account. That is a check that cannot fail. This one asks the DAEMON, by
+# scanning for the account.rearm.applied event IT emits, and requires the
+# event's account.handle to equal HANDLE.
+#
+# SINCE_TS (optional, ISO-8601 UTC "Z" form — the same shape `date -u
+# +%Y-%m-%dT%H:%M:%SZ` and the emitted event's own `ts` field both use, so a
+# plain string compare orders correctly) guards against a DIFFERENT
+# check-that-cannot-fail: the account pool is small (acctN) and fleets
+# legitimately revisit the same handle within a month, so an unbounded scan
+# would accept a stale event from an EARLIER rotation to the same handle as
+# proof that THIS rearm request landed. Callers that care record "now" via
+# `date -u +%Y-%m-%dT%H:%M:%SZ` immediately before signalling the daemon and
+# pass it as SINCE_TS. Omitted (the shell-test callers below) → no freshness
+# filter, matching any occurrence — the pre-CTL-2147-review-fix behavior,
+# kept as the default so a caller that hasn't been threaded a fencepost yet
+# degrades to "was it ever armed" rather than refusing to verify at all.
+#
+# Fail-closed: no event, an unreadable log, a different handle, or (when
+# SINCE_TS is given) a too-old event all return nonzero. Self-limiting
+# deadline loop that SLEEPS (AGENTS.md: never an unbounded `while :; do :;
+# done`) — bounded by TIMEOUT_SECONDS (default CA_SOFT_VERIFY_TIMEOUT).
+# Matches with `jq -R 'try fromjson catch empty'`, never a bare `jq -c
+# select` (which aborts at the first torn/unparseable line and would
+# silently miss every line after it).
+_ca_verify_soft_rearm() {
+  local handle="$1" timeout="${2:-${CA_SOFT_VERIFY_TIMEOUT:-60}}" since_ts="${3:-}"
+  local log_file; log_file="$(_ca_event_log_path)"
+  local end=$((SECONDS + timeout)) match
+  while :; do
+    if [[ -r "$log_file" ]]; then
+      match="$(jq -R --arg h "$handle" --arg since "$since_ts" '
+          (try fromjson catch empty) as $ev
+          | select($ev != null)
+          | ($ev.attributes // {}) as $attrs
+          | (($attrs["event.name"] // $ev.name // $ev.event) == "account.rearm.applied") as $name_ok
+          | (($attrs["account.handle"] // $ev.account_handle) == $h) as $handle_ok
+          | (($since == "") or (($ev.ts // $ev.observedTs // "") >= $since)) as $fresh_ok
+          | select($name_ok and $handle_ok and $fresh_ok)
+          | "match"
+        ' "$log_file" 2>/dev/null)"
+      [[ -n "$match" ]] && return 0
+    fi
+    [[ $SECONDS -lt $end ]] || return 1
+    sleep 1
+  done
+}
+
 # _ca_verify_active HANDLE — sources the just-materialized claude-accounts.env (which
 # sets CLAUDE_CODE_OAUTH_TOKEN from whichever account is now selected) in a subshell
 # and confirms the usage tool reports HANDLE — and only HANDLE — as ACTIVE. Prints the
@@ -4308,17 +4413,52 @@ cmd_claude_account_status() {
   )
 }
 
+# _ca_apply_rotation MODE HANDLE ASSUME_YES LABEL — CTL-2147. The shared switch/sync
+# tail: soft-rearm-and-verify, or restart-and-verify. LABEL is "switch" or "sync",
+# used only for log/error-message wording. Extracted out of both cmd_claude_account_*
+# functions (which were byte-similar here) so the mode decision is testable in
+# isolation — by stubbing cmd_restart / catalyst-execution-core / _ca_verify_soft_rearm
+# / _ca_verify_active as plain shell functions — without having to first drive the
+# real sops/git/probe plumbing above it in either caller.
+_ca_apply_rotation() {
+  local mode="$1" handle="$2" assume_yes="$3" label="$4"
+  if [[ "$mode" == "soft" ]]; then
+    log "claude-account ${label}: soft rotation — signalling the daemon to re-arm (no stack restart)..."
+    # Fencepost recorded BEFORE signalling: _ca_verify_soft_rearm must not accept a
+    # stale event from an earlier rotation to this same handle (the account pool is
+    # small and fleets legitimately revisit a handle within a month).
+    local rearm_since; rearm_since="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    catalyst-execution-core rearm \
+      || fail "could not signal the execution-core daemon to re-arm (not running?) — rerun without --soft"
+    _ca_verify_soft_rearm "$handle" "$CA_SOFT_VERIFY_TIMEOUT" "$rearm_since" \
+      || fail "claude-account ${label} --soft: the daemon did not report re-arming to ${handle}"
+    # File-level check too: soft mode must satisfy BOTH the daemon check above and
+    # the existing file check, never the file check alone.
+    _ca_verify_active "$handle" || fail "claude-account ${label} --soft: post-${label} file verification failed"
+  else
+    log "claude-account ${label}: restarting stack..."
+    if [[ "$assume_yes" == "yes" ]]; then cmd_restart --yes; else cmd_restart; fi
+    _ca_verify_active "$handle" || fail "claude-account ${label}: post-${label} verification failed"
+  fi
+}
+
 cmd_claude_account_switch() {
   local handle="${1:-}"
-  [[ -n "$handle" ]] || fail "usage: catalyst-stack claude-account switch <handle> [--yes] (e.g. acct2)"
+  [[ -n "$handle" ]] || fail "usage: catalyst-stack claude-account switch <handle> [--soft] [--yes] (e.g. acct2)"
   shift
   local assume_yes="${ASSUME_YES:-no}"
   for a in "$@"; do
     case "$a" in
       --yes) assume_yes="yes" ;;
+      --soft) : ;;
       *) fail "unknown claude-account switch arg: $a" ;;
     esac
   done
+  # CTL-2147: single source of truth for the mode decision (also unit-tested
+  # standalone) — recomputed here rather than trusted from the loop above so a
+  # future arg added to one and not the other can't desync the two.
+  local mode; mode="$(_ca_parse_mode "$@")" || fail "unknown claude-account switch arg (see usage)"
+  [[ "$mode" == "soft" ]] && { _ca_soft_supported || fail "claude-account switch --soft: unsupported executor"; }
 
   _ca_valid_handle "$handle" || fail "invalid handle '${handle}' — must match ^acct[0-9]+\$ (e.g. acct2)"
 
@@ -4426,10 +4566,7 @@ cmd_claude_account_switch() {
     || fail "sops decrypt of claude-accounts.env failed"
   chmod 600 "$dest"
 
-  log "claude-account switch: restarting stack..."
-  if [[ "$assume_yes" == "yes" ]]; then cmd_restart --yes; else cmd_restart; fi
-
-  _ca_verify_active "$handle" || fail "claude-account switch: post-switch verification failed"
+  _ca_apply_rotation "$mode" "$handle" "$assume_yes" "switch"
 }
 
 cmd_claude_account_sync() {
@@ -4437,9 +4574,15 @@ cmd_claude_account_sync() {
   for a in "$@"; do
     case "$a" in
       --yes) assume_yes="yes" ;;
+      --soft) : ;;
       *) fail "unknown claude-account sync arg: $a" ;;
     esac
   done
+  # CTL-2147: single source of truth for the mode decision (also unit-tested
+  # standalone) — recomputed here rather than trusted from the loop above so a
+  # future arg added to one and not the other can't desync the two.
+  local mode; mode="$(_ca_parse_mode "$@")" || fail "unknown claude-account sync arg (see usage)"
+  [[ "$mode" == "soft" ]] && { _ca_soft_supported || fail "claude-account sync --soft: unsupported executor"; }
 
   local age_key; age_key="$(_ca_age_key_file)"
   [[ -f "$age_key" ]] || fail "no age key at ${age_key} — this node cannot decrypt cluster secrets"
@@ -4468,10 +4611,7 @@ cmd_claude_account_sync() {
   local handle; handle="$(_ca_current_active_handle "$dest")" \
     || fail "could not determine the active account after sync"
 
-  log "claude-account sync: restarting stack..."
-  if [[ "$assume_yes" == "yes" ]]; then cmd_restart --yes; else cmd_restart; fi
-
-  _ca_verify_active "$handle" || fail "claude-account sync: post-sync verification failed"
+  _ca_apply_rotation "$mode" "$handle" "$assume_yes" "sync"
 }
 
 cmd_claude_account() {
@@ -4481,7 +4621,7 @@ cmd_claude_account() {
     status) cmd_claude_account_status "$@" ;;
     switch) cmd_claude_account_switch "$@" ;;
     sync)   cmd_claude_account_sync "$@" ;;
-    *) fail "usage: catalyst-stack claude-account status | switch <handle> [--yes] | sync [--yes]" ;;
+    *) fail "usage: catalyst-stack claude-account status | switch <handle> [--soft] [--yes] | sync [--soft] [--yes]" ;;
   esac
 }
 

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.mjs
@@ -16,18 +16,25 @@
 //
 // Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-rearm.test.mjs
 
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { readFileSync, mkdirSync, appendFileSync } from "node:fs";
+import { homedir, hostname } from "node:os";
+import { join, dirname } from "node:path";
+import { randomBytes } from "node:crypto";
 
-import { log as defaultLog } from "./config.mjs";
+import { log as defaultLog, getEventLogPath } from "./config.mjs";
 import { containsNul, isValidUtf8RoundTrip } from "../lib/secret-contract.mjs";
+import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 // PLACEHOLDER sentinel that the generator writes when no real token is present.
 const PLACEHOLDER = "PASTE_TOKEN_HERE";
 
-// parseActiveOauthToken — pure, unit-testable. Reads the active-slot token from the
-// text content of a claude-accounts.env file. Returns the resolved token string or null.
+// The event this hook emits on a genuine rotation (CTL-2147 Phase 1). Exported so
+// producer-parity tests import it rather than re-typing the literal.
+export const ACCOUNT_REARM_APPLIED_EVENT = "account.rearm.applied";
+
+// parseActiveOauthTokenDetailed — pure, unit-testable. Reads the active-slot token
+// (and, since CTL-2147, the selector's handle) from the text content of a
+// claude-accounts.env file. Returns { token, handle }; either may be null.
 //
 // The file format (written by catalyst-stack/setup-claude-accounts):
 //   CLAUDE_TOKEN_acct1='sk-ant-oat...'  # email@example.com
@@ -37,9 +44,12 @@ const PLACEHOLDER = "PASTE_TOKEN_HERE";
 //
 // Three resolution paths, in priority order:
 // 1. Selector line  (`_catalyst_active_token="$CLAUDE_TOKEN_<label>"`) — canonical.
-// 2. Direct literal (`export CLAUDE_CODE_OAUTH_TOKEN='<value>'`) — hand-authored fallback.
-// 3. Single CLAUDE_TOKEN_* assignment with no selector — implicit single-account file.
-export function parseActiveOauthToken(text) {
+//    The handle is the <label>.
+// 2. Direct literal (`export CLAUDE_CODE_OAUTH_TOKEN='<value>'`) — hand-authored
+//    fallback. No selector to name, so handle is null.
+// 3. Single CLAUDE_TOKEN_* assignment with no selector — implicit single-account
+//    file. The handle is that single label.
+export function parseActiveOauthTokenDetailed(text) {
   const lines = text.split("\n");
 
   // Collect every CLAUDE_TOKEN_<label>=<value> assignment.
@@ -68,7 +78,7 @@ export function parseActiveOauthToken(text) {
     const m = trimmed.match(SELECTOR_RE);
     if (!m) continue;
     const tok = tokenMap.get(m[1]);
-    if (tok) return tok;
+    if (tok) return { token: tok, handle: m[1] };
   }
 
   // Path 2 — direct literal: export CLAUDE_CODE_OAUTH_TOKEN='<literal>'
@@ -86,16 +96,72 @@ export function parseActiveOauthToken(text) {
     // variable NAME installed as the credential when Path 1 misses (unprovisioned
     // active slot). Guard on the PARSED value so both forms are rejected (CTL-1984 review).
     if (!value || value === PLACEHOLDER || value.startsWith("$")) continue;
-    return value;
+    return { token: value, handle: null };
   }
 
   // Path 3 — single-account implicit: one CLAUDE_TOKEN_* entry with no selector
   if (tokenMap.size === 1) {
-    const [tok] = tokenMap.values();
-    return tok;
+    const [[label, tok]] = tokenMap.entries();
+    return { token: tok, handle: label };
   }
 
-  return null;
+  return { token: null, handle: null };
+}
+
+// parseActiveOauthToken — back-compat wrapper. Existing callers only ever wanted
+// the token string; keep the exact contract so none of them change.
+export function parseActiveOauthToken(text) {
+  return parseActiveOauthTokenDetailed(text).token;
+}
+
+// rearmEventEnvelope — pure v2 OTel envelope builder for a genuine rearm (CTL-2147
+// Phase 1), modelled on cloud-sync-deps.mjs's depSkewEventEnvelope. Never carries a
+// token or email — only the account HANDLE (a label like "acct2") and the node name.
+export function rearmEventEnvelope({
+  handle = null,
+  host = null,
+  ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+  id = null,
+  traceId = null,
+  spanId = null,
+  resource = null,
+} = {}) {
+  return {
+    ts,
+    id,
+    observedTs: ts,
+    // INFO, not WARN: a successful account rotation is normal operation.
+    severityText: "INFO",
+    severityNumber: 9,
+    traceId,
+    spanId,
+    resource,
+    attributes: {
+      "event.name": ACCOUNT_REARM_APPLIED_EVENT,
+      "event.entity": "account",
+      "event.action": "rearm-applied",
+      "account.handle": handle,
+      "node.name": host,
+    },
+    body: {
+      message: `claude-accounts: re-armed in-process${handle ? ` to ${handle}` : ""} — no restart needed`,
+      payload: { handle },
+    },
+  };
+}
+
+// defaultEmitRearmEvent — the real fs-append seam. Fail-open: a failed append must
+// never surface as a rearm failure (the rearm already happened; the event is the
+// receipt, never the act). Same shape as cloud-sync.mjs's emit* helpers.
+function defaultEmitRearmEvent(envelope) {
+  try {
+    const logPath = getEventLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(envelope)}\n`);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // _parseValue — parse the RHS of a shell assignment (quoted or unquoted).
@@ -117,13 +183,20 @@ function _parseValue(rhs) {
 }
 
 // rearmClaudeAccountsFromFile — the registered rearm hook for the
-// claude-accounts.env row. Returns { rearmed, reason }; never throws.
+// claude-accounts.env row. Returns { rearmed, reason, handle }; never throws.
+// `handle` is the rotated-to account's label on a "rotated" result, null on every
+// other path.
 //
 // Injected readFile (for testing): must accept a path and return a Buffer or string.
+// Injected emit (CTL-2147, default defaultEmitRearmEvent): appends the
+// account.rearm.applied event on a genuine rotation; fires AFTER the env mutation,
+// inside its own try/catch, so a throwing emit can never prevent or undo the rearm.
 export function rearmClaudeAccountsFromFile({
   env = process.env,
   readFile = (p) => readFileSync(p),
   log = defaultLog,
+  emit = defaultEmitRearmEvent,
+  host = hostname(),
 } = {}) {
   try {
     const candidates = [
@@ -132,6 +205,7 @@ export function rearmClaudeAccountsFromFile({
     ].filter(Boolean);
 
     let tok = null;
+    let handle = null;
     let anyFound = false;
 
     for (const file of candidates) {
@@ -149,18 +223,19 @@ export function rearmClaudeAccountsFromFile({
       if (!isValidUtf8RoundTrip(buf, decoded)) continue;
       if (containsNul(decoded)) continue;
 
-      const resolved = parseActiveOauthToken(decoded);
-      if (resolved && resolved !== PLACEHOLDER && resolved.trim()) {
-        tok = resolved;
+      const resolved = parseActiveOauthTokenDetailed(decoded);
+      if (resolved.token && resolved.token !== PLACEHOLDER && resolved.token.trim()) {
+        tok = resolved.token;
+        handle = resolved.handle;
         break;
       }
     }
 
-    if (!anyFound) return { rearmed: false, reason: "absent" };
-    if (!tok || !tok.trim()) return { rearmed: false, reason: "empty" };
+    if (!anyFound) return { rearmed: false, reason: "absent", handle: null };
+    if (!tok || !tok.trim()) return { rearmed: false, reason: "empty", handle: null };
 
     if (tok === env.CLAUDE_CODE_OAUTH_TOKEN) {
-      return { rearmed: false, reason: "unchanged" };
+      return { rearmed: false, reason: "unchanged", handle: null };
     }
 
     env.CLAUDE_CODE_OAUTH_TOKEN = tok;
@@ -171,9 +246,54 @@ export function rearmClaudeAccountsFromFile({
         "(cluster-sync materialized a rotation or account-slot switch) — " +
         "re-armed in-process, no restart needed",
     );
-    return { rearmed: true, reason: "rotated" };
+    try {
+      emit(
+        rearmEventEnvelope({
+          handle,
+          host,
+          id: randomBytes(8).toString("hex"),
+          traceId: randomBytes(16).toString("hex"),
+          spanId: randomBytes(8).toString("hex"),
+          resource: buildCatalystResource({ serviceName: "catalyst.execution-core", host }),
+        }),
+      );
+    } catch {
+      // fail-open: the rearm is the act; the event is the receipt. Never let the
+      // receipt fail the act — a full disk must not pin the fleet to a walled account.
+    }
+    return { rearmed: true, reason: "rotated", handle };
   } catch (err) {
     log?.warn?.({ err: err?.message }, "claude-accounts-rearm: re-arm failed (continuing)");
-    return { rearmed: false, reason: "error" };
+    return { rearmed: false, reason: "error", handle: null };
   }
+}
+
+// makeRearmSignalHandler — CTL-2147. The on-demand counterpart to the 5-minute
+// cluster-sync tick. Deliberately arms ONLY claude-accounts.env: a signal handler
+// must not perform network I/O (git pull / sops) or touch unrelated credentials.
+export function makeRearmSignalHandler({ armSecret, env = process.env, log = defaultLog } = {}) {
+  return function onRearmSignal() {
+    try {
+      const r = armSecret("claude-accounts.env", { env });
+      log?.info?.({ armed: r?.armed === true }, "SIGHUP: claude-accounts rearm requested");
+    } catch (err) {
+      // A signal handler that throws takes the daemon down. Never.
+      log?.warn?.({ err: err?.message }, "SIGHUP: rearm threw (continuing)");
+    }
+  };
+}
+
+// wireRearmSighup — CTL-2147. The daemon's actual production wiring, extracted
+// out of daemon.mjs's main() so it is unit-testable: main() itself boots real
+// timers/fs.watch/child processes and is deliberately never called from a test,
+// which left the previous inline `process.on("SIGHUP", ...)` line provable only
+// by a source-scan regex (daemon-signals.test.mjs), never by actually firing the
+// signal and observing armSecret get called. Call with a real `process` in
+// production; a test passes any EventEmitter-shaped stand-in. Returns the
+// registered handler so a test can also invoke it directly without going
+// through emit().
+export function wireRearmSighup(proc = process, { armSecret, env = process.env, log = defaultLog } = {}) {
+  const handler = makeRearmSignalHandler({ armSecret, env, log });
+  proc.on("SIGHUP", handler);
+  return handler;
 }

--- a/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
+++ b/plugins/dev/scripts/execution-core/claude-accounts-rearm.test.mjs
@@ -5,7 +5,15 @@
 // Run: cd plugins/dev/scripts/execution-core && bun test claude-accounts-rearm.test.mjs
 
 import { describe, test, expect } from "bun:test";
-import { rearmClaudeAccountsFromFile, parseActiveOauthToken } from "./claude-accounts-rearm.mjs";
+import { EventEmitter } from "node:events";
+import {
+  rearmClaudeAccountsFromFile,
+  parseActiveOauthToken,
+  parseActiveOauthTokenDetailed,
+  rearmEventEnvelope,
+  makeRearmSignalHandler,
+  wireRearmSighup,
+} from "./claude-accounts-rearm.mjs";
 import {
   registerRearmHook,
   clearRearmHook,
@@ -21,9 +29,19 @@ const TOKEN_C = "sk-ant-oat01-FAKE-THIRD-TOKEN-CCCCCCCCCCCCCCCCCCCCCCCCCC";
 // Default file path the hook uses when CLAUDE_ACCOUNTS_ENV is unset.
 const DEFAULT_PATH = `${process.env.HOME}/.config/catalyst/claude-accounts.env`;
 
+// silentLog — a no-op logger for tests that don't assert on log output.
+const silentLog = { info: () => {}, warn: () => {}, error: () => {} };
+
 // rearmWith — the test harness. Builds a readFile stub from a path→content map and
 // calls rearmClaudeAccountsFromFile with the injected env and a no-op log.
-function rearmWith({ files = {}, env = {} } = {}) {
+//
+// CTL-2147: also injects a no-op `emit` and a fixed `host` by default. Without this,
+// every one of the tests below (none of which care about the event envelope) would
+// fall through to rearmClaudeAccountsFromFile's real default `emit` — appending to
+// THIS machine's actual ~/catalyst/events/YYYY-MM.jsonl on every test run, which
+// breaks the file's own "FULLY OFFLINE" guarantee (top-of-file comment). Tests that
+// DO care about emission (below) override `emit` explicitly.
+function rearmWith({ files = {}, env = {}, emit = () => true, host = "test-host" } = {}) {
   return rearmClaudeAccountsFromFile({
     env,
     readFile: (p) => {
@@ -36,6 +54,8 @@ function rearmWith({ files = {}, env = {} } = {}) {
       throw err;
     },
     log: null, // silence hook logs in test output
+    emit,
+    host,
   });
 }
 
@@ -146,6 +166,38 @@ describe("parseActiveOauthToken", () => {
   });
 });
 
+describe("parseActiveOauthTokenDetailed (CTL-2147)", () => {
+  test("returns the selector's handle alongside the token", () => {
+    const text = [
+      "CLAUDE_TOKEN_acct1='tok-one'",
+      "CLAUDE_TOKEN_acct2='tok-two'",
+      '_catalyst_active_token="$CLAUDE_TOKEN_acct2"',
+    ].join("\n");
+    expect(parseActiveOauthTokenDetailed(text)).toEqual({ token: "tok-two", handle: "acct2" });
+  });
+
+  test("returns handle:null for the direct-literal path (no selector to name)", () => {
+    const text = "export CLAUDE_CODE_OAUTH_TOKEN='tok-direct'";
+    expect(parseActiveOauthTokenDetailed(text)).toEqual({ token: "tok-direct", handle: null });
+  });
+
+  test("returns handle for the implicit single-account file", () => {
+    expect(parseActiveOauthTokenDetailed("CLAUDE_TOKEN_acct7='solo'"))
+      .toEqual({ token: "solo", handle: "acct7" });
+  });
+
+  test("returns {token:null,handle:null} on a placeholder-only file", () => {
+    expect(parseActiveOauthTokenDetailed("CLAUDE_TOKEN_acct1='PASTE_TOKEN_HERE'"))
+      .toEqual({ token: null, handle: null });
+  });
+
+  // Back-compat: the existing exported shape must not change for existing callers.
+  test("parseActiveOauthToken still returns the bare token string", () => {
+    expect(parseActiveOauthToken('CLAUDE_TOKEN_acct2=\'t2\'\n_catalyst_active_token="$CLAUDE_TOKEN_acct2"'))
+      .toBe("t2");
+  });
+});
+
 // ── rearmClaudeAccountsFromFile integration tests ────────────────────────────
 
 describe("rearmClaudeAccountsFromFile", () => {
@@ -157,7 +209,7 @@ describe("rearmClaudeAccountsFromFile", () => {
     ].join("\n");
     const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
     const result = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
-    expect(result).toEqual({ rearmed: true, reason: "rotated" });
+    expect(result).toEqual({ rearmed: true, reason: "rotated", handle: "acct2" });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_B);
     expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBe("shared-file-resynced");
   });
@@ -169,7 +221,7 @@ describe("rearmClaudeAccountsFromFile", () => {
     ].join("\n");
     const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
     const result = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
-    expect(result).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(result).toEqual({ rearmed: false, reason: "unchanged", handle: null });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
     expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBeUndefined();
   });
@@ -186,18 +238,18 @@ describe("rearmClaudeAccountsFromFile", () => {
 
     // acct2 is active → unchanged
     let r = rearmWith({ files: { [DEFAULT_PATH]: mkFile("acct2") }, env });
-    expect(r).toEqual({ rearmed: false, reason: "unchanged" });
+    expect(r).toEqual({ rearmed: false, reason: "unchanged", handle: null });
 
     // flip to acct1 → rotated
     r = rearmWith({ files: { [DEFAULT_PATH]: mkFile("acct1") }, env });
-    expect(r).toEqual({ rearmed: true, reason: "rotated" });
+    expect(r).toEqual({ rearmed: true, reason: "rotated", handle: "acct1" });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
   });
 
   test("absent file (readFile throws ENOENT for every candidate) → rearmed:false, reason:absent", () => {
     const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
     const result = rearmWith({ files: {}, env });
-    expect(result).toEqual({ rearmed: false, reason: "absent" });
+    expect(result).toEqual({ rearmed: false, reason: "absent", handle: null });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
   });
 
@@ -215,7 +267,7 @@ describe("rearmClaudeAccountsFromFile", () => {
       },
       env,
     });
-    expect(result).toEqual({ rearmed: true, reason: "rotated" });
+    expect(result).toEqual({ rearmed: true, reason: "rotated", handle: "custom" });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_C);
   });
 
@@ -223,11 +275,11 @@ describe("rearmClaudeAccountsFromFile", () => {
     const env = { CLAUDE_CODE_OAUTH_TOKEN: TOKEN_A };
     // Placeholder only
     let r = rearmWith({ files: { [DEFAULT_PATH]: "CLAUDE_TOKEN_acct1='PASTE_TOKEN_HERE'" }, env });
-    expect(r).toEqual({ rearmed: false, reason: "empty" });
+    expect(r).toEqual({ rearmed: false, reason: "empty", handle: null });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_A);
     // Whitespace only
     r = rearmWith({ files: { [DEFAULT_PATH]: "   \n  " }, env });
-    expect(r).toEqual({ rearmed: false, reason: "empty" });
+    expect(r).toEqual({ rearmed: false, reason: "empty", handle: null });
   });
 
   test("CTL-1984 review regression: unprovisioned active slot → reason:empty, env NOT set to a $-reference", () => {
@@ -244,7 +296,7 @@ describe("rearmClaudeAccountsFromFile", () => {
       `export CLAUDE_CODE_OAUTH_TOKEN="$_catalyst_active_token"`,
     ].join("\n");
     const r = rearmWith({ files: { [DEFAULT_PATH]: fileContent }, env });
-    expect(r).toEqual({ rearmed: false, reason: "empty" });
+    expect(r).toEqual({ rearmed: false, reason: "empty", handle: null });
     expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe(TOKEN_C);
     expect(env.CATALYST_CLAUDE_ACCOUNTS_SOURCE).toBeUndefined();
   });
@@ -336,5 +388,149 @@ describe("hook-path integration: armSecret uses registered hook for claude-accou
 
     clearRearmHook("claude-accounts.env");
     resetArmState("claude-accounts.env");
+  });
+});
+
+// ── Event emission (CTL-2147 Phase 1) ────────────────────────────────────────
+
+describe("rearmClaudeAccountsFromFile emits (CTL-2147)", () => {
+  const FILE = "CLAUDE_TOKEN_acct2='new-tok'\n_catalyst_active_token=\"$CLAUDE_TOKEN_acct2\"";
+
+  test("emits account.rearm.applied ONCE on a rotation, carrying the handle", () => {
+    const emitted = [];
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: "old-tok" };
+    const r = rearmClaudeAccountsFromFile({
+      env, readFile: () => FILE, log: silentLog, emit: (e) => { emitted.push(e); return true; },
+    });
+    expect(r).toEqual({ rearmed: true, reason: "rotated", handle: "acct2" });
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].attributes["event.name"]).toBe("account.rearm.applied");
+    expect(emitted[0].attributes["account.handle"]).toBe("acct2");
+  });
+
+  test("NEVER puts a token value anywhere in the envelope", () => {
+    const emitted = [];
+    rearmClaudeAccountsFromFile({
+      env: { CLAUDE_CODE_OAUTH_TOKEN: "old-tok" }, readFile: () => FILE,
+      log: silentLog, emit: (e) => { emitted.push(e); return true; },
+    });
+    expect(JSON.stringify(emitted[0])).not.toContain("new-tok");
+    expect(JSON.stringify(emitted[0])).not.toContain("old-tok");
+  });
+
+  test("does NOT emit when the token is unchanged", () => {
+    const emitted = [];
+    const r = rearmClaudeAccountsFromFile({
+      env: { CLAUDE_CODE_OAUTH_TOKEN: "new-tok" }, readFile: () => FILE,
+      log: silentLog, emit: (e) => { emitted.push(e); return true; },
+    });
+    expect(r.rearmed).toBe(false);
+    expect(r.reason).toBe("unchanged");
+    expect(emitted).toHaveLength(0);
+  });
+
+  test("does NOT emit on absent/empty/error, and still never throws", () => {
+    const emitted = [];
+    const push = (e) => { emitted.push(e); return true; };
+    expect(rearmClaudeAccountsFromFile({ env: {}, readFile: () => { throw Object.assign(new Error("x"), { code: "ENOENT" }); }, log: silentLog, emit: push }).reason).toBe("absent");
+    expect(rearmClaudeAccountsFromFile({ env: {}, readFile: () => "# comment only\n", log: silentLog, emit: push }).reason).toBe("empty");
+    expect(emitted).toHaveLength(0);
+  });
+
+  // FAIL-OPEN: the rearm is the load-bearing act; telemetry must never break it.
+  test("still rearms when emit throws", () => {
+    const env = { CLAUDE_CODE_OAUTH_TOKEN: "old-tok" };
+    const r = rearmClaudeAccountsFromFile({
+      env, readFile: () => FILE, log: silentLog, emit: () => { throw new Error("log full"); },
+    });
+    expect(r.rearmed).toBe(true);
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("new-tok");
+  });
+});
+
+describe("rearmEventEnvelope (CTL-2147)", () => {
+  test("builds a v2 envelope with event.name + account.handle + node.name", () => {
+    const env = rearmEventEnvelope({ handle: "acct2", host: "mini", ts: "2026-08-21T23:00:00Z" });
+    expect(env.attributes["event.name"]).toBe("account.rearm.applied");
+    expect(env.attributes["account.handle"]).toBe("acct2");
+    expect(env.attributes["node.name"]).toBe("mini");
+    expect(env.severityText).toBe("INFO");
+    expect(env.body?.payload?.handle).toBe("acct2");
+  });
+
+  test("tolerates a null handle (direct-literal file) without inventing one", () => {
+    expect(rearmEventEnvelope({ handle: null, host: "mini" }).attributes["account.handle"]).toBeNull();
+  });
+});
+
+describe("handleRearmSignal (CTL-2147)", () => {
+  test("invokes armSecret for claude-accounts.env exactly once per signal", () => {
+    const calls = [];
+    const h = makeRearmSignalHandler({ armSecret: (id, o) => { calls.push(id); return { armed: true }; }, log: silentLog });
+    h();
+    expect(calls).toEqual(["claude-accounts.env"]);
+  });
+
+  test("does NOT arm github-token or run cluster-sync (narrow by design)", () => {
+    const calls = [];
+    const h = makeRearmSignalHandler({ armSecret: (id) => { calls.push(id); return {}; }, log: silentLog });
+    h();
+    expect(calls).not.toContain("github-token");
+  });
+
+  test("never throws when armSecret throws (a signal must not kill the daemon)", () => {
+    const h = makeRearmSignalHandler({ armSecret: () => { throw new Error("boom"); }, log: silentLog });
+    expect(() => h()).not.toThrow();
+  });
+
+  test("is re-entrant-safe: N signals produce N arms, no accumulated state", () => {
+    let n = 0;
+    const h = makeRearmSignalHandler({ armSecret: () => { n += 1; return {}; }, log: silentLog });
+    h(); h(); h();
+    expect(n).toBe(3);
+  });
+});
+
+// wireRearmSighup — CTL-2147. The daemon's ACTUAL production wiring (main() calls
+// this, not an inline process.on). daemon-signals.test.mjs additionally source-scans
+// daemon.mjs to prove this function is really called there with the real armSecret;
+// these tests prove the function itself correctly registers a SIGHUP listener that
+// invokes armSecret when fired — main() itself is never called from a test (it boots
+// real timers/fs.watch/child processes), so this is the closest a test gets to
+// firing the real signal path without booting the whole daemon.
+describe("wireRearmSighup (CTL-2147)", () => {
+  test("registers exactly one SIGHUP listener on the given emitter", () => {
+    const proc = new EventEmitter();
+    wireRearmSighup(proc, { armSecret: () => ({ armed: true }), log: silentLog });
+    expect(proc.listenerCount("SIGHUP")).toBe(1);
+  });
+
+  test("firing SIGHUP invokes armSecret for claude-accounts.env", () => {
+    const proc = new EventEmitter();
+    const calls = [];
+    wireRearmSighup(proc, { armSecret: (id) => { calls.push(id); return { armed: true }; }, log: silentLog });
+    proc.emit("SIGHUP");
+    expect(calls).toEqual(["claude-accounts.env"]);
+  });
+
+  test("does NOT register on SIGINT/SIGTERM (narrow by design — not a shutdown path)", () => {
+    const proc = new EventEmitter();
+    wireRearmSighup(proc, { armSecret: () => ({ armed: true }), log: silentLog });
+    expect(proc.listenerCount("SIGINT")).toBe(0);
+    expect(proc.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  test("returns the registered handler so a caller can also invoke it directly", () => {
+    const proc = new EventEmitter();
+    const calls = [];
+    const handler = wireRearmSighup(proc, { armSecret: (id) => { calls.push(id); return {}; }, log: silentLog });
+    handler();
+    expect(calls).toEqual(["claude-accounts.env"]);
+  });
+
+  test("a throwing armSecret does not propagate out of the emitted signal (daemon survives)", () => {
+    const proc = new EventEmitter();
+    wireRearmSighup(proc, { armSecret: () => { throw new Error("boom"); }, log: silentLog });
+    expect(() => proc.emit("SIGHUP")).not.toThrow();
   });
 });

--- a/plugins/dev/scripts/execution-core/daemon-signals.test.mjs
+++ b/plugins/dev/scripts/execution-core/daemon-signals.test.mjs
@@ -1,0 +1,56 @@
+// daemon-signals.test.mjs — CTL-2147. Asserts the execution-core daemon wires its
+// SIGHUP handler via wireRearmSighup(process, { armSecret, log }).
+//
+// WHY A SOURCE SCAN, NOT A LIVE BOOT: the process.on("SIGINT"/"SIGTERM"/"SIGHUP", ...)
+// registrations live inside daemon.mjs's `main()`, which is guarded by
+// `if (import.meta.main) main();` and is not exported — daemon.test.mjs already
+// imports startDaemon/stopDaemon directly and never calls main() (booting the real
+// daemon would start real timers, child processes, and fs.watch handles). This
+// follows the same source-scan convention namespace-parity.test.mjs uses for
+// recovery.mjs's dynamic phase-slot producers: read the real file, assert the wiring
+// text is present, so a later refactor that silently drops the registration fails
+// this test instead of only failing manually on the next `catalyst-execution-core
+// rearm` call.
+//
+// This is deliberately a THIN scan: `wireRearmSighup` (claude-accounts-rearm.mjs) is
+// the function that actually calls `proc.on("SIGHUP", ...)`, and its own live
+// behavior — a listener is registered, firing SIGHUP invokes armSecret, it never
+// registers on SIGINT/SIGTERM, a throwing armSecret doesn't propagate — is exercised
+// against a real EventEmitter in claude-accounts-rearm.test.mjs's "wireRearmSighup"
+// suite. This file's only job is to prove daemon.mjs actually CALLS that function,
+// with the real `process`/`armSecret`/`log`, rather than some dead or divergent copy.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test daemon-signals.test.mjs
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DAEMON_SOURCE = readFileSync(
+  join(fileURLToPath(import.meta.url), "../daemon.mjs"),
+  "utf8",
+);
+
+describe("daemon.mjs SIGHUP wiring (CTL-2147)", () => {
+  test("imports wireRearmSighup from claude-accounts-rearm.mjs", () => {
+    expect(DAEMON_SOURCE).toMatch(
+      /import\s*\{[^}]*wireRearmSighup[^}]*\}\s*from\s*"\.\/claude-accounts-rearm\.mjs"/,
+    );
+  });
+
+  test("calls wireRearmSighup(process, { armSecret, log }) — not a dead/divergent inline handler", () => {
+    expect(DAEMON_SOURCE).toMatch(
+      /wireRearmSighup\(process,\s*\{[^}]*armSecret[^}]*log[^}]*\}\)/,
+    );
+  });
+
+  test("SIGINT and SIGTERM still route to shutdown() (SIGHUP wiring didn't regress them)", () => {
+    expect(DAEMON_SOURCE).toContain('process.on("SIGINT", () => shutdown("SIGINT"));');
+    expect(DAEMON_SOURCE).toContain('process.on("SIGTERM", () => shutdown("SIGTERM"));');
+  });
+
+  test("no leftover inline SIGHUP process.on (superseded by wireRearmSighup)", () => {
+    expect(DAEMON_SOURCE).not.toMatch(/process\.on\("SIGHUP",\s*makeRearmSignalHandler/);
+  });
+});

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -155,7 +155,7 @@ import {
   defaultAppendOperatorEvent,
 } from "./recovery.mjs"; // CTL-655: window the revive budget to this run; CTL-736: reset progress high-water; CTL-768: --resume; CTL-1044: operator-event appender for the scheduler's appendIntentEvent seam
 import { resolveGithubBootAuth, rearmGithubTokenFromFile } from "./github-auth-preflight.mjs"; // CTL-1612: boot GitHub-credential preflight (advisory; alerts only on a definitive 401)
-import { rearmClaudeAccountsFromFile } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook
+import { rearmClaudeAccountsFromFile, wireRearmSighup } from "./claude-accounts-rearm.mjs"; // CTL-1984: account-slot live-rearm hook; CTL-2147: SIGHUP on-demand rearm trigger
 import { resolveBootDependencies, BOOT_DEPENDENCY_HOLD_REASON } from "./boot-dependency-preflight.mjs";
 import { getReconcileHealth } from "./reconcile-health.mjs";
 import { registerRearmHook, armSecret } from "../lib/secret-contract.mjs"; // CTL-1623: wires rearmGithubTokenFromFile as the github-token row's registered timer rearm hook
@@ -2998,6 +2998,13 @@ function main() {
   };
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
+  // CTL-2147: SIGHUP = "re-read the account credential NOW" — the on-demand path for
+  // `catalyst-stack claude-account switch --soft`, which must not wait out a 5-minute
+  // cluster-sync tick while the fleet dispatches on a walled account. Narrow and
+  // non-terminal: it arms one secret and returns; it is NOT a shutdown signal.
+  // wireRearmSighup (not an inline process.on) so the registration itself is
+  // unit-testable against a fake EventEmitter — see daemon-signals.test.mjs.
+  wireRearmSighup(process, { armSecret, log });
 }
 
 // Run main() only on direct invocation, never when imported as a module


### PR DESCRIPTION
38924a5d docs(dev): CTL-2147 — correct stale armSecret claim, wire new tests into CI
708ef5c9 feat(dev): CTL-2147 — wire --soft into claude-account switch/sync
781ac4ca feat(dev): CTL-2147 — make the claude-accounts rearm observable + triggerable

Refs: CTL-2147