### PR TITLE
fix(dev): CAT-216 make journey event log injectable

### DIFF
--- a/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/governance-journey.contract.test.ts
@@ -78,7 +78,9 @@ beforeAll(() => {
     startWatcher: false,
     dbPath: join(tmpDir, "catalyst.db"),
     wtDir: tmpDir,
-    annotationsDbPath: join(tmpDir, "annotations.db"), // hermetic — never the host ~/catalyst path
+    // Hermetic annotations and event-log paths — never the host ~/catalyst path.
+    annotationsDbPath: join(tmpDir, "annotations.db"),
+    catalystDir: join(tmpDir, "catalyst"),
   });
   baseUrl = `http://localhost:${server.port}`;
 });
@@ -154,5 +156,6 @@ describe("GET /api/journey/:ticket — recomputation contract (not cached)", () 
     // The nextPhase must have changed (pass → fail diverts to remediate).
     expect(nextAfter).not.toEqual(nextBefore);
     expect(nextAfter).toBe("remediate");
-  });
+  // CAT-216: backstop only; the endpoint is hermetic, so a breach is a real regression.
+  }, 15000);
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey-endpoint.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey-endpoint.test.ts
@@ -1,7 +1,7 @@
 // CTL-1100 Phase 5: GET /api/journey/:ticket — HTTP integration tests.
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer } from "../server";
@@ -53,6 +53,52 @@ describe("GET /api/journey/:ticket", () => {
     const body = await res.json() as Record<string, unknown>;
     for (const key of ["ticket", "hops", "gates", "verifyVerdict", "remediateCycles", "unblockHints", "hosts"]) {
       expect(key in body).toBe(true);
+    }
+  });
+});
+
+describe("GET /api/journey/:ticket event-log injection", () => {
+  it("reads hops from the injected catalystDir", async () => {
+    const scopedTmp = mkdtempSync(join(tmpdir(), "journey-event-log-test-"));
+    const catalystDir = join(scopedTmp, "catalyst");
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    const eventsDir = join(catalystDir, "events");
+    mkdirSync(eventsDir, { recursive: true });
+    writeFileSync(join(eventsDir, `${ym}.jsonl`), `${JSON.stringify({
+      ts: now.toISOString(),
+      attributes: { "event.name": "phase.implement.complete.CTL-7777" },
+      body: { payload: {} },
+    })}\n`);
+    const scopedServer = createServer({
+      port: 0, startWatcher: false, wtDir: scopedTmp,
+      dbPath: join(scopedTmp, "catalyst.db"), catalystDir,
+    });
+    try {
+      const body = await (await fetch(`http://localhost:${scopedServer.port}/api/journey/CTL-7777`)).json() as {
+        hops: Array<{ phase: string; eventType: string }>;
+      };
+      expect(body.hops).toEqual([expect.objectContaining({ phase: "implement", eventType: "complete" })]);
+    } finally {
+      void scopedServer.stop(true);
+      rmSync(scopedTmp, { recursive: true, force: true });
+    }
+  });
+
+  it("does not read the host log when catalystDir is empty", async () => {
+    const scopedTmp = mkdtempSync(join(tmpdir(), "journey-empty-log-test-"));
+    const scopedServer = createServer({
+      port: 0, startWatcher: false, wtDir: scopedTmp,
+      dbPath: join(scopedTmp, "catalyst.db"), catalystDir: join(scopedTmp, "empty-catalyst"),
+    });
+    try {
+      const body = await (await fetch(`http://localhost:${scopedServer.port}/api/journey/CTL-7777`)).json() as {
+        hops: unknown[];
+      };
+      expect(body.hops).toEqual([]);
+    } finally {
+      void scopedServer.stop(true);
+      rmSync(scopedTmp, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
@@ -1,12 +1,13 @@
 // CTL-1100 Phase 5: journey.mjs unit tests — hops/dedupe/gate/verdict/unblock/host/degradation.
 
-import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { homedir, tmpdir } from "os";
+import { isAbsolute, join } from "path";
 
 // Load journey functions via computed specifier (bun:sqlite-free but guards module graph).
 const journeyMod = await import(["../lib/journey.mjs"].join("")) as {
+  eventLogPathFor: (catalystDir: string, now?: Date) => string;
   scanHops: (ticket: string, opts: { eventLogPath: string }) => Array<{
     phase: string; eventType: string; ts: string; host: string;
     bg_job_id?: string; reason?: string; targetPhase?: string; blockers?: unknown[];
@@ -35,7 +36,7 @@ const journeyMod = await import(["../lib/journey.mjs"].join("")) as {
     hosts: string[];
   }>;
 };
-const { scanHops, dedupeHops, buildGateChecklist, readVerifyVerdictDetail, collectUnblockHints, assembleJourney } = journeyMod;
+const { eventLogPathFor, scanHops, dedupeHops, buildGateChecklist, readVerifyVerdictDetail, collectUnblockHints, assembleJourney } = journeyMod;
 
 // Import deriveAdvancement + readPhaseSignals for backed-by-code assertions.
 const schedMod = await import(["../../execution-core/scheduler.mjs"].join("")) as {
@@ -74,6 +75,40 @@ function writeSignal(dir: string, phase: string, status: string, extra: Record<s
   mkdirSync(dir, { recursive: true });
   writeFileSync(join(dir, `phase-${phase}.json`), JSON.stringify({ status, ...extra }));
 }
+
+describe("event log path resolution", () => {
+  const originalCatalystDir = process.env.CATALYST_DIR;
+
+  beforeEach(() => {
+    process.env.CATALYST_DIR = originalCatalystDir;
+  });
+
+  afterEach(() => {
+    if (originalCatalystDir === undefined) delete process.env.CATALYST_DIR;
+    else process.env.CATALYST_DIR = originalCatalystDir;
+  });
+
+  it("resolves the current UTC month below an injected catalyst dir", () => {
+    const now = new Date();
+    const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+    expect(eventLogPathFor("/tmp/x")).toBe(join("/tmp/x", "events", `${ym}.jsonl`));
+  });
+
+  it("uses UTC and zero-pads a fixed month", () => {
+    expect(eventLogPathFor("/tmp/x", new Date("2026-01-05T00:00:00Z")))
+      .toBe(join("/tmp/x", "events", "2026-01.jsonl"));
+  });
+
+  it("the test preload pins CATALYST_DIR away from the host catalyst dir", () => {
+    expect(process.env.CATALYST_DIR).toBeDefined();
+    expect(isAbsolute(process.env.CATALYST_DIR!)).toBe(true);
+    expect(process.env.CATALYST_DIR).not.toBe(join(homedir(), "catalyst"));
+  });
+
+  it("scanHops degrades to empty for a missing injected event log", () => {
+    expect(scanHops("CTL-9001", { eventLogPath: join(tmpDir, "missing.jsonl") })).toEqual([]);
+  });
+});
 
 // ─── 1. scanHops / dedupeHops — suffix collision guard ──────────────────────
 

--- a/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/journey.test.ts
@@ -100,9 +100,11 @@ describe("event log path resolution", () => {
   });
 
   it("the test preload pins CATALYST_DIR away from the host catalyst dir", () => {
-    expect(process.env.CATALYST_DIR).toBeDefined();
-    expect(isAbsolute(process.env.CATALYST_DIR!)).toBe(true);
-    expect(process.env.CATALYST_DIR).not.toBe(join(homedir(), "catalyst"));
+    const catalystDir = process.env.CATALYST_DIR;
+    expect(catalystDir).toBeDefined();
+    if (catalystDir === undefined) throw new Error("test preload did not set CATALYST_DIR");
+    expect(isAbsolute(catalystDir)).toBe(true);
+    expect(catalystDir).not.toBe(join(homedir(), "catalyst"));
   });
 
   it("scanHops degrades to empty for a missing injected event log", () => {

--- a/plugins/dev/scripts/orch-monitor/lib/journey.d.mts
+++ b/plugins/dev/scripts/orch-monitor/lib/journey.d.mts
@@ -56,6 +56,7 @@ export interface JourneyOptions {
   dbPath?: string;
 }
 
+export declare function eventLogPathFor(catalystDir: string, now?: Date): string;
 export declare function scanHops(ticket: string, opts?: { eventLogPath?: string }): JourneyHop[];
 export declare function dedupeHops(hops: JourneyHop[]): JourneyHop[];
 export declare function readVerifyVerdictDetail(ticket: string, opts?: { orchDir?: string }): VerifyVerdictDetail;

--- a/plugins/dev/scripts/orch-monitor/lib/journey.mjs
+++ b/plugins/dev/scripts/orch-monitor/lib/journey.mjs
@@ -25,10 +25,14 @@ function defaultWorkersDir() {
   return join(defaultOrchDir(), "workers");
 }
 
-function defaultEventLogPath() {
-  const now = new Date();
+// CAT-216: resolve from the same injectable catalyst root used by server.ts.
+export function eventLogPathFor(catalystDir, now = new Date()) {
   const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
-  return join(homedir(), "catalyst", "events", `${ym}.jsonl`);
+  return join(catalystDir, "events", `${ym}.jsonl`);
+}
+
+function defaultEventLogPath() {
+  return eventLogPathFor(process.env.CATALYST_DIR || join(homedir(), "catalyst"));
 }
 
 // ── scanHops ─────────────────────────────────────────────────────────────────

--- a/plugins/dev/scripts/orch-monitor/server.ts
+++ b/plugins/dev/scripts/orch-monitor/server.ts
@@ -84,7 +84,7 @@ import {
   beliefCfg,
 } from "./lib/belief-store-queries.mjs";
 // CTL-1100: journey assembler (bun:sqlite-free — plain static import safe).
-import { assembleJourney } from "./lib/journey.mjs";
+import { assembleJourney, eventLogPathFor } from "./lib/journey.mjs";
 // CTL-887 (BFF5): the live transcript tail for execution-core workers. The
 // legacy /api/worker-stream reads the Plane-B runs/ tree (empty for EC); this
 // is the EC equivalent — tails ~/.claude/projects/*/<sessionId>.jsonl and
@@ -4270,6 +4270,8 @@ export function createServer(opts: CreateServerOptions): BunServer {
             orchDir: wtDir,
             workersDir: `${wtDir}/workers`,
             dbPath: dbPath ?? undefined,
+            // CAT-216: keep request cost scoped to this server's catalyst root.
+            eventLogPath: eventLogPathFor(CATALYST_DIR),
           }));
         }
 

--- a/plugins/dev/scripts/orch-monitor/test-setup.mjs
+++ b/plugins/dev/scripts/orch-monitor/test-setup.mjs
@@ -46,6 +46,8 @@ import { join } from "node:path";
 
 const hermeticDir = mkdtempSync(join(tmpdir(), "orch-monitor-hermetic-"));
 process.env.CATALYST_LAYER2_CONFIG_FILE = join(hermeticDir, "absent-layer2-config.json");
+// CAT-216: keep event-log reads and writes out of the host's ~/catalyst tree.
+process.env.CATALYST_DIR = join(hermeticDir, "catalyst");
 
 // Belt: even if some other resolution path is somehow reached, no app-actor
 // (or personal) token can already be sitting in env for a test to


### PR DESCRIPTION
Rebased re-cut of #3236 (Tony Hagale / thagale/catalyst) onto current main, as part of tonight's full-backlog PR triage (Ryan's directive, 2026-08-20). #3236 itself was built on a much older divergent branch (100 commits including the shared fork-mirror base); this PR cherry-picks just the two commits unique to CAT-216, with authorship preserved, cleanly on top of current main. All affected orch-monitor journey tests pass (25/25) after `bun install` in a fresh worktree.

## Summary
Make journey event-log reads injectable so orch-monitor tests can use a hermetic Catalyst directory instead of scanning the host event log. This removes host load and host state from the journey recomputation contract while preserving the production default.

## Changes Made
- Added `eventLogPathFor` to resolve the current UTC event-log path from an explicit Catalyst root.
- Passed the server's configured Catalyst directory into journey assembly.
- Pinned `CATALYST_DIR` to the orch-monitor test preload's temporary directory.
- Added unit and endpoint coverage for injected, missing, and UTC-month event logs.
- Kept a 15-second backstop on the recomputation contract test while making its data source hermetic.

## Related Issues/PRs
- Fixes https://linear.app/hagale/issue/CAT-216
- Supersedes #3236

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>