### PR TITLE
feat(dev): CTL-1214 slim .catalyst/config.json to project identity

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -29,11 +29,6 @@
       "user": null
     },
     "monitor": {
-      "github": {
-        "repoColors": {
-          "coalesce-labs/catalyst": "green"
-        }
-      },
       "linear": {
         "teams": [
           {
@@ -62,42 +57,6 @@
     "deployment": {
       "mode": "cluster"
     },
-    "orchestration": {
-      "dispatchMode": "phase-agents",
-      "worktreeRefresh": {
-        "enabled": true,
-        "intervalSeconds": 300,
-        "quietSeconds": 30
-      },
-      "reconcile": {
-        "mode": "notify",
-        "intervalSeconds": 600
-      },
-      "executionCore": {
-        "maxParallel": 4,
-        "minParallel": 1,
-        "maxParallelCeiling": 40,
-        "eligibleQuery": {
-          "status": "Todo",
-          "team": null,
-          "project": null,
-          "label": null,
-          "priority": null
-        }
-      }
-    },
-    "feedback": {
-      "autoFile": true,
-      "githubRepo": "coalesce-labs/catalyst",
-      "labels": [
-        "auto-submitted"
-      ]
-    },
-    "sweep": {
-      "idleHours": 48,
-      "intervalHours": 1,
-      "salvagePush": false,
-      "maxRemovalsPerRun": 10
-    }
+    "schemaVersion": 1
   }
 }

--- a/.claude/config.template.json
+++ b/.claude/config.template.json
@@ -2,6 +2,8 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "$comment": "Catalyst Configuration Template - Copy to config.json and fill in values. Secrets (including the Linear app-actor OAuth creds) go in ~/.config/catalyst/config-{projectKey}.json; monitor.linear.botUserId is NOT a secret and stays here in Layer 1.",
   "catalyst": {
+    "_comment_schema": "schemaVersion 1 means this config has opted into the slimmed Layer-1 schema (CTL-1214): no node/cluster-scoped keys. monitor.github.repoColors relocated to the NODE-scoped ~/.config/catalyst/node.json — run `catalyst-config-migrate` to move an existing repo's keys there.",
+    "schemaVersion": 1,
     "projectKey": "my-project",
     "repository": {
       "org": "[YOUR_ORG]",
@@ -59,8 +61,7 @@
       "$comment": "smeeChannel lives in Layer 2 (~/.config/catalyst/config.json) — written by setup-webhooks.sh, never committed.",
       "github": {
         "webhookSecretEnv": "CATALYST_WEBHOOK_SECRET",
-        "watchRepos": [],
-        "repoColors": {}
+        "watchRepos": []
       },
       "linear": {
         "$comment": "botUserId is the Linear USER UUID of the Catalyst app-actor (CTL-550). Required for the Linear app-actor comms channel — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749). It lets execution-core and orch-monitor tell the agent's own mirror comments/issue events apart from a human's (loop / self-echo prevention). To obtain: TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-{projectKey}.json) && curl -s -X POST https://api.linear.app/graphql -H \"Authorization: Bearer $TOKEN\" -H \"Content-Type: application/json\" -d '{\"query\":\"query{viewer{id name}}\"}' | jq -r .data.viewer.id — then restart the monitor and execution-core daemon (both read botUserId only at startup).",

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1069,6 +1069,7 @@ jobs:
         run: |
           bash __tests__/catalyst-layer2-read.test.sh
           bash __tests__/layer2-read-parity.test.sh
+          bash __tests__/layer2-consumer-fallback.test.sh
 
       - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1046,6 +1046,30 @@ jobs:
         working-directory: plugins/dev/scripts
         run: bash __tests__/deployment-mode-parity.test.sh
 
+      - name: Layer-2 merged-read tests + cross-stack parity (CTL-1214)
+        # ⛔ PINNED IN THE SAME CHANGE THAT ADDED THE SUITES. CI here runs an
+        # EXPLICIT list, never a glob, so a suite that merely exists in the tree
+        # gates nothing. Verified before adding this step:
+        # `grep -n 'catalyst-layer2-read\|layer2-read-parity' .github/workflows/`
+        # returned NOTHING; positive control: the same grep for
+        # `deployment-mode-parity` returns the run line directly above.
+        #
+        # These carry CTL-1214 Phase 1, whose whole point is that four relocated
+        # config categories were read from Layer-1 ONLY behind fail-open readers —
+        # so slimming the committed config does not error, it SILENTLY reverts each
+        # knob to a code default. A regression here is invisible by construction,
+        # which is exactly the class that must not be left ungated.
+        #
+        # The parity suite additionally self-checks that its JS driver actually
+        # runs before trusting a matrix of empty answers: a driver that fails to
+        # start returns "" for every cell, which is indistinguishable from a real
+        # absence and would report a false green.
+        # Both need jq, preinstalled on ubuntu-latest runners.
+        working-directory: plugins/dev/scripts
+        run: |
+          bash __tests__/catalyst-layer2-read.test.sh
+          bash __tests__/layer2-read-parity.test.sh
+
       - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),
@@ -1660,6 +1684,7 @@ jobs:
             wait-watcher.test.mjs \
             work-done-probes.test.mjs \
             worktree-refresh-timer.test.mjs \
+            layer2-fallback.test.mjs \
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-seam-deps.test.mjs \

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1071,6 +1071,25 @@ jobs:
           bash __tests__/layer2-read-parity.test.sh
           bash __tests__/layer2-consumer-fallback.test.sh
 
+      - name: Layer-1 → node.json migration tests (CTL-1214)
+        # ⛔ PINNED IN THE SAME CHANGE THAT ADDED THE SUITE — CI here runs an
+        # EXPLICIT list, never a glob. Verified before adding:
+        # `grep -n 'layer1-relocation\|config-schema.test' .github/workflows/`
+        # returned NOTHING for either, so config-schema.test.mjs — the existing
+        # CTL-1214 Phase-1 suite — has never gated anything either; it is
+        # registered here alongside the new one. Positive control: the same grep
+        # for `deployment-mode-parity` returns its run line above.
+        #
+        # These carry the migration's DECISION TABLE (the non-clobber rule that
+        # keeps this host's machine-canonical maxParallel: 4 from being shadowed,
+        # the cluster/node scope split, the dead-key drop) and the ordering
+        # property that node.json is written BEFORE the Layer-1 slim — so a
+        # failure can never leave a repo slimmed with its values nowhere.
+        working-directory: plugins/dev/scripts
+        run: |
+          bun test __tests__/layer1-relocation.test.mjs
+          bun test __tests__/config-schema.test.mjs
+
       - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1090,6 +1090,29 @@ jobs:
           bun test __tests__/layer1-relocation.test.mjs
           bun test __tests__/config-schema.test.mjs
 
+      - name: Config re-leak guards (CTL-1214 Phase 3)
+        # ⛔ PINNED IN THE SAME CHANGE. Verified before adding:
+        # `grep -n 'setup-sweep-config\|check-config-drift\|config-template-statemap\|config-docs-coverage' .github/workflows/`
+        # returned NOTHING for any of the four, so none of them has ever gated a
+        # PR. Positive control: the same grep for `orphan-sweep.test.sh` returns
+        # its own run line.
+        #
+        # These guard the writers that can put a relocated key BACK into a
+        # committed Layer-1 config — setup_sweep_config, feedback-consent grant,
+        # the shipped template, and check-config-drift's --merge-into. Without
+        # them the CTL-1214 slimming survives only until the next setup run, and
+        # the regression is silent: the config simply grows the stanza again.
+        #
+        # setup-sweep-config.test.sh additionally ends with a guard (S6) that
+        # fails if the suite touched the real ~/.config/catalyst/node.json —
+        # it did, while it was being written.
+        working-directory: plugins/dev/scripts
+        run: |
+          bash __tests__/setup-sweep-config.test.sh
+          bash __tests__/check-config-drift.test.sh
+          bash __tests__/config-template-statemap.test.sh
+          bash __tests__/config-docs-coverage.test.sh
+
       - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1113,6 +1113,39 @@ jobs:
           bash __tests__/config-template-statemap.test.sh
           bash __tests__/config-docs-coverage.test.sh
 
+      - name: Config-consumer regression suites (CTL-1214 Phase 5)
+        # ⛔ PINNED IN THE SAME CHANGE THAT TOUCHED THESE SUITES. Verified before
+        # adding, with /usr/bin/grep (the agent shell's `grep` honours .gitignore
+        # and silently skips config*.json — a recursive zero over config is
+        # inconclusive until re-run with the real binary):
+        #   execution-core-config-drift -> 0 hits in .github/workflows/
+        #   orchestrate-dispatch-next   -> 0
+        #   check-project-setup.test.sh -> 0 (the 2 hits for `check-project-setup`
+        #                                     are path-filter triggers for the .sh,
+        #                                     not a run line for the suite)
+        # Positive controls, same instrument, same run: deployment-mode-parity -> 7,
+        # orphan-sweep.test.sh -> 5. So the zeros are real absences, not a broken grep.
+        #
+        # Why each one has to gate from here on:
+        #  • execution-core-config-drift — rewritten by this ticket to encode the
+        #    slimmed-config contract, and it EXITS 1 while ungated, so nothing
+        #    surfaced it.
+        #  • orchestrate-dispatch-next — this ticket gave the dispatcher a Layer-2
+        #    fallback for dispatchMode, which made the suite read the HOST it runs
+        #    on: 49 of 138 assertions flipped on any machine carrying a real
+        #    ~/.config/catalyst/node.json, i.e. the state this ticket's own
+        #    migration creates. The suite now pins CATALYST_LAYER2_CONFIG_FILE to a
+        #    scratch dir (tests 46/47 are the positive control that the pin did not
+        #    simply blind the reader) — registering it is what stops that
+        #    host-dependence from regressing invisibly again.
+        #  • check-project-setup — its drift assertions were re-anchored to the
+        #    post-relocation contract (a relocated key is no longer drift).
+        working-directory: plugins/dev/scripts
+        run: |
+          bash __tests__/execution-core-config-drift.test.sh
+          bash __tests__/orchestrate-dispatch-next.test.sh
+          bash __tests__/check-project-setup.test.sh
+
       - name: Broker tests (CTL-1529, CTL-1809)
         # CTL-1529 round 2: broker/worker-state-projection.test.mjs guards the
         # bounded event-log scan in broker/projection.mjs (replayWorkerStateProjection),

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1728,6 +1728,8 @@ jobs:
             work-done-probes.test.mjs \
             worktree-refresh-timer.test.mjs \
             layer2-fallback.test.mjs \
+            doctor-config-scope-leak.test.mjs \
+            config-dump.test.mjs \
             worktree-safety.test.mjs \
             worktree.test.mjs \
             recovery-seam-deps.test.mjs \

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,10 @@ claude-accounts.env
 website/node_modules/
 website/dist/
 website/.astro/
+# website/ is an npm workspace — website/package-lock.json is the committed
+# lockfile. A stray `bun install` here drops a bun.lock beside it; ignore it so
+# it can never be committed alongside a conflicting lockfile (CTL-1214).
+website/bun.lock
 
 # Plugin-local tooling (orch-monitor)
 plugins/dev/scripts/orch-monitor/node_modules/

--- a/plugins/dev/scripts/__tests__/catalyst-layer2-read.test.sh
+++ b/plugins/dev/scripts/__tests__/catalyst-layer2-read.test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Shell unit tests for plugins/dev/scripts/lib/catalyst-layer2-read.sh (CTL-1214
+# Phase 1). Standalone per-language suite — cross-stack agreement with
+# execution-core/config.mjs's readLayer2Merged() is covered separately by
+# __tests__/layer2-read-parity.test.sh, which checks BOTH stacks against a
+# computed expected value rather than merely against each other.
+#
+# Run: bash plugins/dev/scripts/__tests__/catalyst-layer2-read.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-layer2-read.sh"
+
+FAILURES=0
+PASSES=0
+
+ok() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then ok "$name"; else fail "$name" "expected '$expected' got '$actual'"; fi
+}
+
+if [[ ! -f "$LIB" ]]; then
+  echo "FAIL: missing lib $LIB"
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$LIB"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Each case gets its own config dir so a stale sibling can't leak between cases.
+new_dir() {
+  local d; d="$(mktemp -d "${TMP_DIR}/cfgXXXXXX")"; printf '%s' "$d"
+}
+
+echo "== catalyst-layer2-read.sh =="
+
+# --- idempotent-load guard -------------------------------------------------
+expect_eq "idempotent-source guard set" "1" "${_CATALYST_LAYER2_READ_SH_LOADED:-}"
+
+# --- 1. all three files absent -> empty, rc 0 (fail-open) ------------------
+D="$(new_dir)"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"; RC=$?
+expect_eq "1. all absent -> empty" "" "$OUT"
+expect_eq "1. all absent -> rc 0" "0" "$RC"
+
+# --- 2. only config.json defines the path ----------------------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}' > "${D}/config.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"
+expect_eq "2. config.json only" "phase-agents" "$OUT"
+
+# --- 3. node.json overrides config.json ------------------------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"orchestration":{"dispatchMode":"oneshot-legacy"}}}' > "${D}/config.json"
+printf '%s' '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}' > "${D}/node.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"
+expect_eq "3. node.json beats config.json" "phase-agents" "$OUT"
+
+# --- 4. cluster-secrets.json overrides node.json ---------------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"x":{"y":"from-config"}}}' > "${D}/config.json"
+printf '%s' '{"catalyst":{"x":{"y":"from-node"}}}' > "${D}/node.json"
+printf '%s' '{"catalyst":{"x":{"y":"from-secrets"}}}' > "${D}/cluster-secrets.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.x.y')"
+expect_eq "4. cluster-secrets beats node.json" "from-secrets" "$OUT"
+
+# --- 5. deep merge, not replace --------------------------------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"sweep":{"idleHours":48,"intervalHours":1}}}' > "${D}/config.json"
+printf '%s' '{"catalyst":{"sweep":{"maxRemovalsPerRun":10}}}' > "${D}/node.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.sweep.idleHours')"
+expect_eq "5a. deep merge keeps config.json sibling" "48" "$OUT"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.sweep.maxRemovalsPerRun')"
+expect_eq "5b. deep merge keeps node.json sibling" "10" "$OUT"
+
+# --- 6. malformed JSON in ONE file -> that file is layer-absent -------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"sweep":{"intervalHours":1}}}' > "${D}/config.json"
+printf '%s' '{ this is not json' > "${D}/node.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.sweep.intervalHours' 2>/dev/null)"
+expect_eq "6. malformed node.json -> config.json still read" "1" "$OUT"
+
+# --- 7. a STRING where an object is expected (the live catalyst.feedback case)
+# ~/.config/catalyst/config.json really carries catalyst.feedback as a STRING.
+# A naive `jq '.catalyst.feedback.autoFile'` dies with "Cannot index string".
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"feedback":"https://github.com/coalesce-labs/catalyst.git"}}' > "${D}/config.json"
+ERRFILE="${D}/err.txt"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.feedback.autoFile' 2>"$ERRFILE")"; RC=$?
+expect_eq "7a. string-where-object -> empty" "" "$OUT"
+expect_eq "7b. string-where-object -> rc 0" "0" "$RC"
+expect_eq "7c. string-where-object -> no stderr" "" "$(cat "$ERRFILE")"
+
+# Positive control for case 7: the same file DOES resolve a scalar path, so the
+# empty answer above is a real absence and not a broken reader.
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.feedback')"
+expect_eq "7d. positive control: scalar path still resolves" "https://github.com/coalesce-labs/catalyst.git" "$OUT"
+
+# --- 8. jq absent -> empty + breadcrumb -------------------------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"sweep":{"intervalHours":1}}}' > "${D}/config.json"
+ERRFILE="${D}/err8.txt"
+# Hide jq WITHOUT hiding bash itself: an absolute /bin/bash is invoked and the
+# empty PATH is applied inside the child, so `command -v jq` misses while the
+# interpreter still starts. (A bare `PATH=... bash -c` cannot find `bash`, which
+# fails with 127 for the wrong reason and would silently pass a broken assertion.)
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" \
+       /bin/bash -c 'PATH=/nonexistent-bin; source "$1"; catalyst_layer2_json ".catalyst.sweep.intervalHours"; echo "BREADCRUMB=${CATALYST_LAYER2_READ_JQ_MISSING:-}" >&2' \
+       _ "$LIB" 2>"$ERRFILE")"; RC=$?
+expect_eq "8a. jq absent -> empty" "" "$OUT"
+expect_eq "8b. jq absent -> rc 0" "0" "$RC"
+if /usr/bin/grep -q 'BREADCRUMB=1' "$ERRFILE"; then
+  ok "8c. jq absent -> CATALYST_LAYER2_READ_JQ_MISSING breadcrumb set"
+else
+  fail "8c. jq absent -> breadcrumb set" "stderr was: $(cat "$ERRFILE")"
+fi
+if /usr/bin/grep -qi 'jq' "$ERRFILE"; then
+  ok "8d. jq absent -> one stderr line naming jq"
+else
+  fail "8d. jq absent -> stderr names jq" "stderr was: $(cat "$ERRFILE")"
+fi
+
+# --- 9. HOME unset -> never probes /.config/catalyst/... --------------------
+# The catalyst-secret-contract.sh:222 trap. Assert on the resolved DIRECTORY,
+# because an absent file and a wrongly-probed absent file both read as "".
+OUT="$(env -u HOME -u CATALYST_LAYER2_CONFIG_FILE -u XDG_CONFIG_HOME \
+       bash -c 'source "$1"; _catalyst_layer2_dir' _ "$LIB")"
+case "$OUT" in
+  /.config/catalyst) fail "9. HOME unset -> no bare-root probe" "resolved '$OUT'" ;;
+  ""              ) fail "9. HOME unset -> no bare-root probe" "resolved empty" ;;
+  *               ) ok "9. HOME unset -> no bare-root probe (resolved '$OUT')" ;;
+esac
+
+# --- 10. CATALYST_LAYER2_CONFIG_FILE wins; siblings resolve off ITS dir -----
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"k":"pinned"}}' > "${D}/node.json"
+printf '%s' '{}' > "${D}/config.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.k')"
+expect_eq "10. siblings resolve off the pinned file's dir" "pinned" "$OUT"
+
+# --- 11. a null value is an ABSENCE, not the string "null" ------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"orchestration":{"dispatchMode":null}}}' > "${D}/config.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"
+expect_eq "11. null -> empty (never the literal 'null')" "" "$OUT"
+
+# --- 12. an object/array value round-trips as compact JSON ------------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"feedback":{"labels":["auto-submitted"]}}}' > "${D}/config.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.feedback.labels')"
+expect_eq "12. array value -> compact JSON" '["auto-submitted"]' "$OUT"
+
+# --- 13. false is a VALUE, not an absence (the salvagePush trap) ------------
+D="$(new_dir)"
+printf '%s' '{"catalyst":{"sweep":{"salvagePush":false}}}' > "${D}/config.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" catalyst_layer2_json '.catalyst.sweep.salvagePush')"
+expect_eq "13. false survives (jq-falsy trap)" "false" "$OUT"
+
+echo
+echo "PASSES=${PASSES} FAILURES=${FAILURES}"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/check-config-drift.test.sh
+++ b/plugins/dev/scripts/__tests__/check-config-drift.test.sh
@@ -29,10 +29,21 @@ run() {
 
 expect_exit() {
   local expected="$1"; shift
+  # ⚠️ Restore the shell's PREVIOUS errexit state, never force it ON. This used
+  # to end with a bare `set -e`, which TURNED ERREXIT ON for the rest of the file
+  # even though the suite runs `set -uo pipefail` and never enabled it. Every
+  # test after the first expect_exit call then ran under errexit; the existing
+  # ones survived only because `run()` wraps its command in an `if`, which
+  # suppresses it. The first bare invocation that legitimately returns non-zero
+  # — e.g. `bash "$DRIFT" ...` when drift IS found, which is the expected
+  # outcome of a positive control — silently killed the whole suite mid-run,
+  # taking the trailing "All N tests passed" summary with it. It exited 1, so it
+  # looked like an ordinary failure while the remaining assertions never ran.
+  local _prev_e; case "$-" in *e*) _prev_e=1 ;; *) _prev_e=0 ;; esac
   set +e
   "$@" > "${SCRATCH}/out" 2>&1
   local rc=$?
-  set -e
+  [ "$_prev_e" = "1" ] && set -e
   if [ "$rc" = "$expected" ]; then
     return 0
   else
@@ -64,7 +75,7 @@ cat > "$TPL1" <<'EOF'
 {
   "catalyst": {
     "projectKey": "x",
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -72,7 +83,7 @@ cat > "$CFG1" <<'EOF'
 {
   "catalyst": {
     "projectKey": "x",
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -89,7 +100,7 @@ cat > "$TPL2" <<'EOF'
 {
   "catalyst": {
     "projectKey": "x",
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -98,8 +109,8 @@ cat > "$CFG2" <<'EOF'
 EOF
 run "missing leaf → exit 1" expect_exit 1 bash "$DRIFT" --template "$TPL2" --config "$CFG2"
 bash "$DRIFT" --template "$TPL2" --config "$CFG2" > "${SCRATCH}/out2" 2>/dev/null || true
-run "missing dispatchMode mentioned" expect_contains "${SCRATCH}/out2" "Missing catalyst.orchestration.dispatchMode"
-run "template default quoted" expect_contains "${SCRATCH}/out2" 'template suggests "phase-agents"'
+run "missing executor mentioned" expect_contains "${SCRATCH}/out2" "Missing catalyst.orchestration.executor"
+run "template default quoted" expect_contains "${SCRATCH}/out2" 'template suggests "sdk"'
 run "hint mentions setup-catalyst" expect_contains "${SCRATCH}/out2" "/catalyst-foundry:setup-catalyst"
 
 # ── Test 3: nested object exists but leaf inside is missing ──────────────────
@@ -150,7 +161,7 @@ cat > "$TPL5" <<'EOF'
     "deploy": {
       "[YOUR_ORG]/[YOUR_REPO]": { "timeoutSec": 1800 }
     },
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -162,7 +173,7 @@ bash "$DRIFT" --template "$TPL5" --config "$CFG5" > "${SCRATCH}/out5" 2>/dev/nul
 run "no placeholder drift for YOUR_ORG" expect_not_contains "${SCRATCH}/out5" "YOUR_ORG"
 run "no placeholder drift for YOUR_REPO" expect_not_contains "${SCRATCH}/out5" "YOUR_REPO"
 run "no placeholder drift for deploy" expect_not_contains "${SCRATCH}/out5" "Missing catalyst.deploy"
-run "dispatchMode drift still fires" expect_contains "${SCRATCH}/out5" "Missing catalyst.orchestration.dispatchMode"
+run "executor drift still fires" expect_contains "${SCRATCH}/out5" "Missing catalyst.orchestration.executor"
 
 # ── Test 6: allow-listed roots suppressed (already covered by check-project-setup.sh) ──
 TPL6="${SCRATCH}/tpl6.json"
@@ -177,7 +188,7 @@ cat > "$TPL6" <<'EOF'
       "stateMap": { "research": "In Progress" },
       "stateIds": { "research": "uuid-x" }
     },
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -191,7 +202,7 @@ run "suppresses ticketPrefix" expect_not_contains "${SCRATCH}/out6" "Missing cat
 run "suppresses teamKey" expect_not_contains "${SCRATCH}/out6" "Missing catalyst.linear.teamKey"
 run "suppresses stateMap sub-keys" expect_not_contains "${SCRATCH}/out6" "Missing catalyst.linear.stateMap"
 run "suppresses stateIds sub-keys" expect_not_contains "${SCRATCH}/out6" "Missing catalyst.linear.stateIds"
-run "non-allow-listed dispatchMode still warns" expect_contains "${SCRATCH}/out6" "Missing catalyst.orchestration.dispatchMode"
+run "non-allow-listed executor still warns" expect_contains "${SCRATCH}/out6" "Missing catalyst.orchestration.executor"
 
 # ── Test 7: --json mode emits structured array ───────────────────────────────
 bash "$DRIFT" --json --template "$TPL2" --config "$CFG2" > "${SCRATCH}/out7" 2>/dev/null || true
@@ -216,7 +227,7 @@ cat > "$TPL8" <<'EOF'
 {
   "catalyst": {
     "projectKey": "default",
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -229,9 +240,9 @@ run "merge preserves projectKey" bash -c "
   v=\$(jq -r '.catalyst.projectKey' < '$OUT8')
   [ \"\$v\" = \"user-chosen-name\" ]
 "
-run "merge adds dispatchMode" bash -c "
-  v=\$(jq -r '.catalyst.orchestration.dispatchMode' < '$OUT8')
-  [ \"\$v\" = \"phase-agents\" ]
+run "merge adds executor" bash -c "
+  v=\$(jq -r '.catalyst.orchestration.executor' < '$OUT8')
+  [ \"\$v\" = \"sdk\" ]
 "
 
 # ── Test 9: --merge-into never overwrites user values ────────────────────────
@@ -297,8 +308,8 @@ fi
 
 # ── Test 14: arrays are leaves, not descended into (regression for paths(scalars)) ──
 # Without the fix, paths(scalars) descends into arrays and yields integer-indexed
-# leaves; a project missing the feedback block would see
-# "Missing catalyst.feedback.labels.0" — semantically wrong since users never set
+# leaves; a project missing the filter block would see
+# "Missing catalyst.filter.groqModels.0" — semantically wrong since users never set
 # array elements by integer index. With the fix the array itself is the leaf.
 TPL14="${SCRATCH}/tpl14.json"
 CFG14="${SCRATCH}/cfg14.json"
@@ -306,7 +317,7 @@ cat > "$TPL14" <<'EOF'
 {
   "catalyst": {
     "projectKey": "k",
-    "feedback": { "labels": ["auto-submitted", "needs-triage"] }
+    "filter": { "groqModels": ["llama-3.1-8b-instant", "llama-3.3-70b"] }
   }
 }
 EOF
@@ -317,16 +328,16 @@ run "array template leaves: no integer-indexed warning" bash -c "
   out=\$(bash '$DRIFT' --template '$TPL14' --config '$CFG14' 2>/dev/null || true)
   ! echo \"\$out\" | grep -q 'labels\\.0'
 "
-run "array template leaves: single warning for the labels array" bash -c "
+run "array template leaves: single warning for the groqModels array" bash -c "
   out=\$(bash '$DRIFT' --template '$TPL14' --config '$CFG14' 2>/dev/null || true)
-  count=\$(echo \"\$out\" | grep -c 'Missing catalyst\\.feedback\\.labels' || true)
+  count=\$(echo \"\$out\" | grep -c 'Missing catalyst\\.filter\\.groqModels' || true)
   # one warning + one indented hint line both contain the substring → expect 2
   [ \"\$count\" -ge 1 ]
 "
 run "array template leaves: --json reports the array verbatim" bash -c "
   out=\$(bash '$DRIFT' --json --template '$TPL14' --config '$CFG14' 2>/dev/null || true)
-  v=\$(echo \"\$out\" | jq -c '[.[] | select(.path == [\"catalyst\",\"feedback\",\"labels\"])][0].template_value')
-  [ \"\$v\" = '[\"auto-submitted\",\"needs-triage\"]' ]
+  v=\$(echo \"\$out\" | jq -c '[.[] | select(.path == [\"catalyst\",\"filter\",\"groqModels\"])][0].template_value')
+  [ \"\$v\" = '[\"llama-3.1-8b-instant\",\"llama-3.3-70b\"]' ]
 "
 
 # ── Test 15: --merge-into strips placeholder VALUES, not just placeholder KEYS ──
@@ -340,7 +351,7 @@ cat > "$TPL15" <<'EOF'
 {
   "catalyst": {
     "repository": { "org": "[YOUR_ORG]", "name": "[YOUR_REPO]" },
-    "orchestration": { "dispatchMode": "phase-agents" }
+    "orchestration": { "executor": "sdk" }
   }
 }
 EOF
@@ -368,9 +379,85 @@ run "--merge-into: no [YOUR_*] literal injected when block is absent" bash -c "
   ! jq -r '.. | strings' < '$OUT15B' | grep -q '\\[YOUR_'
 "
 run "--merge-into: non-placeholder template keys still merged" bash -c "
-  v=\$(jq -r '.catalyst.orchestration.dispatchMode' < '$OUT15B')
-  [ \"\$v\" = 'phase-agents' ]
+  v=\$(jq -r '.catalyst.orchestration.executor' < '$OUT15B')
+  [ \"\$v\" = 'sdk' ]
 "
+
+# ─── CTL-1214: a slimmed config vs an OLD (unsanitized) template ─────────────
+# This detector's direction is the inverse of CTL-1214's: it reports template
+# keys MISSING from a project config and can --merge-into them. A repo pinned to
+# a pre-CTL-1214 template would therefore see every relocated key as drift, and a
+# --merge-into would put the whole stanza straight back — undoing the slimming.
+OLD_TPL="${SCRATCH}/tpl-old.json"
+cat > "$OLD_TPL" <<'EOF'
+{
+  "catalyst": {
+    "projectKey": "my-project",
+    "project": { "ticketPrefix": "PROJ" },
+    "filter": { "groqModel": "llama-3.1-8b-instant" },
+    "feedback": { "autoFile": false, "githubRepo": "coalesce-labs/catalyst", "labels": ["auto-submitted"] },
+    "sweep": { "idleHours": 48, "intervalHours": 1 },
+    "monitor": { "github": { "repoColors": { "a/b": "green" } } },
+    "orchestration": {
+      "dispatchMode": "phase-agents",
+      "worktreeRefresh": { "enabled": true },
+      "reconcile": { "mode": "notify" },
+      "executionCore": { "maxParallel": 4 }
+    }
+  }
+}
+EOF
+
+SLIM_CFG="${SCRATCH}/cfg-slim.json"
+cat > "$SLIM_CFG" <<'EOF'
+{
+  "catalyst": {
+    "schemaVersion": 1,
+    "projectKey": "my-project",
+    "project": { "ticketPrefix": "PROJ" },
+    "filter": { "groqModel": "llama-3.1-8b-instant" }
+  }
+}
+EOF
+
+OUT_SLIM="${SCRATCH}/out-slim.txt"
+SLIM_RC=0
+bash "$DRIFT" --template "$OLD_TPL" --config "$SLIM_CFG" > "$OUT_SLIM" 2>&1 || SLIM_RC=$?
+
+run "CTL-1214: a slimmed config vs the OLD template exits 0" \
+  bash -c "[ '$SLIM_RC' = '0' ]"
+run "CTL-1214: zero drift lines for any relocated path" \
+  bash -c "
+    n=\$(grep -cE 'Missing catalyst\\.(orchestration|feedback|sweep|monitor\\.github\\.repoColors)' '$OUT_SLIM' || true)
+    [ \"\$n\" = '0' ]
+  "
+
+# ⚠️ POSITIVE CONTROL. Without it, "zero drift" above could just mean the
+# detector stopped working — a genuine, NON-relocated missing key must still be
+# reported against the very same template.
+OLD_TPL_PLUS="${SCRATCH}/tpl-old-plus.json"
+jq '.catalyst.deployment = {"mode":"single-host"}' "$OLD_TPL" > "$OLD_TPL_PLUS"
+OUT_PC="${SCRATCH}/out-slim-pc.txt"
+PC_RC=0
+bash "$DRIFT" --template "$OLD_TPL_PLUS" --config "$SLIM_CFG" > "$OUT_PC" 2>&1 || PC_RC=$?
+run "CTL-1214 positive control: a non-relocated missing key IS still reported" \
+  bash -c "grep -q 'Missing catalyst\\.deployment\\.mode' '$OUT_PC'"
+run "CTL-1214 positive control: and it still exits non-zero" \
+  bash -c "[ '$PC_RC' != '0' ]"
+
+# --merge-into must never re-add a relocated key.
+MERGED_SLIM="${SCRATCH}/merged-slim.json"
+bash "$DRIFT" --template "$OLD_TPL" --config "$SLIM_CFG" --merge-into "$MERGED_SLIM" >/dev/null 2>&1 || true
+run "CTL-1214: --merge-into does not re-add orchestration" \
+  bash -c "jq -e '.catalyst.orchestration == null' '$MERGED_SLIM'"
+run "CTL-1214: --merge-into does not re-add feedback" \
+  bash -c "jq -e '.catalyst.feedback == null' '$MERGED_SLIM'"
+run "CTL-1214: --merge-into does not re-add sweep" \
+  bash -c "jq -e '.catalyst.sweep == null' '$MERGED_SLIM'"
+run "CTL-1214: --merge-into does not re-add monitor.github.repoColors" \
+  bash -c "jq -e '.catalyst.monitor.github.repoColors == null' '$MERGED_SLIM' 2>/dev/null || jq -e '.catalyst.monitor == null' '$MERGED_SLIM'"
+run "CTL-1214: --merge-into positive control — identity keys ARE still merged" \
+  bash -c "jq -e '.catalyst.projectKey == \"my-project\" and .catalyst.filter.groqModel != null' '$MERGED_SLIM'"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/plugins/dev/scripts/__tests__/check-project-setup.test.sh
+++ b/plugins/dev/scripts/__tests__/check-project-setup.test.sh
@@ -174,8 +174,20 @@ EOF
 }
 
 # ─── Test: drift detected → warning appears in output (CTL-489) ─────────────
-# make_project's baseline config lacks orchestration.dispatchMode, so the drift
-# walker should surface a "Missing catalyst.orchestration.dispatchMode" warning.
+# make_project's baseline config lacks several template leaves, so the drift
+# walker should surface a "Missing catalyst.<path>" warning for each.
+#
+# CTL-1214 re-anchor: this used to assert on catalyst.orchestration.dispatchMode.
+# That key is now NODE-scoped — Phase 3 removed the orchestration stanza from
+# config.template.json AND the drift comparison strips RELOCATED_LAYER1_KEYS — so
+# a committed Layer-1 that omits it is CORRECT, not drifted, and offering it as
+# drift would tell an operator to re-commit the very key this ticket relocated.
+#
+# The probe is therefore re-pointed at catalyst.deployment.mode, a leaf that is
+# still templated and still project-scoped, and PAIRED with a negative assertion
+# on the relocated keys. Both halves are load-bearing: the positive control is
+# what stops "no relocated key is offered as drift" from silently meaning "the
+# drift detector stopped working", which a bare not-grep can never distinguish.
 test_drift_warning_appears() {
   echo "test: missing template key → drift warning in check-project-setup output"
   local proj="$SCRATCH/proj-drift" key="proj-drift"
@@ -191,10 +203,23 @@ EOF
 
   local out
   out=$(run_script "$proj" 2>&1)
-  assert_grep "drift warning fires for dispatchMode" "$out" \
-    "Missing catalyst.orchestration.dispatchMode"
+  # POSITIVE CONTROL — a still-templated, still-project-scoped leaf must drift.
+  assert_grep "drift warning fires for a project-scoped key" "$out" \
+    "Missing catalyst.deployment.mode"
   assert_grep "drift warning quotes template default" "$out" \
-    'template suggests "phase-agents"'
+    'template suggests "single-host"'
+  # The CTL-1214 contract itself: no NODE-scoped relocated key is offered as
+  # drift, on either the template side or the RELOCATED_LAYER1_KEYS strip.
+  assert_not_grep "relocated dispatchMode not offered as drift" "$out" \
+    "Missing catalyst.orchestration.dispatchMode"
+  assert_not_grep "relocated sweep not offered as drift" "$out" \
+    "Missing catalyst.sweep"
+  assert_not_grep "relocated feedback not offered as drift" "$out" \
+    "Missing catalyst.feedback"
+  assert_not_grep "relocated repoColors not offered as drift" "$out" \
+    "Missing catalyst.monitor.github.repoColors"
+  assert_not_grep "relocated executionCore not offered as drift" "$out" \
+    "Missing catalyst.orchestration.executionCore"
   # Drift lines must land in the WARN: block (not leak out unformatted) — guards
   # against a regression where the `while read line; do warnings+=("$line"); done`
   # loop is removed and drift script output reaches stdout directly.

--- a/plugins/dev/scripts/__tests__/config-schema.test.mjs
+++ b/plugins/dev/scripts/__tests__/config-schema.test.mjs
@@ -367,6 +367,61 @@ describe("config.template.json is sanitized (CTL-1214)", () => {
   });
 });
 
+// CTL-1214 Phase 4 — THIS repo's committed .catalyst/config.json, read from disk.
+// The regression guard cuts both ways: a migration that OVER-slims is as bad as
+// one that under-slims, and losing stateMap would break every phase transition in
+// the pipeline.
+describe("this repo's committed .catalyst/config.json is slimmed (CTL-1214)", () => {
+  const layer1Path = join(import.meta.dir, "..", "..", "..", "..", ".catalyst", "config.json");
+  const cfg = JSON.parse(readFileSync(layer1Path, "utf8"));
+
+  test("validates with no hard errors and schemaVersion 1", () => {
+    const r = validateLayer1Config(cfg);
+    expect(r.errors).toEqual([]);
+    expect(r.valid).toBe(true);
+    expect(cfg.catalyst.schemaVersion).toBe(1);
+    expect(r.recommendations).toEqual([]);
+  });
+
+  test("the only remaining leak is the roster, which CTL-1885 owns (D4)", () => {
+    expect(validateLayer1Config(cfg).deprecatedKeys).toEqual(["monitor.linear.teams"]);
+  });
+
+  test("carries no orchestration / feedback / sweep / repoColors", () => {
+    expect(cfg.catalyst.orchestration).toBeUndefined();
+    expect(cfg.catalyst.feedback).toBeUndefined();
+    expect(cfg.catalyst.sweep).toBeUndefined();
+    expect(cfg.catalyst.monitor?.github).toBeUndefined();
+    // The dead key is gone entirely, not relocated.
+    expect(JSON.stringify(cfg)).not.toContain("eligibleQuery");
+  });
+
+  test("the identity block is INTACT (the over-slim guard)", () => {
+    expect(cfg.catalyst.projectKey).toBe("catalyst-workspace");
+    expect(cfg.catalyst.project.ticketPrefix).toBe("CTL");
+    expect(cfg.catalyst.linear.teamKey).toBe("CTL");
+    expect(typeof cfg.catalyst.linear.teamId).toBe("string");
+    expect(cfg.catalyst.linear.teamId.length).toBeGreaterThan(0);
+    // All 12 states — losing stateMap breaks every phase transition.
+    expect(Object.keys(cfg.catalyst.linear.stateMap)).toHaveLength(12);
+    for (const k of [
+      "backlog", "todo", "triage", "research", "planning", "inProgress",
+      "verifying", "reviewing", "remediating", "inReview", "done", "canceled",
+    ]) {
+      expect(typeof cfg.catalyst.linear.stateMap[k]).toBe("string");
+    }
+    expect(cfg.catalyst.thoughts.org).toBe("coalesce-labs");
+    expect(cfg.catalyst.thoughts.directory).toBe("catalyst-workspace");
+    expect(cfg.catalyst.deployment.mode).toBe("cluster");
+    // The roster stays (CTL-1885) and still names this repo — resolveRepoFullName
+    // falls through to monitor.linear.teams[].vcsRepo once feedback.githubRepo is
+    // gone from Layer-1, so an empty roster here would break the plugin-refresh
+    // merge-event matcher.
+    expect(cfg.catalyst.monitor.linear.teams.length).toBeGreaterThan(0);
+    expect(cfg.catalyst.monitor.linear.teams[0].vcsRepo).toBe("coalesce-labs/catalyst");
+  });
+});
+
 describe("catalyst-config.schema.json (Layer-1 schema)", () => {
   test("minimal identity config conforms to the schema", () => {
     expect(validateAgainstSchema(minimalLayer1(), catalystConfigSchema)).toEqual([]);

--- a/plugins/dev/scripts/__tests__/config-schema.test.mjs
+++ b/plugins/dev/scripts/__tests__/config-schema.test.mjs
@@ -172,7 +172,13 @@ describe("validateLayer1Config (CTL-1214)", () => {
   });
 
   test("legacy keys validate but are flagged deprecated (back-compat window)", () => {
-    const r = validateLayer1Config(kitchenSinkLayer1());
+    // The BACK-COMPAT window is by definition a config that has not opted into
+    // the new schema (CTL-1214 D3), so this fixture drops schemaVersion — which
+    // minimalLayer1() supplies. With it present the same config is correctly
+    // INVALID; that direction is asserted in the D3 describe block below.
+    const legacy = kitchenSinkLayer1();
+    delete legacy.catalyst.schemaVersion;
+    const r = validateLayer1Config(legacy);
     expect(r.valid).toBe(true); // still valid during migration
     expect(r.deprecatedKeys.length).toBeGreaterThan(0);
     // CTL-1214 D6: the blanket `orchestration` row is gone — it is now the four
@@ -191,6 +197,17 @@ describe("validateLayer1Config (CTL-1214)", () => {
       expect(r.deprecatedKeys).toContain(path);
     }
     expect(r.deprecatedKeys).not.toContain("orchestration");
+  });
+
+  test("the SAME kitchen-sink config IS invalid once it declares schemaVersion 1", () => {
+    // The other half of the back-compat contract: opting in is what makes the
+    // leaks fatal. Without this, the test above passes for a validator that never
+    // errors at all.
+    const r = validateLayer1Config(kitchenSinkLayer1());
+    expect(r.valid).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+    // The cluster-scoped roster is never the cause (D4).
+    expect(r.errors.join(" ")).not.toContain("monitor.linear.teams");
   });
 
   // CTL-1214 D6 — the narrowing, asserted in both directions. Without the
@@ -364,6 +381,106 @@ describe("config.template.json is sanitized (CTL-1214)", () => {
     expect(template.catalyst.filter).toBeDefined();
     expect("botUserId" in template.catalyst.monitor.linear).toBe(true);
     expect(template.catalyst.thoughts).toBeDefined();
+  });
+});
+
+// CTL-1214 Phase 5 (D3) — schemaVersion is the SELF-GATING opt-in to strictness.
+// Taken literally, "Phase 6 promotes schemaVersion to required" would flag every
+// not-yet-migrated config in the fleet as invalid, in editors and validators, for
+// no benefit. Instead: a PRESENT schemaVersion >= 1 means "this config has opted
+// into the new schema", and in that config a NODE-scoped relocated key becomes a
+// hard error. A config without schemaVersion keeps today's lenient behavior
+// verbatim — so a repo becomes strict exactly when it is slimmed.
+describe("schemaVersion-gated strictness (CTL-1214 D3/D4)", () => {
+  const withLeak = (leak, opts = {}) => {
+    const cfg = minimalLayer1();
+    if (opts.noSchemaVersion) delete cfg.catalyst.schemaVersion;
+    Object.assign(cfg.catalyst, leak);
+    return cfg;
+  };
+
+  test("schemaVersion ABSENT + node leak -> valid, recommendation only (unchanged)", () => {
+    const r = validateLayer1Config(
+      withLeak({ sweep: { idleHours: 48 } }, { noSchemaVersion: true }),
+    );
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.deprecatedKeys).toEqual(["sweep"]);
+    expect(r.recommendations.length).toBeGreaterThan(0);
+  });
+
+  test("schemaVersion 1 + node leak -> INVALID, and the error names the path", () => {
+    const r = validateLayer1Config(withLeak({ sweep: { idleHours: 48 } }));
+    expect(r.valid).toBe(false);
+    expect(r.errors.length).toBeGreaterThan(0);
+    expect(r.errors.join(" ")).toContain("sweep");
+    // The remediation must be actionable, not just a complaint.
+    expect(r.errors.join(" ")).toContain("catalyst-config-migrate");
+  });
+
+  test("schemaVersion 1 + CLUSTER leak (the roster) stays VALID (D4/CTL-1885)", () => {
+    const r = validateLayer1Config(
+      withLeak({ monitor: { linear: { teams: [{ key: "CTL", vcsRepo: "a/b" }] } } }),
+    );
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.deprecatedKeys).toEqual(["monitor.linear.teams"]);
+  });
+
+  test("schemaVersion 1 + a MIX -> invalid for the node half only", () => {
+    const r = validateLayer1Config(
+      withLeak({
+        monitor: { linear: { teams: [{ key: "CTL", vcsRepo: "a/b" }] } },
+        sweep: { idleHours: 48 },
+      }),
+    );
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(" ")).toContain("sweep");
+    expect(r.errors.join(" ")).not.toContain("monitor.linear.teams");
+  });
+
+  test("schemaVersion 1 + clean -> valid, no recommendations", () => {
+    const r = validateLayer1Config(minimalLayer1());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+    expect(r.recommendations).toEqual([]);
+    expect(r.deprecatedKeys).toEqual([]);
+  });
+
+  test("each of the four relocated orchestration subpaths FAILs under schemaVersion 1", () => {
+    for (const [key, value] of [
+      ["dispatchMode", "phase-agents"],
+      ["executionCore", { maxParallel: 4 }],
+      ["worktreeRefresh", { enabled: true }],
+      ["reconcile", { mode: "notify" }],
+    ]) {
+      const r = validateLayer1Config(withLeak({ orchestration: { [key]: value } }));
+      expect(r.valid).toBe(false);
+      expect(r.errors.join(" ")).toContain(`orchestration.${key}`);
+    }
+  });
+
+  test("a genuinely Layer-1 orchestration stanza does NOT fail under schemaVersion 1 (D6)", () => {
+    for (const stanza of [
+      { codex: { codexHome: "/x" } },
+      { executor: "sdk" },
+      { fleetHealth: { mode: "shadow" } },
+      { draftPr: { enabled: true } },
+    ]) {
+      const r = validateLayer1Config(withLeak({ orchestration: stanza }));
+      expect(r.valid).toBe(true);
+      expect(r.errors).toEqual([]);
+    }
+  });
+
+  test("a malformed schemaVersion is still a hard error, and does not gate strictness", () => {
+    const cfg = withLeak({ sweep: { idleHours: 48 } });
+    cfg.catalyst.schemaVersion = 0;
+    const r = validateLayer1Config(cfg);
+    expect(r.valid).toBe(false);
+    expect(r.errors.join(" ")).toContain("schemaVersion");
+    // 0 is not >= 1, so it has NOT opted in — the leak stays a deprecation.
+    expect(r.errors.join(" ")).not.toContain("catalyst-config-migrate");
   });
 });
 

--- a/plugins/dev/scripts/__tests__/config-schema.test.mjs
+++ b/plugins/dev/scripts/__tests__/config-schema.test.mjs
@@ -15,7 +15,7 @@
 // three schemas actually use.
 
 import { describe, test, expect } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -382,6 +382,49 @@ describe("config.template.json is sanitized (CTL-1214)", () => {
     expect("botUserId" in template.catalyst.monitor.linear).toBe(true);
     expect(template.catalyst.thoughts).toBeDefined();
   });
+});
+
+// CTL-1214 remediation — the sanitization assertion above read ONE of the two
+// SHIPPED templates. config-template-statemap.test.sh treats both as maintained
+// artifacts, and the .claude/ one still carried monitor.github.repoColors (a
+// RELOCATED_LAYER1_KEYS path) with no schemaVersion — so the "template is
+// sanitized" AC was satisfied by a file while its sibling re-leaked. Both paths
+// are now asserted from ONE list, so adding a third template surfaces here rather
+// than silently going uncovered.
+describe("every shipped config template is sanitized (CTL-1214)", () => {
+  const SHIPPED_TEMPLATES = [
+    ["plugins/dev/templates/config.template.json", join(import.meta.dir, "..", "..", "templates", "config.template.json")],
+    [".claude/config.template.json", join(import.meta.dir, "..", "..", "..", "..", ".claude", "config.template.json")],
+  ];
+
+  // Positive control on the LIST itself: a path typo would otherwise make the
+  // loop below iterate over a file that does not exist, and a `[].every(p)`-style
+  // clean pass is exactly the false-clean this repo keeps closing.
+  test("every listed template path exists on disk", () => {
+    expect(SHIPPED_TEMPLATES.length).toBeGreaterThan(1);
+    for (const [label, path] of SHIPPED_TEMPLATES) {
+      expect(existsSync(path), `${label} missing`).toBe(true);
+    }
+  });
+
+  for (const [label, path] of SHIPPED_TEMPLATES) {
+    test(`${label} ships no node-scoped relocated key and declares schemaVersion`, () => {
+      const tpl = JSON.parse(readFileSync(path, "utf8"));
+      const r = validateLayer1Config(tpl);
+      expect(tpl.catalyst.schemaVersion).toBe(1);
+      // Node-scoped leaks only: monitor.linear.teams is cluster-scoped (CTL-1885)
+      // and stays lenient by design, so asserting on `errors` (which is
+      // schemaVersion-gated to the node scope) is the right instrument.
+      expect(r.errors).toEqual([]);
+      expect(tpl.catalyst.monitor?.github?.repoColors).toBeUndefined();
+      expect(tpl.catalyst.feedback).toBeUndefined();
+      expect(tpl.catalyst.sweep).toBeUndefined();
+      expect(tpl.catalyst.orchestration?.dispatchMode).toBeUndefined();
+      expect(tpl.catalyst.orchestration?.executionCore).toBeUndefined();
+      expect(tpl.catalyst.orchestration?.worktreeRefresh).toBeUndefined();
+      expect(tpl.catalyst.orchestration?.reconcile).toBeUndefined();
+    });
+  }
 });
 
 // CTL-1214 Phase 5 (D3) — schemaVersion is the SELF-GATING opt-in to strictness.

--- a/plugins/dev/scripts/__tests__/config-schema.test.mjs
+++ b/plugins/dev/scripts/__tests__/config-schema.test.mjs
@@ -146,6 +146,10 @@ const kitchenSinkLayer1 = () => {
   cfg.catalyst.orchestration = {
     dispatchMode: "phase-agents",
     worktreeRefresh: { enabled: true, intervalSeconds: 300, quietSeconds: 30 },
+    // CTL-1214 D7: reconcile is in the relocating set — it is in the committed
+    // config, it is node-scoped (CATALYST_RECONCILE_MODE is documented as the
+    // hardest per-node override), and it already had a two-layer reader.
+    reconcile: { mode: "notify", intervalSeconds: 600 },
     executionCore: {
       maxParallel: 4,
       minParallel: 1,
@@ -170,15 +174,67 @@ describe("validateLayer1Config (CTL-1214)", () => {
     const r = validateLayer1Config(kitchenSinkLayer1());
     expect(r.valid).toBe(true); // still valid during migration
     expect(r.deprecatedKeys.length).toBeGreaterThan(0);
+    // CTL-1214 D6: the blanket `orchestration` row is gone — it is now the four
+    // subpaths that actually relocate, so a config carrying only a genuinely
+    // Layer-1 orchestration stanza (codex, executor, …) is NOT flagged.
     for (const path of [
       "monitor.linear.teams",
       "monitor.github.repoColors",
-      "orchestration",
+      "orchestration.dispatchMode",
+      "orchestration.executionCore",
+      "orchestration.worktreeRefresh",
+      "orchestration.reconcile",
       "feedback",
       "sweep",
     ]) {
       expect(r.deprecatedKeys).toContain(path);
     }
+    expect(r.deprecatedKeys).not.toContain("orchestration");
+  });
+
+  // CTL-1214 D6 — the narrowing, asserted in both directions. Without the
+  // negative cases a blanket row would still pass the positive one.
+  test("D6: a genuinely Layer-1 orchestration stanza is not a leak", () => {
+    for (const stanza of [
+      { codex: { codexHome: "/x/codex-home" } },
+      { executor: "sdk" },
+      { executorByPhase: { implement: "sdk" } },
+      { fleetHealth: { mode: "shadow" } },
+      { daemonWatchdog: { mode: "shadow" } },
+      { publishPreflight: { mode: "shadow" } },
+      { draftPr: { enabled: true } },
+      { orphanReaper: { workerGc: { emptyDirGraceSeconds: 600 } } },
+    ]) {
+      const cfg = minimalLayer1();
+      cfg.catalyst.orchestration = stanza;
+      const r = validateLayer1Config(cfg);
+      expect(r.deprecatedKeys).toEqual([]);
+      expect(r.valid).toBe(true);
+    }
+  });
+
+  test("D6: each relocating orchestration subpath IS a leak, on its own", () => {
+    for (const [key, value] of [
+      ["dispatchMode", "phase-agents"],
+      ["executionCore", { maxParallel: 4 }],
+      ["worktreeRefresh", { enabled: true }],
+      ["reconcile", { mode: "notify" }],
+    ]) {
+      const cfg = minimalLayer1();
+      cfg.catalyst.orchestration = { [key]: value };
+      const r = validateLayer1Config(cfg);
+      expect(r.deprecatedKeys).toEqual([`orchestration.${key}`]);
+    }
+  });
+
+  test("D6: a mixed stanza flags only the relocating half", () => {
+    const cfg = minimalLayer1();
+    cfg.catalyst.orchestration = {
+      codex: { codexHome: "/x" },
+      executor: "sdk",
+      dispatchMode: "phase-agents",
+    };
+    expect(validateLayer1Config(cfg).deprecatedKeys).toEqual(["orchestration.dispatchMode"]);
   });
 
   test("monitor.linear.botUserId is NOT treated as a leak", () => {
@@ -232,17 +288,29 @@ describe("validateLayer1Config (CTL-1214)", () => {
     expect(validateLayer1Config(null).valid).toBe(false);
   });
 
-  test("RELOCATED_LAYER1_KEYS enumerates the five leak categories", () => {
+  test("RELOCATED_LAYER1_KEYS enumerates the leak categories (D6-narrowed)", () => {
     const paths = RELOCATED_LAYER1_KEYS.map((e) => e.path);
     expect(paths).toEqual(
       expect.arrayContaining([
         "monitor.linear.teams",
         "monitor.github.repoColors",
-        "orchestration",
+        "orchestration.dispatchMode",
+        "orchestration.executionCore",
+        "orchestration.worktreeRefresh",
+        "orchestration.reconcile",
         "feedback",
         "sweep",
       ]),
     );
+    // D6: FOUR orchestration rows, never one blanket row.
+    expect(paths.filter((p) => p.startsWith("orchestration"))).toHaveLength(4);
+    expect(paths).not.toContain("orchestration");
+    // D1: every node-scoped destination names node.json, matching where the
+    // migration actually writes. A destination string that named the legacy
+    // config.json would send an operator to a file the migration never touches.
+    for (const entry of RELOCATED_LAYER1_KEYS) {
+      if (entry.scope === "node") expect(entry.destination).toContain("node.json");
+    }
     // every entry names a scope + destination so the doctor check can format remediation
     for (const entry of RELOCATED_LAYER1_KEYS) {
       expect(["cluster", "node"]).toContain(entry.scope);

--- a/plugins/dev/scripts/__tests__/config-schema.test.mjs
+++ b/plugins/dev/scripts/__tests__/config-schema.test.mjs
@@ -16,6 +16,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -317,6 +318,52 @@ describe("validateLayer1Config (CTL-1214)", () => {
       expect(typeof entry.destination).toBe("string");
       expect(entry.destination.length).toBeGreaterThan(0);
     }
+  });
+});
+
+// CTL-1214 Phase 3 — the AC's "template is sanitized" scenario, asserted against
+// the SHIPPED file on disk rather than a fixture. The template is what every new
+// repo starts from, so a relocated stanza here re-leaks into every future config
+// no matter how well the migration works.
+describe("config.template.json is sanitized (CTL-1214)", () => {
+  const templatePath = join(import.meta.dir, "..", "..", "templates", "config.template.json");
+  const template = JSON.parse(readFileSync(templatePath, "utf8"));
+
+  test("validates clean under validateLayer1Config", () => {
+    const r = validateLayer1Config(template);
+    expect(r.deprecatedKeys).toEqual([]);
+    expect(r.errors).toEqual([]);
+    expect(r.recommendations).toEqual([]);
+    expect(r.valid).toBe(true);
+  });
+
+  test("carries schemaVersion 1", () => {
+    expect(template.catalyst.schemaVersion).toBe(1);
+  });
+
+  test("ships no relocated stanza", () => {
+    expect(template.catalyst.orchestration).toBeUndefined();
+    expect(template.catalyst.feedback).toBeUndefined();
+    expect(template.catalyst.sweep).toBeUndefined();
+    expect(template.catalyst.monitor?.github?.repoColors).toBeUndefined();
+  });
+
+  test("keeps ticketPrefix PROJ, no teamId, no roster (the AC's template scenario)", () => {
+    expect(template.catalyst.project.ticketPrefix).toBe("PROJ");
+    expect("teamId" in template.catalyst.linear).toBe(false);
+    expect(template.catalyst.monitor?.linear?.teams).toBeUndefined();
+  });
+
+  test("keeps the genuinely Layer-1 blocks (a template that over-slims is as bad)", () => {
+    expect(template.catalyst.projectKey).toBeDefined();
+    expect(template.catalyst.linear.teamKey).toBe("PROJ");
+    expect(Object.keys(template.catalyst.linear.stateMap)).toHaveLength(12);
+    expect(template.catalyst.deployment.mode).toBe("single-host");
+    expect(template.catalyst.repository).toBeDefined();
+    expect(template.catalyst.deploy).toBeDefined();
+    expect(template.catalyst.filter).toBeDefined();
+    expect("botUserId" in template.catalyst.monitor.linear).toBe(true);
+    expect(template.catalyst.thoughts).toBeDefined();
   });
 });
 

--- a/plugins/dev/scripts/__tests__/execution-core-config-drift.test.sh
+++ b/plugins/dev/scripts/__tests__/execution-core-config-drift.test.sh
@@ -6,12 +6,24 @@
 # projects live in the central registry.json — so the template must never carry
 # eligibleQuery back in.
 #
-# CTL-665 refined this guard: the template's executionCore now DOES carry the
+# CTL-665 refined this guard: the template's executionCore then DID carry the
 # committed worker-slot concurrency knobs (maxParallel/minParallel/
-# maxParallelCeiling), which are legitimately templated config (unlike the
-# central eligibleQuery). The guard's real intent is preserved by asserting
-# executionCore carries the three concurrency keys AND explicitly does NOT carry
-# eligibleQuery, plus that the committed default maxParallel stays 4.
+# maxParallelCeiling), asserted alongside the absence of eligibleQuery.
+#
+# ⚠️ CTL-1214 INVERTS the first half. `orchestration.{dispatchMode,executionCore}`
+# are node-scoped and have relocated to ~/.config/catalyst/node.json, so a
+# template or committed config that still carries them is now the DEFECT, not the
+# baseline. The three assertions written for the old contract went red the moment
+# the slimming landed — and because this suite is not on the CI allowlist
+# (execution-core-tests.yml runs an explicit list, no glob runner), nothing
+# surfaced it. The checks below assert the CURRENT contract, and each one is
+# paired with a positive control so an absent/unreadable file can never be read as
+# a clean pass: `jq -e ... | not` returns true for BOTH "key absent" and "file
+# absent", which is exactly how the old eligibleQuery check kept reporting PASS
+# after the stanza it inspected had ceased to exist.
+#
+# CTL-582 (D4)'s intent — eligibleQuery is central (registry.json) and must never
+# be templated back in — survives the relocation and is asserted at both layers.
 # Run: bash plugins/dev/scripts/__tests__/execution-core-config-drift.test.sh
 
 set -uo pipefail
@@ -38,25 +50,42 @@ check() {
 echo "execution-core config drift tests"
 
 check "config.template.json exists" test -f "$TEMPLATE"
+check "project .catalyst/config.json exists" test -f "$PROJECT_CONFIG"
 
-check "template carries orchestration.dispatchMode" \
-  jq -e '.catalyst.orchestration.dispatchMode' "$TEMPLATE"
+# POSITIVE CONTROLS. Every assertion below is an ABSENCE, and an absence over an
+# unreadable file is not evidence. Prove jq really parses each file first, by
+# reading a key that must be there.
+check "positive control: jq reads the template (linear.teamKey present)" \
+  jq -e '.catalyst.linear.teamKey' "$TEMPLATE"
+check "positive control: jq reads the project config (linear.teamKey present)" \
+  jq -e '.catalyst.linear.teamKey' "$PROJECT_CONFIG"
 
-# CTL-665: the template's executionCore carries the three committed concurrency
-# knobs (the legitimately-templated worker-slot config).
-check "template executionCore carries maxParallel/minParallel/maxParallelCeiling" \
-  jq -e '.catalyst.orchestration.executionCore
-         | .maxParallel and .minParallel and .maxParallelCeiling' "$TEMPLATE"
+# CTL-1214: both relocated node-scoped orchestration stanzas must be GONE from
+# the shipped template — it is what every new repo starts from, so one left here
+# re-leaks into every future config no matter how well the migration works.
+check "template does NOT carry orchestration.dispatchMode (relocated, CTL-1214)" \
+  jq -e '.catalyst.orchestration.dispatchMode == null' "$TEMPLATE"
 
-# CTL-582 (D4) intent preserved: eligibleQuery is central (registry.json), so the
-# template's executionCore must NOT carry it back in.
-check "template executionCore does NOT carry eligibleQuery (CTL-582 intent)" \
-  jq -e '.catalyst.orchestration.executionCore | has("eligibleQuery") | not' "$TEMPLATE"
+check "template does NOT carry orchestration.executionCore (relocated, CTL-1214)" \
+  jq -e '.catalyst.orchestration.executionCore == null' "$TEMPLATE"
 
-# CTL-665: the committed default stays 4 (the operator bump to 10 is gated on
-# CTL-661/662/663 and is a separate config edit, not this plumbing).
-check "project config executionCore.maxParallel equals the documented default 4" \
-  jq -e '.catalyst.orchestration.executionCore.maxParallel == 4' "$PROJECT_CONFIG"
+# CTL-582 (D4) intent, restated for the post-relocation world: eligibleQuery is
+# central (registry.json) and is DROPPED by the migration, never re-homed — so it
+# must not appear anywhere under catalyst.orchestration in either file.
+check "template carries no eligibleQuery anywhere under orchestration (CTL-582)" \
+  jq -e '[.catalyst.orchestration // {} | .. | objects | has("eligibleQuery")] | any | not' "$TEMPLATE"
+
+check "project config carries no eligibleQuery anywhere under orchestration (CTL-582)" \
+  jq -e '[.catalyst.orchestration // {} | .. | objects | has("eligibleQuery")] | any | not' "$PROJECT_CONFIG"
+
+# CTL-1214: the committed config is project identity only. maxParallel's operator
+# value now lives in node.json (re-homed to executionCore.targetParallel, since a
+# node.json maxParallel would shadow the autotuner's runtime mirror).
+check "project config does NOT carry orchestration.executionCore (slimmed, CTL-1214)" \
+  jq -e '.catalyst.orchestration.executionCore == null' "$PROJECT_CONFIG"
+
+check "project config declares schemaVersion >= 1 (opted into the slimmed contract)" \
+  jq -e '(.catalyst.schemaVersion | type == "number") and (.catalyst.schemaVersion >= 1)' "$PROJECT_CONFIG"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
+++ b/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
@@ -1,0 +1,390 @@
+// layer1-relocation.test.mjs — CTL-1214 Phase 2. The Layer-1 → node.json
+// migration's DECISION TABLE, exercised against the pure planner so every rule
+// is testable with no I/O, plus the atomic-write ordering of the applier.
+//
+// Run: cd plugins/dev/scripts && bun test __tests__/layer1-relocation.test.mjs
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync, existsSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  planLayer1Migration,
+  applyLayer1Migration,
+  RELOCATED_PATHS,
+} from "../lib/migrate-layer1-config.mjs";
+
+let dirs = [];
+afterEach(() => {
+  for (const d of dirs) {
+    try {
+      chmodSync(d, 0o755);
+    } catch {
+      /* best effort */
+    }
+    rmSync(d, { recursive: true, force: true });
+  }
+  dirs = [];
+});
+function mkdir() {
+  const d = mkdtempSync(join(tmpdir(), "ctl1214-mig-"));
+  dirs.push(d);
+  return d;
+}
+
+// The full committed shape this repo really carries at a8d4946c.
+const FULL_LAYER1 = () => ({
+  catalyst: {
+    projectKey: "catalyst-workspace",
+    project: { ticketPrefix: "CTL" },
+    linear: { teamKey: "CTL", teamId: "f317bf00", stateMap: { todo: "Todo", done: "Done" } },
+    thoughts: { org: "coalesce-labs", profile: "coalesce-labs", directory: "catalyst-workspace", user: null },
+    monitor: {
+      github: { repoColors: { "coalesce-labs/catalyst": "green" } },
+      linear: { teams: [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }] },
+    },
+    deployment: { mode: "cluster" },
+    orchestration: {
+      dispatchMode: "phase-agents",
+      worktreeRefresh: { enabled: true, intervalSeconds: 300, quietSeconds: 30 },
+      reconcile: { mode: "notify", intervalSeconds: 600 },
+      executionCore: {
+        maxParallel: 4,
+        minParallel: 1,
+        maxParallelCeiling: 40,
+        eligibleQuery: { status: "Todo", team: null, project: null, label: null, priority: null },
+      },
+    },
+    feedback: { autoFile: true, githubRepo: "coalesce-labs/catalyst", labels: ["auto-submitted"] },
+    sweep: { idleHours: 48, intervalHours: 1, salvagePush: false, maxRemovalsPerRun: 10 },
+  },
+});
+
+const movedPaths = (plan) => plan.moves.map((m) => m.path).sort();
+const keptPaths = (plan) => plan.kept.map((k) => k.path).sort();
+
+describe("planLayer1Migration — the non-clobber rule (D1)", () => {
+  it("does NOT write a key the merged Layer-2 already defines, and names it kept", () => {
+    // This host's real state: maxParallel:4 is machine-canonical in Layer-2
+    // (CTL-678). node.json outranks it, so a blind copy of the Layer-1 seed
+    // would SHADOW the operator's value.
+    const plan = planLayer1Migration({
+      layer1: FULL_LAYER1(),
+      mergedLayer2: { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+    });
+    expect(movedPaths(plan)).not.toContain("orchestration.executionCore.maxParallel");
+    expect(movedPaths(plan)).toContain("orchestration.executionCore.minParallel");
+    expect(movedPaths(plan)).toContain("orchestration.executionCore.maxParallelCeiling");
+
+    const kept = plan.kept.find((k) => k.path === "orchestration.executionCore.maxParallel");
+    expect(kept).toBeDefined();
+    expect(kept.existingValue).toBe(4);
+  });
+
+  it("writes a whole stanza the merged Layer-2 defines nothing for", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(movedPaths(plan)).toContain("sweep.idleHours");
+    expect(movedPaths(plan)).toContain("sweep.intervalHours");
+    expect(movedPaths(plan)).toContain("sweep.salvagePush");
+    expect(movedPaths(plan)).toContain("sweep.maxRemovalsPerRun");
+    expect(plan.nodePatch.catalyst.sweep.intervalHours).toBe(1);
+    // `false` must survive: it is a real value, not an absence.
+    expect(plan.nodePatch.catalyst.sweep.salvagePush).toBe(false);
+  });
+
+  it("a Layer-2 value of `false` still counts as DEFINED (jq-falsy trap)", () => {
+    const plan = planLayer1Migration({
+      layer1: FULL_LAYER1(),
+      mergedLayer2: { catalyst: { sweep: { salvagePush: false } } },
+    });
+    expect(movedPaths(plan)).not.toContain("sweep.salvagePush");
+    expect(keptPaths(plan)).toContain("sweep.salvagePush");
+  });
+
+  it("a Layer-2 value of `null` is NOT defined — null is an absence", () => {
+    const plan = planLayer1Migration({
+      layer1: FULL_LAYER1(),
+      mergedLayer2: { catalyst: { sweep: { intervalHours: null } } },
+    });
+    expect(movedPaths(plan)).toContain("sweep.intervalHours");
+  });
+});
+
+describe("planLayer1Migration — scope", () => {
+  it("moves only RELOCATED_LAYER1_KEYS entries; identity is untouched", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    const slim = plan.slimmedLayer1.catalyst;
+    expect(slim.projectKey).toBe("catalyst-workspace");
+    expect(slim.project).toEqual({ ticketPrefix: "CTL" });
+    expect(slim.linear.teamKey).toBe("CTL");
+    expect(slim.linear.teamId).toBe("f317bf00");
+    expect(slim.linear.stateMap).toEqual({ todo: "Todo", done: "Done" });
+    expect(slim.thoughts.org).toBe("coalesce-labs");
+    expect(slim.deployment).toEqual({ mode: "cluster" });
+    for (const p of movedPaths(plan)) {
+      expect(p.startsWith("projectKey") || p.startsWith("linear.") || p.startsWith("thoughts.")).toBe(false);
+    }
+  });
+
+  it("does NOT move scope:'cluster' entries — monitor.linear.teams stays (D4)", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(movedPaths(plan).join("|")).not.toContain("monitor.linear.teams");
+    expect(plan.slimmedLayer1.catalyst.monitor.linear.teams).toHaveLength(1);
+    expect(plan.nodePatch.catalyst.monitor?.linear).toBeUndefined();
+  });
+
+  it("moves monitor.github.repoColors (node-scoped) and leaves monitor itself intact", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(movedPaths(plan)).toContain("monitor.github.repoColors");
+    expect(plan.slimmedLayer1.catalyst.monitor.github).toBeUndefined();
+    expect(plan.slimmedLayer1.catalyst.monitor.linear).toBeDefined();
+    expect(plan.nodePatch.catalyst.monitor.github.repoColors).toEqual({
+      "coalesce-labs/catalyst": "green",
+    });
+  });
+
+  it("does NOT move the non-relocating orchestration stanzas (D6)", () => {
+    const layer1 = FULL_LAYER1();
+    layer1.catalyst.orchestration.codex = { codexHome: "/x/codex" };
+    layer1.catalyst.orchestration.executor = "sdk";
+    layer1.catalyst.orchestration.fleetHealth = { mode: "shadow" };
+    const plan = planLayer1Migration({ layer1, mergedLayer2: { catalyst: {} } });
+    const moved = movedPaths(plan).join("|");
+    expect(moved).not.toContain("orchestration.codex");
+    expect(moved).not.toContain("orchestration.executor");
+    expect(moved).not.toContain("orchestration.fleetHealth");
+    expect(plan.slimmedLayer1.catalyst.orchestration.codex).toEqual({ codexHome: "/x/codex" });
+    expect(plan.slimmedLayer1.catalyst.orchestration.executor).toBe("sdk");
+  });
+
+  it("DROPS the dead eligibleQuery instead of relocating it", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(plan.dropped.map((d) => d.path)).toContain(
+      "orchestration.executionCore.eligibleQuery",
+    );
+    expect(movedPaths(plan).join("|")).not.toContain("eligibleQuery");
+    expect(JSON.stringify(plan.nodePatch)).not.toContain("eligibleQuery");
+    expect(JSON.stringify(plan.slimmedLayer1)).not.toContain("eligibleQuery");
+  });
+
+  it("removes the orchestration stanza entirely once its four members are gone", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(plan.slimmedLayer1.catalyst.orchestration).toBeUndefined();
+    expect(plan.slimmedLayer1.catalyst.feedback).toBeUndefined();
+    expect(plan.slimmedLayer1.catalyst.sweep).toBeUndefined();
+  });
+
+  it("exports the relocated paths so the bash side cannot drift", () => {
+    expect(Array.isArray(RELOCATED_PATHS)).toBe(true);
+    expect(RELOCATED_PATHS).toContain("orchestration.dispatchMode");
+    expect(RELOCATED_PATHS).toContain("sweep");
+    expect(RELOCATED_PATHS).toContain("feedback");
+  });
+});
+
+describe("planLayer1Migration — output shape", () => {
+  it("stamps schemaVersion 1 on the slimmed Layer-1", () => {
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(plan.slimmedLayer1.catalyst.schemaVersion).toBe(1);
+  });
+
+  it("preserves an existing higher schemaVersion", () => {
+    const layer1 = FULL_LAYER1();
+    layer1.catalyst.schemaVersion = 2;
+    const plan = planLayer1Migration({ layer1, mergedLayer2: { catalyst: {} } });
+    expect(plan.slimmedLayer1.catalyst.schemaVersion).toBe(2);
+  });
+
+  it("is idempotent: re-planning an already-slimmed config reports zero moves", () => {
+    const first = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    const second = planLayer1Migration({
+      layer1: first.slimmedLayer1,
+      mergedLayer2: first.nodePatch,
+    });
+    expect(second.moves).toHaveLength(0);
+    expect(second.changed).toBe(false);
+    // Positive control: the FIRST plan really did move things, so "zero moves"
+    // above is convergence and not a planner that never moves anything.
+    expect(first.moves.length).toBeGreaterThan(0);
+    expect(first.changed).toBe(true);
+  });
+
+  it("rejects a malformed Layer-1 rather than guessing", () => {
+    expect(() => planLayer1Migration({ layer1: null, mergedLayer2: { catalyst: {} } })).toThrow();
+    expect(() => planLayer1Migration({ layer1: { nope: 1 }, mergedLayer2: { catalyst: {} } })).toThrow();
+    expect(() => planLayer1Migration({ layer1: [], mergedLayer2: { catalyst: {} } })).toThrow();
+  });
+});
+
+describe("applyLayer1Migration — atomic writes and ordering", () => {
+  const setup = (layer1Obj, nodeObj) => {
+    const d = mkdir();
+    const l1 = join(d, "config.json");
+    const node = join(d, "node.json");
+    writeFileSync(l1, JSON.stringify(layer1Obj, null, 2));
+    if (nodeObj !== undefined) writeFileSync(node, JSON.stringify(nodeObj, null, 2));
+    return { d, l1, node };
+  };
+
+  it("creates node.json 0600 when absent and slims Layer-1", () => {
+    const { l1, node } = setup(FULL_LAYER1());
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    const res = applyLayer1Migration({ plan, layer1Path: l1, nodePath: node });
+    expect(res.wrote).toEqual(expect.arrayContaining([node, l1]));
+    expect(statSync(node).mode & 0o777).toBe(0o600);
+    const written = JSON.parse(readFileSync(node, "utf8"));
+    expect(written.catalyst.orchestration.dispatchMode).toBe("phase-agents");
+    const slim = JSON.parse(readFileSync(l1, "utf8"));
+    expect(slim.catalyst.orchestration).toBeUndefined();
+    expect(slim.catalyst.schemaVersion).toBe(1);
+  });
+
+  it("deep-merges an existing node.json, never replaces it", () => {
+    const { l1, node } = setup(FULL_LAYER1(), {
+      catalyst: { host: { name: "mini-2" }, orchestration: { pluginDirs: "/x" } },
+    });
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    applyLayer1Migration({ plan, layer1Path: l1, nodePath: node });
+    const written = JSON.parse(readFileSync(node, "utf8"));
+    expect(written.catalyst.host.name).toBe("mini-2");
+    expect(written.catalyst.orchestration.pluginDirs).toBe("/x");
+    expect(written.catalyst.orchestration.dispatchMode).toBe("phase-agents");
+  });
+
+  it("--dry-run writes nothing", () => {
+    const { l1, node } = setup(FULL_LAYER1());
+    const before = readFileSync(l1, "utf8");
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    const res = applyLayer1Migration({ plan, layer1Path: l1, nodePath: node, dryRun: true });
+    expect(res.wrote).toEqual([]);
+    expect(readFileSync(l1, "utf8")).toBe(before);
+    expect(existsSync(node)).toBe(false);
+  });
+
+  it("an unwritable node.json leaves Layer-1 UNSLIMMED (never slim-then-fail)", () => {
+    // The load-bearing ordering assertion: node.json is written FIRST, so a
+    // failure can never leave a repo slimmed with its values nowhere.
+    const { d, l1, node } = setup(FULL_LAYER1());
+    const before = readFileSync(l1, "utf8");
+    chmodSync(d, 0o500); // read+execute only: no new file may be created
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(() => applyLayer1Migration({ plan, layer1Path: l1, nodePath: node })).toThrow();
+    chmodSync(d, 0o755);
+    expect(readFileSync(l1, "utf8")).toBe(before);
+  });
+
+  it("re-running is a no-op: second apply writes nothing", () => {
+    const { l1, node } = setup(FULL_LAYER1());
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    applyLayer1Migration({ plan, layer1Path: l1, nodePath: node });
+
+    const layer1b = JSON.parse(readFileSync(l1, "utf8"));
+    const nodeb = JSON.parse(readFileSync(node, "utf8"));
+    const plan2 = planLayer1Migration({ layer1: layer1b, mergedLayer2: nodeb });
+    const res2 = applyLayer1Migration({ plan: plan2, layer1Path: l1, nodePath: node });
+    expect(res2.wrote).toEqual([]);
+    expect(plan2.moves).toHaveLength(0);
+  });
+
+  it("leaves no .tmp residue behind", () => {
+    const { d, l1, node } = setup(FULL_LAYER1());
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    applyLayer1Migration({ plan, layer1Path: l1, nodePath: node });
+    const { readdirSync } = require("node:fs");
+    expect(readdirSync(d).filter((f) => f.includes(".tmp"))).toEqual([]);
+  });
+});
+
+describe("catalyst-config-migrate CLI", () => {
+  const CLI = join(import.meta.dir, "..", "catalyst-config-migrate");
+  const run = (args, env = {}) =>
+    Bun.spawnSync(["bun", CLI, ...args], {
+      env: { ...process.env, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+  it("--paths prints the registry, so the bash side never re-types it", () => {
+    const r = run(["--paths"]);
+    expect(r.exitCode).toBe(0);
+    const lines = new TextDecoder().decode(r.stdout).trim().split("\n");
+    expect(lines).toContain("orchestration.dispatchMode");
+    expect(lines).toContain("sweep");
+    expect(lines).toContain("feedback");
+    expect(lines).toContain("monitor.linear.teams");
+    // Positive control: it is the REGISTRY, not a hardcoded list — the count
+    // must match RELOCATED_PATHS exactly.
+    expect(lines).toHaveLength(RELOCATED_PATHS.length);
+  });
+
+  it("--help exits 0 and an unknown flag exits non-zero", () => {
+    expect(run(["--help"]).exitCode).toBe(0);
+    expect(run(["--no-such-flag"]).exitCode).not.toBe(0);
+  });
+
+  it("--dry-run reports the moves and writes nothing", () => {
+    // Layer-1 and node.json live in SEPARATE directories, as they do in
+    // production (<repo>/.catalyst/config.json vs ~/.config/catalyst/node.json).
+    // The CLI resolves the merged Layer-2 root as node.json's sibling
+    // config.json; sharing one dir would make the Layer-1 file masquerade as
+    // Layer-2, so every key would look already-defined and nothing would move.
+    const d = mkdir();
+    const l1 = join(d, "config.json");
+    const node = join(mkdir(), "node.json");
+    writeFileSync(l1, JSON.stringify(FULL_LAYER1(), null, 2));
+    const before = readFileSync(l1, "utf8");
+
+    const r = run(["--dry-run", "--json", "--config", l1, "--node", node]);
+    expect(r.exitCode).toBe(0);
+    const report = JSON.parse(new TextDecoder().decode(r.stdout));
+    expect(report.dryRun).toBe(true);
+    expect(report.wrote).toEqual([]);
+    expect(report.moved.map((m) => m.path)).toContain("orchestration.dispatchMode");
+    expect(report.dropped.map((x) => x.path)).toContain(
+      "orchestration.executionCore.eligibleQuery",
+    );
+    expect(readFileSync(l1, "utf8")).toBe(before);
+    expect(existsSync(node)).toBe(false);
+  });
+
+  it("a real run migrates, and a second run is a clean no-op", () => {
+    const d = mkdir();
+    const l1 = join(d, "config.json");
+    const node = join(mkdir(), "node.json");
+    writeFileSync(l1, JSON.stringify(FULL_LAYER1(), null, 2));
+
+    const first = run(["--json", "--config", l1, "--node", node]);
+    expect(first.exitCode).toBe(0);
+    const r1 = JSON.parse(new TextDecoder().decode(first.stdout));
+    expect(r1.wrote).toContain(node);
+    expect(r1.wrote).toContain(l1);
+    expect(statSync(node).mode & 0o777).toBe(0o600);
+
+    const second = run(["--json", "--config", l1, "--node", node]);
+    expect(second.exitCode).toBe(0);
+    const r2 = JSON.parse(new TextDecoder().decode(second.stdout));
+    expect(r2.changed).toBe(false);
+    expect(r2.moved).toEqual([]);
+    expect(r2.wrote).toEqual([]);
+    // Positive control: the FIRST run really did move things, so the no-op above
+    // is convergence rather than a CLI that never migrates anything.
+    expect(r1.moved.length).toBeGreaterThan(0);
+  });
+
+  it("a malformed Layer-1 exits non-zero and writes nothing", () => {
+    const d = mkdir();
+    const l1 = join(d, "config.json");
+    const node = join(mkdir(), "node.json");
+    writeFileSync(l1, "{ not json at all");
+    const r = run(["--config", l1, "--node", node]);
+    expect(r.exitCode).not.toBe(0);
+    expect(new TextDecoder().decode(r.stderr)).toContain("malformed");
+    expect(existsSync(node)).toBe(false);
+  });
+
+  it("a missing Layer-1 exits non-zero", () => {
+    const r = run(["--config", "/no/such/config.json", "--node", "/tmp/x-node.json"]);
+    expect(r.exitCode).not.toBe(0);
+  });
+});

--- a/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
+++ b/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
@@ -66,20 +66,86 @@ const keptPaths = (plan) => plan.kept.map((k) => k.path).sort();
 
 describe("planLayer1Migration — the non-clobber rule (D1)", () => {
   it("does NOT write a key the merged Layer-2 already defines, and names it kept", () => {
-    // This host's real state: maxParallel:4 is machine-canonical in Layer-2
-    // (CTL-678). node.json outranks it, so a blind copy of the Layer-1 seed
+    // This host's real state: salvagePush is machine-canonical in Layer-2.
+    // node.json outranks the legacy file, so a blind copy of the Layer-1 seed
     // would SHADOW the operator's value.
     const plan = planLayer1Migration({
       layer1: FULL_LAYER1(),
-      mergedLayer2: { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+      mergedLayer2: { catalyst: { sweep: { maxRemovalsPerRun: 20 } } },
     });
-    expect(movedPaths(plan)).not.toContain("orchestration.executionCore.maxParallel");
-    expect(movedPaths(plan)).toContain("orchestration.executionCore.minParallel");
-    expect(movedPaths(plan)).toContain("orchestration.executionCore.maxParallelCeiling");
+    expect(movedPaths(plan)).not.toContain("sweep.maxRemovalsPerRun");
+    expect(movedPaths(plan)).toContain("sweep.idleHours");
+    expect(movedPaths(plan)).toContain("sweep.intervalHours");
 
-    const kept = plan.kept.find((k) => k.path === "orchestration.executionCore.maxParallel");
+    const kept = plan.kept.find((k) => k.path === "sweep.maxRemovalsPerRun");
     expect(kept).toBeDefined();
-    expect(kept.existingValue).toBe(4);
+    expect(kept.existingValue).toBe(20);
+  });
+
+  // ── CTL-1214 remediation: the executionCore.maxParallel special case ──────
+  //
+  // maxParallel is the ONE relocated leaf that must never LAND in node.json (it
+  // would permanently shadow writeLayer2MaxParallel's runtime mirror in the
+  // legacy Layer-2 file, which node.json outranks) AND whose Layer-1 value must
+  // not be dropped (it is the operator's committed setpoint — the value CTL-750's
+  // recovery-to-layer1 and CTL-770's resolveTargetSetpoint both read). It is
+  // re-homed to the never-tuner-written `targetParallel` key instead.
+  describe("executionCore.maxParallel is re-homed to targetParallel", () => {
+    const withL2 = (mergedLayer2) => planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2 });
+
+    it("never writes maxParallel into node.json, even with an EMPTY Layer-2", () => {
+      // The pre-remediation code took the `moves` arm here and wrote maxParallel
+      // straight into node.json — the shadowing case, invisible on a host that
+      // happened to already carry a Layer-2 maxParallel.
+      const plan = withL2({ catalyst: {} });
+      expect(movedPaths(plan)).not.toContain("orchestration.executionCore.maxParallel");
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.maxParallel).toBeUndefined();
+    });
+
+    it("seeds targetParallel from the Layer-1 maxParallel (empty Layer-2)", () => {
+      const plan = withL2({ catalyst: {} });
+      expect(movedPaths(plan)).toContain("orchestration.executionCore.targetParallel");
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.targetParallel).toBe(4);
+      const move = plan.moves.find((m) => m.path === "orchestration.executionCore.targetParallel");
+      expect(move.from).toBe("orchestration.executionCore.maxParallel");
+      expect(move.scope).toBe("node");
+    });
+
+    it("seeds targetParallel even when Layer-2 already carries the runtime maxParallel mirror", () => {
+      // This host's real state (measured): legacy Layer-2 carries maxParallel:4,
+      // written by the autotuner. That must NOT suppress the setpoint seed —
+      // suppressing it is exactly how setpoint went 4 → undefined after slimming.
+      const plan = withL2({ catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } });
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.targetParallel).toBe(4);
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.maxParallel).toBeUndefined();
+    });
+
+    it("does NOT overwrite an operator-declared targetParallel", () => {
+      const plan = withL2({
+        catalyst: { orchestration: { executionCore: { targetParallel: 9 } } },
+      });
+      expect(movedPaths(plan)).not.toContain("orchestration.executionCore.targetParallel");
+      const kept = plan.kept.find((k) => k.path === "orchestration.executionCore.maxParallel");
+      expect(kept).toBeDefined();
+      expect(kept.existingValue).toBe(9);
+    });
+
+    it("still strips maxParallel from the slimmed Layer-1 in every branch", () => {
+      for (const l2 of [
+        { catalyst: {} },
+        { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+        { catalyst: { orchestration: { executionCore: { targetParallel: 9 } } } },
+      ]) {
+        const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: l2 });
+        expect(plan.slimmedLayer1.catalyst.orchestration).toBeUndefined();
+      }
+    });
+
+    it("the sibling executionCore leaves still relocate normally", () => {
+      const plan = withL2({ catalyst: {} });
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.minParallel).toBe(1);
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.maxParallelCeiling).toBe(40);
+    });
   });
 
   it("writes a whole stanza the merged Layer-2 defines nothing for", () => {
@@ -272,6 +338,63 @@ describe("applyLayer1Migration — atomic writes and ordering", () => {
     expect(() => applyLayer1Migration({ plan, layer1Path: l1, nodePath: node })).toThrow();
     chmodSync(d, 0o755);
     expect(readFileSync(l1, "utf8")).toBe(before);
+  });
+
+  // ── CTL-1214 remediation: the DESTINATION file fails closed too ──────────
+  //
+  // The plan already refuses a malformed Layer-1 INPUT (planLayer1Migration
+  // throws). The destination read swallowed every error to `{}`, so an existing
+  // but malformed/unreadable node.json was silently REPLACED by the patch instead
+  // — losing every other node-scoped key the operator had there. ENOENT is the
+  // only "start fresh" case.
+  it("refuses to overwrite a MALFORMED node.json, and leaves Layer-1 unslimmed", () => {
+    const { d, l1, node } = setup(FULL_LAYER1());
+    writeFileSync(node, "{ this is not json");
+    const before = readFileSync(l1, "utf8");
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(() => applyLayer1Migration({ plan, layer1Path: l1, nodePath: node })).toThrow(
+      /refusing to overwrite malformed config/,
+    );
+    // Both halves: the destination is intact AND the ordering guarantee holds.
+    expect(readFileSync(node, "utf8")).toBe("{ this is not json");
+    expect(readFileSync(l1, "utf8")).toBe(before);
+    expect(d).toBeDefined();
+  });
+
+  it("refuses a node.json that parses to a NON-OBJECT (malformed, not empty)", () => {
+    const { l1, node } = setup(FULL_LAYER1());
+    writeFileSync(node, "[1,2,3]");
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(() => applyLayer1Migration({ plan, layer1Path: l1, nodePath: node })).toThrow(
+      /not a JSON object/,
+    );
+  });
+
+  it("refuses an UNREADABLE node.json rather than replacing it", () => {
+    const { l1, node } = setup(FULL_LAYER1(), { catalyst: { host: { name: "mini-2" } } });
+    chmodSync(node, 0o000);
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    let threw = false;
+    try {
+      applyLayer1Migration({ plan, layer1Path: l1, nodePath: node });
+    } catch (err) {
+      threw = true;
+      expect(err.message).toMatch(/refusing to overwrite unreadable config/);
+    }
+    chmodSync(node, 0o600);
+    // POSITIVE CONTROL: running as root would make the read succeed and this
+    // assertion vacuous, so assert the file is still the operator's, not the patch.
+    expect(JSON.parse(readFileSync(node, "utf8")).catalyst.host.name).toBe("mini-2");
+    expect(threw).toBe(true);
+  });
+
+  // NEGATIVE CONTROL for the three above: an ABSENT node.json must still be the
+  // start-fresh path, or the fail-closed change would break every first migration.
+  it("an ABSENT node.json is still start-fresh, not a refusal", () => {
+    const { l1, node } = setup(FULL_LAYER1());
+    const plan = planLayer1Migration({ layer1: FULL_LAYER1(), mergedLayer2: { catalyst: {} } });
+    expect(() => applyLayer1Migration({ plan, layer1Path: l1, nodePath: node })).not.toThrow();
+    expect(existsSync(node)).toBe(true);
   });
 
   it("re-running is a no-op: second apply writes nothing", () => {

--- a/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
+++ b/plugins/dev/scripts/__tests__/layer1-relocation.test.mjs
@@ -14,6 +14,11 @@ import {
   applyLayer1Migration,
   RELOCATED_PATHS,
 } from "../lib/migrate-layer1-config.mjs";
+// CTL-1214: the REAL resolver the migration exists to keep answering, imported
+// from the zero-import leaf (not scheduler.mjs — same definition, re-exported
+// there). The end-to-end assertion below runs through it rather than restating
+// its ladder, so a change to the precedence rule fails this suite too.
+import { resolveTargetSetpoint } from "../lib/autotune-setpoint.mjs";
 
 let dirs = [];
 afterEach(() => {
@@ -145,6 +150,119 @@ describe("planLayer1Migration — the non-clobber rule (D1)", () => {
       const plan = withL2({ catalyst: {} });
       expect(plan.nodePatch.catalyst.orchestration.executionCore.minParallel).toBe(1);
       expect(plan.nodePatch.catalyst.orchestration.executionCore.maxParallelCeiling).toBe(40);
+    });
+  });
+
+  // ── CTL-1214 remediation round 2: seeding an ALREADY-SLIM Layer-1 ──────────
+  //
+  // The re-home above only fires while Layer-1 still CARRIES maxParallel. But
+  // this repo COMMITS a slimmed Layer-1, so on every host that pulls it the
+  // migration finds nothing to relocate and targetParallel is never written by
+  // anyone — migrate-layer1-config.mjs is its only writer in the tree. Measured
+  // on mini-2: resolveTargetSetpoint 4 → null, which no-ops CTL-770's
+  // convergence branches and (via rawTarget) nulls the layer1Max that RULE 7
+  // recovery-to-layer1 compares against. Nothing errors; that is the failure.
+  describe("targetParallel is seeded when Layer-1 is ALREADY SLIM", () => {
+    // The shape this repo actually commits after Phase 3: identity only.
+    const SLIM_LAYER1 = () => ({
+      catalyst: {
+        schemaVersion: 1,
+        projectKey: "catalyst-workspace",
+        project: { ticketPrefix: "CTL" },
+        linear: { teamKey: "CTL" },
+      },
+    });
+
+    it("seeds targetParallel from the merged Layer-2 maxParallel (the incident)", () => {
+      // mini-2's real state: node.json carries min/ceiling but no maxParallel;
+      // the legacy Layer-2 file carries the autotuner's mirror at 4.
+      const plan = planLayer1Migration({
+        layer1: SLIM_LAYER1(),
+        mergedLayer2: {
+          catalyst: {
+            orchestration: { executionCore: { maxParallel: 4, minParallel: 1, maxParallelCeiling: 40 } },
+          },
+        },
+      });
+      expect(plan.changed).toBe(true);
+      expect(plan.nodePatch.catalyst.orchestration.executionCore.targetParallel).toBe(4);
+      const move = plan.moves.find((m) => m.path === "orchestration.executionCore.targetParallel");
+      expect(move.value).toBe(4);
+      expect(move.scope).toBe("node");
+      // The provenance must say it came from the MERGED LAYER-2, not Layer-1 —
+      // the two seeds have different trustworthiness and the operator-facing CLI
+      // line is the only place that distinction is visible.
+      expect(move.from).toContain("<merged Layer-2>");
+    });
+
+    it("is IDEMPOTENT — a seeded targetParallel is never re-seeded", () => {
+      const mergedLayer2 = {
+        catalyst: { orchestration: { executionCore: { maxParallel: 4, targetParallel: 4 } } },
+      };
+      const plan = planLayer1Migration({ layer1: SLIM_LAYER1(), mergedLayer2 });
+      expect(movedPaths(plan)).not.toContain("orchestration.executionCore.targetParallel");
+      expect(plan.changed).toBe(false);
+    });
+
+    it("does NOT clobber an operator's declared targetParallel with the live mirror", () => {
+      const plan = planLayer1Migration({
+        layer1: SLIM_LAYER1(),
+        mergedLayer2: {
+          catalyst: { orchestration: { executionCore: { maxParallel: 2, targetParallel: 9 } } },
+        },
+      });
+      expect(plan.nodePatch.catalyst.orchestration?.executionCore?.targetParallel).toBeUndefined();
+    });
+
+    it("does NOT fire when Layer-1 still carries maxParallel — the committed target wins", () => {
+      // Both arms could produce a seed here; the step-2 re-home must win, because
+      // the committed operator target is better evidence than the tuner's mirror.
+      const plan = planLayer1Migration({
+        layer1: FULL_LAYER1(), // maxParallel: 4
+        mergedLayer2: { catalyst: { orchestration: { executionCore: { maxParallel: 1 } } } },
+      });
+      const seeds = plan.moves.filter((m) => m.path === "orchestration.executionCore.targetParallel");
+      expect(seeds).toHaveLength(1);
+      expect(seeds[0].value).toBe(4);
+      expect(seeds[0].from).toBe("orchestration.executionCore.maxParallel");
+    });
+
+    it("NEGATIVE CONTROL: no mirror anywhere → no seed, no write", () => {
+      const plan = planLayer1Migration({ layer1: SLIM_LAYER1(), mergedLayer2: { catalyst: {} } });
+      expect(plan.moves).toEqual([]);
+      expect(plan.changed).toBe(false);
+    });
+
+    it("refuses a mirror that is not a positive integer", () => {
+      // A seed that fails resolveTargetSetpoint's own Number.isInteger guard is a
+      // write that LOOKS like a repair and changes nothing downstream.
+      for (const maxParallel of [0, -1, null, "4", 2.5, true, {}]) {
+        const plan = planLayer1Migration({
+          layer1: SLIM_LAYER1(),
+          mergedLayer2: { catalyst: { orchestration: { executionCore: { maxParallel } } } },
+        });
+        expect(plan.moves).toEqual([]);
+      }
+    });
+
+    it("END TO END: the seed is what makes resolveTargetSetpoint stop returning undefined", () => {
+      // The assertion that ties this fix to the symptom. Without it, every test
+      // above could pass while the setpoint stayed null — they assert the PLAN,
+      // this one asserts the CONSEQUENCE, through the real resolver.
+      const layer1 = SLIM_LAYER1();
+      const mergedLayer2 = {
+        catalyst: { orchestration: { executionCore: { maxParallel: 4, minParallel: 1 } } },
+      };
+      const l1EC = layer1.catalyst.orchestration?.executionCore ?? {};
+
+      // BEFORE: node.json has no targetParallel (the state the finding measured).
+      expect(resolveTargetSetpoint(l1EC, {})).toBeUndefined();
+
+      const plan = planLayer1Migration({ layer1, mergedLayer2 });
+      const seededL2 = plan.nodePatch.catalyst.orchestration.executionCore;
+
+      // AFTER: 4, matching pre-slim main.
+      expect(resolveTargetSetpoint(l1EC, seededL2)).toBe(4);
     });
   });
 

--- a/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
+++ b/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
@@ -224,6 +224,43 @@ else
   ok "string-valued catalyst.feedback -> no jq index error"
 fi
 
+# CTL-1214 Phase 3: `grant` must record consent in node.json and leave the
+# committed Layer-1 config byte-for-byte alone — otherwise the Phase-4 slimming
+# survives only until the next consent grant.
+echo "== feedback-consent.sh grant: writes node.json, never Layer-1 =="
+L1="$(mk_l1 "$SLIM_L1")"
+L2DIR="$(mktemp -d "${TMP}/grantXXXXXX")"
+printf '{}' > "${L2DIR}/config.json"
+cp "$L1" "${TMP}/grant-before.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${L2DIR}/config.json" bash "$FC" grant --config "$L1" 2>/dev/null)"
+expect_eq "grant reports granted" "granted" "$OUT"
+if cmp -s "${TMP}/grant-before.json" "$L1"; then
+  ok "grant leaves the committed Layer-1 config byte-for-byte unchanged"
+else
+  fail "grant leaves Layer-1 unchanged" "$(diff "${TMP}/grant-before.json" "$L1" | head -5)"
+fi
+expect_eq "grant writes autoFile into node.json" "true" \
+  "$(jq -r '.catalyst.feedback.autoFile' "${L2DIR}/node.json" 2>/dev/null)"
+expect_eq "grant writes the default githubRepo into node.json" "coalesce-labs/catalyst" \
+  "$(jq -r '.catalyst.feedback.githubRepo' "${L2DIR}/node.json" 2>/dev/null)"
+expect_eq "node.json is 0600" "600" \
+  "$(stat -f '%Lp' "${L2DIR}/node.json" 2>/dev/null || stat -c '%a' "${L2DIR}/node.json" 2>/dev/null)"
+# The granted consent must then READ back through the Layer-2 arm — a write that
+# no read can see would be worse than not writing at all.
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${L2DIR}/config.json" bash "$FC" check --config "$L1" 2>/dev/null)"
+expect_eq "the granted consent reads back as granted" "granted" "$OUT"
+
+# A node.json whose catalyst.feedback is a STRING (the live Layer-2 shape) must
+# be REPLACED with the object, not indexed into and crashed on.
+L1="$(mk_l1 "$SLIM_L1")"
+L2DIR="$(mktemp -d "${TMP}/grantstrXXXXXX")"
+printf '{}' > "${L2DIR}/config.json"
+printf '%s' '{"catalyst":{"feedback":"https://github.com/coalesce-labs/catalyst.git"}}' > "${L2DIR}/node.json"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="${L2DIR}/config.json" bash "$FC" grant --config "$L1" 2>/dev/null)"
+expect_eq "grant over a string-valued feedback still reports granted" "granted" "$OUT"
+expect_eq "grant over a string-valued feedback yields the object" "true" \
+  "$(jq -r '.catalyst.feedback.autoFile' "${L2DIR}/node.json" 2>/dev/null)"
+
 echo
 echo "RESULTS: $PASSES passed, $FAILURES failed"
 [[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
+++ b/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
@@ -188,6 +188,137 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────────
+echo "== orchestrate-register-interests.sh: dispatchMode (CTL-1214 remediation) =="
+# The SECOND bash dispatchMode reader, and it gates the per-ticket
+# phase_lifecycle broker interest. Its own header (:2-9): without that interest
+# "phase-agent completions land in the event log with zero matching interests and
+# are dropped by broker/index.mjs:1782". Same silent-revert-to-oneshot-legacy
+# failure the block above exists to prevent, on a different script.
+RI="${SCRIPTS}/orchestrate-register-interests.sh"
+
+# Same extraction discipline: running the real script would emit broker events.
+# Bounded by the opening default and the comment that begins the next concern,
+# and verified BY CONTENT so a refactor fails loudly instead of testing nothing.
+RI_BLOCK="$(sed -n '/^DISPATCH_MODE="oneshot-legacy"$/,/^# Compute the active ticket \/ PR set/p' "$RI" \
+            | sed '$d')"
+_ri_ok=1
+[[ -z "$RI_BLOCK" ]] && _ri_ok=0
+[[ "$RI_BLOCK" != *"catalyst_layer2_json"* ]] && _ri_ok=0
+[[ "$RI_BLOCK" != *"dispatchMode"* ]] && _ri_ok=0
+[[ "$RI_BLOCK" != *"DISPATCH_MODE_RAW"* ]] && _ri_ok=0
+if [[ "$_ri_ok" -ne 1 ]]; then
+  fail "extract dispatchMode block from orchestrate-register-interests" "extraction incomplete — the test would silently assert on a partial ladder"
+else
+  ok "extract dispatchMode block from orchestrate-register-interests"
+
+  resolve_ri_mode() {
+    local l1="$1" l2="$2"
+    CATALYST_LAYER2_CONFIG_FILE="$l2" bash -c '
+      set -uo pipefail
+      CONFIG_PATH="$1"
+      SCRIPT_DIR="$2"
+      eval "$3"
+      printf "%s" "$DISPATCH_MODE"
+    ' _ "$l1" "$SCRIPTS" "$RI_BLOCK"
+  }
+
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}' '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  OUT="$(resolve_ri_mode "$L1" "$L2")"
+  expect_eq "register-interests: slimmed Layer-1 + node.json -> phase-agents" "phase-agents" "$OUT"
+  expect_ne "register-interests: slimmed Layer-1 + node.json is NOT the silent default" "$OUT" "oneshot-legacy"
+
+  L1="$(mk_l1 '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  L2="$(mk_l2 '{}')"
+  OUT="$(resolve_ri_mode "$L1" "$L2")"
+  expect_eq "register-interests: un-slimmed Layer-1 alone -> phase-agents (back-compat)" "phase-agents" "$OUT"
+
+  L1="$(mk_l1 '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  L2="$(mk_l2 '{}' '{"catalyst":{"orchestration":{"dispatchMode":"execution-core"}}}')"
+  OUT="$(resolve_ri_mode "$L1" "$L2")"
+  expect_eq "register-interests: Layer-1 wins when present (fallback, not override)" "phase-agents" "$OUT"
+
+  # NEGATIVE CONTROL — without it every assertion above could pass from a reader
+  # that unconditionally returns phase-agents.
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}')"
+  OUT="$(resolve_ri_mode "$L1" "$L2")"
+  expect_eq "register-interests: neither layer -> oneshot-legacy default preserved" "oneshot-legacy" "$OUT"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
+echo "== install-orphan-sweep.sh: catalyst.sweep.{intervalHours,procWiden} =="
+# The two fallback sites CTL-1214 Phase 1 added here were the only ones with NO
+# coverage. intervalHours is baked into a launchd plist, where the code's own
+# comment notes the drift becomes invisible afterwards.
+IOS="${SCRIPTS}/install-orphan-sweep.sh"
+
+# Sourcing the whole installer would RUN it, so each resolver's body is
+# extracted and driven in isolation. Probe the names first — a rename would
+# otherwise make every assertion below compare "" to "" and report a false green.
+_ios_fns="$(grep -Eo '^(_interval_seconds|_config_widen_mode)\(\)' "$IOS" | tr -d '()' | sort -u | tr '\n' ' ')"
+if [[ "$_ios_fns" != *"_interval_seconds"* || "$_ios_fns" != *"_config_widen_mode"* ]]; then
+  fail "harness: install-orphan-sweep defines both resolvers" "found: '${_ios_fns}' — refusing to report results"
+else
+  ok "harness: install-orphan-sweep defines both resolvers"
+
+  # Same extract-and-verify discipline as the blocks above.
+  ios_fn_block() { sed -n "/^$1() {/,/^}/p" "$IOS"; }
+  IH_BLOCK="$(ios_fn_block _interval_seconds)"
+  WM_BLOCK="$(ios_fn_block _config_widen_mode)"
+  _ios_ok=1
+  [[ "$IH_BLOCK" != *"catalyst_layer2_json"* ]] && _ios_ok=0
+  [[ "$WM_BLOCK" != *"catalyst_layer2_json"* ]] && _ios_ok=0
+  [[ "$IH_BLOCK" != *"intervalHours"* ]] && _ios_ok=0
+  [[ "$WM_BLOCK" != *"procWiden"* ]] && _ios_ok=0
+  if [[ "$_ios_ok" -ne 1 ]]; then
+    fail "extract install-orphan-sweep resolvers" "a rung is missing from the extracted body — the test would assert on a partial ladder"
+  else
+    ok "extract install-orphan-sweep resolvers"
+
+    run_ios() {
+      local fn="$1" block="$2" repodir="$3" l2="$4"
+      env -u SWEEP_INTERVAL_HOURS -u SWEEP_PROC_WIDEN \
+        CATALYST_LAYER2_CONFIG_FILE="$l2" bash -c '
+          set -uo pipefail
+          cd "$1" || exit 1
+          # shellcheck disable=SC1090
+          . "$2"
+          eval "$3"
+          "$4"
+        ' _ "$repodir" "${SCRIPTS}/lib/catalyst-layer2-read.sh" "$block" "$fn"
+    }
+
+    # mk_l1 returns .../<d>/.catalyst/config.json — the resolvers walk UP from cwd
+    # looking for .catalyst/config.json, so cd to <d>.
+    L1="$(mk_l1 "$SLIM_L1")"; L1DIR="$(dirname "$(dirname "$L1")")"
+    # 3, not the code default 2 and not the clamp bound 1.
+    L2="$(mk_l2 '{}' '{"catalyst":{"sweep":{"intervalHours":3,"procWiden":"on"}}}')"
+    OUT="$(run_ios _interval_seconds "$IH_BLOCK" "$L1DIR" "$L2")"
+    expect_eq "install-orphan-sweep: slimmed Layer-1 + node.json -> 3h (10800s)" "10800" "$OUT"
+    expect_ne "install-orphan-sweep: NOT the code default 1h (3600s)" "$OUT" "3600"
+
+    OUT="$(run_ios _config_widen_mode "$WM_BLOCK" "$L1DIR" "$L2")"
+    expect_eq "install-orphan-sweep: procWiden from node.json -> on" "on" "$OUT"
+
+    # 2, deliberately NOT 1 — 1 is also the code default, so an assertion against
+    # it would pass whether or not the Layer-1 read works.
+    L1="$(mk_l1 '{"catalyst":{"sweep":{"intervalHours":2}}}')"; L1DIR="$(dirname "$(dirname "$L1")")"
+    L2="$(mk_l2 '{}')"
+    OUT="$(run_ios _interval_seconds "$IH_BLOCK" "$L1DIR" "$L2")"
+    expect_eq "install-orphan-sweep: un-slimmed Layer-1 alone -> 2h (back-compat)" "7200" "$OUT"
+
+    # NEGATIVE CONTROL: neither layer must still yield the code default.
+    L1="$(mk_l1 "$SLIM_L1")"; L1DIR="$(dirname "$(dirname "$L1")")"
+    L2="$(mk_l2 '{}')"
+    OUT="$(run_ios _interval_seconds "$IH_BLOCK" "$L1DIR" "$L2")"
+    expect_eq "install-orphan-sweep: neither layer -> code default 1h (3600s)" "3600" "$OUT"
+    OUT="$(run_ios _config_widen_mode "$WM_BLOCK" "$L1DIR" "$L2")"
+    expect_eq "install-orphan-sweep: neither layer -> procWiden empty" "" "$OUT"
+  fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
 echo "== feedback-consent.sh / file-feedback.sh: catalyst.feedback.* =="
 # ⚠️ The live ~/.config/catalyst/config.json carries catalyst.feedback as a
 # STRING, so any Layer-2 read of .catalyst.feedback.autoFile must not die with

--- a/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
+++ b/plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Layer-2 fallback at the five BASH consumer sites (CTL-1214 Phase 1).
+# Run: bash plugins/dev/scripts/__tests__/layer2-consumer-fallback.test.sh
+#
+# Each of these read a relocated key from Layer-1 ONLY, behind a fail-open
+# `// empty` + a local default. Slimming .catalyst/config.json therefore does not
+# ERROR at any of them — it silently reverts the knob. Every case below asserts
+# BOTH halves: the Layer-2 value is resolved, AND the result is not the silent
+# default that a regression would produce.
+#
+# WHY A DEDICATED FILE rather than extending the suites the plan named:
+#   • __tests__/catalyst-config.test.sh is scoped to the `catalyst-config` CLI's
+#     help/JSON/router contract — consumer resolution is a different subject.
+#   • __tests__/orphan-sweep.test.sh is 136 KB and has known CI-flaky log-count
+#     assertions; appending here keeps a flake in that file from masking these.
+# This file is registered in .github/workflows/execution-core-tests.yml in the
+# same change that adds it — CI runs an explicit list, never a glob.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+FAILURES=0
+PASSES=0
+ok() { PASSES=$((PASSES+1)); echo "  PASS: $1"; }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+expect_eq() { if [[ "$2" == "$3" ]]; then ok "$1"; else fail "$1" "expected '$2' got '$3'"; fi; }
+expect_ne() { if [[ "$2" != "$3" ]]; then ok "$1"; else fail "$1" "expected NOT '$3'"; fi; }
+
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# mk_l1 <json> -> path to a Layer-1 .catalyst/config.json
+mk_l1() {
+  local d; d="$(mktemp -d "${TMP}/l1XXXXXX")"
+  mkdir -p "${d}/.catalyst"
+  printf '%s' "$1" > "${d}/.catalyst/config.json"
+  printf '%s' "${d}/.catalyst/config.json"
+}
+# mk_l2 <config.json body> [node.json body] -> path to the Layer-2 config.json
+mk_l2() {
+  local d; d="$(mktemp -d "${TMP}/l2XXXXXX")"
+  printf '%s' "${1:-\{\}}" > "${d}/config.json"
+  [[ -n "${2:-}" ]] && printf '%s' "$2" > "${d}/node.json"
+  printf '%s' "${d}/config.json"
+}
+
+SLIM_L1='{"catalyst":{"schemaVersion":1,"projectKey":"catalyst-workspace","linear":{"teamKey":"CTL"}}}'
+
+# ───────────────────────────────────────────────────────────────────────────
+echo "== orchestrate-dispatch-next: dispatchMode =="
+# ⚠️ THE SHARPEST ASSERTION IN THE PHASE. With no fallback a slimmed config
+# resolves dispatchMode to "oneshot-legacy" — the wrong ORCHESTRATION MODE for
+# the whole fleet, arrived at silently. Assert the resolved value is
+# phase-agents AND explicitly that it is not oneshot-legacy.
+DN="${SCRIPTS}/orchestrate-dispatch-next"
+
+# The resolution block is extracted and driven directly: running the real script
+# would dispatch actual work. The extractor asserts it FOUND the block, so a
+# refactor that moves the code fails loudly instead of silently testing nothing.
+resolve_dispatch_mode() {
+  local l1="$1" l2="$2"
+  CATALYST_LAYER2_CONFIG_FILE="$l2" bash -c '
+    set -uo pipefail
+    CONFIG_PATH="$1"
+    SCRIPTS="$2"
+    # The extracted block sources lib/catalyst-layer2-read.sh off SCRIPT_DIR,
+    # exactly as the real script does.
+    SCRIPT_DIR="$2"
+    eval "$3"
+    printf "%s" "$DISPATCH_MODE"
+  ' _ "$l1" "$SCRIPTS" "$BLOCK"
+}
+
+# Extract the resolution block from the real script, bounded by two ANCHORS: the
+# opening default assignment and the comment that begins the next concern. A
+# `/^fi$/` terminator would truncate at the FIRST `fi`, silently testing half the
+# ladder — so the extraction is verified by CONTENT below, not just non-emptiness.
+BLOCK="$(sed -n '/^DISPATCH_MODE="oneshot-legacy"$/,/^# CTL-452: when dispatchMode resolves/p' "$DN" \
+         | sed '$d')"
+_block_ok=1
+[[ -z "$BLOCK" ]] && _block_ok=0
+# Positive controls on the extraction itself: all three rungs must be present.
+[[ "$BLOCK" != *"catalyst_layer2_json"* ]] && _block_ok=0
+[[ "$BLOCK" != *"dispatchMode"* ]] && _block_ok=0
+[[ "$BLOCK" != *"phase-agents | oneshot-legacy | execution-core"* ]] && _block_ok=0
+if [[ "$_block_ok" -ne 1 ]]; then
+  fail "extract dispatchMode block from orchestrate-dispatch-next" "extraction incomplete — the test would silently assert on a partial ladder"
+else
+  ok "extract dispatchMode block from orchestrate-dispatch-next"
+
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}' '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  OUT="$(resolve_dispatch_mode "$L1" "$L2")"
+  expect_eq "slimmed Layer-1 + node.json -> phase-agents" "phase-agents" "$OUT"
+  expect_ne "slimmed Layer-1 + node.json is NOT the silent default" "$OUT" "oneshot-legacy"
+
+  L1="$(mk_l1 '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  L2="$(mk_l2 '{}')"
+  OUT="$(resolve_dispatch_mode "$L1" "$L2")"
+  expect_eq "un-slimmed Layer-1 alone -> phase-agents (back-compat)" "phase-agents" "$OUT"
+
+  L1="$(mk_l1 '{"catalyst":{"orchestration":{"dispatchMode":"phase-agents"}}}')"
+  L2="$(mk_l2 '{}' '{"catalyst":{"orchestration":{"dispatchMode":"execution-core"}}}')"
+  OUT="$(resolve_dispatch_mode "$L1" "$L2")"
+  expect_eq "Layer-1 wins when present (fallback is a fallback, not an override)" "phase-agents" "$OUT"
+
+  # NEGATIVE CONTROL: with neither layer defining it, the default must still be
+  # oneshot-legacy. Without this, every assertion above could pass from a reader
+  # that unconditionally returns phase-agents.
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}')"
+  OUT="$(resolve_dispatch_mode "$L1" "$L2")"
+  expect_eq "neither layer -> oneshot-legacy default preserved" "oneshot-legacy" "$OUT"
+
+  # An invalid value in Layer-2 must be rejected the same way Layer-1's is.
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}' '{"catalyst":{"orchestration":{"dispatchMode":"bogus-mode"}}}')"
+  OUT="$(resolve_dispatch_mode "$L1" "$L2" 2>/dev/null)"
+  expect_eq "invalid Layer-2 value -> default, not the bogus string" "oneshot-legacy" "$OUT"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
+echo "== orphan-sweep.sh: catalyst.sweep.* =="
+# intervalHours is the one with a real operational bite: Layer-1 sets 1, the code
+# default is 2, so a silent revert HALVES the sweep cadence.
+# orphan-sweep.sh ships a purpose-built `--print-config` mode (the same seam
+# __tests__/orphan-sweep.test.sh drives), so the resolved values are read from
+# the real script rather than by re-sourcing it.
+sweep_val() {
+  local l1="$1" l2="$2" var="$3"
+  env -u SWEEP_IDLE_HOURS -u SWEEP_INTERVAL_HOURS -u SWEEP_SALVAGE_PUSH -u SWEEP_MAX_REMOVALS \
+      SWEEP_CONFIG_PATH="$l1" CATALYST_LAYER2_CONFIG_FILE="$l2" \
+      bash "${SCRIPTS}/orphan-sweep.sh" --print-config 2>/dev/null \
+    | sed -n "s/^${var}=//p" | head -1
+}
+
+# Harness self-check: --print-config must actually emit the variables, or every
+# assertion below compares "" to "" and the suite reports a false green.
+_probe="$(SWEEP_CONFIG_PATH=/nonexistent/c.json bash "${SCRIPTS}/orphan-sweep.sh" --print-config 2>/dev/null | sed -n 's/^SWEEP_INTERVAL_HOURS=//p' | head -1)"
+if [[ -z "$_probe" ]]; then
+  fail "harness: orphan-sweep.sh --print-config emits SWEEP_INTERVAL_HOURS" "got empty — refusing to report sweep results"
+else
+  ok "harness: orphan-sweep.sh --print-config emits SWEEP_INTERVAL_HOURS"
+
+  L1="$(mk_l1 "$SLIM_L1")"
+  # idleHours is deliberately 72, NOT the repo's 48 — 48 is also the CODE
+  # DEFAULT, so an assertion against it passes whether or not the fallback works.
+  L2="$(mk_l2 '{}' '{"catalyst":{"sweep":{"intervalHours":1,"idleHours":72,"maxRemovalsPerRun":10}}}')"
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_INTERVAL_HOURS)"
+  expect_eq "slimmed Layer-1 + node.json -> intervalHours 1" "1" "$OUT"
+  expect_ne "slimmed Layer-1 + node.json is NOT the code default 2" "$OUT" "2"
+
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_IDLE_HOURS)"
+  expect_eq "slimmed Layer-1 + node.json -> idleHours 72" "72" "$OUT"
+  expect_ne "slimmed Layer-1 + node.json idleHours is NOT the code default 48" "$OUT" "48"
+
+  L1="$(mk_l1 '{"catalyst":{"sweep":{"intervalHours":1}}}')"
+  L2="$(mk_l2 '{}')"
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_INTERVAL_HOURS)"
+  expect_eq "un-slimmed Layer-1 alone -> intervalHours 1 (back-compat)" "1" "$OUT"
+
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}')"
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_INTERVAL_HOURS)"
+  expect_eq "neither layer -> the code default 2 is preserved" "2" "$OUT"
+
+  # SWEEP_* env still wins over both layers.
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}' '{"catalyst":{"sweep":{"intervalHours":1}}}')"
+  OUT="$(SWEEP_CONFIG_PATH="$L1" CATALYST_LAYER2_CONFIG_FILE="$L2" SWEEP_INTERVAL_HOURS=3 \
+         bash "${SCRIPTS}/orphan-sweep.sh" --print-config 2>/dev/null \
+         | sed -n 's/^SWEEP_INTERVAL_HOURS=//p' | head -1)"
+  expect_eq "SWEEP_INTERVAL_HOURS env still beats both layers" "3" "$OUT"
+
+  # salvagePush keeps its deliberate no-//-default treatment: false is jq-falsy,
+  # so a `// empty` would erase a genuine `false` and read as "unset".
+  L1="$(mk_l1 "$SLIM_L1")"
+  L2="$(mk_l2 '{}' '{"catalyst":{"sweep":{"salvagePush":true}}}')"
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_SALVAGE_PUSH)"
+  expect_eq "salvagePush true from node.json -> 1" "1" "$OUT"
+  L2="$(mk_l2 '{}' '{"catalyst":{"sweep":{"salvagePush":false}}}')"
+  OUT="$(sweep_val "$L1" "$L2" SWEEP_SALVAGE_PUSH)"
+  expect_eq "salvagePush false from node.json -> 0" "0" "$OUT"
+fi
+
+# ───────────────────────────────────────────────────────────────────────────
+echo "== feedback-consent.sh / file-feedback.sh: catalyst.feedback.* =="
+# ⚠️ The live ~/.config/catalyst/config.json carries catalyst.feedback as a
+# STRING, so any Layer-2 read of .catalyst.feedback.autoFile must not die with
+# "Cannot index string with autoFile".
+FC="${SCRIPTS}/feedback-consent.sh"
+
+L1="$(mk_l1 "$SLIM_L1")"
+L2="$(mk_l2 '{}' '{"catalyst":{"feedback":{"autoFile":true}}}')"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="$L2" bash "$FC" check --config "$L1" 2>/dev/null)"
+expect_eq "slimmed Layer-1 + node.json autoFile -> granted" "granted" "$OUT"
+expect_ne "slimmed Layer-1 + node.json is NOT the silent 'unset'" "$OUT" "unset"
+
+L1="$(mk_l1 '{"catalyst":{"feedback":{"autoFile":true}}}')"
+L2="$(mk_l2 '{}')"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="$L2" bash "$FC" check --config "$L1" 2>/dev/null)"
+expect_eq "un-slimmed Layer-1 alone -> granted (back-compat)" "granted" "$OUT"
+
+L1="$(mk_l1 "$SLIM_L1")"
+L2="$(mk_l2 '{}')"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="$L2" bash "$FC" check --config "$L1" 2>/dev/null)"
+expect_eq "neither layer -> unset (default preserved)" "unset" "$OUT"
+
+# The live string-valued catalyst.feedback must be survivable, not fatal.
+L1="$(mk_l1 "$SLIM_L1")"
+L2="$(mk_l2 '{"catalyst":{"feedback":"https://github.com/coalesce-labs/catalyst.git"}}')"
+ERR="${TMP}/fc-err.txt"
+OUT="$(CATALYST_LAYER2_CONFIG_FILE="$L2" bash "$FC" check --config "$L1" 2>"$ERR")"
+RC=$?
+expect_eq "string-valued catalyst.feedback in Layer-2 -> unset, not a crash" "unset" "$OUT"
+expect_eq "string-valued catalyst.feedback -> rc 0" "0" "$RC"
+if /usr/bin/grep -qi "cannot index" "$ERR"; then
+  fail "string-valued catalyst.feedback -> no jq index error" "$(cat "$ERR")"
+else
+  ok "string-valued catalyst.feedback -> no jq index error"
+fi
+
+echo
+echo "RESULTS: $PASSES passed, $FAILURES failed"
+[[ "$FAILURES" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/layer2-read-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/layer2-read-parity.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Cross-stack parity test for lib/catalyst-layer2-read.sh (bash) vs
+# execution-core/config.mjs's readLayer2Merged() (JS) — CTL-1214 Phase 1.
+#
+# Modelled on __tests__/deployment-mode-parity.test.sh, including its central
+# rule: the expected value for every cell is COMPUTED from the fixture
+# definition (the config.json < node.json < cluster-secrets.json deep-merge
+# cascade), never copied from either implementation. The assertion is threeway —
+#   bash == expected  AND  js == expected
+# — because asserting bash == js alone is a false-green on exactly the property
+# this file exists to guard: two implementations can agree with each other while
+# both disagreeing with the spec.
+#
+# Fixture matrix: 8 layer triples x 6 dotted keys = 48 cells.
+#
+# Run: bash plugins/dev/scripts/__tests__/layer2-read-parity.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+LIB="${REPO_ROOT}/plugins/dev/scripts/lib/catalyst-layer2-read.sh"
+JS_CONFIG="${REPO_ROOT}/plugins/dev/scripts/execution-core/config.mjs"
+
+FAILURES=0
+PASSES=0
+ok() { PASSES=$((PASSES+1)); }
+fail() { FAILURES=$((FAILURES+1)); echo "  FAIL: $1"; echo "    $2"; }
+
+for f in "$LIB" "$JS_CONFIG"; do
+  [[ -f "$f" ]] || { echo "FAIL: missing $f"; exit 1; }
+done
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq unavailable"; exit 0; }
+
+# Runtime: config.mjs loads under BOTH node and bun; prefer whichever exists.
+JS_RUN=""
+command -v bun >/dev/null 2>&1 && JS_RUN="bun"
+[[ -z "$JS_RUN" ]] && command -v node >/dev/null 2>&1 && JS_RUN="node"
+[[ -z "$JS_RUN" ]] && { echo "SKIP: neither bun nor node available"; exit 0; }
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# ─── Fixture axes ──────────────────────────────────────────────────────────
+# Each triple is: <config.json body>|<node.json body>|<cluster-secrets.json body>
+# "-" means the file is ABSENT. "!" means the file is present but MALFORMED
+# (which the contract defines as layer-absent, on BOTH stacks).
+FIXTURES=(
+  "-|-|-"
+  '{"catalyst":{"a":"c","n":{"deep":1}}}|-|-'
+  '{"catalyst":{"a":"c"}}|{"catalyst":{"a":"n"}}|-'
+  '{"catalyst":{"a":"c"}}|{"catalyst":{"a":"n"}}|{"catalyst":{"a":"s"}}'
+  '{"catalyst":{"n":{"deep":1}}}|{"catalyst":{"n":{"other":2}}}|-'
+  '{"catalyst":{"a":"c","n":{"deep":1}}}|!|-'
+  '{"catalyst":{"feedback":"a-string"}}|-|-'
+  '{"catalyst":{"b":false,"z":null}}|-|-'
+)
+
+KEYS=(
+  ".catalyst.a"
+  ".catalyst.n.deep"
+  ".catalyst.n.other"
+  ".catalyst.feedback.autoFile"
+  ".catalyst.b"
+  ".catalyst.z"
+)
+
+# ─── The computed oracle ───────────────────────────────────────────────────
+# Independently re-derives the expected answer from the fixture triple, using a
+# jq program written from the SPEC (deep-merge the well-formed layers in order;
+# a null or unindexable path is an absence). It never consults either
+# implementation under test.
+compute_expected() {
+  local dir="$1" key="$2"
+  local -a good=()
+  local f
+  for f in "${dir}/config.json" "${dir}/node.json" "${dir}/cluster-secrets.json"; do
+    [[ -f "$f" ]] || continue
+    jq -e 'type == "object"' "$f" >/dev/null 2>&1 || continue
+    good+=("$f")
+  done
+  [[ ${#good[@]} -eq 0 ]] && { printf ''; return 0; }
+  jq -rc -n --arg p "$key" '
+      reduce inputs as $x ({}; . * $x)
+      | try (getpath($p | ltrimstr(".") | split("."))) catch empty
+      | if . == null then empty else . end
+    ' "${good[@]}" 2>/dev/null || printf ''
+}
+
+# ─── The JS side ───────────────────────────────────────────────────────────
+# readLayer2Merged() returns { catalyst: {...} }; walk the same dotted path and
+# render with the SAME conventions the bash reader uses (scalars bare, objects
+# and arrays as compact JSON, null/absent as empty) so a difference in the
+# ANSWER is never mistaken for a difference in FORMATTING.
+JS_DRIVER="${TMP_DIR}/driver.mjs"
+# The config module path is passed through the ENVIRONMENT (JS_CONFIG_URL), never
+# interpolated into the driver source. Interpolating it would need bash 4.4's
+# ${var@Q} to be safe, and macOS ships bash 3.2 — the unsupported expansion emits
+# "bad substitution", writes a truncated driver, and every JS cell then returns
+# empty, which reads as a real parity failure rather than a broken harness.
+cat > "$JS_DRIVER" <<'JSEOF'
+const { readLayer2Merged } = await import(process.env.JS_CONFIG_URL);
+const key = process.argv[2];
+const merged = readLayer2Merged();
+let cur = merged;
+for (const seg of key.replace(/^\./, "").split(".")) {
+  if (cur === null || typeof cur !== "object" || Array.isArray(cur) || !(seg in cur)) {
+    cur = undefined;
+    break;
+  }
+  cur = cur[seg];
+}
+if (cur === undefined || cur === null) process.stdout.write("");
+else if (typeof cur === "object") process.stdout.write(JSON.stringify(cur));
+else process.stdout.write(String(cur));
+JSEOF
+export JS_CONFIG_URL="file://${JS_CONFIG}"
+
+# Harness self-check: prove the JS driver actually RUNS before trusting a matrix
+# of empty answers from it. A driver that fails to start returns "" for every
+# cell, which is indistinguishable from a genuine absence.
+_probe_dir="$(mktemp -d "${TMP_DIR}/probeXXXXXX")"
+printf '%s' '{"catalyst":{"probe":"alive"}}' > "${_probe_dir}/config.json"
+_probe_out="$(CATALYST_LAYER2_CONFIG_FILE="${_probe_dir}/config.json" "$JS_RUN" "$JS_DRIVER" ".catalyst.probe" 2>&1)"
+if [[ "$_probe_out" != "alive" ]]; then
+  echo "FAIL: JS driver harness is broken (probe returned '${_probe_out}') — refusing to report parity"
+  exit 1
+fi
+
+cell=0
+for fixture in "${FIXTURES[@]}"; do
+  D="$(mktemp -d "${TMP_DIR}/fxXXXXXX")"
+  IFS='|' read -r c_body n_body s_body <<< "$fixture"
+  write_layer() {
+    local body="$1" path="$2"
+    [[ "$body" == "-" ]] && return 0
+    if [[ "$body" == "!" ]]; then printf '%s' '{ not json at all' > "$path"; return 0; fi
+    printf '%s' "$body" > "$path"
+  }
+  write_layer "$c_body" "${D}/config.json"
+  write_layer "$n_body" "${D}/node.json"
+  write_layer "$s_body" "${D}/cluster-secrets.json"
+
+  for key in "${KEYS[@]}"; do
+    cell=$((cell+1))
+    expected="$(compute_expected "$D" "$key")"
+
+    bash_out="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" \
+                /bin/bash -c 'source "$1"; catalyst_layer2_json "$2"' _ "$LIB" "$key" 2>/dev/null)"
+
+    js_out="$(CATALYST_LAYER2_CONFIG_FILE="${D}/config.json" \
+              "$JS_RUN" "$JS_DRIVER" "$key" 2>/dev/null)"
+
+    if [[ "$bash_out" != "$expected" ]]; then
+      fail "cell ${cell} [${fixture}] ${key}: bash != expected" "expected '${expected}' got '${bash_out}'"
+    else
+      ok
+    fi
+    if [[ "$js_out" != "$expected" ]]; then
+      fail "cell ${cell} [${fixture}] ${key}: js != expected" "expected '${expected}' got '${js_out}'"
+    else
+      ok
+    fi
+  done
+done
+
+# ─── Positive control ──────────────────────────────────────────────────────
+# The matrix above must actually be able to FAIL. Feed the oracle a fixture whose
+# expected value is known by hand and assert the loop's own comparison would
+# reject a wrong answer — otherwise "48 cells passed" could just mean the cells
+# never resolved anything.
+D="$(mktemp -d "${TMP_DIR}/pcXXXXXX")"
+printf '%s' '{"catalyst":{"a":"c"}}' > "${D}/config.json"
+printf '%s' '{"catalyst":{"a":"n"}}' > "${D}/node.json"
+pc_expected="$(compute_expected "$D" ".catalyst.a")"
+if [[ "$pc_expected" == "n" ]]; then
+  ok
+else
+  fail "positive control: oracle resolves node-over-config" "expected 'n' got '${pc_expected}'"
+fi
+if [[ "$pc_expected" != "c" ]]; then
+  ok
+else
+  fail "positive control: oracle is not returning the config.json value" "got '${pc_expected}'"
+fi
+
+echo "cells=${cell} (x2 stacks) PASSES=${PASSES} FAILURES=${FAILURES}"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/plugins/dev/scripts/__tests__/layer2-read-parity.test.sh
+++ b/plugins/dev/scripts/__tests__/layer2-read-parity.test.sh
@@ -70,11 +70,18 @@ KEYS=(
 # jq program written from the SPEC (deep-merge the well-formed layers in order;
 # a null or unindexable path is an absence). It never consults either
 # implementation under test.
+# compute_expected <dir> <key> [legacy_file]
+#
+# CTL-1214 remediation: the legacy (lowest-precedence) file is a PARAMETER, not a
+# hardcoded "${dir}/config.json". Both implementations take the pinned
+# CATALYST_LAYER2_CONFIG_FILE path itself as that layer, so an oracle that always
+# composed config.json could not express the pinned-name case at all — which is
+# precisely why the divergence it exists to catch went unobserved.
 compute_expected() {
-  local dir="$1" key="$2"
+  local dir="$1" key="$2" legacy="${3:-${1}/config.json}"
   local -a good=()
   local f
-  for f in "${dir}/config.json" "${dir}/node.json" "${dir}/cluster-secrets.json"; do
+  for f in "$legacy" "${dir}/node.json" "${dir}/cluster-secrets.json"; do
     [[ -f "$f" ]] || continue
     jq -e 'type == "object"' "$f" >/dev/null 2>&1 || continue
     good+=("$f")
@@ -163,6 +170,67 @@ for fixture in "${FIXTURES[@]}"; do
     fi
   done
 done
+
+# ─── The pinned-name axis (CTL-1214 remediation) ───────────────────────────
+# ⚠️ THE CASE THE MATRIX COULD NOT EXPRESS. Every cell above pins
+# `${D}/config.json`, so the one axis the two implementations actually differed
+# on — WHICH file the pin names as the legacy layer — was unobservable, while
+# catalyst-layer2-read.sh's header claimed agreement "over a fixture matrix".
+#
+# The fixture puts a DIFFERENT value in config.json than in the pinned
+# config-adva.json, so a stack that ignores the pin and reads config.json returns
+# a distinguishable wrong answer instead of accidentally agreeing.
+D="$(mktemp -d "${TMP_DIR}/pinXXXXXX")"
+printf '%s' '{"catalyst":{"probe":"FROM-config.json"}}'      > "${D}/config.json"
+printf '%s' '{"catalyst":{"probe":"FROM-config-adva.json"}}' > "${D}/config-adva.json"
+PINNED="${D}/config-adva.json"
+
+pin_expected="$(compute_expected "$D" ".catalyst.probe" "$PINNED")"
+if [[ "$pin_expected" == "FROM-config-adva.json" ]]; then
+  ok
+else
+  fail "pinned-name oracle composes the PINNED file as the legacy layer" \
+       "expected 'FROM-config-adva.json' got '${pin_expected}'"
+fi
+
+pin_bash="$(CATALYST_LAYER2_CONFIG_FILE="$PINNED" \
+            /bin/bash -c 'source "$1"; catalyst_layer2_json "$2"' _ "$LIB" ".catalyst.probe" 2>/dev/null)"
+pin_js="$(CATALYST_LAYER2_CONFIG_FILE="$PINNED" "$JS_RUN" "$JS_DRIVER" ".catalyst.probe" 2>/dev/null)"
+
+if [[ "$pin_bash" == "$pin_expected" ]]; then ok; else
+  fail "pinned non-config.json name: bash != expected" "expected '${pin_expected}' got '${pin_bash}'"
+fi
+if [[ "$pin_js" == "$pin_expected" ]]; then ok; else
+  fail "pinned non-config.json name: js != expected" "expected '${pin_expected}' got '${pin_js}'"
+fi
+if [[ "$pin_bash" == "$pin_js" ]]; then ok; else
+  fail "pinned non-config.json name: bash != js" "bash '${pin_bash}' vs js '${pin_js}'"
+fi
+
+# Negative control for the case above: the fixture CAN produce the wrong answer,
+# so the three assertions are evidence about the readers rather than about a
+# fixture in which both files happen to say the same thing.
+if [[ "$pin_bash" != "FROM-config.json" ]]; then ok; else
+  fail "pinned-name case: bash fell back to config.json" "got '${pin_bash}'"
+fi
+
+# And the siblings must STILL resolve off the pinned file's directory — the pin
+# changes which file is the legacy layer, never where node.json is looked up.
+printf '%s' '{"catalyst":{"probe":"FROM-node.json"}}' > "${D}/node.json"
+pin2_expected="$(compute_expected "$D" ".catalyst.probe" "$PINNED")"
+pin2_bash="$(CATALYST_LAYER2_CONFIG_FILE="$PINNED" \
+             /bin/bash -c 'source "$1"; catalyst_layer2_json "$2"' _ "$LIB" ".catalyst.probe" 2>/dev/null)"
+pin2_js="$(CATALYST_LAYER2_CONFIG_FILE="$PINNED" "$JS_RUN" "$JS_DRIVER" ".catalyst.probe" 2>/dev/null)"
+if [[ "$pin2_expected" == "FROM-node.json" ]]; then ok; else
+  fail "pinned-name + sibling: oracle lets node.json outrank the pinned legacy file" \
+       "expected 'FROM-node.json' got '${pin2_expected}'"
+fi
+if [[ "$pin2_bash" == "$pin2_expected" ]]; then ok; else
+  fail "pinned-name + sibling: bash != expected" "expected '${pin2_expected}' got '${pin2_bash}'"
+fi
+if [[ "$pin2_js" == "$pin2_expected" ]]; then ok; else
+  fail "pinned-name + sibling: js != expected" "expected '${pin2_expected}' got '${pin2_js}'"
+fi
 
 # ─── Positive control ──────────────────────────────────────────────────────
 # The matrix above must actually be able to FAIL. Feed the oracle a fixture whose

--- a/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
+++ b/plugins/dev/scripts/__tests__/orchestrate-dispatch-next.test.sh
@@ -8,6 +8,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 DISPATCH="${REPO_ROOT}/plugins/dev/scripts/orchestrate-dispatch-next"
 
+# CTL-1214: HERMETIC LAYER-2. orchestrate-dispatch-next now falls back to the
+# merged Layer-2 view for dispatchMode (lib/catalyst-layer2-read.sh), which
+# resolves ~/.config/catalyst whenever CATALYST_LAYER2_CONFIG_FILE is unset —
+# i.e. the DEVELOPER'S LIVE config. Unpinned, this suite reads the host it runs
+# on: measured on a migrated host, 49 of 138 assertions flip (e.g. "defaults to
+# legacy oneshot when no dispatchMode" reads the real dispatchMode=phase-agents),
+# and the state that breaks it is precisely the one this ticket's own migration
+# creates. This is the bash-side twin of the injectable root config.mjs's
+# readLayer2MergedFrom already uses on the JS side ("a suite must not depend on
+# the host it runs on").
+#
+# The pin points at an EMPTY scratch dir, so catalyst_layer2_json finds no
+# config.json/node.json/cluster-secrets.json and every Layer-2 lookup is silent —
+# which is the baseline these assertions were written against. A test that wants
+# a Layer-2 value writes it into this dir explicitly.
+HERMETIC_LAYER2_DIR="$(mktemp -d)"
+export CATALYST_LAYER2_CONFIG_FILE="${HERMETIC_LAYER2_DIR}/config.json"
+trap 'rm -rf "${HERMETIC_LAYER2_DIR}"' EXIT
+
 FAILURES=0
 PASSES=0
 
@@ -902,6 +921,52 @@ DISPATCHED=$(echo "$OUT" | jq -r '.dispatched | join(",")')
 [ "$DISPATCHED" = "T-1" ] && pass "dispatched=[T-1] on success" || fail "dispatched=[T-1] on success" "got: $DISPATCHED"
 COUNT=$(grep -c "phase.dispatch.failed" "$STATE_LOG" || true)
 [ "$COUNT" = "0" ] && pass "no phase.dispatch.failed event on success" || fail "no phase.dispatch.failed event on success" "count=$COUNT log: $(cat "$STATE_LOG")"
+scratch_teardown
+
+# write_layer2_config DISPATCH_MODE — write a Layer-2 config.json into the
+# HERMETIC pin dir. Callers MUST clear it again (clear_layer2_config), since the
+# pin dir outlives a single scratch_setup/teardown pair.
+write_layer2_config() {
+	cat >"${HERMETIC_LAYER2_DIR}/config.json" <<EOF
+{"catalyst": {"orchestration": {"dispatchMode": "$1"}}}
+EOF
+}
+clear_layer2_config() { rm -f "${HERMETIC_LAYER2_DIR}/config.json"; }
+
+# ── CTL-1214: the POSITIVE CONTROL for the hermetic pin above ────────────────
+# Tests 46/47 are what keep "no host leak" from silently meaning "the Layer-2
+# reader stopped working". Every other assertion in this suite passes when the
+# pinned dir is empty, so an empty dir alone cannot distinguish a correctly
+# isolated suite from a fallback that never fires. These two assert the fallback
+# DOES fire out of the pinned dir, and that Layer-1 still outranks it.
+
+echo "test 46 (CTL-1214): no --config → dispatchMode falls back to the merged Layer-2 view"
+scratch_setup
+phase_agent_dispatch_setup
+write_layer2_config "phase-agents"
+write_state "demo" 4 '{"wave1Pending": ["T-1"]}'
+make_worktree "demo" "T-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with Layer-2 dispatchMode" || fail "exit 0 with Layer-2 dispatchMode" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+grep -q -- "--phase triage" "$PHASE_DISPATCH_LOG" && pass "Layer-2 dispatchMode=phase-agents reached the dispatcher" || fail "Layer-2 dispatchMode=phase-agents reached the dispatcher" "log: $(cat "$PHASE_DISPATCH_LOG")"
+grep -q "oneshot" "$CLAUDE_LOG" && fail "legacy oneshot NOT used when Layer-2 says phase-agents" "log: $(cat "$CLAUDE_LOG")" || pass "legacy oneshot NOT used when Layer-2 says phase-agents"
+clear_layer2_config
+scratch_teardown
+
+echo "test 47 (CTL-1214): Layer-1 dispatchMode WINS over Layer-2 (fallback, not override)"
+scratch_setup
+phase_agent_dispatch_setup
+write_layer2_config "phase-agents"
+CONFIG_PATH=$(write_config "oneshot-legacy")
+write_state "demo" 4 '{"wave1Pending": ["T-1"]}'
+make_worktree "demo" "T-1"
+OUT=$("$DISPATCH" --orch-dir "$ORCH_DIR" --config "$CONFIG_PATH" 2>"${SCRATCH}/err")
+RC=$?
+[ "$RC" = "0" ] && pass "exit 0 with Layer-1 over Layer-2" || fail "exit 0 with Layer-1 over Layer-2" "rc=$RC stderr=$(cat "${SCRATCH}/err")"
+grep -q "oneshot" "$CLAUDE_LOG" && pass "Layer-1 oneshot-legacy wins over Layer-2 phase-agents" || fail "Layer-1 oneshot-legacy wins over Layer-2 phase-agents" "log: $(cat "$CLAUDE_LOG")"
+[ ! -s "$PHASE_DISPATCH_LOG" ] && pass "phase-agent-dispatch NOT invoked when Layer-1 says legacy" || fail "phase-agent-dispatch NOT invoked when Layer-1 says legacy" "log: $(cat "$PHASE_DISPATCH_LOG")"
+clear_layer2_config
 scratch_teardown
 
 echo ""

--- a/plugins/dev/scripts/__tests__/setup-sweep-config.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-sweep-config.test.sh
@@ -168,6 +168,63 @@ CATALYST_LAYER2_CONFIG_FILE="${S5C_L2}/config.json" setup_sweep_config >/dev/nul
 run "S5h: a legacy Layer-1 catalyst.sweep is NOT deleted" \
   bash -c "jq -e '.catalyst.sweep.idleHours == 72' '${S5C_DIR}/.catalyst/config.json'"
 
+# ─── S7 (CTL-1214 remediation): setup_dispatch_mode_config seeds node.json ────
+#
+# Phase 4 removed `orchestration.dispatchMode` from the config template and left
+# NO writer behind, so a project scaffolded on a fresh host silently resolved to
+# the `oneshot-legacy` code default. The key is node-scoped and the template
+# declares schemaVersion 1, so it cannot go back in the template without turning
+# checkConfigScopeLeak's FAIL — and catalyst-join.sh's gate — against every new
+# project. These cases pin the seeder that replaces it.
+S7_L2="${SCRATCH}/s7-layer2"
+mkdir -p "$S7_L2"
+printf '{}\n' > "${S7_L2}/config.json"
+CATALYST_LAYER2_CONFIG_FILE="${S7_L2}/config.json" setup_dispatch_mode_config >/dev/null 2>&1 || true
+
+run "S7a: dispatchMode default is seeded into node.json" \
+  bash -c "jq -e '.catalyst.orchestration.dispatchMode == \"phase-agents\"' '${S7_L2}/node.json'"
+
+# Positive control for S7a: the default is NOT what a bare `{}` node.json would
+# already answer, so the assertion above is evidence the seeder ran.
+S7CTRL="${SCRATCH}/s7-control.json"
+printf '{}\n' > "$S7CTRL"
+run "S7b: control — an unseeded node.json has no dispatchMode" \
+  bash -c "jq -e '.catalyst.orchestration.dispatchMode == null' '${S7CTRL}'"
+
+# Idempotent + non-clobbering: a host pinned to execution-core keeps its pin.
+S7B_L2="${SCRATCH}/s7b-layer2"
+mkdir -p "$S7B_L2"
+printf '{}\n' > "${S7B_L2}/config.json"
+printf '{"catalyst":{"orchestration":{"dispatchMode":"execution-core","executor":"sdk"},"host":{"name":"mini-2"}}}\n' \
+  > "${S7B_L2}/node.json"
+CATALYST_LAYER2_CONFIG_FILE="${S7B_L2}/config.json" setup_dispatch_mode_config >/dev/null 2>&1 || true
+
+run "S7c: an operator's existing dispatchMode is NOT overwritten" \
+  bash -c "jq -e '.catalyst.orchestration.dispatchMode == \"execution-core\"' '${S7B_L2}/node.json'"
+run "S7d: sibling orchestration keys survive (merge, not replace)" \
+  bash -c "jq -e '.catalyst.orchestration.executor == \"sdk\"' '${S7B_L2}/node.json'"
+run "S7e: unrelated node.json keys survive" \
+  bash -c "jq -e '.catalyst.host.name == \"mini-2\"' '${S7B_L2}/node.json'"
+
+# Re-running is a no-op on an already-seeded file (setup re-runs are routine).
+_S7_BEFORE="$(cat "${S7_L2}/node.json")"
+CATALYST_LAYER2_CONFIG_FILE="${S7_L2}/config.json" setup_dispatch_mode_config >/dev/null 2>&1 || true
+if [[ "$_S7_BEFORE" == "$(cat "${S7_L2}/node.json")" ]]; then
+  PASSES=$((PASSES+1)); echo "  PASS: S7f: a second run leaves node.json byte-identical"
+else
+  FAILURES=$((FAILURES+1)); echo "  FAIL: S7f: a second run rewrote node.json"
+fi
+
+# The seeder must NEVER write the committed Layer-1 config (that is the whole
+# point of the relocation, and a schemaVersion-1 config carrying it FAILs doctor).
+S7C_DIR="${SCRATCH}/s7c-proj"
+mkdir -p "${S7C_DIR}/.catalyst"
+printf '{"catalyst":{"schemaVersion":1,"projectKey":"TEST"}}\n' > "${S7C_DIR}/.catalyst/config.json"
+PROJECT_DIR="$S7C_DIR"
+CATALYST_LAYER2_CONFIG_FILE="${S7_L2}/config.json" setup_dispatch_mode_config >/dev/null 2>&1 || true
+run "S7g: the committed Layer-1 config gains NO orchestration stanza" \
+  bash -c "jq -e '.catalyst.orchestration == null' '${S7C_DIR}/.catalyst/config.json'"
+
 # ─── S6 (CTL-1214): the suite never touched the REAL host config ─────────────
 # A guard on the guard. Without it this file silently created the developer's
 # ~/.config/catalyst/node.json while it was being written.

--- a/plugins/dev/scripts/__tests__/setup-sweep-config.test.sh
+++ b/plugins/dev/scripts/__tests__/setup-sweep-config.test.sh
@@ -14,6 +14,20 @@ FAILURES=0
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
 
+# ⛔ HERMETICITY (CTL-1214). setup_sweep_config now writes catalyst.sweep into the
+# NODE-scoped ~/.config/catalyst/node.json. Without this pin, every case below
+# would write the developer's REAL node.json — which is exactly what happened
+# while this suite was being written. Export it for the whole file so no
+# individual case can forget, and assert the pin took effect before running.
+DEFAULT_L2="${SCRATCH}/layer2-default"
+mkdir -p "$DEFAULT_L2"
+printf '{}\n' > "${DEFAULT_L2}/config.json"
+export CATALYST_LAYER2_CONFIG_FILE="${DEFAULT_L2}/config.json"
+
+_REAL_NODE_JSON="${HOME}/.config/catalyst/node.json"
+_REAL_NODE_EXISTED=0
+[[ -e "$_REAL_NODE_JSON" ]] && _REAL_NODE_EXISTED=1
+
 run() {
   local name="$1"; shift
   if "$@" >/dev/null 2>&1; then
@@ -38,14 +52,19 @@ printf '{"catalyst":{"projectKey":"TEST"}}\n' > "${S1_DIR}/.catalyst/config.json
 PROJECT_DIR="$S1_DIR"
 setup_sweep_config >/dev/null 2>&1 || true
 
-run "S1a: idleHours default set" \
-  bash -c "jq -e '.catalyst.sweep.idleHours == 48' '${S1_DIR}/.catalyst/config.json'"
-run "S1b: intervalHours default set" \
-  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S1_DIR}/.catalyst/config.json'"
-run "S1c: salvagePush default is false" \
-  bash -c "jq -e '.catalyst.sweep.salvagePush == false' '${S1_DIR}/.catalyst/config.json'"
-run "S1d: maxRemovalsPerRun default is a number" \
-  bash -c "jq -e 'type == \"number\"' <(jq '.catalyst.sweep.maxRemovalsPerRun' '${S1_DIR}/.catalyst/config.json')"
+# CTL-1214: the defaults now land in the NODE-scoped node.json, never back in
+# the committed Layer-1 config.
+S1_NODE="${DEFAULT_L2}/node.json"
+run "S1a: idleHours default set (node.json)" \
+  bash -c "jq -e '.catalyst.sweep.idleHours == 48' '${S1_NODE}'"
+run "S1b: intervalHours default set (node.json)" \
+  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S1_NODE}'"
+run "S1c: salvagePush default is false (node.json)" \
+  bash -c "jq -e '.catalyst.sweep.salvagePush == false' '${S1_NODE}'"
+run "S1d: maxRemovalsPerRun default is a number (node.json)" \
+  bash -c "jq -e 'type == \"number\"' <(jq '.catalyst.sweep.maxRemovalsPerRun' '${S1_NODE}')"
+run "S1e: the committed Layer-1 config gains NO sweep block" \
+  bash -c "jq -e '.catalyst.sweep == null' '${S1_DIR}/.catalyst/config.json'"
 
 # ─── S2: does NOT clobber existing projectKey / dispatchMode ──────────────────
 S2_DIR="${SCRATCH}/s2-proj"
@@ -60,24 +79,28 @@ run "S2a: projectKey preserved" \
   bash -c "jq -e '.catalyst.projectKey == \"MYPROJ\"' '${S2_DIR}/.catalyst/config.json'"
 run "S2b: orchestration.dispatchMode preserved" \
   bash -c "jq -e '.catalyst.orchestration.dispatchMode == \"phase-agents\"' '${S2_DIR}/.catalyst/config.json'"
-run "S2c: sweep section still written" \
-  bash -c "jq -e '.catalyst.sweep.idleHours == 48' '${S2_DIR}/.catalyst/config.json'"
+run "S2c: sweep section still written (to node.json)" \
+  bash -c "jq -e '.catalyst.sweep.idleHours == 48' '${DEFAULT_L2}/node.json'"
 
 # ─── S3: preserves a pre-existing user override (idleHours=72 stays 72) ──────
+# CTL-1214: the override now lives where the value is written — node.json. The
+# Layer-1 copy is a legacy config and is asserted untouched by S5h below.
 S3_DIR="${SCRATCH}/s3-proj"
-mkdir -p "${S3_DIR}/.catalyst"
-printf '{"catalyst":{"projectKey":"X","sweep":{"idleHours":72,"maxRemovalsPerRun":5}}}\n' \
-  > "${S3_DIR}/.catalyst/config.json"
+S3_L2="${SCRATCH}/s3-layer2"
+mkdir -p "${S3_DIR}/.catalyst" "$S3_L2"
+printf '{"catalyst":{"projectKey":"X"}}\n' > "${S3_DIR}/.catalyst/config.json"
+printf '{}\n' > "${S3_L2}/config.json"
+printf '{"catalyst":{"sweep":{"idleHours":72,"maxRemovalsPerRun":5}}}\n' > "${S3_L2}/node.json"
 
 PROJECT_DIR="$S3_DIR"
-setup_sweep_config >/dev/null 2>&1 || true
+CATALYST_LAYER2_CONFIG_FILE="${S3_L2}/config.json" setup_sweep_config >/dev/null 2>&1 || true
 
 run "S3a: pre-existing idleHours=72 survives re-run" \
-  bash -c "jq -e '.catalyst.sweep.idleHours == 72' '${S3_DIR}/.catalyst/config.json'"
+  bash -c "jq -e '.catalyst.sweep.idleHours == 72' '${S3_L2}/node.json'"
 run "S3b: pre-existing maxRemovalsPerRun=5 survives re-run" \
-  bash -c "jq -e '.catalyst.sweep.maxRemovalsPerRun == 5' '${S3_DIR}/.catalyst/config.json'"
+  bash -c "jq -e '.catalyst.sweep.maxRemovalsPerRun == 5' '${S3_L2}/node.json'"
 run "S3c: un-overridden keys still get defaults (intervalHours=1)" \
-  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S3_DIR}/.catalyst/config.json'"
+  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S3_L2}/node.json'"
 
 # ─── S4: missing .catalyst/config.json -> safe no-op ─────────────────────────
 S4_DIR="${SCRATCH}/s4-proj"
@@ -88,6 +111,73 @@ run "S4: missing config.json -> exits 0 (no crash)" \
   bash -c "PROJECT_DIR='${S4_DIR}' CATALYST_SETUP_LIB_ONLY=1 source '${SETUP_SH}' && setup_sweep_config"
 run "S4b: no malformed/empty config.json created" \
   bash -c "[[ ! -f '${S4_DIR}/.catalyst/config.json' ]] || jq -e '.' '${S4_DIR}/.catalyst/config.json'"
+
+# ─── S5 (CTL-1214): the committed Layer-1 config is NEVER re-leaked ──────────
+# setup_sweep_config patched catalyst.sweep back into .catalyst/config.json on
+# EVERY run, so the Phase-4 slimming would survive exactly until the next setup.
+# It now writes node.json instead, and leaves the committed file untouched.
+S5_DIR="${SCRATCH}/s5-proj"
+S5_L2="${SCRATCH}/s5-layer2"
+mkdir -p "${S5_DIR}/.catalyst" "$S5_L2"
+printf '{\n  "catalyst": {\n    "schemaVersion": 1,\n    "projectKey": "SLIM"\n  }\n}\n' \
+  > "${S5_DIR}/.catalyst/config.json"
+printf '{}\n' > "${S5_L2}/config.json"
+cp "${S5_DIR}/.catalyst/config.json" "${SCRATCH}/s5-before.json"
+
+PROJECT_DIR="$S5_DIR"
+CATALYST_LAYER2_CONFIG_FILE="${S5_L2}/config.json" setup_sweep_config >/dev/null 2>&1 || true
+
+run "S5a: slimmed .catalyst/config.json is byte-for-byte UNCHANGED" \
+  cmp -s "${SCRATCH}/s5-before.json" "${S5_DIR}/.catalyst/config.json"
+run "S5b: no catalyst.sweep re-added to Layer-1" \
+  bash -c "jq -e '.catalyst.sweep == null' '${S5_DIR}/.catalyst/config.json'"
+run "S5c: node.json gains the sweep defaults instead" \
+  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S5_L2}/node.json'"
+run "S5d: node.json is 0600" \
+  bash -c "[[ \"\$(stat -f '%Lp' '${S5_L2}/node.json' 2>/dev/null || stat -c '%a' '${S5_L2}/node.json')\" == '600' ]]"
+
+# S5e: non-clobbering — an operator value already in node.json survives.
+S5B_DIR="${SCRATCH}/s5b-proj"
+S5B_L2="${SCRATCH}/s5b-layer2"
+mkdir -p "${S5B_DIR}/.catalyst" "$S5B_L2"
+printf '{"catalyst":{"schemaVersion":1,"projectKey":"SLIM"}}\n' > "${S5B_DIR}/.catalyst/config.json"
+printf '{}\n' > "${S5B_L2}/config.json"
+printf '{"catalyst":{"sweep":{"idleHours":72},"host":{"name":"mini-2"}}}\n' > "${S5B_L2}/node.json"
+
+PROJECT_DIR="$S5B_DIR"
+CATALYST_LAYER2_CONFIG_FILE="${S5B_L2}/config.json" setup_sweep_config >/dev/null 2>&1 || true
+
+run "S5e: an existing node.json sweep override is preserved (idleHours stays 72)" \
+  bash -c "jq -e '.catalyst.sweep.idleHours == 72' '${S5B_L2}/node.json'"
+run "S5f: unrelated node.json keys survive (deep merge, not replace)" \
+  bash -c "jq -e '.catalyst.host.name == \"mini-2\"' '${S5B_L2}/node.json'"
+run "S5g: un-overridden defaults are still filled in" \
+  bash -c "jq -e '.catalyst.sweep.intervalHours == 1' '${S5B_L2}/node.json'"
+
+# S5h: a LEGACY repo that still carries catalyst.sweep in Layer-1 is left alone —
+# no destructive rewrite of a config the operator has not migrated yet.
+S5C_DIR="${SCRATCH}/s5c-proj"
+S5C_L2="${SCRATCH}/s5c-layer2"
+mkdir -p "${S5C_DIR}/.catalyst" "$S5C_L2"
+printf '{"catalyst":{"projectKey":"LEGACY","sweep":{"idleHours":72}}}\n' > "${S5C_DIR}/.catalyst/config.json"
+printf '{}\n' > "${S5C_L2}/config.json"
+
+PROJECT_DIR="$S5C_DIR"
+CATALYST_LAYER2_CONFIG_FILE="${S5C_L2}/config.json" setup_sweep_config >/dev/null 2>&1 || true
+
+run "S5h: a legacy Layer-1 catalyst.sweep is NOT deleted" \
+  bash -c "jq -e '.catalyst.sweep.idleHours == 72' '${S5C_DIR}/.catalyst/config.json'"
+
+# ─── S6 (CTL-1214): the suite never touched the REAL host config ─────────────
+# A guard on the guard. Without it this file silently created the developer's
+# ~/.config/catalyst/node.json while it was being written.
+if [[ "$_REAL_NODE_EXISTED" -eq 0 && -e "$_REAL_NODE_JSON" ]]; then
+  FAILURES=$((FAILURES+1))
+  echo "  FAIL: S6: the suite created the REAL ${_REAL_NODE_JSON}"
+else
+  PASSES=$((PASSES+1))
+  echo "  PASS: S6: the real ~/.config/catalyst/node.json was not touched"
+fi
 
 # ─── results ─────────────────────────────────────────────────────────────────
 echo ""

--- a/plugins/dev/scripts/catalyst-config-migrate
+++ b/plugins/dev/scripts/catalyst-config-migrate
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+// catalyst-config-migrate — CTL-1214 Phase 2. Move a repo's relocated Layer-1
+// keys into the node-scoped ~/.config/catalyst/node.json and stamp
+// schemaVersion on what remains.
+//
+// All decisions live in lib/migrate-layer1-config.mjs's pure planner; this is
+// argument parsing, I/O and reporting.
+//
+// Usage:
+//   catalyst-config-migrate [--config PATH] [--node PATH] [--dry-run] [--json]
+//   catalyst-config-migrate --paths [--json]
+//
+// --paths prints the relocated dotted paths, one per line, so the BASH side can
+// consume the single JS registry instead of re-typing it (the ASSERTED_BY
+// mirror discipline: one registry, mechanically shared, never two lists).
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import {
+  planLayer1Migration,
+  applyLayer1Migration,
+  RELOCATED_PATHS,
+} from "./lib/migrate-layer1-config.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const USAGE = `catalyst-config-migrate — relocate machine-scoped keys out of a committed
+.catalyst/config.json into the node-scoped ~/.config/catalyst/node.json (CTL-1214).
+
+Usage: catalyst-config-migrate [options]
+
+Options:
+  --config PATH   Layer-1 config to slim   (default: <cwd>/.catalyst/config.json)
+  --node PATH     node.json to write into  (default: ~/.config/catalyst/node.json)
+  --dry-run       report what would change; write nothing
+  --json          machine-readable report
+  --paths         print the relocated dotted paths and exit
+  -h, --help      this help
+
+Writes node.json FIRST and the slimmed Layer-1 LAST, so a failure can never
+leave a repo slimmed with its values nowhere. Re-running is a no-op.
+
+⛔ Never run this against a host on a pre-Phase-1 plugin checkout: that host has
+no Layer-2 fallbacks, so a slimmed config silently reverts dispatchMode to
+oneshot-legacy. This CLI refuses when lib/catalyst-layer2-read.sh is missing
+from its own checkout.
+`;
+
+function die(msg, code = 1) {
+  process.stderr.write(`catalyst-config-migrate: ${msg}\n`);
+  process.exit(code);
+}
+
+const argv = process.argv.slice(2);
+const opts = { dryRun: false, json: false, paths: false, config: null, node: null };
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "-h" || a === "--help") {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  } else if (a === "--dry-run") opts.dryRun = true;
+  else if (a === "--json") opts.json = true;
+  else if (a === "--paths") opts.paths = true;
+  else if (a === "--config") opts.config = argv[++i];
+  else if (a === "--node") opts.node = argv[++i];
+  else die(`unknown argument: ${a}\n\n${USAGE}`, 2);
+}
+
+if (opts.paths) {
+  if (opts.json) process.stdout.write(`${JSON.stringify(RELOCATED_PATHS)}\n`);
+  else for (const p of RELOCATED_PATHS) process.stdout.write(`${p}\n`);
+  process.exit(0);
+}
+
+// ⛔ The order-dependency guard from the migration notes. Slimming a config on a
+// host whose checkout predates the Phase-1 fallbacks is the one way this tool can
+// cause the silent revert it exists to prevent, so refuse rather than warn.
+const fallbackLeaf = resolve(HERE, "lib", "catalyst-layer2-read.sh");
+if (!existsSync(fallbackLeaf)) {
+  die(
+    `refusing to migrate: ${fallbackLeaf} is missing from this checkout, so the ` +
+      "Layer-2 fallbacks (CTL-1214 Phase 1) are not present. Slimming the config here " +
+      "would silently revert dispatchMode to oneshot-legacy and halve the sweep cadence. " +
+      "Update the plugin checkout first.",
+  );
+}
+
+const layer1Path = opts.config ?? resolve(process.cwd(), ".catalyst", "config.json");
+const nodePath =
+  opts.node ??
+  (process.env.CATALYST_LAYER2_CONFIG_FILE
+    ? resolve(process.env.CATALYST_LAYER2_CONFIG_FILE, "..", "node.json")
+    : resolve(homedir(), ".config", "catalyst", "node.json"));
+
+if (!existsSync(layer1Path)) die(`Layer-1 config not found: ${layer1Path}`);
+
+let layer1;
+try {
+  layer1 = JSON.parse(readFileSync(layer1Path, "utf8"));
+} catch (err) {
+  // Fail closed: a malformed Layer-1 must never be treated as empty, which would
+  // "successfully" migrate nothing and report a clean run over a broken file.
+  die(`Layer-1 config is unreadable or malformed (${err.message}): ${layer1Path}`);
+}
+
+// The merged Layer-2 view drives the non-clobber rule. Read it through the same
+// composition the daemon uses, rooted at node.json's own directory so --node
+// redirects the whole view rather than just the write target.
+let mergedLayer2 = { catalyst: {} };
+try {
+  const { readLayer2MergedFrom } = await import("./execution-core/config.mjs");
+  mergedLayer2 = readLayer2MergedFrom(resolve(nodePath, "..", "config.json"));
+} catch (err) {
+  die(`could not read the merged Layer-2 view (${err.message})`);
+}
+
+let plan;
+try {
+  plan = planLayer1Migration({ layer1, mergedLayer2 });
+} catch (err) {
+  die(err.message);
+}
+
+let result = { wrote: [], dryRun: opts.dryRun };
+if (!opts.dryRun) {
+  try {
+    result = applyLayer1Migration({ plan, layer1Path, nodePath });
+  } catch (err) {
+    die(`write failed (${err.message}) — Layer-1 left UNSLIMMED at ${layer1Path}`);
+  }
+}
+
+const report = {
+  layer1Path,
+  nodePath,
+  dryRun: opts.dryRun,
+  changed: plan.changed,
+  moved: plan.moves.map((m) => ({ path: m.path, value: m.value })),
+  kept: plan.kept.map((k) => ({ path: k.path, existingValue: k.existingValue, reason: k.reason })),
+  dropped: plan.dropped,
+  wrote: result.wrote,
+};
+
+if (opts.json) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} else {
+  const tag = opts.dryRun ? "[dry-run] " : "";
+  process.stdout.write(`${tag}Layer-1: ${layer1Path}\n${tag}node.json: ${nodePath}\n\n`);
+  if (!plan.changed) {
+    process.stdout.write(`${tag}nothing to do — already migrated\n`);
+  } else {
+    for (const m of report.moved) {
+      process.stdout.write(`${tag}  moved   ${m.path} = ${JSON.stringify(m.value)}\n`);
+    }
+    for (const k of report.kept) {
+      process.stdout.write(
+        `${tag}  kept    ${k.path} — Layer-2 already defines it as ${JSON.stringify(k.existingValue)}\n`,
+      );
+    }
+    for (const d of report.dropped) {
+      process.stdout.write(`${tag}  dropped ${d.path} — ${d.reason}\n`);
+    }
+    process.stdout.write(
+      `\n${tag}${report.moved.length} moved, ${report.kept.length} kept, ${report.dropped.length} dropped\n`,
+    );
+    if (result.wrote.length) process.stdout.write(`wrote: ${result.wrote.join(", ")}\n`);
+  }
+}
+process.exit(0);

--- a/plugins/dev/scripts/catalyst-config-migrate
+++ b/plugins/dev/scripts/catalyst-config-migrate
@@ -138,7 +138,13 @@ const report = {
   nodePath,
   dryRun: opts.dryRun,
   changed: plan.changed,
-  moved: plan.moves.map((m) => ({ path: m.path, value: m.value })),
+  // CTL-1214: `from`/`reason` are carried for the one RE-HOMED leaf
+  // (executionCore.maxParallel → executionCore.targetParallel). The docs tell
+  // operators to keep this report as the record of what went where, so dropping
+  // the rename here would make the report claim a straight move that never
+  // happened. Both are undefined for an ordinary move and JSON.stringify omits
+  // them, so the report shape is unchanged for every other row.
+  moved: plan.moves.map((m) => ({ path: m.path, value: m.value, from: m.from, reason: m.reason })),
   kept: plan.kept.map((k) => ({ path: k.path, existingValue: k.existingValue, reason: k.reason })),
   dropped: plan.dropped,
   wrote: result.wrote,
@@ -153,7 +159,8 @@ if (opts.json) {
     process.stdout.write(`${tag}nothing to do — already migrated\n`);
   } else {
     for (const m of report.moved) {
-      process.stdout.write(`${tag}  moved   ${m.path} = ${JSON.stringify(m.value)}\n`);
+      const via = m.from ? ` (re-homed from ${m.from} — ${m.reason})` : "";
+      process.stdout.write(`${tag}  moved   ${m.path} = ${JSON.stringify(m.value)}${via}\n`);
     }
     for (const k of report.kept) {
       process.stdout.write(

--- a/plugins/dev/scripts/check-config-drift.sh
+++ b/plugins/dev/scripts/check-config-drift.sh
@@ -73,6 +73,31 @@ SUPPRESSED_ROOTS_JSON='[
   ["catalyst","linear","stateIds"]
 ]'
 
+# CTL-1214: the RELOCATED keys are stripped from the TEMPLATE before any
+# comparison, in BOTH modes. This detector's direction is the inverse of that
+# ticket's — it reports template keys MISSING from a project config and can
+# --merge-into them — so a slimmed config would read as drifted, and a
+# --merge-into would put the relocated stanza straight back. Sanitizing the
+# shipped template (same change) already removes them at the source; this is the
+# belt-and-braces arm that also covers a repo pinned to an OLDER template.
+#
+# The path list is read from the shared JS registry via `catalyst-config-migrate
+# --paths`, never re-typed here — one definition of what leaks, exactly as the
+# ASSERTED_BY bash mirrors are held to their registry. If the CLI is unavailable
+# the list is EMPTY and the detector behaves exactly as before: no relocated path
+# is stripped, which is the pre-CTL-1214 behavior rather than a silent
+# over-suppression.
+_CCD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELOCATED_PATHS_JSON='[]'
+if [ -x "${_CCD_DIR}/catalyst-config-migrate" ] && command -v bun >/dev/null 2>&1; then
+  _ccd_paths="$("${_CCD_DIR}/catalyst-config-migrate" --paths --json 2>/dev/null || printf '')"
+  if [ -n "$_ccd_paths" ] && printf '%s' "$_ccd_paths" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    # "orchestration.dispatchMode" -> ["catalyst","orchestration","dispatchMode"]
+    RELOCATED_PATHS_JSON="$(printf '%s' "$_ccd_paths" \
+      | jq -c '[.[] | ["catalyst"] + (. | split("."))]' 2>/dev/null || printf '[]')"
+  fi
+fi
+
 # --merge-into: jq's `*` operator does a recursive merge. Project on the right
 # means user values always win; template keys missing from project are added.
 # Comment/$schema keys and placeholder branches are stripped from the template
@@ -87,11 +112,19 @@ if [ "$MODE" = "merge" ]; then
   if ! jq -n \
       --slurpfile t "$TEMPLATE_PATH" \
       --slurpfile p "$CONFIG_PATH" \
+      --argjson relocated "$RELOCATED_PATHS_JSON" \
       '
       def strip_meta:
         walk(if type == "object"
              then with_entries(select(.key | IN("_comment","$comment","$schema") | not))
              else . end);
+      # CTL-1214: --merge-into must never re-add a relocated key to a Layer-1
+      # config. Same strip as the drift arm, with the empty-container prune.
+      def strip_relocated:
+        reduce $relocated[] as $rp (.; delpaths([$rp]))
+        | walk(if type == "object"
+               then with_entries(select((.value | type) != "object" or ((.value | length) > 0)))
+               else . end);
       # Drop entries whose KEY is a [YOUR_*] placeholder (e.g. the deploy
       # "[YOUR_ORG]/[YOUR_REPO]" sub-tree) AND entries whose VALUE is a
       # [YOUR_*] placeholder string (e.g. repository.org="[YOUR_ORG]").
@@ -107,7 +140,7 @@ if [ "$MODE" = "merge" ]; then
                       or ((.value | test("\\[YOUR_(ORG|REPO)\\]")) | not))
                ))
              else . end);
-      ($t[0] | strip_meta | strip_placeholders) * ($p[0] // {})
+      ($t[0] | strip_meta | strip_placeholders | strip_relocated) * ($p[0] // {})
       ' > "$TMP" 2>"$JQ_ERR"; then
     err=$(cat "$JQ_ERR" 2>/dev/null || true)
     rm -f "$TMP" "$JQ_ERR"
@@ -140,11 +173,20 @@ DRIFT_JSON=$(jq -n \
   --slurpfile t "$TEMPLATE_PATH" \
   --slurpfile p "$CONFIG_PATH" \
   --argjson suppress "$SUPPRESSED_ROOTS_JSON" \
+  --argjson relocated "$RELOCATED_PATHS_JSON" \
   '
   def strip_meta:
     walk(if type == "object"
          then with_entries(select(.key | IN("_comment","$comment","$schema") | not))
          else . end);
+  # CTL-1214: delete every relocated path from the template, then prune any
+  # container the deletion emptied — otherwise an emptied `orchestration: {}`
+  # would still be enumerated as a drifted leaf.
+  def strip_relocated:
+    reduce $relocated[] as $rp (.; delpaths([$rp]))
+    | walk(if type == "object"
+           then with_entries(select((.value | type) != "object" or ((.value | length) > 0)))
+           else . end);
   def has_placeholder($p):
     any($p[]; tostring | test("\\[YOUR_(ORG|REPO)\\]"));
   def is_suppressed($p; $roots):
@@ -153,7 +195,7 @@ DRIFT_JSON=$(jq -n \
                   and ($p[0:($root|length)] == $root));
   def is_object_key_path($p):
     ($p | length) > 0 and (($p | .[-1] | type) == "string");
-  ($t[0] | strip_meta) as $tmpl
+  ($t[0] | strip_meta | strip_relocated) as $tmpl
   | ($p[0] // {}) as $proj
   | [ $tmpl
       | paths(type != "object") as $pp

--- a/plugins/dev/scripts/check-project-setup.sh
+++ b/plugins/dev/scripts/check-project-setup.sh
@@ -197,6 +197,20 @@ if [[ -n $CONFIG_PATH ]]; then
 	# registry entry exists for the team. Local-only — no API call. Gaps are
 	# warnings, consistent with every other linear-config issue here.
 	DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$CONFIG_PATH" 2>/dev/null)
+	# CTL-1214: Layer-2 fallback — the same rung orchestrate-dispatch-next and
+	# orchestrate-register-interests carry. Without it a slimmed Layer-1 resolves
+	# empty here and this entire contract check silently stops running for
+	# execution-core repos: a skipped check reads exactly like a passing one.
+	# Layer-1 still wins when present. `|| true` because this script runs under
+	# `set -e` and a miss must stay a miss, not abort the whole setup check.
+	if [[ -z $DISPATCH_MODE ]]; then
+		_cps_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/catalyst-layer2-read.sh"
+		if [[ -r $_cps_lib ]]; then
+			# shellcheck disable=SC1090
+			. "$_cps_lib"
+			DISPATCH_MODE="$(catalyst_layer2_json '.catalyst.orchestration.dispatchMode' || true)"
+		fi
+	fi
 	if [[ $DISPATCH_MODE == "execution-core" ]]; then
 		# The contract states this check expects. Mirrors contract_states() in
 		# setup-execution-core-states.sh — keep the two in sync (different

--- a/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
+++ b/plugins/dev/scripts/execution-core/autotune-lifecycle.test.mjs
@@ -205,6 +205,93 @@ describe("autoTuneTick", () => {
     expect(decisions[0]).toBe(4); // jumped to layer1Max, not 2
   });
 
+  // --- CTL-1214: the setpoint must survive a SLIMMED Layer-1 -----------------
+  //
+  // Slimming .catalyst/config.json removed catalyst.orchestration.executionCore
+  // from Layer-1, and readLayer1Concurrency is Layer-1-ONLY. MEASURED on the live
+  // host before this remediation: resolveTargetSetpoint 4 → undefined and
+  // layer1Max 4 → null, which silently no-ops the cold-start seed (RULE 2),
+  // recovery-to-layer1 (RULE 7) and all three RULE 9 setpoint branches. The
+  // migration now re-homes the committed target to Layer-2 `targetParallel`
+  // (never `maxParallel`, which the tuner itself writes), and layer1Max is
+  // sourced from the resolved target rather than from Layer-1 alone.
+
+  test("CTL-1214: slimmed Layer-1 + node.json targetParallel → setpoint is NON-NULL and converges", () => {
+    const flatIdle = [
+      { load1: 1.2, load5: 1.2, load15: 1.3, memFreePct: 50, coreCount: 8 },
+      { load1: 1.2, load5: 1.3, load15: 1.2, memFreePct: 50, coreCount: 8 },
+    ];
+    const state = makeState({ window: flatIdle, loadSafeFactor: 2 });
+    const writes = [];
+    const seams = makeSeams({
+      loadavg: () => [1.3, 1.2, 1.2],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(8),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      // The slimmed committed config: NO executionCore stanza at all.
+      readLayer1Concurrency: () => ({}),
+      readLayer2Concurrency: () => ({ minParallel: 1, maxParallelCeiling: 40, targetParallel: 4 }),
+      writeLayer2: (v) => { writes.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    // A null setpoint would take the no-op path and write NOTHING — the exact
+    // silent degradation this pins. cores=8 → bound max(1,6)=6, min(4,6)=4.
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toBe(4);
+  });
+
+  test("CTL-1214: layer1Max comes from the resolved target, so recovery-to-layer1 fires on a slimmed config", () => {
+    const downSamples = [
+      { load1: 2, load5: 4, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 1, load5: 3, load15: 5, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: downSamples, trendMinSamples: 3 });
+    const decisions = [];
+    const seams = makeSeams({
+      loadavg: () => [1, 2, 4],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(4),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer1Concurrency: () => ({}),                    // slimmed
+      readLayer2Concurrency: () => ({ targetParallel: 4 }),  // the re-homed target
+      writeLayer2: (v) => { decisions.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toBe(4); // recovery JUMP to 4, not the +1 trend-down step to 2
+  });
+
+  // ⚠️ RATCHET REGRESSION PIN. The obvious fix — merging Layer-2 into
+  // readLayer1Concurrency — makes layer1Max identically equal to `current` every
+  // tick, because layer2.maxParallel IS the tuner's own live mirror
+  // (writeLayer2MaxParallel). RULE 7's `current < layer1Max` could then never be
+  // true: a dead branch dressed as a fixed one. With ONLY a Layer-2 maxParallel
+  // and no declared target anywhere, there is no committed target to recover to,
+  // so the tuner must take the ordinary +1 trend-down step.
+  test("CTL-1214: a Layer-2 maxParallel (the tuner's own mirror) is NOT treated as a recovery target", () => {
+    const downSamples = [
+      { load1: 2, load5: 4, load15: 6, memFreePct: 50, coreCount: 4 },
+      { load1: 1, load5: 3, load15: 5, memFreePct: 50, coreCount: 4 },
+    ];
+    const state = makeState({ window: downSamples, trendMinSamples: 3 });
+    const decisions = [];
+    const seams = makeSeams({
+      loadavg: () => [1, 2, 4],
+      freemem: () => 8e9,
+      totalmem: () => 16e9,
+      cpus: () => Array(4),
+      readConcurrency: () => ({ maxParallel: 1, minParallel: 1, maxParallelCeiling: 20 }),
+      readLayer1Concurrency: () => ({}),
+      readLayer2Concurrency: () => ({ maxParallel: 4 }), // live mirror only, no targetParallel
+      writeLayer2: (v) => { decisions.push(v); return true; },
+    });
+    autoTuneTick(state, seams);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toBe(2); // +1 trend-down, NOT a jump to the mirrored 4
+  });
+
   // --- CTL-770: setpoint resolution + plumbing -------------------------------
 
   test("autoTuneTick resolves setpoint from Layer-2 targetParallel and passes it to decideMaxParallel", () => {

--- a/plugins/dev/scripts/execution-core/autotune.mjs
+++ b/plugins/dev/scripts/execution-core/autotune.mjs
@@ -525,12 +525,7 @@ export function autoTuneTick(state, seams) {
 
     const concurrency = readConcurrency();
     const current = concurrency.maxParallel ?? 3;
-    // CTL-750: pass Layer-1's committed target so decideMaxParallel can jump on recovery.
-    // Fail-safe: if the seam is absent (old callers), layer1Max stays null.
     const layer1 = readLayer1Concurrency?.();
-    const layer1Max = (Number.isInteger(layer1?.maxParallel) && layer1.maxParallel > 0)
-      ? layer1.maxParallel
-      : null;
 
     // CTL-770: resolve the seek-to setpoint with host-over-repo layering, then
     // core-bound it. Fail-safe: a missing/throwing Layer-2 seam → setpoint
@@ -543,6 +538,21 @@ export function autoTuneTick(state, seams) {
       layer2 = {};
     }
     const rawTarget = resolveTargetSetpoint(layer1 ?? {}, layer2 ?? {});
+
+    // CTL-750 → CTL-1214: RULE 7's recovery jump target. This used to read
+    // `layer1.maxParallel` directly, which went silently null the moment
+    // .catalyst/config.json was slimmed (CTL-1214) — measured 4 → null, taking
+    // recovery-to-layer1 with it.
+    //
+    // ⚠️ It is DELIBERATELY sourced from rawTarget rather than from a
+    // merged-Layer-2 read. layer2.maxParallel is the autotuner's OWN live mirror
+    // (writeLayer2MaxParallel below writes it every adjusted tick), so merging it
+    // in would make layer1Max identically equal to `current` on every tick and
+    // RULE 7's `current < layer1Max` could then never be true — a fix that turns
+    // a dead branch into an undetectably dead branch. rawTarget resolves
+    // layer2.targetParallel → layer1.maxParallel, neither of which the tuner ever
+    // writes, so the recovery target stays ratchet-free.
+    const layer1Max = (Number.isInteger(rawTarget) && rawTarget > 0) ? rawTarget : null;
     const coreCount = sample.coreCount;
     const setpoint =
       rawTarget == null

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -50,6 +50,10 @@ import {
   resolveBeliefsFlag,
   resolveModeSource,
 } from "./config.mjs";
+// CTL-1214 remediation: the DERIVED setpoint row delegates to the real resolver
+// rather than restating its rule, the same discipline resolveModeSource /
+// resolveBeliefsFlag already establish above.
+import { resolveTargetSetpoint } from "../lib/autotune-setpoint.mjs";
 
 export const DUMP_SCHEMA = "catalyst.config.dump/1";
 
@@ -241,9 +245,17 @@ export const CONFIG_KEYS = Object.freeze(
     // the NODE scope (~/.config/catalyst/node.json) and now declare a `layer2`
     // source; the rest (executor, executorByPhase, codex, draftPr, fleetHealth,
     // daemonWatchdog, orphanReaper.workerGc, …) are genuinely Layer-1 and stay.
+    // CTL-1214 remediation: `layer1-first`, not `value`. Every dispatchMode reader
+    // is bash (orchestrate-dispatch-next, orchestrate-register-interests.sh,
+    // check-project-setup.sh, and phase-agent-dispatch's pre-existing
+    // config_value()), and all four consult Layer-2 only when Layer-1 is silent.
+    // Under the "value" ladder this row named layer2 as the winner on an
+    // un-migrated repo where the dispatcher actually answers from layer1 — the
+    // dump pointing at the wrong FILE for the single knob that selects the
+    // orchestration model.
     {
       key: "catalyst.orchestration.dispatchMode",
-      kind: "value",
+      kind: "layer1-first",
       layer1: "catalyst.orchestration.dispatchMode",
       layer2: "catalyst.orchestration.dispatchMode",
       env: [],
@@ -310,6 +322,118 @@ export const CONFIG_KEYS = Object.freeze(
       env: [],
       fallback: null,
       reader: "resolveTargetSetpoint",
+    },
+    // CTL-1214 remediation: the RESOLVED setpoint, beside the raw key above.
+    // The raw row alone reads clean across the exact change the migration makes:
+    // measured on a live host with the same Layer-2, resolveTargetSetpoint goes
+    // 4 (fat Layer-1 maxParallel) -> undefined (slim Layer-1) while every raw row
+    // is byte-identical, so the plan's AC-2 before/after dump comparison reported
+    // 0 differences over a change that silently no-ops the autotuner's
+    // convergence and recovery-to-layer1 branches.
+    {
+      key: "catalyst.orchestration.executionCore.targetParallel.resolved",
+      kind: "derived",
+      layer1: null,
+      layer2: null,
+      env: [],
+      fallback: null,
+      reader: "resolveTargetSetpoint",
+      derive: ({ layer1, layer2 }) =>
+        resolveTargetSetpoint(
+          getPath(layer1, "catalyst.orchestration.executionCore") ?? {},
+          getPath(layer2, "catalyst.orchestration.executionCore") ?? {},
+        ),
+    },
+    // CTL-1214 remediation: reconcile.intervalSeconds — the sibling of
+    // reconcile.mode above. Relocated by the same registry row, read by the same
+    // readLinearReconcileConfig, and previously absent from the dump, so a
+    // migration that moved the interval was invisible to the AC-2 comparison.
+    {
+      key: "catalyst.orchestration.reconcile.intervalSeconds",
+      kind: "value",
+      layer1: "catalyst.orchestration.reconcile.intervalSeconds",
+      layer2: "catalyst.orchestration.reconcile.intervalSeconds",
+      // No env override exists for the interval — CATALYST_RECONCILE_MODE is the
+      // only one readLinearReconcileConfig honours, and it applies to `mode`.
+      env: [],
+      fallback: 600,
+      reader: "readLinearReconcileConfig",
+    },
+    // ── CTL-1214 remediation: the three relocated categories the dump could not
+    // see at all. config-dump is the plan's instrument for AC-2 ("identical
+    // effective values ... verified by a before/after config-dump comparison, not
+    // by inspection"), and it emitted NO row for catalyst.feedback.*,
+    // catalyst.sweep.* or monitor.github.repoColors — 3 of the 7 relocated
+    // categories. An instrument blind to what it is asked to prove reads as a
+    // clean pass over an unmeasured change.
+    //
+    // All of sweep.* and feedback.* are `layer1-first`: their readers are the
+    // bash sites (orphan-sweep's _cfg_str, feedback-consent.sh, file-feedback.sh),
+    // which consult Layer-2 only when Layer-1 is silent.
+    {
+      key: "catalyst.sweep.idleHours",
+      kind: "layer1-first",
+      layer1: "catalyst.sweep.idleHours",
+      layer2: "catalyst.sweep.idleHours",
+      env: [],
+      fallback: 48,
+      reader: "orphan-sweep.sh _cfg_str",
+    },
+    {
+      key: "catalyst.sweep.intervalHours",
+      kind: "layer1-first",
+      layer1: "catalyst.sweep.intervalHours",
+      layer2: "catalyst.sweep.intervalHours",
+      env: [],
+      fallback: 2,
+      reader: "orphan-sweep.sh _cfg_str",
+    },
+    {
+      key: "catalyst.sweep.salvagePush",
+      kind: "layer1-first",
+      layer1: "catalyst.sweep.salvagePush",
+      layer2: "catalyst.sweep.salvagePush",
+      env: [],
+      fallback: false,
+      reader: "orphan-sweep.sh _cfg_str",
+    },
+    {
+      key: "catalyst.sweep.maxRemovalsPerRun",
+      kind: "layer1-first",
+      layer1: "catalyst.sweep.maxRemovalsPerRun",
+      layer2: "catalyst.sweep.maxRemovalsPerRun",
+      env: [],
+      fallback: 20,
+      reader: "orphan-sweep.sh _cfg_str",
+    },
+    {
+      key: "catalyst.feedback.autoFile",
+      kind: "layer1-first",
+      layer1: "catalyst.feedback.autoFile",
+      layer2: "catalyst.feedback.autoFile",
+      env: [],
+      fallback: null,
+      reader: "feedback-consent.sh read_auto_file",
+    },
+    {
+      key: "catalyst.feedback.githubRepo",
+      kind: "layer1-first",
+      layer1: "catalyst.feedback.githubRepo",
+      layer2: "catalyst.feedback.githubRepo",
+      env: [],
+      fallback: null,
+      reader: "file-feedback.sh",
+    },
+    // repoColors is JS-read (loadMonitorConfig overlays Layer-2 + node.json ON TOP
+    // of the Layer-1 base, per key), so it takes the Layer-2-wins "value" ladder.
+    {
+      key: "catalyst.monitor.github.repoColors",
+      kind: "value",
+      layer1: "catalyst.monitor.github.repoColors",
+      layer2: "catalyst.monitor.github.repoColors",
+      env: [],
+      fallback: null,
+      reader: "loadMonitorConfig",
     },
     // CTL-1214: the eligibleQuery.status row is GONE. It reported a Layer-1 key
     // that no runtime reader dereferences — the effective eligibleQuery comes from
@@ -555,6 +679,36 @@ export function resolveRow(row, { env = {}, layer1 = null, layer2 = null } = {})
     if (Number.isInteger(l2) && l2 > 0) return { ...base, value: l2, provenance: PROVENANCE.CONFIG, layer: "layer2" };
     if (l1 !== undefined && l1 !== null) return { ...base, value: l1, provenance: PROVENANCE.CONFIG, layer: "layer1" };
     return { ...base, value: row.fallback, provenance: PROVENANCE.DEFAULT, layer: null };
+  }
+
+  if (row.kind === "layer1-first") {
+    // CTL-1214 remediation: the BASH readers (orchestrate-dispatch-next,
+    // orchestrate-register-interests.sh, check-project-setup.sh, orphan-sweep's
+    // _cfg_str, feedback-consent/file-feedback) treat Layer-2 as a FALLBACK
+    // consulted only when Layer-1 is silent — mirroring phase-agent-dispatch's
+    // pre-existing config_value(). Reporting these rows with the "value" ladder
+    // would name layer2 as the winner on an un-migrated repo where the bash
+    // reader actually answers from layer1: a provenance tool that sends the
+    // operator to the wrong FILE is the failure mode this module exists to end.
+    if (envValue !== undefined) return { ...base, value: envValue, provenance: PROVENANCE.ENV, layer: null };
+    if (l1 !== undefined && l1 !== null) return { ...base, value: l1, provenance: PROVENANCE.CONFIG, layer: "layer1" };
+    if (l2 !== undefined && l2 !== null) return { ...base, value: l2, provenance: PROVENANCE.CONFIG, layer: "layer2" };
+    return { ...base, value: row.fallback, provenance: PROVENANCE.DEFAULT, layer: null };
+  }
+
+  if (row.kind === "derived") {
+    // A row whose value no single key carries — computed by the SAME function the
+    // daemon calls, from both layers. `layer` is "merged" because neither file
+    // alone is the answer. AC-2's before/after comparison reads this row, which is
+    // the point: the raw targetParallel key can be unchanged across a migration
+    // while the RESOLVED setpoint goes 4 -> undefined.
+    const value = row.derive({ layer1, layer2 });
+    return {
+      ...base,
+      value: value === undefined ? row.fallback : value,
+      provenance: value === undefined ? PROVENANCE.DEFAULT : PROVENANCE.CONFIG,
+      layer: value === undefined ? null : "merged",
+    };
   }
 
   // "value": env > layer2 > layer1 > default. Layer-2 is node scope and wins over

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -235,14 +235,20 @@ export const CONFIG_KEYS = Object.freeze(
       reader: "resolveDeploymentMode",
     },
 
-    // ── orchestration (Layer-1 owned) ────────────────────────────────────────
+    // ── orchestration (mixed scope) ──────────────────────────────────────────
+    // CTL-1214 D6: this block is NOT wholly Layer-1 owned. Four members —
+    // dispatchMode, executionCore.*, worktreeRefresh.*, reconcile.* — relocated to
+    // the NODE scope (~/.config/catalyst/node.json) and now declare a `layer2`
+    // source; the rest (executor, executorByPhase, codex, draftPr, fleetHealth,
+    // daemonWatchdog, orphanReaper.workerGc, …) are genuinely Layer-1 and stay.
     {
       key: "catalyst.orchestration.dispatchMode",
       kind: "value",
       layer1: "catalyst.orchestration.dispatchMode",
+      layer2: "catalyst.orchestration.dispatchMode",
       env: [],
       fallback: "oneshot-legacy",
-      reader: "orchestrate-register-interests.sh",
+      reader: "orchestrate-dispatch-next + catalyst_layer2_json",
     },
     {
       key: "catalyst.orchestration.executor",
@@ -305,18 +311,17 @@ export const CONFIG_KEYS = Object.freeze(
       fallback: null,
       reader: "resolveTargetSetpoint",
     },
-    {
-      key: "catalyst.orchestration.executionCore.eligibleQuery.status",
-      kind: "value",
-      layer1: "catalyst.orchestration.executionCore.eligibleQuery.status",
-      env: [],
-      fallback: null,
-      reader: "readExecutionCoreConcurrency",
-    },
+    // CTL-1214: the eligibleQuery.status row is GONE. It reported a Layer-1 key
+    // that no runtime reader dereferences — the effective eligibleQuery comes from
+    // execution-core/registry.json via resolveEligibleQuery, written from a
+    // hardcoded literal in setup-execution-core-states.sh. A provenance tool that
+    // reports a value nothing consumes is worse than silent: during an incident it
+    // sends the operator to edit a key that cannot change anything.
     {
       key: "catalyst.orchestration.worktreeRefresh.enabled",
       kind: "value",
       layer1: "catalyst.orchestration.worktreeRefresh.enabled",
+      layer2: "catalyst.orchestration.worktreeRefresh.enabled",
       env: [],
       fallback: null,
       reader: "readWorktreeRefreshConfig",
@@ -325,6 +330,7 @@ export const CONFIG_KEYS = Object.freeze(
       key: "catalyst.orchestration.worktreeRefresh.intervalSeconds",
       kind: "value",
       layer1: "catalyst.orchestration.worktreeRefresh.intervalSeconds",
+      layer2: "catalyst.orchestration.worktreeRefresh.intervalSeconds",
       env: [],
       fallback: null,
       reader: "readWorktreeRefreshConfig",
@@ -462,6 +468,22 @@ export const CONFIG_KEYS = Object.freeze(
 );
 
 // ─── resolution ──────────────────────────────────────────────────────────────
+
+// deepMergeLayer2 — CTL-1214. Byte-for-byte the same rule as config.mjs's
+// _deepMergeLayer2: recurse into plain objects, replace anything else. Kept local
+// because this module is deliberately import-light (it is the tool an operator
+// runs when the daemon will not start).
+export function deepMergeLayer2(target, source) {
+  const isPlain = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+  const out = isPlain(target) ? { ...target } : {};
+  for (const key of Object.keys(isPlain(source) ? source : {})) {
+    out[key] =
+      isPlain(source[key]) && isPlain(out[key])
+        ? deepMergeLayer2(out[key], source[key])
+        : source[key];
+  }
+  return out;
+}
 
 // getPath — read a dotted key out of a parsed JSON object. Returns undefined for
 // an absent key, a non-object ancestor, or a null root. Never throws.
@@ -609,6 +631,17 @@ export function dumpConfig({
   layer1Text = null,
   layer2Path = null,
   layer2Text = null,
+  // CTL-1214: the two Layer-2 SIBLINGS. readLayer2Merged composes
+  // config.json < node.json < cluster-secrets.json, and the migration writes the
+  // relocated keys to node.json — so a dump that reads only config.json reports
+  // every relocated knob as `default`. That is not a cosmetic gap: this tool's
+  // whole job is to tell an operator WHERE a value came from, and after the
+  // CTL-1214 slimming it would have answered "dispatchMode = oneshot-legacy,
+  // provenance default" while the runtime resolved phase-agents from node.json.
+  nodePath = null,
+  nodeText = null,
+  clusterSecretsPath = null,
+  clusterSecretsText = null,
   execCoreEnvPath = null,
   execCoreEnvText = "",
   daemonLayer1 = null,
@@ -617,8 +650,21 @@ export function dumpConfig({
   const effectiveEnv = overlayEnvFile(env, execCoreEnvText);
   const l1 = parseOrNull(layer1Text);
   const l2 = parseOrNull(layer2Text);
+  const lNode = parseOrNull(nodeText);
+  const lSecrets = parseOrNull(clusterSecretsText);
 
-  const rows = keys.map((row) => resolveRow(row, { env: effectiveEnv, layer1: l1.parsed, layer2: l2.parsed }));
+  // Same precedence and the same deep merge as config.mjs's readLayer2Merged:
+  // config.json (bottom) < node.json < cluster-secrets.json (top). A layer that is
+  // absent or unparseable contributes {} — layer-absent, never fatal — which is
+  // the fail-open posture every readLayer2* site already has.
+  const layer2Merged = deepMergeLayer2(
+    deepMergeLayer2(l2.parsed ?? {}, lNode.parsed ?? {}),
+    lSecrets.parsed ?? {},
+  );
+
+  const rows = keys.map((row) =>
+    resolveRow(row, { env: effectiveEnv, layer1: l1.parsed, layer2: layer2Merged }),
+  );
 
   const envFileEntries = parseEnvFileEntries(execCoreEnvText);
   const envFileKeys = [...new Set(envFileEntries.map((e) => e.key))].sort();
@@ -651,6 +697,18 @@ export function dumpConfig({
       path: layer2Path,
       present: layer2Text !== null && layer2Text !== undefined,
       parsed: l2.ok,
+      // CTL-1214: the siblings are reported individually so "the value is not
+      // where I expected" is answerable without guessing which file was read.
+      node: {
+        path: nodePath,
+        present: nodeText !== null && nodeText !== undefined,
+        parsed: lNode.ok,
+      },
+      clusterSecrets: {
+        path: clusterSecretsPath,
+        present: clusterSecretsText !== null && clusterSecretsText !== undefined,
+        parsed: lSecrets.ok,
+      },
     },
     // The env file's KEY SET is itself a divergence signal — values are never emitted.
     execCoreEnv: { path: execCoreEnvPath, present: execCoreEnvText !== "", keys: envFileKeys, bareKeys },
@@ -679,6 +737,10 @@ function readOrNull(path) {
 export function collectConfigDump({ env = process.env, cwd = process.cwd(), now = new Date() } = {}) {
   const home = env.HOME || "";
   const layer2Path = env.CATALYST_LAYER2_CONFIG_FILE || resolve(home, ".config", "catalyst", "config.json");
+  // CTL-1214: siblings resolved off the SAME directory, exactly as
+  // resolveNodeConfigPath()/resolveClusterSecretsPath() resolve them.
+  const nodePath = resolve(layer2Path, "..", "node.json");
+  const clusterSecretsPath = resolve(layer2Path, "..", "cluster-secrets.json");
   const execCoreEnvPath = env.CATALYST_EXECUTION_CORE_ENV || resolve(home, ".config", "catalyst", "execution-core.env");
   const execCoreEnvText = readOrNull(execCoreEnvPath) ?? "";
   const catalystDir = env.CATALYST_DIR || resolve(home, "catalyst");
@@ -712,6 +774,10 @@ export function collectConfigDump({ env = process.env, cwd = process.cwd(), now 
     layer1Text: readOrNull(layer1Path),
     layer2Path,
     layer2Text: readOrNull(layer2Path),
+    nodePath,
+    nodeText: readOrNull(nodePath),
+    clusterSecretsPath,
+    clusterSecretsText: readOrNull(clusterSecretsPath),
     execCoreEnvPath,
     execCoreEnvText,
     daemonLayer1,

--- a/plugins/dev/scripts/execution-core/config-dump.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.mjs
@@ -473,7 +473,7 @@ export const CONFIG_KEYS = Object.freeze(
 // _deepMergeLayer2: recurse into plain objects, replace anything else. Kept local
 // because this module is deliberately import-light (it is the tool an operator
 // runs when the daemon will not start).
-export function deepMergeLayer2(target, source) {
+function deepMergeLayer2(target, source) {
   const isPlain = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
   const out = isPlain(target) ? { ...target } : {};
   for (const key of Object.keys(isPlain(source) ? source : {})) {

--- a/plugins/dev/scripts/execution-core/config-dump.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.test.mjs
@@ -520,3 +520,107 @@ describe("registry drift guards", () => {
     expect(readFileSync(resolve(HERE, "config-dump.mjs"), "utf8")).toContain("\\u0000");
   });
 });
+
+// ─── CTL-1214: the merged Layer-2 + the relocated rows ───────────────────────
+describe("CTL-1214 — merged Layer-2 and relocated rows", () => {
+  const l1 = JSON.stringify({ catalyst: { projectKey: "p", schemaVersion: 1 } });
+
+  test("a value in node.json resolves, with layer2 provenance", () => {
+    const d = dumpConfig({
+      layer1Text: l1,
+      layer2Text: JSON.stringify({ catalyst: {} }),
+      nodeText: JSON.stringify({
+        catalyst: { orchestration: { dispatchMode: "phase-agents" } },
+      }),
+    });
+    const row = d.rows.find((r) => r.key === "catalyst.orchestration.dispatchMode");
+    expect(row.value).toBe("phase-agents");
+    expect(row.layer).toBe("layer2");
+    // The sharp half: NOT the silent default a Layer-1-only read would report.
+    expect(row.value).not.toBe("oneshot-legacy");
+  });
+
+  test("a slimmed Layer-1 with NO node.json falls to the default (negative control)", () => {
+    const d = dumpConfig({ layer1Text: l1, layer2Text: JSON.stringify({ catalyst: {} }) });
+    const row = d.rows.find((r) => r.key === "catalyst.orchestration.dispatchMode");
+    expect(row.value).toBe("oneshot-legacy");
+    expect(row.provenance).toBe("default");
+  });
+
+  test("cluster-secrets.json outranks node.json, node.json outranks config.json", () => {
+    const mk = (v) => JSON.stringify({ catalyst: { orchestration: { dispatchMode: v } } });
+    const pick = (d) => d.rows.find((r) => r.key === "catalyst.orchestration.dispatchMode").value;
+    expect(pick(dumpConfig({ layer1Text: l1, layer2Text: mk("oneshot-legacy") }))).toBe("oneshot-legacy");
+    expect(
+      pick(dumpConfig({ layer1Text: l1, layer2Text: mk("oneshot-legacy"), nodeText: mk("phase-agents") })),
+    ).toBe("phase-agents");
+    expect(
+      pick(
+        dumpConfig({
+          layer1Text: l1,
+          layer2Text: mk("oneshot-legacy"),
+          nodeText: mk("phase-agents"),
+          clusterSecretsText: mk("execution-core"),
+        }),
+      ),
+    ).toBe("execution-core");
+  });
+
+  test("the Layer-2 merge is DEEP, not a replace", () => {
+    const d = dumpConfig({
+      layer1Text: l1,
+      layer2Text: JSON.stringify({
+        catalyst: { orchestration: { executionCore: { maxParallel: 4 } } },
+      }),
+      nodeText: JSON.stringify({
+        catalyst: { orchestration: { executionCore: { minParallel: 1 } } },
+      }),
+    });
+    const get = (k) => d.rows.find((r) => r.key === k).value;
+    expect(get("catalyst.orchestration.executionCore.maxParallel")).toBe(4);
+    expect(get("catalyst.orchestration.executionCore.minParallel")).toBe(1);
+  });
+
+  test("a malformed sibling is layer-ABSENT, never fatal", () => {
+    const d = dumpConfig({
+      layer1Text: l1,
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { dispatchMode: "phase-agents" } } }),
+      nodeText: "{ not json at all",
+    });
+    expect(d.rows.find((r) => r.key === "catalyst.orchestration.dispatchMode").value).toBe("phase-agents");
+    expect(d.layer2.node.parsed).toBe(false);
+    expect(d.layer2.node.present).toBe(true);
+  });
+
+  test("the dead eligibleQuery.status row is GONE from CONFIG_KEYS", () => {
+    const keys = CONFIG_KEYS.map((r) => r.key);
+    expect(keys).not.toContain("catalyst.orchestration.executionCore.eligibleQuery.status");
+    // Positive control: the row set is otherwise intact and still names its
+    // orchestration neighbours, so "not contains" is not an empty-list artifact.
+    expect(keys).toContain("catalyst.orchestration.dispatchMode");
+    expect(keys).toContain("catalyst.orchestration.executor");
+    expect(keys.length).toBeGreaterThan(20);
+  });
+
+  test("the four relocated row families declare a layer2 source", () => {
+    const byKey = Object.fromEntries(CONFIG_KEYS.map((r) => [r.key, r]));
+    for (const k of [
+      "catalyst.orchestration.dispatchMode",
+      "catalyst.orchestration.reconcile.mode",
+      "catalyst.orchestration.executionCore.maxParallel",
+      "catalyst.orchestration.executionCore.minParallel",
+      "catalyst.orchestration.executionCore.maxParallelCeiling",
+      "catalyst.orchestration.worktreeRefresh.enabled",
+      "catalyst.orchestration.worktreeRefresh.intervalSeconds",
+    ]) {
+      expect(byKey[k]?.layer2).toBeTruthy();
+    }
+    // D6 negative control: the NON-relocating orchestration keys must NOT have
+    // grown a layer2 source — they are genuinely Layer-1.
+    // (some rows declare an explicit `layer2: null`, so the assertion is
+    // "declares no Layer-2 source", not "the property is absent")
+    expect(byKey["catalyst.orchestration.executor"].layer2 ?? null).toBeNull();
+    expect(byKey["catalyst.orchestration.executorByPhase"].layer2 ?? null).toBeNull();
+    expect(byKey["catalyst.orchestration.draftPr.enabled"].layer2 ?? null).toBeNull();
+  });
+});

--- a/plugins/dev/scripts/execution-core/config-dump.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.test.mjs
@@ -448,6 +448,13 @@ describe("registry drift guards", () => {
     "lib/deployment-mode.mjs",
     "lib/draft-pr.sh",
     "lib/secret-contract.mjs",
+    // CTL-1214: resolveTargetSetpoint (and with it the only mention of
+    // `targetParallel`) moved OUT of scheduler.mjs into this zero-import leaf, so
+    // that `catalyst doctor` — which runs under bare Node and cannot load
+    // scheduler.mjs's bun:sqlite graph — can grade the setpoint through the same
+    // ladder instead of a second copy. This guard caught the move, which is what
+    // it is for: the corpus has to follow the reader.
+    "lib/autotune-setpoint.mjs",
     "orchestrate-register-interests.sh",
   ]
     .map((p) => {

--- a/plugins/dev/scripts/execution-core/config-dump.test.mjs
+++ b/plugins/dev/scripts/execution-core/config-dump.test.mjs
@@ -297,6 +297,93 @@ describe("provenance — beliefs flags, merges, and plain values", () => {
     expect(row(d, "catalyst.orchestration.dispatchMode")).toMatchObject({ value: "phase-agents", layer: "layer1" });
   });
 
+  // ── CTL-1214 remediation: the bash-read ladder + the derived setpoint ────────
+  test("a layer1-first knob reports LAYER1 as the winner when both layers carry it", () => {
+    const d = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { dispatchMode: "phase-agents" } } }),
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { dispatchMode: "oneshot-legacy" } } }),
+    });
+    // The bash readers consult Layer-2 only when Layer-1 is silent, so naming
+    // layer2 here would send an operator to edit a file that changes nothing.
+    expect(row(d, "catalyst.orchestration.dispatchMode")).toMatchObject({
+      value: "phase-agents",
+      layer: "layer1",
+    });
+    // Positive control on the SAME pair of layers: a Layer-2-wins row built from
+    // identical inputs resolves the other way, so the assertion above is a
+    // property of the ladder and not of the fixture.
+    const control = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { reconcile: { mode: "notify" } } } }),
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { reconcile: { mode: "apply" } } } }),
+    });
+    expect(row(control, "catalyst.orchestration.reconcile.mode")).toMatchObject({ layer: "layer2" });
+  });
+
+  test("a layer1-first knob falls back to layer2 when Layer-1 is silent (the slimmed repo)", () => {
+    const d = dump({
+      layer1Text: JSON.stringify({ catalyst: { projectKey: "p" } }),
+      layer2Text: JSON.stringify({ catalyst: { sweep: { intervalHours: 1 } } }),
+    });
+    expect(row(d, "catalyst.sweep.intervalHours")).toMatchObject({ value: 1, layer: "layer2" });
+    // …and to the code default when neither layer carries it. 2, not 1: this is
+    // the halved-cadence trap the relocation had to keep visible.
+    expect(row(dump(), "catalyst.sweep.intervalHours")).toMatchObject({
+      value: 2,
+      provenance: PROVENANCE.DEFAULT,
+    });
+  });
+
+  test("the three previously-invisible relocated categories now emit rows", () => {
+    const d = dump({
+      layer2Text: JSON.stringify({
+        catalyst: {
+          sweep: { idleHours: 48 },
+          feedback: { autoFile: true },
+          monitor: { github: { repoColors: { "a/b": "green" } } },
+        },
+      }),
+    });
+    // AC-2's before/after comparison is only as good as the rows it covers.
+    expect(row(d, "catalyst.sweep.idleHours")).toMatchObject({ value: 48 });
+    expect(row(d, "catalyst.feedback.autoFile")).toMatchObject({ value: true });
+    expect(row(d, "catalyst.monitor.github.repoColors")).toMatchObject({ value: { "a/b": "green" } });
+    expect(row(d, "catalyst.orchestration.reconcile.intervalSeconds")).toBeDefined();
+  });
+
+  test("the DERIVED setpoint row moves when the raw rows do not — the AC-2 blind spot", () => {
+    const layer2Text = JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 9 } } } });
+    // BEFORE: a fat Layer-1 supplies maxParallel, so the setpoint resolves to 4.
+    const before = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } }),
+      layer2Text,
+    });
+    expect(row(before, "catalyst.orchestration.executionCore.targetParallel.resolved")).toMatchObject({
+      value: 4,
+      layer: "merged",
+    });
+
+    // AFTER: Layer-1 slimmed, no targetParallel seeded. The setpoint is GONE.
+    const after = dump({ layer1Text: JSON.stringify({ catalyst: { projectKey: "p" } }), layer2Text });
+    expect(row(after, "catalyst.orchestration.executionCore.targetParallel.resolved")).toMatchObject({
+      value: null,
+      provenance: PROVENANCE.DEFAULT,
+    });
+
+    // ⚠️ The whole point: the RAW targetParallel row is identical across the two,
+    // so the before/after comparison reported zero differences over this change.
+    expect(row(before, "catalyst.orchestration.executionCore.targetParallel").value).toEqual(
+      row(after, "catalyst.orchestration.executionCore.targetParallel").value,
+    );
+  });
+
+  test("an explicit Layer-2 targetParallel wins the derived row over Layer-1 maxParallel", () => {
+    const d = dump({
+      layer1Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } }),
+      layer2Text: JSON.stringify({ catalyst: { orchestration: { executionCore: { targetParallel: 7 } } } }),
+    });
+    expect(row(d, "catalyst.orchestration.executionCore.targetParallel.resolved")).toMatchObject({ value: 7 });
+  });
+
   test("a Layer-2-only knob reports layer2 and is overridden by its env var", () => {
     const l2 = JSON.stringify({ catalyst: { node: { class: "monitor" } } });
     expect(row(dump({ layer2Text: l2 }), "catalyst.node.class")).toMatchObject({ value: "monitor", layer: "layer2" });
@@ -456,6 +543,15 @@ describe("registry drift guards", () => {
     // it is for: the corpus has to follow the reader.
     "lib/autotune-setpoint.mjs",
     "orchestrate-register-interests.sh",
+    // CTL-1214 remediation: the dump now carries the three relocated categories
+    // read by BASH (sweep.*, feedback.*) and by orch-monitor (repoColors), so the
+    // corpus has to carry their readers too — otherwise the leaf guard fails on
+    // rows whose reader is real but unrepresented, and the honest fix would look
+    // like deleting the rows. The corpus follows the reader, per the note above.
+    "orphan-sweep.sh",
+    "feedback-consent.sh",
+    "file-feedback.sh",
+    "orch-monitor/lib/monitor-config.ts",
   ]
     .map((p) => {
       try {

--- a/plugins/dev/scripts/execution-core/config.mjs
+++ b/plugins/dev/scripts/execution-core/config.mjs
@@ -530,6 +530,24 @@ function _deepMergeLayer2(target, source) {
   return out;
 }
 export function readLayer2Merged() {
+  return readLayer2MergedFrom(getLayer2ConfigPath());
+}
+
+// CTL-1214: readLayer2Merged, parameterized on the legacy file's path. The two
+// siblings are resolved off THAT file's directory, exactly as
+// resolveNodeConfigPath()/resolveClusterSecretsPath() resolve them off
+// getLayer2ConfigPath() — so the composition rule is identical while the root is
+// injectable.
+//
+// The injectable root is what keeps the Phase-1 fallbacks hermetic. The readers
+// below (worktree-refresh, execution-core concurrency, linear-reconcile) are
+// handed an explicit layer2Path by the daemon and an explicit FIXTURE path by
+// their tests. Had they called readLayer2Merged() directly, a test passing a
+// fixture path would still have picked up the real ~/.config/catalyst/node.json
+// on the developer's machine — a suite whose result depends on the host it runs
+// on. Same composition, injectable root, no ambient read.
+export function readLayer2MergedFrom(layer2Path) {
+  if (!layer2Path) return { catalyst: {} };
   const readCatalyst = (p) => {
     try {
       return JSON.parse(readFileSync(p, "utf8"))?.catalyst ?? {};
@@ -537,9 +555,10 @@ export function readLayer2Merged() {
       return {};
     }
   };
-  const legacy = readCatalyst(getLayer2ConfigPath());
-  const node = readCatalyst(resolveNodeConfigPath());
-  const shared = readCatalyst(resolveClusterSecretsPath());
+  const dir = resolve(layer2Path, "..");
+  const legacy = readCatalyst(layer2Path);
+  const node = readCatalyst(resolve(dir, "node.json"));
+  const shared = readCatalyst(resolve(dir, "cluster-secrets.json"));
   return { catalyst: _deepMergeLayer2(_deepMergeLayer2(legacy, node), shared) };
 }
 

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -3167,23 +3167,28 @@ function main() {
   const configPath =
     process.env.CATALYST_CONFIG_FILE || resolve(process.cwd(), ".catalyst", "config.json");
   const orphanReaperConfig = readOrphanReaperConfig(configPath);
+  // CTL-665 / CTL-678 / CTL-1214: the Layer-2 root. Resolved HERE (ahead of its
+  // first consumer) because CTL-1214 made worktree-refresh a Layer-2-capable
+  // reader too — node.json and cluster-secrets.json are read as this file's
+  // siblings. CATALYST_LAYER2_CONFIG_FILE overrides for tests.
+  const layer2Path =
+    process.env.CATALYST_LAYER2_CONFIG_FILE ||
+    resolve(homedir(), ".config", "catalyst", "config.json");
   // CTL-707: read the worktree-refresh config from the same config file.
-  const worktreeRefreshConfig = readWorktreeRefreshConfig(configPath);
+  // CTL-1214: ...merged with Layer-2, so a slimmed Layer-1 resolves from node.json
+  // instead of silently reverting to the code defaults.
+  const worktreeRefreshConfig = readWorktreeRefreshConfig(configPath, layer2Path);
   // CTL-782: read the stale-PR-rescue config from the same config file.
   const stalePrRescueConfig = readStalePrRescueConfig(configPath);
   // CTL-1175: read the orphan-PR sweep config from the same config file.
   const orphanPrSweepConfig = readOrphanPrSweepConfig(configPath);
   // CTL-1608: read the stalled-PR sweep config from the same config file.
   const stalledPrSweepConfig = readStalledPrSweepConfig(configPath);
-  // CTL-665 / CTL-678: resolve the executionCore concurrency knobs once here
-  // and thread them into startDaemon → scheduler + boot-resume. The
-  // machine-canonical Layer-2 file (~/.config/catalyst/config.json) wins
-  // per-field over the committed Layer-1 seed; absent/partial in both yields
-  // {} → the scheduler falls back to state.json + the hardcoded default. The
-  // env var CATALYST_LAYER2_CONFIG_FILE overrides the Layer-2 path for tests.
-  const layer2Path =
-    process.env.CATALYST_LAYER2_CONFIG_FILE ||
-    resolve(homedir(), ".config", "catalyst", "config.json");
+  // CTL-665 / CTL-678: the executionCore concurrency knobs are resolved once here
+  // (off layer2Path above) and threaded into startDaemon → scheduler +
+  // boot-resume. Layer-2 wins per-field over the committed Layer-1 seed;
+  // absent/partial in both yields {} → the scheduler falls back to state.json +
+  // the hardcoded default.
   // CTL-1371: reconcile config is node-scoped — Layer-2 (+ CATALYST_RECONCILE_MODE
   // env) overrides the committed Layer-1 seed so an operator can flip the writer
   // off/notify/write per node.

--- a/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
@@ -1,0 +1,109 @@
+// doctor-config-scope-leak.test.mjs — CTL-1214 Phase 5.
+// Run: cd plugins/dev/scripts/execution-core && bun test doctor-config-scope-leak.test.mjs
+//
+// checkConfigScopeLeak now GRADES rather than always warning. The grading is
+// load-bearing in a way most doctor checks are not: runDoctor's exit code IS the
+// FAIL count, and catalyst-join.sh's do_doctor_gate activates a cluster member
+// strictly on exit 0. A FAIL here fail-closes the join gate for the whole host,
+// so the promotion may only fire on a config that has DECLARED it is slimmed
+// (schemaVersion >= 1) — never on a fleet member that simply has not migrated.
+//
+// The last case asserts against THIS repo's real committed config on disk, not a
+// fixture: it is the guard that keeps the fleet joinable.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { checkConfigScopeLeak, STATUS } from "./doctor.mjs";
+
+const one = (deps) => {
+  const checks = checkConfigScopeLeak(deps);
+  expect(checks).toHaveLength(1);
+  return checks[0];
+};
+const noHosts = { hostsJsonExists: () => false };
+
+const cfg = (extra, { schemaVersion = 1 } = {}) =>
+  JSON.stringify({
+    catalyst: {
+      ...(schemaVersion === null ? {} : { schemaVersion }),
+      projectKey: "p",
+      project: { ticketPrefix: "PROJ" },
+      linear: { teamKey: "PROJ" },
+      ...extra,
+    },
+  });
+
+describe("checkConfigScopeLeak grading (CTL-1214 D3/D4)", () => {
+  test("schemaVersion absent + node leak -> WARN (legacy repo, join gate unaffected)", () => {
+    const c = one({
+      ...noHosts,
+      readLayer1: () => cfg({ sweep: { idleHours: 48 } }, { schemaVersion: null }),
+    });
+    expect(c.status).toBe(STATUS.WARN);
+  });
+
+  test("schemaVersion 1 + node leak -> FAIL, naming catalyst-config-migrate", () => {
+    const c = one({ ...noHosts, readLayer1: () => cfg({ sweep: { idleHours: 48 } }) });
+    expect(c.status).toBe(STATUS.FAIL);
+    expect(c.detail).toContain("catalyst-config-migrate");
+    expect(c.detail).toContain("sweep");
+  });
+
+  test("schemaVersion 1 + cluster leak only -> WARN, naming CTL-1885", () => {
+    const c = one({
+      ...noHosts,
+      readLayer1: () => cfg({ monitor: { linear: { teams: [{ key: "P", vcsRepo: "a/b" }] } } }),
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("CTL-1885");
+  });
+
+  test("clean -> PASS", () => {
+    const c = one({ ...noHosts, readLayer1: () => cfg({}) });
+    expect(c.status).toBe(STATUS.PASS);
+  });
+
+  test("unreadable / malformed Layer-1 -> INFO, never a false PASS", () => {
+    expect(one({ ...noHosts, readLayer1: () => "{ not json" }).status).toBe(STATUS.INFO);
+  });
+
+  test("an absent Layer-1 does not FAIL the join gate", () => {
+    expect(one({ ...noHosts, readLayer1: () => "" }).status).not.toBe(STATUS.FAIL);
+  });
+
+  test("a hosts.json roster leak is cluster-scoped -> WARN, never FAIL", () => {
+    const c = one({ hostsJsonExists: () => true, readLayer1: () => cfg({}) });
+    expect(c.status).toBe(STATUS.WARN);
+  });
+
+  test("a genuinely Layer-1 orchestration stanza does not FAIL under schemaVersion 1 (D6)", () => {
+    for (const stanza of [{ codex: { codexHome: "/x" } }, { executor: "sdk" }]) {
+      const c = one({ ...noHosts, readLayer1: () => cfg({ orchestration: stanza }) });
+      expect(c.status).toBe(STATUS.PASS);
+    }
+  });
+
+  // ⚠️ THE JOIN-GATE GUARD. Asserted against the file on disk, not a fixture.
+  test("THIS repo's real committed config is NOT graded FAIL", () => {
+    const layer1Path = join(import.meta.dir, "..", "..", "..", "..", ".catalyst", "config.json");
+    const body = readFileSync(layer1Path, "utf8");
+    const c = one({ ...noHosts, readLayer1: () => body });
+    expect(c.status).not.toBe(STATUS.FAIL);
+    // Positive control: the fixture path CAN produce a FAIL, so "not FAIL" above
+    // is a property of this config rather than of a check that never fails.
+    const control = one({ ...noHosts, readLayer1: () => cfg({ sweep: { idleHours: 48 } }) });
+    expect(control.status).toBe(STATUS.FAIL);
+  });
+
+  test("and it is WARN about the roster only (CTL-1885 is the remaining work)", () => {
+    const layer1Path = join(import.meta.dir, "..", "..", "..", "..", ".catalyst", "config.json");
+    const c = one({ ...noHosts, readLayer1: () => readFileSync(layer1Path, "utf8") });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("monitor.linear.teams");
+    for (const gone of ["orchestration", "feedback", "sweep", "repoColors"]) {
+      expect(c.detail).not.toContain(gone);
+    }
+  });
+});

--- a/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
@@ -177,6 +177,60 @@ describe("checkConfigScopeLeak grading (CTL-1214 D3/D4)", () => {
     expect(control.status).toBe(STATUS.FAIL);
   });
 
+  // CTL-1214 remediation (verify regression_risk 5, medium): the FAIL detail used
+  // to assert one blanket cause — "leaving them here silently overrides the node
+  // config" — which is the WRONG direction for 4 of the 7 node-scoped rows. These
+  // three cases pin the per-knob wording in BOTH directions, so a regression to a
+  // single blanket sentence fails rather than merely reading plausibly.
+  test("FAIL detail says OVERRIDES for a bash-read (layer1-wins) leak", () => {
+    const c = one({ ...noHosts, readLayer1: () => cfg({ sweep: { idleHours: 48 } }) });
+    expect(c.status).toBe(STATUS.FAIL);
+    expect(c.detail).toContain("catalyst.sweep");
+    expect(c.detail).toContain("OVERRIDES");
+    // The opposite clause must be ABSENT — a message carrying both would be
+    // unfalsifiable and would "pass" this assertion for the wrong reason.
+    expect(c.detail).not.toContain("SHADOWED");
+  });
+
+  test("FAIL detail says SHADOWED for a JS-read (destination-wins) leak", () => {
+    const c = one({
+      ...noHosts,
+      readLayer1: () => cfg({ orchestration: { worktreeRefresh: { enabled: true } } }),
+    });
+    expect(c.status).toBe(STATUS.FAIL);
+    expect(c.detail).toContain("catalyst.orchestration.worktreeRefresh");
+    expect(c.detail).toContain("SHADOWED");
+    expect(c.detail).not.toContain("OVERRIDES");
+  });
+
+  test("a mixed leak names BOTH consequences, each against its own knob", () => {
+    const c = one({
+      ...noHosts,
+      readLayer1: () =>
+        cfg({
+          sweep: { idleHours: 48 },
+          orchestration: { worktreeRefresh: { enabled: true } },
+        }),
+    });
+    expect(c.status).toBe(STATUS.FAIL);
+    // Scope the assertions to the CONSEQUENCE clause. The leak enumeration ahead
+    // of it already names every leaked key, so a bare indexOf over the whole
+    // detail matches there and proves nothing about the per-knob attribution.
+    const marker = "Precedence differs by knob — ";
+    const at = c.detail.indexOf(marker);
+    expect(at).toBeGreaterThan(-1);
+    const clause = c.detail.slice(at + marker.length);
+    const overrides = clause.indexOf("OVERRIDES");
+    const shadowed = clause.indexOf("SHADOWED");
+    expect(overrides).toBeGreaterThan(-1);
+    expect(shadowed).toBeGreaterThan(-1);
+    // sweep is the layer1-wins row, so within the clause it sits on the
+    // OVERRIDES side; worktreeRefresh (destination-wins) sits on the SHADOWED side.
+    expect(clause.indexOf("catalyst.sweep")).toBeLessThan(overrides);
+    expect(clause.indexOf("catalyst.orchestration.worktreeRefresh")).toBeGreaterThan(overrides);
+    expect(clause.indexOf("catalyst.orchestration.worktreeRefresh")).toBeLessThan(shadowed);
+  });
+
   test("and it is WARN about the roster only (CTL-1885 is the remaining work)", () => {
     const layer1Path = join(import.meta.dir, "..", "..", "..", "..", ".catalyst", "config.json");
     const c = one({ ...noHosts, readLayer1: () => readFileSync(layer1Path, "utf8") });

--- a/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor-config-scope-leak.test.mjs
@@ -73,6 +73,86 @@ describe("checkConfigScopeLeak grading (CTL-1214 D3/D4)", () => {
     expect(one({ ...noHosts, readLayer1: () => "" }).status).not.toBe(STATUS.FAIL);
   });
 
+  // ── CTL-1214 remediation: a malformed schemaVersion is NOT a scope leak ────
+  //
+  // `hard = errors.length > 0` conflated two unrelated error classes, so a
+  // malformed `catalyst.schemaVersion` FAILED this check with a message that
+  // named no leaked key and asserted a schemaVersion the config did not have.
+  // runDoctor returns the FAIL count as its exit code and catalyst-join.sh gates
+  // member activation on exit 0, so that mislabel fail-closed the join gate on a
+  // hand-edit typo. The scope-leak verdict now keys off the error CLASS, and the
+  // schema error gets its own named check.
+  describe("malformed schemaVersion is graded as a schema problem, not a scope leak", () => {
+    const byName = (checks, name) => checks.find((c) => c.name === name);
+
+    // The exact shape this repo's own committed config has today: the ONLY leak
+    // is the cluster-scoped roster (CTL-1885 owns it), which is never FAIL-able.
+    const CLUSTER_ONLY_LEAK = {
+      monitor: { linear: { teams: [{ key: "CTL", vcsRepo: "coalesce-labs/catalyst" }] } },
+    };
+
+    for (const bad of [0, "1", 1.5, -1]) {
+      test(`schemaVersion ${JSON.stringify(bad)} + cluster-only leak -> scope-leak is NOT FAIL`, () => {
+        const checks = checkConfigScopeLeak({
+          ...noHosts,
+          readLayer1: () => cfg(CLUSTER_ONLY_LEAK, { schemaVersion: bad }),
+        });
+        const leak = byName(checks, "config-scope-leak");
+        expect(leak).toBeDefined();
+        expect(leak.status).not.toBe(STATUS.FAIL);
+        // and the message no longer claims a schemaVersion the config lacks
+        expect(leak.detail).not.toContain("declares schemaVersion >= 1");
+      });
+
+      test(`schemaVersion ${JSON.stringify(bad)} is SURFACED under its own check`, () => {
+        const checks = checkConfigScopeLeak({
+          ...noHosts,
+          readLayer1: () => cfg(CLUSTER_ONLY_LEAK, { schemaVersion: bad }),
+        });
+        const schema = byName(checks, "config-layer1-schema");
+        expect(schema).toBeDefined();
+        expect(schema.status).toBe(STATUS.WARN);
+        expect(schema.detail).toContain("catalyst.schemaVersion");
+        // never FAIL: it must not become a second back door into the join gate
+        expect(schema.status).not.toBe(STATUS.FAIL);
+      });
+    }
+
+    // NEGATIVE CONTROLS. Without these, every assertion above could pass from a
+    // check that never emits and a verdict that is never FAIL.
+    test("a WELL-FORMED schemaVersion emits NO schema check", () => {
+      for (const good of [1, 2]) {
+        const checks = checkConfigScopeLeak({
+          ...noHosts,
+          readLayer1: () => cfg(CLUSTER_ONLY_LEAK, { schemaVersion: good }),
+        });
+        expect(byName(checks, "config-layer1-schema")).toBeUndefined();
+        expect(byName(checks, "config-scope-leak").status).toBe(STATUS.WARN);
+      }
+    });
+
+    test("the FAIL path still fires for a real node-scoped leak under schemaVersion 1", () => {
+      const checks = checkConfigScopeLeak({
+        ...noHosts,
+        readLayer1: () => cfg({ sweep: { idleHours: 48 } }, { schemaVersion: 1 }),
+      });
+      expect(byName(checks, "config-scope-leak").status).toBe(STATUS.FAIL);
+      expect(byName(checks, "config-layer1-schema")).toBeUndefined();
+    });
+
+    test("a malformed schemaVersion does NOT suppress a real node-scoped leak's WARN", () => {
+      // A bogus version does not opt in, so the node leak is a deprecation, not
+      // a hard error — but it must still be reported, alongside the schema WARN.
+      const checks = checkConfigScopeLeak({
+        ...noHosts,
+        readLayer1: () => cfg({ sweep: { idleHours: 48 } }, { schemaVersion: 0 }),
+      });
+      expect(byName(checks, "config-scope-leak").status).toBe(STATUS.WARN);
+      expect(byName(checks, "config-scope-leak").detail).toContain("sweep");
+      expect(byName(checks, "config-layer1-schema").status).toBe(STATUS.WARN);
+    });
+  });
+
   test("a hosts.json roster leak is cluster-scoped -> WARN, never FAIL", () => {
     const c = one({ hostsJsonExists: () => true, readLayer1: () => cfg({}) });
     expect(c.status).toBe(STATUS.WARN);

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4364,14 +4364,38 @@ export function checkNodeConfigPresent(deps = {}) {
 // "keep PROJ / keep null / don't commit Linear IDs" rule).
 //
 // Reuses the single-source-of-truth leak-category list (RELOCATED_LAYER1_KEYS) +
-// pure validator (validateLayer1Config) from lib/validate-catalyst-config.mjs —
-// the same module the Phase-1 schema tests exercise — so there is exactly one
-// definition of "what leaks". Back-compat: presence of a relocated key does NOT
-// invalidate the config at runtime; this check is an advisory migration tracker
-// (STATUS.WARN, never FAIL during the back-compat window) that tells operators
-// which repos still need slimming. It must stay WARN until Phase 6 slims the
-// committed configs, because runDoctor's exit code = FAIL count and
-// catalyst-join.sh gates member activation on doctor exit 0.
+// pure validator (validateLayer1Config) from lib/validate-catalyst-config.mjs, so
+// there is exactly one definition of "what leaks".
+//
+// GRADING (CTL-1214 Phase 5). This check was pinned at STATUS.WARN because the
+// committed Layer-1 configs were not yet slimmed, so EVERY node carried the
+// relocated keys and a FAIL would have exited `catalyst doctor` non-zero
+// fleet-wide. That gate is real and still binding: runDoctor returns the FAIL
+// COUNT as the process exit code, and catalyst-join.sh's do_doctor_gate()
+// activates a cluster member strictly on exit 0
+// (run_stage "doctor" do_doctor_gate || exit 1). A FAIL here fail-closes the join.
+//
+// The pin is now replaced by a SELF-GATING promotion rather than removed:
+//   FAIL  — the validator reports hard errors, which happens only when the config
+//           has DECLARED schemaVersion >= 1 (i.e. it says it is slimmed) AND still
+//           carries a NODE-scoped relocated key. That is a config contradicting
+//           its own declaration — a hand-edit or a partial rollback — and it is
+//           exactly the state that silently reverts knobs to code defaults.
+//   WARN  — any other leak: an un-migrated repo (no schemaVersion), or a
+//           CLUSTER-scoped leak such as monitor.linear.teams / .catalyst/hosts.json,
+//           whose relocation is CTL-1885 and deliberately out of scope here.
+//   PASS  — clean.  INFO — unreadable/malformed (never a false PASS).
+//
+// So a fleet member that has simply not migrated can still join, while a repo that
+// claims to be slimmed is held to it. This repo's own committed config is asserted
+// NOT-FAIL by doctor-config-scope-leak.test.mjs, reading the real file on disk —
+// that assertion is what keeps the fleet joinable, so it is not a fixture.
+//
+// The lockstep argument still holds independently (doctor and this repo's config
+// ship in the same repo, and layer1Path() is this-repo-relative, so doctor never
+// grades adva / catalyst-otel / slides / evergreen). The schemaVersion gate is
+// kept ON TOP of that because it additionally survives a hand-edited or
+// rolled-back config, which lockstep alone does not.
 //
 // Injected deps (all have real defaults):
 //   readLayer1      — () => string   (raw Layer-1 config body; "" when absent)
@@ -4407,7 +4431,7 @@ export function checkConfigScopeLeak(deps = {}) {
     }
   }
 
-  const { deprecatedKeys } = validateLayer1Config(parsed ?? {});
+  const { deprecatedKeys, errors } = validateLayer1Config(parsed ?? {});
   const hostsLeak = hostsJsonExists();
 
   if (deprecatedKeys.length === 0 && !hostsLeak) {
@@ -4434,25 +4458,27 @@ export function checkConfigScopeLeak(deps = {}) {
     );
   }
 
+  // The validator only produces hard errors for a config that declared
+  // schemaVersion >= 1 and still carries a NODE-scoped relocated key — see the
+  // grading note in this function's header for why that is the one FAIL-able state.
+  const hard = errors.length > 0;
+
   checks.push(
     mkCheck(
       "config-scope-leak",
-      // WARN, not FAIL, during the back-compat migration window (CTL-1214). runDoctor
-      // returns the FAIL count as the process exit code, and catalyst-join.sh
-      // do_doctor_gate() gates cluster-member activation strictly on exit 0
-      // (run_stage "doctor" do_doctor_gate || exit 1). The committed Layer-1
-      // .catalyst/config.json is NOT yet slimmed (Phase 6 deferred), so EVERY node
-      // today still carries these relocated keys. Emitting FAIL here would make
-      // `catalyst doctor` exit non-zero on every host and fail-close the join gate —
-      // a runtime regression, contradicting the "purely observational" contract.
-      // This mirrors checkReaper's deliberate WARN ("a FAILing reaper check would
-      // BLOCK a node from self-healing via join"). Promote to FAIL only after Phase 6
-      // slims the committed configs.
-      STATUS.WARN,
-      `Layer-1 .catalyst/config.json carries node/cluster-scoped keys (advisory migration tracker): ${leaks.join("; ")}. ` +
-        `Remediation: run plugins/dev/scripts/migrate-config-to-node.sh to seed the node config ` +
-        `(~/.config/catalyst/config.json), move the project roster into ` +
-        `catalyst-cluster/cluster.json, then remove these keys from the committed .catalyst/config.json.`,
+      hard ? STATUS.FAIL : STATUS.WARN,
+      hard
+        ? `Layer-1 .catalyst/config.json declares schemaVersion >= 1 (slimmed) but still carries ` +
+          `node-scoped keys: ${leaks.join("; ")}. Those keys are read from Layer-1 only when present, ` +
+          `so leaving them here silently overrides the node config. Remediation: run ` +
+          `\`plugins/dev/scripts/catalyst-config-migrate\` to move them into ` +
+          `~/.config/catalyst/node.json.` +
+          (hostsLeak || deprecatedKeys.includes("monitor.linear.teams")
+            ? ` (The roster entries above are cluster-scoped and are NOT part of this failure — CTL-1885 owns them.)`
+            : "")
+        : `Layer-1 .catalyst/config.json carries node/cluster-scoped keys (advisory migration tracker): ${leaks.join("; ")}. ` +
+          `Remediation: run \`plugins/dev/scripts/catalyst-config-migrate\` to relocate the node-scoped keys into ` +
+          `~/.config/catalyst/node.json; the project roster relocates to catalyst-cluster/cluster.json under CTL-1885.`,
     ),
   );
   return checks;

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -48,6 +48,11 @@ import { spawnSync, execFileSync } from "node:child_process";
 // REJECTS). The alternative was a hand-maintained copy here, which would keep
 // reporting three uncovered names after CTC-691/CTC-667/CTC-704 close.
 import { resolveGithubFeedMode } from "../lib/github-feed-mode.mjs";
+// CTL-1214: the autotuner's setpoint ladder, from the zero-import leaf. ⛔ NOT from
+// execution-core/scheduler.mjs — that module reaches bun:sqlite and this file runs
+// under BARE NODE, so importing it there fails at load. Sharing the leaf is what
+// keeps checkAutotuneSetpoint grading the SAME rule the autotuner applies.
+import { resolveTargetSetpoint } from "../lib/autotune-setpoint.mjs";
 import {
   GITHUB_CONSUMED_NAMES,
   GITHUB_SUPPRESSIBLE_NAMES,
@@ -4333,6 +4338,17 @@ export function checkClusterSecretsPresent(deps = {}) {
 // Reports whether ~/.config/catalyst/node.json exists and has a non-empty host.name.
 // A missing node.json is fine (new install); a present-but-host-name-less one is the
 // unexpected state worth surfacing.
+//
+// CTL-1214: the host-name-less WARN got a SECOND, much more common cause once
+// `catalyst-config-migrate` began creating node.json. host.name is NOT a relocated
+// Layer-1 key (it does not appear in RELOCATED_LAYER1_KEYS) — it is written by
+// catalyst-join.sh, which only started targeting node.json in CTL-1210. So a
+// migration-created node.json legitimately has no host.name while the LEGACY
+// Layer-2 config.json still serves it, and telling that operator to "run
+// catalyst-join" implies their host identity is missing when it is not. The two
+// states are now reported distinctly. The GRADE is unchanged in both (WARN — the
+// per-node split really is incomplete either way), so no gate moves; only the
+// instruction becomes true.
 export function checkNodeConfigPresent(deps = {}) {
   const {
     nodePath = resolveNodeConfigPath(),
@@ -4344,6 +4360,12 @@ export function checkNodeConfigPresent(deps = {}) {
         return null;
       }
     },
+    // The merged Layer-2 view, used ONLY to tell "unset everywhere" from "still
+    // served by the legacy file". The try/catch lives at the CALL SITE below, not
+    // here, so an INJECTED reader is as fail-open as the default one — a doctor
+    // check that throws aborts the whole run, and putting the guard only in the
+    // default would make that reachable from any caller supplying its own seam.
+    readMerged = () => readLayer2Merged() ?? {},
   } = deps;
   const NAME = "node-config-present";
   if (!fileExists(nodePath)) {
@@ -4352,9 +4374,113 @@ export function checkNodeConfigPresent(deps = {}) {
   const obj = readJson(nodePath);
   const hostName = obj?.catalyst?.host?.name ?? obj?.catalyst?.["host.name"];
   if (!hostName) {
+    let merged = {};
+    try {
+      merged = readMerged() ?? {};
+    } catch {
+      // Fail-open to the ORIGINAL message: an unreadable merge is not evidence
+      // that the legacy file serves host.name, so it must not reach the
+      // reassuring branch.
+      merged = {};
+    }
+    const mergedHostName = merged?.catalyst?.host?.name ?? merged?.catalyst?.["host.name"];
+    if (mergedHostName) {
+      return [
+        mkCheck(
+          NAME,
+          STATUS.WARN,
+          `node.json present but carries no catalyst.host.name — host identity is still served by ` +
+            `the legacy Layer-2 config.json (host.name=${mergedHostName}), so nothing is broken. ` +
+            "Expected on a node.json created by catalyst-config-migrate, which never sees host.name " +
+            "(it is not a relocated Layer-1 key). Run catalyst-join to finish moving it into node.json.",
+        ),
+      ];
+    }
     return [mkCheck(NAME, STATUS.WARN, `node.json present but catalyst.host.name is unset — run catalyst-join or set it manually`)];
   }
   return [mkCheck(NAME, STATUS.PASS, `node.json present, host.name=${hostName}`)];
+}
+
+// checkAutotuneSetpoint — CTL-1214. ADVISORY ONLY (WARN, never FAIL).
+//
+// The knob this ticket nearly lost in silence. Slimming the committed Layer-1
+// removed `orchestration.executionCore.maxParallel`, which is what
+// resolveTargetSetpoint falls back to; with no `targetParallel` in the merged
+// Layer-2 view the setpoint resolves UNDEFINED, and an undefined setpoint does
+// not raise anything — it just makes CTL-770's convergence/seed branches and
+// CTL-750's RULE 7 recovery-to-layer1 jump no-op. Measured on mini-2 mid-ticket:
+// 4 → null, with no error anywhere. The migration now seeds the key
+// (lib/migrate-layer1-config.mjs step 2b), and this arm is the detector that
+// makes a future recurrence visible rather than silent.
+//
+// Grading — the discriminator is "is a setpoint RESOLVABLE", not "does the file
+// contain a key", so it reads the same ladder the autotuner does (the shared
+// zero-import leaf, imported directly because scheduler.mjs reaches bun:sqlite
+// and doctor is bare Node):
+//   PASS — a setpoint resolves (Layer-2 targetParallel, or Layer-1 maxParallel).
+//   WARN — executionCore declares a maxParallel but NO setpoint resolves. This is
+//          the exact post-slim state; the fix is one `catalyst-config-migrate` run.
+//   INFO — no executionCore concurrency is configured at all (nothing to grade),
+//          or the config is unreadable. Deliberately NOT a PASS: "I could not
+//          look" and "the setpoint is fine" must not share a grade.
+export function checkAutotuneSetpoint(deps = {}) {
+  const NAME = "autotune-setpoint-present";
+  const {
+    readLayer1 = () => {
+      try {
+        return JSON.parse(readFileSync(layer1Path(), "utf8"))?.catalyst?.orchestration?.executionCore ?? {};
+      } catch {
+        return null;
+      }
+    },
+    readLayer2 = () => {
+      try {
+        return readLayer2Merged()?.catalyst?.orchestration?.executionCore ?? {};
+      } catch {
+        return null;
+      }
+    },
+  } = deps;
+
+  const l1 = readLayer1();
+  const l2 = readLayer2();
+  if (l1 === null && l2 === null) {
+    return [mkCheck(NAME, STATUS.INFO, "could not read either config layer — autotune setpoint not graded")];
+  }
+  const layer1 = l1 ?? {};
+  const layer2 = l2 ?? {};
+
+  const setpoint = resolveTargetSetpoint(layer1, layer2);
+  if (Number.isInteger(setpoint) && setpoint > 0) {
+    const src =
+      Number.isInteger(layer2?.targetParallel) && layer2.targetParallel > 0
+        ? "Layer-2 targetParallel"
+        : "Layer-1 maxParallel";
+    return [mkCheck(NAME, STATUS.PASS, `autotune setpoint resolves to ${setpoint} (from ${src})`)];
+  }
+
+  const mirror = layer2?.maxParallel ?? layer1?.maxParallel;
+  if (Number.isInteger(mirror) && mirror > 0) {
+    return [
+      mkCheck(
+        NAME,
+        STATUS.WARN,
+        `executionCore resolves maxParallel=${mirror} but NO targetParallel setpoint — ` +
+          "resolveTargetSetpoint returns undefined, which silently no-ops the autotuner's " +
+          "convergence branches and RULE 7 recovery-to-layer1 (CTL-770/CTL-750). " +
+          "Run `catalyst-config-migrate` to seed catalyst.orchestration.executionCore.targetParallel " +
+          "in ~/.config/catalyst/node.json, or set it by hand.",
+      ),
+    ];
+  }
+
+  return [
+    mkCheck(
+      NAME,
+      STATUS.INFO,
+      "no executionCore concurrency configured on this host — no autotune setpoint to grade",
+    ),
+  ];
 }
 
 // checkConfigScopeLeak — CTL-1214. Flags a committed Layer-1 .catalyst/config.json
@@ -6893,6 +7019,7 @@ export function checksForClass(nc, opts = {}) {
       () => checkCloudSyncSkew(), // CTL-1659: is the RUNNING writer serving the lockfile's modules? (advisory)
       () => checkFleetTokenExport(), // CTL-1908: does a login shell spend the FLEET's Claude budget? (advisory)
       () => checkConfigScopeLeak(), // advisory
+      () => checkAutotuneSetpoint(), // CTL-1214: slimming Layer-1 can leave the autotune setpoint unresolvable — a silent no-op of the convergence + RULE 7 branches (advisory)
       () => checkWorkerLabels(), // CTL-1481: worker:<host> label is a best-effort visibility projection, never the claim arbiter — advisory only
       () => checkConfigProvenance(), // CTL-1793: daemon-vs-doctor Layer-1 split + per-host env overrides — advisory only (never FAIL)
       () => checkIndexServingRoot(), // CTL-1935: is this node's catalyst-index serving root the PINNED release? evaluateDepSkew cannot answer it (the indexer is an on-demand CLI with no boot record) — advisory only (never FAIL)
@@ -6977,6 +7104,7 @@ export function checksForClass(nc, opts = {}) {
     () => checkSdkExecutorAuth(), // CTL-1367 item 9: under executor=sdk, subscription auth must be correct (no api-key metering)
     () => checkSdkDaemonEnv(), // CTL-1396 item A: under executor=sdk, the RUNNING daemon's process env must carry CLAUDE_CODE_OAUTH_TOKEN (not just the operator shell) + surface recent silent sdk→bg degrades
     () => checkConfigScopeLeak(), // CTL-1214: committed Layer-1 .catalyst/config.json must not carry node/cluster scope (roster/orchestration/feedback/sweep/repoColors/hosts.json)
+    () => checkAutotuneSetpoint(), // CTL-1214: slimming Layer-1 can leave the autotune setpoint unresolvable — a silent no-op of the convergence + RULE 7 branches (advisory)
     () => checkRepoIconTokenScope(), // CTL-1375: monitor daemon's gh token can read configured private repos' contents (else favicons fall back to the org avatar) — advisory (never FAIL)
     () => checkRepoPushPermission({
       repoRoot,

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -4627,14 +4627,38 @@ export function checkConfigScopeLeak(deps = {}) {
   // validation failure can borrow this check's FAIL (and its join-gate exit code).
   const hard = errorDetails.some((e) => e.code === LAYER1_ERROR_CODES.NODE_SCOPE_LEAK);
 
+  // CTL-1214 remediation: the consequence clause is PER KNOB, not one blanket
+  // sentence. "leaving them here silently overrides the node config" is true only
+  // for the bash-read rows (dispatchMode / sweep / feedback, precedence
+  // "layer1-wins"); for the JS-read rows Layer-2 wins per field, so a leftover
+  // Layer-1 key is SHADOWED, not authoritative — the opposite failure, and the one
+  // an operator is most likely to mis-debug. Formatted from RELOCATED_LAYER1_KEYS'
+  // own `precedence` field so the message cannot drift from the readers.
+  const nodeLeaks = deprecatedKeys
+    .map((key) => RELOCATED_LAYER1_KEYS.find((e) => e.path === key))
+    .filter((e) => e && e.scope === "node");
+  const overriding = nodeLeaks.filter((e) => e.precedence === "layer1-wins").map((e) => `catalyst.${e.path}`);
+  const shadowed = nodeLeaks.filter((e) => e.precedence !== "layer1-wins").map((e) => `catalyst.${e.path}`);
+  const consequence =
+    [
+      overriding.length
+        ? `${overriding.join(", ")} ${overriding.length === 1 ? "is" : "are"} read Layer-1-first, so the value here OVERRIDES ~/.config/catalyst/node.json`
+        : "",
+      shadowed.length
+        ? `${shadowed.join(", ")} ${shadowed.length === 1 ? "is" : "are"} read Layer-2-first, so the value here is SHADOWED by node.json and the two can drift apart unnoticed`
+        : "",
+    ]
+      .filter(Boolean)
+      .join("; ") || "the effective value depends on which stack reads the knob";
+
   checks.push(
     mkCheck(
       "config-scope-leak",
       hard ? STATUS.FAIL : STATUS.WARN,
       hard
         ? `Layer-1 .catalyst/config.json declares schemaVersion >= 1 (slimmed) but still carries ` +
-          `node-scoped keys: ${leaks.join("; ")}. Those keys are read from Layer-1 only when present, ` +
-          `so leaving them here silently overrides the node config. Remediation: run ` +
+          `node-scoped keys: ${leaks.join("; ")}. Precedence differs by knob — ${consequence}. ` +
+          `Remediation: run ` +
           `\`plugins/dev/scripts/catalyst-config-migrate\` to move them into ` +
           `~/.config/catalyst/node.json.` +
           (hostsLeak || deprecatedKeys.includes("monitor.linear.teams")

--- a/plugins/dev/scripts/execution-core/doctor.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.mjs
@@ -153,7 +153,11 @@ import { assertSdkAuth } from "./sdk-run-phase-agent.mjs";
 // CTL-1214: reuse the single-source-of-truth Layer-1 scope-leak validator
 // (pure, no-I/O) shared with the Phase-1 config-schema tests. Lives in
 // plugins/dev/scripts/lib/ (sibling of execution-core/).
-import { validateLayer1Config, RELOCATED_LAYER1_KEYS } from "../lib/validate-catalyst-config.mjs";
+import {
+  validateLayer1Config,
+  RELOCATED_LAYER1_KEYS,
+  LAYER1_ERROR_CODES,
+} from "../lib/validate-catalyst-config.mjs";
 import { resolvePluginCheckoutRoots } from "../broker/plugin-refresh.mjs"; // CTL-1421: same resolver the workers use
 
 // CTL-1931: doctor.mjs lives at <repo>/plugins/dev/scripts/execution-core/, so the repo's
@@ -4431,8 +4435,41 @@ export function checkConfigScopeLeak(deps = {}) {
     }
   }
 
-  const { deprecatedKeys, errors } = validateLayer1Config(parsed ?? {});
+  const { deprecatedKeys, errorDetails } = validateLayer1Config(parsed ?? {});
   const hostsLeak = hostsJsonExists();
+
+  // CTL-1214 remediation: the SCHEMA errors are graded as their own check rather
+  // than folded into the scope-leak verdict. Before this, `hard = errors.length > 0`
+  // made a malformed `catalyst.schemaVersion` — or a missing `catalyst` root —
+  // FAIL this check with a message that named no leaked key and asserted a
+  // schemaVersion the config did not have. Both classes are WARN here on purpose:
+  // runDoctor returns the FAIL count as its exit code and catalyst-join.sh gates
+  // member activation on exit 0, and by the validator's own rule a bogus
+  // schemaVersion is not a back door into strict mode — so it must not be a back
+  // door into a fail-closed join gate either. It is now VISIBLE and correctly
+  // named, which is what was actually missing (this is the sole doctor consumer of
+  // validateLayer1Config, so these errors had no other surface).
+  // Gated on `body` because an ABSENT Layer-1 ("" → parsed null) validates as
+  // MISSING_ROOT, and "there is no config here" is not a schema complaint — it is
+  // the pre-existing absent case this check has always graded PASS.
+  const schemaErrors = body
+    ? errorDetails.filter(
+        (e) =>
+          e.code === LAYER1_ERROR_CODES.SCHEMA_VERSION || e.code === LAYER1_ERROR_CODES.MISSING_ROOT,
+      )
+    : [];
+  if (schemaErrors.length > 0) {
+    checks.push(
+      mkCheck(
+        "config-layer1-schema",
+        STATUS.WARN,
+        `Layer-1 .catalyst/config.json fails schema validation: ${schemaErrors
+          .map((e) => e.message)
+          .join("; ")}. This is a schema problem, not a scope leak — a well-formed ` +
+          `\`catalyst.schemaVersion\` (integer >= 1) is what opts the config into the slimmed contract.`,
+      ),
+    );
+  }
 
   if (deprecatedKeys.length === 0 && !hostsLeak) {
     checks.push(
@@ -4458,10 +4495,11 @@ export function checkConfigScopeLeak(deps = {}) {
     );
   }
 
-  // The validator only produces hard errors for a config that declared
-  // schemaVersion >= 1 and still carries a NODE-scoped relocated key — see the
-  // grading note in this function's header for why that is the one FAIL-able state.
-  const hard = errors.length > 0;
+  // The ONE FAIL-able state: a config that declared schemaVersion >= 1 and still
+  // carries a NODE-scoped relocated key — see the grading note in this function's
+  // header. Gated on the error CLASS, not on `errors.length`, so no other
+  // validation failure can borrow this check's FAIL (and its join-gate exit code).
+  const hard = errorDetails.some((e) => e.code === LAYER1_ERROR_CODES.NODE_SCOPE_LEAK);
 
   checks.push(
     mkCheck(

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -64,6 +64,7 @@ import {
   checkSelfEchoIdentityHistory,
   checkClusterSecretsPresent,
   checkNodeConfigPresent,
+  checkAutotuneSetpoint,
 } from "./doctor.mjs";
 import { resolveSecret as resolveSecretReal } from "../lib/secret-contract.mjs";
 import { TICKET_KEY_RE } from "./ticket-key.mjs";
@@ -6391,6 +6392,47 @@ describe("checkNodeConfigPresent (CTL-1210)", () => {
       nodePath: "/h/node.json",
       fileExists: () => true,
       readJson: () => ({ catalyst: {} }),
+      // CTL-1214: pinned EXPLICITLY rather than left to the default reader. The
+      // hermetic preload (test-setup.mjs) does isolate this today, but a check
+      // whose message depends on ambient host state must say which state it is
+      // asserting — the bash-side twin of this omission is what made
+      // orchestrate-dispatch-next.test.sh flip 49 assertions on a migrated host.
+      readMerged: () => ({ catalyst: {} }),
+    });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toMatch(/host\.name is unset/i);
+  });
+
+  // CTL-1214: host.name is NOT a relocated Layer-1 key, so a node.json created
+  // by catalyst-config-migrate legitimately has none while the LEGACY Layer-2
+  // config.json still serves it. Same grade (the split really is incomplete),
+  // different instruction — "run catalyst-join or set it manually" reads as
+  // "your host identity is missing", which on that host is false.
+  it("WARN naming the legacy fallback when host.name is still served by config.json", () => {
+    const [c] = checkNodeConfigPresent({
+      nodePath: "/h/node.json",
+      fileExists: () => true,
+      readJson: () => ({ catalyst: {} }),
+      readMerged: () => ({ catalyst: { host: { name: "mini-2" } } }),
+    });
+    expect(c.status).toBe(STATUS.WARN); // grade UNCHANGED — no gate moves
+    expect(c.detail).toContain("mini-2");
+    expect(c.detail).toMatch(/legacy Layer-2 config\.json/i);
+    expect(c.detail).not.toMatch(/host\.name is unset/i);
+  });
+
+  it("fails OPEN to the original message when the merged read THROWS", () => {
+    // An unreadable merge is not evidence that the legacy file serves host.name,
+    // so it must not reach the reassuring branch — and a doctor check that
+    // throws aborts the whole run, so an INJECTED seam must be guarded too, not
+    // just the default one.
+    const [c] = checkNodeConfigPresent({
+      nodePath: "/h/node.json",
+      fileExists: () => true,
+      readJson: () => ({ catalyst: {} }),
+      readMerged: () => {
+        throw new Error("EACCES");
+      },
     });
     expect(c.status).toBe(STATUS.WARN);
     expect(c.detail).toMatch(/host\.name is unset/i);
@@ -6416,5 +6458,81 @@ describe("checkNodeConfigPresent (CTL-1210)", () => {
   it("is wired into both worker and developer suites", () => {
     const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
     expect(src.split("checkNodeConfigPresent()").length - 1, "registered in at least 2 class suites").toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─── checkAutotuneSetpoint (CTL-1214) ────────────────────────────────────────
+// The detector for the knob this ticket nearly lost in silence. Slimming Layer-1
+// removed the maxParallel that resolveTargetSetpoint falls back to; with no
+// targetParallel in the merged Layer-2 view the setpoint resolves UNDEFINED, and
+// an undefined setpoint raises nothing — it just no-ops CTL-770's convergence
+// branches and CTL-750's RULE 7 recovery jump. Measured on mini-2: 4 → null.
+describe("checkAutotuneSetpoint (CTL-1214)", () => {
+  const run = (layer1, layer2) => {
+    const checks = checkAutotuneSetpoint({ readLayer1: () => layer1, readLayer2: () => layer2 });
+    expect(checks).toHaveLength(1);
+    return checks[0];
+  };
+
+  it("PASS when the host declares targetParallel", () => {
+    const c = run({}, { targetParallel: 6, maxParallel: 3 });
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("6");
+    expect(c.detail).toContain("Layer-2 targetParallel");
+  });
+
+  it("PASS via the Layer-1 committed maxParallel (an un-migrated repo)", () => {
+    const c = run({ maxParallel: 4 }, {});
+    expect(c.status).toBe(STATUS.PASS);
+    expect(c.detail).toContain("Layer-1 maxParallel");
+  });
+
+  it("WARN on the post-slim state: a mirror exists but NO setpoint resolves", () => {
+    // mini-2's measured state before the migration seed landed.
+    const c = run({}, { maxParallel: 4, minParallel: 1, maxParallelCeiling: 40 });
+    expect(c.status).toBe(STATUS.WARN);
+    expect(c.detail).toContain("maxParallel=4");
+    expect(c.detail).toMatch(/no targetParallel/i);
+    // The message must name the FIX, not just the symptom.
+    expect(c.detail).toContain("catalyst-config-migrate");
+  });
+
+  it("WARN when targetParallel is present but not a positive integer", () => {
+    // The ladder's own Number.isInteger guard rejects these, so the setpoint is
+    // still undefined — a check keyed on key PRESENCE would call this fine.
+    for (const targetParallel of [0, -1, 2.5, "6", null]) {
+      expect(run({}, { maxParallel: 4, targetParallel }).status).toBe(STATUS.WARN);
+    }
+  });
+
+  it("INFO — not PASS — when no executionCore concurrency is configured at all", () => {
+    // "Nothing to grade" and "the setpoint is fine" must not share a grade.
+    const c = run({}, {});
+    expect(c.status).toBe(STATUS.INFO);
+  });
+
+  it("INFO — not PASS — when neither config layer can be read", () => {
+    const c = run(null, null);
+    expect(c.status).toBe(STATUS.INFO);
+    expect(c.detail).toMatch(/could not read/i);
+  });
+
+  it("never FAILs (advisory) — exit-code-safe, so it can never fail-close the join gate", async () => {
+    const code = await runDoctor({
+      checks: [() => checkAutotuneSetpoint({ readLayer1: () => ({}), readLayer2: () => ({ maxParallel: 4 }) })],
+    });
+    expect(code).toBe(0);
+  });
+
+  it("grades through the SAME resolver the autotuner uses, not a restated ladder", () => {
+    // One definition. If doctor re-typed the precedence rule, this drift would be
+    // undetectable — the check would keep reporting on a rule nothing applies.
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    expect(src).toContain('from "../lib/autotune-setpoint.mjs"');
+  });
+
+  it("is wired into both worker and developer suites", () => {
+    const src = readFileSync(new URL("./doctor.mjs", import.meta.url), "utf8");
+    expect(src.split("checkAutotuneSetpoint()").length - 1, "registered in at least 2 class suites").toBeGreaterThanOrEqual(2);
   });
 });

--- a/plugins/dev/scripts/execution-core/doctor.test.mjs
+++ b/plugins/dev/scripts/execution-core/doctor.test.mjs
@@ -4049,16 +4049,33 @@ const MINIMAL_LAYER1 = JSON.stringify({
 });
 
 describe("checkConfigScopeLeak (CTL-1214)", () => {
-  it("WARNs (advisory, not FAIL) on a kitchen-sink Layer-1 still carrying node/cluster keys", () => {
-    // Back-compat window (CTL-1214): the leak is advisory (WARN), never FAIL, because
-    // runDoctor's exit code = FAIL count and catalyst-join.sh gates member activation
-    // on doctor exit 0. A FAIL here would fail-close every un-slimmed node's join.
+  it("FAILs on a kitchen-sink Layer-1 that DECLARES schemaVersion >= 1 and still carries node-scoped keys", () => {
+    // CTL-1214 Phase 5 replaced the blanket WARN pin with a self-gating promotion:
+    // a config that declares schemaVersion >= 1 says it is slimmed, so still carrying
+    // a node-scoped relocated key is a config contradicting its own declaration —
+    // the state that silently reverts knobs to code defaults. KITCHEN_SINK_LAYER1
+    // declares schemaVersion: 1, so it is FAIL-able.
     const checks = checkConfigScopeLeak({
       readLayer1: () => KITCHEN_SINK_LAYER1,
       hostsJsonExists: () => false,
     });
     expect(checks).toHaveLength(1);
     expect(checks[0].name).toBe("config-scope-leak");
+    expect(checks[0].status).toBe(STATUS.FAIL);
+  });
+
+  it("still WARNs (never FAILs) on an UN-SLIMMED Layer-1, so the join gate stays open", () => {
+    // The reason the check was pinned at WARN in the first place, kept as a live
+    // assertion: runDoctor's exit code = FAIL count and catalyst-join.sh's
+    // do_doctor_gate() activates a cluster member strictly on exit 0. A repo that
+    // has simply not migrated yet (no schemaVersion) must never fail-close its join.
+    const unslimmed = JSON.parse(KITCHEN_SINK_LAYER1);
+    delete unslimmed.catalyst.schemaVersion;
+    const checks = checkConfigScopeLeak({
+      readLayer1: () => JSON.stringify(unslimmed),
+      hostsJsonExists: () => false,
+    });
+    expect(checks).toHaveLength(1);
     expect(checks[0].status).toBe(STATUS.WARN);
   });
 
@@ -4084,8 +4101,10 @@ describe("checkConfigScopeLeak (CTL-1214)", () => {
     expect(detail).toContain("orchestration");
     expect(detail).toContain("feedback");
     expect(detail).toContain("sweep");
-    // and it points operators at the migration tooling / cluster destination
-    expect(detail).toContain("migrate-config-to-node.sh");
+    // and it points operators at the migration tooling / cluster destination.
+    // The script is `catalyst-config-migrate` (added by CTL-1214); the name this
+    // previously asserted, migrate-config-to-node.sh, has never existed in-tree.
+    expect(detail).toContain("catalyst-config-migrate");
     expect(detail).toContain("catalyst-cluster/cluster.json");
   });
 

--- a/plugins/dev/scripts/execution-core/layer2-fallback.test.mjs
+++ b/plugins/dev/scripts/execution-core/layer2-fallback.test.mjs
@@ -1,0 +1,237 @@
+// layer2-fallback.test.mjs — CTL-1214 Phase 1. The Layer-2 arm of the three JS
+// readers whose relocated knobs were Layer-1-ONLY before this ticket.
+//
+// WHY A DEDICATED FILE. readExecutionCoreConcurrencyLayer2 is exported from
+// scheduler.mjs and its existing coverage lives in scheduler.test.mjs — which
+// is NOT in .github/workflows/execution-core-tests.yml's allowlist (verified:
+// the only occurrence of `scheduler.test.mjs` in that file is a comment on line
+// 1339, and no `run:` line names it; positive control: the same grep for
+// `deployment-mode-parity.test.sh` returns its own run line). CI there runs an
+// explicit list, never a glob, so an assertion added to scheduler.test.mjs
+// gates nothing. This file is registered as its own list entry in the same
+// change that adds it.
+//
+// THE DEFECT BEING GUARDED. Four relocated categories are read from Layer-1
+// ONLY and every one of those readers is fail-open to a code default. Slimming
+// the committed config therefore does not error — it SILENTLY reverts each knob.
+// These tests assert the fallback resolves the real value, and (the sharp half)
+// that it is not the silent default.
+//
+// Run: cd plugins/dev/scripts/execution-core && bun test layer2-fallback.test.mjs
+
+import { describe, it, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readLayer2MergedFrom } from "./config.mjs";
+import { readExecutionCoreConcurrencyLayer2, mergeExecutionCoreConcurrency } from "./scheduler.mjs";
+import { readLinearReconcileConfig } from "./linear-reconcile-timer.mjs";
+
+let dirs = [];
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs = [];
+});
+
+// Build a hermetic Layer-2 root. The siblings resolve off the returned file's
+// OWN directory (as resolveNodeConfigPath does), so a fixture never reaches into
+// the developer's real ~/.config/catalyst — a suite whose verdict depended on the
+// host it ran on would be worthless here.
+function mkLayer2({ legacy, node, secrets } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1214-l2-"));
+  dirs.push(dir);
+  const path = join(dir, "config.json");
+  writeFileSync(path, typeof legacy === "string" ? legacy : JSON.stringify(legacy ?? {}));
+  if (node !== undefined) {
+    writeFileSync(join(dir, "node.json"), typeof node === "string" ? node : JSON.stringify(node));
+  }
+  if (secrets !== undefined) {
+    writeFileSync(
+      join(dir, "cluster-secrets.json"),
+      typeof secrets === "string" ? secrets : JSON.stringify(secrets),
+    );
+  }
+  return path;
+}
+
+function mkLayer1(obj) {
+  const dir = mkdtempSync(join(tmpdir(), "ctl1214-l1-"));
+  dirs.push(dir);
+  const path = join(dir, "config.json");
+  writeFileSync(path, typeof obj === "string" ? obj : JSON.stringify(obj));
+  return path;
+}
+
+describe("readLayer2MergedFrom (CTL-1214)", () => {
+  it("composes config.json < node.json < cluster-secrets.json", () => {
+    const p = mkLayer2({
+      legacy: { catalyst: { a: "c", keptFromLegacy: 1 } },
+      node: { catalyst: { a: "n", keptFromNode: 2 } },
+      secrets: { catalyst: { a: "s" } },
+    });
+    const merged = readLayer2MergedFrom(p).catalyst;
+    expect(merged.a).toBe("s");
+    expect(merged.keptFromLegacy).toBe(1);
+    expect(merged.keptFromNode).toBe(2);
+  });
+
+  it("deep-merges rather than replacing a nested object", () => {
+    const p = mkLayer2({
+      legacy: { catalyst: { sweep: { idleHours: 48, intervalHours: 1 } } },
+      node: { catalyst: { sweep: { maxRemovalsPerRun: 10 } } },
+    });
+    expect(readLayer2MergedFrom(p).catalyst.sweep).toEqual({
+      idleHours: 48,
+      intervalHours: 1,
+      maxRemovalsPerRun: 10,
+    });
+  });
+
+  it("treats a malformed layer as layer-ABSENT, keeping the others", () => {
+    const p = mkLayer2({
+      legacy: { catalyst: { sweep: { intervalHours: 1 } } },
+      node: "{ not json at all",
+    });
+    expect(readLayer2MergedFrom(p).catalyst.sweep.intervalHours).toBe(1);
+  });
+
+  it("returns an empty catalyst block for a falsy path (never throws)", () => {
+    expect(readLayer2MergedFrom(null)).toEqual({ catalyst: {} });
+    expect(readLayer2MergedFrom("")).toEqual({ catalyst: {} });
+  });
+
+  it("does not read the ambient ~/.config/catalyst when given a fixture root", () => {
+    // Positive control for hermeticity: a fixture whose node.json sets a value
+    // the real host does not have, plus the absence of any real-host key.
+    const p = mkLayer2({ legacy: {}, node: { catalyst: { ctl1214Probe: "fixture-only" } } });
+    const merged = readLayer2MergedFrom(p).catalyst;
+    expect(merged.ctl1214Probe).toBe("fixture-only");
+    expect(merged.linear?.bot).toBeUndefined();
+  });
+});
+
+describe("readExecutionCoreConcurrencyLayer2 — node.json (CTL-1214)", () => {
+  it("resolves a value written ONLY to node.json", () => {
+    const p = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { executionCore: { maxParallel: 7 } } } },
+    });
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({ maxParallel: 7 });
+  });
+
+  it("does NOT shadow a legacy config.json value when node.json omits the field", () => {
+    const p = mkLayer2({
+      legacy: { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+      node: { catalyst: { orchestration: { executionCore: { minParallel: 2 } } } },
+    });
+    // This is the live shape on this host: maxParallel:4 is machine-canonical in
+    // the legacy file (CTL-678). A replace-instead-of-merge would drop it.
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({ maxParallel: 4, minParallel: 2 });
+  });
+
+  it("node.json wins per field over the legacy file", () => {
+    const p = mkLayer2({
+      legacy: { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+      node: { catalyst: { orchestration: { executionCore: { maxParallel: 9 } } } },
+    });
+    expect(readExecutionCoreConcurrencyLayer2(p).maxParallel).toBe(9);
+  });
+
+  it("keeps the {}-on-any-miss contract", () => {
+    expect(readExecutionCoreConcurrencyLayer2(null)).toEqual({});
+    expect(readExecutionCoreConcurrencyLayer2("")).toEqual({});
+    expect(readExecutionCoreConcurrencyLayer2("/no/such/dir/config.json")).toEqual({});
+    expect(readExecutionCoreConcurrencyLayer2(mkLayer2({ legacy: { catalyst: {} } }))).toEqual({});
+  });
+
+  it("a non-object executionCore is {} , never a crash", () => {
+    const p = mkLayer2({ legacy: { catalyst: { orchestration: { executionCore: "nope" } } } });
+    expect(readExecutionCoreConcurrencyLayer2(p)).toEqual({});
+  });
+
+  it("mergeExecutionCoreConcurrency still gets the whole picture end-to-end", () => {
+    // The slimmed-repo shape: Layer-1 carries nothing, node.json carries it all.
+    const l2 = mkLayer2({
+      legacy: { catalyst: { orchestration: { executionCore: { maxParallel: 4 } } } },
+      node: {
+        catalyst: {
+          orchestration: { executionCore: { minParallel: 1, maxParallelCeiling: 40 } },
+        },
+      },
+    });
+    const merged = mergeExecutionCoreConcurrency({}, readExecutionCoreConcurrencyLayer2(l2));
+    expect(merged.maxParallel).toBe(4);
+    expect(merged.minParallel).toBe(1);
+    expect(merged.maxParallelCeiling).toBe(40);
+  });
+});
+
+describe("readLinearReconcileConfig — node.json (CTL-1214)", () => {
+  // CATALYST_RECONCILE_MODE is the documented hardest per-node override and it is
+  // SET in a live phase-agent environment. Strip it around these cases or every
+  // .mode assertion measures the ambient env instead of the resolution ladder.
+  let savedMode;
+  beforeEach(() => {
+    savedMode = process.env.CATALYST_RECONCILE_MODE;
+    delete process.env.CATALYST_RECONCILE_MODE;
+  });
+  afterEach(() => {
+    if (savedMode === undefined) delete process.env.CATALYST_RECONCILE_MODE;
+    else process.env.CATALYST_RECONCILE_MODE = savedMode;
+  });
+
+  it("resolves .mode written ONLY to node.json", () => {
+    const l1 = mkLayer1({ catalyst: { projectKey: "x" } });
+    const l2 = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { reconcile: { mode: "notify", intervalSeconds: 600 } } } },
+    });
+    expect(readLinearReconcileConfig(l1, l2)).toEqual({ mode: "notify", intervalSeconds: 600 });
+  });
+
+  it("CATALYST_RECONCILE_MODE still beats both layers", () => {
+    process.env.CATALYST_RECONCILE_MODE = "off";
+    const l1 = mkLayer1({ catalyst: { orchestration: { reconcile: { mode: "write" } } } });
+    const l2 = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { reconcile: { mode: "notify" } } } },
+    });
+    expect(readLinearReconcileConfig(l1, l2).mode).toBe("off");
+  });
+
+  it("Layer-2 wins per field; Layer-1 fills the rest (D8)", () => {
+    const l1 = mkLayer1({
+      catalyst: { orchestration: { reconcile: { mode: "notify", intervalSeconds: 600 } } },
+    });
+    const l2 = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { reconcile: { mode: "write" } } } },
+    });
+    expect(readLinearReconcileConfig(l1, l2)).toEqual({ mode: "write", intervalSeconds: 600 });
+  });
+
+  it("a legacy config.json value is not shadowed when node.json omits the field", () => {
+    const l1 = mkLayer1({ catalyst: {} });
+    const l2 = mkLayer2({
+      legacy: { catalyst: { orchestration: { reconcile: { mode: "notify" } } } },
+      node: { catalyst: { orchestration: { reconcile: { intervalSeconds: 900 } } } },
+    });
+    expect(readLinearReconcileConfig(l1, l2)).toEqual({ mode: "notify", intervalSeconds: 900 });
+  });
+
+  it("un-slimmed repo: Layer-1 alone still resolves (back-compat)", () => {
+    const l1 = mkLayer1({
+      catalyst: { orchestration: { reconcile: { mode: "notify", intervalSeconds: 600 } } },
+    });
+    const l2 = mkLayer2({ legacy: {} });
+    expect(readLinearReconcileConfig(l1, l2)).toEqual({ mode: "notify", intervalSeconds: 600 });
+  });
+
+  it("malformed Layer-2 leaves Layer-1 intact and never throws", () => {
+    const l1 = mkLayer1({ catalyst: { orchestration: { reconcile: { mode: "notify" } } } });
+    const l2 = mkLayer2({ legacy: "{ not json", node: "{ also not json" });
+    expect(() => readLinearReconcileConfig(l1, l2)).not.toThrow();
+    expect(readLinearReconcileConfig(l1, l2)).toEqual({ mode: "notify" });
+  });
+});

--- a/plugins/dev/scripts/execution-core/linear-reconcile-timer.mjs
+++ b/plugins/dev/scripts/execution-core/linear-reconcile-timer.mjs
@@ -16,7 +16,7 @@
 
 import { readFileSync, writeFileSync, renameSync, appendFileSync } from "node:fs";
 import { join } from "node:path";
-import { log, getEventLogPath } from "./config.mjs";
+import { log, getEventLogPath, readLayer2MergedFrom } from "./config.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 import { DEFAULTS, reconcileDeclarations, orderedStatesForMap } from "./linear-reconcile.mjs";
 import { listDeclarations, markReconciled } from "./linear-reconcile-store.mjs";
@@ -30,7 +30,7 @@ import { isLinearTerminal } from "./terminal-state.mjs";
 // CATALYST_RECONCILE_MODE env override (the per-node safety switch for this
 // WRITER — Codex P2). Returns {} for missing/unreadable/absent keys.
 export function readLinearReconcileConfig(layer1Path, layer2Path) {
-  const readOne = (p) => {
+  const readLayer1 = (p) => {
     if (!p) return {};
     try {
       return JSON.parse(readFileSync(p, "utf8"))?.catalyst?.orchestration?.reconcile ?? {};
@@ -44,8 +44,25 @@ export function readLinearReconcileConfig(layer1Path, layer2Path) {
       return {};
     }
   };
+  // CTL-1214: the Layer-2 arm reads the MERGED view (config.json < node.json <
+  // cluster-secrets.json) so a value the migration wrote to node.json is seen.
+  // Same never-throw, {}-on-any-miss contract; byte-identical with no node.json.
+  const readLayer2 = (p) => {
+    if (!p) return {};
+    try {
+      const block = readLayer2MergedFrom(p)?.catalyst?.orchestration?.reconcile;
+      if (!block || typeof block !== "object" || Array.isArray(block)) return {};
+      return block;
+    } catch (err) {
+      log.warn(
+        { configPath: p, err: err.message },
+        "linear-reconcile: Layer-2 config unreadable; ignoring"
+      );
+      return {};
+    }
+  };
   // Layer-2 wins per field (node-scoped override of the committed Layer-1 seed).
-  const merged = { ...readOne(layer1Path), ...readOne(layer2Path) };
+  const merged = { ...readLayer1(layer1Path), ...readLayer2(layer2Path) };
   const envMode = process.env.CATALYST_RECONCILE_MODE;
   if (envMode) merged.mode = envMode; // hardest per-node override
   return merged;

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -1808,21 +1808,13 @@ export function mergeExecutionCoreConcurrency(layer1 = {}, layer2 = {}) {
   return validatePerProjectBudgets(merged);
 }
 
-// resolveTargetSetpoint — CTL-770: resolve the autotuner's seek-to TARGET with
-// host-over-repo layering. The HOST Layer-2 file may carry a NEW key
-// `catalyst.orchestration.executionCore.targetParallel` (distinct from
-// `maxParallel`, which the autotuner clobbers every tick as its live runtime
-// mirror — reusing it for the target would be overwritten). When the host key is
-// a positive integer it wins; otherwise fall back to Layer-1's committed
-// `maxParallel`. Returns `undefined` when neither is set → the caller's
-// convergence branches no-op (backward-compatible). Positive-int guard mirrors
-// mergeExecutionCoreConcurrency (:463-465) so a malformed host value never zeroes
-// the setpoint. The caller is responsible for core-bounding the result.
-export function resolveTargetSetpoint(layer1 = {}, layer2 = {}) {
-  const t = layer2?.targetParallel;
-  if (Number.isInteger(t) && t > 0) return t;
-  return layer1?.maxParallel;
-}
+// resolveTargetSetpoint — CTL-770's setpoint ladder, now defined in the
+// zero-import leaf `lib/autotune-setpoint.mjs` and RE-EXPORTED here so every
+// existing importer (autotune.mjs, scheduler.test.mjs, config-dump.mjs) is
+// unchanged. CTL-1214: `catalyst doctor` grades the setpoint's presence and runs
+// under bare Node, which cannot load this module (it reaches bun:sqlite) — the
+// extraction is what lets doctor read the SAME ladder instead of a second copy.
+export { resolveTargetSetpoint } from "../lib/autotune-setpoint.mjs";
 
 // validatePerProjectBudgets — clamps over-subscribed reserves so
 // sum(reserve) ≤ maxParallel, warns once per distinct config (CTL-706).

--- a/plugins/dev/scripts/execution-core/scheduler.mjs
+++ b/plugins/dev/scripts/execution-core/scheduler.mjs
@@ -278,6 +278,7 @@ import {
   readCostCapConfig,
   readEmptyWorkerDirGraceMs,
   EMPTY_WORKER_DIR_GRACE_DEFAULT_MS,
+  readLayer2MergedFrom,
 } from "./config.mjs";
 // CTL-1137: cost-cap watcher (Pass 0c) — out-of-process per-session $ preemption.
 import {
@@ -1735,19 +1736,25 @@ export function readExecutionCoreConcurrency(configPath) {
 // overrides are out of scope today (see CTL-678 plan, Decision 1).
 export function readExecutionCoreConcurrencyLayer2(layer2Path) {
   if (!layer2Path) return {};
-  let parsed;
+  // CTL-1214: read the MERGED Layer-2 view (config.json < node.json <
+  // cluster-secrets.json) rather than the legacy file alone, so a value the
+  // migration wrote to node.json is visible here. readLayer2MergedFrom resolves
+  // the two siblings off layer2Path's own directory and swallows an
+  // absent/malformed layer per file, so this keeps the same never-throw,
+  // {}-on-any-miss contract — and with no node.json present (every host today)
+  // the result is byte-identical to the previous single-file read.
+  let block;
   try {
-    parsed = JSON.parse(readFileSync(layer2Path, "utf8"));
+    block = readLayer2MergedFrom(layer2Path)?.catalyst?.orchestration?.executionCore;
   } catch (err) {
-    if (err?.code !== "ENOENT") {
-      log.warn(
-        { layer2Path, err: err.message },
-        "execution-core: Layer-2 concurrency config unreadable; using Layer-1"
-      );
-    }
+    log.warn(
+      { layer2Path, err: err.message },
+      "execution-core: Layer-2 concurrency config unreadable; using Layer-1"
+    );
     return {};
   }
-  return parsed?.catalyst?.orchestration?.executionCore ?? {};
+  if (!block || typeof block !== "object" || Array.isArray(block)) return {};
+  return block;
 }
 
 // mergeExecutionCoreConcurrency — per-field merge of Layer-1 (committed

--- a/plugins/dev/scripts/execution-core/worktree-refresh-timer.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-refresh-timer.mjs
@@ -10,31 +10,65 @@ import { fileURLToPath } from "node:url";
 import { readWorkerSignals } from "./signal-reader.mjs";
 import { isBgJobAlive } from "./claude-agents.mjs";
 import { isSdkWorkerLive as registrySdkWorkerLive } from "./sdk-worker-registry.mjs";
-import { log } from "./config.mjs";
+import { log, readLayer2MergedFrom } from "./config.mjs";
 
 const REFRESH_BIN = fileURLToPath(
   new URL("../lib/worktree-refresh.sh", import.meta.url)
 );
 
 /**
- * readWorktreeRefreshConfig — read catalyst.orchestration.worktreeRefresh.*
- * from .catalyst/config.json. Returns {} for missing/unreadable/absent key.
+ * readWorktreeRefreshConfig — read catalyst.orchestration.worktreeRefresh.*,
+ * merged across Layer-1 (the committed .catalyst/config.json seed) and Layer-2
+ * (the node-scoped ~/.config/catalyst/{config,node,cluster-secrets}.json), with
+ * Layer-2 winning PER FIELD (CTL-1214 D8 — the same rule
+ * mergeExecutionCoreConcurrency and readLinearReconcileConfig already use).
+ *
+ * Before CTL-1214 this was a Layer-1-ONLY read that returns {} on any miss, so
+ * once Phase 4 slims the committed config the whole stanza would have vanished
+ * into the code defaults with no error — enabled/intervalSeconds/quietSeconds
+ * silently reverting. The Layer-2 arm is what makes the slimming safe; with
+ * layer2Path omitted (or no Layer-2 files present) the result is byte-identical
+ * to the old behavior, which is why daemon.mjs's one-argument call still works.
+ *
+ * @param {string} configPath - Layer-1 .catalyst/config.json
+ * @param {string} [layer2Path] - Layer-2 config.json; node.json and
+ *   cluster-secrets.json are resolved as its siblings.
  */
-export function readWorktreeRefreshConfig(configPath) {
-  if (!configPath) return {};
-  let parsed;
-  try {
-    parsed = JSON.parse(readFileSync(configPath, "utf8"));
-  } catch (err) {
-    if (err?.code !== "ENOENT") {
-      log.warn(
-        { configPath, err: err.message },
-        "worktree-refresh: config unreadable; using defaults"
-      );
+export function readWorktreeRefreshConfig(configPath, layer2Path) {
+  const layer1 = (() => {
+    if (!configPath) return {};
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    } catch (err) {
+      if (err?.code !== "ENOENT") {
+        log.warn(
+          { configPath, err: err.message },
+          "worktree-refresh: config unreadable; using defaults"
+        );
+      }
+      return {};
     }
-    return {};
+    return parsed?.catalyst?.orchestration?.worktreeRefresh ?? {};
+  })();
+
+  if (!layer2Path) return layer1;
+
+  // Fail-open: readLayer2MergedFrom swallows absent/malformed layers per file, so
+  // a broken Layer-2 can never take down a healthy Layer-1 value.
+  let layer2 = {};
+  try {
+    layer2 = readLayer2MergedFrom(layer2Path)?.catalyst?.orchestration?.worktreeRefresh ?? {};
+  } catch (err) {
+    log.warn(
+      { layer2Path, err: err.message },
+      "worktree-refresh: Layer-2 config unreadable; using Layer-1"
+    );
+    layer2 = {};
   }
-  return parsed?.catalyst?.orchestration?.worktreeRefresh ?? {};
+  if (!layer2 || typeof layer2 !== "object" || Array.isArray(layer2)) return layer1;
+
+  return { ...layer1, ...layer2 };
 }
 
 function realClock() {

--- a/plugins/dev/scripts/execution-core/worktree-refresh-timer.test.mjs
+++ b/plugins/dev/scripts/execution-core/worktree-refresh-timer.test.mjs
@@ -294,3 +294,98 @@ describe("readWorktreeRefreshConfig", () => {
     expect(readWorktreeRefreshConfig("")).toEqual({});
   });
 });
+
+// CTL-1214 Phase 1: the Layer-2 fallback. catalyst.orchestration.worktreeRefresh
+// was a Layer-1-ONLY read that fails open to {}, so slimming the committed config
+// would have silently reverted the knob to its code defaults. Layer-2 now supplies
+// it, Layer-2 winning per field (D8).
+describe("readWorktreeRefreshConfig Layer-2 fallback (CTL-1214)", () => {
+  let dirs = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs = [];
+  });
+
+  // Layer-2 siblings resolve off the given layer2Path's DIRECTORY, exactly as
+  // resolveNodeConfigPath() does — so a fixture dir stays hermetic (no node.json
+  // there) instead of reaching into the real ~/.config/catalyst.
+  const mkLayer2 = ({ legacy, node }) => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1214-l2-"));
+    dirs.push(dir);
+    const path = join(dir, "config.json");
+    writeFileSync(path, JSON.stringify(legacy ?? {}));
+    if (node !== undefined) writeFileSync(join(dir, "node.json"), JSON.stringify(node));
+    return path;
+  };
+  const mkLayer1 = (obj) => {
+    const dir = mkdtempSync(join(tmpdir(), "ctl1214-l1-"));
+    dirs.push(dir);
+    const path = join(dir, "config.json");
+    writeFileSync(path, JSON.stringify(obj));
+    return path;
+  };
+
+  it("Layer-1 present, Layer-2 absent -> Layer-1 value (un-slimmed repo)", () => {
+    const l1 = mkLayer1({
+      catalyst: { orchestration: { worktreeRefresh: { enabled: true, intervalSeconds: 300 } } },
+    });
+    const l2 = mkLayer2({ legacy: {} });
+    expect(readWorktreeRefreshConfig(l1, l2)).toEqual({ enabled: true, intervalSeconds: 300 });
+  });
+
+  it("Layer-1 absent, node.json present -> node.json value (the slimmed repo)", () => {
+    const l1 = mkLayer1({ catalyst: { projectKey: "x" } });
+    const l2 = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { worktreeRefresh: { enabled: true, intervalSeconds: 300, quietSeconds: 30 } } } },
+    });
+    expect(readWorktreeRefreshConfig(l1, l2)).toEqual({
+      enabled: true,
+      intervalSeconds: 300,
+      quietSeconds: 30,
+    });
+  });
+
+  it("both present, differing fields -> Layer-2 wins per field, Layer-1 fills the rest (D8)", () => {
+    const l1 = mkLayer1({
+      catalyst: {
+        orchestration: { worktreeRefresh: { enabled: true, intervalSeconds: 300, quietSeconds: 30 } },
+      },
+    });
+    const l2 = mkLayer2({
+      legacy: {},
+      node: { catalyst: { orchestration: { worktreeRefresh: { intervalSeconds: 60 } } } },
+    });
+    expect(readWorktreeRefreshConfig(l1, l2)).toEqual({
+      enabled: true,
+      intervalSeconds: 60,
+      quietSeconds: 30,
+    });
+  });
+
+  it("both absent -> {} (unchanged)", () => {
+    const l1 = mkLayer1({ catalyst: {} });
+    const l2 = mkLayer2({ legacy: {} });
+    expect(readWorktreeRefreshConfig(l1, l2)).toEqual({});
+  });
+
+  it("Layer-2 malformed -> Layer-1 preserved, never a throw", () => {
+    const l1 = mkLayer1({
+      catalyst: { orchestration: { worktreeRefresh: { enabled: true, intervalSeconds: 300 } } },
+    });
+    const dir = mkdtempSync(join(tmpdir(), "ctl1214-l2bad-"));
+    dirs.push(dir);
+    const l2 = join(dir, "config.json");
+    writeFileSync(l2, "{ not json");
+    writeFileSync(join(dir, "node.json"), "{ also not json");
+    expect(() => readWorktreeRefreshConfig(l1, l2)).not.toThrow();
+    expect(readWorktreeRefreshConfig(l1, l2)).toEqual({ enabled: true, intervalSeconds: 300 });
+  });
+
+  it("the one-argument signature still works (daemon.mjs:3149 call site)", () => {
+    const l1 = mkLayer1({
+      catalyst: { orchestration: { worktreeRefresh: { enabled: false } } },
+    });
+    expect(readWorktreeRefreshConfig(l1)).toEqual({ enabled: false });
+  });
+});

--- a/plugins/dev/scripts/feedback-consent.sh
+++ b/plugins/dev/scripts/feedback-consent.sh
@@ -104,22 +104,31 @@ case "$SUBCOMMAND" in
     ;;
 
   grant)
-    mkdir -p "$(dirname "$CONFIG_PATH")"
-    if [ ! -f "$CONFIG_PATH" ]; then
-      echo '{}' > "$CONFIG_PATH"
+    # CTL-1214: consent is NODE-scoped, so it is recorded in the machine-local
+    # node.json — never patched back into the committed .catalyst/config.json,
+    # which would re-leak the stanza the Phase-4 slimming removes. Reads stay
+    # Layer-1-then-Layer-2 (see read_auto_file above), so an operator who granted
+    # consent BEFORE this change is unaffected: their Layer-1 value still wins.
+    _FC_L2="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+    _FC_NODE="$(dirname "$_FC_L2")/node.json"
+    mkdir -p "$(dirname "$_FC_NODE")"
+    if [ ! -f "$_FC_NODE" ]; then
+      printf '{}\n' > "$_FC_NODE"
+      chmod 600 "$_FC_NODE"
     fi
-    TMP="${CONFIG_PATH}.tmp.$$"
+    TMP="${_FC_NODE}.tmp.$$"
     if jq '.catalyst = (.catalyst // {})
-           | .catalyst.feedback = (.catalyst.feedback // {})
+           | .catalyst.feedback = (if (.catalyst.feedback | type) == "object" then .catalyst.feedback else {} end)
            | .catalyst.feedback.autoFile = true
            | .catalyst.feedback.githubRepo = (.catalyst.feedback.githubRepo // "coalesce-labs/catalyst")
            | .catalyst.feedback.labels = (.catalyst.feedback.labels // ["auto-submitted"])' \
-         "$CONFIG_PATH" > "$TMP"; then
-      mv "$TMP" "$CONFIG_PATH"
+         "$_FC_NODE" > "$TMP"; then
+      chmod 600 "$TMP"
+      mv "$TMP" "$_FC_NODE"
       echo "granted"
     else
       rm -f "$TMP"
-      echo "ERROR: failed to update config" >&2
+      echo "ERROR: failed to update ${_FC_NODE}" >&2
       exit 1
     fi
     ;;

--- a/plugins/dev/scripts/feedback-consent.sh
+++ b/plugins/dev/scripts/feedback-consent.sh
@@ -66,12 +66,31 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+# CTL-1214: the merged-Layer-2 leaf. catalyst.feedback.* had NO Layer-2 reader,
+# so once the committed config is slimmed a granted consent reads back as
+# "unset" — silently, because an absent key and a withheld consent are the same
+# empty string here.
+_FC_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "${_FC_SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]; then
+  # shellcheck disable=SC1090
+  . "${_FC_SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+fi
+
 read_auto_file() {
-  if [ ! -f "$CONFIG_PATH" ]; then
-    echo ""
-    return 0
+  _fc_val=""
+  if [ -f "$CONFIG_PATH" ]; then
+    _fc_val="$(jq -r '.catalyst.feedback.autoFile // empty' "$CONFIG_PATH" 2>/dev/null)"
   fi
-  jq -r '.catalyst.feedback.autoFile // empty' "$CONFIG_PATH" 2>/dev/null
+  # Layer-1 wins when present; Layer-2 answers only when Layer-1 is silent.
+  # ⚠️ catalyst.feedback is a STRING in the live Layer-2 config
+  # ("https://github.com/coalesce-labs/catalyst.git"), so a bare jq walk of
+  # .catalyst.feedback.autoFile would die with "Cannot index string with
+  # autoFile". catalyst_layer2_json wraps the walk in try/catch and yields empty.
+  if [ -z "$_fc_val" ] && command -v catalyst_layer2_json >/dev/null 2>&1; then
+    _fc_val="$(catalyst_layer2_json '.catalyst.feedback.autoFile')"
+  fi
+  echo "$_fc_val"
+  return 0
 }
 
 case "$SUBCOMMAND" in

--- a/plugins/dev/scripts/file-feedback.sh
+++ b/plugins/dev/scripts/file-feedback.sh
@@ -105,9 +105,29 @@ TEAM_KEY=""
 if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
   AUTO_FILE=$(jq -r '.catalyst.feedback.autoFile // empty' "$CONFIG_PATH" 2>/dev/null)
   GITHUB_REPO=$(jq -r '.catalyst.feedback.githubRepo // empty' "$CONFIG_PATH" 2>/dev/null)
-  CONFIG_LABELS=$(jq -r '.catalyst.feedback.labels // ["auto-submitted"] | join(",")' \
+  CONFIG_LABELS=$(jq -r '.catalyst.feedback.labels // empty | if type == "array" then join(",") else empty end' \
     "$CONFIG_PATH" 2>/dev/null)
   TEAM_KEY=$(jq -r '.catalyst.linear.teamKey // empty' "$CONFIG_PATH" 2>/dev/null)
+fi
+
+# CTL-1214: Layer-2 fallback for the relocated catalyst.feedback.* keys. Layer-1
+# wins when present; Layer-2 answers only when Layer-1 is silent. teamKey is
+# NOT relocated (it is project identity) and keeps its Layer-1-only read.
+# ⚠️ catalyst.feedback is a STRING in the live Layer-2 config, so these must go
+# through catalyst_layer2_json's try/catch rather than a bare jq walk.
+_FF_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -r "${_FF_SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]; then
+  # shellcheck disable=SC1090
+  . "${_FF_SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+  [ -z "$AUTO_FILE" ]   && AUTO_FILE="$(catalyst_layer2_json '.catalyst.feedback.autoFile')"
+  [ -z "$GITHUB_REPO" ] && GITHUB_REPO="$(catalyst_layer2_json '.catalyst.feedback.githubRepo')"
+  if [ -z "$CONFIG_LABELS" ]; then
+    _ff_labels="$(catalyst_layer2_json '.catalyst.feedback.labels')"
+    if [ -n "$_ff_labels" ]; then
+      CONFIG_LABELS="$(printf '%s' "$_ff_labels" \
+        | jq -r 'if type == "array" then join(",") else empty end' 2>/dev/null || printf '')"
+    fi
+  fi
 fi
 
 # Defaults when config is silent.

--- a/plugins/dev/scripts/install-orphan-sweep.sh
+++ b/plugins/dev/scripts/install-orphan-sweep.sh
@@ -26,6 +26,14 @@ SCRIPT_DIR="$(cd "$(dirname "$_SRC")" && pwd)"
   echo "install-orphan-sweep.sh: missing lib/launchd-domain-guard.sh next to this script" >&2; exit 1; }
 # shellcheck source=lib/launchd-domain-guard.sh
 . "${SCRIPT_DIR}/lib/launchd-domain-guard.sh"
+
+# CTL-1214: the merged-Layer-2 leaf, sourced once. Optional by design — the two
+# call sites below both guard with `command -v catalyst_layer2_json`, so a
+# checkout without the leaf keeps its Layer-1-only behavior rather than failing.
+if [[ -r "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]]; then
+  # shellcheck source=lib/catalyst-layer2-read.sh
+  . "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+fi
 launchd_agent_guard() {
   launchd_guard_ok "the orphan-sweep agent" && return 0
   launchd_guard_message "the orphan-sweep agent" >&2
@@ -138,12 +146,18 @@ _interval_seconds() {
     dir="$(dirname "$dir")"
   done
 
+  local raw=""
   if [[ -n "$config_candidate" ]] && command -v jq >/dev/null 2>&1; then
-    local raw
     raw="$(jq -r '.catalyst.sweep.intervalHours // empty' "$config_candidate" 2>/dev/null || true)"
-    if [[ -n "$raw" ]] && [[ "$raw" =~ ^[0-9]+$ ]]; then
-      hours="$raw"
-    fi
+  fi
+  # CTL-1214: Layer-2 fallback — a slimmed Layer-1 config otherwise silently
+  # installs the DEFAULT cadence instead of the configured one, and this value is
+  # baked into a launchd plist where the drift is invisible afterwards.
+  if [[ -z "$raw" ]] && command -v catalyst_layer2_json >/dev/null 2>&1; then
+    raw="$(catalyst_layer2_json '.catalyst.sweep.intervalHours')"
+  fi
+  if [[ -n "$raw" ]] && [[ "$raw" =~ ^[0-9]+$ ]]; then
+    hours="$raw"
   fi
 
   # Clamp to 1–3.
@@ -208,8 +222,16 @@ _config_widen_mode() {
     if [[ -f "$dir/.catalyst/config.json" ]]; then cfg="$dir/.catalyst/config.json"; break; fi
     dir="$(dirname "$dir")"
   done
-  [[ -n "$cfg" ]] && command -v jq >/dev/null 2>&1 || { printf ''; return 0; }
-  jq -r '.catalyst.sweep.procWiden // empty' "$cfg" 2>/dev/null || printf ''
+  local _v=""
+  if [[ -n "$cfg" ]] && command -v jq >/dev/null 2>&1; then
+    _v="$(jq -r '.catalyst.sweep.procWiden // empty' "$cfg" 2>/dev/null || printf '')"
+  fi
+  # CTL-1214: Layer-2 fallback (see _resolve_interval_hours above).
+  if [[ -z "$_v" ]] && command -v catalyst_layer2_json >/dev/null 2>&1; then
+    _v="$(catalyst_layer2_json '.catalyst.sweep.procWiden')"
+  fi
+  printf '%s' "$_v"
+  return 0
 }
 
 _resolve_widen_mode() {

--- a/plugins/dev/scripts/lib/autotune-setpoint.mjs
+++ b/plugins/dev/scripts/lib/autotune-setpoint.mjs
@@ -1,0 +1,38 @@
+// autotune-setpoint.mjs — CTL-770's setpoint resolver, extracted (CTL-1214).
+//
+// ⛔ ZERO-IMPORT LEAF, and that is the whole reason this file exists. The
+// resolver lived in `execution-core/scheduler.mjs`, which reaches `bun:sqlite`
+// and therefore CANNOT be loaded by `catalyst doctor` — doctor runs under BARE
+// NODE (measured: `import("./execution-core/scheduler.mjs")` under node v24
+// rejects with "Only URLs with a scheme in: file, data, and node are supported
+// … Received protocol 'bun:'"). Without the extraction, doctor's
+// `autotune-setpoint-present` arm would have had to re-type the ladder, and a
+// second copy of a 4-line precedence rule is exactly how a grade silently stops
+// matching the behavior it grades. `scheduler.mjs` re-exports this symbol, so
+// every existing importer is unchanged.
+//
+// Same discipline as `lib/event-name.mjs` and `lib/secret-contract.mjs`: one
+// definition, kept reachable from the bare-Node runtime by having no imports at
+// all — do not add any.
+
+/**
+ * resolveTargetSetpoint — CTL-770: resolve the autotuner's seek-to TARGET with
+ * host-over-repo layering. The HOST Layer-2 file may carry
+ * `catalyst.orchestration.executionCore.targetParallel` (distinct from
+ * `maxParallel`, which the autotuner clobbers every tick as its live runtime
+ * mirror — reusing it for the target would be overwritten). When the host key is
+ * a positive integer it wins; otherwise fall back to Layer-1's committed
+ * `maxParallel`. Returns `undefined` when neither is set → the caller's
+ * convergence branches no-op (backward-compatible). The positive-int guard
+ * mirrors mergeExecutionCoreConcurrency so a malformed host value never zeroes
+ * the setpoint. The caller is responsible for core-bounding the result.
+ *
+ * @param {{maxParallel?: unknown}} [layer1]
+ * @param {{targetParallel?: unknown}} [layer2]
+ * @returns {number|undefined}
+ */
+export function resolveTargetSetpoint(layer1 = {}, layer2 = {}) {
+  const t = layer2?.targetParallel;
+  if (Number.isInteger(t) && t > 0) return t;
+  return layer1?.maxParallel;
+}

--- a/plugins/dev/scripts/lib/catalyst-layer2-read.sh
+++ b/plugins/dev/scripts/lib/catalyst-layer2-read.sh
@@ -9,6 +9,12 @@
 # by __tests__/layer2-read-parity.test.sh over a fixture matrix, with each side
 # additionally checked against a computed expected value.
 #
+# ⚠️ "config.json" above names the DEFAULT legacy file, not a fixed one: when
+# CATALYST_LAYER2_CONFIG_FILE pins a path, THAT file is the legacy layer and only
+# node.json / cluster-secrets.json are resolved from its directory — matching
+# readLayer2MergedFrom. The parity suite now pins a non-config.json name in its
+# own case, so this agreement claim is backed by a fixture that can fail.
+#
 # WHY this exists: CTL-1214 Phase 6 slims the committed .catalyst/config.json.
 # Four relocated categories (dispatchMode, worktreeRefresh, feedback, sweep) are
 # read from Layer-1 ONLY and every one of those readers is fail-open to a code
@@ -57,6 +63,33 @@ _catalyst_layer2_dir() {
   printf '%s' "${_home}/.config/catalyst"
 }
 
+# _catalyst_layer2_legacy_file — the LEGACY (lowest-precedence) Layer-2 file.
+#
+# ⚠️ CTL-1214 remediation. This used to be `$(_catalyst_layer2_dir)/config.json`
+# unconditionally, which is NOT what the JS twin does: readLayer2MergedFrom reads
+# the pinned PATH ITSELF as the legacy layer and resolves node.json /
+# cluster-secrets.json as its SIBLINGS (config.mjs:558-562). So with
+# CATALYST_LAYER2_CONFIG_FILE=<dir>/config-adva.json the two stacks read
+# DIFFERENT FILES — measured with distinct probe values, bash returned the
+# config.json value and JS the config-adva.json one — while this file's header
+# claimed the two "are held in agreement over a fixture matrix". They were not:
+# the parity suite pinned `${D}/config.json` at both of its call sites, so the
+# one axis the implementations actually differ on could never be observed.
+#
+# Latent rather than live (no production setter pins a non-config.json name), but
+# per-project Layer-2 files ARE named config-{projectKey}.json and several exist
+# on this host, so the shape is one call away. Taking the pinned filename makes
+# the two stacks agree BY CONSTRUCTION; when the pin is absent or already named
+# config.json — every real case today — the resolved path is byte-identical to
+# before, so this is a no-op in production.
+_catalyst_layer2_legacy_file() {
+  if [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]]; then
+    printf '%s' "$CATALYST_LAYER2_CONFIG_FILE"
+    return 0
+  fi
+  printf '%s' "$(_catalyst_layer2_dir)/config.json"
+}
+
 # _catalyst_layer2_note_divergence — one stderr line + a breadcrumb when the
 # canonical chain would have resolved a different file than the legacy chain we
 # follow. Never changes the answer; makes the split observable.
@@ -90,13 +123,16 @@ catalyst_layer2_json() {
 
   local _dir; _dir="$(_catalyst_layer2_dir)"
   [[ -z "$_dir" ]] && { printf ''; return 0; }
+  local _legacy; _legacy="$(_catalyst_layer2_legacy_file)"
 
   # Build the argument list from the files that exist AND parse. A malformed file
   # must be layer-ABSENT rather than poisoning the whole merge, so each is
   # validated on its own before it joins the composition.
   local -a _files=()
   local _f
-  for _f in "${_dir}/config.json" "${_dir}/node.json" "${_dir}/cluster-secrets.json"; do
+  # Lowest precedence first: the legacy file (the PINNED path when one is set —
+  # see _catalyst_layer2_legacy_file), then its two siblings from _dir.
+  for _f in "$_legacy" "${_dir}/node.json" "${_dir}/cluster-secrets.json"; do
     [[ -f "$_f" ]] || continue
     jq -e 'type == "object"' "$_f" >/dev/null 2>&1 || continue
     _files+=("$_f")

--- a/plugins/dev/scripts/lib/catalyst-layer2-read.sh
+++ b/plugins/dev/scripts/lib/catalyst-layer2-read.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# catalyst-layer2-read.sh — the ONE merged-Layer-2 reader for the bash stack
+# (CTL-1214 Phase 1).
+#
+# Composes the three Layer-2 files, lowest precedence first:
+#   config.json  <  node.json  <  cluster-secrets.json
+# and echoes the value at a caller-supplied jq path. This is the bash twin of
+# execution-core/config.mjs's readLayer2Merged(); the two are held in agreement
+# by __tests__/layer2-read-parity.test.sh over a fixture matrix, with each side
+# additionally checked against a computed expected value.
+#
+# WHY this exists: CTL-1214 Phase 6 slims the committed .catalyst/config.json.
+# Four relocated categories (dispatchMode, worktreeRefresh, feedback, sweep) are
+# read from Layer-1 ONLY and every one of those readers is fail-open to a code
+# default — so deleting them does not error, it SILENTLY reverts each knob. This
+# leaf is the fallback that makes the slimming safe.
+#
+# ⚠️ PATH CHAIN — deliberately the LEGACY chain, not catalyst-secret-contract.sh's.
+# There are two Layer-2 chains in this repo and they differ:
+#   legacy    (config.mjs getLayer2ConfigPath): CATALYST_LAYER2_CONFIG_FILE > ~/.config/catalyst
+#   canonical (secret-contract):  CATALYST_LAYER2_CONFIG_FILE > CATALYST_MACHINE_CONFIG
+#                                 > $XDG_CONFIG_HOME/catalyst > ~/.config/catalyst
+# This reader serves the SAME knobs the JS readers serve, and those readers all
+# resolve through getLayer2ConfigPath(), which returns the LEGACY path on purpose
+# (see its docstring: it feeds write destinations whose readers are split across
+# both chains, and the canonical cutover must land as one sweep). Using the
+# canonical chain here would make bash and JS resolve DIFFERENT FILES on a
+# MACHINE_CONFIG/XDG-only host — a new split of exactly the kind CTL-1616 PR6
+# refused to create, and it would make the parity contract unsatisfiable. So this
+# tracks the legacy chain, and reports the divergence (rather than silently
+# picking a side) via the CATALYST_LAYER2_READ_PATH_DIVERGENCE breadcrumb, the
+# same posture as the JS warn.
+#
+# Failure posture is fail-open at EVERY step: an absent file, a malformed file, a
+# path that indexes through a non-object, or a null value all yield empty + rc 0.
+# A caller's existing default therefore still applies, which is what keeps this
+# additive. jq-less hosts are a DECLARED asymmetry (matching
+# lib/catalyst-deployment-mode.sh): empty + a breadcrumb + one stderr line, so the
+# degradation is observable rather than silent.
+
+[[ -n "${_CATALYST_LAYER2_READ_SH_LOADED:-}" ]] && return 0
+_CATALYST_LAYER2_READ_SH_LOADED=1
+
+# _catalyst_layer2_dir — the directory holding the three Layer-2 files.
+# Mirrors config.mjs getLayer2ConfigPath()'s legacy chain, then takes its dirname
+# exactly as resolveNodeConfigPath()/resolveClusterSecretsPath() do.
+_catalyst_layer2_dir() {
+  if [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]]; then
+    printf '%s' "$(dirname "$CATALYST_LAYER2_CONFIG_FILE")"
+    return 0
+  fi
+  # HOME fallback (the catalyst-secret-contract.sh:222 lesson): a bare "${HOME:-}"
+  # silently probes /.config/catalyst on a HOME-less service environment instead
+  # of the real per-user default. `~` expands via the passwd entry when HOME is unset.
+  local _home="${HOME-}"
+  [[ -z "$_home" ]] && _home=~
+  printf '%s' "${_home}/.config/catalyst"
+}
+
+# _catalyst_layer2_note_divergence — one stderr line + a breadcrumb when the
+# canonical chain would have resolved a different file than the legacy chain we
+# follow. Never changes the answer; makes the split observable.
+_catalyst_layer2_note_divergence() {
+  [[ -n "${CATALYST_LAYER2_CONFIG_FILE:-}" ]] && return 0
+  [[ -z "${CATALYST_MACHINE_CONFIG:-}${XDG_CONFIG_HOME:-}" ]] && return 0
+  [[ -n "${_CATALYST_LAYER2_READ_DIVERGENCE_WARNED:-}" ]] && return 0
+  _CATALYST_LAYER2_READ_DIVERGENCE_WARNED=1
+  export CATALYST_LAYER2_READ_PATH_DIVERGENCE=1
+  echo "catalyst-layer2-read: CATALYST_MACHINE_CONFIG/XDG_CONFIG_HOME is set but this reader follows the LEGACY Layer-2 chain (parity with config.mjs getLayer2ConfigPath); pin CATALYST_LAYER2_CONFIG_FILE to make the two chains agree" >&2
+}
+
+# catalyst_layer2_json <jq-path> — echo the merged Layer-2 value at <jq-path>.
+# Scalars print bare (a string without quotes); objects/arrays print as compact
+# JSON. Absent / null / unindexable / malformed => empty string, rc 0.
+catalyst_layer2_json() {
+  local _path="${1:-}"
+  [[ -z "$_path" ]] && { printf ''; return 0; }
+
+  if ! command -v jq >/dev/null 2>&1; then
+    if [[ -z "${_CATALYST_LAYER2_READ_JQ_WARNED:-}" ]]; then
+      _CATALYST_LAYER2_READ_JQ_WARNED=1
+      echo "catalyst-layer2-read: jq not found — Layer-2 fallback unavailable, callers keep their Layer-1 value or default (declared asymmetry)" >&2
+    fi
+    export CATALYST_LAYER2_READ_JQ_MISSING=1
+    printf ''
+    return 0
+  fi
+
+  _catalyst_layer2_note_divergence
+
+  local _dir; _dir="$(_catalyst_layer2_dir)"
+  [[ -z "$_dir" ]] && { printf ''; return 0; }
+
+  # Build the argument list from the files that exist AND parse. A malformed file
+  # must be layer-ABSENT rather than poisoning the whole merge, so each is
+  # validated on its own before it joins the composition.
+  local -a _files=()
+  local _f
+  for _f in "${_dir}/config.json" "${_dir}/node.json" "${_dir}/cluster-secrets.json"; do
+    [[ -f "$_f" ]] || continue
+    jq -e 'type == "object"' "$_f" >/dev/null 2>&1 || continue
+    _files+=("$_f")
+  done
+  [[ ${#_files[@]} -eq 0 ]] && { printf ''; return 0; }
+
+  # `reduce inputs as $x (.; . * $x)` is jq's recursive-merge fold — the same
+  # deep-merge-not-replace semantics as config.mjs's _deepMergeLayer2, applied in
+  # argument order so later files win. `try ... catch empty` is what survives the
+  # live `catalyst.feedback` being a STRING: indexing a string throws in jq, and
+  # an uncaught throw would print "Cannot index string with ..." to stderr and
+  # exit non-zero. -r prints scalars bare; -c keeps objects/arrays on one line.
+  local _out
+  _out="$(jq -rc -n --arg p "$_path" '
+      reduce inputs as $x ({}; . * $x)
+      | try (getpath($p | ltrimstr(".") | split(".")))
+        catch empty
+      | if . == null then empty else . end
+    ' "${_files[@]}" 2>/dev/null)" || _out=""
+  printf '%s' "$_out"
+  return 0
+}

--- a/plugins/dev/scripts/lib/migrate-layer1-config.mjs
+++ b/plugins/dev/scripts/lib/migrate-layer1-config.mjs
@@ -39,6 +39,37 @@ export const DEAD_LAYER1_PATHS = Object.freeze([
   },
 ]);
 
+/**
+ * AUTOTUNER_MIRROR_LEAF / AUTOTUNER_SETPOINT_LEAF — CTL-1214 remediation.
+ *
+ * `orchestration.executionCore.maxParallel` is the ONE relocated leaf that must
+ * NOT be written to node.json, and whose Layer-1 value must NOT simply be
+ * dropped either. Both halves are load-bearing:
+ *
+ *  - It must not LAND in node.json. The autotuner's runtime mirror is written by
+ *    writeLayer2MaxParallel (autotune.mjs:432) into the LEGACY Layer-2
+ *    `config.json`, and node.json OUTRANKS that file in readLayer2MergedFrom. A
+ *    maxParallel in node.json would therefore permanently shadow every value the
+ *    tuner writes — freezing host capacity at whatever the migration happened to
+ *    copy, with the tuner still logging adjustments nothing reads.
+ *
+ *  - Its VALUE must survive. In Layer-1 that number is the operator's committed
+ *    seek-to target: it is what CTL-750's `readLayer1Concurrency` feeds to RULE 7
+ *    (recovery-to-layer1) and what CTL-770's `resolveTargetSetpoint` falls back
+ *    to for the RULE 2 / RULE 9 setpoint branches. Slimming it away with no
+ *    destination measured setpoint 4 -> undefined and layer1Max 4 -> null, which
+ *    silently no-ops four control-law branches.
+ *
+ * `targetParallel` is the key CTL-770 created for exactly this value ("the
+ * autotuner's seek-to setpoint, separate from maxParallel, which the autotuner
+ * clobbers every tick as its live runtime mirror"). It is never tuner-written, so
+ * re-homing the committed target there preserves the setpoint AND leaves the live
+ * mirror alone. This is the shape the plan's own Layer-2 target model describes
+ * (`{maxParallel, minParallel, maxParallelCeiling, targetParallel}`).
+ */
+const AUTOTUNER_MIRROR_LEAF = "orchestration.executionCore.maxParallel";
+const AUTOTUNER_SETPOINT_LEAF = "orchestration.executionCore.targetParallel";
+
 const isPlainObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
 
 function getPath(obj, dotted) {
@@ -173,6 +204,35 @@ export function planLayer1Migration({ layer1, mergedLayer2 } = {}) {
 
     for (const leaf of leafPaths(present, entry.path, [])) {
       const value = getPath(slimmed.catalyst, leaf);
+      if (leaf === AUTOTUNER_MIRROR_LEAF) {
+        // Re-home to targetParallel instead of moving in place — see the
+        // AUTOTUNER_MIRROR_LEAF block above. Never falls through to the generic
+        // arms below: writing maxParallel to node.json is the failure mode.
+        if (definedInLayer2(mergedCatalyst, AUTOTUNER_SETPOINT_LEAF)) {
+          kept.push({
+            path: leaf,
+            existingValue: getPath(mergedCatalyst, AUTOTUNER_SETPOINT_LEAF),
+            reason:
+              "the Layer-2 view already declares orchestration.executionCore.targetParallel — " +
+              "that host setpoint wins; maxParallel is the autotuner's runtime mirror and is " +
+              "never written to node.json",
+          });
+        } else {
+          moves.push({
+            path: AUTOTUNER_SETPOINT_LEAF,
+            value,
+            scope: entry.scope,
+            from: leaf,
+            reason:
+              "maxParallel in node.json would shadow the autotuner's runtime mirror in the " +
+              "legacy Layer-2 file; the committed target is re-homed to the CTL-770 " +
+              "targetParallel setpoint key, which the autotuner never writes",
+          });
+          setPath(nodePatch.catalyst, AUTOTUNER_SETPOINT_LEAF, value);
+        }
+        deletePath(slimmed.catalyst, leaf);
+        continue;
+      }
       if (definedInLayer2(mergedCatalyst, leaf)) {
         // Non-clobber (D1): node.json OUTRANKS the legacy Layer-2 file in
         // readLayer2Merged, so writing this key would shadow a value that
@@ -216,13 +276,41 @@ function deepMerge(target, source) {
   return out;
 }
 
-function readJson(path) {
+// readJsonDestination — read the file we are about to DEEP-MERGE INTO.
+//
+// CTL-1214: this used to swallow every error to `{}`, so an existing but
+// malformed or unreadable node.json was silently REPLACED by the migration's
+// patch rather than refused — the exact asymmetry the plan set for a malformed
+// Layer-1 INPUT (non-zero exit, no write) was missing on the destination side,
+// where the cost is higher: the operator's other node-scoped keys are gone.
+// ENOENT (and a missing-file ENOTDIR on a broken parent) means "start fresh" and
+// stays a `{}`. Anything else — a parse error, EACCES, EISDIR — throws, matching
+// catalyst-stack's "refusing to overwrite malformed config at <path>" posture.
+// A file that parses to a non-object is malformed too, not empty.
+function readJsonDestination(path) {
+  let raw;
   try {
-    const parsed = JSON.parse(readFileSync(path, "utf8"));
-    return isPlainObject(parsed) ? parsed : {};
-  } catch {
-    return {};
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT" || err?.code === "ENOTDIR") return {};
+    throw new Error(
+      `migrate-layer1-config: refusing to overwrite unreadable config at ${path} (${err?.code ?? err?.message})`,
+    );
   }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `migrate-layer1-config: refusing to overwrite malformed config at ${path} (${err.message})`,
+    );
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `migrate-layer1-config: refusing to overwrite malformed config at ${path} (not a JSON object)`,
+    );
+  }
+  return parsed;
 }
 
 // atomicWrite — tmp + rename in the SAME directory (rename is only atomic within
@@ -267,7 +355,7 @@ export function applyLayer1Migration({ plan, layer1Path, nodePath, dryRun = fals
   // 1. node.json — deep-merged into whatever is already there, never replaced.
   //    0600: it sits beside cluster-secrets.json in the machine-local config dir.
   if (plan.moves.length > 0) {
-    const merged = deepMerge(readJson(nodePath), plan.nodePatch);
+    const merged = deepMerge(readJsonDestination(nodePath), plan.nodePatch);
     atomicWrite(nodePath, `${JSON.stringify(merged, null, 2)}\n`, 0o600);
     wrote.push(nodePath);
   }

--- a/plugins/dev/scripts/lib/migrate-layer1-config.mjs
+++ b/plugins/dev/scripts/lib/migrate-layer1-config.mjs
@@ -250,6 +250,56 @@ export function planLayer1Migration({ layer1, mergedLayer2 } = {}) {
     }
   }
 
+  // 2b. SEED the setpoint for an ALREADY-SLIM Layer-1.
+  //
+  // Step 2's re-home only fires while Layer-1 still CARRIES maxParallel. But
+  // this repo COMMITS an already-slimmed Layer-1, so on every host that pulls it
+  // the migration finds nothing to relocate, reports "already migrated", and
+  // targetParallel is never written by anyone — this module is its only writer
+  // anywhere in the tree. Measured on mini-2: resolveTargetSetpoint went 4 → null,
+  // which no-ops CTL-770's convergence/seed branches AND (via rawTarget) nulls the
+  // layer1Max that RULE 7 recovery-to-layer1 compares against. The knob does not
+  // report an error when it reverts to a code default — that silence is the whole
+  // failure mode, so the migration has to close the window it opened.
+  //
+  // SOURCE — the merged Layer-2 maxParallel. It is the only surviving evidence of
+  // this host's capacity target once Layer-1 is slim, and it is where the
+  // migration's own non-clobber arm PARKED that value on hosts migrated before the
+  // re-home landed (kept, not moved, because the legacy Layer-2 file already
+  // declared it). ⚠️ Its weakness is declared, not hidden: maxParallel is the
+  // autotuner's live mirror, so a host whose tuner is throttled at seed time seeds
+  // a lower setpoint than the operator committed. That is strictly better than
+  // null (which disables the recovery branch outright rather than aiming it low),
+  // it is a ONE-TIME snapshot rather than a per-tick ratchet — the non-clobber
+  // guard below means a seeded targetParallel is never re-seeded — and the new
+  // doctor arm `autotune-setpoint-present` makes both the absence and the seeded
+  // value visible instead of silent.
+  //
+  // IDEMPOTENT + NON-CLOBBERING, on both arms:
+  //   • a targetParallel already in the merged Layer-2 view wins outright;
+  //   • a move planned by step 2 (Layer-1 still carried maxParallel) wins, since
+  //     the committed operator target is better evidence than the live mirror.
+  const setpointAlreadyPlanned = moves.some((m) => m.path === AUTOTUNER_SETPOINT_LEAF);
+  if (!setpointAlreadyPlanned && !definedInLayer2(mergedCatalyst, AUTOTUNER_SETPOINT_LEAF)) {
+    const mirror = getPath(mergedCatalyst, AUTOTUNER_MIRROR_LEAF);
+    // A positive integer only: `0`/`null`/a string would seed a setpoint that
+    // fails resolveTargetSetpoint's own Number.isInteger guard downstream, i.e. a
+    // write that looks like a repair and changes nothing.
+    if (Number.isInteger(mirror) && mirror > 0) {
+      moves.push({
+        path: AUTOTUNER_SETPOINT_LEAF,
+        value: mirror,
+        scope: "node",
+        from: `<merged Layer-2> ${AUTOTUNER_MIRROR_LEAF}`,
+        reason:
+          "Layer-1 is already slim, so the step-2 re-home cannot fire and nothing else " +
+          "writes targetParallel — seeding it from the merged Layer-2 maxParallel keeps " +
+          "resolveTargetSetpoint (and RULE 7's recovery target) from resolving null",
+      });
+      setPath(nodePatch.catalyst, AUTOTUNER_SETPOINT_LEAF, mirror);
+    }
+  }
+
   // 3. schemaVersion opts this config into the strict contract (D3). Never
   //    lower an existing higher version.
   const existingVersion = slimmed.catalyst.schemaVersion;

--- a/plugins/dev/scripts/lib/migrate-layer1-config.mjs
+++ b/plugins/dev/scripts/lib/migrate-layer1-config.mjs
@@ -1,0 +1,280 @@
+// migrate-layer1-config.mjs — CTL-1214 Phase 2. Move a repo's relocated Layer-1
+// keys into the node-scoped ~/.config/catalyst/node.json and stamp
+// schemaVersion on what remains.
+//
+// Split in two on purpose:
+//   planLayer1Migration()  — PURE. No I/O. Returns the whole decision
+//                            (moves / kept / dropped / slimmedLayer1 / nodePatch),
+//                            so the decision table is unit-testable outright.
+//   applyLayer1Migration() — the two atomic writes, in the one safe order.
+//
+// It imports RELOCATED_LAYER1_KEYS from lib/validate-catalyst-config.mjs rather
+// than re-listing anything, so there remains exactly ONE definition of what leaks.
+
+import { readFileSync, writeFileSync, renameSync, chmodSync, unlinkSync, existsSync } from "node:fs";
+import { RELOCATED_LAYER1_KEYS } from "./validate-catalyst-config.mjs";
+
+/** The relocated dotted paths, for the bash side to consume via the CLI's
+ *  --paths mode instead of re-typing them (the ASSERTED_BY mirror discipline). */
+export const RELOCATED_PATHS = Object.freeze(RELOCATED_LAYER1_KEYS.map((e) => e.path));
+
+/**
+ * DEAD_LAYER1_PATHS — relocated-adjacent keys that are DROPPED, not moved.
+ *
+ * orchestration.executionCore.eligibleQuery is dead config: the runtime value
+ * comes from execution-core/registry.json via resolveEligibleQuery, and the
+ * registry entry is written from a hardcoded literal in
+ * setup-execution-core-states.sh — never from Layer-1. readExecutionCoreConcurrency
+ * returns the whole executionCore object, but no call site dereferences
+ * .eligibleQuery on that result. Relocating it would carry a value nothing reads
+ * into a new home and imply it still does something.
+ */
+export const DEAD_LAYER1_PATHS = Object.freeze([
+  {
+    path: "orchestration.executionCore.eligibleQuery",
+    reason:
+      "dead config — the runtime eligibleQuery comes from execution-core/registry.json " +
+      "(resolveEligibleQuery), written from a hardcoded literal in setup-execution-core-states.sh; " +
+      "no reader dereferences it on the Layer-1 object",
+  },
+]);
+
+const isPlainObject = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+
+function getPath(obj, dotted) {
+  let cur = obj;
+  for (const seg of dotted.split(".")) {
+    if (!isPlainObject(cur) || !(seg in cur)) return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+function setPath(obj, dotted, value) {
+  const segs = dotted.split(".");
+  let cur = obj;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (!isPlainObject(cur[segs[i]])) cur[segs[i]] = {};
+    cur = cur[segs[i]];
+  }
+  cur[segs[segs.length - 1]] = value;
+}
+
+// deletePath — remove a key and then every ancestor the removal left empty, so a
+// fully-relocated `orchestration` stanza disappears rather than lingering as `{}`.
+// An ancestor that still holds a NON-relocating sibling (orchestration.codex,
+// monitor.linear) is kept — emptiness is the only trigger.
+function deletePath(obj, dotted) {
+  const segs = dotted.split(".");
+  const chain = [];
+  let cur = obj;
+  for (let i = 0; i < segs.length - 1; i++) {
+    if (!isPlainObject(cur[segs[i]])) return;
+    chain.push([cur, segs[i]]);
+    cur = cur[segs[i]];
+  }
+  delete cur[segs[segs.length - 1]];
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const [parent, key] = chain[i];
+    if (isPlainObject(parent[key]) && Object.keys(parent[key]).length === 0) delete parent[key];
+  }
+}
+
+// A value is DEFINED in the merged Layer-2 when it is present and not null.
+// `false` and `0` are real values — treating them as absent is the jq-falsy trap
+// that would let a migration overwrite a deliberate `salvagePush: false`.
+function definedInLayer2(mergedCatalyst, dotted) {
+  const v = getPath(mergedCatalyst, dotted);
+  return v !== undefined && v !== null;
+}
+
+// SCHEMA_KEY — an identifier-like key, i.e. one that names a FIELD OF A RECORD
+// rather than a piece of DATA. This is the map-vs-record discriminator, and it is
+// structural rather than a hand-maintained list.
+const SCHEMA_KEY = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Expand a relocated entry into the paths the non-clobber check runs at. A record
+// of independent knobs (`sweep`, `executionCore`) expands per FIELD, because
+// all-or-nothing per stanza would either shadow an operator's single override
+// (this host's machine-canonical maxParallel: 4) or strand three sibling keys
+// because one of them already existed.
+//
+// ⚠️ Recursion STOPS at a map whose keys are data, not schema —
+// monitor.github.repoColors is keyed by REPO NAME ("coalesce-labs/catalyst"), and
+// its reader consumes the whole map. Two reasons it must move atomically:
+// splitting it would make the non-clobber rule operate per repository, which is
+// not a unit anyone configures; and this module addresses values by DOTTED PATH,
+// so a repo name containing a "." (`a.b/c`) would be silently mis-nested into
+// `{a: {b/c: ...}}` — a corruption no test of the happy path would catch.
+function leafPaths(value, prefix, out) {
+  if (!isPlainObject(value)) {
+    out.push(prefix);
+    return out;
+  }
+  const keys = Object.keys(value);
+  if (keys.length === 0 || !keys.every((k) => SCHEMA_KEY.test(k))) {
+    out.push(prefix); // atomic: an empty object, or a data-keyed map
+    return out;
+  }
+  for (const k of keys) leafPaths(value[k], `${prefix}.${k}`, out);
+  return out;
+}
+
+/**
+ * planLayer1Migration — decide the whole migration, with no I/O.
+ *
+ * @param {object} args
+ * @param {object} args.layer1 - the parsed Layer-1 config ({ catalyst: {...} })
+ * @param {object} args.mergedLayer2 - the merged Layer-2 view ({ catalyst: {...} })
+ * @returns {{
+ *   moves: Array<{path: string, value: unknown, scope: string}>,
+ *   kept: Array<{path: string, existingValue: unknown, reason: string}>,
+ *   dropped: Array<{path: string, reason: string}>,
+ *   slimmedLayer1: object,
+ *   nodePatch: object,
+ *   changed: boolean,
+ * }}
+ * @throws when the Layer-1 config is not a `{ catalyst: {...} }` object — a
+ *   malformed input must fail closed, never be silently treated as empty (which
+ *   would "successfully" migrate nothing and report a clean run).
+ */
+export function planLayer1Migration({ layer1, mergedLayer2 } = {}) {
+  if (!isPlainObject(layer1) || !isPlainObject(layer1.catalyst)) {
+    throw new Error(
+      "migrate-layer1-config: Layer-1 config must be an object with a `catalyst` object " +
+        `(got ${JSON.stringify(layer1)?.slice(0, 80)})`,
+    );
+  }
+
+  const slimmed = structuredClone(layer1);
+  const mergedCatalyst = isPlainObject(mergedLayer2?.catalyst) ? mergedLayer2.catalyst : {};
+
+  const moves = [];
+  const kept = [];
+  const dropped = [];
+  const nodePatch = { catalyst: {} };
+
+  // 1. Drop the dead keys first, so they can never be picked up as leaves below.
+  for (const dead of DEAD_LAYER1_PATHS) {
+    if (getPath(slimmed.catalyst, dead.path) !== undefined) {
+      dropped.push({ path: dead.path, reason: dead.reason });
+      deletePath(slimmed.catalyst, dead.path);
+    }
+  }
+
+  // 2. Relocate the node-scoped entries, leaf by leaf.
+  for (const entry of RELOCATED_LAYER1_KEYS) {
+    // scope:"cluster" (monitor.linear.teams) is explicitly out of scope — the
+    // roster move is CTL-1885. Leave it in place and untouched.
+    if (entry.scope !== "node") continue;
+
+    const present = getPath(slimmed.catalyst, entry.path);
+    if (present === undefined) continue;
+
+    for (const leaf of leafPaths(present, entry.path, [])) {
+      const value = getPath(slimmed.catalyst, leaf);
+      if (definedInLayer2(mergedCatalyst, leaf)) {
+        // Non-clobber (D1): node.json OUTRANKS the legacy Layer-2 file in
+        // readLayer2Merged, so writing this key would shadow a value that
+        // already wins — e.g. this host's machine-canonical maxParallel: 4.
+        kept.push({
+          path: leaf,
+          existingValue: getPath(mergedCatalyst, leaf),
+          reason: "already defined in the merged Layer-2 view — writing it would shadow that value",
+        });
+      } else {
+        moves.push({ path: leaf, value, scope: entry.scope });
+        setPath(nodePatch.catalyst, leaf, value);
+      }
+      deletePath(slimmed.catalyst, leaf);
+    }
+  }
+
+  // 3. schemaVersion opts this config into the strict contract (D3). Never
+  //    lower an existing higher version.
+  const existingVersion = slimmed.catalyst.schemaVersion;
+  if (!Number.isInteger(existingVersion) || existingVersion < 1) {
+    slimmed.catalyst.schemaVersion = 1;
+  }
+
+  const changed =
+    moves.length > 0 ||
+    dropped.length > 0 ||
+    JSON.stringify(slimmed) !== JSON.stringify(layer1);
+
+  return { moves, kept, dropped, slimmedLayer1: slimmed, nodePatch, changed };
+}
+
+function deepMerge(target, source) {
+  const out = isPlainObject(target) ? { ...target } : {};
+  for (const key of Object.keys(source)) {
+    out[key] =
+      isPlainObject(source[key]) && isPlainObject(out[key])
+        ? deepMerge(out[key], source[key])
+        : source[key];
+  }
+  return out;
+}
+
+function readJson(path) {
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8"));
+    return isPlainObject(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+// atomicWrite — tmp + rename in the SAME directory (rename is only atomic within
+// a filesystem). mode is applied to the tmp file before the rename so the final
+// file is never briefly world-readable.
+function atomicWrite(path, contents, mode) {
+  const tmp = `${path}.tmp.${process.pid}`;
+  try {
+    writeFileSync(tmp, contents, mode === undefined ? undefined : { mode });
+    if (mode !== undefined) chmodSync(tmp, mode);
+    renameSync(tmp, path);
+  } catch (err) {
+    try {
+      if (existsSync(tmp)) unlinkSync(tmp);
+    } catch {
+      /* best effort — never mask the original error */
+    }
+    throw err;
+  }
+}
+
+/**
+ * applyLayer1Migration — perform the two writes.
+ *
+ * ⚠️ ORDER IS LOAD-BEARING: node.json FIRST, the slimmed Layer-1 LAST. A failure
+ * part-way must never leave a repo slimmed with its values nowhere — the
+ * asymmetry is the whole safety property. The reverse order has a window in
+ * which the config is stripped and the destination write then fails, silently
+ * reverting every relocated knob to its code default on the next process start.
+ *
+ * @returns {{ wrote: string[], dryRun: boolean }}
+ */
+export function applyLayer1Migration({ plan, layer1Path, nodePath, dryRun = false } = {}) {
+  if (!plan) throw new Error("migrate-layer1-config: a plan is required");
+  if (!layer1Path || !nodePath) {
+    throw new Error("migrate-layer1-config: layer1Path and nodePath are both required");
+  }
+  if (dryRun || !plan.changed) return { wrote: [], dryRun };
+
+  const wrote = [];
+
+  // 1. node.json — deep-merged into whatever is already there, never replaced.
+  //    0600: it sits beside cluster-secrets.json in the machine-local config dir.
+  if (plan.moves.length > 0) {
+    const merged = deepMerge(readJson(nodePath), plan.nodePatch);
+    atomicWrite(nodePath, `${JSON.stringify(merged, null, 2)}\n`, 0o600);
+    wrote.push(nodePath);
+  }
+
+  // 2. the slimmed Layer-1 — LAST, once its values are provably safe elsewhere.
+  atomicWrite(layer1Path, `${JSON.stringify(plan.slimmedLayer1, null, 2)}\n`);
+  wrote.push(layer1Path);
+
+  return { wrote, dryRun: false };
+}

--- a/plugins/dev/scripts/lib/validate-catalyst-config.mjs
+++ b/plugins/dev/scripts/lib/validate-catalyst-config.mjs
@@ -107,16 +107,34 @@ function getPath(obj, dottedPath) {
 /**
  * Validate a parsed Layer-1 `.catalyst/config.json` object.
  *
- * This is intentionally lenient about the back-compat migration window: neither
- * the relocated stanzas (`deprecatedKeys`) NOR a missing `catalyst.schemaVersion`
- * makes the config invalid. During the back-compat window schemaVersion is
- * RECOMMENDED, not required — every not-yet-slimmed config still lacks it (Phase 6,
- * which slims the committed configs and promotes schemaVersion to required, is
- * deferred), so failing on its absence would flag every live config as invalid in
- * editors/validators. A missing schemaVersion is surfaced as a `recommendation`
- * instead; a PRESENT-but-malformed value (not an integer >= 1) is still a hard
- * error (if you bother to set it, set it correctly). The only other hard
- * requirement is a top-level `catalyst` object.
+ * SELF-GATING STRICTNESS (CTL-1214 D3). `catalyst.schemaVersion` is the opt-in
+ * switch, NOT a hard global requirement:
+ *
+ *   - schemaVersion ABSENT  → today's lenient behavior verbatim. Relocated keys
+ *     are `deprecatedKeys` only, and the missing version is a `recommendation`.
+ *     The in-tree comments used to say Phase 6 would "promote schemaVersion to
+ *     required"; taken literally that flags every not-yet-migrated config in the
+ *     fleet as invalid, in editors and validators, for no benefit.
+ *   - schemaVersion >= 1    → this config has opted into the slimmed schema, so a
+ *     NODE-scoped relocated key is a HARD ERROR. A repo therefore becomes strict
+ *     exactly when it is slimmed, and a hand-edit or a rollback that re-adds a
+ *     relocated stanza fails loudly instead of silently reverting knobs.
+ *   - a PRESENT-but-malformed value (not an integer >= 1) is a hard error in its
+ *     own right and does NOT count as opting in — if you bother to set it, set it
+ *     correctly, and a bogus value must not be a back door into strict mode.
+ *
+ * CLUSTER-scoped leaks stay lenient in BOTH modes (D4). `monitor.linear.teams` is
+ * explicitly out of scope for CTL-1214 — the roster move is CTL-1885 — so it
+ * remains in slimmed configs and must not fail them. The gate keys off the
+ * registry's existing `scope` field; no new field, no second list.
+ *
+ * ⚠️ Why the asymmetry matters operationally: `catalyst doctor`'s exit code is its
+ * FAIL count, and catalyst-join.sh gates member activation on doctor exit 0. A
+ * hard error here becomes a fail-closed join gate, so it may only fire on a config
+ * that has DECLARED it is slimmed — never on a fleet member that simply has not
+ * migrated yet.
+ *
+ * The only other hard requirement is a top-level `catalyst` object.
  *
  * @param {unknown} obj - the parsed config object, expected shape `{ catalyst: {...} }`.
  * @returns {{ valid: boolean, deprecatedKeys: string[], errors: string[], recommendations: string[] }}
@@ -159,10 +177,22 @@ export function validateLayer1Config(obj) {
     );
   }
 
-  // Soft: scope-leak detection. Presence of a relocated key is deprecated, not invalid.
+  // Has this config OPTED IN to the strict contract? Only a well-formed integer
+  // >= 1 counts — the malformed-value branch above already errored, and letting a
+  // bogus value opt in would make garbage stricter than a blank.
+  const optedIn = Number.isInteger(schemaVersion) && schemaVersion >= 1;
+
+  // Scope-leak detection. Presence of a relocated key is always a deprecation;
+  // under an opted-in config a NODE-scoped one is additionally a hard error.
   for (const entry of RELOCATED_LAYER1_KEYS) {
-    if (getPath(catalyst, entry.path) !== undefined) {
-      deprecatedKeys.push(entry.path);
+    if (getPath(catalyst, entry.path) === undefined) continue;
+    deprecatedKeys.push(entry.path);
+    if (optedIn && entry.scope === "node") {
+      errors.push(
+        `catalyst.${entry.path} is node-scoped and must not appear in a schemaVersion ` +
+          `>= 1 Layer-1 config — relocate it to ${entry.destination} by running ` +
+          `\`catalyst-config-migrate\``,
+      );
     }
   }
 

--- a/plugins/dev/scripts/lib/validate-catalyst-config.mjs
+++ b/plugins/dev/scripts/lib/validate-catalyst-config.mjs
@@ -7,7 +7,9 @@
 //     scope (catalyst-cluster/cluster.json → projects[]);
 //   - repo display colors (monitor.github.repoColors), the orchestration.*,
 //     feedback.*, and sweep.* stanzas → relocate to the NODE scope
-//     (~/.config/catalyst/config.json).
+//     (~/.config/catalyst/node.json — CTL-1214 D1; readLayer2Merged already
+//     composes config.json < node.json < cluster-secrets.json, and node.json is
+//     the per-node file that is never mirrored across the cluster).
 //
 // This module is the single source of truth for that leak-category list
 // (RELOCATED_LAYER1_KEYS) and a pure validator (validateLayer1Config) that both
@@ -24,6 +26,21 @@
  * relocated — they are genuinely Layer-1 (the daemon reads botUserId flat from
  * Layer-1, see docs/architecture.md) — so they are deliberately absent here.
  *
+ * ⚠️ CTL-1214 D6 — `catalyst.orchestration` is NOT wholly machine-scoped, so the
+ * blanket `orchestration` row this list used to carry is replaced by the FOUR
+ * subpaths that actually relocate. config-dump.mjs heads that block
+ * "orchestration (Layer-1 owned)", and the daemon reads at least these further
+ * stanzas from Layer-1, every one of which stays:
+ *   executor, executorByPhase, codex (the documented codexHome pin — see
+ *   docs/architecture.md "The Codex account selector seam"), publishPreflight,
+ *   fleetHealth, daemonWatchdog, orphanReaper.workerGc, stalePrRescue,
+ *   orphanPrSweep, stalledPrSweep, draftPr, pluginDirs, phaseAgents.
+ * The narrowing is what lets the Phase-5 promotion be a hard error without making
+ * a documented, supported configuration fail doctor — and doctor's exit code
+ * gates member activation in catalyst-join.sh, so a false FAIL there fail-closes
+ * the fleet. This repo's committed config carries only the four, so the
+ * "no orchestration stanza after migration" outcome is unchanged.
+ *
  * @type {ReadonlyArray<{path: string, scope: "cluster"|"node", destination: string}>}
  */
 export const RELOCATED_LAYER1_KEYS = Object.freeze([
@@ -35,22 +52,37 @@ export const RELOCATED_LAYER1_KEYS = Object.freeze([
   {
     path: "monitor.github.repoColors",
     scope: "node",
-    destination: "~/.config/catalyst/config.json → catalyst.monitor.github.repoColors",
+    destination: "~/.config/catalyst/node.json → catalyst.monitor.github.repoColors",
   },
   {
-    path: "orchestration",
+    path: "orchestration.dispatchMode",
     scope: "node",
-    destination: "~/.config/catalyst/config.json → catalyst.orchestration.*",
+    destination: "~/.config/catalyst/node.json → catalyst.orchestration.dispatchMode",
+  },
+  {
+    path: "orchestration.executionCore",
+    scope: "node",
+    destination: "~/.config/catalyst/node.json → catalyst.orchestration.executionCore.*",
+  },
+  {
+    path: "orchestration.worktreeRefresh",
+    scope: "node",
+    destination: "~/.config/catalyst/node.json → catalyst.orchestration.worktreeRefresh.*",
+  },
+  {
+    path: "orchestration.reconcile",
+    scope: "node",
+    destination: "~/.config/catalyst/node.json → catalyst.orchestration.reconcile.*",
   },
   {
     path: "feedback",
     scope: "node",
-    destination: "~/.config/catalyst/config.json → catalyst.feedback.*",
+    destination: "~/.config/catalyst/node.json → catalyst.feedback.*",
   },
   {
     path: "sweep",
     scope: "node",
-    destination: "~/.config/catalyst/config.json → catalyst.sweep.*",
+    destination: "~/.config/catalyst/node.json → catalyst.sweep.*",
   },
 ]);
 

--- a/plugins/dev/scripts/lib/validate-catalyst-config.mjs
+++ b/plugins/dev/scripts/lib/validate-catalyst-config.mjs
@@ -87,6 +87,26 @@ export const RELOCATED_LAYER1_KEYS = Object.freeze([
 ]);
 
 /**
+ * LAYER1_ERROR_CODES — the hard-error CLASSES validateLayer1Config can report.
+ *
+ * CTL-1214 remediation: `errors` is a flat string[], so its only consumer
+ * (doctor's checkConfigScopeLeak) graded FAIL on `errors.length > 0` and thereby
+ * reported a malformed `catalyst.schemaVersion` as a *scope leak*, with a message
+ * that named no leaked key and asserted a schemaVersion the config did not have.
+ * That FAIL is not cosmetic: runDoctor returns the FAIL count as its exit code and
+ * catalyst-join.sh gates member activation on exit 0.
+ *
+ * `errorDetails` carries the same errors tagged with one of these codes so a
+ * consumer can grade per class. `errors` keeps its exact prior shape and content —
+ * this is additive, and the two are built from one push so they cannot drift.
+ */
+export const LAYER1_ERROR_CODES = Object.freeze({
+  MISSING_ROOT: "missing-catalyst-root",
+  SCHEMA_VERSION: "schema-version-malformed",
+  NODE_SCOPE_LEAK: "node-scope-leak",
+});
+
+/**
  * Read a dotted path out of an object without throwing on missing intermediate
  * nodes. Returns `undefined` when any segment is absent or a non-object is
  * encountered mid-walk.
@@ -141,22 +161,33 @@ function getPath(obj, dottedPath) {
  *   - `valid`: true when there are no hard errors (deprecated keys / missing schemaVersion do not affect this);
  *   - `deprecatedKeys`: dotted paths (relative to `catalyst.`) that have relocated;
  *   - `errors`: human-readable hard-validation failures;
+ *   - `errorDetails`: the same failures as `{code, message}`, `code` drawn from
+ *     LAYER1_ERROR_CODES, so a caller can grade per error class instead of on
+ *     `errors.length`;
  *   - `recommendations`: non-failing migration signals (e.g. a missing schemaVersion).
  */
 export function validateLayer1Config(obj) {
   /** @type {string[]} */
   const errors = [];
+  /** @type {Array<{code: string, message: string}>} */
+  const errorDetails = [];
   /** @type {string[]} */
   const deprecatedKeys = [];
   /** @type {string[]} */
   const recommendations = [];
 
+  // One push site for both lists, so `errors` and `errorDetails` can never drift.
+  const addError = (code, message) => {
+    errors.push(message);
+    errorDetails.push({ code, message });
+  };
+
   const root = obj != null && typeof obj === "object" && !Array.isArray(obj) ? obj : {};
   const catalyst = root.catalyst;
 
   if (catalyst == null || typeof catalyst !== "object" || Array.isArray(catalyst)) {
-    errors.push("missing top-level `catalyst` object");
-    return { valid: false, deprecatedKeys, errors, recommendations };
+    addError(LAYER1_ERROR_CODES.MISSING_ROOT, "missing top-level `catalyst` object");
+    return { valid: false, deprecatedKeys, errors, errorDetails, recommendations };
   }
 
   // Back-compat (CTL-1214): catalyst.schemaVersion is RECOMMENDED, not required.
@@ -172,7 +203,8 @@ export function validateLayer1Config(obj) {
     !Number.isInteger(schemaVersion) ||
     schemaVersion < 1
   ) {
-    errors.push(
+    addError(
+      LAYER1_ERROR_CODES.SCHEMA_VERSION,
       `catalyst.schemaVersion must be an integer >= 1 (got ${JSON.stringify(schemaVersion)})`,
     );
   }
@@ -188,7 +220,8 @@ export function validateLayer1Config(obj) {
     if (getPath(catalyst, entry.path) === undefined) continue;
     deprecatedKeys.push(entry.path);
     if (optedIn && entry.scope === "node") {
-      errors.push(
+      addError(
+        LAYER1_ERROR_CODES.NODE_SCOPE_LEAK,
         `catalyst.${entry.path} is node-scoped and must not appear in a schemaVersion ` +
           `>= 1 Layer-1 config — relocate it to ${entry.destination} by running ` +
           `\`catalyst-config-migrate\``,
@@ -196,5 +229,5 @@ export function validateLayer1Config(obj) {
     }
   }
 
-  return { valid: errors.length === 0, deprecatedKeys, errors, recommendations };
+  return { valid: errors.length === 0, deprecatedKeys, errors, errorDetails, recommendations };
 }

--- a/plugins/dev/scripts/lib/validate-catalyst-config.mjs
+++ b/plugins/dev/scripts/lib/validate-catalyst-config.mjs
@@ -41,48 +41,79 @@
  * the fleet. This repo's committed config carries only the four, so the
  * "no orchestration stanza after migration" outcome is unchanged.
  *
- * @type {ReadonlyArray<{path: string, scope: "cluster"|"node", destination: string}>}
+ * ⚠️ CTL-1214 remediation — `precedence` records which layer WINS when BOTH still
+ * carry the key, because the two stacks genuinely differ and the difference is
+ * what an operator needs at the moment doctor reports a leak:
+ *   - `"destination-wins"` — the JS readers (readLayer2MergedFrom consumers) and
+ *     the cluster roster overlay Layer-2/cluster ON TOP of Layer-1 per field, so a
+ *     leftover Layer-1 key is SHADOWED (silently divergent, not authoritative).
+ *   - `"layer1-wins"` — the bash readers treat Layer-2 as a FALLBACK consulted
+ *     only when Layer-1 is silent (mirroring phase-agent-dispatch's pre-existing
+ *     `config_value()`), so a leftover Layer-1 key OVERRIDES node.json.
+ * `readBy` names the stack that establishes it. Both are documented per knob in
+ * website/src/content/docs/reference/configuration.md → "Precedence"; this array
+ * is the single source of truth the doctor message formats from, so the two
+ * cannot drift into the "one blanket ladder" claim that was wrong for 4 of 7 rows.
+ *
+ * @type {ReadonlyArray<{path: string, scope: "cluster"|"node", destination: string,
+ *   precedence: "destination-wins"|"layer1-wins", readBy: "js"|"bash"}>}
  */
 export const RELOCATED_LAYER1_KEYS = Object.freeze([
   {
     path: "monitor.linear.teams",
     scope: "cluster",
     destination: "catalyst-cluster/cluster.json → projects[]",
+    precedence: "destination-wins",
+    readBy: "js",
   },
   {
     path: "monitor.github.repoColors",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.monitor.github.repoColors",
+    precedence: "destination-wins",
+    readBy: "js",
   },
   {
     path: "orchestration.dispatchMode",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.orchestration.dispatchMode",
+    precedence: "layer1-wins",
+    readBy: "bash",
   },
   {
     path: "orchestration.executionCore",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.orchestration.executionCore.*",
+    precedence: "destination-wins",
+    readBy: "js",
   },
   {
     path: "orchestration.worktreeRefresh",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.orchestration.worktreeRefresh.*",
+    precedence: "destination-wins",
+    readBy: "js",
   },
   {
     path: "orchestration.reconcile",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.orchestration.reconcile.*",
+    precedence: "destination-wins",
+    readBy: "js",
   },
   {
     path: "feedback",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.feedback.*",
+    precedence: "layer1-wins",
+    readBy: "bash",
   },
   {
     path: "sweep",
     scope: "node",
     destination: "~/.config/catalyst/node.json → catalyst.sweep.*",
+    precedence: "layer1-wins",
+    readBy: "bash",
   },
 ]);
 
@@ -157,7 +188,8 @@ function getPath(obj, dottedPath) {
  * The only other hard requirement is a top-level `catalyst` object.
  *
  * @param {unknown} obj - the parsed config object, expected shape `{ catalyst: {...} }`.
- * @returns {{ valid: boolean, deprecatedKeys: string[], errors: string[], recommendations: string[] }}
+ * @returns {{ valid: boolean, deprecatedKeys: string[], errors: string[],
+ *   errorDetails: Array<{code: string, message: string}>, recommendations: string[] }}
  *   - `valid`: true when there are no hard errors (deprecated keys / missing schemaVersion do not affect this);
  *   - `deprecatedKeys`: dotted paths (relative to `catalyst.`) that have relocated;
  *   - `errors`: human-readable hard-validation failures;

--- a/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
+++ b/plugins/dev/scripts/orch-monitor/__tests__/repo-icon-fetcher.test.ts
@@ -709,3 +709,87 @@ describe("fetchRepoIcon — avatar fallback re-probes on the short TTL (CTL-1375
     expect(res.selectedPath).toBe("public/favicon.svg");
   });
 });
+
+// ── loadMonitorConfig — repoColors across the Layer-2 chain (CTL-1214) ───────
+//
+// The plan's reader-coverage table marked monitor.github.repoColors
+// "Layer-2-first → safe", but loadMonitorConfig read only Layer-1 + the LEGACY
+// ~/.config/catalyst/config.json. The migration's destination for this key is
+// node.json — which also OUTRANKS the legacy file in the merged Layer-2 view the
+// JS readers use — so on an already-migrated host the colors measured
+// {"coalesce-labs/catalyst":"green"} → {}.
+
+describe("loadMonitorConfig — repoColors reads node.json (CTL-1214)", () => {
+  let tmpDir: string;
+  let configPath: string;
+  let layer2Path: string;
+  let nodePath: string;
+  let noRegistry: string;
+
+  const write = (p: string, o: unknown) => writeFileSync(p, JSON.stringify(o));
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `ctl-1214-colors-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+    configPath = join(tmpDir, "layer1.json");
+    layer2Path = join(tmpDir, "config.json");
+    nodePath = join(tmpDir, "node.json");
+    noRegistry = join(tmpDir, "no-registry.json");
+    // A slimmed Layer-1: project identity only, no monitor.github stanza.
+    write(configPath, { catalyst: { projectKey: "p", schemaVersion: 1 } });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resolves repoColors from node.json when Layer-1 is slimmed", () => {
+    write(layer2Path, {});
+    write(nodePath, {
+      catalyst: { monitor: { github: { repoColors: { "coalesce-labs/catalyst": "green" } } } },
+    });
+    const cfg = loadMonitorConfig(configPath, noRegistry, layer2Path);
+    expect(cfg.repoColors["coalesce-labs/catalyst"]).toBe("green");
+  });
+
+  it("node.json OUTRANKS the legacy Layer-2 file, matching the merged-Layer-2 order", () => {
+    write(layer2Path, {
+      catalyst: { monitor: { github: { repoColors: { "coalesce-labs/catalyst": "blue" } } } },
+    });
+    write(nodePath, {
+      catalyst: { monitor: { github: { repoColors: { "coalesce-labs/catalyst": "green" } } } },
+    });
+    const cfg = loadMonitorConfig(configPath, noRegistry, layer2Path);
+    expect(cfg.repoColors["coalesce-labs/catalyst"]).toBe("green");
+  });
+
+  it("still reads Layer-1 when nothing has been migrated (back-compat)", () => {
+    write(configPath, {
+      catalyst: { monitor: { github: { repoColors: { "coalesce-labs/catalyst": "red" } } } },
+    });
+    write(layer2Path, {});
+    const cfg = loadMonitorConfig(configPath, noRegistry, layer2Path);
+    expect(cfg.repoColors["coalesce-labs/catalyst"]).toBe("red");
+  });
+
+  it("an ABSENT or MALFORMED node.json contributes nothing and never throws", () => {
+    write(configPath, {
+      catalyst: { monitor: { github: { repoColors: { "coalesce-labs/catalyst": "red" } } } },
+    });
+    write(layer2Path, {});
+    expect(loadMonitorConfig(configPath, noRegistry, layer2Path).repoColors).toEqual({
+      "coalesce-labs/catalyst": "red",
+    });
+    writeFileSync(nodePath, "{ not json");
+    expect(loadMonitorConfig(configPath, noRegistry, layer2Path).repoColors).toEqual({
+      "coalesce-labs/catalyst": "red",
+    });
+  });
+
+  // NEGATIVE CONTROL: without it, every assertion above could pass from a reader
+  // that returns a hardcoded map.
+  it("no layer defining repoColors -> empty map", () => {
+    write(layer2Path, {});
+    expect(loadMonitorConfig(configPath, noRegistry, layer2Path).repoColors).toEqual({});
+  });
+});

--- a/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
+++ b/plugins/dev/scripts/orch-monitor/lib/monitor-config.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, dirname } from "path";
 import { homedir } from "os";
 import { readClusterProjects } from "./cluster-roster";
 
@@ -111,6 +111,21 @@ export function loadMonitorConfig(
   readRepoColorsInto(repoColors, configPath);
   if (layer2ConfigPath && layer2ConfigPath !== configPath) {
     readRepoColorsInto(repoColors, layer2ConfigPath);
+  }
+  // CTL-1214 remediation: node.json, LAST, because it outranks the legacy Layer-2
+  // file in the merged Layer-2 view the JS readers use (readLayer2MergedFrom:
+  // config.json < node.json). It is also where the migration actually PUTS this
+  // key — RELOCATED_LAYER1_KEYS names
+  // `~/.config/catalyst/node.json → catalyst.monitor.github.repoColors` as the
+  // destination — so reading only config.json measured
+  // {"coalesce-labs/catalyst":"green"} → {} on an already-migrated host. Resolved
+  // off layer2ConfigPath's own directory, the same way readLayer2MergedFrom
+  // resolves its siblings, so CATALYST_LAYER2_CONFIG_FILE keeps working in tests.
+  if (layer2ConfigPath) {
+    const nodeConfigPath = join(dirname(layer2ConfigPath), "node.json");
+    if (nodeConfigPath !== configPath && nodeConfigPath !== layer2ConfigPath) {
+      readRepoColorsInto(repoColors, nodeConfigPath);
+    }
   }
 
   // --- roster-derived FALLBACK repoOwners (CTL-961, CTL-1214 Phase 2) ---

--- a/plugins/dev/scripts/orchestrate-dispatch-next
+++ b/plugins/dev/scripts/orchestrate-dispatch-next
@@ -155,11 +155,25 @@ fi
 # for orchestrators that haven't been migrated yet. Explicit --phase always
 # wins over the resolved dispatchMode.
 DISPATCH_MODE="oneshot-legacy"
+RAW_MODE=""
 if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
-	RAW_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // "oneshot-legacy"' "$CONFIG_PATH" 2>/dev/null || echo "oneshot-legacy")
+	RAW_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // empty' "$CONFIG_PATH" 2>/dev/null || echo "")
+fi
+# CTL-1214: Layer-2 fallback. dispatchMode had NO Layer-2 reader, so once the
+# committed config is slimmed a bare Layer-1 read returns nothing and this
+# resolves to "oneshot-legacy" — the wrong orchestration mode for the whole
+# fleet, arrived at silently because the miss is indistinguishable from an
+# intentional legacy setting. Layer-1 still WINS when present (this is a
+# fallback, not an override); Layer-2 answers only when Layer-1 is silent.
+if [ -z "$RAW_MODE" ] && [ -r "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]; then
+	# shellcheck disable=SC1090
+	. "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+	RAW_MODE="$(catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"
+fi
+if [ -n "$RAW_MODE" ]; then
 	case "$RAW_MODE" in
 	phase-agents | oneshot-legacy | execution-core) DISPATCH_MODE="$RAW_MODE" ;;
-	*) echo "WARN: invalid dispatchMode '$RAW_MODE' in $CONFIG_PATH — defaulting to oneshot-legacy" >&2 ;;
+	*) echo "WARN: invalid dispatchMode '$RAW_MODE' — defaulting to oneshot-legacy" >&2 ;;
 	esac
 fi
 

--- a/plugins/dev/scripts/orchestrate-register-interests.sh
+++ b/plugins/dev/scripts/orchestrate-register-interests.sh
@@ -67,10 +67,25 @@ fi
 # Read dispatchMode from config (default: oneshot-legacy — matches the
 # original SKILL.md gate; phase_lifecycle interests only emit in phase-agents).
 DISPATCH_MODE="oneshot-legacy"
+DISPATCH_MODE_RAW=""
 if [ -n "$CONFIG_PATH" ] && [ -f "$CONFIG_PATH" ]; then
-  DISPATCH_MODE=$(jq -r '.catalyst.orchestration.dispatchMode // "oneshot-legacy"' \
-    "$CONFIG_PATH" 2>/dev/null || echo "oneshot-legacy")
+  DISPATCH_MODE_RAW=$(jq -r '.catalyst.orchestration.dispatchMode // empty' \
+    "$CONFIG_PATH" 2>/dev/null || echo "")
 fi
+# CTL-1214: Layer-2 fallback — the SAME rung orchestrate-dispatch-next carries
+# (orchestrate-dispatch-next.sh:168-173). Without it, a slimmed Layer-1 makes
+# this read return nothing and the default silently resolves to
+# "oneshot-legacy", which drops the per-ticket phase_lifecycle interest — the
+# exact failure this script's own header (:2-9) exists to prevent: phase-agent
+# completions land in the event log with zero matching interests and are
+# dropped by broker/index.mjs:1782. Layer-1 still WINS when present; Layer-2
+# answers only when Layer-1 is silent.
+if [ -z "$DISPATCH_MODE_RAW" ] && [ -r "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]; then
+  # shellcheck disable=SC1090
+  . "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+  DISPATCH_MODE_RAW="$(catalyst_layer2_json '.catalyst.orchestration.dispatchMode')"
+fi
+[ -n "$DISPATCH_MODE_RAW" ] && DISPATCH_MODE="$DISPATCH_MODE_RAW"
 
 # Compute the active ticket / PR set from worker signal files.
 shopt -s nullglob

--- a/plugins/dev/scripts/orphan-sweep.sh
+++ b/plugins/dev/scripts/orphan-sweep.sh
@@ -271,16 +271,32 @@ _resolve_sweep_config_path() {
   printf ''
 }
 
+# CTL-1214: the merged-Layer-2 leaf, sourced ONCE per process (not per key) so
+# the sweep pays at most one extra jq per key rather than re-resolving the
+# library on every lookup — matching how _load_sweep_config already batches.
+if [[ -r "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh" ]]; then
+  # shellcheck disable=SC1090
+  . "${SCRIPT_DIR}/lib/catalyst-layer2-read.sh"
+fi
+
 _cfg_str() {
   # CTL-1612 round 7 post-merge hygiene: explicit if/else instead of
   # `A && B || C` — shellcheck SC2015 flags that idiom because C also runs
   # when A is true but B fails, which is not the if-then-else it visually
   # reads as. Same short-circuit semantics, unambiguous now.
-  if [[ ! -f "${SWEEP_CONFIG_PATH:-}" ]] || ! command -v jq >/dev/null 2>&1; then
-    printf ''
-    return 0
+  local _v=''
+  if [[ -f "${SWEEP_CONFIG_PATH:-}" ]] && command -v jq >/dev/null 2>&1; then
+    _v="$(jq -r "$1 // empty" "$SWEEP_CONFIG_PATH" 2>/dev/null || printf '')"
   fi
-  jq -r "$1 // empty" "$SWEEP_CONFIG_PATH" 2>/dev/null || printf ''
+  # CTL-1214: Layer-2 fallback. catalyst.sweep.* had NO Layer-2 reader, so a
+  # slimmed Layer-1 config silently reverts every sweep knob to its code default
+  # — intervalHours 1 -> 2, HALVING the sweep cadence with no error anywhere.
+  # Layer-1 still wins when present; Layer-2 answers only when Layer-1 is silent.
+  if [[ -z "$_v" ]] && command -v catalyst_layer2_json >/dev/null 2>&1; then
+    _v="$(catalyst_layer2_json "$1")"
+  fi
+  printf '%s' "$_v"
+  return 0
 }
 
 _load_sweep_config() {

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -2,6 +2,8 @@
   "$schema": "https://json-schema.org/draft-07/schema#",
   "$comment": "Catalyst Configuration Template - Copy to config.json and fill in values. Secrets go in ~/.config/catalyst/config-{projectKey}.json",
   "catalyst": {
+    "_comment_schema": "schemaVersion 1 means this config has opted into the slimmed Layer-1 schema (CTL-1214): project identity only, no machine-scoped keys. The relocated stanzas — orchestration.{dispatchMode,executionCore,worktreeRefresh,reconcile}, feedback.*, sweep.*, monitor.github.repoColors — now live in the NODE-scoped ~/.config/catalyst/node.json. Run `catalyst-config-migrate` to move an existing repo's keys there. A config carrying schemaVersion is held to the strict contract; one without it stays lenient for the back-compat window.",
+    "schemaVersion": 1,
     "projectKey": "my-project",
     "repository": {
       "org": "[YOUR_ORG]",
@@ -31,11 +33,6 @@
     "thoughts": {
       "user": null
     },
-    "feedback": {
-      "autoFile": false,
-      "githubRepo": "coalesce-labs/catalyst",
-      "labels": ["auto-submitted"]
-    },
     "deploy": {
       "$comment": "Per-repo deploy verification config (CTL-211). Set skipDeployVerification: false for repos that emit GitHub Deployments to enable the orchestrator's merged → deploying → done state machine. Default for unknown repos is skipDeployVerification: true (today's CTL-133 behavior — done immediately on PR merge).",
       "[YOUR_ORG]/[YOUR_REPO]": {
@@ -57,16 +54,6 @@
     },
     "deployment": {
       "mode": "single-host"
-    },
-    "orchestration": {
-      "_comment": "Worker dispatch mode. 'phase-agents' (default) dispatches the 10-phase pipeline on claude --bg; 'oneshot-legacy' keeps the pre-CTL-452 single-shot oneshot worker on claude -p.",
-      "dispatchMode": "phase-agents",
-      "executionCore": {
-        "_comment": "Execution-core scheduler worker-slot ceiling (CTL-665). maxParallel is the committed source of truth (~/catalyst/execution-core/state.json is an optional runtime fallback consulted only when this is absent). minParallel/maxParallelCeiling clamp the resolved value — bounds for the future adaptive-concurrency feature. Default stays 4; the operator bump to 10 is gated on CTL-661/662/663. NOTE: eligibleQuery is intentionally NOT here — it lives centrally in registry.json (CTL-582 D4); only these concurrency knobs are templated.",
-        "maxParallel": 4,
-        "minParallel": 1,
-        "maxParallelCeiling": 10
-      }
     }
   }
 }

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -3355,15 +3355,37 @@ setup_sweep_config() {
 	local REPO_ROOT="${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "$PWD")}"
 	local config_file="${REPO_ROOT}/.catalyst/config.json"
 	[[ -f $config_file ]] || return 0
+
+	# CTL-1214: catalyst.sweep is NODE-scoped, so the defaults go to the
+	# machine-local node.json — NOT back into the committed .catalyst/config.json.
+	# This function used to patch that committed file on EVERY run and print
+	# "wrote catalyst.sweep defaults", which means the Phase-4 slimming would have
+	# survived exactly until the next setup-catalyst.sh run. A repo that still
+	# carries a legacy catalyst.sweep in Layer-1 is deliberately LEFT ALONE — the
+	# Phase-1 readers still prefer that value, and deleting an operator's
+	# un-migrated config from a setup script would be a destructive surprise.
+	local layer2_file="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+	local node_file
+	node_file="$(cd "$(dirname "$layer2_file")" 2>/dev/null && pwd)/node.json" || node_file=""
+	if [[ -z $node_file || $node_file == "/node.json" ]]; then
+		echo "setup: warning: could not resolve the Layer-2 config dir; skipping catalyst.sweep defaults" >&2
+		return 0
+	fi
+
 	local patch tmp
 	patch='{"idleHours":48,"intervalHours":1,"salvagePush":false,"maxRemovalsPerRun":10}'
-	tmp="${config_file}.tmp.$$"
-	# patch first so user overrides win
-	if jq --argjson p "$patch" '.catalyst.sweep = ($p + (.catalyst.sweep // {}))' "$config_file" >"$tmp" && mv "$tmp" "$config_file"; then
-		print_success "wrote catalyst.sweep defaults" 2>/dev/null || echo "setup: wrote catalyst.sweep defaults"
+	[[ -f $node_file ]] || printf '{}\n' >"$node_file"
+	tmp="${node_file}.tmp.$$"
+	# patch first so user overrides win (unchanged `+` semantics — the existing
+	# block is applied ON TOP of the defaults, so an operator's node.json value
+	# survives and only the un-set keys are filled in)
+	if jq --argjson p "$patch" '.catalyst = (.catalyst // {}) | .catalyst.sweep = ($p + (.catalyst.sweep // {}))' "$node_file" >"$tmp" \
+		&& chmod 600 "$tmp" && mv "$tmp" "$node_file"; then
+		print_success "wrote catalyst.sweep defaults to ${node_file}" 2>/dev/null \
+			|| echo "setup: wrote catalyst.sweep defaults to ${node_file}"
 	else
 		rm -f "$tmp"
-		echo "setup: warning: could not write catalyst.sweep defaults" >&2
+		echo "setup: warning: could not write catalyst.sweep defaults to ${node_file}" >&2
 	fi
 	local _os="${CATALYST_FORCE_OS:-$(uname -s 2>/dev/null || echo unknown)}"
 	if [[ $_os == "Darwin" ]]; then

--- a/setup-catalyst.sh
+++ b/setup-catalyst.sh
@@ -3343,6 +3343,55 @@ init_session_database() {
 	echo ""
 }
 
+# CTL-1214 remediation: seed catalyst.orchestration.dispatchMode into node.json.
+#
+# Phase 4 removed the `catalyst.orchestration` stanza — including
+# `dispatchMode: "phase-agents"` — from the config template, and NOTHING replaced
+# it: a grep of this script, setup-execution-core-states.sh and catalyst-join.sh
+# finds no other dispatchMode writer (positive control: the same grep finds
+# dispatchMode in 5 reader scripts). catalyst-config-migrate cannot cover the gap
+# either — a brand-new project has no Layer-1 key to relocate. So a project
+# scaffolded from the template on a host with no node.json resolved dispatchMode
+# through orchestrate-dispatch-next's fallback to nothing and landed on the code
+# default `oneshot-legacy`: a SILENT flip of the documented default, and exactly
+# the failure the Layer-2 fallback was added to prevent.
+#
+# ⛔ The key cannot simply go back in the template. It is node-scoped in
+# RELOCATED_LAYER1_KEYS, the template declares `schemaVersion: 1`, and a slimmed
+# config carrying a node-scoped key is checkConfigScopeLeak's one FAIL — which
+# catalyst-join.sh turns into a fail-closed join gate for every new project.
+# node.json is where the registry says this value lives, so that is where setup
+# writes it.
+#
+# Non-clobbering, matching setup_sweep_config: an operator's existing value wins
+# and is never overwritten (the `//` below fills the key only when it is absent).
+setup_dispatch_mode_config() {
+	local layer2_file="${CATALYST_LAYER2_CONFIG_FILE:-${HOME}/.config/catalyst/config.json}"
+	local node_file
+	node_file="$(cd "$(dirname "$layer2_file")" 2>/dev/null && pwd)/node.json" || node_file=""
+	if [[ -z $node_file || $node_file == "/node.json" ]]; then
+		echo "setup: warning: could not resolve the Layer-2 config dir; skipping dispatchMode default" >&2
+		return 0
+	fi
+
+	local tmp
+	[[ -f $node_file ]] || printf '{}\n' >"$node_file"
+	tmp="${node_file}.tmp.$$"
+	# `// "phase-agents"` fills the key only when it is absent, so a host already
+	# pinned to execution-core or oneshot-legacy keeps its setting across re-runs.
+	if jq '.catalyst = (.catalyst // {})
+	       | .catalyst.orchestration = (.catalyst.orchestration // {})
+	       | .catalyst.orchestration.dispatchMode =
+	           (.catalyst.orchestration.dispatchMode // "phase-agents")' \
+		"$node_file" >"$tmp" && chmod 600 "$tmp" && mv "$tmp" "$node_file"; then
+		print_success "wrote catalyst.orchestration.dispatchMode default to ${node_file}" 2>/dev/null \
+			|| echo "setup: wrote catalyst.orchestration.dispatchMode default to ${node_file}"
+	else
+		rm -f "$tmp"
+		echo "setup: warning: could not write dispatchMode default to ${node_file}" >&2
+	fi
+}
+
 # Write catalyst.sweep defaults into .catalyst/config.json and, on macOS,
 # invoke the launchd installer (CTL-1030).
 setup_sweep_config() {
@@ -3581,6 +3630,7 @@ main() {
 	setup_execution_core_states
 	init_session_database
 	setup_sweep_config
+	setup_dispatch_mode_config
 	init_humanlayer_thoughts
 	sync_thoughts
 	# CTL-1918: perform the steps setup used to print. Runs last so every input it

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -66,13 +66,24 @@ node-scoped `~/.config/catalyst/node.json`:
 | Layer-1 key (relative to `catalyst.`)                                       | Scope     | Destination                                          |
 | --------------------------------------------------------------------------- | --------- | ---------------------------------------------------- |
 | `orchestration.dispatchMode`                                                 | node      | `node.json` → `catalyst.orchestration.dispatchMode`   |
-| `orchestration.executionCore.*`                                              | node      | `node.json` → `catalyst.orchestration.executionCore.*`|
+| `orchestration.executionCore.*`                                              | node      | `node.json` → `catalyst.orchestration.executionCore.*` (but see `maxParallel` below) |
 | `orchestration.worktreeRefresh.*`                                            | node      | `node.json` → `catalyst.orchestration.worktreeRefresh.*` |
 | `orchestration.reconcile.*`                                                  | node      | `node.json` → `catalyst.orchestration.reconcile.*`    |
 | `feedback.*`                                                                 | node      | `node.json` → `catalyst.feedback.*`                   |
 | `sweep.*`                                                                    | node      | `node.json` → `catalyst.sweep.*`                      |
 | `monitor.github.repoColors`                                                  | node      | `node.json` → `catalyst.monitor.github.repoColors`    |
 | `monitor.linear.teams`                                                       | cluster   | `catalyst-cluster/cluster.json` → `projects[]` (CTL-1885, **not yet moved**) |
+
+⚠️ **`orchestration.executionCore.maxParallel` is re-homed, not moved.** It is the one relocated
+leaf the migration never writes into `node.json`, because the autotuner's *runtime mirror* lives in
+`catalyst.orchestration.executionCore.maxParallel` of the **legacy** `~/.config/catalyst/config.json`
+(written every adjusted tick by `writeLayer2MaxParallel`) and `node.json` outranks that file — a
+copy there would permanently freeze host capacity at whatever the migration happened to snapshot.
+But the Layer-1 value must not simply be dropped either: it is the operator's committed *setpoint*,
+the value the autotuner's recovery jump and setpoint-convergence branches seek to. The migration
+therefore writes it to `node.json` → `catalyst.orchestration.executionCore.targetParallel`, the key
+that names exactly this and which the tuner never writes. An operator-declared `targetParallel`
+already present in Layer-2 always wins and is never overwritten.
 
 ⚠️ **`catalyst.orchestration` as a whole is NOT machine-scoped.** Only the four subpaths above
 relocate. `executor`, `executorByPhase`, `codex`, `publishPreflight`, `fleetHealth`,
@@ -105,6 +116,35 @@ fallbacks.
 ⛔ **Never run it against a host running an older plugin checkout.** That host has no Layer-2
 fallbacks, so a slimmed config silently reverts `dispatchMode` to `oneshot-legacy` and halves the
 sweep cadence. Update the checkout first.
+
+⛔ **Run it on EVERY roster host BEFORE the slimming commit reaches them — the CLI cannot recover
+the values afterwards.** `node.json` is per-host and is never committed, but the slimming ships to
+the whole fleet through git. The migration derives its moves from the **Layer-1 content it finds**,
+so the moment `main` carries the slimmed config the CLI is a **no-op** on every host that has not
+already run it: there is nothing left to read, and the values are then recoverable only from git
+history. Measured against an empty Layer-2, that no-op costs:
+
+| Knob                                      | Before | After an un-migrated host pulls the slimming |
+| ----------------------------------------- | ------ | --------------------------------------------- |
+| `orchestration.dispatchMode`              | `phase-agents` | `oneshot-legacy` — the wrong orchestration mode |
+| `orchestration.executionCore`             | `{maxParallel: 4, minParallel: 1, maxParallelCeiling: 40}` | `{}` — autotuner setpoint unresolved |
+| `sweep.intervalHours`                     | 1      | 2 — sweep cadence halved                      |
+| `sweep.maxRemovalsPerRun`                 | 10     | 20                                            |
+
+(`orchestration.worktreeRefresh` and `reconcile.intervalSeconds` are a wash — the code defaults
+equal the Layer-1 values.)
+
+**The operator checklist, in this order:**
+
+1. On **every** host in `cluster.json` → `roster`, from a checkout that still has the un-slimmed
+   Layer-1: `plugins/dev/scripts/catalyst-config-migrate --json` — keep each report.
+2. Verify per host that `~/.config/catalyst/node.json` carries the relocated keys
+   (`jq '.catalyst | {orchestration, sweep, feedback, monitor}' ~/.config/catalyst/node.json`).
+3. Only then merge the slimming commit.
+
+If a host is already past step 3 with no `node.json`, seed it by hand from the `--json` report of a
+host that did migrate, or from `git show <pre-slim-sha>:.catalyst/config.json` — re-running the CLI
+there will not help.
 
 **`catalyst.schemaVersion` is a self-gating opt-in, not a global requirement.**
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -85,6 +85,21 @@ therefore writes it to `node.json` → `catalyst.orchestration.executionCore.tar
 that names exactly this and which the tuner never writes. An operator-declared `targetParallel`
 already present in Layer-2 always wins and is never overwritten.
 
+⚠️ **A repo that is ALREADY slim still gets a setpoint — seeded from the Layer-2 mirror.** The
+re-home above can only fire while Layer-1 still *carries* `maxParallel`. But this repo **commits** a
+slimmed Layer-1, so on every host that pulls it the migration finds nothing to relocate, reports
+"already migrated", and nothing writes `targetParallel` at all — `catalyst-config-migrate` is its
+only writer anywhere in the tree. Measured on `mini-2`: the resolved setpoint went **4 → null**,
+which silently no-ops the autotuner's convergence branches and (via the same resolved value) the
+`recovery-to-layer1` jump. Nothing errors; that silence *is* the failure. So when Layer-1 is already
+slim and no `targetParallel` resolves, the migration seeds it from the merged Layer-2 `maxParallel`.
+Its weakness is declared rather than hidden: `maxParallel` is the tuner's live mirror, so a host
+whose tuner is throttled at seed time seeds a lower setpoint than the operator originally committed.
+That is still strictly better than `null` (which disables the branch outright instead of aiming it
+low), it is a **one-time** snapshot — a seeded `targetParallel` is never re-seeded — and
+`catalyst doctor`'s advisory `autotune-setpoint-present` check reports both the absence and the
+resolved value, so it can never go silent again. Set `targetParallel` explicitly to override.
+
 ⚠️ **`catalyst.orchestration` as a whole is NOT machine-scoped.** Only the four subpaths above
 relocate. `executor`, `executorByPhase`, `codex`, `publishPreflight`, `fleetHealth`,
 `daemonWatchdog`, `orphanReaper.workerGc`, `draftPr`, `stalePrRescue`, `orphanPrSweep`,

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -105,15 +105,49 @@ relocate. `executor`, `executorByPhase`, `codex`, `publishPreflight`, `fleetHeal
 `daemonWatchdog`, `orphanReaper.workerGc`, `draftPr`, `stalePrRescue`, `orphanPrSweep`,
 `stalledPrSweep` and `phaseAgents` are genuinely Layer-1 and stay in the committed config.
 
-**Precedence.** Every relocated knob resolves **Layer-2 over Layer-1, per field**, with each site's
-existing env-var override still winning over both:
+**Precedence — read this per knob, not as one ladder.** Both stacks agree that an env-var override
+wins over everything and that a slimmed Layer-1 resolves from Layer-2. They deliberately differ on
+what happens when **both** layers carry a value, and the split follows which language reads the knob:
+
+| Relocated knob | Read by | When BOTH layers carry it |
+| --- | --- | --- |
+| `orchestration.executionCore` | JS | **Layer-2 wins, per field** |
+| `orchestration.worktreeRefresh` | JS | **Layer-2 wins, per field** |
+| `orchestration.reconcile` | JS | **Layer-2 wins, per field** |
+| `monitor.github.repoColors` | JS | **Layer-2 wins, per key** |
+| `orchestration.dispatchMode` | bash | **Layer-1 wins**; Layer-2 is a fallback |
+| `sweep.*` | bash | **Layer-1 wins**; Layer-2 is a fallback |
+| `feedback.*` | bash | **Layer-1 wins**; Layer-2 is a fallback |
 
 ```
-env var  >  cluster-secrets.json  >  node.json  >  ~/.config/catalyst/config.json  >  .catalyst/config.json  >  code default
+JS-read knobs:    env var  >  cluster-secrets.json  >  node.json  >  ~/.config/catalyst/config.json  >  .catalyst/config.json  >  code default
+bash-read knobs:  env var  >  .catalyst/config.json  >  cluster-secrets.json  >  node.json  >  ~/.config/catalyst/config.json  >  code default
 ```
+
+⚠️ **The bash arm is a fallback, not an override — a `node.json` value for `dispatchMode`,
+`sweep.*` or `feedback.*` does NOT take effect while Layer-1 still carries that key.** This is the
+deliberate direction, not an oversight: `node.json` is host-global and is seeded from **one** repo's
+Layer-1, so letting it outrank every repo's committed config would let one migration silently
+re-point unrelated repos. It also keeps the five bash sites consistent with `phase-agent-dispatch`'s
+pre-existing `config_value()` (Layer-1 → Layer-2 → default), which reads the same `dispatchMode`.
+The practical consequence is confined to **un-migrated** repos: to make a `node.json` override of a
+bash-read knob bite, remove the key from that repo's `.catalyst/config.json` (which is what
+`catalyst-config-migrate` does).
 
 So an un-migrated repo keeps working (Layer-1 supplies the value) and a slimmed one resolves from
-`node.json`. Nothing is required to move on any particular schedule.
+`node.json` — under **either** rule, because a slimmed Layer-1 is silent and the two rules only
+disagree while both layers are populated. Nothing is required to move on any particular schedule.
+
+**A brand-new project needs no migration — but its host needs a `dispatchMode`.**
+`catalyst-config-migrate` derives its moves from the Layer-1 content it finds, so on a repo
+scaffolded from the template there is nothing to relocate. `setup-catalyst.sh` seeds the default
+(`catalyst.orchestration.dispatchMode = "phase-agents"`) into `~/.config/catalyst/node.json`
+directly, non-clobbering — a host already pinned to `execution-core` or `oneshot-legacy` keeps its
+setting. The key deliberately does **not** ship in the template: it is node-scoped, the template
+declares `schemaVersion: 1`, and a slimmed config carrying a node-scoped key is the one
+`catalyst doctor` FAIL that fail-closes `catalyst-join.sh`. If you scaffold a project without
+running `setup-catalyst.sh`, set it by hand — with no value anywhere the code default is
+`oneshot-legacy`, which is the wrong orchestration model and fails silently.
 
 **Migrating a repo.**
 

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -57,6 +57,74 @@ statuses.
 | `catalyst.linear.teamKey`           | Linear team key; must match `ticketPrefix`                 |
 | `catalyst.linear.stateMap`          | Maps each workflow step to one of your Linear status names |
 
+### Slimmed Layer-1 and `schemaVersion` (CTL-1214)
+
+`.catalyst/config.json` is committed to git, so it must carry **project identity only**. Four
+categories of machine-scoped keys historically leaked into it and have now relocated to the
+node-scoped `~/.config/catalyst/node.json`:
+
+| Layer-1 key (relative to `catalyst.`)                                       | Scope     | Destination                                          |
+| --------------------------------------------------------------------------- | --------- | ---------------------------------------------------- |
+| `orchestration.dispatchMode`                                                 | node      | `node.json` → `catalyst.orchestration.dispatchMode`   |
+| `orchestration.executionCore.*`                                              | node      | `node.json` → `catalyst.orchestration.executionCore.*`|
+| `orchestration.worktreeRefresh.*`                                            | node      | `node.json` → `catalyst.orchestration.worktreeRefresh.*` |
+| `orchestration.reconcile.*`                                                  | node      | `node.json` → `catalyst.orchestration.reconcile.*`    |
+| `feedback.*`                                                                 | node      | `node.json` → `catalyst.feedback.*`                   |
+| `sweep.*`                                                                    | node      | `node.json` → `catalyst.sweep.*`                      |
+| `monitor.github.repoColors`                                                  | node      | `node.json` → `catalyst.monitor.github.repoColors`    |
+| `monitor.linear.teams`                                                       | cluster   | `catalyst-cluster/cluster.json` → `projects[]` (CTL-1885, **not yet moved**) |
+
+⚠️ **`catalyst.orchestration` as a whole is NOT machine-scoped.** Only the four subpaths above
+relocate. `executor`, `executorByPhase`, `codex`, `publishPreflight`, `fleetHealth`,
+`daemonWatchdog`, `orphanReaper.workerGc`, `draftPr`, `stalePrRescue`, `orphanPrSweep`,
+`stalledPrSweep` and `phaseAgents` are genuinely Layer-1 and stay in the committed config.
+
+**Precedence.** Every relocated knob resolves **Layer-2 over Layer-1, per field**, with each site's
+existing env-var override still winning over both:
+
+```
+env var  >  cluster-secrets.json  >  node.json  >  ~/.config/catalyst/config.json  >  .catalyst/config.json  >  code default
+```
+
+So an un-migrated repo keeps working (Layer-1 supplies the value) and a slimmed one resolves from
+`node.json`. Nothing is required to move on any particular schedule.
+
+**Migrating a repo.**
+
+```bash
+plugins/dev/scripts/catalyst-config-migrate --dry-run   # report only
+plugins/dev/scripts/catalyst-config-migrate             # move the keys
+plugins/dev/scripts/catalyst-config-migrate --json      # machine-readable report — keep it with the PR
+```
+
+It is non-clobbering (a key the merged Layer-2 already defines is **kept**, never overwritten),
+idempotent, and writes `node.json` **before** slimming Layer-1 so a failure can never leave a repo
+slimmed with its values nowhere. It refuses to run on a checkout that predates the Layer-2
+fallbacks.
+
+⛔ **Never run it against a host running an older plugin checkout.** That host has no Layer-2
+fallbacks, so a slimmed config silently reverts `dispatchMode` to `oneshot-legacy` and halves the
+sweep cadence. Update the checkout first.
+
+**`catalyst.schemaVersion` is a self-gating opt-in, not a global requirement.**
+
+| `schemaVersion` | A node-scoped relocated key is…                | A cluster-scoped one (`monitor.linear.teams`) is… |
+| --------------- | ---------------------------------------------- | -------------------------------------------------- |
+| absent          | a recommendation (`catalyst doctor` **WARN**)   | a recommendation (**WARN**)                        |
+| `1` or higher   | a **hard error** (`catalyst doctor` **FAIL**)   | still just a recommendation (**WARN**, CTL-1885)   |
+
+A config becomes strict exactly when it is slimmed, so repos that have not migrated are never
+flagged as invalid. The asymmetry matters operationally: `catalyst doctor`'s exit code is its FAIL
+count and `catalyst-join.sh` gates cluster-member activation on exit 0, so a FAIL here fail-closes
+the join — it may only fire on a config that has *declared* it is slimmed and then contradicts
+itself. A present-but-malformed `schemaVersion` (not an integer ≥ 1) is its own hard error and does
+**not** count as opting in.
+
+**Rolling back.** `git revert` the slimming commit, then delete the migrated stanzas from
+`node.json` — because the fallbacks are Layer-2-wins-**over**-Layer-1, a restored Layer-1 stanza is
+*shadowed* by `node.json` rather than ignored. The migration's `--json` report records exactly which
+keys those are.
+
 ### State map
 
 As work moves, Catalyst updates the ticket's Linear status for you. `stateMap` says which status


### PR DESCRIPTION
## Summary

CTL-1214 Phase 6 — slims the committed `.catalyst/config.json` to project identity and relocates the machine-scoped keys to the node-scoped `~/.config/catalyst/node.json`.

The hazard that dictates the phase order: **four relocated categories were read from Layer-1 ONLY, and every one of those readers is fail-open to a code default.** Deleting them does not error — it *silently* reverts each knob (`dispatchMode` → `oneshot-legacy`, sweep cadence halved, consent read back as unset). So the fallbacks land first, the re-leak writers are fixed second, and the config is slimmed only once neither can bite.

## Phases

1. **Layer-2 fallback seam** — `lib/catalyst-layer2-read.sh` (bash) + `readLayer2MergedFrom` (JS); the 3 JS readers and 5 bash consumer sites gain a Layer-2 arm, Layer-2-wins-per-field.
2. **Migration CLI** — `catalyst-config-migrate` over a pure, unit-testable planner. Non-clobbering, idempotent, writes `node.json` **before** slimming Layer-1.
3. **Stop the re-leak** — `setup_sweep_config` and `feedback-consent grant` retargeted to `node.json`; template sanitized; `check-config-drift` strips relocated paths in both arms.
4. **Slim the committed config** — 16 moved, 1 kept, 1 dropped; verified by a before/after `config-dump` provenance diff.
5. **Tighten the contract** — `schemaVersion >= 1` opts a config into strictness; a node-scoped leak then FAILs doctor. Cluster-scoped (the roster) stays WARN — CTL-1885 owns it.

## Verification

- Resolved values: **zero changes** across the `config-dump` before/after diff — with a positive control proving the diff *can* fail (perturbing `node.json` shows up; restoring returns to zero).
- Provenance moved `layer1` → `layer2` for exactly the relocated rows.
- Probes unchanged: `dispatchMode=phase-agents` (not `oneshot-legacy`), sweep `intervalHours=1` (not the default 2), consent `granted`, `resolveRepoFullName=coalesce-labs/catalyst`.
- `catalyst doctor`: `config-scope-leak` WARNs about the roster only; its 3 FAILs are unrelated pre-existing host/credential issues.
- Regression: `scheduler.test.mjs` 8 fail / `config.test.mjs` 6 fail — byte-identical by name to the clean-`a8d4946c` baseline built in this worktree.
- All 20 CTL-1214 suites green; every one is now registered in CI (several, including the pre-existing `config-schema.test.mjs`, had never gated anything).

## Notes for review

- The plan listed a fourth re-leak writer (`setup-catalyst.sh:730` "touches dispatchMode"). It does not — that line is prose; a repo-wide search finds no `dispatchMode` writer outside a test assertion. `dispatchMode` reached committed configs only via the template.
- D6 (registry narrowing) landed in Phase 2 rather than Phase 5: the migration planner reads the registry, and the blanket `orchestration` row relocated `codex`/`executor`/`fleetHealth` too.
- `node-config-present` did **not** flip WARN → PASS as the plan predicted; it moved from "absent" to "present but `catalyst.host.name` unset". Still WARN, no functional impact — `host.name` is `catalyst-join`'s to write.
- Two latent test-harness defects were found and fixed: a suite that wrote the developer's real `~/.config/catalyst/node.json`, and an `expect_exit()` that leaked `errexit` and silently killed its own suite mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)