### PR TITLE
CTL-2204: refuse a file path as a Linear comment --body

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -832,6 +832,17 @@ jobs:
         working-directory: plugins/dev/scripts/lib
         run: bun test entitlement.test.mjs
 
+      - name: comment-body-arg resolver unit tests (bun, CTL-2204)
+        # lib/comment-body-arg.mjs is the shared, zero-import leaf that decides what a
+        # Linear comment's body is for BOTH linear-reply.mjs and ask.mjs's `accept` verb —
+        # it refuses a file PATH passed to --body (the mistake that published 23 bad
+        # comments across 16 tickets) and adds --body-file as the correct recipe. Own step
+        # for the same reason as deployment-mode/entitlement above: this lib/ leaf sits
+        # outside the execution-core/ tree the "Run stable unit tests" step below is
+        # scoped to, so it needs an explicit run: line or it never executes in CI.
+        working-directory: plugins/dev/scripts/lib
+        run: bun test comment-body-arg.test.mjs
+
       - name: ask-verb unit tests (bun, CTL-1922 / CTL-1944)
         # ⛔ `ask-verbs.test.mjs` shipped with #3509 and was registered in NO workflow —
         # 20 tests that had never run in CI. Verified with the instrument note above:

--- a/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
+++ b/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
@@ -578,3 +578,138 @@ esac
     expect(r.stderr).toContain("NO relation field");
   });
 });
+
+// ── CTL-2204 ────────────────────────────────────────────────────────────────────
+// ask.mjs accept forwards --body straight to linear-reply.mjs's child process
+// (ask.mjs:619). A guard in linear-reply.mjs alone still leaves a gap: --dry-run
+// never spawns that child, so before this change `ask accept ... --body
+// /tmp/x.md --dry-run` happily printed wouldReply:"/tmp/x.md" and exited 0. The
+// same shared resolver (lib/comment-body-arg.mjs) is wired directly into
+// cmdAccept so the refusal fires in ask.mjs's OWN process, before the replica
+// read — which is why the refusal tests below need no replica/linearis stub at
+// all: a refused body never reaches that code.
+//
+// Every test drives the REAL CLI through spawnSync, same discipline as the
+// CTL-2157 block above.
+
+const runAccept = (args, { env = {} } = {}) =>
+  spawnSync(process.execPath, [ASK_MJS, "accept", ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+
+describe("ask accept — CTL-2204 body guard", () => {
+  const ASK_ID = "CTL-1";
+
+  test("--body pointing at an existing file is refused before anything is written", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
+    const f = join(dir, "real.md");
+    writeFileSync(f, "# real body\n");
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("--body-file");
+  });
+
+  test("--dry-run does NOT report a path as the would-be reply", () => {
+    // The gap a linear-reply-only guard leaves: dry-run never reaches the child
+    // process, so before this change it printed wouldReply:"/tmp/real.md" and
+    // exited 0.
+    const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
+    const f = join(dir, "real.md");
+    writeFileSync(f, "# real body\n");
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).not.toContain(f);
+  });
+
+  test("--body-file missing → refused, naming the path", () => {
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", "/tmp/gone-xyz-ctl2204.md", "--dry-run"]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("/tmp/gone-xyz-ctl2204.md");
+  });
+
+  test("both --body and --body-file → refused as ambiguous", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
+    const f = join(dir, "real.md");
+    writeFileSync(f, "x");
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "hi", "--body-file", f, "--dry-run"]);
+    expect(r.status).not.toBe(0);
+  });
+
+  test("whitespace-only --body → refused", () => {
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "   ", "--dry-run"]);
+    expect(r.status).not.toBe(0);
+  });
+
+  test("an ordinary body clears the guard — the refusal is not what stops it", () => {
+    // The guard runs BEFORE the replica read, so an ordinary body must advance
+    // PAST it. It then legitimately fails at the (nonexistent, isolated) replica
+    // — that failure proves the guard was cleared, not tripped: none of the
+    // guard's own refusal strings appear.
+    const r = runAccept(
+      [ASK_ID, "--as", "COORD", "--body", "accepted — has what it needs", "--dry-run"],
+      { env: { CATALYST_REPLICA_DB: "/nonexistent/replica-ctl2204.db", CATALYST_DIR: mkdtempSync(join(tmpdir(), "ask-noreplica-")) } }
+    );
+    expect(r.stderr).not.toContain("--body-file");
+    expect(r.stderr).not.toContain("ambiguous");
+    expect(r.stderr).not.toContain("comment body is empty");
+  });
+});
+
+describe("ask accept — CTL-2204 --body-file happy path (fresh local replica)", () => {
+  const ASK_ID = "CTL-220499"; // linear_read_ticket requires TEAM-<digits>; no letter suffix
+
+  // Build a hermetic replica the SAME shape lib/linear-read-replica.sh's
+  // linear_read_ticket reads: issues/labels/issue_labels + a FRESH writer.lock
+  // + a sync_meta cursor row, so the read is a replica HIT and never falls back
+  // to a live `linearis` call (none is stubbed on PATH here).
+  const buildFreshReplica = (id, { askLabel = true } = {}) => {
+    const dir = mkdtempSync(join(tmpdir(), "ask-replica-"));
+    const db = join(dir, "replica.db");
+    const labelRows = askLabel
+      ? "INSERT INTO labels VALUES ('L1','catalyst-ask');" +
+        "INSERT INTO issue_labels VALUES ('issue-1','L1');"
+      : "";
+    const sql = `
+CREATE TABLE issues (id TEXT PRIMARY KEY, identifier TEXT, title TEXT, description TEXT,
+  priority INTEGER, estimate INTEGER, url TEXT, branch_name TEXT, state TEXT,
+  assignee_id TEXT, assignee TEXT, removed_at INTEGER);
+CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT);
+CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO issues (id, identifier, title, removed_at) VALUES ('issue-1', '${id}', 't', NULL);
+${labelRows}
+INSERT INTO sync_meta VALUES ('cursor', '1');
+`;
+    const r = spawnSync("sqlite3", [db, sql], { encoding: "utf8" });
+    if (r.status !== 0) throw new Error(`buildFreshReplica: sqlite3 failed: ${r.stderr}`);
+    writeFileSync(`${db}.writer.lock`, ""); // fresh mtime = now
+    return db;
+  };
+
+  test("--body-file resolves to the file's contents in the dry-run preview, never the path", () => {
+    const db = buildFreshReplica(ASK_ID);
+    const bodyDir = mkdtempSync(join(tmpdir(), "ask-body-"));
+    const f = join(bodyDir, "real.md");
+    writeFileSync(f, "# real body\n");
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", f, "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.wouldReply).toContain("real body");
+    expect(out.wouldReply).not.toContain(f);
+  });
+
+  test("an ordinary --body reaches the dry-run preview and exits 0 (guard does not regress the happy path)", () => {
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept(
+      [ASK_ID, "--as", "COORD", "--body", "accepted — has what it needs", "--dry-run"],
+      { env: { CATALYST_REPLICA_DB: db } }
+    );
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout);
+    expect(out.action).toBe("dry-run");
+    expect(out.wouldReply).toContain("accepted");
+  });
+});

--- a/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
+++ b/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
@@ -335,6 +335,13 @@ describe("trap (a) — the documented path must not silently no-op", () => {
     expect(r.status).toBe(1);
     expect(r.stdout).toBe("");
     expect(r.stderr).toContain("could not resolve the ask labels");
+    // CTL-2204 verify round 3: run() was changed to surface spawnSync's `r.error`, because
+    // a spawn that NEVER STARTED leaves status null and stderr UNDEFINED — the operator saw
+    // a bare `rc=1` with an empty stderr tail, a failure with no cause. That branch had no
+    // test of its own; this is the one environment that fires it positively (an empty PATH
+    // hides `linearis`, so spawn returns ENOENT). Deleting the `if (r.error)` block in run()
+    // makes this assertion fail.
+    expect(r.stderr).toContain("the child never started (ENOENT)");
   });
 
   test("⛔ a no-op is LOUD: a real verb that does not reach the entry point exits non-zero", () => {
@@ -827,5 +834,66 @@ describe("ask accept — CTL-2204 a refused body never closes the ask (no --dry-
     // it will not) — only that the recorder captured a real invocation from ask.mjs.
     expect(calls()).toContain("labels list");
     expect(r.status).not.toBe(null); // the child ran; this is not a spawn failure
+  });
+});
+
+// ── CTL-2204 verify round 3: the ask.mjs → linear-reply.mjs MARSHALLING boundary ─────────
+// The remediation that introduced `run(..., ["--body", "-"], { input: body })` justified
+// itself with three measured failures (E2BIG, argv injection via a body of `--top`, and a
+// double refusal). None of them had a regression test: reverting that one line to the old
+// `["--body", body]` left ALL 137 tests across all four CTL-2204 suites GREEN
+// (ask-verbs 56/0, linear-reply-write-path 38/0, comment-body-arg 33/0,
+// install-agent-tools 10/0). A fix whose removal is invisible is a fix that will be removed.
+//
+// The discriminator is exact and needs no stub: with argv marshalling, spawn fails and
+// run()'s r.error branch reports "the child never started (E2BIG)"; with stdin marshalling
+// the child really starts and fails later, downstream, inside the replica read. So this
+// asserts BOTH directions — the spawn-failure marker is absent, and positive evidence that
+// the child actually ran is present.
+describe("ask accept — CTL-2204 the body reaches the child on STDIN, never through argv", () => {
+  const ASK_ID = "CTL-220497";
+
+  // Over MAX_ARG_STRLEN on both platforms: macOS kern.argmax is 1 MiB, and Linux's
+  // per-argument limit (32 pages = 128 KiB) is LOWER, so CI trips it sooner than a laptop.
+  const OVERSIZED = `# big\n${"x".repeat(2_000_000)}`;
+
+  test("a body past the per-argument limit does NOT fail the spawn (E2BIG regression guard)", () => {
+    const db = buildFreshReplica(ASK_ID);
+    const dir = mkdtempSync(join(tmpdir(), "ask-big-"));
+    const f = join(dir, "big.md");
+    writeFileSync(f, OVERSIZED);
+
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", f], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+
+    // The reply cannot SUCCEED here (no write proxy in a unit test) and that is fine —
+    // the property under test is WHERE it fails. It must not be at the spawn.
+    expect(r.stderr).not.toContain("never started");
+    expect(r.stderr).not.toContain("E2BIG");
+    // Positive control: prove the child was genuinely reached rather than the assertions
+    // above passing on an ask.mjs that exited earlier for some unrelated reason.
+    expect(r.stderr).toContain("reply FAILED");
+    expect(r.status).not.toBe(0);
+  });
+
+  test("positive control: the SAME oversized body through argv DOES fail the spawn", () => {
+    // Without this, the test above is equally consistent with 2 MB simply being under the
+    // limit on this host — i.e. with no evidence about marshalling at all. This reproduces
+    // the old code path directly through spawnSync and pins that it really does break.
+    const r = spawnSync(process.execPath, [ASK_MJS, "--body", OVERSIZED], { encoding: "utf8" });
+    expect(r.error?.code).toBe("E2BIG");
+    // A spawn that never ran reports no exit status. node uses null here and bun uses
+    // undefined, and this suite runs under both — normalize rather than pin one runtime.
+    expect(r.status ?? null).toBe(null);
+  });
+
+  test("a SMALL body also reaches the child — the stdin path is not large-body-only", () => {
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "accepted — go ahead"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.stderr).not.toContain("never started");
+    expect(r.stderr).toContain("reply FAILED");
   });
 });

--- a/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
+++ b/plugins/dev/scripts/__tests__/ask-verbs.test.mjs
@@ -20,7 +20,7 @@ import {
   verifyAskBody,
 } from "../ask.mjs";
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -580,14 +580,22 @@ esac
 });
 
 // ── CTL-2204 ────────────────────────────────────────────────────────────────────
-// ask.mjs accept forwards --body straight to linear-reply.mjs's child process
-// (ask.mjs:619). A guard in linear-reply.mjs alone still leaves a gap: --dry-run
-// never spawns that child, so before this change `ask accept ... --body
-// /tmp/x.md --dry-run` happily printed wouldReply:"/tmp/x.md" and exited 0. The
-// same shared resolver (lib/comment-body-arg.mjs) is wired directly into
-// cmdAccept so the refusal fires in ask.mjs's OWN process, before the replica
-// read — which is why the refusal tests below need no replica/linearis stub at
-// all: a refused body never reaches that code.
+// ask.mjs accept forwards the resolved body to linear-reply.mjs's child process. A guard in
+// linear-reply.mjs alone still leaves a gap: --dry-run never spawns that child, so before
+// this change `ask accept ... --body /tmp/x.md --dry-run` happily printed
+// wouldReply:"/tmp/x.md" and exited 0. The same shared resolver (lib/comment-body-arg.mjs)
+// is wired directly into cmdAccept so the refusal fires in ask.mjs's OWN process, before the
+// replica read.
+//
+// ⛔ EVERY TEST HERE RUNS AGAINST A FRESH REPLICA. The first cut of this block ran the
+// refusal cases with NO replica env, reasoning that "a refused body never reaches that
+// code". That is true — and it is exactly why three of them could not fail: ask.mjs exits 1
+// at the replica read whether or not the guard exists, so `expect(status).not.toBe(0)`
+// passed for a reason unrelated to the property under test. Proven by mutation: with the
+// CTL-2204 resolver block removed from cmdAccept, the suite went 52/0 → 49 pass / 3 fail and
+// those three stayed GREEN. A test whose subject can be deleted without it failing is not
+// evidence. Each case now (a) reaches the guard via buildFreshReplica and (b) asserts the
+// EXACT refusal string plus status === 1, so deleting the guard fails it.
 //
 // Every test drives the REAL CLI through spawnSync, same discipline as the
 // CTL-2157 block above.
@@ -598,47 +606,137 @@ const runAccept = (args, { env = {} } = {}) =>
     env: { ...process.env, ...env },
   });
 
+// Build a hermetic replica the SAME shape lib/linear-read-replica.sh's linear_read_ticket
+// reads: issues/labels/issue_labels + a FRESH writer.lock + a sync_meta cursor row, so the
+// read is a replica HIT and never falls back to a live `linearis` call.
+//
+// Hoisted to block scope (CTL-2204 remediation): the refusal cases need it too, or they
+// never reach the guard they claim to test.
+const buildFreshReplica = (id, { askLabel = true } = {}) => {
+  const dir = mkdtempSync(join(tmpdir(), "ask-replica-"));
+  const db = join(dir, "replica.db");
+  const labelRows = askLabel
+    ? "INSERT INTO labels VALUES ('L1','catalyst-ask');" +
+      "INSERT INTO issue_labels VALUES ('issue-1','L1');"
+    : "";
+  const sql = `
+CREATE TABLE issues (id TEXT PRIMARY KEY, identifier TEXT, title TEXT, description TEXT,
+  priority INTEGER, estimate INTEGER, url TEXT, branch_name TEXT, state TEXT,
+  assignee_id TEXT, assignee TEXT, removed_at INTEGER);
+CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT);
+CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT);
+CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO issues (id, identifier, title, removed_at) VALUES ('issue-1', '${id}', 't', NULL);
+${labelRows}
+INSERT INTO sync_meta VALUES ('cursor', '1');
+`;
+  const r = spawnSync("sqlite3", [db, sql], { encoding: "utf8" });
+  if (r.status !== 0) throw new Error(`buildFreshReplica: sqlite3 failed: ${r.stderr}`);
+  writeFileSync(`${db}.writer.lock`, ""); // fresh mtime = now
+  return db;
+};
+
+// A `linearis` stub that RECORDS every invocation, so "linearis was never called" can be
+// asserted as evidence rather than assumed. Prints the labels JSON so `create` (used below
+// purely as the positive control for this recorder) gets past its first call.
+const recordingLinearisStub = () => {
+  const bin = mkdtempSync(join(tmpdir(), "ask-recstub-"));
+  const log = join(bin, "invocations.log");
+  const stub = join(bin, "linearis");
+  writeFileSync(stub, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${log}\nprintf '%s\\n' '${LABELS_JSON}'\n`);
+  chmodSync(stub, 0o755);
+  return { bin, log, calls: () => (existsSync(log) ? readFileSync(log, "utf8").trim() : "") };
+};
+
 describe("ask accept — CTL-2204 body guard", () => {
-  const ASK_ID = "CTL-1";
+  // A replica-resolvable id: linear_read_ticket requires TEAM-<digits>.
+  const ASK_ID = "CTL-220499";
 
   test("--body pointing at an existing file is refused before anything is written", () => {
+    const db = buildFreshReplica(ASK_ID);
     const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
     const f = join(dir, "real.md");
     writeFileSync(f, "# real body\n");
-    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"]);
-    expect(r.status).not.toBe(0);
-    expect(r.stderr).toContain("--body-file");
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("A path is never a valid comment body");
+    expect(r.stderr).toContain(`--body-file ${f}`);
   });
 
   test("--dry-run does NOT report a path as the would-be reply", () => {
-    // The gap a linear-reply-only guard leaves: dry-run never reaches the child
-    // process, so before this change it printed wouldReply:"/tmp/real.md" and
-    // exited 0.
+    // The gap a linear-reply-only guard leaves: dry-run never reaches the child process, so
+    // before this change it printed wouldReply:"/tmp/real.md" and exited 0.
+    //
+    // ⛔ The replica MUST be present here. Without it ask.mjs exits 1 at the replica read and
+    // prints no stdout at all, so both assertions below hold with the guard DELETED — the
+    // mutation-proven false pass this remediation exists to fix.
+    const db = buildFreshReplica(ASK_ID);
     const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
     const f = join(dir, "real.md");
     writeFileSync(f, "# real body\n");
-    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"]);
-    expect(r.status).not.toBe(0);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", f, "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(1);
     expect(r.stdout).not.toContain(f);
+    expect(r.stderr).toContain("A path is never a valid comment body");
+  });
+
+  test("positive control: the SAME argv minus the path reaches the dry-run preview", () => {
+    // Proves the replica fixture above is live and the run really does get past the read —
+    // so "status 1 + no stdout" in the two tests above is the GUARD talking, not the replica.
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "an ordinary body", "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).action).toBe("dry-run");
   });
 
   test("--body-file missing → refused, naming the path", () => {
-    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", "/tmp/gone-xyz-ctl2204.md", "--dry-run"]);
-    expect(r.status).not.toBe(0);
-    expect(r.stderr).toContain("/tmp/gone-xyz-ctl2204.md");
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", "/tmp/gone-xyz-ctl2204.md", "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("--body-file not found: /tmp/gone-xyz-ctl2204.md");
   });
 
   test("both --body and --body-file → refused as ambiguous", () => {
+    const db = buildFreshReplica(ASK_ID);
     const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
     const f = join(dir, "real.md");
     writeFileSync(f, "x");
-    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "hi", "--body-file", f, "--dry-run"]);
-    expect(r.status).not.toBe(0);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "hi", "--body-file", f, "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("both --body and --body-file were given");
   });
 
   test("whitespace-only --body → refused", () => {
-    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "   ", "--dry-run"]);
-    expect(r.status).not.toBe(0);
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body", "   ", "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db },
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("comment body is empty");
+  });
+
+  test("a ~/ --body-file is expanded, so the refusal's own suggested remedy works", () => {
+    // The --body refusal prints `use --body-file <the string you passed>`. If only --body
+    // expanded ~/, that suggestion came straight back as "--body-file not found".
+    const home = mkdtempSync(join(tmpdir(), "ask-home-"));
+    mkdirSync(join(home, ".p"));
+    writeFileSync(join(home, ".p", "b.md"), "# tilde body\n");
+    const db = buildFreshReplica(ASK_ID);
+    const r = runAccept([ASK_ID, "--as", "COORD", "--body-file", "~/.p/b.md", "--dry-run"], {
+      env: { CATALYST_REPLICA_DB: db, HOME: home },
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout).wouldReply).toContain("tilde body");
   });
 
   test("an ordinary body clears the guard — the refusal is not what stops it", () => {
@@ -658,34 +756,6 @@ describe("ask accept — CTL-2204 body guard", () => {
 
 describe("ask accept — CTL-2204 --body-file happy path (fresh local replica)", () => {
   const ASK_ID = "CTL-220499"; // linear_read_ticket requires TEAM-<digits>; no letter suffix
-
-  // Build a hermetic replica the SAME shape lib/linear-read-replica.sh's
-  // linear_read_ticket reads: issues/labels/issue_labels + a FRESH writer.lock
-  // + a sync_meta cursor row, so the read is a replica HIT and never falls back
-  // to a live `linearis` call (none is stubbed on PATH here).
-  const buildFreshReplica = (id, { askLabel = true } = {}) => {
-    const dir = mkdtempSync(join(tmpdir(), "ask-replica-"));
-    const db = join(dir, "replica.db");
-    const labelRows = askLabel
-      ? "INSERT INTO labels VALUES ('L1','catalyst-ask');" +
-        "INSERT INTO issue_labels VALUES ('issue-1','L1');"
-      : "";
-    const sql = `
-CREATE TABLE issues (id TEXT PRIMARY KEY, identifier TEXT, title TEXT, description TEXT,
-  priority INTEGER, estimate INTEGER, url TEXT, branch_name TEXT, state TEXT,
-  assignee_id TEXT, assignee TEXT, removed_at INTEGER);
-CREATE TABLE labels (id TEXT PRIMARY KEY, name TEXT);
-CREATE TABLE issue_labels (issue_id TEXT, label_id TEXT);
-CREATE TABLE sync_meta (key TEXT PRIMARY KEY, value TEXT);
-INSERT INTO issues (id, identifier, title, removed_at) VALUES ('issue-1', '${id}', 't', NULL);
-${labelRows}
-INSERT INTO sync_meta VALUES ('cursor', '1');
-`;
-    const r = spawnSync("sqlite3", [db, sql], { encoding: "utf8" });
-    if (r.status !== 0) throw new Error(`buildFreshReplica: sqlite3 failed: ${r.stderr}`);
-    writeFileSync(`${db}.writer.lock`, ""); // fresh mtime = now
-    return db;
-  };
 
   test("--body-file resolves to the file's contents in the dry-run preview, never the path", () => {
     const db = buildFreshReplica(ASK_ID);
@@ -711,5 +781,51 @@ INSERT INTO sync_meta VALUES ('cursor', '1');
     const out = JSON.parse(r.stdout);
     expect(out.action).toBe("dry-run");
     expect(out.wouldReply).toContain("accepted");
+  });
+});
+
+// ── CTL-2204 remediation: the NON-dry-run tail ──────────────────────────────────
+// The ticket's core safety property is an ORDERING one — a path passed to --body must be
+// refused BEFORE the ask is closed — and every test above passes --dry-run, which returns
+// early. So cmdAccept's tail (spawn linear-reply, then `linearis issues update --status
+// Done`) was executed by NO test at all: nothing asserted that a refused body leaves
+// `linearis` uninvoked and the ask OPEN. The ordering is correct by construction today
+// (the guard is the first statement after arg validation), but an edit that moved the
+// guard below the reply/close block would have shipped green.
+describe("ask accept — CTL-2204 a refused body never closes the ask (no --dry-run)", () => {
+  const ASK_ID = "CTL-220499";
+
+  test("a path as --body → non-zero exit AND linearis is never invoked", () => {
+    const { bin, calls } = recordingLinearisStub();
+    const db = buildFreshReplica(ASK_ID);
+    const dir = mkdtempSync(join(tmpdir(), "ask-body-"));
+    const f = join(dir, "real.md");
+    writeFileSync(f, "# real body\n");
+
+    const r = spawnSync(process.execPath, [ASK_MJS, "accept", ASK_ID, "--as", "COORD", "--body", f], {
+      encoding: "utf8",
+      env: { ...process.env, CATALYST_REPLICA_DB: db, PATH: `${bin}:${process.env.PATH ?? ""}` },
+    });
+
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("A path is never a valid comment body");
+    // The ask is left OPEN: no Done transition, and no linearis call of ANY kind.
+    expect(calls()).toBe("");
+  });
+
+  test("positive control: the same stub DOES record when ask.mjs really calls linearis", () => {
+    // Without this, `calls() === ""` above is equally consistent with a stub that never
+    // ran, was not on PATH, or could not write its log — i.e. with no evidence at all.
+    const { bin, calls } = recordingLinearisStub();
+    const r = spawnSync(
+      process.execPath,
+      [ASK_MJS, "create", "--team", "CTL", "--title", "t", "--why", "w",
+       "--option", "a", "--option", "b", "--default", "a", "--blocks", "CTL-1"],
+      { encoding: "utf8", env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` } }
+    );
+    // We do not care whether create SUCCEEDS (the stub returns label JSON for every call, so
+    // it will not) — only that the recorder captured a real invocation from ask.mjs.
+    expect(calls()).toContain("labels list");
+    expect(r.status).not.toBe(null); // the child ran; this is not a spawn failure
   });
 });

--- a/plugins/dev/scripts/__tests__/install-agent-tools.test.sh
+++ b/plugins/dev/scripts/__tests__/install-agent-tools.test.sh
@@ -86,6 +86,21 @@ else
   bad "symlink target(s) still contain client_credentials:${TARGET_HITS}"
 fi
 
+# 5. CTL-2204: the deployed tool is a SYMLINK, and linear-reply.mjs now imports ./lib/…
+#    in addition to ./execution-core/…. Node resolves relative imports from the REALPATH
+#    (no --preserve-symlinks), so this should work — but nothing executed the deployed copy
+#    before, so the property was unguarded. `node --check` does NOT resolve imports; running
+#    the tool does, because top-level imports run before the usage gate.
+DEPLOY_RC=0
+DEPLOY_OUT="$(node "${TOOLS_DIR}/linear-reply.mjs" 2>&1)" || DEPLOY_RC=$?
+if [[ "$DEPLOY_RC" -eq 2 ]] && printf '%s' "$DEPLOY_OUT" | grep -q "usage:"; then
+  ok "deployed symlink executes: imports resolve, reaches the usage gate (exit 2)"
+elif printf '%s' "$DEPLOY_OUT" | grep -qi "ERR_MODULE_NOT_FOUND\|Cannot find module"; then
+  bad "deployed symlink cannot resolve an import: ${DEPLOY_OUT}"
+else
+  bad "deployed symlink unexpected result (rc=${DEPLOY_RC}, out=${DEPLOY_OUT})"
+fi
+
 rm -rf "$CATALYST_DIR"
 
 echo ""

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -290,6 +290,20 @@ fi
 rm -f "$DB_WITH" "$DB_NOISSUE"
 rm -rf "$BODY_TMP"
 
+# --- CTL-2204: the documented recipe must teach --body-file ---
+DOCS_ROOT="${SCRIPT_DIR}/../../skills"
+# Positive control: the instrument can see a string we know is in the file.
+if grep -q "linear-reply.mjs" "${DOCS_ROOT}/ask/references/threading.md"; then
+  ok "positive control: docs grep instrument reads threading.md"
+  if grep -q -- "--body-file" "${DOCS_ROOT}/ask/references/threading.md"; then
+    ok "threading.md documents --body-file"
+  else
+    bad "threading.md does not document --body-file"
+  fi
+else
+  bad "positive control FAILED — docs path wrong (${DOCS_ROOT}), grep result untrustworthy"
+fi
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 [[ "$FAIL" -eq 0 ]]

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -102,6 +102,45 @@ else
   bad "absent issue path (rc=${LAST_RC}, out=${LAST_OUT})"
 fi
 
+# --- CTL-2204: --body may never be a path; --body-file is the recipe (network-free cases) ---
+BODY_TMP="$(mktemp -d)"
+printf '# a real comment body\nwith two lines\n' >"${BODY_TMP}/real.md"
+
+# (a) path-as-body → exit 2 naming --body-file. Exit 2 (usage family) not 1 (REFUSED family).
+run_tool - "$DB_WITH" CTL-1 --as COORD --body "${BODY_TMP}/real.md"
+if [[ "$LAST_RC" -eq 2 ]] && printf '%s' "$LAST_OUT" | grep -q -- "--body-file"; then
+  ok "path-as-body → exit 2 naming --body-file"
+else
+  bad "path-as-body guard (rc=${LAST_RC}, out=${LAST_OUT})"
+fi
+
+# (b) an absolute path that does NOT exist stays a legitimate body (guard is existence-gated,
+#     so it must fall through to the ordinary refuse path, exit 1 / REFUSED — not exit 2).
+run_tool - "$DB_WITH" CTL-1 --as COORD --body "${BODY_TMP}/nope.md"
+if [[ "$LAST_RC" -ne 2 ]]; then
+  ok "non-existent path is not treated as path-as-body"
+else
+  bad "non-existent path wrongly refused as a path (out=${LAST_OUT})"
+fi
+
+# (c) --body-file pointing at nothing → exit 2 naming the path
+run_tool - "$DB_WITH" CTL-1 --as COORD --body-file "${BODY_TMP}/gone.md"
+if [[ "$LAST_RC" -eq 2 ]] && printf '%s' "$LAST_OUT" | grep -q "gone.md"; then
+  ok "--body-file missing → exit 2 naming the path"
+else
+  bad "--body-file missing (rc=${LAST_RC}, out=${LAST_OUT})"
+fi
+
+# (d) whitespace-only body → exit 2
+run_tool - "$DB_WITH" CTL-1 --as COORD --body "   "
+if [[ "$LAST_RC" -eq 2 ]]; then ok "whitespace-only --body → exit 2"
+else bad "whitespace-only body (rc=${LAST_RC}, out=${LAST_OUT})"; fi
+
+# (e) both flags → exit 2
+run_tool - "$DB_WITH" CTL-1 --as COORD --body "hi" --body-file "${BODY_TMP}/real.md"
+if [[ "$LAST_RC" -eq 2 ]]; then ok "--body + --body-file → exit 2 (ambiguous)"
+else bad "ambiguous flags (rc=${LAST_RC}, out=${LAST_OUT})"; fi
+
 # ============================ MOCK CLOUD (success path) ============================
 MOCK_DIR="$(mktemp -d)"
 MOCK_JS="${MOCK_DIR}/mock.mjs"
@@ -213,11 +252,43 @@ else
   else
     bad "eyes-clear best-effort (rc=${LAST_RC}, out=${LAST_OUT})"
   fi
+  # (CTL-2204) THE NEGATIVE CONTROL. Under enforce + a REACHABLE mock, an unguarded tool
+  # would really post. Two assertions, in this order:
+  #   1. POSITIVE CONTROL — a good body DOES produce an /agent/issue-comment capture, so an
+  #      empty capture below means "refused", not "the mock is broken". (run_mock truncates
+  #      $CAP_FILE on every call, so the two runs cannot contaminate each other.)
+  #   2. the path-as-body run leaves ZERO captures.
+  echo "200" >"$CTRL_FILE"
+  run_mock "$DB_DEF" CTL-1 --as COORD --body "control body"
+  if [[ "$LAST_RC" -eq 0 ]] && [[ -n "$(comment_capture)" ]]; then
+    ok "positive control: a good body DOES reach /agent/issue-comment under the mock"
+    run_mock "$DB_DEF" CTL-1 --as COORD --body "${BODY_TMP}/real.md"
+    if [[ "$LAST_RC" -eq 2 ]] \
+       && [[ -z "$(comment_capture)" ]] \
+       && printf '%s' "$LAST_OUT" | grep -q -- "--body-file"; then
+      ok "path-as-body under ENFORCE: exit 2, NOTHING posted (no /agent/issue-comment capture)"
+    else
+      bad "path-as-body must post nothing under enforce (rc=${LAST_RC}, cap=$(comment_capture), out=${LAST_OUT})"
+    fi
+  else
+    bad "positive control FAILED — the no-capture assertion below would be untrustworthy"
+  fi
+
+  # (CTL-2204) --body-file posts the file's CONTENTS, and never the path.
+  run_mock "$DB_DEF" CTL-1 --as COORD --body-file "${BODY_TMP}/real.md"
+  CAP="$(comment_capture)"
+  if [[ "$LAST_RC" -eq 0 ]] && cap_has 'a real comment body' && cap_lacks "${BODY_TMP}"; then
+    ok "--body-file → the comment carries the file CONTENTS, not the path"
+  else
+    bad "--body-file contents (rc=${LAST_RC}, cap=${CAP})"
+  fi
+
   rm -f "$DB_DEF" "$DB_PAIR"
 fi
 # =================================================================================
 
 rm -f "$DB_WITH" "$DB_NOISSUE"
+rm -rf "$BODY_TMP"
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -417,6 +417,13 @@ check_first_invocation_is_not_bare_body() { # $1=rel path  $2=tool basename
 check_first_invocation_is_not_bare_body "ask/references/threading.md" "linear-reply.mjs"
 check_first_invocation_is_not_bare_body "ask/SKILL.md" "linear-reply.mjs"
 
+# linearis/SKILL.md is the skill most agents read for a Linear invocation, so its primary
+# reply recipe is among the most-copied in the repo — yet it had only the weaker presence
+# check above, which a `#   --body-file …` comment line satisfies while the invocation line
+# itself still taught a bare --body. That is exactly the regression this strict check exists
+# to catch (CTL-2204 verify finding), so linearis is covered here too, not just ask/.
+check_first_invocation_is_not_bare_body "linearis/SKILL.md" "linear-reply.mjs"
+
 # ask/SKILL.md §5 is the `accept` recipe an agent copies when CLOSING an ask, and it is a
 # SECOND invocation in the same file — so the ask.mjs recipe needs its own anchor. Before the
 # CTL-2204 remediation this file's only --body-file mention was on the linear-reply line, so

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -195,6 +195,21 @@ else
       "$RUNTIME" "$TOOL" "$@" 2>&1)" || rc=$?
     rm -rf "$home"; LAST_OUT="$out"; LAST_RC="$rc"
   }
+  # CTL-2204 remediation: the same runner, with fd 0 supplied. `--body -` was REWRITTEN by
+  # this ticket (from `if (body === "-") readFileSync(0)` to `resolved.stdin ? …` plus a new
+  # post-read emptiness check) and had no end-to-end test in either CLI — a regression that
+  # dropped the resolved.stdin branch would have shipped green.
+  run_mock_stdin() { # $1=db $2=stdin-source-file rest=args ; sets LAST_OUT/LAST_RC
+    local db="$1"; shift
+    local stdin_src="$1"; shift
+    local home; home="$(mktemp -d)"; local out rc=0
+    : >"$CAP_FILE"
+    out="$(HOME="$home" CATALYST_DIR="$home/catalyst" CATALYST_REPLICA_DB="$db" \
+      CATALYST_LINEAR_WRITE_PROXY=enforce CATALYST_CLOUD_BASE_URL="http://127.0.0.1:${PORT}" \
+      CATALYST_CLOUD_TOKEN=test-token CATALYST_CLOUD_ACCOUNT=test-acct \
+      "$RUNTIME" "$TOOL" "$@" <"$stdin_src" 2>&1)" || rc=$?
+    rm -rf "$home"; LAST_OUT="$out"; LAST_RC="$rc"
+  }
   comment_capture() { grep '"/agent/issue-comment"' "$CAP_FILE" | tail -1; }
   # The captured request body is a JSON-ENCODED string, so its inner quotes are
   # backslash-escaped on disk. Unescape before matching so assertions read the real payload.
@@ -283,6 +298,56 @@ else
     bad "--body-file contents (rc=${LAST_RC}, cap=${CAP})"
   fi
 
+  # (CTL-2204 remediation) `--body -` reads fd 0 end-to-end, and empty stdin is a clean
+  # refusal rather than a crash. The leaf only pins the {ok:true,stdin:true} SENTINEL —
+  # nothing proved the CALLER actually reads fd 0.
+  STDIN_BODY="${BODY_TMP}/piped.md"
+  printf 'piped through stdin\n' >"$STDIN_BODY"
+  run_mock_stdin "$DB_DEF" "$STDIN_BODY" CTL-1 --as COORD --body -
+  CAP="$(comment_capture)"
+  if [[ "$LAST_RC" -eq 0 ]] && cap_has 'piped through stdin'; then
+    ok "--body - → the comment carries the text piped on stdin"
+  else
+    bad "--body - stdin body (rc=${LAST_RC}, cap=${CAP})"
+  fi
+
+  run_mock_stdin "$DB_DEF" /dev/null CTL-1 --as COORD --body -
+  if [[ "$LAST_RC" -eq 2 ]] \
+     && [[ -z "$(comment_capture)" ]] \
+     && printf '%s' "$LAST_OUT" | grep -q 'stdin produced nothing'; then
+    ok "--body - with EMPTY stdin → exit 2, nothing posted, names the cause"
+  else
+    bad "--body - empty stdin (rc=${LAST_RC}, cap=$(comment_capture), out=${LAST_OUT})"
+  fi
+
+  # (CTL-2204 remediation) The stdin path is what ask.mjs `accept` now uses to hand the body
+  # to this tool, so the two argv artifacts that shape closed must be pinned HERE.
+  #
+  # Artifact 1 — a body whose whole value is a FLAG. `--top` is matched by whole-element
+  # equality (process.argv.includes), so while the body rode argv a reply body of "--top"
+  # silently flipped the post to top-level. On stdin it cannot reach argv at all.
+  printf -- '--top\n' >"$STDIN_BODY"
+  run_mock_stdin "$DB_DEF" "$STDIN_BODY" CTL-1 --as COORD --body -
+  CAP="$(comment_capture)"
+  if [[ "$LAST_RC" -eq 0 ]] && cap_has '"parentId":"c-1"'; then
+    ok "a stdin body of '--top' still THREADS — a body can no longer flip routing"
+  else
+    bad "stdin body must not be parsed as a flag (rc=${LAST_RC}, cap=${CAP})"
+  fi
+
+  # Artifact 2 — a body that IS a path. --body-file/stdin mean "these bytes are the body",
+  # so the path guard deliberately does NOT apply to them; re-refusing here is what left an
+  # ask open with a message about a --body the operator never passed. The guard still fires
+  # on --body (asserted above under ENFORCE) — this is the other side of that same rule.
+  printf '%s\n' "${BODY_TMP}/real.md" >"$STDIN_BODY"
+  run_mock_stdin "$DB_DEF" "$STDIN_BODY" CTL-1 --as COORD --body -
+  CAP="$(comment_capture)"
+  if [[ "$LAST_RC" -eq 0 ]] && cap_has "${BODY_TMP}/real.md"; then
+    ok "a stdin body that LOOKS like a path is posted verbatim (guard is --body-only)"
+  else
+    bad "stdin body that looks like a path (rc=${LAST_RC}, cap=${CAP})"
+  fi
+
   rm -f "$DB_DEF" "$DB_PAIR"
 fi
 # =================================================================================
@@ -295,25 +360,70 @@ rm -rf "$BODY_TMP"
 # threading.md. A future edit that reverts ask/SKILL.md's top-level usage sample back to
 # `--body "<markdown>"` (the exact mistake this ticket exists to stop) is the file an agent
 # actually reads first; without its own check that regression would pass CI silently.
+#
+# ⛔ ANCHORED ON THE INVOCATION LINE, NOT THE FILE (CTL-2204 remediation). The first cut
+# grepped each file for `--body-file` ANYWHERE, which could not detect the very regression
+# the paragraph above names. Measured occurrence counts: ask/SKILL.md 1, closing.md 1,
+# threading.md 3, linearis/SKILL.md 3 — so for the latter two, reverting the PRIMARY sample
+# line while leaving a `#   --body-file …` comment line intact still satisfied a file-wide
+# grep. Confirmed by mutation on a /tmp copy: reverting threading.md's primary sample to
+# `--body "<markdown>"` still yielded 29 passed, 0 failed. The check was strict for
+# ask/SKILL.md only by ACCIDENT — that file happens to have exactly one occurrence.
+#
+# So each file now declares the exact invocation LINE an agent copies, and the check asserts
+# that line is present. A comment line elsewhere in the file can no longer stand in for it.
 DOCS_ROOT="${SCRIPT_DIR}/../../skills"
-check_doc_teaches_body_file() { # $1=path relative to DOCS_ROOT  $2=known-present control string
-  local rel="$1" ctrl="$2"
+check_doc_teaches_body_file() { # $1=rel path  $2=positive-control string  $3=required invocation-line fragment
+  local rel="$1" ctrl="$2" invocation="$3"
   local f="${DOCS_ROOT}/${rel}"
-  if grep -q -- "$ctrl" "$f" 2>/dev/null; then
-    ok "positive control: docs grep instrument reads ${rel}"
-    if grep -q -- "--body-file" "$f"; then
-      ok "${rel} documents --body-file"
-    else
-      bad "${rel} does not document --body-file"
-    fi
-  else
+  if ! grep -q -- "$ctrl" "$f" 2>/dev/null; then
     bad "positive control FAILED — docs path/content wrong (${f}), grep result untrustworthy"
+    return
+  fi
+  ok "positive control: docs grep instrument reads ${rel}"
+  if grep -q -F -- "$invocation" "$f"; then
+    ok "${rel} teaches --body-file ON the invocation line"
+  else
+    bad "${rel}: the documented invocation line no longer carries --body-file (wanted: ${invocation})"
   fi
 }
-check_doc_teaches_body_file "ask/references/threading.md" "linear-reply.mjs"
-check_doc_teaches_body_file "ask/SKILL.md" "linear-reply.mjs"
-check_doc_teaches_body_file "ask/references/closing.md" "ask.mjs"
-check_doc_teaches_body_file "linearis/SKILL.md" "linear-reply.mjs"
+check_doc_teaches_body_file "ask/references/threading.md" "linear-reply.mjs" \
+  'linear-reply.mjs" CTL-NNNN --as <ROLE> --body-file'
+check_doc_teaches_body_file "ask/SKILL.md" "linear-reply.mjs" \
+  'linear-reply.mjs" CTL-NNNN --as <ROLE> --body-file'
+check_doc_teaches_body_file "ask/references/closing.md" "ask.mjs" \
+  '--body-file <path>  post a FILE'"'"'S CONTENTS'
+check_doc_teaches_body_file "linearis/SKILL.md" "linear-reply.mjs" \
+  '--body-file <path>  for anything longer than a one-line body'
+
+# The other half of the same property: the FIRST agent-facing invocation in each file must
+# not hand a bare `--body "` sample to an agent that copies the first recipe it sees. This
+# is what actually catches a revert of the primary line — the presence check above cannot,
+# because a reverted file could still carry the flag on a following comment line.
+check_first_invocation_is_not_bare_body() { # $1=rel path  $2=tool basename
+  local rel="$1" tool="$2"
+  local f="${DOCS_ROOT}/${rel}" first
+  first="$(grep -n -- "$tool" "$f" | grep -v '^\s*#' | grep -- '--body' | head -1)"
+  if [[ -z "$first" ]]; then
+    bad "positive control FAILED — no ${tool} --body line found in ${rel}"
+    return
+  fi
+  if printf '%s' "$first" | grep -q -- '--body-file'; then
+    ok "${rel}: the FIRST ${tool} invocation uses --body-file"
+  else
+    bad "${rel}: the FIRST ${tool} invocation uses a bare --body (${first})"
+  fi
+}
+check_first_invocation_is_not_bare_body "ask/references/threading.md" "linear-reply.mjs"
+check_first_invocation_is_not_bare_body "ask/SKILL.md" "linear-reply.mjs"
+
+# ask/SKILL.md §5 is the `accept` recipe an agent copies when CLOSING an ask, and it is a
+# SECOND invocation in the same file — so the ask.mjs recipe needs its own anchor. Before the
+# CTL-2204 remediation this file's only --body-file mention was on the linear-reply line, so
+# every file-level check passed while §5 taught a bare --body.
+check_doc_teaches_body_file "ask/SKILL.md" "ask.mjs" \
+  '--body-file <path>  for anything longer than a one-line body'
+
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -291,18 +291,29 @@ rm -f "$DB_WITH" "$DB_NOISSUE"
 rm -rf "$BODY_TMP"
 
 # --- CTL-2204: the documented recipe must teach --body-file ---
+# Every doc file Phase 4 rewrote gets its OWN positive-controlled check — not just
+# threading.md. A future edit that reverts ask/SKILL.md's top-level usage sample back to
+# `--body "<markdown>"` (the exact mistake this ticket exists to stop) is the file an agent
+# actually reads first; without its own check that regression would pass CI silently.
 DOCS_ROOT="${SCRIPT_DIR}/../../skills"
-# Positive control: the instrument can see a string we know is in the file.
-if grep -q "linear-reply.mjs" "${DOCS_ROOT}/ask/references/threading.md"; then
-  ok "positive control: docs grep instrument reads threading.md"
-  if grep -q -- "--body-file" "${DOCS_ROOT}/ask/references/threading.md"; then
-    ok "threading.md documents --body-file"
+check_doc_teaches_body_file() { # $1=path relative to DOCS_ROOT  $2=known-present control string
+  local rel="$1" ctrl="$2"
+  local f="${DOCS_ROOT}/${rel}"
+  if grep -q -- "$ctrl" "$f" 2>/dev/null; then
+    ok "positive control: docs grep instrument reads ${rel}"
+    if grep -q -- "--body-file" "$f"; then
+      ok "${rel} documents --body-file"
+    else
+      bad "${rel} does not document --body-file"
+    fi
   else
-    bad "threading.md does not document --body-file"
+    bad "positive control FAILED — docs path/content wrong (${f}), grep result untrustworthy"
   fi
-else
-  bad "positive control FAILED — docs path wrong (${DOCS_ROOT}), grep result untrustworthy"
-fi
+}
+check_doc_teaches_body_file "ask/references/threading.md" "linear-reply.mjs"
+check_doc_teaches_body_file "ask/SKILL.md" "linear-reply.mjs"
+check_doc_teaches_body_file "ask/references/closing.md" "ask.mjs"
+check_doc_teaches_body_file "linearis/SKILL.md" "linear-reply.mjs"
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/plugins/dev/scripts/ask.mjs
+++ b/plugins/dev/scripts/ask.mjs
@@ -31,6 +31,7 @@ import { spawnSync } from "node:child_process";
 // module — the documented form threw a ReferenceError before reading anything.
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { resolveCommentBody } from "./lib/comment-body-arg.mjs";
 
 // ⚠️ ONE alternation-free pattern, deliberately: JS alternation prefers the earliest MATCH
 // POSITION, so a bare `Options:` branch matches at the preceding newline and consumes
@@ -333,7 +334,7 @@ function usage() {
                  --option <label> --option <label> [--option ...]   (at least TWO)
                  --default <text> --blocks <ISSUE> [--blocks <ISSUE> ...]
                  [--priority <1-4>] [--dry-run]
-  ask.mjs accept <ISSUE> --as <AGENT> --body <markdown|-> [--dry-run]
+  ask.mjs accept <ISSUE> --as <AGENT> (--body <markdown|-> | --body-file <path>) [--dry-run]
 
 create files a correctly-shaped ask ticket, then READS IT BACK and proves the decision
 trigger can parse its options AND that every requested blocking relation landed. accept
@@ -574,13 +575,26 @@ function cmdCreate(argv) {
 function cmdAccept(argv) {
   const id = argv[0];
   const as = argOf(argv, "--as");
-  let body = argOf(argv, "--body");
   const dryRun = argv.includes("--dry-run");
-  if (!id || !as || !body) {
-    console.error("ask accept: <ISSUE> --as <AGENT> --body <markdown|-> are required");
+  if (!id || !as) {
+    console.error("ask accept: <ISSUE> --as <AGENT> (--body <markdown|-> | --body-file <path>) are required");
     return 1;
   }
-  if (body === "-") body = readFileSync(0, "utf8");
+  // CTL-2204: same rule as linear-reply.mjs, from the same leaf. Decided HERE so it also
+  // covers --dry-run, which never reaches the linear-reply child process.
+  const resolved = resolveCommentBody({
+    body: argOf(argv, "--body"),
+    bodyFile: argOf(argv, "--body-file"),
+  });
+  if (!resolved.ok) {
+    console.error(`ask accept: ${resolved.message}`);
+    return 1;
+  }
+  let body = resolved.stdin ? readFileSync(0, "utf8") : resolved.body;
+  if (!body.trim()) {
+    console.error("ask accept: comment body is empty (stdin produced nothing)");
+    return 1;
+  }
 
   // Refuse on a non-ask: `accept` moves a ticket to Done, and doing that to a work ticket
   // because someone mistyped an id is not recoverable by the person who typed it.

--- a/plugins/dev/scripts/ask.mjs
+++ b/plugins/dev/scripts/ask.mjs
@@ -298,9 +298,26 @@ export function resolveTeamLabelIds(team, { runFn = run, names = ASK_LABEL_NAMES
 
 const RYAN = process.env.ASK_HUMAN_ID || "c2a8cc92-cab6-4536-9500-0f24abdf702b";
 
-function run(cmd, args) {
-  const r = spawnSync(cmd, args, { encoding: "utf8" });
-  return { code: r.status ?? 1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+/**
+ * run — spawnSync with a THREE-part result, including the case where the child never ran.
+ *
+ * ⛔ CTL-2204: this used to `return { code: r.status ?? 1, ... stderr: r.stderr ?? "" }` and
+ * DISCARD `r.error`. When spawn itself fails — E2BIG (argv over the per-arg limit), ENOENT
+ * (binary not on PATH), EACCES — node leaves `status` null and `stderr` UNDEFINED and puts
+ * the whole diagnosis in `r.error`. So the operator saw a bare `rc=1` followed by an EMPTY
+ * stderr tail: a failure with no cause. Measured on this host (kern.argmax 1048576), a
+ * ~1.1MB argument gives status=null, stderr=undefined, error.code=E2BIG — and Linux's
+ * per-argument MAX_ARG_STRLEN is LOWER, so CI trips it sooner than a laptop does.
+ * A spawn that never started must be distinguishable from a child that exited non-zero.
+ */
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  let stderr = r.stderr ?? "";
+  if (r.error) {
+    const detail = `spawn ${cmd} FAILED — the child never started (${r.error.code ?? r.error.message})`;
+    stderr = stderr ? `${stderr}\n${detail}` : detail;
+  }
+  return { code: r.status ?? 1, stdout: r.stdout ?? "", stderr };
 }
 
 /**
@@ -629,8 +646,24 @@ function cmdAccept(argv) {
     return 0;
   }
 
+  // ⛔ CTL-2204: the body goes to the child on STDIN, never back through argv.
+  //
+  // Re-marshalling the resolved body as `--body <body>` put an arbitrarily large,
+  // arbitrarily shaped string into the child's argv, and produced three failures with no
+  // diagnosable cause:
+  //   1. E2BIG. --body-file is now documented as "preferred for anything multi-line", i.e.
+  //      precisely the large-body shape; a body past the per-argument limit made spawn fail
+  //      before the child existed (see run()'s header).
+  //   2. argv injection. linear-reply.mjs matches --top by WHOLE-ELEMENT equality, so a body
+  //      whose entire value is `--top` silently flipped the reply to top-level posting.
+  //   3. Double refusal. A --body-file whose CONTENTS trim to an existing absolute path was
+  //      re-refused by the child's own (correct) guard, leaving the ask open with a confusing
+  //      message about a --body the operator never passed.
+  // `--body -` + spawnSync `input` closes all three at once, and covers all three body
+  // sources (--body, --body-file, --body -) with ONE path — the parent has already resolved
+  // the bytes, so the child re-reading a file that may have changed underneath is also gone.
   const replyScript = new URL("./linear-reply.mjs", import.meta.url).pathname;
-  const reply = run("node", [replyScript, id, "--as", as, "--body", body]);
+  const reply = run("node", [replyScript, id, "--as", as, "--body", "-"], { input: body });
   if (reply.code !== 0) {
     // ⛔ Do NOT close on a failed reply: a Done ask with no recorded answer is worse than
     // an open one — it leaves the human's view clean and the decision unrecorded.

--- a/plugins/dev/scripts/lib/comment-body-arg.mjs
+++ b/plugins/dev/scripts/lib/comment-body-arg.mjs
@@ -10,6 +10,14 @@
 // mode (the 2026-08-02 fleet 401 was four copies of a secret chain; CTL-1834 was five
 // event-name ladders in three incompatible orders). So: one function, two importers.
 //
+// ⛔ A THIRD agent-facing writer is DELIBERATELY OUT OF SCOPE and still unguarded:
+// `lib/linear-comment-post.sh` takes the body as a POSITIONAL ($2), not a --body flag, and
+// phase-triage/SKILL.md documents it to agents as `linear-comment-post.sh <TICKET> "<body>"`.
+// Its in-repo callers are programmatic phase-mirror blocks that build the body in a shell
+// variable, so the residual exposure is hand-invocation. Porting this rule into that bash
+// helper is a follow-up, NOT part of this leaf — so read "one function, two importers" as a
+// statement about the two --body PARSERS, never as "every path into a Linear comment".
+//
 // ⛔ SCOPE OF THE PATH GUARD — deliberately narrow, and the narrowness is the point.
 // It fires only on an ABSOLUTE (or ~/) path to a file that PROVABLY EXISTS. It does not
 // fire on a relative path (a bare `README.md` could be a legitimate one-word body), nor on
@@ -17,34 +25,77 @@
 // nor on any string containing whitespace or a newline (`\S+` anchored ^…$), so no real
 // markdown body can trip it. Every one of the 23 measured incidents was an absolute path.
 //
-// This leaf NEVER exits and NEVER reads fd 0 — it returns a verdict and lets the caller own
-// its exit code and message. `-` comes back as {ok:true, stdin:true} for the caller to read.
-import { existsSync as _existsSync, readFileSync as _readFileSync } from "node:fs";
+// ⛔ "I COULD NOT LOOK" IS NOT "NO SUCH FILE". node:fs existsSync swallows EVERY error
+// (EACCES, ELOOP, ENAMETOOLONG, dangling symlink) and returns false — so a body.md inside a
+// chmod-000 directory read as "not a file" and the PATH was posted verbatim, which is the
+// incident this leaf exists to prevent. Every existence question therefore goes through the
+// three-valued `probeFile` below (statSync + throwIfNoEntry:false): true / false / null,
+// where null means the check itself could not answer. On the --body side an inconclusive
+// probe REFUSES (PATH_UNCHECKABLE) — refusing a path-shaped string is recoverable, posting
+// one is not. On the --body-file side it falls through to the read, which is the
+// authoritative answer for "can I get these bytes".
+//
+// ⛔ TILDE IS EXPANDED ON BOTH SIDES, THROUGH ONE HELPER. The --body refusal's remedy names
+// the path back to the operator ("use --body-file ~/x.md"), so if only --body expanded `~/`
+// that suggested command would itself fail with "--body-file not found" — a refusal whose
+// own advice is un-followable. Both branches call expandTilde().
+//
+// This leaf NEVER exits, NEVER throws, and NEVER reads fd 0 — it returns a verdict and lets
+// the caller own its exit code and message. `-` comes back as {ok:true, stdin:true} for the
+// caller to read.
+import { statSync as _statSync, readFileSync as _readFileSync } from "node:fs";
 
 export const BODY_REFUSAL = Object.freeze({
   MISSING: "missing",
   EMPTY: "empty",
   AMBIGUOUS: "ambiguous",
   PATH_AS_BODY: "path-as-body",
+  PATH_UNCHECKABLE: "path-uncheckable",
   BODY_FILE_MISSING: "body-file-missing",
   BODY_FILE_UNREADABLE: "body-file-unreadable",
 });
 
-const DEFAULT_FS = { existsSync: _existsSync, readFileSync: _readFileSync };
+const DEFAULT_FS = { statSync: _statSync, readFileSync: _readFileSync };
 
 // Absolute or ~/-rooted, no whitespace anywhere. Anchored, so a multi-line or
 // space-containing body can never match.
+//
+// ⚠️ KNOWN, DELIBERATE SCOPE: an existing path CONTAINING A SPACE is NOT refused. The
+// no-whitespace anchor is exactly what keeps real markdown from tripping the guard, and all
+// 23 measured incidents were space-free job-tmp paths. Widening it trades markdown safety
+// for a shape that has never occurred; `comment-body-arg.test.mjs` pins the trade-off so a
+// later "fix" cannot quietly reverse it.
 const PATH_SHAPED = /^(?:\/|~\/)\S+$/;
 
 function refuse(reason, message) {
   return { ok: false, reason, message };
 }
 
+/** ~/-rooted → absolute, against the injected env. Every other string passes through. */
+function expandTilde(p, env) {
+  return p.startsWith("~/") ? `${env?.HOME ?? ""}${p.slice(1)}` : p;
+}
+
+/**
+ * probeFile — THREE-VALUED existence check that never throws.
+ * @returns {true|false|null} true = it is there; false = proven absent (ENOENT);
+ *          null = the check could not answer (EACCES/ELOOP/ENAMETOOLONG/seam threw).
+ */
+function probeFile(fs, p) {
+  try {
+    // throwIfNoEntry:false makes ENOENT a plain `undefined` while EVERY other errno still
+    // throws — the whole point of using statSync over existsSync here.
+    return fs.statSync(p, { throwIfNoEntry: false }) ? true : false;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * @param {object} o
  * @param {string=} o.body      the --body argument (may be undefined: trailing flag)
  * @param {string=} o.bodyFile  the --body-file argument (may be undefined)
- * @param {object=} o.fs        { existsSync, readFileSync } seam (tests)
+ * @param {object=} o.fs        { statSync, readFileSync } seam (tests)
  * @param {object=} o.env       { HOME } seam (tests)
  * @returns {{ok:true, body:string}|{ok:true, stdin:true}|{ok:false, reason:string, message:string}}
  */
@@ -62,17 +113,26 @@ export function resolveCommentBody({ body, bodyFile, fs = DEFAULT_FS, env = proc
   }
 
   if (rawFile !== "") {
-    if (!fs.existsSync(rawFile)) {
-      return refuse(BODY_REFUSAL.BODY_FILE_MISSING, `--body-file not found: ${rawFile}`);
+    const filePath = expandTilde(rawFile, env);
+    // `as` names what we actually checked when a ~/ was expanded, so an operator debugging a
+    // miss sees the absolute path rather than the tilde they typed.
+    const as = filePath === rawFile ? "" : ` (expanded to ${filePath})`;
+    // null (could not look) deliberately falls THROUGH to the read: "can I get these bytes"
+    // is the authoritative question, and readFileSync answers it with a real errno below.
+    if (probeFile(fs, filePath) === false) {
+      return refuse(BODY_REFUSAL.BODY_FILE_MISSING, `--body-file not found: ${rawFile}${as}`);
     }
     let contents;
     try {
-      contents = fs.readFileSync(rawFile, "utf8");
+      contents = fs.readFileSync(filePath, "utf8");
     } catch (e) {
-      return refuse(BODY_REFUSAL.BODY_FILE_UNREADABLE, `--body-file unreadable: ${rawFile} (${e?.message ?? e})`);
+      return refuse(
+        BODY_REFUSAL.BODY_FILE_UNREADABLE,
+        `--body-file unreadable: ${rawFile}${as} (${e?.message ?? e})`
+      );
     }
     if (!String(contents).trim()) {
-      return refuse(BODY_REFUSAL.EMPTY, `--body-file is empty: ${rawFile}`);
+      return refuse(BODY_REFUSAL.EMPTY, `--body-file is empty: ${rawFile}${as}`);
     }
     return { ok: true, body: String(contents) };
   }
@@ -86,14 +146,23 @@ export function resolveCommentBody({ body, bodyFile, fs = DEFAULT_FS, env = proc
 
   const trimmed = rawBody.trim();
   if (PATH_SHAPED.test(trimmed)) {
-    const resolved = trimmed.startsWith("~/")
-      ? `${env?.HOME ?? ""}${trimmed.slice(1)}`
-      : trimmed;
-    if (fs.existsSync(resolved)) {
+    const resolved = expandTilde(trimmed, env);
+    const probe = probeFile(fs, resolved);
+    if (probe === true) {
       return refuse(
         BODY_REFUSAL.PATH_AS_BODY,
         `--body is a path to an existing file (${trimmed}). A path is never a valid comment body — ` +
           `use --body-file ${trimmed} to post its contents.`
+      );
+    }
+    if (probe === null) {
+      // Inconclusive, not absent. Refusing a path-shaped string costs an exit 2; posting one
+      // is the unrecoverable incident (7 of the 23 measured were unrecoverable).
+      return refuse(
+        BODY_REFUSAL.PATH_UNCHECKABLE,
+        `--body looks like a path (${trimmed}) but it could not be checked (permission, symlink loop, or a ` +
+          `bad path) — refusing rather than posting a path as a comment body. Use --body-file ${trimmed} ` +
+          "to post its contents, or pass the text itself."
       );
     }
   }

--- a/plugins/dev/scripts/lib/comment-body-arg.mjs
+++ b/plugins/dev/scripts/lib/comment-body-arg.mjs
@@ -15,8 +15,9 @@
 // phase-triage/SKILL.md documents it to agents as `linear-comment-post.sh <TICKET> "<body>"`.
 // Its in-repo callers are programmatic phase-mirror blocks that build the body in a shell
 // variable, so the residual exposure is hand-invocation. Porting this rule into that bash
-// helper is a follow-up, NOT part of this leaf — so read "one function, two importers" as a
-// statement about the two --body PARSERS, never as "every path into a Linear comment".
+// helper is a follow-up — filed as CTL-2207 — NOT part of this leaf, so read "one function,
+// two importers" as a statement about the two --body PARSERS, never as "every path into a
+// Linear comment".
 //
 // ⛔ SCOPE OF THE PATH GUARD — deliberately narrow, and the narrowness is the point.
 // It fires only on an ABSOLUTE (or ~/) path to a file that PROVABLY EXISTS. It does not

--- a/plugins/dev/scripts/lib/comment-body-arg.mjs
+++ b/plugins/dev/scripts/lib/comment-body-arg.mjs
@@ -1,0 +1,103 @@
+// comment-body-arg.mjs — CTL-2204. ONE rule for "what is the comment body?", shared by
+// linear-reply.mjs and ask.mjs.
+//
+// ⛔ WHY A SHARED LEAF. The coordinator house rule "write the body to a FILE first" (it
+// exists because `--body -` stdin can 401) led twice in two sessions to passing the file's
+// PATH to --body. Measured 2026-08-23: 23 comments whose whole body was a
+// /Users/ryan/.claude/jobs/…/tmp/*.md path, across 16 tickets, from two concierge jobs;
+// 7 unrecoverable. Two tools parse --body today and the ticket asks for the identical rule
+// in both — and divergent hand-written copies of one rule is this repo's recorded failure
+// mode (the 2026-08-02 fleet 401 was four copies of a secret chain; CTL-1834 was five
+// event-name ladders in three incompatible orders). So: one function, two importers.
+//
+// ⛔ SCOPE OF THE PATH GUARD — deliberately narrow, and the narrowness is the point.
+// It fires only on an ABSOLUTE (or ~/) path to a file that PROVABLY EXISTS. It does not
+// fire on a relative path (a bare `README.md` could be a legitimate one-word body), nor on
+// a non-existent path (that is not evidence of the mistake — refusing it would be a guess),
+// nor on any string containing whitespace or a newline (`\S+` anchored ^…$), so no real
+// markdown body can trip it. Every one of the 23 measured incidents was an absolute path.
+//
+// This leaf NEVER exits and NEVER reads fd 0 — it returns a verdict and lets the caller own
+// its exit code and message. `-` comes back as {ok:true, stdin:true} for the caller to read.
+import { existsSync as _existsSync, readFileSync as _readFileSync } from "node:fs";
+
+export const BODY_REFUSAL = Object.freeze({
+  MISSING: "missing",
+  EMPTY: "empty",
+  AMBIGUOUS: "ambiguous",
+  PATH_AS_BODY: "path-as-body",
+  BODY_FILE_MISSING: "body-file-missing",
+  BODY_FILE_UNREADABLE: "body-file-unreadable",
+});
+
+const DEFAULT_FS = { existsSync: _existsSync, readFileSync: _readFileSync };
+
+// Absolute or ~/-rooted, no whitespace anywhere. Anchored, so a multi-line or
+// space-containing body can never match.
+const PATH_SHAPED = /^(?:\/|~\/)\S+$/;
+
+function refuse(reason, message) {
+  return { ok: false, reason, message };
+}
+
+/**
+ * @param {object} o
+ * @param {string=} o.body      the --body argument (may be undefined: trailing flag)
+ * @param {string=} o.bodyFile  the --body-file argument (may be undefined)
+ * @param {object=} o.fs        { existsSync, readFileSync } seam (tests)
+ * @param {object=} o.env       { HOME } seam (tests)
+ * @returns {{ok:true, body:string}|{ok:true, stdin:true}|{ok:false, reason:string, message:string}}
+ */
+export function resolveCommentBody({ body, bodyFile, fs = DEFAULT_FS, env = process.env } = {}) {
+  // Normalize FIRST. arg()/argOf() return undefined when the flag is the last argv
+  // element, and `undefined.trim()` is a TypeError — a crash where an exit 2 belongs.
+  const rawBody = typeof body === "string" ? body : "";
+  const rawFile = typeof bodyFile === "string" ? bodyFile : "";
+
+  if (rawBody !== "" && rawFile !== "") {
+    return refuse(
+      BODY_REFUSAL.AMBIGUOUS,
+      "both --body and --body-file were given; pass exactly one (refusing rather than guessing which you meant)"
+    );
+  }
+
+  if (rawFile !== "") {
+    if (!fs.existsSync(rawFile)) {
+      return refuse(BODY_REFUSAL.BODY_FILE_MISSING, `--body-file not found: ${rawFile}`);
+    }
+    let contents;
+    try {
+      contents = fs.readFileSync(rawFile, "utf8");
+    } catch (e) {
+      return refuse(BODY_REFUSAL.BODY_FILE_UNREADABLE, `--body-file unreadable: ${rawFile} (${e?.message ?? e})`);
+    }
+    if (!String(contents).trim()) {
+      return refuse(BODY_REFUSAL.EMPTY, `--body-file is empty: ${rawFile}`);
+    }
+    return { ok: true, body: String(contents) };
+  }
+
+  if (rawBody === "") {
+    return refuse(BODY_REFUSAL.MISSING, "a comment body is required: pass --body <markdown>, --body-file <path>, or --body -");
+  }
+
+  // stdin is the caller's to read (keeps this leaf pure).
+  if (rawBody === "-") return { ok: true, stdin: true };
+
+  const trimmed = rawBody.trim();
+  if (PATH_SHAPED.test(trimmed)) {
+    const resolved = trimmed.startsWith("~/")
+      ? `${env?.HOME ?? ""}${trimmed.slice(1)}`
+      : trimmed;
+    if (fs.existsSync(resolved)) {
+      return refuse(
+        BODY_REFUSAL.PATH_AS_BODY,
+        `--body is a path to an existing file (${trimmed}). A path is never a valid comment body — ` +
+          `use --body-file ${trimmed} to post its contents.`
+      );
+    }
+  }
+
+  if (!trimmed) return refuse(BODY_REFUSAL.EMPTY, "comment body is empty");
+  return { ok: true, body: rawBody };
+}

--- a/plugins/dev/scripts/lib/comment-body-arg.test.mjs
+++ b/plugins/dev/scripts/lib/comment-body-arg.test.mjs
@@ -1,0 +1,126 @@
+// comment-body-arg.test.mjs — CTL-2204. The shared body-resolution rule for the Linear
+// comment tools (linear-reply.mjs, ask.mjs). See comment-body-arg.mjs for why this is one
+// leaf shared by two callers rather than two hand-rolled parsers.
+import { describe, test, expect } from "bun:test";
+import { resolveCommentBody, BODY_REFUSAL } from "./comment-body-arg.mjs";
+
+// A hermetic fake fs: only the paths in `files` exist.
+const fakeFs = (files) => ({
+  existsSync: (p) => Object.hasOwn(files, p),
+  readFileSync: (p) => {
+    if (!Object.hasOwn(files, p)) throw new Error(`ENOENT: ${p}`);
+    return files[p];
+  },
+});
+
+describe("plain bodies still work", () => {
+  test("a normal markdown body passes through unchanged", () => {
+    const r = resolveCommentBody({ body: "hello world", fs: fakeFs({}) });
+    expect(r).toEqual({ ok: true, body: "hello world" });
+  });
+
+  test("a multi-line body containing a path-looking line is NOT refused", () => {
+    // The guard is anchored ^…$ over the TRIMMED whole string, so real prose
+    // that merely mentions a path can never trip it.
+    const body = "I wrote it to\n/tmp/x.md\nand it worked";
+    const r = resolveCommentBody({ body, fs: fakeFs({ "/tmp/x.md": "c" }) });
+    expect(r).toEqual({ ok: true, body });
+  });
+
+  test("a body with spaces that starts with a slash is NOT refused", () => {
+    const r = resolveCommentBody({ body: "/tmp/x.md is where I put it", fs: fakeFs({ "/tmp/x.md": "c" }) });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("--body refuses a path to an EXISTING file", () => {
+  test("absolute path that exists → refused, naming --body-file", () => {
+    const r = resolveCommentBody({ body: "/tmp/x.md", fs: fakeFs({ "/tmp/x.md": "contents" }) });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe(BODY_REFUSAL.PATH_AS_BODY);
+    expect(r.message).toContain("--body-file");
+    expect(r.message).toContain("/tmp/x.md");
+  });
+
+  test("surrounding whitespace does not evade the guard", () => {
+    const r = resolveCommentBody({ body: "  /tmp/x.md\n", fs: fakeFs({ "/tmp/x.md": "c" }) });
+    expect(r.reason).toBe(BODY_REFUSAL.PATH_AS_BODY);
+  });
+
+  test("~/ path is expanded against HOME and refused when it exists", () => {
+    const r = resolveCommentBody({
+      body: "~/notes/x.md",
+      env: { HOME: "/Users/ryan" },
+      fs: fakeFs({ "/Users/ryan/notes/x.md": "c" }),
+    });
+    expect(r.reason).toBe(BODY_REFUSAL.PATH_AS_BODY);
+  });
+
+  test("an absolute path that does NOT exist is a legitimate (if odd) body", () => {
+    // Fail direction: only refuse what we can PROVE is a file. A non-existent
+    // path is not evidence of the mistake, and refusing it would be a guess.
+    const r = resolveCommentBody({ body: "/tmp/nope.md", fs: fakeFs({}) });
+    expect(r).toEqual({ ok: true, body: "/tmp/nope.md" });
+  });
+
+  test("a RELATIVE path that exists is NOT refused (documented scope)", () => {
+    const r = resolveCommentBody({ body: "README.md", fs: fakeFs({ "README.md": "c" }) });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("--body-file", () => {
+  test("reads the file and returns its contents", () => {
+    const r = resolveCommentBody({ bodyFile: "/tmp/x.md", fs: fakeFs({ "/tmp/x.md": "# real body\n" }) });
+    expect(r).toEqual({ ok: true, body: "# real body\n" });
+  });
+
+  test("a missing file is refused, naming the path", () => {
+    const r = resolveCommentBody({ bodyFile: "/tmp/gone.md", fs: fakeFs({}) });
+    expect(r.reason).toBe(BODY_REFUSAL.BODY_FILE_MISSING);
+    expect(r.message).toContain("/tmp/gone.md");
+  });
+
+  test("a file whose contents are whitespace-only is refused as empty", () => {
+    const r = resolveCommentBody({ bodyFile: "/tmp/x.md", fs: fakeFs({ "/tmp/x.md": "   \n\t\n" }) });
+    expect(r.reason).toBe(BODY_REFUSAL.EMPTY);
+  });
+
+  test("an unreadable file is refused, not crashed", () => {
+    const fs = { existsSync: () => true, readFileSync: () => { throw new Error("EACCES"); } };
+    const r = resolveCommentBody({ bodyFile: "/tmp/x.md", fs });
+    expect(r.reason).toBe(BODY_REFUSAL.BODY_FILE_UNREADABLE);
+  });
+});
+
+describe("empty / missing / ambiguous", () => {
+  test("neither --body nor --body-file → MISSING", () => {
+    expect(resolveCommentBody({ fs: fakeFs({}) }).reason).toBe(BODY_REFUSAL.MISSING);
+  });
+
+  test("whitespace-only --body → EMPTY", () => {
+    expect(resolveCommentBody({ body: "   \n ", fs: fakeFs({}) }).reason).toBe(BODY_REFUSAL.EMPTY);
+  });
+
+  test("both --body and --body-file → AMBIGUOUS (never a silent precedence)", () => {
+    const r = resolveCommentBody({ body: "hi", bodyFile: "/tmp/x.md", fs: fakeFs({ "/tmp/x.md": "c" }) });
+    expect(r.reason).toBe(BODY_REFUSAL.AMBIGUOUS);
+  });
+
+  test("a trailing --body-file flag with no value is MISSING, never a crash", () => {
+    // arg()/argOf() return undefined when the flag is the last argv element.
+    expect(resolveCommentBody({ bodyFile: undefined, fs: fakeFs({}) }).reason).toBe(BODY_REFUSAL.MISSING);
+  });
+
+  test("a trailing --body flag with no value is MISSING, never a TypeError", () => {
+    expect(() => resolveCommentBody({ body: undefined, fs: fakeFs({}) })).not.toThrow();
+    expect(resolveCommentBody({ body: undefined, fs: fakeFs({}) }).reason).toBe(BODY_REFUSAL.MISSING);
+  });
+});
+
+describe("stdin is resolved by the CALLER, not here", () => {
+  test('"-" is passed through as the STDIN sentinel, not treated as a body', () => {
+    // The leaf must not read fd 0 — that keeps it pure and unit-testable.
+    expect(resolveCommentBody({ body: "-", fs: fakeFs({}) })).toEqual({ ok: true, stdin: true });
+  });
+});

--- a/plugins/dev/scripts/lib/comment-body-arg.test.mjs
+++ b/plugins/dev/scripts/lib/comment-body-arg.test.mjs
@@ -3,13 +3,29 @@
 // leaf shared by two callers rather than two hand-rolled parsers.
 import { describe, test, expect } from "bun:test";
 import { resolveCommentBody, BODY_REFUSAL } from "./comment-body-arg.mjs";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-// A hermetic fake fs: only the paths in `files` exist.
+// A hermetic fake fs: only the paths in `files` exist. The seam is statSync (NOT existsSync)
+// because the leaf needs to tell ENOENT apart from "I could not look" — statSync with
+// throwIfNoEntry:false returns undefined for the former and throws for every other errno.
 const fakeFs = (files) => ({
-  existsSync: (p) => Object.hasOwn(files, p),
+  statSync: (p) => (Object.hasOwn(files, p) ? { isFile: () => true } : undefined),
   readFileSync: (p) => {
     if (!Object.hasOwn(files, p)) throw new Error(`ENOENT: ${p}`);
     return files[p];
+  },
+});
+
+// A seam whose existence check cannot answer — EACCES on a chmod-000 parent dir, ELOOP on a
+// symlink cycle, ENAMETOOLONG. statSync throws for all of these even with throwIfNoEntry.
+const uncheckableFs = (errno = "EACCES") => ({
+  statSync: () => {
+    throw Object.assign(new Error(`${errno}: permission denied`), { code: errno });
+  },
+  readFileSync: () => {
+    throw Object.assign(new Error(`${errno}: permission denied`), { code: errno });
   },
 });
 
@@ -87,7 +103,7 @@ describe("--body-file", () => {
   });
 
   test("an unreadable file is refused, not crashed", () => {
-    const fs = { existsSync: () => true, readFileSync: () => { throw new Error("EACCES"); } };
+    const fs = { statSync: () => ({ isFile: () => true }), readFileSync: () => { throw new Error("EACCES"); } };
     const r = resolveCommentBody({ bodyFile: "/tmp/x.md", fs });
     expect(r.reason).toBe(BODY_REFUSAL.BODY_FILE_UNREADABLE);
   });
@@ -122,5 +138,158 @@ describe("stdin is resolved by the CALLER, not here", () => {
   test('"-" is passed through as the STDIN sentinel, not treated as a body', () => {
     // The leaf must not read fd 0 — that keeps it pure and unit-testable.
     expect(resolveCommentBody({ body: "-", fs: fakeFs({}) })).toEqual({ ok: true, stdin: true });
+  });
+});
+
+describe("the refusal's own remedy must be followable (tilde round trip)", () => {
+  // The --body refusal names a --body-file command back to the operator. When only ONE
+  // branch expanded `~/`, that suggested command failed with "--body-file not found" — a
+  // guard whose advice does not work. This pins the ROUND TRIP, not just the refusal.
+  const HOME = "/Users/ryan";
+  const files = { "/Users/ryan/.p/b.md": "# the real body\n" };
+
+  test("~/ --body is refused AND the --body-file it suggests then succeeds", () => {
+    const refused = resolveCommentBody({ body: "~/.p/b.md", env: { HOME }, fs: fakeFs(files) });
+    expect(refused.ok).toBe(false);
+    expect(refused.reason).toBe(BODY_REFUSAL.PATH_AS_BODY);
+
+    // Extract the remedy the message ITSELF printed and feed it straight back in.
+    const suggested = /--body-file (\S+)/.exec(refused.message)?.[1];
+    expect(suggested).toBe("~/.p/b.md");
+    const retry = resolveCommentBody({ bodyFile: suggested, env: { HOME }, fs: fakeFs(files) });
+    expect(retry).toEqual({ ok: true, body: "# the real body\n" });
+  });
+
+  test("positive control: the ABSOLUTE form of the same file already worked", () => {
+    // If this failed, the test above would prove nothing about tilde handling.
+    const r = resolveCommentBody({ bodyFile: "/Users/ryan/.p/b.md", env: { HOME }, fs: fakeFs(files) });
+    expect(r).toEqual({ ok: true, body: "# the real body\n" });
+  });
+
+  test("a ~/ --body-file that is genuinely absent still refuses, naming both forms", () => {
+    const r = resolveCommentBody({ bodyFile: "~/.p/gone.md", env: { HOME }, fs: fakeFs(files) });
+    expect(r.reason).toBe(BODY_REFUSAL.BODY_FILE_MISSING);
+    expect(r.message).toContain("~/.p/gone.md");
+    expect(r.message).toContain("/Users/ryan/.p/gone.md"); // what was actually checked
+  });
+});
+
+describe("'I could not look' is not 'no such file'", () => {
+  // existsSync swallows EACCES/ELOOP/ENAMETOOLONG and returns false, so a body.md inside a
+  // chmod-000 dir read as "not a file" and the PATH was posted — the exact incident.
+  test("--body: an UNCHECKABLE path-shaped string is refused, not posted", () => {
+    const r = resolveCommentBody({ body: "/locked/body.md", fs: uncheckableFs("EACCES") });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe(BODY_REFUSAL.PATH_UNCHECKABLE);
+    expect(r.message).toContain("/locked/body.md");
+    expect(r.message).toContain("--body-file");
+  });
+
+  test("--body: an uncheckable string that is NOT path-shaped is still an ordinary body", () => {
+    // The inconclusive branch must not swallow real prose — it sits INSIDE the
+    // PATH_SHAPED test, so a probe that cannot answer is only consulted for a
+    // string that already looks like an absolute path.
+    const r = resolveCommentBody({ body: "accepted — go ahead", fs: uncheckableFs("EACCES") });
+    expect(r).toEqual({ ok: true, body: "accepted — go ahead" });
+  });
+
+  test("--body-file: an uncheckable stat falls through to the READ, which is authoritative", () => {
+    // "Can I get these bytes" is the real question for --body-file. A stat that cannot
+    // answer must not become a MISSING refusal naming a file that is actually there.
+    const fs = {
+      statSync: () => { throw Object.assign(new Error("EACCES"), { code: "EACCES" }); },
+      readFileSync: () => "# readable after all\n",
+    };
+    expect(resolveCommentBody({ bodyFile: "/odd/b.md", fs })).toEqual({ ok: true, body: "# readable after all\n" });
+  });
+
+  test("--body-file: uncheckable AND unreadable refuses as UNREADABLE, carrying the errno", () => {
+    const r = resolveCommentBody({ bodyFile: "/locked/b.md", fs: uncheckableFs("EACCES") });
+    expect(r.reason).toBe(BODY_REFUSAL.BODY_FILE_UNREADABLE);
+    expect(r.message).toContain("EACCES");
+  });
+});
+
+describe("the leaf ALWAYS returns a verdict — it never throws out", () => {
+  // The header promises "NEVER exits ... returns a verdict". Before CTL-2204's remediation
+  // the existence checks were unwrapped, so a throwing seam produced a stack trace out of
+  // the leaf instead of an exit-2 refusal. Both seams are now covered.
+  const throwing = {
+    statSync: () => { throw new Error("boom"); },
+    readFileSync: () => { throw new Error("boom"); },
+  };
+
+  test("a throwing statSync on the --body path yields a refusal, not an exception", () => {
+    expect(() => resolveCommentBody({ body: "/tmp/x.md", fs: throwing })).not.toThrow();
+    expect(resolveCommentBody({ body: "/tmp/x.md", fs: throwing }).ok).toBe(false);
+  });
+
+  test("a throwing statSync on the --body-file path yields a refusal, not an exception", () => {
+    expect(() => resolveCommentBody({ bodyFile: "/tmp/x.md", fs: throwing })).not.toThrow();
+    expect(resolveCommentBody({ bodyFile: "/tmp/x.md", fs: throwing }).ok).toBe(false);
+  });
+});
+
+describe("DELIBERATE scope limits, pinned so a later 'fix' cannot silently widen them", () => {
+  test("an EXISTING path containing a space is deliberately NOT refused", () => {
+    // PATH_SHAPED's `\S+` anchor is what keeps real markdown from tripping the guard, and
+    // all 23 measured incidents were space-free job-tmp paths. Widening this would trade
+    // markdown safety for a shape that has never occurred. If you are changing this
+    // assertion, you are making that trade — say so in the commit.
+    const p = "/tmp/ctl2204 space/b.md";
+    const r = resolveCommentBody({ body: p, fs: fakeFs({ [p]: "c" }) });
+    expect(r).toEqual({ ok: true, body: p });
+  });
+
+  test("positive control: the same path WITHOUT the space IS refused", () => {
+    // Proves the fake fs and the guard are both live — so the pass above is a property of
+    // the space, not of a broken fixture.
+    const p = "/tmp/ctl2204-space/b.md";
+    expect(resolveCommentBody({ body: p, fs: fakeFs({ [p]: "c" }) }).reason).toBe(BODY_REFUSAL.PATH_AS_BODY);
+  });
+});
+
+// ── The header's central claim, held mechanically ───────────────────────────────
+// "One function, two importers" is the whole design, and nothing asserted it. A divergent
+// hand-rolled copy in one caller is this repo's recorded failure mode (the 2026-08-02 fleet
+// 401 was four copies of a secret chain; CTL-1834 was five event-name ladders in three
+// incompatible orders) and there is direct precedent for pinning it with a source scan
+// (execution-core/assertion-evidence-parity.test.mjs, execution-core/event-name-read-guard.test.mjs).
+describe("drift guard: both callers IMPORT the leaf, neither re-implements it", () => {
+  const SCRIPTS = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const IMPORTERS = ["ask.mjs", "linear-reply.mjs"];
+  const read = (f) => readFileSync(join(SCRIPTS, f), "utf8");
+
+  test("positive control: the scan instrument really reads both files", () => {
+    // Without this, every assertion below is equally consistent with reading "" — the
+    // false-clean mechanism this repo has shipped before ([].every(p) is true).
+    for (const f of IMPORTERS) {
+      const src = read(f);
+      expect(src.length).toBeGreaterThan(1000);
+      expect(src).toContain("resolveCommentBody");
+    }
+  });
+
+  test("each caller imports resolveCommentBody from the shared leaf", () => {
+    for (const f of IMPORTERS) {
+      expect(read(f)).toContain('from "./lib/comment-body-arg.mjs"');
+    }
+  });
+
+  test("no caller carries a SECOND copy of the path-shape rule", () => {
+    // The regex is the rule. A copy of it in a caller means the two tools can drift, which
+    // is exactly what one shared leaf exists to prevent.
+    for (const f of IMPORTERS) {
+      expect(read(f)).not.toContain("(?:\\/|~\\/)");
+      expect(read(f)).not.toMatch(/PATH_SHAPED/);
+    }
+  });
+
+  test("negative control: the leaf itself DOES carry the rule", () => {
+    // Proves the two assertions above are discriminating rather than vacuously true of any
+    // JS file — the string they look for exists, in exactly one place.
+    const leaf = readFileSync(join(SCRIPTS, "lib", "comment-body-arg.mjs"), "utf8");
+    expect(leaf).toContain("(?:\\/|~\\/)");
+    expect(leaf).toMatch(/PATH_SHAPED/);
   });
 });

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -8,8 +8,10 @@
 //   • the agent tag rendered in the BODY (see the identity note below).
 //
 // Usage:
-//   node linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown> [--parent <commentId>|--top] [--keep-eyes]
-//   (body may also come from stdin: --body -)
+//   node linear-reply.mjs <ISSUE-ID> --as <AGENT> (--body <markdown|-> | --body-file <path>) [--parent <commentId>|--top] [--keep-eyes]
+//   (body may also come from stdin: --body -; or from a file's CONTENTS: --body-file <path>)
+//   ⛔ CTL-2204: --body REFUSES a path to an existing file (exit 2, naming --body-file) — a
+//   path is never a valid comment body. Use --body-file <path> to post that file's contents.
 // Without --parent/--top: threads under the ROOT of the most recent comment authored by a
 // HUMAN (non-bot) user on the issue; if none exists, posts top-level.
 // Prints JSON {ok, via, parentId, eyesCleared} on success; non-zero exit + message on failure.
@@ -39,22 +41,45 @@
 import { readFileSync } from "node:fs";
 import { readReplyContext, readIssueId, readCommentThreadRoot, isReplicaCurrent } from "./execution-core/replica-comment-read.mjs";
 import { getReplicaDbPath } from "./execution-core/config.mjs";
+import { resolveCommentBody } from "./lib/comment-body-arg.mjs";
 
 function arg(name, dflt) {
   const i = process.argv.indexOf(name);
   return i >= 0 ? process.argv[i + 1] : dflt;
 }
+
+const USAGE =
+  "usage: linear-reply.mjs <ISSUE-ID> --as <AGENT> (--body <markdown|-> | --body-file <path>) " +
+  "[--parent <id>|--top] [--keep-eyes]";
+
 const issueKey = process.argv[2];
 const asAgent = arg("--as", "COORD");
-let body = arg("--body", "");
 const parentArg = arg("--parent", null);
 const top = process.argv.includes("--top");
 const keepEyes = process.argv.includes("--keep-eyes");
-if (!issueKey || !body) {
-  console.error("usage: linear-reply.mjs <ISSUE-ID> --as <AGENT> --body <markdown|-> [--parent <id>|--top] [--keep-eyes]");
+if (!issueKey) {
+  console.error(USAGE);
   process.exit(2);
 }
-if (body === "-") body = readFileSync(0, "utf8");
+
+// CTL-2204: ONE rule for what the body is, shared with ask.mjs. Refuses a path passed to
+// --body BEFORE the replica read and BEFORE any proxy call — a path is never a comment body.
+const resolved = resolveCommentBody({
+  body: arg("--body", undefined),
+  bodyFile: arg("--body-file", undefined),
+});
+if (!resolved.ok) {
+  console.error(`linear-reply: ${resolved.message}`);
+  console.error(USAGE);
+  process.exit(2);
+}
+let body = resolved.stdin ? readFileSync(0, "utf8") : resolved.body;
+// A stdin body is resolved here, so re-check emptiness on the bytes we actually got.
+if (!body.trim()) {
+  console.error("linear-reply: comment body is empty (stdin produced nothing)");
+  process.exit(2);
+}
+
 // Identity-loss mitigation (see header): the cloud posts as a generic app actor, so keep the
 // agent tag visible in the body itself.
 const postBody = `${body}\n\n— _${asAgent}_`;

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -56,7 +56,7 @@ in one place: **[`references/threading.md`](references/threading.md)** — one-l
 what a reply must contain. Read it before your first reply.
 
 ```bash
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body-file <path>
 ```
 
 ## 5. Closing (the raising agent)

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -29,8 +29,7 @@ node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" create \
   --title "ASK: <one line>" \
   --why "<what it unblocks>" \
   --option "<option A>" --option "<option B>" \
-  --default "<what happens if silent>" \
-  --blocks CTL-NNNN
+  --default "<what happens if silent>" --blocks CTL-NNNN
 #   --dry-run   print the body and the parsed options without writing
 ```
 

--- a/plugins/dev/skills/ask/SKILL.md
+++ b/plugins/dev/skills/ask/SKILL.md
@@ -66,6 +66,7 @@ permission), then:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" accept CTL-NNNN --as <ROLE> --body "accepted — …"
+#   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 ```
 
 It replies in-thread as the app actor and moves the ticket to Done. The two deliberate refusals, the

--- a/plugins/dev/skills/ask/references/closing.md
+++ b/plugins/dev/skills/ask/references/closing.md
@@ -5,8 +5,9 @@ then:
 
 ```bash
 node "$CLAUDE_PLUGIN_ROOT/scripts/ask.mjs" accept CTL-NNNN --as <AGENT> --body "accepted — …"
-#   --body -     read the reply from stdin
-#   --dry-run    show what it would reply and close, without writing
+#   --body-file <path>  post a FILE'S CONTENTS (preferred for anything multi-line)
+#   --body -            read the reply from stdin
+#   --dry-run           show what it would reply and close, without writing
 ```
 
 `accept` replies in-thread as the app actor and moves the ticket to Done. Two refusals are

--- a/plugins/dev/skills/ask/references/threading.md
+++ b/plugins/dev/skills/ask/references/threading.md
@@ -48,9 +48,18 @@ direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as 
 ```
 
 ⛔ **Write the body to a file, then pass it with `--body-file` — never with `--body`.**
-`--body <path>` is REFUSED (exit 2): a path is never a comment body. This guard exists because
-the file-first habit produced 23 published comments whose entire body was a tmp path, across 16
-tickets, before CTL-2204.
+This guard exists because the file-first habit produced 23 published comments whose entire body
+was a tmp path, across 16 tickets, before CTL-2204.
+
+⚠️ **The guard is a backstop, not the guarantee — `--body-file` is.** `--body` refuses (exit 2)
+only a string that is *provably* the mistake: **absolute or `~/`-rooted**, **whitespace-free**,
+and **naming a file that exists** (an existence probe that cannot answer — EACCES, ELOOP — also
+refuses, since refusing a path-shaped string is recoverable and posting one is not). That
+narrowness is deliberate: it is what keeps a real one-word markdown body from ever tripping the
+guard, and every one of the 23 measured incidents had that shape. So a **relative** path
+(`tmp/reply.md`), a path that does **not exist**, or one **containing a space** is accepted as
+the literal body and published verbatim. Do not treat "`--body` would have caught it" as a
+reason to reach for `--body`; reach for `--body-file`.
 
 The helper posts through the cloud write proxy as the app actor and needs no client
 credentials of its own (CTL-1958); it requires `CATALYST_LINEAR_WRITE_PROXY=enforce` plus a

--- a/plugins/dev/skills/ask/references/threading.md
+++ b/plugins/dev/skills/ask/references/threading.md
@@ -39,14 +39,22 @@ as an ADR before it ships, because history cannot be re-tagged.
 ## The helper (do not hand-roll the write)
 
 ```bash
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body "<markdown>"
-#   --body -          read the body from stdin
-#   --parent <id>     thread under a specific comment (its ROOT is used)
-#   --top             start a new top-level comment
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-NNNN --as <ROLE> --body-file <path>
+#   --body-file <path>  post the FILE'S CONTENTS (preferred for anything multi-line)
+#   --body "<markdown>" post a literal string
+#   --body -            read the body from stdin
+#   --parent <id>       thread under a specific comment (its ROOT is used)
+#   --top               start a new top-level comment
 ```
 
-Needs `LINEAR_SYNC_CLIENT_ID` / `LINEAR_SYNC_CLIENT_SECRET` (the app's client credentials — the
-catalyst-cloud direnv profile carries them); the helper mints the app-actor token itself.
+⛔ **Write the body to a file, then pass it with `--body-file` — never with `--body`.**
+`--body <path>` is REFUSED (exit 2): a path is never a comment body. This guard exists because
+the file-first habit produced 23 published comments whose entire body was a tmp path, across 16
+tickets, before CTL-2204.
+
+The helper posts through the cloud write proxy as the app actor and needs no client
+credentials of its own (CTL-1958); it requires `CATALYST_LINEAR_WRITE_PROXY=enforce` plus a
+cloud token, and refuses under any other resolution.
 
 ## Acknowledging with 👀
 

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -265,7 +265,7 @@ linearis issues update ENG-123 --project-milestone "Milestone Name"
 > with the agent via `createAsUser`:
 >
 > ```bash
-> direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-123 --as <AGENT> --body "…"
+> direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-123 --as <AGENT> --body-file <path>
 > #   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 > ```
 >
@@ -280,7 +280,7 @@ discussion commands").
 ```bash
 # An AGENT starting a comment / discussion thread — go through linear-reply.mjs, NOT `discuss`
 # (the ⛔ callout above; `discuss` posts under the human's own identity):
-direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "…" --top
+direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body-file <path> --top
 #   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 
 # `linearis issues discuss` — ONLY when the comment is genuinely meant to be the human's own:

--- a/plugins/dev/skills/linearis/SKILL.md
+++ b/plugins/dev/skills/linearis/SKILL.md
@@ -266,6 +266,7 @@ linearis issues update ENG-123 --project-milestone "Milestone Name"
 >
 > ```bash
 > direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" CTL-123 --as <AGENT> --body "…"
+> #   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 > ```
 >
 > Use `linearis issues discuss` only when you genuinely intend the comment to be the
@@ -280,6 +281,7 @@ discussion commands").
 # An AGENT starting a comment / discussion thread — go through linear-reply.mjs, NOT `discuss`
 # (the ⛔ callout above; `discuss` posts under the human's own identity):
 direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "…" --top
+#   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 
 # `linearis issues discuss` — ONLY when the comment is genuinely meant to be the human's own:
 linearis issues discuss ENG-123 --body "Starting work on this"
@@ -557,6 +559,7 @@ linearis issues update ENG-123 --status "Done"
 # With comment — an AGENT posting the "Merged" note goes through linear-reply.mjs, not `discuss`
 linearis issues update ENG-123 --status "Done"
 direnv exec . node "$CLAUDE_PLUGIN_ROOT/scripts/linear-reply.mjs" ENG-123 --as <AGENT> --body "Merged: PR #456" --top
+#   --body-file <path>  for anything longer than a one-line body; --body REFUSES a path (CTL-2204)
 ```
 
 ### UUID-based calls (CTL-207)


### PR DESCRIPTION
<!-- Auto-generated: 2026-08-23T00:00:00Z -->
<!-- Last updated: 2026-08-23T00:00:00Z -->
<!-- PR: #3964 -->
<!-- Previous commits: 7c938805,b7539a07,d514da98,bccc185a,c9578708,3a8161f2,6f5aea54,9bca63bf -->

## Summary

Fixes the class of incident where an operator (or agent) passes a file **path** as a
Linear comment `--body` instead of the file's contents, silently publishing the literal
path string as the comment (23 bad comments across 16 tickets, per the motivating
incident). Adds a shared, zero-dependency resolver that refuses a path passed to
`--body` and introduces `--body-file <path>` as the correct way to post file contents,
wires it into both comment-posting call sites (`linear-reply.mjs` and `ask.mjs accept`),
and updates the docs/skills that teach the recipe so agents copy the safe form by
default.

## Changes Made

### New shared resolver

- `plugins/dev/scripts/lib/comment-body-arg.mjs` — a pure, zero-dependency leaf that
  decides what a comment's body is: refuses an absolute/`~`-expanded path to an
  existing file passed via `--body`, refuses empty/whitespace-only/ambiguous bodies,
  and resolves `--body-file <path>` to the file's contents. Existence checks are
  three-valued (`statSync` with `throwIfNoEntry:false`) rather than `existsSync`, so an
  unprovable path (e.g. under a permission-denied directory) refuses rather than
  silently falling through to "post the literal string." Tilde expansion runs through
  one helper on both the refusal message and the `--body-file` read path, so a refused
  `--body ~/x.md` can actually be fixed by following its own suggested command.
  `plugins/dev/scripts/linear-comment-post.sh` is named in the header as a third,
  still-unguarded writer, deliberately out of scope here (tracked as CTL-2207).

### Call-site wiring

- `plugins/dev/scripts/linear-reply.mjs` — `--body` now runs through the shared
  resolver before the replica read and before any proxy call; `--body-file <path>`
  posts the file's contents.
- `plugins/dev/scripts/ask.mjs` (`cmdAccept`) — wired to the same resolver in its own
  process, before the replica read, closing the gap a `linear-reply.mjs`-only guard
  would leave: `--dry-run` never spawns the `linear-reply` child, so without this the
  guard could be bypassed entirely under `--dry-run`. The resolved body is passed to
  the child over **stdin** (`--body -`, `{ input: body }`) rather than re-marshalled
  through argv, which was itself silently broken three ways: `E2BIG` on a body over
  the argv size limit, a body starting with `--top` flipping the child to top-level
  posting, and a `--body-file` argument being re-refused by the child's own guard.
  `run()` now also surfaces `r.error` so a spawn that never started (e.g. `ENOENT`) is
  distinguishable from a child that exited non-zero with empty stderr.

### Docs / skills

- `plugins/dev/skills/ask/SKILL.md`, `references/closing.md`, `references/threading.md`
  — the primary, copy-pasted recipes for posting a Linear comment now teach
  `--body-file` instead of a bare `--body <path>`.
- `plugins/dev/skills/linearis/SKILL.md` — the two placeholder-body recipes there now
  teach `--body-file` too; a stricter doc-contract check (below) now covers this file
  as well as `ask/SKILL.md`, so this can't silently regress.
- `.github/workflows/execution-core-tests.yml` — registers the new `comment-body-arg`
  bun unit-test step.

### Tests

- `plugins/dev/scripts/lib/comment-body-arg.test.mjs` (new) — unit coverage for the
  resolver: path refusal, tilde expansion, three-valued existence, ambiguous/empty
  body handling, and the deliberate scope limit that a path containing a space is not
  refused.
- `plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh` (new) — network-free
  refusal cases for `linear-reply.mjs`, plus a mock-cloud positive control proving a
  good body does reach the proxy so the zero-capture assertion on the refused case is
  trustworthy.
- `plugins/dev/scripts/__tests__/ask-verbs.test.mjs` — new guard-refusal cases for
  `ask accept` (previously these ran with no replica configured, so `ask.mjs` exited 1
  at the replica read regardless of whether the guard existed — the assertions could
  not have failed even without the fix); a non-dry-run refused-body case asserting
  `linearis` is invoked zero times; end-to-end `--body -` coverage in both directions;
  and coverage for the `ask.mjs → linear-reply` stdin marshalling boundary itself
  (reverting the stdin change back to argv passed all 137 prior tests, i.e. was
  invisible to the existing suite until this commit).
- `plugins/dev/scripts/__tests__/install-agent-tools.test.sh` — extended to actually
  execute the deployed symlink copy of the tooling, proving the new
  `./lib/comment-body-arg.mjs` relative import resolves through the symlink the same
  way the existing `./execution-core` import does.
- A new drift guard asserts both call sites import the shared leaf and carry no
  second, hand-rolled copy of the path rule.
- A doc-contract test (`skill-shape`/anchor checks) now covers all four rewritten
  recipe files, anchored on the specific invocation line rather than a whole-file
  grep, so a regression on any one recipe fails the gate.

## How to Verify It

- [x] `bun test plugins/dev/scripts/lib/comment-body-arg.test.mjs` — 33/33 passing
- [x] `bash plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh` — 38/38 passing
- [x] `bun test plugins/dev/scripts/__tests__/ask-verbs.test.mjs` — 59/59 passing
- [x] `bash plugins/dev/scripts/__tests__/install-agent-tools.test.sh` — 10/10 passing
- [x] `skill-shape` / doc-contract gates — 119/119 passing
- [x] CI: `agents-md-gate`, `audit-references`, `docs-gate`, `gitleaks`, `skills-gate`,
      `check-versions`, `detect-changes`, `validate`, CodeQL (`actions`, `python`) — all
      green as of the latest push

## Related Issues/PRs

- Fixes https://linear.app/coalesce-labs/issue/CTL-2204
- Follow-up filed: CTL-2207 — port the path-as-body refusal into the third,
  still-unguarded writer `linear-comment-post.sh` (deliberately out of scope here)

## Reviewer Notes

- `install-agent-tools.test.sh` proves the deployed-copy import resolves correctly, but
  merging this PR does not by itself update `~/catalyst/comms/tools/linear-reply.mjs`
  on any already-running host — re-running `install-agent-tools.sh` per host is a
  landing step, not part of this diff.
- One pre-existing, unrelated red test (`fsm-descriptor.test.mjs:103`) was observed
  during verification and is not touched by this diff.
- Two rounds of review remediation are included: round 1 addressed the deterministic
  findings from `verify` (tilde-expansion follow-through, three-valued existence,
  `run()` error surfacing, untestable guard tests, doc-contract anchoring); round 2
  fixed a merge-blocking `skill-shape` line-count regression introduced by round 1's
  own doc edit, plus extended the strict first-invocation check to
  `linearis/SKILL.md`.

<!-- Linear automation guard (CTL-623/CTL-633): unlink sibling tickets so this PR does not drag their workflow status. -->
skip CTL-2207
