### PR TITLE
chore(config): opus only on plan + verify phases; implement on sonnet (Ryan)

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -89,9 +89,9 @@
         "models": {
           "triage": "sonnet",
           "research": "sonnet",
-          "plan": "sonnet",
-          "implement": "opus",
-          "verify": "sonnet",
+          "plan": "opus",
+          "implement": "sonnet",
+          "verify": "opus",
           "review": "sonnet",
           "pr": "sonnet",
           "remediate": "sonnet",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,9 +159,9 @@ catalyst-execution-core restart
         "models": {
           "triage":         "sonnet",
           "research":       "sonnet",
-          "plan":           "sonnet",
-          "implement":      "opus",
-          "verify":         "sonnet",
+          "plan":           "opus",
+          "implement":      "sonnet",
+          "verify":         "opus",
           "review":         "sonnet",
           "pr":             "sonnet",
           "monitor-merge":  "sonnet",

--- a/plugins/dev/scripts/phase-agent-dispatch
+++ b/plugins/dev/scripts/phase-agent-dispatch
@@ -361,15 +361,20 @@ config_value() {
 		return
 	fi
 	local v
-	if [[ -n $CONFIG_PATH && -f $CONFIG_PATH ]]; then
-		v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
+	# ⭐ #3973 review P1 — MACHINE CONFIG FIRST. docs/configuration.md's contract is "Layer 2 wins over
+	# Layer 1 on a per-field basis" (Layer 2 = ~/.config/catalyst machine config, Layer 1 = the repo's
+	# .catalyst/config.json). This function had the order inverted; it was latent while the repo file
+	# lacked the keys, and became live the moment the repo committed a phaseAgents block — a host's
+	# explicit `implement: opus` override would have been silently shadowed by the repo default.
+	if [[ -f $MACHINE_CONFIG_PATH ]]; then
+		v=$(jq -r "$key // empty" "$MACHINE_CONFIG_PATH" 2>/dev/null)
 		if [[ -n $v ]]; then
 			echo "$v"
 			return
 		fi
 	fi
-	if [[ -f $MACHINE_CONFIG_PATH ]]; then
-		v=$(jq -r "$key // empty" "$MACHINE_CONFIG_PATH" 2>/dev/null)
+	if [[ -n $CONFIG_PATH && -f $CONFIG_PATH ]]; then
+		v=$(jq -r "$key // empty" "$CONFIG_PATH" 2>/dev/null)
 		if [[ -n $v ]]; then
 			echo "$v"
 			return


### PR DESCRIPTION
Ryan's model decision (2026-08-23 4:0x PM): everything on sonnet except the planning and validation phases — so `plan` and `verify` get opus, `implement` moves to sonnet. Subagents already match his intent (locators/research on haiku, analyzers on sonnet — no change needed). Sibling PR on catalyst-cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB8h2N5MU7e7skQApcFQRs