### PR TITLE
feat(execution-core): CTC-921 — lease renewal on asserted progress (fleet-built; pushed via CTC-931)

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -1510,6 +1510,7 @@ jobs:
             lease-authority.test.mjs \
             lease-authority-claim.test.mjs \
             lease-authority-gate.test.mjs \
+            lease-authority-renew.test.mjs \
             cluster-heartbeat.test.mjs \
             cluster-heartbeat-capacity.test.mjs \
             comms-drain.test.mjs \

--- a/plugins/dev/scripts/execution-core/daemon.mjs
+++ b/plugins/dev/scripts/execution-core/daemon.mjs
@@ -191,7 +191,14 @@ import { reconcileSdkRegistryOnBoot } from "./sdk-worker-registry.mjs"; // CTL-1
 import { resolveNodeClass as _resolveNodeClass } from "./lib/node-class.mjs"; // CTL-1654: node-class heartbeat/actuation guard
 // CTL-1786: lease-authority node entitlement, refreshed on the cluster-sync cadence so a
 // not_entitled claim refusal is a rare self-healing edge rather than the steady state.
-import { createLeaseAuthorityClient, ensureEntitled as ensureLeaseEntitled } from "./lease-authority.mjs";
+import {
+  createLeaseAuthorityClient,
+  ensureEntitled as ensureLeaseEntitled,
+  renewActiveLeases, // CTC-921: progress-asserted renewal of this host's live leases
+} from "./lease-authority.mjs";
+import { defaultProgressMark } from "./work-done-probes.mjs"; // CTC-921
+import { teamOf as leaseTeamOf } from "./dispatch.mjs"; // CTC-921: ticket → team → repoRoot
+import { getProjectConfig as leaseProjectConfig } from "./registry.mjs"; // CTC-921
 
 // CTL-1623: register the github-token row's rearm hook at module load — BEFORE either
 // call site below (both live inside startDaemon(), invoked only later) can fire. Makes
@@ -307,6 +314,54 @@ function refreshLeaseEntitlement() {
     log.warn({ err: err?.message }, "cluster-sync timer: lease entitlement refresh threw (continuing)");
   }
 }
+// CTC-921: the progress-asserted renewal loop. `_lastRenewedMark` remembers, per
+// "<ticket>:<phase>", the progress mark this daemon last SUCCESSFULLY renewed on — the state
+// that makes "has this holder actually moved since last time" answerable. In-memory by design:
+// a restart costs at most one redundant or one skipped renewal, both harmless.
+const _lastRenewedMark = new Map();
+
+// refreshActiveLeaseRenewals — keep any genuinely-progressing (ticket, phase) THIS host
+// dispatched alive past its work TTL (45 min > the server's 30-min lease TTL, so without this a
+// long phase silently lost tenure mid-run). A stalled holder is deliberately skipped rather than
+// renewed with a repeated assertion: under invariant I2 (ADR-0027) a renewal is earned by
+// progress, not by being alive, and the store cannot tell a re-POSTed assertion from a fresh one.
+//
+// Same gate, same cadence, and the same FAIL-OPEN contract as refreshLeaseEntitlement — a strict
+// no-op under the default `off` mode, so this is inert until an operator opts a host in.
+function refreshActiveLeaseRenewals({ orchDir } = {}) {
+  let mode;
+  try {
+    mode = resolveLeaseAuthorityMode(process.env);
+  } catch {
+    return;
+  }
+  if (mode !== "shadow" && mode !== "enforce") return;
+  try {
+    if (!_leaseClient) _leaseClient = createLeaseAuthorityClient({ env: process.env });
+    const summary = renewActiveLeases({
+      client: _leaseClient,
+      hostName: getHostName(),
+      orchDir,
+      lastRenewedMarks: _lastRenewedMark,
+      readSignals: readAllPhaseSignals,
+      progressMark: defaultProgressMark,
+      // Resolved exactly like the scheduler's hung-worker probe (scheduler.mjs, CTL-729):
+      // ticket → team → the registry's repoRoot. Without it defaultProgressMark returns 0 for
+      // every code phase and the loop would ship inert.
+      resolveRepoRoot: (ticket) => {
+        const team = leaseTeamOf(ticket);
+        return team ? (leaseProjectConfig(team)?.repoRoot ?? null) : null;
+      },
+      log,
+    });
+    if (summary.renewed > 0 || summary.refused > 0 || summary.errors > 0) {
+      log.info(summary, "cluster-sync timer: lease renewal sweep");
+    }
+  } catch (err) {
+    log.warn({ err: err?.message }, "cluster-sync timer: lease renewal sweep threw (continuing)");
+  }
+}
+
 // CTL-684: auto-tuner stop handle.
 let _stopAutoTuner = null;
 let _eventWatcher = null;
@@ -2372,6 +2427,10 @@ export function startDaemon({
         // claim's not_entitled refusal is a rare self-healing edge, not the steady state. Cached
         // + fail-open (see refreshLeaseEntitlement); a strict no-op when the gate is off.
         refreshLeaseEntitlement();
+        // CTC-921: on the same tick, renew the leases of phases this host is actively running
+        // and that have made progress since the last sweep. Cached + fail-open (see
+        // refreshActiveLeaseRenewals); a strict no-op when the gate is off.
+        refreshActiveLeaseRenewals({ orchDir });
       }, clusterSyncIntervalMs);
       _clusterSyncTimer.unref?.();
     }

--- a/plugins/dev/scripts/execution-core/lease-authority-renew.test.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority-renew.test.mjs
@@ -10,8 +10,12 @@
 // client from re-POSTing the same string forever — a mechanical keep-alive wearing a costume.
 // The refusal has to happen HERE, before the call: a holder whose progress mark has not moved
 // makes no call at all and its lease lapses on its own deadline.
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
-import { decideRenewal, renewActiveLeases } from "./lease-authority.mjs";
+import { decideRenewal, defaultIsPhaseDispatched, renewActiveLeases } from "./lease-authority.mjs";
 
 describe("decideRenewal — the progress gate", () => {
   test("first-ever check with positive progress → renew", () => {
@@ -115,6 +119,7 @@ const scan = (opts) =>
     progressMark: opts.progressMark ?? (() => 1),
     readGeneration: opts.readGeneration ?? (() => 7),
     resolveRepoRoot: opts.resolveRepoRoot,
+    ...(opts.isPhaseDispatched ? { isPhaseDispatched: opts.isPhaseDispatched } : {}),
   });
 
 describe("renewActiveLeases — which of this host's phases get renewed", () => {
@@ -168,10 +173,21 @@ describe("renewActiveLeases — which of this host's phases get renewed", () => 
     }
   });
 
-  test("a running phase with no bg_job_id is skipped (not a daemon-dispatched worker)", () => {
+  // ⛔ CTC-921 regression: `bg_job_id` alone is NOT the dispatch test. It is written only by the
+  // legacy `claude --bg` executor; every `executor:"sdk"` phase carries `bg_job_id:null` for its
+  // whole life. Gating on it made this scan inert for essentially every phase the fleet runs.
+  // What is actually required is that SOME liveness source vouches for the phase.
+  test("a running phase no liveness source vouches for is skipped", () => {
     const client = fakeClient();
-    scan({ client, signals: [signal({ bg: null })] });
+    scan({ client, signals: [signal({ bg: null })], isPhaseDispatched: () => false });
     expect(client.calls).toHaveLength(0);
+  });
+
+  test("a running SDK phase (bg_job_id null) IS renewed when the SDK registry vouches for it", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal({ bg: null })], isPhaseDispatched: () => true });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].ticket).toBe("CTC-1");
   });
 
   test("a legacy FLAT signal is ignored (numeric phase, no lease scope)", () => {
@@ -356,5 +372,59 @@ describe("renewActiveLeases — repoRoot is resolved PER TICKET and handed to th
     });
     expect(seen[0].repoRoot).toBeNull();
     expect(client.calls).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CTC-921 — the dispatch predicate itself, against a real .sdk-workers projection.
+//
+// This block exists because the bug it guards was INVISIBLE to every injected-fake test above:
+// `renewActiveLeases` was correct, and the default predicate handed it a `false` for every
+// SDK-executor phase. Measured on the live fleet orchDir when this was found: 340/353 nested
+// signals were `executor:"sdk"` with `bg_job_id:null`, 13 were `executor:"bg"` with it set, and
+// the sole `status:"running"` signal was an SDK one — i.e. the scan could never have renewed
+// anything. So these tests use the real filesystem reader, not a stub.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("defaultIsPhaseDispatched — both executors' liveness sources", () => {
+  /** An orchDir with a .sdk-workers/<ticket>.json projection, as the SDK executor writes it. */
+  function orchWithProjection({ ticket = "CTC-1", phase = "implement", pid = process.pid, updatedAt = Date.now() }) {
+    const dir = mkdtempSync(join(tmpdir(), "ctc921-"));
+    mkdirSync(join(dir, ".sdk-workers"), { recursive: true });
+    writeFileSync(join(dir, ".sdk-workers", `${ticket}.json`), JSON.stringify({ ticket, phase, pid, updatedAt }));
+    return dir;
+  }
+
+  test("legacy bg executor: a set bg_job_id vouches on its own, no projection needed", () => {
+    expect(defaultIsPhaseDispatched(signal({ bg: "job-1" }), "/nonexistent")).toBe(true);
+  });
+
+  test("SDK executor: bg_job_id null + a live, phase-matching projection → dispatched", () => {
+    const orch = orchWithProjection({ ticket: "CTC-1", phase: "implement" });
+    expect(defaultIsPhaseDispatched(signal({ bg: null }), orch)).toBe(true);
+  });
+
+  test("the projection is per-TICKET, so it may not vouch for a SIBLING phase's signal", () => {
+    const orch = orchWithProjection({ ticket: "CTC-1", phase: "implement" });
+    expect(defaultIsPhaseDispatched(signal({ bg: null, phase: "review" }), orch)).toBe(false);
+  });
+
+  test("a dead pid does not vouch — errs toward letting the lease lapse", () => {
+    // pid 1 is alive but not ours; use an unassignable pid instead.
+    const orch = orchWithProjection({ ticket: "CTC-1", pid: 2 ** 31 - 1 });
+    expect(defaultIsPhaseDispatched(signal({ bg: null }), orch)).toBe(false);
+  });
+
+  test("a stale projection (older than the freshness window) does not vouch", () => {
+    const orch = orchWithProjection({ ticket: "CTC-1", updatedAt: Date.now() - 24 * 60 * 60 * 1000 });
+    expect(defaultIsPhaseDispatched(signal({ bg: null }), orch)).toBe(false);
+  });
+
+  test("no projection at all → not dispatched, never throws", () => {
+    const orch = mkdtempSync(join(tmpdir(), "ctc921-"));
+    expect(defaultIsPhaseDispatched(signal({ bg: null }), orch)).toBe(false);
+  });
+
+  test("a missing/!string orchDir is tolerated rather than thrown", () => {
+    expect(defaultIsPhaseDispatched(signal({ bg: null }), undefined)).toBe(false);
   });
 });

--- a/plugins/dev/scripts/execution-core/lease-authority-renew.test.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority-renew.test.mjs
@@ -1,0 +1,360 @@
+// lease-authority-renew.test.mjs — CTC-921, the progress-gated renewal loop.
+// Run: cd plugins/dev/scripts/execution-core && bun test lease-authority-renew.test.mjs
+//
+// The client CONTRACT for `renew` lives in lease-authority.test.mjs. This file owns the
+// DECISION half: when may a holder renew at all, and which of this host's phases get renewed
+// on a tick. Both are exercised through injected seams — no network, no timer, no daemon.
+//
+// ⛔ The load-bearing property under test is invariant I2 (ADR-0027): a renewal is earned by
+// PROGRESS, not by being alive. The server only rejects an EMPTY assertion, so nothing stops a
+// client from re-POSTing the same string forever — a mechanical keep-alive wearing a costume.
+// The refusal has to happen HERE, before the call: a holder whose progress mark has not moved
+// makes no call at all and its lease lapses on its own deadline.
+import { describe, expect, test } from "bun:test";
+import { decideRenewal, renewActiveLeases } from "./lease-authority.mjs";
+
+describe("decideRenewal — the progress gate", () => {
+  test("first-ever check with positive progress → renew", () => {
+    expect(decideRenewal({ phase: "implement", mark: 3, lastRenewedMark: undefined })).toEqual({
+      shouldRenew: true,
+      assertion: "implement-progress:3",
+    });
+  });
+
+  test("zero progress never renews, even on the first check", () => {
+    // 0 is defaultProgressMark's own documented "no progress observed" value — it is also what
+    // it returns for an unresolvable worktree or a failed git call, so renewing on 0 would
+    // renew on a READ FAILURE.
+    expect(decideRenewal({ phase: "implement", mark: 0, lastRenewedMark: undefined })).toEqual({
+      shouldRenew: false,
+    });
+  });
+
+  test("mark unchanged since the last renewal → skip (a stalled holder is not kept alive)", () => {
+    expect(decideRenewal({ phase: "implement", mark: 5, lastRenewedMark: 5 })).toEqual({
+      shouldRenew: false,
+    });
+  });
+
+  test("mark increased since the last renewal → renew with a DISTINCT assertion", () => {
+    const first = decideRenewal({ phase: "implement", mark: 5, lastRenewedMark: undefined });
+    const second = decideRenewal({ phase: "implement", mark: 6, lastRenewedMark: 5 });
+    expect(second).toEqual({ shouldRenew: true, assertion: "implement-progress:6" });
+    // The CTC-921 acceptance check: assertions across renewals must be pairwise distinct.
+    expect(second.assertion).not.toBe(first.assertion);
+  });
+
+  test("mark regressed (should not happen, but must not crash or renew) → skip", () => {
+    expect(decideRenewal({ phase: "implement", mark: 4, lastRenewedMark: 5 })).toEqual({
+      shouldRenew: false,
+    });
+  });
+
+  test("non-finite or non-numeric marks → skip, never throws", () => {
+    for (const mark of [NaN, Infinity, undefined, null, "7"]) {
+      expect(decideRenewal({ phase: "implement", mark, lastRenewedMark: 5 })).toEqual({
+        shouldRenew: false,
+      });
+    }
+  });
+
+  test("the assertion names the phase, so two phases of one ticket never collide", () => {
+    expect(decideRenewal({ phase: "research", mark: 12, lastRenewedMark: 1 }).assertion).toBe(
+      "research-progress:12"
+    );
+  });
+});
+
+// ─── the per-tick scan ───────────────────────────────────────────────────────
+
+const HOST = "mini";
+
+/** A nested phase signal in readAllPhaseSignals' normalized shape. */
+function signal({
+  ticket = "CTC-1",
+  phase = "implement",
+  status = "running",
+  bg = "job-1",
+  host = { name: HOST, id: "h1" },
+  layout = "nested",
+} = {}) {
+  return {
+    ticket,
+    layout,
+    phase,
+    status,
+    liveness: { kind: "bg", value: bg },
+    host,
+    signalPath: `/fake/${ticket}/phase-${phase}.json`,
+    raw: {},
+  };
+}
+
+/** A recording lease client whose renew() returns a queued outcome. */
+function fakeClient(outcomes = [{ renewed: true }]) {
+  const calls = [];
+  const queue = [...outcomes];
+  return {
+    calls,
+    renew(args) {
+      calls.push(args);
+      const next = queue.length > 1 ? queue.shift() : queue[0];
+      if (typeof next === "function") return next(args);
+      return next;
+    },
+  };
+}
+
+const scan = (opts) =>
+  renewActiveLeases({
+    client: opts.client,
+    hostName: opts.hostName ?? HOST,
+    orchDir: "/fake/orch",
+    lastRenewedMarks: opts.lastRenewedMarks ?? new Map(),
+    readSignals: () => opts.signals ?? [],
+    progressMark: opts.progressMark ?? (() => 1),
+    readGeneration: opts.readGeneration ?? (() => 7),
+    resolveRepoRoot: opts.resolveRepoRoot,
+  });
+
+describe("renewActiveLeases — which of this host's phases get renewed", () => {
+  test("a running, this-host phase with progress → exactly one renew, correctly addressed", () => {
+    const client = fakeClient();
+    const marks = new Map();
+    const res = scan({ client, signals: [signal()], progressMark: () => 3, lastRenewedMarks: marks });
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]).toEqual({
+      ticket: "CTC-1",
+      phase: "implement",
+      holder: HOST,
+      nonce: 7, // the ticket's cluster generation IS the grant nonce
+      assertion: "implement-progress:3",
+    });
+    expect(res.renewed).toBe(1);
+    expect(marks.get("CTC-1:implement")).toBe(3);
+  });
+
+  test("no progress since the last renewal → NO call at all (the lease is left to lapse)", () => {
+    const client = fakeClient();
+    const res = scan({
+      client,
+      signals: [signal()],
+      progressMark: () => 3,
+      lastRenewedMarks: new Map([["CTC-1:implement", 3]]),
+    });
+    expect(client.calls).toHaveLength(0);
+    expect(res.renewed).toBe(0);
+    expect(res.skipped).toBe(1);
+  });
+
+  test("a phase dispatched by a DIFFERENT host is never touched", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal({ host: { name: "mini-2", id: "h2" } })] });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("a signal with no host attribution is never touched (cannot prove it is ours)", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal({ host: null })] });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("only a running phase is renewed — every other status is skipped", () => {
+    for (const status of ["dispatched", "complete", "failed", "skipped", "park", "yielded", ""]) {
+      const client = fakeClient();
+      scan({ client, signals: [signal({ status })] });
+      expect(client.calls).toHaveLength(0);
+    }
+  });
+
+  test("a running phase with no bg_job_id is skipped (not a daemon-dispatched worker)", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal({ bg: null })] });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("a legacy FLAT signal is ignored (numeric phase, no lease scope)", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal({ layout: "flat", phase: 3 })] });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("no cluster-generation.json → skipped: no lease-authority claim on record to renew", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal()], readGeneration: () => null });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("a non-finite generation is never sent as a nonce", () => {
+    const client = fakeClient();
+    scan({ client, signals: [signal()], readGeneration: () => NaN });
+    expect(client.calls).toHaveLength(0);
+  });
+});
+
+describe("renewActiveLeases — outcome handling", () => {
+  test("a refusal does NOT advance the remembered mark (so the next tick re-attempts)", () => {
+    const client = fakeClient([{ renewed: false, refusal: "expired", current: null }]);
+    const marks = new Map();
+    const res = scan({ client, signals: [signal()], progressMark: () => 4, lastRenewedMarks: marks });
+    expect(res.refused).toBe(1);
+    expect(marks.has("CTC-1:implement")).toBe(false);
+  });
+
+  test("a throwing renew is caught and the tick continues to the next ticket (fail-open)", () => {
+    const client = {
+      calls: [],
+      renew(args) {
+        client.calls.push(args);
+        if (args.ticket === "CTC-1") throw new Error("cloud down");
+        return { renewed: true };
+      },
+    };
+    const res = renewActiveLeases({
+      client,
+      hostName: HOST,
+      orchDir: "/fake/orch",
+      lastRenewedMarks: new Map(),
+      readSignals: () => [signal({ ticket: "CTC-1" }), signal({ ticket: "CTC-2" })],
+      progressMark: () => 2,
+      readGeneration: () => 7,
+    });
+    expect(client.calls).toHaveLength(2); // the second ticket still ran
+    expect(res.errors).toBe(1);
+    expect(res.renewed).toBe(1);
+  });
+
+  test("a throwing progressMark for one ticket does not abort the scan", () => {
+    const client = fakeClient();
+    const res = renewActiveLeases({
+      client,
+      hostName: HOST,
+      orchDir: "/fake/orch",
+      lastRenewedMarks: new Map(),
+      readSignals: () => [signal({ ticket: "CTC-1" }), signal({ ticket: "CTC-2" })],
+      progressMark: ({ ticket }) => {
+        if (ticket === "CTC-1") throw new Error("git exploded");
+        return 2;
+      },
+      readGeneration: () => 7,
+    });
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0].ticket).toBe("CTC-2");
+    expect(res.errors).toBe(1);
+  });
+
+  test("an unreadable signal source is survivable — no throw, empty summary", () => {
+    const client = fakeClient();
+    const res = renewActiveLeases({
+      client,
+      hostName: HOST,
+      orchDir: "/fake/orch",
+      lastRenewedMarks: new Map(),
+      readSignals: () => {
+        throw new Error("no workers dir");
+      },
+      progressMark: () => 1,
+      readGeneration: () => 7,
+    });
+    expect(res).toEqual({ scanned: 0, renewed: 0, skipped: 0, refused: 0, errors: 1 });
+    expect(client.calls).toHaveLength(0);
+  });
+
+  test("ACCEPTANCE (CTC-921): across ticks, a progressing holder renews with pairwise-DISTINCT assertions", () => {
+    const client = fakeClient();
+    const marks = new Map();
+    let mark = 1;
+    for (const _ of [1, 2, 3]) {
+      scan({ client, signals: [signal()], progressMark: () => mark++, lastRenewedMarks: marks });
+    }
+    const assertions = client.calls.map((c) => c.assertion);
+    expect(assertions).toEqual([
+      "implement-progress:1",
+      "implement-progress:2",
+      "implement-progress:3",
+    ]);
+    expect(new Set(assertions).size).toBe(assertions.length);
+  });
+
+  test("ACCEPTANCE (CTC-921): a STALLED holder makes no call on any tick, however many elapse", () => {
+    const client = fakeClient();
+    const marks = new Map();
+    for (const _ of [1, 2, 3, 4, 5]) {
+      scan({ client, signals: [signal()], progressMark: () => 2, lastRenewedMarks: marks });
+    }
+    expect(client.calls).toHaveLength(1); // the first tick earned one; nothing after it did
+  });
+
+  test("ACCEPTANCE: the nonce is CONSTANT across renewals — a renewal continues a tenure", () => {
+    const client = fakeClient();
+    const marks = new Map();
+    let mark = 1;
+    for (const _ of [1, 2, 3]) {
+      scan({ client, signals: [signal()], progressMark: () => mark++, lastRenewedMarks: marks });
+    }
+    expect(new Set(client.calls.map((c) => c.nonce))).toEqual(new Set([7]));
+  });
+
+  test("two phases of the same ticket are tracked independently", () => {
+    const client = fakeClient();
+    const marks = new Map();
+    scan({
+      client,
+      signals: [signal({ phase: "implement" }), signal({ phase: "research" })],
+      progressMark: ({ phase }) => (phase === "implement" ? 3 : 9),
+      lastRenewedMarks: marks,
+    });
+    expect(marks.get("CTC-1:implement")).toBe(3);
+    expect(marks.get("CTC-1:research")).toBe(9);
+    expect(client.calls.map((c) => c.assertion).sort()).toEqual([
+      "implement-progress:3",
+      "research-progress:9",
+    ]);
+  });
+});
+
+// ⛔ THE INERT-SHIP GUARD (the CTL-729 defect class, re-armed for this loop).
+// `defaultProgressMark` resolves a code phase's worktree from `repoRoot` — with none, it
+// returns 0 for implement/remediate/research/plan, `decideRenewal` skips forever, and the whole
+// renewal loop ships INERT for the very phase (implement, the longest) this ticket exists to
+// protect. CTL-729 was exactly this bug in the hung-worker probe. So the per-ticket repoRoot
+// resolution is pinned here as a behaviour, not left to a comment.
+describe("renewActiveLeases — repoRoot is resolved PER TICKET and handed to the probe", () => {
+  test("the probe is called with the ticket's resolved repoRoot (never undefined)", () => {
+    const client = fakeClient();
+    const seen = [];
+    scan({
+      client,
+      signals: [signal({ ticket: "CTC-1" }), signal({ ticket: "CTL-2" })],
+      resolveRepoRoot: (ticket) => (ticket === "CTC-1" ? "/repos/cloud" : "/repos/catalyst"),
+      progressMark: (arg) => {
+        seen.push(arg);
+        return 2;
+      },
+    });
+    expect(seen.map((a) => a.repoRoot)).toEqual(["/repos/cloud", "/repos/catalyst"]);
+    // CTL-729's own guard: the probe silently IGNORES worktreePath, so passing it instead of
+    // repoRoot is the bug. Prove we never hand it one.
+    expect(seen.every((a) => !("worktreePath" in a))).toBe(true);
+    expect(seen.every((a) => "orchDir" in a && "ticket" in a && "phase" in a)).toBe(true);
+  });
+
+  test("an unresolvable repoRoot degrades to null and never aborts the scan", () => {
+    const client = fakeClient();
+    const seen = [];
+    scan({
+      client,
+      signals: [signal()],
+      resolveRepoRoot: () => {
+        throw new Error("registry down");
+      },
+      progressMark: (arg) => {
+        seen.push(arg);
+        return 2;
+      },
+    });
+    expect(seen[0].repoRoot).toBeNull();
+    expect(client.calls).toHaveLength(1);
+  });
+});

--- a/plugins/dev/scripts/execution-core/lease-authority.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority.mjs
@@ -55,6 +55,11 @@ import {
   scrub,
 } from "./linear-write-proxy.mjs";
 import { getEventLogPath } from "./config.mjs";
+// CTC-921: SDK-executor liveness. `bg_job_id` is populated ONLY by the legacy
+// `claude --bg` executor; every `executor:"sdk"` phase carries `bg_job_id:null`, so a
+// bg-only dispatch test would skip ~every phase the fleet actually runs (see
+// `defaultIsPhaseDispatched`).
+import { isSdkWorkerLiveOnDisk } from "./sdk-worker-registry.mjs";
 import { buildCatalystResource } from "./lib/catalyst-resource.mjs";
 
 /** The lease verb family. Frozen — this is DATA. Distinct from the write-proxy /agent/* family. */
@@ -509,12 +514,50 @@ function defaultReadClusterGeneration(orchDir, ticket) {
 }
 
 /**
+ * defaultIsPhaseDispatched — "is this signal a phase THIS daemon is actually running right now?"
+ *
+ * ⛔ THIS MAY NOT BE A BARE `bg_job_id != null` TEST. That field is written only by the legacy
+ * `claude --bg` executor. Every `executor:"sdk"` phase — the executor the fleet runs on today —
+ * leaves it `null` for the whole of its life, so a bg-only test returns false for essentially
+ * every live phase and `renewActiveLeases` becomes a scan that can never renew anything: the
+ * feature would ship INERT and look healthy doing it (measured on this fleet's orchDir: 340/353
+ * nested signals `executor:"sdk"` with `bg_job_id:null`, versus 13 `executor:"bg"` with it set —
+ * and the only `status:"running"` signal present was an SDK one).
+ *
+ * So a phase counts as dispatched when EITHER liveness source vouches for it:
+ *   • `liveness.value` (i.e. `bg_job_id`) is set — the legacy bg executor; or
+ *   • the `.sdk-workers/<ticket>.json` projection is live (pid alive AND fresh) and names THIS
+ *     phase — the SDK executor's equivalent record.
+ *
+ * The phase equality check is what keeps the per-TICKET projection from vouching for a sibling
+ * phase's signal left at `status:"running"` by an unclean exit.
+ *
+ * Errs toward NOT renewing: any unreadable/missing projection is simply "not dispatched". That is
+ * the safe direction — a missed renewal lets a lease lapse on its own deadline (recoverable, and
+ * exactly what happens today), whereas a spurious renewal would prop up a holder that has died.
+ */
+export function defaultIsPhaseDispatched(sig, orchDir) {
+  if (sig?.liveness?.value != null) return true;
+  const ticket = sig?.ticket;
+  if (typeof ticket !== "string" || typeof orchDir !== "string") return false;
+  try {
+    if (!isSdkWorkerLiveOnDisk(orchDir, ticket)) return false;
+    const proj = JSON.parse(readFileSync(join(orchDir, ".sdk-workers", `${ticket}.json`), "utf8"));
+    return proj?.phase === sig?.phase;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * renewActiveLeases — one tick of the renewal scan. Walks this host's actively-running phases,
  * asks `decideRenewal` whether each has earned a renewal, and renews the ones that have.
  *
  * Scoping, in order — every one of these is a REFUSAL to act, never a best guess:
  *   • nested phase signals only (a legacy flat signal has a numeric phase and no lease scope)
- *   • `status === "running"` with a `bg_job_id` — a phase this daemon actually dispatched
+ *   • `status === "running"` AND vouched for by a liveness source — `bg_job_id` for the legacy
+ *     bg executor, or a live+phase-matching `.sdk-workers` projection for the SDK executor. See
+ *     `defaultIsPhaseDispatched`: a bg-only test here would make this whole scan inert.
  *   • `host.name` equal to THIS node — never renew a tenure another host holds. The holder
  *     identity on the wire IS the host name (`claimViaLease` claims with `node: getHostName()`).
  *   • a `cluster-generation.json` on record — that generation IS the grant nonce, and renewing
@@ -543,6 +586,7 @@ export function renewActiveLeases({
   readSignals,
   progressMark,
   readGeneration = defaultReadClusterGeneration,
+  isPhaseDispatched = defaultIsPhaseDispatched,
   resolveRepoRoot = () => null,
   log: logger = null,
 }) {
@@ -561,7 +605,7 @@ export function renewActiveLeases({
     try {
       if (sig?.layout !== "nested") continue;
       if (sig.status !== "running") continue;
-      if (sig.liveness?.value == null) continue;
+      if (!isPhaseDispatched(sig, orchDir)) continue;
       if (sig.host?.name !== hostName) continue;
       const ticket = sig.ticket;
       const phase = sig.phase;

--- a/plugins/dev/scripts/execution-core/lease-authority.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority.mjs
@@ -16,9 +16,15 @@
 //               grant = {nonce, expiresAtMs, scope:{ticket,phase}, coordinationHeadSeqAtGrant}
 //        loss → {claimed:false, refusal:"not_entitled"|"lease_held", current, attribution:null}
 //   POST /lease/release  {ticket, phase, holder, nonce} → ReleaseResult (advances the generation)
-//   POST /lease/renew    — OUT OF SCOPE here: the store requires a non-empty progress
-//        assertion (invariant I2), so a mechanical keep-alive is forbidden. `renew` is a
-//        loud stub; progress-asserted renewal is the follow-up ticket.
+//   POST /lease/renew    {ticket, phase, holder, nonce, assertion, ttlMs?}
+//        renewed → {renewed:true,  lease, grant}   — the nonce is PRESERVED, not advanced
+//        refused → {renewed:false, refusal:"no_lease"|"not_holder"|"stale_generation"|"expired",
+//                   current}
+//        ⛔ The store requires a non-empty progress `assertion` (invariant I2), so a mechanical
+//        keep-alive is forbidden BY THE STORE. `nowMs` is stamped server-side — never sent.
+//        Deciding whether progress has actually happened is `decideRenewal`'s job, below: the
+//        client refuses to re-assert a mark it has already renewed on, so a stalled holder makes
+//        no call at all and its lease lapses on its own deadline (CTC-921).
 //
 // ⛔ `grant.nonce` IS the `generation`. `fence-guard.mjs` compares generations by EQUALITY,
 // so any unique token is a drop-in — the nonce is mapped to `generation` at THIS boundary so
@@ -306,13 +312,44 @@ export function createLeaseAuthorityClient({
     },
 
     /**
-     * renew — OUT OF SCOPE (CTL-1786). The store requires a non-empty progress assertion
-     * (invariant I2), so a mechanical keep-alive is forbidden by the store. A loud stub rather
-     * than a silent no-op so a future caller cannot believe it renewed. Progress-asserted
-     * renewal is the follow-up ticket.
+     * renew — extend THIS tenure on the strength of an assertion of progress (CTC-921).
+     *
+     * ⛔ A REFUSAL IS A NORMAL RETURN. `{renewed:false, refusal}` means the store arbitrated —
+     * empty assertion, wrong holder, stale generation, or an already-expired lease — and there is
+     * nothing to retry. Only a transport failure or an unreadable 2xx body throws, exactly as for
+     * `claim`. A renewal may NEVER be reported that the store did not grant, so an ambiguous 2xx
+     * throws rather than defaulting to renewed.
+     *
+     * ⛔ The generation does NOT advance across a renewal (server-side invariant, lease-verbs.ts):
+     * one tenure, one fencing token, however many renewals. Callers must keep passing the SAME
+     * `nonce` they were granted — `res.grant.nonce` is returned unchanged, not a new token.
+     *
+     * `nowMs` is stamped by the server (`handleLeaseRenew`), so it is deliberately absent from the
+     * body; `ttlMs` rides only when the caller overrides the server default.
      */
-    renew() {
-      throw new LeaseAuthorityError("renew-not-implemented", { retryable: false });
+    renew({ ticket, phase, holder, nonce, assertion, ttlMs = null }) {
+      const payload = { ticket, phase, holder, nonce, assertion };
+      if (ttlMs != null) payload.ttlMs = ttlMs;
+      const { status, body } = callVerb("renew", payload);
+
+      if (is2xx(status)) {
+        if (!body || typeof body !== "object") {
+          throw new LeaseAuthorityError("renew-unreadable-body", { retryable: true, status });
+        }
+        if (body.renewed === true) {
+          return { renewed: true, lease: body.lease ?? null, grant: body.grant ?? null };
+        }
+        if (body.renewed === false) {
+          return {
+            renewed: false,
+            refusal: typeof body.refusal === "string" ? body.refusal : "unknown",
+            current: body.current ?? null,
+          };
+        }
+        // A 2xx that is neither a renewal nor a refusal is an answer we do not have.
+        throw new LeaseAuthorityError("renew-unreadable", { retryable: false, status });
+      }
+      throw leaseErrorForStatus(status, body);
     },
   };
 }

--- a/plugins/dev/scripts/execution-core/lease-authority.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority.mjs
@@ -45,8 +45,8 @@
 // path may NEVER return a silent `won:true` it did not earn — an ambiguous 2xx throws.
 
 import { randomBytes } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
-import { dirname } from "node:path";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import {
   defaultHttpFn,
   parseProxyBody,
@@ -464,6 +464,153 @@ export function ensureEntitled({
   const res = client.entitle({ node, ttlMs, workTtlMs, budgetUsd });
   const expiresAtMs = typeof res?.entitlement?.expiresAtMs === "number" ? res.entitlement.expiresAtMs : null;
   return { entitled: res?.ok === true, refreshed: true, expiresAtMs, entitlement: res?.entitlement ?? null };
+}
+
+// ─── Progress-asserted renewal (CTC-921) ─────────────────────────────────────
+//
+// `renewLease` has been complete and wired in catalyst-cloud since CTC-410; until now nothing
+// called it, so a phase whose work TTL (45 min) outran the server lease TTL (30 min) silently
+// lost tenure mid-phase. These two functions are the caller.
+//
+// ⛔ WHY THE GATE LIVES HERE AND NOT IN THE STORE. The server rejects only an EMPTY assertion
+// (invariant I2, `renewLease`'s MissingAssertionError). It cannot tell a fresh assertion from
+// the same string re-POSTed every tick — so a client that stringified whatever number it had
+// and called on every tick would satisfy the store while shipping exactly the mechanical
+// keep-alive I2 exists to forbid. The client therefore refuses FIRST: no observed progress, no
+// call at all, and the lease lapses on its own deadline. That is also what makes the ticket's
+// "assertion values are pairwise DISTINCT" acceptance check true by construction.
+
+/**
+ * decideRenewal — the pure progress gate. `{shouldRenew:true, assertion}` only when `mark` is a
+ * genuine INCREASE over `lastRenewedMark`; `{shouldRenew:false}` otherwise.
+ *
+ * ⛔ A mark of 0 never renews, even on the first check. Zero is `defaultProgressMark`'s own
+ * "no progress observed" value AND what it returns when it cannot resolve the worktree or the
+ * git call fails — so renewing on 0 would mean renewing on a READ FAILURE, which is precisely
+ * the "a liveness verdict was wrong" class this plane exists to eliminate. A non-finite or
+ * non-numeric mark is treated the same way: skip, never throw.
+ *
+ * Pure and total, so the distinct-assertion property is provable without a network or a timer.
+ */
+export function decideRenewal({ phase, mark, lastRenewedMark }) {
+  if (typeof mark !== "number" || !Number.isFinite(mark) || mark <= 0) return { shouldRenew: false };
+  if (typeof lastRenewedMark === "number" && mark <= lastRenewedMark) return { shouldRenew: false };
+  return { shouldRenew: true, assertion: `${phase}-progress:${mark}` };
+}
+
+/** defaultReadClusterGeneration — the ticket's granted nonce, as written by the claim path. */
+function defaultReadClusterGeneration(orchDir, ticket) {
+  try {
+    const raw = JSON.parse(readFileSync(join(orchDir, "workers", ticket, "cluster-generation.json"), "utf8"));
+    return raw?.generation ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * renewActiveLeases — one tick of the renewal scan. Walks this host's actively-running phases,
+ * asks `decideRenewal` whether each has earned a renewal, and renews the ones that have.
+ *
+ * Scoping, in order — every one of these is a REFUSAL to act, never a best guess:
+ *   • nested phase signals only (a legacy flat signal has a numeric phase and no lease scope)
+ *   • `status === "running"` with a `bg_job_id` — a phase this daemon actually dispatched
+ *   • `host.name` equal to THIS node — never renew a tenure another host holds. The holder
+ *     identity on the wire IS the host name (`claimViaLease` claims with `node: getHostName()`).
+ *   • a `cluster-generation.json` on record — that generation IS the grant nonce, and renewing
+ *     without one would mean inventing a fencing token.
+ *
+ * ⛔ The nonce is passed through UNCHANGED and the server does not advance it: one tenure, one
+ * fencing token, however many renewals. A container credential is bound to that nonce.
+ *
+ * FAIL-OPEN, like `refreshLeaseEntitlement`: every per-ticket step is individually guarded so a
+ * git failure, an unreadable signal, or a cloud outage costs at most one ticket's renewal on one
+ * tick and never breaks the daemon's timer. Losing a lease this way is not silent — the fence
+ * machinery refuses the next external write and a later claim reclaims it.
+ *
+ * `lastRenewedMarks` is the caller's `Map<"ticket:phase", number>`, mutated in place and only on
+ * a CONFIRMED renewal: a refusal or a throw deliberately leaves it alone so the next tick
+ * re-attempts with the same mark. It is in-memory by design — a daemon restart costs at most one
+ * redundant or one skipped renewal, both harmless.
+ *
+ * Returns a `{scanned, renewed, skipped, refused, errors}` summary for logging and tests.
+ */
+export function renewActiveLeases({
+  client,
+  hostName,
+  orchDir,
+  lastRenewedMarks,
+  readSignals,
+  progressMark,
+  readGeneration = defaultReadClusterGeneration,
+  resolveRepoRoot = () => null,
+  log: logger = null,
+}) {
+  const summary = { scanned: 0, renewed: 0, skipped: 0, refused: 0, errors: 0 };
+
+  let signals;
+  try {
+    signals = readSignals(orchDir);
+  } catch (err) {
+    logger?.warn?.({ err: err?.message }, "lease renewal: could not read phase signals (continuing)");
+    summary.errors += 1;
+    return summary;
+  }
+
+  for (const sig of signals ?? []) {
+    try {
+      if (sig?.layout !== "nested") continue;
+      if (sig.status !== "running") continue;
+      if (sig.liveness?.value == null) continue;
+      if (sig.host?.name !== hostName) continue;
+      const ticket = sig.ticket;
+      const phase = sig.phase;
+      if (typeof ticket !== "string" || typeof phase !== "string") continue;
+
+      const generation = readGeneration(orchDir, ticket);
+      if (typeof generation !== "number" || !Number.isFinite(generation)) continue;
+
+      summary.scanned += 1;
+      const key = `${ticket}:${phase}`;
+      // ⛔ repoRoot, NOT worktreePath. `defaultProgressMark` resolves a code phase's worktree
+      // from repoRoot and SILENTLY IGNORES a worktreePath — passing the latter is how CTL-729
+      // made the hung-worker probe read 0 forever. Resolved per ticket (tickets on one host
+      // span repos) and degraded to null rather than allowed to abort the scan.
+      let repoRoot = null;
+      try {
+        repoRoot = resolveRepoRoot(ticket) ?? null;
+      } catch {
+        repoRoot = null;
+      }
+      const mark = progressMark({ ticket, phase, repoRoot, orchDir });
+      const { shouldRenew, assertion } = decideRenewal({
+        phase,
+        mark,
+        lastRenewedMark: lastRenewedMarks.get(key),
+      });
+      if (!shouldRenew) {
+        summary.skipped += 1;
+        continue;
+      }
+
+      const res = client.renew({ ticket, phase, holder: hostName, nonce: generation, assertion });
+      if (res?.renewed === true) {
+        lastRenewedMarks.set(key, mark);
+        summary.renewed += 1;
+      } else {
+        // Expected under I2 for a superseded or lapsed holder — informational, not an error.
+        summary.refused += 1;
+        logger?.info?.({ ticket, phase, refusal: res?.refusal }, "lease renewal refused");
+      }
+    } catch (err) {
+      summary.errors += 1;
+      logger?.warn?.(
+        { ticket: sig?.ticket, phase: sig?.phase, err: err?.message },
+        "lease renewal threw for one phase (continuing)"
+      );
+    }
+  }
+  return summary;
 }
 
 // ─── Auth spike (CTL-1786 Phase 1 §2) ────────────────────────────────────────

--- a/plugins/dev/scripts/execution-core/lease-authority.test.mjs
+++ b/plugins/dev/scripts/execution-core/lease-authority.test.mjs
@@ -363,12 +363,163 @@ describe("probeAuth — the non-mutating auth spike", () => {
   });
 });
 
-describe("renew — stub (progress-asserted renewal is out of scope, CTL-1786)", () => {
-  test("renew throws a typed not-implemented error (no silent no-op)", () => {
-    const { httpFn } = fakeHttp(ok({}));
-    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
-    expect(() => client.renew({ ticket: "CTL-1", phase: "implement", holder: "mini", nonce: "n1" })).toThrow(
-      LeaseAuthorityError
+// ─── renew — the progress-asserted renewal verb (CTC-921) ────────────────────
+//
+// The server contract this pins is `renewLease` (catalyst-cloud
+// apps/mirror/src/do/lease-verbs.ts:126) reached via `POST /lease/renew`
+// (MirrorDO.handleLeaseRenew): the wire body is `{ticket, phase, holder, nonce,
+// assertion, ttlMs?}` — `nowMs` is supplied SERVER-side (`Date.now()`), so the client
+// must not send it.
+//
+// ⛔ The load-bearing property: a refusal (`renewed:false`) is a NORMAL RETURN. The store
+// arbitrated — the assertion was empty, the generation stale, the holder wrong, or the lease
+// already expired — and there is nothing to retry. Only a transport failure or an unreadable
+// 2xx body throws, exactly as for `claim`. A renewal path may NEVER report a renewal it did
+// not earn, so an ambiguous 2xx throws rather than defaulting to renewed.
+describe("renew — request shape", () => {
+  test("POSTs {ticket,phase,holder,nonce,assertion} → {renewed:true, lease, grant}", () => {
+    const { httpFn, calls } = fakeHttp(
+      ok({
+        renewed: true,
+        lease: { ticket: "CTC-1", phase: "implement", generation: 4, holder: "mini", deadlineMs: 999 },
+        grant: { nonce: 4, expiresAtMs: 999, scope: { ticket: "CTC-1", phase: "implement" } },
+      })
     );
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    const res = client.renew({
+      ticket: "CTC-1",
+      phase: "implement",
+      holder: "mini",
+      nonce: 4,
+      assertion: "implement-progress:3",
+    });
+    expect(calls[0].url).toBe(`${DEFAULT_CLOUD_BASE_URL}/lease/renew`);
+    expect(calls[0].method).toBe("POST");
+    expect(JSON.parse(calls[0].body)).toEqual({
+      ticket: "CTC-1",
+      phase: "implement",
+      holder: "mini",
+      nonce: 4,
+      assertion: "implement-progress:3",
+    });
+    expect(res.renewed).toBe(true);
+    expect(res.grant).toEqual({ nonce: 4, expiresAtMs: 999, scope: { ticket: "CTC-1", phase: "implement" } });
+    expect(res.lease.generation).toBe(4);
+  });
+
+  test("nowMs is NEVER sent — the server stamps it (handleLeaseRenew: nowMs: Date.now())", () => {
+    const { httpFn, calls } = fakeHttp(ok({ renewed: true, lease: {}, grant: {} }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+    expect(JSON.parse(calls[0].body).nowMs).toBeUndefined();
+  });
+
+  test("ttlMs rides only when explicitly passed (server default otherwise)", () => {
+    const { httpFn, calls } = fakeHttp(ok({ renewed: true, lease: {}, grant: {} }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x", ttlMs: 60_000 });
+    expect(JSON.parse(calls[0].body).ttlMs).toBe(60_000);
+  });
+});
+
+describe("renew — outcome classification", () => {
+  test("refusal (renewed:false) is a NORMAL return, never a throw", () => {
+    const { httpFn } = fakeHttp(ok({ renewed: false, refusal: "expired", current: { generation: 4 } }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    const res = client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 4, assertion: "x" });
+    expect(res).toEqual({ renewed: false, refusal: "expired", current: { generation: 4 } });
+  });
+
+  test("every documented refusal reason round-trips unchanged", () => {
+    // The closed set from lease-verbs.ts's `refuse()` — a client that silently remaps one of
+    // these would make an I2 refusal indistinguishable from a bug.
+    for (const refusal of ["no_lease", "not_holder", "stale_generation", "expired"]) {
+      const { httpFn } = fakeHttp(ok({ renewed: false, refusal, current: null }));
+      const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+      const res = client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+      expect(res.renewed).toBe(false);
+      expect(res.refusal).toBe(refusal);
+    }
+  });
+
+  test("a refusal with a non-string refusal field degrades to 'unknown', never to renewed", () => {
+    const { httpFn } = fakeHttp(ok({ renewed: false }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    const res = client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+    expect(res).toEqual({ renewed: false, refusal: "unknown", current: null });
+  });
+
+  test("2xx body with neither renewed:true nor renewed:false → typed error (never a false renewal)", () => {
+    const { httpFn } = fakeHttp(ok({ weird: true }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    expect(() =>
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" })
+    ).toThrow(LeaseAuthorityError);
+  });
+
+  test("an unreadable 2xx body throws retryable, and reports no renewal", () => {
+    const { httpFn } = fakeHttp({ transportOk: true, status: 200, bodyText: "<html>gateway</html>" });
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    try {
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LeaseAuthorityError);
+      expect(err.retryable).toBe(true);
+    }
+  });
+});
+
+describe("renew — HTTP error classification", () => {
+  test("5xx → retryable typed error", () => {
+    const { httpFn } = fakeHttp(httpStatus(500, { error: "boom" }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    try {
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LeaseAuthorityError);
+      expect(err.retryable).toBe(true);
+      expect(err.status).toBe(500);
+    }
+  });
+
+  test("403 (the CTC-871 auth shape) → terminal typed error, NOT retryable", () => {
+    const { httpFn } = fakeHttp(httpStatus(403, { error: "nope" }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    try {
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LeaseAuthorityError);
+      expect(err.retryable).toBe(false);
+      expect(err.status).toBe(403);
+    }
+  });
+
+  test("400 (the server's own empty-assertion rejection) → terminal, never read as renewed", () => {
+    const { httpFn } = fakeHttp(httpStatus(400, { error: "assertion" }));
+    const client = createLeaseAuthorityClient({ env: envWithKey(), httpFn });
+    try {
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: " " });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LeaseAuthorityError);
+      expect(err.retryable).toBe(false);
+      expect(err.status).toBe(400);
+    }
+  });
+
+  test("no per-host credential → no-cloud-token, and NO wire call (same guard as every other verb)", () => {
+    const { httpFn, calls } = fakeHttp(ok({ renewed: true }));
+    const client = createLeaseAuthorityClient({ env: {}, httpFn });
+    try {
+      client.renew({ ticket: "CTC-1", phase: "implement", holder: "mini", nonce: 1, assertion: "x" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LeaseAuthorityError);
+      expect(err.reason).toBe("no-cloud-token");
+    }
+    expect(calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

CTC-921 — the lease client renews on asserted progress; the daemon's renewal scan covers SDK workers (not just bg ones); test registered in the execution-core CI list. Implemented by the fleet (mini, phase pipeline), verified green there (184 pass / 0 fail); pushed by the concierge because the worker's git credential lacks `workflow` scope for the CI-list commit (CTC-931 resolved as option A).

## ⚠️ Known gap for the review round — the CTC-929 precedent amendment

This branch implements the ORIGINAL spec (invariant I2: renew must carry a progress assertion). After the worker started, the external-precedent study amended CTC-921's scope (see the ticket's scope-amendment comment, 2026-08-23 11:30): **renew stays cheap; a separate, longer progress deadline revokes tenure; `report progress` carries a resume checkpoint** — the Kafka KIP-62 shape, because a phase legitimately waiting minutes on a model response has no progress to assert and would lose a lease it should keep under I2.

The delta is where the refusal lives (renewal-time vs progress-deadline-time), not the plumbing — the progress-assertion machinery this branch builds is what the amended shape consumes. Review should decide: land as-is and amend in a follow-up, or fold the two-deadline change into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB8h2N5MU7e7skQApcFQRs
