### PR TITLE
fix(meta): CTL-2217 — reflow catalyst repo docs to unwrapped prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,15 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository. This file is the
-portable, tool-agnostic source of truth. Tool-specific agents may keep their own
-thin bridge file that imports this one and adds tool-specific notes — keep that
-detail out of here.
+Guidance for AI coding agents working in this repository. This file is the portable, tool-agnostic source of truth. Tool-specific agents may keep their own thin bridge file that imports this one and adds tool-specific notes — keep that detail out of here.
 
 ## What This Repository Is
 
-A **portable collection of agents, skills, and workflows** for AI-assisted
-development, distributed as plugins. It is both:
+A **portable collection of agents, skills, and workflows** for AI-assisted development, distributed as plugins. It is both:
 
 1. A **source repository** for plugin-based agents and skills
 2. A **working installation** that uses its own tools (dogfooding)
 
-Agents and skills are organized in `plugins/*/` and surfaced to the agent via
-local symlinks.
+Agents and skills are organized in `plugins/*/` and surfaced to the agent via local symlinks.
 
 ## Agent Philosophy
 
@@ -78,45 +73,22 @@ No build process — this is markdown files and bash scripts.
 
 ## Skill & Agent References
 
-Skills are namespaced `plugin-name:skill-name` (e.g. `catalyst-dev:create-plan`,
-`catalyst-pm:prd-draft`). When instructing a reader to invoke a skill, use the
-fully-qualified name; bare names are acceptable in explanatory prose describing
-workflow relationships. Agent (subagent) references always use the full
-`plugin-name:agent-name` form.
+Skills are namespaced `plugin-name:skill-name` (e.g. `catalyst-dev:create-plan`, `catalyst-pm:prd-draft`). When instructing a reader to invoke a skill, use the fully-qualified name; bare names are acceptable in explanatory prose describing workflow relationships. Agent (subagent) references always use the full `plugin-name:agent-name` form.
 
 ## Knowledge Store
 
-- `thoughts/shared/learnings/` — past problem→solution entries (grep by component/tags/problem_type).
-  Search before implementing or debugging in a known area. Curated by `catalyst-dev:ticket-compound`.
+- `thoughts/shared/learnings/` — past problem→solution entries (grep by component/tags/problem_type). Search before implementing or debugging in a known area. Curated by `catalyst-dev:ticket-compound`.
 - `thoughts/shared/CONCEPTS.md` — shared domain vocabulary (reclaim, revive-budget, orphan, signal ownership…).
-- `thoughts/shared/retros/` — compound-loop outputs, written automatically at every merge
-  (CTL-831): `ticket/<date>.md` cross-ticket retros (`catalyst-dev:ticket-retro`);
-  `estimate/<YYYY-WW>-compound-log.md` per-PR estimation actuals (`catalyst-dev:compound-estimate`).
+- `thoughts/shared/retros/` — compound-loop outputs, written automatically at every merge (CTL-831): `ticket/<date>.md` cross-ticket retros (`catalyst-dev:ticket-retro`); `estimate/<YYYY-WW>-compound-log.md` per-PR estimation actuals (`catalyst-dev:compound-estimate`).
 
 ## Code Understanding (Serena)
 
-Coding agents orient on this codebase through **Serena** — a self-hosted, local, LSP-backed MCP
-server that provides semantic code retrieval (the replacement for the removed DeepWiki MCP). It lets
-agents answer "where does X live / how is Y wired / who calls Z" in a few precise calls instead of
-many broad `Grep`s, getting up to speed with far fewer tool calls and tokens.
+Coding agents orient on this codebase through **Serena** — a self-hosted, local, LSP-backed MCP server that provides semantic code retrieval (the replacement for the removed DeepWiki MCP). It lets agents answer "where does X live / how is Y wired / who calls Z" in a few precise calls instead of many broad `Grep`s, getting up to speed with far fewer tool calls and tokens.
 
-- **Install (per machine):** `uv tool install -p 3.13 serena-agent`, then register it as a
-  **user-scope MCP server** that runs `serena start-mcp-server`. Use the absolute path to the
-  `serena` binary so background worker jobs with a restricted `PATH` can launch it, and run it
-  headless on servers. It connects with no startup project and activates lazily. The exact
-  per-agent registration command lives in the bridge file.
-- **Versioned config (committed):** `.serena/project.yml` (languages `typescript` + `bash`,
-  `read_only: true`, ignores the harness worktree dir / `thoughts` / build output, plus an
-  `initial_prompt` pointer) and
-  `.serena/memories/codebase_map.md` (the directory map agents read via `read_memory("codebase_map")`).
-  The per-machine symbol cache `.serena/cache/` is gitignored; build it with `serena project index`.
-- **Wiring:** the research/analysis agents (`codebase-analyzer`, `codebase-locator`,
-  `codebase-pattern-finder`) and skills (`research-codebase`, `create-plan`, `phase-research`,
-  `phase-plan`) grant the read-only `mcp__serena__*` tools; `research-codebase` Step 0 activates the
-  project, reads the `codebase_map` memory, and maps symbols before spawning sub-agents.
-- **Use it:** `activate_project` (repo root / `.`) → `list_memories` / `read_memory` →
-  `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`. It is
-  read-only — editing stays with the implement agents' `Edit`/`Write`.
+- **Install (per machine):** `uv tool install -p 3.13 serena-agent`, then register it as a **user-scope MCP server** that runs `serena start-mcp-server`. Use the absolute path to the `serena` binary so background worker jobs with a restricted `PATH` can launch it, and run it headless on servers. It connects with no startup project and activates lazily. The exact per-agent registration command lives in the bridge file.
+- **Versioned config (committed):** `.serena/project.yml` (languages `typescript` + `bash`, `read_only: true`, ignores the harness worktree dir / `thoughts` / build output, plus an `initial_prompt` pointer) and `.serena/memories/codebase_map.md` (the directory map agents read via `read_memory("codebase_map")`). The per-machine symbol cache `.serena/cache/` is gitignored; build it with `serena project index`.
+- **Wiring:** the research/analysis agents (`codebase-analyzer`, `codebase-locator`, `codebase-pattern-finder`) and skills (`research-codebase`, `create-plan`, `phase-research`, `phase-plan`) grant the read-only `mcp__serena__*` tools; `research-codebase` Step 0 activates the project, reads the `codebase_map` memory, and maps symbols before spawning sub-agents.
+- **Use it:** `activate_project` (repo root / `.`) → `list_memories` / `read_memory` → `get_symbols_overview`, `find_symbol`, `find_referencing_symbols`, `search_for_pattern`. It is read-only — editing stays with the implement agents' `Edit`/`Write`.
 
 ## Commit Conventions
 
@@ -128,8 +100,7 @@ many broad `Grep`s, getting up to speed with far fewer tool calls and tokens.
 
 **How release-please routes version bumps (monorepo):**
 
-- Routing is by **file paths changed**, NOT by commit message scope. A commit touching files in both
-  `plugins/dev/` and `plugins/playground/pm/` bumps both plugins regardless of scope.
+- Routing is by **file paths changed**, NOT by commit message scope. A commit touching files in both `plugins/dev/` and `plugins/playground/pm/` bumps both plugins regardless of scope.
 - The `(scope)` in `fix(dev):` controls **changelog grouping**, not which plugin gets bumped.
 - Squash merges work correctly — the GitHub API provides the file list to release-please.
 - Use the scope that best describes the primary intent. Both plugins still get their version bumps.
@@ -138,13 +109,11 @@ many broad `Grep`s, getting up to speed with far fewer tool calls and tokens.
 
 This workspace tracks: agent definitions, skills, documentation, scripts, configuration templates.
 
-**Do NOT commit**: Specific ticket prefixes (keep "PROJ"), Linear team/project IDs (keep null),
-personal thoughts user (keep null).
+**Do NOT commit**: Specific ticket prefixes (keep "PROJ"), Linear team/project IDs (keep null), personal thoughts user (keep null).
 
 ## CI/Automation
 
-CI skills (`ci-commit`, `ci-describe-pr`) follow the same conventions but skip all interactive
-prompts. They never commit sensitive files or add self-attribution.
+CI skills (`ci-commit`, `ci-describe-pr`) follow the same conventions but skip all interactive prompts. They never commit sensitive files or add self-attribution.
 
 ## Configuration
 
@@ -157,75 +126,30 @@ Two-layer config system:
 
 **Required**: Git, Bash, and an AI coding agent
 
-**Optional**: HumanLayer CLI (`humanlayer`) for the thoughts persistence system, Linearis CLI
-(`linearis`), GitHub CLI (`gh`), `catalyst-session` CLI
-(`plugins/dev/scripts/catalyst-session.sh`), `sqlite3`
+**Optional**: HumanLayer CLI (`humanlayer`) for the thoughts persistence system, Linearis CLI (`linearis`), GitHub CLI (`gh`), `catalyst-session` CLI (`plugins/dev/scripts/catalyst-session.sh`), `sqlite3`
 
 ## Plugin Development
 
-Edit plugin files in `plugins/*/`, test locally (symlinks make changes immediate), reload by
-restarting your agent session.
+Edit plugin files in `plugins/*/`, test locally (symlinks make changes immediate), reload by restarting your agent session.
 
 ## Orchestration
 
-Catalyst's **execution-core daemon** ships work as **phase-agent workers** — one short-lived
-background agent job per phase, walking a 10-phase pipeline (triage → research → plan → implement →
-verify → review → pr → monitor-merge → monitor-deploy → teardown). The legacy wave-orchestration model is
-preserved in the **catalyst-legacy** plugin as a fallback; the mode is selected by
-`.catalyst/config.json → catalyst.orchestration.dispatchMode`.
+Catalyst's **execution-core daemon** ships work as **phase-agent workers** — one short-lived background agent job per phase, walking a 10-phase pipeline (triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown). The legacy wave-orchestration model is preserved in the **catalyst-legacy** plugin as a fallback; the mode is selected by `.catalyst/config.json → catalyst.orchestration.dispatchMode`.
 
-Cross-process communication is built on a **single unified event log** at
-`~/catalyst/events/YYYY-MM.jsonl`. Workers, the phase dispatcher, the broker, the webhook
-receiver, and `catalyst-comms send` all append; the broker daemon, the HUD, the orch-monitor web
-dashboard, and `catalyst-events wait-for` all read.
+Cross-process communication is built on a **single unified event log** at `~/catalyst/events/YYYY-MM.jsonl`. Workers, the phase dispatcher, the broker, the webhook receiver, and `catalyst-comms send` all append; the broker daemon, the HUD, the orch-monitor web dashboard, and `catalyst-events wait-for` all read.
 
 ## Observability (OpenTelemetry: Loki · Tempo · Prometheus · Grafana)
 
-The Catalyst daemons and the underlying AI coding agent emit OpenTelemetry signals through a shared
-OTel Collector that fans out to three backends, all visualized and alerted in Grafana. **Traces
-EXPLAIN; metrics DETECT + LOCALIZE** — and the scheduler-health (RED) metrics are derived from the
-*unsampled* Tier-1 logs (via Collector connectors), so never wire health metrics off the
-tail-sampled spans. Other metrics (the native `catalyst.agent` host gauges, the agent's own native
-counters) are emitted *directly* to the OTLP metrics pipeline, not log-derived.
+The Catalyst daemons and the underlying AI coding agent emit OpenTelemetry signals through a shared OTel Collector that fans out to three backends, all visualized and alerted in Grafana. **Traces EXPLAIN; metrics DETECT + LOCALIZE** — and the scheduler-health (RED) metrics are derived from the *unsampled* Tier-1 logs (via Collector connectors), so never wire health metrics off the tail-sampled spans. Other metrics (the native `catalyst.agent` host gauges, the agent's own native counters) are emitted *directly* to the OTLP metrics pipeline, not log-derived.
 
-- **Logs & events → Loki (LogQL).** Catalyst events (forwarded by the `otel-forward` service) and the
-  Tier-1 daemon `.log` lines (shipped by Alloy) both land in Loki — confirm a given event/field is
-  present before alerting on it. Only `service_name` and `service_namespace` are stream labels
-  (the cheap selectors and the
-  cross-signal join key); every other field (`host_name`, `event_*`, `catalyst_node_name`, …) is
-  **structured metadata** — filter with `| field="x"`, aggregate with `sum by (field)`;
-  `label_values(field)` returns empty for it. The log body is a plain string — do **not** `| json` it
-  unless the line is a full-JSON daemon `.log`. Use `absent_over_time` for silence detection
-  (a fully-dead daemon is a missing series, which `count_over_time == 0` cannot assert).
-- **Traces → Tempo (TraceQL).** Daemon spans are live: `scheduler.tick` (root) with threshold-gated
-  `scheduler.pass` children and `liveness.refresh`, plus per-run `install` and context-engine
-  `index.run` traces. Tempo serves the per-tick/per-run flame graph that explains a wedge after the
-  metrics localize it; the metrics-generator is off and trace↔log correlation does not fully
-  round-trip yet (disjoint id spaces).
-- **Metrics → Prometheus (PromQL).** OTel dotted names become underscores and counters gain a
-  `_total` suffix; counters need `rate()`/`increase()` **innermost** then `sum by (...)` outermost —
-  never graph the raw counter. `signal_to_metrics` gauges are last-value and expire ~15m at rest.
-  Cross-signal joins go through the normalized labels `service_name`/`service_namespace` (underscore
-  form — the dotted `service.name` is the semantic-convention name, not the Prometheus label); host
-  identity is only reliable within `catalyst.*` (short `host_name`).
-- **Alerting → Grafana.** Alert rules are **file-provisioned** (`provisioning/alerting/*.yaml`) and
-  **upsert-only** — a malformed rule file crash-loops the *shared* Grafana, so validate any change
-  against a throwaway Grafana before deploying. Active rules cover the scheduler wedge
-  (tick / recovery-pass / liveness-timeout), system trouble (CTL-2156), slot starvation, and install/updater
-  failures.
+- **Logs & events → Loki (LogQL).** Catalyst events (forwarded by the `otel-forward` service) and the Tier-1 daemon `.log` lines (shipped by Alloy) both land in Loki — confirm a given event/field is present before alerting on it. Only `service_name` and `service_namespace` are stream labels (the cheap selectors and the cross-signal join key); every other field (`host_name`, `event_*`, `catalyst_node_name`, …) is **structured metadata** — filter with `| field="x"`, aggregate with `sum by (field)`; `label_values(field)` returns empty for it. The log body is a plain string — do **not** `| json` it unless the line is a full-JSON daemon `.log`. Use `absent_over_time` for silence detection (a fully-dead daemon is a missing series, which `count_over_time == 0` cannot assert).
+- **Traces → Tempo (TraceQL).** Daemon spans are live: `scheduler.tick` (root) with threshold-gated `scheduler.pass` children and `liveness.refresh`, plus per-run `install` and context-engine `index.run` traces. Tempo serves the per-tick/per-run flame graph that explains a wedge after the metrics localize it; the metrics-generator is off and trace↔log correlation does not fully round-trip yet (disjoint id spaces).
+- **Metrics → Prometheus (PromQL).** OTel dotted names become underscores and counters gain a `_total` suffix; counters need `rate()`/`increase()` **innermost** then `sum by (...)` outermost — never graph the raw counter. `signal_to_metrics` gauges are last-value and expire ~15m at rest. Cross-signal joins go through the normalized labels `service_name`/`service_namespace` (underscore form — the dotted `service.name` is the semantic-convention name, not the Prometheus label); host identity is only reliable within `catalyst.*` (short `host_name`).
+- **Alerting → Grafana.** Alert rules are **file-provisioned** (`provisioning/alerting/*.yaml`) and **upsert-only** — a malformed rule file crash-loops the *shared* Grafana, so validate any change against a throwaway Grafana before deploying. Active rules cover the scheduler wedge (tick / recovery-pass / liveness-timeout), system trouble (CTL-2156), slot starvation, and install/updater failures.
 
-**Signal catalog — the data dictionary.** The authoritative, signal-by-signal reference (every
-metric, log/event, trace span, and alert — with dimensions, gotchas, and copy-pasteable query
-patterns) lives in the sister repo **`catalyst-otel`** at `docs/data-dictionary.md`. **Read it before
-designing telemetry or trusting a query.** That repo (`collector-config.yaml`,
-`grafana-datasources.yml`, `tempo.yaml`, `dashboards/`, `provisioning/alerting/`) is the authoritative
-stack topology.
+**Signal catalog — the data dictionary.** The authoritative, signal-by-signal reference (every metric, log/event, trace span, and alert — with dimensions, gotchas, and copy-pasteable query patterns) lives in the sister repo **`catalyst-otel`** at `docs/data-dictionary.md`. **Read it before designing telemetry or trusting a query.** That repo (`collector-config.yaml`, `grafana-datasources.yml`, `tempo.yaml`, `dashboards/`, `provisioning/alerting/`) is the authoritative stack topology.
 
-**Endpoints are environment-specific.** Backend addresses are resolved from environment variables —
-`OTEL_EXPORTER_OTLP_ENDPOINT` / `CATALYST_OTLP_ENDPOINT` for the daemons (collector ingest), and
-`CATALYST_AGENT_OTLP_ENDPOINT` / `CATALYST_AGENT_METRICS_ENDPOINT` for the standalone `catalyst-agent`
-emitter (which stays silent if those are unset). The concrete addresses for a given deployment live in
-that deployment's config and the team's notes, not in this repository.
+**Endpoints are environment-specific.** Backend addresses are resolved from environment variables — `OTEL_EXPORTER_OTLP_ENDPOINT` / `CATALYST_OTLP_ENDPOINT` for the daemons (collector ingest), and `CATALYST_AGENT_OTLP_ENDPOINT` / `CATALYST_AGENT_METRICS_ENDPOINT` for the standalone `catalyst-agent` emitter (which stays silent if those are unset). The concrete addresses for a given deployment live in that deployment's config and the team's notes, not in this repository.
 
 ## Pull requests
 
@@ -236,22 +160,9 @@ A pull request is **not mergeable** until BOTH are true:
 
 So after opening a PR: wait for the checks to go green (subscribe to the event log — see **Working the Loop**, don't poll `gh` in a loop), then address every review comment (push fixes), reply, and resolve each thread before considering the PR done.
 
-**Reading the automated reviewer's signal.** When the automated code reviewer finds nothing, it
-signals a clean pass with a 👍 reaction (or a brief "no major issues" note) **instead of** opening
-review threads — that counts as a resolved review with nothing to address, not a missing one. The
-clean-pass result may arrive as a reaction or a plain comment rather than a structured review
-object, so detect it via reactions/comments, not only the reviews API. A re-review after a fix
-push may need to be requested explicitly rather than firing automatically.
+**Reading the automated reviewer's signal.** When the automated code reviewer finds nothing, it signals a clean pass with a 👍 reaction (or a brief "no major issues" note) **instead of** opening review threads — that counts as a resolved review with nothing to address, not a missing one. The clean-pass result may arrive as a reaction or a plain comment rather than a structured review object, so detect it via reactions/comments, not only the reviews API. A re-review after a fix push may need to be requested explicitly rather than firing automatically.
 
-**Deferring lower-priority findings after round one.** Fix every P0/P1 finding immediately, on
-every review round — that severity is never deferred. On a PR's *first* round of review-driven
-fixes, use judgment on P2-and-lower findings: fix the ones that are real, cheap, and clearly
-correct; defer the rest. On any later round (a re-review after a remediation push), P2-and-lower is
-always deferred, no exceptions — even a trivial one-liner goes to a follow-up ticket, not an inline
-fix: file the ticket, reply on the thread linking it, and resolve the thread. This still satisfies
-"every review thread resolved" above — deferral resolves the thread via that reply, it does not
-leave it open. The point is to stop chasing progressively finer findings across many review↔fix
-rounds; see `catalyst-dev:review-comments` for the mechanism.
+**Deferring lower-priority findings after round one.** Fix every P0/P1 finding immediately, on every review round — that severity is never deferred. On a PR's *first* round of review-driven fixes, use judgment on P2-and-lower findings: fix the ones that are real, cheap, and clearly correct; defer the rest. On any later round (a re-review after a remediation push), P2-and-lower is always deferred, no exceptions — even a trivial one-liner goes to a follow-up ticket, not an inline fix: file the ticket, reply on the thread linking it, and resolve the thread. This still satisfies "every review thread resolved" above — deferral resolves the thread via that reply, it does not leave it open. The point is to stop chasing progressively finer findings across many review↔fix rounds; see `catalyst-dev:review-comments` for the mechanism.
 
 ## Reference Docs
 
@@ -260,12 +171,7 @@ Read these on demand:
 - **Architecture & data flow** — `docs/architecture.md`
 - **Run lifecycle** — `docs/orchestrator-overview.md`
 - **Decision records (ADRs)** — `docs/adrs.md`
-- **Specs & mockups** — `docs/specs/` (durable `draft → accepted` home for specs, requirements,
-  and mockups; distinct from ADRs and `thoughts/` — see `docs/specs/README.md`)
-- **smee retirement + rollback** — `docs/runbooks/cloud-feed-cutover.md` (CTL-1928 retired the
-  Linear half 2026-08-17; CTL-1929 retired the **GitHub** half 2026-08-18 — both ingestion legs
-  are now the cloud feed, all 15 webhooks are disabled-not-deleted, and the runbook holds the
-  four per-host verify-by-content checks and both rollback lever pairs)
+- **Specs & mockups** — `docs/specs/` (durable `draft → accepted` home for specs, requirements, and mockups; distinct from ADRs and `thoughts/` — see `docs/specs/README.md`)
+- **smee retirement + rollback** — `docs/runbooks/cloud-feed-cutover.md` (CTL-1928 retired the Linear half 2026-08-17; CTL-1929 retired the **GitHub** half 2026-08-18 — both ingestion legs are now the cloud feed, all 15 webhooks are disabled-not-deleted, and the runbook holds the four per-host verify-by-content checks and both rollback lever pairs)
 - **Release process** — `docs/releases.md`
-- **Observability signal catalog** — `catalyst-otel/docs/data-dictionary.md` (sister repo: every
-  metric, log/event, trace, and alert; see the Observability section above)
+- **Observability signal catalog** — `catalyst-otel/docs/data-dictionary.md` (sister repo: every metric, log/event, trace, and alert; see the Observability section above)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,47 +2,28 @@
 
 ## Claude Code
 
-This is the Claude Code bridge file. All portable project guidance lives in
-`AGENTS.md` (imported above). Add **only** genuinely Claude-Code-specific notes
-below — if a note applies to any agent, it belongs in `AGENTS.md` instead. (A CI
-lint enforces that this file's first line is `@AGENTS.md` and that `AGENTS.md`
-stays tool-agnostic.)
+This is the Claude Code bridge file. All portable project guidance lives in `AGENTS.md` (imported above). Add **only** genuinely Claude-Code-specific notes below — if a note applies to any agent, it belongs in `AGENTS.md` instead. (A CI lint enforces that this file's first line is `@AGENTS.md` and that `AGENTS.md` stays tool-agnostic.)
 
 ### Loading & invocation
 
-- Plugins are surfaced via `.claude/` symlinks; restart Claude Code to reload after editing
-  `plugins/*/`. Changes are distributed via the Claude Code plugin marketplace.
+- Plugins are surfaced via `.claude/` symlinks; restart Claude Code to reload after editing `plugins/*/`. Changes are distributed via the Claude Code plugin marketplace.
 - Invoke skills with the slash prefix: `/plugin-name:skill-name` (e.g. `/catalyst-dev:create-plan`).
 
 ### Orchestration runtime
 
-- Phase-agent workers run as `claude --bg` jobs; the legacy oneshot mode runs a long-lived
-  `claude -p /catalyst-legacy:oneshot` per ticket.
+- Phase-agent workers run as `claude --bg` jobs; the legacy oneshot mode runs a long-lived `claude -p /catalyst-legacy:oneshot` per ticket.
 
 ### Pull request review (Codex)
 
-The repo runs **Codex** (`chatgpt-codex-connector[bot]`) as an automated PR reviewer (this is the
-concrete instance of the tool-agnostic "automated code reviewer" in `AGENTS.md` → "Pull requests").
+The repo runs **Codex** (`chatgpt-codex-connector[bot]`) as an automated PR reviewer (this is the concrete instance of the tool-agnostic "automated code reviewer" in `AGENTS.md` → "Pull requests").
 
-- **Triggers:** PR opened for review, draft marked ready, or a `@codex review` comment — **not**
-  every push. After a remediation push, request a re-review with `@codex review`.
-- **Findings:** posted as inline **review threads** (P1/P2/P3 — Codex has no P0). Resolve each via
-  GraphQL `addPullRequestReviewThreadReply` + `resolveReviewThread` — never `--admin`. **Round 1**
-  (the review right after the PR opens or is marked ready): P1 is mandatory-fix; use judgment on
-  which P2/P3 findings are worth fixing now vs. deferring. **Round 2+** (any re-review after a
-  remediation push): P1 stays mandatory-fix; P2/P3 is always deferred to a follow-up ticket, no
-  exceptions — see `AGENTS.md` → "Pull requests" and `/catalyst-dev:review-comments`.
-- **No findings = a clean pass:** Codex reacts 👍 **or** posts an issue comment "Codex Review:
-  Didn't find any major issues 🎉 / Reviewed commit: `<sha>`". This is a resolved review, not a
-  missing one. Note the clean-pass result is an **issue comment / reaction**, not a `reviews` API
-  node — so a `reviews{}`-only poll misses it; also check `issues/<n>/comments` and reactions.
+- **Triggers:** PR opened for review, draft marked ready, or a `@codex review` comment — **not** every push. After a remediation push, request a re-review with `@codex review`.
+- **Findings:** posted as inline **review threads** (P1/P2/P3 — Codex has no P0). Resolve each via GraphQL `addPullRequestReviewThreadReply` + `resolveReviewThread` — never `--admin`. **Round 1** (the review right after the PR opens or is marked ready): P1 is mandatory-fix; use judgment on which P2/P3 findings are worth fixing now vs. deferring. **Round 2+** (any re-review after a remediation push): P1 stays mandatory-fix; P2/P3 is always deferred to a follow-up ticket, no exceptions — see `AGENTS.md` → "Pull requests" and `/catalyst-dev:review-comments`.
+- **No findings = a clean pass:** Codex reacts 👍 **or** posts an issue comment "Codex Review: Didn't find any major issues 🎉 / Reviewed commit: `<sha>`". This is a resolved review, not a missing one. Note the clean-pass result is an **issue comment / reaction**, not a `reviews` API node — so a `reviews{}`-only poll misses it; also check `issues/<n>/comments` and reactions.
 
 ### Code understanding (Serena MCP)
 
-Serena is wired into the research/analysis agents for semantic code retrieval — see
-`AGENTS.md` → "Code Understanding (Serena)" for what it is and how it's used. Register it
-once per machine as a **user-scope** MCP (the absolute `serena` path lets restricted-`PATH`
-`claude --bg` phase-agent workers launch it; the headless flags keep it browser-free on servers):
+Serena is wired into the research/analysis agents for semantic code retrieval — see `AGENTS.md` → "Code Understanding (Serena)" for what it is and how it's used. Register it once per machine as a **user-scope** MCP (the absolute `serena` path lets restricted-`PATH` `claude --bg` phase-agent workers launch it; the headless flags keep it browser-free on servers):
 
 ```bash
 uv tool install -p 3.13 serena-agent
@@ -50,13 +31,10 @@ claude mcp add --scope user serena -- "$HOME/.local/bin/serena" start-mcp-server
   --context claude-code --enable-web-dashboard False --enable-gui-log-window False
 ```
 
-It connects with no startup project and activates lazily, so a fresh session connects fast and pays
-the language-server startup cost only when an agent first calls `activate_project`.
+It connects with no startup project and activates lazily, so a fresh session connects fast and pays the language-server startup cost only when an agent first calls `activate_project`.
 
 ### Always-loaded reference docs
 
-`@`-imports are a Claude Code feature and load the file in full at session start (they do **not**
-reduce context), so keep this list minimal. Architecture is the one doc worth keeping always-on;
-ADRs and the release process are referenced by path in `AGENTS.md` for on-demand reading.
+`@`-imports are a Claude Code feature and load the file in full at session start (they do **not** reduce context), so keep this list minimal. Architecture is the one doc worth keeping always-on; ADRs and the release process are referenced by path in `AGENTS.md` for on-demand reading.
 
 @docs/architecture.md

--- a/README.md
+++ b/README.md
@@ -7,23 +7,18 @@
 
 A portable development workflow for Claude Code, packaged as a Claude Code plugin marketplace.
 
-This is the workspace I use daily for AI-assisted development. It's battle-tested on real projects
-and optimized for efficient, context-aware AI collaboration. I'm sharing it so others can use it,
-fork it, and contribute ideas back.
+This is the workspace I use daily for AI-assisted development. It's battle-tested on real projects and optimized for efficient, context-aware AI collaboration. I'm sharing it so others can use it, fork it, and contribute ideas back.
 
 ## Tech Stack & Integrations
 
-Catalyst integrates with your development tools through both **CLI-based** (token-efficient) and
-**MCP-based** (richer features) approaches:
+Catalyst integrates with your development tools through both **CLI-based** (token-efficient) and **MCP-based** (richer features) approaches:
 
 ### Project Management & Issue Tracking
 
-- **Linear** - Issue tracking, sprint planning, ticket lifecycle (CLI via
-  [Linearis](https://www.npmjs.com/package/linearis))
+- **Linear** - Issue tracking, sprint planning, ticket lifecycle (CLI via [Linearis](https://www.npmjs.com/package/linearis))
   - `catalyst-dev`: Core research agents and workflow commands
   - `catalyst-pm`: Advanced PM workflows (PRDs, strategy, priorities)
-  - `catalyst-pm-ops`: Operational PM workflows (cycle analysis, milestone tracking, backlog
-    grooming, cadence, comms)
+  - `catalyst-pm-ops`: Operational PM workflows (cycle analysis, milestone tracking, backlog grooming, cadence, comms)
 
 ### Version Control & Code Hosting
 
@@ -66,16 +61,13 @@ This keeps your typical session lean while having powerful tools available when 
 
 ## What's Inside
 
-**Catalyst** is an 8-plugin system for Claude Code focused on **token efficiency**, **session-aware
-MCP management**, and **persistent context** through parallel agent research, structured handoffs,
-and shared memory systems.
+**Catalyst** is an 8-plugin system for Claude Code focused on **token efficiency**, **session-aware MCP management**, and **persistent context** through parallel agent research, structured handoffs, and shared memory systems.
 
 **catalyst-dev** (Core - Always enabled)
 
 - 9 research agents (codebase + infrastructure)
 - 21 skills covering full dev lifecycle
-- Three-tier model strategy (Opus for planning/implementation, Sonnet for CI/automation, Haiku for
-  data collection)
+- Three-tier model strategy (Opus for planning/implementation, Sonnet for CI/automation, Haiku for data collection)
 - Linear integration via Linearis CLI
 - CI/automation commands for non-interactive workflows
 - Handoff system for context persistence
@@ -163,8 +155,7 @@ chmod +x setup-catalyst.sh
 | Linear API token       | `LINEAR_API_TOKEN`, or `~/.linear_api_token` | must be a **personal** key (`lin_api_…`). An OAuth token (`lin_oauth_…`) is rejected                    |
 | Sentry / PostHog / Exa | prompted, or their usual env vars            | all optional                                                                                            |
 
-Nothing above is required to get a working node — omit the cloud flags and setup behaves exactly as
-it always has.
+Nothing above is required to get a working node — omit the cloud flags and setup behaves exactly as it always has.
 
 This script will guide you through:
 
@@ -185,11 +176,7 @@ This script will guide you through:
 # Restart Claude Code
 ```
 
-**Install the CLI tools** — _setup now does this for you._ It puts `catalyst-stack` and the other
-`catalyst-*` commands in `$HOME/.catalyst/bin`, provisions `plugin-source`, turns on replica reads,
-and enrols the project. Anything it could not finish is printed at the end of the run as a
-**deferred step**, with the command that completes it and the command that verifies it — so if that
-list says "No steps were deferred", these are already done.
+**Install the CLI tools** — _setup now does this for you._ It puts `catalyst-stack` and the other `catalyst-*` commands in `$HOME/.catalyst/bin`, provisions `plugin-source`, turns on replica reads, and enrols the project. Anything it could not finish is printed at the end of the run as a **deferred step**, with the command that completes it and the command that verifies it — so if that list says "No steps were deferred", these are already done.
 
 To run it by hand anyway (or to complete a deferred step):
 
@@ -264,9 +251,7 @@ Plugins automatically load/unload MCPs when enabled/disabled:
 /plugin enable catalyst-pm catalyst-analytics catalyst-debugging
 ```
 
-**Why this matters**: Most development sessions don't need analytics or debugging MCPs. Starting
-with just `catalyst-dev` keeps your context at ~3.5k tokens instead of ~65k, leaving more room for
-code and conversation.
+**Why this matters**: Most development sessions don't need analytics or debugging MCPs. Starting with just `catalyst-dev` keeps your context at ~3.5k tokens instead of ~65k, leaving more room for code and conversation.
 
 ### Updating Plugins
 
@@ -286,8 +271,7 @@ claude plugin marketplace update catalyst
 - ✨ **New features**: Minor versions (e.g., 3.0.0 → 3.1.0) - New commands or capabilities
 - 🔄 **Breaking changes**: Major versions (e.g., 3.0.0 → 4.0.0) - May require configuration updates
 
-**Important:** A restart is required for plugin updates to take effect. Active sessions use the old
-version until you restart Claude Code.
+**Important:** A restart is required for plugin updates to take effect. Active sessions use the old version until you restart Claude Code.
 
 **One-command post-merge update** (ff-pull + rsync into the live cache + restart):
 
@@ -304,10 +288,8 @@ catalyst-stack restart --hotpatch
 
 **Need help?**
 
-- [Documentation Site](https://catalyst.coalescelabs.ai) - Complete setup, installation, and
-  configuration
-- [Claude Code Plugin Guide](https://docs.claude.com/en/docs/claude-code/plugins.md) - Official
-  plugin documentation
+- [Documentation Site](https://catalyst.coalescelabs.ai) - Complete setup, installation, and configuration
+- [Claude Code Plugin Guide](https://docs.claude.com/en/docs/claude-code/plugins.md) - Official plugin documentation
 
 ## Complete Workflow
 
@@ -321,8 +303,7 @@ With handoffs for context persistence:
 /create-handoff → /resume-handoff
 ```
 
-Agents proactively monitor context during implementation and will prompt you to create handoffs
-before running out of context, creating structured handoff documents that add to persistent memory.
+Agents proactively monitor context during implementation and will prompt you to create handoffs before running out of context, creating structured handoff documents that add to persistent memory.
 
 **Learn More:**
 
@@ -331,19 +312,14 @@ before running out of context, creating structured handoff documents that add to
 
 ### Agent Teams
 
-For complex implementations spanning multiple domains, Catalyst supports
-[Claude Code agent teams](https://www.anthropic.com/news/claude-opus-4-6) — multiple Claude
-instances working in parallel on a shared codebase:
+For complex implementations spanning multiple domains, Catalyst supports [Claude Code agent teams](https://www.anthropic.com/news/claude-opus-4-6) — multiple Claude instances working in parallel on a shared codebase:
 
 ```
 /implement-plan --team thoughts/shared/plans/my-plan.md
 /oneshot --team PROJ-123
 ```
 
-A lead agent (Opus) coordinates the work, spawning teammates (Sonnet) that each own distinct files.
-Each teammate can spawn its own research sub-agents, enabling two-level parallelism. See
-[How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system)
-for the patterns behind this approach.
+A lead agent (Opus) coordinates the work, spawning teammates (Sonnet) that each own distinct files. Each teammate can spawn its own research sub-agents, enabling two-level parallelism. See [How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) for the patterns behind this approach.
 
 ## Core Philosophy
 
@@ -356,9 +332,7 @@ for the patterns behind this approach.
 
 ### Reusability and Shared Memory
 
-Uses the [HumanLayer thoughts system](https://github.com/humanlayer/humanlayer) for shared
-persistent memory across teams and projects. The research → plan → implement → validate workflow is
-adapted from HumanLayer's approach.
+Uses the [HumanLayer thoughts system](https://github.com/humanlayer/humanlayer) for shared persistent memory across teams and projects. The research → plan → implement → validate workflow is adapted from HumanLayer's approach.
 
 ### CLI-First Integration
 
@@ -418,8 +392,7 @@ Run the prerequisite check:
 
 ## Recurring Workflows with /loop
 
-The built-in `/loop` command runs a skill or prompt on a recurring interval. Use it for monitoring
-and periodic tasks during active development sessions.
+The built-in `/loop` command runs a skill or prompt on a recurring interval. Use it for monitoring and periodic tasks during active development sessions.
 
 ### CI Check Monitoring (after pushing a PR)
 
@@ -443,8 +416,7 @@ Monitors GitHub Actions workflow runs triggered by your merge.
 /loop 1d /context-daily
 ```
 
-Refreshes the context engineering adoption dashboard once per day. Alternative to the GitHub Actions
-cron — useful in long-running sessions.
+Refreshes the context engineering adoption dashboard once per day. Alternative to the GitHub Actions cron — useful in long-running sessions.
 
 ### Cycle Health Monitoring
 
@@ -462,51 +434,41 @@ Generates a fresh cycle health report every 4 hours during a sprint.
 
 Checks for orphaned PRs and out-of-sync Linear issues every 2 hours.
 
-**Note**: `/loop` is session-scoped (max ~3 days). For persistent scheduling, use GitHub Actions
-cron. `/loop` is best for active monitoring during development sessions.
+**Note**: `/loop` is session-scoped (max ~3 days). For persistent scheduling, use GitHub Actions cron. `/loop` is best for active monitoring during development sessions.
 
 ## Credits
 
 Built on patterns from:
 
-- [HumanLayer](https://github.com/humanlayer/humanlayer) - Thoughts system for shared persistent
-  memory and research/plan/implement/validate workflow
+- [HumanLayer](https://github.com/humanlayer/humanlayer) - Thoughts system for shared persistent memory and research/plan/implement/validate workflow
 
 Personal refinement over hundreds of hours on real projects.
 
 ## Contributing
 
-**This is my personal workflow workspace**, primarily built for my own development style and
-preferences. That said, I'm happy to:
+**This is my personal workflow workspace**, primarily built for my own development style and preferences. That said, I'm happy to:
 
 - **Discuss ideas** - Open issues with workflow suggestions or improvements
 - **See your forks** - Adapt it to your needs and share what you built
 - **Fix bugs** - If something's broken, let me know
 - **Learn together** - Share your workflow patterns and approaches
 
-**Important**: I may not accept PRs that change core workflows or add features I don't personally
-use, since this is the workspace I rely on daily. But I **love** seeing how others adapt these
-patterns to their own needs!
+**Important**: I may not accept PRs that change core workflows or add features I don't personally use, since this is the workspace I rely on daily. But I **love** seeing how others adapt these patterns to their own needs!
 
 **Best approach**: Fork it, make it yours, and share what you learned. That's how we all get better!
 
 ## Documentation
 
-- [Documentation Site](https://catalyst.coalescelabs.ai) - Comprehensive guides, reference, and
-  tutorials
+- [Documentation Site](https://catalyst.coalescelabs.ai) - Comprehensive guides, reference, and tutorials
 - [Architecture](docs/architecture.md) - Three-layer system and memory model
 - [ADRs](docs/adrs.md) - Architecture decision records
 - [Releases](docs/releases.md) - Release Please workflow
 
 ## Brand Assets
 
-Catalyst ships a V2 brand kit (Ignition Chevron) under [`assets/brand-v2/`](assets/brand-v2/): the
-mark, wordmark, lockups, favicon set, and the 1200×630 social preview card. All SVGs use
-`stroke="currentColor"` so they theme via CSS; the OG card raster (`assets/brand-v2/og-card.png`)
-bakes in the Operator Console palette.
+Catalyst ships a V2 brand kit (Ignition Chevron) under [`assets/brand-v2/`](assets/brand-v2/): the mark, wordmark, lockups, favicon set, and the 1200×630 social preview card. All SVGs use `stroke="currentColor"` so they theme via CSS; the OG card raster (`assets/brand-v2/og-card.png`) bakes in the Operator Console palette.
 
-Repo admins: to set the GitHub repository social preview, go to **Settings → Social preview → Upload
-an image** and upload `assets/brand-v2/og-card.png`.
+Repo admins: to set the GitHub repository social preview, go to **Settings → Social preview → Upload an image** and upload `assets/brand-v2/og-card.png`.
 
 ## License
 
@@ -514,11 +476,7 @@ MIT - Use it however you want!
 
 ## Note on Personal Use
 
-This is my personal workflow shared for learning and inspiration. You're welcome to use it as-is,
-fork it, or adapt the patterns to your own needs. Just keep in mind that it's optimized for my
-development style, so your mileage may vary. Some decisions are opinionated based on my preferences,
-and I may not accept PRs that don't align with how I work. Think of it as a starting point rather
-than a one-size-fits-all solution—take what works, adapt what doesn't!
+This is my personal workflow shared for learning and inspiration. You're welcome to use it as-is, fork it, or adapt the patterns to your own needs. Just keep in mind that it's optimized for my development style, so your mileage may vary. Some decisions are opinionated based on my preferences, and I may not accept PRs that don't align with how I work. Think of it as a starting point rather than a one-size-fits-all solution—take what works, adapt what doesn't!
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 # Developer Documentation
 
-Reference documentation for Catalyst contributors. User-facing docs live at
-[catalyst.coalescelabs.ai](https://catalyst.coalescelabs.ai).
+Reference documentation for Catalyst contributors. User-facing docs live at [catalyst.coalescelabs.ai](https://catalyst.coalescelabs.ai).
 
 ## Contents
 

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -1,7 +1,6 @@
 # Architecture Decision Records
 
-Decision log. Each entry: Decision + key rationale/consequences. ADR numbers and outcomes are
-load-bearing — do not renumber or drop.
+Decision log. Each entry: Decision + key rationale/consequences. ADR numbers and outcomes are load-bearing — do not renumber or drop.
 
 > Code-anchored note (verified 2026-06-21): the broker was refactored from a single ~1300-line
 > `broker/index.mjs` into modules. `index.mjs` (~635 lines) is now a barrel that re-exports.
@@ -14,857 +13,303 @@ load-bearing — do not renumber or drop.
 
 ## ADR-001: Plugin-Based Distribution
 
-Distribute Catalyst as Claude Code plugins (not git clone). Updates via `/plugin update`;
-marketplace discoverability; local `.catalyst/config.json` preserved. Cost: plugin structure in
-`plugins/*/` must be maintained; breaking changes need version management; users install only what
-they need (dev/meta/pm/…).
+Distribute Catalyst as Claude Code plugins (not git clone). Updates via `/plugin update`; marketplace discoverability; local `.catalyst/config.json` preserved. Cost: plugin structure in `plugins/*/` must be maintained; breaking changes need version management; users install only what they need (dev/meta/pm/…).
 
 ## ADR-002: HumanLayer Profile-Based Configuration
 
-Use HumanLayer's native `profile`/`repoMappings` to auto-select the thoughts repo per working
-directory — no manual `configName`. Init with `humanlayer thoughts init --profile <name>`; scripts
-discover the current repo via `humanlayer thoughts status`. Projects stay isolated.
+Use HumanLayer's native `profile`/`repoMappings` to auto-select the thoughts repo per working directory — no manual `configName`. Init with `humanlayer thoughts init --profile <name>`; scripts discover the current repo via `humanlayer thoughts status`. Projects stay isolated.
 
 ## ADR-003: Three-Layer Memory Architecture
 
-Separate **config** (project settings, committable), **long-term** (thoughts, git-backed, synced via
-`humanlayer thoughts sync`), and **short-term** (workflow-context, session state, gitignored).
-Skills update workflow-context when creating docs.
+Separate **config** (project settings, committable), **long-term** (thoughts, git-backed, synced via `humanlayer thoughts sync`), and **short-term** (workflow-context, session state, gitignored). Skills update workflow-context when creating docs.
 
 ## ADR-004: Workflow-Context for Session State
 
-Store recent doc references in `.catalyst/.workflow-context.json` so skills chain
-(`research → plan → implement`) without users tracking paths. Local per-worktree, never committed,
-no secrets. Managed via `scripts/workflow-context.sh`. Lost on worktree delete (by design).
+Store recent doc references in `.catalyst/.workflow-context.json` so skills chain (`research → plan → implement`) without users tracking paths. Local per-worktree, never committed, no secrets. Managed via `scripts/workflow-context.sh`. Lost on worktree delete (by design).
 
 ## ADR-005: Configurable Worktree Convention
 
-Organize repos/worktrees via `GITHUB_SOURCE_ROOT`. Main: `${ROOT}/<org>/<repo>`; worktrees:
-`${ROOT}/<org>/<repo>-worktrees/<feature>`. `create-worktree.sh` detects org from git remote; falls
-back to `~/wt/<repo>`. No hardcoded paths.
+Organize repos/worktrees via `GITHUB_SOURCE_ROOT`. Main: `${ROOT}/<org>/<repo>`; worktrees: `${ROOT}/<org>/<repo>-worktrees/<feature>`. `create-worktree.sh` detects org from git remote; falls back to `~/wt/<repo>`. No hardcoded paths.
 
 ## ADR-006: Global Orchestrator State
 
-Single `~/catalyst/state.json` global registry of active orchestrators + append-only event log
-`~/catalyst/events/YYYY-MM.jsonl` (rotated monthly) + completed snapshots in
-`~/catalyst/history/<id>--<startedAt>.json`. Layout also includes `~/catalyst/catalyst.db` (SQLite,
-WAL) and `~/catalyst/wt/`.
+Single `~/catalyst/state.json` global registry of active orchestrators + append-only event log `~/catalyst/events/YYYY-MM.jsonl` (rotated monthly) + completed snapshots in `~/catalyst/history/<id>--<startedAt>.json`. Layout also includes `~/catalyst/catalyst.db` (SQLite, WAL) and `~/catalyst/wt/`.
 
-- Global state is a denormalized query summary; per-worktree `state.json` still serves crash
-  recovery.
-- Writes go through `catalyst-state.sh` (mkdir-based locking, no flock dep). Events append lock-free
-  (POSIX atomic). `cat *.jsonl | jq` queries across months.
-- Heartbeat: orchestrators write `lastHeartbeat` each poll; `catalyst-state.sh gc` archives entries
-  stale >10 min as `abandoned`.
-- Contract schemas: `plugins/dev/templates/global-state.json`. The event envelope's contract is
-  **executable**, not a template — `plugins/dev/scripts/lib/event-envelope.mjs` (CTL-1819). The
-  former `global-event.json` was deleted: measured against the live log it passed **zero** live
-  events, and no code ever imported it.
+- Global state is a denormalized query summary; per-worktree `state.json` still serves crash recovery.
+- Writes go through `catalyst-state.sh` (mkdir-based locking, no flock dep). Events append lock-free (POSIX atomic). `cat *.jsonl | jq` queries across months.
+- Heartbeat: orchestrators write `lastHeartbeat` each poll; `catalyst-state.sh gc` archives entries stale >10 min as `abandoned`.
+- Contract schemas: `plugins/dev/templates/global-state.json`. The event envelope's contract is **executable**, not a template — `plugins/dev/scripts/lib/event-envelope.mjs` (CTL-1819). The former `global-event.json` was deleted: measured against the live log it passed **zero** live events, and no code ever imported it.
 
 ## ADR-008: SQLite Session Store
 
-Add `~/catalyst/catalyst.db` (SQLite, WAL) as the durable store for **session analytics** (not a
-replacement for the event log, which remains the live cross-process bus per ADR-006/018). Managed by
-`catalyst-db.sh` (schema/migrate/CRUD) and `catalyst-session.sh` (sub-50ms write CLI:
-`start|phase|metric|tool|pr|end|emit-context`).
+Add `~/catalyst/catalyst.db` (SQLite, WAL) as the durable store for **session analytics** (not a replacement for the event log, which remains the live cross-process bus per ADR-006/018). Managed by `catalyst-db.sh` (schema/migrate/CRUD) and `catalyst-session.sh` (sub-50ms write CLI: `start|phase|metric|tool|pr|end|emit-context`).
 
-Schema (`db-migrations/001_initial_schema.sql`): `sessions`, `session_events`, `session_metrics`,
-`session_tools`, `session_prs`, `schema_migrations`. (Migrations dir now runs 001–006.)
-`orch-monitor` reads the DB directly (WAL concurrent readers). Dual-write to the JSONL stream is
-retained for tools that consume it. `sqlite3` is an optional dep.
+Schema (`db-migrations/001_initial_schema.sql`): `sessions`, `session_events`, `session_metrics`, `session_tools`, `session_prs`, `schema_migrations`. (Migrations dir now runs 001–006.) `orch-monitor` reads the DB directly (WAL concurrent readers). Dual-write to the JSONL stream is retained for tools that consume it. `sqlite3` is an optional dep.
 
 ## ADR-009: Daily Release Cadence
 
-Cut one release/day via scheduled merge at 05:00 UTC instead of auto-merging the release-please
-Release PR on every push to `main` — avoids per-merge point releases and mid-wave `update-branch`
-rebase cascades.
+Cut one release/day via scheduled merge at 05:00 UTC instead of auto-merging the release-please Release PR on every push to `main` — avoids per-merge point releases and mid-wave `update-branch` rebase cascades.
 
 - `release-please.yml` opens/updates the Release PR + runs `enhance-release-notes.sh` on every push.
-- `release-please-scheduled-merge.yml` (05:00 UTC) finds the `autorelease: pending` PR, verifies
-  mergeability, merges; exits 0 on empty day; `workflow_dispatch` = manual "cut now".
-  Blocked/conflicted PR → dedup'd `release-health` issue.
-- **Intraday channel (deferred):** marketplace auto-update gates on `plugin.json.version`, which
-  moves once/day. MVP for early access = install from a commit SHA on `main` (zero plumbing).
-  Designed-but-deferred: a `next` branch fast-forwarding `main` with `-rc.<n>` version bumps + a
-  second marketplace entry. `check-release-health.sh` check #2 unchanged. Rollback = revert the two
-  workflow changes.
+- `release-please-scheduled-merge.yml` (05:00 UTC) finds the `autorelease: pending` PR, verifies mergeability, merges; exits 0 on empty day; `workflow_dispatch` = manual "cut now". Blocked/conflicted PR → dedup'd `release-health` issue.
+- **Intraday channel (deferred):** marketplace auto-update gates on `plugin.json.version`, which moves once/day. MVP for early access = install from a commit SHA on `main` (zero plumbing). Designed-but-deferred: a `next` branch fast-forwarding `main` with `-rc.<n>` version bumps + a second marketplace entry. `check-release-health.sh` check #2 unchanged. Rollback = revert the two workflow changes.
 
 ## ADR-010: Catalyst CLI Install via `~/.catalyst/bin/`
 
-Install `catalyst-*` CLIs as symlinks in `~/.catalyst/bin/` with one `$PATH` entry — works across
-zsh/bash/fish without shell-specific alias blocks; `ls` is a discoverable inventory; symlinks strip
-`.sh`. `install-cli.sh` is authoritative for the exposed-CLI allowlist (update it when adding a
-CLI). Plugin updates move scripts to a version-stamped cache path, staling symlinks; re-run
-`setup-catalyst`/`install-cli.sh` to repair (`check-setup.sh` surfaces broken links). Uninstall:
-`install-cli.sh --uninstall`.
+Install `catalyst-*` CLIs as symlinks in `~/.catalyst/bin/` with one `$PATH` entry — works across zsh/bash/fish without shell-specific alias blocks; `ls` is a discoverable inventory; symlinks strip `.sh`. `install-cli.sh` is authoritative for the exposed-CLI allowlist (update it when adding a CLI). Plugin updates move scripts to a version-stamped cache path, staling symlinks; re-run `setup-catalyst`/`install-cli.sh` to repair (`check-setup.sh` surfaces broken links). Uninstall: `install-cli.sh --uninstall`.
 
 ## ADR-011: Hybrid SQLite + Filesystem Archive for Orchestrator Artifacts
 
-Persist orchestrator artifacts out of runs/worktrees into a two-layer store: **blobs** at
-`~/catalyst/archives/{orchId}/` (summaries, briefings, signals, phase logs, comms, metadata.json) +
-**index** in three SQLite tables (`orchestrators`, `archived_workers` PK `(orch_id,worker_id)`,
-`archived_artifacts` UNIQUE `(orch_id,path)`; `db-migrations/003_archives.sql`). Written by
-`orch-monitor/catalyst-archive.ts sweep`; served read-only via `/api/archive/*`.
+Persist orchestrator artifacts out of runs/worktrees into a two-layer store: **blobs** at `~/catalyst/archives/{orchId}/` (summaries, briefings, signals, phase logs, comms, metadata.json) + **index** in three SQLite tables (`orchestrators`, `archived_workers` PK `(orch_id,worker_id)`, `archived_artifacts` UNIQUE `(orch_id,path)`; `db-migrations/003_archives.sql`). Written by `orch-monitor/catalyst-archive.ts sweep`; served read-only via `/api/archive/*`.
 
-- Rationale: pure-SQLite balloons on text blobs; pure-FS loses query speed. Hybrid = indexed
-  metadata + unbounded blobs.
-- **Filesystem-first invariant**: blobs written via atomic tmp+rename BEFORE SQLite rows; on SQLite
-  failure `catalyst-archive sync` rebuilds the index from disk.
-- Teardown refuses to delete unless the sweep succeeded (or `--force`). File serving is
-  path-traversal safe (`realpathSync` must resolve within `archive_path`; rel segments
-  regex-validated). Subcommands: `sweep|sync|prune|list|show` (prune respects
-  `archive.retentionDays`).
+- Rationale: pure-SQLite balloons on text blobs; pure-FS loses query speed. Hybrid = indexed metadata + unbounded blobs.
+- **Filesystem-first invariant**: blobs written via atomic tmp+rename BEFORE SQLite rows; on SQLite failure `catalyst-archive sync` rebuilds the index from disk.
+- Teardown refuses to delete unless the sweep succeeded (or `--force`). File serving is path-traversal safe (`realpathSync` must resolve within `archive_path`; rel segments regex-validated). Subcommands: `sweep|sync|prune|list|show` (prune respects `archive.retentionDays`).
 
 ## ADR-012: Webhook-Driven orch-monitor with smee.io Tunnel
 
-Migrate orch-monitor from 30s poll-everything to webhook-driven ingestion via a smee.io tunnel,
-polling kept as a 10-min fallback. The 30s loop ran ~26.6k GraphQL calls/hr (222 PRs, ~3 active),
-draining the 5k/hr GitHub bucket in ~11 min (CTL-209). Webhooks deliver in seconds at zero budget.
-smee.io = least-resistance local delivery (no public ingress/Worker); `gh webhook forward` rejected
-(CLI-session-oriented). Repo-level subscriptions via lazy `ensureSubscribed(repo)`. Hard cutover (no
-feature flag); worst case = 10-min poll fallback.
+Migrate orch-monitor from 30s poll-everything to webhook-driven ingestion via a smee.io tunnel, polling kept as a 10-min fallback. The 30s loop ran ~26.6k GraphQL calls/hr (222 PRs, ~3 active), draining the 5k/hr GitHub bucket in ~11 min (CTL-209). Webhooks deliver in seconds at zero budget. smee.io = least-resistance local delivery (no public ingress/Worker); `gh webhook forward` rejected (CLI-session-oriented). Repo-level subscriptions via lazy `ensureSubscribed(repo)`. Hard cutover (no feature flag); worst case = 10-min poll fallback.
 
-- New dep `smee-client@^5.0.0`; `lib/webhook-*.ts` modules; `POST /api/webhook`. Config adds
-  `catalyst.monitor.github.smeeChannel` + `webhookSecretEnv` (HMAC secret in env);
-  `setup-webhooks.sh` is the idempotent helper.
-- Startup replay: 1-hr delivery window from `gh api repos/{repo}/hooks/{id}/deliveries` replayed
-  through the live handler (synthetic signing) to reconcile downtime.
-- Every accepted event fans out to `~/catalyst/events/YYYY-MM.jsonl` with topic
-  `<source>.<noun>.<verb>` (e.g. `github.pr.merged`) — seeded the unified event bus that CTL-210
-  (Linear webhooks + `catalyst-events` CLI, shipped) and CTL-211 (worker DoD = deploy success,
-  shipped) build on. Steady state: well under the 5k/hr ceilings.
+- New dep `smee-client@^5.0.0`; `lib/webhook-*.ts` modules; `POST /api/webhook`. Config adds `catalyst.monitor.github.smeeChannel` + `webhookSecretEnv` (HMAC secret in env); `setup-webhooks.sh` is the idempotent helper.
+- Startup replay: 1-hr delivery window from `gh api repos/{repo}/hooks/{id}/deliveries` replayed through the live handler (synthetic signing) to reconcile downtime.
+- Every accepted event fans out to `~/catalyst/events/YYYY-MM.jsonl` with topic `<source>.<noun>.<verb>` (e.g. `github.pr.merged`) — seeded the unified event bus that CTL-210 (Linear webhooks + `catalyst-events` CLI, shipped) and CTL-211 (worker DoD = deploy success, shipped) build on. Steady state: well under the 5k/hr ceilings.
 
 ## ADR-013: Event-Driven Worker Waits (`wait-for-github` two-phase)
 
-Replace `gh pr view --json` (GraphQL) poll loops in worker skills with a `catalyst-events wait-for`
-blocking call over the unified event log, plus a REST-authoritative re-check after each wake.
-GraphQL polling exhausted the 5k/hr budget (CTL-209). REST (`gh api repos/{repo}/pulls/{n}`) is
-cheaper and returns `.mergeable_state`.
+Replace `gh pr view --json` (GraphQL) poll loops in worker skills with a `catalyst-events wait-for` blocking call over the unified event log, plus a REST-authoritative re-check after each wake. GraphQL polling exhausted the 5k/hr budget (CTL-209). REST (`gh api repos/{repo}/pulls/{n}`) is cheaper and returns `.mergeable_state`.
 
-Two-phase: (1) `wait-for --timeout 180` for any relevant event → REST check; on timeout run
-diagnostics. (2) Diagnostics: count heartbeats in last 500 lines, re-check tunnel; healthy → extend,
-else REST fallback. (3) `--timeout 7200` (2-hr) when infra confirmed healthy. (4) REST fallback
-`sleep 300` loop when tunnel down. Filter jq must cover v1 (`.event`) and v2
-(`.attributes."event.name"`) envelopes. Never use `.mergeable_state` as sole signal
-(eventually-consistent) — always REST re-check.
+Two-phase: (1) `wait-for --timeout 180` for any relevant event → REST check; on timeout run diagnostics. (2) Diagnostics: count heartbeats in last 500 lines, re-check tunnel; healthy → extend, else REST fallback. (3) `--timeout 7200` (2-hr) when infra confirmed healthy. (4) REST fallback `sleep 300` loop when tunnel down. Filter jq must cover v1 (`.event`) and v2 (`.attributes."event.name"`) envelopes. Never use `.mergeable_state` as sole signal (eventually-consistent) — always REST re-check.
 
 ## ADR-014: Worker Owns Full PR Lifecycle (CTL-252)
 
-Remove `gh pr merge --auto` from all worker skills. After opening a PR the worker enters the ADR-013
-listen loop, resolves blockers inline, runs `gh pr merge --squash --delete-branch` directly when
-CLEAN, and writes `status:"done"`. Orchestrator Phase 4 becomes a safety net for crashed workers
-only (poll relaxed to 10-min). `autoMergeArmedAt` removed from the `pr` signal subobject. State
-machine shrinks to `pr-created → done`.
+Remove `gh pr merge --auto` from all worker skills. After opening a PR the worker enters the ADR-013 listen loop, resolves blockers inline, runs `gh pr merge --squash --delete-branch` directly when CLEAN, and writes `status:"done"`. Orchestrator Phase 4 becomes a safety net for crashed workers only (poll relaxed to 10-min). `autoMergeArmedAt` removed from the `pr` signal subobject. State machine shrinks to `pr-created → done`.
 
 ## ADR-015: Bidirectional catalyst-comms (CTL-249)
 
-Add inbound reads to workers: poll the shared comms channel at each phase boundary for
-`--filter-to <ticket-id>` messages, using a `COMMS_LAST_READ` cursor (initialized to line count at
-join) to skip pre-join history. Recognized inbound: `abort` (immediate exit); others TBD. **ACK
-gap**: no delivery guarantee (CTL-253 tracks ACK). `catalyst-comms send` emits
-`comms.message.posted` (v2 envelope) so tools observe traffic without reading the channel file. ~5
-poll calls/run added.
+Add inbound reads to workers: poll the shared comms channel at each phase boundary for `--filter-to <ticket-id>` messages, using a `COMMS_LAST_READ` cursor (initialized to line count at join) to skip pre-join history. Recognized inbound: `abort` (immediate exit); others TBD. **ACK gap**: no delivery guarantee (CTL-253 tracks ACK). `catalyst-comms send` emits `comms.message.posted` (v2 envelope) so tools observe traffic without reading the channel file. ~5 poll calls/run added.
 
 ## ADR-016: Claude Code metadata on the canonical envelope (CTL-374)
 
-**Accepted 2026-05-13.** Claude Code per-session telemetry (context %, cost, turns, model) is
-exposed only via the statusLine pipeline, not hooks. Add five typed attributes —
-`claude.session.id`, `claude.model`, `claude.context.used_pct`, `claude.context.tokens`,
-`claude.turn` — plus a `session.context` event emitted by `catalyst-statusline.sh` per tick, and
-`attention.context_pressure` when context crosses 70% upward.
+**Accepted 2026-05-13.** Claude Code per-session telemetry (context %, cost, turns, model) is exposed only via the statusLine pipeline, not hooks. Add five typed attributes — `claude.session.id`, `claude.model`, `claude.context.used_pct`, `claude.context.tokens`, `claude.turn` — plus a `session.context` event emitted by `catalyst-statusline.sh` per tick, and `attention.context_pressure` when context crosses 70% upward.
 
-Migration `005_claude_session_metadata.sql` adds `claude_session_id` (bound via
-`catalyst-session.sh start --claude-session-id`, fallback `CLAUDE_CODE_SESSION_ID`; indexed) and
-`last_context_pct` (threshold bookkeeping; read/written by `emit-context`).
+Migration `005_claude_session_metadata.sql` adds `claude_session_id` (bound via `catalyst-session.sh start --claude-session-id`, fallback `CLAUDE_CODE_SESSION_ID`; indexed) and `last_context_pct` (threshold bookkeeping; read/written by `emit-context`).
 
-**PII boundary**: `cost_usd` is intentionally NOT a typed attribute — it rides in
-`body.payload.cost_usd`, which the OTLP forwarder (`otel-forward/lib/destinations/otlp.ts`) does NOT
-forward (it forwards `attributes` + `body.message` only). Payload stays on-machine. **Install**:
-point `statusLine.command` at `catalyst-statusline.sh` (renders via `ccstatusline` /
-`$CATALYST_STATUSLINE_CMD`; emit runs detached so failures never break the status bar). Single 70%
-threshold matches the implement-plan handoff rule; more thresholds deferred.
+**PII boundary**: `cost_usd` is intentionally NOT a typed attribute — it rides in `body.payload.cost_usd`, which the OTLP forwarder (`otel-forward/lib/destinations/otlp.ts`) does NOT forward (it forwards `attributes` + `body.message` only). Payload stays on-machine. **Install**: point `statusLine.command` at `catalyst-statusline.sh` (renders via `ccstatusline` / `$CATALYST_STATUSLINE_CMD`; emit runs detached so failures never break the status bar). Single 70% threshold matches the implement-plan handoff rule; more thresholds deferred.
 
 ## ADR-017: Phase-Agent Dispatch Architecture (CTL-447 → CTL-470)
 
-**Accepted 2026-05-17.** Pre-CTL-452 dispatched one long-lived
-`claude -p /catalyst-legacy:oneshot <TICKET>` per ticket, running the full lifecycle in one context
-window → context rot, one worst-case turn cap for all phases, crash-recovery from a saturated state.
+**Accepted 2026-05-17.** Pre-CTL-452 dispatched one long-lived `claude -p /catalyst-legacy:oneshot <TICKET>` per ticket, running the full lifecycle in one context window → context rot, one worst-case turn cap for all phases, crash-recovery from a saturated state.
 
-**Decision**: dispatch one short-lived
-`claude --bg --resume /catalyst-dev:phase-<name> <TICKET> --orch-dir <ORCH_DIR>` per phase. The
-orchestrator walks the canonical **10-phase** sequence
-`triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown`
-(teardown split out as the dedicated terminal phase in CTL-703) via `orchestrate-phase-advance`,
-waking on `phase.<name>.complete.<TICKET>` routed by the broker `phase_lifecycle` interest. Selected
-by `.catalyst/config.json → catalyst.orchestration.dispatchMode`: `"phase-agents"` is the template
-default; `"oneshot-legacy"` is the fallback.
+**Decision**: dispatch one short-lived `claude --bg --resume /catalyst-dev:phase-<name> <TICKET> --orch-dir <ORCH_DIR>` per phase. The orchestrator walks the canonical **10-phase** sequence `triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown` (teardown split out as the dedicated terminal phase in CTL-703) via `orchestrate-phase-advance`, waking on `phase.<name>.complete.<TICKET>` routed by the broker `phase_lifecycle` interest. Selected by `.catalyst/config.json → catalyst.orchestration.dispatchMode`: `"phase-agents"` is the template default; `"oneshot-legacy"` is the fallback.
 
-- Per-phase turn caps (`phase-agent-dispatch` `phase_default_turn_cap`, overridable via
-  `catalyst.orchestration.phaseAgents.turnCaps`) — e.g. triage ~10, implement ~75. Per-phase model
-  selection (`phaseAgents`) lets cheap phases (monitor-deploy defaults to Haiku) skip Opus cost.
-- `phase_lifecycle` is a deterministic regex match (`broker/namespace-contract.mjs`:
-  `^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped)\.([A-Za-z][A-Za-z0-9_]*-\d+)$`) —
-  no LLM classification; one interest per ticket. All four orchestrator interests (`pr_lifecycle`,
-  `ticket_lifecycle`, `comms_lifecycle`, `phase_lifecycle`) fire back as `filter.wake.<ORCH_NAME>`.
+- Per-phase turn caps (`phase-agent-dispatch` `phase_default_turn_cap`, overridable via `catalyst.orchestration.phaseAgents.turnCaps`) — e.g. triage ~10, implement ~75. Per-phase model selection (`phaseAgents`) lets cheap phases (monitor-deploy defaults to Haiku) skip Opus cost.
+- `phase_lifecycle` is a deterministic regex match (`broker/namespace-contract.mjs`: `^phase\.([^.]+)\.(complete|failed|turn-cap-exhausted|skipped)\.([A-Za-z][A-Za-z0-9_]*-\d+)$`) — no LLM classification; one interest per ticket. All four orchestrator interests (`pr_lifecycle`, `ticket_lifecycle`, `comms_lifecycle`, `phase_lifecycle`) fire back as `filter.wake.<ORCH_NAME>`.
 
 **Consequences**:
 
-- Signal layout splits: flat `workers/<TICKET>.json` plus per-phase
-  `workers/<TICKET>/phase-<name>.json`.
-- `--bg` healthcheck (`orchestrate-healthcheck`) stats `${JOBS_ROOT}/<bg>/state.json` (default
-  `~/.claude/jobs/<bg>/state.json`); files older than `--stale-bg-seconds` (default 900) with
-  `.state` not in `{done,failed,errored,stopped}` = stalled. PID liveness still covers
-  `oneshot-legacy`.
-- Intermediate Linear states (CTL-454): `triaged`, `researching`, `planning`, `verifying`,
-  `reviewing` (+ existing `inProgress`/`inReview`), mapped via `stateMap` (opt-in).
-- Revive budget at the top-level signal (`reviveCount`); `>= MAX_REVIVES` (default 10) → `stalled`,
-  `attentionReason="revive-budget-exhausted"`. Once-per-phase; second `failed` for the same phase
-  escalates.
+- Signal layout splits: flat `workers/<TICKET>.json` plus per-phase `workers/<TICKET>/phase-<name>.json`.
+- `--bg` healthcheck (`orchestrate-healthcheck`) stats `${JOBS_ROOT}/<bg>/state.json` (default `~/.claude/jobs/<bg>/state.json`); files older than `--stale-bg-seconds` (default 900) with `.state` not in `{done,failed,errored,stopped}` = stalled. PID liveness still covers `oneshot-legacy`.
+- Intermediate Linear states (CTL-454): `triaged`, `researching`, `planning`, `verifying`, `reviewing` (+ existing `inProgress`/`inReview`), mapped via `stateMap` (opt-in).
+- Revive budget at the top-level signal (`reviveCount`); `>= MAX_REVIVES` (default 10) → `stalled`, `attentionReason="revive-budget-exhausted"`. Once-per-phase; second `failed` for the same phase escalates.
 - Legacy `oneshot-legacy` preserved (catalyst-legacy plugin); cutover is per-project.
-- Built across CTL-447 (broker interest), 452 (state-machine rewrite + `--bg` cutover), 454 (Linear
-  states), 455 (session_metrics fix) → 470. Internal reference: `docs/orchestrator-overview.md`.
-  Related: ADR-006, ADR-008, ADR-014.
+- Built across CTL-447 (broker interest), 452 (state-machine rewrite + `--bg` cutover), 454 (Linear states), 455 (session_metrics fix) → 470. Internal reference: `docs/orchestrator-overview.md`. Related: ADR-006, ADR-008, ADR-014.
 
 ## ADR-018: Event-Sourced Worker Signal Files via Broker Projection (CTL-483)
 
-**Accepted 2026-05-17. Phase 1 mechanism retired 2026-08-03 (CTL-1628) — see "What actually
-shipped" below.** `workers/<TICKET>.json` is written by seven racing code paths (dispatch-next,
-followup, the worker agent, healthcheck, revive, auto-fixup, auto-rebase) with no inter-process
-locking — cross-script races silent. The broker already event-sources `broker-interests.json` from
-`filter.register/deregister`.
+**Accepted 2026-05-17. Phase 1 mechanism retired 2026-08-03 (CTL-1628) — see "What actually shipped" below.** `workers/<TICKET>.json` is written by seven racing code paths (dispatch-next, followup, the worker agent, healthcheck, revive, auto-fixup, auto-rebase) with no inter-process locking — cross-script races silent. The broker already event-sources `broker-interests.json` from `filter.register/deregister`.
 
-**Original decision**: move worker-state mutations to "emit a `worker.state_changed` command event;
-broker projects to disk". Event carries the FULL new state in `body.payload.state` (not a patch).
-Dual-write in three phases (mirrors ADR-008):
+**Original decision**: move worker-state mutations to "emit a `worker.state_changed` command event; broker projects to disk". Event carries the FULL new state in `body.payload.state` (not a patch). Dual-write in three phases (mirrors ADR-008):
 
-- **Phase 1**: writers keep direct `jq>tmp&&mv` AND emit the event; broker projects to a **shadow
-  path** `workers/<TICKET>.json.projected` (never races direct writes). `orchestrate-shadow-diff`
-  reports drift. PoC writer: `orchestrate-auto-rebase`; the other six migrate one at a time.
-- **Phase 2 (cutover)**: at zero drift across a full cycle for all seven, remove direct writes;
-  broker becomes sole writer at the canonical path.
+- **Phase 1**: writers keep direct `jq>tmp&&mv` AND emit the event; broker projects to a **shadow path** `workers/<TICKET>.json.projected` (never races direct writes). `orchestrate-shadow-diff` reports drift. PoC writer: `orchestrate-auto-rebase`; the other six migrate one at a time.
+- **Phase 2 (cutover)**: at zero drift across a full cycle for all seven, remove direct writes; broker becomes sole writer at the canonical path.
 - **Phase 3 (optional)**: mirror to SQLite `worker_state` `(orch_id,ticket)` (ADR-011 hybrid).
 
-**What actually shipped**: only `orchestrate-auto-rebase` ever migrated to Phase 1 (1 of 7 writers);
-the migration stalled there from 2026-05-17. Phase 1's only reader was the manual
-`orchestrate-shadow-diff` verification CLI (a human-run drift check) — nothing operational or
-automated ever consumed the `.json.projected` shadow files. CTL-1628 removed the Phase 1
-shadow-write **scaffolding** as dead weight — the broker's
-`handleWorkerStateChanged`/`getProjectedWorkerStatePath`/`writeProjectedWorkerState`, the dedicated
-`lib/emit-worker-state-changed.sh` emitter, and `orchestrate-shadow-diff` itself. **Phase 2's plan**
-(cut over to broker-sole-writer once Phase 1 reached zero drift) **is dead** — it depended on the
-now-retired Phase 1 drift-check pipeline, so that specific implementation can no longer execute; the
-canonical `workers/<TICKET>.json` files are still written exactly as before, by the same seven
-racing scripts. The *problem* Phase 2 was meant to solve — the seven-script single-writer race — is
-still open, but it is no longer tracked as this ADR's Phase 2: **CTL-1631** now owns it as a
-standalone ticket, replacing the retired Phase-2 plan rather than continuing it. **Phase 3** — as
-originally scoped, a `(orch_id,ticket)` SQLite mirror — **did ship**, as CTL-532 below; both
-`projection.mjs:291` and `broker-state.mjs:194` label it in-code as `(ADR-018 Phase 3)`.
+**What actually shipped**: only `orchestrate-auto-rebase` ever migrated to Phase 1 (1 of 7 writers); the migration stalled there from 2026-05-17. Phase 1's only reader was the manual `orchestrate-shadow-diff` verification CLI (a human-run drift check) — nothing operational or automated ever consumed the `.json.projected` shadow files. CTL-1628 removed the Phase 1 shadow-write **scaffolding** as dead weight — the broker's `handleWorkerStateChanged`/`getProjectedWorkerStatePath`/`writeProjectedWorkerState`, the dedicated `lib/emit-worker-state-changed.sh` emitter, and `orchestrate-shadow-diff` itself. **Phase 2's plan** (cut over to broker-sole-writer once Phase 1 reached zero drift) **is dead** — it depended on the now-retired Phase 1 drift-check pipeline, so that specific implementation can no longer execute; the canonical `workers/<TICKET>.json` files are still written exactly as before, by the same seven racing scripts. The *problem* Phase 2 was meant to solve — the seven-script single-writer race — is still open, but it is no longer tracked as this ADR's Phase 2: **CTL-1631** now owns it as a standalone ticket, replacing the retired Phase-2 plan rather than continuing it. **Phase 3** — as originally scoped, a `(orch_id,ticket)` SQLite mirror — **did ship**, as CTL-532 below; both `projection.mjs:291` and `broker-state.mjs:194` label it in-code as `(ADR-018 Phase 3)`.
 
-The `worker.state_changed` **event name and wire schema are not gone**, only the dedicated producer
-and shadow-file consumer: `reduceWorkerStateEvent` (below) still treats it as valid input, both (a)
-on every broker restart within the same calendar month — `replayWorkerStateProjection` folds the
-*entire* current-month event log, so any `worker.state_changed` record already on disk from before
-this change remains live replay input — and (b) as a defensive compat-consume in the broker router
-(`if (name === "worker.state_changed") return;`, CTL-1628) for an un-upgraded `orchestrate-auto-rebase`
-still emitting it during a mixed-version fleet rollout. The wire schema stays documented in
-`references/event-schema.md`, marked as a retired producer retained for replay/compat.
+The `worker.state_changed` **event name and wire schema are not gone**, only the dedicated producer and shadow-file consumer: `reduceWorkerStateEvent` (below) still treats it as valid input, both (a) on every broker restart within the same calendar month — `replayWorkerStateProjection` folds the *entire* current-month event log, so any `worker.state_changed` record already on disk from before this change remains live replay input — and (b) as a defensive compat-consume in the broker router (`if (name === "worker.state_changed") return;`, CTL-1628) for an un-upgraded `orchestrate-auto-rebase` still emitting it during a mixed-version fleet rollout. The wire schema stays documented in `references/event-schema.md`, marked as a retired producer retained for replay/compat.
 
-**CTL-532 shipped this ADR's Phase 3.** `processEvent` folds every event (not just
-`worker.state_changed`) into `projectWorkerStateEvent` unconditionally, above all routing gates; the
-pure `reduceWorkerStateEvent` reducer normalizes `worker.state_changed`, `phase.<name>.<status>.<TICKET>`,
-and a specific subset of `orchestrator.worker.*` actions into a patch. For the phase family, only
-`status` ∈ `{complete, failed, turn-cap-exhausted}` matches `WORKER_PHASE_EVENT_PATTERN`;
-`phase.<name>.skipped.<TICKET>` (e.g. `phase-monitor-deploy`'s no-deploy-observed outcome) is a real,
-separately-routed event but is **not** in that pattern's alternation, so it is not folded here. For
-the `orchestrator.worker.*` family it is **not** a wildcard: `revived`, `pr_created`, and
-`status_terminal` are special-cased, and `dispatched`/`done`/`failed`/`launch_failed` map through
-`WORKER_LIFECYCLE_STATUS`; `pr_merged` and `phase_advanced` are real, separately-routed
-`orchestrator.worker.*` events that hit no branch and are silently dropped (`return null`).
-`upsertWorkerState` gates `phase`, `status`, and the `last_event_id`/`last_event_ts` watermark itself
-on an order-independent watermark — an incoming event's `last_event_ts` must be `>=` (not `>`) the
-row's current watermark to apply, so on an exact timestamp tie the later-*processed* event wins, not
-the later-*occurring* one (pinned by `worker-state-projection.test.mjs:1140-1163`). `pr_number`
-(`COALESCE(excluded.pr_number, worker_state.pr_number)`) and `revive_count`
-(`MAX(excluded.revive_count, worker_state.revive_count)`) are **not** watermark-gated — every upsert
-applies them unconditionally regardless of event order (revive_count's `MAX` can't regress either
-way; pr_number's `COALESCE` can be clobbered by an out-of-order event supplying a different non-null
-value). The result lands in the broker SQLite `worker_state` table — one row per
-`(orchestrator, ticket)` holding phase/status/PR-number/revive-count — plus `worker_revive_events`
-(idempotency ledger) and `projection_meta` (single-row watermark), all defined in
-`broker/broker-state.mjs:194-232` and shipped in #936. This was previously undocumented against this
-ADR.
+**CTL-532 shipped this ADR's Phase 3.** `processEvent` folds every event (not just `worker.state_changed`) into `projectWorkerStateEvent` unconditionally, above all routing gates; the pure `reduceWorkerStateEvent` reducer normalizes `worker.state_changed`, `phase.<name>.<status>.<TICKET>`, and a specific subset of `orchestrator.worker.*` actions into a patch. For the phase family, only `status` ∈ `{complete, failed, turn-cap-exhausted}` matches `WORKER_PHASE_EVENT_PATTERN`; `phase.<name>.skipped.<TICKET>` (e.g. `phase-monitor-deploy`'s no-deploy-observed outcome) is a real, separately-routed event but is **not** in that pattern's alternation, so it is not folded here. For the `orchestrator.worker.*` family it is **not** a wildcard: `revived`, `pr_created`, and `status_terminal` are special-cased, and `dispatched`/`done`/`failed`/`launch_failed` map through `WORKER_LIFECYCLE_STATUS`; `pr_merged` and `phase_advanced` are real, separately-routed `orchestrator.worker.*` events that hit no branch and are silently dropped (`return null`). `upsertWorkerState` gates `phase`, `status`, and the `last_event_id`/`last_event_ts` watermark itself on an order-independent watermark — an incoming event's `last_event_ts` must be `>=` (not `>`) the row's current watermark to apply, so on an exact timestamp tie the later-*processed* event wins, not the later-*occurring* one (pinned by `worker-state-projection.test.mjs:1140-1163`). `pr_number` (`COALESCE(excluded.pr_number, worker_state.pr_number)`) and `revive_count` (`MAX(excluded.revive_count, worker_state.revive_count)`) are **not** watermark-gated — every upsert applies them unconditionally regardless of event order (revive_count's `MAX` can't regress either way; pr_number's `COALESCE` can be clobbered by an out-of-order event supplying a different non-null value). The result lands in the broker SQLite `worker_state` table — one row per `(orchestrator, ticket)` holding phase/status/PR-number/revive-count — plus `worker_revive_events` (idempotency ledger) and `projection_meta` (single-row watermark), all defined in `broker/broker-state.mjs:194-232` and shipped in #936. This was previously undocumented against this ADR.
 
-**CTL-532 is observational, not a fix for the single-writer-race problem.**
-`upsertWorkerState` only inserts/updates the SQLite `worker_state` row; it never reads or writes the
-canonical `workers/<TICKET>.json` file. That problem — originally Phase 2's remit — is CTL-1631's to
-close, not this ADR's.
+**CTL-532 is observational, not a fix for the single-writer-race problem.** `upsertWorkerState` only inserts/updates the SQLite `worker_state` row; it never reads or writes the canonical `workers/<TICKET>.json` file. That problem — originally Phase 2's remit — is CTL-1631's to close, not this ADR's.
 
-**No supersession happened.** Phase 2 — the only phase that would have replaced the direct-write
-`workers/<TICKET>.json` design (from ADR-017's signal layout) with a broker-sole-writer path — was
-never built. The original seven-script write path, races included, is unchanged from before this
-ADR. Global state + event log (ADR-006) were never in scope here and stay in force regardless.
+**No supersession happened.** Phase 2 — the only phase that would have replaced the direct-write `workers/<TICKET>.json` design (from ADR-017's signal layout) with a broker-sole-writer path — was never built. The original seven-script write path, races included, is unchanged from before this ADR. Global state + event log (ADR-006) were never in scope here and stay in force regardless.
 
 ## ADR-019: Turn-cap exhaustion → automated handoff continuation (CTL-484)
 
-Phase agents have turn caps (default 75 for implement). Before CTL-484, `orchestrate-revive` treated
-a turn-cap stop as a failure, burning the revive budget on successful forward progress; tickets
-needing >75 turns silently hit `revive-budget-exhausted`.
+Phase agents have turn caps (default 75 for implement). Before CTL-484, `orchestrate-revive` treated a turn-cap stop as a failure, burning the revive budget on successful forward progress; tickets needing >75 turns silently hit `revive-budget-exhausted`.
 
-**Decision**: introduce `turn-cap-exhausted` as a distinct non-terminal status in `phase_lifecycle`
-routing. A worker nearing the cap writes a handoff to
-`thoughts/shared/handoffs/<TICKET>/<ts>_turn-cap-continuation.md` and emits
-`phase.<name>.turn-cap-exhausted.<TICKET>` (handoff path in payload). `orchestrate-revive`: detects
-it → spawns `claude --bg --resume <session_id>` with `CATALYST_IS_CONTINUATION=true`,
-`CATALYST_HANDOFF_PATH`, `CATALYST_CONTINUATION_COUNT` → bumps `.continuationCount` on a
-**separate** budget (`MAX_CONTINUATIONS`, default 3) → exhaustion = `stalled`,
-`attentionReason="continuation-budget-exhausted"`. Resumed worker reads the handoff and trusts the
-summary.
+**Decision**: introduce `turn-cap-exhausted` as a distinct non-terminal status in `phase_lifecycle` routing. A worker nearing the cap writes a handoff to `thoughts/shared/handoffs/<TICKET>/<ts>_turn-cap-continuation.md` and emits `phase.<name>.turn-cap-exhausted.<TICKET>` (handoff path in payload). `orchestrate-revive`: detects it → spawns `claude --bg --resume <session_id>` with `CATALYST_IS_CONTINUATION=true`, `CATALYST_HANDOFF_PATH`, `CATALYST_CONTINUATION_COUNT` → bumps `.continuationCount` on a **separate** budget (`MAX_CONTINUATIONS`, default 3) → exhaustion = `stalled`, `attentionReason="continuation-budget-exhausted"`. Resumed worker reads the handoff and trusts the summary.
 
-Lives in: `phase-agent-emit-complete` / `lib/phase-emit-complete.sh`
-(`--status turn-cap-exhausted --handoff-path`); broker `PHASE_EVENT_PATTERN`
-(`namespace-contract.mjs`, tests `phase-lifecycle.test.mjs`); `templates/worker-signal.json`
-(`continuationCount`, `continuations[]`, `handoffPath`) + `signal-schema.ts` + `state-reader.ts`;
-`orchestrate-revive` (`spawn_continuation_bg`, `--max-continuations`); `resume-handoff/SKILL.md`;
-`phase-implement/SKILL.md` (producer). Rationale: distinct routable status (not a payload
-discriminator); separate budget (reviveCount ≠ continuationCount); worker self-detection (no
-external watchdog); bash-templated handoff (background path can't run interactive `create-handoff`);
-non-terminal (omits `completedAt`, off `TERMINAL_STATUSES`). Rejected: raise MAX_REVIVES, bump caps
-in config, external watchdog. Scope = `phase-implement` for v1; reusable infra.
+Lives in: `phase-agent-emit-complete` / `lib/phase-emit-complete.sh` (`--status turn-cap-exhausted --handoff-path`); broker `PHASE_EVENT_PATTERN` (`namespace-contract.mjs`, tests `phase-lifecycle.test.mjs`); `templates/worker-signal.json` (`continuationCount`, `continuations[]`, `handoffPath`) + `signal-schema.ts` + `state-reader.ts`; `orchestrate-revive` (`spawn_continuation_bg`, `--max-continuations`); `resume-handoff/SKILL.md`; `phase-implement/SKILL.md` (producer). Rationale: distinct routable status (not a payload discriminator); separate budget (reviveCount ≠ continuationCount); worker self-detection (no external watchdog); bash-templated handoff (background path can't run interactive `create-handoff`); non-terminal (omits `completedAt`, off `TERMINAL_STATUSES`). Rejected: raise MAX_REVIVES, bump caps in config, external watchdog. Scope = `phase-implement` for v1; reusable infra.
 
 ## ADR-020: Phase-mode turn-cap continuation lives in `orchestrate-revive`, not the daemon (CTL-613)
 
-ADR-019's loop ran against the legacy top-level signal; phase-mode workers (ADR-017 default) write
-only per-phase `workers/<TICKET>/phase-<name>.json`, so it's a no-op for them. The CTL-493 per-phase
-loop only consumed `stalled` and silently skipped `turn-cap-exhausted` → handoff sat unused, ticket
-hung (incident ADV-1134). The daemon's `execution-core/signal-reader.mjs` correctly classifies
-`turn-cap-exhausted` as terminal (continuation ≠ reclaim).
+ADR-019's loop ran against the legacy top-level signal; phase-mode workers (ADR-017 default) write only per-phase `workers/<TICKET>/phase-<name>.json`, so it's a no-op for them. The CTL-493 per-phase loop only consumed `stalled` and silently skipped `turn-cap-exhausted` → handoff sat unused, ticket hung (incident ADV-1134). The daemon's `execution-core/signal-reader.mjs` correctly classifies `turn-cap-exhausted` as terminal (continuation ≠ reclaim).
 
-**Decision**: add a branch to `orchestrate-revive`'s CTL-493 per-phase loop that consumes
-`P_STATUS=="turn-cap-exhausted"` directly: budget-check `.phaseContinuationCount` (shares
-`MAX_CONTINUATIONS`=3 with ADR-019's counter, tracked separately), resolve session id + worktree,
-spawn via `spawn_continuation_bg`, set per-phase signal back to `running`, emit
-`phase.<name>.dispatched` to re-arm the broker. Resolve the prior session id from
-`~/.claude/jobs/<bg>/state.json::linkScanPath` (basename minus `.jsonl`) rather than plumbing it
-into the signal — keeps the dispatcher's single-write contract intact. Daemon terminal
-classification stays; recovery is the script's job, invoked by the daemon sweep. New
-`resolve_phase_session_id` coexists with the legacy `resolve_session_id`.
+**Decision**: add a branch to `orchestrate-revive`'s CTL-493 per-phase loop that consumes `P_STATUS=="turn-cap-exhausted"` directly: budget-check `.phaseContinuationCount` (shares `MAX_CONTINUATIONS`=3 with ADR-019's counter, tracked separately), resolve session id + worktree, spawn via `spawn_continuation_bg`, set per-phase signal back to `running`, emit `phase.<name>.dispatched` to re-arm the broker. Resolve the prior session id from `~/.claude/jobs/<bg>/state.json::linkScanPath` (basename minus `.jsonl`) rather than plumbing it into the signal — keeps the dispatcher's single-write contract intact. Daemon terminal classification stays; recovery is the script's job, invoked by the daemon sweep. New `resolve_phase_session_id` coexists with the legacy `resolve_session_id`.
 
 ## ADR-021: Workspace-level type-label taxonomy (CTL-995)
 
-All six type labels (`bug`, `feature`, `refactor`, `docs`, `chore`, `test`) live at **workspace**
-scope under a `type` label group, with canonical colors: bug `#e5484d`, feature `#8b5cf6`, refactor
-`#14b8a6`, docs `#3b82f6`, chore `#8d8d8d`, test `#22c55e`. Pre-migration, four were per-team
-duplicates (color drift, per-team ID lists). `issueLabelUpdate(teamId:null)` was rejected by the API
-→ used rename-create-relabel-delete. Tooling must filter by the workspace IDs in
-`thoughts/shared/research/2026-06-10-ctl-995-label-taxonomy-migration.md`. Component labels
-(orchestrator/broker/phase-agent/monitor/cli/ci/website/estimation/worktree) remain team-scoped;
-only the type axis is workspace-level.
+All six type labels (`bug`, `feature`, `refactor`, `docs`, `chore`, `test`) live at **workspace** scope under a `type` label group, with canonical colors: bug `#e5484d`, feature `#8b5cf6`, refactor `#14b8a6`, docs `#3b82f6`, chore `#8d8d8d`, test `#22c55e`. Pre-migration, four were per-team duplicates (color drift, per-team ID lists). `issueLabelUpdate(teamId:null)` was rejected by the API → used rename-create-relabel-delete. Tooling must filter by the workspace IDs in `thoughts/shared/research/2026-06-10-ctl-995-label-taxonomy-migration.md`. Component labels (orchestrator/broker/phase-agent/monitor/cli/ci/website/estimation/worktree) remain team-scoped; only the type axis is workspace-level.
 
 ## ADR-022: Belief engine is a derivation layer; "log → projection" is the directional target, not the shipped reality
 
-**Accepted (direction) 2026-06-14.** Track A active; Track B is a deliberate un-started bet.
-Sources: `thoughts/shared/research/2026-06-14-resilience-and-peer-platform-learnings.md`,
-`…/2026-06-13-catalyst-patentability-and-open-core-strategy.md`.
+**Accepted (direction) 2026-06-14.** Track A active; Track B is a deliberate un-started bet. Sources: `thoughts/shared/research/2026-06-14-resilience-and-peer-platform-learnings.md`, `…/2026-06-13-catalyst-patentability-and-open-core-strategy.md`.
 
-The conceptual fit is exact — Datalog EDB→IDB closure **is** event-sourcing's `state=fold(log)`. The
-engine (`execution-core/beliefs/`, CTL-962→967, CTL-1063) gets determinism right: `now` captured
-once/tick (`collector.mjs`), EDB frozen in one SQLite txn during eval, and a differential shadow
-oracle (`advance-shadow.mjs`) comparing Datalog `advance_to` vs procedural `deriveAdvancement`. But
-three facts bound the claim:
+The conceptual fit is exact — Datalog EDB→IDB closure **is** event-sourcing's `state=fold(log)`. The engine (`execution-core/beliefs/`, CTL-962→967, CTL-1063) gets determinism right: `now` captured once/tick (`collector.mjs`), EDB frozen in one SQLite txn during eval, and a differential shadow oracle (`advance-shadow.mjs`) comparing Datalog `advance_to` vs procedural `deriveAdvancement`. But three facts bound the claim:
 
-1. **EDB is fed from mutable live state, not the log.** 8 of 9 `obs_*` tables are live probes; the
-   one log-sourced table `obs_heartbeat` is permanently empty (no `worker.heartbeat` emitter,
-   `collector.mjs`). As shipped = "the filesystem is the agent, observed through Datalog," not a log
-   projection.
-2. **The `rules.dl` compiler compiles only 3 of 18 rules** (`compiler/index.mjs`); load-bearing
-   logic (recursive S5 deps, S6 `advance_to`/`cycle_exhausted`) is `extern` hand-written SQL with a
-   61 KB hand-synced generated artifact.
-3. **Advancement is graded against the 33-line procedural `deriveAdvancement` as ground truth** —
-   porting to Datalog can at best equal it (low standalone ROI).
+1. **EDB is fed from mutable live state, not the log.** 8 of 9 `obs_*` tables are live probes; the one log-sourced table `obs_heartbeat` is permanently empty (no `worker.heartbeat` emitter, `collector.mjs`). As shipped = "the filesystem is the agent, observed through Datalog," not a log projection.
+2. **The `rules.dl` compiler compiles only 3 of 18 rules** (`compiler/index.mjs`); load-bearing logic (recursive S5 deps, S6 `advance_to`/`cycle_exhausted`) is `extern` hand-written SQL with a 61 KB hand-synced generated artifact.
+3. **Advancement is graded against the 33-line procedural `deriveAdvancement` as ground truth** — porting to Datalog can at best equal it (low standalone ROI).
 
-The engine has been shadow/dark its whole life; graduation is blocked on prerequisites that don't
-exist (a log-sourced EDB; `caused_by` + monotonic `seq` on the envelope, both verified absent).
+The engine has been shadow/dark its whole life; graduation is blocked on prerequisites that don't exist (a log-sourced EDB; `caused_by` + monotonic `seq` on the envelope, both verified absent).
 
-**Decision**: (1) Affirm "immutable log → deterministic projection" as the target; keep the engine
-as the projection substrate — don't rip it out. (2) Stop calling the EDB a "log projection" in docs
-until its authoritative tables come from the log. (3) Split the ambition: **Track A** —
-derivation/health/provenance/absence-detection (S5 deps, `catalyst why`, negation-over-time); keep,
-invest, graduate. **Track B** — Datalog owns the control path (R16/R17 replace `deriveAdvancement`,
-log-sourced EDB, `signal.json` demoted to regeneratable projection); a deliberate bet gated by the
-`advance-shadow` zero-disagreement oracle. (4) First graduation = the resilience absence-detector
-("no `github.*`/`linear.*` event in N min → `ingestion_stale`"), which forces emitting
-heartbeat/webhook-freshness events (fixes empty `obs_heartbeat`) — all Track A.
+**Decision**: (1) Affirm "immutable log → deterministic projection" as the target; keep the engine as the projection substrate — don't rip it out. (2) Stop calling the EDB a "log projection" in docs until its authoritative tables come from the log. (3) Split the ambition: **Track A** — derivation/health/provenance/absence-detection (S5 deps, `catalyst why`, negation-over-time); keep, invest, graduate. **Track B** — Datalog owns the control path (R16/R17 replace `deriveAdvancement`, log-sourced EDB, `signal.json` demoted to regeneratable projection); a deliberate bet gated by the `advance-shadow` zero-disagreement oracle. (4) First graduation = the resilience absence-detector ("no `github.*`/`linear.*` event in N min → `ingestion_stale`"), which forces emitting heartbeat/webhook-freshness events (fixes empty `obs_heartbeat`) — all Track A.
 
-Rationale: decide/act seam stays a bright line (Datalog derives; an imperative executor acts —
-`escalate.mjs`, gated `CATALYST_INTENTS_ENFORCE=1`, sits outside the rule engine). Datalog not
-Prolog (guaranteed termination for a control plane; bounded `WITH RECURSIVE` only). Per-tick EDB
-checkpoints = the snapshot half of event sourcing. Consequences: `caused_by` + monotonic `seq` are
-prerequisites (`EVENT_SCHEMA_CAUSAL_SEQ` gap, near-free). The 3/18 compiler's fate is decided by
-Track-B intent (migrate `extern` rules or retire the compiler). Do NOT "fix" `REVIVE_BUDGET=1` (dead
-code; CTL-736 progress-gate is live). Complements ADR-018 / ADR-006/008. Rejected: rip out the
-engine; promote `advance_to` now; full "log is the agent" rewrite now (= Track B).
+Rationale: decide/act seam stays a bright line (Datalog derives; an imperative executor acts — `escalate.mjs`, gated `CATALYST_INTENTS_ENFORCE=1`, sits outside the rule engine). Datalog not Prolog (guaranteed termination for a control plane; bounded `WITH RECURSIVE` only). Per-tick EDB checkpoints = the snapshot half of event sourcing. Consequences: `caused_by` + monotonic `seq` are prerequisites (`EVENT_SCHEMA_CAUSAL_SEQ` gap, near-free). The 3/18 compiler's fate is decided by Track-B intent (migrate `extern` rules or retire the compiler). Do NOT "fix" `REVIVE_BUDGET=1` (dead code; CTL-736 progress-gate is live). Complements ADR-018 / ADR-006/008. Rejected: rip out the engine; promote `advance_to` now; full "log is the agent" rewrite now (= Track B).
 
-**Amendment, 2026-08-20 — Track B is retired; Track A stands, pending a lease-liveness follow-up.**
-Two-plus months after acceptance, neither gating flag (`CATALYST_BELIEFS_SHADOW`,
-`CATALYST_INTENTS_ENFORCE`) is set anywhere in `catalyst-cluster` — not in either host's
-`hosts/{mini,mini-2}/execution-core.env`, not anywhere else in that repo (verified live via grep,
-2026-08-20). Both default to off in code (`config.mjs:2714-2716`'s flag map; `label-guard.mjs:113/497`,
-`recovery.mjs:2821`, `scheduler.mjs:9101` all gate on `env.X === "1"` / `env.X ?? "0"`), so both are
-dark on both hosts by default-absence, not an explicit `=0` override — same practical effect (the
-shadow oracle Track B's graduation was gated on has never run a single tick), corrected citation.
+**Amendment, 2026-08-20 — Track B is retired; Track A stands, pending a lease-liveness follow-up.** Two-plus months after acceptance, neither gating flag (`CATALYST_BELIEFS_SHADOW`, `CATALYST_INTENTS_ENFORCE`) is set anywhere in `catalyst-cluster` — not in either host's `hosts/{mini,mini-2}/execution-core.env`, not anywhere else in that repo (verified live via grep, 2026-08-20). Both default to off in code (`config.mjs:2714-2716`'s flag map; `label-guard.mjs:113/497`, `recovery.mjs:2821`, `scheduler.mjs:9101` all gate on `env.X === "1"` / `env.X ?? "0"`), so both are dark on both hosts by default-absence, not an explicit `=0` override — same practical effect (the shadow oracle Track B's graduation was gated on has never run a single tick), corrected citation.
 
 Two independent things happened in the interim that change the call, not one:
 
-1. **The control path is already solved.** ADR-029 (2026-08-13) and the lease-authority work
-   (CTL-1785/1786) together give the pipeline's control path (advancement, dispatch exclusion) a
-   real mechanism — Linear as trigger, a cloud-DO lease as the conditional-write lock — with no
-   rule-engine derivation involved. This alone retires Track B's stated goal (Datalog owning
-   `advance_to`/dispatch exclusion): there's nothing left for it to graduate into.
-2. **Leases are also a better fit for the liveness reasoning Track B and part of Track A were doing
-   heuristically.** A live example, from the same day this amendment was written: CTL-2090 (mini-2's
-   scheduler admitting zero new work despite a free slot and a ready ticket) required hours of
-   stewards manually SSHing in, grepping `daemon.log`, and diffing tick counters by hand to answer
-   "is this claim actually still alive" — exactly the kind of question a rules engine encoding
-   heuristics was meant to answer, done instead as ad-hoc inference because no first-class "is this
-   lease currently held and recently renewed" fact exists yet. A real claim/renew/release lease
-   answers that directly, once renewal ships (`renew()` is currently stubbed —
-   `lease-verbs.ts`'s `renew-not-implemented` — the actual blocking prerequisite, not a reason to
-   abandon the approach).
+1. **The control path is already solved.** ADR-029 (2026-08-13) and the lease-authority work (CTL-1785/1786) together give the pipeline's control path (advancement, dispatch exclusion) a real mechanism — Linear as trigger, a cloud-DO lease as the conditional-write lock — with no rule-engine derivation involved. This alone retires Track B's stated goal (Datalog owning `advance_to`/dispatch exclusion): there's nothing left for it to graduate into.
+2. **Leases are also a better fit for the liveness reasoning Track B and part of Track A were doing heuristically.** A live example, from the same day this amendment was written: CTL-2090 (mini-2's scheduler admitting zero new work despite a free slot and a ready ticket) required hours of stewards manually SSHing in, grepping `daemon.log`, and diffing tick counters by hand to answer "is this claim actually still alive" — exactly the kind of question a rules engine encoding heuristics was meant to answer, done instead as ad-hoc inference because no first-class "is this lease currently held and recently renewed" fact exists yet. A real claim/renew/release lease answers that directly, once renewal ships (`renew()` is currently stubbed — `lease-verbs.ts`'s `renew-not-implemented` — the actual blocking prerequisite, not a reason to abandon the approach).
 
-CTL-1244 (the epic executing this ADR's Track B) is retargeted: the "kill `signal.json` as primary
-state" goal stays, but its mechanism becomes the plain log+projection rewrite the lease/trigger work
-already implies, not a Datalog-derived EDB. **Track B is retired, not merely left ungraduated** — the
-3/18-compiled `rules.dl`/`compiler/index.mjs` and the `advance-shadow` comparator are dead weight to
-delete alongside CTL-1244's rescoped work, not a bet to keep open.
+CTL-1244 (the epic executing this ADR's Track B) is retargeted: the "kill `signal.json` as primary state" goal stays, but its mechanism becomes the plain log+projection rewrite the lease/trigger work already implies, not a Datalog-derived EDB. **Track B is retired, not merely left ungraduated** — the 3/18-compiled `rules.dl`/`compiler/index.mjs` and the `advance-shadow` comparator are dead weight to delete alongside CTL-1244's rescoped work, not a bet to keep open.
 
-**Track A stands as this amendment's decision — not reopened here — but item 2 above puts its
-liveness/absence-detection half on watch, not settled.** Provenance work with no liveness angle
-(`catalyst why`, negation-over-time) is unaffected. The CTL-1143 ingestion-stale-detector graduation
-(Hardening backlog) is exactly the kind of absence-detection Track A was scoped to own, and it is the
-same shape of problem leases solved for CTL-2090 — worth a real comparison once lease renewal lands,
-not before. That comparison is future work, explicitly not decided by this amendment. Separately, an
-unratified proposal (`thoughts/.../2026-08-11-event-delivery-plane.md`, status "proposal — not yet
-ratified", explicitly marked DO NOT IMPLEMENT) argues for deleting the whole 15,202-line engine
-outright now; that broader call was considered and deferred, same as before this amendment.
+**Track A stands as this amendment's decision — not reopened here — but item 2 above puts its liveness/absence-detection half on watch, not settled.** Provenance work with no liveness angle (`catalyst why`, negation-over-time) is unaffected. The CTL-1143 ingestion-stale-detector graduation (Hardening backlog) is exactly the kind of absence-detection Track A was scoped to own, and it is the same shape of problem leases solved for CTL-2090 — worth a real comparison once lease renewal lands, not before. That comparison is future work, explicitly not decided by this amendment. Separately, an unratified proposal (`thoughts/.../2026-08-11-event-delivery-plane.md`, status "proposal — not yet ratified", explicitly marked DO NOT IMPLEMENT) argues for deleting the whole 15,202-line engine outright now; that broader call was considered and deferred, same as before this amendment.
 
-(HRW — the deterministic-hashing layer that assigns ticket ownership across the roster — is a
-separate mechanism from both Track A and Track B and is out of scope here. It depends on every
-member knowing the full roster, which is fine while the roster is a small set of long-lived hosts;
-it becomes worth revisiting only once execution moves toward elastic/cloud-managed workers with a
-dynamic roster, which is a real but not-yet-scheduled direction, not a current decision.)
+(HRW — the deterministic-hashing layer that assigns ticket ownership across the roster — is a separate mechanism from both Track A and Track B and is out of scope here. It depends on every member knowing the full roster, which is fine while the roster is a small set of long-lived hosts; it becomes worth revisiting only once execution moves toward elastic/cloud-managed workers with a dynamic roster, which is a real but not-yet-scheduled direction, not a current decision.)
 
 ## ADR-023: Shadow→Enforce Rollout Discipline for Autonomous Actuators
 
-**Accepted 2026-06-16.** The fleet has many autonomous actuators (session reaper CTL-649/657,
-proc-reaper CTL-1165, stall-janitor CTL-1004/1064, unstuck-sweep CTL-1064, belief executors
-CTL-962→967, fleet-health self-heal CTL-1165 D5), each able to take a hard-to-reverse action. The
-1,798-job / 17 GB-swap reap-leak (CTL-1165) is the cautionary case. Verified 2026-06-16: every
-recovery actuator runs on its conservative default (shadow/off).
+**Accepted 2026-06-16.** The fleet has many autonomous actuators (session reaper CTL-649/657, proc-reaper CTL-1165, stall-janitor CTL-1004/1064, unstuck-sweep CTL-1064, belief executors CTL-962→967, fleet-health self-heal CTL-1165 D5), each able to take a hard-to-reverse action. The 1,798-job / 17 GB-swap reap-leak (CTL-1165) is the cautionary case. Verified 2026-06-16: every recovery actuator runs on its conservative default (shadow/off).
 
 **Decision** — one discipline for every actuator:
 
 1. **Rules DERIVE, executors ACT** — decide/act bright line (mirrors ADR-022).
-2. **Dark by default** — ships `off`/`shadow`, gated by one knob (env flag
-   `CATALYST_INTENTS_ENFORCE` / `CATALYST_STALL_JANITOR` / `CATALYST_UNSTUCK_SWEEP` /
-   `CATALYST_DIAGNOSTICIAN` / `EXECUTION_CORE_FLEET_SELF_HEAL`, or Layer-1 mode
-   `orphanReaper.procReaper.mode`).
-3. **Three-state `off → shadow → enforce`** — shadow emits a "would-X" twin
-   (`procOrphans.would-reap`, `unstuck.would.push`, `janitor.would.kill`, the `advance-shadow`
-   comparator).
-4. **Gated criteria flips** — shadow→enforce needs written criteria verified on real hosts over a
-   real window (CTL-1165 proc-reaper criteria = template: ≥3–5 days of real candidates, each
-   spot-checked, no false spared/reaped, steady-state bounded).
+2. **Dark by default** — ships `off`/`shadow`, gated by one knob (env flag `CATALYST_INTENTS_ENFORCE` / `CATALYST_STALL_JANITOR` / `CATALYST_UNSTUCK_SWEEP` / `CATALYST_DIAGNOSTICIAN` / `EXECUTION_CORE_FLEET_SELF_HEAL`, or Layer-1 mode `orphanReaper.procReaper.mode`).
+3. **Three-state `off → shadow → enforce`** — shadow emits a "would-X" twin (`procOrphans.would-reap`, `unstuck.would.push`, `janitor.would.kill`, the `advance-shadow` comparator).
+4. **Gated criteria flips** — shadow→enforce needs written criteria verified on real hosts over a real window (CTL-1165 proc-reaper criteria = template: ≥3–5 days of real candidates, each spot-checked, no false spared/reaped, steady-state bounded).
 5. **Reversible by unset** — flip reverts by unsetting + restart; gates fail closed.
 6. **One at a time** — independent knobs; never a blanket on.
 
-Rationale: shadow-first + gated criteria makes harm observable before possible. **Known
-coarseness**: `CATALYST_INTENTS_ENFORCE` is today a single flag arming four belief executors at once
-— safety rests on each being idempotent/bounded (`labelOnce`, bgJobId-pinned kill, max-attempts)
-until per-intent granularity exists. This is the deterministic-vs-flexible boundary (flexible LLM
-layer = ADR-025). Consequences: new actuators MUST ship `off|shadow|enforce` + `would-X` + written
-criteria; modes instantiated in `website/.../reference/configuration.md` + schema enum; flips
-operator-owned (no auto-promotion) — the **ownerless-gate risk** (clean shadow evidence with nobody
-flipping) is itself an operator concern (ADR-025/CTL-1176). Rejected: enable-on-merge; single global
-enforce flag.
+Rationale: shadow-first + gated criteria makes harm observable before possible. **Known coarseness**: `CATALYST_INTENTS_ENFORCE` is today a single flag arming four belief executors at once — safety rests on each being idempotent/bounded (`labelOnce`, bgJobId-pinned kill, max-attempts) until per-intent granularity exists. This is the deterministic-vs-flexible boundary (flexible LLM layer = ADR-025). Consequences: new actuators MUST ship `off|shadow|enforce` + `would-X` + written criteria; modes instantiated in `website/.../reference/configuration.md` + schema enum; flips operator-owned (no auto-promotion) — the **ownerless-gate risk** (clean shadow evidence with nobody flipping) is itself an operator concern (ADR-025/CTL-1176). Rejected: enable-on-merge; single global enforce flag.
 
 ## ADR-024: Mechanical Fleet Hygiene — Reapers, Janitors, GC (Thread 1)
 
-**Accepted 2026-06-16.** Each phase-agent worker leaves durable state: a `~/.claude/jobs/<id>` dir,
-an `execution-core/workers/<TICKET>/` signal dir, a `~/catalyst/wt/` worktree, reparented
-`node`/`bun` children. Two incidents: the reap-leak (1,798 dirs / 17 GB, CTL-1165) and a 2026-06-16
-incident where 137 `execution-core/workers/` dirs cold the CTL-731 liveness snapshot
-(`inFlightCount:0` while workers live) → daemon held all new-work dispatch incl Urgent.
+**Accepted 2026-06-16.** Each phase-agent worker leaves durable state: a `~/.claude/jobs/<id>` dir, an `execution-core/workers/<TICKET>/` signal dir, a `~/catalyst/wt/` worktree, reparented `node`/`bun` children. Two incidents: the reap-leak (1,798 dirs / 17 GB, CTL-1165) and a 2026-06-16 incident where 137 `execution-core/workers/` dirs cold the CTL-731 liveness snapshot (`inFlightCount:0` while workers live) → daemon held all new-work dispatch incl Urgent.
 
 **Decision** — one named layer of bounded deterministic cleaners, each governed by ADR-023:
 
 1. **Session/bg-worker reaper** (CTL-649/657) — `claude stop` + `reap-complete`. Enforce.
-2. **proc-reaper** (CTL-1165 D2, `orphanReaper.procReaper.mode`) — kills reparented grandchildren.
-   Shadow; flip gated on CTL-1165 criteria.
+2. **proc-reaper** (CTL-1165 D2, `orphanReaper.procReaper.mode`) — kills reparented grandchildren. Shadow; flip gated on CTL-1165 criteria.
 3. **job-dir GC** (CTL-1165 D3) — removes aged `~/.claude/jobs` past 24 h.
-4. **worker-dir GC** (CTL-1205, NEW) — removes `execution-core/workers/<TICKET>/` on pipeline
-   completion (reaper `pr.merged` cleanup, after worktree removal) + periodic Done/merged sweep.
-   Nothing reaped these before; the per-tick `readdirSync` over the pile cold the CTL-731 snapshot.
-5. **stall-janitor** (CTL-1004/1064, `CATALYST_STALL_JANITOR`) — J1 reaps orphan worktrees, J2 kills
-   idle ghost sessions, J3 re-dispatches the narrow `prior-artifact-retry-exhausted` stall.
-   Shadow→enforce.
-6. **unstuck-sweep** (CTL-1064, `CATALYST_UNSTUCK_SWEEP`) — category-aware rescuer; `actByCategory`
-   seams intentionally unwired (`{}`).
-7. **fleet-health probe** (CTL-1165 D5) — alerts `fleet.health.degraded` on jobs/swap/procs
-   thresholds; self-heal default-off.
+4. **worker-dir GC** (CTL-1205, NEW) — removes `execution-core/workers/<TICKET>/` on pipeline completion (reaper `pr.merged` cleanup, after worktree removal) + periodic Done/merged sweep. Nothing reaped these before; the per-tick `readdirSync` over the pile cold the CTL-731 snapshot.
+5. **stall-janitor** (CTL-1004/1064, `CATALYST_STALL_JANITOR`) — J1 reaps orphan worktrees, J2 kills idle ghost sessions, J3 re-dispatches the narrow `prior-artifact-retry-exhausted` stall. Shadow→enforce.
+6. **unstuck-sweep** (CTL-1064, `CATALYST_UNSTUCK_SWEEP`) — category-aware rescuer; `actByCategory` seams intentionally unwired (`{}`).
+7. **fleet-health probe** (CTL-1165 D5) — alerts `fleet.health.degraded` on jobs/swap/procs thresholds; self-heal default-off.
 
-**Boundary (load-bearing)**: these operate on fleet _state_, not ticket content (= ADR-025). Not
-interchangeable: the stall-janitor reaps worktrees+sessions but NOT worker-state dirs (= worker-dir
-GC). A cold liveness snapshot is a worker-dir-GC problem, not a stall-janitor one (misdiagnosed the
-2026-06-16 incident). Rationale: liveness depends on hygiene (CTL-731 guard pressured by per-tick
-I/O over accumulated dirs); single clear target per cleaner; the event log is source of truth so
-removing a completed ticket's dir is safe (daemon restores on boot). Consequences: worker-dir GC
-(CTL-1205) is the durable fix for the cold-snapshot class; each cleaner follows ADR-023. Rejected:
-let state accumulate; one mega-reaper.
+**Boundary (load-bearing)**: these operate on fleet _state_, not ticket content (= ADR-025). Not interchangeable: the stall-janitor reaps worktrees+sessions but NOT worker-state dirs (= worker-dir GC). A cold liveness snapshot is a worker-dir-GC problem, not a stall-janitor one (misdiagnosed the 2026-06-16 incident). Rationale: liveness depends on hygiene (CTL-731 guard pressured by per-tick I/O over accumulated dirs); single clear target per cleaner; the event log is source of truth so removing a completed ticket's dir is safe (daemon restores on boot). Consequences: worker-dir GC (CTL-1205) is the durable fix for the cold-snapshot class; each cleaner follows ADR-023. Rejected: let state accumulate; one mega-reaper.
 
 ## ADR-025: Pre-Human Reasoning-Recovery Sweep and Operator Surfacing (Thread 3)
 
-**Accepted (direction) 2026-06-16.** Surfacing shipped (CTL-1180/1182/1181); the reasoning sweep
-(CTL-1176) is proposed, not built. When a ticket stalls/fails/needs a decision, it must **surface**
-to the operator and ideally something should try to **unstick** it first. Both were broken:
-ADV-1392's `pr` phase failed (`push_rejected_no_workflow_scope`) and surfaced nowhere (the escalation
-was applied only for `stalled`, never `failed`); CTL-1167 stalled with no comment; a scan found **31
-silently-stuck tickets/month vs 6 `escalate.human` events**. Nothing reasons over the queue
-(diagnostician CTL-937/828 evidence-only/dark; janitor J3 narrow; `phase-remediate` CTL-653
-in-pipeline only; unstuck-sweep seams unwired).
+**Accepted (direction) 2026-06-16.** Surfacing shipped (CTL-1180/1182/1181); the reasoning sweep (CTL-1176) is proposed, not built. When a ticket stalls/fails/needs a decision, it must **surface** to the operator and ideally something should try to **unstick** it first. Both were broken: ADV-1392's `pr` phase failed (`push_rejected_no_workflow_scope`) and surfaced nowhere (the escalation was applied only for `stalled`, never `failed`); CTL-1167 stalled with no comment; a scan found **31 silently-stuck tickets/month vs 6 `escalate.human` events**. Nothing reasons over the queue (diagnostician CTL-937/828 evidence-only/dark; janitor J3 narrow; `phase-remediate` CTL-653 in-pipeline only; unstuck-sweep seams unwired).
 
-**Decision** — a flexible LLM-reasoning recovery layer in front of the human inbox (distinct from
-ADR-024 hygiene and ADR-022 belief):
+**Decision** — a flexible LLM-reasoning recovery layer in front of the human inbox (distinct from ADR-024 hygiene and ADR-022 belief):
 
-1. **Reasoning recovery sweep (CTL-1176)** — periodic LLM pass over the stuck/failed/escalated
-   queue; per item, reconstruct from log + belief store + worktree/PR/CI and ask "human-decision or
-   can I unblock?". Resolves mechanical cases via existing deterministic seams; escalates only true
-   human-decisions **with a written reason**. Unifies diagnostician + janitor + sweeper +
-   remediator. **Guardrail (CTL-828 three-panel)**: NOT a general fixer — DETERMINISTIC when
-   stuck-type is typed and fix mechanical; LLM only with a structured brief + downstream
-   deterministic re-check + hard cycle cap; HUMAN otherwise. No open-ended re-dispatch authority
-   (reopens CTL-736 revive-storm). Every decision → log + Linear comment.
-2. **Surfacing model (CTL-1180, shipped)** — a terminally-`failed` phase surfaces like `stalled`:
-   an escalation for `status ∈ {failed, stalled}` when not pipeline-done (scheduler terminal sweep),
-   plus a `phaseFailed`/`escalationType` trigger in the monitor's `deriveAttention` → Needs-You
-   inbox + nav dot + `/queue`. Closes the `failed ≠ stalled` gap.
-3. **Always-record comment policy (CTL-1182, shipped)** — every phase, including failed, records its
-   outcome on the ticket; codified `linearis` fallback when the app-actor mirror fails.
-4. **Registered deterministic act-seams the sweep invokes** — workflow-scope push detour (CTL-1181),
-   sibling-conflict resolve (CTL-855), orphan-PR detect/adopt (CTL-1175/1159/1160), ADR-024
-   cleaners. The LLM _selects among_ registered seams; it never invents mutations.
+1. **Reasoning recovery sweep (CTL-1176)** — periodic LLM pass over the stuck/failed/escalated queue; per item, reconstruct from log + belief store + worktree/PR/CI and ask "human-decision or can I unblock?". Resolves mechanical cases via existing deterministic seams; escalates only true human-decisions **with a written reason**. Unifies diagnostician + janitor + sweeper + remediator. **Guardrail (CTL-828 three-panel)**: NOT a general fixer — DETERMINISTIC when stuck-type is typed and fix mechanical; LLM only with a structured brief + downstream deterministic re-check + hard cycle cap; HUMAN otherwise. No open-ended re-dispatch authority (reopens CTL-736 revive-storm). Every decision → log + Linear comment.
+2. **Surfacing model (CTL-1180, shipped)** — a terminally-`failed` phase surfaces like `stalled`: an escalation for `status ∈ {failed, stalled}` when not pipeline-done (scheduler terminal sweep), plus a `phaseFailed`/`escalationType` trigger in the monitor's `deriveAttention` → Needs-You inbox + nav dot + `/queue`. Closes the `failed ≠ stalled` gap.
+3. **Always-record comment policy (CTL-1182, shipped)** — every phase, including failed, records its outcome on the ticket; codified `linearis` fallback when the app-actor mirror fails.
+4. **Registered deterministic act-seams the sweep invokes** — workflow-scope push detour (CTL-1181), sibling-conflict resolve (CTL-855), orphan-PR detect/adopt (CTL-1175/1159/1160), ADR-024 cleaners. The LLM _selects among_ registered seams; it never invents mutations.
 
-Rationale: the fleet only alerts + escalates then stops; the "try to clean it up first" step was
-scaffolding only (31:6 quantifies the cost). Deterministic-vs-flexible boundary (ADR-023): hygiene
-stays gated; LLM judgment is bounded to "human-or-not + which seam." Surfacing is the floor — inbox
-membership keys on worker-dir/event status (`failed`/`stalled`), not just
-`gh pr list`, so failed-but-no-PR cases surface. Consequences: CTL-1176 needs its own scoping doc
-(becomes this ADR's implementation vehicle); belief executors (ADR-022) and this sweep are
-complementary; this is the "supervisor" record previously split across CTL-780/828/937. Rejected: a
-general open-ended re-dispatch agent (CTL-828 panel — reopens CTL-736); surfacing-only (leaves
-resolvable stalls consuming attention); leave re-engagement to the inference engine's lease rules
-(CTL-780 — that's the deterministic complement, held).
+Rationale: the fleet only alerts + escalates then stops; the "try to clean it up first" step was scaffolding only (31:6 quantifies the cost). Deterministic-vs-flexible boundary (ADR-023): hygiene stays gated; LLM judgment is bounded to "human-or-not + which seam." Surfacing is the floor — inbox membership keys on worker-dir/event status (`failed`/`stalled`), not just `gh pr list`, so failed-but-no-PR cases surface. Consequences: CTL-1176 needs its own scoping doc (becomes this ADR's implementation vehicle); belief executors (ADR-022) and this sweep are complementary; this is the "supervisor" record previously split across CTL-780/828/937. Rejected: a general open-ended re-dispatch agent (CTL-828 panel — reopens CTL-736); surfacing-only (leaves resolvable stalls consuming attention); leave re-engagement to the inference engine's lease rules (CTL-780 — that's the deterministic complement, held).
 
 ## ADR-026: Two-Axis Worker State Model + worker-status Label Group (CTL-764)
 
-**Decision** — worker state transitions **that the scheduler records** are consolidated behind a
-single chokepoint and a workspace-scoped, single-valued `worker-status` Linear label group carrying
-worker _disposition_ independently of _pipeline stage_ (known gaps in that coverage are listed
-below). The live chokepoint is the **inline
-`recordTransition`** function inside `scheduler.mjs`'s `schedulerTick` — not the standalone
-`recordWorkerTransition` module (`record-worker-transition.mjs`) named in this ADR's original
-design: that module's own doc comment declared only three of the eventual five sinks (Sink 1 Linear
-workflow status via `applyPhaseStatus`, Sink 2 the disposition label via `convergeLabel`, Sink 3 the
-unified event log via `appendWorkerTransitionEvent`) and flagged itself as unfinished — "Phase 5 will
-wire the production defaults... and route all call sites here." That Phase 5 wiring never happened;
-the scheduler's live path never called the module. Of the two sinks the module never reached, only
-sink 4 (OTLP via `otel-forward`) is actually live — it rides automatically on sink 3's event-log
-write. Sink 5 (a broker `ticket_state_transitions` table, CTL-764 Phase 10) was **never
-implemented** anywhere, live path or otherwise — no schema, no writer, no broker consumer exist in
-the codebase. CTL-1628 removed the retired module as consumer-free.
+**Decision** — worker state transitions **that the scheduler records** are consolidated behind a single chokepoint and a workspace-scoped, single-valued `worker-status` Linear label group carrying worker _disposition_ independently of _pipeline stage_ (known gaps in that coverage are listed below). The live chokepoint is the **inline `recordTransition`** function inside `scheduler.mjs`'s `schedulerTick` — not the standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) named in this ADR's original design: that module's own doc comment declared only three of the eventual five sinks (Sink 1 Linear workflow status via `applyPhaseStatus`, Sink 2 the disposition label via `convergeLabel`, Sink 3 the unified event log via `appendWorkerTransitionEvent`) and flagged itself as unfinished — "Phase 5 will wire the production defaults... and route all call sites here." That Phase 5 wiring never happened; the scheduler's live path never called the module. Of the two sinks the module never reached, only sink 4 (OTLP via `otel-forward`) is actually live — it rides automatically on sink 3's event-log write. Sink 5 (a broker `ticket_state_transitions` table, CTL-764 Phase 10) was **never implemented** anywhere, live path or otherwise — no schema, no writer, no broker consumer exist in the codebase. CTL-1628 removed the retired module as consumer-free.
 
-**The chokepoint is not the only `worker.transition` emitter.** The daemon's `handleCommentWake`
-(CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two
-structurally distinct sites, both bypassing `recordTransition` but for different reasons:
-- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the
-  label, emits the clear, and redispatches the parked worker in the same block. Its own code comment
-  explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the
-  daemon removes the durable label out-of-band and redispatches — the scheduler never observes this
-  edge)."
-- The **escalation clear** runs once per comment-wake call, gated on positive human provenance
-  and a managed ticket, with **no redispatch** in that block. It bypasses `recordTransition` because
-  the scheduler's own escalation handling is STICKY-by-design (never clears it itself on a
-  steady-state admission pass, per the `recordTransition` suppression logic above) — the
-  "redispatches" half of the quoted rationale does not apply to this site.
+**The chokepoint is not the only `worker.transition` emitter.** The daemon's `handleCommentWake` (CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two structurally distinct sites, both bypassing `recordTransition` but for different reasons:
+- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the label, emits the clear, and redispatches the parked worker in the same block. Its own code comment explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon removes the durable label out-of-band and redispatches — the scheduler never observes this edge)."
+- The **escalation clear** runs once per comment-wake call, gated on positive human provenance and a managed ticket, with **no redispatch** in that block. It bypasses `recordTransition` because the scheduler's own escalation handling is STICKY-by-design (never clears it itself on a steady-state admission pass, per the `recordTransition` suppression logic above) — the "redispatches" half of the quoted rationale does not apply to this site.
 
 Both are deliberate, self-documented second-producer sites.
 
-**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's
-hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
-progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when
-`bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But
-it publishes the escalation via the shared guard (`label-guard.mjs`) and
-never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition`
-emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike
-the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream
-specifically, not an alternate producer. See "Two-axis worker state & the recordWorkerTransition
-chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
+**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when `bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But it publishes the escalation via the shared guard (`label-guard.mjs`) and never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition` emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream specifically, not an alternate producer. See "Two-axis worker state & the recordWorkerTransition chokepoint (CTL-764)" in `docs/architecture.md` for the live mechanism.
 
 **Two orthogonal axes (never blurred):**
 
-- **Axis 1 — Pipeline stage** (where the ticket is in the pipeline): Linear workflow Status, written
-  through the single `applyPhaseStatus` chokepoint.
-- **Axis 2 — Worker disposition** (how the worker is doing): **three** mutually exclusive values in
-  the `worker-status` label group (`queued`, `blocked`, `needs-input`).
+- **Axis 1 — Pipeline stage** (where the ticket is in the pipeline): Linear workflow Status, written through the single `applyPhaseStatus` chokepoint.
+- **Axis 2 — Worker disposition** (how the worker is doing): **three** mutually exclusive values in the `worker-status` label group (`queued`, `blocked`, `needs-input`).
 
-  ⛔ **CTL-2161 — the group went from FOUR members to THREE.** `needs-human` was the fourth. It is
-  deleted (CTL-2155 epic): measured across 86 items it flagged, 3 genuinely needed a person and 41
-  were the model provider being overloaded, escalated one ticket at a time. It is replaced by two
-  distinct paths, neither of which is a worker-disposition label — SYSTEM trouble raises ONE
-  fleet-scoped, auto-clearing alert (CTL-2156) with zero per-ticket artifacts, and a genuine human
-  question becomes ONE ask ticket carrying a `blocks` relation to the work it holds (CTL-2157). The
-  surviving three keep their meanings unchanged: they are all *worker* states, which is what the
-  axis is for; `needs-human` never was.
+⛔ **CTL-2161 — the group went from FOUR members to THREE.** `needs-human` was the fourth. It is deleted (CTL-2155 epic): measured across 86 items it flagged, 3 genuinely needed a person and 41 were the model provider being overloaded, escalated one ticket at a time. It is replaced by two distinct paths, neither of which is a worker-disposition label — SYSTEM trouble raises ONE fleet-scoped, auto-clearing alert (CTL-2156) with zero per-ticket artifacts, and a genuine human question becomes ONE ask ticket carrying a `blocks` relation to the work it holds (CTL-2157). The surviving three keep their meanings unchanged: they are all *worker* states, which is what the axis is for; `needs-human` never was.
 
-**Single-valued workspace group** — workspace scope (shared by CTL and ADV teams) ensures the label
-is always readable regardless of which team's ticket is in flight. Exclusive group enforces
-single-value; the daemon removes stale members before applying a new one.
+**Single-valued workspace group** — workspace scope (shared by CTL and ADV teams) ensures the label is always readable regardless of which team's ticket is in flight. Exclusive group enforces single-value; the daemon removes stale members before applying a new one.
 
-**Precedence** — `needs-input > blocked > queued > none`. All three are tick-converged (re-derived
-on diff each tick). The sticky, apply-once member (`needs-human`) is gone with CTL-2161; the
-`labelOnce` once-marker machinery survives it because five retry loops read its return value as
-their STOP condition and boot-resume reads the marker to suppress auto-resume of a chronically
-failing ticket (see CTL-2159).
+**Precedence** — `needs-input > blocked > queued > none`. All three are tick-converged (re-derived on diff each tick). The sticky, apply-once member (`needs-human`) is gone with CTL-2161; the `labelOnce` once-marker machinery survives it because five retry loops read its return value as their STOP condition and boot-resume reads the marker to suppress auto-resume of a chronically failing ticket (see CTL-2159).
 
-**Resolution-gated clearing.** The two confirmed-removal paths built for `needs-human` — (1)
-`clearStalledLabel`'s `onRemoved` callback at scheduler-side resolution points, and (2) the daemon's
-`handleCommentWake` clear on a managed ticket's confirmed human reply — remain in place for the
-surviving members and for clearing the label off tickets that still wear it during the CTL-2160
-migration. They are deliberately NOT deleted with the producers: deleting a clearer before the
-backlog is swept strands every ticket already carrying the label.
+**Resolution-gated clearing.** The two confirmed-removal paths built for `needs-human` — (1) `clearStalledLabel`'s `onRemoved` callback at scheduler-side resolution points, and (2) the daemon's `handleCommentWake` clear on a managed ticket's confirmed human reply — remain in place for the surviving members and for clearing the label off tickets that still wear it during the CTL-2160 migration. They are deliberately NOT deleted with the producers: deleting a clearer before the backlog is swept strands every ticket already carrying the label.
 
-**`waiting` → `queued` rename** — the prior `waiting` label was renamed to `queued` to align with
-the disposition vocabulary. Back-compat: legacy `waiting` labels map to `queued` in the HUD and
-`heldFor`. CTL-755 team-level `blocked`/`waiting` labels are superseded by the workspace group.
+**`waiting` → `queued` rename** — the prior `waiting` label was renamed to `queued` to align with the disposition vocabulary. Back-compat: legacy `waiting` labels map to `queued` in the HUD and `heldFor`. CTL-755 team-level `blocked`/`waiting` labels are superseded by the workspace group.
 
-**Rationale** — scattered label writes produced observable drift (an escalation in the event log but
-healthy in Linear, or vice versa). One chokepoint, one group, one canonical `worker.transition`
-event per genuine change eliminates the coordination problem without per-site reasoning.
+**Rationale** — scattered label writes produced observable drift (an escalation in the event log but healthy in Linear, or vice versa). One chokepoint, one group, one canonical `worker.transition` event per genuine change eliminates the coordination problem without per-site reasoning.
 
-**Alternatives considered** — per-site label writes (rejected: coordination problem persists);
-merged axes into a single status enum (rejected: pipeline stage and disposition are independent and
-both need independent observability); async `recordWorkerTransition` only (rejected: `schedulerTick`
-is sync; async would require a separate flush loop with new failure modes).
+**Alternatives considered** — per-site label writes (rejected: coordination problem persists); merged axes into a single status enum (rejected: pipeline stage and disposition are independent and both need independent observability); async `recordWorkerTransition` only (rejected: `schedulerTick` is sync; async would require a separate flush loop with new failure modes).
 
-**Consequences** — four sinks are **live** (Linear Status, label, event log, OTLP via otel-forward);
-all fail-open. No single transition reaches all four — each recordTransition call is either
-stage-only or disposition-only (`toDisposition === undefined` means "no disposition guard, always
-emit" for a pure stage move; omitting `toStage`/`fromStage` means no Linear-Status write for a pure
-disposition move), so a transition reaches at most three: a stage move touches Linear Status + event
-log + OTLP (skips the label sink); a disposition move touches the label + event log + OTLP (skips
-Linear Status) — e.g. the dependency-cycle escalation (`scheduler.mjs`) routes through the shared
-escalation guard (event log + OTLP) with no stage touched at all. Since CTL-2161 that path publishes
-an ASK ticket rather than a `needs-human` disposition. Only a call that sets both `toStage` and
-`toDisposition` together would reach all four. A fifth sink (an optional broker
-`ticket_state_transitions` table, CTL-764 Phase 10) was designed but never implemented — no schema,
-writer, or broker consumer exist for it. The HUD capacity header gains per-disposition buckets and
-triage is carved out of `maxParallel` counting. AGENTS.md / architecture.md carry the two-axis model
-as first-class concepts.
+**Consequences** — four sinks are **live** (Linear Status, label, event log, OTLP via otel-forward); all fail-open. No single transition reaches all four — each recordTransition call is either stage-only or disposition-only (`toDisposition === undefined` means "no disposition guard, always emit" for a pure stage move; omitting `toStage`/`fromStage` means no Linear-Status write for a pure disposition move), so a transition reaches at most three: a stage move touches Linear Status + event log + OTLP (skips the label sink); a disposition move touches the label + event log + OTLP (skips Linear Status) — e.g. the dependency-cycle escalation (`scheduler.mjs`) routes through the shared escalation guard (event log + OTLP) with no stage touched at all. Since CTL-2161 that path publishes an ASK ticket rather than a `needs-human` disposition. Only a call that sets both `toStage` and `toDisposition` together would reach all four. A fifth sink (an optional broker `ticket_state_transitions` table, CTL-764 Phase 10) was designed but never implemented — no schema, writer, or broker consumer exist for it. The HUD capacity header gains per-disposition buckets and triage is carved out of `maxParallel` counting. AGENTS.md / architecture.md carry the two-axis model as first-class concepts.
 
 ## ADR-027: Browser automation stays local — cloud browser backends rejected (2026-07-25)
 
-**Decision** — Catalyst's browser automation continues to run **local Chromium** via
-`agent-browser`'s default backend. A hosted browser provider (Browserbase, and by extension Kernel /
-Browserless-cloud / BrowserStack) is **not** adopted. Recorded because the proposal is superficially
-attractive and will otherwise be re-proposed.
+**Decision** — Catalyst's browser automation continues to run **local Chromium** via `agent-browser`'s default backend. A hosted browser provider (Browserbase, and by extension Kernel / Browserless-cloud / BrowserStack) is **not** adopted. Recorded because the proposal is superficially attractive and will otherwise be re-proposed.
 
-**Killer 1 — a cloud browser cannot reach a local dev server.** Every browser target Catalyst cares
-about is loopback or tailnet: `mini:7400` (orch-monitor SPA), `localhost:3000/4000/8080` (dev
-servers in worktrees), `127.0.0.1:<rand>` (gstack control plane). Browserbase ships **no tunnel** —
-no BrowserStack-Local / Sauce-Connect equivalent; verified as a documented absence across
-`docs.browserbase.com` (`llms.txt` index, `remote-browser-versus-local-browser`,
-`building-automated-tests`, `allowed-domains`), and stated affirmatively in
-`platform/browser/files/uploads`: the remote browser "can't access files on your local machine". The
-adjacent `platform/identity/vpn` feature runs the **opposite** direction (routes the cloud browser's
-_egress_ through a proxy you deploy) and validates proxies eagerly at session creation, so a
-local-only proxy fails the session outright. `agent-browser` ships no tunneling either — navigation
-executes as CDP `Page.navigate` **inside the remote container**, so `localhost` resolves there.
-Adopting a cloud backend is a capability deletion.
+**Killer 1 — a cloud browser cannot reach a local dev server.** Every browser target Catalyst cares about is loopback or tailnet: `mini:7400` (orch-monitor SPA), `localhost:3000/4000/8080` (dev servers in worktrees), `127.0.0.1:<rand>` (gstack control plane). Browserbase ships **no tunnel** — no BrowserStack-Local / Sauce-Connect equivalent; verified as a documented absence across `docs.browserbase.com` (`llms.txt` index, `remote-browser-versus-local-browser`, `building-automated-tests`, `allowed-domains`), and stated affirmatively in `platform/browser/files/uploads`: the remote browser "can't access files on your local machine". The adjacent `platform/identity/vpn` feature runs the **opposite** direction (routes the cloud browser's _egress_ through a proxy you deploy) and validates proxies eagerly at session creation, so a local-only proxy fails the session outright. `agent-browser` ships no tunneling either — navigation executes as CDP `Page.navigate` **inside the remote container**, so `localhost` resolves there. Adopting a cloud backend is a capability deletion.
 
-**Killer 2 — the stated motive was false.** The proposal's premise was relieving pressure from local
-headless Chromium. Measured live on 2026-07-25: **0 headless Chromium processes on mini and 0 on
-mini-2**; mini-2 has no browser binary installed at all and still swaps. No skill in
-`plugins/*/skills/` invokes `agent-browser` on the fleet — every fleet-side reference is
-provisioning (`install-cli.sh:242`, `check-setup.sh:106`), env injection
-(`phase-agent-dispatch:863,944`), or leak containment (`orphan-sweep.sh:779`). Actual memory
-pressure is exec-core (3.7–6 GB), orch-monitor (2.5 GB), an 826 MB monthly event log, and 101
-worktrees on mini. Offloading browsers reclaims ~0 MB of a 15 GB problem.
+**Killer 2 — the stated motive was false.** The proposal's premise was relieving pressure from local headless Chromium. Measured live on 2026-07-25: **0 headless Chromium processes on mini and 0 on mini-2**; mini-2 has no browser binary installed at all and still swaps. No skill in `plugins/*/skills/` invokes `agent-browser` on the fleet — every fleet-side reference is provisioning (`install-cli.sh:242`, `check-setup.sh:106`), env injection (`phase-agent-dispatch:863,944`), or leak containment (`orphan-sweep.sh:779`). Actual memory pressure is exec-core (3.7–6 GB), orch-monitor (2.5 GB), an 826 MB monthly event log, and 101 worktrees on mini. Offloading browsers reclaims ~0 MB of a 15 GB problem.
 
-**Do not solve Killer 1 with a reverse tunnel.** `orphan-sweep.sh` has five vectors and zero tunnel
-coverage, so a tunnel spawned in a `claude --bg` worker is a new unreapable orphan class — and a
-leaked tunnel is not a wasted process but persistent public ingress. Critically,
-`orch-monitor/server.ts:795` binds `0.0.0.0` with no auth across ~80 routes including actuation
-(`POST /api/ec-worker/<T>/stop`, `POST /api/ticket/<T>/respond` → re-dispatches an autonomous agent
-holding repo-write and PR-merge authority), and `/debug/heap-snapshot` (~server.ts:4632) is gated on
-`server.requestIP(req)?.address === 127.0.0.1`. Tunnel daemons dial the origin over loopback, so
-**every tunneled request presents as 127.0.0.1 and that gate fails open to the internet.** A tunnel
-converts the localhost trust boundary into a fail-open one. (The webhook routes are properly
-HMAC-verified with `timingSafeEqual`; the actuation routes are not.)
+**Do not solve Killer 1 with a reverse tunnel.** `orphan-sweep.sh` has five vectors and zero tunnel coverage, so a tunnel spawned in a `claude --bg` worker is a new unreapable orphan class — and a leaked tunnel is not a wasted process but persistent public ingress. Critically, `orch-monitor/server.ts:795` binds `0.0.0.0` with no auth across ~80 routes including actuation (`POST /api/ec-worker/<T>/stop`, `POST /api/ticket/<T>/respond` → re-dispatches an autonomous agent holding repo-write and PR-merge authority), and `/debug/heap-snapshot` (~server.ts:4632) is gated on `server.requestIP(req)?.address === 127.0.0.1`. Tunnel daemons dial the origin over loopback, so **every tunneled request presents as 127.0.0.1 and that gate fails open to the internet.** A tunnel converts the localhost trust boundary into a fail-open one. (The webhook routes are properly HMAC-verified with `timingSafeEqual`; the actuation routes are not.)
 
-**Cost inversion** — even inside the included tier, the economics fail on leak behavior, not price.
-A leaked session goes **free → metered**: CTL-1500's exact failure shape (worker dies, browser
-survives) costs $0 today and is reaped hourly; on a hosted provider it bills to the 6-hour session
-cap, and `orphan-sweep.sh` vector 5 cannot see — let alone reap — a remote session.
-`AGENT_BROWSER_IDLE_TIMEOUT_MS` becomes a billing floor stacked on the 1-minute session minimum
-rather than a safety net.
+**Cost inversion** — even inside the included tier, the economics fail on leak behavior, not price. A leaked session goes **free → metered**: CTL-1500's exact failure shape (worker dies, browser survives) costs $0 today and is reaped hourly; on a hosted provider it bills to the 6-hour session cap, and `orphan-sweep.sh` vector 5 cannot see — let alone reap — a remote session. `AGENT_BROWSER_IDLE_TIMEOUT_MS` becomes a billing floor stacked on the 1-minute session minimum rather than a safety net.
 
-**BrowserStack specifically is structurally incompatible**, independent of price. Its endpoint
-`wss://cdp.browserstack.com/playwright?caps=…` speaks Playwright's proprietary **server** protocol
-despite the `cdp.` hostname; `agent-browser` speaks **raw CDP** (`connectOverCDP`). Compounding:
-credentials must ride inside a URL-encoded caps JSON (no header auth), caps must carry a
-`client.playwrightVersion` matching the caller's bundled Playwright, and a **90-second idle
-timeout** would kill sessions during normal LLM reasoning pauses. Noted because BrowserStack Local
-is ironically the only mature localhost tunnel in the comparison — it solves the exact blocker, on
-the one vendor we cannot drive.
+**BrowserStack specifically is structurally incompatible**, independent of price. Its endpoint `wss://cdp.browserstack.com/playwright?caps=…` speaks Playwright's proprietary **server** protocol despite the `cdp.` hostname; `agent-browser` speaks **raw CDP** (`connectOverCDP`). Compounding: credentials must ride inside a URL-encoded caps JSON (no header auth), caps must carry a `client.playwrightVersion` matching the caller's bundled Playwright, and a **90-second idle timeout** would kill sessions during normal LLM reasoning pauses. Noted because BrowserStack Local is ironically the only mature localhost tunnel in the comparison — it solves the exact blocker, on the one vendor we cannot drive.
 
-**Alternatives considered** — _Kernel / Browser Use / AgentCore_: same localhost blocker.
-_Cloudflare Browser Rendering_: same, plus always bot-identified. _Browserless self-hosted_: viable
-on reachability but SSPL-1.0-or-commercial, a license decision plain Chrome sidesteps. **If browser
-consolidation is ever genuinely wanted**, the correct shape is plain headless Chrome on the `home`
-OTel box (100.65.193.30, Linux) + `agent-browser connect ws://<ip>:9222` — raw CDP, $0, no license
-question, and unlike any hosted provider it can reach `mini:7400`. Requires
-`--remote-debugging-address=0.0.0.0`, addressing by **IP not hostname** (Chrome host-header
-validation, CVE-2018-6101), and `--user-data-dir` on Chrome 136+. Note this yields _tailnet_
-reachability, not literal localhost: dev servers must bind `0.0.0.0`. Do not site it on mini.
+**Alternatives considered** — _Kernel / Browser Use / AgentCore_: same localhost blocker. _Cloudflare Browser Rendering_: same, plus always bot-identified. _Browserless self-hosted_: viable on reachability but SSPL-1.0-or-commercial, a license decision plain Chrome sidesteps. **If browser consolidation is ever genuinely wanted**, the correct shape is plain headless Chrome on the `home` OTel box (100.65.193.30, Linux) + `agent-browser connect ws://<ip>:9222` — raw CDP, $0, no license question, and unlike any hosted provider it can reach `mini:7400`. Requires `--remote-debugging-address=0.0.0.0`, addressing by **IP not hostname** (Chrome host-header validation, CVE-2018-6101), and `--user-data-dir` on Chrome 136+. Note this yields _tailnet_ reachability, not literal localhost: dev servers must bind `0.0.0.0`. Do not site it on mini.
 
-**Consequences** — no vendor dependency, no subscription, no new orphan class, and the localhost
-trust boundary is preserved. `orphan-sweep.sh` vector 5 remains the correct and sufficient
-containment for browser leaks. Revisit only if a _stated_ driver appears that local Chrome cannot
-serve — parallel session isolation, execution on non-Mac hosts, IP diversity, or stealth — and note
-that for stealth or persistent auth, Kernel (`KERNEL_STEALTH`, `KERNEL_PROFILE_NAME`) and
-Browserless (`BROWSERLESS_STEALTH`) expose knobs the Browserbase create path in `agent-browser` does
-not send at all.
+**Consequences** — no vendor dependency, no subscription, no new orphan class, and the localhost trust boundary is preserved. `orphan-sweep.sh` vector 5 remains the correct and sufficient containment for browser leaks. Revisit only if a _stated_ driver appears that local Chrome cannot serve — parallel session isolation, execution on non-Mac hosts, IP diversity, or stealth — and note that for stealth or persistent auth, Kernel (`KERNEL_STEALTH`, `KERNEL_PROFILE_NAME`) and Browserless (`BROWSERLESS_STEALTH`) expose knobs the Browserbase create path in `agent-browser` does not send at all.
 
-**Verification caveat** — provider internals were established against `agent-browser 0.27.2`
-(laptop); the fleet runs **0.32.4**. Re-verify binary-level claims (that the Browserbase create path
-sends no `projectId` / `keepAlive` / `browserSettings` / `advancedStealth`) against 0.32.4 before
-relying on them.
+**Verification caveat** — provider internals were established against `agent-browser 0.27.2` (laptop); the fleet runs **0.32.4**. Re-verify binary-level claims (that the Browserbase create path sends no `projectId` / `keepAlive` / `browserSettings` / `advancedStealth`) against 0.32.4 before relying on them.
 
-**Follow-up, independent of this decision** — the unauthenticated orch-monitor control plane on
-`0.0.0.0` is a standing finding, currently contained only by the tailnet perimeter. Untickted as of
-this ADR.
+**Follow-up, independent of this decision** — the unauthenticated orch-monitor control plane on `0.0.0.0` is a standing finding, currently contained only by the tailnet perimeter. Untickted as of this ADR.
 
 ## ADR-028: Catalyst self-hosts its CAT backlog via a separate fork clone (CAT-52)
 
-**Decision.** The CAT team is registered in `execution-core/registry.json`, allowing the fleet to
-work Catalyst's own self-healing findings. Its `repoRoot` is a **separate clone of the fork**
-(`thagale/catalyst`), never the live `plugin-source` checkout from which the fleet loads its
-plugins. This is CAT-52's option 2.
+**Decision.** The CAT team is registered in `execution-core/registry.json`, allowing the fleet to work Catalyst's own self-healing findings. Its `repoRoot` is a **separate clone of the fork** (`thagale/catalyst`), never the live `plugin-source` checkout from which the fleet loads its plugins. This is CAT-52's option 2.
 
-**Why not option 1** (register `plugin-source` itself): phase agents would edit the execution-core
-currently executing them, and `plugin-source` has no `/github/<owner>/<repo>` path segment, so
-`ownerRepoFromRepoRoot` cannot resolve it and board-health falls back to number-only ambiguous
-skips for CAT tickets.
+**Why not option 1** (register `plugin-source` itself): phase agents would edit the execution-core currently executing them, and `plugin-source` has no `/github/<owner>/<repo>` path segment, so `ownerRepoFromRepoRoot` cannot resolve it and board-health falls back to number-only ambiguous skips for CAT tickets.
 
-**Why not option 3** (exclude CAT and work it by hand): recovery-pass findings are routed into CAT
-so the system learns and recurring wedge classes disappear. A queue that only fills re-derives
-defects already filed and unread. No exclusion primitive exists and none is introduced here.
+**Why not option 3** (exclude CAT and work it by hand): recovery-pass findings are routed into CAT so the system learns and recurring wedge classes disappear. A queue that only fills re-derives defects already filed and unread. No exclusion primitive exists and none is introduced here.
 
 **A correct CAT `repoRoot` must satisfy all three:**
 
 1. It is a checkout of the fork (`thagale/catalyst`), whose main carries CAT-numbered history.
-2. Its Layer-1 `catalyst.linear.teamKey` is `CAT`, matching the registry schema's contract and the
-   warn-only enforcement added in CAT-52.
-3. Its path contains `/github/<owner>/<repo>` so `ownerRepoFromRepoRoot` resolves
-   `thagale/catalyst`. The canonical path is `~/code-repos/github/thagale/catalyst`.
+2. Its Layer-1 `catalyst.linear.teamKey` is `CAT`, matching the registry schema's contract and the warn-only enforcement added in CAT-52.
+3. Its path contains `/github/<owner>/<repo>` so `ownerRepoFromRepoRoot` resolves `thagale/catalyst`. The canonical path is `~/code-repos/github/thagale/catalyst`.
 
-**Deploy story.** Merged CAT pull requests land on `thagale/catalyst` main. Because
-`plugin-source`'s `origin` is that fork, the updater pulls those changes into the running plugins,
-closing the self-hosting loop.
+**Deploy story.** Merged CAT pull requests land on `thagale/catalyst` main. Because `plugin-source`'s `origin` is that fork, the updater pulls those changes into the running plugins, closing the self-hosting loop.
 
-**Consequences.** The registry's `team` ↔ `teamKey` contract is observable through a
-`registry.mjs` warning and the advisory `registry-team-identity` doctor check. A mismatched entry
-is still dispatched so a typo cannot silently stop fleet work. Nothing yet detects a Linear team
-with Todo work that is wholly absent from the registry; that requires a workspace-wide Linear team
-sweep and remains outside CAT-52. The `coalesce-labs/catalyst` clone remains the CTL project and
-keeps its `CTL` Layer-1 declaration; it is not a valid CAT `repoRoot`.
+**Consequences.** The registry's `team` ↔ `teamKey` contract is observable through a `registry.mjs` warning and the advisory `registry-team-identity` doctor check. A mismatched entry is still dispatched so a typo cannot silently stop fleet work. Nothing yet detects a Linear team with Todo work that is wholly absent from the registry; that requires a workspace-wide Linear team sweep and remains outside CAT-52. The `coalesce-labs/catalyst` clone remains the CTL project and keeps its `CTL` Layer-1 declaration; it is not a valid CAT `repoRoot`.
 
 ## ADR-029: The event–automation contract — Linear is the trigger, the lease is the lock (2026-08-13)
 
-**Decision.** Every side effect in the fleet belongs to a subscriber, not to the actor that caused
-it. A phase is a goal-loop: it works until its goal is met, posts one outcome, and stops — it does
-not advance the ticket, write Linear, or dispatch the next phase. The complete list of triggers,
-their bounded actions, and — for each — **which component refuses the second delivery** is ratified
-as `docs/event-automation-contract.md`. An 18-row automation table and a 33-row stage-transition
-lookup table (20 machine edges keyed on the holder's declaration, 13 human/foreign-agent intents
-keyed on `(class, to_state)`) are the contract; this entry is the decision, not the data.
+**Decision.** Every side effect in the fleet belongs to a subscriber, not to the actor that caused it. A phase is a goal-loop: it works until its goal is met, posts one outcome, and stops — it does not advance the ticket, write Linear, or dispatch the next phase. The complete list of triggers, their bounded actions, and — for each — **which component refuses the second delivery** is ratified as `docs/event-automation-contract.md`. An 18-row automation table and a 33-row stage-transition lookup table (20 machine edges keyed on the holder's declaration, 13 human/foreign-agent intents keyed on `(class, to_state)`) are the contract; this entry is the decision, not the data.
 
-**Linear is the trigger, never the lock.** A Linear stage change says "go look" and starts an
-automation. It is never asked to refuse anything, and no design may propose it as the exclusion
-point. The direct consequence is worked through rather than avoided: two hosts receiving the same
-stage-change webhook both pass the trigger, so the claim is acquired **after** the trigger and
-**before** any side effect, and exactly one wins. Linear is written **last**, as a mirror — which is
-what the code already does (`scheduler.mjs` advancement sweep: `dispatchAndVerify` → emit
-`phase.advance.applied` → reap predecessor → `applyPhaseStatus`, whose own comment reads "idempotent
-… never aborts the tick"). The ADR names the fact rather than contradicting it.
+**Linear is the trigger, never the lock.** A Linear stage change says "go look" and starts an automation. It is never asked to refuse anything, and no design may propose it as the exclusion point. The direct consequence is worked through rather than avoided: two hosts receiving the same stage-change webhook both pass the trigger, so the claim is acquired **after** the trigger and **before** any side effect, and exactly one wins. Linear is written **last**, as a mirror — which is what the code already does (`scheduler.mjs` advancement sweep: `dispatchAndVerify` → emit `phase.advance.applied` → reap predecessor → `applyPhaseStatus`, whose own comment reads "idempotent … never aborts the tick"). The ADR names the fact rather than contradicting it.
 
-**Machine edges are keyed on the declaration, not on `(from_state, to_state)`.** The phase→state map
-is many-to-one: `verify` and `review` both map to `Validate`, and `pr` / `monitor-merge` /
-`monitor-deploy` / `teardown` all map to `PR`, so four of the ten pipeline advances produce no
-observable Linear transition at all (measured on mini, 2026-08: 185 no-op same-state writes;
-`review` 48 of 49). A tuple lookup structurally cannot address those edges. Keying on
-`(declaration, phase)` dissolves the problem — and the transport is the one that works:
-intermediate-stage webhooks deliver at ~2–5% (replica 323 CTL transitions vs. 116 events,
-2026-08-01→13), while the local declaration append does not lose. The collapse itself is **kept**:
-it is a deliberate lossy projection of a value authoritative elsewhere, and widening it would
-re-couple board granularity to the pipeline across every saved view in the workspace.
+**Machine edges are keyed on the declaration, not on `(from_state, to_state)`.** The phase→state map is many-to-one: `verify` and `review` both map to `Validate`, and `pr` / `monitor-merge` / `monitor-deploy` / `teardown` all map to `PR`, so four of the ten pipeline advances produce no observable Linear transition at all (measured on mini, 2026-08: 185 no-op same-state writes; `review` 48 of 49). A tuple lookup structurally cannot address those edges. Keying on `(declaration, phase)` dissolves the problem — and the transport is the one that works: intermediate-stage webhooks deliver at ~2–5% (replica 323 CTL transitions vs. 116 events, 2026-08-01→13), while the local declaration append does not lose. The collapse itself is **kept**: it is a deliberate lossy projection of a value authoritative elsewhere, and widening it would re-couple board granularity to the pipeline across every saved view in the workspace.
 
-**Terminology.** The contract asks **"Who says no?"** — when the same trigger is delivered twice,
-which component refuses the second attempt. The phrase "exclusion store" is retired as unclear
-jargon. A cursored log redelivers after a crash (the reaper's boot replay does exactly this), so
-redelivery is normal operation and every row owes an answer. `git --ff-only`, `set -o noclobber`,
-GitHub's `--match-head-commit`, and a conditional write can refuse; a plain file write, an
-append-only log, and a Linear state field cannot. **The log declares; it cannot exclude.**
+**Terminology.** The contract asks **"Who says no?"** — when the same trigger is delivered twice, which component refuses the second attempt. The phrase "exclusion store" is retired as unclear jargon. A cursored log redelivers after a crash (the reaper's boot replay does exactly this), so redelivery is normal operation and every row owes an answer. `git --ff-only`, `set -o noclobber`, GitHub's `--match-head-commit`, and a conditional write can refuse; a plain file write, an append-only log, and a Linear state field cannot. **The log declares; it cannot exclude.**
 
-**Consequences.** Seven automation rows (2, 3, 5, 9, 11, 14, 15) have no cross-host refusal today
-and are blocked on lease work, not on event-substrate work; until then their refusal is host-local
-and graded as such. `phase.advance.applied` gets its first consumer (the Linear mirror write, row
-18), and the consumer-free `linear.state.write` emitter becomes deletable. Two reconcilers that do
-**not** exist must ship with the human-intent table: a replica-side sweep for lost INTENT commands
-(a lost kill leaves a worker burning), and anything that can re-derive "in a build stage with no
-live holder". The self-echo guard is demoted to defence-in-depth: it already discriminates on our
-own app-actor ids rather than on "is a bot" (`daemon.mjs:264-288`), which keeps other agents' Linear
-comments deliverable, but it fails open on an unknown id, so an echo record carries the weight.
+**Consequences.** Seven automation rows (2, 3, 5, 9, 11, 14, 15) have no cross-host refusal today and are blocked on lease work, not on event-substrate work; until then their refusal is host-local and graded as such. `phase.advance.applied` gets its first consumer (the Linear mirror write, row 18), and the consumer-free `linear.state.write` emitter becomes deletable. Two reconcilers that do **not** exist must ship with the human-intent table: a replica-side sweep for lost INTENT commands (a lost kill leaves a worker burning), and anything that can re-derive "in a build stage with no live holder". The self-echo guard is demoted to defence-in-depth: it already discriminates on our own app-actor ids rather than on "is a bot" (`daemon.mjs:264-288`), which keeps other agents' Linear comments deliverable, but it fails open on an unknown id, so an echo record carries the weight.
 
-**Citation hygiene.** The governing invariants are catalyst-cloud's **ADR-0027**
-(`catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md`, accepted
-2026-08-12). That is a **different repository's numbering** from this repo's **ADR-027** ("Browser
-automation stays local"), which is unrelated. Always cite the cloud ADR by repo + path, never by
-bare number.
+**Citation hygiene.** The governing invariants are catalyst-cloud's **ADR-0027** (`catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md`, accepted 2026-08-12). That is a **different repository's numbering** from this repo's **ADR-027** ("Browser automation stays local"), which is unrelated. Always cite the cloud ADR by repo + path, never by bare number.
 
-**Amendment, 2026-08-13 — the pipeline tail becomes subscribers, and human intent preempts.** The
-contract's §7a records seven rulings that extend this decision without changing it. **The tail
-collapses:** `monitor-merge`, `monitor-deploy` and `teardown` stop being phase agents — the pipeline
-goes **10 phases → 7**, with `pr` as the terminal — and their work moves to subscribers on
-`github.pr.merged` (447 delivered on mini in 2026-08, carrying `vcs.pr.number` and
-`body.payload.mergeCommitSha`), plus a per-repo deploy-watcher and a level-triggered reconciler. Two
-things must move _with_ the deletion, not after it: **Done** (teardown is today the sole originating
-authority — `scheduler.mjs:3675` fires only when `signals[TERMINAL_PHASE] === "done"` at `:8092`, so
-it is re-homed onto a done-writer whose evidence is the CTL-1667 PR-identity gate plus a live
-`gh pr view … MERGED` read, I6) and **BEHIND-rebase on an open PR** (today's only owner is the live
-monitor-merge agent; it becomes a demand-driven `fix_class:"rebase"`, never an eager sweep — an
-eager one reproduces the CTL-1704 Pages/re-review serialization incident by construction). **Human
-intent preempts:** any human or foreign state change on a ticket with a live worker alerts that
-worker, which wraps up, pushes WIP, posts a closure comment saying what it did and where it left it,
-and exits on `phase.<P>.abandoned.<T>` — a terminal `PHASE_EVENT_PATTERN` already routes
-(`namespace-contract.mjs:81-86`, CTL-1790), so the protocol needs **no** namespace change. **The
-departing worker does not decide what happens next; the new state does** — which retires this ADR's
-§9.1 open question ("a human sets Done on a live worker") by generalizing past it. **And the
-many-to-one collapse this ADR kept is precisely what makes the deletion free:** `pr`,
-`monitor-merge`, `monitor-deploy` and `teardown` all carry `linearKey: "inReview"` → `PR`
-(`workflow.default.json:65-68`, verified), so the ticket sits in `PR` until `Done` either way and
-the board loses nothing. Ryan explicitly **considered and rejected** adding `Review` and `Merge`
-Linear states — he proposed them, was shown this ADR's rationale (widening re-couples board
-granularity to the pipeline across nine teams' saved views), and reversed. **No new Linear states.**
-`Ready` is archived (21 `issue_history` transitions workspace-wide, zero live occupants). Full
-design, re-homing table, preempt failure modes and quantified deletion:
-`docs/event-automation-contract.md` §7a.
+**Amendment, 2026-08-13 — the pipeline tail becomes subscribers, and human intent preempts.** The contract's §7a records seven rulings that extend this decision without changing it. **The tail collapses:** `monitor-merge`, `monitor-deploy` and `teardown` stop being phase agents — the pipeline goes **10 phases → 7**, with `pr` as the terminal — and their work moves to subscribers on `github.pr.merged` (447 delivered on mini in 2026-08, carrying `vcs.pr.number` and `body.payload.mergeCommitSha`), plus a per-repo deploy-watcher and a level-triggered reconciler. Two things must move _with_ the deletion, not after it: **Done** (teardown is today the sole originating authority — `scheduler.mjs:3675` fires only when `signals[TERMINAL_PHASE] === "done"` at `:8092`, so it is re-homed onto a done-writer whose evidence is the CTL-1667 PR-identity gate plus a live `gh pr view … MERGED` read, I6) and **BEHIND-rebase on an open PR** (today's only owner is the live monitor-merge agent; it becomes a demand-driven `fix_class:"rebase"`, never an eager sweep — an eager one reproduces the CTL-1704 Pages/re-review serialization incident by construction). **Human intent preempts:** any human or foreign state change on a ticket with a live worker alerts that worker, which wraps up, pushes WIP, posts a closure comment saying what it did and where it left it, and exits on `phase.<P>.abandoned.<T>` — a terminal `PHASE_EVENT_PATTERN` already routes (`namespace-contract.mjs:81-86`, CTL-1790), so the protocol needs **no** namespace change. **The departing worker does not decide what happens next; the new state does** — which retires this ADR's §9.1 open question ("a human sets Done on a live worker") by generalizing past it. **And the many-to-one collapse this ADR kept is precisely what makes the deletion free:** `pr`, `monitor-merge`, `monitor-deploy` and `teardown` all carry `linearKey: "inReview"` → `PR` (`workflow.default.json:65-68`, verified), so the ticket sits in `PR` until `Done` either way and the board loses nothing. Ryan explicitly **considered and rejected** adding `Review` and `Merge` Linear states — he proposed them, was shown this ADR's rationale (widening re-couples board granularity to the pipeline across nine teams' saved views), and reversed. **No new Linear states.** `Ready` is archived (21 `issue_history` transitions workspace-wide, zero live occupants). Full design, re-homing table, preempt failure modes and quantified deletion: `docs/event-automation-contract.md` §7a.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,44 +1,24 @@
 # Architecture
 
-For the local Linear writer, freshness gate, read tiers, configuration order, and health signals,
-see [Linear read replica](linear-replica.md).
+For the local Linear writer, freshness gate, read tiers, configuration order, and health signals, see [Linear read replica](linear-replica.md).
 
 ## Three-Layer System
 
-1. **Plugin Source** (`plugins/dev/`, `plugins/meta/`, `plugins/playground/pm/`, `plugins/legacy/`, …) —
-   canonical agent/skill definitions; edit these.
-2. **Installation Layer** — `.claude/` (symlinks Claude Code reads plugins from) + `.catalyst/`
-   (workflow state: `config.json`, `.workflow-context.json`).
-3. **Thoughts System** — external git-backed context at `~/thoughts/`, shared across worktrees,
-   initialized per-project via `init-project.sh`.
+1. **Plugin Source** (`plugins/dev/`, `plugins/meta/`, `plugins/playground/pm/`, `plugins/legacy/`, …) — canonical agent/skill definitions; edit these.
+2. **Installation Layer** — `.claude/` (symlinks Claude Code reads plugins from) + `.catalyst/` (workflow state: `config.json`, `.workflow-context.json`).
+3. **Thoughts System** — external git-backed context at `~/thoughts/`, shared across worktrees, initialized per-project via `init-project.sh`.
 
 ## Multi-Target Packaging (CTL-1463)
 
-Each plugin's canonical identity/distribution metadata lives in a hand-authored `pack.json`
-(`plugins/<name>/pack.json`) — everything except the version, which stays exclusively owned by
-Release Please via each target's `plugin.json` `extra-files` jsonpath (see `docs/releases.md`).
-`scripts/packaging/cli.mjs render --target <claude|codex|agentsSkills> --write` compiles that
-manifest through a provisional source provider (behind a seam CTL-1461 replaces wholesale) into
-three targets: Claude (`.claude-plugin/`, byte-exact regeneration of the existing tree), Codex
-(`.codex-plugin/` + `.agents/plugins/marketplace.json`), and a plain `.agents/skills/` bundle for
-skills whose `pack.json` opts them into a neutral (vendor-independent) classification. A two-tier
-loss classifier omits anything safety-relevant that isn't classified and warns on everything else —
-see the full model, the seam contract, and the day-one scope in
-`docs/specs/accepted/vendor-neutral-packaging/spec.md`.
+Each plugin's canonical identity/distribution metadata lives in a hand-authored `pack.json` (`plugins/<name>/pack.json`) — everything except the version, which stays exclusively owned by Release Please via each target's `plugin.json` `extra-files` jsonpath (see `docs/releases.md`). `scripts/packaging/cli.mjs render --target <claude|codex|agentsSkills> --write` compiles that manifest through a provisional source provider (behind a seam CTL-1461 replaces wholesale) into three targets: Claude (`.claude-plugin/`, byte-exact regeneration of the existing tree), Codex (`.codex-plugin/` + `.agents/plugins/marketplace.json`), and a plain `.agents/skills/` bundle for skills whose `pack.json` opts them into a neutral (vendor-independent) classification. A two-tier loss classifier omits anything safety-relevant that isn't classified and warns on everything else — see the full model, the seam contract, and the day-one scope in `docs/specs/accepted/vendor-neutral-packaging/spec.md`.
 
 ## Memory & Workflow State
 
 Three memory layers manage context across projects:
 
-1. **Project config** (`.catalyst/config.json`, committable) — ticket prefix, Linear team, etc.
-   HumanLayer maps cwd → profile via `repoMappings`.
-2. **Long-term memory** — HumanLayer thoughts repo (git-backed, synced via
-   `humanlayer thoughts sync`): `shared/research/`, `shared/plans/`, `shared/prs/`,
-   `shared/handoffs/`.
-3. **Short-term memory** (`.catalyst/.workflow-context.json`, per-worktree, not committed) —
-   pointers to recent docs enabling skill chaining:
-   `/research-codebase`→`/create-plan`→`/implement-plan`, `/create-handoff`→`/resume-handoff`.
-   Auto-updated by workflow skills.
+1. **Project config** (`.catalyst/config.json`, committable) — ticket prefix, Linear team, etc. HumanLayer maps cwd → profile via `repoMappings`.
+2. **Long-term memory** — HumanLayer thoughts repo (git-backed, synced via `humanlayer thoughts sync`): `shared/research/`, `shared/plans/`, `shared/prs/`, `shared/handoffs/`.
+3. **Short-term memory** (`.catalyst/.workflow-context.json`, per-worktree, not committed) — pointers to recent docs enabling skill chaining: `/research-codebase`→`/create-plan`→`/implement-plan`, `/create-handoff`→`/resume-handoff`. Auto-updated by workflow skills.
 
 ```
 .catalyst/config.json              <- project config (committable)
@@ -48,38 +28,18 @@ Three memory layers manage context across projects:
 .catalyst/.workflow-context.json   <- short-term (session pointers)
 ```
 
-`.workflow-context.json` structure:
-`{lastUpdated, currentTicket, orchestration, mostRecentDocument:{type,path,created,ticket}, workflow:{research[],plans[],handoffs[],prs[]}}`.
+`.workflow-context.json` structure: `{lastUpdated, currentTicket, orchestration, mostRecentDocument:{type,path,created,ticket}, workflow:{research[],plans[],handoffs[],prs[]}}`.
 
 ## Global Orchestrator State
 
-Cross-orchestrator visibility lives at `~/catalyst/state.json` — a single lock-protected JSON file
-all orchestrators/workers write via `catalyst-state.sh`. It is a **denormalized summary**;
-per-orchestrator local state in worktrees stays the source of truth for crash recovery (ADR-006).
+Cross-orchestrator visibility lives at `~/catalyst/state.json` — a single lock-protected JSON file all orchestrators/workers write via `catalyst-state.sh`. It is a **denormalized summary**; per-orchestrator local state in worktrees stays the source of truth for crash recovery (ADR-006).
 
-**Liveness (audited CTL-1791, 2026-08-11).** `state.json` is written by the **legacy-wave** path
-only; the execution-core daemon writes none of it, so on an execution-core host the file is
-routinely **absent** (measured: no `~/catalyst/state.json`, `catalyst.db.orchestrators` = 0 rows).
-Absence is therefore not evidence the machinery is dead. `catalyst-state.sh` is nonetheless **not**
-removable, because it retains live callers in two places:
+**Liveness (audited CTL-1791, 2026-08-11).** `state.json` is written by the **legacy-wave** path only; the execution-core daemon writes none of it, so on an execution-core host the file is routinely **absent** (measured: no `~/catalyst/state.json`, `catalyst.db.orchestrators` = 0 rows). Absence is therefore not evidence the machinery is dead. `catalyst-state.sh` is nonetheless **not** removable, because it retains live callers in two places:
 
-1. **The legacy-wave path** — its coordinator `plugins/legacy/skills/orchestrate/SKILL.md`
-   (`ensure-run-dir`, `register`, `update`, `worker`, `heartbeat`, `attention`, `resolve-attention`,
-   `archive`, `event`) together with the `/oneshot` worker it dispatches under
-   `dispatchMode: "oneshot-legacy"` (`plugins/legacy/skills/oneshot/SKILL.md`: `event`, `worker`,
-   `attention`). These are **one path, not two modes**: `oneshot-legacy` is a worker-dispatch
-   strategy the wave coordinator selects, and those `worker`/`attention` calls are the worker half
-   of that same path. (Standalone `/oneshot` as a direct single-ticket lifecycle is documented
-   separately and is not a second orchestration mode.)
-2. **Standalone/helper tooling** outside the legacy plugin — `setup-orchestrator.sh` (`init`,
-   `ensure-run-dir`), `emit-worker-status-change.sh`, `compound-log.sh`, `orchestrate-roll-usage.sh`,
-   `orchestrate-status.sh`, and the `orchestrate-*` helper family, with `install-cli.sh` /
-   `check-setup.sh` installing and verifying it as the `catalyst-state` CLI.
+1. **The legacy-wave path** — its coordinator `plugins/legacy/skills/orchestrate/SKILL.md` (`ensure-run-dir`, `register`, `update`, `worker`, `heartbeat`, `attention`, `resolve-attention`, `archive`, `event`) together with the `/oneshot` worker it dispatches under `dispatchMode: "oneshot-legacy"` (`plugins/legacy/skills/oneshot/SKILL.md`: `event`, `worker`, `attention`). These are **one path, not two modes**: `oneshot-legacy` is a worker-dispatch strategy the wave coordinator selects, and those `worker`/`attention` calls are the worker half of that same path. (Standalone `/oneshot` as a direct single-ticket lifecycle is documented separately and is not a second orchestration mode.)
+2. **Standalone/helper tooling** outside the legacy plugin — `setup-orchestrator.sh` (`init`, `ensure-run-dir`), `emit-worker-status-change.sh`, `compound-log.sh`, `orchestrate-roll-usage.sh`, `orchestrate-status.sh`, and the `orchestrate-*` helper family, with `install-cli.sh` / `check-setup.sh` installing and verifying it as the `catalyst-state` CLI.
 
-Those two are what "retains live callers" means here — **execution-core is not one of them**: a
-search of `plugins/dev/scripts/execution-core` finds no `catalyst-state.sh` invocation at all
-(0 files; positive control — the same search over `plugins/legacy` returns 2). Read this paragraph as
-evidence about `catalyst-state.sh`'s **callers**, not as an execution-core dependency.
+Those two are what "retains live callers" means here — **execution-core is not one of them**: a search of `plugins/dev/scripts/execution-core` finds no `catalyst-state.sh` invocation at all (0 files; positive control — the same search over `plugins/legacy` returns 2). Read this paragraph as evidence about `catalyst-state.sh`'s **callers**, not as an execution-core dependency.
 
 ```
 ~/catalyst/
@@ -91,396 +51,67 @@ evidence about `catalyst-state.sh`'s **callers**, not as an execution-core depen
 └── wt/                     # worktrees
 ```
 
-- **catalyst.db** — durable session source of truth (solo + orchestrated). Managed by
-  `catalyst-db.sh` (CRUD/migrations) and `catalyst-session.sh` (lifecycle CLI). Tables: `sessions`,
-  `session_events`, `session_metrics`, `session_tools`, `session_prs`, `schema_migrations`. WAL mode
-  → concurrent readers (incl. `orch-monitor`). Schema: `plugins/dev/scripts/db-migrations/`.
-  ADR-008. `catalyst-state.sh` still writes JSON/JSONL during the migration period for backward
-  compatibility, so SQLite and the JSONL log coexist. **Row counts are not a liveness signal**
-  (audited CTL-1791): `session_metrics` / `session_tools` / `session_prs` measure **0 rows** on the
-  execution-core fleet while `sessions` holds 960 — the `catalyst-session.sh metric|tool|pr` writers
-  are simply never reached by the phase-agent dispatch path, not absent. All three tables keep live
-  readers that a `DROP` breaks with `no such table`: `catalyst-session.sh read`/`history`/`stats`/
-  `compare`, orch-monitor's `board-data.mjs` (per-ticket and per-phase cost rollups),
-  `history-store.ts`, `session-store.ts`, `ticket-runs.mjs`, and `ticket-retro/gather-retro.sh` —
-  and `check-setup.sh` grades all three in its 5-table `core_tables` gate.
-- **state.json** — active-orchestrator registry (progress, worker status, attention items). Schema:
-  `plugins/dev/templates/global-state.json`.
-- **events/** — every phase transition, PR creation, verification result, attention item. Schema:
-  `plugins/dev/scripts/lib/event-envelope.mjs` (CTL-1819) — an executable, measured contract
-  validated at the read boundary, counting violations without ever throwing. It replaced
-  `plugins/dev/templates/global-event.json`, a draft-07 file cited here and in `docs/adrs.md` as the
-  contract for the life of the project which **passed ZERO live events** (the denominator lives in
-  the module header — it grows) and was imported by no code; that file is deleted. Multiple writers, **four** envelope shapes coexisting — v1, v2,
-  their dual superset, and v3 `name`. ⚠️ **The census lives in ONE place: the module's own header.**
-  It is a volatile measurement (the log grows), and duplicating it here is what made three separate
-  review rounds spend their time reconciling copies that had drifted apart. Read the counts, the
-  frozen-snapshot methodology, and the positive controls there rather than from a restatement:
+- **catalyst.db** — durable session source of truth (solo + orchestrated). Managed by `catalyst-db.sh` (CRUD/migrations) and `catalyst-session.sh` (lifecycle CLI). Tables: `sessions`, `session_events`, `session_metrics`, `session_tools`, `session_prs`, `schema_migrations`. WAL mode → concurrent readers (incl. `orch-monitor`). Schema: `plugins/dev/scripts/db-migrations/`. ADR-008. `catalyst-state.sh` still writes JSON/JSONL during the migration period for backward compatibility, so SQLite and the JSONL log coexist. **Row counts are not a liveness signal** (audited CTL-1791): `session_metrics` / `session_tools` / `session_prs` measure **0 rows** on the execution-core fleet while `sessions` holds 960 — the `catalyst-session.sh metric|tool|pr` writers are simply never reached by the phase-agent dispatch path, not absent. All three tables keep live readers that a `DROP` breaks with `no such table`: `catalyst-session.sh read`/`history`/`stats`/ `compare`, orch-monitor's `board-data.mjs` (per-ticket and per-phase cost rollups), `history-store.ts`, `session-store.ts`, `ticket-runs.mjs`, and `ticket-retro/gather-retro.sh` — and `check-setup.sh` grades all three in its 5-table `core_tables` gate.
+- **state.json** — active-orchestrator registry (progress, worker status, attention items). Schema: `plugins/dev/templates/global-state.json`.
+- **events/** — every phase transition, PR creation, verification result, attention item. Schema: `plugins/dev/scripts/lib/event-envelope.mjs` (CTL-1819) — an executable, measured contract validated at the read boundary, counting violations without ever throwing. It replaced `plugins/dev/templates/global-event.json`, a draft-07 file cited here and in `docs/adrs.md` as the contract for the life of the project which **passed ZERO live events** (the denominator lives in the module header — it grows) and was imported by no code; that file is deleted. Multiple writers, **four** envelope shapes coexisting — v1, v2, their dual superset, and v3 `name`. ⚠️ **The census lives in ONE place: the module's own header.** It is a volatile measurement (the log grows), and duplicating it here is what made three separate review rounds spend their time reconciling copies that had drifted apart. Read the counts, the frozen-snapshot methodology, and the positive controls there rather than from a restatement:
   - **v1** (bash, `catalyst-state.sh event`): `{ts, event, orchestrator, worker, detail}`.
-  - **v2 OTel** (`plugins/dev/scripts/orch-monitor/lib/webhook-events.ts` for `github.*`/`linear.*`;
-    `catalyst-comms send` for `comms.message.posted`): `{ts, attributes, body, resource}`.
-  - **v3 bare-name** — `{ts, name, …flat payload}` (e.g. `phase.rescue.*`,
-    `phase.orphan-pr.detected.*`, `ticket.completion.declared.*`). Live
-    and accepted, not legacy residue: CTL-1834 records **three separate v3 producers each discovered
-    and fixed reactively, one at a time, after their events had already been lost** — which is why
-    `lib/event-name.mjs` resolves it and this contract validates it.
-  - **Superset (CTL-1795, phase 1)** — every v1 emit site now writes ONE line carrying BOTH the
-    top-level `event` and a full v2 `attributes`/`body`/`resource` block, built through the shared
-    builders `execution-core/lib/canonical-event.mjs` (`buildDualEnvelopeLine`) and
-    `lib/canonical-event.sh` (`canonical_dual_envelope_line`). Measured motivation: 159,009 v1
-    events across **31 distinct names** in 2026-08 were invisible to any consumer reading
-    `attributes["event.name"]`. It is **one** line, not two: a v1 line plus a v2 twin would be
-    routed twice, double-applying `handleAgentCheckin`'s `upsertAgent`/`_autoRegisterPrLifecycle`.
-    Key **order** within that one line is a separate question and this paragraph used to conflate
-    them — a single dual line resolves to one name and routes once under *any* ordering.
-    Measured by CTL-1834 across every log file ever written **as of that ticket** (4,034,067
-    parsed lines), all **322** dual lines — a historical figure, deliberately left as CTL-1834
-    recorded it; the current count lives in `lib/event-envelope.mjs`'s header and is larger, because
-    dual emission began with CTL-1795 phase 1 and is still accumulating. All
-    carry identical values in both keys and disagreement is not constructible on the dual path
-    (`canonical_dual_envelope_line` reads `name` from `.event` and passes that same string to
-    `--event-name`), so order is unobservable. The boundary
-    (`lib/event-name.mjs`, CTL-1834 — see "The one event-name boundary" below) reads `event`
-    first because that is what shipped, not because routing depends on it. Flat
-    fields are promoted to attributes by the same map otel-forward's `normalizeFlatEvent` uses, so
-    the OTLP attribute set is unchanged; unmapped fields land in `body.payload`; every v1 key also
-    survives verbatim. Phase 1 is **additive** — removing v1 emission and narrowing
-    `catalyst-events tail`/`wait-for` to v2 is an explicit follow-up one release later.
-  - **Declared asymmetry (jq-less hosts).** The bash v2 builder is a jq program, so two bash
-    fallbacks — `catalyst-state.sh`'s jq-less branch and `emit-worker-status-change.sh`'s
-    missing-`$STATE_SCRIPT` branch, both of which exist *because* the canonical path is
-    unavailable — emit v1 only; no jq-free JSON assembler is written for them. Same posture as the
-    jq-less deployment-mode resolver above: the divergence is made observable rather than silent,
-    via a `CATALYST_EVENT_ENVELOPE_V1_ONLY` breadcrumb plus one stderr line per process
-    (`canonical_note_v1_only`) — stderr because a separate CLI process cannot hand an exported var
-    back, and because it rides the Alloy-shipped daemon `.log` rather than the event log whose
-    degradation it reports.
-  - **One write(2) per bash append (CTL-1809).** Every bash producer appends through the single
-    seam `canonical_atomic_append_line` (`lib/canonical-event.sh`), which pipes the line through
-    `/bin/dd obs=1048576` — dd accumulates the whole line into one output block and issues exactly
-    one `write(2)` up to 1 MiB (`0+1 records out` for a 256 KiB input at `obs=1m`, vs `4+1` at
-    `obs=64k`). The replaced `printf '%s\n' … >>` is NOT atomic: `O_APPEND` makes the file *offset*
-    atomic, not a multi-`write(2)` sequence, and bash's builtin printf flushes through stdio in
-    BUFSIZ chunks (1024 on macOS, 8192 on glibc), so a line past BUFSIZ is ⌈n/BUFSIZ⌉ writes and a
-    concurrent producer's append lands between them. Measured with
-    `__tests__/event-append-atomicity.test.sh` case 3 (the same 8-producer × 150-line harness run
-    through the naive `printf >>`), over 20 runs on two hosts — a 12-core M2 laptop (macOS 26.5,
-    bash 5.3) and a 10-core Mac mini (macOS 26.6, bash 3.2): **28–134 of 1,200** lines damaged at
-    1,025 B and **165–523 of 1,200** at 19,086 B. Those are ranges, not point values — the count
-    is load- and host-dependent and swung ~5× run to run on one host, so it is not a regression
-    threshold. What reproduces is the direction: the 19 KB line tore more often than the 1 KB line
-    in 20 of 20 runs (2.6–7.2×). Under the CTL-1795 superset envelope
-    a large share of one bash producer's lines already sits past the 1,024 B macOS threshold, so
-    this was latent, not theoretical. Measured on mini's `2026-08.jsonl` (through 2026-08-13):
-    `catalyst.phase-agent` n=671, mean 1,094 B, median 1,021 B, max 2,870 B — **40.8% of its lines
-    exceed 1,024 B**; `catalyst.worktree-salvage` n=4,891, mean 910 B, median 900 B, max 1,216 B —
-    1.9% exceed it. Note neither *median* clears the threshold (phase-agent's sits 3 bytes under
-    it); the exposure is the upper tail, not the typical line, and the mean is above the median in
-    both because that tail is what drags it there.
-    `/bin/dd` is absolute because a restricted-`PATH` phase-agent worker is exactly where a
-    PATH-resolved helper becomes a silent no-op; there is deliberately no size branch and no
-    printf fallback in the primitive. **Hard cap 262,144 bytes** (byte length, 4.2× the observed
-    all-time fleet max of 62,597 B, inside dd's proven-atomic range): over it, the write is
-    REFUSED — never truncated or split — with a stderr WARNING carrying the size and event name,
-    plus a `catalyst.event.oversized` tombstone appended in-band. The tombstone carries its **own**
-    name, never the dropped event's: re-emitting the original name with a gutted payload would fire
-    that event's `wait-for` subscribers and the broker's phase-lifecycle router on fabricated
-    content. The **JS** writers are untouched — `appendFileSync` is already atomic far past this cap.
-    Seven bash sites converge on the seam (`canonical_jsonl_append`, `catalyst-state.sh`'s jq-less
-    branch, `emit-worker-status-change.sh`, `lib/emit-reap-intent.sh`, `lib/phase-emit-complete.sh`,
-    `catalyst-events`'s `wait.*` emitter, and `catalyst-stack`'s `_emit_checkout_updated` — the last
-    a whole-function stdout redirect rather than a `printf`, which is why it is the easiest to miss).
-    The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud**
-    one; `__tests__/event-append-atomicity.test.sh` scans for any silent raw append and recognizes
-    the exemption only by that warning.
-  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at the
-    readers listed below. This is a LIST OF THE COVERED SITES, not a census of every reader of the
-    log — read it as "these are instrumented", never as "these are all of them":
-    `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`), `execution-core/event-tail.mjs`
-    (`tornLineCount()`), `broker/tailer.mjs`'s **live** tail, `execution-core/monitor.mjs`'s
-    **live** `readNewEvents`, and `catalyst-events`' filter (`torn_lines_total` on stderr).
-    (`grep -n 'noteTornLine' plugins/dev/scripts` is the instrument that enumerates the JS half;
-    the count it returns is the number to trust, not this sentence.)
+  - **v2 OTel** (`plugins/dev/scripts/orch-monitor/lib/webhook-events.ts` for `github.*`/`linear.*`; `catalyst-comms send` for `comms.message.posted`): `{ts, attributes, body, resource}`.
+  - **v3 bare-name** — `{ts, name, …flat payload}` (e.g. `phase.rescue.*`, `phase.orphan-pr.detected.*`, `ticket.completion.declared.*`). Live and accepted, not legacy residue: CTL-1834 records **three separate v3 producers each discovered and fixed reactively, one at a time, after their events had already been lost** — which is why `lib/event-name.mjs` resolves it and this contract validates it.
+  - **Superset (CTL-1795, phase 1)** — every v1 emit site now writes ONE line carrying BOTH the top-level `event` and a full v2 `attributes`/`body`/`resource` block, built through the shared builders `execution-core/lib/canonical-event.mjs` (`buildDualEnvelopeLine`) and `lib/canonical-event.sh` (`canonical_dual_envelope_line`). Measured motivation: 159,009 v1 events across **31 distinct names** in 2026-08 were invisible to any consumer reading `attributes["event.name"]`. It is **one** line, not two: a v1 line plus a v2 twin would be routed twice, double-applying `handleAgentCheckin`'s `upsertAgent`/`_autoRegisterPrLifecycle`. Key **order** within that one line is a separate question and this paragraph used to conflate them — a single dual line resolves to one name and routes once under *any* ordering. Measured by CTL-1834 across every log file ever written **as of that ticket** (4,034,067 parsed lines), all **322** dual lines — a historical figure, deliberately left as CTL-1834 recorded it; the current count lives in `lib/event-envelope.mjs`'s header and is larger, because dual emission began with CTL-1795 phase 1 and is still accumulating. All carry identical values in both keys and disagreement is not constructible on the dual path (`canonical_dual_envelope_line` reads `name` from `.event` and passes that same string to `--event-name`), so order is unobservable. The boundary (`lib/event-name.mjs`, CTL-1834 — see "The one event-name boundary" below) reads `event` first because that is what shipped, not because routing depends on it. Flat fields are promoted to attributes by the same map otel-forward's `normalizeFlatEvent` uses, so the OTLP attribute set is unchanged; unmapped fields land in `body.payload`; every v1 key also survives verbatim. Phase 1 is **additive** — removing v1 emission and narrowing `catalyst-events tail`/`wait-for` to v2 is an explicit follow-up one release later.
+  - **Declared asymmetry (jq-less hosts).** The bash v2 builder is a jq program, so two bash fallbacks — `catalyst-state.sh`'s jq-less branch and `emit-worker-status-change.sh`'s missing-`$STATE_SCRIPT` branch, both of which exist *because* the canonical path is unavailable — emit v1 only; no jq-free JSON assembler is written for them. Same posture as the jq-less deployment-mode resolver above: the divergence is made observable rather than silent, via a `CATALYST_EVENT_ENVELOPE_V1_ONLY` breadcrumb plus one stderr line per process (`canonical_note_v1_only`) — stderr because a separate CLI process cannot hand an exported var back, and because it rides the Alloy-shipped daemon `.log` rather than the event log whose degradation it reports.
+  - **One write(2) per bash append (CTL-1809).** Every bash producer appends through the single seam `canonical_atomic_append_line` (`lib/canonical-event.sh`), which pipes the line through `/bin/dd obs=1048576` — dd accumulates the whole line into one output block and issues exactly one `write(2)` up to 1 MiB (`0+1 records out` for a 256 KiB input at `obs=1m`, vs `4+1` at `obs=64k`). The replaced `printf '%s\n' … >>` is NOT atomic: `O_APPEND` makes the file *offset* atomic, not a multi-`write(2)` sequence, and bash's builtin printf flushes through stdio in BUFSIZ chunks (1024 on macOS, 8192 on glibc), so a line past BUFSIZ is ⌈n/BUFSIZ⌉ writes and a concurrent producer's append lands between them. Measured with `__tests__/event-append-atomicity.test.sh` case 3 (the same 8-producer × 150-line harness run through the naive `printf >>`), over 20 runs on two hosts — a 12-core M2 laptop (macOS 26.5, bash 5.3) and a 10-core Mac mini (macOS 26.6, bash 3.2): **28–134 of 1,200** lines damaged at 1,025 B and **165–523 of 1,200** at 19,086 B. Those are ranges, not point values — the count is load- and host-dependent and swung ~5× run to run on one host, so it is not a regression threshold. What reproduces is the direction: the 19 KB line tore more often than the 1 KB line in 20 of 20 runs (2.6–7.2×). Under the CTL-1795 superset envelope a large share of one bash producer's lines already sits past the 1,024 B macOS threshold, so this was latent, not theoretical. Measured on mini's `2026-08.jsonl` (through 2026-08-13): `catalyst.phase-agent` n=671, mean 1,094 B, median 1,021 B, max 2,870 B — **40.8% of its lines exceed 1,024 B**; `catalyst.worktree-salvage` n=4,891, mean 910 B, median 900 B, max 1,216 B — 1.9% exceed it. Note neither *median* clears the threshold (phase-agent's sits 3 bytes under it); the exposure is the upper tail, not the typical line, and the mean is above the median in both because that tail is what drags it there. `/bin/dd` is absolute because a restricted-`PATH` phase-agent worker is exactly where a PATH-resolved helper becomes a silent no-op; there is deliberately no size branch and no printf fallback in the primitive. **Hard cap 262,144 bytes** (byte length, 4.2× the observed all-time fleet max of 62,597 B, inside dd's proven-atomic range): over it, the write is REFUSED — never truncated or split — with a stderr WARNING carrying the size and event name, plus a `catalyst.event.oversized` tombstone appended in-band. The tombstone carries its **own** name, never the dropped event's: re-emitting the original name with a gutted payload would fire that event's `wait-for` subscribers and the broker's phase-lifecycle router on fabricated content. The **JS** writers are untouched — `appendFileSync` is already atomic far past this cap. Seven bash sites converge on the seam (`canonical_jsonl_append`, `catalyst-state.sh`'s jq-less branch, `emit-worker-status-change.sh`, `lib/emit-reap-intent.sh`, `lib/phase-emit-complete.sh`, `catalyst-events`'s `wait.*` emitter, and `catalyst-stack`'s `_emit_checkout_updated` — the last a whole-function stdout redirect rather than a `printf`, which is why it is the easiest to miss). The three dependency-free leaves keep a raw-append fallback for a missing helper, but a **loud** one; `__tests__/event-append-atomicity.test.sh` scans for any silent raw append and recognizes the exemption only by that warning.
+  - **Read side is a tripwire, not the fix (CTL-1809).** Torn lines are COUNTED and SKIPPED at the readers listed below. This is a LIST OF THE COVERED SITES, not a census of every reader of the log — read it as "these are instrumented", never as "these are all of them": `otel-forward/lib/tail.ts` (`onUnparseable` → `stats.torn`), `execution-core/event-tail.mjs` (`tornLineCount()`), `broker/tailer.mjs`'s **live** tail, `execution-core/monitor.mjs`'s **live** `readNewEvents`, and `catalyst-events`' filter (`torn_lines_total` on stderr). (`grep -n 'noteTornLine' plugins/dev/scripts` is the instrument that enumerates the JS half; the count it returns is the number to trust, not this sentence.)
 
-    Two of those are **hand-rolled live tails of the same file, and they are peers** — the broker's
-    `readNewEvents` (`broker/tailer.mjs`) and the monitor's (`execution-core/monitor.mjs`), both
-    resolving `getEventLogPath()` to `~/catalyst/events/YYYY-MM.jsonl`, each driven for its whole
-    process lifetime. Neither is "the" load-bearing one. The broker routes every `filter.wake`,
-    every phase-lifecycle terminal, the ingestion-recency map and the worker-state projection; the
-    monitor routes `handleStateChangedEvent` → **dispatchTriage**, `handleIssueUpdatedEvent` → the
-    eligible projection fold, and `handleCommentCreatedEvent` → **onComment** (the CTL-768
-    comment-wake needs-input clear + worker redispatch). A torn line on either drops real work.
+Two of those are **hand-rolled live tails of the same file, and they are peers** — the broker's `readNewEvents` (`broker/tailer.mjs`) and the monitor's (`execution-core/monitor.mjs`), both resolving `getEventLogPath()` to `~/catalyst/events/YYYY-MM.jsonl`, each driven for its whole process lifetime. Neither is "the" load-bearing one. The broker routes every `filter.wake`, every phase-lifecycle terminal, the ingestion-recency map and the worker-state projection; the monitor routes `handleStateChangedEvent` → **dispatchTriage**, `handleIssueUpdatedEvent` → the eligible projection fold, and `handleCommentCreatedEvent` → **onComment** (the CTL-768 comment-wake needs-input clear + worker redispatch). A torn line on either drops real work.
 
-    The broker is additionally covered in two halves that must not be confused: its **boot replay**
-    goes through `tailParsedEvents` (counted inside `event-tail.mjs`), while its **live**
-    `readNewEvents` loop hand-rolls its own `JSON.parse` and calls the same module's exported
-    `noteTornLine` directly — as the monitor's now does too. Sharing one process counter (and one
-    sparse-warn key budget) across those is deliberate: they are one detector reading one file. The
-    "one flood must not exhaust another detector's budget" rule applies **across** readers —
-    separate processes, separate files — not within a single process's view of one log.
+The broker is additionally covered in two halves that must not be confused: its **boot replay** goes through `tailParsedEvents` (counted inside `event-tail.mjs`), while its **live** `readNewEvents` loop hand-rolls its own `JSON.parse` and calls the same module's exported `noteTornLine` directly — as the monitor's now does too. Sharing one process counter (and one sparse-warn key budget) across those is deliberate: they are one detector reading one file. The "one flood must not exhaust another detector's budget" rule applies **across** readers — separate processes, separate files — not within a single process's view of one log.
 
-    Only COMPLETE lines are counted. Every hand-rolled reader holds its trailing fragment back
-    (`leftover`/`leftoverBuf`) until a newline arrives, because a poll landing mid-append sees a
-    nonempty final fragment that is a healthy in-flight write, not damage — and since the byte
-    cursor has already advanced, counting it would also let the record's suffix be counted a
-    second time on the next poll. A torn-line counter that counts healthy writes is not a
-    torn-line counter.
-    Every reader **advances past** the line: a torn line is permanently
-    corrupt, so parking a cursor on it would wedge the reader forever
-    (`event-tail.mjs:12-17`). `catalyst-events` was worse than skipping — plain
-    `jq -c "select(...)"` ABORTS at the first unparseable line (exit 5), so every valid event after
-    a torn one in the same wake batch was silently lost and a `wait-for` sharing that batch timed
-    out; it now uses `jq -R 'fromjson?'`. These counters are a **lower bound**, never proof of
-    cleanliness: the RCA reproduced a splice that parses as valid JSON with a matching declared
-    length and three different events' contents, which no parser can detect. A monitor node's count
-    legitimately EXCEEDS a worker's — event-mirror is a transport, not a repair layer, and a torn
-    line has no extractable id for its dedup ring to suppress.
-  - Consumers: `catalyst-events tail` (stream), `catalyst-events wait-for` (blocking single-event).
-    Both shapes handled. See `website/src/content/docs/observability/catalyst-events.md`.
-  - **The one event-name boundary (CTL-1834).** Every JS/TS consumer resolves a name through
-    `plugins/dev/scripts/lib/event-name.mjs` `getEventName(event)` — `event` →
-    `attributes["event.name"]` → `name`, **first non-empty string wins**. It is an import-free leaf
-    in the zero-npm-import `lib/` zone (bare-Node `catalyst doctor` must load it) with an
-    `event-name.d.mts` sidecar for the TS stacks; it was `broker/event-name.mjs` until this ticket.
-    The motivation is measured, not hypothetical: **three separate v3 producers were each
-    discovered and fixed reactively, one at a time, after their events were already lost**, and
-    CTL-1817's own in-tree comment undercounted the v3 population it had just measured by 1.9×
-    (531 claimed vs 1,006 actual, 44 distinct names). Before this ticket five files hand-rolled
-    their own key ladder in three mutually-incompatible orders, each with a different blind spot:
-    `event ?? attributes` missed 1,006 lines/month, `attributes ?? name` missed 160,789, and
-    `attributes`-only missed 161,795 — the last not as a visible zero but as a **biased slice**
-    (`orphans.reap-requested` reads as 1.56% of its real volume, which looks like data).
-    `execution-core/event-name-read-guard.test.mjs` holds the multi-key-ladder set at snapshot
-    equality so the next drift fails at CI rather than on the log; it fails in BOTH directions, so
-    a fixed site must delete its allowlist entry. **Deliberately still out of scope** and tracked
-    separately: ~35 single-key `attributes`-only presentation/analysis readers, the v1-only
-    `execution-core/reaper.mjs` family (whose *payload* reads are v1-flat too, so a name-only fold
-    would recognize-then-silently-drop), and the bash/jq consumers (`catalyst-events --filter`'s
-    97 caller sites, `god-gather.sh`'s 7 provably-dead v1 selects).
+Only COMPLETE lines are counted. Every hand-rolled reader holds its trailing fragment back (`leftover`/`leftoverBuf`) until a newline arrives, because a poll landing mid-append sees a nonempty final fragment that is a healthy in-flight write, not damage — and since the byte cursor has already advanced, counting it would also let the record's suffix be counted a second time on the next poll. A torn-line counter that counts healthy writes is not a torn-line counter. Every reader **advances past** the line: a torn line is permanently corrupt, so parking a cursor on it would wedge the reader forever (`event-tail.mjs:12-17`). `catalyst-events` was worse than skipping — plain `jq -c "select(...)"` ABORTS at the first unparseable line (exit 5), so every valid event after a torn one in the same wake batch was silently lost and a `wait-for` sharing that batch timed out; it now uses `jq -R 'fromjson?'`. These counters are a **lower bound**, never proof of cleanliness: the RCA reproduced a splice that parses as valid JSON with a matching declared length and three different events' contents, which no parser can detect. A monitor node's count legitimately EXCEEDS a worker's — event-mirror is a transport, not a repair layer, and a torn line has no extractable id for its dedup ring to suppress.
+  - Consumers: `catalyst-events tail` (stream), `catalyst-events wait-for` (blocking single-event). Both shapes handled. See `website/src/content/docs/observability/catalyst-events.md`.
+  - **The one event-name boundary (CTL-1834).** Every JS/TS consumer resolves a name through `plugins/dev/scripts/lib/event-name.mjs` `getEventName(event)` — `event` → `attributes["event.name"]` → `name`, **first non-empty string wins**. It is an import-free leaf in the zero-npm-import `lib/` zone (bare-Node `catalyst doctor` must load it) with an `event-name.d.mts` sidecar for the TS stacks; it was `broker/event-name.mjs` until this ticket. The motivation is measured, not hypothetical: **three separate v3 producers were each discovered and fixed reactively, one at a time, after their events were already lost**, and CTL-1817's own in-tree comment undercounted the v3 population it had just measured by 1.9× (531 claimed vs 1,006 actual, 44 distinct names). Before this ticket five files hand-rolled their own key ladder in three mutually-incompatible orders, each with a different blind spot: `event ?? attributes` missed 1,006 lines/month, `attributes ?? name` missed 160,789, and `attributes`-only missed 161,795 — the last not as a visible zero but as a **biased slice** (`orphans.reap-requested` reads as 1.56% of its real volume, which looks like data). `execution-core/event-name-read-guard.test.mjs` holds the multi-key-ladder set at snapshot equality so the next drift fails at CI rather than on the log; it fails in BOTH directions, so a fixed site must delete its allowlist entry. **Deliberately still out of scope** and tracked separately: ~35 single-key `attributes`-only presentation/analysis readers, the v1-only `execution-core/reaper.mjs` family (whose *payload* reads are v1-flat too, so a name-only fold would recognize-then-silently-drop), and the bash/jq consumers (`catalyst-events --filter`'s 97 caller sites, `god-gather.sh`'s 7 provably-dead v1 selects).
 - **history/** — full snapshots archived on completion/failure/stale.
-- **execution-core/registry.json** — for `dispatchMode: execution-core` teams, the central
-  `team → repoRoot → eligibleQuery` registry. The Linear-state contract is setup-tooling-owned (D8):
-  `setup-catalyst.sh` ensures contract workflow states, writes the phase→5-state `stateMap`, and
-  upserts each team's entry. Daemon reads the registry directly (D4). The CTL-554 per-repo
-  enrollment under `execution-core/projects/` and the `/orchestrate` enroll step were retired in
-  CTL-582. Access flows through `registry.mjs` `list-projects`/`get-project-config` — the D9 cloud
-  seam (swappable to a hosted table without touching callers). Each entry's `team` must match its
-  `repoRoot`'s Layer-1 `catalyst.linear.teamKey`. The hot-path `listProjects()` check reads the
-  working tree and warns on mismatch; the opt-in `catalyst doctor` arm reads the dispatch revision
-  from local refs only and grades working-tree/revision drift as WARN. Both remain advisory under
-  `registry-team-identity`. Catalyst's own CAT registration is recorded in ADR-028.
-- **Heartbeat** — orchestrators write `lastHeartbeat` every 2–3 min; entries stale >10 min are GC'd
-  as `abandoned`.
+- **execution-core/registry.json** — for `dispatchMode: execution-core` teams, the central `team → repoRoot → eligibleQuery` registry. The Linear-state contract is setup-tooling-owned (D8): `setup-catalyst.sh` ensures contract workflow states, writes the phase→5-state `stateMap`, and upserts each team's entry. Daemon reads the registry directly (D4). The CTL-554 per-repo enrollment under `execution-core/projects/` and the `/orchestrate` enroll step were retired in CTL-582. Access flows through `registry.mjs` `list-projects`/`get-project-config` — the D9 cloud seam (swappable to a hosted table without touching callers). Each entry's `team` must match its `repoRoot`'s Layer-1 `catalyst.linear.teamKey`. The hot-path `listProjects()` check reads the working tree and warns on mismatch; the opt-in `catalyst doctor` arm reads the dispatch revision from local refs only and grades working-tree/revision drift as WARN. Both remain advisory under `registry-team-identity`. Catalyst's own CAT registration is recorded in ADR-028.
+- **Heartbeat** — orchestrators write `lastHeartbeat` every 2–3 min; entries stale >10 min are GC'd as `abandoned`.
 
-**Cross-host ticket ownership (HRW + liveness, CTL-859 → CTL-1091).** In a multi-host cluster,
-ticket ownership is partitioned by Highest-Random-Weight (rendezvous) hashing (`hrw.mjs` `ownedBy`):
-each daemon acts only on the tickets it owns, so one ticket is considered by exactly one host. Two
-gates evaluate ownership, and — since CTL-1091 — **both hash over a liveness-filtered roster**, so
-an offline owner's slice fails over to a live host instead of stranding in Todo forever:
+**Cross-host ticket ownership (HRW + liveness, CTL-859 → CTL-1091).** In a multi-host cluster, ticket ownership is partitioned by Highest-Random-Weight (rendezvous) hashing (`hrw.mjs` `ownedBy`): each daemon acts only on the tickets it owns, so one ticket is considered by exactly one host. Two gates evaluate ownership, and — since CTL-1091 — **both hash over a liveness-filtered roster**, so an offline owner's slice fails over to a live host instead of stranding in Todo forever:
 
-- **Dispatch gates** (new-work `ready` filter in `scheduler.mjs`; triage predicate in `monitor.mjs`)
-  hash over the **dispatch roster** = `computeDispatchSurvivingRoster(roster)` (POSITIVE liveness —
-  a host must have heartbeated within `HEARTBEAT_GRACE_MS`, so a _never-live_ rostered host is shed;
-  CTL-1057) with a restore-side **deflap** on top (`liveness-deflap.mjs` `computeDispatchRoster` — a
-  dead→live host is held out for `HEARTBEAT_RESTORE_HOLD_MS` so a flapping laptop can't
-  grab-then-strand work; scheduler is the sole writer of `.liveness-deflap.json`, monitor reads it).
-- **Recovery gates** (`ownsForRecovery`, `reclaimDeadHostWork`) hash over the **surviving roster** =
-  `computeSurvivingRoster(roster)` (fail-OPEN `deadHosts` — an unseen host is "not proven dead" and
-  is NOT reclaimed, since a never-seen host has no work to reclaim). The asymmetry is deliberate:
-  dispatch fails an unseen owner's slice **over**; recovery must not reclaim a host's non-existent
-  work.
+- **Dispatch gates** (new-work `ready` filter in `scheduler.mjs`; triage predicate in `monitor.mjs`) hash over the **dispatch roster** = `computeDispatchSurvivingRoster(roster)` (POSITIVE liveness — a host must have heartbeated within `HEARTBEAT_GRACE_MS`, so a _never-live_ rostered host is shed; CTL-1057) with a restore-side **deflap** on top (`liveness-deflap.mjs` `computeDispatchRoster` — a dead→live host is held out for `HEARTBEAT_RESTORE_HOLD_MS` so a flapping laptop can't grab-then-strand work; scheduler is the sole writer of `.liveness-deflap.json`, monitor reads it).
+- **Recovery gates** (`ownsForRecovery`, `reclaimDeadHostWork`) hash over the **surviving roster** = `computeSurvivingRoster(roster)` (fail-OPEN `deadHosts` — an unseen host is "not proven dead" and is NOT reclaimed, since a never-seen host has no work to reclaim). The asymmetry is deliberate: dispatch fails an unseen owner's slice **over**; recovery must not reclaim a host's non-existent work.
 
-Both altitudes preserve the same fail-safes: single-host is a strict no-op, and a total liveness
-outage (heartbeat read throws / everyone looks dead) degrades to the **full roster** (each node owns
-only its own HRW slice — never double-acts). The Linear-CAS claim (`cluster-claim.mjs` soft-CAS on
-`catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains the transition-race serializer.
+Both altitudes preserve the same fail-safes: single-host is a strict no-op, and a total liveness outage (heartbeat read throws / everyone looks dead) degrades to the **full roster** (each node owns only its own HRW slice — never double-acts). The Linear-CAS claim (`cluster-claim.mjs` soft-CAS on `catalyst://fence/<TICKET>`, applied HRW-first/claim-second) remains the transition-race serializer.
 
-**Host entitlement vs. existence (CTL-1785, W13 — host half of CTC-411).** The static `cluster.json`
-roster conflates two facts, and the conflation is load-bearing: **existence** ("is this node in the
-fleet, observable/monitorable?" — local, self-declared, no network) and **entitlement** ("may this
-node take work?" — a lease from an external authority, required to claim, self-expiring on its own
-TTL). Because being *listed* implied being *entitled*, CTL-1760's mini-2 stayed a work-owner "by
-declaration" for **33 days** after it went silent. This ticket splits them behind two accessors —
-`getExistenceHosts()` (topology / observability / display / archive; also the source of the `multiHost`
-`fenceGuard` `!multiHost` disarm, so shedding can never re-enable an N=1 disarm) and
-`getEntitledHosts()` (every dispatch / recovery / reclaim / HRW-ownership gate) — with each caller
-reclassified per the two classes. `getClusterHosts()` is **retained**, not deleted: it is byte-for-byte
-the existence roster, so display callers not yet migrated still read correct data. The hard invariant
-a source-scan guard enforces is that **no entitlement caller reads `getClusterHosts()`**.
+**Host entitlement vs. existence (CTL-1785, W13 — host half of CTC-411).** The static `cluster.json` roster conflates two facts, and the conflation is load-bearing: **existence** ("is this node in the fleet, observable/monitorable?" — local, self-declared, no network) and **entitlement** ("may this node take work?" — a lease from an external authority, required to claim, self-expiring on its own TTL). Because being *listed* implied being *entitled*, CTL-1760's mini-2 stayed a work-owner "by declaration" for **33 days** after it went silent. This ticket splits them behind two accessors — `getExistenceHosts()` (topology / observability / display / archive; also the source of the `multiHost` `fenceGuard` `!multiHost` disarm, so shedding can never re-enable an N=1 disarm) and `getEntitledHosts()` (every dispatch / recovery / reclaim / HRW-ownership gate) — with each caller reclassified per the two classes. `getClusterHosts()` is **retained**, not deleted: it is byte-for-byte the existence roster, so display callers not yet migrated still read correct data. The hard invariant a source-scan guard enforces is that **no entitlement caller reads `getClusterHosts()`**.
 
-Entitlement is resolved through an injectable `EntitlementProvider` seam (`lib/entitlement.mjs`, a
-zero-import leaf) whose default **local provider** answers ENTITLED iff self ∈ roster — reproducing
-today's behavior with **fail direction ENTITLED** (any inability to decide preserves the full roster,
-the opposite of a lock: this is a permit whose absence must not strand a healthy fleet before the
-authority is wired). Rollout is the tri-state `CATALYST_ENTITLEMENT` ∈ `off` (default,
-byte-identical) → `shadow` (emit `entitlement.would-shed.<host>`, change nothing) → `enforce`
-(actually shed unentitled hosts — self always admitted, total-outage degrades to the full roster —
-and revoke this host's held leases). The **load-bearing ordering constraint** is
-`ENTITLEMENT_TTL_MS` (15 min) `>` the work-lease TTL (5 min, the claim-stale window), asserted loudly
-at module load: otherwise a node loses entitlement while still holding a fresher work lease, and the
-work is invisible to a reclaim loop that iterates roster members (an **orphan by construction**).
-Losing self-entitlement therefore **revokes** the held leases — `revokeLeasesOnEntitlementLoss`
-(`entitlement-revoke.mjs`) is the **first production caller** of the previously-never-wired
-`emitFenceReleased`, threaded into the heartbeat-publisher tick as a single gated, fail-open call.
+Entitlement is resolved through an injectable `EntitlementProvider` seam (`lib/entitlement.mjs`, a zero-import leaf) whose default **local provider** answers ENTITLED iff self ∈ roster — reproducing today's behavior with **fail direction ENTITLED** (any inability to decide preserves the full roster, the opposite of a lock: this is a permit whose absence must not strand a healthy fleet before the authority is wired). Rollout is the tri-state `CATALYST_ENTITLEMENT` ∈ `off` (default, byte-identical) → `shadow` (emit `entitlement.would-shed.<host>`, change nothing) → `enforce` (actually shed unentitled hosts — self always admitted, total-outage degrades to the full roster — and revoke this host's held leases). The **load-bearing ordering constraint** is `ENTITLEMENT_TTL_MS` (15 min) `>` the work-lease TTL (5 min, the claim-stale window), asserted loudly at module load: otherwise a node loses entitlement while still holding a fresher work lease, and the work is invisible to a reclaim loop that iterates roster members (an **orphan by construction**). Losing self-entitlement therefore **revokes** the held leases — `revokeLeasesOnEntitlementLoss` (`entitlement-revoke.mjs`) is the **first production caller** of the previously-never-wired `emitFenceReleased`, threaded into the heartbeat-publisher tick as a single gated, fail-open call.
 
-Acceptance is "an observable event and an absence" (`entitlement-audit.mjs`): the absence query counts
-tickets whose live work-lease holder has no current entitlement (must be **0**), and its mandatory
-**positive control** counts leases held by an entitled node (must be **> 0** when work exists) — a
-bare zero over zero live leases returns **`inconclusive`**, never a clean pass. Config/rollout ladder,
-the TTL knobs, and the modes live in `website/src/content/docs/reference/configuration.md` →
-"Entitlement mode". **Not in scope here**: the lease *store* itself (W12 = **CTL-1786**, the Durable
-Object — this ticket ships against an injectable provider + a local fallback, so `enforce` is
-byte-identical to today until that authority is injected), deleting the inferred-liveness apparatus
-(W16 = **CTL-1787**), and progress-gated lease renewal (W14 = **CTL-1784**). `catalyst doctor`'s
-advisory `entitlement-*` checks report the resolved mode, the provider (local vs authority), and
-whether the ordering constraint holds — INFO/WARN only, never FAIL. The `entitlement.*` event prefix
-is **unprotected** under the CTL-1142 namespace contract.
+Acceptance is "an observable event and an absence" (`entitlement-audit.mjs`): the absence query counts tickets whose live work-lease holder has no current entitlement (must be **0**), and its mandatory **positive control** counts leases held by an entitled node (must be **> 0** when work exists) — a bare zero over zero live leases returns **`inconclusive`**, never a clean pass. Config/rollout ladder, the TTL knobs, and the modes live in `website/src/content/docs/reference/configuration.md` → "Entitlement mode". **Not in scope here**: the lease *store* itself (W12 = **CTL-1786**, the Durable Object — this ticket ships against an injectable provider + a local fallback, so `enforce` is byte-identical to today until that authority is injected), deleting the inferred-liveness apparatus (W16 = **CTL-1787**), and progress-gated lease renewal (W14 = **CTL-1784**). `catalyst doctor`'s advisory `entitlement-*` checks report the resolved mode, the provider (local vs authority), and whether the ordering constraint holds — INFO/WARN only, never FAIL. The `entitlement.*` event prefix is **unprotected** under the CTL-1142 namespace contract.
 
-**Fence-standoff bound (CAT-173).** Two live hosts can each hold evidence that the other owns a
-ticket, causing every fence-guarded human escalation to be suppressed. Each escalation site records
-that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both
-the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an
-unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the
-notification bridge can surface the ticket without a Linear write.
+**Fence-standoff bound (CAT-173).** Two live hosts can each hold evidence that the other owns a ticket, causing every fence-guarded human escalation to be suppressed. Each escalation site records that suppression in the host-local, GC-surviving `.fence-standoff/<TICKET>.json` ledger. After both the configured count (default 4) and age (default 45 minutes) are reached, Catalyst writes an unfenced `.escalations/<TICKET>.json` record and emits `escalation.fence-standoff.<TICKET>`, so the notification bridge can surface the ticket without a Linear write.
 
-Only a MUTUAL standoff counts, and a standoff is by definition AMBIGUOUS — nobody can tell who owns
-the ticket. Just two `fenceGuard` verdicts are ambiguous in that sense and so accumulate toward the
-bound: `unverifiable` (the authoritative read neither confirmed nor refuted this host's generation)
-and `threw` (fail-closed on an error), alongside a non-fail-open `missing-generation`.
+Only a MUTUAL standoff counts, and a standoff is by definition AMBIGUOUS — nobody can tell who owns the ticket. Just two `fenceGuard` verdicts are ambiguous in that sense and so accumulate toward the bound: `unverifiable` (the authoritative read neither confirmed nor refuted this host's generation) and `threw` (fail-closed on an error), alongside a non-fail-open `missing-generation`.
 
-The CONFIRMED-TAKEOVER verdicts are the opposite — positive evidence that a specific other host holds
-the claim, which is the correct outcome on the superseded host after a healthy takeover, where
-`fenceGuard` deliberately leaves the escalation to the current owner (whose own fence passes).
-There are TWO of them and BOTH are excluded: `foreign-owner` (the projection names a different owner
-host) and `superseded` (the authoritative read returned `stale: true`, i.e. a newer generation
-exists — the shape an ordinary healthy takeover takes on the old host, discovered via generation
-rather than owner identity). Counting either would let a lingering worker directory on the old host
-cross the bound and page an operator about a ticket the new owner is actively processing, so both are
-excluded from accounting and additionally CLEAR the ledger, letting a later genuine standoff start
-a fresh episode instead of inheriting a stale count and age.
+The CONFIRMED-TAKEOVER verdicts are the opposite — positive evidence that a specific other host holds the claim, which is the correct outcome on the superseded host after a healthy takeover, where `fenceGuard` deliberately leaves the escalation to the current owner (whose own fence passes). There are TWO of them and BOTH are excluded: `foreign-owner` (the projection names a different owner host) and `superseded` (the authoritative read returned `stale: true`, i.e. a newer generation exists — the shape an ordinary healthy takeover takes on the old host, discovered via generation rather than owner identity). Counting either would let a lingering worker directory on the old host cross the bound and page an operator about a ticket the new owner is actively processing, so both are excluded from accounting and additionally CLEAR the ledger, letting a later genuine standoff start a fresh episode instead of inheriting a stale count and age.
 
-The record is GC-surviving and reaches the board two ways. When the ticket has **no** card,
-`synthesizeDurableEscalations` mints one. When it already has a card, that function's id dedupe
-drops the record, so `mergeDurableEscalationsIntoCards` runs first and stamps the escalation's
-reason onto the existing card — but only when that card carries no `attention` yet, so a live
-reason always wins. Both halves are needed: a terminal-sweep standoff has a live `failed`/`stalled`
-signal (hence a card, hence `deriveAttention`'s `phaseFailed` → `ask`) and only wanted the
-standoff-specific reason, whereas a stale-PR standoff on a `BEHIND` PR has a card with **no**
-attention at all — `BEHIND` is excluded from `PR_BLOCKER_STATES` as auto-rebasable and the fence
-suppressed the label — so before the merge pass its break-glass reached no operator surface,
-including the push bridge, which projects only board tickets.
+The record is GC-surviving and reaches the board two ways. When the ticket has **no** card, `synthesizeDurableEscalations` mints one. When it already has a card, that function's id dedupe drops the record, so `mergeDurableEscalationsIntoCards` runs first and stamps the escalation's reason onto the existing card — but only when that card carries no `attention` yet, so a live reason always wins. Both halves are needed: a terminal-sweep standoff has a live `failed`/`stalled` signal (hence a card, hence `deriveAttention`'s `phaseFailed` → `ask`) and only wanted the standoff-specific reason, whereas a stale-PR standoff on a `BEHIND` PR has a card with **no** attention at all — `BEHIND` is excluded from `PR_BLOCKER_STATES` as auto-rebasable and the fence suppressed the label — so before the merge pass its break-glass reached no operator surface, including the push bridge, which projects only board tickets.
 
-This changes no `fenceGuard` decision: every write suppressed before CAT-173 remains suppressed.
-It does change the **retry cadence** of those suppressed writes. Crossing the bound stamps a
-`.fence-standoff-cooldown` (default 6 h) that gates the same terminal-sweep probe+write block
-`.fence-suppressed` (15 min) already gated, so after a break-glass a healed standoff's escalation
-label write — and the terminal-clear branch that retracts it on a late Done — is retried every 6 h
-rather than every 15 min. A break-glass whose delivery FAILS drops the 15-minute marker to retry on
-the next tick, bounded by `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` (default 5) so a persistently
-unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn. That bound is only enforceable
-while the attempt counter survives the tick, so a failed-delivery increment that cannot be persisted
-(full disk, read-only mount) fails CLOSED — reported as not-retryable rather than retryable-forever,
-since an unpersisted counter can never grow past the max.
+This changes no `fenceGuard` decision: every write suppressed before CAT-173 remains suppressed. It does change the **retry cadence** of those suppressed writes. Crossing the bound stamps a `.fence-standoff-cooldown` (default 6 h) that gates the same terminal-sweep probe+write block `.fence-suppressed` (15 min) already gated, so after a break-glass a healed standoff's escalation label write — and the terminal-clear branch that retracts it on a late Done — is retried every 6 h rather than every 15 min. A break-glass whose delivery FAILS drops the 15-minute marker to retry on the next tick, bounded by `CATALYST_FENCE_STANDOFF_DELIVERY_RETRY_MAX` (default 5) so a persistently unwritable sink cannot reintroduce the CTL-1329 per-tick probe burn. That bound is only enforceable while the attempt counter survives the tick, so a failed-delivery increment that cannot be persisted (full disk, read-only mount) fails CLOSED — reported as not-retryable rather than retryable-forever, since an unpersisted counter can never grow past the max.
 
-**Worker signal projection (CTL-532 = ADR-018 Phase 3, shipped; Phase 1 retired, CTL-1628).**
-Per-worker `workers/<TICKET>.json` files are still written by ~7 scripts with no inter-process
-locking; ADR-018 originally proposed closing that gap via a `worker.state_changed` command event and
-a JSON shadow file with a three-phase dual-write cutover. Phase 1 (the JSON shadow-write mechanism)
-stalled at 1 of 7 writers migrated and was retired as dead weight — its only reader was the manual
-`orchestrate-shadow-diff` verification CLI, removed with it; nothing operational ever consumed the
-shadow files. Phase 2's plan (cut over to broker-sole-writer once Phase 1 reached zero drift) is
-dead — it depended on the now-retired Phase 1 drift-check pipeline. The _problem_ Phase 2 was meant
-to solve — the seven-script single-writer race — is still open, but it is no longer tracked as this
-ADR's Phase 2: **CTL-1631** now owns it as a standalone ticket, replacing the retired Phase-2 plan
-rather than continuing it. Phase 3 — as originally scoped, a `(orch_id,ticket)` SQLite mirror —
-**did ship**, as **CTL-532**: the broker folds every event on the log (not just a dedicated command
-event) into a pure `reduceWorkerStateEvent` reducer via `projectWorkerStateEvent`, and upserts the
-result into a SQLite `worker_state` table (`broker/broker-state.mjs`) — one row per
-`(orchestrator, ticket)` with phase, status, PR number, and revive count. Only `phase`/`status` (and
-the `last_event_id`/`last_event_ts` watermark itself) are gated on that watermark —
-order-independent for distinct timestamps, last-write-wins by processing order on an exact tie;
-`pr_number` (COALESCE) and `revive_count` (MAX) apply unconditionally on every upsert regardless of
-event order. The table is purely observational **with respect to worker state** — it never reads or
-writes the canonical `workers/<TICKET>.json`. That is a statement about what it does *not* drive,
-**not** a claim that nothing consumes it: `worker_state` has a live, **default-on** reader (audited
-CTL-1791). `hasActiveWorkers` (`broker/broker-state.mjs`) answers "is the fleet working right now?"
-from a single `EXISTS` over non-terminal rows fresher than `ACTIVE_WORKER_FRESHNESS_MS` (30 min);
-`router.mjs`'s tri-state `fleetActivity` wrapper feeds it to the **CTL-1122 ingestion-recency gate**
-(`checkSourceRecency`, enabled unless `CATALYST_INGESTION_RECENCY=0`) and to the watchdog's
-empty-interests severity discriminator. Dropping the table would not fail loudly — `fleetActivity`
-catches the `no such table` throw and returns `null` (unknown), which the fail-closed gate reads as
-"not demonstrably active" and forces severity `up`, **silently blinding** the ingestion-recency
-detector. (`RECENCY_SOURCES` wires **monitor and GitHub only**; `catalyst.linear` is deliberately
-DEFERRED — the linear-webhook bot-skip guard suppresses bot-authored issue events before they reach
-the log, so the source goes quiet even with a worker in flight.) `getStaleWorkers` is the one genuinely unwired export (its own comment
-says so). See ADR-018 for the full history.
+**Worker signal projection (CTL-532 = ADR-018 Phase 3, shipped; Phase 1 retired, CTL-1628).** Per-worker `workers/<TICKET>.json` files are still written by ~7 scripts with no inter-process locking; ADR-018 originally proposed closing that gap via a `worker.state_changed` command event and a JSON shadow file with a three-phase dual-write cutover. Phase 1 (the JSON shadow-write mechanism) stalled at 1 of 7 writers migrated and was retired as dead weight — its only reader was the manual `orchestrate-shadow-diff` verification CLI, removed with it; nothing operational ever consumed the shadow files. Phase 2's plan (cut over to broker-sole-writer once Phase 1 reached zero drift) is dead — it depended on the now-retired Phase 1 drift-check pipeline. The _problem_ Phase 2 was meant to solve — the seven-script single-writer race — is still open, but it is no longer tracked as this ADR's Phase 2: **CTL-1631** now owns it as a standalone ticket, replacing the retired Phase-2 plan rather than continuing it. Phase 3 — as originally scoped, a `(orch_id,ticket)` SQLite mirror — **did ship**, as **CTL-532**: the broker folds every event on the log (not just a dedicated command event) into a pure `reduceWorkerStateEvent` reducer via `projectWorkerStateEvent`, and upserts the result into a SQLite `worker_state` table (`broker/broker-state.mjs`) — one row per `(orchestrator, ticket)` with phase, status, PR number, and revive count. Only `phase`/`status` (and the `last_event_id`/`last_event_ts` watermark itself) are gated on that watermark — order-independent for distinct timestamps, last-write-wins by processing order on an exact tie; `pr_number` (COALESCE) and `revive_count` (MAX) apply unconditionally on every upsert regardless of event order. The table is purely observational **with respect to worker state** — it never reads or writes the canonical `workers/<TICKET>.json`. That is a statement about what it does *not* drive, **not** a claim that nothing consumes it: `worker_state` has a live, **default-on** reader (audited CTL-1791). `hasActiveWorkers` (`broker/broker-state.mjs`) answers "is the fleet working right now?" from a single `EXISTS` over non-terminal rows fresher than `ACTIVE_WORKER_FRESHNESS_MS` (30 min); `router.mjs`'s tri-state `fleetActivity` wrapper feeds it to the **CTL-1122 ingestion-recency gate** (`checkSourceRecency`, enabled unless `CATALYST_INGESTION_RECENCY=0`) and to the watchdog's empty-interests severity discriminator. Dropping the table would not fail loudly — `fleetActivity` catches the `no such table` throw and returns `null` (unknown), which the fail-closed gate reads as "not demonstrably active" and forces severity `up`, **silently blinding** the ingestion-recency detector. (`RECENCY_SOURCES` wires **monitor and GitHub only**; `catalyst.linear` is deliberately DEFERRED — the linear-webhook bot-skip guard suppresses bot-authored issue events before they reach the log, so the source goes quiet even with a worker in flight.) `getStaleWorkers` is the one genuinely unwired export (its own comment says so). See ADR-018 for the full history.
 
-The Linear route now has a complementary **route-comparison** silence alarm (CTL-1841) that lives
-in the orch-monitor server, not in the broker. It compares `/api/webhook/linear` HTTP response
-codes against the `/api/webhook` (GitHub) control — both share the same smee tunnel, Bun process,
-and minute — and raises when Linear has returned only non-2xx past a threshold while GitHub keeps
-200-ing. This detects HMAC authentication failure (the 2026-08-14 7.5-hour outage) **without**
-depending on Linear event volume, so it does NOT revert the `RECENCY_SOURCES` `catalyst.linear`
-exclusion. It is **alert-only**: a durable marker (`~/catalyst/linear-webhook-401-latch.json`) and a
-`console.warn` line in `orch-monitor.log` (Alloy-shipped independently of the broken webhook path).
-No restart, no mutation. Routing the alarm to a human (a Loki `absent_over_time` rule in
-`catalyst-otel`) is the separate follow-up. Config knobs: `CATALYST_LINEAR_WEBHOOK_ALARM` and
-related `_SILENT_MS`/`_FAIL_RECENCY_MS`/`_GITHUB_WINDOW_MS`/`_TICK_MS` — see
-`website/src/content/docs/reference/configuration.md`.
+The Linear route now has a complementary **route-comparison** silence alarm (CTL-1841) that lives in the orch-monitor server, not in the broker. It compares `/api/webhook/linear` HTTP response codes against the `/api/webhook` (GitHub) control — both share the same smee tunnel, Bun process, and minute — and raises when Linear has returned only non-2xx past a threshold while GitHub keeps 200-ing. This detects HMAC authentication failure (the 2026-08-14 7.5-hour outage) **without** depending on Linear event volume, so it does NOT revert the `RECENCY_SOURCES` `catalyst.linear` exclusion. It is **alert-only**: a durable marker (`~/catalyst/linear-webhook-401-latch.json`) and a `console.warn` line in `orch-monitor.log` (Alloy-shipped independently of the broken webhook path). No restart, no mutation. Routing the alarm to a human (a Loki `absent_over_time` rule in `catalyst-otel`) is the separate follow-up. Config knobs: `CATALYST_LINEAR_WEBHOOK_ALARM` and related `_SILENT_MS`/`_FAIL_RECENCY_MS`/`_GITHUB_WINDOW_MS`/`_TICK_MS` — see `website/src/content/docs/reference/configuration.md`.
 
 ## Deployment Mode (CTL-1617)
 
-One declared answer — **`catalyst.deployment.mode` ∈ `single-host` | `cluster` | `cloud`** —
-replaces the per-host hand-wiring of mode-dependent choices. Resolved by a zero-import bash+JS pair
-(`plugins/dev/scripts/lib/deployment-mode.mjs` + `lib/catalyst-deployment-mode.sh`), kept honest by
-an exhaustive cross-stack parity fixture matrix (`__tests__/deployment-mode-parity.test.sh`). The
-schema itself (precedence ladder, examples, defaulting, every caveat) lives in its canonical
-reference, `website/src/content/docs/reference/configuration.md` — this section covers only the
-architectural role. **This repo's Layer-1 declares `cluster`**; dev-clones override to `single-host`
-via Layer-2.
+One declared answer — **`catalyst.deployment.mode` ∈ `single-host` | `cluster` | `cloud`** — replaces the per-host hand-wiring of mode-dependent choices. Resolved by a zero-import bash+JS pair (`plugins/dev/scripts/lib/deployment-mode.mjs` + `lib/catalyst-deployment-mode.sh`), kept honest by an exhaustive cross-stack parity fixture matrix (`__tests__/deployment-mode-parity.test.sh`). The schema itself (precedence ladder, examples, defaulting, every caveat) lives in its canonical reference, `website/src/content/docs/reference/configuration.md` — this section covers only the architectural role. **This repo's Layer-1 declares `cluster`**; dev-clones override to `single-host` via Layer-2.
 
-- **Degradation is the safety direction**: invalid values settle at their layer as
-  `single-host, recognized:false` (asserting the fewest cross-host guarantees); malformed files are
-  layer-absent in BOTH languages. Two supported, deliberate asymmetry bounds: on a **jq-less host**
-  the bash resolver treats config files as absent (env-else-default, with a
-  `CATALYST_DEPLOYMENT_MODE_JQ_MISSING` breadcrumb for doctor) while the JS resolver still reads
-  them; and file-acceptance parity is defined by jq's parser (multi-document, BOM, and
-  lone-surrogate-escape documents are whole-document-malformed on both sides — the JS reader scans
-  raw text to match).
-- **Consumers today**: `catalyst doctor` (`checkDeploymentModeConsistency`, advisory:
-  declared/inferred, typo FAIL, roster-consistency WARN — every message says "deployment mode",
-  never bare "mode", since `dispatchMode`, executor dispatch-mode telemetry, and the replica
-  reader's `mode` are unrelated concepts) and the orch-monitor smee tunnel gate (a declared-`cloud`
-  node suppresses tunnel start; the replacement cloud-SDK event connection is **future work** — the
-  smee→cloud cutover, ADR-0008 lineage — so `cloud` today means "no smee ingestion", not "cloud
-  ingestion wired"). **Consumer**: the CTL-1616 secret contract's provider-of-record dispatch
-  (below) can receive the full resolution object and never activates a cloud provider on
-  `inferred:true` — but only `catalyst doctor` actually threads `deploymentMode` into its
-  `resolveSecret` calls today. The folded Linear/OAuth call sites (`linear-query.mjs`,
-  `cluster-claim.mjs`, etc.) call `resolveSecret(id)`/`resolveSecret(id, { env })` with no
-  `deploymentMode` argument at all, so the cloud guard never engages for them regardless of the
-  node's declared mode — deployment-mode dispatch for those consumers stays **planned**, not shipped
-  (see the Secret Contract section below).
-- **Orthogonal axes, never merged**: deployment mode (fleet topology) × `catalyst.node.class`
-  (per-machine role: `worker` runs the full execution layer; `monitor`/`developer` run observation
-  substrate only — broker + monitor + event-mirror, no heartbeat/dispatch/recovery) ×
-  `orchestration.dispatchMode` (process substrate within a node).
+- **Degradation is the safety direction**: invalid values settle at their layer as `single-host, recognized:false` (asserting the fewest cross-host guarantees); malformed files are layer-absent in BOTH languages. Two supported, deliberate asymmetry bounds: on a **jq-less host** the bash resolver treats config files as absent (env-else-default, with a `CATALYST_DEPLOYMENT_MODE_JQ_MISSING` breadcrumb for doctor) while the JS resolver still reads them; and file-acceptance parity is defined by jq's parser (multi-document, BOM, and lone-surrogate-escape documents are whole-document-malformed on both sides — the JS reader scans raw text to match).
+- **Consumers today**: `catalyst doctor` (`checkDeploymentModeConsistency`, advisory: declared/inferred, typo FAIL, roster-consistency WARN — every message says "deployment mode", never bare "mode", since `dispatchMode`, executor dispatch-mode telemetry, and the replica reader's `mode` are unrelated concepts) and the orch-monitor smee tunnel gate (a declared-`cloud` node suppresses tunnel start; the replacement cloud-SDK event connection is **future work** — the smee→cloud cutover, ADR-0008 lineage — so `cloud` today means "no smee ingestion", not "cloud ingestion wired"). **Consumer**: the CTL-1616 secret contract's provider-of-record dispatch (below) can receive the full resolution object and never activates a cloud provider on `inferred:true` — but only `catalyst doctor` actually threads `deploymentMode` into its `resolveSecret` calls today. The folded Linear/OAuth call sites (`linear-query.mjs`, `cluster-claim.mjs`, etc.) call `resolveSecret(id)`/`resolveSecret(id, { env })` with no `deploymentMode` argument at all, so the cloud guard never engages for them regardless of the node's declared mode — deployment-mode dispatch for those consumers stays **planned**, not shipped (see the Secret Contract section below).
+- **Orthogonal axes, never merged**: deployment mode (fleet topology) × `catalyst.node.class` (per-machine role: `worker` runs the full execution layer; `monitor`/`developer` run observation substrate only — broker + monitor + event-mirror, no heartbeat/dispatch/recovery) × `orchestration.dispatchMode` (process substrate within a node).
 - Design + migration plan: `thoughts/shared/research/2026-08-02-ctl-1617-deployment-mode-design.md`.
 
 ## Secret Contract (CTL-1616)
 
-The 2026-08-02 fleet 401 outage was four divergent hand-written copies of one secret-resolution
-chain. CTL-1616 generalizes CTL-1612's proven github-token/webhook-secret pair into **one registry,
-two engines**: `plugins/dev/scripts/lib/secret-contract.mjs` (a zero-import JS leaf —
-`node:fs`/`os`/`path` only, so `catalyst doctor`'s bare-Node runtime can import it without pulling
-in `execution-core/config.mjs`'s `bun:sqlite` graph) and its independently-maintained bash mirror
-`lib/catalyst-secret-contract.sh`, held honest by a cross-stack **three-way parity suite**
-(`__tests__/secret-contract-parity.test.sh`: bash and JS each checked against a computed-expected
-value, never merely against each other, plus row-id-set equality between the two registries). The
-schema — the 11 registered secrets, the 7 delivery types, the resolution result shape, the cloud
-guard, and the Layer-2 path chain — is documented in full in its canonical reference,
-`website/src/content/docs/reference/configuration.md`; this section covers only the architectural
-role.
+The 2026-08-02 fleet 401 outage was four divergent hand-written copies of one secret-resolution chain. CTL-1616 generalizes CTL-1612's proven github-token/webhook-secret pair into **one registry, two engines**: `plugins/dev/scripts/lib/secret-contract.mjs` (a zero-import JS leaf — `node:fs`/`os`/`path` only, so `catalyst doctor`'s bare-Node runtime can import it without pulling in `execution-core/config.mjs`'s `bun:sqlite` graph) and its independently-maintained bash mirror `lib/catalyst-secret-contract.sh`, held honest by a cross-stack **three-way parity suite** (`__tests__/secret-contract-parity.test.sh`: bash and JS each checked against a computed-expected value, never merely against each other, plus row-id-set equality between the two registries). The schema — the 11 registered secrets, the 7 delivery types, the resolution result shape, the cloud guard, and the Layer-2 path chain — is documented in full in its canonical reference, `website/src/content/docs/reference/configuration.md`; this section covers only the architectural role.
 
 ```mermaid
 flowchart LR
@@ -494,8 +125,7 @@ flowchart LR
   SH --> HEALTH[health-responder.sh<br/>bash fallback, PR5]
 ```
 
-**Bootstrap classes, one per deployment mode** — the one credential the contract can never itself
-deliver, since it is what unlocks (or stands in for) everything else the chain resolves:
+**Bootstrap classes, one per deployment mode** — the one credential the contract can never itself deliver, since it is what unlocks (or stands in for) everything else the chain resolves:
 
 | Mode          | Bootstrap credential                                                                     | Row                                                          |
 | ------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -503,58 +133,13 @@ deliver, since it is what unlocks (or stands in for) everything else the chain r
 | `cluster`     | the SOPS age private key (`~/.config/catalyst/age.key`, `SOPS_AGE_KEY_FILE`-overridable) | `age-key` (`local-only`, presence-checked, value never read) |
 | `cloud`       | `CATALYST_CLOUD_TOKEN` (name itself resolvable via a 3-tier ladder)                      | `cloud-token` (`platform-env`)                               |
 
-**Rotation classes** generalize `cluster-sync.mjs`'s "captured at process start" prose into
-structured per-row data: `boot-only` (a value change needs a restart), `re-armable`/`timer`
-(proactively re-checked on a recurring tick — `github-token`'s declared shape; its actual re-arm
-today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile`, called every daemon
-cluster-sync tick in `execution-core/daemon.mjs`, not yet through this contract's own
-`registerRearmHook`/`armSecret` seam), and `re-armable`/`on-401` (reactively re-minted on an
-observed auth failure — the Linear OAuth-mint shape). `armSecret()` never throws and reports
-`{ armed, rotated, restartRequired }` — `restartRequired: true` is the literal mechanism the
-2026-08-02 outage lacked: a `boot-only` row (or a `re-armable` row with no hook registered yet — the
-two degrade identically, by design, so a consumer that never wires the arm path can't look safer
-than one that structurally can't) reports it when a caller invokes `armSecret` and the resolved
-value has changed since the PROCESS's last `armSecret` observation for that id (`_lastArmedValue` is
-module-level, one baseline per secret id shared by every caller in the process — caller B observing
-a rotation resets what caller A sees) — a caller-invoked report, not an automatic one fired the
-moment the value changes. No production call site invokes `armSecret` today (a repo-wide search
-outside tests finds only the definition and a comment reference in `linear-remint.mjs`), so this
-reporting is not yet wired to any running daemon.
+**Rotation classes** generalize `cluster-sync.mjs`'s "captured at process start" prose into structured per-row data: `boot-only` (a value change needs a restart), `re-armable`/`timer` (proactively re-checked on a recurring tick — `github-token`'s declared shape; its actual re-arm today still runs through the pre-existing CTL-1612 `rearmGithubTokenFromFile`, called every daemon cluster-sync tick in `execution-core/daemon.mjs`, not yet through this contract's own `registerRearmHook`/`armSecret` seam), and `re-armable`/`on-401` (reactively re-minted on an observed auth failure — the Linear OAuth-mint shape). `armSecret()` never throws and reports `{ armed, rotated, restartRequired }` — `restartRequired: true` is the literal mechanism the 2026-08-02 outage lacked: a `boot-only` row (or a `re-armable` row with no hook registered yet — the two degrade identically, by design, so a consumer that never wires the arm path can't look safer than one that structurally can't) reports it when a caller invokes `armSecret` and the resolved value has changed since the PROCESS's last `armSecret` observation for that id (`_lastArmedValue` is module-level, one baseline per secret id shared by every caller in the process — caller B observing a rotation resets what caller A sees) — a caller-invoked report, not an automatic one fired the moment the value changes. No production call site invokes `armSecret` today (a repo-wide search outside tests finds only the definition and a comment reference in `linear-remint.mjs`), so this reporting is not yet wired to any running daemon.
 
-**Consumers folded onto the contract so far**: the 10-file/12-site Linear-token read
-(`linear-query.mjs` — 3 sites, `cluster-heartbeat.mjs`, `cluster-claim.mjs`,
-`linear-estimation-method.mjs`, `linear-reconcile-cli.mjs`, three `orch-monitor/lib/linear-*`
-fallback readers, `score-tickets.ts`, and the bash `catalyst_resolve_secret linear-api-token`
-snippet in `plugins/dev/skills/phase-triage/SKILL.md`); the Linear OAuth-mint trio
-(`linear-app-actor.sh`'s bash mint, `linear-remint.mjs`'s orchestrator-actor reminter — registered
-as the row's live rearm hook — and `linear-comment-post.sh`'s worker-actor chain, legacy tiers
-preserved verbatim); the cloud-token env-var **name** resolver (`config.mjs`'s
-`resolveNodeCloudTokenEnv` now delegates directly to `resolveCloudTokenName`;
-`health-responder.sh`'s bun-less fallback path instead calls the independently-maintained bash
-mirror `catalyst_secret_cloud_token_name` — kept byte-for-byte with the JS resolver by the parity
-suite, not a shared function call); and `catalyst doctor` itself, which consults the contract
-through `resolveSecret` directly rather than a parallel presence check — as a **shadow** comparison
-(INFO-only, never changes a grade) for most checks, with `checkPeerUniqueness` /
-`checkBotCredentials` / `checkWorkerLabels` cut over to the contract as their _live_
-`linear-api-token` answer, and one grade-changing addition: `checkCloudTokenEnv` now FAILs when the
-active deployment mode is declared `cloud` and the `cloud-token` bootstrap row doesn't resolve — the
-one FAIL doctor cannot route around. The GitHub-token/webhook-secret pair that motivated the
-contract (CTL-1612's `catalyst-secret-env.sh` / `github-auth-preflight.mjs`) has **not yet** been
-re-pointed onto the shared engine — both rows exist in the registry today for shadow comparison and
-future consumers, but the live CTL-1612 code path is still its own, pre-existing implementation.
+**Consumers folded onto the contract so far**: the 10-file/12-site Linear-token read (`linear-query.mjs` — 3 sites, `cluster-heartbeat.mjs`, `cluster-claim.mjs`, `linear-estimation-method.mjs`, `linear-reconcile-cli.mjs`, three `orch-monitor/lib/linear-*` fallback readers, `score-tickets.ts`, and the bash `catalyst_resolve_secret linear-api-token` snippet in `plugins/dev/skills/phase-triage/SKILL.md`); the Linear OAuth-mint trio (`linear-app-actor.sh`'s bash mint, `linear-remint.mjs`'s orchestrator-actor reminter — registered as the row's live rearm hook — and `linear-comment-post.sh`'s worker-actor chain, legacy tiers preserved verbatim); the cloud-token env-var **name** resolver (`config.mjs`'s `resolveNodeCloudTokenEnv` now delegates directly to `resolveCloudTokenName`; `health-responder.sh`'s bun-less fallback path instead calls the independently-maintained bash mirror `catalyst_secret_cloud_token_name` — kept byte-for-byte with the JS resolver by the parity suite, not a shared function call); and `catalyst doctor` itself, which consults the contract through `resolveSecret` directly rather than a parallel presence check — as a **shadow** comparison (INFO-only, never changes a grade) for most checks, with `checkPeerUniqueness` / `checkBotCredentials` / `checkWorkerLabels` cut over to the contract as their _live_ `linear-api-token` answer, and one grade-changing addition: `checkCloudTokenEnv` now FAILs when the active deployment mode is declared `cloud` and the `cloud-token` bootstrap row doesn't resolve — the one FAIL doctor cannot route around. The GitHub-token/webhook-secret pair that motivated the contract (CTL-1612's `catalyst-secret-env.sh` / `github-auth-preflight.mjs`) has **not yet** been re-pointed onto the shared engine — both rows exist in the registry today for shadow comparison and future consumers, but the live CTL-1612 code path is still its own, pre-existing implementation.
 
-The same PR5 that unified the cloud-token name resolver did adjacent, unrelated cleanup on Groq's
-`GROQ_API_KEY` ladder (`dsl-cli.mjs` and `hud.tsx` joined `broker/config.mjs` on the shared
-`resolveApiKey`) — but that is `lib/api-key-health.mjs`'s pre-existing (CTL-343) resolver, not this
-contract: none of those three call sites import `secret-contract.mjs`, and the registry's own
-`groq-api-key` row has no consumer today besides `checkSecretContract`'s shadow-only observation.
+The same PR5 that unified the cloud-token name resolver did adjacent, unrelated cleanup on Groq's `GROQ_API_KEY` ladder (`dsl-cli.mjs` and `hud.tsx` joined `broker/config.mjs` on the shared `resolveApiKey`) — but that is `lib/api-key-health.mjs`'s pre-existing (CTL-343) resolver, not this contract: none of those three call sites import `secret-contract.mjs`, and the registry's own `groq-api-key` row has no consumer today besides `checkSecretContract`'s shadow-only observation.
 
-**Secret-env hygiene rule**: the bash engine's `_csc_set_result` exports the non-secret
-`CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell's convenience but
-**never** exports the resolved value itself (`CATALYST_SECRET_LAST_VALUE` stays same-shell-only,
-with `export -n` reasserted on every call since bash's export attribute is sticky across
-reassignment) — a long-lived daemon shell must not leak a credential into every child process it
-launches.
+**Secret-env hygiene rule**: the bash engine's `_csc_set_result` exports the non-secret `CATALYST_SECRET_LAST_SOURCE`/`_PROVIDER` breadcrumbs for the calling shell's convenience but **never** exports the resolved value itself (`CATALYST_SECRET_LAST_VALUE` stays same-shell-only, with `export -n` reasserted on every call since bash's export attribute is sticky across reassignment) — a long-lived daemon shell must not leak a credential into every child process it launches.
 
 ## Agent Teams vs Subagents
 
@@ -565,22 +150,14 @@ launches.
 | Cross-layer features (FE+BE+tests)              | NO              | YES         |
 | Cost-sensitive                                  | YES             | NO          |
 
-- **Subagents (Task tool)** — own context window, results return to caller; cannot nest; lower cost.
-  Default for research/analysis/search.
-- **Agent Teams (TeammateTool, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`)** — each teammate is a full
-  session that CAN spawn its own subagents (two-level parallelism); peer messaging; higher cost. For
-  cross-layer/complex work.
+- **Subagents (Task tool)** — own context window, results return to caller; cannot nest; lower cost. Default for research/analysis/search.
+- **Agent Teams (TeammateTool, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`)** — each teammate is a full session that CAN spawn its own subagents (two-level parallelism); peer messaging; higher cost. For cross-layer/complex work.
 
-Best practices: lead on Opus, teammates on Sonnet; ~5–6 tasks/teammate; each teammate owns distinct
-files; plan-approval gates for risky work.
+Best practices: lead on Opus, teammates on Sonnet; ~5–6 tasks/teammate; each teammate owns distinct files; plan-approval gates for risky work.
 
 ## Agent Communication (catalyst-comms)
 
-File-based JSONL messaging at `~/catalyst/comms/channels/<name>.jsonl`. Bidirectional (CTL-249):
-orchestrators broadcast to and directly message individual workers; workers poll for directed
-messages at each phase boundary. `catalyst-comms send` also emits a `comms.message.posted` v2 event
-to the unified log, so monitoring tools and `catalyst-events wait-for` observe comms from the same
-file as GitHub/Linear events.
+File-based JSONL messaging at `~/catalyst/comms/channels/<name>.jsonl`. Bidirectional (CTL-249): orchestrators broadcast to and directly message individual workers; workers poll for directed messages at each phase boundary. `catalyst-comms send` also emits a `comms.message.posted` v2 event to the unified log, so monitoring tools and `catalyst-events wait-for` observe comms from the same file as GitHub/Linear events.
 
 ```bash
 catalyst-comms join "$CHANNEL" --as <id> [--as orchestrator|--parent orchestrator]
@@ -589,105 +166,42 @@ catalyst-comms poll "$CHANNEL" --filter-to "$TICKET_ID" --since "$LAST_READ"
 catalyst-comms watch "$CHANNEL"   # live tail (human auditor)
 ```
 
-(Legacy `/oneshot` worker examples now live in the `plugins/legacy` plugin — see Phase-Agent
-Communication for the current model.) Contract: every worker produces ≥4 messages/run. Signal files
-remain authoritative state; comms is observability + coordination. Full protocol:
-`plugins/dev/skills/catalyst-comms/SKILL.md`.
+(Legacy `/oneshot` worker examples now live in the `plugins/legacy` plugin — see Phase-Agent Communication for the current model.) Contract: every worker produces ≥4 messages/run. Signal files remain authoritative state; comms is observability + coordination. Full protocol: `plugins/dev/skills/catalyst-comms/SKILL.md`.
 
 ## Phase-Agent Communication
 
-In `dispatchMode = "phase-agents"` (template default; also used internally by the `execution-core`
-daemon) the orchestrator spawns one short-lived `claude --bg` job per phase, walking the 10-phase
-pipeline (triage → research → plan → implement → verify → review → pr → monitor-merge →
-monitor-deploy → teardown — see `docs/orchestrator-overview.md`). Phase agents never message each
-other; they **append typed events to the shared log** `~/catalyst/events/YYYY-MM.jsonl`. The
-orchestrator wakes on those events via the broker (`filter.wake.<ORCH_NAME>`), advances the ticket
-via `orchestrate-phase-advance`, and dispatches the next `--bg` job. Dispatcher:
-`plugins/dev/scripts/phase-agent-dispatch` (CTL-448). `oneshot-legacy` (single long-lived
-job/ticket) is the runtime fallback when the key is missing.
+In `dispatchMode = "phase-agents"` (template default; also used internally by the `execution-core` daemon) the orchestrator spawns one short-lived `claude --bg` job per phase, walking the 10-phase pipeline (triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown — see `docs/orchestrator-overview.md`). Phase agents never message each other; they **append typed events to the shared log** `~/catalyst/events/YYYY-MM.jsonl`. The orchestrator wakes on those events via the broker (`filter.wake.<ORCH_NAME>`), advances the ticket via `orchestrate-phase-advance`, and dispatches the next `--bg` job. Dispatcher: `plugins/dev/scripts/phase-agent-dispatch` (CTL-448). `oneshot-legacy` (single long-lived job/ticket) is the runtime fallback when the key is missing.
 
 ### Publish-capability preflight and the push remote (CAT-60)
 
-GitHub access is asymmetric: cloning, fetching, and reading a repository can succeed for an identity
-that cannot publish a branch there. Catalyst resolves the write target separately and checks its
-push capability inside `dispatchAndVerify`, immediately before launching a phase worker.
+GitHub access is asymmetric: cloning, fetching, and reading a repository can succeed for an identity that cannot publish a branch there. Catalyst resolves the write target separately and checks its push capability inside `dispatchAndVerify`, immediately before launching a phase worker.
 
-Historically three surfaces assumed `origin`: the rebase/diff base, the push target, and remote-branch
-discovery during resume. CAT-60 makes the push target and resume discovery use the resolved push
-remote. The rebase/diff base deliberately remains `origin/<base>`; publication routing cannot
-change the canonical integration base.
+Historically three surfaces assumed `origin`: the rebase/diff base, the push target, and remote-branch discovery during resume. CAT-60 makes the push target and resume discovery use the resolved push remote. The rebase/diff base deliberately remains `origin/<base>`; publication routing cannot change the canonical integration base.
 
-The probe returns `allowed`, `denied`, or `unknown` under an `off` / `shadow` / `enforce` rollout
-flag (`CATALYST_PUBLISH_PREFLIGHT` over Layer-2 configuration, default `shadow`). Shadow emits
-`publish.preflight.would-block` and continues. Enforce blocks only a definitive denial and emits
-`publish.preflight.blocked`; unknown always proceeds. A bounded identity-aware cache conserves
-GitHub quota. The worker-only doctor check reports PASS when allowed, WARN for shadow denial, FAIL
-for enforce denial, and INFO when inconclusive.
+The probe returns `allowed`, `denied`, or `unknown` under an `off` / `shadow` / `enforce` rollout flag (`CATALYST_PUBLISH_PREFLIGHT` over Layer-2 configuration, default `shadow`). Shadow emits `publish.preflight.would-block` and continues. Enforce blocks only a definitive denial and emits `publish.preflight.blocked`; unknown always proceeds. A bounded identity-aware cache conserves GitHub quota. The worker-only doctor check reports PASS when allowed, WARN for shadow denial, FAIL for enforce denial, and INFO when inconclusive.
 
 ### The Codex account selector seam (CTL-2072)
 
-`codexConfig().codexHome` (`execution-core/config.mjs`) resolves
-`CATALYST_CODEX_HOME` → Layer-1 `catalyst.orchestration.codex.codexHome` →
-`${catalystDir()}/codex-home`, and `buildCodexEnv` sets the child's `CODEX_HOME` from it on
-every dispatch. With neither pin set that third rung is a **constant path that is a symlink**,
-re-resolved per dispatch — so repointing the symlink changes which account the next `codex exec`
-child runs under **with no daemon restart and no rearm hook**. That is the whole switching
-mechanism (`catalyst-stack codex-account switch`), and it is strictly simpler than the Claude
-side, which must call `cmd_restart` because the SDK executor captures its token at boot.
-`execution-core` needs **zero** changes for this: the resolver's single-string contract is
-preserved, and multi-account state lives entirely in the filesystem layout beside it.
+`codexConfig().codexHome` (`execution-core/config.mjs`) resolves `CATALYST_CODEX_HOME` → Layer-1 `catalyst.orchestration.codex.codexHome` → `${catalystDir()}/codex-home`, and `buildCodexEnv` sets the child's `CODEX_HOME` from it on every dispatch. With neither pin set that third rung is a **constant path that is a symlink**, re-resolved per dispatch — so repointing the symlink changes which account the next `codex exec` child runs under **with no daemon restart and no rearm hook**. That is the whole switching mechanism (`catalyst-stack codex-account switch`), and it is strictly simpler than the Claude side, which must call `cmd_restart` because the SDK executor captures its token at boot. `execution-core` needs **zero** changes for this: the resolver's single-string contract is preserved, and multi-account state lives entirely in the filesystem layout beside it.
 
 Two consequences are load-bearing:
 
-- **The symlink is the LAST rung, so a pin silently wins.** A host with `CATALYST_CODEX_HOME`
-  exported or Layer-1 `codexHome` set never reaches the selector, and a switch would repoint a
-  link nothing reads while reporting success. `_cx_assert_selector_unpinned` refuses instead,
-  naming the pin. A check that cannot fail is not a check.
-- **Credentials never travel.** Codex subscription `auth.json` is rotation-bound — a copy goes
-  stale the moment the original refreshes — so each host runs `codex login` per account into its
-  own `CODEX_HOME` and the cluster SOPS bundle carries only the selector's handle NAME. That
-  entry deliberately has **no `SECRET_REGISTRY` row**: every delivery type that would fit is in
-  `_BOOT_CAPTURED_DELIVERIES`, so a row would make every account switch emit a fleet-wide
-  restart-required signal (`cluster-sync.mjs:1182`) for a change that provably needs no restart.
-  `syncSecretFiles` materializes the entry regardless of registry membership, so nothing is lost.
+- **The symlink is the LAST rung, so a pin silently wins.** A host with `CATALYST_CODEX_HOME` exported or Layer-1 `codexHome` set never reaches the selector, and a switch would repoint a link nothing reads while reporting success. `_cx_assert_selector_unpinned` refuses instead, naming the pin. A check that cannot fail is not a check.
+- **Credentials never travel.** Codex subscription `auth.json` is rotation-bound — a copy goes stale the moment the original refreshes — so each host runs `codex login` per account into its own `CODEX_HOME` and the cluster SOPS bundle carries only the selector's handle NAME. That entry deliberately has **no `SECRET_REGISTRY` row**: every delivery type that would fit is in `_BOOT_CAPTURED_DELIVERIES`, so a row would make every account switch emit a fleet-wide restart-required signal (`cluster-sync.mjs:1182`) for a change that provably needs no restart. `syncSecretFiles` materializes the entry regardless of registry membership, so nothing is lost.
 
-The account plane itself (`codex app-server`'s `account/read` + `account/rateLimits/read`) is
-read by `codex-accounts-usage.mjs` at **zero token cost**, unlike the Claude twin which must
-spend one inference call per account. Its `initialize` reply echoes the resolved `codexHome`
-back, which is a free positive control the Claude side never had: a read whose echo does not
-match the requested home is an `error`, never an `ok` with plausible numbers. ⚠️ The echo is
-**realpath-resolved**, so that comparison must resolve both sides — the selector being a symlink
-is exactly the case a raw string compare would break on.
+The account plane itself (`codex app-server`'s `account/read` + `account/rateLimits/read`) is read by `codex-accounts-usage.mjs` at **zero token cost**, unlike the Claude twin which must spend one inference call per account. Its `initialize` reply echoes the resolved `codexHome` back, which is a free positive control the Claude side never had: a read whose echo does not match the requested home is an `error`, never an `ok` with plausible numbers. ⚠️ The echo is **realpath-resolved**, so that comparison must resolve both sides — the selector being a symlink is exactly the case a raw string compare would break on.
 
-⛔ Quota windows are named from `windowDurationMins`, **never** from field position. Measured on
-mini-2 (codex-cli 0.147.0, 2026-08-22): the top-level `codex` bucket's `primary` is a WEEKLY
-window with `secondary: null`, while a real 5-hour window exists only under a different bucket
-(`codex_bengalfox`). The naive positional `{primary→fiveHour, secondary→sevenDay}` port of the
-Claude shape would mislabel the weekly window as 5h and report the 5h window as absent — both in
-the direction that reads as "quota to spare".
+⛔ Quota windows are named from `windowDurationMins`, **never** from field position. Measured on mini-2 (codex-cli 0.147.0, 2026-08-22): the top-level `codex` bucket's `primary` is a WEEKLY window with `secondary: null`, while a real 5-hour window exists only under a different bucket (`codex_bengalfox`). The naive positional `{primary→fiveHour, secondary→sevenDay}` port of the Claude shape would mislabel the weekly window as 5h and report the 5h window as absent — both in the direction that reads as "quota to spare".
 
 ### Dispatch-time rebase (front-load conflict surfacing, CTL-667 + CTL-707 + CAT-31)
 
-On a **fresh** dispatch of a **build** phase (`research`,`plan`,`implement`,`verify`,`review`),
-`phase-agent-dispatch` rebases the ticket's worktree onto current `origin/<base>` before launching
-the worker, so divergence surfaces early instead of riding stale to `monitor-merge` (CTL-608).
-CTL-707 replaced the binary CTL-667 rebase with a 4-layer strategy:
+On a **fresh** dispatch of a **build** phase (`research`,`plan`,`implement`,`verify`,`review`), `phase-agent-dispatch` rebases the ticket's worktree onto current `origin/<base>` before launching the worker, so divergence surfaces early instead of riding stale to `monitor-merge` (CTL-608). CTL-707 replaced the binary CTL-667 rebase with a 4-layer strategy:
 
-Before config resolution, signal creation, rebase, and worker launch, the dispatcher resolves the
-ticket worktree through an explicit flag, the project registry, the current repository, then a
-backwards-compatible cwd fallback. It changes into that resolved tree, making dispatch safe from any
-caller cwd; the JS caller's `cwd` remains a belt-and-braces reinforcement. This also prevents L3
-destroy-and-recreate from selecting a bystander worktree.
+Before config resolution, signal creation, rebase, and worker launch, the dispatcher resolves the ticket worktree through an explicit flag, the project registry, the current repository, then a backwards-compatible cwd fallback. It changes into that resolved tree, making dispatch safe from any caller cwd; the JS caller's `cwd` remains a belt-and-braces reinforcement. This also prevents L3 destroy-and-recreate from selecting a bystander worktree.
 
-- **L1 — Periodic background refresh** (`execution-core/worktree-refresh-timer.mjs`): keeps idle
-  running worktrees current. Config
-  `catalyst.orchestration.worktreeRefresh.{enabled,intervalSeconds,quietSeconds}`.
-- **L2 — Dispatch-time conflict classifier** (`lib/worktree-rebase.sh:rebase_onto_base_classified`):
-  tests-only → auto-resolve (`--theirs`); noise (`.catalyst/`,`.trunk/`) → `--ours`; `thoughts/**` →
-  stall rc=3; real source → CTL-708 stub (always unavailable) → stall rc=2.
-- **L3 — Phase-aware fallback** (`phase-agent-dispatch`): terminal source conflict (rc=2) on
-  `research`/`plan` → destroy+recreate worktree fresh; same on `implement`/`verify`/`review` → park
-  an escalation; thoughts conflict (rc=3) → park on all phases.
+- **L1 — Periodic background refresh** (`execution-core/worktree-refresh-timer.mjs`): keeps idle running worktrees current. Config `catalyst.orchestration.worktreeRefresh.{enabled,intervalSeconds,quietSeconds}`.
+- **L2 — Dispatch-time conflict classifier** (`lib/worktree-rebase.sh:rebase_onto_base_classified`): tests-only → auto-resolve (`--theirs`); noise (`.catalyst/`,`.trunk/`) → `--ours`; `thoughts/**` → stall rc=3; real source → CTL-708 stub (always unavailable) → stall rc=2.
+- **L3 — Phase-aware fallback** (`phase-agent-dispatch`): terminal source conflict (rc=2) on `research`/`plan` → destroy+recreate worktree fresh; same on `implement`/`verify`/`review` → park an escalation; thoughts conflict (rc=3) → park on all phases.
 - **L4 — Telemetry** (`lib/rebase-telemetry.sh`):
 
 | Event                                                | Severity | Emitter                  |
@@ -698,20 +212,13 @@ destroy-and-recreate from selecting a bystander worktree.
 | `phase.<phase>.rebase-conflict-stalled.<ticket>`     | ERROR    | L2 (terminal)            |
 | `phase.<phase>.dispatch-cwd-corrected.<ticket>`      | WARN     | CAT-31 resolver          |
 
-Loki:
-`{job="catalyst-events"} | json | attributes["event.name"] =~ "phase\\..*\\.auto-rebased\\..*"`
-(swap suffix per event).
+Loki: `{job="catalyst-events"} | json | attributes["event.name"] =~ "phase\\..*\\.auto-rebased\\..*"` (swap suffix per event).
 
-Invariants (unchanged from CTL-667): **cwd-independent** (the target is resolved, not inherited);
-**fresh-only** (resume `--resume-session` skips, CTL-658); **build-phase-only** (`is_rebase_phase`
-in `lib/phase-sequence.sh`; `triage`/`pr`/`remediate`/`monitor-*`/`teardown` exempt); **local-only**
-(never pushes/touches the PR; `.catalyst/config.json`,`.trunk/*` stashed across rebase); transient
-`git fetch` failure (rc=1) → proceed un-rebased.
+Invariants (unchanged from CTL-667): **cwd-independent** (the target is resolved, not inherited); **fresh-only** (resume `--resume-session` skips, CTL-658); **build-phase-only** (`is_rebase_phase` in `lib/phase-sequence.sh`; `triage`/`pr`/`remediate`/`monitor-*`/`teardown` exempt); **local-only** (never pushes/touches the PR; `.catalyst/config.json`,`.trunk/*` stashed across rebase); transient `git fetch` failure (rc=1) → proceed un-rebased.
 
 ### PR as the durable work record (CTL-783)
 
-During an orchestrated implement phase the draft PR is the off-disk, restart-surviving record of
-active work:
+During an orchestrated implement phase the draft PR is the off-disk, restart-surviving record of active work:
 
 | Signal        | Meaning                       |
 | ------------- | ----------------------------- |
@@ -720,325 +227,80 @@ active work:
 | PR ready      | in review (phase-pr promoted) |
 | PR merged     | done                          |
 
-- **Branch naming**: from Linear `branchName` (`ryan/<ticket>-slug`); `create-worktree.sh` never
-  overrides.
-- **PR title**: `<type>(<scope>): <ticket> …` via `draft_pr_title` in
-  `plugins/dev/scripts/lib/draft-pr.sh` (injects ticket after the conventional prefix; both
-  `draft_pr_ensure` and `create-pr` Step 7 route through it).
-- **Lifecycle**: (1) `implement-plan` runs `implement-plan-draft-pr-early` after each plan-phase
-  commit — `draft_pr_push`+`draft_pr_ensure` (idempotent; first opens, later push). Interactive runs
-  gated by `[[ -n "${CATALYST_PHASE:-}" ]]`. (2) `phase-implement` End block runs
-  `phase-implement-draft-pr` as idempotent backstop and is the **sole writer** of
-  `.draftPr={number,url,isDraft}` into the signal file. (3) `phase-pr` calls `draft_pr_promote` to
-  flip draft→ready (avoids `create-pr`'s "PR already exists" hang).
-- **Config**: `orchestration.draftPr.enabled` (default `true`) — set `false` for no early draft, so
-  the PR is created only at the `pr` phase.
-- **Resume consumer (CTL-1640)**: the pushed commits on `origin/<ticket>` are the durable record a
-  new worktree resumes from. `create-worktree.sh` seeds a fresh branch from `origin/<ticket>` when
-  it exists (default-on; `--no-from-remote` opts out), so both normal dispatch and cross-host
-  reclaim (`defaultRebuildWorktree`) rebuild on the dead host's pushed work instead of orphaning it
-  under a fresh branch off base. Resolved straight from git (`origin/<ticket>`), not by reading
-  `.draftPr`. The operator-facing CLI contract (default-on, the `--no-from-remote` / `--skip-fetch`
-  opt-outs) is owned by and documented in `plugins/dev/skills/create-worktree/SKILL.md`.
-- **Deferred**: reading `.draftPr` draft-state as a secondary advancement signal (advancement
-  currently driven by signal `status === "done"` only).
+- **Branch naming**: from Linear `branchName` (`ryan/<ticket>-slug`); `create-worktree.sh` never overrides.
+- **PR title**: `<type>(<scope>): <ticket> …` via `draft_pr_title` in `plugins/dev/scripts/lib/draft-pr.sh` (injects ticket after the conventional prefix; both `draft_pr_ensure` and `create-pr` Step 7 route through it).
+- **Lifecycle**: (1) `implement-plan` runs `implement-plan-draft-pr-early` after each plan-phase commit — `draft_pr_push`+`draft_pr_ensure` (idempotent; first opens, later push). Interactive runs gated by `[[ -n "${CATALYST_PHASE:-}" ]]`. (2) `phase-implement` End block runs `phase-implement-draft-pr` as idempotent backstop and is the **sole writer** of `.draftPr={number,url,isDraft}` into the signal file. (3) `phase-pr` calls `draft_pr_promote` to flip draft→ready (avoids `create-pr`'s "PR already exists" hang).
+- **Config**: `orchestration.draftPr.enabled` (default `true`) — set `false` for no early draft, so the PR is created only at the `pr` phase.
+- **Resume consumer (CTL-1640)**: the pushed commits on `origin/<ticket>` are the durable record a new worktree resumes from. `create-worktree.sh` seeds a fresh branch from `origin/<ticket>` when it exists (default-on; `--no-from-remote` opts out), so both normal dispatch and cross-host reclaim (`defaultRebuildWorktree`) rebuild on the dead host's pushed work instead of orphaning it under a fresh branch off base. Resolved straight from git (`origin/<ticket>`), not by reading `.draftPr`. The operator-facing CLI contract (default-on, the `--no-from-remote` / `--skip-fetch` opt-outs) is owned by and documented in `plugins/dev/skills/create-worktree/SKILL.md`.
+- **Deferred**: reading `.draftPr` draft-state as a secondary advancement signal (advancement currently driven by signal `status === "done"` only).
 
 ### Orphan-stale merged-PR reconciliation (CAT-47)
 
-`runTick` constructs the `unstuckSeamDeps` bundle — PR-state resolver, background-job liveness
-probe, stall clearer, and status writer — once via `buildRecoverySeamDeps`, and Pass 0u uses it to
-build its act registry. (CTL-2141 deleted Pass 0r, the bundle's other historical consumer; the
-bundle-then-registry shape and the `seamFallbackSuppressed` posture below are unchanged for Pass 0u
-alone.)
+`runTick` constructs the `unstuckSeamDeps` bundle — PR-state resolver, background-job liveness probe, stall clearer, and status writer — once via `buildRecoverySeamDeps`, and Pass 0u uses it to build its act registry. (CTL-2141 deleted Pass 0r, the bundle's other historical consumer; the bundle-then-registry shape and the `seamFallbackSuppressed` posture below are unchanged for Pass 0u alone.)
 
-An embedder- or test-supplied `unstuckActByCategory` is an intentional posture: a partial registry
-or `{}` sets `seamFallbackSuppressed`, so the pass reports suppression instead of silently rebuilding
-a live registry behind the override. With no injected registry, capability fallback remains active.
+An embedder- or test-supplied `unstuckActByCategory` is an intentional posture: a partial registry or `{}` sets `seamFallbackSuppressed`, so the pass reports suppression instead of silently rebuilding a live registry behind the override. With no injected registry, capability fallback remains active.
 
-The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact
-`.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the
-liveness gate. Marker construction fails closed when phase is absent, preventing malformed
-`undefined` or `null` marker names. PR-state readers are synchronous. The act seam surfaces a
-thenable as `pr-state-async-unsupported` with an error-code identity; the census warns and returns
-`null`, which classifies as `pr-state-unknown`. A resolver error merely mentioning the unsupported
-code still fails closed to `pr-state-unknown`.
+The recovery candidate contract is `{ ticket, phase, signal }`. `phase` names the exact `.unstuck-orphan-merge-<phase>.applied` idempotency marker, and `signal.bg_job_id` feeds the liveness gate. Marker construction fails closed when phase is absent, preventing malformed `undefined` or `null` marker names. PR-state readers are synchronous. The act seam surfaces a thenable as `pr-state-async-unsupported` with an error-code identity; the census warns and returns `null`, which classifies as `pr-state-unknown`. A resolver error merely mentioning the unsupported code still fails closed to `pr-state-unknown`.
 
-Synthetic completion is restricted by `ORPHAN_MERGE_PHASE_ALLOWLIST` to `monitor-merge` and
-`monitor-deploy`. The classifier applies that as its first gate, refusing an early phase with
-`phase-not-allowlisted` even when its PR is merged.
+Synthetic completion is restricted by `ORPHAN_MERGE_PHASE_ALLOWLIST` to `monitor-merge` and `monitor-deploy`. The classifier applies that as its first gate, refusing an early phase with `phase-not-allowlisted` even when its PR is merged.
 
 ### Explanation-required escalation chokepoint (CTL-1609, delegate-first routing removed CTL-2141)
 
-CTL-1609 originally closed two gaps at the point where the scheduler escalates a ticket: a
-delegate-first routing seam (`routeStuckTicketToDelegate` / `execution-core/delegate-first.mjs`,
-gated by `CATALYST_DELEGATE_FIRST`) that could route a stuck ticket to the delegate runner instead
-of labelling it, and an explanation-required chokepoint on the direct label path. CTL-2141 deleted
-the delegate-first seam along with the rest of the recovery-pass/board-health judgment layer it fed
-— off-mode was always byte-identical to the direct label call in production, so removing it changed
-no live behavior. All six escalation producer sites (`scheduler.mjs` / `monitor.mjs` /
-`stale-pr-rescue-timer.mjs`) now call `labelNeedsHumanUnlessBeliefOwner` directly, as they did before
-CTL-1609 and as they always resolved to in production regardless.
+CTL-1609 originally closed two gaps at the point where the scheduler escalates a ticket: a delegate-first routing seam (`routeStuckTicketToDelegate` / `execution-core/delegate-first.mjs`, gated by `CATALYST_DELEGATE_FIRST`) that could route a stuck ticket to the delegate runner instead of labelling it, and an explanation-required chokepoint on the direct label path. CTL-2141 deleted the delegate-first seam along with the rest of the recovery-pass/board-health judgment layer it fed — off-mode was always byte-identical to the direct label call in production, so removing it changed no live behavior. All six escalation producer sites (`scheduler.mjs` / `monitor.mjs` / `stale-pr-rescue-timer.mjs`) now call `labelNeedsHumanUnlessBeliefOwner` directly, as they did before CTL-1609 and as they always resolved to in production regardless.
 
-**The explanation-required chokepoint stays.** `labelNeedsHumanUnlessBeliefOwner`
-(`execution-core/label-guard.mjs`) accepts an optional `explanation` object. After a confirmed label
-application:
+**The explanation-required chokepoint stays.** `labelNeedsHumanUnlessBeliefOwner` (`execution-core/label-guard.mjs`) accepts an optional `explanation` object. After a confirmed label application:
 
-- If `explanation` is absent → emits `escalation.explanation-absent` warn and coerces a degraded
-  fallback via `coerceExplanation` (type `authorization`, `degraded: true`).
-- Writes the coerced or caller-supplied explanation to `workers/<TICKET>/phase-recovery-pass.json`
-  via `writeExplanationSignal` (atomic tmp+rename).
-- All six wired sites supply a `problem` + `call_to_action` structured explanation so the operator
-  inbox can render a real "What's needed now" card instead of a bare label.
+- If `explanation` is absent → emits `escalation.explanation-absent` warn and coerces a degraded fallback via `coerceExplanation` (type `authorization`, `degraded: true`).
+- Writes the coerced or caller-supplied explanation to `workers/<TICKET>/phase-recovery-pass.json` via `writeExplanationSignal` (atomic tmp+rename).
+- All six wired sites supply a `problem` + `call_to_action` structured explanation so the operator inbox can render a real "What's needed now" card instead of a bare label.
 
 New event name (registered in `broker/namespace-parity.test.mjs`): `escalation.explanation-absent`.
 
 ### Runaway-loop guards (CTL-671)
 
-`schedulerTick` is hardened against runaway dispatch/reclaim loops on phantom/non-resolving tickets
-(phantom CTL-9 once spammed ~24,560 `phase.*` events over 3 days, 92% per-tick `work-done-probe`
-reclaim storms). Three additive defenses:
+`schedulerTick` is hardened against runaway dispatch/reclaim loops on phantom/non-resolving tickets (phantom CTL-9 once spammed ~24,560 `phase.*` events over 3 days, 92% per-tick `work-done-probe` reclaim storms). Three additive defenses:
 
-- **Pass 0a — phantom worker-dir validity sweep** (before reclaim): quarantines `workers/<ticket>/`
-  to terminal `stalled` (`stalledReason:"phantom-ticket"`) only when all three hold: ticket
-  definitively **not-found** in Linear, **not in eligible set**, and **no live bg worker**. The
-  conjunction + 3-valued `classifyTicketResolution` (transient outage → `unknown`, never
-  `not-found`) means a Linear outage can't quarantine a healthy in-flight ticket.
-  `classifyTicketResolution`/`isBgJobAlive` are safe no-ops by default in `schedulerTick`, armed
-  with real impls by the daemon's `runTick`.
-- **Dispatch circuit breaker** (Linear-independent backstop): the CTL-624 cool-down marker carries
-  `consecutiveFailures`; after `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` (default 8) consecutive failed
-  dispatches with no progress → quarantine `stalled` (`stalledReason:"dispatch-circuit-breaker"`). A
-  successful dispatch clears it.
-- **Runaway-rate alert (observability only)**: when a single ticket's `phase.*.<ticket>` rate
-  crosses `SCHEDULER_RUNAWAY_THRESHOLD` (default 50) within `SCHEDULER_RUNAWAY_WINDOW_MS` (default
-  10 min), emit one `phase.dispatch.runaway.<ticket>` per window (marker under
-  `orchDir/.runaway-alerts/`). Surfaces in HUD; does not quarantine.
+- **Pass 0a — phantom worker-dir validity sweep** (before reclaim): quarantines `workers/<ticket>/` to terminal `stalled` (`stalledReason:"phantom-ticket"`) only when all three hold: ticket definitively **not-found** in Linear, **not in eligible set**, and **no live bg worker**. The conjunction + 3-valued `classifyTicketResolution` (transient outage → `unknown`, never `not-found`) means a Linear outage can't quarantine a healthy in-flight ticket. `classifyTicketResolution`/`isBgJobAlive` are safe no-ops by default in `schedulerTick`, armed with real impls by the daemon's `runTick`.
+- **Dispatch circuit breaker** (Linear-independent backstop): the CTL-624 cool-down marker carries `consecutiveFailures`; after `SCHEDULER_CIRCUIT_BREAKER_THRESHOLD` (default 8) consecutive failed dispatches with no progress → quarantine `stalled` (`stalledReason:"dispatch-circuit-breaker"`). A successful dispatch clears it.
+- **Runaway-rate alert (observability only)**: when a single ticket's `phase.*.<ticket>` rate crosses `SCHEDULER_RUNAWAY_THRESHOLD` (default 50) within `SCHEDULER_RUNAWAY_WINDOW_MS` (default 10 min), emit one `phase.dispatch.runaway.<ticket>` per window (marker under `orchDir/.runaway-alerts/`). Surfaces in HUD; does not quarantine.
 
-Enforcement reuses the sweep + breaker: a `stalled` signal makes `isTicketInFlight` drop the ticket;
-the terminal sweep publishes the escalation via `labelOnce`.
+Enforcement reuses the sweep + breaker: a `stalled` signal makes `isTicketInFlight` drop the ticket; the terminal sweep publishes the escalation via `labelOnce`.
 
-A worker directory must not persist with zero phase signals (CAT-24). The shared stall-clear seam
-removes the directory when it deletes the last real signal — but only once `clearStalledLabel`
-reports a CONFIRMED label removal (`onSettled`), since production's `removeLabel` is async: removing
-inline would race the `onRemoved` callback that re-creates the dir to write
-`.janitor-cleared-<phase>.applied`, and on a FAILED removal would drop the once-marker while Linear
-still carries the label. Aged signal-less residue is also dropped from the new-work exclude set
-(grace: `orchestration.orphanReaper.workerGc.emptyDirGraceSeconds`, default 600s) and reclaimed by
-worker-dir GC after its retention gate. Three fail-closed guards bound the reclaim: a dir whose
-phase JSON is unreadable/malformed is skipped entirely (the discarded session id is what the
-liveness gate correlates on), a zero-signal dir preserving a non-empty unconsumed `inbox.jsonl` is
-never deleted (and is re-pullable immediately rather than parked for the grace), and every deletion
-DETACHES first — the dir is atomically renamed to a GC-owned `.gc-<ticket>-<ts>` sibling so a
-concurrent redispatch writes into a fresh inode the sweep can no longer touch.
+A worker directory must not persist with zero phase signals (CAT-24). The shared stall-clear seam removes the directory when it deletes the last real signal — but only once `clearStalledLabel` reports a CONFIRMED label removal (`onSettled`), since production's `removeLabel` is async: removing inline would race the `onRemoved` callback that re-creates the dir to write `.janitor-cleared-<phase>.applied`, and on a FAILED removal would drop the once-marker while Linear still carries the label. Aged signal-less residue is also dropped from the new-work exclude set (grace: `orchestration.orphanReaper.workerGc.emptyDirGraceSeconds`, default 600s) and reclaimed by worker-dir GC after its retention gate. Three fail-closed guards bound the reclaim: a dir whose phase JSON is unreadable/malformed is skipped entirely (the discarded session id is what the liveness gate correlates on), a zero-signal dir preserving a non-empty unconsumed `inbox.jsonl` is never deleted (and is re-pullable immediately rather than parked for the grace), and every deletion DETACHES first — the dir is atomically renamed to a GC-owned `.gc-<ticket>-<ts>` sibling so a concurrent redispatch writes into a fresh inode the sweep can no longer touch.
 
 ### Stuck-but-alive daemon watchdog (CTL-1502)
 
-Both existing daemon-supervision paths — the launchd `KeepAlive`/`StartInterval` agents and
-`catalyst-monitor forward-start` — are **pid-liveness only** (`kill -0`), so a wedged process that
-holds its pid passes every check. The stuck-but-alive watchdog closes that emit→act gap for the
-otel-forward stack daemon: it reads _stuck predicates pid-liveness cannot see_ and, in `enforce`
-mode, restarts the stuck daemon exactly once per breach episode.
+Both existing daemon-supervision paths — the launchd `KeepAlive`/`StartInterval` agents and `catalyst-monitor forward-start` — are **pid-liveness only** (`kill -0`), so a wedged process that holds its pid passes every check. The stuck-but-alive watchdog closes that emit→act gap for the otel-forward stack daemon: it reads _stuck predicates pid-liveness cannot see_ and, in `enforce` mode, restarts the stuck daemon exactly once per breach episode.
 
-- **Two disk-only predicates (OR'd), both O(1) `statSync`/small-JSON reads that never touch the
-  daemon or the bytes they measure.** **P1 DLQ-size** — the DLQ file's `statSync().size` at or above
-  `dlqMaxBytes` (default 1 GiB); read by size, not `readFileSync`, so it stays honest past 2 GB
-  where a whole-file read throws and the in-payload `dlqDepth` silently freezes. **P2
-  forwarding-lag** — the checkpoint's `lastForwardedTs` frozen for ≥ `stalenessMs` _while the event
-  log has fresher writes_ (real backlog), so a legitimately idle forwarder never trips.
-  `lastForwardedTs` is the honest progress signal because it advances only on real forwarding,
-  unlike the checkpoint file's mtime (rewritten unconditionally every 10 s — the same trap as the
-  unconditional heartbeat).
-- **Out-of-band alert path** (the watched daemon's own egress may be the wedged thing): the alert
-  rides the exec-core daemon's pino `.log` (Alloy-shipped, independent of otel-forward) plus a
-  durable local marker `~/catalyst/watchdog/<daemon>.alert.json` latching the current stuck/cleared
-  state (a HUD/orch-monitor renderer over that marker is a follow-up — CTL-1502 Codex P2). A
-  best-effort `catalyst.alert.raised|cleared {kind:"daemon_stuck"}` event to the log (for
-  dashboards) is explicitly _not_ load-bearing — it rides the very egress that may be broken.
-- **State machine** (a structural clone of the fleet-health probe, hysteresis + cooldown): a
-  sustained breach (≥ `sustainedTicks`) restarts once; a **post-restart verify window** re-checks
-  for `verifyTicks` ticks — if the predicate clears, it emits `cleared` and re-arms; if it stays
-  tripped, it **escalates** (a latched, non-clearing raised alert + a `severity:high` recovery
-  finding) with no second restart until the `cooldownMs` (default 15 min, deliberately > the 600 s
-  launchd `StartInterval` so the two supervision layers never race) expires and a healthy tick
-  re-arms.
-- **Modes** `off/shadow/enforce` (default **`shadow`** — detect + log `would-restart`, mutate
-  nothing). Ships shadow-first; an operator flips it to `enforce` via
-  `catalyst.orchestration.daemonWatchdog.mode` or `EXECUTION_CORE_DAEMON_WATCHDOG_MODE`. Every
-  reader returns a non-crossing sentinel on throw so the guardrail can never wedge the daemon tick.
-  First ship registers exactly one target (otel-forward) behind a descriptor registry, so a second
-  watched daemon is a one-line addition.
-- **Two hosts for one probe, gated by node class.** `catalyst-stack` starts otel-forward on both
-  worker and monitor nodes but execution-core on workers only, so arming the probe solely from
-  `startDaemon` would leave every **monitor**-node forwarder supervised by pid-liveness alone. A
-  **worker** keeps the in-daemon probe; a **monitor** node runs the same probe standalone via
-  `execution-core/daemon-watchdog-run.mjs`, supervised by
-  `catalyst-monitor watchdog-start|watchdog-stop|watchdog-status` (pid file + identity check, the
-  `forward-*` shape). A **developer** node runs no forwarder, so nothing to watch. Exactly one
-  supervisor per forwarder in every topology; `cmd_stop` stops the watchdog _before_ the forwarder
-  so an in-flight enforced restart cannot relaunch it after shutdown.
-- **Restart safety in `catalyst-monitor.sh`.** The forwarder's start/stop/restart share a portable
-  `mkdir`-based mutation lock (stock macOS has no `flock`) with a dead-owner stale reaper and a
-  bounded wait; `forward-restart` holds **one** lock across both halves, so a concurrent
-  `catalyst-stack start` can't observe the momentarily-stopped forwarder and launch a second,
-  untracked one. Its `INT`/`TERM` handler **exits** rather than returning (a returning handler would
-  let an aborted restart resume into the start half). Pid files are matched by process **identity**,
-  not just `kill -0`, and fail closed — a recycled pid is treated as a stale file, never a kill
-  target. Covered by `__tests__/daemon-watchdog-supervision.test.sh`.
+- **Two disk-only predicates (OR'd), both O(1) `statSync`/small-JSON reads that never touch the daemon or the bytes they measure.** **P1 DLQ-size** — the DLQ file's `statSync().size` at or above `dlqMaxBytes` (default 1 GiB); read by size, not `readFileSync`, so it stays honest past 2 GB where a whole-file read throws and the in-payload `dlqDepth` silently freezes. **P2 forwarding-lag** — the checkpoint's `lastForwardedTs` frozen for ≥ `stalenessMs` _while the event log has fresher writes_ (real backlog), so a legitimately idle forwarder never trips. `lastForwardedTs` is the honest progress signal because it advances only on real forwarding, unlike the checkpoint file's mtime (rewritten unconditionally every 10 s — the same trap as the unconditional heartbeat).
+- **Out-of-band alert path** (the watched daemon's own egress may be the wedged thing): the alert rides the exec-core daemon's pino `.log` (Alloy-shipped, independent of otel-forward) plus a durable local marker `~/catalyst/watchdog/<daemon>.alert.json` latching the current stuck/cleared state (a HUD/orch-monitor renderer over that marker is a follow-up — CTL-1502 Codex P2). A best-effort `catalyst.alert.raised|cleared {kind:"daemon_stuck"}` event to the log (for dashboards) is explicitly _not_ load-bearing — it rides the very egress that may be broken.
+- **State machine** (a structural clone of the fleet-health probe, hysteresis + cooldown): a sustained breach (≥ `sustainedTicks`) restarts once; a **post-restart verify window** re-checks for `verifyTicks` ticks — if the predicate clears, it emits `cleared` and re-arms; if it stays tripped, it **escalates** (a latched, non-clearing raised alert + a `severity:high` recovery finding) with no second restart until the `cooldownMs` (default 15 min, deliberately > the 600 s launchd `StartInterval` so the two supervision layers never race) expires and a healthy tick re-arms.
+- **Modes** `off/shadow/enforce` (default **`shadow`** — detect + log `would-restart`, mutate nothing). Ships shadow-first; an operator flips it to `enforce` via `catalyst.orchestration.daemonWatchdog.mode` or `EXECUTION_CORE_DAEMON_WATCHDOG_MODE`. Every reader returns a non-crossing sentinel on throw so the guardrail can never wedge the daemon tick. First ship registers exactly one target (otel-forward) behind a descriptor registry, so a second watched daemon is a one-line addition.
+- **Two hosts for one probe, gated by node class.** `catalyst-stack` starts otel-forward on both worker and monitor nodes but execution-core on workers only, so arming the probe solely from `startDaemon` would leave every **monitor**-node forwarder supervised by pid-liveness alone. A **worker** keeps the in-daemon probe; a **monitor** node runs the same probe standalone via `execution-core/daemon-watchdog-run.mjs`, supervised by `catalyst-monitor watchdog-start|watchdog-stop|watchdog-status` (pid file + identity check, the `forward-*` shape). A **developer** node runs no forwarder, so nothing to watch. Exactly one supervisor per forwarder in every topology; `cmd_stop` stops the watchdog _before_ the forwarder so an in-flight enforced restart cannot relaunch it after shutdown.
+- **Restart safety in `catalyst-monitor.sh`.** The forwarder's start/stop/restart share a portable `mkdir`-based mutation lock (stock macOS has no `flock`) with a dead-owner stale reaper and a bounded wait; `forward-restart` holds **one** lock across both halves, so a concurrent `catalyst-stack start` can't observe the momentarily-stopped forwarder and launch a second, untracked one. Its `INT`/`TERM` handler **exits** rather than returning (a returning handler would let an aborted restart resume into the start half). Pid files are matched by process **identity**, not just `kill -0`, and fail closed — a recycled pid is treated as a stale file, never a kill target. Covered by `__tests__/daemon-watchdog-supervision.test.sh`.
 
 ### Forward-drop surface (CTL-1818)
 
-The watchdog above catches a **wedged** forwarder. A forwarder that is working perfectly and
-**discarding** events is a different failure, and none of the three existing instruments can see it:
-`emitDrop` (`otel-forward/lib/destinations/otlp.ts`) fires for `aged` or `terminal_4xx`, and an aged
-record **never rides the DLQ in the primary path** — so the watchdog's DLQ-size predicate stays flat,
-the checkpoint keeps advancing (a discard *is* read progress), and the
-`catalyst.observability.forward_dropped` event it writes ships through the very path that just
-discarded something. Measured on the fleet's mirrored `2026-08.jsonl` (coverage 08-08 → 08-13):
-**87,706 drop events carrying 7,623,269 discarded records, 100% `reason: "aged"`** — read by nothing
-in this repo, and by nothing in `catalyst-otel` either (the provisioned Grafana rule reads
-`forward_failed`, a different name).
+The watchdog above catches a **wedged** forwarder. A forwarder that is working perfectly and **discarding** events is a different failure, and none of the three existing instruments can see it: `emitDrop` (`otel-forward/lib/destinations/otlp.ts`) fires for `aged` or `terminal_4xx`, and an aged record **never rides the DLQ in the primary path** — so the watchdog's DLQ-size predicate stays flat, the checkpoint keeps advancing (a discard *is* read progress), and the `catalyst.observability.forward_dropped` event it writes ships through the very path that just discarded something. Measured on the fleet's mirrored `2026-08.jsonl` (coverage 08-08 → 08-13): **87,706 drop events carrying 7,623,269 discarded records, 100% `reason: "aged"`** — read by nothing in this repo, and by nothing in `catalyst-otel` either (the provisioned Grafana rule reads `forward_failed`, a different name).
 
-- **Where it is counted** — `recordDrop` (`otel-forward/lib/drop-surface.ts`) is called from
-  `emitDrop` **before** its `!eventLogPath` / `isSelfBatch` guards, both of which suppress the event
-  entirely. Counters are process-exact, per reason, in events (batches) **and** records.
-- **Three sinks, none of which ride the failing pipe** — (1) the exact in-memory counters;
-  (2) a durable marker `~/catalyst/otel-forward-drops.json` (atomic tmp+rename, `cumulative` totals
-  carried across restarts, ≤1 s write throttle bypassed on any alert transition); (3) the daemon's
-  pino `.log`, Alloy-shipped independently of its own OTLP egress. Deliberately **no** event sink —
-  an alarm sourced from the forwarded stream measures the survivors and reads clean during exactly
-  the outage it exists to detect.
-- **Sustained-rate alert** — pure `classifyDropWindow` over a bounded 60-bucket ring: breach when
-  window records `>= thresholdRecords`, alert when the breach persists `>= sustainMs` (defaults 5 min
-  / 1,000 records / 10 min, resolved env > `forwarders.otlp.dropSurface` > frozen default). Raise and
-  clear are **edge-triggered**, so a storm logs one `ERROR`, not one per batch; the forwarder's
-  existing 30 s lag timer re-evaluates so a host that recovered and went quiet does not latch raised
-  forever.
-- **ALERT-ONLY, by ruling.** This is *not* a third member of `classifyDaemonStuck`'s `tripped` list —
-  that list is wired straight to `restart()` in the CTL-1502 probe, and restarting a forwarder does
-  not fix a Loki-accept-window/backlog condition; it only loses the in-memory buffer. A Grafana rule
-  over the `.log` stream is the follow-up, and belongs in the `catalyst-otel` repo.
-- **One mechanism, three callers** — the CTL-1817 count-every/log-sparsely gate moved to
-  `otel-forward/lib/sparse-warn.ts` (semantics unchanged); the tailer's unknown-shape alarm, this
-  drop alarm, and (CTL-1823) the OTLP degenerate-record alarm each build their own gate so a flood
-  of one cannot exhaust the others' key budget.
+- **Where it is counted** — `recordDrop` (`otel-forward/lib/drop-surface.ts`) is called from `emitDrop` **before** its `!eventLogPath` / `isSelfBatch` guards, both of which suppress the event entirely. Counters are process-exact, per reason, in events (batches) **and** records.
+- **Three sinks, none of which ride the failing pipe** — (1) the exact in-memory counters; (2) a durable marker `~/catalyst/otel-forward-drops.json` (atomic tmp+rename, `cumulative` totals carried across restarts, ≤1 s write throttle bypassed on any alert transition); (3) the daemon's pino `.log`, Alloy-shipped independently of its own OTLP egress. Deliberately **no** event sink — an alarm sourced from the forwarded stream measures the survivors and reads clean during exactly the outage it exists to detect.
+- **Sustained-rate alert** — pure `classifyDropWindow` over a bounded 60-bucket ring: breach when window records `>= thresholdRecords`, alert when the breach persists `>= sustainMs` (defaults 5 min / 1,000 records / 10 min, resolved env > `forwarders.otlp.dropSurface` > frozen default). Raise and clear are **edge-triggered**, so a storm logs one `ERROR`, not one per batch; the forwarder's existing 30 s lag timer re-evaluates so a host that recovered and went quiet does not latch raised forever.
+- **ALERT-ONLY, by ruling.** This is *not* a third member of `classifyDaemonStuck`'s `tripped` list — that list is wired straight to `restart()` in the CTL-1502 probe, and restarting a forwarder does not fix a Loki-accept-window/backlog condition; it only loses the in-memory buffer. A Grafana rule over the `.log` stream is the follow-up, and belongs in the `catalyst-otel` repo.
+- **One mechanism, three callers** — the CTL-1817 count-every/log-sparsely gate moved to `otel-forward/lib/sparse-warn.ts` (semantics unchanged); the tailer's unknown-shape alarm, this drop alarm, and (CTL-1823) the OTLP degenerate-record alarm each build their own gate so a flood of one cannot exhaust the others' key budget.
 
-**Degenerate-record counting is taken at batch accept, not at serialization (CTL-1823).** The
-CTL-1817 detector incremented inside `buildOtlpPayload`, which is the serializer: it is re-entered
-once per `rawSend` attempt (it sits inside `withHttpRetry`) and again on every DLQ drain, so one
-record was re-counted on every OTLP retry and once more on replay — the counter INFLATED during
-exactly the backend trouble that makes an operator read it. The count now runs once per batch at
-`OtlpSender.flush` entry (`noteDegenerateRecords`), the single point at which each record is seen
-exactly once (`index.ts`'s `flushDest` hands `buffer.splice(0)` to one `flush()`). It counts records
-this PROCESS accepted for forwarding; a DLQ entry written by a previous process and drained by this
-one is not counted here, which is the deliberate fail direction for a detector whose job is to sit
-at zero. The asymmetry with the two GATE counters (`unrecognized`, `skippedNoAttributes`) is
-intended and unchanged: those sit on the tail path, run once per line, and were always exact.
+**Degenerate-record counting is taken at batch accept, not at serialization (CTL-1823).** The CTL-1817 detector incremented inside `buildOtlpPayload`, which is the serializer: it is re-entered once per `rawSend` attempt (it sits inside `withHttpRetry`) and again on every DLQ drain, so one record was re-counted on every OTLP retry and once more on replay — the counter INFLATED during exactly the backend trouble that makes an operator read it. The count now runs once per batch at `OtlpSender.flush` entry (`noteDegenerateRecords`), the single point at which each record is seen exactly once (`index.ts`'s `flushDest` hands `buffer.splice(0)` to one `flush()`). It counts records this PROCESS accepted for forwarding; a DLQ entry written by a previous process and drained by this one is not counted here, which is the deliberate fail direction for a detector whose job is to sit at zero. The asymmetry with the two GATE counters (`unrecognized`, `skippedNoAttributes`) is intended and unchanged: those sit on the tail path, run once per line, and were always exact.
 
 ### Installed-in-name-only: the install that exits 0 without relinking (CTL-1831)
 
-The link BEFORE the one below, and the one that makes a correct lockfile on `main` never reach any
-host's disk in the first place. `plugin-refresh.mjs` installs with `bun install --frozen-lockfile`,
-falling back to a plain `bun install`. **Neither relinks an existing `node_modules` when only a
-TRANSITIVE resolution changed** — bun prints `no changes` and exits 0, so a successful install and a
-no-op install are byte-identical to the caller. Measured on `mini` 2026-08-13, immediately after
-#3337 moved the root `bun.lock` from `@catalyst-cloud/schema@0.1.3` to `0.1.5`: plugin-source HEAD
-and `bun.lock` were both correct, and `--frozen-lockfile` **and** the plain fallback each left the
-SDK's resolved schema at 0.1.3; only `bun install --force` relinked it. The fleet was unblocked that
-day only by an operator running `--force` by hand on three hosts. `deps_install_failed` already
-covered a FAILING install; a no-op produced no signal at all.
+The link BEFORE the one below, and the one that makes a correct lockfile on `main` never reach any host's disk in the first place. `plugin-refresh.mjs` installs with `bun install --frozen-lockfile`, falling back to a plain `bun install`. **Neither relinks an existing `node_modules` when only a TRANSITIVE resolution changed** — bun prints `no changes` and exits 0, so a successful install and a no-op install are byte-identical to the caller. Measured on `mini` 2026-08-13, immediately after #3337 moved the root `bun.lock` from `@catalyst-cloud/schema@0.1.3` to `0.1.5`: plugin-source HEAD and `bun.lock` were both correct, and `--frozen-lockfile` **and** the plain fallback each left the SDK's resolved schema at 0.1.3; only `bun install --force` relinked it. The fleet was unblocked that day only by an operator running `--force` by hand on three hosts. `deps_install_failed` already covered a FAILING install; a no-op produced no signal at all.
 
-- **Detect, then force — never force always.** A blanket `--force` re-extracts 1168 packages (3-8 s
-  measured) on every refresh, so the refresh instead AUDITS the tree after the normal install and
-  escalates only on a proven mismatch. `--frozen-lockfile` stays the right default: the checkout was
-  just reset to `origin/main`, so the lockfile IS authoritative.
-- **The discriminator is the IMPORTING package's resolved dependency, not the hoisted top-level
-  copy.** `cloud-sync.mjs` imports the schema THROUGH the SDK, and under bun's isolated linker there
-  is frequently no top-level copy at all (measured on this repo, both instruments agreeing:
-  `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` and the
-  disk probe returns null, while resolving it from the SDK's own directory returns 0.1.5). A
-  top-level probe reports "absent" or "fine" and never sees the stale copy the daemons load.
-- **Placement, not enumeration — and read off the DISK, never through the module loader.** bun's
-  `.bun` store keeps stale entries after an upgrade (measured on this checkout:
-  `@catalyst-cloud+schema@0.1.3` and `@0.1.5` both present, and `@catalyst-cloud+sdk@0.8.1`
-  alongside `0.8.2`), so a version's presence in the store says nothing about what any importer
-  loads; only the entry the importer's own `node_modules` ladder lands on does. The probe
-  (`plugin-refresh.mjs` `defaultResolvePackageFn`) walks that ladder with `readFileSync`, which is
-  layout-agnostic — under the hoisted linker the rung IS the package, under the isolated linker it
-  is a symlink into `.bun/`, and the read follows either. It deliberately does **not** use
-  `createRequire().resolve()`: **Node/bun module resolution is cached PROCESS-WIDE and a fresh
-  `createRequire` does not clear it**, so the first cut of this detector answered from cache rather
-  than disk (measured identically under node v25.8.2 and bun 1.3.5 — link flipped to 0.1.3, resolve
-  still reported 0.1.5). Inside the long-lived updater/broker daemons that meant the post-`--force`
-  re-audit reported a FALSE `deps_relink_failed` on every genuine repair, `deps_relinked` was always
-  `[]`, and a process that had once audited a good tree reported CLEAN on a tree that later went
-  stale. A question about bytes on disk gets answered by reading the disk.
-- **Scope of the audit** (`broker/lock-resolution-audit.mjs`, a leaf whose only I/O is an injected
-  `resolvePackageFn` seam): just the entries whose resolution the pulled range MOVED, read off a
-  structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk.
-  A NESTED key (`chalk/ansi-styles`) is judged from its own parent only — judging it from the
-  workspace root would compare against a legitimately different hoisted copy and force a needless
-  re-extract. The key minus its last element is an install PATH, walked hop by hop from a workspace
-  root, because this repo's own lockfile nests deeper than one level (measured: 48 nested keys, 5
-  deeper than one hop, max chain 4 —
-  `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`); resolving only
-  the immediate parent finds whichever copy is root-visible, which is a different tree. A BARE key is
-  judged from the workspace roots plus every lockfile entry that DECLARES the id, minus any site
-  whose resolution of that id is governed by a nested entry — its own (`<declarer>/<id>`), an
-  ANCESTOR's, or a workspace member root's (`<member>/<id>`, of which this repo really has three:
-  `orch-monitor-ui/react`, `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`).
-  Entitlement climbs with resolution, so the governing entry is the one keyed by the longest prefix
-  of the site's install path that carries `<prefix>/<id>`; testing only the site's OWN key misses
-  the sibling shape bun really produces (measured: `@opentelemetry/exporter-trace-otlp-http/
-  @opentelemetry/sdk-trace-base` and `…/@opentelemetry/resources` are siblings under the exporter
-  with no `…/sdk-trace-base/@opentelemetry/resources` key, so sdk-trace-base is entitled to
-  resources 2.8.0 by its PARENT while the bare entry is 2.10.0). Shedding the member **root** is not
-  sufficient either: entitlement to that member's nested version belongs to the whole SUBTREE reached
-  through it, so a declarer is located only from the roots that survived the shed. Locating it by
-  first hit across every root is the bare-key twin of the one-hop bug the deep path fixes — bun's
-  isolated linker writes a separate **peer-disambiguated** store entry per peer set while the
-  lockfile records ONE bare entry covering all of them, so `packages.has("<declarer>/<id>")` is false
-  and the nested-key exclusion cannot see the difference. Reproducible on this checkout: a single
-  bare `eslint@9.39.5` lock entry with no nested key anywhere, two store copies
-  (`.bun/eslint@9.39.5+1a1acd4c2fa5b1a4` and `+5e91b0bf22d6303b`) resolving
-  `@eslint-community/eslint-utils` to two different store dirs — same version, different peer set,
-  one lock key. Measured on this repo's real `bun.lock` + `node_modules`, a bare `react` move
-  reported `mismatched=1, expected 18.3.1, found ["19.2.8"], 16 importers` on a correct tree — every
-  one of those 16 located through `orch-monitor-ui` — and a real `bun install --force`
-  (1168 packages, 4.21 s) does **not** clear it, because the placement is lockfile-determined: a
-  permanent ERROR plus a re-extract on every refresh carrying that move. A declarer reachable ONLY
-  through a shed root is named in the INCONCLUSIVE reason, never folded into "could not locate" and
-  never silently matched.
-- **Selecting the right root is only half of it — the site must be located as the COPY ITS OWN LOCK
-  KEY NAMES.** A site is EXCLUDED by its key but was LOCATED by its id, so a nested declarer was
-  found at whatever the first bare hit from a root happened to be. Measured on the real tree, which
-  is CORRECT on disk: `@opentelemetry/sdk-logs/@opentelemetry/resources` is locked at 2.8.0, has no
-  nested core key, is selected as a site for a bare `@opentelemetry/core` move, and was then located
-  at the 2.10.0 `@opentelemetry/resources` copy — the copy of the entry the exclusion had just shed —
-  whose core is legitimately 2.10.0. That emitted `deps_relink_failed, expected 2.8.0,
-  found ["2.10.0"], 2 importers` on a tree no install can repair. Six such sites; over all 689 bare
-  ids, **5** had at least one — 1 produced that live false ERROR and **4** (`@opentelemetry/api`,
-  `@opentelemetry/semantic-conventions`, `@opentelemetry/resources`, `csstype`) read `matched` ONLY
-  because the wrong copy happened to agree, a latent FALSE CLEAN in the other direction. One defect,
-  both failure modes. Every site is therefore located by walking its own lock key as an install path
-  with the located copy's version checked against the governing entry at EVERY hop; a hop that lands
-  on a version the lockfile does not record for that path is not evidence in either direction — it
-  can neither raise a mismatch nor contribute to a match, and it is named on the verdict as
-  `wrongCopy` rather than dropped. (A `workspace:` hop is exempt from the version check alone: a link
-  records `<name>@workspace:<path>`, not a semver.) Because selection already sheds
-  every site entitled to a different version, a SELECTED site holding anything but the locked version
-  is a **mismatch** — including a version the lockfile records elsewhere for the same id. Excusing
-  those as a benign `alternate` hid the defect the audit exists to catch: with bare `x` moving
-  1.0.0 → 2.0.0 while a nested `a/x` legitimately stays 1.0.0, a stale workspace-root link at 1.0.0
-  was labelled an alternate, `refreshPluginCheckout` ignores alternates, and no force ever ran.
-- **Every verdict is three-valued and fails closed.** An unusable lockfile, an empty site list, an
-  unlocatable importer, a broken hop in an install path, or a throwing probe each yield a named
-  INCONCLUSIVE — never a clean pass (`[].every(p)` is `true`, and a zero-site loop printing an
-  all-clear is a false-clean mechanism this repo has shipped before). That applies to the
-  **post-`--force` re-audit** too: only a CONCLUSIVE re-audit with neither mismatches nor per-entry
-  inconclusives may record the dir in `deps_relinked`. An empty `mismatched` from a re-audit that
-  threw is byte-identical to a repaired tree, so claiming repair off it would be a
-  check-that-cannot-fail inside the fix for a check-that-cannot-fail; the doubt is emitted as
-  `deps_audit_inconclusive` with `forced: true` (the detection pass carries `forced: false`).
+- **Detect, then force — never force always.** A blanket `--force` re-extracts 1168 packages (3-8 s measured) on every refresh, so the refresh instead AUDITS the tree after the normal install and escalates only on a proven mismatch. `--frozen-lockfile` stays the right default: the checkout was just reset to `origin/main`, so the lockfile IS authoritative.
+- **The discriminator is the IMPORTING package's resolved dependency, not the hoisted top-level copy.** `cloud-sync.mjs` imports the schema THROUGH the SDK, and under bun's isolated linker there is frequently no top-level copy at all (measured on this repo, both instruments agreeing: `require.resolve("@catalyst-cloud/schema")` from the workspace root is `MODULE_NOT_FOUND` and the disk probe returns null, while resolving it from the SDK's own directory returns 0.1.5). A top-level probe reports "absent" or "fine" and never sees the stale copy the daemons load.
+- **Placement, not enumeration — and read off the DISK, never through the module loader.** bun's `.bun` store keeps stale entries after an upgrade (measured on this checkout: `@catalyst-cloud+schema@0.1.3` and `@0.1.5` both present, and `@catalyst-cloud+sdk@0.8.1` alongside `0.8.2`), so a version's presence in the store says nothing about what any importer loads; only the entry the importer's own `node_modules` ladder lands on does. The probe (`plugin-refresh.mjs` `defaultResolvePackageFn`) walks that ladder with `readFileSync`, which is layout-agnostic — under the hoisted linker the rung IS the package, under the isolated linker it is a symlink into `.bun/`, and the read follows either. It deliberately does **not** use `createRequire().resolve()`: **Node/bun module resolution is cached PROCESS-WIDE and a fresh `createRequire` does not clear it**, so the first cut of this detector answered from cache rather than disk (measured identically under node v25.8.2 and bun 1.3.5 — link flipped to 0.1.3, resolve still reported 0.1.5). Inside the long-lived updater/broker daemons that meant the post-`--force` re-audit reported a FALSE `deps_relink_failed` on every genuine repair, `deps_relinked` was always `[]`, and a process that had once audited a good tree reported CLEAN on a tree that later went stale. A question about bytes on disk gets answered by reading the disk.
+- **Scope of the audit** (`broker/lock-resolution-audit.mjs`, a leaf whose only I/O is an injected `resolvePackageFn` seam): just the entries whose resolution the pulled range MOVED, read off a structured parse of the `packages` block in `git show <oldSha>:<lockfile>` versus the file on disk. A NESTED key (`chalk/ansi-styles`) is judged from its own parent only — judging it from the workspace root would compare against a legitimately different hoisted copy and force a needless re-extract. The key minus its last element is an install PATH, walked hop by hop from a workspace root, because this repo's own lockfile nests deeper than one level (measured: 48 nested keys, 5 deeper than one hop, max chain 4 — `@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match`); resolving only the immediate parent finds whichever copy is root-visible, which is a different tree. A BARE key is judged from the workspace roots plus every lockfile entry that DECLARES the id, minus any site whose resolution of that id is governed by a nested entry — its own (`<declarer>/<id>`), an ANCESTOR's, or a workspace member root's (`<member>/<id>`, of which this repo really has three: `orch-monitor-ui/react`, `orch-monitor-ui/@types/react`, `orch-monitor-ui/typescript`). Entitlement climbs with resolution, so the governing entry is the one keyed by the longest prefix of the site's install path that carries `<prefix>/<id>`; testing only the site's OWN key misses the sibling shape bun really produces (measured: `@opentelemetry/exporter-trace-otlp-http/ @opentelemetry/sdk-trace-base` and `…/@opentelemetry/resources` are siblings under the exporter with no `…/sdk-trace-base/@opentelemetry/resources` key, so sdk-trace-base is entitled to resources 2.8.0 by its PARENT while the bare entry is 2.10.0). Shedding the member **root** is not sufficient either: entitlement to that member's nested version belongs to the whole SUBTREE reached through it, so a declarer is located only from the roots that survived the shed. Locating it by first hit across every root is the bare-key twin of the one-hop bug the deep path fixes — bun's isolated linker writes a separate **peer-disambiguated** store entry per peer set while the lockfile records ONE bare entry covering all of them, so `packages.has("<declarer>/<id>")` is false and the nested-key exclusion cannot see the difference. Reproducible on this checkout: a single bare `eslint@9.39.5` lock entry with no nested key anywhere, two store copies (`.bun/eslint@9.39.5+1a1acd4c2fa5b1a4` and `+5e91b0bf22d6303b`) resolving `@eslint-community/eslint-utils` to two different store dirs — same version, different peer set, one lock key. Measured on this repo's real `bun.lock` + `node_modules`, a bare `react` move reported `mismatched=1, expected 18.3.1, found ["19.2.8"], 16 importers` on a correct tree — every one of those 16 located through `orch-monitor-ui` — and a real `bun install --force` (1168 packages, 4.21 s) does **not** clear it, because the placement is lockfile-determined: a permanent ERROR plus a re-extract on every refresh carrying that move. A declarer reachable ONLY through a shed root is named in the INCONCLUSIVE reason, never folded into "could not locate" and never silently matched.
+- **Selecting the right root is only half of it — the site must be located as the COPY ITS OWN LOCK KEY NAMES.** A site is EXCLUDED by its key but was LOCATED by its id, so a nested declarer was found at whatever the first bare hit from a root happened to be. Measured on the real tree, which is CORRECT on disk: `@opentelemetry/sdk-logs/@opentelemetry/resources` is locked at 2.8.0, has no nested core key, is selected as a site for a bare `@opentelemetry/core` move, and was then located at the 2.10.0 `@opentelemetry/resources` copy — the copy of the entry the exclusion had just shed — whose core is legitimately 2.10.0. That emitted `deps_relink_failed, expected 2.8.0, found ["2.10.0"], 2 importers` on a tree no install can repair. Six such sites; over all 689 bare ids, **5** had at least one — 1 produced that live false ERROR and **4** (`@opentelemetry/api`, `@opentelemetry/semantic-conventions`, `@opentelemetry/resources`, `csstype`) read `matched` ONLY because the wrong copy happened to agree, a latent FALSE CLEAN in the other direction. One defect, both failure modes. Every site is therefore located by walking its own lock key as an install path with the located copy's version checked against the governing entry at EVERY hop; a hop that lands on a version the lockfile does not record for that path is not evidence in either direction — it can neither raise a mismatch nor contribute to a match, and it is named on the verdict as `wrongCopy` rather than dropped. (A `workspace:` hop is exempt from the version check alone: a link records `<name>@workspace:<path>`, not a semver.) Because selection already sheds every site entitled to a different version, a SELECTED site holding anything but the locked version is a **mismatch** — including a version the lockfile records elsewhere for the same id. Excusing those as a benign `alternate` hid the defect the audit exists to catch: with bare `x` moving 1.0.0 → 2.0.0 while a nested `a/x` legitimately stays 1.0.0, a stale workspace-root link at 1.0.0 was labelled an alternate, `refreshPluginCheckout` ignores alternates, and no force ever ran.
+- **Every verdict is three-valued and fails closed.** An unusable lockfile, an empty site list, an unlocatable importer, a broken hop in an install path, or a throwing probe each yield a named INCONCLUSIVE — never a clean pass (`[].every(p)` is `true`, and a zero-site loop printing an all-clear is a false-clean mechanism this repo has shipped before). That applies to the **post-`--force` re-audit** too: only a CONCLUSIVE re-audit with neither mismatches nor per-entry inconclusives may record the dir in `deps_relinked`. An empty `mismatched` from a re-audit that threw is byte-identical to a repaired tree, so claiming repair off it would be a check-that-cannot-fail inside the fix for a check-that-cannot-fail; the doubt is emitted as `deps_audit_inconclusive` with `forced: true` (the detection pass carries `forced: false`).
 
 | Event                                     | Severity | Emitted when                                                                                     |
 | ----------------------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
@@ -1047,30 +309,13 @@ covered a FAILING install; a no-op produced no signal at all.
 | `plugin.checkout.deps_audit_inconclusive` | WARN     | the audit could not conclude — "could not look" made distinguishable from "the tree is correct"  |
 | `plugin.checkout.deps_install_failed`     | WARN     | pre-existing; now also carries `forced: true` when the remediation install itself throws         |
 
-`plugin.checkout.updated` gains `deps_relinked` — the dirs a forced relink actually repaired. The
-audit only runs for dirs whose install SUCCEEDED (a tree that was never built has nothing to audit),
-and it is fail-open end to end: a throwing audit degrades to an inconclusive event and never takes
-down the refresh that already succeeded.
+`plugin.checkout.updated` gains `deps_relinked` — the dirs a forced relink actually repaired. The audit only runs for dirs whose install SUCCEEDED (a tree that was never built has nothing to audit), and it is fail-open end to end: a throwing audit degrades to an inconclusive event and never takes down the refresh that already succeeded.
 
 ### Installed-but-unloaded: cloud-sync dependency skew (CTL-1659)
 
-The **third** link in the CTL-1506 chain, and the one no existing mechanism covers. `plugin-refresh`
-emits `restart_needed` and deliberately stops ("restart stays a gated OPERATOR action — never
-automated here"); `decideStackReload` restarts exactly `monitor`, `execution-core`, `otel-forward`
-(cloud-sync in neither). Measured 2026-08-04: a dependency fix landed on main, the updater pulled it,
-the install succeeded, and **both minis' cloud-sync writers kept serving the old modules for days**
-— the CTC-328 delete-corruption guard sat correctly installed while the daemons ran unguarded, until
-a human kickstarted them. Nothing was red; `restart_needed` is a field in an event nobody watches.
+The **third** link in the CTL-1506 chain, and the one no existing mechanism covers. `plugin-refresh` emits `restart_needed` and deliberately stops ("restart stays a gated OPERATOR action — never automated here"); `decideStackReload` restarts exactly `monitor`, `execution-core`, `otel-forward` (cloud-sync in neither). Measured 2026-08-04: a dependency fix landed on main, the updater pulled it, the install succeeded, and **both minis' cloud-sync writers kept serving the old modules for days** — the CTC-328 delete-corruption guard sat correctly installed while the daemons ran unguarded, until a human kickstarted them. Nothing was red; `restart_needed` is a field in an event nobody watches.
 
-**It is deliberately NOT a fourth restart mechanism.** Adding cloud-sync to `decideStackReload` (the
-symmetric CTL-1506 move) fires only where the *broker* advances the checkout — a host whose
-`catalyst-updater` pulls without a broker never gets the push — and needs new kickstart plumbing plus
-a real per-component confirmation probe (cloud-sync has no pid file `readPidFor` knows, and
-CTL-1506's own P1 lesson is that a best-effort `return true` confirmation is exactly how a stale
-daemon hides). CTL-1502's watchdog is also the wrong reuse target: its predicates are **stuckness**
-for a daemon that cannot help itself, and its restart action is hardwired to `catalyst-monitor.sh`
-argv. Dep-skew is neither — the writer is healthy and fully capable of self-action — so it becomes a
-**second predicate on the CTL-1508 self-heal exit that already exists** in `cloud-sync.mjs`:
+**It is deliberately NOT a fourth restart mechanism.** Adding cloud-sync to `decideStackReload` (the symmetric CTL-1506 move) fires only where the *broker* advances the checkout — a host whose `catalyst-updater` pulls without a broker never gets the push — and needs new kickstart plumbing plus a real per-component confirmation probe (cloud-sync has no pid file `readPidFor` knows, and CTL-1506's own P1 lesson is that a best-effort `return true` confirmation is exactly how a stale daemon hides). CTL-1502's watchdog is also the wrong reuse target: its predicates are **stuckness** for a daemon that cannot help itself, and its restart action is hardwired to `catalyst-monitor.sh` argv. Dep-skew is neither — the writer is healthy and fully capable of self-action — so it becomes a **second predicate on the CTL-1508 self-heal exit that already exists** in `cloud-sync.mjs`:
 
 | Piece                  | Already existed                                                                  |
 | ---------------------- | -------------------------------------------------------------------------------- |
@@ -1080,89 +325,28 @@ argv. Dep-skew is neither — the writer is healthy and fully capable of self-ac
 | Restart-failed net     | `health-responder.sh`'s `no-respawn`, keyed on the breadcrumb this path writes    |
 | Loop terminator (new)  | a durable `{ts,count}` budget, `~/catalyst/cloud-sync.depskew.json`               |
 
-- **Boot record** (`cloud-sync-deps.mjs` `captureLoadedDeps` → `~/catalyst/cloud-sync.deps.json`):
-  what the process **actually resolved** — `createRequire().resolve()`'s path, the version from THAT
-  path's `package.json`, an entry-file digest, the serving root, and a SHA-256 of that root's
-  `bun.lock`. Deliberately not "what the lockfile said": a claim derived from the lockfile
-  re-manufactures the CTL-1646 shadowed-install lie. The **digest**, not the version string, is the
-  verdict — a repointed tarball / workspace link / git dep ships new bytes under the same semver.
-- **Predicate** (`cloud-sync-telemetry.mjs` `classifyDepSkew`, beside `classifyStall`, same
-  never-false-kill discipline): an unknown digest on either side never asserts; `sustainedTicks`
-  consecutive mismatches are required (bun rewrites `bun.lock` in place, so one tick can catch it
-  mid-write); an uptime floor holds a just-relaunched writer; the durable budget bounds the
-  pathological continuous-rewrite case, and its refusal is NAMED rather than folded into "no
-  restart". Modes `off`/`shadow`/`enforce`, **shadow by default**.
-- **Exit**: `writeSelfHealBreadcrumb(..., {reason:"dep-skew"})` + bounded `close()` + **exit 1**. The
-  ticket's own Option-1 wording ("exit cleanly and let KeepAlive relaunch") is mechanically wrong
-  here — exit **0** is the plist's "clean no-op, stay DOWN" contract, so a clean exit would
-  permanently stop the replica writer. The `reason` key is emitted only when supplied, so the stall
-  path's on-disk shape (which `health-responder.sh` parses with `jq`) is byte-identical.
-- **Alarm** rides the writer's existing structured heartbeat line in **every** mode
-  (`depSkewFields` → stderr → `cloud-sync.log` → Alloy → Loki, `service_name=catalyst.cloud-sync`),
-  because shadow-with-nobody-watching is precisely the failure being fixed. `catalyst doctor`'s
-  advisory `cloud-sync-skew` check grades the same record over four fail-closed links —
-  record-identity (pid must still name a live `cloud-sync.mjs`; a recycled pid is stale evidence),
-  boot-record-complete, loaded-vs-locked (the incident), installed-vs-locked (the partial install a
-  restart does **not** fix) — and can never PASS on absent, stale, or zero-comparison input.
-- **What each comparator is anchored on, and why the obvious anchor is not enough.**
-  `loaded-vs-locked` compares TWO digests, not one: the root lockfile's, AND each package's boot
-  `entryHash` re-hashed from its recorded `resolvedPath`. The entry digest is not redundant — a
-  repointed mutable artifact, a `bun link`ed workspace output, or an in-place rebuild changes the
-  bytes the running process holds while the lockfile TEXT and the package version stay
-  byte-identical, so the lockfile digest alone reports ok and the writer never restarts. (Capturing
-  a field as the discriminator and never reading it back is "a check that cannot fail" — the same
-  shape as `restart_needed`, one level in.) `installed-vs-locked` matches each package to **its own**
-  lock entry via the install-location key bun uses (`<id>` hoisted, `<parent>/<id>` nested,
-  chained deeper — `lockKeyForPackageJsonPath`), never to "any occurrence of this id in the file":
-  with the SDK locked at 0.8.2 at the root and 0.7.0 under a nested parent, an any-occurrence match
-  accepts a stale 0.7.0 root install, hiding exactly the shadowed/partial install the link exists to
-  detect. A path that cannot be associated with a lock entry (outside the recorded root, or a
-  workspace link) reports **inconclusive naming the elsewhere-resolutions**, never a permissive match.
-- **The restart-budget ledger read is TRI-STATE.** Absent (`ENOENT`) → full budget; a ledger that
-  exists but cannot be read or parsed → `RESTART_LEDGER_UNREADABLE`, and the classifier declines.
-  Collapsing the two into one `null` meant a corrupt or momentarily-unreadable ledger granted a full
-  budget and then overwrote the evidence — the durable loop terminator disarmed by the corruption it
-  exists to survive. Field types are checked before any coercion, since `Number(null)`/`Number([])`
-  are `0` (an "expired window" → full budget) and `Number(undefined) || 0` is `0` ("nothing spent
-  yet"); the gate runs BEFORE the expired-window shortcut so a bogus count cannot re-arm on an anchor
-  read out of the same untrusted file.
-- **The undurable-ledger decline is edge-triggered.** That branch sits inside `if (depSkew.restart)`,
-  outside the posture latch guarding the alert above it, so a sustained skew with an unwritable
-  ledger emitted an ERROR line plus a `dep_skew_would_restart` event on **every** 30 s heartbeat for
-  the whole incident. `_depSkewDeclinedPosture` latches the announcement (re-arming on any posture
-  change and when skew clears) while the write itself is still retried each tick — same
-  count-exactly / warn-sparsely discipline as CTL-1817/CTL-1823's `otel-forward/lib/sparse-warn.ts`.
-- **Unified event log** (the ticket's AC1 clause "the restart is visible in the event log"). The
-  heartbeat line above is a **log** stream; it never reaches `catalyst-events wait-for`, the broker,
-  the HUD, or orch-monitor, all of which read `~/catalyst/events/YYYY-MM.jsonl`. So the dep-skew
-  path appends a **v2 envelope** to that file through the same `getEventLogPath()` +
-  `appendFileSync` call `emitWriterIdleEvent` (CAT-21) already used in `cloud-sync.mjs` — the
-  capability was present and merely unused here. Two names, not one name plus a payload flag,
-  because `otel-forward` strips `body.payload` off-machine and an alert must be able to select a
-  real restart from `attributes` alone:
+- **Boot record** (`cloud-sync-deps.mjs` `captureLoadedDeps` → `~/catalyst/cloud-sync.deps.json`): what the process **actually resolved** — `createRequire().resolve()`'s path, the version from THAT path's `package.json`, an entry-file digest, the serving root, and a SHA-256 of that root's `bun.lock`. Deliberately not "what the lockfile said": a claim derived from the lockfile re-manufactures the CTL-1646 shadowed-install lie. The **digest**, not the version string, is the verdict — a repointed tarball / workspace link / git dep ships new bytes under the same semver.
+- **Predicate** (`cloud-sync-telemetry.mjs` `classifyDepSkew`, beside `classifyStall`, same never-false-kill discipline): an unknown digest on either side never asserts; `sustainedTicks` consecutive mismatches are required (bun rewrites `bun.lock` in place, so one tick can catch it mid-write); an uptime floor holds a just-relaunched writer; the durable budget bounds the pathological continuous-rewrite case, and its refusal is NAMED rather than folded into "no restart". Modes `off`/`shadow`/`enforce`, **shadow by default**.
+- **Exit**: `writeSelfHealBreadcrumb(..., {reason:"dep-skew"})` + bounded `close()` + **exit 1**. The ticket's own Option-1 wording ("exit cleanly and let KeepAlive relaunch") is mechanically wrong here — exit **0** is the plist's "clean no-op, stay DOWN" contract, so a clean exit would permanently stop the replica writer. The `reason` key is emitted only when supplied, so the stall path's on-disk shape (which `health-responder.sh` parses with `jq`) is byte-identical.
+- **Alarm** rides the writer's existing structured heartbeat line in **every** mode (`depSkewFields` → stderr → `cloud-sync.log` → Alloy → Loki, `service_name=catalyst.cloud-sync`), because shadow-with-nobody-watching is precisely the failure being fixed. `catalyst doctor`'s advisory `cloud-sync-skew` check grades the same record over four fail-closed links — record-identity (pid must still name a live `cloud-sync.mjs`; a recycled pid is stale evidence), boot-record-complete, loaded-vs-locked (the incident), installed-vs-locked (the partial install a restart does **not** fix) — and can never PASS on absent, stale, or zero-comparison input.
+- **What each comparator is anchored on, and why the obvious anchor is not enough.** `loaded-vs-locked` compares TWO digests, not one: the root lockfile's, AND each package's boot `entryHash` re-hashed from its recorded `resolvedPath`. The entry digest is not redundant — a repointed mutable artifact, a `bun link`ed workspace output, or an in-place rebuild changes the bytes the running process holds while the lockfile TEXT and the package version stay byte-identical, so the lockfile digest alone reports ok and the writer never restarts. (Capturing a field as the discriminator and never reading it back is "a check that cannot fail" — the same shape as `restart_needed`, one level in.) `installed-vs-locked` matches each package to **its own** lock entry via the install-location key bun uses (`<id>` hoisted, `<parent>/<id>` nested, chained deeper — `lockKeyForPackageJsonPath`), never to "any occurrence of this id in the file": with the SDK locked at 0.8.2 at the root and 0.7.0 under a nested parent, an any-occurrence match accepts a stale 0.7.0 root install, hiding exactly the shadowed/partial install the link exists to detect. A path that cannot be associated with a lock entry (outside the recorded root, or a workspace link) reports **inconclusive naming the elsewhere-resolutions**, never a permissive match.
+- **The restart-budget ledger read is TRI-STATE.** Absent (`ENOENT`) → full budget; a ledger that exists but cannot be read or parsed → `RESTART_LEDGER_UNREADABLE`, and the classifier declines. Collapsing the two into one `null` meant a corrupt or momentarily-unreadable ledger granted a full budget and then overwrote the evidence — the durable loop terminator disarmed by the corruption it exists to survive. Field types are checked before any coercion, since `Number(null)`/`Number([])` are `0` (an "expired window" → full budget) and `Number(undefined) || 0` is `0` ("nothing spent yet"); the gate runs BEFORE the expired-window shortcut so a bogus count cannot re-arm on an anchor read out of the same untrusted file.
+- **The undurable-ledger decline is edge-triggered.** That branch sits inside `if (depSkew.restart)`, outside the posture latch guarding the alert above it, so a sustained skew with an unwritable ledger emitted an ERROR line plus a `dep_skew_would_restart` event on **every** 30 s heartbeat for the whole incident. `_depSkewDeclinedPosture` latches the announcement (re-arming on any posture change and when skew clears) while the write itself is still retried each tick — same count-exactly / warn-sparsely discipline as CTL-1817/CTL-1823's `otel-forward/lib/sparse-warn.ts`.
+- **Unified event log** (the ticket's AC1 clause "the restart is visible in the event log"). The heartbeat line above is a **log** stream; it never reaches `catalyst-events wait-for`, the broker, the HUD, or orch-monitor, all of which read `~/catalyst/events/YYYY-MM.jsonl`. So the dep-skew path appends a **v2 envelope** to that file through the same `getEventLogPath()` + `appendFileSync` call `emitWriterIdleEvent` (CAT-21) already used in `cloud-sync.mjs` — the capability was present and merely unused here. Two names, not one name plus a payload flag, because `otel-forward` strips `body.payload` off-machine and an alert must be able to select a real restart from `attributes` alone:
 
   | Event                                    | Emitted when                                                                                    |
   | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
   | `catalyst.replica.dep_skew_restart`      | the writer IS exiting — budget spent, before `exitAfterClose`. At most once per process.        |
   | `catalyst.replica.dep_skew_would_restart`| sustained skew that did NOT act: shadow mode (the default), exhausted budget, or an undurable ledger. `reason` names which. |
 
-  Both are built by the pure `depSkewEventEnvelope` (`cloud-sync-deps.mjs`) so the shape is
-  unit-testable without running the script-shaped writer, and both reuse `depSkewFields` for their
-  digest attributes so the event and the heartbeat line cannot drift. Emission is **fail-open** —
-  a failed append never blocks the self-heal exit — and the restart event is sequenced **before**
-  `exitAfterClose`, which can terminate the process at any point once called. Ordering rule: the
-  posture block emits only the *held* event (`wouldRestart && !restart`); the restart block owns
-  the acted one, so an event never claims a restart the ledger then declines. Registered in
-  `broker/namespace-parity.test.mjs` by import, not by re-typed literal.
+Both are built by the pure `depSkewEventEnvelope` (`cloud-sync-deps.mjs`) so the shape is unit-testable without running the script-shaped writer, and both reuse `depSkewFields` for their digest attributes so the event and the heartbeat line cannot drift. Emission is **fail-open** — a failed append never blocks the self-heal exit — and the restart event is sequenced **before** `exitAfterClose`, which can terminate the process at any point once called. Ordering rule: the posture block emits only the *held* event (`wouldRestart && !restart`); the restart block owns the acted one, so an event never claims a restart the ledger then declines. Registered in `broker/namespace-parity.test.mjs` by import, not by re-typed literal.
 
 ### Two-axis worker state & the recordTransition chokepoint (CTL-764)
 
 Every worker ticket has **two orthogonal axes** — never blurred:
 
-- **Axis 1 — Pipeline stage** (WHERE the ticket is in the pipeline): written through the single
-  `applyPhaseStatus` chokepoint → Linear workflow Status, audited by `linear.state.write.<TICKET>`.
-- **Axis 2 — Worker disposition** (HOW the worker is doing): a single-valued workspace-scoped
-  `worker-status` Linear label group with **three** mutually exclusive values:
+- **Axis 1 — Pipeline stage** (WHERE the ticket is in the pipeline): written through the single `applyPhaseStatus` chokepoint → Linear workflow Status, audited by `linear.state.write.<TICKET>`.
+- **Axis 2 — Worker disposition** (HOW the worker is doing): a single-valued workspace-scoped `worker-status` Linear label group with **three** mutually exclusive values:
 
   | Value         | Detection seam                                      | Cleared by                  |
   | ------------- | --------------------------------------------------- | --------------------------- |
@@ -1170,89 +354,27 @@ Every worker ticket has **two orthogonal axes** — never blurred:
   | `blocked`     | converger (dependency not terminal, tick-converged) | dep becomes terminal / Done |
   | `needs-input` | daemon `handleCommentWake` (worker paused, CTL-768) | human reply                 |
 
-⛔ **CTL-2161 — the group lost its fourth member, `needs-human`.** It is deleted (CTL-2155 epic):
-across 86 items it flagged, 3 genuinely needed a person and 41 were the model provider being
-overloaded, escalated one ticket at a time. Its replacements are not worker-disposition labels at
-all — SYSTEM trouble raises ONE fleet-scoped, auto-clearing alert (CTL-2156) with zero per-ticket
-artifacts, and a genuine human question becomes ONE ask ticket carrying a `blocks` relation to the
-work it holds (CTL-2157). The three survivors are genuinely *worker* states, which is what this axis
-is for; `needs-human` never was.
+⛔ **CTL-2161 — the group lost its fourth member, `needs-human`.** It is deleted (CTL-2155 epic): across 86 items it flagged, 3 genuinely needed a person and 41 were the model provider being overloaded, escalated one ticket at a time. Its replacements are not worker-disposition labels at all — SYSTEM trouble raises ONE fleet-scoped, auto-clearing alert (CTL-2156) with zero per-ticket artifacts, and a genuine human question becomes ONE ask ticket carrying a `blocks` relation to the work it holds (CTL-2157). The three survivors are genuinely *worker* states, which is what this axis is for; `needs-human` never was.
 
-**Precedence** (only one label at a time): `needs-input > blocked > queued > none`. All three are
-tick-converged (re-derived on every tick, applied/removed on diff). The sticky, `labelOnce`-applied
-member is gone with `needs-human` — but the `labelOnce` machinery and its on-disk once-marker are
-NOT: five retry loops read the publish result as their STOP, and `boot-resume` reads the marker to
-suppress auto-resume of a chronically failing ticket (CTL-2159).
+**Precedence** (only one label at a time): `needs-input > blocked > queued > none`. All three are tick-converged (re-derived on every tick, applied/removed on diff). The sticky, `labelOnce`-applied member is gone with `needs-human` — but the `labelOnce` machinery and its on-disk once-marker are NOT: five retry loops read the publish result as their STOP, and `boot-resume` reads the marker to suppress auto-resume of a chronically failing ticket (CTL-2159).
 
-**Resolution-gated clearing — the TWO removal paths (Codex #2970 round 5).** Built for
-`needs-human`, they are deliberately retained after it: they are what clears the label off the ~69
-tickets that still wear it during the CTL-2160 migration, and deleting a clearer before the backlog
-is swept strands every one of them. The two confirmed-removal signals:
+**Resolution-gated clearing — the TWO removal paths (Codex #2970 round 5).** Built for `needs-human`, they are deliberately retained after it: they are what clears the label off the ~69 tickets that still wear it during the CTL-2160 migration, and deleting a clearer before the backlog is swept strands every one of them. The two confirmed-removal signals:
 
-1. **`clearStalledLabel`'s `onRemoved` callback**, fired only on a confirmed Linear label removal at
-   scheduler-side resolution points (terminal-done-clear, terminal-sweep-clear, no-stall-clear).
-2. **The daemon's `handleCommentWake` escalation clear** (CTL-1612/#2970) — a _write-gated_,
-   _emission-carrying_ removal on a managed ticket's confirmed human reply. It calls `removeLabel`
-   directly (not `clearStalledLabel`), only treats the removal as genuine when the call performed a
-   real write (not a no-op re-check), emits the `worker.transition` clear itself
-   (`appendWorkerTransitionEvent`, bypassing `recordTransition`), and resets the scheduler's
-   in-process `lastDispositionEmit` dedup entry (`clearDispositionEmit`) so the shared chokepoint's
-   only-on-change guard doesn't swallow a later genuine re-escalation. See the producer-split
-   paragraph below for why this path exists separately from `clearStalledLabel`.
+1. **`clearStalledLabel`'s `onRemoved` callback**, fired only on a confirmed Linear label removal at scheduler-side resolution points (terminal-done-clear, terminal-sweep-clear, no-stall-clear).
+2. **The daemon's `handleCommentWake` escalation clear** (CTL-1612/#2970) — a _write-gated_, _emission-carrying_ removal on a managed ticket's confirmed human reply. It calls `removeLabel` directly (not `clearStalledLabel`), only treats the removal as genuine when the call performed a real write (not a no-op re-check), emits the `worker.transition` clear itself (`appendWorkerTransitionEvent`, bypassing `recordTransition`), and resets the scheduler's in-process `lastDispositionEmit` dedup entry (`clearDispositionEmit`) so the shared chokepoint's only-on-change guard doesn't swallow a later genuine re-escalation. See the producer-split paragraph below for why this path exists separately from `clearStalledLabel`.
 
-Worker transitions **originating from the scheduler** are recorded at its transition sites,
-coordinated around a single **inline `recordTransition` chokepoint** inside `schedulerTick`. That
-chokepoint owns sink (3): it emits exactly one canonical `worker.transition.<TICKET>` event per
-genuine change to the unified event log, and the only-on-change guard (`lastDispositionEmit`)
-prevents double-emit on steady-state ticks. Its emitter defaults to `null` so a bare unit tick stays
-silent; **production threads the real emitter (`defaultAppendWorkerTransitionEvent`) via `runTick`**
-— without that wiring every `recordTransition` early-returns and the event stream is dark. That
-event feeds sink (4), OTLP via `otel-forward` (dims as attributes — `body.payload` is stripped
-off-machine) — the only other sink that's actually live. Sink (5), an optional broker
-`ticket_state_transitions` table (CTL-764 Phase 10), was **never implemented** — no schema, no
-writer, no broker consumer exist anywhere in the codebase; it remains a planned item, not a shipped
-one. The remaining scheduler-side sinks are written at their own scheduler sites around the same
-transition (not fanned out from inside the chokepoint): (1) Linear Status via the `applyPhaseStatus`
-chokepoint (Axis 1), (2) the `worker-status` label via the admission converger (`convergeHeldLabel`)
-/ `labelOnce` (Axis 2).
+Worker transitions **originating from the scheduler** are recorded at its transition sites, coordinated around a single **inline `recordTransition` chokepoint** inside `schedulerTick`. That chokepoint owns sink (3): it emits exactly one canonical `worker.transition.<TICKET>` event per genuine change to the unified event log, and the only-on-change guard (`lastDispositionEmit`) prevents double-emit on steady-state ticks. Its emitter defaults to `null` so a bare unit tick stays silent; **production threads the real emitter (`defaultAppendWorkerTransitionEvent`) via `runTick`** — without that wiring every `recordTransition` early-returns and the event stream is dark. That event feeds sink (4), OTLP via `otel-forward` (dims as attributes — `body.payload` is stripped off-machine) — the only other sink that's actually live. Sink (5), an optional broker `ticket_state_transitions` table (CTL-764 Phase 10), was **never implemented** — no schema, no writer, no broker consumer exist anywhere in the codebase; it remains a planned item, not a shipped one. The remaining scheduler-side sinks are written at their own scheduler sites around the same transition (not fanned out from inside the chokepoint): (1) Linear Status via the `applyPhaseStatus` chokepoint (Axis 1), (2) the `worker-status` label via the admission converger (`convergeHeldLabel`) / `labelOnce` (Axis 2).
 
-**The scheduler chokepoint is not the only `worker.transition` emitter.** The daemon's
-`handleCommentWake` (CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent`
-directly at two structurally distinct sites, both bypassing `recordTransition` — but for different
-reasons, not one shared rationale:
+**The scheduler chokepoint is not the only `worker.transition` emitter.** The daemon's `handleCommentWake` (CTL-768, `execution-core/daemon.mjs`) calls `appendWorkerTransitionEvent` directly at two structurally distinct sites, both bypassing `recordTransition` — but for different reasons, not one shared rationale:
 
-- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the
-  label, emits the clear, and then redispatches the parked worker in the same block. Its own code
-  comment explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted
-  here (the daemon removes the durable label out-of-band and redispatches — the scheduler never
-  observes this edge)."
-- The **escalation clear** runs once per comment-wake call, gated on positive human provenance
-  and a managed ticket — before any per-signal / worker-dir lookup, and with **no redispatch** in
-  that block at all. It bypasses `recordTransition` for the same underlying reason (the scheduler's
-  own STICKY escalation handling explicitly defers clearing to an external confirmed-removal
-  signal, never clearing it itself on a steady-state admission pass), but the "redispatches" half of
-  the quoted rationale above does not apply to this site.
+- The **`needs-input` clear** (a per-signal branch gated on `status === "needs-input"`) removes the label, emits the clear, and then redispatches the parked worker in the same block. Its own code comment explains the bypass: "scheduler.mjs owns the park/apply emission; the clear is emitted here (the daemon removes the durable label out-of-band and redispatches — the scheduler never observes this edge)."
+- The **escalation clear** runs once per comment-wake call, gated on positive human provenance and a managed ticket — before any per-signal / worker-dir lookup, and with **no redispatch** in that block at all. It bypasses `recordTransition` for the same underlying reason (the scheduler's own STICKY escalation handling explicitly defers clearing to an external confirmed-removal signal, never clearing it itself on a steady-state admission pass), but the "redispatches" half of the quoted rationale above does not apply to this site.
 
 Both are deliberate, self-documented second-producer sites, not a gap in the chokepoint design.
 
-**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's
-hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s
-progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when
-`bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But
-it publishes the escalation via the shared guard (`label-guard.mjs`) and
-never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition`
-emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike
-the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream
-specifically, not an alternate producer.
+**A separate escalation path emits no `worker.transition` for its disposition change.** Pass 0w's hung-worker escalation (`killHungWorker` in `watchdog-action.mjs`, invoked from `scheduler.mjs`'s progress-watchdog pass) does emit `phase.terminal.reap-requested` (via `emitReapIntent`, when `bgJobId` exists) for the kill/reap side of the sequence — that part of the path is observable. But it publishes the escalation via the shared guard (`label-guard.mjs`) and never calls `recordTransition`, `appendWorkerTransitionEvent`, or any other `worker.transition` emitter anywhere in that path — a real Axis-2 transition with no `worker.transition` record. Unlike the daemon's comment-wake sites above, this is a genuine coverage gap in the transition stream specifically, not an alternate producer.
 
-The standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted,
-unit-tested scaffold for sinks 1–3 only (Linear status, disposition label, event log) whose own doc
-comment flagged sinks 4–5 and full call-site wiring as unfinished ("Phase 5 will wire the production
-defaults... and route all call sites here") — never reached that Phase 5 and was retired as
-consumer-free (CTL-1628): the scheduler's live path has only ever used the inline `recordTransition`
-chokepoint described above. The analogous worker-state projection need
-(phase/status/PR/revive-count, not disposition) is served live by the separate CTL-532 SQLite
-projection — see "Worker signal projection" above.
+The standalone `recordWorkerTransition` module (`record-worker-transition.mjs`) — an extracted, unit-tested scaffold for sinks 1–3 only (Linear status, disposition label, event log) whose own doc comment flagged sinks 4–5 and full call-site wiring as unfinished ("Phase 5 will wire the production defaults... and route all call sites here") — never reached that Phase 5 and was retired as consumer-free (CTL-1628): the scheduler's live path has only ever used the inline `recordTransition` chokepoint described above. The analogous worker-state projection need (phase/status/PR/revive-count, not disposition) is served live by the separate CTL-532 SQLite projection — see "Worker signal projection" above.
 
 ### Unified data-flow
 
@@ -1285,94 +407,34 @@ flowchart LR
   EL -- "tails *.reap-requested<br/>(boot-replay + byte-cursor)" --> REAPER
 ```
 
-Writers (phase-agent workers, `phase-agent-dispatch`, broker daemon, webhook receiver,
-`catalyst-comms send`, reap-intent producers
-`lib/emit-reap-intent.sh`/`execution-core/reap-intent.mjs`, and the daemon reaper re-emitting
-`*.reap-complete`/`*.reap-failed`) all append to `~/catalyst/events/YYYY-MM.jsonl`. Readers
-(`catalyst-events tail`/`wait-for`, broker daemon, the daemon reaper [CTL-649: boot-replay +
-`fs.watch` byte-cursor driving `claude stop`/`git worktree remove`/`git branch -D`], `catalyst-hud`,
-orch-monitor) consume that log plus per-run state and broker registry without coordinating. The
-broker and the reaper are each both reader and writer of the same file.
+Writers (phase-agent workers, `phase-agent-dispatch`, broker daemon, webhook receiver, `catalyst-comms send`, reap-intent producers `lib/emit-reap-intent.sh`/`execution-core/reap-intent.mjs`, and the daemon reaper re-emitting `*.reap-complete`/`*.reap-failed`) all append to `~/catalyst/events/YYYY-MM.jsonl`. Readers (`catalyst-events tail`/`wait-for`, broker daemon, the daemon reaper [CTL-649: boot-replay + `fs.watch` byte-cursor driving `claude stop`/`git worktree remove`/`git branch -D`], `catalyst-hud`, orch-monitor) consume that log plus per-run state and broker registry without coordinating. The broker and the reaper are each both reader and writer of the same file.
 
-**Event-mirror (CTL-1654) — observation-node fleet feed.** On `monitor`/`developer` nodes,
-`catalyst-stack start` launches the event-mirror daemon (`event-mirror/index.ts` supervised by
-launchd KeepAlive). It fans each worker host's `~/catalyst/events/YYYY-MM.jsonl` into the local copy
-via `ssh tail -c +N`, advancing a per-host byte cursor and deduplicating by event id (in-memory
-ring, scoped to the current month's file). The append is idempotent: events already in the local
-file are never double-written. `catalyst-events tail`/`wait-for` on the observation node then
-resolve fleet events locally with no polling loop. The fan-in is transport-abstracted (injectable
-`fetchFn`) so a future cloud-changefeed transport drops in without touching the dedup core.
+**Event-mirror (CTL-1654) — observation-node fleet feed.** On `monitor`/`developer` nodes, `catalyst-stack start` launches the event-mirror daemon (`event-mirror/index.ts` supervised by launchd KeepAlive). It fans each worker host's `~/catalyst/events/YYYY-MM.jsonl` into the local copy via `ssh tail -c +N`, advancing a per-host byte cursor and deduplicating by event id (in-memory ring, scoped to the current month's file). The append is idempotent: events already in the local file are never double-written. `catalyst-events tail`/`wait-for` on the observation node then resolve fleet events locally with no polling loop. The fan-in is transport-abstracted (injectable `fetchFn`) so a future cloud-changefeed transport drops in without touching the dedup core.
 
 ### GitHub core REST quota snapshot (CAT-40)
 
-The execution-core daemon samples `gh api rate_limit` on a dedicated timer and atomically writes the
-host's normalized core REST quota to `<orchDir>/github-quota.json` (`orchestration.githubQuotaSweep`,
-see the configuration reference). CTL-2141 deleted this snapshot's only consumer (board-health's
-`rateLimitHeadroom` gate and its `recovery.board-scan` emission); the sampler still runs and
-publishes the snapshot, so the local read-avoidance benefit is retained, but nothing currently acts
-on the published quota.
+The execution-core daemon samples `gh api rate_limit` on a dedicated timer and atomically writes the host's normalized core REST quota to `<orchDir>/github-quota.json` (`orchestration.githubQuotaSweep`, see the configuration reference). CTL-2141 deleted this snapshot's only consumer (board-health's `rateLimitHeadroom` gate and its `recovery.board-scan` emission); the sampler still runs and publishes the snapshot, so the local read-avoidance benefit is retained, but nothing currently acts on the published quota.
 
-**Worktree salvage-before-destroy (CTL-1639).** Every destructive worktree removal — the
-dispatcher's L3 destroy+recreate, the orphan-sweep, phase-teardown, and the JS reaper's PR-merged
-cleanup — first calls the shared `lib/worktree-salvage.sh` primitive, which snapshots the worktree's
-unpushed commits (`git bundle`), tracked uncommitted diff (`.patch`, plus a separate `.index.patch`
-for a staged-only delta), and untracked files (`.tar`) to `~/catalyst/salvage/` and emits one
-`worktree.salvage.{created,skipped,failed}` event (service `catalyst.worktree-salvage`). Every
-recovery-patch `git diff` is routed through a shared `_wsv_diff` helper (`--no-ext-diff` +
-`-c color.ui=false` + `--no-textconv`) so a repo/global `diff.external`/`GIT_EXTERNAL_DIFF`/forced-
-color config or a `.gitattributes` textconv driver can't substitute non-applyable output for the
-real bytes, and a `git update-index --assume-unchanged` bit is cleared before diffing so such a
-file's edit isn't invisible to the salvage the same way it's invisible to plain `git status`. A
-dirty/uninitialized submodule (any depth, via `git submodule status --recursive`) is salvaged
-recursively — its own uncommitted diff + untracked files, not just the superproject's opaque
-`Subproject commit <sha>-dirty` marker. The orphan-sweep's `ORPHAN_GITFILE` case (a stale/missing
-`.git` file pointer — not a usable git worktree, so the git-based primitive above can't inspect it
-at all) instead calls the primitive's sibling `salvage_raw_directory` (plain `tar`, no git involved)
-before its `rm -rf`. Because the sweep runs every 1–3h and revisits a retained
-`SALVAGE_UNPUSHED`/`SALVAGE_DIRTY` worktree every pass, orphan-sweep wraps its own calls in a
-`salvage_worktree_dedup` fingerprint check (HEAD sha + a git-blob-hash of the working diff/staged
-diff/untracked-file set, stored per-worktree under `~/catalyst/salvage/.state/`) so an unchanged
-tree is NOT re-archived under a new unique name every single sweep — this dedup lives in
-orphan-sweep.sh itself, not inside `salvage_worktree`, so the primitive's other callers (each acting
-on a worktree exactly once) and its own multi-call test contract are unaffected. The
-`worktree.salvage.*` prefix is **unprotected** under the CTL-1142 namespace contract (no
-`isBrokerProtectedName` collision — it routes through `shouldSkipEvent` normally). Salvage is
-best-effort/fail-open — it never blocks a removal — layered on top of the existing fail-closed
-`_removal_guard_ok` live-handle gate, which is re-asserted immediately after salvage completes (not
-just before it starts) at every synchronous call site, since salvage's own duration widens the
-window a live handle could appear in. (Retention/GC of `~/catalyst/salvage/` beyond the dedup above
-is deferred follow-up.)
+**Worktree salvage-before-destroy (CTL-1639).** Every destructive worktree removal — the dispatcher's L3 destroy+recreate, the orphan-sweep, phase-teardown, and the JS reaper's PR-merged cleanup — first calls the shared `lib/worktree-salvage.sh` primitive, which snapshots the worktree's unpushed commits (`git bundle`), tracked uncommitted diff (`.patch`, plus a separate `.index.patch` for a staged-only delta), and untracked files (`.tar`) to `~/catalyst/salvage/` and emits one `worktree.salvage.{created,skipped,failed}` event (service `catalyst.worktree-salvage`). Every recovery-patch `git diff` is routed through a shared `_wsv_diff` helper (`--no-ext-diff` + `-c color.ui=false` + `--no-textconv`) so a repo/global `diff.external`/`GIT_EXTERNAL_DIFF`/forced- color config or a `.gitattributes` textconv driver can't substitute non-applyable output for the real bytes, and a `git update-index --assume-unchanged` bit is cleared before diffing so such a file's edit isn't invisible to the salvage the same way it's invisible to plain `git status`. A dirty/uninitialized submodule (any depth, via `git submodule status --recursive`) is salvaged recursively — its own uncommitted diff + untracked files, not just the superproject's opaque `Subproject commit <sha>-dirty` marker. The orphan-sweep's `ORPHAN_GITFILE` case (a stale/missing `.git` file pointer — not a usable git worktree, so the git-based primitive above can't inspect it at all) instead calls the primitive's sibling `salvage_raw_directory` (plain `tar`, no git involved) before its `rm -rf`. Because the sweep runs every 1–3h and revisits a retained `SALVAGE_UNPUSHED`/`SALVAGE_DIRTY` worktree every pass, orphan-sweep wraps its own calls in a `salvage_worktree_dedup` fingerprint check (HEAD sha + a git-blob-hash of the working diff/staged diff/untracked-file set, stored per-worktree under `~/catalyst/salvage/.state/`) so an unchanged tree is NOT re-archived under a new unique name every single sweep — this dedup lives in orphan-sweep.sh itself, not inside `salvage_worktree`, so the primitive's other callers (each acting on a worktree exactly once) and its own multi-call test contract are unaffected. The `worktree.salvage.*` prefix is **unprotected** under the CTL-1142 namespace contract (no `isBrokerProtectedName` collision — it routes through `shouldSkipEvent` normally). Salvage is best-effort/fail-open — it never blocks a removal — layered on top of the existing fail-closed `_removal_guard_ok` live-handle gate, which is re-asserted immediately after salvage completes (not just before it starts) at every synchronous call site, since salvage's own duration widens the window a live handle could appear in. (Retention/GC of `~/catalyst/salvage/` beyond the dedup above is deferred follow-up.)
 
 ### Linear app-actor self-echo guard (`botUserId`)
 
-The execution-core daemon mirrors phase-agent output to Linear and wakes on human replies, so it
-must tell its **own** app-actor comments/updates from a human's. `catalyst.monitor.linear.botUserId`
-(app-actor user UUID, read flat from Layer-1 `.catalyst/config.json`) is that discriminator. The
-daemon's `createCommentInboxWriter`/`createUpdateInboxWriter` (`execution-core/daemon.mjs`) and
-orch-monitor's Linear webhook handler skip events authored by `botUserId`, so mirror comments don't
-land in worker `inbox.jsonl` as false "human replied" signals and bot events don't feed back as
-write loops. See `docs/configuration.md` to obtain/set the value.
+The execution-core daemon mirrors phase-agent output to Linear and wakes on human replies, so it must tell its **own** app-actor comments/updates from a human's. `catalyst.monitor.linear.botUserId` (app-actor user UUID, read flat from Layer-1 `.catalyst/config.json`) is that discriminator. The daemon's `createCommentInboxWriter`/`createUpdateInboxWriter` (`execution-core/daemon.mjs`) and orch-monitor's Linear webhook handler skip events authored by `botUserId`, so mirror comments don't land in worker `inbox.jsonl` as false "human replied" signals and bot events don't feed back as write loops. See `docs/configuration.md` to obtain/set the value.
 
 ### `shouldSkipEvent` self-filter
 
-The broker both reads and writes the same JSONL log, so it would re-ingest the
-`filter.wake.*`/`broker.daemon.*` events it emits, creating a feedback loop (CTL-346, 2026-05-12
-incident). Every event passes `shouldSkipEvent` (`plugins/dev/scripts/broker/router.mjs:1873`)
-before processing. It drops:
+The broker both reads and writes the same JSONL log, so it would re-ingest the `filter.wake.*`/`broker.daemon.*` events it emits, creating a feedback loop (CTL-346, 2026-05-12 incident). Every event passes `shouldSkipEvent` (`plugins/dev/scripts/broker/router.mjs:1873`) before processing. It drops:
 
 - `resource."service.name" === "catalyst.broker"` (own emissions)
 - names starting `filter.` (wakes, (de)registrations)
 - names starting `broker.daemon` (daemon lifecycle)
 - `session.heartbeat` (also short-circuited earlier in `processEvent`)
 
-`BROKER_INGEST_OWN_EMISSIONS=1` flips to "accept only `filter.*`" for debugging. This filter is what
-makes the single unified log safe as both broker input and output.
+`BROKER_INGEST_OWN_EMISSIONS=1` flips to "accept only `filter.*`" for debugging. This filter is what makes the single unified log safe as both broker input and output.
 
 ### Lifecycle-event namespace contract (CTL-1142)
 
-Four protected name-spaces, enforced as a verified invariant. Only
-`service.name = "catalyst.broker"` may emit in the first three; the fourth governs valid phase-slot
-strings.
+Four protected name-spaces, enforced as a verified invariant. Only `service.name = "catalyst.broker"` may emit in the first three; the fourth governs valid phase-slot strings.
 
 | Space                                                                   | Rule                                                                                                                           |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
@@ -1381,145 +443,43 @@ strings.
 | `session.heartbeat`                                                     | Exact match; broker liveness pings only (CTL-401).                                                                             |
 | `phase.<name>.(complete\|failed\|turn-cap-exhausted\|skipped).<ticket>` | Routing namespace matched by `PHASE_EVENT_PATTERN`; `<name>` must be in `KNOWN_PHASES` or `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`. |
 
-**`broker.daemon.*` members** (the complete emitted set, verified): `broker.daemon.startup` and
-`broker.daemon.shutdown` (`index.mjs`), `broker.daemon.heartbeat` (`index.mjs`), `broker.daemon.gc`
-(`gc-startup.mjs`), `broker.daemon.prose_disabled` (`router.mjs`), and the CTL-1523
-`broker.daemon.degraded` / `broker.daemon.recovered` pair (`broker-degraded.mjs`).
+**`broker.daemon.*` members** (the complete emitted set, verified): `broker.daemon.startup` and `broker.daemon.shutdown` (`index.mjs`), `broker.daemon.heartbeat` (`index.mjs`), `broker.daemon.gc` (`gc-startup.mjs`), `broker.daemon.prose_disabled` (`router.mjs`), and the CTL-1523 `broker.daemon.degraded` / `broker.daemon.recovered` pair (`broker-degraded.mjs`).
 
-That degraded/recovered pair is an EDGE-TRIGGERED episode with a **durable latch** (marker
-`~/catalyst/broker-degraded-latch.json`), and it is **OPT-IN and dormant by default** — it evaluates
-nothing unless `FILTER_BROKER_DEGRADED_ENABLED=1`. Under **execution-core dispatch** its
-`interests.size === 0` conjunct is permanently true (the daemon runs no `filter.register` producer),
-so the gate carries no information there. That is a property of execution-core, **not** of every
-configuration named `phase-agents`: a **legacy-wave** host — one driving
-`/catalyst-legacy:orchestrate`, which invokes
-`plugins/dev/scripts/orchestrate-register-interests.sh` — does register interests (pr/ticket/comms
-unconditionally, plus a per-ticket `phase_lifecycle` when `dispatchMode` is `phase-agents`), so
-there an empty table IS anomalous and enabling the knob is appropriate.
+That degraded/recovered pair is an EDGE-TRIGGERED episode with a **durable latch** (marker `~/catalyst/broker-degraded-latch.json`), and it is **OPT-IN and dormant by default** — it evaluates nothing unless `FILTER_BROKER_DEGRADED_ENABLED=1`. Under **execution-core dispatch** its `interests.size === 0` conjunct is permanently true (the daemon runs no `filter.register` producer), so the gate carries no information there. That is a property of execution-core, **not** of every configuration named `phase-agents`: a **legacy-wave** host — one driving `/catalyst-legacy:orchestrate`, which invokes `plugins/dev/scripts/orchestrate-register-interests.sh` — does register interests (pr/ticket/comms unconditionally, plus a per-ticket `phase_lifecycle` when `dispatchMode` is `phase-agents`), so there an empty table IS anomalous and enabling the knob is appropriate.
 
-**Neither this detector nor CTL-1122's `checkSourceRecency` can detect a fully-dead broker** — both
-execute inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an
-ingestion **stall** (an upstream source gone silent) while the broker is **alive**, via
-`catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`. Proving the process itself is
-gone requires an **external absence-based check** on the broker's own heartbeat/log series — a Loki
-`absent_over_time` alert on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because
-a fully-dead daemon is a _missing series_, which `count_over_time == 0` cannot assert).
+**Neither this detector nor CTL-1122's `checkSourceRecency` can detect a fully-dead broker** — both execute inside the broker process, so a dead broker emits neither. `checkSourceRecency` detects an ingestion **stall** (an upstream source gone silent) while the broker is **alive**, via `catalyst.ingestion.stale` + `catalyst.alert.raised(system_down)`. Proving the process itself is gone requires an **external absence-based check** on the broker's own heartbeat/log series — a Loki `absent_over_time` alert on `broker.daemon.heartbeat` or the broker `.log` stream (absence, because a fully-dead daemon is a _missing series_, which `count_over_time == 0` cannot assert).
 
-**`KNOWN_PHASES`** (canonical 10, in order): `triage`, `research`, `plan`, `implement`, `verify`,
-`review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown`.
+**`KNOWN_PHASES`** (canonical 10, in order): `triage`, `research`, `plan`, `implement`, `verify`, `review`, `pr`, `monitor-merge`, `monitor-deploy`, `teardown`.
 
-**`<name>` slot exceptions** (in `recovery.mjs`, NOT pipeline phases): `dispatch`
-(`phase.dispatch.failed.<ticket>` — the only exception with a terminal-status suffix that matches
-the pattern; real phase rides `payload.target_phase`); `scheduler` (internal observability:
-`yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate — `held` on a refusal, `applied`
-on a performed advance, CTL-1789). The latter two never match the terminal-status set, so
-`tryPhaseLifecycleRoute` returns `[]` for every event in them — pure audit, zero wake side effect.
+**`<name>` slot exceptions** (in `recovery.mjs`, NOT pipeline phases): `dispatch` (`phase.dispatch.failed.<ticket>` — the only exception with a terminal-status suffix that matches the pattern; real phase rides `payload.target_phase`); `scheduler` (internal observability: `yield-file-skip`, `cooldown-gc`, …); `advance` (phase-advance gate — `held` on a refusal, `applied` on a performed advance, CTL-1789). The latter two never match the terminal-status set, so `tryPhaseLifecycleRoute` returns `[]` for every event in them — pure audit, zero wake side effect.
 
 ### Advancement-gate observability + terminal attribution (CTL-1789)
 
-The advancement gate used to emit **only on refusal**: 2026-08 held 307 `phase.advance.held` events
-and zero `phase.advance.*` of any other name, so the FSM's actual advances were invisible and every
-consumer had to infer them from the successor phase's dispatch (which conflates a fresh advance with
-a revive, a resume, and a new-work pull).
+The advancement gate used to emit **only on refusal**: 2026-08 held 307 `phase.advance.held` events and zero `phase.advance.*` of any other name, so the FSM's actual advances were invisible and every consumer had to infer them from the successor phase's dispatch (which conflates a fresh advance with a revive, a resume, and a new-work pull).
 
-- **`phase.advance.applied.<TICKET>`** (`recovery.mjs` `defaultAppendPhaseAdvanceAppliedEvent`,
-  emitted from the scheduler's advancement sweep inside the `dv.ok` branch, i.e. only after
-  `dispatchAndVerify` confirmed a live successor worker). Severity **INFO** (`held` stays WARN).
-  Payload: `{from, to, evidence, evidence_reason, asserted_by, assertion_ref}`; `evidence` plus
-  `from`/`to` are also promoted to attributes (`catalyst.advance.*`) because otel-forward strips
-  `body.payload` off-machine. `from` is re-derived with the extracted pure
-  `latestLivePhase(signals)` — the SAME function `deriveAdvancement` keys off, so the audit can
-  never name a different predecessor than the FSM used. **One exception — the remediate detour**:
-  `remediate` is ANCILLARY (∉ `PHASES`), so `latestLivePhase` can never return it, and
-  `maybeResetForRemediateCycle` has already deleted `phase-remediate.json` before the sweep reads
-  its map. Left on `latestLivePhase` alone, every remediation re-entry named `from=implement` and
-  classified its evidence off the stale implement terminal — laundering a FABRICATED remediation
-  into a DECLARED advance. That one edge is resolved through `resolveReapPredecessor` over the
-  PRE-reset snapshot (with `remediateRaw` for the deleted file), the same snapshot + resolver the
-  predecessor reap uses, so the audit's `from` and the reaped worker are always the same phase.
-- **`assertedBy` on the phase signal** (`execution-core/assertion-evidence.mjs`, a zero-import leaf
-  owning `ASSERTED_BY` + `classifyAdvanceEvidence`/`explainAdvanceEvidence`). Three producers can
-  write a terminal `done` and were previously byte-indistinguishable: the agent's own
-  `phase-agent-emit-complete` (**declared**), `flipSignalDoneOnSuccess`'s clean-SDK-exit flip
-  (**fabricated** — the agent never declared anything), and the recovery-reclaim / legacy-revive
-  synthetic completes (**fabricated** — inferred from a work-done probe). Writers stamp their id:
-  the wrapper defaults to `phase-agent-emit-complete` and accepts `--asserted-by` so infrastructure
-  callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the fail
-  direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` / `no-marker` /
-  `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued. **One
-  registry, two unavoidable bash mirrors**: the JS writers (`recovery.mjs`,
-  `sdk-run-phase-agent.mjs`) import `ASSERTED_BY`, but `phase-agent-emit-complete` (its
-  `--asserted-by` default) and `orchestrate-revive` (its flag value) are bash and cannot. Those two
-  literals are held byte-identical to the registry MECHANICALLY by
-  `execution-core/assertion-evidence-parity.test.mjs` — the same one-registry/hand-written-mirror/
-  cross-stack-parity-suite discipline as `lib/secret-contract.mjs`. Each anchor matches on the
-  variable/flag, never the value, and fails CLOSED when an anchor disappears, so a rename on either
-  side alone fails rather than silently reclassifying valid terminals as `unknown-writer`.
-- **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline
-  pass after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has
-  cycled.
-- **Scope**: only the terminal-**success** writers are stamped (plus the SDK backstop). The ~20
-  `stalled`/`failed`/`aborted` writers are deliberately unstamped — those statuses are
-  never advance-eligible (`deriveAdvancement` gates on `done`, or `skipped` for `monitor-deploy`
-  only), so they can never be the `from` signal of an applied advance.
+- **`phase.advance.applied.<TICKET>`** (`recovery.mjs` `defaultAppendPhaseAdvanceAppliedEvent`, emitted from the scheduler's advancement sweep inside the `dv.ok` branch, i.e. only after `dispatchAndVerify` confirmed a live successor worker). Severity **INFO** (`held` stays WARN). Payload: `{from, to, evidence, evidence_reason, asserted_by, assertion_ref}`; `evidence` plus `from`/`to` are also promoted to attributes (`catalyst.advance.*`) because otel-forward strips `body.payload` off-machine. `from` is re-derived with the extracted pure `latestLivePhase(signals)` — the SAME function `deriveAdvancement` keys off, so the audit can never name a different predecessor than the FSM used. **One exception — the remediate detour**: `remediate` is ANCILLARY (∉ `PHASES`), so `latestLivePhase` can never return it, and `maybeResetForRemediateCycle` has already deleted `phase-remediate.json` before the sweep reads its map. Left on `latestLivePhase` alone, every remediation re-entry named `from=implement` and classified its evidence off the stale implement terminal — laundering a FABRICATED remediation into a DECLARED advance. That one edge is resolved through `resolveReapPredecessor` over the PRE-reset snapshot (with `remediateRaw` for the deleted file), the same snapshot + resolver the predecessor reap uses, so the audit's `from` and the reaped worker are always the same phase.
+- **`assertedBy` on the phase signal** (`execution-core/assertion-evidence.mjs`, a zero-import leaf owning `ASSERTED_BY` + `classifyAdvanceEvidence`/`explainAdvanceEvidence`). Three producers can write a terminal `done` and were previously byte-indistinguishable: the agent's own `phase-agent-emit-complete` (**declared**), `flipSignalDoneOnSuccess`'s clean-SDK-exit flip (**fabricated** — the agent never declared anything), and the recovery-reclaim / legacy-revive synthetic completes (**fabricated** — inferred from a work-done probe). Writers stamp their id: the wrapper defaults to `phase-agent-emit-complete` and accepts `--asserted-by` so infrastructure callers self-identify. Unknown/missing markers classify **absent**, never `declared` — the fail direction is deliberate. `evidence_reason` (`no-predecessor` / `unreadable-signal` / `no-marker` / `unknown-writer`) keeps `absent` diagnosable while the contract stays three-valued. **One registry, two unavoidable bash mirrors**: the JS writers (`recovery.mjs`, `sdk-run-phase-agent.mjs`) import `ASSERTED_BY`, but `phase-agent-emit-complete` (its `--asserted-by` default) and `orchestrate-revive` (its flag value) are bash and cannot. Those two literals are held byte-identical to the registry MECHANICALLY by `execution-core/assertion-evidence-parity.test.mjs` — the same one-registry/hand-written-mirror/ cross-stack-parity-suite discipline as `lib/secret-contract.mjs`. Each anchor matches on the variable/flag, never the value, and fails CLOSED when an anchor disappears, so a rename on either side alone fails rather than silently reclassifying valid terminals as `unknown-writer`.
+- **Rollout caveat**: signals written before this shipped carry no marker, so the first pipeline pass after deploy reads `absent` / `no-marker`. Do not alarm on `absent` until a full ticket has cycled.
+- **Scope**: only the terminal-**success** writers are stamped (plus the SDK backstop). The ~20 `stalled`/`failed`/`aborted` writers are deliberately unstamped — those statuses are never advance-eligible (`deriveAdvancement` gates on `done`, or `skipped` for `monitor-deploy` only), so they can never be the `from` signal of an applied advance.
 
 ### The declared, bounded wait — `awaiting-work` (CTL-1854)
 
-An agent that delegates to a background job, says "I'll be re-invoked when it completes", and ends
-its turn is recorded by `sdk-run-phase-agent` as `failed`/`abandoned`/`ended-without-declaration`
-(CTL-1790). Measured 2026-08-14: **5 such runs across both hosts in one day**, all in `implement`
-and `monitor-merge` — the two phases with a reason to await background work — every one a clean SDK
-exit at turn 11–15 of 500 with 8% context left. Two were fleet-blocking; one *was* the
-ingestion-silence alarm, so the defect ate the fix for another defect.
+An agent that delegates to a background job, says "I'll be re-invoked when it completes", and ends its turn is recorded by `sdk-run-phase-agent` as `failed`/`abandoned`/`ended-without-declaration` (CTL-1790). Measured 2026-08-14: **5 such runs across both hosts in one day**, all in `implement` and `monitor-merge` — the two phases with a reason to await background work — every one a clean SDK exit at turn 11–15 of 500 with 8% context left. Two were fleet-blocking; one *was* the ingestion-silence alarm, so the defect ate the fix for another defect.
 
-`phase-agent-emit-complete --status yield` is the declaration. It writes status **`awaiting-work`**
-plus `yieldedAt`/`firstYieldedAt`, reusing the shape `park` already established: non-terminal (no
-`completedAt`) and **no `PHASE_EVENT_PATTERN` match**, so it creates no phase-lifecycle route.
-Deliberately NOT `needs-input` — that means waiting on a HUMAN and pages one; an agent waiting on
-its own job needs nobody, and conflating them imports CTL-1850's false-page defect.
+`phase-agent-emit-complete --status yield` is the declaration. It writes status **`awaiting-work`** plus `yieldedAt`/`firstYieldedAt`, reusing the shape `park` already established: non-terminal (no `completedAt`) and **no `PHASE_EVENT_PATTERN` match**, so it creates no phase-lifecycle route. Deliberately NOT `needs-input` — that means waiting on a HUMAN and pages one; an agent waiting on its own job needs nobody, and conflating them imports CTL-1850's false-page defect.
 
-- **A yield is a deadline, not a permit.** `isTicketInFlight` frees a slot only for
-  `failed|stalled|aborted`, so `awaiting-work` HOLDS it. Contract + classifier:
-  `lib/phase-yield.mjs` (zero-import leaf).
-- **⚠️ Expiry lives in the scheduler tick, NOT in the runner.**
-  `sdk-run-phase-agent` evaluates a yield exactly once, as the worker exits — microseconds after
-  `yieldedAt` was written, when it is always live — so that call site can never observe a deadline
-  pass. Enforcement is `reclaimDeadWorkIfPossible` (recovery.mjs), which `schedulerTick` runs once
-  per signal per tick, placed **above** the `classifyWorker` short-circuit (an SDK-path signal has
-  no `bg_job_id` → `unknown` → early `noop`, the exact stranding path) **and above the
-  `inFlightTickets` filter**. That second placement is not symmetry: the tempting argument — "the
-  sweep must reach every yield, because a yield holds the slot" — is true only for a **pipeline**
-  phase. An **ancillary** yield (a `recovery-pass` beside a failed/stalled pipeline phase) leaves
-  `isTicketInFlight` false, so the filter skipped it and its deadline was never evaluated, reserving
-  the slot forever. The yield branch is therefore evaluated unconditionally.
-- **The ceiling bounds the EPISODE** (30 min, matching Linear's session-stale deadline).
-  The deadline **never moves later**: both anchors are set once per episode and `yieldMs` only ever
-  shrinks (a re-yield takes the minimum, and never deletes it). Ten re-yields buy exactly as much as
-  one — and that holds for SHORT waits too, not just at the ceiling: a 60-second yield re-declared
-  after 30 seconds still expires at 60. Absent anchor → anchors on `yieldedAt`; **present but
-  unreadable → expires**.
-- **An expired yield is TERMINAL, not a re-dispatch.** It writes `failed` + `outcome: "abandoned"` +
-  `failureReason: "yield-expired"`, `assertedBy: recovery-reclaim` (fabricated by the sweep, not
-  declared). `failed` is in `signal-reader.mjs`'s `TERMINAL` set, so reclaim short-circuits to
-  `noop` and the terminal sweep routes through the CTL-1609 delegate-first path — identical to a
-  plain abandonment, so no yield-expire-redispatch loop is constructible. Deliberately not
-  `stalled`, which routes to the escalation guard and would page an operator for every expired yield.
-- **Vocabulary collision**: CTL-615/CTL-702's `phase-*-yield-*.json` tombstones are an unrelated
-  mechanism (a duplicate worker bowing out to the canonical one). A `grep` for "yield" returns both.
+- **A yield is a deadline, not a permit.** `isTicketInFlight` frees a slot only for `failed|stalled|aborted`, so `awaiting-work` HOLDS it. Contract + classifier: `lib/phase-yield.mjs` (zero-import leaf).
+- **⚠️ Expiry lives in the scheduler tick, NOT in the runner.** `sdk-run-phase-agent` evaluates a yield exactly once, as the worker exits — microseconds after `yieldedAt` was written, when it is always live — so that call site can never observe a deadline pass. Enforcement is `reclaimDeadWorkIfPossible` (recovery.mjs), which `schedulerTick` runs once per signal per tick, placed **above** the `classifyWorker` short-circuit (an SDK-path signal has no `bg_job_id` → `unknown` → early `noop`, the exact stranding path) **and above the `inFlightTickets` filter**. That second placement is not symmetry: the tempting argument — "the sweep must reach every yield, because a yield holds the slot" — is true only for a **pipeline** phase. An **ancillary** yield (a `recovery-pass` beside a failed/stalled pipeline phase) leaves `isTicketInFlight` false, so the filter skipped it and its deadline was never evaluated, reserving the slot forever. The yield branch is therefore evaluated unconditionally.
+- **The ceiling bounds the EPISODE** (30 min, matching Linear's session-stale deadline). The deadline **never moves later**: both anchors are set once per episode and `yieldMs` only ever shrinks (a re-yield takes the minimum, and never deletes it). Ten re-yields buy exactly as much as one — and that holds for SHORT waits too, not just at the ceiling: a 60-second yield re-declared after 30 seconds still expires at 60. Absent anchor → anchors on `yieldedAt`; **present but unreadable → expires**.
+- **An expired yield is TERMINAL, not a re-dispatch.** It writes `failed` + `outcome: "abandoned"` + `failureReason: "yield-expired"`, `assertedBy: recovery-reclaim` (fabricated by the sweep, not declared). `failed` is in `signal-reader.mjs`'s `TERMINAL` set, so reclaim short-circuits to `noop` and the terminal sweep routes through the CTL-1609 delegate-first path — identical to a plain abandonment, so no yield-expire-redispatch loop is constructible. Deliberately not `stalled`, which routes to the escalation guard and would page an operator for every expired yield.
+- **Vocabulary collision**: CTL-615/CTL-702's `phase-*-yield-*.json` tombstones are an unrelated mechanism (a duplicate worker bowing out to the canonical one). A `grep` for "yield" returns both.
 
 **Enforcement surfaces:**
 
-- `plugins/dev/scripts/broker/namespace-contract.mjs` — single source of truth:
-  `FORBIDDEN_PREFIXES`, `PROTECTED_EXACT_NAMES`, `KNOWN_PHASES`,
-  `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`, `PHASE_EVENT_PATTERN`, `isBrokerProtectedName`,
-  `phaseSlotOf`, `isAllowedPhaseSlot`. `router.mjs`'s `shouldSkipEvent` imports from here.
-- `plugins/dev/scripts/broker/namespace-parity.test.mjs` — exec-core producer parity (static names +
-  `recovery.mjs` source-scan).
-- `plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts` — orch-monitor producer
-  parity (GitHub/Linear/service-health names + prefix-family invariant).
-- `plugins/dev/scripts/execution-core/assertion-evidence-parity.test.mjs` — CTL-1789 writer-id
-  parity: the `ASSERTED_BY` registry vs its two bash mirrors, plus a no-re-typed-literal check on
-  the JS writers. Wired into the required `execution-core-tests` stable list.
+- `plugins/dev/scripts/broker/namespace-contract.mjs` — single source of truth: `FORBIDDEN_PREFIXES`, `PROTECTED_EXACT_NAMES`, `KNOWN_PHASES`, `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`, `PHASE_EVENT_PATTERN`, `isBrokerProtectedName`, `phaseSlotOf`, `isAllowedPhaseSlot`. `router.mjs`'s `shouldSkipEvent` imports from here.
+- `plugins/dev/scripts/broker/namespace-parity.test.mjs` — exec-core producer parity (static names + `recovery.mjs` source-scan).
+- `plugins/dev/scripts/orch-monitor/__tests__/namespace-parity.test.ts` — orch-monitor producer parity (GitHub/Linear/service-health names + prefix-family invariant).
+- `plugins/dev/scripts/execution-core/assertion-evidence-parity.test.mjs` — CTL-1789 writer-id parity: the `ASSERTED_BY` registry vs its two bash mirrors, plus a no-re-typed-literal check on the JS writers. Wired into the required `execution-core-tests` stable list.
 
 See `thoughts/shared/plans/2026-06-16-ctl-1142.md` §3.8.
 
@@ -1534,22 +494,12 @@ See `thoughts/shared/plans/2026-06-16-ctl-1142.md` §3.8.
 
 ## Artifact Persistence (hybrid SQLite + filesystem, ADR-011)
 
-Orchestrator runs produce artifacts that must survive worktree/runtime cleanup (SUMMARY.md, wave
-briefings, per-worker signal files + phase logs, rollup fragments, comms channels, state.json),
-archived keyed by orchestrator id.
+Orchestrator runs produce artifacts that must survive worktree/runtime cleanup (SUMMARY.md, wave briefings, per-worker signal files + phase logs, rollup fragments, comms channels, state.json), archived keyed by orchestrator id.
 
-- **Index (SQLite)** — `~/catalyst/catalyst.db`, migration `003_archives.sql`: `orchestrators` (one
-  row/orch), `archived_workers` (PK `orch_id,worker_id`), `archived_artifacts` (UNIQUE
-  `orch_id,path`).
-- **Blobs (filesystem)** — `~/catalyst/archives/<orchId>/`: root
-  `metadata.json`/`SUMMARY.md`/`rollup-briefing.md`; `briefings/wave-*.md`;
-  `workers/<ticket>/{signal-final.json,phase-log.jsonl,SUMMARY.md,rollup-fragment.md}`;
-  `comms/<channel>.jsonl`.
+- **Index (SQLite)** — `~/catalyst/catalyst.db`, migration `003_archives.sql`: `orchestrators` (one row/orch), `archived_workers` (PK `orch_id,worker_id`), `archived_artifacts` (UNIQUE `orch_id,path`).
+- **Blobs (filesystem)** — `~/catalyst/archives/<orchId>/`: root `metadata.json`/`SUMMARY.md`/`rollup-briefing.md`; `briefings/wave-*.md`; `workers/<ticket>/{signal-final.json,phase-log.jsonl,SUMMARY.md,rollup-fragment.md}`; `comms/<channel>.jsonl`.
 
-**Filesystem-first invariant**: blobs land on disk (via `atomicWrite()` = tmp + `rename`) before any
-SQLite row; INSERTs run in a transaction after all FS writes succeed. So a failed SQLite write
-leaves recoverable files (picked up by `sync`); a mid-sweep crash leaves only deletable `.tmp`
-files; re-running is safe (all inserts are `ON CONFLICT … DO UPDATE`).
+**Filesystem-first invariant**: blobs land on disk (via `atomicWrite()` = tmp + `rename`) before any SQLite row; INSERTs run in a transaction after all FS writes succeed. So a failed SQLite write leaves recoverable files (picked up by `sync`); a mid-sweep crash leaves only deletable `.tmp` files; re-running is safe (all inserts are `ON CONFLICT … DO UPDATE`).
 
 **CLI** (`plugins/dev/scripts/orch-monitor/catalyst-archive.ts`, all accept `--dry-run`):
 
@@ -1560,17 +510,8 @@ prune --older-than 30d  # delete archives older than N days
 list [--json] | show <orchId>
 ```
 
-Config from `.catalyst/config.json` merged with `~/.config/catalyst/config.json` via `archive.*`
-keys.
+Config from `.catalyst/config.json` merged with `~/.config/catalyst/config.json` via `archive.*` keys.
 
-**Monitor + UI** — orch-monitor read-only endpoints: `GET /api/archive/orchestrators` (paginated,
-since/until/ticket/status filters); `GET /api/archive/orchestrators/:id` (detail w/
-workers+artifacts); `GET /api/archive/orchestrators/:id/files/:relPath+` (streams a file; paths
-validated via `isSafeArchivePart`/`isSafeArchiveFileRel` + `realpathSync` against `archive_path` to
-block symlink escapes — 403/400/404). The `/history` page renders an "Archived Orchestrators"
-section over these.
+**Monitor + UI** — orch-monitor read-only endpoints: `GET /api/archive/orchestrators` (paginated, since/until/ticket/status filters); `GET /api/archive/orchestrators/:id` (detail w/ workers+artifacts); `GET /api/archive/orchestrators/:id/files/:relPath+` (streams a file; paths validated via `isSafeArchivePart`/`isSafeArchiveFileRel` + `realpathSync` against `archive_path` to block symlink escapes — 403/400/404). The `/history` page renders an "Archived Orchestrators" section over these.
 
-**Lifecycle** — Orchestrate Phase 7 runs the sweep after the final SUMMARY.md and before worktree
-cleanup (idempotent). The teardown skill (`/catalyst-dev:teardown <orchId>`) deletes runtime +
-worktree state but refuses unless the archive exists and the SQLite row is present (`--force`
-bypasses).
+**Lifecycle** — Orchestrate Phase 7 runs the sweep after the final SUMMARY.md and before worktree cleanup (idempotent). The teardown skill (`/catalyst-dev:teardown <orchId>`) deletes runtime + worktree state but refuses unless the archive exists and the SQLite row is present (`--force` bypasses).

--- a/docs/ci-required-checks-rollout.md
+++ b/docs/ci-required-checks-rollout.md
@@ -1,36 +1,18 @@
 # CI required-checks rollout — swap `Cloudflare Pages` → `docs-gate` (CTL-670)
 
-Operator runbook for making `docs-gate` the sole required status check on `main` and demoting the
-slow `Cloudflare Pages` preview build to a non-required, build-watch-path-gated deploy.
+Operator runbook for making `docs-gate` the sole required status check on `main` and demoting the slow `Cloudflare Pages` preview build to a non-required, build-watch-path-gated deploy.
 
-**Why:** ~75% of PRs change nothing under `website/`, yet every PR pays the ~3-min Cloudflare Pages
-build before it can merge, because `Cloudflare Pages` is the repo's *sole* required check under a
-strict policy. Cloudflare posts **no** check-run/commit-status when a build is skipped (CI Skip,
-build watch paths, or branch deployment controls), so we cannot simply skip the CF build on non-docs
-PRs — that would leave a required check that never reports, blocking every non-docs PR forever.
-Instead we introduce an in-repo `docs-gate` Action that *always* reports (honoring the invariant in
-[configuration.md](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md):
-"only mark a check as required if it runs on every PR to `main`"), make **it** the required check,
-and let Cloudflare Pages keep deploying via watch paths without being required.
+**Why:** ~75% of PRs change nothing under `website/`, yet every PR pays the ~3-min Cloudflare Pages build before it can merge, because `Cloudflare Pages` is the repo's *sole* required check under a strict policy. Cloudflare posts **no** check-run/commit-status when a build is skipped (CI Skip, build watch paths, or branch deployment controls), so we cannot simply skip the CF build on non-docs PRs — that would leave a required check that never reports, blocking every non-docs PR forever. Instead we introduce an in-repo `docs-gate` Action that *always* reports (honoring the invariant in [configuration.md](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md): "only mark a check as required if it runs on every PR to `main`"), make **it** the required check, and let Cloudflare Pages keep deploying via watch paths without being required.
 
-**What `docs-gate` does** (`.github/workflows/docs-gate.yml`): runs on every PR with no path filter;
-computes changed paths and delegates the docs-relevance decision to
-`scripts/ci/docs-paths-changed.sh` (docs-relevant = anything under `website/`, or any
-`plugins/*/CHANGELOG.md` — the changelog dependency in `website/astro.config.mjs`). Non-docs PRs
-pass in seconds; docs PRs run `npm ci && npm run build` and must be green.
+**What `docs-gate` does** (`.github/workflows/docs-gate.yml`): runs on every PR with no path filter; computes changed paths and delegates the docs-relevance decision to `scripts/ci/docs-paths-changed.sh` (docs-relevant = anything under `website/`, or any `plugins/*/CHANGELOG.md` — the changelog dependency in `website/astro.config.mjs`). Non-docs PRs pass in seconds; docs PRs run `npm ci && npm run build` and must be green.
 
 ---
 
 ## ⚠️ Critical ordering invariant
 
-**Never set the Cloudflare "Build watch paths" (step 5) before removing `Cloudflare Pages` from the
-required set (step 4).** In the gap between those two actions, non-docs PRs would skip the CF build
-(no status posted) while CF is still required → every non-docs PR becomes permanently unmergeable.
-The ordering below keeps `main` mergeable at every step, and every step is reversible (re-add
-`Cloudflare Pages` to the required set to roll back).
+**Never set the Cloudflare "Build watch paths" (step 5) before removing `Cloudflare Pages` from the required set (step 4).** In the gap between those two actions, non-docs PRs would skip the CF build (no status posted) while CF is still required → every non-docs PR becomes permanently unmergeable. The ordering below keeps `main` mergeable at every step, and every step is reversible (re-add `Cloudflare Pages` to the required set to roll back).
 
-Read branch protection from the **ruleset** endpoint, not classic protection — the classic
-`/branches/main/protection` endpoint returns **404** for this repo and reading it lies:
+Read branch protection from the **ruleset** endpoint, not classic protection — the classic `/branches/main/protection` endpoint returns **404** for this repo and reading it lies:
 
 ```bash
 gh api repos/coalesce-labs/catalyst/rules/branches/main
@@ -42,8 +24,7 @@ gh api repos/coalesce-labs/catalyst/rules/branches/main
 
 ### 1. Merge the `docs-gate` workflow (this PR)
 
-Once merged, `docs-gate` runs on subsequent PRs but is **not yet required**. (This PR itself is
-still gated by the current `Cloudflare Pages`-only requirement — that is fine.)
+Once merged, `docs-gate` runs on subsequent PRs but is **not yet required**. (This PR itself is still gated by the current `Cloudflare Pages`-only requirement — that is fine.)
 
 ### 2. Empirical pre-flight (research OQ #1) — confirm the CF skip behavior
 
@@ -54,9 +35,7 @@ gh pr checks <n>           # docs-gate should complete in seconds with the
                            # "No docs-relevant changes" log line
 ```
 
-At this point `Cloudflare Pages` still builds — expected, because CF watch paths are not set yet.
-This step exists to confirm the vendor-documented skip behavior empirically *before* touching
-branch protection.
+At this point `Cloudflare Pages` still builds — expected, because CF watch paths are not set yet. This step exists to confirm the vendor-documented skip behavior empirically *before* touching branch protection.
 
 ### 3. Add `docs-gate` to the required set **alongside** `Cloudflare Pages`
 
@@ -90,9 +69,7 @@ gh api -X PUT repos/coalesce-labs/catalyst/rulesets/<RULESET_ID> --input /tmp/ru
 
 ### 5. Set Cloudflare "Build watch paths"
 
-In the Cloudflare Pages dashboard: **Settings → Builds & deployments → Build watch paths**. Set
-**Include paths** to mirror the Phase 1 docs-relevant set (CF `*` crosses `/`, so `website/*`
-recurses):
+In the Cloudflare Pages dashboard: **Settings → Builds & deployments → Build watch paths**. Set **Include paths** to mirror the Phase 1 docs-relevant set (CF `*` crosses `/`, so `website/*` recurses):
 
 - `website/*`
 - `plugins/*/CHANGELOG.md`
@@ -116,20 +93,17 @@ Open a scratch `website/` PR:
 gh pr checks <n>   # expect: docs-gate running the build, AND a "Cloudflare Pages" deploy row
 ```
 
-Optionally prove the gate blocks broken docs: push a deliberately malformed `.mdx` and confirm
-`docs-gate` **fails**.
+Optionally prove the gate blocks broken docs: push a deliberately malformed `.mdx` and confirm `docs-gate` **fails**.
 
 ### 8. Re-verify `phase-monitor-merge` picks up `docs-gate` dynamically
 
-The merge monitor reads the required-check set from the ruleset at runtime — it does **not**
-hardcode `Cloudflare Pages`. Confirm no hardcoded required-check string regressed:
+The merge monitor reads the required-check set from the ruleset at runtime — it does **not** hardcode `Cloudflare Pages`. Confirm no hardcoded required-check string regressed:
 
 ```bash
 grep -rn "Cloudflare Pages" plugins/dev/scripts plugins/dev/skills | grep -iv test
 ```
 
-This should return nothing that treats `Cloudflare Pages` as *the required check*. No
-`phase-monitor-merge` code change is needed.
+This should return nothing that treats `Cloudflare Pages` as *the required check*. No `phase-monitor-merge` code change is needed.
 
 ---
 
@@ -147,50 +121,25 @@ gh api repos/coalesce-labs/catalyst/rules/branches/main \
 
 ## Rollback
 
-Re-add `Cloudflare Pages` to the required set (step 3 in reverse) and/or clear the CF Build watch
-paths so CF builds on every push again. Every step above is individually reversible.
+Re-add `Cloudflare Pages` to the required set (step 3 in reverse) and/or clear the CF Build watch paths so CF builds on every push again. Every step above is individually reversible.
 
 ## Current live state — Cloudflare Pages project config (2026-08-21)
 
-The rollout above is complete: `main`'s required checks are `docs-gate`, `gitleaks`,
-`agents-md-gate`, `audit-references`, `check-versions`, `execution-core-unit-tests` — no
-`Cloudflare Pages` entry. Step 5 (CF Build watch paths) is also live, applied directly via the
-Cloudflare Pages API rather than the dashboard:
+The rollout above is complete: `main`'s required checks are `docs-gate`, `gitleaks`, `agents-md-gate`, `audit-references`, `check-versions`, `execution-core-unit-tests` — no `Cloudflare Pages` entry. Step 5 (CF Build watch paths) is also live, applied directly via the Cloudflare Pages API rather than the dashboard:
 
-- **Project:** `catalyst` (Cloudflare Pages), serving the docs/marketing site at
-  [catalyst.coalescelabs.ai](https://catalyst.coalescelabs.ai). Managed via Cloudflare's native
-  GitHub integration — there is no Pages deploy workflow file in `.github/workflows/`; the build
-  is configured and triggered entirely on the Cloudflare side.
-- **Build command:** `cd website && npm install && npm run build`, publishing `website/dist`
-  (the Astro Starlight site under `website/`).
-- **Watch-path scoping (live now):** `source.config.path_includes` = `["website/**"]`. A PR or
-  push only triggers a CF build+deploy when it touches something under `website/`.
-  ⚠️ This is **narrower** than the docs-relevant set `docs-gate` itself uses (`website/*` **and**
-  `plugins/*/CHANGELOG.md` / `plugins/playground/*/CHANGELOG.md` — see
-  `scripts/ci/docs-paths-changed.sh`). The "keep in sync" invariant noted below is not currently
-  satisfied by the live `path_includes`; a changelog-only PR builds under `docs-gate` but will not
-  trigger a CF deploy.
-- **Source of truth / how to verify or change it:** this setting lives in the Cloudflare
-  dashboard/API, not in this repo — `GET`/`PATCH
-  accounts/{account_id}/pages/projects/catalyst` (Cloudflare Pages API). If it's changed again,
-  update this section to match.
+- **Project:** `catalyst` (Cloudflare Pages), serving the docs/marketing site at [catalyst.coalescelabs.ai](https://catalyst.coalescelabs.ai). Managed via Cloudflare's native GitHub integration — there is no Pages deploy workflow file in `.github/workflows/`; the build is configured and triggered entirely on the Cloudflare side.
+- **Build command:** `cd website && npm install && npm run build`, publishing `website/dist` (the Astro Starlight site under `website/`).
+- **Watch-path scoping (live now):** `source.config.path_includes` = `["website/**"]`. A PR or push only triggers a CF build+deploy when it touches something under `website/`. ⚠️ This is **narrower** than the docs-relevant set `docs-gate` itself uses (`website/*` **and** `plugins/*/CHANGELOG.md` / `plugins/playground/*/CHANGELOG.md` — see `scripts/ci/docs-paths-changed.sh`). The "keep in sync" invariant noted below is not currently satisfied by the live `path_includes`; a changelog-only PR builds under `docs-gate` but will not trigger a CF deploy.
+- **Source of truth / how to verify or change it:** this setting lives in the Cloudflare dashboard/API, not in this repo — `GET`/`PATCH accounts/{account_id}/pages/projects/catalyst` (Cloudflare Pages API). If it's changed again, update this section to match.
 
 ## Notes / edge cases
 
-- **CF force-builds** on 0-file, 3000+-file, or 20+-commit pushes regardless of watch paths. These
-  produce a `Cloudflare Pages` status on PRs that `docs-gate` classifies non-docs — harmless (CF is
-  no longer required), but worth knowing if anyone re-adds CF to the required set.
-- **Hard-block on deploy vs build** is out of scope. `docs-gate` blocks docs PRs on the in-CI
-  `astro build`, not the CF *deployment*. Blocking merge on the CF preview/production deploy itself
-  needs a different mechanism (a job polling the CF deployment commit-status / CF API) and is a
-  follow-up — it is *not* achievable by keeping CF as a required check while it skips.
-- **Context-name coupling:** if the `docs-gate` job is ever renamed, the ruleset's required-context
-  string must be updated in lockstep (the same coupling `Cloudflare Pages` had).
+- **CF force-builds** on 0-file, 3000+-file, or 20+-commit pushes regardless of watch paths. These produce a `Cloudflare Pages` status on PRs that `docs-gate` classifies non-docs — harmless (CF is no longer required), but worth knowing if anyone re-adds CF to the required set.
+- **Hard-block on deploy vs build** is out of scope. `docs-gate` blocks docs PRs on the in-CI `astro build`, not the CF *deployment*. Blocking merge on the CF preview/production deploy itself needs a different mechanism (a job polling the CF deployment commit-status / CF API) and is a follow-up — it is *not* achievable by keeping CF as a required check while it skips.
+- **Context-name coupling:** if the `docs-gate` job is ever renamed, the ruleset's required-context string must be updated in lockstep (the same coupling `Cloudflare Pages` had).
 
 ## References
 
-- [`website/src/content/docs/reference/configuration.md`](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md)
-  — the required-check model and the "only require checks that run on every PR" invariant.
+- [`website/src/content/docs/reference/configuration.md`](https://github.com/coalesce-labs/catalyst/blob/main/website/src/content/docs/reference/configuration.md) — the required-check model and the "only require checks that run on every PR" invariant.
 - `.github/workflows/docs-gate.yml` — the always-running, path-aware gate.
-- `scripts/ci/docs-paths-changed.sh` — the docs-relevance decision helper (keep in sync with the CF
-  watch-path include set).
+- `scripts/ci/docs-paths-changed.sh` — the docs-relevance decision helper (keep in sync with the CF watch-path include set).

--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -4,9 +4,7 @@ This document describes how to onboard a fresh macOS node into a Catalyst cluste
 
 ## Quick Start
 
-As of CTL-1214, `catalyst-join` provisions a node end-to-end on its own — thoughts
-clone + clean `humanlayer.json`, GitHub auth, the daemon stack, and the Stage-0
-SHADOW gate are all baked in. The canonical flow is two commands:
+As of CTL-1214, `catalyst-join` provisions a node end-to-end on its own — thoughts clone + clean `humanlayer.json`, GitHub auth, the daemon stack, and the Stage-0 SHADOW gate are all baked in. The canonical flow is two commands:
 
 ```bash
 # 1. On the seed (mini): mint a single-use token + arm the bundle listener
@@ -28,28 +26,15 @@ CATALYST_SEED=mini:7401 CATALYST_JOIN_TOKEN=<jt_…> \
 #    (offline / seed-unreachable variant: --bundle ~/catalyst/join-bundle.json)
 ```
 
-The join token is single-use with a 15-minute TTL — if a stage fails and you need
-to re-mint, `catalyst cluster join-token` again and re-run; the script resumes
-from the last completed stage (it does NOT need to re-fetch the bundle if
-`acquire-bundle` already succeeded).
+The join token is single-use with a 15-minute TTL — if a stage fails and you need to re-mint, `catalyst cluster join-token` again and re-run; the script resumes from the last completed stage (it does NOT need to re-fetch the bundle if `acquire-bundle` already succeeded).
 
-`catalyst-join` walks resumable stages: preflight → acquire-bundle → **github-auth**
-→ **provision-thoughts** → setup-catalyst → install-cli → setup-plugin-source →
-config-merge → **doctor** (the CTL-1186 `catalyst-doctor` gate) → stack. It is
-idempotent — re-run after any failure and it resumes from the failed stage.
+`catalyst-join` walks resumable stages: preflight → acquire-bundle → **github-auth** → **provision-thoughts** → setup-catalyst → install-cli → setup-plugin-source → config-merge → **doctor** (the CTL-1186 `catalyst-doctor` gate) → stack. It is idempotent — re-run after any failure and it resumes from the failed stage.
 
-**Result:** the node is provisioned and the stack is running under launchd, but its name
-has not been added to the committed roster (`cluster.json` `roster[]` in the private
-`catalyst-cluster` repo), so it owns **zero tickets** (Stage-0 SHADOW). Activation
-(adding it to the roster) is a deliberate later step — see
-[Activation](#activation-m2).
+**Result:** the node is provisioned and the stack is running under launchd, but its name has not been added to the committed roster (`cluster.json` `roster[]` in the private `catalyst-cluster` repo), so it owns **zero tickets** (Stage-0 SHADOW). Activation (adding it to the roster) is a deliberate later step — see [Activation](#activation-m2).
 
 ### Convenience wrapper (seed-driven)
 
-`~/catalyst/hlt-dev/cluster-node-onboard.sh mini <target>` is an operator helper
-that SSHes the above into a target node and also copies the seed's
-`~/.claude/settings.json` (OTel identity). It is laptop ops glue, not part of the
-installer — the durable provisioning lives in `catalyst-join` itself.
+`~/catalyst/hlt-dev/cluster-node-onboard.sh mini <target>` is an operator helper that SSHes the above into a target node and also copies the seed's `~/.claude/settings.json` (OTel identity). It is laptop ops glue, not part of the installer — the durable provisioning lives in `catalyst-join` itself.
 
 ## Prerequisites
 
@@ -73,19 +58,12 @@ installer — the durable provisioning lives in `catalyst-join` itself.
 
 ### Phase 1: GitHub Authentication (built into the `github-auth` stage)
 
-Cluster nodes have no SSH keys, so thoughts clone+push uses HTTPS + a token. The
-`github-auth` stage establishes this two ways, in order:
+Cluster nodes have no SSH keys, so thoughts clone+push uses HTTPS + a token. The `github-auth` stage establishes this two ways, in order:
 
-1. **`CATALYST_JOIN_GITHUB_TOKEN`** (recommended for headless joins) → written to a
-   `0600 ~/.netrc`. gh is not required; git uses `.netrc` for both clone and push.
-2. Otherwise the stage installs the `gh` CLI binary (if absent) and uses an
-   existing `gh auth login` credential helper.
+1. **`CATALYST_JOIN_GITHUB_TOKEN`** (recommended for headless joins) → written to a `0600 ~/.netrc`. gh is not required; git uses `.netrc` for both clone and push.
+2. Otherwise the stage installs the `gh` CLI binary (if absent) and uses an existing `gh auth login` credential helper.
 
-The token needs `repo` scope (and `workflow` if the node will push workflow files).
-A Stage-0 SHADOW node owns zero tickets and the thoughts **sync-gate only activates
-at roster>1**, so missing push auth is non-fatal at join time but is the explicit
-precondition for [Activation](#activation-m2) — verify `humanlayer thoughts
-sync` round-trips before adding the node to the committed roster.
+The token needs `repo` scope (and `workflow` if the node will push workflow files). A Stage-0 SHADOW node owns zero tickets and the thoughts **sync-gate only activates at roster>1**, so missing push auth is non-fatal at join time but is the explicit precondition for [Activation](#activation-m2) — verify `humanlayer thoughts sync` round-trips before adding the node to the committed roster.
 
 ### Phase 2: Provision Thoughts Repositories
 
@@ -166,9 +144,7 @@ Pick one of the two mechanisms below, per the precedence documented above.
 
 ### Option A — static-roster escape hatch (no `catalyst-cluster` repo needed)
 
-1. **Verify each node's own reported identity first** (see the host-identity
-   gotcha below — a node's `catalyst.host.name` is NOT guaranteed to match the
-   name you intend to put in the roster unless you've explicitly set it):
+1. **Verify each node's own reported identity first** (see the host-identity gotcha below — a node's `catalyst.host.name` is NOT guaranteed to match the name you intend to put in the roster unless you've explicitly set it):
    ```bash
    # on each node:
    python3 -c "import json; print(json.load(open('/Users/thagale/.config/catalyst/config.json'))['catalyst']['host']['name'])"
@@ -181,49 +157,24 @@ Pick one of the two mechanisms below, per the precedence documented above.
    chmod 600 ~/.config/catalyst/config.json
    ```
 
-3. **Restart the stack on every node** (see the "plist env changes need a real
-   restart" gotcha below — a `launchctl kickstart` alone is not sufficient).
+3. **Restart the stack on every node** (see the "plist env changes need a real restart" gotcha below — a `launchctl kickstart` alone is not sufficient).
 
-4. **Verify**: `catalyst cluster status` shows all hosts; `catalyst doctor`'s
-   `hrw-partition` check on each node should show a non-trivial ticket count
-   (not 100% on one host) — this is the concrete proof the partition is real.
+4. **Verify**: `catalyst cluster status` shows all hosts; `catalyst doctor`'s `hrw-partition` check on each node should show a non-trivial ticket count (not 100% on one host) — this is the concrete proof the partition is real.
 
 ### Option B — committed `catalyst-cluster` roster (durable, versioned)
 
-**Prerequisite:** **every** activated node — not just the machine performing this edit — needs its
-own local clone of the private `catalyst-cluster` repo at the default `CATALYST_CLUSTER_DIR`
-location (`~/catalyst/catalyst-cluster`). `cluster-sync` only pulls an *existing* clone (it never
-clones fresh), and `resolveClusterHosts()` reads `cluster.json.roster` from that same local clone to
-resolve the fleet roster; without it, a node fails open to the `static`/`single-host` roster source
-(it silently treats itself as the only host in the fleet), which risks HRW double-ownership against
-nodes that do see the shared roster. A read-only clone is sufficient for that; only the machine used
-to perform the roster edit below additionally needs *write* access (push rights) to the repo. Like
-the age key, `catalyst-join` does **not** clone this repo (see the Scope note in "Provisioning the
-shared cloud token" below) — the clone is a pre-existing prerequisite provisioned once, separately,
-on each node. See the [config-mirror contract](../website/src/content/docs/reference/cluster-config-mirror.md)
-for the full SHARED/PER-NODE classification.
+**Prerequisite:** **every** activated node — not just the machine performing this edit — needs its own local clone of the private `catalyst-cluster` repo at the default `CATALYST_CLUSTER_DIR` location (`~/catalyst/catalyst-cluster`). `cluster-sync` only pulls an *existing* clone (it never clones fresh), and `resolveClusterHosts()` reads `cluster.json.roster` from that same local clone to resolve the fleet roster; without it, a node fails open to the `static`/`single-host` roster source (it silently treats itself as the only host in the fleet), which risks HRW double-ownership against nodes that do see the shared roster. A read-only clone is sufficient for that; only the machine used to perform the roster edit below additionally needs *write* access (push rights) to the repo. Like the age key, `catalyst-join` does **not** clone this repo (see the Scope note in "Provisioning the shared cloud token" below) — the clone is a pre-existing prerequisite provisioned once, separately, on each node. See the [config-mirror contract](../website/src/content/docs/reference/cluster-config-mirror.md) for the full SHARED/PER-NODE classification.
 
-1. **Add to committed roster:** in the private `catalyst-cluster` repo, add the node's name to
-   `cluster.json` `roster[]` and push:
+1. **Add to committed roster:** in the private `catalyst-cluster` repo, add the node's name to `cluster.json` `roster[]` and push:
    ```bash
    # in the catalyst-cluster repo
    jq '.roster += ["mini-2"]' cluster.json > /tmp/cluster.json && mv /tmp/cluster.json cluster.json
    git add cluster.json && git commit -m "feat: activate mini-2 to cluster roster (CTL-1217)"
    git push
    ```
-   `cluster-sync` pulls the update on every node and the next scheduler tick honors it — no restart
-   needed. See the [config-mirror contract](../website/src/content/docs/reference/cluster-config-mirror.md)
-   for the full SHARED/PER-NODE classification.
+`cluster-sync` pulls the update on every node and the next scheduler tick honors it — no restart needed. See the [config-mirror contract](../website/src/content/docs/reference/cluster-config-mirror.md) for the full SHARED/PER-NODE classification.
 
-2. **Re-run the join on the activated node to wire webhook ingestion** — the
-   Stage-0 join deliberately skipped webhook wiring (`stage0-roster-guard` in
-   the webhook-wiring gate: wiring a roster≤1 node would double-dispatch, since
-   runtime fencing is roster-derived). The join's progress marker records
-   `webhookWiringDeferred` for this case. Once the node is in the committed
-   roster, re-run the join **with fresh credentials** — the original join
-   token was single-use, and a seed-fetched bundle is deleted after the join
-   (it carries live bot tokens), so a bare `--no-resume` re-run would exit at
-   the token preflight:
+2. **Re-run the join on the activated node to wire webhook ingestion** — the Stage-0 join deliberately skipped webhook wiring (`stage0-roster-guard` in the webhook-wiring gate: wiring a roster≤1 node would double-dispatch, since runtime fencing is roster-derived). The join's progress marker records `webhookWiringDeferred` for this case. Once the node is in the committed roster, re-run the join **with fresh credentials** — the original join token was single-use, and a seed-fetched bundle is deleted after the join (it carries live bot tokens), so a bare `--no-resume` re-run would exit at the token preflight:
    ```bash
    # On the seed host: mint a fresh single-use join token
    catalyst cluster join-token
@@ -232,11 +183,7 @@ for the full SHARED/PER-NODE classification.
    CATALYST_SEED=<seed-host:7400> CATALYST_JOIN_TOKEN=jt_<fresh> \
      bash catalyst-join.sh --no-resume   # re-evaluates the gate at roster>1 and wires
    ```
-   (For an offline `--bundle` join, reuse the retained bundle file instead:
-   `bash catalyst-join.sh --bundle <path> --no-resume`.)
-   Until this runs, `catalyst-doctor` FAILs `webhook-ingestion` on the
-   activated node — that FAIL is the loud signal this step was missed, not a
-   new problem.
+(For an offline `--bundle` join, reuse the retained bundle file instead: `bash catalyst-join.sh --bundle <path> --no-resume`.) Until this runs, `catalyst-doctor` FAILs `webhook-ingestion` on the activated node — that FAIL is the loud signal this step was missed, not a new problem.
 
 ### After either option
 
@@ -247,31 +194,17 @@ for the full SHARED/PER-NODE classification.
 
 2. **Monitor the reaper** — once activated, mini-2 worktrees are eligible for reaping (CTL-1218). Watch for safe signal+merge patterns before auto-reap.
 
-3. **(Optional but recommended) Set a liveness anchor** — without
-   `catalyst.cluster.livenessAnchorIssue` (a Linear ticket key, set identically
-   on every node) or `CATALYST_LIVENESS_ANCHOR_ISSUE`, HRW partitioning still
-   works (it's a pure hash over the roster), but cross-host DEAD-NODE detection
-   is disabled (fail-open, one-time warning) — a crashed peer's in-flight
-   tickets won't get reclaimed by a live node. File one ticket, park it in
-   Backlog (never Todo — Todo auto-dispatches), and never close it.
+3. **(Optional but recommended) Set a liveness anchor** — without `catalyst.cluster.livenessAnchorIssue` (a Linear ticket key, set identically on every node) or `CATALYST_LIVENESS_ANCHOR_ISSUE`, HRW partitioning still works (it's a pure hash over the roster), but cross-host DEAD-NODE detection is disabled (fail-open, one-time warning) — a crashed peer's in-flight tickets won't get reclaimed by a live node. File one ticket, park it in Backlog (never Todo — Todo auto-dispatches), and never close it.
 
 ## Provisioning the shared cloud token (`CATALYST_CLOUD_TOKEN`, CTL-1307)
 
-`CATALYST_CLOUD_TOKEN` is a single **shared** service credential (the catalyst-cloud `ADMIN_TOKEN`,
-interim per CTC-27 / ADR-0006) that must be **identical on every node**. It is an **optional
-extension**: setting it changes nothing on its own — nothing in Catalyst reads it, and a node stays
-fully local-only until the operator separately opts into cloud services. Only the opt-in,
-out-of-repo cloud host-sync daemon (`catalyst-replica` / `catalyst-cloud`) consumes it. It is safe
-to roll out cluster-wide without altering default behavior.
+`CATALYST_CLOUD_TOKEN` is a single **shared** service credential (the catalyst-cloud `ADMIN_TOKEN`, interim per CTC-27 / ADR-0006) that must be **identical on every node**. It is an **optional extension**: setting it changes nothing on its own — nothing in Catalyst reads it, and a node stays fully local-only until the operator separately opts into cloud services. Only the opt-in, out-of-repo cloud host-sync daemon (`catalyst-replica` / `catalyst-cloud`) consumes it. It is safe to roll out cluster-wide without altering default behavior.
 
-It is stored once in the `catalyst-cluster` repo (encrypted, alongside the other secrets) and flows
-to every node's **machine-level environment** automatically — no manual per-host step.
+It is stored once in the `catalyst-cluster` repo (encrypted, alongside the other secrets) and flows to every node's **machine-level environment** automatically — no manual per-host step.
 
 ### Add or rotate the token (laptop only)
 
-Per the cluster repo's write policy, all `secrets/` writes are operator-initiated from the laptop and
-serialized (pull → edit → push); SOPS re-encryption rewrites the whole data-key wrap, so concurrent
-commits don't merge.
+Per the cluster repo's write policy, all `secrets/` writes are operator-initiated from the laptop and serialized (pull → edit → push); SOPS re-encryption rewrites the whole data-key wrap, so concurrent commits don't merge.
 
 ```bash
 cd ~/catalyst/catalyst-cluster        # the clone with your age key + sops installed
@@ -293,28 +226,19 @@ git push
 
 ### How each node picks it up
 
-Each node converges automatically (prerequisite: the node already has the `catalyst-cluster` repo
-cloned and its age key at `~/.config/catalyst/age.key` — the same prerequisite as every other cluster
-secret):
+Each node converges automatically (prerequisite: the node already has the `catalyst-cluster` repo cloned and its age key at `~/.config/catalyst/age.key` — the same prerequisite as every other cluster secret):
 
-1. `cluster-sync` (daemon boot, and the periodic pull) decrypts `secrets/cluster-cloud.sops.json` to
-   `~/.config/catalyst/cluster-cloud.json` (mode `0600`).
-2. `catalyst-stack start` (boot + every keep-alive) runs `cloud-token-env.mjs`, which writes the
-   secret to `~/.config/catalyst/cluster.env` (mode `0600`) and adds a non-secret guard line to
-   `~/.zshenv` that sources it.
-3. Every login/zsh shell — and any cloud daemon **(re)started in a shell context** — inherits
-   `CATALYST_CLOUD_TOKEN`.
+1. `cluster-sync` (daemon boot, and the periodic pull) decrypts `secrets/cluster-cloud.sops.json` to `~/.config/catalyst/cluster-cloud.json` (mode `0600`).
+2. `catalyst-stack start` (boot + every keep-alive) runs `cloud-token-env.mjs`, which writes the secret to `~/.config/catalyst/cluster.env` (mode `0600`) and adds a non-secret guard line to `~/.zshenv` that sources it.
+3. Every login/zsh shell — and any cloud daemon **(re)started in a shell context** — inherits `CATALYST_CLOUD_TOKEN`.
 
-After the writer has been adopted or restarted on each node, use the end-to-end verifier as the
-per-node acceptance check:
+After the writer has been adopted or restarted on each node, use the end-to-end verifier as the per-node acceptance check:
 
 ```bash
 catalyst-stack verify-cloud-sync --strict
 ```
 
-Do not activate replica reads on that node until this exits successfully. Once it does,
-`catalyst-stack activate-replica` performs the guarded Layer-2 flag change; on worker nodes, restart
-execution-core afterward so the scheduler constructs its replica reader.
+Do not activate replica reads on that node until this exits successfully. Once it does, `catalyst-stack activate-replica` performs the guarded Layer-2 flag change; on worker nodes, restart execution-core afterward so the scheduler constructs its replica reader.
 
 ### Apply immediately (instead of waiting for the keep-alive)
 
@@ -333,9 +257,7 @@ catalyst-stack adopt-cloud-sync
 catalyst-stack verify-cloud-sync --strict
 ```
 
-`catalyst doctor` reports an advisory `cloud-token` check: `INFO` when no token is provisioned
-(local-only, expected), `WARN` when a token is decrypted but not yet projected (or is stale), `PASS`
-when it is projected to the machine-level env.
+`catalyst doctor` reports an advisory `cloud-token` check: `INFO` when no token is provisioned (local-only, expected), `WARN` when a token is decrypted but not yet projected (or is stale), `PASS` when it is projected to the machine-level env.
 
 > **Scope note:** `catalyst-join` does not itself clone the `catalyst-cluster` repo or provision the
 > age key (a pre-existing prerequisite shared by *all* cluster secrets, tracked separately). Once
@@ -343,81 +265,34 @@ when it is projected to the machine-level env.
 
 ## Known Gotchas (from real multi-node onboarding)
 
-These are real failure modes hit while onboarding actual nodes, not theoretical
-— each cost real debugging time, so check them proactively rather than
-rediscovering them.
+These are real failure modes hit while onboarding actual nodes, not theoretical — each cost real debugging time, so check them proactively rather than rediscovering them.
 
 ### A fresh macOS node's `bash` is 3.2, not whatever you tested with
 
-macOS ships bash 3.2 (GPL licensing) as `/bin/bash`, and a bare `bash script.sh`
-invocation resolves to whichever is first on PATH — which may be a much newer
-Homebrew bash on your dev machine, masking bash-3.2-only syntax errors until the
-same script runs on a genuinely fresh node. One concrete trap: a heredoc
-embedded inside a `$(...)` command substitution, whose body contains an
-apostrophe (even in a comment), confuses bash 3.2's quote-tracking across that
-nested boundary and produces a syntax error dozens of lines away from the real
-cause — bash 4+/5 parses the identical file fine. Before trusting any script
-that ships as part of the join path, run `/bin/bash -n script.sh` explicitly
-(not just whatever `bash` resolves to), and consider adding that as a permanent
-regression test (see `setup-plugin-source.test.sh` for the pattern).
+macOS ships bash 3.2 (GPL licensing) as `/bin/bash`, and a bare `bash script.sh` invocation resolves to whichever is first on PATH — which may be a much newer Homebrew bash on your dev machine, masking bash-3.2-only syntax errors until the same script runs on a genuinely fresh node. One concrete trap: a heredoc embedded inside a `$(...)` command substitution, whose body contains an apostrophe (even in a comment), confuses bash 3.2's quote-tracking across that nested boundary and produces a syntax error dozens of lines away from the real cause — bash 4+/5 parses the identical file fine. Before trusting any script that ships as part of the join path, run `/bin/bash -n script.sh` explicitly (not just whatever `bash` resolves to), and consider adding that as a permanent regression test (see `setup-plugin-source.test.sh` for the pattern).
 
 ### A node's identity may not be what you expect, and won't self-correct
 
-`catalyst-join.sh` defaults a node's `catalyst.host.name` to `hostname -s` (the
-machine's own local/system hostname) unless overridden — which can silently
-differ from whatever name you actually refer to the node by (a Tailscale
-MagicDNS name, an SSH config alias, etc.). Symptom: you activate the node under
-the name you call it, but its daemon silently owns zero tickets under HRW,
-because its actual runtime identity doesn't match any roster entry.
+`catalyst-join.sh` defaults a node's `catalyst.host.name` to `hostname -s` (the machine's own local/system hostname) unless overridden — which can silently differ from whatever name you actually refer to the node by (a Tailscale MagicDNS name, an SSH config alias, etc.). Symptom: you activate the node under the name you call it, but its daemon silently owns zero tickets under HRW, because its actual runtime identity doesn't match any roster entry.
 
-Fix with `catalyst cluster rename <name>` — but this ONLY updates the Layer-2
-config file. The **running daemon's actual identity comes from the
-`CATALYST_HOST_NAME` environment variable baked into the launchd plist at join
-time, which wins over the config file** (env-over-config precedence, same
-pattern used throughout this stack). A rename requires manually fixing that env
-var in the plist(s) too — `ai.coalesce.catalyst-stack.plist` and
-`ai.coalesce.catalyst-log-shipper.plist` both carry it, and `~/.claude/settings.json`'s
-`OTEL_RESOURCE_ATTRIBUTES=host.name=...` should match for telemetry
-consistency. **Verify the actual running process, not just the config file**:
+Fix with `catalyst cluster rename <name>` — but this ONLY updates the Layer-2 config file. The **running daemon's actual identity comes from the `CATALYST_HOST_NAME` environment variable baked into the launchd plist at join time, which wins over the config file** (env-over-config precedence, same pattern used throughout this stack). A rename requires manually fixing that env var in the plist(s) too — `ai.coalesce.catalyst-stack.plist` and `ai.coalesce.catalyst-log-shipper.plist` both carry it, and `~/.claude/settings.json`'s `OTEL_RESOURCE_ATTRIBUTES=host.name=...` should match for telemetry consistency. **Verify the actual running process, not just the config file**:
 ```bash
 ps eww $(pgrep -f "execution-core/daemon.mjs") | grep -o "CATALYST_HOST_NAME=[^ ]*"
 ```
-A doctor/config check run from a fresh ad-hoc shell will NOT catch this — it
-reads the config file, which may say the right thing while the actual daemon
-(with the stale plist env) disagrees. Always cross-check the live process.
+A doctor/config check run from a fresh ad-hoc shell will NOT catch this — it reads the config file, which may say the right thing while the actual daemon (with the stale plist env) disagrees. Always cross-check the live process.
 
 ### A plist env change needs a full stop, not just `launchctl kickstart`
 
-The daemon plists deliberately set `AbandonProcessGroup` so a keep-alive tick
-doesn't SIGTERM the nohup'd children it just started (see the plist comment).
-This means an already-running broker/monitor/execution-core survives a
-`launchctl kickstart` (or even a `bootout`+`bootstrap` of the wrapper job) — the
-wrapper's own "already running" check sees the live PID and skips respawning,
-so an edited plist env var is silently NOT picked up. To actually apply a plist
-change:
+The daemon plists deliberately set `AbandonProcessGroup` so a keep-alive tick doesn't SIGTERM the nohup'd children it just started (see the plist comment). This means an already-running broker/monitor/execution-core survives a `launchctl kickstart` (or even a `bootout`+`bootstrap` of the wrapper job) — the wrapper's own "already running" check sees the live PID and skips respawning, so an edited plist env var is silently NOT picked up. To actually apply a plist change:
 ```bash
 catalyst-stack stop        # kills the actual children (log-shipper excluded, by design)
 launchctl kickstart -k gui/<uid>/ai.coalesce.catalyst-stack
 ```
-A bare `catalyst-stack restart` run over SSH has a related but different
-failure mode: SSH session teardown can kill the nohup'd children even with
-`disown`, so a manually-triggered restart may not survive your SSH connection
-closing. Prefer `launchctl kickstart` (after an explicit `stop`) for anything
-you need to actually persist.
+A bare `catalyst-stack restart` run over SSH has a related but different failure mode: SSH session teardown can kill the nohup'd children even with `disown`, so a manually-triggered restart may not survive your SSH connection closing. Prefer `launchctl kickstart` (after an explicit `stop`) for anything you need to actually persist.
 
 ### Codex needs its own separate per-node setup — the join process doesn't touch it
 
-If your fleet routes any phase to a Codex executor (`executorByPhase`), each
-node needs its OWN Codex auth — `mkdir -p ~/catalyst/codex-home && CODEX_HOME=~/catalyst/codex-home codex login`
-(a dedicated auth home is deliberately isolated from any personal `codex` CLI
-login). This is NOT part of `catalyst-join.sh` — a freshly joined node has
-`codex` on PATH (if some other step installed it) but no credentials, and will
-fail immediately on any phase routed to it. If a fleet-wide `executorByPhase`
-setting isn't the same for every node (e.g., you're rolling Codex out
-node-by-node), pin the not-yet-ready node to non-Codex executors via the
-`CATALYST_EXECUTOR_BY_PHASE` env var in ITS OWN plist (env wins over the shared
-Layer-1 `executorByPhase` config, and — unlike a Layer-1 edit on a worker node,
-which gets reset on the next config pull — an env var in the plist is durable):
+If your fleet routes any phase to a Codex executor (`executorByPhase`), each node needs its OWN Codex auth — `mkdir -p ~/catalyst/codex-home && CODEX_HOME=~/catalyst/codex-home codex login` (a dedicated auth home is deliberately isolated from any personal `codex` CLI login). This is NOT part of `catalyst-join.sh` — a freshly joined node has `codex` on PATH (if some other step installed it) but no credentials, and will fail immediately on any phase routed to it. If a fleet-wide `executorByPhase` setting isn't the same for every node (e.g., you're rolling Codex out node-by-node), pin the not-yet-ready node to non-Codex executors via the `CATALYST_EXECUTOR_BY_PHASE` env var in ITS OWN plist (env wins over the shared Layer-1 `executorByPhase` config, and — unlike a Layer-1 edit on a worker node, which gets reset on the next config pull — an env var in the plist is durable):
 ```xml
 <key>CATALYST_EXECUTOR_BY_PHASE</key>
 <string>{"triage":"bg","research":"bg","plan":"bg","implement":"bg","remediate":"bg","verify":"bg","review":"bg","pr":"bg"}</string>
@@ -425,36 +300,15 @@ which gets reset on the next config pull — an env var in the plist is durable)
 
 ### Webhook ingestion doesn't propagate via the join bundle
 
-`catalyst doctor`'s `webhook-ingestion` check fails-closed on any multi-host
-member with no wired route (`FAILs so the activation gate fail-closes`, per the
-check's own code comment) — but the join bundle does NOT carry the webhook
-smee-channel URLs or HMAC secret files, since those come from a one-time
-registration done on whichever node originally set up the webhook. To wire a
-new node: copy the secret files (`~/.config/catalyst/webhook-secret`,
-`~/.config/catalyst/linear-webhook-secret`) and the `catalyst.monitor.github.smeeChannel`
-/ `catalyst.monitor.linear.smeeChannel` (+ `.workspace.webhookId`) values from
-an already-wired node into the new node's own Layer-2 config. smee.io channels
-broadcast to every connected listener, so multiple nodes CAN share the same
-channel — each node's own HRW ownership check is what prevents double-acting on
-the same event (this is the "double-dispatch guard" the single-host PASS
-message refers to).
+`catalyst doctor`'s `webhook-ingestion` check fails-closed on any multi-host member with no wired route (`FAILs so the activation gate fail-closes`, per the check's own code comment) — but the join bundle does NOT carry the webhook smee-channel URLs or HMAC secret files, since those come from a one-time registration done on whichever node originally set up the webhook. To wire a new node: copy the secret files (`~/.config/catalyst/webhook-secret`, `~/.config/catalyst/linear-webhook-secret`) and the `catalyst.monitor.github.smeeChannel` / `catalyst.monitor.linear.smeeChannel` (+ `.workspace.webhookId`) values from an already-wired node into the new node's own Layer-2 config. smee.io channels broadcast to every connected listener, so multiple nodes CAN share the same channel — each node's own HRW ownership check is what prevents double-acting on the same event (this is the "double-dispatch guard" the single-host PASS message refers to).
 
 ### Org/thoughts convention must be explicit for a forked install
 
-`provision-thoughts.sh`'s primary org is NOT hardcoded (a prior version hardcoded
-one specific org, which is exactly the anti-pattern that broke a downstream
-fork) — set it via `--orgs`/`--registry` (which `catalyst-join.sh` derives
-automatically from the join bundle's `layer1Identity.projectKey`) or the
-`CATALYST_PROVISION_THOUGHTS_PRIMARY_ORG` env var for a from-scratch standalone
-run. With none of the three, the script fails loudly rather than guessing.
+`provision-thoughts.sh`'s primary org is NOT hardcoded (a prior version hardcoded one specific org, which is exactly the anti-pattern that broke a downstream fork) — set it via `--orgs`/`--registry` (which `catalyst-join.sh` derives automatically from the join bundle's `layer1Identity.projectKey`) or the `CATALYST_PROVISION_THOUGHTS_PRIMARY_ORG` env var for a from-scratch standalone run. With none of the three, the script fails loudly rather than guessing.
 
 ### Layer-2 config file permissions drift back to 644
 
-Several code paths that rewrite `~/.config/catalyst/config.json` (a `jq ...  >
-tmp && mv tmp file` pattern, or an `npm install -g` touching the directory)
-don't preserve the original file mode — the temp file inherits the process
-umask instead. `catalyst doctor`'s `layer2-perms` check catches this, but check
-after any manual edit or package install: `chmod 600 ~/.config/catalyst/config.json`.
+Several code paths that rewrite `~/.config/catalyst/config.json` (a `jq ...  > tmp && mv tmp file` pattern, or an `npm install -g` touching the directory) don't preserve the original file mode — the temp file inherits the process umask instead. `catalyst doctor`'s `layer2-perms` check catches this, but check after any manual edit or package install: `chmod 600 ~/.config/catalyst/config.json`.
 
 ## Troubleshooting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,6 @@
 # Catalyst Configuration Reference
 
-This document describes every configuration file Catalyst reads or writes, how the two-layer config
-system works, and common patterns for tuning behavior per-machine or per-project.
+This document describes every configuration file Catalyst reads or writes, how the two-layer config system works, and common patterns for tuning behavior per-machine or per-project.
 
 JSON Schema files for all config shapes live in [`docs/schemas/`](./schemas/).
 
@@ -16,8 +15,7 @@ Catalyst uses two separate JSON files that are merged at runtime:
 | **Layer 1** | `.catalyst/config.json` (repo root) | Yes | Team-wide defaults, safe to share |
 | **Layer 2** | `~/.config/catalyst/config.json` | Never | Machine-specific secrets and overrides |
 
-Layer 2 wins over Layer 1 on a **per-field basis** — only the fields present in Layer 2 override
-their Layer-1 counterparts. Fields absent from Layer 2 fall back to Layer-1 values.
+Layer 2 wins over Layer 1 on a **per-field basis** — only the fields present in Layer 2 override their Layer-1 counterparts. Fields absent from Layer 2 fall back to Layer-1 values.
 
 ---
 
@@ -90,8 +88,7 @@ cp plugins/dev/templates/config.template.json .catalyst/config.json
 }
 ```
 
-All `stateMap` values must exactly match the state names in your Linear team. The daemon uses
-these to transition tickets as phases complete.
+All `stateMap` values must exactly match the state names in your Linear team. The daemon uses these to transition tickets as phases complete.
 
 #### Linear Webhook Bot Identity
 
@@ -107,25 +104,14 @@ these to transition tickets as phases complete.
 }
 ```
 
-`monitor.linear.botUserId` is the Linear user UUID of the Catalyst app-actor — the "Linear for
-Agents" app user that posts comments **as the app**. It is the self-echo / loop-prevention guard
-for the whole Linear app-actor comms channel:
+`monitor.linear.botUserId` is the Linear user UUID of the Catalyst app-actor — the "Linear for Agents" app user that posts comments **as the app**. It is the self-echo / loop-prevention guard for the whole Linear app-actor comms channel:
 
-- The orch-monitor server uses it to suppress bot-authored issue events so the app's own writes
-  don't feed back into the event log as write loops.
-- The execution-core daemon uses it to filter the agent's own mirror comments and
-  description-updates out of each worker's `inbox.jsonl`, so a human reply on a ticket is the
-  only thing that wakes a parked worker (not the agent's own echo).
+- The orch-monitor server uses it to suppress bot-authored issue events so the app's own writes don't feed back into the event log as write loops.
+- The execution-core daemon uses it to filter the agent's own mirror comments and description-updates out of each worker's `inbox.jsonl`, so a human reply on a ticket is the only thing that wakes a parked worker (not the agent's own echo).
 
-**When to set it:** required for the Linear app-actor comms channel — i.e. when the execution-core
-daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 /
-CTL-749). Without it, the system cannot tell the agent's own comments apart from a human's. The
-value is not secret (it appears on every comment the app posts) but it **is workspace-specific**,
-so the committed config ships `null` and each operator fills in their own.
+**When to set it:** required for the Linear app-actor comms channel — i.e. when the execution-core daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749). Without it, the system cannot tell the agent's own comments apart from a human's. The value is not secret (it appears on every comment the app posts) but it **is workspace-specific**, so the committed config ships `null` and each operator fills in their own.
 
-**How to obtain it:** query `viewer.id` with the app-actor token. The app OAuth credentials live
-in the per-project Layer-2 file (`~/.config/catalyst/config-<projectKey>.json` →
-`catalyst.linear.agent.{clientId,clientSecret,accessToken}`). Using the stored access token:
+**How to obtain it:** query `viewer.id` with the app-actor token. The app OAuth credentials live in the per-project Layer-2 file (`~/.config/catalyst/config-<projectKey>.json` → `catalyst.linear.agent.{clientId,clientSecret,accessToken}`). Using the stored access token:
 
 ```bash
 TOKEN=$(jq -r '.catalyst.linear.agent.accessToken' ~/.config/catalyst/config-<projectKey>.json)
@@ -135,8 +121,7 @@ BOT_ID=$(curl -s -X POST https://api.linear.app/graphql \
   -d '{"query":"query{viewer{id name}}"}' | jq -r .data.viewer.id)
 ```
 
-Write `$BOT_ID` into `.catalyst/config.json` → `catalyst.monitor.linear.botUserId`, then restart
-both readers (they read `botUserId` only at startup):
+Write `$BOT_ID` into `.catalyst/config.json` → `catalyst.monitor.linear.botUserId`, then restart both readers (they read `botUserId` only at startup):
 
 ```bash
 catalyst-monitor stop && catalyst-monitor start
@@ -191,20 +176,12 @@ catalyst-execution-core restart
 
 **`dispatchMode`**
 
-- `"phase-agents"` (default) — runs one short-lived `claude --bg` job per pipeline phase
-  (triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown).
-- `"oneshot-legacy"` — runs a single long-lived `claude -p /catalyst-legacy:oneshot` job per ticket.
-  Preserved as a fallback; not recommended for new setups.
+- `"phase-agents"` (default) — runs one short-lived `claude --bg` job per pipeline phase (triage → research → plan → implement → verify → review → pr → monitor-merge → monitor-deploy → teardown).
+- `"oneshot-legacy"` — runs a single long-lived `claude -p /catalyst-legacy:oneshot` job per ticket. Preserved as a fallback; not recommended for new setups.
 
-**`phaseAgents.models` / `modelOverrides`** — `models[<phase>]` is the model every worker for that
-phase runs on; `modelOverrides[<phase>][<ticket>]` is a per-ticket exception. Resolution order in
-`phase-agent-dispatch`: CLI `--model` > `modelOverrides` > `models` > workflow descriptor > the
-script's fallback (`sonnet`). ⚠️ If the whole `phaseAgents` block is absent the fallback applies to
-every phase — which is how the fleet silently ran everything on opus until 2026-08-23. Commit the
-block; do not rely on the fallback.
+**`phaseAgents.models` / `modelOverrides`** — `models[<phase>]` is the model every worker for that phase runs on; `modelOverrides[<phase>][<ticket>]` is a per-ticket exception. Resolution order in `phase-agent-dispatch`: CLI `--model` > `modelOverrides` > `models` > workflow descriptor > the script's fallback (`sonnet`). ⚠️ If the whole `phaseAgents` block is absent the fallback applies to every phase — which is how the fleet silently ran everything on opus until 2026-08-23. Commit the block; do not rely on the fallback.
 
-**`executionCore.eligibleQuery`** is **deprecated** — this field is ignored by the daemon. Use
-the registry instead (see [Registry](#registry) below).
+**`executionCore.eligibleQuery`** is **deprecated** — this field is ignored by the daemon. Use the registry instead (see [Registry](#registry) below).
 
 ---
 
@@ -230,8 +207,7 @@ This file is machine-local and **must never be committed**. It contains:
 
 ### Merging Rules
 
-The scheduler and phase-agent-dispatch scripts read both files. For the following fields, Layer 2
-wins **per-field**:
+The scheduler and phase-agent-dispatch scripts read both files. For the following fields, Layer 2 wins **per-field**:
 
 | Field | Layer-2 path |
 |-------|-------------|
@@ -317,8 +293,7 @@ wins **per-field**:
 }
 ```
 
-Required when `catalyst.filter.groqModel` is configured and the broker's LLM event filtering is
-active.
+Required when `catalyst.filter.groqModel` is configured and the broker's LLM event filtering is active.
 
 ---
 
@@ -328,17 +303,9 @@ active.
 
 ### Purpose
 
-A **machine-local, never-committed** shell env file that the execution-core daemon sources on
-start. `catalyst-execution-core start` runs `[[ -f "$file" ]] && source "$file"` immediately before
-it launches the daemon, so every variable the file exports is inherited by the daemon process and
-by every phase-agent bg job it dispatches. `restart` re-sources it (it calls `stop` then `start`),
-so edits take effect on the next restart — **not** live.
+A **machine-local, never-committed** shell env file that the execution-core daemon sources on start. `catalyst-execution-core start` runs `[[ -f "$file" ]] && source "$file"` immediately before it launches the daemon, so every variable the file exports is inherited by the daemon process and by every phase-agent bg job it dispatches. `restart` re-sources it (it calls `stop` then `start`), so edits take effect on the next restart — **not** live.
 
-The path defaults to `~/.config/catalyst/execution-core.env` and can be overridden with the
-`CATALYST_EXECUTION_CORE_ENV` environment variable. This file is **entirely opt-in**: an absent file
-is a complete no-op, which is the common case. Because the values are machine-specific (proxy port,
-local CA path), setup never writes it for you — copy the committed example template and edit it by
-hand.
+The path defaults to `~/.config/catalyst/execution-core.env` and can be overridden with the `CATALYST_EXECUTION_CORE_ENV` environment variable. This file is **entirely opt-in**: an absent file is a complete no-op, which is the common case. Because the values are machine-specific (proxy port, local CA path), setup never writes it for you — copy the committed example template and edit it by hand.
 
 ### Options
 
@@ -352,9 +319,7 @@ hand.
 
 ### Debugging Linear API rate-limiting (mitmproxy — opt-in, default OFF)
 
-The mitmproxy is a **rare diagnostic tool**, not always-on infrastructure. The daemon runs
-correctly without it. Use it for a short window when you need to observe Linear API traffic, inspect
-rate-limit headers, or trace which callers are exhausting the quota. Turn it off again when done.
+The mitmproxy is a **rare diagnostic tool**, not always-on infrastructure. The daemon runs correctly without it. Use it for a short window when you need to observe Linear API traffic, inspect rate-limit headers, or trace which callers are exhausting the quota. Turn it off again when done.
 
 **Turn ON for a diagnostic session:**
 
@@ -362,11 +327,7 @@ rate-limit headers, or trace which callers are exhausting the quota. Turn it off
 catalyst-stack restart --proxy
 ```
 
-This starts mitmproxy, then restarts the execution-core daemon with `HTTPS_PROXY`,
-`NODE_USE_ENV_PROXY=1`, `NODE_EXTRA_CA_CERTS`, and `NO_PROXY=api.anthropic.com,...` set as an
-inline env prefix (not written to disk). Traffic is logged to `~/catalyst/linear-proxy.jsonl`.
-On first use, `catalyst-stack` installs mitmproxy via `brew install mitmproxy` if absent and
-generates the CA cert.
+This starts mitmproxy, then restarts the execution-core daemon with `HTTPS_PROXY`, `NODE_USE_ENV_PROXY=1`, `NODE_EXTRA_CA_CERTS`, and `NO_PROXY=api.anthropic.com,...` set as an inline env prefix (not written to disk). Traffic is logged to `~/catalyst/linear-proxy.jsonl`. On first use, `catalyst-stack` installs mitmproxy via `brew install mitmproxy` if absent and generates the CA cert.
 
 **Turn OFF:**
 
@@ -374,11 +335,9 @@ generates the CA cert.
 catalyst-stack restart
 ```
 
-Restarts the daemon without any proxy vars. The proxy vars are **never sticky** — they are
-injected only for the lifetime of the `--proxy` daemon process.
+Restarts the daemon without any proxy vars. The proxy vars are **never sticky** — they are injected only for the lifetime of the `--proxy` daemon process.
 
-**Important:** `NO_PROXY=api.anthropic.com,...` is always included in the `--proxy` prefix so
-Claude worker API calls bypass the proxy even if mitmdump hiccups mid-session.
+**Important:** `NO_PROXY=api.anthropic.com,...` is always included in the `--proxy` prefix so Claude worker API calls bypass the proxy even if mitmdump hiccups mid-session.
 
 > **Do not `source` `execution-core.env` in an interactive shell or shell profile.** It is sourced
 > by `catalyst-execution-core start` for the daemon only. Sourcing it in your terminal pins
@@ -394,28 +353,17 @@ Claude worker API calls bypass the proxy even if mitmdump hiccups mid-session.
 > and prints the exact line to delete. If you already have one, remove it and open a fresh terminal —
 > the daemon still routes through the proxy because it sources the file itself at launch.
 
-**Why `NODE_USE_ENV_PROXY=1` is required.** Node 20+/24+ native `fetch` (undici) **ignores**
-`HTTPS_PROXY`/`HTTP_PROXY` unless `NODE_USE_ENV_PROXY=1` is also set. Omit it and the daemon's
-Linear calls bypass the proxy entirely while looking perfectly healthy — the audit silently captures
-nothing.
+**Why `NODE_USE_ENV_PROXY=1` is required.** Node 20+/24+ native `fetch` (undici) **ignores** `HTTPS_PROXY`/`HTTP_PROXY` unless `NODE_USE_ENV_PROXY=1` is also set. Omit it and the daemon's Linear calls bypass the proxy entirely while looking perfectly healthy — the audit silently captures nothing.
 
 ### Health check
 
-A misconfigured proxy silently breaks the daemon's Linear connectivity on a fresh or changed
-machine, which is otherwise hard to debug. `check-setup.sh` (and `/catalyst-foundry:setup-catalyst`)
-therefore verify the setup whenever the env file configures a proxy, and warn loudly + actionably on
-each failure mode:
+A misconfigured proxy silently breaks the daemon's Linear connectivity on a fresh or changed machine, which is otherwise hard to debug. `check-setup.sh` (and `/catalyst-foundry:setup-catalyst`) therefore verify the setup whenever the env file configures a proxy, and warn loudly + actionably on each failure mode:
 
 - the proxy host:port is **not listening** → start `mitmdump` or unset the proxy vars;
-- `NODE_EXTRA_CA_CERTS` points at a **missing file** → fix the path or re-run mitmproxy to
-  regenerate its CA;
-- `*_PROXY` is set but `NODE_USE_ENV_PROXY=1` is **missing** → Node fetch will ignore the proxy and
-  calls bypass the audit silently.
+- `NODE_EXTRA_CA_CERTS` points at a **missing file** → fix the path or re-run mitmproxy to regenerate its CA;
+- `*_PROXY` is set but `NODE_USE_ENV_PROXY=1` is **missing** → Node fetch will ignore the proxy and calls bypass the audit silently.
 
-When no env file exists (or it sets no proxy) the check is a no-op and reports nothing but an
-informational pointer to the example template. `check-project-setup.sh` (the hot-path workflow gate)
-carries only the highest-impact `NODE_USE_ENV_PROXY` silent-bypass warning; the full port/CA
-diagnostics live in `check-setup.sh`.
+When no env file exists (or it sets no proxy) the check is a no-op and reports nothing but an informational pointer to the example template. `check-project-setup.sh` (the hot-path workflow gate) carries only the highest-impact `NODE_USE_ENV_PROXY` silent-bypass warning; the full port/CA diagnostics live in `check-setup.sh`.
 
 ---
 
@@ -425,12 +373,9 @@ diagnostics live in `check-setup.sh`.
 
 ### Purpose
 
-The registry is the execution-core daemon's source of truth for which projects are enrolled and
-what Linear state constitutes "eligible for dispatch." It is **not** part of the two-layer config
-— it lives in the daemon's working directory and is managed separately.
+The registry is the execution-core daemon's source of truth for which projects are enrolled and what Linear state constitutes "eligible for dispatch." It is **not** part of the two-layer config — it lives in the daemon's working directory and is managed separately.
 
-This file supersedes the deprecated `catalyst.orchestration.executionCore.eligibleQuery` field in
-Layer-1 config. The daemon ignores that field and reads the registry exclusively.
+This file supersedes the deprecated `catalyst.orchestration.executionCore.eligibleQuery` field in Layer-1 config. The daemon ignores that field and reads the registry exclusively.
 
 ### Structure
 
@@ -465,19 +410,9 @@ node plugins/dev/scripts/execution-core/registry.mjs upsert \
   --status Todo
 ```
 
-**The `team` ↔ `teamKey` contract.** A registry entry's `team` MUST equal — exactly, since the
-runtime compares with `===`/`!==` — the `catalyst.linear.teamKey` declared in
-`<repoRoot>/.catalyst/config.json`. The contract, its failure mode, and the full repair procedure
-(including preserving a custom `eligibleQuery` and cleaning up worktrees already cut from the wrong
-checkout) are documented in the canonical configuration reference:
-`website/src/content/docs/reference/configuration.md` → "The `team` ↔ `teamKey` contract".
+**The `team` ↔ `teamKey` contract.** A registry entry's `team` MUST equal — exactly, since the runtime compares with `===`/`!==` — the `catalyst.linear.teamKey` declared in `<repoRoot>/.catalyst/config.json`. The contract, its failure mode, and the full repair procedure (including preserving a custom `eligibleQuery` and cleaning up worktrees already cut from the wrong checkout) are documented in the canonical configuration reference: `website/src/content/docs/reference/configuration.md` → "The `team` ↔ `teamKey` contract".
 
-Implementation notes for this repo (CAT-52): the contract is declared by
-`docs/schemas/registry.schema.json` and observed by `teamIdentityOf()` in `registry.mjs`, which
-attaches a runtime-only `identity` field to each entry `listProjects()` returns — `matches: null`
-means "unknown", deliberately distinct from `false` ("mismatch"). `listProjects()` warns on a
-mismatch and `checkRegistryTeamIdentity()` in `doctor.mjs` grades it (WARN mismatch / INFO
-unverified / PASS all-verified, never FAIL).
+Implementation notes for this repo (CAT-52): the contract is declared by `docs/schemas/registry.schema.json` and observed by `teamIdentityOf()` in `registry.mjs`, which attaches a runtime-only `identity` field to each entry `listProjects()` returns — `matches: null` means "unknown", deliberately distinct from `false` ("mismatch"). `listProjects()` warns on a mismatch and `checkRegistryTeamIdentity()` in `doctor.mjs` grades it (WARN mismatch / INFO unverified / PASS all-verified, never FAIL).
 
 See ADR-028 for Catalyst's own CAT registration.
 
@@ -489,12 +424,9 @@ See ADR-028 for Catalyst's own CAT registration.
 
 **Location:** `~/catalyst/execution-core/workers/{TICKET}/phase-{name}.json`
 
-Phase signal files are the coordination channel between the execution-core daemon and phase-agent
-workers. The daemon writes the file to dispatch a phase; the worker updates `status` and
-`bg_job_id` as it runs; the daemon reads the file to decide when to advance to the next phase.
+Phase signal files are the coordination channel between the execution-core daemon and phase-agent workers. The daemon writes the file to dispatch a phase; the worker updates `status` and `bg_job_id` as it runs; the daemon reads the file to decide when to advance to the next phase.
 
-Workers emit terminal status values (`done`, `failed`, `skipped`, `turn-cap-exhausted`) using the
-`phase-agent-emit-complete` helper script, which updates the signal file atomically.
+Workers emit terminal status values (`done`, `failed`, `skipped`, `turn-cap-exhausted`) using the `phase-agent-emit-complete` helper script, which updates the signal file atomically.
 
 ---
 
@@ -504,14 +436,11 @@ Workers emit terminal status values (`done`, `failed`, `skipped`, `turn-cap-exha
 
 This file is **written by Claude Code, not Catalyst**. Catalyst reads it read-only for:
 
-- **Session continuation** — `resumeSessionId` (Claude Code ≥2.x) is the primary field passed as
-  `--resume-session` when boot-resume or turn-cap revival re-launches a phase-agent.
-- **Job liveness probes** — the `state` field (`"running"` / `"stopped"`) is read by
-  `defaultStatJob` to determine if a bg job is still alive.
+- **Session continuation** — `resumeSessionId` (Claude Code ≥2.x) is the primary field passed as `--resume-session` when boot-resume or turn-cap revival re-launches a phase-agent.
+- **Job liveness probes** — the `state` field (`"running"` / `"stopped"`) is read by `defaultStatJob` to determine if a bg job is still alive.
 - **Worktree validation** — `cwd` is read during orphan detection.
 
-The legacy `linkScanPath` field (Claude Code <2.x) is still read as a fallback for sessions
-running older Claude Code versions.
+The legacy `linkScanPath` field (Claude Code <2.x) is still read as a fallback for sessions running older Claude Code versions.
 
 ---
 
@@ -558,8 +487,7 @@ Edit `~/.config/catalyst/config.json`:
 }
 ```
 
-This overrides Layer-1's `maxParallel` for this machine only. The committed `.catalyst/config.json`
-is unchanged.
+This overrides Layer-1's `maxParallel` for this machine only. The committed `.catalyst/config.json` is unchanged.
 
 ### "Route triage, research, and implement to specific models"
 
@@ -630,13 +558,7 @@ Edit `.catalyst/config.json`:
 
 ### "Tune (or disable) the `~/.claude/jobs` directory GC"
 
-The orphan reaper also garbage-collects stale `~/.claude/jobs/<id>` directories
-on its periodic cadence (CTL-1165). The sweep is **fail-closed** — if `claude
-agents` cannot be read it deletes nothing — and only removes a job directory when
-it is not a live or registered session, not the controlling session, and older
-than `retentionSeconds` (default 24h). It deletes the job directory alone (never
-`claude rm`), capped at `batchCap` per sweep with the remainder draining on the
-next tick. Edit `.catalyst/config.json`:
+The orphan reaper also garbage-collects stale `~/.claude/jobs/<id>` directories on its periodic cadence (CTL-1165). The sweep is **fail-closed** — if `claude agents` cannot be read it deletes nothing — and only removes a job directory when it is not a live or registered session, not the controlling session, and older than `retentionSeconds` (default 24h). It deletes the job directory alone (never `claude rm`), capped at `batchCap` per sweep with the remainder draining on the next tick. Edit `.catalyst/config.json`:
 
 ```json
 {
@@ -654,11 +576,7 @@ next tick. Edit `.catalyst/config.json`:
 }
 ```
 
-Set `"enabled": false` to disable only the directory GC (the orphan-reaper sweep
-still runs). The env vars `CATALYST_JOB_GC_RETENTION_SECONDS` and
-`CATALYST_JOB_GC_BATCH_CAP` override the corresponding fields. See
-[`catalyst-config.schema.json`](./schemas/catalyst-config.schema.json) for the
-canonical field reference.
+Set `"enabled": false` to disable only the directory GC (the orphan-reaper sweep still runs). The env vars `CATALYST_JOB_GC_RETENTION_SECONDS` and `CATALYST_JOB_GC_BATCH_CAP` override the corresponding fields. See [`catalyst-config.schema.json`](./schemas/catalyst-config.schema.json) for the canonical field reference.
 
 ### "Change the Linear state the daemon polls for new work"
 

--- a/docs/event-automation-contract.md
+++ b/docs/event-automation-contract.md
@@ -2,25 +2,13 @@
 
 ## 1. What this is
 
-The binding contract between **events** and **actions** in the Catalyst fleet: which events the
-coordination plane needs, what exactly one bounded automation does when each lands, and — for every
-one of them — which component **refuses the second delivery**. A phase is a goal-loop: it is given a
-goal and a bounded context, it works until the goal is met, and it posts one thing, its outcome.
-That posting _is_ the event. It does not advance the ticket, does not write Linear, does not
-dispatch the next phase. Everything that happens next is a separate subscriber. This document is the
-list of those subscribers. Ratified as **ADR-029**; the measured evidence behind every claim is in
-`thoughts/shared/research/2026-08-13-event-automation-catalog.md`.
+The binding contract between **events** and **actions** in the Catalyst fleet: which events the coordination plane needs, what exactly one bounded automation does when each lands, and — for every one of them — which component **refuses the second delivery**. A phase is a goal-loop: it is given a goal and a bounded context, it works until the goal is met, and it posts one thing, its outcome. That posting _is_ the event. It does not advance the ticket, does not write Linear, does not dispatch the next phase. Everything that happens next is a separate subscriber. This document is the list of those subscribers. Ratified as **ADR-029**; the measured evidence behind every claim is in `thoughts/shared/research/2026-08-13-event-automation-catalog.md`.
 
 ## 2. Reading this document — "Who says no?"
 
-Every automation row answers one question in plain language: **when the same trigger is delivered
-twice, which component refuses the second attempt?**
+Every automation row answers one question in plain language: **when the same trigger is delivered twice, which component refuses the second attempt?**
 
-This is not a hypothetical. The event log is read through a byte cursor, and a process that crashes
-between acting and advancing its cursor **re-reads the same event on restart** — the reaper does
-exactly this on every boot (`execution-core/reaper.mjs:938-989 bootReplay`). Redelivery is normal
-operation, not an incident. So every subscriber must be safe when its trigger arrives twice, and the
-thing that makes it safe has to be a component that can _say no_.
+This is not a hypothetical. The event log is read through a byte cursor, and a process that crashes between acting and advancing its cursor **re-reads the same event on restart** — the reaper does exactly this on every boot (`execution-core/reaper.mjs:938-989 bootReplay`). Redelivery is normal operation, not an incident. So every subscriber must be safe when its trigger arrives twice, and the thing that makes it safe has to be a component that can _say no_.
 
 Not everything can. The distinction is mechanical:
 
@@ -34,23 +22,15 @@ Not everything can. The distinction is mechanical:
 
 Three phrases recur in the tables and mean specific things:
 
-- **⚠ HOST-LOCAL** — the refusing component exists, but only on one machine (a marker file, an
-  in-memory `Set`). It is correct for a single host and is a correctness hole the moment a second
-  worker node receives the same webhook.
-- **a guard we wrote** — an `if` statement in our own code. It is advisory. It refuses a duplicate
-  only when both attempts run in the same process, in a known order. Per ADR-0027 §I3, naming a
-  guard here is the same as naming nothing.
-- **convergent** — the action has no second effect worth refusing (removing an already-removed
-  worktree, fetching an already-current checkout). Correctly, nothing needs to say no.
+- **⚠ HOST-LOCAL** — the refusing component exists, but only on one machine (a marker file, an in-memory `Set`). It is correct for a single host and is a correctness hole the moment a second worker node receives the same webhook.
+- **a guard we wrote** — an `if` statement in our own code. It is advisory. It refuses a duplicate only when both attempts run in the same process, in a known order. Per ADR-0027 §I3, naming a guard here is the same as naming nothing.
+- **convergent** — the action has no second effect worth refusing (removing an already-removed worktree, fetching an already-current checkout). Correctly, nothing needs to say no.
 
-The phrase **"exclusion store"** is deliberately not used anywhere in this document. It obscured the
-question. Ask "who says no?" instead.
+The phrase **"exclusion store"** is deliberately not used anywhere in this document. It obscured the question. Ask "who says no?" instead.
 
 ## 2a. Notation — what `<P>` and `<T>` mean
 
-Event names in this document are written as **templates**. Angle-bracket segments are placeholders
-substituted at emit time; everything else is literal. `phase.<P>.complete.<T>` is not an event name
-— it is the shape of a family of them.
+Event names in this document are written as **templates**. Angle-bracket segments are placeholders substituted at emit time; everything else is literal. `phase.<P>.complete.<T>` is not an event name — it is the shape of a family of them.
 
 | placeholder           | stands for                     | substituted with                                                                 | example     |
 | --------------------- | ------------------------------ | -------------------------------------------------------------------------------- | ----------- |
@@ -63,20 +43,13 @@ substituted at emit time; everything else is literal. `phase.<P>.complete.<T>` i
 | `<check_suite_id>`    | GitHub check-suite id          | an integer                                                                       | `48219…`    |
 | `<target>`            | the phase being dispatched TO  | a phase name; rides `payload.target_phase`, **not** the event name               | `research`  |
 
-**Legacy spellings.** Earlier sections and sibling docs use `<TICKET>` for `<T>`, `<phase>`/`<name>`
-for `<P>`, and `<suite_id>` for `<check_suite_id>`. They mean the same thing; `<P>`/`<T>` are the
-form to use in new writing.
+**Legacy spellings.** Earlier sections and sibling docs use `<TICKET>` for `<T>`, `<phase>`/`<name>` for `<P>`, and `<suite_id>` for `<check_suite_id>`. They mean the same thing; `<P>`/`<T>` are the form to use in new writing.
 
-**`<P>` is not always a real phase.** Three names occupy the phase slot without being pipeline
-phases — `dispatch`, `scheduler`, and `advance` (`namespace-contract.mjs`
-`INTENTIONAL_PHASE_SLOT_EXCEPTIONS`). `phase.advance.applied.<T>` is an _audit_ record about the
-FSM, not a phase named "advance". Only `dispatch` produces a name matching the routing pattern, and
-its real phase rides `payload.target_phase`.
+**`<P>` is not always a real phase.** Three names occupy the phase slot without being pipeline phases — `dispatch`, `scheduler`, and `advance` (`namespace-contract.mjs` `INTENTIONAL_PHASE_SLOT_EXCEPTIONS`). `phase.advance.applied.<T>` is an _audit_ record about the FSM, not a phase named "advance". Only `dispatch` produces a name matching the routing pattern, and its real phase rides `payload.target_phase`.
 
 ### A real event, annotated
 
-Taken verbatim from `mini:~/catalyst/events/2026-08.jsonl` — this is the substitution of
-`phase.<P>.complete.<T>` with `<P>` = `plan` and `<T>` = `CTC-324`:
+Taken verbatim from `mini:~/catalyst/events/2026-08.jsonl` — this is the substitution of `phase.<P>.complete.<T>` with `<P>` = `plan` and `<T>` = `CTC-324`:
 
 ```jsonc
 {
@@ -105,9 +78,7 @@ Taken verbatim from `mini:~/catalyst/events/2026-08.jsonl` — this is the subst
 }
 ```
 
-⛔ **Match on the parsed name, never a substring grep of the log.** A bare `grep` for a name also
-matches commit messages and Linear descriptions that merely quote it — measured: 46 raw matches for
-`phase.advance.applied`, of which **all 46 were false positives**. Parse the JSON.
+⛔ **Match on the parsed name, never a substring grep of the log.** A bare `grep` for a name also matches commit messages and Linear descriptions that merely quote it — measured: 46 raw matches for `phase.advance.applied`, of which **all 46 were false positives**. Parse the JSON.
 
 ⛔ **And read the name through the shared boundary — never hand-roll the ladder:**
 
@@ -116,18 +87,11 @@ import { getEventName } from "../lib/event-name.mjs"; // CTL-1834: THE boundary
 const name = getEventName(event); // v1 `event` -> v2 attributes["event.name"] -> v3 `name`
 ```
 
-A hand-rolled two-key read (`attributes?.["event.name"] ?? event`) misses **v3** entirely and
-returns the wrong value for an empty-string key. That is exactly the drift CTL-1834 removed by
-folding every read point onto one resolver, so a fourth envelope shape is a one-line change in one
-file instead of a hunt across five.
+A hand-rolled two-key read (`attributes?.["event.name"] ?? event`) misses **v3** entirely and returns the wrong value for an empty-string key. That is exactly the drift CTL-1834 removed by folding every read point onto one resolver, so a fourth envelope shape is a one-line change in one file instead of a hunt across five.
 
-An `attributes`-only reader misses every v1 event — **19,914 of them in 2026-08 on mini**, including
-the whole `reap-requested` family, which is the fleet's most active actuator (§4.1). This is the
-single easiest way to produce a confident, wrong zero.
+An `attributes`-only reader misses every v1 event — **19,914 of them in 2026-08 on mini**, including the whole `reap-requested` family, which is the fleet's most active actuator (§4.1). This is the single easiest way to produce a confident, wrong zero.
 
-`body.payload` is **stripped off-machine** by `otel-forward`, so anything a remote consumer needs
-must be promoted to an attribute — and v1 events have no attributes at all, so they carry nothing
-off-host but their name and timestamp.
+`body.payload` is **stripped off-machine** by `otel-forward`, so anything a remote consumer needs must be promoted to an attribute — and v1 events have no attributes at all, so they carry nothing off-host but their name and timestamp.
 
 ## 3. The principles
 
@@ -146,20 +110,12 @@ off-host but their name and timestamp.
 
 **The two lease traps.** Both recorded 2026-08-12, both load-bearing:
 
-1. **A LEASE IS NOT A HEARTBEAT.** "Still alive" is precisely the inference being removed. Renew on
-   **visible progress** — a commit count, a turn count, a phase artifact — so a wedged agent loses
-   its claim while its process is perfectly healthy. Renew on time and you have rebuilt `kill -0`
-   with extra steps.
-2. **A LEASE NEEDS SOMETHING THAT CAN REFUSE.** An append-only log cannot reject a write, so "the
-   claim is just an event" reproduces the bug in a new place.
+1. **A LEASE IS NOT A HEARTBEAT.** "Still alive" is precisely the inference being removed. Renew on **visible progress** — a commit count, a turn count, a phase artifact — so a wedged agent loses its claim while its process is perfectly healthy. Renew on time and you have rebuilt `kill -0` with extra steps.
+2. **A LEASE NEEDS SOMETHING THAT CAN REFUSE.** An append-only log cannot reject a write, so "the claim is just an event" reproduces the bug in a new place.
 
-**THE LOG DECLARES; IT CANNOT EXCLUDE.** Those two roles are kept separate in every row below: the
-log carries the declaration, and a different component says no.
+**THE LOG DECLARES; IT CANNOT EXCLUDE.** Those two roles are kept separate in every row below: the log carries the declaration, and a different component says no.
 
-**Governing invariants** —
-`catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md` (accepted
-2026-08-12; **a different repository's numbering** — this repo's `docs/adrs.md` ADR-027 is "Browser
-automation stays local", unrelated; always cite the cloud ADR by repo + path):
+**Governing invariants** — `catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md` (accepted 2026-08-12; **a different repository's numbering** — this repo's `docs/adrs.md` ADR-027 is "Browser automation stays local", unrelated; always cite the cloud ADR by repo + path):
 
 | #       | Invariant                                                                                           |
 | ------- | --------------------------------------------------------------------------------------------------- |
@@ -181,30 +137,19 @@ automation stays local", unrelated; always cite the cloud ADR by repo + path):
 
 > "linear as the trigger not the lock sounds correct to me"
 
-The Linear stage change **starts** an automation. The **lease** is what refuses a duplicate. Linear
-is never asked to refuse anything, and no design may propose it as the refusal point. The direct
-consequence — worked through, not around — is §6.3: two hosts receiving the same stage-change
-webhook both pass the trigger, so the lease is acquired **after** the trigger and **before** any
-side effect, and exactly one wins.
+The Linear stage change **starts** an automation. The **lease** is what refuses a duplicate. Linear is never asked to refuse anything, and no design may propose it as the refusal point. The direct consequence — worked through, not around — is §6.3: two hosts receiving the same stage-change webhook both pass the trigger, so the lease is acquired **after** the trigger and **before** any side effect, and exactly one wins.
 
 ## 4. The event catalog — the coordination set
 
-The full census is 117 rows over 304 distinct event names, of which **63 have no subscriber at all**
-(`thoughts/shared/research/2026-08-13-event-automation-catalog.md` §3). This section lists only the
-**coordination set**: events some component acts on, or must act on in the target design. Everything
-else is telemetry — its loss costs visibility, never correctness.
+The full census is 117 rows over 304 distinct event names, of which **63 have no subscriber at all** (`thoughts/shared/research/2026-08-13-event-automation-catalog.md` §3). This section lists only the **coordination set**: events some component acts on, or must act on in the target design. Everything else is telemetry — its loss costs visibility, never correctness.
 
-Volume context: two telemetry names (`catalyst.linear.read` 833,499 and `recovery.tick` 557,069) are
-**56% of all traffic**; seven names are 71%. Exactly one of those seven is coordination. The log is
-overwhelmingly a telemetry firehose with a thin coordination lane threaded through it.
+Volume context: two telemetry names (`catalyst.linear.read` 833,499 and `recovery.tick` 557,069) are **56% of all traffic**; seven names are 71%. Exactly one of those seven is coordination. The log is overwhelmingly a telemetry firehose with a thin coordination lane threaded through it.
 
 ### 4.1 Phase declarations — the holder speaks
 
-Emitted by `phase-agent-emit-complete:315` (name) / `:402-427` (append), called from every
-`plugins/dev/skills/phase-*/SKILL.md` terminal block.
+Emitted by `phase-agent-emit-complete:315` (name) / `:402-427` (append), called from every `plugins/dev/skills/phase-*/SKILL.md` terminal block.
 
-Every name below is a **template** — see §2a. `<P>` is the phase, `<T>` is the ticket. The example
-column shows a real name observed in `mini:~/catalyst/events/2026-08.jsonl`, not an invented one.
+Every name below is a **template** — see §2a. `<P>` is the phase, `<T>` is the ticket. The example column shows a real name observed in `mini:~/catalyst/events/2026-08.jsonl`, not an invented one.
 
 | event (template)                             | example (real, from the log)           | meaning                                                                                                                                                                                                                                                                    | drives anything today?                                                                                                                                                                                                              |
 | -------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -220,8 +165,7 @@ column shows a real name observed in `mini:~/catalyst/events/2026-08.jsonl`, not
 
 ### ⚠ Observed while sampling: the reap echoes are almost all failures
 
-Measured on mini, 2026-08, all `reap-complete` / `reap-failed` echoes — **330 events, 5 distinct
-names**:
+Measured on mini, 2026-08, all `reap-complete` / `reap-failed` echoes — **330 events, 5 distinct names**:
 
 | name                              | count |
 | --------------------------------- | ----: |
@@ -231,52 +175,29 @@ names**:
 | `phase.abort.reap-complete`       |     2 |
 | `phase.predecessor.reap-complete` |     1 |
 
-**The abort path reports failure 320 times and success twice**, against 14,568 `terminal`
-reap-requests that produce only 4 completes. Two readings are possible and this sample cannot
-separate them: the reaper is genuinely failing to abort, or the echo is emitted on a benign
-already-gone condition. Either way it is unexamined — nothing consumes `reap-failed`, so a 99%
-failure rate on an actuator path has been accumulating silently. Recorded as an observation with its
-numbers, **not** as a diagnosis; it needs its own ticket.
+**The abort path reports failure 320 times and success twice**, against 14,568 `terminal` reap-requests that produce only 4 completes. Two readings are possible and this sample cannot separate them: the reaper is genuinely failing to abort, or the echo is emitted on a benign already-gone condition. Either way it is unexamined — nothing consumes `reap-failed`, so a 99% failure rate on an actuator path has been accumulating silently. Recorded as an observation with its numbers, **not** as a diagnosis; it needs its own ticket.
 
 ### ⛔ Two envelope shapes coexist, and the reap family is the impoverished one
 
-**Do not assume every event has attributes.** Measured on mini, 2026-08, over all `reap-requested`
-events: **19,914 are v1 and 12 are v2.** A v1 event is literally two keys —
+**Do not assume every event has attributes.** Measured on mini, 2026-08, over all `reap-requested` events: **19,914 are v1 and 12 are v2.** A v1 event is literally two keys —
 
 ```json
 { "ts": "2026-08-01T00:04:42Z", "event": "phase.reconcile.reap-requested" }
 ```
 
-— no `attributes`, no `resource`, no `body`, **and no ticket anywhere**. Verified: **zero**
-`reap-requested` names carry a ticket suffix.
+— no `attributes`, no `resource`, no `body`, **and no ticket anywhere**. Verified: **zero** `reap-requested` names carry a ticket suffix.
 
 Three consequences, all load-bearing:
 
-1. **A consumer matching only on `attributes["event.name"]` silently sees none of them.** That is
-   19,914 events — including the single most active actuator in the fleet — invisible to an
-   attribute-only subscriber. Any filter must resolve the name through the shared boundary
-   (`lib/event-name.mjs`'s `getEventName`, CTL-1834) — not a hand-rolled two-key read, which
-   misses v3.
-2. **`<T>` is genuinely absent here**, so the reaper cannot learn the ticket from the event. It
-   doesn't try: the event is a **contentless wake**, and the reaper then makes its own authoritative
-   read of the worker directories. That is "let the event wake the scan" working correctly in
-   production — and it is why this row is the reference implementation.
-3. The declaration families (`phase.<P>.complete.<T>` and siblings) **are** v2 and do carry
-   `event.entity`, `event.action`, and `linear.issue.identifier` as attributes, so for those a
-   subscriber matches on attributes and never splits the name. The rule is per-family, not global.
+1. **A consumer matching only on `attributes["event.name"]` silently sees none of them.** That is 19,914 events — including the single most active actuator in the fleet — invisible to an attribute-only subscriber. Any filter must resolve the name through the shared boundary (`lib/event-name.mjs`'s `getEventName`, CTL-1834) — not a hand-rolled two-key read, which misses v3.
+2. **`<T>` is genuinely absent here**, so the reaper cannot learn the ticket from the event. It doesn't try: the event is a **contentless wake**, and the reaper then makes its own authoritative read of the worker directories. That is "let the event wake the scan" working correctly in production — and it is why this row is the reference implementation.
+3. The declaration families (`phase.<P>.complete.<T>` and siblings) **are** v2 and do carry `event.entity`, `event.action`, and `linear.issue.identifier` as attributes, so for those a subscriber matches on attributes and never splits the name. The rule is per-family, not global.
 
 ### 4.1a ⛔ Where does the ticket live? Three conventions, one log
 
-The `<T>` in `phase.<P>.complete.<T>` is **in the event name**. The ticket in
-`linear.issue.state_changed` is **not** — it rides `attributes["linear.issue.identifier"]`. Both are
-our choices, and they disagree.
+The `<T>` in `phase.<P>.complete.<T>` is **in the event name**. The ticket in `linear.issue.state_changed` is **not** — it rides `attributes["linear.issue.identifier"]`. Both are our choices, and they disagree.
 
-**Correcting a natural assumption:** `linear.issue.state_changed` is **not** Linear's format passed
-through. Linear sends `{action:"update", type:"Issue", data:{…}, updatedFrom:{…}}` and has no such
-event name. We synthesise it — `linear-webhook-events.ts:181` derives `state_changed` by testing
-`updatedFromKeys.includes("stateId")`, with siblings at `:182-183` for priority and assignee. So we
-are not preserving a provider shape we do not control; we picked this shape, and we picked a
-different one for phases.
+**Correcting a natural assumption:** `linear.issue.state_changed` is **not** Linear's format passed through. Linear sends `{action:"update", type:"Issue", data:{…}, updatedFrom:{…}}` and has no such event name. We synthesise it — `linear-webhook-events.ts:181` derives `state_changed` by testing `updatedFromKeys.includes("stateId")`, with siblings at `:182-183` for priority and assignee. So we are not preserving a provider shape we do not control; we picked this shape, and we picked a different one for phases.
 
 **The cost, measured on mini, 2026-08:**
 
@@ -286,10 +207,7 @@ different one for phases.
 | distinct names with `<T>` collapsed    |   **242** |
 | names that are purely ticket-inflation | **1,225** |
 
-**84% of this log's name cardinality is ticket identifiers.** Five families embed them — `phase`
-1,066 · `worker` 110 · `fence` 57 · `linear` 51 · `ticket` 25 — so the inconsistency is not
-Catalyst-vs-provider, it is _inside_ the Linear family too: `linear.issue.state_changed` is clean
-while `linear.state.write.<T>` is inflated.
+**84% of this log's name cardinality is ticket identifiers.** Five families embed them — `phase` 1,066 · `worker` 110 · `fence` 57 · `linear` 51 · `ticket` 25 — so the inconsistency is not Catalyst-vs-provider, it is _inside_ the Linear family too: `linear.issue.state_changed` is clean while `linear.state.write.<T>` is inflated.
 
 Three conventions therefore coexist, and a consumer must handle all three:
 
@@ -299,27 +217,15 @@ Three conventions therefore coexist, and a consumer must handle all three:
 | **in an attribute** | `linear.issue.state_changed`    | `linear.issue.identifier`             |
 | **absent entirely** | `phase.terminal.reap-requested` | nowhere — the consumer re-reads state |
 
-**Target: the ticket is a field, never a name segment.** A name should be low-cardinality so it can
-be a metric dimension and a stable subscription key; an identifier belongs in an attribute. The
-attribute already exists on every v2 event, so for those families this is a subtraction, not an
-addition.
+**Target: the ticket is a field, never a name segment.** A name should be low-cardinality so it can be a metric dimension and a stable subscription key; an identifier belongs in an attribute. The attribute already exists on every v2 event, so for those families this is a subtraction, not an addition.
 
-⚠ **It is load-bearing today, not cosmetic.** `PHASE_EVENT_PATTERN`
-(`broker/namespace-contract.mjs:85`) matches `phase.<name>.<status>.<TICKET>` and the broker's phase
-routing depends on that suffix — as does `filter.wake.<ORCH_NAME>`. The mitigating fact is that this
-routing is **inert** (zero interests exist under execution-core, §6.4), so the migration cost is far
-lower than the coupling suggests. Sequence it with the subscription work rather than alone.
+⚠ **It is load-bearing today, not cosmetic.** `PHASE_EVENT_PATTERN` (`broker/namespace-contract.mjs:85`) matches `phase.<name>.<status>.<TICKET>` and the broker's phase routing depends on that suffix — as does `filter.wake.<ORCH_NAME>`. The mitigating fact is that this routing is **inert** (zero interests exist under execution-core, §6.4), so the migration cost is far lower than the coupling suggests. Sequence it with the subscription work rather than alone.
 
 ### 4.1b ⛔ The redundancy is near-total — and the 531-event exception is live data loss
 
-§4.1a's census read the name as `attributes["event.name"] ?? event`. That is a **two-key read, and
-there are three envelope shapes.** The third is `defaultEmit` at
-`execution-core/stale-pr-rescue-timer.mjs:444-447`, which writes
-`JSON.stringify({ name, ...payload, ts })` — key `name`, **no `attributes` object at all.**
+§4.1a's census read the name as `attributes["event.name"] ?? event`. That is a **two-key read, and there are three envelope shapes.** The third is `defaultEmit` at `execution-core/stale-pr-rescue-timer.mjs:444-447`, which writes `JSON.stringify({ name, ...payload, ts })` — key `name`, **no `attributes` object at all.**
 
-Re-measured on mini (`2026-08.jsonl`, 1,117,131 lines) reading
-`attributes["event.name"] ?? event ?? name`. Positive control on the same pass: `recovery.tick` =
-**326,940**, so a zero below is absence, not a broken instrument.
+Re-measured on mini (`2026-08.jsonl`, 1,117,131 lines) reading `attributes["event.name"] ?? event ?? name`. Positive control on the same pass: `recovery.tick` = **326,940**, so a zero below is absence, not a broken instrument.
 
 | envelope | name key                   |         count | producer shape                                     |
 | -------- | -------------------------- | ------------: | -------------------------------------------------- |
@@ -327,8 +233,7 @@ Re-measured on mini (`2026-08.jsonl`, 1,117,131 lines) reading
 | v1       | `event`                    |    **25,013** | bash `catalyst-state.sh event` — `{ts,event}` only |
 | v3       | `name`                     |       **532** | flat `{name,...payload,ts}` — **no attributes**    |
 
-The corrected cardinality is materially the same as §4.1a's — the v3 shape adds 9 names — so **that
-table stands.** What changes is the redundancy claim.
+The corrected cardinality is materially the same as §4.1a's — the v3 shape adds 9 names — so **that table stands.** What changes is the redundancy claim.
 
 | metric                                 | §4.1a (2-key) | corrected (3-key) |
 | -------------------------------------- | ------------: | ----------------: |
@@ -347,74 +252,30 @@ table stands.** What changes is the redundancy claim.
 | `ticket.*` |                **73** |                          73 |                           0 |
 | **total**  |            **16,346** |                  **15,815** |                     **531** |
 
-**96.8% of the strip is a pure subtraction.** §4.1a's per-family `phase` count of 2,953 was the
-attribute-carrying _subset_, not the family total.
+**96.8% of the strip is a pure subtraction.** §4.1a's per-family `phase` count of 2,953 was the attribute-carrying _subset_, not the family total.
 
-⛔ **The 531 are being destroyed off-machine today, before any migration.** They are
-`phase.rescue.escalated.<T>` (523), `.dispatched.<T>` (5), `.dispatch-failed.<T>` (3).
-⚠ **Mechanism corrected 2026-08-13 (CTL-1817, PR #3325 round-1 review).** An earlier revision of
-this paragraph said a v3 event "forwards with an empty body and an empty attribute set", reasoning
-from the OTLP mapper (`otel-forward/lib/destinations/otlp.ts`), which builds the body from
-`ev.body?.message ?? ev.attributes?.["event.name"] ?? ""` and the attributes from
-`ev.attributes ?? {}` — neither of which a v3 event satisfies. **That is not what happens: a v3 event
-never reaches the mapper.**
+⛔ **The 531 are being destroyed off-machine today, before any migration.** They are `phase.rescue.escalated.<T>` (523), `.dispatched.<T>` (5), `.dispatch-failed.<T>` (3). ⚠ **Mechanism corrected 2026-08-13 (CTL-1817, PR #3325 round-1 review).** An earlier revision of this paragraph said a v3 event "forwards with an empty body and an empty attribute set", reasoning from the OTLP mapper (`otel-forward/lib/destinations/otlp.ts`), which builds the body from `ev.body?.message ?? ev.attributes?.["event.name"] ?? ""` and the attributes from `ev.attributes ?? {}` — neither of which a v3 event satisfies. **That is not what happens: a v3 event never reaches the mapper.**
 
-**One gate accounts for all 531:** `otel-forward/lib/tail.ts` `shouldForward` accepts only
-`attributes` | a string `event` | pino (numeric `level` + string `msg`). A v3 line matches none, so
-`readNewLines` never hands it to `processLine` — it is filtered out **at the tailer** and never read
-into the pipeline at all.
+**One gate accounts for all 531:** `otel-forward/lib/tail.ts` `shouldForward` accepts only `attributes` | a string `event` | pino (numeric `level` + string `msg`). A v3 line matches none, so `readNewLines` never hands it to `processLine` — it is filtered out **at the tailer** and never read into the pipeline at all.
 
-(A *second*, independent guard exists downstream — `otel-forward/index.ts` `processLine` drops any
-record with no `attributes` — but it is **unreachable for v3** and discards none of the 531. It
-governs only records that already passed the tailer. It is named here because it is the other place
-a record can vanish without a trace, **not** because it is a second step in this loss.)
+(A *second*, independent guard exists downstream — `otel-forward/index.ts` `processLine` drops any record with no `attributes` — but it is **unreachable for v3** and discards none of the 531. It governs only records that already passed the tailer. It is named here because it is the other place a record can vanish without a trace, **not** because it is a second step in this loss.)
 
-So the 531 do not arrive off-machine degraded — **they never leave the host.** The loss is total, and
-it was invisible because an unrecognized line is indistinguishable from no line, which is why a month
-of it looked like silence rather than like corruption. This is a standing bug the migration merely
-surfaced, not a migration cost to be weighed — and it is worse than the original text claimed.
+So the 531 do not arrive off-machine degraded — **they never leave the host.** The loss is total, and it was invisible because an unrecognized line is indistinguishable from no line, which is why a month of it looked like silence rather than like corruption. This is a standing bug the migration merely surfaced, not a migration cost to be weighed — and it is worse than the original text claimed.
 
-The lesson generalizes past this one shape: **reasoning from the mapper alone skips the filters in
-front of it.** A detector placed at the mapper cannot observe what a filter already threw away —
-which is exactly the mistake the first fix made.
+The lesson generalizes past this one shape: **reasoning from the mapper alone skips the filters in front of it.** A detector placed at the mapper cannot observe what a filter already threw away — which is exactly the mistake the first fix made.
 
-✅ **Status of the fix: both gates now record their drops** (CTL-1817, PR #3325, merged 2026-08-13).
-`noteUnrecognizedLine` reports at the tailer and a `skippedNoAttributes` counter reports at
-`processLine`; both count every occurrence and warn sparsely (once per distinct event name, then on
-exponentially-spaced totals), on the pino `~/catalyst/otel-forward.log` that Alloy ships
-**independently of otel-forward's own OTLP egress** — an alarm riding the pipe it measures reads
-clean during exactly the outage it exists to detect. Both producers of the v3 shape were fixed in the
-same PR, so the counters should sit at zero; any non-zero value is itself the alarm.
+✅ **Status of the fix: both gates now record their drops** (CTL-1817, PR #3325, merged 2026-08-13). `noteUnrecognizedLine` reports at the tailer and a `skippedNoAttributes` counter reports at `processLine`; both count every occurrence and warn sparsely (once per distinct event name, then on exponentially-spaced totals), on the pino `~/catalyst/otel-forward.log` that Alloy ships **independently of otel-forward's own OTLP egress** — an alarm riding the pipe it measures reads clean during exactly the outage it exists to detect. Both producers of the v3 shape were fixed in the same PR, so the counters should sit at zero; any non-zero value is itself the alarm.
 
-✅ **The one caveat that remained is now closed** (CTL-1823, merged 2026-08-13). What it said, and
-what changed:
+✅ **The one caveat that remained is now closed** (CTL-1823, merged 2026-08-13). What it said, and what changed:
 
-- **The defect, as recorded here on 2026-08-13:** the separate *mapper*-level degenerate counter
-  (`degenerateRecordTotal`) was incremented inside `buildOtlpPayload`, which runs once per send
-  **attempt** — so under OTLP retries or a DLQ replay it counted the same record more than once.
-  It was an attempt count, not a record count, precisely when the backend was in trouble.
-- **The fix:** counting moved out of the serializer entirely — `buildOtlpPayload` is now pure
-  mapping and does no accounting at all. The count is taken once per batch at `OtlpSender.flush`
-  entry, via `noteDegenerateRecords` (`otel-forward/lib/destinations/otlp.ts`). That is the one
-  point on the path at which each record is seen exactly once: `index.ts`'s `flushDest` hands
-  `buffer.splice(0)` to a single `flush()`, and both the retry loop and the DLQ drain sit
-  downstream of it.
-- **Current semantics — RECORDS, not attempts:** `degenerateRecordTotal()` counts degenerate
-  records **this process accepted for forwarding**, one increment per record. It includes records
-  subsequently aged out or terminally dropped (the call is deliberately ahead of the age
-  partition), and it excludes a DLQ entry written by a previous process and drained by this one —
-  that record was counted by the process that accepted it. Undercounting a prior process's backlog
-  is the deliberate fail direction for a detector whose job is to sit at zero; the failure being
-  fixed was inflation.
-- **Unchanged:** the two **gate** counters above sit on the tail path, run once per line, and never
-  had this defect. That asymmetry is intended and was not touched.
+- **The defect, as recorded here on 2026-08-13:** the separate *mapper*-level degenerate counter (`degenerateRecordTotal`) was incremented inside `buildOtlpPayload`, which runs once per send **attempt** — so under OTLP retries or a DLQ replay it counted the same record more than once. It was an attempt count, not a record count, precisely when the backend was in trouble.
+- **The fix:** counting moved out of the serializer entirely — `buildOtlpPayload` is now pure mapping and does no accounting at all. The count is taken once per batch at `OtlpSender.flush` entry, via `noteDegenerateRecords` (`otel-forward/lib/destinations/otlp.ts`). That is the one point on the path at which each record is seen exactly once: `index.ts`'s `flushDest` hands `buffer.splice(0)` to a single `flush()`, and both the retry loop and the DLQ drain sit downstream of it.
+- **Current semantics — RECORDS, not attempts:** `degenerateRecordTotal()` counts degenerate records **this process accepted for forwarding**, one increment per record. It includes records subsequently aged out or terminally dropped (the call is deliberately ahead of the age partition), and it excludes a DLQ entry written by a previous process and drained by this one — that record was counted by the process that accepted it. Undercounting a prior process's backlog is the deliberate fail direction for a detector whose job is to sit at zero; the failure being fixed was inflation.
+- **Unchanged:** the two **gate** counters above sit on the tail path, run once per line, and never had this defect. That asymmetry is intended and was not touched.
 
-The same change routed the degenerate warning through the shared count-every/warn-sparsely gate
-(`otel-forward/lib/sparse-warn.ts`) with its own key budget, so a flood of degenerate shapes cannot
-exhaust the budget the two gate alarms above depend on.
+The same change routed the degenerate warning through the shared count-every/warn-sparsely gate (`otel-forward/lib/sparse-warn.ts`) with its own key budget, so a flood of degenerate shapes cannot exhaust the budget the two gate alarms above depend on.
 
-**Four producers put an identifier in the name and nowhere else.** All four must gain an attribute
-**before** any suffix is stripped, or the migration destroys information:
+**Four producers put an identifier in the name and nowhere else.** All four must gain an attribute **before** any suffix is stripped, or the migration destroys information:
 
 | producer                     | file:line                           | identifier     | live 2026-08       |
 | ---------------------------- | ----------------------------------- | -------------- | ------------------ |
@@ -423,14 +284,9 @@ exhaust the budget the two gate alarms above depend on.
 | `defaultAppendOperatorEvent` | `recovery.mjs:1512-1514`            | ticket         | 0 (source-present) |
 | `thoughts-sync-gate`         | `lib/thoughts-sync-gate.sh:102-106` | phase + ticket | 0 (source-present) |
 
-`defaultAppendOperatorEvent` sets `attributes: { "event.name": name }` and nothing else, so
-`escalation.label-unconfirmed.<T>` (`recovery.mjs:2717`) is name-only by construction. It is a
-generic seam shared with `beliefs.*` and `intent.ineffective` — the fix is a ticket/label parameter
-on the seam, not a special case at the call site. `thoughts-sync-gate.sh:104-106` passes only
-`--ts --severity --service --event-name`, so both identifiers exist exclusively in the name.
+`defaultAppendOperatorEvent` sets `attributes: { "event.name": name }` and nothing else, so `escalation.label-unconfirmed.<T>` (`recovery.mjs:2717`) is name-only by construction. It is a generic seam shared with `beliefs.*` and `intent.ineffective` — the fix is a ticket/label parameter on the seam, not a special case at the call site. `thoughts-sync-gate.sh:104-106` passes only `--ts --severity --service --event-name`, so both identifiers exist exclusively in the name.
 
-**Three inflation vectors the five-family census structurally could not see**, because they do not
-match `[A-Za-z]+-\d+`:
+**Three inflation vectors the five-family census structurally could not see**, because they do not match `[A-Za-z]+-\d+`:
 
 | vector       | name                                | file:line                             | already in an attribute                                  |
 | ------------ | ----------------------------------- | ------------------------------------- | -------------------------------------------------------- |
@@ -439,15 +295,11 @@ match `[A-Za-z]+-\d+`:
 | **date**     | `briefing.followup.complete.<DATE>` | `briefing-followup/writeback.sh:244`  | `event.label` (`:272`)                                   |
 | **mid-name** | `phase.<TICKET>.auto-rebased.clean` | `worktree-refresh-timer.mjs:116,:120` | ⛔ never fires — `daemon.mjs:2000-2006` passes no `emit` |
 
-Live team-key names on mini: `monitor.reconcile.failing.{ADV,SLI,CTC,CRM}`, one event each. The date
-vector is the worse defect of the two: it mints **one new name per day, forever**. The mid-name
-ticket is the one a suffix-stripping migration would silently survive — it must be fixed as part of
-the standard, not after it.
+Live team-key names on mini: `monitor.reconcile.failing.{ADV,SLI,CTC,CRM}`, one event each. The date vector is the worse defect of the two: it mints **one new name per day, forever**. The mid-name ticket is the one a suffix-stripping migration would silently survive — it must be fixed as part of the standard, not after it.
 
 ### 4.1c The target grammar — closed vocabulary in the name, identifiers in attributes
 
-**`<entity>.<subject>.<action>[.<qualifier>]` — every segment drawn from a closed set, never
-interpolated from data.**
+**`<entity>.<subject>.<action>[.<qualifier>]` — every segment drawn from a closed set, never interpolated from data.**
 
 | slot                   | rule                                                                                                                                                       |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -455,8 +307,7 @@ interpolated from data.**
 | `<subject>`/`<action>` | closed, lowercase-hyphen. **Never** a ticket, team, host, PR number, date, session id, or orch id                                                          |
 | identifier             | **never a name segment.** Always an attribute                                                                                                              |
 
-**The identifier attribute contract** — every row but one is already emitted today, which is why
-this is a subtraction:
+**The identifier attribute contract** — every row but one is already emitted today, which is why this is a subtraction:
 
 | identifier           | attribute                                    | already emitted at                                                                                                         |
 | -------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
@@ -491,30 +342,16 @@ ticket = attributes["linear.issue.identifier"]
       ?? <legacy: trailing name segment>                     // fallback, dated
 ```
 
-Never a regex on the name to obtain an identifier. `references/event-schema.md:777` already
-documents this shape for `filter.wake` (`event.name == "filter.wake" and event.label == "${id}"`) —
-the target was designed and the emitter simply never stamped `event.label`.
+Never a regex on the name to obtain an identifier. `references/event-schema.md:777` already documents this shape for `filter.wake` (`event.name == "filter.wake" and event.label == "${id}"`) — the target was designed and the emitter simply never stamped `event.label`.
 
 ### 4.1d The decision — **yes, but only Steps 0–1 are committed**
 
-**The governing property, stated first, because it is what killed the last migration of this
-shape.** ADR-018 Phase 1 died at 1-of-7 writers and left the tree carrying a shadow mechanism with
-one consumer, a verification CLI. **Every prefix of this plan must leave the system strictly better
-than today.** Step 0 and Step 1 satisfy that trivially — they are bug fixes and drift-deletion with
-zero wire changes and zero routing risk. Everything after them is a 1–6-line PR that is
-independently safe and independently abandonable.
+**The governing property, stated first, because it is what killed the last migration of this shape.** ADR-018 Phase 1 died at 1-of-7 writers and left the tree carrying a shadow mechanism with one consumer, a verification CLI. **Every prefix of this plan must leave the system strictly better than today.** Step 0 and Step 1 satisfy that trivially — they are bug fixes and drift-deletion with zero wire changes and zero routing risk. Everything after them is a 1–6-line PR that is independently safe and independently abandonable.
 
-**The argument that is not cardinality.** `event.name` is Loki _structured metadata_, not a stream
-label — 1,476 names cost zero index cardinality and zero Prometheus series. If the case rested on
-name count, the honest answer would be "don't bother." It does not. It rests on three measured
-facts:
+**The argument that is not cardinality.** `event.name` is Loki _structured metadata_, not a stream label — 1,476 names cost zero index cardinality and zero Prometheus series. If the case rested on name count, the honest answer would be "don't bother." It does not. It rests on three measured facts:
 
-1. **Live data loss** — 531 events/month **discarded before they leave the host**, all of them at
-   `tail.ts`'s `shouldForward` filter (see §4.1b — NOT forwarded degenerately at `otlp.ts`, the
-   original and corrected reading, and NOT at `index.ts`'s no-attributes drop, which these records
-   never reach). Fixed by Step 0 alone.
-2. **Proven grammar drift** — the phase grammar exists in **four** hand-copies, and one of them has
-   _already_ silently diverged in production:
+1. **Live data loss** — 531 events/month **discarded before they leave the host**, all of them at `tail.ts`'s `shouldForward` filter (see §4.1b — NOT forwarded degenerately at `otlp.ts`, the original and corrected reading, and NOT at `index.ts`'s no-attributes drop, which these records never reach). Fixed by Step 0 alone.
+2. **Proven grammar drift** — the phase grammar exists in **four** hand-copies, and one of them has _already_ silently diverged in production:
 
    | copy                         | file:line                             | status                                                                                                                                     |
    | ---------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -523,19 +360,11 @@ facts:
    | `WORKFLOW_SUBSTEP_PATTERN`   | `broker/router.mjs:2100-2101`         | separate family, same ticket-suffix grammar re-typed                                                                                       |
    | `MONITOR_MERGE_COMPLETE_RE`  | `broker/plugin-refresh.mjs:457`       | fourth copy; found by only one of three audit lenses                                                                                       |
 
-   That comment is in-repo proof the duplication is a live defect **independent of the migration**.
-   Folding all four onto `namespace-contract` exports is worth doing even if nothing else ships.
+That comment is in-repo proof the duplication is a live defect **independent of the migration**. Folding all four onto `namespace-contract` exports is worth doing even if nothing else ships.
 
-3. **Unbounded growth** — dates and tickets mint names forever, and every _future_ name-keyed
-   surface inherits the defect at higher cost than closing the vocabulary now.
+3. **Unbounded growth** — dates and tickets mint names forever, and every _future_ name-keyed surface inherits the defect at higher cost than closing the vocabulary now.
 
-**The coupling, and why it is cheaper than §4.1a's warning implies.** `PHASE_EVENT_PATTERN`'s third
-capture group is `$`-anchored, so the ticket suffix is **mandatory for the match to occur at all**
-(`namespace-contract.mjs:86`); `phaseSlotOf` returns `null` without it (`:99-101`).
-`tryPhaseLifecycleRoute` then reads the ticket **only** from that capture (`router.mjs:2064`) and
-matches `reg.ticket !== ticket` (`:2070`) — but the same envelope has carried the ticket in
-`attributes` for 15,815 of 16,346 events all along. **The regex reads the name by historical
-accident, not by necessity.**
+**The coupling, and why it is cheaper than §4.1a's warning implies.** `PHASE_EVENT_PATTERN`'s third capture group is `$`-anchored, so the ticket suffix is **mandatory for the match to occur at all** (`namespace-contract.mjs:86`); `phaseSlotOf` returns `null` without it (`:99-101`). `tryPhaseLifecycleRoute` then reads the ticket **only** from that capture (`router.mjs:2064`) and matches `reg.ticket !== ticket` (`:2070`) — but the same envelope has carried the ticket in `attributes` for 15,815 of 16,346 events all along. **The regex reads the name by historical accident, not by necessity.**
 
 | fact                                                                                     | file:line                                                                                                           |
 | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -545,28 +374,15 @@ accident, not by necessity.**
 | Producers of the routable phase name — the complete set, must move in lockstep           | `recovery.mjs:482`, `sdk-run-phase-agent.mjs:616`, `phase-agent-emit-complete:315`, `lib/phase-emit-complete.sh:69` |
 | 59 `phase-agent-emit-complete` invocations across 10 SKILL.md files need **zero** edits  | they pass `--phase`/`--ticket`, never a name                                                                        |
 
-The real cost is not the 38 producer sites — they funnel into a handful of builders. It is the ~10
-consumers that reconstruct or parse the name (`event-scan.mjs:67,:244,:265,:291`,
-`recovery.mjs:4394,:4403`, `orch-monitor/lib/journey.mjs:35`,
-`orch-monitor/cli/lib/format.ts:523,:527,:541`, `orch-monitor/lib/otel-queries.ts:1471`) and the ~10
-SKILL.md `wait-for` filters pinned to the exact `filter.wake.<id>` string.
+The real cost is not the 38 producer sites — they funnel into a handful of builders. It is the ~10 consumers that reconstruct or parse the name (`event-scan.mjs:67,:244,:265,:291`, `recovery.mjs:4394,:4403`, `orch-monitor/lib/journey.mjs:35`, `orch-monitor/cli/lib/format.ts:523,:527,:541`, `orch-monitor/lib/otel-queries.ts:1471`) and the ~10 SKILL.md `wait-for` filters pinned to the exact `filter.wake.<id>` string.
 
-**Exit dates live in code, not in a review meeting.** `LEGACY_SUFFIX_DEADLINES` is frozen in
-`namespace-contract.mjs` and read by `catalyst doctor`: **INFO** before the date, **FAIL** after it.
-A dated table in a spec is what ADR-018 had. The deadline **forces the review**; deletion of the
-name-suffix fallback additionally requires its instrumented counter to read **zero** over a full
-retention window — because replay tooling over pre-migration months is exactly the false negative a
-calendar-only delete produces (tickets silently resolve to `null`, and a null ticket looks like a
-clean scan). **Deadline-forced, evidence-approved.**
+**Exit dates live in code, not in a review meeting.** `LEGACY_SUFFIX_DEADLINES` is frozen in `namespace-contract.mjs` and read by `catalyst doctor`: **INFO** before the date, **FAIL** after it. A dated table in a spec is what ADR-018 had. The deadline **forces the review**; deletion of the name-suffix fallback additionally requires its instrumented counter to read **zero** over a full retention window — because replay tooling over pre-migration months is exactly the false negative a calendar-only delete produces (tickets silently resolve to `null`, and a null ticket looks like a clean scan). **Deadline-forced, evidence-approved.**
 
-**The trigger that upgrades this from "worth it" to "urgent":** anyone proposing a name-keyed
-metric, alert, dashboard group-by, or routing surface. They should find the vocabulary already
-closed. Until then, Steps 0–1 are committed and the producer flips are opportunistic.
+**The trigger that upgrades this from "worth it" to "urgent":** anyone proposing a name-keyed metric, alert, dashboard group-by, or routing surface. They should find the vocabulary already closed. Until then, Steps 0–1 are committed and the producer flips are opportunistic.
 
 ### 4.1e Immutable history and out-of-repo dashboards
 
-**The log is append-only and is never rewritten.** Every past month keeps the old grammar forever,
-so "migrated" can only ever mean _producers emit the new form and consumers accept both._
+**The log is append-only and is never rewritten.** Every past month keeps the old grammar forever, so "migrated" can only ever mean _producers emit the new form and consumers accept both._
 
 | surface                                      | what the flip does to it                                                      | required mitigation                                                                                                             |
 | -------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -576,19 +392,9 @@ so "migrated" can only ever mean _producers emit the new form and consumers acce
 | `catalyst-otel/provisioning/alerting/*.yaml` | ⛔ **upsert-only; a malformed rule crash-loops the SHARED Grafana**           | validate every change against a throwaway Grafana first (AGENTS.md house rule). Needs a named owner before the phase flip       |
 | `catalyst-otel/dashboards/*`                 | name-keyed panels silently go flat                                            | `grep` over `dashboards/ provisioning/ docs/data-dictionary.md`, with a positive control that returns non-zero on the same pass |
 
-⚠ **The failure mode here is silence, not error.** An alert whose selector matches only the old
-name does not error when the new name arrives — **it goes quiet, and quiet reads as healthy.** That
-is the "stale copy reports healthy" pattern this fleet has hit four times. Every alert and connector
-touched must be shown to **fire on a synthetic new-form event** before the flip; "it did not error"
-is not evidence.
+⚠ **The failure mode here is silence, not error.** An alert whose selector matches only the old name does not error when the new name arrives — **it goes quiet, and quiet reads as healthy.** That is the "stale copy reports healthy" pattern this fleet has hit four times. Every alert and connector touched must be shown to **fire on a synthetic new-form event** before the flip; "it did not error" is not evidence.
 
-**What is out of scope, and why.** The reap family is v1 `{ts,event}` with **no ticket anywhere** —
-25,013 events on mini, zero of them ticket-suffixed. There is no suffix to strip. It is in scope for
-any _consumer_ rewrite (an attributes-only reader cannot see it at all — hence the three-key read
-above), and its v2 upgrade is a separate, optional piece of scope with real observability payoff and
-no relevance to name stripping. Likewise the ingest families are already correct:
-`webhook-handler.ts:172-418` and `linear-webhook-handler.ts:166-273` interpolate only the
-**action**, and `linear-webhook-events.ts:178-187` returns fixed strings.
+**What is out of scope, and why.** The reap family is v1 `{ts,event}` with **no ticket anywhere** — 25,013 events on mini, zero of them ticket-suffixed. There is no suffix to strip. It is in scope for any _consumer_ rewrite (an attributes-only reader cannot see it at all — hence the three-key read above), and its v2 upgrade is a separate, optional piece of scope with real observability payoff and no relevance to name stripping. Likewise the ingest families are already correct: `webhook-handler.ts:172-418` and `linear-webhook-handler.ts:166-273` interpolate only the **action**, and `linear-webhook-events.ts:178-187` returns fixed strings.
 
 ### 4.2 GitHub ingest — provider reality
 
@@ -632,10 +438,7 @@ Emitted by `orch-monitor/lib/webhook-events.ts` / `webhook-handler.ts:328`.
 
 ## 5. The automation table
 
-One row per subscriber. Rows **1–12** are carried over verbatim in intent from
-`thoughts/shared/research/2026-08-13-event-automation-catalog.md` §4 (numbering preserved so the
-carry-over is checkable); rows **13–18** are the Linear stage-transition subscribers Ryan identified
-as missing.
+One row per subscriber. Rows **1–12** are carried over verbatim in intent from `thoughts/shared/research/2026-08-13-event-automation-catalog.md` §4 (numbering preserved so the carry-over is checkable); rows **13–18** are the Linear stage-transition subscribers Ryan identified as missing.
 
 > ### ⭐ Rows 1 and 5 are NOT a duplicate
 >
@@ -672,31 +475,21 @@ as missing.
 
 **Two rules fall out of this table.**
 
-- **Rows 2, 3, 5, 9, 11, 14, 15 have no cross-host refusal today.** They are blocked on the lease
-  work, not on event-substrate work. Row 18 is the one Linear-writing row and needs no refusal at
-  all, which is the ruling made structural.
-- **The event log appears in exactly zero "who says no?" cells.** That is deliberate, and it is
-  trap 2. The log declares; something else excludes.
+- **Rows 2, 3, 5, 9, 11, 14, 15 have no cross-host refusal today.** They are blocked on the lease work, not on event-substrate work. Row 18 is the one Linear-writing row and needs no refusal at all, which is the ruling made structural.
+- **The event log appears in exactly zero "who says no?" cells.** That is deliberate, and it is trap 2. The log declares; something else excludes.
 
-**Row 18 is a move, not new code.** `applyPhaseStatus` is called inline today from the scheduler's
-advancement sweep (`scheduler.mjs:7315`, `:7456`, `:7993`) — and the source comment there already
-reads _"CTL-558: write the dispatched phase's mapped Linear status. Idempotent … never aborts the
-tick."_ Linear is **already** written last, as a projection. Row 18 names the fact and gives
-`phase.advance.applied` its first consumer.
+**Row 18 is a move, not new code.** `applyPhaseStatus` is called inline today from the scheduler's advancement sweep (`scheduler.mjs:7315`, `:7456`, `:7993`) — and the source comment there already reads _"CTL-558: write the dispatched phase's mapped Linear status. Idempotent … never aborts the tick."_ Linear is **already** written last, as a projection. Row 18 names the fact and gives `phase.advance.applied` its first consumer.
 
 ## 6. The stage-transition lookup table
 
 Two keying schemes, because the pipeline and the humans do not speak the same language.
 
-- **Machine edges** are keyed on `(declaration, phase)` — the holder's own assertion, delivered on
-  the local append-only log. This is I2, and it is the transport that is measured lossless.
-- **Human / foreign-agent intent** is keyed on `(class, to_state)` from the
-  `linear.issue.state_changed` webhook. Measured ~100% delivered for human authors.
+- **Machine edges** are keyed on `(declaration, phase)` — the holder's own assertion, delivered on the local append-only log. This is I2, and it is the transport that is measured lossless.
+- **Human / foreign-agent intent** is keyed on `(class, to_state)` from the `linear.issue.state_changed` webhook. Measured ~100% delivered for human authors.
 
 ### 6.1 Machine edges — trigger `phase.<P>.<status>.<T>`
 
-**TODAY** names what refuses now; **TARGET** is the cross-host lease. The advance-ledger's key is
-lease-shaped, so the swap changes no row.
+**TODAY** names what refuses now; **TARGET** is the cross-host lease. The advance-ledger's key is lease-shaped, so the swap changes no row.
 
 | #       | declaration                                                     | phase          | dispatch next                                                                               | Linear reflection                                                                         | who says no?                                                                                                                                      |
 | ------- | --------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -722,20 +515,13 @@ lease-shaped, so the swap changes no row.
 | **D19** | `needs-input`                                                   | any            | park                                                                                        | none                                                                                      | write-gated `removeLabel` on the human reply (daemon comment-wake)                                                                                |
 | **D20** | **lease expiry** (the store's own alarm — does not exist today) | any            | the ticket becomes claimable; re-dispatch the same phase. No probe, no `kill -0`.           | none                                                                                      | **the store itself**                                                                                                                              |
 
-**Defaults, so the table is a total function.** A declaration from a phase _behind_ the ticket's
-current phase → **discard**, emitting `phase.advance.held` with reason `stale-declaration` (a dead
-nonce cannot acquire). A declaration on a **terminal** ticket → discard; this subsumes the CTL-758
-backward-write guard (`linear-write.mjs:103-119`) as a table property rather than a special case. An
-**unknown** declaration status → freeze and go loud; never guess.
+**Defaults, so the table is a total function.** A declaration from a phase _behind_ the ticket's current phase → **discard**, emitting `phase.advance.held` with reason `stale-declaration` (a dead nonce cannot acquire). A declaration on a **terminal** ticket → discard; this subsumes the CTL-758 backward-write guard (`linear-write.mjs:103-119`) as a table property rather than a special case. An **unknown** declaration status → freeze and go loud; never guess.
 
-The scheduler's tick-scan **remains** as the convergence backstop, emitting
-`phase.advance.reconciled` — never `applied` — so that `reconciled / (applied + reconciled)` is the
-bus's own loss metric.
+The scheduler's tick-scan **remains** as the convergence backstop, emitting `phase.advance.reconciled` — never `applied` — so that `reconciled / (applied + reconciled)` is the bus's own loss metric.
 
 ### 6.2 PR-stage in-stage subscribers — no stage change occurs
 
-The `pr` / `monitor-merge` / `monitor-deploy` / `teardown` phases all sit at Linear state **PR**
-(§7). Everything that happens during that window is triggered by GitHub, not by a stage change.
+The `pr` / `monitor-merge` / `monitor-deploy` / `teardown` phases all sit at Linear state **PR** (§7). Everything that happens during that window is triggered by GitHub, not by a stage change.
 
 | #      | trigger                                                                                                                    | action (the whole automation)                                                                | who says no?                                                                                                                              |
 | ------ | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
@@ -746,24 +532,19 @@ The `pr` / `monitor-merge` / `monitor-deploy` / `teardown` phases all sit at Lin
 | **P5** | `github.pr.merged`                                                                                                         | **keep checkouts current** (§5 row 1)                                                        | idempotent fetch — convergent                                                                                                             |
 | **P6** | `github.pr.closed` unmerged                                                                                                | publish an escalation (review), release, no auto-dispatch                                        | the label-guard                                                                                                                           |
 
-**P4 and P5 are the §5 row-1/row-5 pair, restated at the PR altitude.** Two subscribers, one event,
-one job each.
+**P4 and P5 are the §5 row-1/row-5 pair, restated at the PR altitude.** Two subscribers, one event, one job each.
 
 ### 6.3 Human / foreign-agent intent — trigger `linear.issue.state_changed`
 
 Every intent gets **HONOUR**, **REWIND**, or **REFUSE-AND-EXPLAIN**. Never silence — rule 5.
 
-State classification is **declared configuration**, not inferred, and matches the measured write-set
-split (the pipeline wrote zero INTENT states in a full month):
+State classification is **declared configuration**, not inferred, and matches the measured write-set split (the pipeline wrote zero INTENT states in a full month):
 
-- **INTENT** = {Backlog, Todo, Triage, Canceled, Duplicate, Ready} — a human telling the system what
-  to do. Inbound changes here are **commands**.
-- **PROGRESS** = {Research, Plan, Implement, Validate, Remediate, PR} — the pipeline's own mirror.
-  Inbound changes here are either **our echo** or a **human rewind**.
+- **INTENT** = {Backlog, Todo, Triage, Canceled, Duplicate, Ready} — a human telling the system what to do. Inbound changes here are **commands**.
+- **PROGRESS** = {Research, Plan, Implement, Validate, Remediate, PR} — the pipeline's own mirror. Inbound changes here are either **our echo** or a **human rewind**.
 - **SHARED** = {Done}.
 - Anything else → H12, freeze and go loud.
-- `Ready` is **archived** (§7a.1 R3) and leaves the INTENT set once the archive lands; until then H1
-  treats it as Todo-equivalent, **loudly**.
+- `Ready` is **archived** (§7a.1 R3) and leaves the INTENT set once the archive lands; until then H1 treats it as Todo-equivalent, **loudly**.
 
 > ### ⭐ 2026-08-13 — PREEMPT is the uniform answer for every in-flight row (§7a.7 R1)
 >
@@ -800,42 +581,19 @@ split (the pipeline wrote zero INTENT states in a full month):
 | **H12** | any state not in the declared partition                           | —          | **freeze + go loud**            | no action; emit `linear.state.unclassified`; label `unknown-state` and raise an ask                                                                          | never guess                                                                                  |
 | **H13** | (human comment on a `needs-input` ticket)                         | yes        | HONOUR                          | clear the label, redispatch (daemon comment-wake, CTL-768)                                                                                              | write-gated removal + `clearDispositionEmit`                                                 |
 
-\*`Ready` is **archived** (R3). Measured: **21** `issue_history.to_state` rows workspace-wide — CTL
-14 (all 2026-05-25) + ADV 7 (all 2026-05-27) — and **zero** issues currently occupy it (positive
-control on the same query: `PR` = 15 live), so the archive strands nothing. Until it lands, H1
-treats it as Todo-equivalent, **loudly**.
+\*`Ready` is **archived** (R3). Measured: **21** `issue_history.to_state` rows workspace-wide — CTL 14 (all 2026-05-25) + ADV 7 (all 2026-05-27) — and **zero** issues currently occupy it (positive control on the same query: `PR` = 15 live), so the archive strands nothing. Until it lands, H1 treats it as Todo-equivalent, **loudly**.
 
-**Every `yes` row's first act is the same, and it is not in the row.** PREEMPT (§7a.7) runs before
-any destination logic: latch `O_EXCL`, inbox + SDK interrupt, ack within `ackGraceMs` 120 s, wrap up
-within `wrapUpBudgetMs` 600 s, push WIP, closure comment, `phase.<P>.abandoned.<T>`. Only then does
-the row fire. A **wedged** worker is killed **by its claim-time `bg_job_id`, never by ticket**, and
-the closure comment is then **infrastructure-authored and attributed as such** — infrastructure
-never speaks as the worker (I2). Failure modes in full: §7a.7.
+**Every `yes` row's first act is the same, and it is not in the row.** PREEMPT (§7a.7) runs before any destination logic: latch `O_EXCL`, inbox + SDK interrupt, ack within `ackGraceMs` 120 s, wrap up within `wrapUpBudgetMs` 600 s, push WIP, closure comment, `phase.<P>.abandoned.<T>`. Only then does the row fire. A **wedged** worker is killed **by its claim-time `bg_job_id`, never by ticket**, and the closure comment is then **infrastructure-authored and attributed as such** — infrastructure never speaks as the worker (I2). Failure modes in full: §7a.7.
 
-**Cancel / reopen, explicitly.** Cancel is H4/H5 — Canceled and Duplicate are INTENT-kill, honoured
-whether or not a worker is live, and the abort is bound to the recorded job id. Reopen is the same
-table read in the other direction: Canceled→Todo is H1 (idle) or H2 (live, rewind-to-start);
-Done→Todo is H2; Done→a PROGRESS stage is H6 (rewind) when the ticket is idle, because a Done ticket
-by definition holds no lease. There is no separate reopen rule.
+**Cancel / reopen, explicitly.** Cancel is H4/H5 — Canceled and Duplicate are INTENT-kill, honoured whether or not a worker is live, and the abort is bound to the recorded job id. Reopen is the same table read in the other direction: Canceled→Todo is H1 (idle) or H2 (live, rewind-to-start); Done→Todo is H2; Done→a PROGRESS stage is H6 (rewind) when the ticket is idle, because a Done ticket by definition holds no lease. There is no separate reopen rule.
 
 ### 6.4 The trigger is not a state machine — name the reconciler
 
-Ryan's own constraint: _"a trigger is not a state machine. If Linear is only the trigger, then
-losing the webhook must not lose the work."_
+Ryan's own constraint: _"a trigger is not a state machine. If Linear is only the trigger, then losing the webhook must not lose the work."_
 
-**Measured, and it is severe for exactly the stages an automation would key on.** The replica
-records **323** CTL state transitions for 2026-08-01→13; mini's event log carries **116** CTL
-`state_changed` events for the same window. The skew is not uniform: Done 62→53 and PR 50→18, but
-Research 37→1, Triage 35→2, Validate 39→1, Plan 39→2, Implement 42→7. Ticket-scoped proof on
-CTL-1774 (a full clean pipeline run, 2026-08-12): the replica shows 8 transitions; the event log
-carries **four** `linear.issue.*` events for that ticket in its entire life — created,
-`state_changed(Todo)`, `assignee_changed`, `state_changed(Done)`. The six intermediate
-daemon-written transitions produced no inbound event of any kind, and they were not misclassified as
-`linear.issue.updated` (there are none for that ticket). CTL-1680 has the identical shape.
+**Measured, and it is severe for exactly the stages an automation would key on.** The replica records **323** CTL state transitions for 2026-08-01→13; mini's event log carries **116** CTL `state_changed` events for the same window. The skew is not uniform: Done 62→53 and PR 50→18, but Research 37→1, Triage 35→2, Validate 39→1, Plan 39→2, Implement 42→7. Ticket-scoped proof on CTL-1774 (a full clean pipeline run, 2026-08-12): the replica shows 8 transitions; the event log carries **four** `linear.issue.*` events for that ticket in its entire life — created, `state_changed(Todo)`, `assignee_changed`, `state_changed(Done)`. The six intermediate daemon-written transitions produced no inbound event of any kind, and they were not misclassified as `linear.issue.updated` (there are none for that ticket). CTL-1680 has the identical shape.
 
-So the intermediate-stage trigger is **~2–5% delivered**, and Done and PR are the only reliably
-delivered ones. This is the direct justification for keying machine edges on the local declaration
-(§6.1) rather than on the Linear echo.
+So the intermediate-stage trigger is **~2–5% delivered**, and Done and PR are the only reliably delivered ones. This is the direct justification for keying machine edges on the local declaration (§6.1) rather than on the Linear echo.
 
 **Which reconcilers exist:**
 
@@ -846,15 +604,11 @@ delivered ones. This is the direct justification for keying machine edges on the
 | **an INTENT command is lost** (a kill that never arrives leaves a worker burning) | a bounded replica-side sweep: "tickets in an INTENT state holding a live claim, and tickets claim-held whose board state is INTENT"                                                                                                    | ⛔ **NO. Must ship with §6.3.** `linear-reconcile-timer.mjs` covers only the projection direction (local phase → Linear), never intent ingestion.                                                                                               |
 | **"in a build stage with no live lease holder"**                                  | —                                                                                                                                                                                                                                      | ⛔ **NO — there is no lease.** The nearest analogues are the scheduler's Pass 0a phantom-worker sweep and the CTL-624 cool-down/circuit-breaker markers, and both reason about worker **directories**, not about a claim anything could refuse. |
 
-**Loss behaviour, both halves.** PROGRESS loss converges via D17/D20 (no scan needed once the lease
-exists; the tick-scan is the backstop until then). **INTENT loss does not converge on its own** — a
-lost kill leaves a worker burning until a human notices.
+**Loss behaviour, both halves.** PROGRESS loss converges via D17/D20 (no scan needed once the lease exists; the tick-scan is the backstop until then). **INTENT loss does not converge on its own** — a lost kill leaves a worker burning until a human notices.
 
 ### 6.5 The trigger→lease→act→mirror sequence, and the two-host race
 
-Because Linear cannot refuse, both hosts receiving the same stage-change webhook **both pass the
-trigger**. That is expected and fine. The lease is acquired after the trigger and before any side
-effect, and exactly one wins.
+Because Linear cannot refuse, both hosts receiving the same stage-change webhook **both pass the trigger**. That is expected and fine. The lease is acquired after the trigger and before any side effect, and exactly one wins.
 
 ```mermaid
 sequenceDiagram
@@ -877,32 +631,14 @@ sequenceDiagram
   Note over L: Linear is written LAST and is never consulted for exclusion
 ```
 
-Read the diagram against the ruling: Linear appears at the top as the trigger and at the bottom as
-the mirror, and **never in the middle**. A design that moves it into the middle is disqualified.
+Read the diagram against the ruling: Linear appears at the top as the trigger and at the bottom as the mirror, and **never in the middle**. A design that moves it into the middle is disqualified.
 
-**The self-echo discriminator.** The bottom arrow is what creates the loop risk once intermediate
-delivery is fixed. Two facts, both verified in source:
+**The self-echo discriminator.** The bottom arrow is what creates the loop risk once intermediate delivery is fixed. Two facts, both verified in source:
 
-1. **The current guard already discriminates on "our own echo", not on "is a bot".**
-   `readLinearBotUserIds` (`daemon.mjs:264-288`) builds a `Set` of exactly three of **our own**
-   app-actor UUIDs — Layer-2 `catalyst.linear.bot.worker.botUserId`, Layer-2
-   `catalyst.linear.bot.orchestrator.botUserId`, and legacy Layer-1
-   `catalyst.monitor.linear.botUserId`. `orch-monitor`'s mirror `loadLinearBotUserIds`
-   (`webhook-config.ts:400-426`) builds the identical set. There is **no** generic is-this-a-bot
-   test anywhere in either path; `actorId` comes straight from `payload.actor.id`
-   (`linear-webhook-events.ts:204`). A third-party agent's app actor (Codex, observed authoring a
-   comment) is not in the set and is not filtered. **The cross-agent-messaging-over-Linear-comments
-   direction is therefore compatible with the guard as written — no re-expression is needed.**
-2. **It nevertheless must be demoted to defence-in-depth**, because it fails **open** on an unknown
-   actor id, and a workspace migration or credential rotation changes those ids silently. The
-   load-bearing discriminator becomes an **echo record**: after each reflection write, record
-   `last_reflected_state` / `last_reflected_at` (on the lease row later; in the worker signal
-   directory now). An inbound `state_changed` matching that record inside a 60s window is our echo
-   (H11/§5 row 16).
+1. **The current guard already discriminates on "our own echo", not on "is a bot".** `readLinearBotUserIds` (`daemon.mjs:264-288`) builds a `Set` of exactly three of **our own** app-actor UUIDs — Layer-2 `catalyst.linear.bot.worker.botUserId`, Layer-2 `catalyst.linear.bot.orchestrator.botUserId`, and legacy Layer-1 `catalyst.monitor.linear.botUserId`. `orch-monitor`'s mirror `loadLinearBotUserIds` (`webhook-config.ts:400-426`) builds the identical set. There is **no** generic is-this-a-bot test anywhere in either path; `actorId` comes straight from `payload.actor.id` (`linear-webhook-events.ts:204`). A third-party agent's app actor (Codex, observed authoring a comment) is not in the set and is not filtered. **The cross-agent-messaging-over-Linear-comments direction is therefore compatible with the guard as written — no re-expression is needed.**
+2. **It nevertheless must be demoted to defence-in-depth**, because it fails **open** on an unknown actor id, and a workspace migration or credential rotation changes those ids silently. The load-bearing discriminator becomes an **echo record**: after each reflection write, record `last_reflected_state` / `last_reflected_at` (on the lease row later; in the worker signal directory now). An inbound `state_changed` matching that record inside a 60s window is our echo (H11/§5 row 16).
 
-Note the guard's scope: `linear-webhook-handler.ts:386-397` suppresses on `kind === "issue"`, which
-**includes** `state_changed` and **excludes** comments — which is exactly why bot comments still
-reach the log and are filtered later, and exactly what the comments-as-messaging direction needs.
+Note the guard's scope: `linear-webhook-handler.ts:386-397` suppresses on `kind === "issue"`, which **includes** `state_changed` and **excludes** comments — which is exactly why bot comments still reach the log and are filtered later, and exactly what the comments-as-messaging direction needs.
 
 > **INCONCLUSIVE, and stated as such.** Whether that guard actually _fires_ on our own state writes
 > could not be separated from Linear never delivering an OAuth app's own mutations back to that app.
@@ -924,19 +660,9 @@ reach the log and are filtered later, and exactly what the comments-as-messaging
 
 ## 7. The many-to-one collapse
 
-**Stated plainly: the phase→Linear-state map is many-to-one, and a `(from_state, to_state)` tuple
-therefore cannot identify a phase edge.** Four of the ten pipeline advances produce no observable
-Linear state change at all.
+**Stated plainly: the phase→Linear-state map is many-to-one, and a `(from_state, to_state)` tuple therefore cannot identify a phase edge.** Four of the ten pipeline advances produce no observable Linear state change at all.
 
-The chain is four hops through one bash chokepoint. Phase→key is declared as data in
-`plugins/dev/scripts/lib/workflow.default.json` (each step's `linearKey`), derived into
-`PHASE_LINEAR_KEY` by `lib/workflow-descriptor.mjs:44-46`, re-exported by `lib/phase-fsm.mjs:25-32`,
-and accessed via `linearKeyForPhase()` (`phase-fsm.mjs:84-89`, which **throws** on an unknown phase
-rather than silently no-opping). Key→write is
-`execution-core/linear-write.mjs:163-167 applyPhaseStatus`. Key→state-name is
-`plugins/dev/scripts/linear-transition.sh:112-144` (note: **not** under `lib/`), precedence
-`--state` > per-project stateMap > `catalyst.linear.stateMap` > registry `triageStatus` > built-in
-default.
+The chain is four hops through one bash chokepoint. Phase→key is declared as data in `plugins/dev/scripts/lib/workflow.default.json` (each step's `linearKey`), derived into `PHASE_LINEAR_KEY` by `lib/workflow-descriptor.mjs:44-46`, re-exported by `lib/phase-fsm.mjs:25-32`, and accessed via `linearKeyForPhase()` (`phase-fsm.mjs:84-89`, which **throws** on an unknown phase rather than silently no-opping). Key→write is `execution-core/linear-write.mjs:163-167 applyPhaseStatus`. Key→state-name is `plugins/dev/scripts/linear-transition.sh:112-144` (note: **not** under `lib/`), precedence `--state` > per-project stateMap > `catalyst.linear.stateMap` > registry `triageStatus` > built-in default.
 
 | #     | phase                 | stateMap key | CTL state    | collapse                                                                                                                                                                                             |
 | ----- | --------------------- | ------------ | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -963,64 +689,32 @@ default.
 > regression. **The lossy projection §7 defends on board-design grounds turns out to be the enabling
 > property for deleting the tail.** COLLAPSE A (verify/review → Validate) is untouched.
 
-**Measured on mini, 2026-08** (structured JSON parse of `attributes["event.name"]` matching prefix
-`linear.state.write.`, comparing `from_state` vs `to_state` — never substring-grepped):
+**Measured on mini, 2026-08** (structured JSON parse of `attributes["event.name"]` matching prefix `linear.state.write.`, comparing `from_state` vs `to_state` — never substring-grepped):
 
 - `review`: **48 of 49** writes were Validate→Validate no-ops.
 - `monitor-merge`: **44 of 47** were PR→PR no-ops.
 - `monitor-deploy`: 46 of 66 PR→PR no-ops, 19 more refused by the backward-write guard.
 - `teardown`: 47 no-ops (28 PR→PR, 19 Done→Done), 12 guard-refused, 10 genuine PR→Done.
-- The 1:1 phases moved as expected: verify Implement→Validate 48, pr Validate→PR 46, plan
-  Research→Plan 45, implement Plan→Implement 45, research Triage→Research 41, remediate
-  Validate→Remediate 13.
+- The 1:1 phases moved as expected: verify Implement→Validate 48, pr Validate→PR 46, plan Research→Plan 45, implement Plan→Implement 45, research Triage→Research 41, remediate Validate→Remediate 13.
 
 **185 no-op writes in one month**, each a bash subprocess round-trip that changes nothing.
 
 **Two traps in the current telemetry, both load-bearing for anyone keying off it:**
 
-1. **`applied: true` does not mean the state moved.** `linear-transition.sh:217-220` emits
-   `action="skipped"` and exits 0 for an already-in-target write, and `linear-write.mjs:144`
-   computes `applied = code === 0 && action !== "update-failed"`. **The only reliable no-op
-   discriminator in the emitted event is `from_state === to_state`.**
-2. **`phase-fsm.mjs:68-69`'s comment is stale.** It says the terminal Done is written "on
-   monitor-deploy completion"; CTL-703 moved `TERMINAL_PHASE` to **teardown**
-   (`workflow.default.json:7 "terminalStep": "teardown"`). `scheduler.mjs:8085-8087` flags the
-   correction in-code; the fsm comment was never updated.
+1. **`applied: true` does not mean the state moved.** `linear-transition.sh:217-220` emits `action="skipped"` and exits 0 for an already-in-target write, and `linear-write.mjs:144` computes `applied = code === 0 && action !== "update-failed"`. **The only reliable no-op discriminator in the emitted event is `from_state === to_state`.**
+2. **`phase-fsm.mjs:68-69`'s comment is stale.** It says the terminal Done is written "on monitor-deploy completion"; CTL-703 moved `TERMINAL_PHASE` to **teardown** (`workflow.default.json:7 "terminalStep": "teardown"`). `scheduler.mjs:8085-8087` flags the correction in-code; the fsm comment was never updated.
 
 ### The resolution
 
-**Key machine edges on the declaration, not on the tuple.** `(declaration, phase)` — §6.1 — is
-unique by construction, so there is nothing to disambiguate. The four invisible edges (D5, D11, D12,
-D13) become **stated** empty-reflection rows rather than a discovery someone makes at 2 a.m. The
-daemon _already emits_ the exact phase-keyed discriminator this needs and nothing reads it:
-`linear.state.write.<T>` carries `{phase, transition_key, from_state, to_state, applied, source}`
-(`linear-state-write-event.mjs:75-99`), and `phase.advance.applied.<T>` carries
-`{from, to, evidence, evidence_reason, asserted_by}`.
+**Key machine edges on the declaration, not on the tuple.** `(declaration, phase)` — §6.1 — is unique by construction, so there is nothing to disambiguate. The four invisible edges (D5, D11, D12, D13) become **stated** empty-reflection rows rather than a discovery someone makes at 2 a.m. The daemon _already emits_ the exact phase-keyed discriminator this needs and nothing reads it: `linear.state.write.<T>` carries `{phase, transition_key, from_state, to_state, applied, source}` (`linear-state-write-event.mjs:75-99`), and `phase.advance.applied.<T>` carries `{from, to, evidence, evidence_reason, asserted_by}`.
 
-**The collapse is kept.** It is a deliberate lossy projection of a value that is authoritative
-elsewhere — the board shows a human where the ticket is, at board granularity; the pipeline knows
-where it is, at pipeline granularity. Adding `Review` and `Deploy` states would re-couple board
-granularity to the pipeline and touch every saved view across 9 registered teams. If sub-phase
-visibility inside Validate/PR is wanted, the cheap options are a single-valued `phase:<name>` Linear
-label group (ADR-026's mechanism) or a link to the orch-monitor journey view — see §9.3.
+**The collapse is kept.** It is a deliberate lossy projection of a value that is authoritative elsewhere — the board shows a human where the ticket is, at board granularity; the pipeline knows where it is, at pipeline granularity. Adding `Review` and `Deploy` states would re-couple board granularity to the pipeline and touch every saved view across 9 registered teams. If sub-phase visibility inside Validate/PR is wanted, the cheap options are a single-valued `phase:<name>` Linear label group (ADR-026's mechanism) or a link to the orch-monitor journey view — see §9.3.
 
-**A correction to a premise that circulated with this finding.** "Triage / Research / Plan / Todo
-appear in the map but are not in live use" is **false**; the current-snapshot zero is a throughput
-artifact (tickets pass through in minutes), not absence. Transitions _into_ each state on CTL over
-the last 14 days: Done 78, PR 60, Implement 52, **Plan 42**, Validate 41, **Research 40**, **Triage
-37**, **Todo 11**, Remediate 5, Canceled 3, Backlog 3. The right instrument is
-`issue_history.to_state` in the replica (9,907 populated rows), not `DISTINCT issues.state` — the
-replica has **no** `workflow_states` table (verified: `.tables` lists 19, none of them states).
-All-time `to_state` also reveals two states the stateMap does not name: **Ready** (14 transitions,
-all 2026-05-25) and **Duplicate** (4 live issues, present in `monitor.mjs:166 DRAG_OUT_STATES` and
-`linear-transition.sh:52` but with no stateMap key). The actual CTL state set is 13; the stateMap
-names 12.
+**A correction to a premise that circulated with this finding.** "Triage / Research / Plan / Todo appear in the map but are not in live use" is **false**; the current-snapshot zero is a throughput artifact (tickets pass through in minutes), not absence. Transitions _into_ each state on CTL over the last 14 days: Done 78, PR 60, Implement 52, **Plan 42**, Validate 41, **Research 40**, **Triage 37**, **Todo 11**, Remediate 5, Canceled 3, Backlog 3. The right instrument is `issue_history.to_state` in the replica (9,907 populated rows), not `DISTINCT issues.state` — the replica has **no** `workflow_states` table (verified: `.tables` lists 19, none of them states). All-time `to_state` also reveals two states the stateMap does not name: **Ready** (14 transitions, all 2026-05-25) and **Duplicate** (4 live issues, present in `monitor.mjs:166 DRAG_OUT_STATES` and `linear-transition.sh:52` but with no stateMap key). The actual CTL state set is 13; the stateMap names 12.
 
 ## 7a. The pipeline tail becomes subscribers (2026-08-13 decisions)
 
-Ryan ruled on the pipeline tail on 2026-08-13. The rulings are recorded here as **data, not
-proposals**. They supersede §6.1 rows **D11–D14**, absorb §6.2 rows **P1–P6** as the implementation
-rather than as a companion to a phase, and close §9.1, the first half of §9.2, §9.4 and §9.6.
+Ryan ruled on the pipeline tail on 2026-08-13. The rulings are recorded here as **data, not proposals**. They supersede §6.1 rows **D11–D14**, absorb §6.2 rows **P1–P6** as the implementation rather than as a companion to a phase, and close §9.1, the first half of §9.2, §9.4 and §9.6.
 
 ### 7a.1 The seven rulings
 
@@ -1034,16 +728,11 @@ rather than as a companion to a phase, and close §9.1, the first half of §9.2,
 | **R6** | **`monitor-deploy` stops being a phase agent** → an async subscriber. Conditional, verbatim: _"not everything will have a cloud deploy … We'd have to figure out and plan for cases in which there is no deployment step."_                                                                                             | §7a.6                                                                                           |
 | **R7** | **`teardown` is durable-host-only** → an optional step.                                                                                                                                                                                                                                                                 | ⛔ **not optional as written** — teardown is the sole originating authority for Done. See §7a.5 |
 
-**Measured, for R3.** `Ready` has **21** `issue_history.to_state` rows workspace-wide — **CTL 14**
-(all 2026-05-25) and **ADV 7** (all 2026-05-27). §7's "14 transitions" is the CTL-scoped count and
-is not wrong; the workspace-scoped count is 21, and archiving the state touches a **second team**.
-**Zero issues currently sit in `Ready`** (positive control on the same query: `PR` = 15 live), so no
-ticket is stranded by the archive.
+**Measured, for R3.** `Ready` has **21** `issue_history.to_state` rows workspace-wide — **CTL 14** (all 2026-05-25) and **ADV 7** (all 2026-05-27). §7's "14 transitions" is the CTL-scoped count and is not wrong; the workspace-scoped count is 21, and archiving the state touches a **second team**. **Zero issues currently sit in `Ready`** (positive control on the same query: `PR` = 15 live), so no ticket is stranded by the archive.
 
 ### 7a.2 The structural fact that makes R5/R6/R7 cheap — verified first-hand, not inherited
 
-All four tail phases map to **one** Linear state, so deleting three of them costs **zero** board
-granularity: the ticket sits in `PR` from the `pr` phase until `Done` either way.
+All four tail phases map to **one** Linear state, so deleting three of them costs **zero** board granularity: the ticket sits in `PR` from the `pr` phase until `Done` either way.
 
 | descriptor row                                                                           | `linearKey` | CTL state |
 | ---------------------------------------------------------------------------------------- | ----------- | --------- |
@@ -1052,14 +741,9 @@ granularity: the ticket sits in `PR` from the `pr` phase until `Done` either way
 | `workflow.default.json:67` `{"id":"monitor-deploy","rank":9,"preemptable":false,…}`      | `inReview`  | **PR**    |
 | `workflow.default.json:68` `{"id":"teardown","rank":10,"preemptable":false,"next":null}` | `inReview`  | **PR**    |
 
-Resolution chain, unchanged from §7: `linear-write.mjs:163-167 applyPhaseStatus` →
-`linearKeyForPhase()` (`phase-fsm.mjs:84-89`) → `PHASE_LINEAR_KEY` (`workflow-descriptor.mjs:44-46`)
-→ `linear-transition.sh:112-144` resolves `inReview` against `.catalyst.linear.stateMap` → `"PR"`.
-`phase-fsm.mjs:68-69` already says it in prose.
+Resolution chain, unchanged from §7: `linear-write.mjs:163-167 applyPhaseStatus` → `linearKeyForPhase()` (`phase-fsm.mjs:84-89`) → `PHASE_LINEAR_KEY` (`workflow-descriptor.mjs:44-46`) → `linear-transition.sh:112-144` resolves `inReview` against `.catalyst.linear.stateMap` → `"PR"`. `phase-fsm.mjs:68-69` already says it in prose.
 
-**R4 is what makes R5/R6/R7 free.** Had the board been widened with `Review`/`Merge` states — R4's
-rejected alternative — every deleted phase would have been a visible board regression. The collapse
-ADR-029 kept is precisely the property that makes deleting the tail cost nothing.
+**R4 is what makes R5/R6/R7 free.** Had the board been widened with `Review`/`Merge` states — R4's rejected alternative — every deleted phase would have been a visible board regression. The collapse ADR-029 kept is precisely the property that makes deleting the tail cost nothing.
 
 ### 7a.3 The phase list — before → after
 
@@ -1076,28 +760,15 @@ ADR-029 kept is precisely the property that makes deleting the tail cost nothing
 | 9   | monitor-deploy | — **deleted**     | R6 → deploy-watcher, registered per repo (§7a.6)                                                                                                                                                                   |
 | 10  | teardown       | — **deleted**     | R7 → done-writer + the already-shipped reaper (§7a.5)                                                                                                                                                              |
 
-**Descriptor edits:** delete `workflow.default.json:66-68`; set `:65` `"next": null`; move
-`"terminalStep"` (`:8`) from `teardown` to `pr`. `KNOWN_PHASES` (`namespace-contract.mjs:36-47`)
-goes 10 → 7, enforced in the same PR across all three parity surfaces
-(`broker/namespace-parity.test.mjs`, `orch-monitor/__tests__/namespace-parity.test.ts`,
-`execution-core/assertion-evidence-parity.test.mjs`).
+**Descriptor edits:** delete `workflow.default.json:66-68`; set `:65` `"next": null`; move `"terminalStep"` (`:8`) from `teardown` to `pr`. `KNOWN_PHASES` (`namespace-contract.mjs:36-47`) goes 10 → 7, enforced in the same PR across all three parity surfaces (`broker/namespace-parity.test.mjs`, `orch-monitor/__tests__/namespace-parity.test.ts`, `execution-core/assertion-evidence-parity.test.mjs`).
 
-⛔ **`terminalStep` is not a rename.** `scheduler.mjs:8092` gates the Done write on
-`signals[TERMINAL_PHASE] === "done"`. Repointing `TERMINAL_PHASE` at `pr` without §7a.5 would make
-Done fire when the PR **opens**. Done must be re-homed **before** the descriptor moves, not with it.
+⛔ **`terminalStep` is not a rename.** `scheduler.mjs:8092` gates the Done write on `signals[TERMINAL_PHASE] === "done"`. Repointing `TERMINAL_PHASE` at `pr` without §7a.5 would make Done fire when the PR **opens**. Done must be re-homed **before** the descriptor moves, not with it.
 
-⚠ **`NON_PREEMPTABLE_PHASES` shrinks 3 → 1.** It is derived from `preemptable:false`
-(`workflow-descriptor.mjs:59-61`) and today holds `{triage, monitor-deploy, teardown}`. Deleting two
-of them leaves `{triage}`. Consumers: `scheduler.mjs:7014` (slot preemption),
-`fsm-descriptor.mjs:25`, and a contract test that deep-equals the orch-monitor endpoint's
-`nonPreemptable` array (`orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts:97-100`)
-— all three must move together.
+⚠ **`NON_PREEMPTABLE_PHASES` shrinks 3 → 1.** It is derived from `preemptable:false` (`workflow-descriptor.mjs:59-61`) and today holds `{triage, monitor-deploy, teardown}`. Deleting two of them leaves `{triage}`. Consumers: `scheduler.mjs:7014` (slot preemption), `fsm-descriptor.mjs:25`, and a contract test that deep-equals the orch-monitor endpoint's `nonPreemptable` array (`orch-monitor/__tests__/governance-fsm-descriptor.contract.test.ts:97-100`) — all three must move together.
 
 ### 7a.4 The re-homing table
 
-Every responsibility that lives in the three deleted skills, and where it goes. **Nothing on this
-list is dropped**; the ones with no owner today are marked ⛔ and are the reason the collapse ships
-_with_ its subscribers, not before them.
+Every responsibility that lives in the three deleted skills, and where it goes. **Nothing on this list is dropped**; the ones with no owner today are marked ⛔ and are the reason the collapse ships _with_ its subscribers, not before them.
 
 | responsibility                                                                                                                                                                                                                         | subscriber                                                                                                                                                                                                   | trigger                                                                                                                                      | who says no?                                                                                                                                        | what goes loud                                                                                                                                                                  |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1119,18 +790,11 @@ _with_ its subscribers, not before them.
 | **Deploy watch, canary, preview-URL comment** (`phase-monitor-deploy/SKILL.md:319-360`)                                                                                                                                                | **deploy-watcher**, only where a repo registers a deploy (§7a.6); canary **rebuilt, not ported**                                                                                                             | `github.deployment_status.*` matched on `(mergeSHA, env)`                                                                                    | per-`(sha, env)` dedupe                                                                                                                             | `deploy.overdue`; `catalyst doctor` WARNs **both** directions (declared-but-silent, emitting-but-undeclared)                                                                    |
 | **The level-triggered backstop** (§6.4's missing reconciler, at the PR altitude)                                                                                                                                                       | **reconciler sweep** (extends `linear-reconcile-cli.mjs` / the daemon tick)                                                                                                                                  | timer — the one deliberate, bounded poll                                                                                                     | it **is** the refusal of silence                                                                                                                    | its four gauges: mergeable-unmerged, BEHIND-age, merged-without-Done, failing-check-without-attempt                                                                             |
 
-**Why a reconciler is not optional here.** Machine-written Linear transitions deliver at 3–36%
-(§6.4) and provider→log ingest is single-homed at-most-once smee with three recorded loss incidents.
-An edge-triggered-only tail dies **silently**, which is exactly how monitor-merge's broker-interest
-path already died (§4/§6.2: `router.mjs:2831 if (!interests.size) return;`, zero `filter.*` events
-in 2026-08). Subscribers everywhere, **plus exactly one authoritative reconciler per external source
-of truth**.
+**Why a reconciler is not optional here.** Machine-written Linear transitions deliver at 3–36% (§6.4) and provider→log ingest is single-homed at-most-once smee with three recorded loss incidents. An edge-triggered-only tail dies **silently**, which is exactly how monitor-merge's broker-interest path already died (§4/§6.2: `router.mjs:2831 if (!interests.size) return;`, zero `filter.*` events in 2026-08). Subscribers everywhere, **plus exactly one authoritative reconciler per external source of truth**.
 
 ### 7a.5 Who writes Done, and on what evidence (I6)
 
-**Today teardown is the sole originating authority for Done, and every automated Done writer is
-downstream of its declaration.** The four writers, enumerated by `applyTerminalDone` call sites plus
-the skill's own transition:
+**Today teardown is the sole originating authority for Done, and every automated Done writer is downstream of its declaration.** The four writers, enumerated by `applyTerminalDone` call sites plus the skill's own transition:
 
 | writer                                                                       | gate                                                                                                        |
 | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -1139,17 +803,9 @@ the skill's own transition:
 | `scheduler.mjs:3816 reconcileTerminalBackstop`                               | drift only, behind the CTL-863 stale-fence guard (`:3810`)                                                  |
 | `linear-reconcile-cli.mjs:263-268` (`kind === "done"`)                       | the correction `linear-reconcile.mjs` proposes from the **local phase signals** — teardown's signal again   |
 
-**Making teardown "optional" (R7) without re-homing `phase-teardown/SKILL.md:332-335` makes Done
-optional.** That is the one place the rulings must be read as a re-homing instruction rather than a
-deletion instruction.
+**Making teardown "optional" (R7) without re-homing `phase-teardown/SKILL.md:332-335` makes Done optional.** That is the one place the rulings must be read as a re-homing instruction rather than a deletion instruction.
 
-⛔ **One inherited claim corrected.** It was reported that `linear-reconcile-cli.mjs:268` consumes a
-`.teardown-complete` marker dropped at `SKILL.md:382`. It does not. The marker is written at
-`phase-teardown/SKILL.md:585-586` and its only consumer is
-`reconstruct-ticket-state.mjs:103 ARCHIVE_TERMINAL_MARKER` (positive control: `grep` finds 7 other
-`teardown` hits in `linear-reconcile-cli.mjs`, so the instrument was not blind). **The collapse must
-therefore re-home two independent things, not one:** the Done write _and_ the archive terminal
-marker that cross-host reconstruction reads.
+⛔ **One inherited claim corrected.** It was reported that `linear-reconcile-cli.mjs:268` consumes a `.teardown-complete` marker dropped at `SKILL.md:382`. It does not. The marker is written at `phase-teardown/SKILL.md:585-586` and its only consumer is `reconstruct-ticket-state.mjs:103 ARCHIVE_TERMINAL_MARKER` (positive control: `grep` finds 7 other `teardown` hits in `linear-reconcile-cli.mjs`, so the instrument was not blind). **The collapse must therefore re-home two independent things, not one:** the Done write _and_ the archive terminal marker that cross-host reconstruction reads.
 
 **The done-writer, in order. Each step can refuse; none is inferred.**
 
@@ -1161,67 +817,28 @@ marker that cross-host reconstruction reads.
 | 4    | **Write** — `applyTerminalDone` (`linear-write.mjs:173`) via `linear-transition.sh`, then the CTL-1371 completion declaration                | `phase-teardown/SKILL.md:332-335`                           | reconciler re-fires                                                                                |
 | 5    | **Emit `ticket.done.<T>`** — the fan-out point for the scribe and cleanup                                                                    | new                                                         | scribe never runs → gauge                                                                          |
 
-**The open-PR enumerator stays alarm-not-block.** `defaultCheckOpenPrs` supplies facts for the
-`recovery.done-applied-with-open-pr` alarm; it is **not** a refuse-gate — `scheduler.mjs:155` says
-so in-code ("NOT a refuse-gate (THE REVERSAL)", CTL-1157). Step 2 is the refusal; step 2 is I6.
-`terminalDoneOnce` survives as the drift backstop, re-keyed from `signals[TERMINAL_PHASE]` to the
-merge-evidence marker.
+**The open-PR enumerator stays alarm-not-block.** `defaultCheckOpenPrs` supplies facts for the `recovery.done-applied-with-open-pr` alarm; it is **not** a refuse-gate — `scheduler.mjs:155` says so in-code ("NOT a refuse-gate (THE REVERSAL)", CTL-1157). Step 2 is the refusal; step 2 is I6. `terminalDoneOnce` survives as the drift backstop, re-keyed from `signals[TERMINAL_PHASE]` to the merge-evidence marker.
 
-**I6 read the other way:** a prematurely-Done ticket is **re-admissible**. A post-Done deploy or
-canary failure is a new bounded remediation against a Done ticket, not a silent revert — see
-§7a.9(3).
+**I6 read the other way:** a prematurely-Done ticket is **re-admissible**. A post-Done deploy or canary failure is a new bounded remediation against a Done ticket, not a silent revert — see §7a.9(3).
 
 ### 7a.6 The no-deploy rule (R6's conditional)
 
-**"No deployment step" is not an edge case — it is the measured majority.** Across all 85 archived
-`phase-monitor-deploy.json` on mini: `skipped` **47**, `success` **4**, absent 34. Mini's entire
-2026-08 event log — **1,117,980 events** on 2026-08-13, parsed as JSON per line with the name read
-as `attributes["event.name"] ?? event`, never substring-grepped — contains **ZERO**
-`github.deployment_status.success`. **Positive controls on the same pass:**
-`github.deployment_status.failure` = 4, `.in_progress` = 4, `github.deployment.created` = 4 (the
-instrument sees deployment events when they exist) and `recovery.tick` = 326,940 (the parse reached
-the whole file).
+**"No deployment step" is not an edge case — it is the measured majority.** Across all 85 archived `phase-monitor-deploy.json` on mini: `skipped` **47**, `success` **4**, absent 34. Mini's entire 2026-08 event log — **1,117,980 events** on 2026-08-13, parsed as JSON per line with the name read as `attributes["event.name"] ?? event`, never substring-grepped — contains **ZERO** `github.deployment_status.success`. **Positive controls on the same pass:** `github.deployment_status.failure` = 4, `.in_progress` = 4, `github.deployment.created` = 4 (the instrument sees deployment events when they exist) and `recovery.tick` = 326,940 (the parse reached the whole file).
 
 **The rule.** Deployment is **declared, never waited for.**
 
-- A repo either **registers a deploy** in its config (`catalyst.deploy = {environment, verifier}`,
-  reached through the D9 `registry.mjs` seam) or it does not.
-- **Not registered** → `catalyst.merge.resolved.<T>` fans out to done-writer, scribe and cleanup,
-  and **no deploy subscriber exists**. The honest encoding is "no deploy subscriber registered for
-  this repo" — **not a 1,800 s wait that expires** (`phase-monitor-deploy/SKILL.md:115`,`:155-166`).
-- **Registered** → the deploy-watcher stays subscribed on `(mergeSHA, environment)` until a
-  **terminal** `deployment_status` arrives. This deletes a known-wrong shortcut for free: the
-  current non-terminal branch (`SKILL.md:264-271`) treats `pending`/`in_progress` as **failed**,
-  self-described as "mainly defensive … future work can re-enter the wait loop instead" — a one-shot
-  agent cannot re-subscribe; a subscriber never had to.
-- **`catalyst doctor` grades both directions**: declared-but-silent (registered, no
-  `deployment_status` in N days) → WARN; emitting-but-undeclared (deployment events for an
-  unregistered repo) → WARN. Neither can be a `count == 0` Loki rule — §8.
+- A repo either **registers a deploy** in its config (`catalyst.deploy = {environment, verifier}`, reached through the D9 `registry.mjs` seam) or it does not.
+- **Not registered** → `catalyst.merge.resolved.<T>` fans out to done-writer, scribe and cleanup, and **no deploy subscriber exists**. The honest encoding is "no deploy subscriber registered for this repo" — **not a 1,800 s wait that expires** (`phase-monitor-deploy/SKILL.md:115`,`:155-166`).
+- **Registered** → the deploy-watcher stays subscribed on `(mergeSHA, environment)` until a **terminal** `deployment_status` arrives. This deletes a known-wrong shortcut for free: the current non-terminal branch (`SKILL.md:264-271`) treats `pending`/`in_progress` as **failed**, self-described as "mainly defensive … future work can re-enter the wait loop instead" — a one-shot agent cannot re-subscribe; a subscriber never had to.
+- **`catalyst doctor` grades both directions**: declared-but-silent (registered, no `deployment_status` in N days) → WARN; emitting-but-undeclared (deployment events for an unregistered repo) → WARN. Neither can be a `count == 0` Loki rule — §8.
 
-**Canary is unbuilt (I11), and is rebuilt rather than ported.** The default `CANARY_CMD`
-(`SKILL.md:117`,`:274-293`) targets a skill that **cannot run**:
-`~/.claude/skills/gstack/canary/SKILL.md:664-679` hard-requires
-`$HOME/.claude/skills/gstack/browse/dist/browse`, and that directory is **absent** (positive
-control: siblings `gstack/canary` and `gstack/review` both resolve; the global CLAUDE.md records the
-`browse` skill deleted 2026-08-03 and names `canary` among the skills that will not run). Exactly
-**3** `canary-output.json` files exist anywhere under `~/catalyst` on mini, all agent-hand-authored
-HTTP/health probes — one literally records
-`"method": "direct-verification (no github deployment_status; wrangler deploy on push-to-main)"`,
-which proves it did **not** come from the deterministic body. Post-deploy verification is worth
-keeping **as a concept**; nothing in the current implementation is worth preserving.
+**Canary is unbuilt (I11), and is rebuilt rather than ported.** The default `CANARY_CMD` (`SKILL.md:117`,`:274-293`) targets a skill that **cannot run**: `~/.claude/skills/gstack/canary/SKILL.md:664-679` hard-requires `$HOME/.claude/skills/gstack/browse/dist/browse`, and that directory is **absent** (positive control: siblings `gstack/canary` and `gstack/review` both resolve; the global CLAUDE.md records the `browse` skill deleted 2026-08-03 and names `canary` among the skills that will not run). Exactly **3** `canary-output.json` files exist anywhere under `~/catalyst` on mini, all agent-hand-authored HTTP/health probes — one literally records `"method": "direct-verification (no github deployment_status; wrangler deploy on push-to-main)"`, which proves it did **not** come from the deterministic body. Post-deploy verification is worth keeping **as a concept**; nothing in the current implementation is worth preserving.
 
 ### 7a.7 PREEMPT — the uniform answer to human intent on a live worker (R1)
 
-R1 generalizes §9.1's single question into a protocol that applies to **every** state, and it
-resolves the §6.3 in-flight rows uniformly: **preempt the worker, then let the destination state
-decide.** The departing worker's only job is to stop cleanly and say what it did.
+R1 generalizes §9.1's single question into a protocol that applies to **every** state, and it resolves the §6.3 in-flight rows uniformly: **preempt the worker, then let the destination state decide.** The departing worker's only job is to stop cleanly and say what it did.
 
-⚠ **NAME COLLISION, and it is real.** CTL-705 already ships a **slot** preemption that emits
-`phase.<P>.preempted.<T>` and `phase.<P>.resumed-after-preemption.<T>` (`recovery.mjs:1184-1216`,
-gated at `scheduler.mjs:7014`), where `preempted_by` is _the ticket that took the slot_ and the
-worker is **resumable**. Human-intent preemption is **terminal** and has a different actor. The two
-must not share a name. This protocol uses `worker.preempt.*` for its own lifecycle and reuses the
-shipped terminal for the exit.
+⚠ **NAME COLLISION, and it is real.** CTL-705 already ships a **slot** preemption that emits `phase.<P>.preempted.<T>` and `phase.<P>.resumed-after-preemption.<T>` (`recovery.mjs:1184-1216`, gated at `scheduler.mjs:7014`), where `preempted_by` is _the ticket that took the slot_ and the worker is **resumable**. Human-intent preemption is **terminal** and has a different actor. The two must not share a name. This protocol uses `worker.preempt.*` for its own lifecycle and reuses the shipped terminal for the exit.
 
 **The protocol.**
 
@@ -1292,90 +909,42 @@ shipped terminal for the exit.
 | Dead thoughts rows               | 2 `THOUGHTS_DIRS` entries (`reconstruct-ticket-state.mjs:29-30`) + the tail thoughts-doc writes — measured **2 / 3 / 4** files for monitor-merge / monitor-deploy / pr against a **697 / 636** positive control (research / plans). Reconstruction re-keys on `ticket.done.<T>` + the merge evidence.              |
 | Per-agent envelopes              | ×3 (comms join/send, `catalyst-session.sh start` — whose `session_metrics`/`session_tools` writers measure **0 rows** on this dispatch path anyway, per `docs/architecture.md`)                                                                                                                                    |
 
-⛔ **One deletion that is actually a move.** Idempotency markers currently live in the worker
-directory, which the reaper destroys shortly after merge. Every post-merge marker
-(`.linear-mirror-*`, compound-log, retro) must relocate to `~/catalyst/archives/<T>/` **before** the
-worker dir becomes reapable, or a replayed `github.pr.merged` double-posts.
+⛔ **One deletion that is actually a move.** Idempotency markers currently live in the worker directory, which the reaper destroys shortly after merge. Every post-merge marker (`.linear-mirror-*`, compound-log, retro) must relocate to `~/catalyst/archives/<T>/` **before** the worker dir becomes reapable, or a replayed `github.pr.merged` double-posts.
 
 ### 7a.9 What these rulings do NOT settle
 
-1. **Per-repo `doneGate:"deploy"`.** Done-at-merge is the ratified default. Does any repo get to
-   gate Done on `deployment_status.success` — an event with **zero** measured occurrences?
-2. **Preempt budgets.** `ackGraceMs` 120 s / `wrapUpBudgetMs` 600 s are proposed defaults. Per-phase
-   overrides in the descriptor?
-3. **Re-admission after a post-Done deploy/canary failure.** Auto re-admit (I6's "prematurely-Done
-   is re-admissible") or file a fresh linked ticket? New machinery either way.
+1. **Per-repo `doneGate:"deploy"`.** Done-at-merge is the ratified default. Does any repo get to gate Done on `deployment_status.success` — an event with **zero** measured occurrences?
+2. **Preempt budgets.** `ackGraceMs` 120 s / `wrapUpBudgetMs` 600 s are proposed defaults. Per-phase overrides in the descriptor?
+3. **Re-admission after a post-Done deploy/canary failure.** Auto re-admit (I6's "prematurely-Done is re-admissible") or file a fresh linked ticket? New machinery either way.
 4. **The scribe's model tier and batching.** One `claude --bg` job per merge, or per N merges?
-5. **The reviewer-arrival window (300 s today)** once it is event-driven: keep it as the
-   reconciler's `no-verdict-on-head` threshold, or drop it and rely on the unresolved-thread gate
-   alone?
-6. **Reconciler cadence and authority** — gauge-only forever, or allowed to re-fire missing edges
-   (proposed), and the T threshold per gauge.
+5. **The reviewer-arrival window (300 s today)** once it is event-driven: keep it as the reconciler's `no-verdict-on-head` threshold, or drop it and rely on the unresolved-thread gate alone?
+6. **Reconciler cadence and authority** — gauge-only forever, or allowed to re-fire missing edges (proposed), and the T threshold per gauge.
 
 ## 8. What is NOT automated, and why
 
-**If it needs a decision, it is not this automation.** Every row above is a bounded action with a
-deterministic path and a loud refusal. The following are deliberately excluded, and each exclusion
-is a rule, not an omission:
+**If it needs a decision, it is not this automation.** Every row above is a bounded action with a deterministic path and a loud refusal. The following are deliberately excluded, and each exclusion is a rule, not an omission:
 
-- **Anything whose deterministic path is not genuinely deterministic** (rule 3). The checkout
-  fast-forward automates exactly one shape — clean, on the default branch, upstream resolvable — and
-  refuses seven named others rather than guessing. A "usually works" path is not a deterministic
-  path.
-- **Product-scope judgement.** Whether a ticket should exist, what it should say, whether a finding
-  is worth fixing at all. The delegate denylist is the mechanism: remediate everything by default,
-  route to a human only for product-scope calls and significant cost.
-- **Advancing on anything other than the holder's declaration** (I2). A clean process exit is not a
-  declaration — CTL-1790 shipped `flipSignalAbandonedOnUndeclaredExit`
-  (`sdk-run-phase-agent.mjs:521`, called `:1269`) and `assertion-evidence.mjs:104` now marks the old
-  `SDK_SUCCESS_FLIP` writer "historical (CTL-1790 removed the writer)". `abandoned` never advances.
-- **Any side effect whose refusal is only "a guard we wrote"** (I3/I4), until the lease exists.
-  Shipping those rows in enforce mode before there is something that can say no would mean two hosts
-  double-advancing on one declaration.
-- **Detectors whose unique failure nobody can name** (I10). A detector that duplicates another's
-  coverage is deleted, not kept just in case.
-- **Mechanisms that have never produced an output** (I11).
-  `delegate.{would-route,routed,route-fallback}` and `escalation.explanation-absent` are at **0**
-  occurrences. Their next ticket is either "make it emit" or "delete it" — and a shadow mode is a
-  stage with an exit date, never a resting state.
-- **Reacting to "a bot did this".** The discriminator is always **our own echo**, never bot-vs-human
-  — other agents' Linear comments and state changes must remain deliverable to us. See §6.5.
-- **Absence alerting via a Loki `count == 0` rule.** Loki cannot assert absent, and the metric path
-  hits the `metric_expiration: 15m` trap;
-  `catalyst-otel/provisioning/alerting/read-path-alerts.yaml:786-793` rules the shape out and
-  assigns ownership to Gatus active probes plus the catalyst-survivability `system_down` rule. Name
-  that owner; do not cite a rule nobody wrote.
+- **Anything whose deterministic path is not genuinely deterministic** (rule 3). The checkout fast-forward automates exactly one shape — clean, on the default branch, upstream resolvable — and refuses seven named others rather than guessing. A "usually works" path is not a deterministic path.
+- **Product-scope judgement.** Whether a ticket should exist, what it should say, whether a finding is worth fixing at all. The delegate denylist is the mechanism: remediate everything by default, route to a human only for product-scope calls and significant cost.
+- **Advancing on anything other than the holder's declaration** (I2). A clean process exit is not a declaration — CTL-1790 shipped `flipSignalAbandonedOnUndeclaredExit` (`sdk-run-phase-agent.mjs:521`, called `:1269`) and `assertion-evidence.mjs:104` now marks the old `SDK_SUCCESS_FLIP` writer "historical (CTL-1790 removed the writer)". `abandoned` never advances.
+- **Any side effect whose refusal is only "a guard we wrote"** (I3/I4), until the lease exists. Shipping those rows in enforce mode before there is something that can say no would mean two hosts double-advancing on one declaration.
+- **Detectors whose unique failure nobody can name** (I10). A detector that duplicates another's coverage is deleted, not kept just in case.
+- **Mechanisms that have never produced an output** (I11). `delegate.{would-route,routed,route-fallback}` and `escalation.explanation-absent` are at **0** occurrences. Their next ticket is either "make it emit" or "delete it" — and a shadow mode is a stage with an exit date, never a resting state.
+- **Reacting to "a bot did this".** The discriminator is always **our own echo**, never bot-vs-human — other agents' Linear comments and state changes must remain deliverable to us. See §6.5.
+- **Absence alerting via a Loki `count == 0` rule.** Loki cannot assert absent, and the metric path hits the `metric_expiration: 15m` trap; `catalyst-otel/provisioning/alerting/read-path-alerts.yaml:786-793` rules the shape out and assigns ownership to Gatus active probes plus the catalyst-survivability `system_down` rule. Name that owner; do not cite a rule nobody wrote.
 
 ## 9. Open decisions — Ryan's, not engineering's
 
-**Five of these were decided on 2026-08-13 (§7a) and are kept here, struck, so the record shows what
-was asked and what was answered. Do not re-litigate them.**
+**Five of these were decided on 2026-08-13 (§7a) and are kept here, struck, so the record shows what was asked and what was answered. Do not re-litigate them.**
 
-1. ~~**A human sets Done on a ticket with a live worker (H10).**~~ **CLOSED — R1.** Neither
-   "honour-as-kill" nor "refuse-and-revert": **PREEMPT**, and then the done-writer's I6 gate decides
-   (§7a.5, §7a.7). The question generalized past Done — _any_ state move on a live worker preempts.
-2. ~~**`Ready`**~~ **CLOSED — R3: archive it** (21 workspace transitions, zero live occupants).
-   **`Duplicate` remains open**: give it a stateMap key, or keep it kill-only via `DRAG_OUT_STATES`?
-3. **Sub-phase visibility during Validate/PR.** ~~A single-valued `phase:<name>` Linear label
-   group~~ **rejected — R2.** What remains open is only whether to link the orch-monitor journey
-   view from the ticket. Pure operator-UX preference.
-4. ~~**Board granularity long-term.**~~ **CLOSED — R4: stay many-to-one.** Ryan proposed adding
-   `Review`/`Merge` states and reversed on §7's rationale. The reversal is load-bearing, not
-   cosmetic — the collapse is what makes §7a's tail deletion free.
-5. **Shadow exit dates.** I11 says shadow is a stage with an exit date, and the date is an operator
-   commitment — needed for the ledger's shadow→enforce step, the trigger-inversion step, **and the
-   done-writer's shadow→enforce flip (§7a.5)**.
-6. ~~**Phase subtraction.**~~ **CLOSED — R5/R6/R7, and larger than proposed:** `monitor-merge`,
-   `monitor-deploy` **and** `teardown` all go, 10 phases → **7** (not 8), with `pr` as the terminal.
-   §7a is the design; §7a.9 lists the six sub-decisions it did **not** settle.
-7. **Cross-agent messaging over Linear comments.** Directional for a follow-up design. It constrains
-   this contract in exactly one way, already honoured: the self-echo discriminator is scoped to our
-   own actor, never to "is a bot" (§6.5). The follow-up should adopt the echo-record discriminator
-   from day one rather than inheriting the actor-id set.
+1. ~~**A human sets Done on a ticket with a live worker (H10).**~~ **CLOSED — R1.** Neither "honour-as-kill" nor "refuse-and-revert": **PREEMPT**, and then the done-writer's I6 gate decides (§7a.5, §7a.7). The question generalized past Done — _any_ state move on a live worker preempts.
+2. ~~**`Ready`**~~ **CLOSED — R3: archive it** (21 workspace transitions, zero live occupants). **`Duplicate` remains open**: give it a stateMap key, or keep it kill-only via `DRAG_OUT_STATES`?
+3. **Sub-phase visibility during Validate/PR.** ~~A single-valued `phase:<name>` Linear label group~~ **rejected — R2.** What remains open is only whether to link the orch-monitor journey view from the ticket. Pure operator-UX preference.
+4. ~~**Board granularity long-term.**~~ **CLOSED — R4: stay many-to-one.** Ryan proposed adding `Review`/`Merge` states and reversed on §7's rationale. The reversal is load-bearing, not cosmetic — the collapse is what makes §7a's tail deletion free.
+5. **Shadow exit dates.** I11 says shadow is a stage with an exit date, and the date is an operator commitment — needed for the ledger's shadow→enforce step, the trigger-inversion step, **and the done-writer's shadow→enforce flip (§7a.5)**.
+6. ~~**Phase subtraction.**~~ **CLOSED — R5/R6/R7, and larger than proposed:** `monitor-merge`, `monitor-deploy` **and** `teardown` all go, 10 phases → **7** (not 8), with `pr` as the terminal. §7a is the design; §7a.9 lists the six sub-decisions it did **not** settle.
+7. **Cross-agent messaging over Linear comments.** Directional for a follow-up design. It constrains this contract in exactly one way, already honoured: the self-echo discriminator is scoped to our own actor, never to "is a bot" (§6.5). The follow-up should adopt the echo-record discriminator from day one rather than inheriting the actor-id set.
 
 ---
 
-**Provenance.** Measured evidence, the full 117-row event census, the cut list, and the review
-record are in `thoughts/shared/research/2026-08-13-event-automation-catalog.md`. Invariants:
-`catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md` (a **different
-repo's** ADR numbering — see §3). Ratified by ADR-029 in `docs/adrs.md`.
+**Provenance.** Measured evidence, the full 117-row event census, the cut list, and the review record are in `thoughts/shared/research/2026-08-13-event-automation-catalog.md`. Invariants: `catalyst-cloud/docs/adr/0027-reliability-initiative-invariants-and-acceptance.md` (a **different repo's** ADR numbering — see §3). Ratified by ADR-029 in `docs/adrs.md`.

--- a/docs/health-responder.md
+++ b/docs/health-responder.md
@@ -1,18 +1,10 @@
 # Cloud-Sync Health Responder
 
-`health-responder.sh` is a launchd-scheduled bash script that runs every 3 minutes (configurable)
-and performs a **bounded, local ACT step** for the supervised cloud-sync replica writer:
-catalyst-doctor only *detects* a dead/wedged writer; the responder *kickstarts* it — at most a few
-times per window — then escalates loudly and stops (CTL-1509).
+`health-responder.sh` is a launchd-scheduled bash script that runs every 3 minutes (configurable) and performs a **bounded, local ACT step** for the supervised cloud-sync replica writer: catalyst-doctor only *detects* a dead/wedged writer; the responder *kickstarts* it — at most a few times per window — then escalates loudly and stops (CTL-1509).
 
 ## Why a Periodic Sweep, Not a Daemon
 
-The responder guards long-lived daemons against exactly the failure class long-lived daemons
-suffer: silent wedging. A watcher **daemon** can zombie the same way its patient does; a
-short-lived launchd `StartInterval` job (the orphan-sweep pattern) is a fresh process every
-interval and cannot. All detection is **local** — plist on disk, `pgrep`, `writer.lock` mtime, the
-CTL-1508 breadcrumb file — never Linear, never Loki, so the responder keeps working through
-exactly the outages it exists to respond to.
+The responder guards long-lived daemons against exactly the failure class long-lived daemons suffer: silent wedging. A watcher **daemon** can zombie the same way its patient does; a short-lived launchd `StartInterval` job (the orphan-sweep pattern) is a fresh process every interval and cannot. All detection is **local** — plist on disk, `pgrep`, `writer.lock` mtime, the CTL-1508 breadcrumb file — never Linear, never Loki, so the responder keeps working through exactly the outages it exists to respond to.
 
 ## What It Watches (Three Conditions)
 
@@ -22,46 +14,28 @@ exactly the outages it exists to respond to.
 | 2 | stale-writer | process EXISTS but `<db>.writer.lock` mtime older than `RESPONDER_LOCK_STALE_SECS` (900s) | the SDK rewrites the lock ~5s, **feed-independently** — a quiet Linear feed never stales the lock; only a dead SDK heartbeat does. Doctor WARNs at 60s; the responder ACTS only at 900s (act-threshold ≫ detect-threshold, so heartbeat jitter is never kickstarted) |
 | 3 | no-respawn | cloud-sync plist installed, `~/catalyst/cloud-sync.selfheal.json` has `expectRestart:true`, no process, and the breadcrumb `ts` (or file mtime) is older than `RESPONDER_SELFHEAL_GRACE_SECS` (120s) | the CTL-1508 self-heal exit expected a launchd relaunch that never came. **File absent = the normal case** (CTL-1508 ships in parallel); absent/malformed is silently ignored |
 
-All three conditions are **installed-gated** — a node without the cloud-sync plist is not on the
-replica tier and is never acted on, even if a stale breadcrumb is lying around.
+All three conditions are **installed-gated** — a node without the cloud-sync plist is not on the replica tier and is never acted on, even if a stale breadcrumb is lying around.
 
-**Settling hold:** a breadcrumb *within* the grace window suppresses **all** action (including
-dead-writer) and heartbeats `status=settling` — the writer exited on purpose expecting a launchd
-relaunch, and a `kickstart -k` during that window would race and kill the legitimately-settling
-instance. The breadcrumb either clears (relaunch landed) or ages into condition 3.
+**Settling hold:** a breadcrumb *within* the grace window suppresses **all** action (including dead-writer) and heartbeats `status=settling` — the writer exited on purpose expecting a launchd relaunch, and a `kickstart -k` during that window would race and kill the legitimately-settling instance. The breadcrumb either clears (relaunch landed) or ages into condition 3.
 
-**Fail-safe cap:** if the attempt marker cannot be written (unwritable state dir), the responder
-refuses to kickstart at all (`status=degraded`, loud ERROR each sweep) — an uncountable attempt
-would make the cap unenforceable, degrading into exactly the unbounded restart storm the cap
-exists to prevent. `--dry-run` is read-only end to end: no state dir creation, no marker pruning,
-no re-arm — only `would-…` log lines.
+**Fail-safe cap:** if the attempt marker cannot be written (unwritable state dir), the responder refuses to kickstart at all (`status=degraded`, loud ERROR each sweep) — an uncountable attempt would make the cap unenforceable, degrading into exactly the unbounded restart storm the cap exists to prevent. `--dry-run` is read-only end to end: no state dir creation, no marker pruning, no re-arm — only `would-…` log lines.
 
-An **absent** `writer.lock` is *not* stale (guard disabled / writer never started / older SDK —
-doctor makes the same call); only a **present-but-old** lock is the strong "SDK heartbeat died"
-signal. A node without the cloud-sync plist is not on the replica tier and is simply left alone.
+An **absent** `writer.lock` is *not* stale (guard disabled / writer never started / older SDK — doctor makes the same call); only a **present-but-old** lock is the strong "SDK heartbeat died" signal. A node without the cloud-sync plist is not on the replica tier and is simply left alone.
 
 ## What It Does (Bounded Kickstart)
 
-On any condition: `launchctl kickstart -k gui/$(id -u)/ai.coalesce.catalyst-cloud-sync`, capped at
-`RESPONDER_MAX_ATTEMPTS` (3) per `RESPONDER_ATTEMPT_WINDOW_SECS` (3600). Attempts are timestamped
-marker files under `~/catalyst/.health-responder/`, pruned past the window on every run. After a
-kickstart the responder waits ~10s, re-probes, and logs `recovered` or `still-down`. A failed
-`launchctl` call is logged and **still counted** — the responder never crash-loops launchctl.
+On any condition: `launchctl kickstart -k gui/$(id -u)/ai.coalesce.catalyst-cloud-sync`, capped at `RESPONDER_MAX_ATTEMPTS` (3) per `RESPONDER_ATTEMPT_WINDOW_SECS` (3600). Attempts are timestamped marker files under `~/catalyst/.health-responder/`, pruned past the window on every run. After a kickstart the responder waits ~10s, re-probes, and logs `recovered` or `still-down`. A failed `launchctl` call is logged and **still counted** — the responder never crash-loops launchctl.
 
 ## Escalation Contract
 
 When the cap is exhausted and the condition persists:
 
 1. Write the one-shot marker `~/catalyst/.health-responder/ESCALATED.cloud-sync`.
-2. Emit `catalyst.responder.escalated` via `emit-otel-event.sh` (fail-open — a telemetry failure
-   never fails the responder).
-3. Log an `ERROR: escalated …` line (Alloy ships `~/catalyst/health-responder.log` conventions to
-   Loki for alerting).
-4. **Stop kickstarting.** While the marker exists and the condition persists, every run is a
-   heartbeat-only hold.
+2. Emit `catalyst.responder.escalated` via `emit-otel-event.sh` (fail-open — a telemetry failure never fails the responder).
+3. Log an `ERROR: escalated …` line (Alloy ships `~/catalyst/health-responder.log` conventions to Loki for alerting).
+4. **Stop kickstarting.** While the marker exists and the condition persists, every run is a heartbeat-only hold.
 
-The condition clearing (a healthy probe) removes the marker and the attempt files — the responder
-re-arms itself with a fresh budget for the next incident.
+The condition clearing (a healthy probe) removes the marker and the attempt files — the responder re-arms itself with a fresh budget for the next incident.
 
 ## Heartbeat (a Dead Responder Must Be Distinguishable From a Quiet One)
 
@@ -71,8 +45,7 @@ Every run — healthy, acting, escalated, disabled, dry-run — ends with exactl
 [health-responder <run-id>] heartbeat status=<healthy|recovered|still-down|escalated|disabled|dry-run> installed=… alive=… dead_writer=… stale_lock=… no_respawn=… attempts=N/M escalated=…
 ```
 
-Silence in `~/catalyst/health-responder.log` for longer than the interval means the **responder**
-is down (the stale-copy-reports-healthy rule), not that everything is fine.
+Silence in `~/catalyst/health-responder.log` for longer than the interval means the **responder** is down (the stale-copy-reports-healthy rule), not that everything is fine.
 
 ## Configuration (env overrides)
 
@@ -95,55 +68,25 @@ is down (the stale-copy-reports-healthy rule), not that everything is fine.
 | `CATALYST_REPLICA_DB` | `~/catalyst/catalyst-replica.db` | Lock = `<db>.writer.lock` (mirrors `getReplicaDbPath`) |
 | `CATALYST_LAUNCHAGENTS_DIR` | `~/Library/LaunchAgents` | Plist dir (mirrors doctor.mjs) |
 
-The launchd schedule comes from `.catalyst/config.json` → `catalyst.responder.intervalSeconds`
-(default 180, clamped 60–900) at install time.
+The launchd schedule comes from `.catalyst/config.json` → `catalyst.responder.intervalSeconds` (default 180, clamped 60–900) at install time.
 
 ## Scheduling: launchd + cron, Because launchd Alone Cannot Be Trusted
 
-The original design assumed a `StartInterval` sweep "cannot zombie". A fleet host disproved that
-live (mini-2, 2026-07-25): launchd held the job loaded with a clean last exit and dispatched
-**nothing** — the interval spawn stayed pended for hours, and after a clean `bootout`/`bootstrap`
-even `RunAtLoad` stopped firing, while `launchctl kickstart` ran the sweep fine and an older
-`StartInterval` job kept firing in the same gui domain. So the installer now provisions **two
-independent schedulers**:
+The original design assumed a `StartInterval` sweep "cannot zombie". A fleet host disproved that live (mini-2, 2026-07-25): launchd held the job loaded with a clean last exit and dispatched **nothing** — the interval spawn stayed pended for hours, and after a clean `bootout`/`bootstrap` even `RunAtLoad` stopped firing, while `launchctl kickstart` ran the sweep fine and an older `StartInterval` job kept firing in the same gui domain. So the installer now provisions **two independent schedulers**:
 
 1. The launchd `StartInterval` LaunchAgent (unchanged), and
-2. a self-tagged user **crontab backstop** (`# ai.coalesce.catalyst-health-responder backstop
-   CTL-1510`), at the interval rounded up to whole minutes, with the plist's PATH + `CATALYST_DIR`
-   inline.
+2. a self-tagged user **crontab backstop** (`# ai.coalesce.catalyst-health-responder backstop CTL-1510`), at the interval rounded up to whole minutes, with the plist's PATH + `CATALYST_DIR` inline.
 
-Overlap between the two is serialized by a **whole-sweep `mkdir` reservation**
-(`$RESPONDER_STATE_DIR/sweep.lock`): the loser of the race heartbeats `status=skipped` and exits, so
-a double schedule can never double-kickstart. A lock older than
-`RESPONDER_SWEEP_LOCK_STALE_SECS` belongs to a crashed sweep and is broken. On a read-only state
-dir the sweep proceeds unlocked (it cannot act anyway — the attempt-cap fail-safe refuses).
+Overlap between the two is serialized by a **whole-sweep `mkdir` reservation** (`$RESPONDER_STATE_DIR/sweep.lock`): the loser of the race heartbeats `status=skipped` and exits, so a double schedule can never double-kickstart. A lock older than `RESPONDER_SWEEP_LOCK_STALE_SECS` belongs to a crashed sweep and is broken. On a read-only state dir the sweep proceeds unlocked (it cannot act anyway — the attempt-cap fail-safe refuses).
 
-If **both** schedulers die, `catalyst-doctor`'s `responder-dispatch` check WARNs when the heartbeat
-log's mtime exceeds 3× the plist's `StartInterval` (floor 900 s), and remotely the heartbeat simply
-disappears from Loki (see below).
+If **both** schedulers die, `catalyst-doctor`'s `responder-dispatch` check WARNs when the heartbeat log's mtime exceeds 3× the plist's `StartInterval` (floor 900 s), and remotely the heartbeat simply disappears from Loki (see below).
 
 ## Remote Visibility (Loki) and Its Two Known Traps
 
-The heartbeat line ships to Loki as the `catalyst.health-responder` stream (Alloy's 7th) — and
-**absence of the heartbeat in Loki IS the dead-responder signal**. Two operational caveats, both
-learned live:
+The heartbeat line ships to Loki as the `catalyst.health-responder` stream (Alloy's 7th) — and **absence of the heartbeat in Loki IS the dead-responder signal**. Two operational caveats, both learned live:
 
-- **Late-created log files were invisible to Alloy.** Alloy's `loki.source.file` targets are
-  static: a log file that does not exist when Alloy starts was never picked up later, so a host
-  whose responder log appeared minutes after an Alloy restart shipped nothing (dark for 4 h on
-  mini-2 while the other six streams flowed). The log-shipper launcher now **pre-creates every
-  tailed log file** before `exec alloy` (CTL-1510 item 7).
-- **dev/monitor-class hosts have no Alloy at all** (item 2, documented decision): those classes get
-  the responder via `adopt-cloud-sync`, but only `install-services` (worker-class setup) installs
-  the log shipper. On a dev/monitor host the responder's heartbeat and escalation are therefore
-  **host-local only** (`~/catalyst/health-responder.log`) — the Loki absence-signal does not cover
-  them, and remote alerting must not assume it does. **Do not run `catalyst-stack
-  install-services` on a dev/monitor host to get remote coverage** — it is not shipper-only; its
-  `RunAtLoad` also bootstraps the full stack LaunchAgent (`catalyst-stack start`, which starts
-  broker/execution-core), exactly what a class meant to stay daemonless must avoid. There is
-  currently no shipper-only launchd install path; the only way to ship this host's log without
-  installing the daemon stack is running `log-shipper/launch.sh` manually/foreground. Treat
-  host-local-only as the accepted default for these classes.
+- **Late-created log files were invisible to Alloy.** Alloy's `loki.source.file` targets are static: a log file that does not exist when Alloy starts was never picked up later, so a host whose responder log appeared minutes after an Alloy restart shipped nothing (dark for 4 h on mini-2 while the other six streams flowed). The log-shipper launcher now **pre-creates every tailed log file** before `exec alloy` (CTL-1510 item 7).
+- **dev/monitor-class hosts have no Alloy at all** (item 2, documented decision): those classes get the responder via `adopt-cloud-sync`, but only `install-services` (worker-class setup) installs the log shipper. On a dev/monitor host the responder's heartbeat and escalation are therefore **host-local only** (`~/catalyst/health-responder.log`) — the Loki absence-signal does not cover them, and remote alerting must not assume it does. **Do not run `catalyst-stack install-services` on a dev/monitor host to get remote coverage** — it is not shipper-only; its `RunAtLoad` also bootstraps the full stack LaunchAgent (`catalyst-stack start`, which starts broker/execution-core), exactly what a class meant to stay daemonless must avoid. There is currently no shipper-only launchd install path; the only way to ship this host's log without installing the daemon stack is running `log-shipper/launch.sh` manually/foreground. Treat host-local-only as the accepted default for these classes.
 
 ## Installation
 
@@ -152,18 +95,14 @@ learned live:
 > can be deleted, after which the job exit-127s silently every interval — and the fleet loses its
 > cloud-sync self-healer exactly when nobody is watching.
 
-Normally installed automatically by `catalyst-stack install-services` (same delegated,
-non-fatal block as the orphan-sweep reaper). To (re)install manually, run **from the pristine
-clone**:
+Normally installed automatically by `catalyst-stack install-services` (same delegated, non-fatal block as the orphan-sweep reaper). To (re)install manually, run **from the pristine clone**:
 
 ```bash
 bash ~/catalyst/plugin-source/plugins/dev/scripts/install-health-responder.sh
 launchctl list | grep health-responder   # LastExit must be 0
 ```
 
-`install-health-responder.sh` is idempotent, prefers the registered `pluginDirs` clone, and
-**refuses** to bake a linked-worktree or `/tmp` path. Preview with `--print-only`; remove with
-`--uninstall`.
+`install-health-responder.sh` is idempotent, prefers the registered `pluginDirs` clone, and **refuses** to bake a linked-worktree or `/tmp` path. Preview with `--print-only`; remove with `--uninstall`.
 
 ```bash
 # Dry-run — logs intended actions without performing any
@@ -174,33 +113,15 @@ tail -f ~/catalyst/health-responder.log
 
 ## Health Check
 
-`catalyst-doctor` asserts the responder is healthy (`checkHealthResponder`, mirroring
-`checkReaper`). Every check is a **WARN**, never a FAIL — doctor's exit code gates the
-`catalyst-join` activation gate, which runs *before* `install-services` would reinstall a stale
-plist, so a FAILing responder check would block a node from self-healing via join:
-`responder-installed` (plist absent/malformed), `responder-path` (baked program path gone — the
-CTL-1306 silent-death signature), `responder-killswitch` (installed script lacks the
-`RESPONDER_ENABLED` marker — stale install), `responder-loaded` (present but never bootstrapped),
-`responder-health` (`LastExit` 127 / non-zero), and `responder-dispatch` (heartbeat log mtime older
-than 3× the `StartInterval` — loaded + clean exit but **no scheduler is actually dispatching**, the
-CTL-1510 launchd wedge). Loaded + exit 0 (or never run yet) with a fresh heartbeat is PASS.
+`catalyst-doctor` asserts the responder is healthy (`checkHealthResponder`, mirroring `checkReaper`). Every check is a **WARN**, never a FAIL — doctor's exit code gates the `catalyst-join` activation gate, which runs *before* `install-services` would reinstall a stale plist, so a FAILing responder check would block a node from self-healing via join: `responder-installed` (plist absent/malformed), `responder-path` (baked program path gone — the CTL-1306 silent-death signature), `responder-killswitch` (installed script lacks the `RESPONDER_ENABLED` marker — stale install), `responder-loaded` (present but never bootstrapped), `responder-health` (`LastExit` 127 / non-zero), and `responder-dispatch` (heartbeat log mtime older than 3× the `StartInterval` — loaded + clean exit but **no scheduler is actually dispatching**, the CTL-1510 launchd wedge). Loaded + exit 0 (or never run yet) with a fresh heartbeat is PASS.
 
 ## Relationship to Other Components
 
-- **doctor `checkCloudSync`** — the detect side (60s lock-stale WARN, agent-installed,
-  process-alive). The responder deliberately re-implements the same probes in bash with a far more
-  conservative act threshold; it never changes doctor behavior.
-- **CTL-1508 self-heal breadcrumb** — built in parallel; the responder treats file-absent as the
-  normal case. `expectRestart:true` relaunches within the grace window are *expected* and never
-  counted against the attempt cap.
-- **`catalyst-stack adopt-cloud-sync`** — the install/repair path for the writer itself; the
-  responder only kickstarts the existing LaunchAgent, never bootstraps or reconfigures it (and
-  never runs `bun cloud-sync.mjs` directly — that would fight the SDK single-writer lock and
-  bypass token sourcing).
-- **orphan-sweep (`docs/orphan-sweep.md`)** — the structural template: same installer contract,
-  same launchd pattern, same fail-open telemetry idiom.
+- **doctor `checkCloudSync`** — the detect side (60s lock-stale WARN, agent-installed, process-alive). The responder deliberately re-implements the same probes in bash with a far more conservative act threshold; it never changes doctor behavior.
+- **CTL-1508 self-heal breadcrumb** — built in parallel; the responder treats file-absent as the normal case. `expectRestart:true` relaunches within the grace window are *expected* and never counted against the attempt cap.
+- **`catalyst-stack adopt-cloud-sync`** — the install/repair path for the writer itself; the responder only kickstarts the existing LaunchAgent, never bootstraps or reconfigures it (and never runs `bun cloud-sync.mjs` directly — that would fight the SDK single-writer lock and bypass token sourcing).
+- **orphan-sweep (`docs/orphan-sweep.md`)** — the structural template: same installer contract, same launchd pattern, same fail-open telemetry idiom.
 
 ## Log
 
-All output goes to `~/catalyst/health-responder.log` (configured in the plist). Each line is
-prefixed with `[health-responder <run-id>]` for correlation.
+All output goes to `~/catalyst/health-responder.log` (configured in the plist). Each line is prefixed with `[health-responder <run-id>]` for correlation.

--- a/docs/linear-replica.md
+++ b/docs/linear-replica.md
@@ -1,34 +1,21 @@
 # Linear read replica
 
-The local Linear tier has three layers: the cloud-sync writer seeds and updates the SQLite
-database, its writer-lock heartbeat proves the writer is alive independently of feed activity,
-and the agent/daemon read paths serve single-ticket and board reads from that database.
+The local Linear tier has three layers: the cloud-sync writer seeds and updates the SQLite database, its writer-lock heartbeat proves the writer is alive independently of feed activity, and the agent/daemon read paths serve single-ticket and board reads from that database.
 
 ## Configuration order
 
-Two independent settings are required, and neither takes effect on its own: the token alone leaves
-readers disconnected, and the flag alone produces replica misses against an empty file. Provision
-the token FIRST, activate the writer, wait for a verified seed, and only then flip the read flag.
+Two independent settings are required, and neither takes effect on its own: the token alone leaves readers disconnected, and the flag alone produces replica misses against an empty file. Provision the token FIRST, activate the writer, wait for a verified seed, and only then flip the read flag.
 
-1. **Provision the resolved cloud-token variable.** The name defaults to `CATALYST_CLOUD_TOKEN`,
-   but `resolveCloudTokenName` honours the `CATALYST_CLOUD_TOKEN_ENV` env override and the Layer-2
-   `catalyst.cloud.tokenEnv` key — on a host that sets either, exporting `CATALYST_CLOUD_TOKEN`
-   does **not** authenticate the writer. Export whichever name resolves, into
-   `~/.config/catalyst/cloud-sync.env` (`chmod 600`).
-2. **Activate the writer**: `catalyst-stack adopt-cloud-sync`. Provisioning the token does not
-   itself install or start the supervised writer.
-3. **Wait for a verified seed** — `catalyst doctor`'s `replica-fresh` PASS, or
-   `sqlite3 ~/catalyst/catalyst-replica.db 'SELECT COUNT(*) FROM issues'` > 0.
-4. **Then set `CATALYST_LINEAR_REPLICA=on`** and restart execution-core on a worker — an
-   already-running process does not construct a reader just because the flag changed.
+1. **Provision the resolved cloud-token variable.** The name defaults to `CATALYST_CLOUD_TOKEN`, but `resolveCloudTokenName` honours the `CATALYST_CLOUD_TOKEN_ENV` env override and the Layer-2 `catalyst.cloud.tokenEnv` key — on a host that sets either, exporting `CATALYST_CLOUD_TOKEN` does **not** authenticate the writer. Export whichever name resolves, into `~/.config/catalyst/cloud-sync.env` (`chmod 600`).
+2. **Activate the writer**: `catalyst-stack adopt-cloud-sync`. Provisioning the token does not itself install or start the supervised writer.
+3. **Wait for a verified seed** — `catalyst doctor`'s `replica-fresh` PASS, or `sqlite3 ~/catalyst/catalyst-replica.db 'SELECT COUNT(*) FROM issues'` > 0.
+4. **Then set `CATALYST_LINEAR_REPLICA=on`** and restart execution-core on a worker — an already-running process does not construct a reader just because the flag changed.
 
-The canonical seed-before-flip runbook, including every key's precedence, lives in
-`website/src/content/docs/reference/configuration.md`; this list is its replica-tier summary.
+The canonical seed-before-flip runbook, including every key's precedence, lives in `website/src/content/docs/reference/configuration.md`; this list is its replica-tier summary.
 
 ## Supplemental display reads (CTL-1806)
 
-Three resolvers outside the eligible path used to call the Linear GraphQL API with no replica
-consultation at all. Two are now replica-first; the third cannot be, and says so.
+Three resolvers outside the eligible path used to call the Linear GraphQL API with no replica consultation at all. Two are now replica-first; the third cannot be, and says so.
 
 | Resolver | Local tier | Gate | On a miss |
 | --- | --- | --- | --- |
@@ -38,31 +25,11 @@ consultation at all. Two are now replica-first; the third cannot be, and says so
 
 Three properties are deliberate and easy to "fix" wrongly:
 
-- **File presence, never writer liveness.** A liveness gate on a *display* read falls through to
-  Linear precisely when the board is UNCHANGED (a live writer on a quiet feed reads as stale —
-  CTL-1397), turning a healthy quiet period into a burst of API calls. That is backwards for a read
-  whose purpose is removing them.
-- **A replica `NULL` estimate is a MISS, not an authoritative null.** Locally, "Linear has none" and
-  "this row predates the estimate projection" are indistinguishable, so serving the null would drop
-  the board chip for a refresh. Mirrors what `titles()` already does with an empty title.
-- **The team estimation method has no replica source and must not be defaulted.** The replica has no
-  `teams` table and carries no `issueEstimation`; the `$.team` projection is `{id,key,name}` only. So
-  its Linear fetch stays, labelled and bounded at 8 team keys per host per TTL. It is **never**
-  defaulted to a scale: the value gates a real Linear write (`applyEstimate` on the triage→research
-  advance), where `null` makes the scheduler SKIP the write and a guess would write a Fibonacci
-  number into a tShirt team's estimate field. The durable fix is a cloud-side `teams.issue_estimation`
-  column, not a local guess.
+- **File presence, never writer liveness.** A liveness gate on a *display* read falls through to Linear precisely when the board is UNCHANGED (a live writer on a quiet feed reads as stale — CTL-1397), turning a healthy quiet period into a burst of API calls. That is backwards for a read whose purpose is removing them.
+- **A replica `NULL` estimate is a MISS, not an authoritative null.** Locally, "Linear has none" and "this row predates the estimate projection" are indistinguishable, so serving the null would drop the board chip for a refresh. Mirrors what `titles()` already does with an empty title.
+- **The team estimation method has no replica source and must not be defaulted.** The replica has no `teams` table and carries no `issueEstimation`; the `$.team` projection is `{id,key,name}` only. So its Linear fetch stays, labelled and bounded at 8 team keys per host per TTL. It is **never** defaulted to a scale: the value gates a real Linear write (`applyEstimate` on the triage→research advance), where `null` makes the scheduler SKIP the write and a guess would write a Fibonacci number into a tShirt team's estimate field. The durable fix is a cloud-side `teams.issue_estimation` column, not a local guess.
 
-`state.type` is not in the replica either (the enrichment pass overwrites `raw` with a projection
-that drops it). It is **synthesized from lifecycle timestamps** — `canceled_at` → `completed_at` →
-`started_at` → `backlog` — deliberately not from the state NAME, which would hardcode this
-workspace's contract states and break under a bring-your-own-workspace tenant. Measured 109/109
-exact on every class the consumer renders distinctly, against a committed ground-truth fixture
-(`execution-core/__fixtures__/state-type-ground-truth.json`); the one residual is a true `unstarted`
-collapsing to `backlog`, which costs a stroke-dash difference on a muted ring. The type is carried
-rather than omitted because it also selects the 24h-vs-5min cache TTL, and dropping it would move
-every terminal ticket to the short TTL — a quota regression inside a quota reduction. The durable
-fix is a cloud-side `workflow_states` table (`issues.state_id` is already fully populated).
+`state.type` is not in the replica either (the enrichment pass overwrites `raw` with a projection that drops it). It is **synthesized from lifecycle timestamps** — `canceled_at` → `completed_at` → `started_at` → `backlog` — deliberately not from the state NAME, which would hardcode this workspace's contract states and break under a bring-your-own-workspace tenant. Measured 109/109 exact on every class the consumer renders distinctly, against a committed ground-truth fixture (`execution-core/__fixtures__/state-type-ground-truth.json`); the one residual is a true `unstarted` collapsing to `backlog`, which costs a stroke-dash difference on a muted ring. The type is carried rather than omitted because it also selects the 24h-vs-5min cache TTL, and dropping it would move every terminal ticket to the short TTL — a quota regression inside a quota reduction. The durable fix is a cloud-side `workflow_states` table (`issues.state_id` is already fully populated).
 
 ## Signals
 
@@ -76,10 +43,7 @@ fix is a cloud-side `workflow_states` table (`issues.state_id` is already fully 
 
 ## Loki queries
 
-`service_name` is the only stream label here; every other field — including the event name — arrives
-as **structured metadata**, because `otel-forward` sends the body as a plain string and the event
-attributes as OTLP log attributes (dots normalized to underscores). Do not `| json` these lines:
-there is no JSON body to parse, and `attributes["event.name"]` never matches.
+`service_name` is the only stream label here; every other field — including the event name — arrives as **structured metadata**, because `otel-forward` sends the body as a plain string and the event attributes as OTLP log attributes (dots normalized to underscores). Do not `| json` these lines: there is no JSON body to parse, and `attributes["event.name"]` never matches.
 
 ```logql
 {service_name="catalyst.execution-core"} | event_name=~"monitor\\.replica\\.degraded\\..*"
@@ -89,9 +53,6 @@ there is no JSON body to parse, and `attributes["event.name"]` never matches.
 {service_name="catalyst.linear-read"} | event_name="catalyst.replica.read_fallback"
 ```
 
-The degradation streak rides the `replica_consecutive_degraded` metadata field on those events, so
-`sum by (catalyst_team) (...)`-style aggregation over it works without touching the body.
+The degradation streak rides the `replica_consecutive_degraded` metadata field on those events, so `sum by (catalyst_team) (...)`-style aggregation over it works without touching the body.
 
-Grafana alert provisioning belongs in the sibling `catalyst-otel` repository. Validate any rule
-file against a throwaway Grafana before deploying it because malformed provisioned rules can stop
-the shared Grafana instance from starting.
+Grafana alert provisioning belongs in the sibling `catalyst-otel` repository. Validate any rule file against a throwaway Grafana before deploying it because malformed provisioned rules can stop the shared Grafana instance from starting.

--- a/docs/orchestrator-overview.md
+++ b/docs/orchestrator-overview.md
@@ -1,55 +1,30 @@
 <!-- CTL tracer bullet: 2026-05-25 — verifies execution-core pickup -->
 # Orchestrator Overview
 
-How a Catalyst orchestrator runs today (post-CTL-452, post-2026-05-17 ship). This doc
-describes what exists in `origin/main` — it is not a roadmap.
+How a Catalyst orchestrator runs today (post-CTL-452, post-2026-05-17 ship). This doc describes what exists in `origin/main` — it is not a roadmap.
 
 ## Why this exists
 
-Catalyst orchestrates AI engineering work under the constraints of LLM agents. Every
-design choice — phases, background dispatch, broker interests, the immutable event
-log — is in service of these:
+Catalyst orchestrates AI engineering work under the constraints of LLM agents. Every design choice — phases, background dispatch, broker interests, the immutable event log — is in service of these:
 
-- **Context engineering.** Per-turn cost compounds, and long contexts hit diminishing
-  then negative returns as attention degrades ("context rot"). Breaking ticket-sized
-  work into bounded phases (research → plan → implement → verify → review → ship)
-  keeps each agent in a focused context where sharp decisions stay cheap.
+- **Context engineering.** Per-turn cost compounds, and long contexts hit diminishing then negative returns as attention degrades ("context rot"). Breaking ticket-sized work into bounded phases (research → plan → implement → verify → review → ship) keeps each agent in a focused context where sharp decisions stay cheap.
 
-- **Background continuity.** Agents should keep working while the operator is away
-  from the keyboard. Phase workers run as `claude --bg` jobs and emit events when
-  they finish; the orchestrator wakes on those events and dispatches the next phase
-  asynchronously. Work does not stop when the human stops looking.
+- **Background continuity.** Agents should keep working while the operator is away from the keyboard. Phase workers run as `claude --bg` jobs and emit events when they finish; the orchestrator wakes on those events and dispatches the next phase asynchronously. Work does not stop when the human stops looking.
 
-- **Human-in-the-loop oversight.** When something stalls, needs a design call, or
-  surfaces a finding, observability — HUD, web dashboard, comms channel, event tail
-  — makes worker state visible without forcing the operator to reconstruct context
-  from raw logs.
+- **Human-in-the-loop oversight.** When something stalls, needs a design call, or surfaces a finding, observability — HUD, web dashboard, comms channel, event tail — makes worker state visible without forcing the operator to reconstruct context from raw logs.
 
-- **Cost-aware parallelism.** Running tickets in parallel waves multiplies throughput,
-  and it also multiplies the risk of conflicts, rework, and tokens spent on doomed
-  work. Wave scheduling lets unblocked work advance independently; revive budgets,
-  healthchecks, and turn caps cap the blast radius of any single stuck worker.
+- **Cost-aware parallelism.** Running tickets in parallel waves multiplies throughput, and it also multiplies the risk of conflicts, rework, and tokens spent on doomed work. Wave scheduling lets unblocked work advance independently; revive budgets, healthchecks, and turn caps cap the blast radius of any single stuck worker.
 
-- **Signal-routed IPC.** Background agents share no memory. They communicate by
-  appending to an immutable event log (`~/catalyst/events/YYYY-MM.jsonl`) and
-  registering broker interests that describe which subset of events should wake
-  them. Each agent's context loads only signals relevant to its task — no inbox
-  sweeping, no low-value polling, no spam.
+- **Signal-routed IPC.** Background agents share no memory. They communicate by appending to an immutable event log (`~/catalyst/events/YYYY-MM.jsonl`) and registering broker interests that describe which subset of events should wake them. Each agent's context loads only signals relevant to its task — no inbox sweeping, no low-value polling, no spam.
 
 ## TL;DR
 
-A single operator command (`/catalyst-legacy:orchestrate …`) launches an interactive
-Claude Code session that schedules tickets into waves and dispatches **phase-agent
-workers** (or legacy `oneshot` workers, depending on `dispatchMode`) into one git
-worktree per ticket.
+A single operator command (`/catalyst-legacy:orchestrate …`) launches an interactive Claude Code session that schedules tickets into waves and dispatches **phase-agent workers** (or legacy `oneshot` workers, depending on `dispatchMode`) into one git worktree per ticket.
 
 > **Note (v11.0.0, CTL-726):** The wave-based orchestration skills (`orchestrate`, `oneshot`, etc.)
 > moved to the `catalyst-legacy` plugin. The *current* multi-ticket model is the execution-core
 > daemon — see [architecture.md](architecture.md) for the end-to-end phase-agent pipeline. Phase-agent workers run as `claude --bg` jobs and walk a
-**10-phase pipeline** — one `--bg` job per phase — emitting `phase.<name>.complete.<TICKET>`
-events the orchestrator wakes on via the broker. The orchestrator advances each
-ticket through the pipeline, opens a PR, waits for CI and merge, runs teardown,
-and archives the run.
+**10-phase pipeline** — one `--bg` job per phase — emitting `phase.<name>.complete.<TICKET>` events the orchestrator wakes on via the broker. The orchestrator advances each ticket through the pipeline, opens a PR, waits for CI and merge, runs teardown, and archives the run.
 
 ## User flow
 
@@ -69,8 +44,7 @@ flowchart TD
   I --> J[~/catalyst/archives/&lt;orchId&gt;/<br/>+ catalyst.db rows]
 ```
 
-The orchestrator itself runs as a normal Claude Code session — there is no `--bg`
-flag on the `orchestrate` skill. Only its workers are backgrounded.
+The orchestrator itself runs as a normal Claude Code session — there is no `--bg` flag on the `orchestrate` skill. Only its workers are backgrounded.
 
 ## Dispatch mode
 
@@ -81,58 +55,26 @@ Selected by `.catalyst/config.json → catalyst.orchestration.dispatchMode`:
 | `"phase-agents"` | `claude --bg --resume /catalyst-dev:phase-<name> <TICKET> --orch-dir <ORCH_DIR>` via `phase-agent-dispatch` | Template default. One `--bg` job per phase. State at `~/.claude/jobs/<bg_job_id>/state.json`. |
 | `"oneshot-legacy"` | `claude -p /catalyst-legacy:oneshot <TICKET> --auto-merge` (long-lived, streaming JSON) | Runtime default when key missing. Pre-CTL-452 model. |
 
-Dispatch-mode resolution lives in `plugins/dev/scripts/orchestrate-dispatch-next`.
-Without `--config <path>`, the dispatcher always uses `oneshot-legacy`; the
-`orchestrate` skill passes `--config "${REPO_ROOT}/.catalyst/config.json"` so the
-project config wins.
+Dispatch-mode resolution lives in `plugins/dev/scripts/orchestrate-dispatch-next`. Without `--config <path>`, the dispatcher always uses `oneshot-legacy`; the `orchestrate` skill passes `--config "${REPO_ROOT}/.catalyst/config.json"` so the project config wins.
 
 ### Config drift detection (CTL-489)
 
-When `plugins/dev/templates/config.template.json` gains a new key (e.g. CTL-452's
-`orchestration.dispatchMode`), existing projects' `.catalyst/config.json` files do not
-automatically receive it. To prevent the silent-fallback class of bug (CTL-487 — catalyst itself
-ran in `oneshot-legacy` mode for two months because the new key was absent),
-`plugins/dev/scripts/check-config-drift.sh` walks the template and emits one warning per missing
-leaf key. The drift script is wired into `check-project-setup.sh`, so every workflow that runs
-the prereq check (`/orchestrate`, `/oneshot`, `/research-codebase`, etc.) prints drift warnings
-until the user runs `/catalyst-foundry:setup-catalyst`, which offers a `jq` deep-merge that adds the
-missing keys while preserving every existing user value (jq's `*` recursive merge with project
-on the right). Allow-listed roots (`projectKey`, `project.ticketPrefix`, `linear.teamKey`,
-`linear.stateMap`, `linear.stateIds`) are suppressed to avoid double-warning — those are already
-checked individually by `check-project-setup.sh`.
+When `plugins/dev/templates/config.template.json` gains a new key (e.g. CTL-452's `orchestration.dispatchMode`), existing projects' `.catalyst/config.json` files do not automatically receive it. To prevent the silent-fallback class of bug (CTL-487 — catalyst itself ran in `oneshot-legacy` mode for two months because the new key was absent), `plugins/dev/scripts/check-config-drift.sh` walks the template and emits one warning per missing leaf key. The drift script is wired into `check-project-setup.sh`, so every workflow that runs the prereq check (`/orchestrate`, `/oneshot`, `/research-codebase`, etc.) prints drift warnings until the user runs `/catalyst-foundry:setup-catalyst`, which offers a `jq` deep-merge that adds the missing keys while preserving every existing user value (jq's `*` recursive merge with project on the right). Allow-listed roots (`projectKey`, `project.ticketPrefix`, `linear.teamKey`, `linear.stateMap`, `linear.stateIds`) are suppressed to avoid double-warning — those are already checked individually by `check-project-setup.sh`.
 
 ### Execution-core entry triggers (two-state monitor)
 
-In `execution-core` dispatch mode the daemon's monitor reacts to Linear
-`state_changed` events:
+In `execution-core` dispatch mode the daemon's monitor reacts to Linear `state_changed` events:
 
-- **`→Triage`** one-shot-dispatches the triage phase agent (the ticket is not
-  scheduler-pulled).
-- **`→Todo`** is the scheduler-eligible entry. New work enters the pipeline at
-  the `research` phase on the contract that a Todo ticket has already been
-  triaged.
+- **`→Triage`** one-shot-dispatches the triage phase agent (the ticket is not scheduler-pulled).
+- **`→Todo`** is the scheduler-eligible entry. New work enters the pipeline at the `research` phase on the contract that a Todo ticket has already been triaged.
 
-A user may move a ticket **Backlog → Todo directly**, skipping `→Triage`
-(an intentional human shortcut). When this happens and no `triage.json` exists
-for the ticket, the monitor **auto-dispatches the triage phase agent** rather
-than reconciling the ticket into the eligible set — triage then runs and its
-completion advances the ticket to `research` normally. This makes "Todo" a
-valid manual entry point: the system transparently runs the missing triage
-instead of dead-locking the research prior-artifact gate. (CTL-625)
+A user may move a ticket **Backlog → Todo directly**, skipping `→Triage` (an intentional human shortcut). When this happens and no `triage.json` exists for the ticket, the monitor **auto-dispatches the triage phase agent** rather than reconciling the ticket into the eligible set — triage then runs and its completion advances the ticket to `research` normally. This makes "Todo" a valid manual entry point: the system transparently runs the missing triage instead of dead-locking the research prior-artifact gate. (CTL-625)
 
-**Linear app-actor self-echo guard.** `catalyst.monitor.linear.botUserId` (Layer-1
-`.catalyst/config.json`, the Linear user UUID of the Catalyst app-actor) is the
-self-echo guard the daemon uses to tell the agent's *own* mirror comments from a
-human reply, so bot-authored issue events don't feed back as a false "human
-replied" signal or a write loop. Required for the Linear app-actor comms channel —
-i.e. when the daemon mirrors phase-agent output to Linear and wakes on human
-replies (CTL-550 / CTL-549 / CTL-749). Set it via `/catalyst-foundry:setup-catalyst`;
-distributed templates ship `null`.
+**Linear app-actor self-echo guard.** `catalyst.monitor.linear.botUserId` (Layer-1 `.catalyst/config.json`, the Linear user UUID of the Catalyst app-actor) is the self-echo guard the daemon uses to tell the agent's *own* mirror comments from a human reply, so bot-authored issue events don't feed back as a false "human replied" signal or a write loop. Required for the Linear app-actor comms channel — i.e. when the daemon mirrors phase-agent output to Linear and wakes on human replies (CTL-550 / CTL-549 / CTL-749). Set it via `/catalyst-foundry:setup-catalyst`; distributed templates ship `null`.
 
 ## The 10-phase pipeline (phase-agents mode)
 
-Canonical sequence is defined in `plugins/dev/scripts/orchestrate-phase-advance`
-and mirrored in the orchestrate skill's pipeline reference table.
+Canonical sequence is defined in `plugins/dev/scripts/orchestrate-phase-advance` and mirrored in the orchestrate skill's pipeline reference table.
 
 | # | Phase | Sub-skill / agent | Linear state | Signal file | Default model | Turn cap |
 |---|---|---|---|---|---|---|
@@ -147,64 +89,27 @@ and mirrored in the orchestrate skill's pipeline reference table.
 | 9 | `monitor-deploy` | `/canary` (gstack) | — | `phase-monitor-deploy.json` | Haiku | 30 |
 | 10 | `teardown` | `/catalyst-dev:teardown` | `done` | `phase-teardown.json` | Sonnet | 15 |
 
-**Teardown is the terminal phase.** It owns all end-of-ticket housekeeping that
-previously had no clear owner:
+**Teardown is the terminal phase.** It owns all end-of-ticket housekeeping that previously had no clear owner:
 
 - Posts the final Linear comment summarising the completed run.
 - Transitions the Linear ticket to `Done`.
-- Removes the git worktree (non-force `git worktree remove`, gated on a
-  merge-confirmation check + worktree presweep liveness check).
-- Deletes the local branch (`git branch -D`; the remote branch was already
-  deleted by monitor-merge's `gh pr merge --delete-branch`).
+- Removes the git worktree (non-force `git worktree remove`, gated on a merge-confirmation check + worktree presweep liveness check).
+- Deletes the local branch (`git branch -D`; the remote branch was already deleted by monitor-merge's `gh pr merge --delete-branch`).
 - Archives the worker directory under `~/catalyst/archives/<TICKET>/`.
 
-**monitor-merge no longer writes Done or removes the worktree.** It merges the PR
-and emits `phase.monitor-merge.complete`, then hands off to monitor-deploy and
-subsequently teardown for all cleanup.
+**monitor-merge no longer writes Done or removes the worktree.** It merges the PR and emits `phase.monitor-merge.complete`, then hands off to monitor-deploy and subsequently teardown for all cleanup.
 
-**Ancillary phase — `remediate` (CTL-653).** Not a member of the linear
-sequence: it is a *router-orchestrated conditional detour* the scheduler takes
-when `verify` produces a verdict-fail (`verify.json.regression_risk ≥ 5` OR any
-`severity:"high"` finding). It reads `verify.json.findings[]` as its brief, fixes
-the code, commits, emits `phase.remediate.complete`, and the router cycles back
-to a fresh `verify`. The loop repeats up to **3** times (a counter distinct from
-the revive budget, event-counted via `phase.remediate.complete.<ticket>`); only a
-verdict-fail *after* the budget is spent escalates to `stalled` → the escalation guard.
+**Ancillary phase — `remediate` (CTL-653).** Not a member of the linear sequence: it is a *router-orchestrated conditional detour* the scheduler takes when `verify` produces a verdict-fail (`verify.json.regression_risk ≥ 5` OR any `severity:"high"` finding). It reads `verify.json.findings[]` as its brief, fixes the code, commits, emits `phase.remediate.complete`, and the router cycles back to a fresh `verify`. The loop repeats up to **3** times (a counter distinct from the revive budget, event-counted via `phase.remediate.complete.<ticket>`); only a verdict-fail *after* the budget is spent escalates to `stalled` → the escalation guard.
 
 | Phase | Sub-skill / agent | Linear state | Prior artifact | Default model | Turn cap |
 |---|---|---|---|---|---|
 | `remediate` | (none — fixes findings inline via Edit/Write) | `remediating` (→ Remediate) | `verify.json` | Opus | 40 |
 
-The conditional routing lives entirely in `deriveAdvancement`
-(`execution-core/scheduler.mjs`); the pure FSM (`lib/phase-fsm.mjs`) keeps
-`verify → review` as its single happy-path edge, so `remediate` is added only as
-a *known ancillary phase* (`isKnownPhase`, `ANCILLARY_PHASES`,
-`REMEDIATE_CYCLE_CAP = 3`). Re-entry past the `next.phase in sig` guard is done by
-deleting the verify+remediate cycle signals (`maybeResetForRemediateCycle`); the
-cap escalation stalls the verify signal (`maybeEscalateRemediateExhausted`).
+The conditional routing lives entirely in `deriveAdvancement` (`execution-core/scheduler.mjs`); the pure FSM (`lib/phase-fsm.mjs`) keeps `verify → review` as its single happy-path edge, so `remediate` is added only as a *known ancillary phase* (`isKnownPhase`, `ANCILLARY_PHASES`, `REMEDIATE_CYCLE_CAP = 3`). Re-entry past the `next.phase in sig` guard is done by deleting the verify+remediate cycle signals (`maybeResetForRemediateCycle`); the cap escalation stalls the verify signal (`maybeEscalateRemediateExhausted`).
 
-Each phase writes its signal file at
-`~/catalyst/runs/<orchId>/workers/<TICKET>/phase-<name>.json`. Per-phase turn-cap
-defaults live in `plugins/dev/scripts/phase-agent-dispatch` (functions
-`phase_default_turn_cap` and `resolve_turn_cap`, which honors a CLI flag override
-and the `catalyst.orchestration.phaseAgents.turnCaps[<phase>]` config key in that
-order). The prior-artifact gate — which file must already exist before a phase
-launches — sits alongside in the same script.
+Each phase writes its signal file at `~/catalyst/runs/<orchId>/workers/<TICKET>/phase-<name>.json`. Per-phase turn-cap defaults live in `plugins/dev/scripts/phase-agent-dispatch` (functions `phase_default_turn_cap` and `resolve_turn_cap`, which honors a CLI flag override and the `catalyst.orchestration.phaseAgents.turnCaps[<phase>]` config key in that order). The prior-artifact gate — which file must already exist before a phase launches — sits alongside in the same script.
 
-**Dispatch-time rebase (CTL-667).** On a **fresh** dispatch of a **build** phase
-(`research`, `plan`, `implement`, `verify`, `review`), `phase-agent-dispatch`
-rebases the ticket's worktree onto current `origin/main` *before* launching the
-worker, so each build phase starts current with merged sibling work and a
-divergence surfaces at dispatch instead of riding all the way to `monitor-merge`.
-It is local-only (never pushes, never touches the PR) and mechanical: a clean
-rebase falls through to the normal launch; a textual **conflict** aborts, parks
-the ticket (`status:"stalled"` + `failureReason:"rebase_conflict_with_origin_main"`,
-`phase.<phase>.failed` emitted) and routes it to the escalation guard without launching a
-worker — conflicts are never auto-resolved. Resume dispatches (CTL-658) and the
-non-build phases (`triage`/`pr`/`remediate`/`monitor-merge`/`monitor-deploy`/`teardown`) skip
-the rebase; the `monitor-*` and `teardown` phases operate on the PR / merged SHA and keep their
-own `BEHIND` handling. Git logic lives in `lib/worktree-rebase.sh`; the build-phase
-set is `is_rebase_phase` in `lib/phase-sequence.sh`.
+**Dispatch-time rebase (CTL-667).** On a **fresh** dispatch of a **build** phase (`research`, `plan`, `implement`, `verify`, `review`), `phase-agent-dispatch` rebases the ticket's worktree onto current `origin/main` *before* launching the worker, so each build phase starts current with merged sibling work and a divergence surfaces at dispatch instead of riding all the way to `monitor-merge`. It is local-only (never pushes, never touches the PR) and mechanical: a clean rebase falls through to the normal launch; a textual **conflict** aborts, parks the ticket (`status:"stalled"` + `failureReason:"rebase_conflict_with_origin_main"`, `phase.<phase>.failed` emitted) and routes it to the escalation guard without launching a worker — conflicts are never auto-resolved. Resume dispatches (CTL-658) and the non-build phases (`triage`/`pr`/`remediate`/`monitor-merge`/`monitor-deploy`/`teardown`) skip the rebase; the `monitor-*` and `teardown` phases operate on the PR / merged SHA and keep their own `BEHIND` handling. Git logic lives in `lib/worktree-rebase.sh`; the build-phase set is `is_rebase_phase` in `lib/phase-sequence.sh`.
 
 ### State machine for one worker
 
@@ -235,18 +140,11 @@ stateDiagram-v2
   stalled --> [*]
 ```
 
-Revives are once-per-phase; on the second `phase.<name>.failed` for the same phase
-the orchestrator marks the worker `stalled`, posts `attention`, and stops advancing.
-The `verify ⇄ remediate` cycle (CTL-653) is the one exception to the
-"escalate on second failure" rule: a verify *verdict*-fail (a `complete` event
-with a high `regression_risk`, distinct from a verify *crash* `failed` event)
-self-heals through `remediate` up to 3 times before stalling — so a fixable
-verify failure no longer needs a human on the first try.
+Revives are once-per-phase; on the second `phase.<name>.failed` for the same phase the orchestrator marks the worker `stalled`, posts `attention`, and stops advancing. The `verify ⇄ remediate` cycle (CTL-653) is the one exception to the "escalate on second failure" rule: a verify *verdict*-fail (a `complete` event with a high `regression_risk`, distinct from a verify *crash* `failed` event) self-heals through `remediate` up to 3 times before stalling — so a fixable verify failure no longer needs a human on the first try.
 
 ## Phase 4 monitor — broker interests + event flow
 
-The orchestrator registers four broker interests at Phase 4 start. All four route
-back as `filter.wake.<ORCH_NAME>` so the orchestrator only watches one event stream:
+The orchestrator registers four broker interests at Phase 4 start. All four route back as `filter.wake.<ORCH_NAME>` so the orchestrator only watches one event stream:
 
 | Interest | Type | Cardinality | Source |
 |---|---|---|---|
@@ -255,11 +153,7 @@ back as `filter.wake.<ORCH_NAME>` so the orchestrator only watches one event str
 | `${ORCH_NAME}-comms-lifecycle` | `comms_lifecycle` | 1 per orchestrator | always |
 | `${ORCH_NAME}-phase-lifecycle-<TICKET>` | `phase_lifecycle` | 1 per ticket | only when `dispatchMode = "phase-agents"` |
 
-The `phase_lifecycle` interest carries `{ticket, phase_names[10]}`. The broker's
-`tryPhaseLifecycleRoute` function in `plugins/dev/scripts/broker/index.mjs` matches
-incoming events against
-`^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-\d+)$`
-deterministically (no Groq).
+The `phase_lifecycle` interest carries `{ticket, phase_names[10]}`. The broker's `tryPhaseLifecycleRoute` function in `plugins/dev/scripts/broker/index.mjs` matches incoming events against `^phase\.([^.]+)\.(complete|failed)\.([A-Za-z][A-Za-z0-9_]*-\d+)$` deterministically (no Groq).
 
 ```mermaid
 sequenceDiagram
@@ -287,49 +181,20 @@ sequenceDiagram
 
 `orchestrate-healthcheck` does two passes:
 
-1. **Legacy PID liveness** — for `workers/*.json` at `status=dispatched`, after a
-   `--grace-seconds` (default 15s) wait, checks `kill -0 $PID`. Dead PIDs →
-   `status=failed` + `worker-launch-failed` event.
-2. **Phase-mode `--bg` state-file mtime** — for each `workers/*/phase-*.json` with a
-   `bg_job_id`, stats `${JOBS_ROOT}/<bg>/state.json` (where `JOBS_ROOT` defaults
-   to `$HOME/.claude/jobs`). Stalled if:
+1. **Legacy PID liveness** — for `workers/*.json` at `status=dispatched`, after a `--grace-seconds` (default 15s) wait, checks `kill -0 $PID`. Dead PIDs → `status=failed` + `worker-launch-failed` event.
+2. **Phase-mode `--bg` state-file mtime** — for each `workers/*/phase-*.json` with a `bg_job_id`, stats `${JOBS_ROOT}/<bg>/state.json` (where `JOBS_ROOT` defaults to `$HOME/.claude/jobs`). Stalled if:
    - file missing → `STALL_REASON="state-json-missing"`, OR
-   - mtime older than `--stale-bg-seconds` (default 900s) AND `.state` not in
-     `{done, failed, errored, stopped}` → `STALL_REASON="state-json-stale"`
+   - mtime older than `--stale-bg-seconds` (default 900s) AND `.state` not in `{done, failed, errored, stopped}` → `STALL_REASON="state-json-stale"`
 
-   A **git-activity liveness guard** (CTL-509) protects the `state-json-stale`
-   branch: before flagging, it reads the worker worktree's most-recent commit
-   timestamp and, if it is newer than `--git-activity-seconds` (defaults to
-   `--stale-bg-seconds`), suppresses the stall (signal left `running`, a
-   `worker-phase-stale-suppressed` event logged, `gitActiveSuppressed` bumped in
-   the summary). This mirrors the execution-core `stalled-detector.mjs` guard
-   (inactive in phase-agents mode) so a live worker blocked in one long tool call
-   is not falsely re-dispatched. It never guards `state-json-missing` and is
-   opt-out via `--no-git-guard` / `CATALYST_HEALTHCHECK_GIT_GUARD=0`.
+A **git-activity liveness guard** (CTL-509) protects the `state-json-stale` branch: before flagging, it reads the worker worktree's most-recent commit timestamp and, if it is newer than `--git-activity-seconds` (defaults to `--stale-bg-seconds`), suppresses the stall (signal left `running`, a `worker-phase-stale-suppressed` event logged, `gitActiveSuppressed` bumped in the summary). This mirrors the execution-core `stalled-detector.mjs` guard (inactive in phase-agents mode) so a live worker blocked in one long tool call is not falsely re-dispatched. It never guards `state-json-missing` and is opt-out via `--no-git-guard` / `CATALYST_HEALTHCHECK_GIT_GUARD=0`.
 
-Revive budget: the top-level `workers/<TICKET>.json` carries `.reviveCount`. When
-`reviveCount >= MAX_REVIVES` (default 10), the worker is marked `stalled` with
-`attentionReason="revive-budget-exhausted"`.
+Revive budget: the top-level `workers/<TICKET>.json` carries `.reviveCount`. When `reviveCount >= MAX_REVIVES` (default 10), the worker is marked `stalled` with `attentionReason="revive-budget-exhausted"`.
 
-Phase-mode workers that emit `phase.<name>.turn-cap-exhausted.<TICKET>` are
-continued via `orchestrate-revive`'s per-phase loop (CTL-613): the loop reads
-`.handoffPath` off the per-phase signal, resolves the prior Claude session id
-from `${JOBS_ROOT}/<bg_job_id>/state.json`'s `linkScanPath` field, resolves the
-worktree from the orchestrator's `state.json`, and spawns a `claude --bg --resume`
-worker with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH=<path>` +
-`CATALYST_CONTINUATION_COUNT=<n>`. The per-phase signal flips back to `running`
-with the new `bg_job_id`, `phaseContinuationCount` bumps, and a
-`phase.<name>.dispatched` event re-arms the broker. `phaseContinuationCount` is
-budgeted separately from `phaseReviveCount` (which counts hard-error
-re-dispatches) and shares `MAX_CONTINUATIONS` with the legacy top-level
-continuation branch.
+Phase-mode workers that emit `phase.<name>.turn-cap-exhausted.<TICKET>` are continued via `orchestrate-revive`'s per-phase loop (CTL-613): the loop reads `.handoffPath` off the per-phase signal, resolves the prior Claude session id from `${JOBS_ROOT}/<bg_job_id>/state.json`'s `linkScanPath` field, resolves the worktree from the orchestrator's `state.json`, and spawns a `claude --bg --resume` worker with `CATALYST_IS_CONTINUATION=true` + `CATALYST_HANDOFF_PATH=<path>` + `CATALYST_CONTINUATION_COUNT=<n>`. The per-phase signal flips back to `running` with the new `bg_job_id`, `phaseContinuationCount` bumps, and a `phase.<name>.dispatched` event re-arms the broker. `phaseContinuationCount` is budgeted separately from `phaseReviveCount` (which counts hard-error re-dispatches) and shares `MAX_CONTINUATIONS` with the legacy top-level continuation branch.
 
 ## The events JSONL is the unified log
 
-Everything Catalyst does — worker dispatch, phase transitions, PR lifecycle,
-GitHub/Linear webhooks, broker wakes — flows through one append-only file at
-`~/catalyst/events/YYYY-MM.jsonl` (monthly rotation, canonical OTel-style envelope).
-This is the single source of cross-process truth.
+Everything Catalyst does — worker dispatch, phase transitions, PR lifecycle, GitHub/Linear webhooks, broker wakes — flows through one append-only file at `~/catalyst/events/YYYY-MM.jsonl` (monthly rotation, canonical OTel-style envelope). This is the single source of cross-process truth.
 
 ```mermaid
 flowchart LR
@@ -377,86 +242,17 @@ flowchart LR
   REAPER -- "re-emits *.reap-complete<br/>/ *.reap-failed echoes (CTL-649)" --> EL
 ```
 
-**The broker is both a producer and a consumer** — it tails the same log it writes
-into. The `shouldSkipEvent` function (in `broker/index.mjs`) prevents the feedback
-loop: events whose `resource."service.name"` equals `"catalyst.broker"` are dropped
-on read (belt-and-suspenders fallback also drops names prefixed `filter.` or
-`broker.daemon.`). A separate `_emittedWakeCache` (60s TTL on
-`(source_event_id, interest_id)`) deduplicates wakes when `fs.watch` fires twice
-on the same append.
+**The broker is both a producer and a consumer** — it tails the same log it writes into. The `shouldSkipEvent` function (in `broker/index.mjs`) prevents the feedback loop: events whose `resource."service.name"` equals `"catalyst.broker"` are dropped on read (belt-and-suspenders fallback also drops names prefixed `filter.` or `broker.daemon.`). A separate `_emittedWakeCache` (60s TTL on `(source_event_id, interest_id)`) deduplicates wakes when `fs.watch` fires twice on the same append.
 
-**The broker is also the ingestion-silence detector (CTL-1122).** Because it tails
-every event, the broker is the surviving process that can judge whether an upstream
-ingestion source has gone quiet — the out-of-process check the monitor can't do for
-itself (the SPOF behind a 2026-06-14 11h silent outage). Each watchdog tick it
-evaluates per-source event recency and edge-triggers `catalyst.ingestion.{stale,recovered}`
-(emit-only; CTL-1123 consumes them). The `catalyst.monitor` heartbeat is judged on a
-tight fixed cadence (3m/10m, ungated). The `catalyst.github` webhook source is judged
-on a wide threshold (15m/30m) **gated on fleet activity** — github silence only alarms
-while a worker is in-flight (a fresh non-terminal `worker_state` row), so an idle fleet
-never false-alarms. Linear is deferred (its bot-skip guard makes the source quiet even
-during active work). See the configuration reference for the env knobs.
+**The broker is also the ingestion-silence detector (CTL-1122).** Because it tails every event, the broker is the surviving process that can judge whether an upstream ingestion source has gone quiet — the out-of-process check the monitor can't do for itself (the SPOF behind a 2026-06-14 11h silent outage). Each watchdog tick it evaluates per-source event recency and edge-triggers `catalyst.ingestion.{stale,recovered}` (emit-only; CTL-1123 consumes them). The `catalyst.monitor` heartbeat is judged on a tight fixed cadence (3m/10m, ungated). The `catalyst.github` webhook source is judged on a wide threshold (15m/30m) **gated on fleet activity** — github silence only alarms while a worker is in-flight (a fresh non-terminal `worker_state` row), so an idle fleet never false-alarms. Linear is deferred (its bot-skip guard makes the source quiet even during active work). See the configuration reference for the env knobs.
 
-**On top of the detector, the broker is the alert-policy layer (CTL-1123).** The
-`catalyst.ingestion.*` events above are low-level; the broker promotes the
-operator-actionable subset into a stable `catalyst.alert.{raised,cleared}` topic
-(`event.label` = the alert kind). `system_down` is promoted from a critical source's
-sustained `catalyst.ingestion.stale` (a dead monitor).
+**On top of the detector, the broker is the alert-policy layer (CTL-1123).** The `catalyst.ingestion.*` events above are low-level; the broker promotes the operator-actionable subset into a stable `catalyst.alert.{raised,cleared}` topic (`event.label` = the alert kind). `system_down` is promoted from a critical source's sustained `catalyst.ingestion.stale` (a dead monitor).
 
-**System trouble is ONE fleet-scoped, auto-clearing alert — never one per ticket
-(CTL-2156).** Three kinds — `provider_degraded` (429/529 provider overload),
-`rate_limit_exhausted` (a Claude account / Linear / GitHub budget spent) and
-`capacity_unavailable` (a node with no execution slots) — are detected by
-`broker/system-trouble.mjs` from telemetry the fleet already emits
-(`execution-core.sdk.overloaded`, `account.status.changed`,
-`account.ratelimit.{sampled,unsampled}`, `linear.write.proxy.budget-exhausted`,
-`linear.label.retry-exhausted`, `node.capacity.changed`). Each kind's LEVEL is the
-number of *distinct* affected things (tickets / accounts / nodes) inside a trailing
-window, debounced by threshold + persistence + cooldown, so a provider outage
-touching forty tickets raises exactly **one** alert and writes **zero** per-ticket
-artifacts — the tickets simply wait and resume by themselves. The alert clears
-itself when the condition ends, either because a producer retracts (capacity
-restored, account no longer rejected) or because every affected key ages out of the
-window. This replaces the retired `needs_human_pileup` kind, which counted
-escalation LABELS — the per-ticket artifact — rather than the
-condition. These alert events ride the same event log → `otel-forward` → OTel collector → fan-out (Loki, dash0),
-where a downstream alert rule routes them to a channel. **Delivery is a separate concern**
-— the broker emits intent only; no channel or credential lives in the daemon, so the
-alerter survives a monitor death without depending on it.
+**System trouble is ONE fleet-scoped, auto-clearing alert — never one per ticket (CTL-2156).** Three kinds — `provider_degraded` (429/529 provider overload), `rate_limit_exhausted` (a Claude account / Linear / GitHub budget spent) and `capacity_unavailable` (a node with no execution slots) — are detected by `broker/system-trouble.mjs` from telemetry the fleet already emits (`execution-core.sdk.overloaded`, `account.status.changed`, `account.ratelimit.{sampled,unsampled}`, `linear.write.proxy.budget-exhausted`, `linear.label.retry-exhausted`, `node.capacity.changed`). Each kind's LEVEL is the number of *distinct* affected things (tickets / accounts / nodes) inside a trailing window, debounced by threshold + persistence + cooldown, so a provider outage touching forty tickets raises exactly **one** alert and writes **zero** per-ticket artifacts — the tickets simply wait and resume by themselves. The alert clears itself when the condition ends, either because a producer retracts (capacity restored, account no longer rejected) or because every affected key ages out of the window. This replaces the retired `needs_human_pileup` kind, which counted escalation LABELS — the per-ticket artifact — rather than the condition. These alert events ride the same event log → `otel-forward` → OTel collector → fan-out (Loki, dash0), where a downstream alert rule routes them to a channel. **Delivery is a separate concern** — the broker emits intent only; no channel or credential lives in the daemon, so the alerter survives a monitor death without depending on it.
 
-**Every stall resolves to exactly ONE class — or is HELD (CTL-2158).**
-`execution-core/stall-class.mjs` is the single classifier: `classifyStall(evidence)`
-maps a stall reason to **S — system** (provider overload, rate/account limits, tokens
-exhausted, connectivity, executor or worker death, an artifact written late,
-retry/cycle caps, an untidy working copy, fence/zombie trips, orphan-sweep staleness
-→ retry with backoff; if persistent, the ONE fleet alert above, and **zero**
-per-ticket artifacts), **A — ask** (scope, priority, approval, a credential or
-dashboard action only a person can take, design sign-off → one ask ticket carrying
-`blocks`), or **M — moot** (already done, superseded, no actionable plan → close).
-An exact table is tried first, then prefix rules, then three family patterns; if two
-families match, or none does, the verdict is **HELD** — not a fourth disposition but
-the *absence* of one. A held stall is never dropped, never guessed at, never
-auto-retried forever and never auto-cleared, because both possible defaults are
-expensive: defaulting to *ask* re-creates the bin (of 86 items flagged as waiting on
-a human, 3 genuinely were), and defaulting to *system* strands a real judgment call
-silently. `needs_human` itself classifies as HELD by construction — it records
-*that* an escalation happened and nothing about *why*. The verdict is stamped onto
-the phase signal (`stallClass`, `stallClassRule`, `stallClassManufactured`) by the
-four producers that publish a complete escalation, alongside `escalationPublished`,
-which is what `unstuck-sweep.mjs`'s quiet-gate now keys on — a property, not the
-`stalledReason:"needs_human"` token — so a ticket a human is already holding never
-receives a second authored Linear comment once that token goes away.
+**Every stall resolves to exactly ONE class — or is HELD (CTL-2158).** `execution-core/stall-class.mjs` is the single classifier: `classifyStall(evidence)` maps a stall reason to **S — system** (provider overload, rate/account limits, tokens exhausted, connectivity, executor or worker death, an artifact written late, retry/cycle caps, an untidy working copy, fence/zombie trips, orphan-sweep staleness → retry with backoff; if persistent, the ONE fleet alert above, and **zero** per-ticket artifacts), **A — ask** (scope, priority, approval, a credential or dashboard action only a person can take, design sign-off → one ask ticket carrying `blocks`), or **M — moot** (already done, superseded, no actionable plan → close). An exact table is tried first, then prefix rules, then three family patterns; if two families match, or none does, the verdict is **HELD** — not a fourth disposition but the *absence* of one. A held stall is never dropped, never guessed at, never auto-retried forever and never auto-cleared, because both possible defaults are expensive: defaulting to *ask* re-creates the bin (of 86 items flagged as waiting on a human, 3 genuinely were), and defaulting to *system* strands a real judgment call silently. `needs_human` itself classifies as HELD by construction — it records *that* an escalation happened and nothing about *why*. The verdict is stamped onto the phase signal (`stallClass`, `stallClassRule`, `stallClassManufactured`) by the four producers that publish a complete escalation, alongside `escalationPublished`, which is what `unstuck-sweep.mjs`'s quiet-gate now keys on — a property, not the `stalledReason:"needs_human"` token — so a ticket a human is already holding never receives a second authored Linear comment once that token goes away.
 
-**The execution-core daemon reaper (CTL-649) is the second producer-and-consumer.**
-It consumes the reap-intent requests appended by the reap-intent producers
-(`lib/emit-reap-intent.sh`, `execution-core/reap-intent.mjs`) — `phase.<kind>.reap-requested`,
-`worktree.presweep.reap-requested`, `pr.merged.cleanup-requested`, `orphans.reap-requested` — by
-boot-replaying any request with no matching `*-complete` echo on daemon start, then following new
-appends via an `fs.watch` + byte-cursor tail. For each it runs the matching local executor
-(`claude stop`, `git worktree remove`, `git branch -D`) and re-emits a `*.reap-complete` /
-`*.reap-failed` echo back into the same log; `orphans.reap-requested` fans out to one
-`phase.abort.reap-requested` per orphaned session. An in-memory dedupe window (keyed on
-`event:bg_job_id|worktree_path`) suppresses duplicate intents.
+**The execution-core daemon reaper (CTL-649) is the second producer-and-consumer.** It consumes the reap-intent requests appended by the reap-intent producers (`lib/emit-reap-intent.sh`, `execution-core/reap-intent.mjs`) — `phase.<kind>.reap-requested`, `worktree.presweep.reap-requested`, `pr.merged.cleanup-requested`, `orphans.reap-requested` — by boot-replaying any request with no matching `*-complete` echo on daemon start, then following new appends via an `fs.watch` + byte-cursor tail. For each it runs the matching local executor (`claude stop`, `git worktree remove`, `git branch -D`) and re-emits a `*.reap-complete` / `*.reap-failed` echo back into the same log; `orphans.reap-requested` fans out to one `phase.abort.reap-requested` per orphaned session. An in-memory dedupe window (keyed on `event:bg_job_id|worktree_path`) suppresses duplicate intents.
 
 ## Where you observe a running orchestration
 
@@ -470,74 +266,31 @@ Five operator surfaces — four read structured state, one reads diagnostic logs
 | **`catalyst-execution-core sessions/worktrees/branches list`** | live `claude agents` inventory + git worktree/branch state (read path of the CTL-649 audit CLI) | `plugins/dev/scripts/catalyst-execution-core` → `execution-core/cli/{sessions,worktrees,branches}.mjs` | Inventory and classify live sessions, worktrees, and branches — what the reaper sees before it acts |
 | **`catalyst broker logs`** | tails `~/catalyst/broker.log` (pino-structured daemon stdout) | `plugins/dev/scripts/catalyst-broker` | Broker daemon diagnostics — Groq errors, routing traces, key-missing warnings |
 
-**Broker logs vs events JSONL — these are different things.** The events log is the
-system's semantic fact record (sparse, structured, durable); `broker.log` is the
-daemon's operational diary (verbose, diagnostic). A `broker.daemon.startup` event
-appears in the events log specifically so orchestrators know to re-register their
-interests — not for human debugging. Broker errors that surface a named event go
-to both; ordinary daemon noise goes only to `broker.log`.
+**Broker logs vs events JSONL — these are different things.** The events log is the system's semantic fact record (sparse, structured, durable); `broker.log` is the daemon's operational diary (verbose, diagnostic). A `broker.daemon.startup` event appears in the events log specifically so orchestrators know to re-register their interests — not for human debugging. Broker errors that surface a named event go to both; ordinary daemon noise goes only to `broker.log`.
 
-`catalyst-hud` surfaces both layouts: flat `workers/*.json` and per-phase
-`workers/<TICKET>/phase-<name>.json`. The reader
-(`worker-signals-reader.ts::scanOrchestratorWorkersDir`) descends one level into
-per-ticket subdirectories, picks the most recent non-terminal phase, and overlays
-its `phaseName`/`status` onto the flat signal so the PHASE column shows the live
-phase (e.g. `implement`, `monitor-merge`).
+`catalyst-hud` surfaces both layouts: flat `workers/*.json` and per-phase `workers/<TICKET>/phase-<name>.json`. The reader (`worker-signals-reader.ts::scanOrchestratorWorkersDir`) descends one level into per-ticket subdirectories, picks the most recent non-terminal phase, and overlays its `phaseName`/`status` onto the flat signal so the PHASE column shows the live phase (e.g. `implement`, `monitor-merge`).
 
 ## Cost capture
 
-Both dispatch modes write the same four cost surfaces — `signal.cost`,
-`state.workers[ticket].usage`, `state.usage`, and the `session_metrics` SQLite
-mirror — but the USAGE source differs by mode. `orchestrate-roll-usage.sh`,
-invoked by `update-dashboard.sh --roll-usage` on every monitor wake-up,
-abstracts the difference.
+Both dispatch modes write the same four cost surfaces — `signal.cost`, `state.workers[ticket].usage`, `state.usage`, and the `session_metrics` SQLite mirror — but the USAGE source differs by mode. `orchestrate-roll-usage.sh`, invoked by `update-dashboard.sh --roll-usage` on every monitor wake-up, abstracts the difference.
 
-**Legacy (`oneshot-legacy` dispatch).** Workers run as `claude -p
---output-format stream-json`. The CLI streams a final `"type":"result"` event
-carrying `total_cost_usd`, `usage`, `num_turns`, and `duration_ms` into
-`workers/output/<TICKET>-stream.jsonl`. roll-usage parses that event into a
-USAGE record.
+**Legacy (`oneshot-legacy` dispatch).** Workers run as `claude -p --output-format stream-json`. The CLI streams a final `"type":"result"` event carrying `total_cost_usd`, `usage`, `num_turns`, and `duration_ms` into `workers/output/<TICKET>-stream.jsonl`. roll-usage parses that event into a USAGE record.
 
-**Phase-agent (`phase-agents` dispatch, CTL-496).** Workers run as `claude
---bg` jobs. There is no `result` event because there is no `--output-format
-stream-json` flag on the bg invocation; instead the CLI writes the full
-conversation to `~/.claude/projects/<wt>/<sessionId>.jsonl`. roll-usage
-resolves the JSONL path via `~/.claude/jobs/<bg_job_id>/state.json
--> linkScanPath` and shells `extract-cost-from-jsonl.sh --jsonl <path>
---pricing claude-pricing.json` to aggregate per-assistant-event `usage` by
-model, split cache_creation by 5m / 1h TTL, and apply the per-model rates
-from a versioned `plugins/dev/scripts/claude-pricing.json`. The four
-downstream writes are then unchanged from legacy.
+**Phase-agent (`phase-agents` dispatch, CTL-496).** Workers run as `claude --bg` jobs. There is no `result` event because there is no `--output-format stream-json` flag on the bg invocation; instead the CLI writes the full conversation to `~/.claude/projects/<wt>/<sessionId>.jsonl`. roll-usage resolves the JSONL path via `~/.claude/jobs/<bg_job_id>/state.json -> linkScanPath` and shells `extract-cost-from-jsonl.sh --jsonl <path> --pricing claude-pricing.json` to aggregate per-assistant-event `usage` by model, split cache_creation by 5m / 1h TTL, and apply the per-model rates from a versioned `plugins/dev/scripts/claude-pricing.json`. The four downstream writes are then unchanged from legacy.
 
-Phase mode aggregates `state.workers[ticket].usage` across phases (`+=`),
-not overwriting, so `state.workers[T].usage.costUSD == sum(phase.cost.costUSD)`
-for that ticket. The `session_metrics` mirror finds the right row via
-`signal.catalystSessionId` (persisted by the phase-agent prelude) or, for
-in-flight runs that predate that persistence, a DB lookup keyed on
-`ticket_key + skill_name = 'phase-<name>'`.
+Phase mode aggregates `state.workers[ticket].usage` across phases (`+=`), not overwriting, so `state.workers[T].usage.costUSD == sum(phase.cost.costUSD)` for that ticket. The `session_metrics` mirror finds the right row via `signal.catalystSessionId` (persisted by the phase-agent prelude) or, for in-flight runs that predate that persistence, a DB lookup keyed on `ticket_key + skill_name = 'phase-<name>'`.
 
-The sweep loop in `update-dashboard.sh` iterates both layouts on every
-wake-up. Killed-worker sidecars (`workers/<T>/phase-<name>.json.dead-<id>.json`)
-are skipped so booked cost is never double-counted.
+The sweep loop in `update-dashboard.sh` iterates both layouts on every wake-up. Killed-worker sidecars (`workers/<T>/phase-<name>.json.dead-<id>.json`) are skipped so booked cost is never double-counted.
 
 ## On Claude Code's "agent view" / agents sidebar
 
-Phase-agent workers run as `claude --bg` jobs and live under
-`~/.claude/jobs/<bg_job_id>/`. **Catalyst does not integrate with Claude Code's
-native UI surfaces.** Specifically:
+Phase-agent workers run as `claude --bg` jobs and live under `~/.claude/jobs/<bg_job_id>/`. **Catalyst does not integrate with Claude Code's native UI surfaces.** Specifically:
 
-- The Claude CLI **writes** `~/.claude/jobs/<id>/state.json`; Catalyst only reads
-  it (for healthcheck mtime / staleness detection).
+- The Claude CLI **writes** `~/.claude/jobs/<id>/state.json`; Catalyst only reads it (for healthcheck mtime / staleness detection).
 - Catalyst ships no UI that hooks into Claude Code's agents sidebar.
-- Whether Claude Code's agents sidebar displays `--bg` jobs is a **Claude Code
-  question**, not a Catalyst question, and is not described in any catalyst source.
+- Whether Claude Code's agents sidebar displays `--bg` jobs is a **Claude Code question**, not a Catalyst question, and is not described in any catalyst source.
 
-If you want to monitor a running orchestration, use `catalyst-hud`, the
-orch-monitor web dashboard, `catalyst-events tail`, the
-`catalyst-execution-core sessions/worktrees/branches list` audit CLI, or
-`catalyst broker logs` — those are the surfaces Catalyst owns. If you want to see
-backgrounded Claude jobs directly, consult the Claude CLI's own documentation for
-whatever inventory it exposes.
+If you want to monitor a running orchestration, use `catalyst-hud`, the orch-monitor web dashboard, `catalyst-events tail`, the `catalyst-execution-core sessions/worktrees/branches list` audit CLI, or `catalyst broker logs` — those are the surfaces Catalyst owns. If you want to see backgrounded Claude jobs directly, consult the Claude CLI's own documentation for whatever inventory it exposes.
 
 ## Canonical artifact / state locations
 
@@ -574,14 +327,11 @@ whatever inventory it exposes.
 | Healthcheck | PID liveness only | PID liveness + `~/.claude/jobs/<bg>/state.json` mtime (`--stale-bg-seconds`, default 900s) |
 | Linear states | Backlog / In Progress / In Review / Done / Canceled | + intermediate `triaged`, `researching`, `planning`, `verifying`, `reviewing`, `inReview` (CTL-454) |
 
-Legacy `oneshot-legacy` mode is unchanged — all the above only activates when
-`dispatchMode = "phase-agents"` is set in `.catalyst/config.json`.
+Legacy `oneshot-legacy` mode is unchanged — all the above only activates when `dispatchMode = "phase-agents"` is set in `.catalyst/config.json`.
 
 ## Cold-start recovery (CTL-639)
 
-When the daemon restarts after a crash or `kill`, the boot-resume pass
-(`boot-resume.mjs::reconcileBootResume`) re-dispatches in-flight tickets whose
-`--bg` workers are no longer alive. The pass classifies each candidate by phase:
+When the daemon restarts after a crash or `kill`, the boot-resume pass (`boot-resume.mjs::reconcileBootResume`) re-dispatches in-flight tickets whose `--bg` workers are no longer alive. The pass classifies each candidate by phase:
 
 | Phase class | Phases | Boot behaviour |
 |---|---|---|
@@ -596,10 +346,7 @@ To approve re-dispatch of a gated ticket, create the approval sentinel:
 touch "$ORCH_DIR/workers/<TICKET>/.boot-resume-approved"
 ```
 
-The scheduler picks it up within one tick (≤30 s) and calls `reviveDispatch`
-for that ticket's phase — subject to the same MAX_REVIVES and storm-breaker
-guards as a per-tick reclaim. Both sentinels are deleted on a successful
-dispatch so a subsequent reboot does not re-dispatch.
+The scheduler picks it up within one tick (≤30 s) and calls `reviveDispatch` for that ticket's phase — subject to the same MAX_REVIVES and storm-breaker guards as a per-tick reclaim. Both sentinels are deleted on a successful dispatch so a subsequent reboot does not re-dispatch.
 
 To list currently gated tickets:
 
@@ -609,8 +356,7 @@ find "$ORCH_DIR/workers" -name ".boot-resume-pending-approval" | while read p; d
 done
 ```
 
-If a HUD button later writes the same sentinel it requires no logic changes —
-`processApprovedResumes` polls for the file, not for the transport that wrote it.
+If a HUD button later writes the same sentinel it requires no logic changes — `processApprovedResumes` polls for the file, not for the transport that wrote it.
 
 ## See also
 
@@ -664,7 +410,7 @@ Two prerequisites block the board-visibility outcome (assigned agent visible in 
    jq --arg id "$BOT_ID" '.catalyst.linear.bot.orchestrator.botUserId = $id' \
      ~/.config/catalyst/config.json > /tmp/cfg.json && mv /tmp/cfg.json ~/.config/catalyst/config.json
    ```
-   Repeat on every host that runs the execution-core daemon.
+Repeat on every host that runs the execution-core daemon.
 
 5. **Restart the daemon** — `botUserId` is read only at startup:
    ```bash

--- a/docs/orphan-sweep.md
+++ b/docs/orphan-sweep.md
@@ -1,8 +1,6 @@
 # Periodic Orphan Sweep
 
-`orphan-sweep.sh` is a launchd-scheduled bash script that runs every 30 minutes and reclaims
-orphaned resources on unattended hosts. It complements the execution-core real-time reaper
-(CTL-657) — it acts whether or not the orchestrator daemon is alive.
+`orphan-sweep.sh` is a launchd-scheduled bash script that runs every 30 minutes and reclaims orphaned resources on unattended hosts. It complements the execution-core real-time reaper (CTL-657) — it acts whether or not the orchestrator daemon is alive.
 
 ## What It Reclaims (Five Vectors)
 
@@ -18,8 +16,7 @@ Telemetry: one `emit-otel-event.sh` call per reclaimed resource (`catalyst.sweep
 
 ### Vector 5 tuning (agent-browser reaper)
 
-Version-agnostic backstop for the CTL-1500 leak (old agent-browser builds have no
-idle timeout). Knobs (env, all with production defaults):
+Version-agnostic backstop for the CTL-1500 leak (old agent-browser builds have no idle timeout). Knobs (env, all with production defaults):
 
 | Env | Default | Meaning |
 |-----|---------|---------|
@@ -29,12 +26,7 @@ idle timeout). Knobs (env, all with production defaults):
 | `SWEEP_AB_TTL_SECS` | `14400` | absolute leaked-browser age cap (4h) |
 | `SWEEP_AB_SOCKET_DIR` | `$AGENT_BROWSER_SOCKET_DIR` → `$XDG_RUNTIME_DIR/agent-browser` → `~/.agent-browser` | sock/pid dir |
 
-Reap = graceful `kill` of the owning daemon (its `SIGTERM` handler closes the browser)
-plus the root browser process (cascades helper children), then removal of that
-session's `.sock`/`.pid`. A shared-Playwright-marker browser with no live agent-browser
-daemon owner is left alone (it may be an unrelated Playwright job). Complements the
-forward fix: phase workers now launch with `AGENT_BROWSER_IDLE_TIMEOUT_MS` set so newer
-agent-browser self-shuts-down when idle.
+Reap = graceful `kill` of the owning daemon (its `SIGTERM` handler closes the browser) plus the root browser process (cascades helper children), then removal of that session's `.sock`/`.pid`. A shared-Playwright-marker browser with no live agent-browser daemon owner is left alone (it may be an unrelated Playwright job). Complements the forward fix: phase workers now launch with `AGENT_BROWSER_IDLE_TIMEOUT_MS` set so newer agent-browser self-shuts-down when idle.
 
 ## Installation
 
@@ -49,22 +41,16 @@ agent-browser self-shuts-down when idle.
 
 ### 1. Install the launchd job
 
-Normally the reaper is installed automatically as the 4th agent by
-`catalyst-stack install-services` (which `catalyst-join.sh` runs during
-onboarding), so a joined member gets it for free. To (re)install manually, run
-the installer **from the pristine clone**:
+Normally the reaper is installed automatically as the 4th agent by `catalyst-stack install-services` (which `catalyst-join.sh` runs during onboarding), so a joined member gets it for free. To (re)install manually, run the installer **from the pristine clone**:
 
 ```bash
 bash ~/catalyst/plugin-source/plugins/dev/scripts/install-orphan-sweep.sh
 launchctl list | grep orphan-sweep   # LastExit must be 0
 ```
 
-`install-orphan-sweep.sh` is idempotent, prefers the registered `pluginDirs`
-clone, and **refuses** to bake a linked-worktree or `/tmp` path. Preview with
-`--print-only`; remove with `--uninstall`.
+`install-orphan-sweep.sh` is idempotent, prefers the registered `pluginDirs` clone, and **refuses** to bake a linked-worktree or `/tmp` path. Preview with `--print-only`; remove with `--uninstall`.
 
-If `~/catalyst/plugin-source` is stale (e.g. a non-daemon host with no broker
-auto-pull), fast-forward it first: `bash <repo>/plugins/dev/scripts/setup-plugin-source.sh`.
+If `~/catalyst/plugin-source` is stale (e.g. a non-daemon host with no broker auto-pull), fast-forward it first: `bash <repo>/plugins/dev/scripts/setup-plugin-source.sh`.
 
 ### 2. Verify a clean run
 
@@ -84,14 +70,9 @@ launchctl unload ~/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist
 
 ### Flipping the widened branch to enforce
 
-Vector 1's widened (any-command) branch ships **dark** (`SWEEP_PROC_WIDEN=shadow`): it classifies
-and logs every candidate as `[shadow] would kill …` and signals nothing. Bake it, read the log, size
-the cap, then flip.
+Vector 1's widened (any-command) branch ships **dark** (`SWEEP_PROC_WIDEN=shadow`): it classifies and logs every candidate as `[shadow] would kill …` and signals nothing. Bake it, read the log, size the cap, then flip.
 
-**Do not hand-edit the installed plist.** `install-orphan-sweep.sh` unconditionally regenerates and
-replaces `~/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist`, and it runs as part of
-every routine `catalyst-stack install-services` — a hand-edit is silently reverted by the next
-install. The knob is therefore part of the shipped plist template and is resolved by the installer:
+**Do not hand-edit the installed plist.** `install-orphan-sweep.sh` unconditionally regenerates and replaces `~/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist`, and it runs as part of every routine `catalyst-stack install-services` — a hand-edit is silently reverted by the next install. The knob is therefore part of the shipped plist template and is resolved by the installer:
 
 | # | Source | When to use it |
 |---|--------|----------------|
@@ -100,9 +81,7 @@ install. The knob is therefore part of the shipped plist template and is resolve
 | 3 | the value already in the installed plist | **preservation** — a previous flip survives a plain reinstall |
 | 4 | `shadow` | the ADR-023 default |
 
-So a plain `bash install-orphan-sweep.sh` on a host already at `enforce` keeps `enforce`, and a
-host that has never been flipped stays at `shadow`. Anything outside `off|shadow|enforce` is
-rejected with a warning and falls back to `shadow` — never to `enforce`.
+So a plain `bash install-orphan-sweep.sh` on a host already at `enforce` keeps `enforce`, and a host that has never been flipped stays at `shadow`. Anything outside `off|shadow|enforce` is rejected with a warning and falls back to `shadow` — never to `enforce`.
 
 Verify what is actually installed (this is the production value, not the in-script default):
 
@@ -110,11 +89,9 @@ Verify what is actually installed (this is the production value, not the in-scri
 grep -A2 SWEEP_PROC_WIDEN ~/Library/LaunchAgents/ai.coalesce.catalyst-orphan-sweep.plist
 ```
 
-To roll back, reinstall with `SWEEP_PROC_WIDEN=off` (which removes the widened admission entirely)
-or `SWEEP_PROC_WIDEN=shadow` (which keeps observing).
+To roll back, reinstall with `SWEEP_PROC_WIDEN=off` (which removes the widened admission entirely) or `SWEEP_PROC_WIDEN=shadow` (which keeps observing).
 
-The daemon-side sibling of this knob is `orchestration.orphanReaper.procReaper.widenMode`. The two
-are **independent** — flipping one does not arm the other.
+The daemon-side sibling of this knob is `orchestration.orphanReaper.procReaper.widenMode`. The two are **independent** — flipping one does not arm the other.
 
 ## Configuration (env overrides)
 
@@ -139,24 +116,10 @@ All widened numerics are parsed as **bounded base-10** integers. A value Bash ar
 
 ## Health check & troubleshooting
 
-`catalyst-doctor` asserts the reaper is healthy (CTL-1306). Every reaper check is
-a **WARN**, never a FAIL — the doctor's exit code gates the `catalyst-join`
-activation gate, which runs *before* `install-services` would reinstall a stale
-plist, so a FAILing reaper check would block a node from self-healing via join:
-`reaper-installed` (WARN if the LaunchAgent is absent), `reaper-path` (WARN if the
-baked program path no longer exists — the silent-death signature), `reaper-loaded`
-(WARN if the plist is present but launchd never loaded the job), and
-`reaper-health` (WARN on a `LastExit` of 127 or any other non-zero exit). A
-loaded job with `LastExit` 0 (or that has never run yet) is `reaper-health` PASS.
+`catalyst-doctor` asserts the reaper is healthy (CTL-1306). Every reaper check is a **WARN**, never a FAIL — the doctor's exit code gates the `catalyst-join` activation gate, which runs *before* `install-services` would reinstall a stale plist, so a FAILing reaper check would block a node from self-healing via join: `reaper-installed` (WARN if the LaunchAgent is absent), `reaper-path` (WARN if the baked program path no longer exists — the silent-death signature), `reaper-loaded` (WARN if the plist is present but launchd never loaded the job), and `reaper-health` (WARN on a `LastExit` of 127 or any other non-zero exit). A loaded job with `LastExit` 0 (or that has never run yet) is `reaper-health` PASS.
 
-- **`launchctl list | grep orphan-sweep` shows exit 127**, log full of
-  `No such file or directory` → the baked path was deleted. Re-point from the
-  pristine clone (Installation above). This is the CTL-1306 failure mode.
-- **Debris not shrinking** → SAFE removals are capped per run
-  (`maxRemovalsPerRun`, default 10). For a one-shot drain raise it:
-  `SWEEP_MAX_REMOVALS=50 orphan-sweep.sh`. Remaining trees are protected
-  SALVAGE/dirty — triage by hand, never `rm -rf` (that also leaves stale
-  `.git/worktrees` admin entries; use `git worktree remove` + `git worktree prune`).
+- **`launchctl list | grep orphan-sweep` shows exit 127**, log full of `No such file or directory` → the baked path was deleted. Re-point from the pristine clone (Installation above). This is the CTL-1306 failure mode.
+- **Debris not shrinking** → SAFE removals are capped per run (`maxRemovalsPerRun`, default 10). For a one-shot drain raise it: `SWEEP_MAX_REMOVALS=50 orphan-sweep.sh`. Remaining trees are protected SALVAGE/dirty — triage by hand, never `rm -rf` (that also leaves stale `.git/worktrees` admin entries; use `git worktree remove` + `git worktree prune`).
 
 ## Relationship to Other Components
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -5,12 +5,9 @@ Catalyst uses **Release Please** for automated per-plugin releases on a **daily 
 ## How It Works
 
 1. Merge PRs to `main` with conventional commit titles (`feat(dev):`, `fix(pm):`, etc.).
-2. Release Please opens/updates **a single aggregating Release PR** as commits land
-   (`separate-pull-requests: false` → one PR covers all affected plugins).
-3. A scheduled workflow merges the Release PR **once a day at 05:00 UTC** (22:00 PT / 01:00 ET).
-   Merging creates git tags, GitHub Releases, updated CHANGELOGs, and bumped versions.
-4. Empty days skip: with no merged PRs since the last release, no Release PR is open and the
-   scheduled workflow exits 0.
+2. Release Please opens/updates **a single aggregating Release PR** as commits land (`separate-pull-requests: false` → one PR covers all affected plugins).
+3. A scheduled workflow merges the Release PR **once a day at 05:00 UTC** (22:00 PT / 01:00 ET). Merging creates git tags, GitHub Releases, updated CHANGELOGs, and bumped versions.
+4. Empty days skip: with no merged PRs since the last release, no Release PR is open and the scheduled workflow exits 0.
 
 ### Hotfix / urgent release
 
@@ -22,32 +19,22 @@ gh workflow run release-please-scheduled-merge.yml
 
 ### Intraday consumption (pre-release)
 
-`plugin.json.version` only changes when the Release PR merges (daily), so marketplace installs
-auto-update at most once per day. To dogfood merged-but-not-yet-released commits, register a local
-checkout as a dev marketplace:
+`plugin.json.version` only changes when the Release PR merges (daily), so marketplace installs auto-update at most once per day. To dogfood merged-but-not-yet-released commits, register a local checkout as a dev marketplace:
 
 ```
 bash scripts/install-dev-marketplace.sh   # registers the local path as a marketplace
 ```
 
-Run from the **main checkout, not a linked worktree** — the script refuses from a worktree (it
-would freeze the plugin at that branch's HEAD; CTL-120). Pass `--allow-worktree` to override.
+Run from the **main checkout, not a linked worktree** — the script refuses from a worktree (it would freeze the plugin at that branch's HEAD; CTL-120). Pass `--allow-worktree` to override.
 
 #### Refreshing after `git pull`
 
-Claude Code copies plugin files into a version-keyed cache at install time; `git pull` does NOT
-propagate to the cache. Two supported flows:
+Claude Code copies plugin files into a version-keyed cache at install time; `git pull` does NOT propagate to the cache. Two supported flows:
 
-- **Standard** (after the daily release bumped `plugin.json.version`):
-  `git -C <repo> pull` then `claude plugin update <plugin>@catalyst` per plugin, then restart.
-- **Live-read** (active dev on one plugin, every edit propagates without a version bump):
-  `claude --plugin-dir <repo>/plugins/<x>` — the official per-session dev mode, takes precedence
-  over the installed plugin, does not persist across restarts.
+- **Standard** (after the daily release bumped `plugin.json.version`): `git -C <repo> pull` then `claude plugin update <plugin>@catalyst` per plugin, then restart.
+- **Live-read** (active dev on one plugin, every edit propagates without a version bump): `claude --plugin-dir <repo>/plugins/<x>` — the official per-session dev mode, takes precedence over the installed plugin, does not persist across restarts.
 
-There is no native live-read for `source: directory` marketplaces (see
-`thoughts/shared/research/2026-04-22-CTL-122-plugin-cache-live-read.md`). To detect a drifted dev
-marketplace, run `plugins/dev/scripts/check-marketplace-drift.sh` (CTL-121) — warns at ≥5 commits
-(`DRIFT_COMMIT_THRESHOLD`) or ≥24h (`DRIFT_AGE_HOURS`) behind `origin/main`.
+There is no native live-read for `source: directory` marketplaces (see `thoughts/shared/research/2026-04-22-CTL-122-plugin-cache-live-read.md`). To detect a drifted dev marketplace, run `plugins/dev/scripts/check-marketplace-drift.sh` (CTL-121) — warns at ≥5 commits (`DRIFT_COMMIT_THRESHOLD`) or ≥24h (`DRIFT_AGE_HOURS`) behind `origin/main`.
 
 A `next` branch + auto-updating companion marketplace is designed but not built — see ADR-009.
 
@@ -62,19 +49,9 @@ A `next` branch + auto-updating companion marketplace is designed but not built 
 | `.claude-plugin/marketplace.json` | Claude plugin registry (paths only, **no versions**) | Manual |
 | `.agents/plugins/marketplace.json` | Codex plugin catalog (paths only, **no versions**) (CTL-1463) | Generated (`bun scripts/packaging/cli.mjs render --target codex --write`) |
 
-The `version` field in `plugin.json` is the auto-update gate: at session start Claude Code fetches
-the marketplace repo, and if `plugin.json.version` at the new HEAD differs from the installed
-version, it refreshes the cache. Same version → skipped even if code changed.
+The `version` field in `plugin.json` is the auto-update gate: at session start Claude Code fetches the marketplace repo, and if `plugin.json.version` at the new HEAD differs from the installed version, it refreshes the cache. Same version → skipped even if code changed.
 
-**CTL-1463 invariant**: release-please writes BOTH `plugin.json` files' `$.version` in the same
-commit, via two `extra-files` entries per package — the Claude and Codex manifests can never drift
-because they are never bumped separately. `scripts/packaging/cli.mjs` (the vendor-neutral packaging
-pipeline — see `docs/specs/accepted/vendor-neutral-packaging/spec.md`) never writes a
-version itself: its Claude emitter copies `$.version` verbatim from the existing file, and its Codex
-emitter seeds from the Claude manifest on create and FAILS on regenerate if the two disagree. The
-compiler reads and asserts a version; it is never the version's source. `.codex-plugin/` and
-`.agents/plugins/` are **generated, gitattributes-marked** trees — never hand-edited — regenerated
-with `bun scripts/packaging/cli.mjs render --target <claude|codex|agentsSkills> --write`.
+**CTL-1463 invariant**: release-please writes BOTH `plugin.json` files' `$.version` in the same commit, via two `extra-files` entries per package — the Claude and Codex manifests can never drift because they are never bumped separately. `scripts/packaging/cli.mjs` (the vendor-neutral packaging pipeline — see `docs/specs/accepted/vendor-neutral-packaging/spec.md`) never writes a version itself: its Claude emitter copies `$.version` verbatim from the existing file, and its Codex emitter seeds from the Claude manifest on create and FAILS on regenerate if the two disagree. The compiler reads and asserts a version; it is never the version's source. `.codex-plugin/` and `.agents/plugins/` are **generated, gitattributes-marked** trees — never hand-edited — regenerated with `bun scripts/packaging/cli.mjs render --target <claude|codex|agentsSkills> --write`.
 
 ## Commit Conventions
 
@@ -85,13 +62,9 @@ with `bun scripts/packaging/cli.mjs render --target <claude|codex|agentsSkills> 
 | `feat(dev)!: …` | Major bump (catalyst-dev) |
 | `chore(meta): …` | No version bump |
 
-Scopes (one per plugin): `dev`, `pm`, `meta`, `analytics`, `debugging`, `pm-ops`,
-`meeting-hygiene`, `discovery`, `legacy`, `foundry`.
+Scopes (one per plugin): `dev`, `pm`, `meta`, `analytics`, `debugging`, `pm-ops`, `meeting-hygiene`, `discovery`, `legacy`, `foundry`.
 
-**Routing is by file paths changed, not scope.** A commit touching `plugins/dev/` and
-`plugins/playground/pm/` bumps **both** plugins regardless of scope; the `(scope)` only sets the changelog
-section header. Squash merges work (GitHub API supplies the full file list). Use the scope of the
-primary plugin.
+**Routing is by file paths changed, not scope.** A commit touching `plugins/dev/` and `plugins/playground/pm/` bumps **both** plugins regardless of scope; the `(scope)` only sets the changelog section header. Squash merges work (GitHub API supplies the full file list). Use the scope of the primary plugin.
 
 ## Tags
 
@@ -101,22 +74,13 @@ Format `<component>-v<version>`, e.g. `catalyst-dev-v12.14.0`.
 
 - `release-please-config.json` — plugin paths, `release-type: simple`, components, extra-files
 - `.release-please-manifest.json` — current version per plugin
-- `.github/workflows/release-please.yml` — opens/updates Release PRs + enhances notes on every
-  push to `main` (and `workflow_dispatch`)
-- `.github/workflows/release-please-scheduled-merge.yml` — merges the open Release PR at 05:00 UTC
-  (also `workflow_dispatch`)
+- `.github/workflows/release-please.yml` — opens/updates Release PRs + enhances notes on every push to `main` (and `workflow_dispatch`)
+- `.github/workflows/release-please-scheduled-merge.yml` — merges the open Release PR at 05:00 UTC (also `workflow_dispatch`)
 
 ## Troubleshooting
 
-- The open Release PR (label `autorelease: pending`, find via `gh pr list --label "autorelease: pending"`)
-  is the authoritative summary of what's pending. AI-enhanced CHANGELOGs refresh on each push via
-  `scripts/enhance-release-notes.sh`.
-- In `release-please.yml` logs, `✔ No user facing commits found since <sha> - skipping` is
-  **per-plugin**: that plugin had no `feat:`/`fix:`/`perf:` commits under its `plugins/<x>/` paths
-  since its last tag. `<sha>` is that plugin's last-release SHA (two plugins bootstrapped together
-  can share it).
-- For stuck releases run `bash scripts/check-release-health.sh` (also daily via
-  `release-health.yml`) — reports `UNHEALTHY` only when releasable commits exist with no open
-  release PR.
+- The open Release PR (label `autorelease: pending`, find via `gh pr list --label "autorelease: pending"`) is the authoritative summary of what's pending. AI-enhanced CHANGELOGs refresh on each push via `scripts/enhance-release-notes.sh`.
+- In `release-please.yml` logs, `✔ No user facing commits found since <sha> - skipping` is **per-plugin**: that plugin had no `feat:`/`fix:`/`perf:` commits under its `plugins/<x>/` paths since its last tag. `<sha>` is that plugin's last-release SHA (two plugins bootstrapped together can share it).
+- For stuck releases run `bash scripts/check-release-health.sh` (also daily via `release-health.yml`) — reports `UNHEALTHY` only when releasable commits exist with no open release PR.
 
 > Never hand-edit `version.txt`, `plugin.json` versions, or the manifest — Release Please owns them.

--- a/docs/runbooks/cloud-feed-cutover.md
+++ b/docs/runbooks/cloud-feed-cutover.md
@@ -1,25 +1,14 @@
 # Runbook — the smee retirement, and how to undo it
 
-**Status: smee is fully retired.** The **Linear** half went first,
-**2026-08-17 ~16:50–17:02 CT** (CTL-1928). The **GitHub** half followed
-**2026-08-18 13:58–14:16 CT** (CTL-1929, scope decided as CTL-1965 = B: *all eight*
-webhooks, not just `coalesce-labs/catalyst`).
+**Status: smee is fully retired.** The **Linear** half went first, **2026-08-17 ~16:50–17:02 CT** (CTL-1928). The **GitHub** half followed **2026-08-18 13:58–14:16 CT** (CTL-1929, scope decided as CTL-1965 = B: *all eight* webhooks, not just `coalesce-labs/catalyst`).
 
-⚠️ Read the scope section before touching anything. The two halves rode the *same*
-smee channel, so "turn smee back on" is not one switch — and the two halves have
-**separate** flags, **separate** rollback levers, and **different** consequences.
+⚠️ Read the scope section before touching anything. The two halves rode the *same* smee channel, so "turn smee back on" is not one switch — and the two halves have **separate** flags, **separate** rollback levers, and **different** consequences.
 
 ---
 
 ## 1. What is true now
 
-Linear ingestion is the **cloud feed** (`execution-core/cloud-feed-timer.mjs`,
-gate `CATALYST_CLOUD_FEED=enforce`). The three dispatch-class events —
-`linear.issue.state_changed`, `linear.issue.updated`, `linear.comment.created` —
-are produced from the local replica and appended to `~/catalyst/events/YYYY-MM.jsonl`,
-where `monitor.mjs`'s existing tail dispatches them through the same three
-handlers as before. Nothing about dispatch *semantics* changed at the cutover;
-only the producer did.
+Linear ingestion is the **cloud feed** (`execution-core/cloud-feed-timer.mjs`, gate `CATALYST_CLOUD_FEED=enforce`). The three dispatch-class events — `linear.issue.state_changed`, `linear.issue.updated`, `linear.comment.created` — are produced from the local replica and appended to `~/catalyst/events/YYYY-MM.jsonl`, where `monitor.mjs`'s existing tail dispatches them through the same three handlers as before. Nothing about dispatch *semantics* changed at the cutover; only the producer did.
 
 | Surface | State after CTL-1928 |
 | --- | --- |
@@ -35,74 +24,36 @@ only the producer did.
 
 ### Why the GitHub half stayed until 2026-08-18 — and what changed
 
-Everything below this heading was true when CTL-1928 shipped and is kept because it
-explains the shape of the GitHub leg. **Three things changed, and each was measured
-rather than assumed:**
+Everything below this heading was true when CTL-1928 shipped and is kept because it explains the shape of the GitHub leg. **Three things changed, and each was measured rather than assumed:**
 
-1. **A GitHub producer now exists** — `execution-core/github-feed-timer.mjs`, gated by
-   `catalyst.githubFeed.mode`, reading the same local replica the Linear leg reads.
-2. **The last two coverage gaps closed with schema 0.1.18** (CTC-712 `check_suites.
-   pull_request_numbers` + migration 0028; CTC-704 for `pushes`). Both were *statically*
-   excluded in `lib/github-feed-names.mjs` and are resolved **per host at runtime** by
-   `githubUncoveredNames(db)`, because the pin rolls as a canary. With 0.1.18 on both
-   minis the runtime probe reports `pushIsLossy:false, checkSuiteHasPrAssociation:true`
-   and **12 of 12** consumed names suppressible.
-3. **Parity was measured on live traffic, not argued.**
-   `execution-core/github-feed-parity-run.mjs` compares the two streams by
-   multiplicity over a window. mini-2: `clean = true · exit 0` over 65 min, 60/60
-   agreeing. mini: 38/38 post-coverage, and 160/160 over 42 min.
+1. **A GitHub producer now exists** — `execution-core/github-feed-timer.mjs`, gated by `catalyst.githubFeed.mode`, reading the same local replica the Linear leg reads.
+2. **The last two coverage gaps closed with schema 0.1.18** (CTC-712 `check_suites. pull_request_numbers` + migration 0028; CTC-704 for `pushes`). Both were *statically* excluded in `lib/github-feed-names.mjs` and are resolved **per host at runtime** by `githubUncoveredNames(db)`, because the pin rolls as a canary. With 0.1.18 on both minis the runtime probe reports `pushIsLossy:false, checkSuiteHasPrAssociation:true` and **12 of 12** consumed names suppressible.
+3. **Parity was measured on live traffic, not argued.** `execution-core/github-feed-parity-run.mjs` compares the two streams by multiplicity over a window. mini-2: `clean = true · exit 0` over 65 min, 60/60 agreeing. mini: 38/38 post-coverage, and 160/160 over 42 min.
 
 ⚠️ **Two instrument traps the ledger will hand you, both self-reported:**
 
-- **A window whose `hi` lands at or after the producer's last tick manufactures its own
-  gap.** The producer ticks every ~30 s; smee is immediate. The runner prints
-  `window-outruns-producer` when this happens — believe it, and re-run with `hi` at
-  least 3 min inside the producer's coverage before reading any `smee-unjoined` count.
-- **A host reads dirty for every window that predates its own coverage.** mini emitted
-  its first `check_suite.completed` at 18:16:25Z, ~15 min after its 0.1.18 writer
-  kickstart; every such event before that instant is legitimately smee-only, because
-  the gate correctly declined a name the host could not serve. Start the window after
-  the host's first emission of the name you care about.
+- **A window whose `hi` lands at or after the producer's last tick manufactures its own gap.** The producer ticks every ~30 s; smee is immediate. The runner prints `window-outruns-producer` when this happens — believe it, and re-run with `hi` at least 3 min inside the producer's coverage before reading any `smee-unjoined` count.
+- **A host reads dirty for every window that predates its own coverage.** mini emitted its first `check_suite.completed` at 18:16:25Z, ~15 min after its 0.1.18 writer kickstart; every such event before that instant is legitimately smee-only, because the gate correctly declined a name the host could not serve. Start the window after the host's first emission of the name you care about.
 
 ### ⛔ Why the GitHub half stayed (historical — the CTL-1928 reasoning)
 
-The cloud feed replaces **Linear only**. `DISPATCH_CLASS_NAMES` in
-`cloud-feed-gate.mjs` is three `linear.*` names; there is no GitHub producer, and
-`catalyst-cloud` has no webhook ingestion route at all (verified by content, with
-a positive control — the string `webhook` *does* occur in that repo, in
-`packages/crypto` and `packages/read-model`, so the search works).
+The cloud feed replaces **Linear only**. `DISPATCH_CLASS_NAMES` in `cloud-feed-gate.mjs` is three `linear.*` names; there is no GitHub producer, and `catalyst-cloud` has no webhook ingestion route at all (verified by content, with a positive control — the string `webhook` *does* occur in that repo, in `packages/crypto` and `packages/read-model`, so the search works).
 
-Measured on mini-2, 6 h window: **1,616 `github.*` events** — `workflow_run` 924,
-`check_suite` 375, `push` 120, `pr` 111, `issue_comment` 70, `deployment_status` 16.
-Those drive `phase-monitor-merge`'s `wait-for`, the broker's PR-lifecycle routing,
-and CI waits. Deleting the GitHub webhook would blind the fleet to all of it.
-Retiring the GitHub half is **not** part of this cutover and needs a cloud
-GitHub-ingestion path to exist first.
+Measured on mini-2, 6 h window: **1,616 `github.*` events** — `workflow_run` 924, `check_suite` 375, `push` 120, `pr` 111, `issue_comment` 70, `deployment_status` 16. Those drive `phase-monitor-merge`'s `wait-for`, the broker's PR-lifecycle routing, and CI waits. Deleting the GitHub webhook would blind the fleet to all of it. Retiring the GitHub half is **not** part of this cutover and needs a cloud GitHub-ingestion path to exist first.
 
 ### ⚠️ One shared channel, not two
 
-Both tunnels subscribed to the **same** smee channel
-(`https://smee.io/WDgeZys5ST0uqtL`) and forwarded every payload to *both* local
-routes. That is why the pre-cutover logs showed mirror-image histograms — e.g.
-69× `200` on `/api/webhook` and 69× `401` on `/api/webhook/linear`, then 3× the
-reverse. **Those 401s were cross-delivery, not auth failure.** Anyone diagnosing
-a "Linear webhook 401 outage" from a one-sided count will reach the wrong
-conclusion; always read both routes' histograms together.
+Both tunnels subscribed to the **same** smee channel (`https://smee.io/WDgeZys5ST0uqtL`) and forwarded every payload to *both* local routes. That is why the pre-cutover logs showed mirror-image histograms — e.g. 69× `200` on `/api/webhook` and 69× `401` on `/api/webhook/linear`, then 3× the reverse. **Those 401s were cross-delivery, not auth failure.** Anyone diagnosing a "Linear webhook 401 outage" from a one-sided count will reach the wrong conclusion; always read both routes' histograms together.
 
 ---
 
 ## 2. Rollback
 
-Two independent levers. **Lever A alone restores Linear dispatch via smee**;
-Lever B is the belt-and-braces flip if you also want the cloud feed to stop
-suppressing the webhook copies.
+Two independent levers. **Lever A alone restores Linear dispatch via smee**; Lever B is the belt-and-braces flip if you also want the cloud feed to stop suppressing the webhook copies.
 
 ### Lever A — put the smee path back (≈2 min)
 
-1. **Re-enable the subscriptions** (they were disabled, not deleted, precisely so
-   this is one call each — Linear **never re-issues a webhook secret**, so a
-   deleted webhook must be re-registered *and* have its local HMAC secret file
-   rewritten):
+1. **Re-enable the subscriptions** (they were disabled, not deleted, precisely so this is one call each — Linear **never re-issues a webhook secret**, so a deleted webhook must be re-registered *and* have its local HMAC secret file rewritten):
 
    ```bash
    # ids as of the cutover; re-read with `{ webhooks { nodes { id label enabled } } }`
@@ -119,10 +70,7 @@ suppressing the webhook copies.
    done
    ```
 
-2. **Restore the channel in Layer-2 config on each host.** Every host kept a
-   pre-cutover backup at `~/.config/catalyst/config.json.bak-ctl1928-<ts>`; the
-   smallest correct restore is to put the channel back, not to overwrite the
-   whole file (it has moved on since):
+2. **Restore the channel in Layer-2 config on each host.** Every host kept a pre-cutover backup at `~/.config/catalyst/config.json.bak-ctl1928-<ts>`; the smallest correct restore is to put the channel back, not to overwrite the whole file (it has moved on since):
 
    ```bash
    node -e '
@@ -135,16 +83,9 @@ suppressing the webhook copies.
    ~/.catalyst/bin/catalyst-monitor restart
    ```
 
-   ⚠️ **The top-level key is enough to restore, but was NOT enough to retire.**
-   `readLinearSmeeChannel` (`orch-monitor/lib/webhook-config.ts`) falls back to
-   the **first per-team entry's** `smeeChannel`, so retiring required clearing
-   all 8 keys. Verified the hard way: clearing only the documented top-level key
-   and restarting still brought the tunnel up.
+⚠️ **The top-level key is enough to restore, but was NOT enough to retire.** `readLinearSmeeChannel` (`orch-monitor/lib/webhook-config.ts`) falls back to the **first per-team entry's** `smeeChannel`, so retiring required clearing all 8 keys. Verified the hard way: clearing only the documented top-level key and restarting still brought the tunnel up.
 
-3. **Verify by content** — `[linear-tunnel] … Forwarding …` must appear in
-   `~/catalyst/monitor.log` under the *new* pid, and
-   `grep -ac "linear-tunnel" ~/catalyst/monitor.log` must be non-zero. Use the
-   GitHub tunnel's own lines as the positive control that the log is live at all.
+3. **Verify by content** — `[linear-tunnel] … Forwarding …` must appear in `~/catalyst/monitor.log` under the *new* pid, and `grep -ac "linear-tunnel" ~/catalyst/monitor.log` must be non-zero. Use the GitHub tunnel's own lines as the positive control that the log is live at all.
 
 ### Lever B — stop the cloud feed driving dispatch
 
@@ -157,20 +98,13 @@ sed -i "" "s/^export CATALYST_CLOUD_FEED=enforce$/export CATALYST_CLOUD_FEED=sha
 
 ⚠️ That env file holds a live `ghp_` PAT — `grep` the one line, never `cat` it.
 
-⛔ **Lever B is only a rollback when Lever A has already been done.** Before the
-cutover, flipping to `shadow` was safe because smee was still authoritative
-underneath. It no longer is: `shadow` with the Linear subscriptions disabled
-means **nothing** drives Linear dispatch. Order matters — A then B, never B alone.
+⛔ **Lever B is only a rollback when Lever A has already been done.** Before the cutover, flipping to `shadow` was safe because smee was still authoritative underneath. It no longer is: `shadow` with the Linear subscriptions disabled means **nothing** drives Linear dispatch. Order matters — A then B, never B alone.
 
 ### 2.3 GitHub — Lever C (put the webhooks back) and Lever D (stop the feed)
 
-Same shape as A/B, same ordering rule: **C then D, never D alone.** At `enforce` the
-broker suppresses the smee copy for 12 names *and* orch-monitor never starts the
-tunnel, so flipping the mode back without re-enabling the webhooks leaves nothing
-driving `github.*` dispatch.
+Same shape as A/B, same ordering rule: **C then D, never D alone.** At `enforce` the broker suppresses the smee copy for 12 names *and* orch-monitor never starts the tunnel, so flipping the mode back without re-enabling the webhooks leaves nothing driving `github.*` dispatch.
 
-**Lever C — re-enable the eight webhooks (≈10 s).** They were disabled, never deleted,
-so the secret and the 12-event subscription survive and this is one `PATCH` each.
+**Lever C — re-enable the eight webhooks (≈10 s).** They were disabled, never deleted, so the secret and the 12-event subscription survive and this is one `PATCH` each.
 
 | repo | hook id |
 | --- | --- |
@@ -197,12 +131,9 @@ for h in coalesce-labs/catalyst:616654741 coalesce-labs/catalyst-cloud:657402518
 done
 ```
 
-⚠️ The block above is written **as the rollback** (`active=true`). The retirement ran the
-identical loop with `active=false`; do not copy it from here and change one word in a hurry.
+⚠️ The block above is written **as the rollback** (`active=true`). The retirement ran the identical loop with `active=false`; do not copy it from here and change one word in a hurry.
 
-Re-read every hook back from GitHub afterwards; do not trust the PATCH's own output.
-The **positive control** for the sweep is that unrelated GitKraken hook: a query for
-"any still-active hook" that returns *it* and nothing else is a query that still works.
+Re-read every hook back from GitHub afterwards; do not trust the PATCH's own output. The **positive control** for the sweep is that unrelated GitKraken hook: a query for "any still-active hook" that returns *it* and nothing else is a query that still works.
 
 **Lever D — stop the feed driving dispatch.**
 
@@ -217,15 +148,9 @@ node -e '
 ~/.catalyst/bin/catalyst-stack restart --yes
 ```
 
-⛔ **`catalyst-stack restart`, not a single-daemon restart.** `CATALYST_GITHUB_FEED` has
-**four readers in three processes** — the producer (execution-core), the dispatch gate
-(broker), and the tunnel gate (orch-monitor), plus doctor. All three resolve it at
-**boot**, so restarting one leaves the host split.
+⛔ **`catalyst-stack restart`, not a single-daemon restart.** `CATALYST_GITHUB_FEED` has **four readers in three processes** — the producer (execution-core), the dispatch gate (broker), and the tunnel gate (orch-monitor), plus doctor. All three resolve it at **boot**, so restarting one leaves the host split.
 
-⛔⛔ **AND `execution-core.env` MUST NOT PIN THIS FLAG.** `resolveGithubFeedMode` puts
-**env above Layer-2**, and `~/.config/catalyst/execution-core.env` is read by
-**execution-core alone**. A pin there splits the host in the worst direction — measured
-live on `mini`, 2026-08-18 14:09:47–14:13:21 CT:
+⛔⛔ **AND `execution-core.env` MUST NOT PIN THIS FLAG.** `resolveGithubFeedMode` puts **env above Layer-2**, and `~/.config/catalyst/execution-core.env` is read by **execution-core alone**. A pin there splits the host in the worst direction — measured live on `mini`, 2026-08-18 14:09:47–14:13:21 CT:
 
 | reader | resolved from | mode |
 | --- | --- | --- |
@@ -233,12 +158,7 @@ live on `mini`, 2026-08-18 14:09:47–14:13:21 CT:
 | dispatch gate (broker) | Layer-2 | `enforce` → smee suppressed for 12 names |
 | **producer (execution-core)** | **`execution-core.env`** | ⛔ `shadow` → emits `would-dispatch` MARKERS |
 
-Smee closed **and** the producer emitting markers = **nothing dispatches** for any of
-the 12 covered names, for 3m34s. Every instrument an operator would check read green:
-`github-feed gate: armed mode:"enforce"`, `suppressing GitHub webhook smee tunnel
-start`, `catalyst-stack status` all-running, Layer-2 `"enforce"`. Set the mode in
-Layer-2; leave the env var unset. → CTL-2011 makes `catalyst doctor` FAIL on the
-disagreement.
+Smee closed **and** the producer emitting markers = **nothing dispatches** for any of the 12 covered names, for 3m34s. Every instrument an operator would check read green: `github-feed gate: armed mode:"enforce"`, `suppressing GitHub webhook smee tunnel start`, `catalyst-stack status` all-running, Layer-2 `"enforce"`. Set the mode in Layer-2; leave the env var unset. → CTL-2011 makes `catalyst doctor` FAIL on the disagreement.
 
 ### 2.4 Verify a GitHub flip by content — four checks, and only one of them catches the split
 
@@ -266,64 +186,28 @@ grep '"event.channel":"cloud-feed"' <(tail -c 3000000 ~/catalyst/events/$(date -
 
 ### 2.5 ⚠️ What a rollback re-adopts
 
-Rolling back is correct if dispatch breaks, but it is not a return to a *better* leg.
-Two smee weaknesses were measured on the way out, both with positive controls:
+Rolling back is correct if dispatch breaks, but it is not a return to a *better* leg. Two smee weaknesses were measured on the way out, both with positive controls:
 
-- **A dropped delivery.** For `coalesce-labs/catalyst@5d842e7e`, GitHub's API reports 4
-  completed-`success` check suites. The feed emitted **4**; smee delivered **3** to
-  `mini`. The missing delivery id appears **zero** times in mini's whole 1.57 GB event
-  log, while a control delivery id from the same window appears once — so the event is
-  genuinely absent, not missed by the search.
-- **~5% rejected at the door.** In the 13 min after a restart, mini's monitor logged
-  **7 × `401`** against **132 × `200`** on `/api/webhook`. A 401'd delivery never
-  reaches the event log at all. (Cause unattributed; it is *not* a per-repo secret gap.)
-  Note the direction — a 401 hides an event from the **smee** side, which makes the
-  parity ledger report `feed-unjoined`. It biases the instrument **against** a cutover,
-  so it can never manufacture a false CLEAN.
+- **A dropped delivery.** For `coalesce-labs/catalyst@5d842e7e`, GitHub's API reports 4 completed-`success` check suites. The feed emitted **4**; smee delivered **3** to `mini`. The missing delivery id appears **zero** times in mini's whole 1.57 GB event log, while a control delivery id from the same window appears once — so the event is genuinely absent, not missed by the search.
+- **~5% rejected at the door.** In the 13 min after a restart, mini's monitor logged **7 × `401`** against **132 × `200`** on `/api/webhook`. A 401'd delivery never reaches the event log at all. (Cause unattributed; it is *not* a per-repo secret gap.) Note the direction — a 401 hides an event from the **smee** side, which makes the parity ledger report `feed-unjoined`. It biases the instrument **against** a cutover, so it can never manufacture a false CLEAN.
 
 ### 2.6 ⛔ What the GitHub cutover cost — the PR caches
 
-`pr_status_cache` and `pr_cache` (`~/catalyst/filter-state.db`) are written **only** by
-orch-monitor's webhook handler (`orch-monitor/lib/pr-cache.ts`). Nothing on the feed
-path writes them, and `lib/pr-status-backfill.ts` is **one-shot by design** ("skipped
-entirely when the table already has rows … a migration step, not a poll"). **They froze
-at the cutover.**
+`pr_status_cache` and `pr_cache` (`~/catalyst/filter-state.db`) are written **only** by orch-monitor's webhook handler (`orch-monitor/lib/pr-cache.ts`). Nothing on the feed path writes them, and `lib/pr-status-backfill.ts` is **one-shot by design** ("skipped entirely when the table already has rows … a migration step, not a poll"). **They froze at the cutover.**
 
-Measured A/B at 14:02 CT, one variable, the same merge (`catalyst-cloud#882`): `mini`
-(tunnel open) recorded it `merged` at 18:59:42Z; `mini-2` (tunnel closed) still read
-`open` from 18:42:27Z, with **0** rows written to either table after its flip.
+Measured A/B at 14:02 CT, one variable, the same merge (`catalyst-cloud#882`): `mini` (tunnel open) recorded it `merged` at 18:59:42Z; `mini-2` (tunnel closed) still read `open` from 18:42:27Z, with **0** rows written to either table after its flip.
 
-`getAllPrStatuses()` reads `pr_status_cache` as its **primary** source (`filter_state`
-is empty on every execution-core host) and feeds `scheduler.mjs` and `board-health.mjs`.
-Both guard on `map.size === 0 → observable:false` — a **frozen non-empty** map defeats
-that guard: it looks observable and answers wrong, and it rots with time.
-`checkPhantomMergedPr` goes blind; `checkOrphanedOpenPr` accumulates false positives.
+`getAllPrStatuses()` reads `pr_status_cache` as its **primary** source (`filter_state` is empty on every execution-core host) and feeds `scheduler.mjs` and `board-health.mjs`. Both guard on `map.size === 0 → observable:false` — a **frozen non-empty** map defeats that guard: it looks observable and answers wrong, and it rots with time. `checkPhantomMergedPr` goes blind; `checkOrphanedOpenPr` accumulates false positives.
 
-**This is not dispatch loss** — the feed carries `github.pr.merged` with its
-`mergeCommitSha`. It is detector rot. → **CTL-2008**. Lever C restores the caches.
+**This is not dispatch loss** — the feed carries `github.pr.merged` with its `mergeCommitSha`. It is detector rot. → **CTL-2008**. Lever C restores the caches.
 
 ---
 
 ## 3. What this removed that you may still be relying on
 
-- **The `shadow`-flip containment lever.** Cutting the writer over to `shadow`
-  around a `cloud-sync` restart used to be safe *because smee stayed
-  authoritative*. Post-retirement there is no second stream, so a re-seeding
-  writer restart is defended **only** by the CTL-1920 torn-read guard. That guard
-  is merged, loaded and mutation-tested, but as of the cutover it had **never
-  fired in production**. Treat the first re-seed after this date as the guard's
-  real first test and watch `catalyst.linear` event volume across it.
-- **The parity harness's comparison stream** (CTL-1916). It compared the feed
-  against smee out of one log; with smee's Linear side silent it now has one
-  input and can only ever report agreement. Retire or repurpose it deliberately —
-  an instrument that cannot disagree is not a check.
-- **CTL-1841's route-comparison alarm** (`webhook-route-health.ts`). It cannot
-  false-page — `raise` requires a *recent non-2xx* on the Linear route and that
-  route now receives nothing — but for the same reason it can never fire again.
-  Note its in-code comment ("GitHub and Linear use INDEPENDENT smee channels") was
-  already wrong on this fleet, and the shared channel had it **latched raised on
-  both minis** at cutover time, because GitHub cross-delivery kept making the
-  last Linear-route outcome a 401.
+- **The `shadow`-flip containment lever.** Cutting the writer over to `shadow` around a `cloud-sync` restart used to be safe *because smee stayed authoritative*. Post-retirement there is no second stream, so a re-seeding writer restart is defended **only** by the CTL-1920 torn-read guard. That guard is merged, loaded and mutation-tested, but as of the cutover it had **never fired in production**. Treat the first re-seed after this date as the guard's real first test and watch `catalyst.linear` event volume across it.
+- **The parity harness's comparison stream** (CTL-1916). It compared the feed against smee out of one log; with smee's Linear side silent it now has one input and can only ever report agreement. Retire or repurpose it deliberately — an instrument that cannot disagree is not a check.
+- **CTL-1841's route-comparison alarm** (`webhook-route-health.ts`). It cannot false-page — `raise` requires a *recent non-2xx* on the Linear route and that route now receives nothing — but for the same reason it can never fire again. Note its in-code comment ("GitHub and Linear use INDEPENDENT smee channels") was already wrong on this fleet, and the shared channel had it **latched raised on both minis** at cutover time, because GitHub cross-delivery kept making the last Linear-route outcome a 401.
 
 ---
 
@@ -331,40 +215,19 @@ that guard: it looks observable and answers wrong, and it rots with time.
 
 Short answer: **nothing drops from this cutover.**
 
-- The 7 Linear webhook subscriptions were **workspace webhooks created with a
-  personal API key** (`creator: Ryan Rozich`), not per-host app grants. Disabling
-  them changes no app authorization.
-- **CATALYST / CATALYST Orchestrator (Linear app-actors) stay.** They are how the
-  daemon *writes* — status transitions, labels, mirrored comments — and how
-  `catalyst-monitor` authenticates ("authenticated as Catalyst Orchestrator
-  app-actor, isolated 5000/hr bucket"). Reads still come from the replica, which
-  the cloud writer fills. These drop only when **CTL-1889** moves daemon writes
-  behind the cloud write proxy.
-- **GitHub app authorizations stay** — the GitHub webhook and `gh` operations are
-  untouched by this ticket.
+- The 7 Linear webhook subscriptions were **workspace webhooks created with a personal API key** (`creator: Ryan Rozich`), not per-host app grants. Disabling them changes no app authorization.
+- **CATALYST / CATALYST Orchestrator (Linear app-actors) stay.** They are how the daemon *writes* — status transitions, labels, mirrored comments — and how `catalyst-monitor` authenticates ("authenticated as Catalyst Orchestrator app-actor, isolated 5000/hr bucket"). Reads still come from the replica, which the cloud writer fills. These drop only when **CTL-1889** moves daemon writes behind the cloud write proxy.
+- **GitHub app authorizations stay** — the GitHub webhook and `gh` operations are untouched by this ticket.
 
 ---
 
 ## 5. New-host installs
 
-`join-bundle.mjs` no longer emits the Linear webhook block, and
-`catalyst-join.sh` strips it from any bundle that still carries one (a bundle is
-a file that outlives the code that wrote it). The whole block goes — both the
-top-level channel and the per-team `webhookId` map — because the per-team entry
-alone is enough to start a tunnel, and a `webhookId` arriving without its HMAC
-secret is what `catalyst doctor` grades as half-wired config residue.
+`join-bundle.mjs` no longer emits the Linear webhook block, and `catalyst-join.sh` strips it from any bundle that still carries one (a bundle is a file that outlives the code that wrote it). The whole block goes — both the top-level channel and the per-team `webhookId` map — because the per-team entry alone is enough to start a tunnel, and a `webhookId` arriving without its HMAC secret is what `catalyst doctor` grades as half-wired config residue.
 
-A **declared-`cloud`** node already created no smee wiring before this ticket
-(`catalyst-join.sh`'s gate settles on `decision=skip` for any recognized
-non-cluster mode); CTL-1928 additionally makes a **cluster** join stop re-creating
-the retired Linear path.
+A **declared-`cloud`** node already created no smee wiring before this ticket (`catalyst-join.sh`'s gate settles on `decision=skip` for any recognized non-cluster mode); CTL-1928 additionally makes a **cluster** join stop re-creating the retired Linear path.
 
-`catalyst doctor` needs no change and got none for this: measured on both minis
-after the cutover it reports
-`[PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false, linear keys=7)`.
-Its declared-`cloud` WARN text was corrected, though — it used to say such a node
-had "no event ingestion at all", which is now wrong in the direction that sends an
-operator hunting a Linear outage that does not exist.
+`catalyst doctor` needs no change and got none for this: measured on both minis after the cutover it reports `[PASS] webhook-ingestion: webhook ingestion wired (github=true, linear=false, linear keys=7)`. Its declared-`cloud` WARN text was corrected, though — it used to say such a node had "no event ingestion at all", which is now wrong in the direction that sends an operator hunting a Linear outage that does not exist.
 
 ## 6. Proving a host is actually running the code — `verify-loaded.sh` (CTL-1916)
 
@@ -373,13 +236,7 @@ plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host mini
 plugins/dev/scripts/verify-loaded.sh --root ~/catalyst/plugin-source --host laptop --role monitor
 ```
 
-⛔ **A git sha on disk is not evidence.** It proves the bytes arrived; it says nothing
-about what the running process is executing. Every link below is anchored on the **live
-pid**, and the fourth is the one that makes the difference explicit — a daemon that
-started *before* the file changed is serving the previous bytes no matter how current the
-checkout looks. That is not a hypothetical: it is the whole content of CTL-1919 (a writer
-serving a checkout three schema versions stale while every git-level check on the host
-read clean), and of CTL-1659 before it.
+⛔ **A git sha on disk is not evidence.** It proves the bytes arrived; it says nothing about what the running process is executing. Every link below is anchored on the **live pid**, and the fourth is the one that makes the difference explicit — a daemon that started *before* the file changed is serving the previous bytes no matter how current the checkout looks. That is not a hypothetical: it is the whole content of CTL-1919 (a writer serving a checkout three schema versions stale while every git-level check on the host read clean), and of CTL-1659 before it.
 
 | link | question | why it is not covered by the others |
 | --- | --- | --- |
@@ -388,33 +245,19 @@ read clean), and of CTL-1659 before it.
 | `armed-line` | did **this pid** write the mode line? | anchored on the pid, because a log is append-only across restarts — an unanchored grep happily matches the line a *previous* process wrote before the rollback you are checking for |
 | `started-after` | did the pid start after the module's mtime? | links 1–3 all pass for a daemon that booted before the pull landed |
 
-Every link **fails closed**: "I could not measure it" exits non-zero and names the link.
-`--role monitor` **asserts the absence** of an execution-core daemon rather than skipping —
-a skipped link reports the same "no complaint" as a verified one.
+Every link **fails closed**: "I could not measure it" exits non-zero and names the link. `--role monitor` **asserts the absence** of an execution-core daemon rather than skipping — a skipped link reports the same "no complaint" as a verified one.
 
-⚠️ The declared **mode** and the runtime **`armed`** flag are different facts and the tool
-prints both. Measured on the fleet 2026-08-17, mini-2 reports `mode=enforce` with
-`armed=false`: enforce is configured, the feed is not currently armed (CTL-1909). That is
-a runtime condition, not a load failure, so it is surfaced rather than failed — failing it
-would make a correctly-loaded host report FAIL and train operators to ignore the tool.
+⚠️ The declared **mode** and the runtime **`armed`** flag are different facts and the tool prints both. Measured on the fleet 2026-08-17, mini-2 reports `mode=enforce` with `armed=false`: enforce is configured, the feed is not currently armed (CTL-1909). That is a runtime condition, not a load failure, so it is surfaced rather than failed — failing it would make a correctly-loaded host report FAIL and train operators to ignore the tool.
 
-Tests: `plugins/dev/scripts/__tests__/verify-loaded.test.sh`, gated in CI. Both controls
-are present — a correctly-loaded fixture PASSES, and each failure case changes exactly one
-fact, so a green result is evidence about that fact rather than about the harness.
+Tests: `plugins/dev/scripts/__tests__/verify-loaded.test.sh`, gated in CI. Both controls are present — a correctly-loaded fixture PASSES, and each failure case changes exactly one fact, so a green result is evidence about that fact rather than about the harness.
 
 ### Parity sampling — a one-liner, not a script
 
-The overnight sampler that lived at `~/catalyst/parity-hourly.sh` on mini-2 is **retired**
-(CTL-1916). It was hand-placed and untracked, it was never scheduled, and since the Linear
-smee retirement (CTL-1928) the parity run has only one stream left to look at, so it can
-report agreement but no longer a *comparison*. Run the CLI directly when you want a sample:
+The overnight sampler that lived at `~/catalyst/parity-hourly.sh` on mini-2 is **retired** (CTL-1916). It was hand-placed and untracked, it was never scheduled, and since the Linear smee retirement (CTL-1928) the parity run has only one stream left to look at, so it can report agreement but no longer a *comparison*. Run the CLI directly when you want a sample:
 
 ```bash
 cd ~/catalyst/plugin-source && \
   bun plugins/dev/scripts/execution-core/linear-feed-parity-run.mjs --since-min 60
 ```
 
-⚠️ If you ever need it on a loop again, put the deadline **inside** the loop and make it
-sleep, never spin — `end=$((SECONDS+N)); while [ $SECONDS -lt $end ]; do sleep 60; done`.
-Cleanup must never be load-bearing (AGENTS.md); four spinners once leaked out of one test
-run here and burned ~4 CPU-cores for 16.5 h while the script reported `cleanup verified`.
+⚠️ If you ever need it on a loop again, put the deadline **inside** the loop and make it sleep, never spin — `end=$((SECONDS+N)); while [ $SECONDS -lt $end ]; do sleep 60; done`. Cleanup must never be load-bearing (AGENTS.md); four spinners once leaked out of one test run here and burned ~4 CPU-cores for 16.5 h while the script reported `cleanup verified`.

--- a/docs/specs/MIGRATION.md
+++ b/docs/specs/MIGRATION.md
@@ -1,20 +1,13 @@
 # Migration record — `mockups/` → `docs/specs/` (CTL-1411)
 
-When the `docs/specs/` convention landed, the existing mockup HTML from repo-root
-`mockups/` was migrated here. This file records where each piece went and why, so
-the classification is transparent and easy to correct — remember, promotion or
-demotion is a single `git mv`.
+When the `docs/specs/` convention landed, the existing mockup HTML from repo-root `mockups/` was migrated here. This file records where each piece went and why, so the classification is transparent and easy to correct — remember, promotion or demotion is a single `git mv`.
 
 ## Classification rule
 
-- **accepted/** — the mockup's design was already committed to the repo as
-  reviewed source, **or** its feature demonstrably shipped (a Done ticket / merged
-  PR whose design this mockup represents).
-- **draft/** — an exploratory or competing direction with no confirmation it
-  shipped.
+- **accepted/** — the mockup's design was already committed to the repo as reviewed source, **or** its feature demonstrably shipped (a Done ticket / merged PR whose design this mockup represents).
+- **draft/** — an exploratory or competing direction with no confirmation it shipped.
 
-Where ship-status was uncertain, the call is noted below as **(best-guess)** —
-flip it with a `git mv` if you know better.
+Where ship-status was uncertain, the call is noted below as **(best-guess)** — flip it with a `git mv` if you know better.
 
 ## What moved
 
@@ -36,20 +29,12 @@ flip it with a `git mv` if you know better.
 | `rules-explorer-living-textbook.html` | `draft/rules-explorer/` | Competing rules-explorer direction |
 | `rules-explorer-mission-control.html` | `draft/rules-explorer/` | Competing rules-explorer direction |
 
-Tracked files (first three) were moved with `git mv` to preserve history. The
-rest were previously **untracked** WIP in `mockups/` and are newly committed here.
+Tracked files (first three) were moved with `git mv` to preserve history. The rest were previously **untracked** WIP in `mockups/` and are newly committed here.
 
 ## `mockups/board-redesign-2026-06-13/` — decision: **discard**
 
-That directory held three screenshots (`img1.png`, `img2.png`, `img3.png`) and
-**no spec prose**. Per the "screenshots are not specs" rule, and because the board
-redesign already shipped and is documented (CTL-996 · #1745), these screenshots
-have no durable value. **Decision: discard** — they were never tracked (matched
-`mockups/**/*.png` in `.gitignore`), so this is simply removing the local
-directory; nothing leaves git history.
+That directory held three screenshots (`img1.png`, `img2.png`, `img3.png`) and **no spec prose**. Per the "screenshots are not specs" rule, and because the board redesign already shipped and is documented (CTL-996 · #1745), these screenshots have no durable value. **Decision: discard** — they were never tracked (matched `mockups/**/*.png` in `.gitignore`), so this is simply removing the local directory; nothing leaves git history.
 
 ## `mockups/` after this migration
 
-`mockups/` retains only its ephemeral, gitignored screenshots (`mockups/**/*.png`).
-All reviewed mockup HTML now lives under `docs/specs/`. New design work should
-start under `docs/specs/`, not `mockups/`.
+`mockups/` retains only its ephemeral, gitignored screenshots (`mockups/**/*.png`). All reviewed mockup HTML now lives under `docs/specs/`. New design work should start under `docs/specs/`, not `mockups/`.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,12 +1,8 @@
 # Specs
 
-The durable, in-repo home for **design and requirements explorations** — specs,
-mockups, and the prose that frames them — with an explicit `draft → accepted`
-lifecycle recorded in git history.
+The durable, in-repo home for **design and requirements explorations** — specs, mockups, and the prose that frames them — with an explicit `draft → accepted` lifecycle recorded in git history.
 
-If you are starting a new design or requirements exploration and want a
-committed, discoverable place for it (not repo-root `mockups/`, not the external
-`thoughts/` repo), it goes here.
+If you are starting a new design or requirements exploration and want a committed, discoverable place for it (not repo-root `mockups/`, not the external `thoughts/` repo), it goes here.
 
 ## Layout
 
@@ -23,16 +19,11 @@ docs/specs/
         └── *.html
 ```
 
-Each spec is a **folder** named with a short kebab-case `<slug>`, containing a
-`spec.md` plus any mockup HTML it references. Keeping the prose and the mockup
-side by side means a spec is self-describing — you never have to hunt for "which
-mockup did this doc mean?"
+Each spec is a **folder** named with a short kebab-case `<slug>`, containing a `spec.md` plus any mockup HTML it references. Keeping the prose and the mockup side by side means a spec is self-describing — you never have to hunt for "which mockup did this doc mean?"
 
 ## Lifecycle: draft → accepted
 
-- **draft/** — the exploration is still under discussion. Competing directions,
-  prototypes, and proofs-of-concept live here. Nothing in `draft/` is a promise
-  that it will ship.
+- **draft/** — the exploration is still under discussion. Competing directions, prototypes, and proofs-of-concept live here. Nothing in `draft/` is a promise that it will ship.
 - **accepted/** — the design was approved and/or has shipped to the product.
 
 **Promotion is a `git mv`:**
@@ -41,9 +32,7 @@ mockup did this doc mean?"
 git mv docs/specs/draft/<slug> docs/specs/accepted/<slug>
 ```
 
-Because promotion is a single tracked move, the PR history shows *exactly* when
-something crossed from "under discussion" to "approved" — no separate status
-field to keep in sync, no ambiguity about when a decision was made.
+Because promotion is a single tracked move, the PR history shows *exactly* when something crossed from "under discussion" to "approved" — no separate status field to keep in sync, no ambiguity about when a decision was made.
 
 ## `spec.md` frontmatter
 
@@ -69,9 +58,7 @@ describe each and what distinguishes them.
 ## Outcome                  # accepted — what shipped, and where
 ```
 
-`status:` in frontmatter must always agree with the folder the spec lives in
-(`draft/` ↔ `status: draft`). The folder is the source of truth; the field is a
-convenience for readers and tooling.
+`status:` in frontmatter must always agree with the folder the spec lives in (`draft/` ↔ `status: draft`). The folder is the source of truth; the field is a convenience for readers and tooling.
 
 ## How this differs from ADRs and `thoughts/`
 
@@ -81,24 +68,12 @@ convenience for readers and tooling.
 | **`docs/adrs.md`** | Architecture **decisions already made** — *retrospective*, append-only log | Immutable once recorded |
 | **`thoughts/`** (external, gitignored) | Research, plans, session-continuity notes | Ephemeral / not durably checked in |
 
-A spec proposes and explores; an ADR records the decision that resulted. When a
-spec's design settles into an architectural commitment, that commitment is
-written up as an ADR — the spec is the *how we got there*, the ADR is the *what
-we decided*.
+A spec proposes and explores; an ADR records the decision that resulted. When a spec's design settles into an architectural commitment, that commitment is written up as an ADR — the spec is the *how we got there*, the ADR is the *what we decided*.
 
 ## Screenshots are not specs
 
-Ephemeral screenshots captured while iterating (agent-browser / design-review
-captures) do **not** belong in the repo. They default to a scratchpad dir and
-are gitignored (`docs/specs/**/*.png` — same rule that already covers
-`mockups/**/*.png`). Commit a mockup's HTML, which reflows and is diffable — not
-a pile of PNGs. If a screenshot genuinely must be preserved (e.g. a
-before/after that the mockup HTML can't reproduce), that is the rare exception,
-and it should be called out in the spec's `spec.md`.
+Ephemeral screenshots captured while iterating (agent-browser / design-review captures) do **not** belong in the repo. They default to a scratchpad dir and are gitignored (`docs/specs/**/*.png` — same rule that already covers `mockups/**/*.png`). Commit a mockup's HTML, which reflows and is diffable — not a pile of PNGs. If a screenshot genuinely must be preserved (e.g. a before/after that the mockup HTML can't reproduce), that is the rare exception, and it should be called out in the spec's `spec.md`.
 
 ## Relationship to `mockups/`
 
-Repo-root `mockups/` predates this convention and holds ad-hoc mockup HTML with
-no accompanying prose. New design work should start under `docs/specs/`, not
-`mockups/`. See [`MIGRATION.md`](./MIGRATION.md) for the record of what moved
-here from `mockups/` when this convention landed (CTL-1411).
+Repo-root `mockups/` predates this convention and holds ad-hoc mockup HTML with no accompanying prose. New design work should start under `docs/specs/`, not `mockups/`. See [`MIGRATION.md`](./MIGRATION.md) for the record of what moved here from `mockups/` when this convention landed (CTL-1411).

--- a/docs/specs/accepted/board-redesign/spec.md
+++ b/docs/specs/accepted/board-redesign/spec.md
@@ -7,15 +7,11 @@ pr: 1745
 
 ## Problem
 
-The orch-monitor board and its surrounding surfaces needed a calmer, denser,
-more legible layout — reading surfaces that feel Linear-like rather than a
-knockoff, without losing operational density on the board itself.
+The orch-monitor board and its surrounding surfaces needed a calmer, denser, more legible layout — reading surfaces that feel Linear-like rather than a knockoff, without losing operational density on the board itself.
 
 ## Outcome
 
-Shipped as part of the web UI redesign (CTL-996 · #1745): a calm Inbox, a dense
-board, and a Linear-calm detail page. `catalyst-board.html` is the board mockup
-that fed that work.
+Shipped as part of the web UI redesign (CTL-996 · #1745): a calm Inbox, a dense board, and a Linear-calm detail page. `catalyst-board.html` is the board mockup that fed that work.
 
 ## Mockup
 

--- a/docs/specs/accepted/rulebook-swimlane/spec.md
+++ b/docs/specs/accepted/rulebook-swimlane/spec.md
@@ -7,16 +7,11 @@ pr: 2345
 
 ## Problem
 
-The belief/rule engine ("Reason") was hard to scan as a whole. Operators needed
-to see the belief layers at a glance and jump from a rendered rule to its source.
+The belief/rule engine ("Reason") was hard to scan as a whole. Operators needed to see the belief layers at a glance and jump from a rendered rule to its source.
 
 ## Outcome
 
-Shipped as the `/rules` swim-lane view (CTL-1328 · #2345): the belief layers
-render as a swim-lane board with a click-to-source drawer, making the whole
-engine scannable. This mockup is the accepted direction that shipped — the
-competing rulebook explorations live under
-[`../../draft/governance-rulebook/`](../../draft/governance-rulebook/).
+Shipped as the `/rules` swim-lane view (CTL-1328 · #2345): the belief layers render as a swim-lane board with a click-to-source drawer, making the whole engine scannable. This mockup is the accepted direction that shipped — the competing rulebook explorations live under [`../../draft/governance-rulebook/`](../../draft/governance-rulebook/).
 
 ## Mockup
 

--- a/docs/specs/accepted/ticket-journey/spec.md
+++ b/docs/specs/accepted/ticket-journey/spec.md
@@ -6,14 +6,11 @@ ticket: CTL-1003
 
 ## Problem
 
-A ticket's detail page needed to read like Linear — one header, prose typography,
-real tabs, floating rail cards — and to surface where the ticket is in its
-execution journey through the phase pipeline.
+A ticket's detail page needed to read like Linear — one header, prose typography, real tabs, floating rail cards — and to surface where the ticket is in its execution journey through the phase pipeline.
 
 ## Outcome
 
-The ticket-detail / Journey design (design-v1) landed with CTL-1003 (Done). These
-mockups fed the shipped detail page and its execution/journey tab.
+The ticket-detail / Journey design (design-v1) landed with CTL-1003 (Done). These mockups fed the shipped detail page and its execution/journey tab.
 
 > **Best-guess classification.** These two governance mockups are attributed to
 > the shipped CTL-1003 detail/Journey work; if the shipped tab used a different

--- a/docs/specs/accepted/vendor-neutral-packaging/spec.md
+++ b/docs/specs/accepted/vendor-neutral-packaging/spec.md
@@ -7,16 +7,9 @@ created: 2026-08-24
 
 ## Problem
 
-Catalyst packaged its 10 plugins for exactly one distribution target: Claude Code. Each plugin
-carried a `.claude-plugin/plugin.json`, discovery ran through the root `.claude-plugin/marketplace.json`,
-and Release Please owned every version through a per-package `extra-files` entry. That mechanism was
-clean but single-target — a design that happened to have only one instance, not one that resisted a
-second.
+Catalyst packaged its 10 plugins for exactly one distribution target: Claude Code. Each plugin carried a `.claude-plugin/plugin.json`, discovery ran through the root `.claude-plugin/marketplace.json`, and Release Please owned every version through a per-package `extra-files` entry. That mechanism was clean but single-target — a design that happened to have only one instance, not one that resisted a second.
 
-CTL-1461 (the ratified design, `docs/agent-skill-portability-design.md` in catalyst-cloud) defines the
-neutral render interface Catalyst's skills/agents should ultimately compile through. CTL-1463 ships
-the multi-target *system* around a **provisional** version of that interface, behind a seam CTL-1461
-can swap in later without reworking anything downstream.
+CTL-1461 (the ratified design, `docs/agent-skill-portability-design.md` in catalyst-cloud) defines the neutral render interface Catalyst's skills/agents should ultimately compile through. CTL-1463 ships the multi-target *system* around a **provisional** version of that interface, behind a seam CTL-1461 can swap in later without reworking anything downstream.
 
 ## Model
 
@@ -47,37 +40,22 @@ plugins/*/                                   authored source — never moved, ne
 └──────────────────────────────┘
 ```
 
-**The seam is load-bearing, not aspirational.** `scripts/packaging/__tests__/packaging-seam.test.mjs`
-enforces, by source-scanning `core/` and `emitters/`, that neither imports `providers/` or reads a
-`plugins/` path literal, and that `providers/local-provisional.mjs` is imported by exactly one file
-(`cli.mjs`). When CTL-1461 lands, the swap is: delete `providers/local-provisional.mjs`, add
-`providers/ctl1461.mjs`, delete the per-skill `effects`/`invocation` block from each `pack.json` (it
-moves to CTL-1461's `agents/portability.yaml` sidecars), flip one default in the CLI. No change to the
-pack manifest schema's identity/distribution halves, no emitter, no `release-please-config.json`, no
-CI gate. If a future reviewer finds that swap touching an emitter or a gate, this design was wrong.
+**The seam is load-bearing, not aspirational.** `scripts/packaging/__tests__/packaging-seam.test.mjs` enforces, by source-scanning `core/` and `emitters/`, that neither imports `providers/` or reads a `plugins/` path literal, and that `providers/local-provisional.mjs` is imported by exactly one file (`cli.mjs`). When CTL-1461 lands, the swap is: delete `providers/local-provisional.mjs`, add `providers/ctl1461.mjs`, delete the per-skill `effects`/`invocation` block from each `pack.json` (it moves to CTL-1461's `agents/portability.yaml` sidecars), flip one default in the CLI. No change to the pack manifest schema's identity/distribution halves, no emitter, no `release-please-config.json`, no CI gate. If a future reviewer finds that swap touching an emitter or a gate, this design was wrong.
 
 ## The pack manifest (`plugins/<name>/pack.json`)
 
 One hand-authored file per plugin, carrying everything except the version:
 
-- `identity` — description, author, homepage, repository, keywords, license, optional
-  `dependencies`/`agents` (the Claude-only subagent-file list).
-- `distribution.claude.marketplace` — the independently-maintained, hand-tuned prose/category/
-  keywords that already differ from `plugin.json`'s own description (verified: `plugins/dev`'s
-  `plugin.json` description and `marketplace.json` description are materially different strings).
+- `identity` — description, author, homepage, repository, keywords, license, optional `dependencies`/`agents` (the Claude-only subagent-file list).
+- `distribution.claude.marketplace` — the independently-maintained, hand-tuned prose/category/ keywords that already differ from `plugin.json`'s own description (verified: `plugins/dev`'s `plugin.json` description and `marketplace.json` description are materially different strings).
 - `distribution.codex` / `distribution.agentsSkills` — `{ enabled }` only.
-- `skills` — the per-skill neutral opt-in block (`{ effects, invocation, exposure }`). This is the ONE
-  field whose *source* moves when CTL-1461 lands.
+- `skills` — the per-skill neutral opt-in block (`{ effects, invocation, exposure }`). This is the ONE field whose *source* moves when CTL-1461 lands.
 
-**Version is deliberately absent.** Release Please owns it exclusively via each `plugin.json`'s
-`extra-files` jsonpath; a `version` key in `pack.json` would be a third source of truth.
-`pack-manifest.mjs` rejects one with a message naming release-please as the owner — not merely
-"unknown key", because that would read as a typo rather than a deliberate constraint.
+**Version is deliberately absent.** Release Please owns it exclusively via each `plugin.json`'s `extra-files` jsonpath; a `version` key in `pack.json` would be a third source of truth. `pack-manifest.mjs` rejects one with a message naming release-please as the owner — not merely "unknown key", because that would read as a typo rather than a deliberate constraint.
 
 ## The two-tier loss classifier
 
-The enumeration is closed (it comes from the ratified design's schema-field-shaped boundary), so
-this is a table (`core/loss.mjs`), not a detector:
+The enumeration is closed (it comes from the ratified design's schema-field-shaped boundary), so this is a table (`core/loss.mjs`), not a detector:
 
 | Component | Class | Policy for a non-Claude target |
 | --- | --- | --- |
@@ -88,65 +66,36 @@ this is a table (`core/loss.mjs`), not a detector:
 | `${CLAUDE_PLUGIN_ROOT}`, `/plugin:skill`, `Task(subagent_type=…)` in prose | **presentation** | warned (rewriting is CTL-1462's lint, not this pipeline's) |
 | `.mcp.json` co-location | **capability** | reported; emitting a Codex tool-wiring equivalent is out of scope |
 
-**Only safety-class losses omit.** Everything else is a target that is less powerful or less pretty,
-not less safe — the ratified design's line is exactly there.
+**Only safety-class losses omit.** Everything else is a target that is less powerful or less pretty, not less safe — the ratified design's line is exactly there.
 
-**No silent caps.** `cli.mjs render` exits non-zero on any unacknowledged loss unless `--allow-losses`
-is passed, and always prints the omitted/degraded/warning counts. `dist/loss-report.json` +
-`dist/LOSSES.md` (gitignored generated output, `--write` to persist) are byte-deterministic for the
-same input.
+**No silent caps.** `cli.mjs render` exits non-zero on any unacknowledged loss unless `--allow-losses` is passed, and always prints the omitted/degraded/warning counts. `dist/loss-report.json` + `dist/LOSSES.md` (gitignored generated output, `--write` to persist) are byte-deterministic for the same input.
 
 ## Day-one scope: a pipeline, not 115 portable skills
 
-Every `plugins/dev` skill carries `allowed-tools:` (a Claude-vocabulary effects guard); none has a
-neutral declaration yet — authoring those is CTL-1461/1462's scope. So on day one the Codex and
-`.agents/skills` targets export only the skills whose `pack.json` opts them in, and every other skill
-is correctly omitted and named in the loss report. Measured on this repo at ship time: 114 skills, 3
-opted in (`catalyst-dev:linearis`, `catalyst-meta:validate-frontmatter`,
-`catalyst-foundry:setup-catalyst` — chosen to prove the emitters end-to-end), 111 omitted with a
-named safety reason. That large loss report is the correct, designed output of this ticket, not a
-gap — it is the work-list CTL-1461/1462 burn down.
+Every `plugins/dev` skill carries `allowed-tools:` (a Claude-vocabulary effects guard); none has a neutral declaration yet — authoring those is CTL-1461/1462's scope. So on day one the Codex and `.agents/skills` targets export only the skills whose `pack.json` opts them in, and every other skill is correctly omitted and named in the loss report. Measured on this repo at ship time: 114 skills, 3 opted in (`catalyst-dev:linearis`, `catalyst-meta:validate-frontmatter`, `catalyst-foundry:setup-catalyst` — chosen to prove the emitters end-to-end), 111 omitted with a named safety reason. That large loss report is the correct, designed output of this ticket, not a gap — it is the work-list CTL-1461/1462 burn down.
 
 ## Real drift the byte-exact round-trip surfaced
 
-Proving the Claude emitter byte-identical (`claude-emitter.test.mjs`) surfaced two pre-existing facts
-about the committed tree, reproduced faithfully rather than "fixed":
+Proving the Claude emitter byte-identical (`claude-emitter.test.mjs`) surfaced two pre-existing facts about the committed tree, reproduced faithfully rather than "fixed":
 
-- `.claude-plugin/plugin.json` stores non-ASCII as literal UTF-8 (no `\u` escapes, verified across
-  all 10 files); `.claude-plugin/marketplace.json` stores it as `\uXXXX` escapes. The byte-exact JSON
-  writer (`core/json-format.mjs`) takes `escapeNonAscii` as a required per-call parameter because the
-  two files disagree with each other.
-- Every `marketplace.json` entry's `author` is a constant catalog-level `{name, email}` — independent
-  of that plugin's own `plugin.json` author (which differs for `dev`/`foundry`/`legacy`,
-  `hello@coalesce-labs.com` vs. every marketplace entry's `hello@coalesce.dev`).
+- `.claude-plugin/plugin.json` stores non-ASCII as literal UTF-8 (no `\u` escapes, verified across all 10 files); `.claude-plugin/marketplace.json` stores it as `\uXXXX` escapes. The byte-exact JSON writer (`core/json-format.mjs`) takes `escapeNonAscii` as a required per-call parameter because the two files disagree with each other.
+- Every `marketplace.json` entry's `author` is a constant catalog-level `{name, email}` — independent of that plugin's own `plugin.json` author (which differs for `dev`/`foundry`/`legacy`, `hello@coalesce-labs.com` vs. every marketplace entry's `hello@coalesce.dev`).
 
-Separately, shipping a REAL YAML parser (`Bun.YAML.parse`, not a regex) surfaced 4 genuinely invalid
-YAML frontmatter blocks (`description:` prose containing an unquoted colon-space sequence — confirmed
-invalid against PyYAML, not a Bun quirk) in already-committed `SKILL.md` files. Fixed by quoting the
-value; prose and rendered text are byte-identical.
+Separately, shipping a REAL YAML parser (`Bun.YAML.parse`, not a regex) surfaced 4 genuinely invalid YAML frontmatter blocks (`description:` prose containing an unquoted colon-space sequence — confirmed invalid against PyYAML, not a Bun quirk) in already-committed `SKILL.md` files. Fixed by quoting the value; prose and rendered text are byte-identical.
 
 ## Version propagation (the ticket's acceptance criterion)
 
 > Given a release PR merges with a version bump for a plugin, when release-please updates manifests,
 > then the Claude and Codex manifests for that plugin carry the same new version.
 
-Satisfied by making **release-please itself** write both files in the same commit — a second
-`extra-files` entry per package in `release-please-config.json` — so the criterion holds even if the
-compiler never runs. `scripts/validate-release-config.sh` Checks 9–11 assert the invariant on every
-PR (Check 10's "0 comparisons → inconclusive, never PASS" guard is deliberately the strictest check in
-the set — every other check in this phase can be satisfied by a script that never compares anything).
+Satisfied by making **release-please itself** write both files in the same commit — a second `extra-files` entry per package in `release-please-config.json` — so the criterion holds even if the compiler never runs. `scripts/validate-release-config.sh` Checks 9–11 assert the invariant on every PR (Check 10's "0 comparisons → inconclusive, never PASS" guard is deliberately the strictest check in the set — every other check in this phase can be satisfied by a script that never compares anything).
 
 ## What this ticket explicitly did NOT do
 
-- Build the render/compile engine, real source discovery, or conformance fixtures graded across
-  Catalyst AND catalyst-cloud — **CTL-1461's** scope.
-- Build the portability lint that flags executor-specific constructs in authored source —
-  **CTL-1462's** scope.
-- Prove Codex installs the generated artifacts — the **CTL-1465** probe. This pipeline claims
-  well-formedness only.
-- Extract `@coalesce/agent-skills` as a standalone package — the ratified criterion ("only after
-  Catalyst AND catalyst-cloud pass the shared fixture set") is not met; `cli.mjs extraction-readiness`
-  reports `inconclusive` and names why.
+- Build the render/compile engine, real source discovery, or conformance fixtures graded across Catalyst AND catalyst-cloud — **CTL-1461's** scope.
+- Build the portability lint that flags executor-specific constructs in authored source — **CTL-1462's** scope.
+- Prove Codex installs the generated artifacts — the **CTL-1465** probe. This pipeline claims well-formedness only.
+- Extract `@coalesce/agent-skills` as a standalone package — the ratified criterion ("only after Catalyst AND catalyst-cloud pass the shared fixture set") is not met; `cli.mjs extraction-readiness` reports `inconclusive` and names why.
 
 ## References
 

--- a/docs/specs/accepted/warm-identity/spec.md
+++ b/docs/specs/accepted/warm-identity/spec.md
@@ -6,15 +6,11 @@ ticket: CTL-1071
 
 ## Problem
 
-Catalyst read as a Linear knockoff. The goal was to give it its own product
-identity — a warmer, "textbook-calm" visual language across the app, website,
-and logo — rather than borrowing Linear's cool greys wholesale.
+Catalyst read as a Linear knockoff. The goal was to give it its own product identity — a warmer, "textbook-calm" visual language across the app, website, and logo — rather than borrowing Linear's cool greys wholesale.
 
 ## Outcome
 
-Explored and landed as the CTL-1071 identity spike (Done). These mockups are the
-reference deliverables for that direction: the warm board, the warm inbox proof,
-and the type specimen that pins down the typography.
+Explored and landed as the CTL-1071 identity spike (Done). These mockups are the reference deliverables for that direction: the warm board, the warm inbox proof, and the type specimen that pins down the typography.
 
 ## Mockups
 

--- a/docs/specs/draft/governance-process-map/spec.md
+++ b/docs/specs/draft/governance-process-map/spec.md
@@ -5,16 +5,12 @@ status: draft
 
 ## Problem
 
-Can the phase pipeline be shown as a "process machine" — a map of the states a
-ticket walks through — so the mechanics of execution are legible at a glance?
+Can the phase pipeline be shown as a "process machine" — a map of the states a ticket walks through — so the mechanics of execution are legible at a glance?
 
 ## Approach / options
 
-- [`governance-track1-process-map.html`](./governance-track1-process-map.html) —
-  the pipeline rendered as a process/state machine map.
+- [`governance-track1-process-map.html`](./governance-track1-process-map.html) — the pipeline rendered as a process/state machine map.
 
 ## Open questions
 
-Exploratory. Not shipped. Relationship to the shipped Journey/execution view
-([`accepted/ticket-journey/`](../../accepted/ticket-journey/)) is unresolved —
-this is the "machine" framing, that is the "journey" framing of the same pipeline.
+Exploratory. Not shipped. Relationship to the shipped Journey/execution view ([`accepted/ticket-journey/`](../../accepted/ticket-journey/)) is unresolved — this is the "machine" framing, that is the "journey" framing of the same pipeline.

--- a/docs/specs/draft/governance-rulebook/spec.md
+++ b/docs/specs/draft/governance-rulebook/spec.md
@@ -5,26 +5,17 @@ status: draft
 
 ## Problem
 
-How should the belief/rule engine ("Reason") present its rulebook so operators
-can read and trust how the daemon reasons? Several directions were mocked before
-the `/rules` swim-lane was chosen.
+How should the belief/rule engine ("Reason") present its rulebook so operators can read and trust how the daemon reasons? Several directions were mocked before the `/rules` swim-lane was chosen.
 
 ## Approach / options
 
 Competing directions, none of these exact mockups shipped:
 
-- [`rulebook-redesign.html`](./rulebook-redesign.html) — an early redesign of the
-  belief-engine rulebook, superseded by the shipped swim-lane.
-- [`governance-rulebook-v2-textbook.html`](./governance-rulebook-v2-textbook.html)
-  — Direction A, "textbook calm": the rulebook as a calm, readable document.
-- [`governance-rulebook-v2-livefeed.html`](./governance-rulebook-v2-livefeed.html)
-  — Direction B, "live inference feed": the rulebook as a running feed of
-  inferences.
-- [`governance-track2-beliefs-view.html`](./governance-track2-beliefs-view.html)
-  — a beliefs-centric view of the engine.
+- [`rulebook-redesign.html`](./rulebook-redesign.html) — an early redesign of the belief-engine rulebook, superseded by the shipped swim-lane.
+- [`governance-rulebook-v2-textbook.html`](./governance-rulebook-v2-textbook.html) — Direction A, "textbook calm": the rulebook as a calm, readable document.
+- [`governance-rulebook-v2-livefeed.html`](./governance-rulebook-v2-livefeed.html) — Direction B, "live inference feed": the rulebook as a running feed of inferences.
+- [`governance-track2-beliefs-view.html`](./governance-track2-beliefs-view.html) — a beliefs-centric view of the engine.
 
 ## Open questions
 
-The swim-lane board ([accepted](../../accepted/rulebook-swimlane/)) is what
-shipped for `/rules`. These remain as reference for future rulebook iterations —
-whether any of the "textbook calm" / "live feed" ideas get folded back in is open.
+The swim-lane board ([accepted](../../accepted/rulebook-swimlane/)) is what shipped for `/rules`. These remain as reference for future rulebook iterations — whether any of the "textbook calm" / "live feed" ideas get folded back in is open.

--- a/docs/specs/draft/rules-explorer/spec.md
+++ b/docs/specs/draft/rules-explorer/spec.md
@@ -5,22 +5,16 @@ status: draft
 
 ## Problem
 
-How should operators explore the execution-core rules — "how the daemon thinks" —
-as an interactive surface rather than a static list? Three visual metaphors were
-mocked.
+How should operators explore the execution-core rules — "how the daemon thinks" — as an interactive surface rather than a static list? Three visual metaphors were mocked.
 
 ## Approach / options
 
 Three competing directions, none confirmed shipped:
 
-- [`rules-explorer-mission-control.html`](./rules-explorer-mission-control.html)
-  — "Mission Control": a dashboard/console framing.
-- [`rules-explorer-circuit-schematic.html`](./rules-explorer-circuit-schematic.html)
-  — "Dataflow Schematic": rules as a circuit / dataflow diagram.
-- [`rules-explorer-living-textbook.html`](./rules-explorer-living-textbook.html)
-  — "Living Textbook": rules as annotated, readable prose.
+- [`rules-explorer-mission-control.html`](./rules-explorer-mission-control.html) — "Mission Control": a dashboard/console framing.
+- [`rules-explorer-circuit-schematic.html`](./rules-explorer-circuit-schematic.html) — "Dataflow Schematic": rules as a circuit / dataflow diagram.
+- [`rules-explorer-living-textbook.html`](./rules-explorer-living-textbook.html) — "Living Textbook": rules as annotated, readable prose.
 
 ## Open questions
 
-Which metaphor (if any) becomes the Rules Explorer surface is undecided. Promote
-the chosen one to `accepted/` with a `git mv` once a direction is picked and ships.
+Which metaphor (if any) becomes the Rules Explorer surface is undecided. Promote the chosen one to `accepted/` with a `git mv` once a direction is picked and ships.

--- a/docs/workflow-descriptors-design.md
+++ b/docs/workflow-descriptors-design.md
@@ -1,16 +1,9 @@
 <!-- CTL design doc — 2026-05-30. Status: DESIGN (not yet implemented). Author: Ryan + Claude (multi-agent design panel). -->
 # Workflow Descriptors — Design
 
-**Status:** Design proposal. Not implemented. This document specifies a reusable *workflow
-descriptor* that collapses the orchestrator's hardcoded 10-phase pipeline into a single declarative
-source of truth, and reserves the seams for non-Linear triggers and off-box executors.
+**Status:** Design proposal. Not implemented. This document specifies a reusable *workflow descriptor* that collapses the orchestrator's hardcoded 10-phase pipeline into a single declarative source of truth, and reserves the seams for non-Linear triggers and off-box executors.
 
-**Why now:** the question that started this — *"do we have a good general way to encode workflow
-steps so the engine is reusable for other trigger events and sequential/parallel steps?"* The honest
-answer today: the *substrate* (dispatch, claim/fencing, event bus, recovery, concurrency) is already
-general, but the *workflow definition* is hardwired to one pipeline and to Linear-as-trigger, encoded
-as constants and switch statements duplicated across ~10 files. This design extracts that definition
-into data without rebuilding the substrate.
+**Why now:** the question that started this — *"do we have a good general way to encode workflow steps so the engine is reusable for other trigger events and sequential/parallel steps?"* The honest answer today: the *substrate* (dispatch, claim/fencing, event bus, recovery, concurrency) is already general, but the *workflow definition* is hardwired to one pipeline and to Linear-as-trigger, encoded as constants and switch statements duplicated across ~10 files. This design extracts that definition into data without rebuilding the substrate.
 
 > Companion artifacts: the implementation plan lives in
 > `thoughts/shared/plans/` (TDD, follows this design); the user-facing docs land under `website/`
@@ -20,9 +13,7 @@ into data without rebuilding the substrate.
 
 ## 1. Problem: one pipeline, ten copies
 
-The death/advance logic is data-driven on the happy path (`lib/phase-fsm.mjs` `PHASES` +
-`NEXT_PHASE`), but the *same ordered list of phases* and its per-phase attributes are re-encoded in
-~10 places that must be kept in lockstep by hand:
+The death/advance logic is data-driven on the happy path (`lib/phase-fsm.mjs` `PHASES` + `NEXT_PHASE`), but the *same ordered list of phases* and its per-phase attributes are re-encoded in ~10 places that must be kept in lockstep by hand:
 
 | Site | What it encodes |
 |---|---|
@@ -38,51 +29,30 @@ The death/advance logic is data-driven on the happy path (`lib/phase-fsm.mjs` `P
 | `orchestrate-phase-advance:82,102` | `phase_next()` + `linear_key_for_phase()` bash mirrors |
 | `plugins/dev/skills/phase-<name>/SKILL.md` | one bespoke skill body per step |
 
-Adding, removing, or reordering a step today means editing all of these and trusting a
-byte-identical drift-guard test to catch divergence. The pipeline is also **singular** — there is no
-way to express a *second* workflow (e.g. a PR-triggered review pipeline) without forking the engine.
+Adding, removing, or reordering a step today means editing all of these and trusting a byte-identical drift-guard test to catch divergence. The pipeline is also **singular** — there is no way to express a *second* workflow (e.g. a PR-triggered review pipeline) without forking the engine.
 
-The **only** non-linear edge in the whole engine is `verify → remediate`, and it is a hardcoded
-`if (latest === "verify" && verifyVerdict === "fail")` at `scheduler.mjs:874`, with the
-`remediate → verify` cycle implemented by *deleting signal files* so the `PHASES` walk re-lands on
-`verify`. The cycle cap (`REMEDIATE_CYCLE_CAP=3`) is counted from the durable event log, not signals.
+The **only** non-linear edge in the whole engine is `verify → remediate`, and it is a hardcoded `if (latest === "verify" && verifyVerdict === "fail")` at `scheduler.mjs:874`, with the `remediate → verify` cycle implemented by *deleting signal files* so the `PHASES` walk re-lands on `verify`. The cycle cap (`REMEDIATE_CYCLE_CAP=3`) is counted from the durable event log, not signals.
 
 ## 2. Goals & non-goals
 
 **Goals (v1):**
 1. One JSON descriptor is the single source of truth for the step list and every per-step attribute.
 2. The lone non-linear edge (`verify→remediate`) becomes **data**, not a hardcoded `if`.
-3. Per-step `model`, `effort` (reasoning) level, `turnCap`, and prompt `preamble`/`postamble` —
-   three orthogonal levers (§6), conditionally overridable by a small, safe rules engine (e.g. *large
-   ticket ⇒ plan uses a stronger model + more effort + is told to use `/workflows`*).
-4. Global descriptor, with narrow per-ticket overrides; changes are deterministic and never mutate an
-   in-flight run.
+3. Per-step `model`, `effort` (reasoning) level, `turnCap`, and prompt `preamble`/`postamble` — three orthogonal levers (§6), conditionally overridable by a small, safe rules engine (e.g. *large ticket ⇒ plan uses a stronger model + more effort + is told to use `/workflows`*).
+4. Global descriptor, with narrow per-ticket overrides; changes are deterministic and never mutate an in-flight run.
 5. **Zero behavior change at cutover** — a pure provenance swap proven by a drift-guard test.
 
-**Non-goals (v1 — reserved for v2, see [§10](#10-v2-extensibility-reserved-seams)):** parallel/DAG
-steps, multiple triggers, reusable/parameterized templates, full predicate composition, a YAML
-authoring lane, and off-box executors. These are designed as *reserved seams* so v1 doesn't preclude
-them, but **v1 fails loud** if an unimplemented field/value appears (no silent accept-and-ignore).
+**Non-goals (v1 — reserved for v2, see [§10](#10-v2-extensibility-reserved-seams)):** parallel/DAG steps, multiple triggers, reusable/parameterized templates, full predicate composition, a YAML authoring lane, and off-box executors. These are designed as *reserved seams* so v1 doesn't preclude them, but **v1 fails loud** if an unimplemented field/value appears (no silent accept-and-ignore).
 
 ## 3. Format decision: canonical JSON + JSON Schema
 
-**Decision: the descriptor is JSON**, validated by a versioned JSON Schema (`schemaVersion:
-"workflow/v1"`), stored at `.catalyst/workflows/default.json` (Layer-1, committable). This was the
-strong consensus of the design panel and survived two adversarial format critics.
+**Decision: the descriptor is JSON**, validated by a versioned JSON Schema (`schemaVersion: "workflow/v1"`), stored at `.catalyst/workflows/default.json` (Layer-1, committable). This was the strong consensus of the design panel and survived two adversarial format critics.
 
 Rationale — the decision is over-determined by the existing system:
 
-- **The engine is already all-JSON with zero non-stdlib parsers in the core.** `phase-fsm.mjs`
-  imports nothing; `registry.mjs` is the single I/O seam; every signal, the registry, config, and the
-  eligible projections are `JSON.parse`d. The **bash recovery path is deliberately node-free** and
-  reads JSON via `jq`. Adding a YAML/TOML runtime parser would introduce a new dependency and failure
-  mode into a deliberately dependency-free core — and there is no bash YAML reader.
-- **The primary author is a headless agent** (req: agents create/edit workflows). LLMs emit valid
-  JSON natively and self-correct against a parse/schema error in a deterministic loop;
-  whitespace-significant YAML is a top LLM failure mode (and Linear ids like `CTL-736` plus `#`
-  comments collide with YAML syntax).
-- **The orch-monitor UI round-trips JSON losslessly** via `JSON.stringify(obj, null, 2)` + atomic
-  `tmp+rename`. There is no comment/format to destroy on form save.
+- **The engine is already all-JSON with zero non-stdlib parsers in the core.** `phase-fsm.mjs` imports nothing; `registry.mjs` is the single I/O seam; every signal, the registry, config, and the eligible projections are `JSON.parse`d. The **bash recovery path is deliberately node-free** and reads JSON via `jq`. Adding a YAML/TOML runtime parser would introduce a new dependency and failure mode into a deliberately dependency-free core — and there is no bash YAML reader.
+- **The primary author is a headless agent** (req: agents create/edit workflows). LLMs emit valid JSON natively and self-correct against a parse/schema error in a deterministic loop; whitespace-significant YAML is a top LLM failure mode (and Linear ids like `CTL-736` plus `#` comments collide with YAML syntax).
+- **The orch-monitor UI round-trips JSON losslessly** via `JSON.stringify(obj, null, 2)` + atomic `tmp+rename`. There is no comment/format to destroy on form save.
 
 | Format | Verdict |
 |---|---|
@@ -93,13 +63,10 @@ Rationale — the decision is over-determined by the existing system:
 | JSON5 / HCL / Starlark | ❌ JSON5 needs a non-stdlib runtime parser (breaks `JSON.parse`-everywhere); HCL/Starlark are config-as-code. |
 
 **Recovering JSON's two real warts cheaply (no second format):**
-- **Multi-line prompts** (`preamble`/`postamble`) are stored as **arrays of lines**, joined with
-  `\n` at load. Clean in diffs, editable as a UI textarea.
-- **Comments** are first-class `description` / `$comment` *data* fields (which the JSON Schema
-  tolerates) — they survive UI form saves because they are real data, not lexical trivia.
+- **Multi-line prompts** (`preamble`/`postamble`) are stored as **arrays of lines**, joined with `\n` at load. Clean in diffs, editable as a UI textarea.
+- **Comments** are first-class `description` / `$comment` *data* fields (which the JSON Schema tolerates) — they survive UI form saves because they are real data, not lexical trivia.
 
-*(Optional future nicety, not v1: the `catalyst-workflow` CLI may accept JSON5 on input and normalize
-to JSON on write — strictly less machinery than a YAML compile lane, deferred until asked for.)*
+*(Optional future nicety, not v1: the `catalyst-workflow` CLI may accept JSON5 on input and normalize to JSON on write — strictly less machinery than a YAML compile lane, deferred until asked for.)*
 
 ## 4. The descriptor schema (v1)
 
@@ -165,56 +132,26 @@ A worked example for the current pipeline (abridged — every step shown structu
 
 Key schema decisions:
 
-- **`run` is derived, not stored** by default: `run = "/catalyst-dev:phase-${id}"`. The signal path
-  (`workers/<ticket>/phase-<id>.json`), env vars (incl. the `CATALYST_GENERATION` fence), and event
-  name (`phase.<id>.<status>.<ticket>`) stay **mechanically derived from `id`** — so all 9 existing
-  `SKILL.md` files work unchanged. The descriptor changes *where the lists live*, never the contract.
-- **`next` is a string (linear) OR an ordered list of `{when, to}` clauses with a `{default}`.** This
-  turns the one hardcoded non-linear edge into data. The `when` is a structured predicate (§6), never
-  an eval'd string.
-- **`remediate` is an `ancillarySteps[]` member, NOT in `steps[]`,** with an **explicit `rank: 4`**
-  (not array-index-derived). This preserves `phaseIndex(remediate) = verify`'s index
-  (`phase-fsm.mjs:119`) and the non-dense `STAGE_RANK` whose `Object.keys` order is
-  `[...PHASES, "remediate"]` — both of which the preemption logic and the drift-guard depend on. A
-  naive positional rank would rank `remediate` as last/closest-to-done and corrupt preemption.
-- **Cycles are a named, durable, reusable structure.** `countBy: "event"` is **load-bearing**: the
-  cap is counted from the immutable event log (`countRemediateCycles`), which *survives* the signal
-  deletion the reset performs. Re-deriving the cap from signal files (which the reset deletes) would
-  reset it to 0 each cycle → infinite remediate loop (the exact CTL-735/736 storm class). The reset's
-  **`releaseClaims: true`** is also load-bearing — see [Appendix A](#appendix-a-gate-0).
-- **`workDoneProbe` is a string name resolved against the `WORK_DONE_PROBES` registry**; probe
-  *functions* stay in `work-done-probes.mjs` (behavior-in-modules, data-in-JSON). **Validation
-  HARD-FAILS any step without a registered probe** — a probe-less step false-deads into the
-  `no-probe-for-phase` → an escalation, defeating autonomy. This is a completeness gate, not
-  a warning.
-- **`input`** mirrors `prior_artifact_for_phase()`: `null` | `{ "signal": "x.json" }` |
-  `{ "glob": "...-${ticket}.md" }`.
+- **`run` is derived, not stored** by default: `run = "/catalyst-dev:phase-${id}"`. The signal path (`workers/<ticket>/phase-<id>.json`), env vars (incl. the `CATALYST_GENERATION` fence), and event name (`phase.<id>.<status>.<ticket>`) stay **mechanically derived from `id`** — so all 9 existing `SKILL.md` files work unchanged. The descriptor changes *where the lists live*, never the contract.
+- **`next` is a string (linear) OR an ordered list of `{when, to}` clauses with a `{default}`.** This turns the one hardcoded non-linear edge into data. The `when` is a structured predicate (§6), never an eval'd string.
+- **`remediate` is an `ancillarySteps[]` member, NOT in `steps[]`,** with an **explicit `rank: 4`** (not array-index-derived). This preserves `phaseIndex(remediate) = verify`'s index (`phase-fsm.mjs:119`) and the non-dense `STAGE_RANK` whose `Object.keys` order is `[...PHASES, "remediate"]` — both of which the preemption logic and the drift-guard depend on. A naive positional rank would rank `remediate` as last/closest-to-done and corrupt preemption.
+- **Cycles are a named, durable, reusable structure.** `countBy: "event"` is **load-bearing**: the cap is counted from the immutable event log (`countRemediateCycles`), which *survives* the signal deletion the reset performs. Re-deriving the cap from signal files (which the reset deletes) would reset it to 0 each cycle → infinite remediate loop (the exact CTL-735/736 storm class). The reset's **`releaseClaims: true`** is also load-bearing — see [Appendix A](#appendix-a-gate-0).
+- **`workDoneProbe` is a string name resolved against the `WORK_DONE_PROBES` registry**; probe *functions* stay in `work-done-probes.mjs` (behavior-in-modules, data-in-JSON). **Validation HARD-FAILS any step without a registered probe** — a probe-less step false-deads into the `no-probe-for-phase` → an escalation, defeating autonomy. This is a completeness gate, not a warning.
+- **`input`** mirrors `prior_artifact_for_phase()`: `null` | `{ "signal": "x.json" }` | `{ "glob": "...-${ticket}.md" }`.
 
 ## 5. Conditional rules — safe, structured, UI-bindable
 
-Every condition (routing `when`, per-step `rules[].when`) uses **one structured predicate shape** —
-not a string DSL, not JS eval, not CEL/Jinja (those are documented v2 upgrades):
+Every condition (routing `when`, per-step `rules[].when`) uses **one structured predicate shape** — not a string DSL, not JS eval, not CEL/Jinja (those are documented v2 upgrades):
 
 ```json
 { "field": "ticket.scope", "op": "in", "value": ["large", "epic"] }
 ```
 
-- **Ops for v1: `{ eq, gte, lt, in }`** (a deliberately small set; the design panel's 10-operator
-  engine with `allOf`/`anyOf`/`not` composition and regex `matches` was cut as YAGNI — added when a
-  second real rule demands it). `matches`/regex is explicitly excluded from v1 (ReDoS surface).
-- **Why structured, not a string:** the object binds 1:1 to UI form controls (field/op/value
-  dropdowns) → lossless round-trip; it is statically validatable; and it is structurally incapable of
-  arbitrary code execution. An agent emits it as trivial JSON.
-- **`rules[]` shape:** `{ when, set: {…fields to patch…}, appendPreamble: [...], appendPostamble:
-  [...] }`. Resolution is a pure function `resolveStep(baseStep, context) → effectiveStep`:
-  matching rules patch the step in array order (last-match-wins for `set`; `append*` accumulate). It
-  emits an `_applied` audit trail into the dispatch event so the HUD shows *why* a step resolved as it
-  did. Bounded: the accumulated `--append-system-prompt` has a max length (falls back to
-  `--append-system-prompt-file`).
+- **Ops for v1: `{ eq, gte, lt, in }`** (a deliberately small set; the design panel's 10-operator engine with `allOf`/`anyOf`/`not` composition and regex `matches` was cut as YAGNI — added when a second real rule demands it). `matches`/regex is explicitly excluded from v1 (ReDoS surface).
+- **Why structured, not a string:** the object binds 1:1 to UI form controls (field/op/value dropdowns) → lossless round-trip; it is statically validatable; and it is structurally incapable of arbitrary code execution. An agent emits it as trivial JSON.
+- **`rules[]` shape:** `{ when, set: {…fields to patch…}, appendPreamble: [...], appendPostamble: [...] }`. Resolution is a pure function `resolveStep(baseStep, context) → effectiveStep`: matching rules patch the step in array order (last-match-wins for `set`; `append*` accumulate). It emits an `_applied` audit trail into the dispatch event so the HUD shows *why* a step resolved as it did. Bounded: the accumulated `--append-system-prompt` has a max length (falls back to `--append-system-prompt-file`).
 
-**The context contract (frozen, schema-enforced).** A `when.field` may only reference a documented
-context path; an unknown path is a **validation error**, not silent-false — otherwise an agent can't
-tell "my rule is wrong" from "my rule didn't match." v1 context:
+**The context contract (frozen, schema-enforced).** A `when.field` may only reference a documented context path; an unknown path is a **validation error**, not silent-false — otherwise an agent can't tell "my rule is wrong" from "my rule didn't match." v1 context:
 
 | Path | Source | Notes |
 |---|---|---|
@@ -233,11 +170,7 @@ tell "my rule is wrong" from "my rule didn't match." v1 context:
 
 ## 6. Per-step execution levers — three orthogonal axes
 
-A step controls *how* its worker runs through **three independent levers**. They are easy to
-conflate (the question that prompted this section: *"is `opus-plan` a model param, and is that
-different from putting the `workflow` keyword in a prompt?"* — yes, and yes). Keeping them separate
-in the schema is deliberate; a single rule can set all three. All three are verified against
-`claude --help` (`--model`, `--effort`, `--append-system-prompt`) on the installed CLI.
+A step controls *how* its worker runs through **three independent levers**. They are easy to conflate (the question that prompted this section: *"is `opus-plan` a model param, and is that different from putting the `workflow` keyword in a prompt?"* — yes, and yes). Keeping them separate in the schema is deliberate; a single rule can set all three. All three are verified against `claude --help` (`--model`, `--effort`, `--append-system-prompt`) on the installed CLI.
 
 | Lever | Field | Threads to | What it changes |
 |---|---|---|---|
@@ -245,52 +178,23 @@ in the schema is deliberate; a single rule can set all three. All three are veri
 | **Effort (reasoning)** | `effort` | `claude --effort <v>` | *how hard* it reasons |
 | **Prompt directives** | `preamble` / `postamble` | `claude --append-system-prompt` | *what the worker does* (e.g. use `/workflows`) |
 
-**1. `model` — which model (`--model`).** Accepts a latest-model alias (`opus`, `sonnet`, `haiku`),
-a full id (`claude-opus-4-8`), **or a Claude Code model alias** — including **`opusplan`** ("Opus
-Plan Mode": Opus for plan-mode reasoning, Sonnet for execution). So `"model": "opusplan"` is a valid,
-first-class step value; it is a *model-selection* lever, unrelated to the `/workflows` keyword.
-Precedence is preserved exactly as today — `CLI flag > config.modelOverrides[phase][ticket] >
-config.models[phase] > descriptor.step.model > descriptor.defaults.model` — the descriptor is the new
-innermost default (covered by a precedence test).
+**1. `model` — which model (`--model`).** Accepts a latest-model alias (`opus`, `sonnet`, `haiku`), a full id (`claude-opus-4-8`), **or a Claude Code model alias** — including **`opusplan`** ("Opus Plan Mode": Opus for plan-mode reasoning, Sonnet for execution). So `"model": "opusplan"` is a valid, first-class step value; it is a *model-selection* lever, unrelated to the `/workflows` keyword. Precedence is preserved exactly as today — `CLI flag > config.modelOverrides[phase][ticket] > config.models[phase] > descriptor.step.model > descriptor.defaults.model` — the descriptor is the new innermost default (covered by a precedence test).
 
-**2. `effort` — how hard it reasons (`--effort`).** `claude` exposes a **native** effort flag,
-`--effort <low|medium|high|xhigh|max>` — this is the correct, native way to thread "thinking level,"
-*not* a system-prompt hack (an earlier draft of this doc mis-stated that no such flag exists; it
-does). The descriptor `effort` enum **mirrors the flag exactly: `low | medium | high | xhigh | max`**
-(plus `default` = omit the flag / inherit). It is independent of `model`: combine `model: opusplan`
-\+ `effort: max` freely.
+**2. `effort` — how hard it reasons (`--effort`).** `claude` exposes a **native** effort flag, `--effort <low|medium|high|xhigh|max>` — this is the correct, native way to thread "thinking level," *not* a system-prompt hack (an earlier draft of this doc mis-stated that no such flag exists; it does). The descriptor `effort` enum **mirrors the flag exactly: `low | medium | high | xhigh | max`** (plus `default` = omit the flag / inherit). It is independent of `model`: combine `model: opusplan` \+ `effort: max` freely.
   > The interactive `/effort ultracode` is a Claude Code convenience that *bundles* `xhigh` effort
   > **plus** auto-`/workflows` orchestration — i.e. lever 2 (`xhigh`) **and** lever 3 (the workflow
   > nudge) together. The descriptor keeps them **unbundled** so authors opt into each independently;
   > to reproduce "ultracode," set `effort: xhigh` **and** add the `/workflows` postamble (lever 3).
 
-**3. `preamble` / `postamble` — prompt directives (`--append-system-prompt`).** This is the
-*"`workflow` keyword in a prompt"* mechanism, genuinely distinct from model/effort: it changes **what
-the worker does**, not which model or how hard it thinks. There is **no `--append-system-prompt`
-block in `phase-agent-dispatch` today** — net-new dispatch surface. v1 adds one block composing
-`preamble` + `postamble` + any rule `append*` lines into a single `--append-system-prompt` arg
-(bounded length; `--append-system-prompt-file` fallback). The flagship *"for large tickets, tell the
-plan step to use `/workflows`"* is exactly a rule-appended postamble (the `plan` step in §4) — it
-works *because* the worker's prompt carries the `/workflows` instruction, independent of `effort`.
+**3. `preamble` / `postamble` — prompt directives (`--append-system-prompt`).** This is the *"`workflow` keyword in a prompt"* mechanism, genuinely distinct from model/effort: it changes **what the worker does**, not which model or how hard it thinks. There is **no `--append-system-prompt` block in `phase-agent-dispatch` today** — net-new dispatch surface. v1 adds one block composing `preamble` + `postamble` + any rule `append*` lines into a single `--append-system-prompt` arg (bounded length; `--append-system-prompt-file` fallback). The flagship *"for large tickets, tell the plan step to use `/workflows`"* is exactly a rule-appended postamble (the `plan` step in §4) — it works *because* the worker's prompt carries the `/workflows` instruction, independent of `effort`.
 
-**Why support both the native flags and the prompt nudge (the original question):** they do
-different jobs and compose. A large ticket might want *all three* — `model: opusplan` (stronger
-planning model), `effort: max` (more reasoning), **and** a postamble telling the worker to decompose
-via `/workflows` (multi-agent fan-out). The descriptor exposes them as three separate fields; the
-`website/` docs + configuration reference state the distinction explicitly so authors never assume
-one implies the others. *(A fourth, optional lever — `--max-budget-usd` per step — is available but
-deferred from v1-core; noted as a reserved field.)*
+**Why support both the native flags and the prompt nudge (the original question):** they do different jobs and compose. A large ticket might want *all three* — `model: opusplan` (stronger planning model), `effort: max` (more reasoning), **and** a postamble telling the worker to decompose via `/workflows` (multi-agent fan-out). The descriptor exposes them as three separate fields; the `website/` docs + configuration reference state the distinction explicitly so authors never assume one implies the others. *(A fourth, optional lever — `--max-budget-usd` per step — is available but deferred from v1-core; noted as a reserved field.)*
 
-**The v1 vertical slice (must run end-to-end, not just be schema):** per-step `model` + `turnCap` +
-`effort` (native `--effort`) + `preamble`/`postamble` (native `--append-system-prompt`), plus the one
-`scope→points` predicate that actually fires. If this slice doesn't run, the design fails the core
-ask regardless of schema cleanliness. Proven by a dispatch dry-run test asserting the exact
-`--model` / `--effort` / `--append-system-prompt` args composed for a large vs. small ticket.
+**The v1 vertical slice (must run end-to-end, not just be schema):** per-step `model` + `turnCap` + `effort` (native `--effort`) + `preamble`/`postamble` (native `--append-system-prompt`), plus the one `scope→points` predicate that actually fires. If this slice doesn't run, the design fails the core ask regardless of schema cleanliness. Proven by a dispatch dry-run test asserting the exact `--model` / `--effort` / `--append-system-prompt` args composed for a large vs. small ticket.
 
 ## 7. Dynamic config & layering
 
-Three layers, deep-merged, with steps merged **by `id`/name** (never by array index — the one merge
-rule teams get wrong; index-merge corrupts every step when overriding one):
+Three layers, deep-merged, with steps merged **by `id`/name** (never by array index — the one merge rule teams get wrong; index-merge corrupts every step when overriding one):
 
 ```
 effective = merge( engine-default descriptor,          // shipped, = today's pipeline
@@ -298,115 +202,44 @@ effective = merge( engine-default descriptor,          // shipped, = today's pip
                    workers/<ticket>/workflow-override.json )   // per-ticket (RFC-7386 merge patch)
 ```
 
-- **Global change:** edit `.catalyst/workflows/default.json` (or via the CLI/UI). Affects tickets
-  that *enter* after the edit.
-- **Per-ticket change (req: "change globally OR per-ticket"):** a narrow
-  `workers/<ticket>/workflow-override.json` JSON Merge Patch. **v1 restricts per-ticket overrides to
-  leaf fields** (`model`, `effort`, `turnCap`, `preamble`, `postamble`, `rules`) — **routing/`next`
-  overrides are forbidden** so a one-off patch can never construct an unreachable/cyclic graph that
-  the base schema already validated. (`model` already has a per-ticket path today via
-  `config.modelOverrides[phase][ticket]`, which is preserved.)
-- **No mid-flight surprises — pinned-per-ticket.** At a ticket's **first dispatch** the engine stamps
-  a frozen `workers/<ticket>/resolved-workflow.json` + a `resolvedWorkflowVersion`; every subsequent
-  dispatch for that ticket reads the *pin*, not the live global file. A global edit therefore can
-  **never** mutate an in-flight multi-hour run — directly applying CTL-736's "no mid-flight surprises"
-  fencing discipline (a hot-reloaded topology could make `deriveAdvancement`'s `PHASES` walk land on
-  a phase with no signal and hard-stall the run). An explicit, operator-only `repin` is the escape
-  hatch, and it must respect/bump the generation fence token (don't re-pin a ticket whose worker
-  holds a live claim without bumping the generation).
-- **Merge semantics, frozen:** scalars deep-merge by key; `preamble`/`postamble`/`rules` **replace**
-  (predictable); "append" is expressed only via a rule's `appendPreamble`/`appendPostamble`. The
-  dispatch precedence ladder is unchanged: `CLI > config.modelOverrides > descriptor-override >
-  descriptor-base > engine-default`, with an explicit precedence test.
+- **Global change:** edit `.catalyst/workflows/default.json` (or via the CLI/UI). Affects tickets that *enter* after the edit.
+- **Per-ticket change (req: "change globally OR per-ticket"):** a narrow `workers/<ticket>/workflow-override.json` JSON Merge Patch. **v1 restricts per-ticket overrides to leaf fields** (`model`, `effort`, `turnCap`, `preamble`, `postamble`, `rules`) — **routing/`next` overrides are forbidden** so a one-off patch can never construct an unreachable/cyclic graph that the base schema already validated. (`model` already has a per-ticket path today via `config.modelOverrides[phase][ticket]`, which is preserved.)
+- **No mid-flight surprises — pinned-per-ticket.** At a ticket's **first dispatch** the engine stamps a frozen `workers/<ticket>/resolved-workflow.json` + a `resolvedWorkflowVersion`; every subsequent dispatch for that ticket reads the *pin*, not the live global file. A global edit therefore can **never** mutate an in-flight multi-hour run — directly applying CTL-736's "no mid-flight surprises" fencing discipline (a hot-reloaded topology could make `deriveAdvancement`'s `PHASES` walk land on a phase with no signal and hard-stall the run). An explicit, operator-only `repin` is the escape hatch, and it must respect/bump the generation fence token (don't re-pin a ticket whose worker holds a live claim without bumping the generation).
+- **Merge semantics, frozen:** scalars deep-merge by key; `preamble`/`postamble`/`rules` **replace** (predictable); "append" is expressed only via a rule's `appendPreamble`/`appendPostamble`. The dispatch precedence ladder is unchanged: `CLI > config.modelOverrides > descriptor-override > descriptor-base > engine-default`, with an explicit precedence test.
 
-*(Full `repin`/etag optimistic-concurrency is v1.1 — see §8; v1 is last-write-wins on the global file
-\+ the frozen per-ticket pin, which is sufficient and far less machinery.)*
+*(Full `repin`/etag optimistic-concurrency is v1.1 — see §8; v1 is last-write-wins on the global file \+ the frozen per-ticket pin, which is sufficient and far less machinery.)*
 
 ## 8. Authoring DevEx — CLI + UI
 
-- **`catalyst-workflow` CLI** (`show` | `validate` | `set` | `diff` | `codegen` | `graph` | `lint`).
-  `set`/write **refuses unless `validate` passes on the MERGED effective result**, not just the
-  patch. This is the load-bearing piece for the headless-agent feedback loop and UI write-safety.
-- **Validation gives a tight feedback loop** — errors emit `{ path, expected, got, hint }` in **both
-  human and `--json`** form. Validation covers: schema; **every step has a registered
-  `workDoneProbe`** (hard fail, §4); edge reachability (every step reachable, terminal reachable, no
-  orphan/cycle except declared `cycles[]`); referenced steps/skills exist; `when.field` references a
-  documented context path; reserved fields hold their v1-restricted values (`executor == "local"`,
-  `trigger.kind == "linear.ready"` — §10).
-- **orch-monitor UI** reads the descriptor, renders the step graph (mermaid/flow), and edits per-step
-  `model`/`effort`/`turnCap`/`preamble`/`postamble` + rules via forms (the structured `{field, op,
-  value}` predicate binds 1:1 to field/op/value form controls — the reason §5 chose it). A
-  scope toggle `[ Global | This ticket ]` writes the global file vs. a per-ticket patch.
-  - **Honest scoping:** the UI write-back is **net-new server code** — `orch-monitor/server.ts` has
-    *no* existing etag/If-Match/validate-before-write framework (only an annotation flag-toggle PUT).
-    v1 ships either read-only display **or** a single validate-before-write route reusing the shared
-    `validateWorkflow()` (the same function the CLI calls); etag optimistic concurrency for
-    concurrent agent-vs-UI edits is deferred to v1.1 (the pinned-per-ticket model already sidesteps
-    the mid-flight race).
+- **`catalyst-workflow` CLI** (`show` | `validate` | `set` | `diff` | `codegen` | `graph` | `lint`). `set`/write **refuses unless `validate` passes on the MERGED effective result**, not just the patch. This is the load-bearing piece for the headless-agent feedback loop and UI write-safety.
+- **Validation gives a tight feedback loop** — errors emit `{ path, expected, got, hint }` in **both human and `--json`** form. Validation covers: schema; **every step has a registered `workDoneProbe`** (hard fail, §4); edge reachability (every step reachable, terminal reachable, no orphan/cycle except declared `cycles[]`); referenced steps/skills exist; `when.field` references a documented context path; reserved fields hold their v1-restricted values (`executor == "local"`, `trigger.kind == "linear.ready"` — §10).
+- **orch-monitor UI** reads the descriptor, renders the step graph (mermaid/flow), and edits per-step `model`/`effort`/`turnCap`/`preamble`/`postamble` + rules via forms (the structured `{field, op, value}` predicate binds 1:1 to field/op/value form controls — the reason §5 chose it). A scope toggle `[ Global | This ticket ]` writes the global file vs. a per-ticket patch.
+  - **Honest scoping:** the UI write-back is **net-new server code** — `orch-monitor/server.ts` has *no* existing etag/If-Match/validate-before-write framework (only an annotation flag-toggle PUT). v1 ships either read-only display **or** a single validate-before-write route reusing the shared `validateWorkflow()` (the same function the CLI calls); etag optimistic concurrency for concurrent agent-vs-UI edits is deferred to v1.1 (the pinned-per-ticket model already sidesteps the mid-flight race).
 
 ## 9. Migration & sequencing — a pure provenance swap
 
 The single most important constraint: **zero behavior change at cutover**, proven, not asserted.
 
-1. **`lib/workflow-descriptor.mjs`** loads `lib/workflow.default.json` and **re-exports the IDENTICAL
-   constant names** the engine already imports — `PHASES`, `NEXT_PHASE`, `PHASE_LINEAR_KEY`,
-   `STAGE_RANK` (incl. `Object.keys` order), `TERMINAL_PHASE`, `NEW_WORK_ENTRY_PHASE`,
-   `NON_PREEMPTABLE_PHASES`, the prior-artifact map, default turn caps, the probe registry. Only
-   `scheduler.mjs` and `recovery.mjs` import these FSM constants, so the blast radius is two import
-   lines: they change their *source*, not their *interface*.
-2. **Drift-guard test FIRST** (`workflow-descriptor.test.mjs`): asserts descriptor-derived constants
-   **deep-equal today's frozen literals** (including `Object.keys(STAGE_RANK)` *order*) **before any
-   consumer switches source**. This turns the refactor into a provable provenance swap — the single
-   most important destabilization control.
-3. **Bash mirror is generated, not hand-maintained.** A `gen-phase-sequence.mjs` codegen emits
-   `phase-sequence.sh` + `phase-tables.generated.sh` (the `phase_next` / `linear_key_for_phase` /
-   turn-cap / prior-artifact case statements). CI runs the codegen and `git diff --exit-code` to
-   prove it was run — retiring the hand-mirroring + byte-identical drift guard. **Constraints:** the
-   generated `.sh` stays **pure bash, node-free** (CTL-736's claim path must not gain a node
-   dependency); emits **POSIX-portable** case statements only (no `${VAR,,}` / `shopt` / `declare -A`
-   bash-4 idioms — they silently break under the zsh Bash-tool harness); and is tested under **both
-   `zsh -c 'source …'` and `bash -c`**.
-4. **No `bun`/`node` in the dispatch claim window.** Any descriptor read in `phase-agent-dispatch`
-   must be `jq` against a **static pre-generated JSON file**, hoisted **before** the claim window
-   (`:503`), never interleaved with it — because two concurrent `bun` launches race the execution-core
-   lockfile and one returns empty, re-opening the double-spawn CTL-736 just closed. Best: **zero**
-   runtime descriptor read on the bash side (use the generated, sourced constants).
+1. **`lib/workflow-descriptor.mjs`** loads `lib/workflow.default.json` and **re-exports the IDENTICAL constant names** the engine already imports — `PHASES`, `NEXT_PHASE`, `PHASE_LINEAR_KEY`, `STAGE_RANK` (incl. `Object.keys` order), `TERMINAL_PHASE`, `NEW_WORK_ENTRY_PHASE`, `NON_PREEMPTABLE_PHASES`, the prior-artifact map, default turn caps, the probe registry. Only `scheduler.mjs` and `recovery.mjs` import these FSM constants, so the blast radius is two import lines: they change their *source*, not their *interface*.
+2. **Drift-guard test FIRST** (`workflow-descriptor.test.mjs`): asserts descriptor-derived constants **deep-equal today's frozen literals** (including `Object.keys(STAGE_RANK)` *order*) **before any consumer switches source**. This turns the refactor into a provable provenance swap — the single most important destabilization control.
+3. **Bash mirror is generated, not hand-maintained.** A `gen-phase-sequence.mjs` codegen emits `phase-sequence.sh` + `phase-tables.generated.sh` (the `phase_next` / `linear_key_for_phase` / turn-cap / prior-artifact case statements). CI runs the codegen and `git diff --exit-code` to prove it was run — retiring the hand-mirroring + byte-identical drift guard. **Constraints:** the generated `.sh` stays **pure bash, node-free** (CTL-736's claim path must not gain a node dependency); emits **POSIX-portable** case statements only (no `${VAR,,}` / `shopt` / `declare -A` bash-4 idioms — they silently break under the zsh Bash-tool harness); and is tested under **both `zsh -c 'source …'` and `bash -c`**.
+4. **No `bun`/`node` in the dispatch claim window.** Any descriptor read in `phase-agent-dispatch` must be `jq` against a **static pre-generated JSON file**, hoisted **before** the claim window (`:503`), never interleaved with it — because two concurrent `bun` launches race the execution-core lockfile and one returns empty, re-opening the double-spawn CTL-736 just closed. Best: **zero** runtime descriptor read on the bash side (use the generated, sourced constants).
 
 ### 🔴 Sequencing vs CTL-736 — a HARD gate (and a blocker found en route)
 
-CTL-736 is mid-stabilization in the **exact** `scheduler.mjs` / `recovery.mjs` /
-`phase-agent-dispatch` regions this refactor re-sources. Therefore:
+CTL-736 is mid-stabilization in the **exact** `scheduler.mjs` / `recovery.mjs` / `phase-agent-dispatch` regions this refactor re-sources. Therefore:
 
-- **Land the descriptor as a pure-provenance PR _after_ CTL-736 Phases 2-3 merge.** No descriptor
-  commit may touch the claim/revive/reclaim regions. **Defer the bash-codegen half** (highest textual
-  collision with CTL-736's `phase-agent-dispatch` edits) to a follow-up PR. If forced to interleave,
-  do the `.mjs` half first.
-- The `verify→remediate`-as-data change and the conditional/`effort`/preamble slice are **separate
-  follow-up PRs**, never bundled into the constant-swap.
-- **Blocker found (GATE 0 — CONFIRMED, see [Appendix A](#appendix-a-gate-0)):** the
-  `verify→remediate→verify` cycle is **already broken on HEAD** under CTL-736 fencing (the cycle reset
-  deletes signals but not `.claim.<gen>` tombstones → the 2nd verify loses its claim and never
-  dispatches). The descriptor must **not** model the cycle until this is fixed in the CTL-736 thread,
-  and when it does, the `cycles[].reset.releaseClaims: true` (§4) is the declarative form of the fix.
+- **Land the descriptor as a pure-provenance PR _after_ CTL-736 Phases 2-3 merge.** No descriptor commit may touch the claim/revive/reclaim regions. **Defer the bash-codegen half** (highest textual collision with CTL-736's `phase-agent-dispatch` edits) to a follow-up PR. If forced to interleave, do the `.mjs` half first.
+- The `verify→remediate`-as-data change and the conditional/`effort`/preamble slice are **separate follow-up PRs**, never bundled into the constant-swap.
+- **Blocker found (GATE 0 — CONFIRMED, see [Appendix A](#appendix-a-gate-0)):** the `verify→remediate→verify` cycle is **already broken on HEAD** under CTL-736 fencing (the cycle reset deletes signals but not `.claim.<gen>` tombstones → the 2nd verify loses its claim and never dispatches). The descriptor must **not** model the cycle until this is fixed in the CTL-736 thread, and when it does, the `cycles[].reset.releaseClaims: true` (§4) is the declarative form of the fix.
 
 ## 10. v2 extensibility — reserved seams (off-box executors + non-Linear triggers)
 
-This section designs the *direction* (off-box executors; triggers beyond Linear) and the **minimal
-v1 seams** that keep it reachable. **Binding invariant: no off-box and no off-Linear value is
-*reachable* before v2.0.** v1 reserves *shape*, never *behavior*.
+This section designs the *direction* (off-box executors; triggers beyond Linear) and the **minimal v1 seams** that keep it reachable. **Binding invariant: no off-box and no off-Linear value is *reachable* before v2.0.** v1 reserves *shape*, never *behavior*.
 
 ### 10.1 The load-bearing insight: the generation token is already a distributed fencing token
 
-CTL-736's fence (`isCurrentGeneration`, `claim.mjs:99-107`; the emit-complete check,
-`phase-agent-emit-complete:167-181`) compares **two persisted integers** — the worker's
-`CATALYST_GENERATION` vs the signal's `generation` — with **zero local-process / pid / host
-dependency**. That is precisely a **Lamport / Kleppmann fencing token**: a stale-generation remote
-completion is rejected by the *same* check that rejects a local false-dead duplicate. So the
-**at-most-one-*write*** guarantee generalizes off-box **for free**. What does *not* generalize is the
-local mutual-exclusion *primitive* (`openSync(path,"wx")` is single-filesystem) and local liveness
-(`claude agents --json`). Off-box therefore needs only: relocate the *claim caller* to the
-coordinator, add a *lease + heartbeat* for liveness, and add an *authenticated bus-ingest* for
-completion — **not** a new claim protocol.
+CTL-736's fence (`isCurrentGeneration`, `claim.mjs:99-107`; the emit-complete check, `phase-agent-emit-complete:167-181`) compares **two persisted integers** — the worker's `CATALYST_GENERATION` vs the signal's `generation` — with **zero local-process / pid / host dependency**. That is precisely a **Lamport / Kleppmann fencing token**: a stale-generation remote completion is rejected by the *same* check that rejects a local false-dead duplicate. So the **at-most-one-*write*** guarantee generalizes off-box **for free**. What does *not* generalize is the local mutual-exclusion *primitive* (`openSync(path,"wx")` is single-filesystem) and local liveness (`claude agents --json`). Off-box therefore needs only: relocate the *claim caller* to the coordinator, add a *lease + heartbeat* for liveness, and add an *authenticated bus-ingest* for completion — **not** a new claim protocol.
 
 > **Honesty up front (promoted from a footnote):** the "needs only a lease, not a new claim" framing
 > is true **for a single coordinator**. The O_EXCL claim fences only callers sharing one filesystem;
@@ -416,11 +249,7 @@ completion — **not** a new claim protocol.
 
 ### 10.2 The executor seam
 
-The executor is already one injectable function — `dispatch.mjs` `defaultRunPhaseAgent:55` (the only
-shell-out to `phase-agent-dispatch`), with `lib/executor.sh` owning `claude --bg` + `claude stop`
-behind one file (its header literally calls itself "the single executor seam (D9)"). v2 turns that
-into a name→impl **executor registry** (mirroring the `WORK_DONE_PROBES` HARD-FAIL pattern) behind a
-small adapter interface — the verbs the engine *already* calls, made transport-agnostic:
+The executor is already one injectable function — `dispatch.mjs` `defaultRunPhaseAgent:55` (the only shell-out to `phase-agent-dispatch`), with `lib/executor.sh` owning `claude --bg` + `claude stop` behind one file (its header literally calls itself "the single executor seam (D9)"). v2 turns that into a name→impl **executor registry** (mirroring the `WORK_DONE_PROBES` HARD-FAIL pattern) behind a small adapter interface — the verbs the engine *already* calls, made transport-agnostic:
 
 ```
 ExecutorAdapter (v2):
@@ -432,79 +261,25 @@ ExecutorAdapter (v2):
   //   phase.<step>.complete event carrying its `generation` to the authenticated bus ingest.
 ```
 
-Off-box dispatch is **three coordinator steps, not "relocate the caller"** (a correction the
-feasibility critic forced): (1) `claim` runs **on the coordinator** *before* the provider call;
-(2) the returned **handle persists to the signal *before* the provider create returns** — else a
-coordinator crash orphans an uncancellable remote session; (3) there is **no `bg_job_id`-from-stdout
-analogue** off-box, so the provider session id *is* the handle. The signal stays **coordinator-owned**
-— a remote worker never writes the local signal file; the coordinator flips it on a fenced completion
-event (preserving recovery.mjs's "the signal is the source of truth" invariant).
+Off-box dispatch is **three coordinator steps, not "relocate the caller"** (a correction the feasibility critic forced): (1) `claim` runs **on the coordinator** *before* the provider call; (2) the returned **handle persists to the signal *before* the provider create returns** — else a coordinator crash orphans an uncancellable remote session; (3) there is **no `bg_job_id`-from-stdout analogue** off-box, so the provider session id *is* the handle. The signal stays **coordinator-owned** — a remote worker never writes the local signal file; the coordinator flips it on a fenced completion event (preserving recovery.mjs's "the signal is the source of truth" invariant).
 
 ### 10.3 Liveness, artifacts, ingest — and the honest gaps
 
-- **Liveness = lease TTL + heartbeats on the existing bus.** A new canonical action
-  `phase.<step>.heartbeat.<workItem>` renews `signal.leaseExpiresAt`; death = lease lapse. The broker
-  already ignores non-`PHASE_EVENT_PATTERN` audit events, so heartbeats need **zero broker change**
-  (only `shouldSkipEvent` must list the new action so the broker doesn't self-loop). `claude-agents.mjs:50-55`
-  *already names this* as the required distributed substitute. This **extends** `classifyWorker`'s
-  existing `terminal|running|dead|unknown` quad-state (it is *not* a new tri-state — the
-  non-Linear-triggers perspective misread this; corrected).
-- **Artifacts = commits pushed to `origin/<branch>`.** ⚠️ **Probe portability is *not* free** (the
-  feasibility critic's key correction): the work-done probes read git **of the local worktree**
-  (`implementProbe` `git -C <worktree> rev-list origin/main..HEAD`, `work-done-probes.mjs:229`;
-  `artifactProbe` reads local `.md` files, `:282`). Off-box, `resolveWorktree` returns null → every
-  probe returns false → **the reclaim safety net vanishes**. v2 must give the coordinator a **mirror
-  clone** that fetches `origin/<branch>` for the probes (or a shared store). This is **v2-blocking**,
-  not a reserved seam. Likewise the `thoughts/*` research/plan handoff: off-box producers must commit
-  those docs to the branch and the prior-artifact gate (`phase-agent-dispatch:403`, refuse+exit 2)
-  must read `origin/<branch>` — otherwise a mixed local/off-box pipeline **strands** at "prior
-  artifact missing." v1 keeps `input` strictly `null|{signal}|{glob}`; the off-box artifact transport
-  is a named v2 problem, **not** a v1 `gitRef` input source (a reserved-but-unhandled value would be
-  dead config).
-- **Ingest is new code + a new SPOF** (not "near-free reuse"): `webhook-handler.ts` has an HMAC
-  secret but parses *GitHub* payloads only. The agent-completion ingest needs: a **fence-on-ingest**
-  check (`isCurrentGeneration` *before* append) that **fails CLOSED** — the local fence returns
-  *true* on missing/non-numeric `generation` (fail-open, fine for legacy local emits), but **over the
-  network a dropped/garbled generation must be rejected `4xx`**, never accepted; and a
-  **fsync-before-`2xx`** exactly-once contract (a fire-and-forget webhook loses the completion of a
-  worker whose session already ended). The `commits-ahead` reclaim probe (host-independent, via the
-  mirror clone) is the safety net for a dropped completion POST.
+- **Liveness = lease TTL + heartbeats on the existing bus.** A new canonical action `phase.<step>.heartbeat.<workItem>` renews `signal.leaseExpiresAt`; death = lease lapse. The broker already ignores non-`PHASE_EVENT_PATTERN` audit events, so heartbeats need **zero broker change** (only `shouldSkipEvent` must list the new action so the broker doesn't self-loop). `claude-agents.mjs:50-55` *already names this* as the required distributed substitute. This **extends** `classifyWorker`'s existing `terminal|running|dead|unknown` quad-state (it is *not* a new tri-state — the non-Linear-triggers perspective misread this; corrected).
+- **Artifacts = commits pushed to `origin/<branch>`.** ⚠️ **Probe portability is *not* free** (the feasibility critic's key correction): the work-done probes read git **of the local worktree** (`implementProbe` `git -C <worktree> rev-list origin/main..HEAD`, `work-done-probes.mjs:229`; `artifactProbe` reads local `.md` files, `:282`). Off-box, `resolveWorktree` returns null → every probe returns false → **the reclaim safety net vanishes**. v2 must give the coordinator a **mirror clone** that fetches `origin/<branch>` for the probes (or a shared store). This is **v2-blocking**, not a reserved seam. Likewise the `thoughts/*` research/plan handoff: off-box producers must commit those docs to the branch and the prior-artifact gate (`phase-agent-dispatch:403`, refuse+exit 2) must read `origin/<branch>` — otherwise a mixed local/off-box pipeline **strands** at "prior artifact missing." v1 keeps `input` strictly `null|{signal}|{glob}`; the off-box artifact transport is a named v2 problem, **not** a v1 `gitRef` input source (a reserved-but-unhandled value would be dead config).
+- **Ingest is new code + a new SPOF** (not "near-free reuse"): `webhook-handler.ts` has an HMAC secret but parses *GitHub* payloads only. The agent-completion ingest needs: a **fence-on-ingest** check (`isCurrentGeneration` *before* append) that **fails CLOSED** — the local fence returns *true* on missing/non-numeric `generation` (fail-open, fine for legacy local emits), but **over the network a dropped/garbled generation must be rejected `4xx`**, never accepted; and a **fsync-before-`2xx`** exactly-once contract (a fire-and-forget webhook loses the completion of a worker whose session already ended). The `commits-ahead` reclaim probe (host-independent, via the mirror clone) is the safety net for a dropped completion POST.
 
 ### 10.4 Non-Linear triggers + the generic work-item
 
-- **The monitor becomes a registry of trigger adapters** (`registerTriggerAdapter(kind, {onEvent,
-  poll})`); the Linear poll is just the first registration (wrapping today's exact handlers → zero
-  CTL behavior change). **GitHub envelopes are already on the bus** (`webhook-handler.ts:657-693`
-  appends `github.*`); `monitor.mjs` simply drops them today. A `bus-event` adapter lets them enter
-  the **same** scheduler — no second pipeline.
-- **`trigger.kind` is the `<source>.<entity>.<action>` discriminant**, matched 1:1 against the bus
-  `attributes["event.name"]` the receiver already writes: `linear.ready` (v1),
-  `github.pull_request.opened`, `github.push`, `schedule.cron`, `manual.api`, `webhook.generic`.
-- **The deepest Linear assumption is `teamOf()`'s `^<PREFIX>-<n>$` regex** (`dispatch.mjs:28`) — the
-  *only* place a work-item string is *interpreted* rather than passed through. The fix is
-  **structural, not schema**: route all work-item→repoRoot resolution through `resolveProject`
-  (already the seam at `dispatch.mjs:35`); `teamOf` becomes *one implementation* (the `source:linear`
-  branch), and the registry owns the mapping (a GitHub item resolves `repoRoot` by repo). The
-  work-item stays a **bare string** in v1; `workItem.source` is **doc-reserved only** (no second
-  computable value today → a v1 field would be dead config).
-- **Conditions are source-scoped.** A GitHub PR exposes `pr_*`, not `estimate`/`scope`; a `when.field`
-  referencing a field the source doesn't expose is a **validation error** (extends the §5 rule). The
-  *same* `{field, op, value}` vocabulary serves v2 `trigger.match` — no new DSL is ever introduced.
-- **Linear mirror is optional per descriptor.** `workflow.linearMirror` (const `true` in v1) gates
-  the `PHASE_LINEAR_KEY` write-back in `linear-write.safeWrite`. A v2 non-Linear descriptor sets it
-  `false` and posts verdicts to its native system (e.g. a GitHub PR comment); steps with no stateMap
-  entry advance silently (exactly how `remediate` already behaves). ⚠️ Flipping it `false` is **gated
-  on first defining a non-Linear stop/kill channel** — today the human-override/kill path
-  (`DRAG_OUT_STATES`, `monitor.mjs:56`) is Linear-state-driven, so a non-Linear workflow has *no*
-  equivalent "stop this work-item" switch until v2 adds a `manual.api`/`webhook` cancel intent.
+- **The monitor becomes a registry of trigger adapters** (`registerTriggerAdapter(kind, {onEvent, poll})`); the Linear poll is just the first registration (wrapping today's exact handlers → zero CTL behavior change). **GitHub envelopes are already on the bus** (`webhook-handler.ts:657-693` appends `github.*`); `monitor.mjs` simply drops them today. A `bus-event` adapter lets them enter the **same** scheduler — no second pipeline.
+- **`trigger.kind` is the `<source>.<entity>.<action>` discriminant**, matched 1:1 against the bus `attributes["event.name"]` the receiver already writes: `linear.ready` (v1), `github.pull_request.opened`, `github.push`, `schedule.cron`, `manual.api`, `webhook.generic`.
+- **The deepest Linear assumption is `teamOf()`'s `^<PREFIX>-<n>$` regex** (`dispatch.mjs:28`) — the *only* place a work-item string is *interpreted* rather than passed through. The fix is **structural, not schema**: route all work-item→repoRoot resolution through `resolveProject` (already the seam at `dispatch.mjs:35`); `teamOf` becomes *one implementation* (the `source:linear` branch), and the registry owns the mapping (a GitHub item resolves `repoRoot` by repo). The work-item stays a **bare string** in v1; `workItem.source` is **doc-reserved only** (no second computable value today → a v1 field would be dead config).
+- **Conditions are source-scoped.** A GitHub PR exposes `pr_*`, not `estimate`/`scope`; a `when.field` referencing a field the source doesn't expose is a **validation error** (extends the §5 rule). The *same* `{field, op, value}` vocabulary serves v2 `trigger.match` — no new DSL is ever introduced.
+- **Linear mirror is optional per descriptor.** `workflow.linearMirror` (const `true` in v1) gates the `PHASE_LINEAR_KEY` write-back in `linear-write.safeWrite`. A v2 non-Linear descriptor sets it `false` and posts verdicts to its native system (e.g. a GitHub PR comment); steps with no stateMap entry advance silently (exactly how `remediate` already behaves). ⚠️ Flipping it `false` is **gated on first defining a non-Linear stop/kill channel** — today the human-override/kill path (`DRAG_OUT_STATES`, `monitor.mjs:56`) is Linear-state-driven, so a non-Linear workflow has *no* equivalent "stop this work-item" switch until v2 adds a `manual.api`/`webhook` cancel intent.
 
 ### 10.5 The v1 reserved-seam discipline (shape-valid, value-restricted)
 
-The rule that resolves "scope discipline vs reserve seams": **a reserved seam is schema-*valid* but
-value-*restricted*** (fails as a *known-key bad-value* error, e.g. `executor:"cloud"` → "must be
-`local`"); an **unimplemented behavior key fails loud** as an *unknown-key* error via
-`additionalProperties:false` at **every** object level. A v1 file is thus *a valid v2 file by
-construction*, yet no v2 behavior is expressible in it.
+The rule that resolves "scope discipline vs reserve seams": **a reserved seam is schema-*valid* but value-*restricted*** (fails as a *known-key bad-value* error, e.g. `executor:"cloud"` → "must be `local`"); an **unimplemented behavior key fails loud** as an *unknown-key* error via `additionalProperties:false` at **every** object level. A v1 file is thus *a valid v2 file by construction*, yet no v2 behavior is expressible in it.
 
 | Reserved field | v1 form | v2 widening | Real or doc-only? |
 |---|---|---|---|
@@ -515,40 +290,15 @@ construction*, yet no v2 behavior is expressible in it.
 | `signal.generation` | already written every dispatch (CTL-736) | reused as the off-box fence token | **Real** (already present) |
 | `step.claimBackend`, `workItem.source` | **not in the schema** (`additionalProperties:false` rejects them) | added in `workflow/v2` | **Doc-reserved only** |
 
-Explicitly **rejected from v1** (the scope-coherence critic's cuts): an open-string `executor` + a
-populated `executorConfig`/`signal.executor` object (would make a v1 file a degenerate v2 file); a
-pre-widened `trigger.kind` enum; `workItem.kind`/`registryKey` schema fields; a `gitRef` input
-source. And two **factual corrections** baked in above: `classifyWorker` already returns `unknown`
-(no new tri-state needed); `work-done-probes` is **phase-name-keyed** (re-keying to probe-name is a
-real v1.1 refactor with its own test, *not* a free seam).
+Explicitly **rejected from v1** (the scope-coherence critic's cuts): an open-string `executor` + a populated `executorConfig`/`signal.executor` object (would make a v1 file a degenerate v2 file); a pre-widened `trigger.kind` enum; `workItem.kind`/`registryKey` schema fields; a `gitRef` input source. And two **factual corrections** baked in above: `classifyWorker` already returns `unknown` (no new tri-state needed); `work-done-probes` is **phase-name-keyed** (re-keying to probe-name is a real v1.1 refactor with its own test, *not* a free seam).
 
 ### 10.6 Prior-art anchor
 
-Closest analogue: **AWS Step Functions *Activities*** (opaque `taskToken` + worker `poll` +
-`SendTaskSuccess`/`SendTaskHeartbeat`) — the worker is off-box and reports back over an arbitrary
-channel, exactly our event-bus model (vs. GitHub Actions' runner-registration or Temporal's held-TCP
-long-poll, both wrong for ephemeral 30-min agent sessions). The synthesis we adopt: **Temporal-style
-lease heartbeat on the bus + Kleppmann fencing token at the coordinator + a thin per-harness
-adapter.** Agent-as-a-service invocation (Devin `POST /sessions`→poll→`structured_output`; Claude
-Managed Agents `POST /sessions`→events→poll; Codex cloud tasks) is **poll-based** (none offer
-outbound completion webhooks as of design time) and lives **behind the adapter's `dispatch`/`liveness`
-verbs**. *(All concrete provider endpoints / TTL constants / SDK surfaces are knowledge-cutoff-dated
-external research and are **quarantined to a v2 design doc**, never the v1 schema — the only thing
-prior-art contributes to v1 is corroboration that `generation` must be on every dispatch (already
-true) and that heartbeat-on-the-bus is the right distributed liveness substitute.)*
+Closest analogue: **AWS Step Functions *Activities*** (opaque `taskToken` + worker `poll` + `SendTaskSuccess`/`SendTaskHeartbeat`) — the worker is off-box and reports back over an arbitrary channel, exactly our event-bus model (vs. GitHub Actions' runner-registration or Temporal's held-TCP long-poll, both wrong for ephemeral 30-min agent sessions). The synthesis we adopt: **Temporal-style lease heartbeat on the bus + Kleppmann fencing token at the coordinator + a thin per-harness adapter.** Agent-as-a-service invocation (Devin `POST /sessions`→poll→`structured_output`; Claude Managed Agents `POST /sessions`→events→poll; Codex cloud tasks) is **poll-based** (none offer outbound completion webhooks as of design time) and lives **behind the adapter's `dispatch`/`liveness` verbs**. *(All concrete provider endpoints / TTL constants / SDK surfaces are knowledge-cutoff-dated external research and are **quarantined to a v2 design doc**, never the v1 schema — the only thing prior-art contributes to v1 is corroboration that `generation` must be on every dispatch (already true) and that heartbeat-on-the-bus is the right distributed liveness substitute.)*
 
 ### 10.7 Hard problems (v2 must solve; named, not waved)
 
-Distributed claim (multi-coordinator CAS); distributed liveness (per-harness status + the local-bg
-recovery jurisprudence re-derived off-box); **probe portability** (coordinator mirror clone —
-v2-blocking); off-box **artifact handoff** (`thoughts/*` + prior-artifact gate over `origin/<branch>`);
-**ingest as a SPOF** (fence-on-ingest fail-closed + fsync-before-2xx); **lease-TTL false-death** on
-legitimate long sub-agent fan-outs (the CTL-662 trap, off-box); **branch push-races** (a false-dead
-gen-N and its gen-N+1 revive can both push before the *signal* fence rejects the loser → need
-*git-ref* fencing: force-reset to `origin/main` on revive, or generation-namespaced refs the
-coordinator promotes); network-partition-vs-death (fence keeps the *write* correct but wastes a paid
-duplicate session); heterogeneous **cost attribution** (Devin/Codex emit no Claude OTEL); and the
-non-Linear **kill switch**.
+Distributed claim (multi-coordinator CAS); distributed liveness (per-harness status + the local-bg recovery jurisprudence re-derived off-box); **probe portability** (coordinator mirror clone — v2-blocking); off-box **artifact handoff** (`thoughts/*` + prior-artifact gate over `origin/<branch>`); **ingest as a SPOF** (fence-on-ingest fail-closed + fsync-before-2xx); **lease-TTL false-death** on legitimate long sub-agent fan-outs (the CTL-662 trap, off-box); **branch push-races** (a false-dead gen-N and its gen-N+1 revive can both push before the *signal* fence rejects the loser → need *git-ref* fencing: force-reset to `origin/main` on revive, or generation-namespaced refs the coordinator promotes); network-partition-vs-death (fence keeps the *write* correct but wastes a paid duplicate session); heterogeneous **cost attribution** (Devin/Codex emit no Claude OTEL); and the non-Linear **kill switch**.
 
 ### 10.8 The phase ladder (binding)
 
@@ -566,150 +316,67 @@ v2.0  ── workflow/v2 schema: executor + trigger adapters widen the enums; of
 
 ### 10.9 Event-driven state transitions — unifying triggers and edges
 
-A refinement raised after v1 (and a better framing than §10.4's start-only triggers): **a trigger that
-*starts* a workflow and an event that *advances* it are the same primitive — a registered bus event →
-a workflow state change.** The descriptor becomes a true event-driven state machine on the bus we
-already have.
+A refinement raised after v1 (and a better framing than §10.4's start-only triggers): **a trigger that *starts* a workflow and an event that *advances* it are the same primitive — a registered bus event → a workflow state change.** The descriptor becomes a true event-driven state machine on the bus we already have.
 
 **Today's two edge kinds, made explicit:**
-- *worker-completion edge* (the default): a step advances when its worker emits
-  `phase.<step>.complete.<ticket>` (`deriveAdvancement` walks these). This is v1.
-- *event-gated edge* (v2): a step advances when an **arbitrary registered bus event** matches —
-  e.g. `monitor-merge` advances on `github.pull_request.merged`, `monitor-deploy` on a
-  `deployment.success`. **This already happens today — but imperatively, hardcoded inside the
-  `phase-monitor-merge`/`phase-monitor-deploy` skills** (they block on `catalyst-events wait-for`,
-  then emit their own `phase.complete`). v2 lifts that into the descriptor as data:
+- *worker-completion edge* (the default): a step advances when its worker emits `phase.<step>.complete.<ticket>` (`deriveAdvancement` walks these). This is v1.
+- *event-gated edge* (v2): a step advances when an **arbitrary registered bus event** matches — e.g. `monitor-merge` advances on `github.pull_request.merged`, `monitor-deploy` on a `deployment.success`. **This already happens today — but imperatively, hardcoded inside the `phase-monitor-merge`/`phase-monitor-deploy` skills** (they block on `catalyst-events wait-for`, then emit their own `phase.complete`). v2 lifts that into the descriptor as data:
 
 ```json
 { "id": "monitor-merge", "linearKey": "inReview",
   "advanceOn": { "event": "github.pull_request.merged", "to": "monitor-deploy" } }
 ```
 
-**Engine mechanism — reuse the existing substrate, add nothing new:** the bus, the broker (routes by
-interest), `catalyst-events wait-for` (blocks on predicates), and `monitor.mjs`'s tailer already
-exist. The engine registers each descriptor `advanceOn` as an interest; on a matching event
-**correlated to the in-flight instance** (the bus envelope already stamps `linear.issue.identifier` /
-`catalyst.orchestration` = the work-item key), it advances the FSM and dispatches the next step — **no
-worker emit required.** A pure event-wait step can therefore be **workerless** (the engine just waits
-for the event and advances), which *removes* the `monitor-merge`/`monitor-deploy` wait-loops rather
-than reimplementing them.
+**Engine mechanism — reuse the existing substrate, add nothing new:** the bus, the broker (routes by interest), `catalyst-events wait-for` (blocks on predicates), and `monitor.mjs`'s tailer already exist. The engine registers each descriptor `advanceOn` as an interest; on a matching event **correlated to the in-flight instance** (the bus envelope already stamps `linear.issue.identifier` / `catalyst.orchestration` = the work-item key), it advances the FSM and dispatches the next step — **no worker emit required.** A pure event-wait step can therefore be **workerless** (the engine just waits for the event and advances), which *removes* the `monitor-merge`/`monitor-deploy` wait-loops rather than reimplementing them.
 
-**The reused condition vocabulary:** `advanceOn` carries the same closed `{field, op, value}` predicate
-(`when`) as §5, so "advance on `github.pull_request.merged` **where** `pr.base == main`" needs no new
-DSL.
+**The reused condition vocabulary:** `advanceOn` carries the same closed `{field, op, value}` predicate (`when`) as §5, so "advance on `github.pull_request.merged` **where** `pr.base == main`" needs no new DSL.
 
 **Bounding + correctness (the real risks):**
-- An event-gated edge is **asynchronous** — the event may never come. It needs a **timeout →
-  escalate/skip**, exactly like `monitor-deploy`'s `skipped` path today.
-- The **work-done-probe completeness gate** generalizes: every step must have **either** a
-  `workDoneProbe` (worker edge) **or** an `advanceOn` event (event edge) — a step with neither is a
-  validation error.
-- **Fencing/idempotency:** the CTL-736 **generation token** still arbitrates — an external event that
-  arrives twice advances the instance **once** (keyed by `(instance, generation)`); a late event for a
-  superseded generation is dropped by the same fence that drops a stale worker completion.
+- An event-gated edge is **asynchronous** — the event may never come. It needs a **timeout → escalate/skip**, exactly like `monitor-deploy`'s `skipped` path today.
+- The **work-done-probe completeness gate** generalizes: every step must have **either** a `workDoneProbe` (worker edge) **or** an `advanceOn` event (event edge) — a step with neither is a validation error.
+- **Fencing/idempotency:** the CTL-736 **generation token** still arbitrates — an external event that arrives twice advances the instance **once** (keyed by `(instance, generation)`); a late event for a superseded generation is dropped by the same fence that drops a stale worker completion.
 
-**v1 reservation: essentially none.** `next` routes already allow `{when, to}`; `advanceOn` is a
-purely **additive** key in the `workflow/v2` schema (`additionalProperties:false` rejects it in v1, so
-no v1 field is spent). The one thing worth reserving now is a **`workflowId`/`instanceId`** namespace
-on signals/events if/when multi-workflow (§10.10) lands.
+**v1 reservation: essentially none.** `next` routes already allow `{when, to}`; `advanceOn` is a purely **additive** key in the `workflow/v2` schema (`additionalProperties:false` rejects it in v1, so no v1 field is spent). The one thing worth reserving now is a **`workflowId`/`instanceId`** namespace on signals/events if/when multi-workflow (§10.10) lands.
 
 ### 10.10 Named / multi-workflow (likely not v1)
 
-The descriptor already has `id` (`"default"`) + `schemaVersion` — so multi-workflow is **just an
-id-keyed registry** (`.catalyst/workflows/<id>.json`: built-in `default` + user-named `pr-review`,
-`hotfix`, …). A trigger event selects **which** workflow to instantiate: each descriptor declares its
-`trigger` with an optional `match` predicate (the same `{field, op, value}`), and the engine
-instantiates the **first match** (ambiguity → explicit `priority`, resolving the §10.4 open question).
-A workflow **instance** is keyed by `(workflowId, workItemId)` so a ticket-pipeline and a PR-review
-pipeline can touch related work items without signal collision; `linearMirror` is per-descriptor
-(a non-Linear workflow mirrors nothing).
+The descriptor already has `id` (`"default"`) + `schemaVersion` — so multi-workflow is **just an id-keyed registry** (`.catalyst/workflows/<id>.json`: built-in `default` + user-named `pr-review`, `hotfix`, …). A trigger event selects **which** workflow to instantiate: each descriptor declares its `trigger` with an optional `match` predicate (the same `{field, op, value}`), and the engine instantiates the **first match** (ambiguity → explicit `priority`, resolving the §10.4 open question). A workflow **instance** is keyed by `(workflowId, workItemId)` so a ticket-pipeline and a PR-review pipeline can touch related work items without signal collision; `linearMirror` is per-descriptor (a non-Linear workflow mirrors nothing).
 
-**Recommendation:** v1 ships the single, unnamed `default` — naming is a v2 authoring nicety (the
-`catalyst-workflow` CLI), **not needed for v1**, and the `id`/`schemaVersion`/`trigger` shape already
-reserves it. This is pure v2, gated behind the §10.8 ladder.
+**Recommendation:** v1 ships the single, unnamed `default` — naming is a v2 authoring nicety (the `catalyst-workflow` CLI), **not needed for v1**, and the `id`/`schemaVersion`/`trigger` shape already reserves it. This is pure v2, gated behind the §10.8 ladder.
 
 ## 11. Docs & website update plan
 
-(Numbered 11 to sit after the v2 section; produced from a full `website/` audit.) The pipeline is
-documented in ~14 pages that assume a fixed 10-phase list; the descriptor reframes those as *one
-instance of a descriptor*.
+(Numbered 11 to sit after the v2 section; produced from a full `website/` audit.) The pipeline is documented in ~14 pages that assume a fixed 10-phase list; the descriptor reframes those as *one instance of a descriptor*.
 
-- **New concept page:** `website/src/content/docs/reference/orchestration/workflows.md` — titled
-  **"Workflow descriptors"** (`sidebar.order: 0`), modeled on `phase-agents.md`. ⚠️ name-collision
-  caveat with the existing top-level `reference/workflows.md` (the *Level-2 manual* dev cycle) — hence
-  the distinct title.
-- **New extensibility/roadmap page:** `reference/orchestration/extensibility.md` — non-Linear triggers
-  \+ off-box/Codex/Devin executors (content from §10).
-- **Schema home:** extend `reference/configuration.md` with a `### Workflow descriptor` subsection
-  under `## Orchestration Config` (after the `phaseAgents` table). New keys must also land in
-  `plugins/dev/templates/config.template.json` or the config drift-checker warns.
-- **Heaviest rewrites:** `reference/orchestration/phase-agents.md` (reframe the fixed 10-phase as *the
-  default descriptor*; the per-phase model/turnCap tables move to step fields + the new `effort` /
-  preamble levers) and `reference/orchestration/scheduler.md` (stage-rank + non-preemptable set derive
-  from descriptor edges).
-- **Prose touch-ups:** `reference/orchestration.md`, `guided-workflows/phases.md`,
-  `getting-started/how-catalyst-works.md` (phase sequence list), `guided-workflows/index.md`,
-  and the `phase.*` event-name pages in `observability/`. **Lockstep (repo-root, dev-only):**
-  `docs/orchestrator-overview.md` + `docs/architecture.md`.
-- **Conventions:** Starlight frontmatter with `sidebar.order`; mermaid via fenced blocks;
-  `Field | Type | Default | Description` tables; the `docs-gate` CI requires a clean `astro build`.
+- **New concept page:** `website/src/content/docs/reference/orchestration/workflows.md` — titled **"Workflow descriptors"** (`sidebar.order: 0`), modeled on `phase-agents.md`. ⚠️ name-collision caveat with the existing top-level `reference/workflows.md` (the *Level-2 manual* dev cycle) — hence the distinct title.
+- **New extensibility/roadmap page:** `reference/orchestration/extensibility.md` — non-Linear triggers \+ off-box/Codex/Devin executors (content from §10).
+- **Schema home:** extend `reference/configuration.md` with a `### Workflow descriptor` subsection under `## Orchestration Config` (after the `phaseAgents` table). New keys must also land in `plugins/dev/templates/config.template.json` or the config drift-checker warns.
+- **Heaviest rewrites:** `reference/orchestration/phase-agents.md` (reframe the fixed 10-phase as *the default descriptor*; the per-phase model/turnCap tables move to step fields + the new `effort` / preamble levers) and `reference/orchestration/scheduler.md` (stage-rank + non-preemptable set derive from descriptor edges).
+- **Prose touch-ups:** `reference/orchestration.md`, `guided-workflows/phases.md`, `getting-started/how-catalyst-works.md` (phase sequence list), `guided-workflows/index.md`, and the `phase.*` event-name pages in `observability/`. **Lockstep (repo-root, dev-only):** `docs/orchestrator-overview.md` + `docs/architecture.md`.
+- **Conventions:** Starlight frontmatter with `sidebar.order`; mermaid via fenced blocks; `Field | Type | Default | Description` tables; the `docs-gate` CI requires a clean `astro build`.
 
 ## 12. Open questions
 
-- The `effort` enum mirrors `--effort` (`low|medium|high|xhigh|max`). If a future native
-  reasoning-budget knob ships, do we widen the enum or keep the flag-faithful set?
-- `triage.json.estimate` provenance: write the `scope→points` map at triage time (chosen v1), and
-  *optionally* also write through a real Linear points field when present — confirm the eligible
-  projection (`linear-query.mjs`) can carry points without an extra fetch.
-- Per-ticket override of `rules` (allowed) vs `next` (forbidden v1): is leaf-only too restrictive for
-  any real near-term use case, or exactly right?
-- Bash codegen ownership: a pre-commit hook vs. a CI-only regenerate-and-diff (a forgotten local
-  regen reintroduces the drift the descriptor exists to delete).
+- The `effort` enum mirrors `--effort` (`low|medium|high|xhigh|max`). If a future native reasoning-budget knob ships, do we widen the enum or keep the flag-faithful set?
+- `triage.json.estimate` provenance: write the `scope→points` map at triage time (chosen v1), and *optionally* also write through a real Linear points field when present — confirm the eligible projection (`linear-query.mjs`) can carry points without an extra fetch.
+- Per-ticket override of `rules` (allowed) vs `next` (forbidden v1): is leaf-only too restrictive for any real near-term use case, or exactly right?
+- Bash codegen ownership: a pre-commit hook vs. a CI-only regenerate-and-diff (a forgotten local regen reintroduces the drift the descriptor exists to delete).
 
 ## Appendix A: GATE 0 — the verify→remediate cycle is broken on HEAD (CONFIRMED)
 
-While grounding this design, an adversarial reviewer flagged — and a forensic verification
-**confirmed against `main` @ `d09fb2b2`** — a latent correctness bug in the merged CTL-736 Phase-1
-claim. It is **not** caused by this descriptor work, but it (a) must be fixed before the descriptor
-can faithfully model the cycle, and (b) is exactly why `cycles[].reset.releaseClaims: true` (§4) is in
-the schema.
+While grounding this design, an adversarial reviewer flagged — and a forensic verification **confirmed against `main` @ `d09fb2b2`** — a latent correctness bug in the merged CTL-736 Phase-1 claim. It is **not** caused by this descriptor work, but it (a) must be fixed before the descriptor can faithfully model the cycle, and (b) is exactly why `cycles[].reset.releaseClaims: true` (§4) is in the schema.
 
 **The bug.** The `verify→remediate→verify` self-healing cycle silently dies under fencing:
 
-1. `maybeResetForRemediateCycle` (`scheduler.mjs:903-918`) deletes only signal files —
-   `REMEDIATE_CYCLE_FILES = ["phase-verify.json", "phase-remediate.json", "verify.json"]`
-   (`scheduler.mjs:893`) — and **never** the `*.claim.<gen>` tombstones. `releaseClaim`
-   (`claim.mjs:61`) has **zero** production callers.
-2. On the re-dispatch, `phase-agent-dispatch:503-509` derives `TARGET_GENERATION` **from the (now
-   absent) signal** ⇒ `EXISTING_STATUS` empty ⇒ `TARGET_GENERATION=1`. (The high-water-mark
-   `currentGeneration` path that would compute `2` is *deliberately* not used here —
-   `phase-agent-dispatch:482-484` forbids it to preserve the fixed-target single-flight invariant.)
-3. The `noclobber` create of `verify.claim.1` collides with the **leftover** `verify.claim.1` from the
-   first verify ⇒ `EEXIST` ⇒ the dispatcher prints `claim-lost`, `exit 0`, **writes no signal, spawns
-   no worker** (`phase-agent-dispatch:528-541`).
-4. `verifyDispatched` then reads a missing signal ⇒ `{ok:false, reason:"signal_missing"}` ⇒ the
-   scheduler demotes it to a **dispatch failure + cooldown** (`scheduler.mjs:1766+`), accruing toward
-   `escalateDispatchExhausted → escalate`. The second verify never runs; the loop is dead.
+1. `maybeResetForRemediateCycle` (`scheduler.mjs:903-918`) deletes only signal files — `REMEDIATE_CYCLE_FILES = ["phase-verify.json", "phase-remediate.json", "verify.json"]` (`scheduler.mjs:893`) — and **never** the `*.claim.<gen>` tombstones. `releaseClaim` (`claim.mjs:61`) has **zero** production callers.
+2. On the re-dispatch, `phase-agent-dispatch:503-509` derives `TARGET_GENERATION` **from the (now absent) signal** ⇒ `EXISTING_STATUS` empty ⇒ `TARGET_GENERATION=1`. (The high-water-mark `currentGeneration` path that would compute `2` is *deliberately* not used here — `phase-agent-dispatch:482-484` forbids it to preserve the fixed-target single-flight invariant.)
+3. The `noclobber` create of `verify.claim.1` collides with the **leftover** `verify.claim.1` from the first verify ⇒ `EEXIST` ⇒ the dispatcher prints `claim-lost`, `exit 0`, **writes no signal, spawns no worker** (`phase-agent-dispatch:528-541`).
+4. `verifyDispatched` then reads a missing signal ⇒ `{ok:false, reason:"signal_missing"}` ⇒ the scheduler demotes it to a **dispatch failure + cooldown** (`scheduler.mjs:1766+`), accruing toward `escalateDispatchExhausted → escalate`. The second verify never runs; the loop is dead.
 
-**Why no test caught it.** Coverage exercises the cycle only at the `.mjs` signal layer
-(`scheduler.test.mjs:1027-1042`, no `.claim.*` created). Worse, `phase-agent-dispatch.test.sh` Test 43
-pre-seeds `triage.claim.1` with no signal and asserts `claim-lost`/no-spawn **as intended** — it
-codifies the failing state, seeing it only through the concurrent-race lens, blind to the
-remediate-reset producing the same state non-concurrently.
+**Why no test caught it.** Coverage exercises the cycle only at the `.mjs` signal layer (`scheduler.test.mjs:1027-1042`, no `.claim.*` created). Worse, `phase-agent-dispatch.test.sh` Test 43 pre-seeds `triage.claim.1` with no signal and asserts `claim-lost`/no-spawn **as intended** — it codifies the failing state, seeing it only through the concurrent-race lens, blind to the remediate-reset producing the same state non-concurrently.
 
-**The author already knew the failure mode** — the worktree-recreate path (added by CTL-736 at
-`phase-agent-dispatch:735-739`) explicitly `rm -f "${WORKER_DIR}/${PHASE}.claim."*` "so the re-exec's
-fresh (no-signal ⇒ gen 1) claim is exclusive and wins instead of colliding on gen 1." That same
-cleanup was simply not applied in `maybeResetForRemediateCycle`.
+**The author already knew the failure mode** — the worktree-recreate path (added by CTL-736 at `phase-agent-dispatch:735-739`) explicitly `rm -f "${WORKER_DIR}/${PHASE}.claim."*` "so the re-exec's fresh (no-signal ⇒ gen 1) claim is exclusive and wins instead of colliding on gen 1." That same cleanup was simply not applied in `maybeResetForRemediateCycle`.
 
-**Fix (recommended — #1 of 3 candidates).** Extend `maybeResetForRemediateCycle` to glob-unlink the
-cycle's `verify.claim.*` and `remediate.claim.*` tombstones (mirroring `phase-agent-dispatch:739`),
-keeping the fixed-generation invariant intact. Add a **bash-level** e2e test that runs
-`verify→remediate→verify` under fencing and asserts the 2nd verify dispatches a **live worker**.
-*(Alternatives: have the reset call `releaseClaim` — collapses into #1 since it must read the claim
-files; or derive `TARGET_GENERATION` from `currentGeneration()` when "signal absent but claims exist"
-— riskiest, conflicts with the fixed-target invariant / Test 43.)*
+**Fix (recommended — #1 of 3 candidates).** Extend `maybeResetForRemediateCycle` to glob-unlink the cycle's `verify.claim.*` and `remediate.claim.*` tombstones (mirroring `phase-agent-dispatch:739`), keeping the fixed-generation invariant intact. Add a **bash-level** e2e test that runs `verify→remediate→verify` under fencing and asserts the 2nd verify dispatches a **live worker**. *(Alternatives: have the reset call `releaseClaim` — collapses into #1 since it must read the claim files; or derive `TARGET_GENERATION` from `currentGeneration()` when "signal absent but claims exist" — riskiest, conflicts with the fixed-target invariant / Test 43.)*
 
-**Ownership.** This is a **CTL-736 thread** fix (tracked separately), landing before/with Phase 2-3 —
-not part of the descriptor PR. The descriptor's declarative `cycles[].reset.releaseClaims: true` is
-the forward-compatible encoding of the fix.
+**Ownership.** This is a **CTL-736 thread** fix (tracked separately), landing before/with Phase 2-3 — not part of the descriptor PR. The descriptor's declarative `cycles[].reset.releaseClaims: true` is the forward-compatible encoding of the fix.


### PR DESCRIPTION
## Summary
- Reflows this repo's markdown instruction/docs files — `AGENTS.md` (outside the CTL-2216-owned house-rules sentinel block), `CLAUDE.md`, `README.md`, and `docs/**` (27 files) — to one line per semantic block (paragraph/list-item), so prose reads naturally wherever it renders instead of carrying artificial mid-sentence hard-wraps.
- Item 5 follow-through of CTL-2216 (see that ticket's investigation for the root cause: hard-wrapped prose in seeded docs taught agents to imitate the wrap habit). This is the catalyst (orchestrator repo) instance; catalyst-cloud and catalyst-cloud-sdk are separate tickets.
- Zero content change: only paragraph line-break positions moved. Code fences, tables, frontmatter, blockquotes, and list-item structure are untouched. The `AGENTS.md` house-rules sentinel block (`<!-- catalyst-house-rules:begin/end -->`) was deliberately skipped — that block is owned by the CTL-2216 template and was already re-stamped on `main` by PR #3983 before this branch rebased on top of it.

## Hard property

> Given the repo's markdown instruction/docs files, when prose paragraphs are reflowed, then no artificial mid-sentence line breaks remain, and code fences/tables/frontmatter/list structure/sentinel blocks are byte-identical, and a newline-normalized diff of before vs after is empty (reflow-only, zero content change).

Verified with a standalone Python verifier (`git show origin/main:<path>` vs the working tree, per file):
1. Frontmatter block extracted and compared byte-for-byte.
2. Code-fence blocks extracted (in order) and compared byte-for-byte.
3. Table blocks extracted (in order) and compared byte-for-byte.
4. Blockquote blocks extracted (in order) and compared byte-for-byte.
5. Whitespace/newline-normalized (`" ".join(text.split())`) full-text diff — must be identical.

The verifier itself was validated with positive controls before trusting a "clean" result (per this repo's own verification-discipline house rule): a word-swap, a table-cell edit, a fence-body edit, a blockquote edit, and a frontmatter edit were each confirmed to trip the corresponding check, and a genuine line-wrap-only reflow was confirmed **not** to trip the whitespace-normalize check.

```
MATCH    AGENTS.md
MATCH    CLAUDE.md
MATCH    README.md
MATCH    docs/README.md
MATCH    docs/adrs.md
MATCH    docs/architecture.md
MATCH    docs/ci-required-checks-rollout.md
MATCH    docs/cluster-onboarding.md
MATCH    docs/configuration.md
MATCH    docs/event-automation-contract.md
MATCH    docs/health-responder.md
MATCH    docs/linear-replica.md
MATCH    docs/orchestrator-overview.md
MATCH    docs/orphan-sweep.md
MATCH    docs/releases.md
MATCH    docs/runbooks/cloud-feed-cutover.md
MATCH    docs/specs/MIGRATION.md
MATCH    docs/specs/README.md
MATCH    docs/specs/accepted/board-redesign/spec.md
MATCH    docs/specs/accepted/rulebook-swimlane/spec.md
MATCH    docs/specs/accepted/ticket-journey/spec.md
MATCH    docs/specs/accepted/vendor-neutral-packaging/spec.md
MATCH    docs/specs/accepted/warm-identity/spec.md
MATCH    docs/specs/draft/governance-process-map/spec.md
MATCH    docs/specs/draft/governance-rulebook/spec.md
MATCH    docs/specs/draft/rules-explorer/spec.md
MATCH    docs/workflow-descriptors-design.md

OK: all 27 files verified identical (reflow-only) vs origin/main
```

Additionally confirmed per-file list-item start counts (`-`/`*`/`+`/`N.`) are identical old vs new across all 27 files — this catches a list-item merge/split that the whitespace-normalize check alone can't see (newlines and spaces are equivalent under normalization).

## Local gate results (this is a docs-only change; no code-path gates apply)
- `bash scripts/ci/check-agents-md-bridge.sh` — PASS
- `bash plugins/dev/scripts/ensure-agent-house-rules.sh --repo . --quiet` — exit 0 (house-rules block current vs template)
- `git diff origin/main --name-only | bash scripts/ci/docs-paths-changed.sh` → `nodocs` (docs-gate website build correctly skipped; no `website/**` or changelog paths touched)
- `bash plugins/dev/skills/__tests__/skill-shape.test.sh` — 119 passed, 0 failed
- `bash plugins/dev/skills/__tests__/project-orchestrator-shape.test.sh` — 22 passed, 0 failed
- `bash plugins/dev/skills/__tests__/handoff-contract.test.sh` — 21 passed, 0 failed
- `bash plugins/meta/scripts/audit-references.sh --ci` — 0 critical, 206 warnings (identical to the `origin/main` baseline measured in a side-by-side worktree — zero new reference issues introduced)
- `bun test scripts/packaging/__tests__/` — 145 passed, 0 failed
- `bash scripts/check-plugin-version.sh` (STRICT_VERSION_CHECK=true, BASE_REF=origin/main) — exit 0 (no plugin paths touched)
- `bash scripts/validate-release-config.sh` + its test suite — all checks passed, 15/15 tests passed

## Test plan
- [x] Reflow-preservation verifier: 27/27 files MATCH vs `origin/main`
- [x] Verifier validated with positive controls (word/table/fence/blockquote/frontmatter mutations each caught; legitimate reflow not flagged)
- [x] List-item counts identical old vs new, all 27 files
- [x] All CI gates without a path filter re-run locally and green
- [x] Rebased cleanly onto `origin/main` (post #3983/CTL-2216) with zero merge conflicts — `AGENTS.md`'s sentinel block now matches main's fixed version; this lane's reflow of the surrounding content is layered on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)