### PR TITLE
docs: CTL-2218 — drop removed catalyst-discovery from the Serena codebase map

### DIFF
--- a/.serena/memories/codebase_map.md
+++ b/.serena/memories/codebase_map.md
@@ -17,7 +17,7 @@ no build step for the plugins themselves; the orchestration runtime under
     - `scripts/` — the runtime (see below)
     - `templates/` — global-state.json schema (the former `global-event.json` was deleted in CTL-1819: it passed ZERO live events and no code imported it — counts in that module's header)
     - `scripts/lib/` — zero-npm-import leaves: `event-name.mjs` (the one event-name boundary, CTL-1834) and `event-envelope.mjs` (the executable event-envelope contract, CTL-1819)
-  - `plugins/playground/pm-ops/`, `plugins/meta/`, `plugins/legacy/`, `plugins/playground/discovery/`, `plugins/foundry/` — other plugins
+  - `plugins/meta/`, `plugins/legacy/`, `plugins/foundry/`, `plugins/playground/pm-ops/` (holds only `groom-backlog`) — other plugins. The CTL-2218 cleanup removed `catalyst-pm`, `catalyst-discovery`, `catalyst-analytics`, `catalyst-debugging` and `catalyst-meeting-hygiene` outright, so `plugins/playground/` now contains `pm-ops/` alone.
 - `docs/` — `architecture.md`, `orchestrator-overview.md`, `adrs.md`, `releases.md`
 - `AGENTS.md` — portable, tool-agnostic source of truth (CLAUDE.md is a thin `@AGENTS.md` bridge)
 - `website/` — Astro docs site (`website/src/content/docs/…`, esp. `reference/configuration.md`)

--- a/.serena/memories/codebase_map.md
+++ b/.serena/memories/codebase_map.md
@@ -17,7 +17,7 @@ no build step for the plugins themselves; the orchestration runtime under
     - `scripts/` — the runtime (see below)
     - `templates/` — global-state.json schema (the former `global-event.json` was deleted in CTL-1819: it passed ZERO live events and no code imported it — counts in that module's header)
     - `scripts/lib/` — zero-npm-import leaves: `event-name.mjs` (the one event-name boundary, CTL-1834) and `event-envelope.mjs` (the executable event-envelope contract, CTL-1819)
-  - `plugins/meta/`, `plugins/legacy/`, `plugins/foundry/`, `plugins/playground/pm-ops/` (holds only `groom-backlog`) — other plugins. The CTL-2218 cleanup removed `catalyst-pm`, `catalyst-discovery`, `catalyst-analytics`, `catalyst-debugging` and `catalyst-meeting-hygiene` outright, so `plugins/playground/` now contains `pm-ops/` alone.
+  - `plugins/meta/`, `plugins/legacy/`, `plugins/foundry/`, `plugins/playground/pm-ops/` (one surviving skill, `groom-backlog`, plus `agents/backlog-analyzer.md` and `scripts/`) — other plugins. The CTL-2218 cleanup removed `catalyst-pm`, `catalyst-discovery`, `catalyst-analytics`, `catalyst-debugging` and `catalyst-meeting-hygiene` outright, so `plugins/playground/` now contains `pm-ops/` alone.
 - `docs/` — `architecture.md`, `orchestrator-overview.md`, `adrs.md`, `releases.md`
 - `AGENTS.md` — portable, tool-agnostic source of truth (CLAUDE.md is a thin `@AGENTS.md` bridge)
 - `website/` — Astro docs site (`website/src/content/docs/…`, esp. `reference/configuration.md`)

--- a/docs/runbooks/plugin-removal.md
+++ b/docs/runbooks/plugin-removal.md
@@ -87,7 +87,7 @@ Check every one of these. Not all will have a hit for every plugin; report which
 | `AGENTS.md` | The `plugin-name:skill-name` example, the commit-convention example, the "Valid scopes" list |
 | `docs/architecture.md` | The "Plugin Source" bullet's example directory list |
 | `docs/releases.md` | Any plugin-specific versioning callouts |
-| `.serena/memories/codebase_map.md` | The "other plugins" directory list |
+| `.serena/memories/codebase_map.md` | The "other plugins" directory list. ⚠️ No gate asserts on this file, and CTL-2235 missed it — a deleted plugin sat listed as live until a post-batch sweep caught it. Serena serves this map to agents for navigation, so a stale entry actively misdirects them. Check it by hand. |
 | `website/astro.config.mjs` | The `plugins` changelog array |
 | `website/src/content.config.ts` | The `changelogsLoader` entries array |
 | `website/src/content/docs/reference/plugins.md` | The plugin table row + install command |


### PR DESCRIPTION
## What

`.serena/memories/codebase_map.md` still listed `plugins/playground/discovery/` among the live plugins after the CTL-2218 cleanup removed `catalyst-discovery` (CTL-2235, #4042). Serena serves this map to agents for repo navigation, so the stale entry pointed them at a directory that no longer exists. The line now reflects reality: `plugins/playground/` holds `pm-ops/` alone, and that in turn holds only `groom-backlog`.

Also records the miss in `docs/runbooks/plugin-removal.md`, which already listed this file as a checklist item — the item exists, it just got skipped, and no gate would have caught it.

## How it was found

A post-batch sweep over `origin/main` for references to every removed plugin. The first version of that sweep returned zero for its own positive controls, meaning the instrument was broken rather than the tree clean; re-running with `git grep` against the ref (positive controls firing 3 / 6 / 1) surfaced this hit.

Everything else the corrected sweep turned up is benign and deliberately left alone:

- `plugins/dev/scripts/estimate/*` — three `plugins/playground/pm/` mentions, all in comments recording the CTL-2222 relocation. Accurate provenance.
- `plugins/dev/scripts/__tests__/setup-plugin-source.test.sh` — a synthetic seed fixture under a temp dir, not a reference to the real plugin.
- `plugins/dev/scripts/catalyst-session.sh:1215` — a dead `catalyst-pm:` prefix-strip, checked and left by CTL-2222.

## Verification

- `skill-shape.test.sh`: 224 passed, 0 failed
- `check-agents-md-bridge.sh`: PASSED
- `audit-references.sh --ci`: exit 0 (pre-existing warnings only, none from this change)

Docs-only; no skill, plugin manifest, or generated tree touched.