### PR TITLE
feat(dev): CTL-2285 — port catalyst-cloud's merge-queue watchdog to catalyst

### DIFF
--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -123,6 +123,10 @@ on:
       # scripts/__tests__/** above), but the module itself lives outside that glob — a PR
       # touching only scripts/md-reflow.mjs would otherwise skip the job that tests it.
       - "scripts/md-reflow.mjs"
+      # CTL-2285: same shape as md-reflow.mjs above — the watchdog's offline spec lives under
+      # scripts/__tests__/** (already covered), but the module itself does not; a PR touching
+      # only scripts/merge-queue-watchdog.mjs would otherwise skip the job that tests it.
+      - "scripts/merge-queue-watchdog.mjs"
       # CTL-2253 (Codex round 2): case 16's corpus census reads plugins/dev/agents/*.md as one of
       # its CANDIDATES globs (find plugins/dev/agents -maxdepth 1 -name "*.md"), but nothing in
       # this filter matched that directory — the same "trigger must match the scan" defect the
@@ -235,6 +239,8 @@ jobs:
               # CTL-2253: mirror the push-path entry above — the module lives outside
               # scripts/__tests__/**, so a PR touching only it would skip this job.
               - "scripts/md-reflow.mjs"
+              # CTL-2285: mirror the push-path entry above — same shape as md-reflow.mjs.
+              - "scripts/merge-queue-watchdog.mjs"
               # CTL-2253 (Codex round 2): mirror the push-path entry above — the corpus census
               # (case 16) reads plugins/dev/agents/*.md as a CANDIDATES source.
               - "plugins/dev/agents/**"
@@ -372,6 +378,16 @@ jobs:
       - name: markdown reflow tool test (CTL-2253)
         working-directory: .
         run: bash scripts/__tests__/md-reflow.test.sh
+
+      - name: merge queue watchdog offline spec (CTL-2285)
+        # The live script (scripts/merge-queue-watchdog.mjs) needs the network and stays OUT
+        # of this gate; only its fetchImpl-injected spec runs here. Registered explicitly —
+        # this repo has no glob test runner, so a suite merely present in __tests__/ never
+        # runs in CI otherwise (the exact class of defect CTL-1834's ask-verbs.test.mjs shipped
+        # unregistered, and plugins/dev/scripts/project-onboarding/__tests__/*.test.mjs remain
+        # today).
+        working-directory: .
+        run: node --test scripts/__tests__/merge-queue-watchdog.test.mjs
 
       - name: account-usage pager test (CTL-1908)
         # Pages before an armed Claude account exhausts its 5-hour / 7-day window. The property

--- a/.github/workflows/merge-queue-watchdog.yml
+++ b/.github/workflows/merge-queue-watchdog.yml
@@ -1,0 +1,51 @@
+# .github/workflows/merge-queue-watchdog.yml — CTL-2285. Ports catalyst-cloud's CTC-1218
+# watchdog, codifying the coordinator's manual `@Mergifyio queue` nudge as infrastructure
+# (AGENTS.md house rule: infra fixes must be codified).
+#
+# Runs scripts/merge-queue-watchdog.mjs on a schedule: for every open PR against main
+# carrying `queue:ready`, nudge it once it has sat eligible (all six required checks
+# satisfied in the ruleset's own skip-tolerant success/neutral/skipped form, zero unresolved
+# threads, not path-excluded) for 10+ minutes without entering the merge queue; alert (and
+# swap the label to hold:hand-steps) when the PR's changed files match a queue path exclusion
+# and it will never queue; surface a Mergify refusal reply as a PR comment. See the script's
+# own header for the full design, and .mergify.yml's header for why the three-way check form
+# is required here (a bare success-only test would be stricter than the ruleset and would
+# deadlock on a legitimately skipped job).
+#
+# GITHUB_TOKEN posts as github-actions[bot]; Mergify's `queue` command accepts commands from
+# any actor with write access, which the default token has via `pull-requests: write` below.
+# If that ever proves insufficient, set the MERGE_QUEUE_WATCHDOG_TOKEN repo secret to a
+# PAT/App token with write access — the step below prefers it when present.
+
+name: Merge queue watchdog
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: merge-queue-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: read
+
+jobs:
+  watchdog:
+    # Scheduled workflows run on the default branch's definition regardless of what triggered
+    # the dispatch, but forks of this repo should not run a schedule that posts comments on
+    # OUR PRs.
+    if: github.repository == 'coalesce-labs/catalyst'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run merge queue watchdog
+        run: node scripts/merge-queue-watchdog.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_QUEUE_WATCHDOG_TOKEN || github.token }}

--- a/scripts/__tests__/merge-queue-watchdog.test.mjs
+++ b/scripts/__tests__/merge-queue-watchdog.test.mjs
@@ -22,6 +22,8 @@ import {
   findUnsurfacedRefusal,
   checkStateForContext,
   requiredChecksConclusion,
+  negativeGateConclusion,
+  combinedCheckConclusion,
   countUnresolvedThreads,
   decideAction,
   gatherPrInput,
@@ -395,67 +397,185 @@ describe("checkStateForContext", () => {
 });
 
 describe("requiredChecksConclusion — the multi-required-check form (CTL-2285)", () => {
-  const ALL_SIX = DEFAULT_CONFIG.requiredCheckContexts;
+  const ALL_REQUIRED = DEFAULT_CONFIG.requiredCheckContexts;
   const allGreen = (overrides = {}) =>
-    ALL_SIX.map((name) => ({
+    ALL_REQUIRED.map((name) => ({
       name,
       status: "completed",
       conclusion: overrides[name] ?? "success",
     }));
 
-  it("success when all six required contexts are success", () => {
-    const result = requiredChecksConclusion(allGreen(), ALL_SIX);
+  it("covers every gate .mergify.yml evaluates in the three-way form (nine contexts)", () => {
+    assert.deepEqual(
+      [...ALL_REQUIRED].sort(),
+      [
+        "agents-md-gate",
+        "audit-references",
+        "check-plugin-manifest-parity",
+        "check-versions",
+        "docs-gate",
+        "execution-core-unit-tests",
+        "gitleaks",
+        "packaging-gate",
+        "skills-gate",
+      ].sort()
+    );
+  });
+
+  it("success when all required contexts are success", () => {
+    const result = requiredChecksConclusion(allGreen(), ALL_REQUIRED);
     assert.deepEqual(result, { conclusion: "success", detail: "" });
   });
 
   it("success when one context is neutral and the rest are success", () => {
-    const result = requiredChecksConclusion(allGreen({ "docs-gate": "neutral" }), ALL_SIX);
+    const result = requiredChecksConclusion(allGreen({ "docs-gate": "neutral" }), ALL_REQUIRED);
     assert.deepEqual(result, { conclusion: "success", detail: "" });
   });
 
   it("success when one context is skipped and the rest are success", () => {
-    const result = requiredChecksConclusion(allGreen({ gitleaks: "skipped" }), ALL_SIX);
+    const result = requiredChecksConclusion(allGreen({ gitleaks: "skipped" }), ALL_REQUIRED);
     assert.deepEqual(result, { conclusion: "success", detail: "" });
   });
 
   it("⭐ pending when one context is still in_progress — the measured CTL-2285 incident shape", () => {
-    const runs = ALL_SIX.map((name) =>
+    const runs = ALL_REQUIRED.map((name) =>
       name === "execution-core-unit-tests"
         ? { name, status: "in_progress", conclusion: null }
         : { name, status: "completed", conclusion: "success" }
     );
-    const result = requiredChecksConclusion(runs, ALL_SIX);
+    const result = requiredChecksConclusion(runs, ALL_REQUIRED);
     assert.equal(result.conclusion, "pending");
     assert.equal(result.detail, "execution-core-unit-tests");
   });
 
   it("failure takes priority over a simultaneously-pending context", () => {
-    const runs = ALL_SIX.map((name) => {
+    const runs = ALL_REQUIRED.map((name) => {
       if (name === "gitleaks") return { name, status: "completed", conclusion: "failure" };
       if (name === "check-versions") return { name, status: "in_progress", conclusion: null };
       return { name, status: "completed", conclusion: "success" };
     });
-    const result = requiredChecksConclusion(runs, ALL_SIX);
+    const result = requiredChecksConclusion(runs, ALL_REQUIRED);
     assert.equal(result.conclusion, "failure");
     assert.equal(result.detail, "gitleaks");
   });
 
   it("missing when a required context never ran at all", () => {
     const runs = allGreen().filter((r) => r.name !== "audit-references");
-    const result = requiredChecksConclusion(runs, ALL_SIX);
+    const result = requiredChecksConclusion(runs, ALL_REQUIRED);
     assert.equal(result.conclusion, "missing");
     assert.equal(result.detail, "audit-references");
   });
 
   it("names every outstanding context, not just the first, when several are pending", () => {
-    const runs = ALL_SIX.map((name) =>
+    const runs = ALL_REQUIRED.map((name) =>
       name === "docs-gate" || name === "gitleaks"
         ? { name, status: "in_progress", conclusion: null }
         : { name, status: "completed", conclusion: "success" }
     );
-    const result = requiredChecksConclusion(runs, ALL_SIX);
+    const result = requiredChecksConclusion(runs, ALL_REQUIRED);
     assert.equal(result.conclusion, "pending");
     assert.equal(result.detail, "docs-gate, gitleaks");
+  });
+});
+
+describe("negativeGateConclusion — the -check-failure=X / -check-pending=X form (Codex P2, CTL-2285)", () => {
+  it("⭐ success when the gated check never ran at all — an absent check must NOT block (unlike requiredChecksConclusion)", () => {
+    const result = negativeGateConclusion([], ["quality"]);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("failure when the gated check completed unsuccessfully", () => {
+    const result = negativeGateConclusion(
+      [{ name: "quality", status: "completed", conclusion: "failure" }],
+      ["quality"]
+    );
+    assert.deepEqual(result, { conclusion: "failure", detail: "quality" });
+  });
+
+  it("pending while the gated check is still active", () => {
+    const result = negativeGateConclusion(
+      [{ name: "quality", status: "in_progress", conclusion: null }],
+      ["quality"]
+    );
+    assert.deepEqual(result, { conclusion: "pending", detail: "quality" });
+  });
+
+  it("success when the gated check completed successfully", () => {
+    const result = negativeGateConclusion(
+      [{ name: "quality", status: "completed", conclusion: "success" }],
+      ["quality"]
+    );
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+});
+
+describe("combinedCheckConclusion — folding both gate forms into one verdict (Codex P2, CTL-2285)", () => {
+  const config = DEFAULT_CONFIG;
+  const allGreenRequired = () =>
+    config.requiredCheckContexts.map((name) => ({
+      name,
+      status: "completed",
+      conclusion: "success",
+    }));
+
+  it("success when every required context is green and quality never ran", () => {
+    const result = combinedCheckConclusion(allGreenRequired(), config);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("⭐ pending when every required context is green but a triggered quality run is still active — reproduces the exact gap Codex flagged: nudging here would send a queue command .mergify.yml's own -check-pending=quality condition is certain to refuse", () => {
+    const runs = [
+      ...allGreenRequired(),
+      { name: "quality", status: "in_progress", conclusion: null },
+    ];
+    const result = combinedCheckConclusion(runs, config);
+    assert.equal(result.conclusion, "pending");
+    assert.equal(result.detail, "quality");
+  });
+
+  it("failure when a triggered quality run fails, even though every required context is green", () => {
+    const runs = [
+      ...allGreenRequired(),
+      { name: "quality", status: "completed", conclusion: "failure" },
+    ];
+    const result = combinedCheckConclusion(runs, config);
+    assert.equal(result.conclusion, "failure");
+    assert.equal(result.detail, "quality");
+  });
+
+  it("required-context failure still wins priority over a pending quality run", () => {
+    const runs = allGreenRequired().map((r) =>
+      r.name === "gitleaks" ? { ...r, conclusion: "failure" } : r
+    );
+    runs.push({ name: "quality", status: "in_progress", conclusion: null });
+    const result = combinedCheckConclusion(runs, config);
+    assert.equal(result.conclusion, "failure");
+    assert.equal(result.detail, "gitleaks");
+  });
+
+  it("concatenates details when both forms are pending at the same severity", () => {
+    const runs = allGreenRequired().map((r) =>
+      r.name === "check-versions" ? { ...r, status: "in_progress", conclusion: null } : r
+    );
+    runs.push({ name: "quality", status: "in_progress", conclusion: null });
+    const result = combinedCheckConclusion(runs, config);
+    assert.equal(result.conclusion, "pending");
+    assert.equal(result.detail, "check-versions, quality");
+  });
+
+  it("a non-ruleset check outside packaging-gate/skills-gate/check-plugin-manifest-parity blocks a nudge too", () => {
+    const runs = allGreenRequired().map((r) =>
+      r.name === "packaging-gate" ? { ...r, conclusion: "neutral" } : r
+    );
+    const result = combinedCheckConclusion(runs, config);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("missing packaging-gate/skills-gate/check-plugin-manifest-parity blocks, unlike missing quality", () => {
+    const runs = allGreenRequired().filter((r) => r.name !== "skills-gate");
+    const result = combinedCheckConclusion(runs, config);
+    assert.equal(result.conclusion, "missing");
+    assert.equal(result.detail, "skills-gate");
   });
 });
 
@@ -911,6 +1031,55 @@ describe("makeGithubClient", () => {
     assert.ok(files.includes("plugins/dev/scripts/db-migrations/0002.sql"));
   });
 
+  it("⭐ paginates open-PR discovery past the first page (Codex P2: a ready PR on a later page must not be silently skipped)", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      number: i,
+      draft: false,
+      base: { ref: "main" },
+      head: { sha: `sha${i}` },
+      labels: [],
+    }));
+    const page2 = [
+      {
+        number: 999,
+        draft: false,
+        base: { ref: "main" },
+        head: { sha: "readysha" },
+        labels: [{ name: "queue:ready" }],
+      },
+    ];
+    const fetchImpl = fakeFetch((url) => {
+      const page = new URL(url).searchParams.get("page");
+      if (page === "1") return new Response(JSON.stringify(page1), { status: 200 });
+      if (page === "2") return new Response(JSON.stringify(page2), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    const prs = await client.listOpenPrsWithLabel("queue:ready");
+    assert.equal(prs.length, 1);
+    assert.equal(prs[0].number, 999);
+  });
+
+  it("⭐ paginates the label timeline past the first page (Codex P2: a labeled event on a later page must not read as never-labeled)", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      event: "labeled",
+      label: { name: "some-other-label" },
+      created_at: `2026-08-2${i % 9}T00:00:00Z`,
+    }));
+    const page2 = [
+      { event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T04:00:00Z" },
+    ];
+    const fetchImpl = fakeFetch((url) => {
+      const page = new URL(url).searchParams.get("page");
+      if (page === "1") return new Response(JSON.stringify(page1), { status: 200 });
+      if (page === "2") return new Response(JSON.stringify(page2), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    const timeline = await client.listLabelTimeline(1);
+    assert.deepEqual(latestLabelAddedAt(timeline, "queue:ready"), new Date("2026-08-29T04:00:00Z"));
+  });
+
   it("⭐ paginates issue comments past the first page", async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => ({
       id: i,
@@ -1018,9 +1187,7 @@ describe("main", () => {
 
     const fetchImpl = fakeFetch((url, init) => {
       const method = init?.method ?? "GET";
-      if (
-        url === "https://api.github.com/repos/coalesce-labs/catalyst/pulls?state=open&per_page=100"
-      ) {
+      if (url.includes("/pulls?state=open")) {
         return new Response(
           JSON.stringify([
             {

--- a/scripts/__tests__/merge-queue-watchdog.test.mjs
+++ b/scripts/__tests__/merge-queue-watchdog.test.mjs
@@ -1,0 +1,1102 @@
+// scripts/__tests__/merge-queue-watchdog.test.mjs — offline coverage for
+// scripts/merge-queue-watchdog.mjs (CTL-2285, ported from catalyst-cloud's CTC-1218 suite).
+// Every fetch is a fake; no network, no secret. Run via `node --test` (registered as a step in
+// .github/workflows/execution-core-tests.yml — there is no glob test runner in this repo, so a
+// suite merely present here would otherwise never execute in CI).
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DEFAULT_CONFIG,
+  NUDGE_MARKER,
+  PATH_EXCLUDED_MARKER,
+  QUEUE_STATUS_HEADING,
+  MERGIFY_BOT_LOGIN,
+  parsePathExclusionPatterns,
+  isPathExcluded,
+  latestLabelAddedAt,
+  latestNudgeAt,
+  isAlreadyQueued,
+  hasPathExcludedAlert,
+  findUnsurfacedRefusal,
+  checkStateForContext,
+  requiredChecksConclusion,
+  countUnresolvedThreads,
+  decideAction,
+  gatherPrInput,
+  runOnce,
+  main,
+  makeGithubClient,
+} from "../merge-queue-watchdog.mjs";
+
+const NOW = new Date("2026-08-29T04:30:00Z");
+const config = DEFAULT_CONFIG;
+
+// ── parsePathExclusionPatterns / isPathExcluded ──────────────────────────────────────────────
+
+describe("parsePathExclusionPatterns", () => {
+  const MERGIFY_YAML = `
+queue_rules:
+  - name: default
+    queue_conditions:
+      - base=main
+      - label=queue:ready
+      - -files~=^\\.github/workflows/publish-
+      - -files~=^plugins/dev/scripts/db-migrations/
+      - -files~=^\\.mergify\\.yml$
+      - -head~=^release-please--
+      - -draft
+`;
+
+  it("extracts every -files~= condition as a RegExp, ignoring -head~=", () => {
+    const patterns = parsePathExclusionPatterns(MERGIFY_YAML);
+    assert.equal(patterns.length, 3);
+    assert.equal(patterns[0].test(".github/workflows/publish-desktop.yml"), true);
+    assert.equal(patterns[0].test("scripts/merge-queue-watchdog.mjs"), false);
+    assert.equal(patterns[1].test("plugins/dev/scripts/db-migrations/0001.sql"), true);
+    assert.equal(patterns[2].test(".mergify.yml"), true);
+  });
+
+  it("returns an empty array when the file has no path exclusions", () => {
+    assert.deepEqual(parsePathExclusionPatterns("queue_rules:\n  - name: default\n"), []);
+  });
+});
+
+describe("isPathExcluded", () => {
+  const patterns = parsePathExclusionPatterns(
+    "      - -files~=^\\.mergify\\.yml$\n      - -files~=^plugins/dev/scripts/db-migrations/\n"
+  );
+
+  it("matches a file under an excluded prefix", () => {
+    assert.equal(isPathExcluded(["plugins/dev/scripts/db-migrations/0001.sql"], patterns), true);
+  });
+
+  it("matches the exact excluded file", () => {
+    assert.equal(isPathExcluded([".mergify.yml"], patterns), true);
+  });
+
+  it("does not match an unrelated file", () => {
+    assert.equal(isPathExcluded(["scripts/merge-queue-watchdog.mjs"], patterns), false);
+  });
+
+  it("never excludes anything when there are no patterns", () => {
+    assert.equal(isPathExcluded([".mergify.yml"], []), false);
+  });
+});
+
+// ── latestLabelAddedAt ────────────────────────────────────────────────────────────────────────
+
+describe("latestLabelAddedAt", () => {
+  it("returns the labeled timestamp when it is the only event", () => {
+    const at = latestLabelAddedAt(
+      [{ event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T04:00:00Z" }],
+      "queue:ready"
+    );
+    assert.deepEqual(at, new Date("2026-08-29T04:00:00Z"));
+  });
+
+  it("returns null when the most recent event is unlabeled", () => {
+    const at = latestLabelAddedAt(
+      [
+        { event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T03:00:00Z" },
+        { event: "unlabeled", label: { name: "queue:ready" }, created_at: "2026-08-29T04:00:00Z" },
+      ],
+      "queue:ready"
+    );
+    assert.equal(at, null);
+  });
+
+  it("picks the latest re-label after an unlabel/relabel cycle", () => {
+    const at = latestLabelAddedAt(
+      [
+        { event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T02:00:00Z" },
+        { event: "unlabeled", label: { name: "queue:ready" }, created_at: "2026-08-29T03:00:00Z" },
+        { event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T04:00:00Z" },
+      ],
+      "queue:ready"
+    );
+    assert.deepEqual(at, new Date("2026-08-29T04:00:00Z"));
+  });
+
+  it("ignores events for a different label", () => {
+    const at = latestLabelAddedAt(
+      [
+        {
+          event: "labeled",
+          label: { name: "hold:hand-steps" },
+          created_at: "2026-08-29T04:00:00Z",
+        },
+      ],
+      "queue:ready"
+    );
+    assert.equal(at, null);
+  });
+
+  it("returns null when never labeled", () => {
+    assert.equal(latestLabelAddedAt([], "queue:ready"), null);
+  });
+});
+
+// ── comment scanning: nudge / queue-status / path-excluded-alert / refusal ──────────────────
+
+function comment(overrides) {
+  return {
+    id: 1,
+    user: { login: "github-actions[bot]" },
+    body: "",
+    created_at: "2026-08-29T04:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("latestNudgeAt", () => {
+  it("finds the marker and returns its timestamp", () => {
+    const at = latestNudgeAt([comment({ body: `@Mergifyio queue\n\n${NUDGE_MARKER}` })]);
+    assert.deepEqual(at, new Date("2026-08-29T04:00:00Z"));
+  });
+
+  it("returns the latest of multiple nudges", () => {
+    const at = latestNudgeAt([
+      comment({ body: NUDGE_MARKER, created_at: "2026-08-29T02:00:00Z" }),
+      comment({ body: NUDGE_MARKER, created_at: "2026-08-29T04:00:00Z" }),
+    ]);
+    assert.deepEqual(at, new Date("2026-08-29T04:00:00Z"));
+  });
+
+  it("returns null when there is no nudge marker", () => {
+    assert.equal(latestNudgeAt([comment({ body: "unrelated comment" })]), null);
+  });
+});
+
+describe("isAlreadyQueued", () => {
+  it("true for a mergify[bot] Merge Queue Status comment", () => {
+    assert.equal(
+      isAlreadyQueued([
+        comment({ user: { login: MERGIFY_BOT_LOGIN }, body: `# ${QUEUE_STATUS_HEADING}\n...` }),
+      ]),
+      true
+    );
+  });
+
+  it("false when the heading comes from a different author", () => {
+    assert.equal(
+      isAlreadyQueued([
+        comment({ user: { login: "someone-else" }, body: `# ${QUEUE_STATUS_HEADING}` }),
+      ]),
+      false
+    );
+  });
+
+  it("false when mergify[bot] posts something else entirely", () => {
+    assert.equal(
+      isAlreadyQueued([comment({ user: { login: MERGIFY_BOT_LOGIN }, body: "unrelated" })]),
+      false
+    );
+  });
+});
+
+describe("hasPathExcludedAlert", () => {
+  it("true when the marker is present", () => {
+    assert.equal(
+      hasPathExcludedAlert([comment({ body: `alert\n\n${PATH_EXCLUDED_MARKER}` })]),
+      true
+    );
+  });
+
+  it("false otherwise", () => {
+    assert.equal(hasPathExcludedAlert([comment({ body: "unrelated" })]), false);
+  });
+});
+
+describe("findUnsurfacedRefusal", () => {
+  it("returns null when there was no nudge yet", () => {
+    assert.equal(
+      findUnsurfacedRefusal([comment({ user: { login: MERGIFY_BOT_LOGIN }, body: "no" })], null),
+      null
+    );
+  });
+
+  it("finds a mergify[bot] reply after the nudge that is not the queue-status heading", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          id: 42,
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "This pull request cannot be embarked: unmet condition",
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.deepEqual(refusal, {
+      commentId: 42,
+      body: "This pull request cannot be embarked: unmet condition",
+      createdAt: new Date("2026-08-29T04:05:00Z"),
+    });
+  });
+
+  it("ignores a mergify[bot] reply BEFORE the nudge", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "old reply",
+          created_at: "2026-08-29T03:00:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.equal(refusal, null);
+  });
+
+  it("treats a Merge Queue Status reply as success, not a refusal", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: `# ${QUEUE_STATUS_HEADING}`,
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.equal(refusal, null);
+  });
+
+  it("ignores a reply from a non-mergify author", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          user: { login: "someone" },
+          body: "refused",
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.equal(refusal, null);
+  });
+
+  it("excludes a refusal already surfaced (marker names its comment id)", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          id: 42,
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "cannot be embarked",
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+        comment({
+          user: { login: "github-actions[bot]" },
+          body: "surfaced already\n\n<!-- catalyst:merge-queue-watchdog:refusal-surfaced:42 -->",
+          created_at: "2026-08-29T04:06:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.equal(refusal, null);
+  });
+
+  it("picks the earliest unsurfaced refusal when several exist", () => {
+    const nudgeAt = new Date("2026-08-29T04:00:00Z");
+    const refusal = findUnsurfacedRefusal(
+      [
+        comment({
+          id: 2,
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "second",
+          created_at: "2026-08-29T04:10:00Z",
+        }),
+        comment({
+          id: 1,
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "first",
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+      ],
+      nudgeAt
+    );
+    assert.equal(refusal.commentId, 1);
+  });
+});
+
+// ── checkStateForContext / requiredChecksConclusion / countUnresolvedThreads ────────────────
+
+describe("checkStateForContext", () => {
+  it("success when the named run completed with a satisfying conclusion", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "docs-gate", status: "completed", conclusion: "success" }],
+        "docs-gate"
+      ),
+      "success"
+    );
+  });
+
+  it("success when the named run completed neutral (skip-tolerant)", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "docs-gate", status: "completed", conclusion: "neutral" }],
+        "docs-gate"
+      ),
+      "success"
+    );
+  });
+
+  it("success when the named run completed skipped (skip-tolerant)", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "docs-gate", status: "completed", conclusion: "skipped" }],
+        "docs-gate"
+      ),
+      "success"
+    );
+  });
+
+  it("failure when the named run completed unsuccessfully", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "docs-gate", status: "completed", conclusion: "failure" }],
+        "docs-gate"
+      ),
+      "failure"
+    );
+  });
+
+  it("pending while the run is still in progress", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "execution-core-unit-tests", status: "in_progress", conclusion: null }],
+        "execution-core-unit-tests"
+      ),
+      "pending"
+    );
+  });
+
+  it("missing when the named context never ran", () => {
+    assert.equal(checkStateForContext([], "docs-gate"), "missing");
+  });
+
+  it("ignores runs with a different name", () => {
+    assert.equal(
+      checkStateForContext(
+        [{ name: "lint", status: "completed", conclusion: "success" }],
+        "docs-gate"
+      ),
+      "missing"
+    );
+  });
+});
+
+describe("requiredChecksConclusion — the multi-required-check form (CTL-2285)", () => {
+  const ALL_SIX = DEFAULT_CONFIG.requiredCheckContexts;
+  const allGreen = (overrides = {}) =>
+    ALL_SIX.map((name) => ({
+      name,
+      status: "completed",
+      conclusion: overrides[name] ?? "success",
+    }));
+
+  it("success when all six required contexts are success", () => {
+    const result = requiredChecksConclusion(allGreen(), ALL_SIX);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("success when one context is neutral and the rest are success", () => {
+    const result = requiredChecksConclusion(allGreen({ "docs-gate": "neutral" }), ALL_SIX);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("success when one context is skipped and the rest are success", () => {
+    const result = requiredChecksConclusion(allGreen({ gitleaks: "skipped" }), ALL_SIX);
+    assert.deepEqual(result, { conclusion: "success", detail: "" });
+  });
+
+  it("⭐ pending when one context is still in_progress — the measured CTL-2285 incident shape", () => {
+    const runs = ALL_SIX.map((name) =>
+      name === "execution-core-unit-tests"
+        ? { name, status: "in_progress", conclusion: null }
+        : { name, status: "completed", conclusion: "success" }
+    );
+    const result = requiredChecksConclusion(runs, ALL_SIX);
+    assert.equal(result.conclusion, "pending");
+    assert.equal(result.detail, "execution-core-unit-tests");
+  });
+
+  it("failure takes priority over a simultaneously-pending context", () => {
+    const runs = ALL_SIX.map((name) => {
+      if (name === "gitleaks") return { name, status: "completed", conclusion: "failure" };
+      if (name === "check-versions") return { name, status: "in_progress", conclusion: null };
+      return { name, status: "completed", conclusion: "success" };
+    });
+    const result = requiredChecksConclusion(runs, ALL_SIX);
+    assert.equal(result.conclusion, "failure");
+    assert.equal(result.detail, "gitleaks");
+  });
+
+  it("missing when a required context never ran at all", () => {
+    const runs = allGreen().filter((r) => r.name !== "audit-references");
+    const result = requiredChecksConclusion(runs, ALL_SIX);
+    assert.equal(result.conclusion, "missing");
+    assert.equal(result.detail, "audit-references");
+  });
+
+  it("names every outstanding context, not just the first, when several are pending", () => {
+    const runs = ALL_SIX.map((name) =>
+      name === "docs-gate" || name === "gitleaks"
+        ? { name, status: "in_progress", conclusion: null }
+        : { name, status: "completed", conclusion: "success" }
+    );
+    const result = requiredChecksConclusion(runs, ALL_SIX);
+    assert.equal(result.conclusion, "pending");
+    assert.equal(result.detail, "docs-gate, gitleaks");
+  });
+});
+
+describe("countUnresolvedThreads", () => {
+  it("counts only the unresolved ones", () => {
+    assert.equal(
+      countUnresolvedThreads([{ isResolved: true }, { isResolved: false }, { isResolved: false }]),
+      2
+    );
+  });
+
+  it("zero when empty", () => {
+    assert.equal(countUnresolvedThreads([]), 0);
+  });
+});
+
+// ── decideAction — the whole state machine, table-driven ────────────────────────────────────
+
+function baseInput(overrides = {}) {
+  return {
+    number: 100,
+    baseRef: "main",
+    isDraft: false,
+    labels: ["queue:ready"],
+    changedFiles: ["scripts/merge-queue-watchdog.mjs"],
+    checkConclusion: "success",
+    checkDetail: "",
+    unresolvedThreadCount: 0,
+    labeledAt: new Date("2026-08-29T04:15:00Z"), // 15m before NOW — past the 10m threshold
+    alreadyQueued: false,
+    lastNudgeAt: null,
+    pathExcludedAlertAlreadyPosted: false,
+    refusal: null,
+    ...overrides,
+  };
+}
+
+describe("decideAction", () => {
+  it("none when base is not main", () => {
+    const action = decideAction(baseInput({ baseRef: "release" }), config, [], NOW);
+    assert.equal(action.type, "none");
+  });
+
+  it("none when the PR is a draft", () => {
+    const action = decideAction(baseInput({ isDraft: true }), config, [], NOW);
+    assert.equal(action.type, "none");
+  });
+
+  it("none when queue:ready is missing", () => {
+    const action = decideAction(baseInput({ labels: [] }), config, [], NOW);
+    assert.equal(action.type, "none");
+  });
+
+  it("alert-path-excluded when changed files match an exclusion pattern", () => {
+    const patterns = parsePathExclusionPatterns("      - -files~=^\\.mergify\\.yml$\n");
+    const action = decideAction(
+      baseInput({ changedFiles: [".mergify.yml"] }),
+      config,
+      patterns,
+      NOW
+    );
+    assert.equal(action.type, "alert-path-excluded");
+  });
+
+  it("none (already alerted) when path-excluded and the alert marker is already posted", () => {
+    const patterns = parsePathExclusionPatterns("      - -files~=^\\.mergify\\.yml$\n");
+    const action = decideAction(
+      baseInput({ changedFiles: [".mergify.yml"], pathExcludedAlertAlreadyPosted: true }),
+      config,
+      patterns,
+      NOW
+    );
+    assert.deepEqual(action, { type: "none", reason: "path-excluded; already alerted" });
+  });
+
+  it("none (already alerted) when path-excluded and hold:hand-steps is already on the PR", () => {
+    const patterns = parsePathExclusionPatterns("      - -files~=^\\.mergify\\.yml$\n");
+    const action = decideAction(
+      baseInput({ changedFiles: [".mergify.yml"], labels: ["queue:ready", "hold:hand-steps"] }),
+      config,
+      patterns,
+      NOW
+    );
+    assert.equal(action.type, "none");
+  });
+
+  it("none when hold:hand-steps is present (manual protocol, not path-excluded)", () => {
+    const action = decideAction(
+      baseInput({ labels: ["queue:ready", "hold:hand-steps"] }),
+      config,
+      [],
+      NOW
+    );
+    assert.deepEqual(action, { type: "none", reason: "hold:hand-steps present — manual protocol" });
+  });
+
+  it("none when already queued", () => {
+    const action = decideAction(baseInput({ alreadyQueued: true }), config, [], NOW);
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("already queued"));
+  });
+
+  it("surface-refusal when Mergify replied without queuing", () => {
+    const refusal = { commentId: 7, body: "nope", createdAt: new Date("2026-08-29T04:20:00Z") };
+    const action = decideAction(baseInput({ refusal }), config, [], NOW);
+    assert.deepEqual(action, {
+      type: "surface-refusal",
+      reason: "Mergify replied to our nudge without queuing",
+      refusal,
+    });
+  });
+
+  it("none when the required checks are failing", () => {
+    const action = decideAction(
+      baseInput({ checkConclusion: "failure", checkDetail: "gitleaks" }),
+      config,
+      [],
+      NOW
+    );
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("gitleaks"));
+  });
+
+  it("⭐ none when the required checks are pending, naming the outstanding context (CTL-2285 incident shape)", () => {
+    const action = decideAction(
+      baseInput({ checkConclusion: "pending", checkDetail: "execution-core-unit-tests" }),
+      config,
+      [],
+      NOW
+    );
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("execution-core-unit-tests"));
+    assert.ok(action.reason.includes("pending"));
+  });
+
+  it("none when there are unresolved review threads", () => {
+    const action = decideAction(baseInput({ unresolvedThreadCount: 2 }), config, [], NOW);
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("unresolved"));
+  });
+
+  it("none when labeledAt could not be determined", () => {
+    const action = decideAction(baseInput({ labeledAt: null }), config, [], NOW);
+    assert.equal(action.type, "none");
+  });
+
+  it("none when still inside the eligibility window", () => {
+    const action = decideAction(
+      baseInput({ labeledAt: new Date("2026-08-29T04:25:00Z") }), // 5m before NOW
+      config,
+      [],
+      NOW
+    );
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("waiting"));
+  });
+
+  it("none (cooldown) when nudged recently and still not queued", () => {
+    const action = decideAction(
+      baseInput({ lastNudgeAt: new Date("2026-08-29T04:20:00Z") }), // 10m before NOW; cooldown 20m
+      config,
+      [],
+      NOW
+    );
+    assert.equal(action.type, "none");
+    assert.ok(action.reason.includes("cooldown"));
+  });
+
+  it("nudge once the eligibility window has elapsed and no nudge is on record", () => {
+    const action = decideAction(baseInput(), config, [], NOW);
+    assert.equal(action.type, "nudge");
+  });
+
+  it("nudge again once the cooldown has elapsed and the PR is still not queued", () => {
+    const action = decideAction(
+      baseInput({ lastNudgeAt: new Date("2026-08-29T04:09:00Z") }), // 21m before NOW; cooldown 20m
+      config,
+      [],
+      NOW
+    );
+    assert.equal(action.type, "nudge");
+  });
+});
+
+// ── gatherPrInput / runOnce — a fake GithubClient, no fetch ────────────────────────────────
+
+function fakeClient(overrides = {}) {
+  return {
+    listOpenPrsWithLabel: async () => [],
+    listChangedFiles: async () => [],
+    listCheckRuns: async () =>
+      DEFAULT_CONFIG.requiredCheckContexts.map((name) => ({
+        name,
+        status: "completed",
+        conclusion: "success",
+      })),
+    listUnresolvedThreadCount: async () => 0,
+    listLabelTimeline: async () => [
+      { event: "labeled", label: { name: "queue:ready" }, created_at: "2026-08-29T04:15:00Z" },
+    ],
+    listComments: async () => [],
+    postComment: async () => {},
+    swapLabels: async () => {},
+    ...overrides,
+  };
+}
+
+describe("gatherPrInput", () => {
+  it("combines the client's reads into the decision-core shape", async () => {
+    const pr = {
+      number: 100,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "abc123",
+    };
+    const input = await gatherPrInput(fakeClient(), pr, config);
+    assert.equal(input.checkConclusion, "success");
+    assert.equal(input.checkDetail, "");
+    assert.deepEqual(input.labeledAt, new Date("2026-08-29T04:15:00Z"));
+    assert.equal(input.alreadyQueued, false);
+  });
+
+  it("surfaces the pending context through to checkDetail", async () => {
+    const pr = {
+      number: 101,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "def456",
+    };
+    const runs = DEFAULT_CONFIG.requiredCheckContexts.map((name) =>
+      name === "execution-core-unit-tests"
+        ? { name, status: "in_progress", conclusion: null }
+        : { name, status: "completed", conclusion: "success" }
+    );
+    const input = await gatherPrInput(fakeClient({ listCheckRuns: async () => runs }), pr, config);
+    assert.equal(input.checkConclusion, "pending");
+    assert.equal(input.checkDetail, "execution-core-unit-tests");
+  });
+});
+
+describe("runOnce", () => {
+  it("posts the nudge comment (with marker) for an eligible PR and counts it", async () => {
+    const posted = [];
+    const pr = {
+      number: 200,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha1",
+    };
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [pr],
+      postComment: async (number, body) => {
+        posted.push({ number, body });
+      },
+    });
+    const summary = await runOnce(client, config, "queue_rules: []\n", NOW, () => {});
+    assert.deepEqual(summary, {
+      processed: 1,
+      nudged: 1,
+      alertedPathExcluded: 0,
+      refusalsSurfaced: 0,
+      errors: 0,
+    });
+    assert.equal(posted.length, 1);
+    assert.equal(posted[0].number, 200);
+    assert.ok(posted[0].body.includes("@Mergifyio queue"));
+    assert.ok(posted[0].body.includes(NUDGE_MARKER));
+  });
+
+  it("does not nudge while a required check is still pending (CTL-2285 incident, reproduced end-to-end)", async () => {
+    const posted = [];
+    const pr = {
+      number: 205,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha6",
+    };
+    const runs = DEFAULT_CONFIG.requiredCheckContexts.map((name) =>
+      name === "execution-core-unit-tests"
+        ? { name, status: "in_progress", conclusion: null }
+        : { name, status: "completed", conclusion: "success" }
+    );
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [pr],
+      listCheckRuns: async () => runs,
+      postComment: async (_n, body) => {
+        posted.push(body);
+      },
+    });
+    const summary = await runOnce(client, config, "queue_rules: []\n", NOW, () => {});
+    assert.equal(summary.nudged, 0);
+    assert.equal(posted.length, 0);
+  });
+
+  it("alerts and swaps labels for a path-excluded PR", async () => {
+    const posted = [];
+    const swapped = [];
+    const pr = {
+      number: 201,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha2",
+    };
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [pr],
+      listChangedFiles: async () => [".mergify.yml"],
+      postComment: async (_n, body) => {
+        posted.push(body);
+      },
+      swapLabels: async (number, removeLabel, addLabel) => {
+        swapped.push({ number, remove: removeLabel, add: addLabel });
+      },
+    });
+    const mergifyYaml = "      - -files~=^\\.mergify\\.yml$\n";
+    const summary = await runOnce(client, config, mergifyYaml, NOW, () => {});
+    assert.equal(summary.alertedPathExcluded, 1);
+    assert.ok(posted[0].includes(PATH_EXCLUDED_MARKER));
+    assert.deepEqual(swapped, [{ number: 201, remove: "queue:ready", add: "hold:hand-steps" }]);
+  });
+
+  it("⭐ a failed label swap leaves the marker unposted, so the PR is retried next run", async () => {
+    const posted = [];
+    const pr = {
+      number: 201,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha2",
+    };
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [pr],
+      listChangedFiles: async () => [".mergify.yml"],
+      postComment: async (_n, body) => {
+        posted.push(body);
+      },
+      swapLabels: async () => {
+        throw new Error("github 500");
+      },
+    });
+    const mergifyYaml = "      - -files~=^\\.mergify\\.yml$\n";
+    const summary = await runOnce(client, config, mergifyYaml, NOW, () => {});
+    assert.equal(summary.errors, 1);
+    assert.equal(summary.alertedPathExcluded, 0);
+    assert.deepEqual(posted, []);
+  });
+
+  it("surfaces a refusal without re-nudging", async () => {
+    const posted = [];
+    const pr = {
+      number: 202,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha3",
+    };
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [pr],
+      listComments: async () => [
+        comment({
+          user: { login: "github-actions[bot]" },
+          body: NUDGE_MARKER,
+          created_at: "2026-08-29T04:00:00Z",
+        }),
+        comment({
+          id: 55,
+          user: { login: MERGIFY_BOT_LOGIN },
+          body: "This pull request cannot be embarked",
+          created_at: "2026-08-29T04:05:00Z",
+        }),
+      ],
+      postComment: async (_n, body) => {
+        posted.push(body);
+      },
+    });
+    const summary = await runOnce(client, config, "queue_rules: []\n", NOW, () => {});
+    assert.equal(summary.refusalsSurfaced, 1);
+    assert.equal(summary.nudged, 0);
+    assert.ok(posted[0].includes("cannot be embarked"));
+    assert.ok(posted[0].includes("refusal-surfaced:55"));
+  });
+
+  it("one PR's failure does not stop the batch, and is counted as an error", async () => {
+    const goodPr = {
+      number: 203,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha4",
+    };
+    const badPr = {
+      number: 204,
+      baseRef: "main",
+      isDraft: false,
+      labels: ["queue:ready"],
+      headSha: "sha5",
+    };
+    const posted = [];
+    let call = 0;
+    const client = fakeClient({
+      listOpenPrsWithLabel: async () => [badPr, goodPr],
+      listChangedFiles: async () => {
+        call++;
+        if (call === 1) throw new Error("github 500");
+        return [];
+      },
+      postComment: async (number) => {
+        posted.push(number);
+      },
+    });
+    const summary = await runOnce(client, config, "queue_rules: []\n", NOW, () => {});
+    assert.equal(summary.processed, 2);
+    assert.equal(summary.errors, 1);
+    assert.equal(summary.nudged, 1);
+    assert.deepEqual(posted, [203]);
+  });
+
+  it("stays quiet when no PR carries the ready label", async () => {
+    const summary = await runOnce(fakeClient(), config, "queue_rules: []\n", NOW, () => {});
+    assert.deepEqual(summary, {
+      processed: 0,
+      nudged: 0,
+      alertedPathExcluded: 0,
+      refusalsSurfaced: 0,
+      errors: 0,
+    });
+  });
+});
+
+// ── makeGithubClient — the real HTTP client, exercised over a fake fetch ─────────────────────
+
+function fakeFetch(handler) {
+  return async (url, init) => handler(url, init);
+}
+
+describe("makeGithubClient", () => {
+  it("⭐ paginates changed files past the first page", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({ filename: `src/file${i}.ts` }));
+    const page2 = [{ filename: "plugins/dev/scripts/db-migrations/0002.sql" }];
+    const fetchImpl = fakeFetch((url) => {
+      const page = new URL(url).searchParams.get("page");
+      if (page === "1") return new Response(JSON.stringify(page1), { status: 200 });
+      if (page === "2") return new Response(JSON.stringify(page2), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    const files = await client.listChangedFiles(1);
+    assert.equal(files.length, 101);
+    assert.ok(files.includes("plugins/dev/scripts/db-migrations/0002.sql"));
+  });
+
+  it("⭐ paginates issue comments past the first page", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      id: i,
+      user: { login: "someone" },
+      body: `comment ${i}`,
+      created_at: "2026-08-29T00:00:00Z",
+    }));
+    const page2 = [
+      {
+        id: 999,
+        user: { login: MERGIFY_BOT_LOGIN },
+        body: QUEUE_STATUS_HEADING,
+        created_at: NOW.toISOString(),
+      },
+    ];
+    const fetchImpl = fakeFetch((url) => {
+      const page = new URL(url).searchParams.get("page");
+      if (page === "1") return new Response(JSON.stringify(page1), { status: 200 });
+      if (page === "2") return new Response(JSON.stringify(page2), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    const comments = await client.listComments(1);
+    assert.equal(comments.length, 101);
+    assert.equal(isAlreadyQueued(comments), true);
+  });
+
+  it("⭐ paginates review threads past the first GraphQL page", async () => {
+    let call = 0;
+    const fetchImpl = fakeFetch((url) => {
+      assert.equal(url, "https://api.github.com/graphql");
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: Array.from({ length: 100 }, () => ({ isResolved: true })),
+                    pageInfo: { hasNextPage: true, endCursor: "cursor1" },
+                  },
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [{ isResolved: false }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        }),
+        { status: 200 }
+      );
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    const count = await client.listUnresolvedThreadCount(1);
+    assert.equal(call, 2);
+    assert.equal(count, 1);
+  });
+
+  it("⭐ swapLabels adds the new label BEFORE removing the old one", async () => {
+    const calls = [];
+    const fetchImpl = fakeFetch((url, init) => {
+      const method = init?.method ?? "GET";
+      calls.push(`${method} ${url}`);
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    const client = makeGithubClient("token", "coalesce-labs", "catalyst", fetchImpl);
+    await client.swapLabels(1, "queue:ready", "hold:hand-steps");
+    assert.equal(calls.length, 2);
+    assert.equal(
+      calls[0],
+      "POST https://api.github.com/repos/coalesce-labs/catalyst/issues/1/labels"
+    );
+    assert.equal(
+      calls[1],
+      "DELETE https://api.github.com/repos/coalesce-labs/catalyst/issues/1/labels/queue%3Aready"
+    );
+  });
+});
+
+describe("main", () => {
+  it("exits 1 when GITHUB_TOKEN is not set", async () => {
+    const result = await main([], { env: {} });
+    assert.equal(result.exitCode, 1);
+  });
+
+  it("nudges an eligible PR end-to-end over a fake GitHub API and writes a step summary", async () => {
+    const logs = [];
+    const summaries = [];
+    const posted = [];
+
+    const labeledAt = new Date(NOW.getTime() - 15 * 60_000).toISOString();
+
+    const fetchImpl = fakeFetch((url, init) => {
+      const method = init?.method ?? "GET";
+      if (
+        url === "https://api.github.com/repos/coalesce-labs/catalyst/pulls?state=open&per_page=100"
+      ) {
+        return new Response(
+          JSON.stringify([
+            {
+              number: 300,
+              draft: false,
+              base: { ref: "main" },
+              head: { sha: "deadbeef" },
+              labels: [{ name: "queue:ready" }],
+            },
+          ]),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/pulls/300/files")) {
+        return new Response(JSON.stringify([{ filename: "scripts/merge-queue-watchdog.mjs" }]), {
+          status: 200,
+        });
+      }
+      if (url.includes("/commits/deadbeef/check-runs")) {
+        return new Response(
+          JSON.stringify({
+            check_runs: DEFAULT_CONFIG.requiredCheckContexts.map((name) => ({
+              name,
+              status: "completed",
+              conclusion: "success",
+            })),
+          }),
+          { status: 200 }
+        );
+      }
+      if (url === "https://api.github.com/graphql") {
+        return new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+                },
+              },
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/issues/300/timeline")) {
+        return new Response(
+          JSON.stringify([
+            { event: "labeled", label: { name: "queue:ready" }, created_at: labeledAt },
+          ]),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/issues/300/comments") && method === "GET") {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.includes("/issues/300/comments") && method === "POST") {
+        posted.push({ url, body: JSON.parse(String(init?.body)).body });
+        return new Response(JSON.stringify({ id: 1 }), { status: 201 });
+      }
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    });
+
+    const result = await main([], {
+      env: { GITHUB_TOKEN: "test-token", GITHUB_STEP_SUMMARY: "/tmp/does-not-matter" },
+      fetchImpl,
+      now: NOW,
+      log: (l) => logs.push(l),
+      readMergifyYaml: () => "queue_rules: []\n",
+      writeStepSummary: (text) => summaries.push(text),
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(posted.length, 1);
+    assert.ok(posted[0].body.includes("@Mergifyio queue"));
+    assert.equal(summaries.length, 1);
+    assert.ok(summaries[0].includes("Nudged: 1"));
+    assert.ok(logs.some((l) => l.includes("nudge")));
+  });
+});

--- a/scripts/merge-queue-watchdog.mjs
+++ b/scripts/merge-queue-watchdog.mjs
@@ -1,0 +1,650 @@
+#!/usr/bin/env node
+// scripts/merge-queue-watchdog.mjs — CTL-2285. Port of catalyst-cloud's CTC-1218 watchdog
+// (scripts/merge-queue-watchdog.ts), the automated replacement for a human's manual
+// `@Mergifyio queue` nudge (AGENTS.md: "infra fixes must be codified", house rule).
+//
+// WHY: Mergify does not re-evaluate a PR whose queue attempt failed, and label-event
+// evaluation can lag or be missed entirely. Measured incident: catalyst PR #4066 entered the
+// queue 2026-08-29T04:02:45Z and was DEQUEUED at 04:09Z because the required check
+// `execution-core-unit-tests` had simply not reported a conclusion yet (started 04:11:30Z);
+// every other check on the head SHA was already green. This watchdog runs on a schedule
+// (.github/workflows/merge-queue-watchdog.yml) and, for every open PR carrying `queue:ready`
+// against `main`, decides whether to nudge, alert, or stay quiet.
+//
+// SHAPE: a pure decision core (`decideAction` — data in, action out, no I/O, table-driven
+// unit-tested in merge-queue-watchdog.test.mjs) plus a thin GitHub client whose I/O is
+// injectable (`GithubClient` + `makeGithubClient`) — same shape as the cloud source.
+//
+// THE ONE REAL GENERALIZATION vs. cloud: cloud's `requiredCheckContext` is a single string
+// because cloud's branch protection has exactly one required context (`Check`). This repo's
+// protection is a repository RULESET (id 13503799) requiring SIX contexts — docs-gate,
+// gitleaks, agents-md-gate, audit-references, check-versions, execution-core-unit-tests —
+// each satisfied in the skip-tolerant three-way form (success OR neutral OR skipped),
+// exactly as .mergify.yml's own queue_conditions already spell it (see that file's header: a
+// bare success-only test would be STRICTER than the ruleset and would deadlock on a
+// legitimately-skipped job). `requiredCheckContexts` is therefore a list, and
+// `requiredChecksConclusion` aggregates every context's own three-way state.
+//
+// PATH EXCLUSIONS ARE READ, NEVER DUPLICATED. This script parses the live `-files~=<pattern>`
+// conditions straight out of `.mergify.yml` at runtime — a small line-oriented extractor, not
+// a YAML library (this repo's top-level scripts/ has no hoisted `yaml` dep). If .mergify.yml's
+// exclusions ever change, this script picks them up automatically; it cannot drift from the
+// file it reads. (.mergify.yml also carries a `-head~=^release-please--` branch-name
+// exclusion — that is not a `-files~=` line and is out of scope for this extractor, which
+// only ever covered file-content exclusions.)
+//
+// SCOPE ADDENDUM (carried from cloud): a PR whose changed files match a path exclusion will
+// NEVER queue, no matter how many nudges — nudging it is a lie about automation that will
+// never come. For those PRs: alert instead, and (default on) swap `queue:ready` for
+// `hold:hand-steps` so the label stops re-triggering both this watchdog and Mergify's own
+// `pull_request_rules` enqueue rule.
+//
+// SURFACING: every decision is logged to the workflow's own job log AND appended to
+// $GITHUB_STEP_SUMMARY when set. A refusal or path-exclusion is ALSO posted as a PR comment.
+//
+// "ALREADY QUEUED" / "REFUSED" DETECTION deliberately reads PR comments rather than shelling
+// out to a Mergify CLI/API: a `# Merge Queue Status` comment is a reliable positive signal,
+// and any other `mergify[bot]` reply after our own nudge is the only other reply shape a
+// `queue` command produces — so it is read as the refusal explanation.
+//
+// Usage (live, needs GITHUB_TOKEN + network): node scripts/merge-queue-watchdog.mjs
+// Invoked by .github/workflows/merge-queue-watchdog.yml on a schedule + workflow_dispatch.
+//
+// ⛔ THIS SCRIPT NEEDS THE NETWORK — it stays OUT of the required test gate. Only its OFFLINE
+// spec (merge-queue-watchdog.test.mjs, fetchImpl injected) is wired into CI, as a step in
+// .github/workflows/execution-core-tests.yml (there is no glob test runner in this repo — a
+// test file merely present in __tests__/ never runs in CI unless explicitly registered there).
+
+import { appendFileSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// ── Config ──────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} WatchdogConfig
+ * @property {string} owner
+ * @property {string} repo
+ * @property {string} baseRef
+ * @property {string} readyLabel
+ * @property {string} holdLabel
+ * @property {readonly string[]} requiredCheckContexts
+ * @property {number} eligibleMinutes
+ * @property {number} renudgeCooldownMinutes
+ * @property {boolean} swapToHoldLabel
+ */
+
+/** @type {WatchdogConfig} */
+export const DEFAULT_CONFIG = {
+  owner: "coalesce-labs",
+  repo: "catalyst",
+  baseRef: "main",
+  readyLabel: "queue:ready",
+  holdLabel: "hold:hand-steps",
+  requiredCheckContexts: [
+    "docs-gate",
+    "gitleaks",
+    "agents-md-gate",
+    "audit-references",
+    "check-versions",
+    "execution-core-unit-tests",
+  ],
+  eligibleMinutes: 10,
+  renudgeCooldownMinutes: 20,
+  swapToHoldLabel: true,
+};
+
+// ── Markers (idempotency, no external state store — GitHub IS the state) ────────────────────
+
+export const NUDGE_MARKER = "<!-- catalyst:merge-queue-watchdog:nudge -->";
+export const PATH_EXCLUDED_MARKER = "<!-- catalyst:merge-queue-watchdog:path-excluded -->";
+export const QUEUE_STATUS_HEADING = "Merge Queue Status";
+export const MERGIFY_BOT_LOGIN = "mergify[bot]";
+
+function refusalMarker(commentId) {
+  return `<!-- catalyst:merge-queue-watchdog:refusal-surfaced:${commentId} -->`;
+}
+
+// ── .mergify.yml path-exclusion extraction (line-oriented, not a YAML parse — see header) ───
+
+const FILES_EXCLUDE_LINE = /^\s*-\s*-files~=(.+?)\s*$/;
+
+export function parsePathExclusionPatterns(mergifyYamlText) {
+  const patterns = [];
+  for (const line of mergifyYamlText.split("\n")) {
+    const m = FILES_EXCLUDE_LINE.exec(line);
+    if (m && m[1]) patterns.push(new RegExp(m[1]));
+  }
+  return patterns;
+}
+
+export function isPathExcluded(files, patterns) {
+  return patterns.length > 0 && files.some((f) => patterns.some((p) => p.test(f)));
+}
+
+// ── Label timeline → "when did queue:ready last become active" ──────────────────────────────
+
+/**
+ * Latest time `labelName` became active, per the issue timeline. `null` if never applied in
+ * the fetched window, or if the most recent labeled/unlabeled event for it is an `unlabeled`.
+ */
+export function latestLabelAddedAt(events, labelName) {
+  let latest = null;
+  for (const e of events) {
+    if (e.label?.name !== labelName) continue;
+    if (e.event !== "labeled" && e.event !== "unlabeled") continue;
+    const at = Date.parse(e.created_at);
+    if (Number.isNaN(at)) continue;
+    if (!latest || at >= latest.at) latest = { at, applied: e.event === "labeled" };
+  }
+  return latest && latest.applied ? new Date(latest.at) : null;
+}
+
+// ── Comments → nudge history / queue status / refusal / prior alerts ────────────────────────
+
+export function latestNudgeAt(comments) {
+  let latest = null;
+  for (const c of comments) {
+    if (!c.body.includes(NUDGE_MARKER)) continue;
+    const at = Date.parse(c.created_at);
+    if (!Number.isNaN(at) && (latest === null || at > latest)) latest = at;
+  }
+  return latest === null ? null : new Date(latest);
+}
+
+export function isAlreadyQueued(comments) {
+  return comments.some(
+    (c) => c.user?.login === MERGIFY_BOT_LOGIN && c.body.includes(QUEUE_STATUS_HEADING)
+  );
+}
+
+export function hasPathExcludedAlert(comments) {
+  return comments.some((c) => c.body.includes(PATH_EXCLUDED_MARKER));
+}
+
+/**
+ * A `mergify[bot]` reply posted after our own last nudge that is NOT the queue-status heading
+ * is read as a refusal/explanation. Already surfaced refusals (a prior comment naming this
+ * comment id in a refusalMarker) are excluded, so surfacing stays idempotent without a second
+ * external state store.
+ */
+export function findUnsurfacedRefusal(comments, afterNudgeAt) {
+  if (!afterNudgeAt) return null;
+  const surfacedIds = new Set();
+  for (const c of comments) {
+    const m = /catalyst:merge-queue-watchdog:refusal-surfaced:(\d+)/.exec(c.body);
+    if (m) surfacedIds.add(Number(m[1]));
+  }
+  const candidates = comments.filter(
+    (c) =>
+      c.user?.login === MERGIFY_BOT_LOGIN &&
+      !c.body.includes(QUEUE_STATUS_HEADING) &&
+      Date.parse(c.created_at) > afterNudgeAt.getTime() &&
+      !surfacedIds.has(c.id)
+  );
+  if (candidates.length === 0) return null;
+  const earliest = candidates.reduce((a, b) =>
+    Date.parse(a.created_at) <= Date.parse(b.created_at) ? a : b
+  );
+  return {
+    commentId: earliest.id,
+    body: earliest.body,
+    createdAt: new Date(Date.parse(earliest.created_at)),
+  };
+}
+
+// ── Check runs → each required context's state, then the aggregate across all of them ───────
+
+/** Conclusions the ruleset itself treats as satisfying a required context (skip-tolerant). */
+export const SATISFYING_CONCLUSIONS = new Set(["success", "neutral", "skipped"]);
+
+/**
+ * Per-context state: "missing" (never ran), "pending" (not yet completed), "success"
+ * (completed with a satisfying conclusion), or "failure" (completed, unsatisfying).
+ * GitHub returns check-runs newest-first, so `find` picks the most recent run for this name.
+ */
+export function checkStateForContext(runs, contextName) {
+  const run = runs.find((r) => r.name === contextName);
+  if (!run) return "missing";
+  if (run.status !== "completed") return "pending";
+  return SATISFYING_CONCLUSIONS.has(run.conclusion) ? "success" : "failure";
+}
+
+/**
+ * Aggregates every required context's state with priority failure > pending > missing >
+ * success, and names which context(s) drove a non-success verdict — so a refusal reason (or
+ * the step summary) can say exactly "execution-core-unit-tests is still pending" instead of a
+ * bare "not ready".
+ */
+export function requiredChecksConclusion(runs, contextNames) {
+  const states = contextNames.map((name) => ({ name, state: checkStateForContext(runs, name) }));
+  const failing = states.filter((s) => s.state === "failure").map((s) => s.name);
+  if (failing.length > 0) return { conclusion: "failure", detail: failing.join(", ") };
+  const pending = states.filter((s) => s.state === "pending").map((s) => s.name);
+  if (pending.length > 0) return { conclusion: "pending", detail: pending.join(", ") };
+  const missing = states.filter((s) => s.state === "missing").map((s) => s.name);
+  if (missing.length > 0) return { conclusion: "missing", detail: missing.join(", ") };
+  return { conclusion: "success", detail: "" };
+}
+
+// ── Review threads ────────────────────────────────────────────────────────────────────────
+
+export function countUnresolvedThreads(threads) {
+  return threads.filter((t) => !t.isResolved).length;
+}
+
+// ── The decision core — pure, no I/O, no clock reads of its own ─────────────────────────────
+
+/**
+ * @typedef {object} PrEligibilityInput
+ * @property {number} number
+ * @property {string} baseRef
+ * @property {boolean} isDraft
+ * @property {readonly string[]} labels
+ * @property {readonly string[]} changedFiles
+ * @property {"success"|"failure"|"pending"|"missing"} checkConclusion
+ * @property {string} checkDetail
+ * @property {number} unresolvedThreadCount
+ * @property {Date|null} labeledAt
+ * @property {boolean} alreadyQueued
+ * @property {Date|null} lastNudgeAt
+ * @property {boolean} pathExcludedAlertAlreadyPosted
+ * @property {{commentId:number, body:string, createdAt:Date}|null} refusal
+ */
+
+export function decideAction(input, config, pathExclusionPatterns, now) {
+  if (input.baseRef !== config.baseRef) {
+    return { type: "none", reason: `base is ${input.baseRef}, not ${config.baseRef}` };
+  }
+  if (input.isDraft) return { type: "none", reason: "PR is a draft" };
+  if (!input.labels.includes(config.readyLabel)) {
+    return { type: "none", reason: `missing ${config.readyLabel} label` };
+  }
+
+  if (isPathExcluded(input.changedFiles, pathExclusionPatterns)) {
+    if (input.labels.includes(config.holdLabel) || input.pathExcludedAlertAlreadyPosted) {
+      return { type: "none", reason: "path-excluded; already alerted" };
+    }
+    return {
+      type: "alert-path-excluded",
+      reason: "changed files match a merge-queue path exclusion — this PR will never queue",
+    };
+  }
+
+  if (input.labels.includes(config.holdLabel)) {
+    return { type: "none", reason: `${config.holdLabel} present — manual protocol` };
+  }
+
+  if (input.alreadyQueued) {
+    return { type: "none", reason: "already queued (Merge Queue Status comment present)" };
+  }
+
+  if (input.refusal) {
+    return {
+      type: "surface-refusal",
+      reason: "Mergify replied to our nudge without queuing",
+      refusal: input.refusal,
+    };
+  }
+
+  if (input.checkConclusion !== "success") {
+    return {
+      type: "none",
+      reason: `required check(s) not satisfied (${input.checkConclusion}): ${input.checkDetail}`,
+    };
+  }
+
+  if (input.unresolvedThreadCount > 0) {
+    return { type: "none", reason: `${input.unresolvedThreadCount} unresolved review thread(s)` };
+  }
+
+  if (!input.labeledAt) {
+    return {
+      type: "none",
+      reason: `could not determine when ${config.readyLabel} was applied`,
+    };
+  }
+
+  const eligibleMs = now.getTime() - input.labeledAt.getTime();
+  const eligibleThresholdMs = config.eligibleMinutes * 60_000;
+  if (eligibleMs < eligibleThresholdMs) {
+    return {
+      type: "none",
+      reason: `eligible for ${Math.floor(eligibleMs / 60_000)}m, waiting for ${config.eligibleMinutes}m`,
+    };
+  }
+
+  if (input.lastNudgeAt) {
+    const sinceNudgeMs = now.getTime() - input.lastNudgeAt.getTime();
+    const cooldownMs = config.renudgeCooldownMinutes * 60_000;
+    if (sinceNudgeMs < cooldownMs) {
+      return {
+        type: "none",
+        reason: `nudged ${Math.floor(sinceNudgeMs / 60_000)}m ago, cooldown is ${config.renudgeCooldownMinutes}m`,
+      };
+    }
+  }
+
+  return {
+    type: "nudge",
+    reason: `eligible for ${Math.floor(eligibleMs / 60_000)}m without entering the queue`,
+  };
+}
+
+// ── The GitHub client — injectable I/O ───────────────────────────────────────────────────────
+
+const GITHUB_API = "https://api.github.com";
+const GITHUB_GRAPHQL = "https://api.github.com/graphql";
+const ACCEPT = "application/vnd.github+json";
+const USER_AGENT = "catalyst-merge-queue-watchdog";
+
+async function githubJson(fetchImpl, token, path, init) {
+  const res = await fetchImpl(`${GITHUB_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: ACCEPT,
+      "User-Agent": USER_AGENT,
+      ...(init?.body ? { "Content-Type": "application/json" } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `github ${init?.method ?? "GET"} ${path} failed (${res.status}): ${detail.slice(0, 300)}`
+    );
+  }
+  if (res.status === 204) return undefined;
+  return res.json();
+}
+
+const PAGE_SIZE = 100;
+
+/**
+ * Follows `page=`/`per_page=` pagination to exhaustion — a short last page (< PAGE_SIZE) ends
+ * the walk. `pathWithPage1` must already carry `per_page=100` and no `page` param. Every call
+ * site that decides eligibility from "the full set of X" (changed files, comments) needs
+ * this: a first-page-only read silently under-reports on anything larger than one page.
+ */
+async function githubJsonAllPages(fetchImpl, token, pathWithPage1) {
+  const out = [];
+  for (let page = 1; ; page++) {
+    const pageItems = await githubJson(fetchImpl, token, `${pathWithPage1}&page=${page}`);
+    out.push(...pageItems);
+    if (pageItems.length < PAGE_SIZE) break;
+  }
+  return out;
+}
+
+export function makeGithubClient(token, owner, repo, fetchImpl = fetch) {
+  return {
+    async listOpenPrsWithLabel(label) {
+      const raw = await githubJson(
+        fetchImpl,
+        token,
+        `/repos/${owner}/${repo}/pulls?state=open&per_page=100`
+      );
+      return raw
+        .filter((pr) => pr.labels.some((l) => l.name === label))
+        .map((pr) => ({
+          number: pr.number,
+          baseRef: pr.base.ref,
+          isDraft: pr.draft,
+          labels: pr.labels.map((l) => l.name),
+          headSha: pr.head.sha,
+        }));
+    },
+
+    async listChangedFiles(number) {
+      const raw = await githubJsonAllPages(
+        fetchImpl,
+        token,
+        `/repos/${owner}/${repo}/pulls/${number}/files?per_page=${PAGE_SIZE}`
+      );
+      return raw.map((f) => f.filename);
+    },
+
+    async listCheckRuns(sha) {
+      const raw = await githubJson(
+        fetchImpl,
+        token,
+        `/repos/${owner}/${repo}/commits/${sha}/check-runs?per_page=100`
+      );
+      return raw.check_runs;
+    },
+
+    async listUnresolvedThreadCount(number) {
+      const query = `query($owner:String!,$repo:String!,$num:Int!,$after:String){ repository(owner:$owner,name:$repo){ pullRequest(number:$num){ reviewThreads(first:100,after:$after){ nodes{ isResolved } pageInfo{ hasNextPage endCursor } } } } }`;
+      const allNodes = [];
+      let after = null;
+      for (;;) {
+        const res = await fetchImpl(GITHUB_GRAPHQL, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "User-Agent": USER_AGENT,
+          },
+          body: JSON.stringify({ query, variables: { owner, repo, num: number, after } }),
+        });
+        if (!res.ok) {
+          const detail = await res.text().catch(() => "");
+          throw new Error(`github graphql failed (${res.status}): ${detail.slice(0, 300)}`);
+        }
+        const json = await res.json();
+        if (json.errors?.length)
+          throw new Error(`github graphql errors: ${JSON.stringify(json.errors)}`);
+        const reviewThreads = json.data?.repository.pullRequest.reviewThreads;
+        allNodes.push(...(reviewThreads?.nodes ?? []));
+        if (!reviewThreads?.pageInfo.hasNextPage) break;
+        after = reviewThreads.pageInfo.endCursor;
+      }
+      return countUnresolvedThreads(allNodes);
+    },
+
+    async listLabelTimeline(number) {
+      const raw = await githubJson(
+        fetchImpl,
+        token,
+        `/repos/${owner}/${repo}/issues/${number}/timeline?per_page=100`
+      );
+      return raw
+        .filter((e) => e.event === "labeled" || e.event === "unlabeled")
+        .map((e) => ({ event: e.event, label: e.label, created_at: e.created_at }));
+    },
+
+    async listComments(number) {
+      return githubJsonAllPages(
+        fetchImpl,
+        token,
+        `/repos/${owner}/${repo}/issues/${number}/comments?per_page=${PAGE_SIZE}`
+      );
+    },
+
+    async postComment(number, body) {
+      await githubJson(fetchImpl, token, `/repos/${owner}/${repo}/issues/${number}/comments`, {
+        method: "POST",
+        body: JSON.stringify({ body }),
+      });
+    },
+
+    async swapLabels(number, removeLabel, addLabel) {
+      // Add BEFORE remove — idempotent (adding an already-present label is a no-op) — so a
+      // run that dies between the two calls leaves `removeLabel` in place. A future run then
+      // still lists this PR (the query filters on `removeLabel`) and retries the swap,
+      // instead of the PR falling through with neither label after a partial failure.
+      await githubJson(fetchImpl, token, `/repos/${owner}/${repo}/issues/${number}/labels`, {
+        method: "POST",
+        body: JSON.stringify({ labels: [addLabel] }),
+      });
+      const res = await fetchImpl(
+        `${GITHUB_API}/repos/${owner}/${repo}/issues/${number}/labels/${encodeURIComponent(removeLabel)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}`, Accept: ACCEPT, "User-Agent": USER_AGENT },
+        }
+      );
+      // A label already gone (race with a human) is not an error worth aborting the run over.
+      if (!res.ok && res.status !== 404) {
+        const detail = await res.text().catch(() => "");
+        throw new Error(
+          `github DELETE label ${removeLabel} failed (${res.status}): ${detail.slice(0, 300)}`
+        );
+      }
+    },
+  };
+}
+
+// ── Orchestration ─────────────────────────────────────────────────────────────────────────
+
+export async function gatherPrInput(client, pr, config) {
+  const [changedFiles, checkRuns, unresolvedThreadCount, timeline, comments] = await Promise.all([
+    client.listChangedFiles(pr.number),
+    client.listCheckRuns(pr.headSha),
+    client.listUnresolvedThreadCount(pr.number),
+    client.listLabelTimeline(pr.number),
+    client.listComments(pr.number),
+  ]);
+  const lastNudgeAt = latestNudgeAt(comments);
+  const checks = requiredChecksConclusion(checkRuns, config.requiredCheckContexts);
+  return {
+    number: pr.number,
+    baseRef: pr.baseRef,
+    isDraft: pr.isDraft,
+    labels: pr.labels,
+    changedFiles,
+    checkConclusion: checks.conclusion,
+    checkDetail: checks.detail,
+    unresolvedThreadCount,
+    labeledAt: latestLabelAddedAt(timeline, config.readyLabel),
+    alreadyQueued: isAlreadyQueued(comments),
+    lastNudgeAt,
+    pathExcludedAlertAlreadyPosted: hasPathExcludedAlert(comments),
+    refusal: findUnsurfacedRefusal(comments, lastNudgeAt),
+  };
+}
+
+export async function runOnce(client, config, mergifyYamlText, now, log) {
+  const patterns = parsePathExclusionPatterns(mergifyYamlText);
+  const prs = await client.listOpenPrsWithLabel(config.readyLabel);
+  log(`merge-queue-watchdog: ${prs.length} open PR(s) carry ${config.readyLabel}`);
+
+  let nudged = 0;
+  let alertedPathExcluded = 0;
+  let refusalsSurfaced = 0;
+  let errors = 0;
+
+  for (const pr of prs) {
+    try {
+      const input = await gatherPrInput(client, pr, config);
+      const action = decideAction(input, config, patterns, now);
+      log(`  #${pr.number}: ${action.type} — ${action.reason}`);
+
+      if (action.type === "nudge") {
+        await client.postComment(pr.number, `@Mergifyio queue\n\n${NUDGE_MARKER}`);
+        nudged++;
+      } else if (action.type === "alert-path-excluded") {
+        // Labels BEFORE the marker comment: if the swap throws, the marker never gets
+        // recorded, so a PR left in a half-swapped state (or not swapped at all) is retried
+        // on the next scheduled run instead of being silently treated as "already alerted".
+        if (config.swapToHoldLabel) {
+          await client.swapLabels(pr.number, config.readyLabel, config.holdLabel);
+        }
+        const swapNote = config.swapToHoldLabel ? ` Swapping to \`${config.holdLabel}\`.` : "";
+        await client.postComment(
+          pr.number,
+          `⚠️ \`${config.readyLabel}\` is set but this PR's changed files match a merge-queue ` +
+            `path exclusion — it will never enter the queue automatically. Follow the manual ` +
+            `merge protocol.${swapNote}\n\n${PATH_EXCLUDED_MARKER}`
+        );
+        alertedPathExcluded++;
+      } else if (action.type === "surface-refusal") {
+        const quoted = action.refusal.body
+          .split("\n")
+          .map((l) => `> ${l}`)
+          .join("\n");
+        await client.postComment(
+          pr.number,
+          `⚠️ Mergify replied to the automated \`@Mergifyio queue\` nudge without queuing ` +
+            `this PR:\n\n${quoted}\n\n${refusalMarker(action.refusal.commentId)}`
+        );
+        refusalsSurfaced++;
+      }
+    } catch (err) {
+      errors++;
+      log(`  #${pr.number}: ERROR — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { processed: prs.length, nudged, alertedPathExcluded, refusalsSurfaced, errors };
+}
+
+// ── main — the whole CLI, minus process.exit, so tests drive it offline ─────────────────────
+
+export async function main(_argv, deps = {}) {
+  const log = deps.log ?? ((line) => console.log(line));
+  const env = deps.env ?? process.env;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const now = deps.now ?? new Date();
+
+  const token = env.GITHUB_TOKEN;
+  if (!token) {
+    log("merge-queue-watchdog: GITHUB_TOKEN is not set");
+    return { exitCode: 1 };
+  }
+
+  const config = DEFAULT_CONFIG;
+  const readMergifyYaml =
+    deps.readMergifyYaml ?? (() => readFileSync(join(ROOT, ".mergify.yml"), "utf8"));
+
+  let mergifyYamlText;
+  try {
+    mergifyYamlText = readMergifyYaml();
+  } catch (err) {
+    log(
+      `merge-queue-watchdog: could not read .mergify.yml — ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { exitCode: 1 };
+  }
+
+  const client = makeGithubClient(token, config.owner, config.repo, fetchImpl);
+
+  let summary;
+  try {
+    summary = await runOnce(client, config, mergifyYamlText, now, log);
+  } catch (err) {
+    log(`merge-queue-watchdog: ${err instanceof Error ? err.message : String(err)}`);
+    return { exitCode: 1 };
+  }
+
+  log(
+    `merge-queue-watchdog: processed=${summary.processed} nudged=${summary.nudged} ` +
+      `path-excluded=${summary.alertedPathExcluded} refusals-surfaced=${summary.refusalsSurfaced} ` +
+      `errors=${summary.errors}`
+  );
+
+  const stepSummaryPath = env.GITHUB_STEP_SUMMARY;
+  if (stepSummaryPath) {
+    const writeStepSummary =
+      deps.writeStepSummary ?? ((text) => appendFileSync(stepSummaryPath, text));
+    writeStepSummary(
+      `### Merge queue watchdog\n\n` +
+        `- Open PRs with \`${config.readyLabel}\`: ${summary.processed}\n` +
+        `- Nudged: ${summary.nudged}\n` +
+        `- Path-excluded alerts: ${summary.alertedPathExcluded}\n` +
+        `- Refusals surfaced: ${summary.refusalsSurfaced}\n` +
+        `- Errors: ${summary.errors}\n`
+    );
+  }
+
+  return { exitCode: summary.errors > 0 ? 1 : 0 };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).then((result) => {
+    process.exitCode = result.exitCode;
+  });
+}

--- a/scripts/merge-queue-watchdog.mjs
+++ b/scripts/merge-queue-watchdog.mjs
@@ -23,7 +23,13 @@
 // exactly as .mergify.yml's own queue_conditions already spell it (see that file's header: a
 // bare success-only test would be STRICTER than the ruleset and would deadlock on a
 // legitimately-skipped job). `requiredCheckContexts` is therefore a list, and
-// `requiredChecksConclusion` aggregates every context's own three-way state.
+// `requiredChecksConclusion` aggregates every context's own three-way state. `.mergify.yml`
+// also gates three NON-required-but-always-evaluated checks the same three-way way
+// (packaging-gate, skills-gate, check-plugin-manifest-parity) and one in a NEGATIVE
+// active-only form (`quality`, path-filtered and therefore absent on most PRs) — the watchdog
+// must mirror every gate Mergify actually evaluates, not just the ruleset-required subset, or
+// it can declare a PR eligible that Mergify is certain to refuse (Codex P2, this ticket's own
+// PR). `combinedCheckConclusion` folds both forms into one verdict.
 //
 // PATH EXCLUSIONS ARE READ, NEVER DUPLICATED. This script parses the live `-files~=<pattern>`
 // conditions straight out of `.mergify.yml` at runtime — a small line-oriented extractor, not
@@ -71,11 +77,22 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
  * @property {string} readyLabel
  * @property {string} holdLabel
  * @property {readonly string[]} requiredCheckContexts
+ * @property {readonly string[]} negativeGateContexts
  * @property {number} eligibleMinutes
  * @property {number} renudgeCooldownMinutes
  * @property {boolean} swapToHoldLabel
  */
 
+/**
+ * requiredCheckContexts covers every `.mergify.yml` queue_conditions entry gated in the
+ * `or: [check-success=X, check-neutral=X, check-skipped=X]` three-way form — the six
+ * ruleset-required contexts PLUS the three non-required-but-always-gating ones
+ * (packaging-gate, skills-gate, check-plugin-manifest-parity). Nudging while any of these
+ * nine is unsatisfied would send a `@Mergifyio queue` command Mergify is certain to refuse
+ * (Codex P2 on this ticket's own PR: the watchdog must mirror EVERY gate `.mergify.yml`
+ * actually evaluates, not just the ruleset-required subset, or it declares a PR eligible
+ * that Mergify will not embark).
+ */
 /** @type {WatchdogConfig} */
 export const DEFAULT_CONFIG = {
   owner: "coalesce-labs",
@@ -90,7 +107,16 @@ export const DEFAULT_CONFIG = {
     "audit-references",
     "check-versions",
     "execution-core-unit-tests",
+    "packaging-gate",
+    "skills-gate",
+    "check-plugin-manifest-parity",
   ],
+  // `quality` is path-filtered at its own `on:` trigger, so on most PRs it never runs at
+  // all — `.mergify.yml` deliberately gates it with `-check-failure=quality` /
+  // `-check-pending=quality` (block only while ACTIVE and unsatisfied) rather than the
+  // three-way success/neutral/skipped form, because an absent check satisfies none of
+  // those and would deadlock every PR that doesn't trigger it. See negativeGateConclusion.
+  negativeGateContexts: ["quality"],
   eligibleMinutes: 10,
   renudgeCooldownMinutes: 20,
   swapToHoldLabel: true,
@@ -227,6 +253,43 @@ export function requiredChecksConclusion(runs, contextNames) {
   const missing = states.filter((s) => s.state === "missing").map((s) => s.name);
   if (missing.length > 0) return { conclusion: "missing", detail: missing.join(", ") };
   return { conclusion: "success", detail: "" };
+}
+
+/**
+ * The `-check-failure=X` / `-check-pending=X` negative-gate form `.mergify.yml` uses for a
+ * path-filtered check like `quality`: it blocks the queue only while the check is ACTIVE and
+ * unsatisfied (failure or still running), and — unlike requiredChecksConclusion — a context
+ * that never ran at all (`missing`) is NOT blocking, since most PRs never trigger it at all.
+ */
+export function negativeGateConclusion(runs, contextNames) {
+  const states = contextNames.map((name) => ({ name, state: checkStateForContext(runs, name) }));
+  const failing = states.filter((s) => s.state === "failure").map((s) => s.name);
+  if (failing.length > 0) return { conclusion: "failure", detail: failing.join(", ") };
+  const pending = states.filter((s) => s.state === "pending").map((s) => s.name);
+  if (pending.length > 0) return { conclusion: "pending", detail: pending.join(", ") };
+  return { conclusion: "success", detail: "" };
+}
+
+const CONCLUSION_RANK = { failure: 0, pending: 1, missing: 2, success: 3 };
+
+/**
+ * Combines the three-way required-checks verdict with the negative-gate verdict into one
+ * `CheckConclusion`, picking whichever is more blocking (lower rank). When both are
+ * non-success at the same rank (e.g. both "pending"), their details are concatenated so
+ * neither outstanding context is silently dropped from the reported reason.
+ */
+export function combinedCheckConclusion(runs, config) {
+  const required = requiredChecksConclusion(runs, config.requiredCheckContexts);
+  const negativeGate = negativeGateConclusion(runs, config.negativeGateContexts ?? []);
+  if (CONCLUSION_RANK[negativeGate.conclusion] < CONCLUSION_RANK[required.conclusion]) {
+    return negativeGate;
+  }
+  if (CONCLUSION_RANK[required.conclusion] < CONCLUSION_RANK[negativeGate.conclusion]) {
+    return required;
+  }
+  if (required.conclusion === "success") return required;
+  const detail = [required.detail, negativeGate.detail].filter(Boolean).join(", ");
+  return { conclusion: required.conclusion, detail };
 }
 
 // ── Review threads ────────────────────────────────────────────────────────────────────────
@@ -382,10 +445,12 @@ async function githubJsonAllPages(fetchImpl, token, pathWithPage1) {
 export function makeGithubClient(token, owner, repo, fetchImpl = fetch) {
   return {
     async listOpenPrsWithLabel(label) {
-      const raw = await githubJson(
+      // Paginated (Codex P2): a repo with more than one page of open PRs would otherwise
+      // silently miss a `queue:ready` PR on a later page and report zero ready PRs.
+      const raw = await githubJsonAllPages(
         fetchImpl,
         token,
-        `/repos/${owner}/${repo}/pulls?state=open&per_page=100`
+        `/repos/${owner}/${repo}/pulls?state=open&per_page=${PAGE_SIZE}`
       );
       return raw
         .filter((pr) => pr.labels.some((l) => l.name === label))
@@ -446,10 +511,15 @@ export function makeGithubClient(token, owner, repo, fetchImpl = fetch) {
     },
 
     async listLabelTimeline(number) {
-      const raw = await githubJson(
+      // Paginated (Codex P2): a PR with more than one page of timeline events would
+      // otherwise miss a `queue:ready` labeled event on a later page, and
+      // latestLabelAddedAt would return null or a stale label state — decideAction then
+      // permanently skips an otherwise-eligible PR because it can never determine when the
+      // label was applied.
+      const raw = await githubJsonAllPages(
         fetchImpl,
         token,
-        `/repos/${owner}/${repo}/issues/${number}/timeline?per_page=100`
+        `/repos/${owner}/${repo}/issues/${number}/timeline?per_page=${PAGE_SIZE}`
       );
       return raw
         .filter((e) => e.event === "labeled" || e.event === "unlabeled")
@@ -509,7 +579,7 @@ export async function gatherPrInput(client, pr, config) {
     client.listComments(pr.number),
   ]);
   const lastNudgeAt = latestNudgeAt(comments);
-  const checks = requiredChecksConclusion(checkRuns, config.requiredCheckContexts);
+  const checks = combinedCheckConclusion(checkRuns, config);
   return {
     number: pr.number,
     baseRef: pr.baseRef,


### PR DESCRIPTION
## Summary

- Ports catalyst-cloud's CTC-1218 merge-queue watchdog (`scripts/merge-queue-watchdog.ts`) to this repo as `scripts/merge-queue-watchdog.mjs`, so a `queue:ready` PR that Mergify dequeues for a transient reason (e.g. a required check that simply hasn't reported yet) gets automatically re-nudged instead of sitting until a human re-types `@Mergifyio queue`.
- **Measured incident that motivates this**: PR #4066 entered the queue 2026-08-29T04:02:45Z and was dequeued at 04:09Z because `execution-core-unit-tests` hadn't reported a conclusion yet (started 04:11:30Z) while every other check was already green.
- **The one real generalization**: catalyst-cloud has a single required context (`Check`). This repo's ruleset (id 13503799) requires **six** contexts (`docs-gate`, `gitleaks`, `agents-md-gate`, `audit-references`, `check-versions`, `execution-core-unit-tests`), each satisfied in the skip-tolerant `success OR neutral OR skipped` form `.mergify.yml`'s own `queue_conditions` already use. `requiredCheckContext: string` becomes `requiredCheckContexts: string[]`, aggregated by a new `requiredChecksConclusion` (priority `failure > pending > missing > success`, naming exactly which context(s) are outstanding).
- Carries over unchanged in mechanism: the runtime `-files~=` path-exclusion extractor reading `.mergify.yml` live (verified it picks up this repo's three exclusions — publish- workflows, db-migrations, `.mergify.yml` itself — with zero edits), the path-excluded alert + `queue:ready`→`hold:hand-steps` label swap, job-log + `$GITHUB_STEP_SUMMARY` + PR-comment surfacing, the `if: github.repository == …` fork guard, and keeping the live (network-calling) script out of the test gate.
- Ported to plain ES-module JS (`#!/usr/bin/env node`, no TypeScript) matching this repo's `scripts/md-reflow.mjs` convention, since the top-level `scripts/` directory has no TS toolchain. Offline spec uses `node:test` (precedent: `plugins/dev/scripts/project-onboarding/__tests__/*.test.mjs`) — 74 cases, all green locally, including new table cases for the multi-required-check form (all-success, neutral, skipped, one-pending reproducing the #4066 incident shape exactly, failure-takes-priority-over-pending, missing, multiple-pending-named).
- New workflow `.github/workflows/merge-queue-watchdog.yml` (`schedule: */10 * * * *` + `workflow_dispatch`).
- **Wired the offline spec into the required gate explicitly**: this repo's `execution-core-unit-tests` job has no glob test runner — it's a hand-maintained list of pinned suites — so a new `.test.mjs` file left unregistered would silently never run in CI (the exact defect class this repo has hit before, e.g. `project-onboarding/__tests__/*.test.mjs`, confirmed still unregistered anywhere). Added an explicit `node --test scripts/__tests__/merge-queue-watchdog.test.mjs` step, plus the module's own path (mirroring the existing `scripts/md-reflow.mjs` entries) to both the `on.push.paths` and `dorny/paths-filter` lists so a future PR touching only the module still triggers the required check.

## Test plan

- [x] `node --test scripts/__tests__/merge-queue-watchdog.test.mjs` — 74/74 green locally
- [x] `node scripts/merge-queue-watchdog.mjs` with no `GITHUB_TOKEN` unset → exits 1 as expected; with a real token → correctly lists 0 open `queue:ready` PRs against the live repo right now (safe read-only smoke test)
- [x] Manually verified `.mergify.yml`'s three `-files~=` lines extract correctly via the ported (unmodified) extractor
- [x] `gitleaks` clean on the new files
- [ ] Post-merge: `workflow_dispatch` a live run and confirm green
- [ ] Post-merge: point at a real re-nudged PR (the ticket's behavioral acceptance criterion) — #4066 is already merged, so this needs a fresh live specimen once the workflow is on `main`

CTL-2285