### PR TITLE
fix(dev): CTC-1384 — remediate-plan skill drops the same-session-as-validate assumption

### DIFF
--- a/plugins/dev/skills/remediate-plan/SKILL.md
+++ b/plugins/dev/skills/remediate-plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: remediate-plan
 description:
-  "Fixes what /catalyst-dev:validate-plan just found, in the same session. Consumes validate-plan's actual output — the Validation Report it renders into the conversation, since validate-plan has no Write tool and produces no verify.json — and applies the fixes directly via Edit/Write, re-runs a scoped gate, and commits. Use right after validate-plan reports FAIL or PARTIAL, especially inside a /relay-ticket session: relay-ticket's phase list names '(→ remediate)' but the only other remediation-shaped skill, phase-remediate, is bound to the daemon-era verify.json contract relay-ticket does not produce — this is the relay-native replacement (CTL-2243). Not for a fresh implementation pass; scope stays to what the Validation Report named."
+  "Fixes what /catalyst-dev:validate-plan found. Consumes validate-plan's Validation Report from either of two places — the report rendered into this conversation by a same-session validate-plan run (validate-plan has no Write tool and produces no verify.json), or a persisted report handed to a fresh session as a materialized prior-artifact file whose path the dispatch prompt names (the cloud runner's path — CTC-1384) — then applies the fixes directly via Edit/Write, re-runs a scoped gate, and commits. Use right after validate-plan reports FAIL or PARTIAL, or when dispatched as a remediate session with a validation report on disk, especially inside a /relay-ticket session: relay-ticket's phase list names '(→ remediate)' but the only other remediation-shaped skill, phase-remediate, is bound to the daemon-era verify.json contract relay-ticket does not produce — this is the relay-native replacement (CTL-2243). Not for a fresh implementation pass; scope stays to what the Validation Report named."
 disable-model-invocation: false
 user-invocable: true
 allowed-tools: Read, Grep, Glob, Bash, Edit, Write, Task
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Remediate Plan
@@ -16,11 +16,16 @@ Read `plugins/dev/skills/validate-plan/SKILL.md` for the schema this skill reads
 
 ## When to run it
 
-Only in the same session as the validate-plan run that produced the report you are fixing. There is no persisted, verify.json-equivalent artifact to hand to a fresh session, and a relay worker cannot self-sustain a wait for one or hand off to a background job. If no Validation Report is in context yet, run `/catalyst-dev:validate-plan` first, in this session, before invoking this skill.
+Two modes, same report, same steps:
+
+- **Same-session (laptop):** right after a `/catalyst-dev:validate-plan` run in this session reported FAIL or PARTIAL — its Validation Report is sitting in the conversation.
+- **Fresh session (cloud dispatch):** the session was dispatched to remediate a validate failure and the persisted Validation Report is a real file on disk — primarily a materialized prior-artifact file (the runner fetches the failed validate phase's `validation.md` from the R2 artifact store and your dispatch prompt names its local path); failing that, a thoughts doc or Linear attachment the prompt points at.
+
+If no Validation Report is in context and no report file is named in your prompt, run `/catalyst-dev:validate-plan` first, in this session, before invoking this skill.
 
 ## Steps
 
-1. **Read the Validation Report** already in context — every gate failure, every deviation and potential issue, and any manual-testing item that is actually automatable.
+1. **Read the Validation Report** — from the conversation if a same-session validate-plan run produced one, otherwise from the prior-artifact path (or fallback location) named in your prompt. Take in every gate failure, every deviation and potential issue, and any manual-testing item that is actually automatable. If neither source exists, stop and run `/catalyst-dev:validate-plan` first.
 2. **Triage**: fix now vs. defer. Anything that would keep the report's own verdict off PASS is must-fix; a bullet the report itself calls an "improvement" is not.
 3. **Apply fixes** via Edit/Write, scoped to the files the report named — this is a fix pass, not a redesign.
 4. **Re-run a targeted gate** (this repo's `bun run check`, or the touched workspace's slice of it) and print the real `exit 0` to the transcript.

--- a/plugins/dev/skills/remediate-plan/references/single-session-fix.md
+++ b/plugins/dev/skills/remediate-plan/references/single-session-fix.md
@@ -2,9 +2,9 @@
 
 ## Why there is no verify.json here
 
-`phase-remediate` (daemon-era) reads `${ORCH_DIR}/workers/<ticket>/verify.json`, a structured file written by `phase-verify` (`allowed-tools` include Write). `validate-plan` is a different skill with a different contract — read `plugins/dev/skills/validate-plan/SKILL.md` for its `allowed-tools` and its "Step 3: Generate Validation Report" section, which ends in a markdown block the skill renders as its own response rather than a file it writes. That block, sitting in the conversation, is the artifact. Any remediate step for validate-plan has to consume that in-session text, not a file — which is why this skill has to run in the same session: the report does not outlive the conversation that produced it. Do not re-derive validate-plan's report schema here; read it from the owning skill so this file never goes stale against it.
+`phase-remediate` (daemon-era) reads `${ORCH_DIR}/workers/<ticket>/verify.json`, a structured file written by `phase-verify` (`allowed-tools` include Write). `validate-plan` is a different skill with a different contract — read `plugins/dev/skills/validate-plan/SKILL.md` for its `allowed-tools` and its "Step 3: Generate Validation Report" section, which ends in a markdown block the skill renders as its own response rather than a file it writes. In a laptop session that block, sitting in the conversation, is the artifact — which is why the same-session mode reads it from context. The cloud runner is the exception that makes the fresh-session mode possible: when a cloud validate phase fails, the runner persists the session's `validation.md` to the R2 artifact store and a later remediate dispatch materializes it back to a real local file whose path the dispatch prompt names (CTC-1384). Either way, do not re-derive validate-plan's report schema here; read it from the owning skill so this file never goes stale against it.
 
-## Worked example
+## Worked example (same-session mode)
 
 A validate-plan run reports a failing test suite in `packages/schema` and a missing index on a new foreign key, with a `file:line` pointer. `remediate-plan`'s pass:
 
@@ -14,6 +14,8 @@ A validate-plan run reports a failing test suite in `packages/schema` and a miss
 4. Commit: `fix(schema): CTL-NNNN remediate validate-plan findings (missing index, failing tests)`.
 5. Re-run `/catalyst-dev:validate-plan` against the same plan. A clean report — no more failing gates, the bullets gone — is the only evidence the fix worked; this skill's own transcript claiming so is not.
 
+The fresh-session (cloud) mode runs the same pass; the only difference is step 0 — the report is read from the materialized prior-artifact file the dispatch prompt names instead of from the conversation.
+
 ## Relation to relay-ticket's phase list
 
-`relay-ticket`'s phase list includes `(→ remediate)` after `validate`. Until a `/relay-ticket` session's validate phase exists to invoke this automatically, invoke it explicitly: `/catalyst-dev:remediate-plan`, in the same session as the validate-plan run whose report you are fixing. There is no background dispatch path — a relay worker cannot hand off this fix to a `claude --bg` job the way `phase-agent-dispatch` handed work to `phase-remediate`, and it cannot self-sustain a wait for one to finish, so the whole read → fix → re-verify cycle has to complete in this one invocation.
+`relay-ticket`'s phase list includes `(→ remediate)` after `validate`. In a laptop `/relay-ticket` session, invoke this skill explicitly — `/catalyst-dev:remediate-plan` — in the same session as the validate-plan run whose report you are fixing: a laptop relay worker has no persisted report to hand to a background job and cannot self-sustain a wait for one, so its read → fix → re-verify cycle completes in this one invocation. A cloud remediate session is the dispatched fresh-session mode instead: it starts with the persisted report already materialized on disk and runs the same cycle from that file.


### PR DESCRIPTION
## Summary

Leg B of CTC-1384 (remediate router). The remediate-plan skill's stated precondition — "Only in the same session as the validate-plan run that produced the report" — is violated by construction on every cloud remediate dispatch, which is always a fresh session. The cloud runner's remediate-prompt previously papered over it in its own JSDoc.

This PR makes the skill honest for both execution modes (2 files, +14/−7):

- **`plugins/dev/skills/remediate-plan/SKILL.md`** — the description and "When to run it" now name two modes: same-session after a laptop validate-plan run (report read from the conversation), and a fresh cloud session handed a persisted Validation Report as a **materialized prior-artifact file** whose path the dispatch prompt names — R2 artifact store primary, thoughts doc / Linear attachment fallback. Step 1 reads from context if a same-session run produced a report, otherwise from the named file; only when neither exists does it fall back to running validate-plan first. The "There is no persisted, verify.json-equivalent artifact" claim is dropped — CTC-1384's runner leg (catalyst-cloud PR #2069) persists a failed validate's `validation.md` to R2 under the standard nonce-scoped artifact key and materializes it via the existing `priorArtifacts` mechanism to `$CATALYST_ARTIFACT_DIR/prior/validation.md`. Skill frontmatter `version` 1.0.0 → 1.1.0.
- **`references/single-session-fix.md`** — the same-session rationale is scoped to laptop sessions, the worked example is labeled as the same-session mode with a one-line note on how the cloud mode differs (step 0 reads the file), and the relay-ticket section describes the cloud fresh-session mode instead of asserting the cycle must be single-session.
- Steps 2–6, phase-completion evidence, and the phase-remediate disambiguation stand unchanged, per the plan. No hard-wrapped prose.

Plan: `thoughts/shared/plans/2026-09-01-CTC-1384-remediate-router.md` (Phase 6, leg B).

## Validation

Scope-checked as part of CTC-1384's coordinator-verified validation (round 2, PASS — `thoughts/shared/research/2026-09-01-CTC-1384-validation-round2.md`): in scope, matches the plan, no stray edits. PR CI is green (CodeQL, agents-md-gate, audit-references, check-plugin-manifest-parity, check-versions, detect-changes).

## Gate

- `plugins/dev/skills/__tests__/skill-shape.test.sh`: 159 passed, 0 failed
- `project-orchestrator-shape.test.sh`, `handoff-contract.test.sh`: pass
- No plugin manifest version bump in this PR: conventional-commit escape hatch (release-please bumps post-merge, per `scripts/check-plugin-version.sh`)

## What follows this PR (coordinator-owned)

This PR is independent of the catalyst-cloud router PR and can merge any time. The skill reaches cloud containers only via the pinned bundle: after merge, bump `CATALYST_PLUGIN_BUNDLE_REF` in catalyst-cloud's `images/runner/Dockerfile` (`scripts/verify-baked-skills.ts` must pass), rebuild the runner image, and land that pin PR. Until the pin moves, cloud sessions keep running the old SKILL.md under the runner's existing override, which stays authoritative in the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
