### PR TITLE
feat(dev): CTL-2299 — the human, the ask team and the dispatch verb come from the tenant, not from us

### DIFF
--- a/.catalyst/config.json
+++ b/.catalyst/config.json
@@ -1,6 +1,10 @@
 {
   "catalyst": {
     "projectKey": "catalyst-workspace",
+    "human": {
+      "linearUserId": "c2a8cc92-cab6-4536-9500-0f24abdf702b",
+      "name": "Ryan"
+    },
     "project": {
       "ticketPrefix": "CTL"
     },

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -886,6 +886,22 @@ jobs:
         working-directory: plugins/dev/scripts/lib
         run: bun test comment-body-arg.test.mjs
 
+      - name: tenant-identity resolver + fleet-owner-literal scan (bun, CTL-2299)
+        # lib/tenant-identity.mjs resolves WHO the human is, WHICH team an ask is filed on,
+        # and WHAT the status doc calls them — from the tenant's own config, with no
+        # person-shaped fallback. Own step for the same reason as the three leaves above:
+        # it sits outside the execution-core/ tree the "Run stable unit tests" step below is
+        # scoped to, so it needs an explicit run: line or it never executes in CI.
+        #
+        # The suite's second half is a CORPUS SCAN asserting the fleet owner's Linear user
+        # id appears in no shipped skill text and no default — the guard for the rule this
+        # ticket enforces, registered in the SAME change that adds it (the
+        # four-times-burned exec-core-stable-test-allowlist lesson). Positive control:
+        # `grep -n tenant-identity.test .github/workflows/execution-core-tests.yml` returns
+        # this run: line.
+        working-directory: plugins/dev/scripts/lib
+        run: bun test tenant-identity.test.mjs
+
       - name: ask-verb unit tests (bun, CTL-1922 / CTL-1944)
         # ⛔ `ask-verbs.test.mjs` shipped with #3509 and was registered in NO workflow —
         # 20 tests that had never run in CI. Verified with the instrument note above:

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -307,10 +307,25 @@ jobs:
       # It was only visible because those suites plant positive controls. A guard that scans for
       # the absence of a token, with no planted control, would have gone GREEN here while checking
       # nothing at all — which is the failure this whole epic is about.
+      # ⛔ `apt-get update` is NOT allowed to be the gate. The hosted runner image ships
+      # third-party apt sources we neither control nor need — and on 2026-09-09 Google's
+      # `dl.google.com/linux/chrome-stable` served a `Packages.gz` whose hash did not match
+      # its own Release file, so `apt-get update -qq` exited 100 and, under `bash -e`, killed
+      # this step before `install ripgrep` ever ran. Every PR in the repo went red on a step
+      # that had not yet done anything, and rerunning did not help because the bad index was
+      # not transient. ripgrep comes from the UBUNTU ARCHIVE, so an unrelated repo's broken
+      # index has no bearing on whether it can be installed.
+      #
+      # The tolerance is scoped precisely: the update is allowed to report errors, the
+      # INSTALL is not, and `rg --version` still has to succeed. So a genuinely unreachable
+      # Ubuntu archive fails this step exactly as loudly as before — which matters, because
+      # the whole reason this step exists is that a missing `rg` makes the scan suites read
+      # an empty tree and pass while checking nothing.
       - name: Install ripgrep (required by the scan-based suites)
         working-directory: .
         run: |
-          sudo apt-get update -qq
+          sudo apt-get update -qq \
+            || echo "::warning::apt-get update reported errors (third-party repo index); continuing — ripgrep comes from the Ubuntu archive and the install below still has to succeed"
           sudo apt-get install -y -qq ripgrep
           rg --version
 

--- a/.github/workflows/execution-core-tests.yml
+++ b/.github/workflows/execution-core-tests.yml
@@ -307,25 +307,36 @@ jobs:
       # It was only visible because those suites plant positive controls. A guard that scans for
       # the absence of a token, with no planted control, would have gone GREEN here while checking
       # nothing at all — which is the failure this whole epic is about.
-      # ⛔ `apt-get update` is NOT allowed to be the gate. The hosted runner image ships
-      # third-party apt sources we neither control nor need — and on 2026-09-09 Google's
-      # `dl.google.com/linux/chrome-stable` served a `Packages.gz` whose hash did not match
-      # its own Release file, so `apt-get update -qq` exited 100 and, under `bash -e`, killed
-      # this step before `install ripgrep` ever ran. Every PR in the repo went red on a step
-      # that had not yet done anything, and rerunning did not help because the bad index was
-      # not transient. ripgrep comes from the UBUNTU ARCHIVE, so an unrelated repo's broken
-      # index has no bearing on whether it can be installed.
+      # ⛔ A THIRD-PARTY APT SOURCE MUST NOT BE ABLE TO FAIL THIS JOB. The hosted runner image
+      # ships apt sources for software this job never installs, and on 2026-09-09 Google's
+      # `dl.google.com/linux/chrome-stable` served a `Packages.gz` whose hash did not match its
+      # own Release file. `apt-get update` exits 100 on that, and under `bash -e` it killed the
+      # ripgrep step before `install` ever ran — every PR in the repo red on a step that had not
+      # yet done anything, and rerunning did not help, because the bad index was not transient.
       #
-      # The tolerance is scoped precisely: the update is allowed to report errors, the
-      # INSTALL is not, and `rg --version` still has to succeed. So a genuinely unreachable
-      # Ubuntu archive fails this step exactly as loudly as before — which matters, because
-      # the whole reason this step exists is that a missing `rg` makes the scan suites read
-      # an empty tree and pass while checking nothing.
+      # Fixed ONCE, here, rather than by making each `apt-get update` tolerant: this job runs
+      # three of them (ripgrep below, direnv, zsh) and they must keep their identical fail-closed
+      # shape — a `|| true` at each site would also swallow a genuinely unreachable Ubuntu
+      # archive, which is the case that MUST stay red. Dropping the source we do not use leaves
+      # every apt call strict against the archive it actually installs from.
+      #
+      # Scoped to `sources.list.d` entries naming dl.google.com, and a no-op when there are none
+      # (a future runner image that ships no such source is not an error).
+      - name: Neutralise unused third-party apt sources
+        working-directory: .
+        run: |
+          hits=$(grep -rlE 'dl\.google\.com' /etc/apt/sources.list.d 2>/dev/null || true)
+          if [ -n "$hits" ]; then
+            echo "removing unused third-party apt sources:"; echo "$hits"
+            echo "$hits" | sudo xargs -r rm -f
+          else
+            echo "no dl.google.com apt source present — nothing to remove"
+          fi
+
       - name: Install ripgrep (required by the scan-based suites)
         working-directory: .
         run: |
-          sudo apt-get update -qq \
-            || echo "::warning::apt-get update reported errors (third-party repo index); continuing — ripgrep comes from the Ubuntu archive and the install below still has to succeed"
+          sudo apt-get update -qq
           sudo apt-get install -y -qq ripgrep
           rg --version
 

--- a/plugins/dev/scripts/__tests__/linear-ack-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-ack-write-path.test.sh
@@ -58,6 +58,11 @@ else
   bad "linear-ack.mjs failed node --check"
 fi
 
+HUMAN="11111111-2222-3333-4444-555555555555"
+# CTL-2299: the tool no longer carries a baked-in human id — it resolves the tenant's
+# configured one and refuses when there is none. Declare the identity this suite seeds.
+export ASK_HUMAN_ID="$HUMAN"
+
 # --- Hermetic replica seeding helper ---
 seed_replica() { # $1=db path  $2=with_human_comment(1/0)
   local db="$1" withc="$2"
@@ -69,7 +74,7 @@ CREATE TABLE comments (id TEXT PRIMARY KEY, issue_id TEXT, body TEXT, updated_at
 INSERT INTO issues VALUES ('issue-1','CTL-1','t',NULL);
 SQL
   if [[ "$withc" == "1" ]]; then
-    sqlite3 "$db" "INSERT INTO comments (id,issue_id,is_bot,author_id,removed_at,created_at) VALUES ('c-1','issue-1',0,'c2a8cc92-cab6-4536-9500-0f24abdf702b',NULL,100);"
+    sqlite3 "$db" "INSERT INTO comments (id,issue_id,is_bot,author_id,removed_at,created_at) VALUES ('c-1','issue-1',0,'$HUMAN',NULL,100);"
   fi
 }
 

--- a/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
+++ b/plugins/dev/scripts/__tests__/linear-reply-write-path.test.sh
@@ -16,7 +16,11 @@ FAIL=0
 ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
 bad() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
 
-HUMAN="c2a8cc92-cab6-4536-9500-0f24abdf702b"
+HUMAN="11111111-2222-3333-4444-555555555555"
+# CTL-2299: the tool no longer carries a baked-in human id — it resolves the tenant's
+# configured one and refuses when there is none. This suite seeds comments authored by
+# $HUMAN, so it must declare that identity rather than rely on a default that is gone.
+export ASK_HUMAN_ID="$HUMAN"
 
 # The tool reads the replica via node:sqlite (node >= 24) OR bun:sqlite, selected at runtime.
 # CI runners may ship an older system `node` without node:sqlite, so run the TOOL under a

--- a/plugins/dev/scripts/ask.mjs
+++ b/plugins/dev/scripts/ask.mjs
@@ -32,6 +32,7 @@ import { spawnSync } from "node:child_process";
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { resolveCommentBody } from "./lib/comment-body-arg.mjs";
+import { resolveAskHuman, resolveAskTeam } from "./lib/tenant-identity.mjs";
 
 // ⚠️ ONE alternation-free pattern, deliberately: JS alternation prefers the earliest MATCH
 // POSITION, so a bare `Options:` branch matches at the preceding newline and consumes
@@ -296,7 +297,12 @@ export function resolveTeamLabelIds(team, { runFn = run, names = ASK_LABEL_NAMES
 
 // ── CLI ────────────────────────────────────────────────────────────────────────────────
 
-const RYAN = process.env.ASK_HUMAN_ID || "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+// ⛔ CTL-2299: this used to be `process.env.ASK_HUMAN_ID || "<one Linear user's uuid>"` —
+// the fleet owner's id, baked in as the assignee every ask fell back to. On any other
+// tenant that id names nobody, so the ask filed, reported success, and was assigned to a
+// user who does not exist in that workspace: undecidable, and silent. The resolver reads
+// the tenant's own config (`catalyst.human.linearUserId`, Layer 1 then Layer 2) and
+// returns a NAMED failure rather than guessing a person — see lib/tenant-identity.mjs.
 
 /**
  * run — spawnSync with a THREE-part result, including the case where the child never ran.
@@ -347,7 +353,7 @@ function readTicketViaReplica(id) {
 
 function usage() {
   console.error(`Usage:
-  ask.mjs create --team <TEAM> --title <t> --why <text>
+  ask.mjs create [--team <TEAM>] --title <t> --why <text>
                  --option <label> --option <label> [--option ...]   (at least TWO)
                  --default <text> --blocks <ISSUE> [--blocks <ISSUE> ...]
                  [--priority <1-4>] [--dry-run]
@@ -357,6 +363,10 @@ create files a correctly-shaped ask ticket, then READS IT BACK and proves the de
 trigger can parse its options AND that every requested blocking relation landed. accept
 replies in-thread as the app actor and moves the ticket to Done — refusing if the ticket
 is not an ask.
+
+--team and the assignee come from the TENANT's config when not given (CTL-2299):
+catalyst.linear.teamKey and catalyst.human.linearUserId, Layer 1 then Layer 2. Neither has
+a person-shaped fallback — an unconfigured tenant gets a named refusal, not a guess.
 
 ⛔ --option (>=2), --default and --blocks are REQUIRED (CTL-2157). An ask with nothing to
 choose between, no meaning for silence, or no work attached is the pile-up asks exist to
@@ -374,7 +384,11 @@ function argOf(argv, name, { many = false } = {}) {
 }
 
 function cmdCreate(argv) {
-  const team = argOf(argv, "--team");
+  // CTL-2299: `--team` stays available (a decision may belong to a team other than the
+  // repo's own) but is no longer REQUIRED — the tenant's `catalyst.linear.teamKey` is the
+  // default, so a customer runs this verb without knowing our team key.
+  const teamResolved = resolveAskTeam({ team: argOf(argv, "--team") });
+  const team = teamResolved.ok ? teamResolved.team : null;
   const title = argOf(argv, "--title");
   const why = argOf(argv, "--why");
   const options = argOf(argv, "--option", { many: true });
@@ -383,8 +397,12 @@ function cmdCreate(argv) {
   const priority = argOf(argv, "--priority") ?? "2";
   const dryRun = argv.includes("--dry-run");
 
-  if (!team || !title || !why) {
-    console.error("ask create: --team, --title and --why are required");
+  if (!team) {
+    console.error(`ask create: REFUSING — ${teamResolved.message}`);
+    return 1;
+  }
+  if (!title || !why) {
+    console.error("ask create: --title and --why are required");
     return 1;
   }
 
@@ -459,10 +477,29 @@ function cmdCreate(argv) {
   }
   const labelIds = lbl.labelIds;
 
+  // CTL-2299: resolve the assignee BEFORE the dry-run returns, for the same reason the
+  // labels are resolved here — a rehearsal that skips the step which actually fails is not
+  // a rehearsal. An ask assigned to nobody never reaches a human.
+  const human = resolveAskHuman();
+  if (!human.ok) {
+    console.error(`ask create: REFUSING — ${human.message}`);
+    return 1;
+  }
+
   if (dryRun) {
     console.log(
       JSON.stringify(
-        { action: "dry-run", team, title, body, parsedOptions: pre.parsed, labelIds },
+        {
+          action: "dry-run",
+          team,
+          teamSource: teamResolved.source,
+          assignee: human.humanId,
+          assigneeSource: human.source,
+          title,
+          body,
+          parsedOptions: pre.parsed,
+          labelIds,
+        },
         null,
         2
       )
@@ -479,7 +516,7 @@ function cmdCreate(argv) {
     "--priority",
     String(priority),
     "--assignee",
-    RYAN,
+    human.humanId,
     "--labels",
     labelIds.join(","),
     "--description",

--- a/plugins/dev/scripts/execution-core/__tests__/replica-comment-read.test.mjs
+++ b/plugins/dev/scripts/execution-core/__tests__/replica-comment-read.test.mjs
@@ -10,7 +10,7 @@
 // comment" is a clean null. Both are asserted below.
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync, utimesSync } from "node:fs";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -20,10 +20,13 @@ import {
   readCommentThreadRoot,
   isReplicaCurrent,
   ReplicaUnavailableError,
-  DEFAULT_ASK_HUMAN_ID,
+  HumanNotConfiguredError,
 } from "../replica-comment-read.mjs";
 
-const HUMAN = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+// CTL-2299: an arbitrary uuid, not a real person's. It used to be the fleet owner's id
+// because the module DEFAULTED to it; the default is now the tenant's own config, so this
+// is a fixture and nothing more.
+const HUMAN = "11111111-2222-3333-4444-555555555555";
 const OTHER_HUMAN = "99999999-0000-0000-0000-000000000000";
 
 let dir;
@@ -134,11 +137,53 @@ describe("readLatestHumanComment", () => {
     expect(thrown.dbPath).toBe(missing);
   });
 
-  test("humanId defaults to the ASK_HUMAN_ID sentinel", async () => {
-    expect(DEFAULT_ASK_HUMAN_ID).toBe(HUMAN);
-    seed([{ id: "c-def", author_id: HUMAN, is_bot: 0, created_at: 600 }]);
-    const got = await readLatestHumanComment({ dbPath, identifier: "CTL-1" });
-    expect(got).toEqual({ id: "c-def", parentId: "c-def" });
+  // CTL-2299 — the default humanId is the TENANT's, read from config, with no
+  // person-shaped fallback. Both halves are asserted: the configured tenant resolves, and
+  // the unconfigured one REFUSES loudly instead of querying an id nobody authored (which
+  // returns no row and reads, wrongly, as "the human has not commented").
+  describe("the default humanId comes from the tenant's config", () => {
+    let savedEnv;
+
+    beforeEach(() => {
+      savedEnv = {
+        ASK_HUMAN_ID: process.env.ASK_HUMAN_ID,
+        CATALYST_CONFIG_FILE: process.env.CATALYST_CONFIG_FILE,
+        CATALYST_LAYER2_CONFIG_FILE: process.env.CATALYST_LAYER2_CONFIG_FILE,
+      };
+      delete process.env.ASK_HUMAN_ID;
+      // Point BOTH layers somewhere this test owns, so whatever config the runner's cwd or
+      // home happens to carry cannot decide the answer.
+      process.env.CATALYST_LAYER2_CONFIG_FILE = join(dir, "absent-layer2.json");
+    });
+
+    afterEach(() => {
+      for (const [k, v] of Object.entries(savedEnv)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    });
+
+    test("resolves the configured human", async () => {
+      const cfg = join(dir, "config.json");
+      writeFileSync(cfg, JSON.stringify({ catalyst: { human: { linearUserId: HUMAN } } }));
+      process.env.CATALYST_CONFIG_FILE = cfg;
+      seed([{ id: "c-def", author_id: HUMAN, is_bot: 0, created_at: 600 }]);
+      const got = await readLatestHumanComment({ dbPath, identifier: "CTL-1" });
+      expect(got).toEqual({ id: "c-def", parentId: "c-def" });
+    });
+
+    test("REFUSES when no human is configured, rather than silently matching nobody", async () => {
+      process.env.CATALYST_CONFIG_FILE = join(dir, "absent-layer1.json");
+      seed([{ id: "c-def", author_id: HUMAN, is_bot: 0, created_at: 600 }]);
+      let thrown;
+      try {
+        await readLatestHumanComment({ dbPath, identifier: "CTL-1" });
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(HumanNotConfiguredError);
+      expect(thrown.message).toContain("catalyst.human.linearUserId");
+    });
   });
 });
 

--- a/plugins/dev/scripts/execution-core/replica-comment-read.mjs
+++ b/plugins/dev/scripts/execution-core/replica-comment-read.mjs
@@ -18,15 +18,39 @@
 // identical across both, so only the constructor + option key differ.
 //
 // zero-npm-import: node:sqlite / bun:sqlite are runtime built-ins; getReplicaDbPath comes
-// from the sibling config.mjs (which the tools already import) and isReplicaFresh from the
-// SQLite-free replica-freshness.mjs leaf.
+// from the sibling config.mjs (which the tools already import), isReplicaFresh from the
+// SQLite-free replica-freshness.mjs leaf, and resolveAskHuman from ../lib/tenant-identity.mjs
+// (node:fs/os/path only — see CTL-2299 below).
 import { getReplicaDbPath } from "./config.mjs";
 import { isReplicaFresh } from "./replica-freshness.mjs";
+import { resolveAskHuman } from "../lib/tenant-identity.mjs";
 
-// The ASK_HUMAN default: the fleet's single human decision-maker. Kept here as the leaf's
-// documented default so both tools resolve the same id; callers may override via env at
-// their call site (process.env.ASK_HUMAN_ID) and pass it in — the leaf stays pure.
-export const DEFAULT_ASK_HUMAN_ID = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+// ⛔ CTL-2299 — THE DEFAULT HUMAN IS THE TENANT'S, NOT A PERSON WE BAKED IN.
+//
+// This used to be `export const DEFAULT_ASK_HUMAN_ID = "<one Linear user's uuid>"` — the
+// fleet owner. On any other tenant that id authored nothing, so the query below returned
+// no row and both tools read it as "the human has not commented": threading and the 👀
+// clear silently dropped, with no error anywhere. A default that names a person is the
+// single-tenant assumption in its most expensive form.
+//
+// The leaf stays pure in the sense that mattered: callers may still pass `humanId`
+// explicitly, and nothing here reads process.env. What changed is the DEFAULT — it now
+// resolves the tenant's configured human, and REFUSES when none is configured, matching
+// this module's existing loud contract (an unanswerable read is never a clean `null`).
+export class HumanNotConfiguredError extends Error {
+  constructor(detail) {
+    super(detail);
+    this.name = "HumanNotConfiguredError";
+  }
+}
+
+// Resolved lazily, at call time — a default parameter expression only evaluates when the
+// argument is omitted, so a caller that passes its own id never touches config at all.
+function defaultHumanId() {
+  const resolved = resolveAskHuman();
+  if (!resolved.ok) throw new HumanNotConfiguredError(resolved.message);
+  return resolved.humanId;
+}
 
 // A NAMED error (not a falsy sentinel) for an absent/unreadable replica, so a missing DB
 // is a loud failure the tools surface — never a silent empty read that reads as "no human
@@ -75,7 +99,7 @@ function closeQuietly(db) {
 export async function readLatestHumanComment({
   dbPath = getReplicaDbPath(),
   identifier,
-  humanId = DEFAULT_ASK_HUMAN_ID,
+  humanId = defaultHumanId(),
 } = {}) {
   if (!identifier) return null;
   const db = await openReadonly(dbPath);
@@ -120,7 +144,7 @@ export async function readIssueId({ dbPath = getReplicaDbPath(), identifier } = 
 export async function readReplyContext({
   dbPath = getReplicaDbPath(),
   identifier,
-  humanId = DEFAULT_ASK_HUMAN_ID,
+  humanId = defaultHumanId(),
 } = {}) {
   if (!identifier) return { issueId: null, latest: null };
   const db = await openReadonly(dbPath);

--- a/plugins/dev/scripts/lib/tenant-identity.mjs
+++ b/plugins/dev/scripts/lib/tenant-identity.mjs
@@ -1,0 +1,203 @@
+// tenant-identity.mjs — CTL-2299. WHO the human is, WHICH team their asks are filed on,
+// and WHAT the status doc calls them — all read from the tenant's own config instead of
+// baked into the tools.
+//
+// ## What this replaces
+//
+// Three Ryan-shaped literals sat in the machinery and the skill text, so a customer who
+// installed the plugin bundle and joined their own tenant still ran a fleet-owner's
+// workspace:
+//
+//   * `ask.mjs`'s assignee default and `replica-comment-read.mjs`'s DEFAULT_ASK_HUMAN_ID
+//     were both the string `c2a8cc92-…` — one specific Linear user in one workspace;
+//   * `ask/references/creating.md` hard-coded that id AND `--team CTL`;
+//   * `steward/references/status-doc.md` templated a `Needs from <one person's name>`
+//     heading, so every tenant's status doc asked its own human for the fleet owner.
+//
+// A default that names a person is not a default: on any other tenant it resolves to a
+// user who does not exist there. The ask is then assigned to nobody, the "latest human
+// comment" query filters on an author id that authored nothing, and the ONLY symptom is
+// silence — the exact shape of failure AGENTS.md's positive-control rule exists to stop.
+// So this module has NO person-shaped fallback at all: it resolves from config or it
+// returns a NAMED failure the caller can print.
+//
+// ## The ladder
+//
+//   humanId:  env.ASK_HUMAN_ID  →  layer1 catalyst.human.linearUserId
+//                               →  layer2 catalyst.human.linearUserId  →  named failure
+//   team:     explicit arg      →  env.ASK_TEAM
+//                               →  layer1 catalyst.linear.teamKey      →  named failure
+//   name:     env.ASK_HUMAN_NAME →  layer1/layer2 catalyst.human.name  →  null
+//
+// Layer 1 is the committed, per-repo `.catalyst/config.json` (override:
+// `CATALYST_CONFIG_FILE`); Layer 2 is the per-machine `~/.config/catalyst/config.json`
+// (override: `CATALYST_LAYER2_CONFIG_FILE`). Both path resolvers are deliberate
+// near-verbatim mirrors of lib/deployment-mode.mjs and lib/entitlement.mjs — the same two
+// layers, resolved the same way, so an operator who has learned one config ladder has
+// learned all of them. Layer 2 is consulted for the human because a host runs agent tools
+// from MANY checkouts (catalyst, catalyst-cloud, a customer repo) and the human answering
+// for that host is a property of the host, not of whichever directory the tool was
+// launched in.
+//
+// ## Why a display name is allowed to be absent but an id is not
+//
+// The id is load-bearing — a wrong or missing one silently mis-files the ask. The name is
+// only prose, so `statusDocHumanHeading()` falls back to "the human", which is correct on
+// every tenant and reads as deliberate rather than as a placeholder someone forgot.
+//
+// ## Zero-npm-import leaf
+//
+// node:fs / node:os / node:path only, for the same reason lib/deployment-mode.mjs states:
+// `catalyst doctor` and the bare-Node agent tools import this class of module without a
+// `bun install`, so it may never pull a package.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/** The config key that carries the human, in both layers. */
+export const HUMAN_CONFIG_PATH = "catalyst.human.linearUserId";
+
+/** What a status doc calls the human when the tenant has not named one. */
+export const UNNAMED_HUMAN = "the human";
+
+// resolveLayer1Path / resolveLayer2Path — mirrors of lib/deployment-mode.mjs's pair.
+// Reads the INJECTED env (never process.env directly) so resolution stays pure and a test
+// can hand in a whole fixture home.
+//
+// ⚠️ The Layer-1 rung WALKS UP from cwd, where deployment-mode.mjs only checks cwd itself.
+// That is deliberate and it is the same walk lib/secret-contract.mjs's
+// resolveLegacyPerTeamConfigPath and linear-comment-post.sh's `_find_layer2_config` already
+// do: these identities are read by agent TOOLS, which run from wherever the agent happens
+// to be — a package subdirectory, a `__tests__` folder, a worktree's `plugins/dev/scripts`.
+// A cwd-only check would refuse for a repo that is plainly configured, one directory down.
+// The walk stops at the FIRST ancestor carrying a `.catalyst/config.json`, so a nested
+// checkout never reads its parent's tenant.
+function resolveLayer1Path(env, layer1ConfigPath, cwd = process.cwd()) {
+  if (typeof layer1ConfigPath === "string" && layer1ConfigPath.length > 0) return layer1ConfigPath;
+  const override = env?.CATALYST_CONFIG_FILE;
+  if (typeof override === "string" && override.length > 0) return override;
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".catalyst", "config.json");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
+  }
+  // Nothing found: return the cwd-relative path anyway, so the refusal message names the
+  // file the operator would create rather than a path that only exists in this function.
+  return resolve(cwd, ".catalyst", "config.json");
+}
+
+function resolveLayer2Path(env, layer2ConfigPath) {
+  if (typeof layer2ConfigPath === "string" && layer2ConfigPath.length > 0) return layer2ConfigPath;
+  const override = env?.CATALYST_LAYER2_CONFIG_FILE;
+  if (typeof override === "string" && override.length > 0) return override;
+  const home = typeof env?.HOME === "string" && env.HOME.length > 0 ? env.HOME : homedir();
+  return resolve(home, ".config", "catalyst", "config.json");
+}
+
+// readConfigField — pull a dotted path out of a JSON config file. An absent, unreadable or
+// malformed file and an absent key are the SAME answer here — "nothing at this layer, try
+// the next one" — which is the readLayer2NodeClass contract the other resolvers share.
+// Never throws.
+function readConfigField(path, dotted) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return undefined;
+  }
+  let node = parsed;
+  for (const segment of dotted.split(".")) {
+    if (node == null || typeof node !== "object") return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+/** A trimmed non-empty string, or null. An empty/whitespace value is NOT a declaration. */
+function declared(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : null;
+}
+
+/**
+ * resolveAskHuman — the Linear user id an ask is assigned to and whose comments count as
+ * "the human's" on this tenant.
+ *
+ * @param {{env?: Record<string, string|undefined>, layer1ConfigPath?: string,
+ *          layer2ConfigPath?: string}} [opts]
+ * @returns {{ok: true, humanId: string, name: string|null,
+ *            source: "env"|"layer1"|"layer2"}
+ *          | {ok: false, reason: "human-not-configured", message: string}}
+ */
+export function resolveAskHuman({ env = process.env, layer1ConfigPath, layer2ConfigPath } = {}) {
+  const layer1 = resolveLayer1Path(env, layer1ConfigPath);
+  const layer2 = resolveLayer2Path(env, layer2ConfigPath);
+
+  const name =
+    declared(env?.ASK_HUMAN_NAME) ??
+    declared(readConfigField(layer1, "catalyst.human.name")) ??
+    declared(readConfigField(layer2, "catalyst.human.name"));
+
+  const fromEnv = declared(env?.ASK_HUMAN_ID);
+  if (fromEnv) return { ok: true, humanId: fromEnv, name, source: "env" };
+
+  const fromLayer1 = declared(readConfigField(layer1, HUMAN_CONFIG_PATH));
+  if (fromLayer1) return { ok: true, humanId: fromLayer1, name, source: "layer1" };
+
+  const fromLayer2 = declared(readConfigField(layer2, HUMAN_CONFIG_PATH));
+  if (fromLayer2) return { ok: true, humanId: fromLayer2, name, source: "layer2" };
+
+  return {
+    ok: false,
+    reason: "human-not-configured",
+    message:
+      `no human is configured for this tenant. Set ${HUMAN_CONFIG_PATH} in ${layer1} ` +
+      `(committed, per-repo) or ${layer2} (per-machine), or export ASK_HUMAN_ID. ` +
+      "This resolver will not guess a person on your behalf — an ask assigned to a user " +
+      "who does not exist on your workspace fails silently.",
+  };
+}
+
+/**
+ * resolveAskTeam — the Linear team key an ask is filed on. An explicit `team` (a `--team`
+ * flag) always wins: a decision may belong to a team other than the repo's own.
+ *
+ * @param {{team?: unknown, env?: Record<string, string|undefined>,
+ *          layer1ConfigPath?: string}} [opts]
+ * @returns {{ok: true, team: string, source: "explicit"|"env"|"layer1"}
+ *          | {ok: false, reason: "team-not-configured", message: string}}
+ */
+export function resolveAskTeam({ team, env = process.env, layer1ConfigPath } = {}) {
+  const explicit = declared(team);
+  if (explicit) return { ok: true, team: explicit, source: "explicit" };
+
+  const fromEnv = declared(env?.ASK_TEAM);
+  if (fromEnv) return { ok: true, team: fromEnv, source: "env" };
+
+  const layer1 = resolveLayer1Path(env, layer1ConfigPath);
+  const fromLayer1 = declared(readConfigField(layer1, "catalyst.linear.teamKey"));
+  if (fromLayer1) return { ok: true, team: fromLayer1, source: "layer1" };
+
+  return {
+    ok: false,
+    reason: "team-not-configured",
+    message:
+      `no ask team resolved. Pass --team, or set catalyst.linear.teamKey in ${layer1}. ` +
+      "Filing on a guessed team puts the ask on a board nobody is watching.",
+  };
+}
+
+/**
+ * statusDocHumanHeading — the status doc's second heading, named for whoever this tenant's
+ * human is. Takes the resolver's own result so a caller cannot accidentally pass an id
+ * where a display name belongs.
+ *
+ * @param {ReturnType<typeof resolveAskHuman>|{name?: unknown}} [human]
+ * @returns {string}
+ */
+export function statusDocHumanHeading(human) {
+  return `## Needs from ${declared(human?.name) ?? UNNAMED_HUMAN}`;
+}

--- a/plugins/dev/scripts/lib/tenant-identity.test.mjs
+++ b/plugins/dev/scripts/lib/tenant-identity.test.mjs
@@ -1,0 +1,268 @@
+// tenant-identity.test.mjs — CTL-2299.
+//
+// Two halves, and the second is the one the ticket is actually about.
+//
+//   1. The resolver is a pure function over (env, two config paths), so every ladder rung
+//      is a table row — including the NAMED-FAILURE rung, which is the whole point: an
+//      unconfigured tenant must get a loud refusal, never a person-shaped guess.
+//
+//   2. A CORPUS SCAN over the shipped skill text and the non-test scripts, asserting the
+//      fleet owner's Linear user id and the `Needs from <that person>` heading appear
+//      nowhere. This is the ticket's own acceptance sentence ("no Ryan-specific value
+//      remains in any skill text or default") turned into a guard — a rule stated in a
+//      review comment is a rule that comes back.
+//
+//      ⛔ AGENTS.md's positive-control rule binds this scan: a corpus walk that silently
+//      enumerated zero files would report a clean sweep for a repo full of violations.
+//      So the scan is asserted to have READ a known-populated corpus (a floor on the file
+//      count, and a control string that IS present), and the matcher itself is run against
+//      a planted literal to prove it can return non-zero at all.
+
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  HUMAN_CONFIG_PATH,
+  UNNAMED_HUMAN,
+  resolveAskHuman,
+  resolveAskTeam,
+  statusDocHumanHeading,
+} from "./tenant-identity.mjs";
+
+// The literal this ticket exists to remove. Written here — in a TEST, where a specific id
+// is a fixture rather than a default — so the scan below has something concrete to hunt.
+const FLEET_OWNER_ID = "c2a8cc92-cab6-4536-9500-0f24abdf702b";
+
+// `import.meta.url`, not a cwd-relative path: `bun test` is run from several
+// working-directories in CI, and a cwd-derived root would silently walk nothing.
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+function writeConfig(dir, relPath, obj) {
+  const full = join(dir, relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, JSON.stringify(obj));
+  return full;
+}
+
+function fixtureDir() {
+  return mkdtempSync(join(tmpdir(), "ctl2299-"));
+}
+
+// A layer path that certainly does not exist, so a rung under test cannot be satisfied by
+// whatever config happens to sit in the runner's cwd or home.
+const ABSENT = "/nonexistent/ctl-2299/config.json";
+
+describe("resolveAskHuman — the ladder", () => {
+  test("env.ASK_HUMAN_ID wins", () => {
+    const r = resolveAskHuman({
+      env: { ASK_HUMAN_ID: "env-user" },
+      layer1ConfigPath: ABSENT,
+      layer2ConfigPath: ABSENT,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.humanId).toBe("env-user");
+    expect(r.source).toBe("env");
+  });
+
+  test("layer 1 (.catalyst/config.json) supplies the human when env is unset", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "repo/.catalyst/config.json", {
+      catalyst: { human: { linearUserId: "tenant-human", name: "Dana" } },
+    });
+    const r = resolveAskHuman({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: ABSENT });
+    expect(r.ok).toBe(true);
+    expect(r.humanId).toBe("tenant-human");
+    expect(r.name).toBe("Dana");
+    expect(r.source).toBe("layer1");
+  });
+
+  test("layer 2 (~/.config/catalyst/config.json) backstops a checkout that carries no human", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "repo/.catalyst/config.json", { catalyst: { projectKey: "p" } });
+    const l2 = writeConfig(dir, "home/.config/catalyst/config.json", {
+      catalyst: { human: { linearUserId: "machine-human" } },
+    });
+    const r = resolveAskHuman({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: l2 });
+    expect(r.ok).toBe(true);
+    expect(r.humanId).toBe("machine-human");
+    expect(r.source).toBe("layer2");
+  });
+
+  test("an UNCONFIGURED tenant is a named failure, never a person", () => {
+    const r = resolveAskHuman({ env: {}, layer1ConfigPath: ABSENT, layer2ConfigPath: ABSENT });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("human-not-configured");
+    expect(r.message).toContain(HUMAN_CONFIG_PATH);
+    // The regression this ticket is named for: the failure must NOT be the fleet owner.
+    expect(JSON.stringify(r)).not.toContain(FLEET_OWNER_ID);
+  });
+
+  test("an empty ASK_HUMAN_ID is not a declaration — it falls through, it does not blank the id", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "repo/.catalyst/config.json", {
+      catalyst: { human: { linearUserId: "tenant-human" } },
+    });
+    const r = resolveAskHuman({
+      env: { ASK_HUMAN_ID: "   " },
+      layer1ConfigPath: l1,
+      layer2ConfigPath: ABSENT,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.humanId).toBe("tenant-human");
+  });
+
+  test("Layer 1 is found by walking UP from cwd — an agent tool runs from a subdirectory", () => {
+    const dir = fixtureDir();
+    writeConfig(dir, "repo/.catalyst/config.json", {
+      catalyst: { human: { linearUserId: "tenant-human" } },
+    });
+    const deep = join(dir, "repo/plugins/dev/scripts/__tests__");
+    mkdirSync(deep, { recursive: true });
+    const saved = process.cwd();
+    try {
+      process.chdir(deep);
+      const r = resolveAskHuman({ env: {}, layer2ConfigPath: ABSENT });
+      expect(r.ok).toBe(true);
+      expect(r.humanId).toBe("tenant-human");
+      expect(r.source).toBe("layer1");
+    } finally {
+      process.chdir(saved);
+    }
+  });
+
+  test("a malformed config is 'nothing at this layer', not a throw", () => {
+    const dir = fixtureDir();
+    const full = join(dir, "broken.json");
+    writeFileSync(full, "{ not json");
+    const r = resolveAskHuman({ env: {}, layer1ConfigPath: full, layer2ConfigPath: ABSENT });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("human-not-configured");
+  });
+});
+
+describe("resolveAskTeam — the ladder", () => {
+  test("an explicit --team wins: a decision may belong to another team", () => {
+    const r = resolveAskTeam({ team: "OPS", env: { ASK_TEAM: "ENV" }, layer1ConfigPath: ABSENT });
+    expect(r.ok).toBe(true);
+    expect(r.team).toBe("OPS");
+    expect(r.source).toBe("explicit");
+  });
+
+  test("the tenant's own teamKey is the default", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "repo/.catalyst/config.json", {
+      catalyst: { linear: { teamKey: "TEN" } },
+    });
+    const r = resolveAskTeam({ env: {}, layer1ConfigPath: l1 });
+    expect(r.ok).toBe(true);
+    expect(r.team).toBe("TEN");
+    expect(r.source).toBe("layer1");
+  });
+
+  test("no team anywhere is a named failure, not a fallback to CTL", () => {
+    const r = resolveAskTeam({ env: {}, layer1ConfigPath: ABSENT });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("team-not-configured");
+    expect(JSON.stringify(r)).not.toContain("CTL");
+  });
+});
+
+describe("statusDocHumanHeading", () => {
+  test("names the tenant's human", () => {
+    expect(statusDocHumanHeading({ name: "Dana" })).toBe("## Needs from Dana");
+  });
+
+  test("an unnamed human reads as deliberate, not as a placeholder", () => {
+    expect(statusDocHumanHeading({})).toBe(`## Needs from ${UNNAMED_HUMAN}`);
+    expect(statusDocHumanHeading(undefined)).toBe(`## Needs from ${UNNAMED_HUMAN}`);
+  });
+
+  test("takes the resolver's result straight through", () => {
+    const dir = fixtureDir();
+    const l1 = writeConfig(dir, "repo/.catalyst/config.json", {
+      catalyst: { human: { linearUserId: "u", name: "Dana" } },
+    });
+    const human = resolveAskHuman({ env: {}, layer1ConfigPath: l1, layer2ConfigPath: ABSENT });
+    expect(statusDocHumanHeading(human)).toBe("## Needs from Dana");
+  });
+});
+
+// ── the corpus scan ────────────────────────────────────────────────────────────────────
+
+const SKIP_DIRS = new Set(["node_modules", "dist", "build", ".git", "__tests__", "coverage"]);
+
+function walk(dir, keep, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue;
+      walk(full, keep, out);
+      continue;
+    }
+    let isFile = e.isFile();
+    if (!isFile && e.isSymbolicLink()) {
+      try {
+        isFile = statSync(full).isFile();
+      } catch {
+        continue;
+      }
+    }
+    if (isFile && keep(e.name)) out.push(full);
+  }
+  return out;
+}
+
+/** The shipped surface: skill text plus the non-test scripts that carry defaults. */
+function shippedFiles() {
+  const skills = walk(join(REPO_ROOT, "plugins/dev/skills"), (n) => n.endsWith(".md"));
+  const scripts = walk(
+    join(REPO_ROOT, "plugins/dev/scripts"),
+    (n) => n.endsWith(".mjs") && !n.endsWith(".test.mjs"),
+  );
+  return [...skills, ...scripts];
+}
+
+function filesContaining(files, needle) {
+  const hits = [];
+  for (const f of files) {
+    try {
+      if (readFileSync(f, "utf8").includes(needle)) hits.push(f.slice(REPO_ROOT.length + 1));
+    } catch {
+      /* unreadable file — not evidence either way */
+    }
+  }
+  return hits;
+}
+
+describe("no fleet-owner literal survives in the shipped surface (CTL-2299 Tier 1)", () => {
+  const files = shippedFiles();
+
+  test("POSITIVE CONTROL: the scan actually read a populated corpus", () => {
+    // A silent zero-file walk would make every assertion below pass vacuously.
+    expect(files.length).toBeGreaterThan(50);
+    // …and the matcher can return non-zero: `catalyst-ask` is present by construction.
+    expect(filesContaining(files, "catalyst-ask").length).toBeGreaterThan(0);
+    // …and it finds a planted literal in a file of exactly the scanned shape.
+    const dir = fixtureDir();
+    const planted = join(dir, "planted.md");
+    writeFileSync(planted, `assignee ${FLEET_OWNER_ID}\n`);
+    expect(filesContaining([planted], FLEET_OWNER_ID).length).toBe(1);
+  });
+
+  test("the fleet owner's Linear user id appears in no skill text and no shipped default", () => {
+    expect(filesContaining(files, FLEET_OWNER_ID)).toEqual([]);
+  });
+
+  test("the status-doc template heading is not named for one person", () => {
+    expect(filesContaining(files, "Needs from Ryan")).toEqual([]);
+  });
+});

--- a/plugins/dev/scripts/linear-ack.mjs
+++ b/plugins/dev/scripts/linear-ack.mjs
@@ -51,11 +51,24 @@ if (!commentId) {
   if (!isReplicaCurrent(dbPath)) {
     console.error("linear-ack: WARN — replica may be STALE (cloud-sync writer not fresh); the latest human comment could be missed.");
   }
-  const latest = await readLatestHumanComment({
-    dbPath,
-    identifier: key,
-    humanId: process.env.ASK_HUMAN_ID || undefined, // '' or unset → the leaf's DEFAULT_ASK_HUMAN_ID (JS defaults fire on undefined only, not '')
-  });
+  // CTL-2299: '' or unset → the leaf resolves THIS TENANT's configured human
+  // (catalyst.human.linearUserId). JS defaults fire on undefined only, not '', so the
+  // `|| undefined` still matters. A tenant that configured none gets a one-line refusal
+  // here rather than an unhandled rejection's stack.
+  let latest;
+  try {
+    latest = await readLatestHumanComment({
+      dbPath,
+      identifier: key,
+      humanId: process.env.ASK_HUMAN_ID || undefined,
+    });
+  } catch (err) {
+    if (err?.name === "HumanNotConfiguredError") {
+      console.error(`linear-ack: REFUSED — ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
   if (!latest) {
     console.log("no human comment");
     process.exit(0);

--- a/plugins/dev/scripts/linear-reply.mjs
+++ b/plugins/dev/scripts/linear-reply.mjs
@@ -112,7 +112,18 @@ if (top) {
 } else {
   // `|| undefined`: JS default parameters fire on undefined only, not '', so an explicitly-empty
   // ASK_HUMAN_ID='' would otherwise query author_id='' (matches nothing) → a silent "no comment".
-  const ctx = await readReplyContext({ dbPath: DB, identifier: issueKey, humanId: process.env.ASK_HUMAN_ID || undefined });
+  // CTL-2299: unset now resolves THIS TENANT's configured human, and a tenant that configured
+  // none gets a one-line refusal here rather than an unhandled rejection's stack.
+  let ctx;
+  try {
+    ctx = await readReplyContext({ dbPath: DB, identifier: issueKey, humanId: process.env.ASK_HUMAN_ID || undefined });
+  } catch (err) {
+    if (err?.name === "HumanNotConfiguredError") {
+      console.error(`linear-reply: REFUSED — ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
   issueId = ctx.issueId;
   if (ctx.latest) {
     parentId = ctx.latest.parentId;

--- a/plugins/dev/skills/ask/references/creating.md
+++ b/plugins/dev/skills/ask/references/creating.md
@@ -2,8 +2,8 @@
 
 The body shape below is parsed by the decision trigger (`apps/mirror/src/do/ask-decision.ts`). A body in any other shape yields **zero** options, and then every reply the human writes is rejected.
 
-- **Team:** the team the decision belongs to. **Assignee = the human** (Ryan:
-  `c2a8cc92-cab6-4536-9500-0f24abdf702b`); no delegate.
+- **Team and assignee come from THIS tenant's config, never from a literal you copy out of
+  here (CTL-2299).** The team is `catalyst.linear.teamKey` and the assignee is `catalyst.human.linearUserId`, both read from `.catalyst/config.json` (or the per-machine `~/.config/catalyst/config.json`); `ask.mjs create` resolves both for you, and `--team` is only for the case where the decision belongs to a team other than the repo's own. There is no default human — an unconfigured tenant gets a named refusal, because an ask assigned to a user who does not exist on that workspace files cleanly and reaches nobody. No delegate: the assignee is the human.
 - **Labels — both, exact names:** `catalyst-ask` + `ask/decision`. Linear labels are **team-scoped**:
   if a team lacks them, create them once (`issueLabelCreate` with the personal token — the app actor cannot create labels, measured CTC-626). `catalyst-ask` is what the "Waiting on me" view and the push trigger key on; `ask/decision` is the human-readable class.
 - **Title:** starts with `ASK:` (or names the click/decision itself); one line a phone can show.
@@ -26,13 +26,16 @@ The body shape below is parsed by the decision trigger (`apps/mirror/src/do/ask-
   (`A`, `A.`, `option A`) or the option's exact text, or `DECIDED: <free text>`. `(A)` inside a sentence is NOT recognized until CTC-653 lands. The trigger is deterministic — no LLM reads the reply (CTC-554).
 - Priority 1 if it blocks a live customer path, else 2.
 
-The raw form, for reference (or when you must hand-build):
+The raw form, for reference (or when you must hand-build). Read the two identities out of the config rather than typing them — a pasted id is how a single-tenant assumption spreads:
 
 ```bash
-linearis issues create "ASK: <one line>" --team CTL --priority 2 \
-  --assignee c2a8cc92-cab6-4536-9500-0f24abdf702b \
+cfg=.catalyst/config.json
+team=$(jq -r '.catalyst.linear.teamKey' "$cfg")
+human=$(jq -r '.catalyst.human.linearUserId' "$cfg")
+linearis issues create "ASK: <one line>" --team "$team" --priority 2 \
+  --assignee "$human" \
   --labels "catalyst-ask,ask/decision" \
-  --blocks CTL-NNNN \
+  --blocks "$team-NNNN" \
   --description "$(printf '**Why:** …\n\n**Options:**\n- …\n- …\n\n**Default if silent:** …')"
 ```
 

--- a/plugins/dev/skills/ask/references/threading.md
+++ b/plugins/dev/skills/ask/references/threading.md
@@ -57,7 +57,7 @@ The human is looking at the **last message they wrote**, not the top of the thre
 - **On reply** — `linear-reply.mjs` removes the eyes automatically when the reply posts (`--keep-eyes`
   to leave it).
 
-⚠️ **Linear returns comments newest-first.** Sort explicitly before choosing "the latest human comment". Both helpers do; anything you write yourself must too — acking the oldest message has already happened. Only the human's own comments count (`ASK_HUMAN_ID`, default Ryan); the decision trigger's replies carry a `user` field too and will fool a naive check.
+⚠️ **Linear returns comments newest-first.** Sort explicitly before choosing "the latest human comment". Both helpers do; anything you write yourself must too — acking the oldest message has already happened. Only the human's own comments count — `ASK_HUMAN_ID`, defaulting to this tenant's `catalyst.human.linearUserId` (CTL-2299; there is no person-shaped fallback, an unconfigured tenant refuses loudly); the decision trigger's replies carry a `user` field too and will fool a naive check.
 
 ## What a reply says
 

--- a/plugins/dev/skills/ask/references/triage.md
+++ b/plugins/dev/skills/ask/references/triage.md
@@ -83,4 +83,4 @@ Rules that make this land:
 
 ## Routing: who to send it to
 
-Today: one human, so every ask goes to Ryan and routing is a no-op. **Deliberately deferred, not overlooked.** When more than one human can answer, this section gains: how an ask picks its addressee (scope owner? assignee of the blocked work? explicit `--to`?), what happens when the addressee doesn't answer, and whether an unrouted ask is an error or falls back to a default owner. Do not invent that scheme ad-hoc when the second human appears — extend this file.
+Today: one human per tenant, so every ask goes to `catalyst.human.linearUserId` and routing is a no-op. **Deliberately deferred, not overlooked.** When more than one human can answer, this section gains: how an ask picks its addressee (scope owner? assignee of the blocked work? explicit `--to`?), what happens when the addressee doesn't answer, and whether an unrouted ask is an error or falls back to a default owner. Do not invent that scheme ad-hoc when the second human appears — extend this file.

--- a/plugins/dev/skills/concierge/references/asks.md
+++ b/plugins/dev/skills/concierge/references/asks.md
@@ -24,7 +24,7 @@ The board's *needs-you* cell is the **title plus the one-word options** — `A /
 
 - ⛔ **Answer an ask.** Not even an obvious one. The whole value of the surface is that the human's word is
   distinguishable from an agent's guess; one answered-by-proxy ask destroys that for every future ask.
-- ⛔ Re-assign an ask away from the scope's decider — except on Ryan's explicit override, recorded in-thread.
+- ⛔ Re-assign an ask away from the scope's decider — except on the workspace owner's explicit override, recorded in-thread.
 - ⛔ Let downstream work live on the ask. The ask is a decision, not a task; the work is its own ticket,
   linked `blocks →`.
 - ⛔ Batch a **P1** ask into the next window. P1 pushes any hour.

--- a/plugins/dev/skills/concierge/references/board.md
+++ b/plugins/dev/skills/concierge/references/board.md
@@ -35,4 +35,4 @@
 
 ## Two humans, one board
 
-One board per workspace, one `Concierge — <human>` pinned ticket per human. Rows carry the **decider** so each human can find their own *needs-you* items. Ryan, as workspace owner, may override anything — record it in-thread and re-assign the ask; if two humans disagree, the ask goes to the scope's decider quoting both, and you do not pick.
+One board per workspace, one `Concierge — <human>` pinned ticket per human. Rows carry the **decider** so each human can find their own *needs-you* items. The workspace owner (`catalyst.human.linearUserId` — the tenant's configured human) may override anything — record it in-thread and re-assign the ask; if two humans disagree, the ask goes to the scope's decider quoting both, and you do not pick.

--- a/plugins/dev/skills/steward/SKILL.md
+++ b/plugins/dev/skills/steward/SKILL.md
@@ -18,7 +18,7 @@ You own one project or initiative until it closes: for each ready ticket you lau
 | deciding what is ready to dispatch | `references/readiness.md` |
 | creating or updating the status doc | `references/status-doc.md` |
 | replying to anyone, or picking a thread | `ask/references/threading.md` (canonical), then `references/threads.md` |
-| launching a relay-ticket session, reading its report, or holding a ticket back | `references/dispatch.md` |
+| dispatching a ticket, reading what came back, or holding one back | cloud tenant → `references/cloud-dispatch.md`; no cloud mirror → `references/dispatch.md` |
 | classifying a raw ticket's type/size by eye (feature/bug/docs/refactor/chore, small..epic) | `references/classify-and-estimate.md` |
 | a ticket has not moved, or a worker went quiet | `references/stalls.md` |
 | setting up a NEW project or initiative | `references/initiative-setup.md` |
@@ -27,7 +27,7 @@ You own one project or initiative until it closes: for each ready ticket you lau
 
 ## Invariants
 
-- **Launching `/relay-ticket <TICKET>` is your only dispatch verb** — never a worktree, hand-rolled worker, or phase agent — you write no product code: you launch sessions, change state, comment.
+- **One dispatch verb, and cloud-detection picks it** — off-cloud you launch `/relay-ticket <TICKET>`; on a cloud tenant you move the card to Todo through the write proxy and launch nothing (`references/cloud-dispatch.md`). Never a worktree, hand-rolled worker, or phase agent: you write no product code.
 - **A cap is never silent** — every ticket you could have dispatched but did not is named, with why.
 - **No status doc = you have not started.** It exists before your first dispatch.
 - **A stall with no nudge in its own thread is your defect**, not the worker's.

--- a/plugins/dev/skills/steward/references/cloud-dispatch.md
+++ b/plugins/dev/skills/steward/references/cloud-dispatch.md
@@ -1,0 +1,54 @@
+# Dispatch on a CLOUD tenant — you move the card, the cloud runs the phase
+
+`references/dispatch.md` describes the **local** shape: you launch `/relay-ticket <TICKET>` yourself, in a session on this machine. On a Catalyst Cloud tenant that shape is wrong in its first sentence — the phases run in the tenant's runner containers, dispatched by the tenant's own scheduler. **Read this file instead of `dispatch.md` whenever cloud-detection says you are on a cloud tenant** (`references/cloud-detection.md` — a fresh replica *and* a `.catalyst/config.json` marker; both, or you are not).
+
+The difference matters because the two failure modes are opposite. Launch a local session on a cloud tenant and you get two workers on one ticket, racing on the same branch. Wait for a local session on a cloud tenant and you wait forever for a session nobody started.
+
+## The dispatch verb: move the card to Todo, through the write proxy
+
+Your dispatch is a **state move**, not a launch. The tenant's scheduler picks up eligible cards in its Todo state and claims them into a runner container; there is nothing for you to spawn and no PID for you to watch.
+
+Write it through the cloud **write proxy**, never with a personal Linear credential — a proxied write carries the tenant's app actor, which is what keeps your dispatch from reading as the human typing (`ask/references/threading.md` on why that matters, and `linear-write-proxy.mjs` for the client):
+
+```
+POST /api/v1/agent/issue-state   {issueId, stateId, hostId}
+```
+
+Two things that route deliberately does **not** do for you:
+
+- **It does not resolve a state NAME.** It forwards a `stateId` and nothing else. You resolve the id from this tenant's own `catalyst.linear.stateMap` (`.catalyst/config.json` → the `todo` entry) against the team's workflow states — the replica's `workflow_states` table is the lookup. A name you guessed is how a dispatch lands in another team's Todo.
+- **It does not tell you the card was eligible.** The scheduler applies its own gates after your move — ask-shape, scope overlap, a park, a hold. A `succeeded` write is proof the card moved, never proof that work started.
+
+⛔ **Do not launch `/relay-ticket` on a cloud tenant**, and do not open a worktree to "just check something" on a ticket the cloud is running. The container has the branch; your checkout does not.
+
+## Phase-completion evidence: read the record, not a session's word
+
+There is no RELAY REPORT here — no session reports to you at all. The evidence is what the tenant wrote down, and you read all of it from the **replica**, gated for freshness the same way every other read is:
+
+| what you are asking | where the answer is |
+| -- | -- |
+| did a phase run, and how did it end | the phase-outcome record on the ticket: a `phase.<phase>.complete` / `phase.<phase>.failed` comment written by the app actor (`comments`, `is_bot = 1`) |
+| what the phase produced | the artifact projection — the Linear document/attachment the projection layer posts for `research` / `plan` / `validate` (ADR-0060) |
+| where the card is now | `issues.state` plus the transition in `issue_history` — a failed phase moves the card to Remediate rather than leaving it where it was |
+| is a session narrating right now | `agent_sessions` / `agent_activities` for that ticket |
+
+Two readings that have actually misled a steward here:
+
+- **A ledger row that says `complete` is the phase's own verdict, not a merge.** Read the artifact it names before you treat the phase as done — the same artifact-beats-claim rule `dispatch.md` states for the local path, with the ledger row playing the part the RELAY REPORT plays there.
+- **Silence is not a stall.** A container that has claimed the ticket but not yet published writes nothing at all for the length of a phase. Before you nudge, check the card's state and the newest ledger row; `references/stalls.md` is what you do once you have actually established that nothing moved.
+
+## What stays exactly the same
+
+- **A cap is never silent.** Every ticket you could have moved to Todo and did not is named in your plan comment, with the reason.
+- **Announce the dispatch on the ticket** — a top-level comment saying it was queued, by whom, and why it was judged ready, with the same explicit "ask me in this thread, do not stall silently."
+- **Say `steward/<scope>`**, and post as the app actor. The write path differs; the attribution rule does not.
+- **State what you cannot enforce.** You have fewer levers here, not more: the scheduler owns ordering, retries and parks, so a hold you want is a request unless you can point at the gate that holds it.
+
+## Which file governs
+
+| this host | dispatch verb | evidence |
+| -- | -- | -- |
+| cloud tenant (fresh replica + `.catalyst` marker) | move the card to Todo via the write proxy — **this file** | ledger rows + artifact projections, read from the replica |
+| no cloud mirror | launch `/relay-ticket <TICKET>` — `references/dispatch.md` | the RELAY REPORT, confirmed against the artifact it cites |
+
+When you cannot tell which you are on, you have not run cloud-detection yet. Run it; do not pick by feel.

--- a/plugins/dev/skills/steward/references/dispatch.md
+++ b/plugins/dev/skills/steward/references/dispatch.md
@@ -1,5 +1,7 @@
 # Dispatch — launching a relay-ticket session
 
+⚠️ **This is the OFF-CLOUD shape.** On a Catalyst Cloud tenant the phases run in the tenant's runner containers and you dispatch by moving the card, not by launching anything — read [`cloud-dispatch.md`](cloud-dispatch.md) instead. `cloud-detection.md` is what tells you which you are on; launching a local session on a cloud tenant puts two workers on one branch.
+
 ## Launching `/relay-ticket <TICKET>` IS the dispatch
 
 There is no daemon and no pull-based scheduler to hand a ticket to — both retired 2026-08-24 (CTL-2218). You dispatch by launching a session that runs `/relay-ticket <TICKET>` yourself (a background agent / `claude --bg` session — whatever your environment's session primitive is). Three shapes, from the `relay-ticket` skill:

--- a/plugins/dev/skills/steward/references/status-doc.md
+++ b/plugins/dev/skills/steward/references/status-doc.md
@@ -14,13 +14,13 @@ The first line under the title, always:
 > Last updated: <America/Chicago timestamp> by <steward/scope>
 ```
 
-Then, exactly these five headings:
+Then, exactly these five headings. `<human>` is **this tenant's** human, read from `catalyst.human.name` in `.catalyst/config.json` (CTL-2299) — never a name you remember from another workspace. When the tenant has named no human, the heading reads `## Needs from the human`, which is correct everywhere and reads as deliberate rather than as a placeholder left behind. `statusDocHumanHeading()` in `lib/tenant-identity.mjs` renders exactly this.
 
 ```markdown
 ## Goal right now
 One sentence: the outcome this work is driving to, and the landing date.
 
-## Needs from Ryan
+## Needs from <human>
 Live items only. Each row links to an ask; a row with no ask does not belong.
 
 | what | default if silent |

--- a/plugins/dev/templates/config.template.json
+++ b/plugins/dev/templates/config.template.json
@@ -3,6 +3,11 @@
   "$comment": "Catalyst Configuration Template - Copy to config.json and fill in values. Secrets go in ~/.config/catalyst/config-{projectKey}.json",
   "catalyst": {
     "projectKey": "my-project",
+    "human": {
+      "$comment": "CTL-2299. WHO this tenant's human decision-maker is. linearUserId is the Linear user UUID an ask is assigned to and whose comments count as 'the human's' (the ask/concierge/steward skills and ask.mjs read it; ASK_HUMAN_ID overrides, and ~/.config/catalyst/config.json backstops it per-machine). name is a display string only — it is what the steward status doc's 'Needs from <human>' heading is named for, and an absent name reads as 'the human'. Not secret, but workspace-specific: keep null in committed templates. Obtain via: linearis users list, or curl the Linear GraphQL viewer{id} with your own token. There is NO built-in default — an unconfigured tenant gets a named refusal, because an ask assigned to a user who does not exist on that workspace files cleanly and reaches nobody.",
+      "linearUserId": null,
+      "name": null
+    },
     "repository": {
       "org": "[YOUR_ORG]",
       "name": "[YOUR_REPO]"

--- a/website/src/content/docs/reference/configuration.md
+++ b/website/src/content/docs/reference/configuration.md
@@ -33,6 +33,7 @@ statuses.
 {
   "catalyst": {
     "projectKey": "acme",
+    "human": { "linearUserId": "8f0c…", "name": "Sam" },
     "repository": { "org": "acme-corp", "name": "api" },
     "project": { "ticketPrefix": "ACME", "name": "Acme Corp API" },
     "linear": {
@@ -52,6 +53,8 @@ statuses.
 | Key                                 | What it does                                               |
 | ----------------------------------- | ---------------------------------------------------------- |
 | `catalyst.projectKey`               | Links to the secrets file (`config-{projectKey}.json`)     |
+| `catalyst.human.linearUserId`       | The Linear user an ask is assigned to, and whose comments count as "the human's" (CTL-2299) |
+| `catalyst.human.name`               | Display name only — what the steward status doc's `Needs from <human>` heading is named for |
 | `catalyst.repository.org` / `.name` | Your GitHub org and repo                                   |
 | `catalyst.project.ticketPrefix`     | Linear ticket prefix, e.g. `ACME`                          |
 | `catalyst.linear.teamKey`           | Linear team key; must match `ticketPrefix`                 |


### PR DESCRIPTION
Closes CTL-2299.

## What was wrong

A customer can already install the plugin bundle and point it at their own tenant with their own credentials. The skill text and the tools underneath it still assumed one workspace and one person:

- `ask.mjs` fell back to a single hard-coded Linear user id as the assignee for every ask, and `execution-core/replica-comment-read.mjs` used the same id as `DEFAULT_ASK_HUMAN_ID` for "the latest human comment".
- `ask/references/creating.md` printed that id and `--team CTL` as the copy-paste recipe.
- `steward/references/status-doc.md` templated a `Needs from <one person's name>` heading.
- `concierge/references/board.md` and `asks.md` named that person as the workspace owner.
- `steward/references/dispatch.md` said dispatch *is* launching a `/relay-ticket` session — true off-cloud, wrong on a cloud tenant whose phases run in runner containers.

The first two are the expensive ones, because they fail **silently**. On another tenant that id names nobody: the ask files cleanly and is assigned to a user who does not exist there, and the comment query filters on an author who authored nothing and returns "the human has not commented". A default that names a person is not a default.

## The plan I followed

**1. One resolver, no person-shaped fallback.** `plugins/dev/scripts/lib/tenant-identity.mjs` is a new zero-npm-import leaf (node built-ins only, same contract as `deployment-mode.mjs` / `replica-path.mjs`) exporting `resolveAskHuman`, `resolveAskTeam` and `statusDocHumanHeading`. The ladders:

```
humanId:  ASK_HUMAN_ID  →  layer1 catalyst.human.linearUserId
                        →  layer2 catalyst.human.linearUserId  →  NAMED FAILURE
team:     --team        →  ASK_TEAM  →  layer1 catalyst.linear.teamKey  →  NAMED FAILURE
name:     ASK_HUMAN_NAME →  layer1/layer2 catalyst.human.name  →  "the human"
```

Layer 1 is the committed `.catalyst/config.json`, Layer 2 the per-machine `~/.config/catalyst/config.json` — the same two layers every other resolver here uses, so an operator who has learned one has learned all of them. Layer 2 is consulted for the *human* on purpose: a host runs agent tools from several checkouts, and who answers for that host is a property of the host, not of the directory the tool was launched in.

Two deliberate differences from `deployment-mode.mjs`, both commented in the file:

- **Layer 1 is found by walking UP from cwd**, stopping at the first ancestor with a `.catalyst/config.json`. These identities are read by agent *tools*, which run from a package subdirectory or a `__tests__` folder; a cwd-only check refuses for a repo that is plainly configured one directory down. This is the same walk `secret-contract.mjs`'s `resolveLegacyPerTeamConfigPath` and `linear-comment-post.sh` already do.
- **The id has no fallback; the display name does.** A wrong id mis-files the ask; an absent name is only prose, so the heading reads `Needs from the human`, which is correct on every tenant and reads as deliberate rather than as a placeholder someone forgot.

**2. Wire the two defaults.** `ask.mjs` resolves both the team and the assignee, and does so **before the dry-run returns** — for the same reason the label resolution already sits there: a rehearsal that skips the step which actually fails is not a rehearsal. `--team` stays available (a decision may belong to a team other than the repo's own) but is no longer required. `replica-comment-read.mjs` loses the literal entirely; its default parameter now resolves the tenant's human at call time and throws a named `HumanNotConfiguredError` when there is none — matching that module's existing loud contract, where an unanswerable read is never a clean `null`. `linear-ack.mjs` / `linear-reply.mjs` catch it by name and print a one-line `REFUSED` instead of an unhandled rejection's stack.

**3. The skill text.** Every tenant-shaped literal in `ask`, `concierge` and `steward` references now points at the config key instead: the creating recipe reads both ids out of `.catalyst/config.json` with `jq`, threading names the config key rather than a person, triage says "one human per tenant", the board and asks references say "the workspace owner". Dated provenance attributions (`Ryan, 2026-08-21: "…"`) are kept on purpose — those are citations of who said what, not defaults a customer would inherit, and deleting them destroys the reasoning the rules carry.

**4. `steward/references/cloud-dispatch.md` (new).** On a cloud tenant the dispatch verb is **moving the card to Todo through the write proxy** — `POST /api/v1/agent/issue-state {issueId, stateId, hostId}` — with the two things that route deliberately does not do (it never resolves a state *name*, and a `succeeded` write is not proof work started). Phase-completion evidence is what the tenant wrote down, read from the replica: the `phase.<phase>.complete|failed` outcome comment, the artifact projection, `issues.state` + `issue_history`, `agent_sessions`. No local relay-ticket session is launched — doing so puts two workers on one branch. `dispatch.md` gains a banner pointing here, `SKILL.md`'s dispatch invariant now branches on cloud-detection, and the new file ends with a which-file-governs table.

**5. Config surface.** `catalyst.human.{linearUserId,name}` added to `config.template.json` (null, with the full `$comment` explaining how to obtain it and why there is no default), to this workspace's own `.catalyst/config.json`, and to the configuration reference.

## Tests

`plugins/dev/scripts/lib/tenant-identity.test.mjs` — 16 tests, registered in `execution-core-tests.yml` in this same PR (the four-times-burned unregistered-suite lesson), run under `bun test`, no skips.

Two halves. The ladder half covers every rung including the ones that bite: an empty `ASK_HUMAN_ID` falls through rather than blanking the id, a malformed config is "nothing at this layer" rather than a throw, the upward walk finds Layer 1 from a subdirectory, and **an unconfigured tenant is a named failure whose payload does not contain the old id**.

The second half is the ticket's own acceptance sentence turned into a guard: a **corpus scan** over the shipped skill text and the non-test scripts asserting the fleet owner's Linear user id and the one-person status heading appear nowhere. Per AGENTS.md, a scan that could silently read zero files would report a clean sweep for a repo full of violations — so there is a positive control asserting the walk read a populated corpus (>50 files), that the matcher returns non-zero for a string that *is* present, and that it finds a planted literal in a file of exactly the scanned shape. The scan caught two real violations while I was writing this change, including one in my own new file's header.

Also updated: `replica-comment-read.test.mjs` (the "defaults to the sentinel" test becomes "resolves the configured human / REFUSES when none is configured"), and the two `linear-{ack,reply}-write-path.test.sh` suites now export the identity they seed instead of relying on a default that no longer exists. Their fixture ids are arbitrary uuids now, not a real person's.

## Gate

Run on **mini-2** under the gate lock, against the pushed branch: tenant-identity 16/16, replica-comment-read 16/16, ask-verbs 59/59, linear-ack-write-path 10/10, linear-reply-write-path 38/38, cli-reference-drift 135/135, check-config-drift 51/51, config-template-statemap 6/6, execution-core-config-drift 5/5, skill-shape 161/161.

One step could not run on that host: `plugins/meta/scripts/audit-references.sh` dies at `declare -A` under mini-2's system bash 3.2.57. **Positive control: the identical command fails the same way on mini-2's `main` checkout**, so it is a host limitation, not this branch. It exits 0 on the laptop, and CI runs it on `ubuntu-latest`.

## Scope

Tier 1 only. Tier 2 (the single customer join command) is the cloud side — CTC-493 / CTC-1316 / CTC-1144 — and is not this ticket's half.
